### PR TITLE
Fix loadOrder plugins in FIREFOX and SAFARI

### DIFF
--- a/packages/strapi-admin/admin/src/app.js
+++ b/packages/strapi-admin/admin/src/app.js
@@ -35,13 +35,15 @@ import LanguageProvider from 'containers/LanguageProvider';
 
 import App from 'containers/App';
 import { showNotification } from 'containers/NotificationProvider/actions';
-import { pluginLoaded, updatePlugin } from 'containers/App/actions';
+import { pluginLoaded, updatePlugin, setHasUserPlugin } from 'containers/App/actions';
 import auth from 'utils/auth';
-
+import plugins from './config/plugins.json';
 import configureStore from './store';
 import { translationMessages, languages } from './i18n';
+import { findIndex } from 'lodash';
 /* eslint-enable */
 
+let appPlugins = plugins;
 // Create redux store with history
 const initialState = {};
 const history = createHistory({
@@ -91,6 +93,7 @@ if (window.location.port !== '4000') {
       return response.json();
     })
     .then(plugins => {
+      appPlugins = plugins;
       (plugins || []).forEach(plugin => {
         const script = document.createElement('script');
         script.type = 'text/javascript';
@@ -117,7 +120,7 @@ if (window.location.port !== '4000') {
       });
     })
     .catch(err => {
-      console.log('kkk', err);
+      console.log(err);
     });
 }
 
@@ -171,6 +174,10 @@ const registerPlugin = (plugin) => {
 const displayNotification = (message, status) => {
   store.dispatch(showNotification(message, status));
 };
+
+if (findIndex(appPlugins, ['id', 'users-permissions']) === -1) {
+  store.dispatch(setHasUserPlugin());
+}
 
 window.strapi = Object.assign(window.strapi || {}, {
   remoteURL: devFrontURL || remoteURL,

--- a/packages/strapi-admin/admin/src/containers/App/actions.js
+++ b/packages/strapi-admin/admin/src/containers/App/actions.js
@@ -9,6 +9,7 @@ import {
   UPDATE_PLUGIN,
   PLUGIN_LOADED,
   PLUGIN_DELETED,
+  SET_HAS_USERS_PLUGIN,
 } from './constants';
 
 export function loadPlugin(newPlugin) {
@@ -38,5 +39,11 @@ export function pluginDeleted(plugin) {
   return {
     type: PLUGIN_DELETED,
     plugin,
+  };
+}
+
+export function setHasUserPlugin() {
+  return {
+    type: SET_HAS_USERS_PLUGIN,
   };
 }

--- a/packages/strapi-admin/admin/src/containers/App/constants.js
+++ b/packages/strapi-admin/admin/src/containers/App/constants.js
@@ -4,6 +4,7 @@
  *
  */
 
+export const SET_HAS_USERS_PLUGIN = 'app/App/SET_HAS_USERS_PLUGIN';
 export const LOAD_PLUGIN = 'app/App/LOAD_PLUGIN';
 export const UPDATE_PLUGIN = 'app/App/UPDATE_PLUGIN';
 export const PLUGIN_LOADED = 'app/App/PLUGIN_LOADED';

--- a/packages/strapi-admin/admin/src/containers/App/reducer.js
+++ b/packages/strapi-admin/admin/src/containers/App/reducer.js
@@ -3,10 +3,12 @@ import {
   UPDATE_PLUGIN,
   PLUGIN_DELETED,
   PLUGIN_LOADED,
+  SET_HAS_USERS_PLUGIN,
 } from './constants';
 
 const initialState = fromJS({
   plugins: {},
+  hasUserPlugin: true,
 });
 
 function appReducer(state = initialState, action) {
@@ -17,6 +19,8 @@ function appReducer(state = initialState, action) {
       return state.setIn(['plugins', action.pluginId, action.updatedKey], fromJS(action.updatedValue));
     case PLUGIN_DELETED:
       return state.deleteIn(['plugins', action.plugin]);
+    case SET_HAS_USERS_PLUGIN:
+      return state.set('hasUserPlugin', false);
     default:
       return state;
   }

--- a/packages/strapi-admin/admin/src/containers/App/selectors.js
+++ b/packages/strapi-admin/admin/src/containers/App/selectors.js
@@ -14,7 +14,13 @@ const selectPlugins = () => createSelector(
   (appState) => appState.get('plugins')
 );
 
+const selectHasUserPlugin = () => createSelector(
+  selectApp(),
+  (appState) => appState.get('hasUserPlugin'),
+);
+
 export {
   selectApp,
+  selectHasUserPlugin,
   selectPlugins,
 };

--- a/packages/strapi-admin/admin/src/containers/ListPluginsPage/saga.js
+++ b/packages/strapi-admin/admin/src/containers/ListPluginsPage/saga.js
@@ -1,6 +1,7 @@
 import { fork, call, put, select, takeLatest } from 'redux-saga/effects';
 
 import { pluginDeleted } from 'containers/App/actions';
+import auth from 'utils/auth';
 import request from 'utils/request';
 
 import { deletePluginSucceeded, getPluginsSucceeded } from './actions';
@@ -13,6 +14,11 @@ export function* deletePlugin() {
     const requestUrl = `/admin/plugins/uninstall/${plugin}`;
 
     const resp = yield call(request, requestUrl, { method: 'DELETE' });
+
+    // Remove the logout button
+    if (plugin === 'users-permissions') {
+      auth.clearAppStorage();
+    }
 
     if (resp.ok) {
       yield put(deletePluginSucceeded(plugin));

--- a/packages/strapi-plugin-users-permissions/config/roles.json
+++ b/packages/strapi-plugin-users-permissions/config/roles.json
@@ -254,6 +254,9 @@
             }
           }
         }
+      },
+      "application": {
+        "controllers": {}
       }
     }
   },
@@ -512,6 +515,9 @@
             }
           }
         }
+      },
+      "application": {
+        "controllers": {}
       }
     }
   }


### PR DESCRIPTION
- Prevent plugins from being loaded if the 'users-permissions' plugin is present in the app and the user is not logged in