### PR TITLE
strapi new connection config fail fix #476 #485 issues

### DIFF
--- a/packages/strapi-generate-new/lib/before.js
+++ b/packages/strapi-generate-new/lib/before.js
@@ -187,14 +187,14 @@ module.exports = (scope, cb) => {
           });
         }),
         new Promise(resolve => {
-          let cmd = `npm install --prefix ${scope.rootPath} ${scope.client.connector}@alpha`;
+          let cmd = `npm install --prefix "${scope.rootPath}" ${scope.client.connector}@alpha`;
           if (scope.client.module) {
             cmd += ` ${scope.client.module}`;
           }
 
           exec(cmd, () => {
             if (scope.client.module) {
-              const lock = require(`${scope.rootPath}/node_modules/${scope.client.module}/package.json`);
+              const lock =require(path.join(`${scope.rootPath}`,`/node_modules/`,`${scope.client.module}/package.json`));
               scope.client.version = lock.version;
             }
 
@@ -206,7 +206,7 @@ module.exports = (scope, cb) => {
       Promise.all(asyncFn)
       .then(() => {
         try {
-          require(path.resolve(`${scope.rootPath}/node_modules/${scope.client.connector}/lib/utils/connectivity.js`))(scope, cb.success, connectionValidation);
+          require(path.join(`${scope.rootPath}`,`/node_modules/`,`${scope.client.connector}/lib/utils/connectivity.js`))(scope, cb.success, connectionValidation);
         } catch(err) {
           shell.rm('-r', scope.rootPath);
           logger.info('Copying the dashboard...');

--- a/packages/strapi-generate-new/lib/before.js
+++ b/packages/strapi-generate-new/lib/before.js
@@ -194,7 +194,7 @@ module.exports = (scope, cb) => {
 
           exec(cmd, () => {
             if (scope.client.module) {
-              const lock =require(path.join(`${scope.rootPath}`,`/node_modules/`,`${scope.client.module}/package.json`));
+              const lock = require(path.join(`${scope.rootPath}`,`/node_modules/`,`${scope.client.module}/package.json`));
               scope.client.version = lock.version;
             }
 


### PR DESCRIPTION
The problem was in paths with backslashes on windows. The path.join() solved the problem.