### PR TITLE
Center popupwarning and remove confirm button border

### DIFF
--- a/packages/strapi-admin/admin/src/components/LeftMenuHeader/index.js
+++ b/packages/strapi-admin/admin/src/components/LeftMenuHeader/index.js
@@ -9,16 +9,14 @@ import { Link } from 'react-router-dom';
 
 import styles from './styles.scss';
 
-class LeftMenuHeader extends React.Component { // eslint-disable-line react/prefer-stateless-function
-  render() {
-    return (
-      <div className={styles.leftMenuHeader}>
-        <Link to="/" className={styles.leftMenuHeaderLink}>
-          <span className={styles.projectName}></span>
-        </Link>
-      </div>
-    );
-  }
+function LeftMenuHeader() {
+  return (
+    <div className={styles.leftMenuHeader}>
+      <Link to="/" className={styles.leftMenuHeaderLink}>
+        <span className={styles.projectName}></span>
+      </Link>
+    </div>
+  );
 }
 
 export default LeftMenuHeader;

--- a/packages/strapi-admin/admin/src/components/LeftMenuLinkContainer/index.js
+++ b/packages/strapi-admin/admin/src/components/LeftMenuLinkContainer/index.js
@@ -7,18 +7,23 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
-import { map } from 'lodash';
+import { get, map, size } from 'lodash';
 
 import LeftMenuLink from 'components/LeftMenuLink';
 
 import styles from './styles.scss';
 import messages from './messages.json';
 
-class LeftMenuLinkContainer extends React.Component { // eslint-disable-line react/prefer-stateless-function
-  render() {
-    // Generate the list of sections
-    const linkSections = map(this.props.plugins.toJS(), plugin => (
-      plugin.leftMenuSections.map((leftMenuSection, j) => (
+function LeftMenuLinkContainer({ plugins }) {
+  // Generate the list of sections
+  const linkSections = map(plugins.toJS(), plugin => (
+    plugin.leftMenuSections.map((leftMenuSection, j) => {
+
+      if (size(get(leftMenuSection, 'links')) === 0) {
+        return <div />
+      }
+
+      return (
         <div key={j}>
           <p className={styles.title}>{leftMenuSection.name}</p>
           <ul className={styles.list}>
@@ -27,57 +32,57 @@ class LeftMenuLinkContainer extends React.Component { // eslint-disable-line rea
             )}
           </ul>
         </div>
-      ))
-    ));
-
-    // Check if the plugins list is empty or not
-    const pluginsLinks = this.props.plugins.size
-      ? this.props.plugins.valueSeq().map((plugin) => (
-        <LeftMenuLink
-          key={plugin.get('id')}
-          icon={plugin.get('icon') || 'plug'}
-          label={plugin.get('name')}
-          destination={`/plugins/${plugin.get('id')}`}
-        />
-      ))
-      : (
-        <li className={styles.noPluginsInstalled}>
-          <FormattedMessage {...messages.noPluginsInstalled} />.
-        </li>
       );
+    })
+  ));
 
-    return (
-      <div className={styles.leftMenuLinkContainer}>
-        {linkSections}
-        <div>
-          <p className={styles.title}><FormattedMessage {...messages.plugins} /></p>
-          <ul className={styles.list}>
-            {pluginsLinks}
-          </ul>
-        </div>
-        <div>
-          <p className={styles.title}><FormattedMessage {...messages.general} /></p>
-          <ul className={styles.list}>
-            <LeftMenuLink
-              icon="cubes"
-              label={messages.listPlugins.id}
-              destination="/list-plugins"
-            />
-            <LeftMenuLink
-              icon="download"
-              label={messages.installNewPlugin.id}
-              destination="/install-plugin"
-            />
-            <LeftMenuLink
-              icon="gear"
-              label={messages.configuration.id}
-              destination="/configuration"
-            />
-          </ul>
-        </div>
-      </div>
+  // Check if the plugins list is empty or not
+  const pluginsLinks = plugins.size
+    ? plugins.valueSeq().map((plugin) => (
+      <LeftMenuLink
+        key={plugin.get('id')}
+        icon={plugin.get('icon') || 'plug'}
+        label={plugin.get('name')}
+        destination={`/plugins/${plugin.get('id')}`}
+      />
+    ))
+    : (
+      <li className={styles.noPluginsInstalled}>
+        <FormattedMessage {...messages.noPluginsInstalled} />.
+      </li>
     );
-  }
+
+  return (
+    <div className={styles.leftMenuLinkContainer}>
+      {linkSections}
+      <div>
+        <p className={styles.title}><FormattedMessage {...messages.plugins} /></p>
+        <ul className={styles.list}>
+          {pluginsLinks}
+        </ul>
+      </div>
+      <div>
+        <p className={styles.title}><FormattedMessage {...messages.general} /></p>
+        <ul className={styles.list}>
+          <LeftMenuLink
+            icon="cubes"
+            label={messages.listPlugins.id}
+            destination="/list-plugins"
+          />
+          <LeftMenuLink
+            icon="download"
+            label={messages.installNewPlugin.id}
+            destination="/install-plugin"
+          />
+          <LeftMenuLink
+            icon="gear"
+            label={messages.configuration.id}
+            destination="/configuration"
+          />
+        </ul>
+      </div>
+    </div>
+  );
 }
 
 LeftMenuLinkContainer.propTypes = {

--- a/packages/strapi-helper-plugin/lib/src/components/PopUpWarning/styles.scss
+++ b/packages/strapi-helper-plugin/lib/src/components/PopUpWarning/styles.scss
@@ -17,8 +17,9 @@
 }
 .modalPosition {
   top: 16.8rem;
+  left: 18.2rem;
   margin-top: 0 !important;
-  
+
   > div {
     border:none;
     border-radius: 2px;
@@ -52,7 +53,6 @@
     position: relative;
     border-radius: 0.3rem;
     text-transform: capitalize;
-    // margin-right: 1.8rem;
     cursor: pointer;
     font-family: Lato;
     &:focus {
@@ -81,6 +81,7 @@
   background: linear-gradient(315deg, #0097F6 0%, #005EEA 100%);
   -webkit-font-smoothing: antialiased;
   color: white !important;
+  border: none;
   &:active {
    box-shadow: inset 1px 1px 3px rgba(0,0,0,.15);
  }

--- a/packages/strapi-plugin-content-type-builder/admin/src/components/PopUpWarning/styles.scss
+++ b/packages/strapi-plugin-content-type-builder/admin/src/components/PopUpWarning/styles.scss
@@ -41,7 +41,7 @@
 }
 
 .modalPosition {
-  // top: 16.8rem;
+  left: 18.2rem;
   > div {
     border:none;
     border-radius: 2px;
@@ -80,7 +80,6 @@
     position: relative;
     border-radius: 0.3rem;
     text-transform: capitalize;
-    // margin-right: 1.8rem;
     cursor: pointer;
     font-family: Lato;
     &:focus {
@@ -110,6 +109,7 @@
   background: linear-gradient(315deg, #0097F6 0%, #005EEA 100%);
   -webkit-font-smoothing: antialiased;
   color: white !important;
+  border: none;
   &:active {
    box-shadow: inset 1px 1px 3px rgba(0,0,0,.15);
  }


### PR DESCRIPTION
- Center popUpWarning component
- Remove confirm button border-color
- Hide leftMenu content types section if there isn't any model
- Change `LeftMenuLinkContainer` component to stateless function instead of `React.Component`
- Same for `LeftMenuHeader` component