### PR TITLE
fixed missing associations

### DIFF
--- a/packages/strapi/lib/configuration/hooks/models/utils/index.js
+++ b/packages/strapi/lib/configuration/hooks/models/utils/index.js
@@ -218,7 +218,9 @@ module.exports = {
 
   defineAssociations: function (model, definition, association, key) {
     // Initialize associations object
-    definition.associations = [];
+    if (definition.associations === undefined) {
+      definition.associations = [];
+    }
 
     // Exclude non-relational attribute
     if (!association.hasOwnProperty('collection') && !association.hasOwnProperty('model')) {


### PR DESCRIPTION
`strapi.models.modelname.associations` contained only one association before because the array was reset on every call to `defineAssociations`.