### PR TITLE
Fix local installation

### DIFF
--- a/packages/strapi-generate-new/lib/after.js
+++ b/packages/strapi-generate-new/lib/after.js
@@ -78,6 +78,8 @@ module.exports = (scope, cb) => {
     pluginsInstallation();
   }
 
+  const strapiBin = path.join(scope.strapiRoot, scope.strapiPackageJSON.bin.strapi);
+
   // Install default plugins and link dependencies.
   function pluginsInstallation() {
     // Define the list of default plugins.
@@ -86,7 +88,7 @@ module.exports = (scope, cb) => {
     // Install each plugin.
     defaultPlugins.forEach(defaultPlugin => {
       try {
-        execSync(`strapi install ${defaultPlugin} ${scope.developerMode ? '--dev' : ''}`);
+        execSync(`node ${strapiBin} install ${defaultPlugin} ${scope.developerMode ? '--dev' : ''}`);
         logger.info(`The plugin ${defaultPlugin} has been successfully installed.`);
       } catch (error) {
         logger.error(`An error occurred during ${defaultPlugin} plugin installation.`);

--- a/packages/strapi-generate/lib/target.js
+++ b/packages/strapi-generate/lib/target.js
@@ -232,8 +232,15 @@ function parseTarget(target, scope, cb) {
     // If we couldn't find a generator using the configured module,
     // try requiring `strapi-generate-<module>` to get the core generator.
     if (!subGenerator && !module.match(/^strapi-generate-/)) {
+      let strapiRoot = scope.strapiRoot;
+
+      // Handle local installation
+      if (strapiRoot.endsWith('node_modules/strapi')) {
+        strapiRoot = process.cwd();
+      }
+
       try {
-        subGenerator = require(path.resolve(scope.strapiRoot, 'node_modules', 'strapi-generate-' + module));
+        subGenerator = require(path.resolve(strapiRoot, 'node_modules', 'strapi-generate-' + module));
       } catch (e1) {
         requireError = e1;
       }


### PR DESCRIPTION
- Fallback to `process.cwd()` during module resolution in case of local installation
- Use full path to `strapi` binary, instead of global one