### PR TITLE
Add beforeFetchCollection & afterFetchCollection lifecycle hooks

### DIFF
--- a/packages/strapi-bookshelf/lib/index.js
+++ b/packages/strapi-bookshelf/lib/index.js
@@ -202,7 +202,9 @@ module.exports = function(strapi) {
                     updating: 'beforeUpdate',
                     updated: 'afterUpdate',
                     fetching: 'beforeFetch',
+                    'fetching:collection': 'beforeFetchCollection',
                     fetched: 'afterFetch',
+                    'fetched:collection': 'afterFetchCollection',
                     saving: 'beforeSave',
                     saved: 'afterSave'
                   };


### PR DESCRIPTION
the lifecycle methods fetched and fetching are not called when the user uses fetchPage or fetchAll in Bookshelf.js. Therefore I added these two mapping to be able to use the appropriate lifecycle methods for collections as well:

'fetching:collection': 'beforeFetchCollection'
'fetched:collection': 'afterFetchCollection'