### PR TITLE
SSL option for strapi-knex connections.

### DIFF
--- a/packages/strapi-knex/lib/index.js
+++ b/packages/strapi-knex/lib/index.js
@@ -95,7 +95,9 @@ module.exports = strapi => {
             charset: _.get(connection.settings, 'charset'),
             schema: _.get(connection.settings, 'schema') || 'public',
             port: _.get(connection.settings, 'port'),
-            socket: _.get(connection.settings, 'socketPath')
+            socket: _.get(connection.settings, 'socketPath'),
+            ssl: _.get(connection.settings, 'ssl') || false
+
           },
           debug: _.get(connection.options, 'debug') || false,
           acquireConnectionTimeout: _.get(connection.options, 'acquireConnectionTimeout'),


### PR DESCRIPTION
This is necessary option for ssl-only remote DB services e.g. heroku-postgres. This option can be set, as any other, in database.json file in 'settings' section.
