### PR TITLE
Setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,58 +5,18 @@ git:
 
 language: node_js
 
+cache:
+  yarn: true
+  directories:
+    - node_modules
+
 before_install:
   - export CHROME_BIN=chromium-browser
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
 
 install:
-  - cd packages/strapi-utils
-  - npm link
-  - cd ../strapi-mongoose
-  - npm link strapi-utils
-  - npm link
-  - cd ../strapi-bookshelf
-  - npm link strapi-utils
-  - npm link
-  - cd ../strapi-generate-migrations
-  - npm link strapi-bookshelf
-  - npm link strapi-utils
-  - npm link
-  - cd ../strapi-generate
-  - npm link strapi-utils
-  - npm link
-  - cd ../strapi-generate-admin
-  - npm link strapi-utils
-  - npm link
-  - cd ../strapi-generate-api
-  - npm link
-  - cd ../strapi-generate-policy
-  - npm link
-  - cd ../strapi-generate-service
-  - npm link
-  - cd ../strapi-generate-new
-  - npm link strapi-utils
-  - npm link
-  - cd ../strapi
-  - npm link strapi-generate-new
-  - npm link strapi-generate
-  - npm link strapi-generate-admin
-  - npm link strapi-generate-api
-  - npm link strapi-generate-policy
-  - npm link strapi-generate-service
-  - npm link strapi-generate-migrations
-  - npm link strapi-mongoose
-  - npm link strapi-utils
-  - npm install
-  - cd ./node_modules/koa-joi-router
-  - sed -i.bu 's/await-busboy/co-busboy/' joi-router.js
-  - npm install co-busboy
-  - cd ..
-  - cd ..
-  - cd ..
-  - cd ..
-  - npm install
+  - yarn run setup
 
 node_js:
   - "7"
@@ -64,4 +24,4 @@ node_js:
 sudo: false
 
 script:
-  - npm test
+  - yarn run test

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
   - sh -e /etc/init.d/xvfb start
 
 install:
-  - yarn run setup
+  - npm run setup
 
 node_js:
   - "7"
@@ -24,4 +24,4 @@ node_js:
 sudo: false
 
 script:
-  - yarn run test
+  - npm run test

--- a/Makefile
+++ b/Makefile
@@ -12,3 +12,6 @@ test: lint
 
 docs:
 	mkdocs build --clean
+
+setup:
+	./scripts/setup.sh

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     }
   },
   "scripts": {
-    "test": "make test"
+    "test": "make test",
+    "setup": "make setup"
   },
   "author": {
     "email": "hi@strapi.io",

--- a/packages/strapi/lib/configuration/hooks/core/static/index.js
+++ b/packages/strapi/lib/configuration/hooks/core/static/index.js
@@ -32,7 +32,7 @@ module.exports = strapi => {
 
     initialize: cb => {
       if (strapi.config.static === true) {
-        const isIndexRoute = strapi.config.routes.find(route => route.path === '/');
+        const isIndexRoute = _.isEmpty(strapi.config.routes) ? false : strapi.config.routes.find(route => route.path === '/');
 
         strapi.app.use(strapi.middlewares.convert(strapi.middlewares.betterStatic(path.resolve(strapi.config.appPath, strapi.config.paths.static), {
           index: isIndexRoute ? false : 'index.html',

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+set -e
+
+cd packages/strapi-utils
+npm link
+cd ../strapi-mongoose
+npm link strapi-utils
+npm link
+cd ../strapi-bookshelf
+npm link strapi-utils
+npm link
+cd ../strapi-generate-migrations
+npm link strapi-bookshelf
+npm link strapi-utils
+npm link
+cd ../strapi-generate
+npm link strapi-utils
+npm link
+cd ../strapi-generate-admin
+npm link strapi-utils
+npm link
+cd files/admin/public
+npm install
+npm run build
+cd ../../../
+cd ../strapi-generate-api
+npm link
+cd ../strapi-generate-policy
+npm link
+cd ../strapi-generate-service
+npm link
+cd ../strapi-generate-new
+npm link strapi-utils
+npm link
+cd ../strapi
+npm link strapi-generate-new
+npm link strapi-generate
+npm link strapi-generate-admin
+npm link strapi-generate-api
+npm link strapi-generate-policy
+npm link strapi-generate-service
+npm link strapi-generate-migrations
+npm link strapi-mongoose
+npm link strapi-utils
+npm install
+npm link
+cd ./node_modules/koa-joi-router
+sed -i.bu 's/await-busboy/co-busboy/' joi-router.js
+npm install co-busboy
+cd ..
+cd ..
+cd ..
+cd ..
+npm install


### PR DESCRIPTION
Improve the way to install Strapi for contributing by executing two simple commands:

`git clone git@github.com:strapi/strapi.git && npm run setup`

The `setup` command will execute a shell script to symlink the dependencies and build the dashboard. Moreover, the `.travis.yml` is now using the same shell script.


