### PR TITLE
Add keyboard shortcuts in content type builder plugin

### DIFF
--- a/docs/3.x.x/en/SUMMARY.md
+++ b/docs/3.x.x/en/SUMMARY.md
@@ -34,6 +34,7 @@
 * [Helpers](plugins/utils.md)
 * [UI Components](plugins/ui-components.md)
 * [Advanced usage](plugins/advanced.md)
+* [Keyboard shortcuts](plguins/plugins-keyboard-shortcuts.md)
 
 ### Advanced Usage
 * [Admin panel](advanced/customize-admin.md)

--- a/docs/3.x.x/en/plugins/plugins-keyboard-shortcuts.md
+++ b/docs/3.x.x/en/plugins/plugins-keyboard-shortcuts.md
@@ -1,0 +1,11 @@
+# Plugins keyboard shortcuts
+
+This section lists the available keyboard shortcuts in each Plugins
+
+## Content Type Builder
+
+| Keys | Action |
+| ---- | ------ |
+| <kbd>option</kbd> + <kbd>a</kbd> | Opens the Attributes modal |
+| <kbd>option</kbd> + <kbd>n</kbd> | Opens the Create Content Type modal |
+| <kbd>option</kbd> + <kbd>s</kbd> | Saves the content type's attributes |

--- a/packages/strapi-helper-plugin/lib/src/components/Input/index.js
+++ b/packages/strapi-helper-plugin/lib/src/components/Input/index.js
@@ -182,6 +182,7 @@ class Input extends React.Component { // eslint-disable-line react/prefer-statel
           disabled={this.props.disabled}
           onBlur={handleBlur}
           tabIndex={this.props.tabIndex}
+          autoFocus={this.props.autoFocus}
         >
           {map(this.props.selectOptions, (option, key) => (
             option.name ?
@@ -229,6 +230,7 @@ class Input extends React.Component { // eslint-disable-line react/prefer-statel
               onFocus={this.props.onFocus}
               placeholder={placeholder}
               disabled={this.props.disabled}
+              autoFocus={this.props.autoFocus}
             />
           )}
         </FormattedMessage>
@@ -297,6 +299,7 @@ class Input extends React.Component { // eslint-disable-line react/prefer-statel
           placeholder={message}
           autoComplete="off"
           disabled={this.props.disabled}
+          autoFocus={this.props.autoFocus}
         />
       )}
     </FormattedMessage>
@@ -332,6 +335,7 @@ class Input extends React.Component { // eslint-disable-line react/prefer-statel
               placeholder={placeholder}
               disabled={this.props.disabled}
               type={type}
+              autoFocus={this.props.autoFocus}
             />
           )}
         </FormattedMessage>
@@ -374,6 +378,7 @@ class Input extends React.Component { // eslint-disable-line react/prefer-statel
                 placeholder={placeholder}
                 disabled={this.props.disabled}
                 type="text"
+                autoFocus={this.props.autoFocus}
               />
             )}
           </FormattedMessage>
@@ -413,6 +418,7 @@ class Input extends React.Component { // eslint-disable-line react/prefer-statel
         className={`form-control ${!this.props.deactivateErrorHighlight && !isEmpty(this.state.errors) ? 'is-invalid': ''}`}
         placeholder={placeholder}
         disabled={this.props.disabled}
+        autoFocus={this.props.autoFocus}
       />;
 
     const link = !isEmpty(this.props.linkContent) ? <a href={this.props.linkContent.link} target="_blank"><FormattedMessage id={this.props.linkContent.description} /></a> : '';
@@ -473,6 +479,7 @@ Input.propTypes = {
     PropTypes.string,
   ]),
   addRequiredInputDesign: PropTypes.bool,
+  autoFocus: PropTypes.bool,
   customBootstrapClass: PropTypes.string,
   deactivateErrorHighlight: PropTypes.bool,
   didCheckErrors: PropTypes.bool,
@@ -512,6 +519,7 @@ Input.propTypes = {
 Input.defaultProps = {
   addon: false,
   addRequiredInputDesign: false,
+  autoFocus: false,
   deactivateErrorHighlight: false,
   didCheckErrors: false,
   disabled: false,

--- a/packages/strapi-plugin-content-type-builder/admin/src/components/AttributeCard/index.js
+++ b/packages/strapi-plugin-content-type-builder/admin/src/components/AttributeCard/index.js
@@ -20,6 +20,7 @@ import IcoText from '../../assets/images/icon_text.png';
 import styles from './styles.scss';
 
 /* eslint-disable jsx-a11y/no-static-element-interactions */
+/* eslint-disable jsx-a11y/no-autofocus */
 const asset = {
   'boolean': IcoBoolean,
   'date': IcoDate,
@@ -31,10 +32,10 @@ const asset = {
   'text': IcoText,
 };
 
-function AttributeCard({ attribute, handleClick }) {
+function AttributeCard({ attribute, autoFocus, handleClick, tabIndex }) {
   return (
     <div className="col-md-6">
-      <div className={styles.attributeCardContainer} onClick={() => handleClick(attribute.type)}>
+      <button className={styles.attributeCardContainer} style={{ width: '100%' }} onClick={() => handleClick(attribute.type)} type="button" tabIndex={tabIndex + 1} autoFocus={autoFocus}>
         <div className={styles.attributeCard}>
           <img src={asset[attribute.type]} alt="ico" />
           <FormattedMessage id={`content-type-builder.popUpForm.attributes.${attribute.type}.name`}>
@@ -42,14 +43,16 @@ function AttributeCard({ attribute, handleClick }) {
           </FormattedMessage>
           <FormattedMessage id={attribute.description} />
         </div>
-      </div>
+      </button>
     </div>
   );
 }
 
 AttributeCard.propTypes = {
   attribute: PropTypes.object.isRequired,
+  autoFocus: PropTypes.bool.isRequired,
   handleClick: PropTypes.func.isRequired,
+  tabIndex: PropTypes.number.isRequired,
 };
 
 export default AttributeCard;

--- a/packages/strapi-plugin-content-type-builder/admin/src/components/AttributeCard/index.js
+++ b/packages/strapi-plugin-content-type-builder/admin/src/components/AttributeCard/index.js
@@ -35,7 +35,14 @@ const asset = {
 function AttributeCard({ attribute, autoFocus, handleClick, tabIndex }) {
   return (
     <div className="col-md-6">
-      <button className={styles.attributeCardContainer} style={{ width: '100%' }} onClick={() => handleClick(attribute.type)} type="button" tabIndex={tabIndex + 1} autoFocus={autoFocus}>
+      <button
+        autoFocus={autoFocus}
+        className={styles.attributeCardContainer}
+        onClick={() => handleClick(attribute.type)}
+        style={{ width: '100%' }}
+        type="button"
+        tabIndex={tabIndex + 1}
+      >
         <div className={styles.attributeCard}>
           <img src={asset[attribute.type]} alt="ico" />
           <FormattedMessage id={`content-type-builder.popUpForm.attributes.${attribute.type}.name`}>

--- a/packages/strapi-plugin-content-type-builder/admin/src/components/AttributeCard/styles.scss
+++ b/packages/strapi-plugin-content-type-builder/admin/src/components/AttributeCard/styles.scss
@@ -5,7 +5,7 @@
   align-items: center;
   height: 4rem;
   margin-top: .6rem;
-  margin-bottom: .9rem;
+  margin-bottom: .8rem;
   padding: 0 1rem 0 1rem;
   border: 1px solid #E3E9F3;
   border-radius: 0.25rem;
@@ -13,7 +13,7 @@
   background: #FFFFFF;
   box-shadow: 1px 1px 1px rgba(104, 118,145, 0.05);
 
-  &:hover, &:active {
+  &:hover, &:active, &:focus {
     background: #F7F7F7;
 
     > div:after{

--- a/packages/strapi-plugin-content-type-builder/admin/src/components/AttributeCard/styles.scss
+++ b/packages/strapi-plugin-content-type-builder/admin/src/components/AttributeCard/styles.scss
@@ -1,22 +1,25 @@
 .attributeCardContainer { /* stylelint-disable */
-  cursor: pointer;
   display: flex;
   justify-content: space-between;
   align-items: center;
+
   height: 4rem;
+  padding: 0 1rem 0 1rem;
+  border-radius: 0.25rem;
+  border: 1px solid #E3E9F3;
   margin-top: .6rem;
   margin-bottom: .8rem;
-  padding: 0 1rem 0 1rem;
-  border: 1px solid #E3E9F3;
-  border-radius: 0.25rem;
-  line-height: 4rem;
+
   background: #FFFFFF;
   box-shadow: 1px 1px 1px rgba(104, 118,145, 0.05);
+
+  line-height: 4rem;
+  cursor: pointer;
 
   &:hover, &:active, &:focus {
     background: #F7F7F7;
 
-    > div:after{
+    > div:after {
       color: #0097F6;
     }
   }
@@ -25,30 +28,35 @@
 .attributeCard {
   font-size: 1.3rem;
 
-  &:hover{
-    background: none;
-  }
 
   &:after{
-    position: absolute;
-    top: 7px; right: 26px;
     content: '\f05d';
+    position: absolute;
+    top: 7px;
+    right: 26px;
+
+    color: #E3E9F3;
+
     font-size: 1.4rem;
     font-family: 'FontAwesome';
-    color: #E3E9F3;
     -webkit-font-smoothing: antialiased;
   }
 
+  &:hover{
+    background: none;
+
+  }
   > img{
     display: inline-block;
-    width: 35px;
     height: 20px;
+    width: 35px;
     margin-top: -3px;
     margin-right: 10px;
   }
 
   > span {
     color: #9EA7B8;
+
     font-size: 1.2rem;
     font-style: italic;
     font-weight: 400;
@@ -57,11 +65,13 @@
 }
 
 .attributeType {
-  color: #323740 !important;
   margin-right: 1.2rem;
-  font-style: normal !important;
+
+  color: #323740 !important;
+  
+  text-transform: capitalize;
   font-size: 1.3rem !important;
   font-weight: 500 !important;
-  text-transform: capitalize;
+  font-style: normal !important;
   -webkit-font-smoothing: subpixel-antialiased !important;
 }

--- a/packages/strapi-plugin-content-type-builder/admin/src/components/PopUpForm/index.js
+++ b/packages/strapi-plugin-content-type-builder/admin/src/components/PopUpForm/index.js
@@ -56,6 +56,7 @@ class PopUpForm extends React.Component { // eslint-disable-line react/prefer-st
         didCheckErrors={this.props.didCheckErrors}
         pluginID={this.props.pluginID}
         linkContent={item.linkContent}
+        autoFocus={key === 0}
       />
     );
   }

--- a/packages/strapi-plugin-content-type-builder/admin/src/containers/Form/index.js
+++ b/packages/strapi-plugin-content-type-builder/admin/src/containers/Form/index.js
@@ -457,10 +457,12 @@ export class Form extends React.Component { // eslint-disable-line react/prefer-
   renderModalBodyChooseAttributes = () => (
     map(forms.attributesDisplay.items, (attribute, key) => (
       <AttributeCard
+        autoFocus={key === 0}
         key={key}
         attribute={attribute}
         routePath={this.props.routePath}
         handleClick={this.goToAttributeTypeView}
+        tabIndex={key}
       />
     ))
   )

--- a/packages/strapi-plugin-content-type-builder/admin/src/containers/HomePage/index.js
+++ b/packages/strapi-plugin-content-type-builder/admin/src/containers/HomePage/index.js
@@ -8,7 +8,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators, compose } from 'redux';
 import { createStructuredSelector } from 'reselect';
-import { size } from 'lodash';
+import { clone, includes, size } from 'lodash';
 import Helmet from 'react-helmet';
 import PropTypes from 'prop-types';
 import { router } from 'app';
@@ -32,14 +32,30 @@ import styles from './styles.scss';
 import saga from './sagas';
 import reducer from './reducer';
 
+const keyBoardShortCuts = [18, 78];
+
 export class HomePage extends React.Component { // eslint-disable-line react/prefer-stateless-function
   constructor(props) {
     super(props);
+
+    this.state = {
+      mapKeys: {},
+    };
 
     this.popUpHeaderNavLinks = [
       { name: 'baseSettings', message: 'content-type-builder.popUpForm.navContainer.base', nameToReplace: 'advancedSettings' },
       { name: 'advancedSettings', message: 'content-type-builder.popUpForm.navContainer.advanced', nameToReplace: 'baseSettings' },
     ];
+  }
+
+  componentDidMount() {
+    document.addEventListener('keydown', this.handleShortCut);
+    document.addEventListener('keyup', this.handleShortCut);
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener('keydown', this.handleShortCut);
+    document.removeEventListener('keyup', this.handleShortCut);
   }
 
   handleButtonClick = () => {
@@ -52,6 +68,20 @@ export class HomePage extends React.Component { // eslint-disable-line react/pre
 
   handleDelete = (contentTypeName) => {
     this.props.deleteContentType(contentTypeName, this.context);
+  }
+
+  handleShortCut = (e) => {
+    if (includes(keyBoardShortCuts, e.keyCode)) {
+      const mapKeys = clone(this.state.mapKeys);
+      mapKeys[e.keyCode] = e.type === 'keydown';
+      this.setState({ mapKeys });
+
+      // Check if user pressed option + n;
+      if (mapKeys[18] && mapKeys[78]) {
+        this.setState({ mapKey: {} });
+        this.handleButtonClick();
+      }
+    }
   }
 
   toggleModal = () => {

--- a/packages/strapi-plugin-content-type-builder/admin/src/containers/HomePage/index.js
+++ b/packages/strapi-plugin-content-type-builder/admin/src/containers/HomePage/index.js
@@ -78,7 +78,7 @@ export class HomePage extends React.Component { // eslint-disable-line react/pre
 
       // Check if user pressed option + n;
       if (mapKeys[18] && mapKeys[78]) {
-        this.setState({ mapKey: {} });
+        this.setState({ mapKeys: {} });
         this.handleButtonClick();
       }
     }

--- a/packages/strapi-plugin-content-type-builder/admin/src/containers/HomePage/index.js
+++ b/packages/strapi-plugin-content-type-builder/admin/src/containers/HomePage/index.js
@@ -32,6 +32,7 @@ import styles from './styles.scss';
 import saga from './sagas';
 import reducer from './reducer';
 
+// KeyCode 18 === alt; 78 === n;
 const keyBoardShortCuts = [18, 78];
 
 export class HomePage extends React.Component { // eslint-disable-line react/prefer-stateless-function

--- a/packages/strapi-plugin-content-type-builder/admin/src/containers/ModelPage/index.js
+++ b/packages/strapi-plugin-content-type-builder/admin/src/containers/ModelPage/index.js
@@ -58,7 +58,7 @@ import styles from './styles.scss';
 /* eslint-disable jsx-a11y/no-static-element-interactions */
 /* eslint-disable react/jsx-wrap-multilines */
 
-const keyBoardShortCuts = [18, 78];
+const keyBoardShortCuts = [18, 65, 78, 83];
 
 export class ModelPage extends React.Component { // eslint-disable-line react/prefer-stateless-function
   constructor(props) {
@@ -200,8 +200,21 @@ export class ModelPage extends React.Component { // eslint-disable-line react/pr
 
       // Check if user pressed option + n;
       if (mapKeys[18] && mapKeys[78]) {
-        this.setState({ mapKey: {} });
+        this.setState({ mapKeys: {} });
         this.handleAddLinkClick();
+      }
+
+      // Check if user pressed option + a
+      if (mapKeys[18] && mapKeys[65]) {
+        this.setState({ mapKeys: {} });
+        this.handleClickAddAttribute();
+      }
+
+      // Check if the user pressed option + s
+      if (mapKeys[18] && mapKeys[83]) {
+        if (get(storeData.getContentType(), 'name') === this.props.match.params.modelName && size(get(storeData.getContentType(), 'attributes')) > 0 || this.props.modelPage.showButtons) {
+          this.handleSubmit();
+        }
       }
     }
   }
@@ -280,7 +293,7 @@ export class ModelPage extends React.Component { // eslint-disable-line react/pr
   }
 
   render() {
-    // Url to redirects the user if he modifies the temporary content type name
+    // Url to redirect the user if he modifies the temporary content type name
     const redirectRoute = replace(this.props.match.path, '/:modelName', '');
     const addButtons  = get(storeData.getContentType(), 'name') === this.props.match.params.modelName && size(get(storeData.getContentType(), 'attributes')) > 0 || this.props.modelPage.showButtons;
     const showNoTableWarning = this.props.modelPage.tableExists ? '' : <NoTableWarning modelName={this.props.modelPage.model.name} />;

--- a/packages/strapi-plugin-content-type-builder/admin/src/containers/ModelPage/index.js
+++ b/packages/strapi-plugin-content-type-builder/admin/src/containers/ModelPage/index.js
@@ -8,7 +8,16 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
 import { bindActionCreators, compose } from 'redux';
-import { get, has, size, replace, startCase, findIndex } from 'lodash';
+import {
+  clone,
+  get,
+  findIndex,
+  has,
+  includes,
+  replace,
+  size,
+  startCase,
+} from 'lodash';
 import { FormattedMessage } from 'react-intl';
 import { NavLink } from 'react-router-dom';
 import PropTypes from 'prop-types';
@@ -49,12 +58,15 @@ import styles from './styles.scss';
 /* eslint-disable jsx-a11y/no-static-element-interactions */
 /* eslint-disable react/jsx-wrap-multilines */
 
+const keyBoardShortCuts = [18, 78];
+
 export class ModelPage extends React.Component { // eslint-disable-line react/prefer-stateless-function
   constructor(props) {
     super(props);
 
     this.state = {
       contentTypeTemporary: false,
+      mapKeys: {},
     };
 
     this.popUpHeaderNavLinks = [
@@ -70,6 +82,8 @@ export class ModelPage extends React.Component { // eslint-disable-line react/pr
 
   componentDidMount() {
     this.fetchModel(this.props);
+    document.addEventListener('keydown', this.handleShortCut);
+    document.addEventListener('keyup', this.handleShortCut);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -95,6 +109,8 @@ export class ModelPage extends React.Component { // eslint-disable-line react/pr
 
   componentWillUnmount() {
     this.props.resetShowButtonsProps();
+    document.removeEventListener('keydown', this.handleShortCut);
+    document.removeEventListener('keyup', this.handleShortCut);
   }
 
   addCustomSection = (sectionStyles) => (
@@ -174,6 +190,20 @@ export class ModelPage extends React.Component { // eslint-disable-line react/pr
     }
 
     router.push(`/plugins/content-type-builder/models/${this.props.match.params.modelName}#edit${this.props.match.params.modelName}::attribute${attributeType}::${settingsType}::${index}${hasParallelAttribute}`);
+  }
+
+  handleShortCut = (e) => {
+    if (includes(keyBoardShortCuts, e.keyCode)) {
+      const mapKeys = clone(this.state.mapKeys);
+      mapKeys[e.keyCode] = e.type === 'keydown';
+      this.setState({ mapKeys });
+
+      // Check if user pressed option + n;
+      if (mapKeys[18] && mapKeys[78]) {
+        this.setState({ mapKey: {} });
+        this.handleAddLinkClick();
+      }
+    }
   }
 
   handleSubmit = () => {

--- a/packages/strapi-plugin-content-type-builder/admin/src/containers/ModelPage/index.js
+++ b/packages/strapi-plugin-content-type-builder/admin/src/containers/ModelPage/index.js
@@ -58,6 +58,8 @@ import styles from './styles.scss';
 /* eslint-disable jsx-a11y/no-static-element-interactions */
 /* eslint-disable react/jsx-wrap-multilines */
 
+// KeyCode 19 === alt; 78 === n;
+// KeyCode 65 === a; 83 === s;
 const keyBoardShortCuts = [18, 65, 78, 83];
 
 export class ModelPage extends React.Component { // eslint-disable-line react/prefer-stateless-function


### PR DESCRIPTION
- Add <kbd>option</kbd> + <kbd>a</kbd> to open the Attributes modal
- Add <kbd>option</kbd> + <kbd>n</kbd> to open the create content type modal
- Add <kbd>option</kbd> + <kbd>s</kbd> to save the content type's attributes

- Created documentation accordingly