### PR TITLE
Improve/lib input

### DIFF
--- a/docs/3.x.x/en/plugin-development/ui-components.md
+++ b/docs/3.x.x/en/plugin-development/ui-components.md
@@ -364,23 +364,53 @@ export default function Foo(props) {
     <div>
       {/* Example without i18n */}
       <Label htmlFor="email" message="Enter your email" />
-      <input name="email" id="email" value={props.values.email} onChange={props.onChange} type="email" />
+      <input
+        id="email"
+        name="email"
+        onChange={props.onChange}
+        type="email"
+        value={props.values.email}
+      />
 
       {/* Example using children className and style */}
       <Label htmlFor="address" className={styles.labelEmail} style={{ marginTop: '10px' }} >Enter your address</Label>
-      <input name="address" value={props.values.address} onChange={props.onChange} type="text" />
+      <input
+        id="address"
+        name="address"
+        onChange={props.onChange}
+        type="text"
+        value={props.values.address}
+      />
 
       {/* Example using a function */}
       <Label htmlFor="name" message={() => <span>Enter your <b>name</b></span>} />
-      <input name="name" value={props.values.name} onChange={props.onChange} type="text" />
+      <input
+        id="name"
+        name="name"
+        onChange={props.onChange}
+        type="text"
+        value={props.values.name}
+      />
 
       {/* Example using i18n only */}
       <Label htmlFor="tel" message={{ id: 'my-plugin.tel.label' />
-      <input name="tel" value={props.values.tel} onChange={props.onChange} type="number" />
+      <input
+        id="tel"
+        name="tel"
+        onChange={props.onChange}
+        type="number"
+        value={props.values.tel}
+      />
 
       {/* Example using i18n and dynamic value */}
       <Label htmlFor="foo" message={{ id: 'my-plugin.foo.label', params: { bar: 'baz' } }} />
-      <input name="foo" value={props.values.foo} onChange={props.onChange} type="text" />
+      <input
+        id="foo"
+        name="foo"
+        type="text"
+        onChange={props.onChange}
+        value={props.values.foo}
+      />
     </div>
   );
 }

--- a/docs/3.x.x/en/plugin-development/ui-components.md
+++ b/docs/3.x.x/en/plugin-development/ui-components.md
@@ -423,6 +423,27 @@ InputText Component
 
 ***
 
+## InputNumber
+
+InputNumber component.
+
+| Property | Type | Required | Description |
+| -------- | ---- | -------- | ----------- |
+| autoFocus | bool | no | Sets the input's autoFocus |
+| className | string | no | custom className for the input |
+| deactivateErrorHighlight | bool | no | Allow to deactivate the red border on the input when there is an error |
+| disabled | bool | no | Disables the input |
+| errors | array | no | Sets the red border on the input |
+| onBlur | func | no | Function executed when the user leaves the input |
+| onFocus | func | no | Function executed when the user enters the input |
+| name | string | yes | The name of the input |
+| placeholder | string | no | Input's placeholder, works with i18n |
+| style | object | no | Input's style property |
+| tabIndex | string | Input's tabIndex |
+| value | string or number | yes | Input's value |
+
+***
+
 ## Label
 
 Label component that integrates FormattedMessage if needed

--- a/docs/3.x.x/en/plugin-development/ui-components.md
+++ b/docs/3.x.x/en/plugin-development/ui-components.md
@@ -328,6 +328,101 @@ export default FooPage;
 
 ***
 
+## InputDescription
+
+Component that allows to put a description under an input, it works with or without i18n
+
+| Property | Type | Required | Description |
+| -------- | ---- | -------- | ----------- |
+| children | node | no | Anything that is wrapped inside the Description |
+| className | string | no | custom className for the Description |
+| message | func or string or object | no | Define the content of the Description |
+| style | object | no | Label style property |
+
+
+### Usage
+
+**Path -** `my-plugin/admin/src/translations.en.json`.
+
+```json
+{
+  "Email.inputDescription": "Don't know how to set variables, {documentationLink}",
+  "Tel.inputDescription": "Make sure to provide a phone number where you can be reached"
+}
+```
+**Path -** `my-plugin/admin/src/components/Foo/index.js`;
+
+```js
+import React from 'react';
+import InputText from 'components/InputText';
+import InputDescription from 'components/InputDescription';
+
+import styles from './styles.scss';
+
+function Foo({ onChange, value }) {
+  return (
+    <div className={`col-md-6 ${styles.inputContainer}`}>
+      <InputText name="tel" value={value} onChange={onChange} />
+      {/* Usage without i18n, custom className and style */}
+      <InputDescription
+        className={styles.inputDescription}
+        message="Make sure to provide a phone number where you can be reached"
+        style={{ paddingTop: '10px'}}
+      />
+
+      {/* Usage with function */}
+      <InputText name="email" value={value} onChange={onChange} />
+      <InputDescription
+        message={ () => <span>Don&#44;t know how to set variables, <a href="strapi.io" target="_blank">check out our doc!</a></span>}
+      />
+
+      {/* Usage with i18n and rich text formatting */}
+      <InputText name="email" value={value} onChange={onChange} />
+      <InputDescription
+        message={{
+          id: 'my-plugin.Email.inputDescription',
+          params: {
+            documentationLink: <a href="strapi.io" target="_blank">check out our doc!</a>
+          }
+        }}
+      />
+
+      {/* Usage with i18n only */}
+      <InputText name="tel" value={value} onChange={onChange} />
+      <InputDescription
+        message={{ id: 'my-plugin.Tel.inputDescription' }}
+      />
+    </div>
+  );
+}
+
+export default Foo;
+```
+
+***
+
+## InputText
+
+InputText Component
+
+| Property | Type | Required | Description |
+| -------- | ---- | -------- | ----------- |
+| autoFocus | bool | no | Sets the input's autoFocus |
+| className | string | no | custom className for the input |
+| deactivateErrorHighlight | bool | no | Allow to deactivate the red border on the input when there is an error |
+| disabled | bool | no | Disables the input |
+| errors | array | no | Sets the red border on the input |
+| onBlur | func | no | Function executed when the user leaves the input |
+| onFocus | func | no | Function executed when the user enters the input |
+| name | string | yes | The name of the input |
+| placeholder | string | no | Input's placeholder, works with i18n |
+| style | object | no | Input's style property |
+| tabIndex | string | Input's tabIndex |
+| value | string | yes | Input's value |
+
+
+***
+
 ## Label
 
 Label component that integrates FormattedMessage if needed
@@ -353,6 +448,7 @@ Label component that integrates FormattedMessage if needed
 ```
 
 **Path -** `my-plugin/admin/src/components/Foo/index.js`;
+
 ```js
 import React from 'react';
 import Label from 'components/Label';

--- a/docs/3.x.x/en/plugin-development/ui-components.md
+++ b/docs/3.x.x/en/plugin-development/ui-components.md
@@ -417,7 +417,7 @@ InputText Component
 | name | string | yes | The name of the input |
 | placeholder | string | no | Input's placeholder, works with i18n |
 | style | object | no | Input's style property |
-| tabIndex | string | Input's tabIndex |
+| tabIndex | string | no | Input's tabIndex |
 | value | string | yes | Input's value |
 
 
@@ -439,7 +439,7 @@ InputNumber component.
 | name | string | yes | The name of the input |
 | placeholder | string | no | Input's placeholder, works with i18n |
 | style | object | no | Input's style property |
-| tabIndex | string | Input's tabIndex |
+| tabIndex | string | no | Input's tabIndex |
 | value | string or number | yes | Input's value |
 
 ***

--- a/docs/3.x.x/en/plugin-development/ui-components.md
+++ b/docs/3.x.x/en/plugin-development/ui-components.md
@@ -328,6 +328,67 @@ export default FooPage;
 
 ***
 
+## Label
+
+Label component that integrates FormattedMessage if needed
+
+| Property | Type | Required | Description |
+| -------- | ---- | -------- | ----------- |
+| children | node | no | Anything that is wrapped inside the Label |
+| className | string | no | custom className for the Label |
+| htmlFor | string | no | Represents the id of the element the label is bound to |
+| message | func or string or object | no | Define the content of the label |
+| style | object | no | Label style property |
+
+
+### Usage
+
+**Path -** `my-plugin/admin/src/translations.en.json`.
+
+```json
+{
+  "foo.label": "This is {bar} label",
+  "tel.label": "Enter your phone number"
+}
+```
+
+**Path -** `my-plugin/admin/src/components/Foo/index.js`;
+```js
+import React from 'react';
+import Label from 'components/Label';
+
+import styles from './styles.scss';
+
+export default function Foo(props) {
+  return (
+    <div>
+      {/* Example without i18n */}
+      <Label htmlFor="email" message="Enter your email" />
+      <input name="email" id="email" value={props.values.email} onChange={props.onChange} type="email" />
+
+      {/* Example using children className and style */}
+      <Label htmlFor="address" className={styles.labelEmail} style={{ marginTop: '10px' }} >Enter your address</Label>
+      <input name="address" value={props.values.address} onChange={props.onChange} type="text" />
+
+      {/* Example using a function */}
+      <Label htmlFor="name" message={() => <span>Enter your <b>name</b></span>} />
+      <input name="name" value={props.values.name} onChange={props.onChange} type="text" />
+
+      {/* Example using i18n only */}
+      <Label htmlFor="tel" message={{ id: 'my-plugin.tel.label' />
+      <input name="tel" value={props.values.tel} onChange={props.onChange} type="number" />
+
+      {/* Example using i18n and dynamic value */}
+      <Label htmlFor="foo" message={{ id: 'my-plugin.foo.label', params: { bar: 'baz' } }} />
+      <input name="foo" value={props.values.foo} onChange={props.onChange} type="text" />
+    </div>
+  );
+}
+```
+
+
+***
+
 ## OverlayBlocker
 
 The OverlayBlocker is a React component that is very useful to block user interactions when the strapi server is restarting in order to avoid front-end errors. This component is automatically displayed when the server needs to restart. You need to disable it in order to override the current design (once disabled it won't show on the other plugins so it's really important to enable it back when the component is unmounting).

--- a/docs/3.x.x/en/plugin-development/ui-components.md
+++ b/docs/3.x.x/en/plugin-development/ui-components.md
@@ -401,28 +401,6 @@ export default Foo;
 
 ***
 
-## InputText
-
-InputText Component
-
-| Property | Type | Required | Description |
-| -------- | ---- | -------- | ----------- |
-| autoFocus | bool | no | Sets the input's autoFocus |
-| className | string | no | custom className for the input |
-| deactivateErrorHighlight | bool | no | Allow to deactivate the red border on the input when there is an error |
-| disabled | bool | no | Disables the input |
-| errors | array | no | Sets the red border on the input |
-| onBlur | func | no | Function executed when the user leaves the input |
-| onFocus | func | no | Function executed when the user enters the input |
-| name | string | yes | The name of the input |
-| placeholder | string | no | Input's placeholder, works with i18n |
-| style | object | no | Input's style property |
-| tabIndex | string | no | Input's tabIndex |
-| value | string | yes | Input's value |
-
-
-***
-
 ## InputNumber
 
 InputNumber component.
@@ -441,6 +419,138 @@ InputNumber component.
 | style | object | no | Input's style property |
 | tabIndex | string | no | Input's tabIndex |
 | value | string or number | yes | Input's value |
+
+***
+
+## InputText
+
+InputText Component
+
+| Property | Type | Required | Description |
+| -------- | ---- | -------- | ----------- |
+| autoFocus | bool | no | Sets the input's autoFocus |
+| className | string | no | custom className for the input |
+| deactivateErrorHighlight | bool | no | Allow to deactivate the red border on the input when there is an error |
+| disabled | bool | no | Disables the input |
+| error | bool | no | Sets the red border on the input |
+| onBlur | func | no | Function executed when the user leaves the input |
+| onChange | func | yes | Handler to modify the input's value |
+| onFocus | func | no | Function executed when the user enters the input |
+| name | string | yes | The name of the input |
+| placeholder | string | no | Input's placeholder, works with i18n |
+| style | object | no | Input's style property |
+| tabIndex | string | no | Input's tabIndex |
+| value | string | yes | Input's value |
+
+***
+
+## InputNumberWithErrors
+
+Please refer to the [InputTextWithErrors](#InputTextWithErrors) documentation.
+
+***
+
+## InputTextWithErrors
+
+Component integrates Label, InputText, InputDescription and InputErrors.
+
+| Property | Type | Required | Description |
+| -------- | ---- | -------- | ----------- |
+| autoFocus | bool | no | Sets the input's autoFocus |
+| className | string | no | Overrides the container className |
+| customBootstrapClass | string | no | Allows to override the input bootstrap col system |
+| deactivateErrorHighlight | bool | no | Allow to deactivate the red border on the input when there is an error |
+| didCheckErrors | bool | no | Use this props to display errors after submitting a form. |
+| disabled | bool | no | Disables the input |
+| errors | array | no | Array of errors |
+| errorsClassName | string | no | Overrides the InputErrors' className |
+| errorsStyle | object | no | Overrides the InputErrors' style |
+| inputClassName | string | no | Overrides the InputText's className |
+| inputDescriptionClassName | string | no | Overrides the InputDescription's className |
+| inputDescriptionStyle | object | no | Overrides the InputDescription's style|
+| inputStyle | object | no | Overrides the InputText's style |
+| labelClassName | string | no | Overrides the Label's className |
+| labelStyle | object | no | Overrides the Label's style |
+| onBlur | func | no | Function executed when the user leaves the input |
+| onChange | func | yes | Handler to modify the input's value |
+| onFocus | func | no | Function executed when the user enters the input |
+| name | string | yes | The name of the input |
+| placeholder | string | no | Input's placeholder, works with i18n |
+| style | object | no | Overrides the container style |
+| tabIndex | string | no | Input's tabIndex |
+| validations | object | no | Input's validations |
+| value | string | yes | Input's value |
+
+
+### Usage
+
+**Path -** `my-plugin/admin/src/translations.en.json`.
+```json
+{
+  "inputFoo.label": "This is a label, {foo}",
+  "inputFoo.description": "Awesome description {bar}"
+}
+```
+
+**Path -** `my-plugin/admin/src/components/Foo/index.js`.
+
+```js
+  import React from 'react';
+
+  class Foo extends React.Component {
+    state = { didCheckErrors: false, errors: [], foo: '' };
+
+    handleChange = ({ target }) => this.setState({ [target.name]: target.value });
+
+    handleSubmit = () => {
+      const errors = [];
+
+      if (this.state.value.length === 0) {
+        errors.push({ id: 'components.Input.error.validation.required' });
+      }
+
+      this.setState({ didCheckErrors: !this.state.didCheckErrors, errors });
+    }
+
+    render() {
+      const { didCheckErrors, errors, foo } = this.state;
+      const inputDescription = {
+        message: {
+          id: 'my-plugin.inputFoo.description',
+          params: { bar: 'Something' }
+        }
+      };
+
+      // This can also works (it's the same behavior for the label)
+      // const inputDescription = () => <span>Something</span>;
+      // const inputDescription = 'Something';
+      return (
+        <form onSubmit={this.handleSubmit}>
+          <div className="container-fluid">
+            <div className="row">
+              <InputTextWithErrors
+                autoFocus
+                customBootstrapClass="col-md-12"
+                didCheckErrors={didCheckErrors}
+                errors={errors}
+                inputDescription={inputDescription}
+                name="foo"
+                onChange={this.handleChange}
+                label={{ message: {
+                  id: 'my-plugin.inputFoo.label',
+                  params: { name: <a href="strapi.io" target="_blank">Click me</a> }
+                }}}
+                value={foo}
+                validations={{ required: true }}
+              />
+              <button type="submit">Submit</button>
+            </div>
+          </div>
+        </form>
+      )
+    }
+  }
+```
 
 ***
 

--- a/packages/strapi-admin/admin/src/translations/en.json
+++ b/packages/strapi-admin/admin/src/translations/en.json
@@ -55,6 +55,8 @@
   "app.components.PluginCard.price.free": "Free",
   "app.components.PluginCard.more-details": "More details",
 
+  "app.utils.placeholder.defaultMessage": " ",
+
   "components.AutoReloadBlocker.header": "Reload feature is required for this plugin.",
   "components.AutoReloadBlocker.description": "Open the following file and enable the feature.",
 

--- a/packages/strapi-admin/admin/src/translations/fr.json
+++ b/packages/strapi-admin/admin/src/translations/fr.json
@@ -55,6 +55,8 @@
   "app.components.PluginCard.price.free": "Gratuit",
   "app.components.PluginCard.more-details": "Plus de détails",
 
+  "app.utils.placeholder.defaultMessage": " ",
+
   "components.AutoReloadBlocker.header": "L'autoReload doit être activé pour ce plugin.",
   "components.AutoReloadBlocker.description": "Ouvrez le fichier suivant pour activer cette fonctionnalité.",
 

--- a/packages/strapi-helper-plugin/lib/src/components/InputDescription/index.js
+++ b/packages/strapi-helper-plugin/lib/src/components/InputDescription/index.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
-import { isFunction, isObject, upperFirst } from 'lodash';
+import { isEmpty, isFunction, isObject } from 'lodash';
 import cn from 'classnames';
 
 import styles from './styles.scss';
 
-function Label(props) {
+function InputDescription(props) {
   let content = props.children;
 
   if (typeof(props.message) === 'string') {
@@ -20,33 +20,33 @@ function Label(props) {
   if (isFunction(props.message)) {
     content = props.message();
   }
-
   return (
-    <label
-      className={cn(styles.label, props.className)}
-      htmlFor={props.htmlFor}
+    <div className={cn(
+        styles.inputDescriptionContainer,
+        !isEmpty(props.className) && props.className
+      )}
       style={props.style}
     >
-      {content}
-    </label>
+      <small>
+        {content}
+      </small>
+    </div>
   );
 }
 
-Label.defaultProps = {
+InputDescription.defaultProps = {
   children: '',
   className: '',
-  htmlFor: '',
   message: '',
   style: {},
 };
 
-Label.propTypes = {
+InputDescription.propTypes = {
   children: PropTypes.node,
   className: PropTypes.string,
-  htmlFor: PropTypes.string,
   message: PropTypes.oneOfType([
-    PropTypes.func,
     PropTypes.string,
+    PropTypes.func,
     PropTypes.shape({
       id: PropTypes.string,
       params: PropTypes.object,
@@ -55,4 +55,4 @@ Label.propTypes = {
   style: PropTypes.object,
 };
 
-export default Label;
+export default InputDescription;

--- a/packages/strapi-helper-plugin/lib/src/components/InputDescription/styles.scss
+++ b/packages/strapi-helper-plugin/lib/src/components/InputDescription/styles.scss
@@ -1,0 +1,11 @@
+.inputDescriptionContainer {
+  width: 200%;
+  margin-top: 1.3rem;
+  line-height: 1.2rem;
+
+  > small {
+    color: #9EA7B8;
+    font-family: 'Lato';
+    font-size: 1.2rem;
+  }
+}

--- a/packages/strapi-helper-plugin/lib/src/components/InputErrors/index.js
+++ b/packages/strapi-helper-plugin/lib/src/components/InputErrors/index.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+import { isEmpty, isObject, map } from 'lodash';
+import cn from 'classnames';
+
+import styles from './styles.scss';
+
+function InputErrors(props) {
+  const divStyle = Object.assign({ display: 'block' }, props.style);
+
+  return (
+    <div>
+      {map(props.errors, (error, key) => {
+        const displayError = isObject(error) && error.id ?
+          <FormattedMessage {...error} values={{ errorMessage: error.errorMessage }} /> : error;
+
+        return (
+          <div className={cn(
+              'form-control-feedback',
+              'invalid-feedback',
+              styles.errorContainer,
+              !isEmpty(props.className) && props.className,
+            )}
+            key={key}
+            style={divStyle}
+            >
+            {displayError}
+          </div>
+        )
+      })}
+    </div>
+  );
+}
+
+InputErrors.defaultProps = {
+  className: '',
+  errors: [],
+  style: {},
+};
+
+InputErrors.propTypes = {
+  className: PropTypes.string,
+  errors: PropTypes.array,
+  style: PropTypes.object,
+};
+
+export default InputErrors;

--- a/packages/strapi-helper-plugin/lib/src/components/InputErrors/styles.scss
+++ b/packages/strapi-helper-plugin/lib/src/components/InputErrors/styles.scss
@@ -1,0 +1,6 @@
+.errorContainer {
+  margin-top: .5rem;
+  margin-bottom: .5rem;
+  line-height: 1.3rem;
+  font-size: 1.3rem;
+}

--- a/packages/strapi-helper-plugin/lib/src/components/InputNumber/index.js
+++ b/packages/strapi-helper-plugin/lib/src/components/InputNumber/index.js
@@ -6,7 +6,7 @@ import cn from 'classnames';
 
 import styles from './styles.scss';
 
-function InputText(props) {
+function InputNumber(props) {
   return (
     <FormattedMessage id={props.placeholder} defaultMessage={props.placeholder}>
       {(message) => (
@@ -27,7 +27,7 @@ function InputText(props) {
           placeholder={message}
           style={props.style}
           tabIndex={props.tabIndex}
-          type="text"
+          type="number"
           value={props.value}
         />
       )}
@@ -35,7 +35,7 @@ function InputText(props) {
   )
 }
 
-InputText.defaultProps = {
+InputNumber.defaultProps = {
   autoFocus: false,
   className: '',
   deactivateErrorHighlight: false,
@@ -48,7 +48,7 @@ InputText.defaultProps = {
   tabIndex: '0',
 };
 
-InputText.propTypes = {
+InputNumber.propTypes = {
   autoFocus: PropTypes.bool,
   className: PropTypes.string,
   deactivateErrorHighlight: PropTypes.bool,
@@ -64,4 +64,4 @@ InputText.propTypes = {
   value: PropTypes.string.isRequired,
 };
 
-export default InputText;
+export default InputNumber;

--- a/packages/strapi-helper-plugin/lib/src/components/InputNumber/index.js
+++ b/packages/strapi-helper-plugin/lib/src/components/InputNumber/index.js
@@ -61,7 +61,10 @@ InputNumber.propTypes = {
   placeholder: PropTypes.string,
   style: PropTypes.object,
   tabIndex: PropTypes.string,
-  value: PropTypes.string.isRequired,
+  value: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.string,
+  ]).isRequired,
 };
 
 export default InputNumber;

--- a/packages/strapi-helper-plugin/lib/src/components/InputNumber/styles.scss
+++ b/packages/strapi-helper-plugin/lib/src/components/InputNumber/styles.scss
@@ -1,0 +1,12 @@
+.input {
+  height: 3.4rem;
+  margin-top: .9rem;
+  padding-left: 1rem;
+  background-size: 0 !important;
+  border: 1px solid #E3E9F3;
+  border-radius: 0.25rem;
+  line-height: 3.4rem;
+  font-size: 1.3rem;
+  font-family: 'Lato' !important;
+  box-shadow: 0px 1px 1px rgba(104, 118, 142, 0.05);
+}

--- a/packages/strapi-helper-plugin/lib/src/components/InputNumberWithErrors/index.js
+++ b/packages/strapi-helper-plugin/lib/src/components/InputNumberWithErrors/index.js
@@ -7,11 +7,11 @@ import cn from 'classnames';
 import Label from 'components/Label';
 import InputDescription from 'components/InputDescription';
 import InputErrors from 'components/InputErrors';
-import InputText from 'components/InputText';
+import InputNumber from 'components/InputNumber';
 
 import styles from './styles.scss';
 
-class InputTextWithErrors extends React.Component { // eslint-disable-line react/prefer-stateless-function
+class InputNumberWithErrors extends React.Component { // eslint-disable-line react/prefer-stateless-function
   state = { errors: [], hasInitialValue: false };
 
   componentDidMount() {
@@ -52,7 +52,7 @@ class InputTextWithErrors extends React.Component { // eslint-disable-line react
   render() {
     const { autoFocus, errorsClassName, errorsStyle, inputClassName, inputStyle, name, onChange, onFocus, placeholder, value } = this.props;
     const handleBlur = isFunction(this.props.onBlur) ? this.props.onBlur : this.handleBlur;
-
+    
     return (
       <div className={cn(
           styles.container,
@@ -61,7 +61,7 @@ class InputTextWithErrors extends React.Component { // eslint-disable-line react
         )}
       >
         <Label htmlFor={name} message={this.props.label && this.props.label.message || this.props.label} />
-        <InputText
+        <InputNumber
           autoFocus={autoFocus}
           className={inputClassName}
           errors={this.state.errors}
@@ -85,20 +85,21 @@ class InputTextWithErrors extends React.Component { // eslint-disable-line react
 
     mapKeys(this.props.validations, (validationValue, validationKey) => {
       switch (validationKey) {
-        case 'maxLength': {
-          if (value.length > validationValue) {
-            errors.push({ id: 'components.Input.error.validation.maxLength' });
+        case 'max': {
+          if (parseInt(value, 10) > validationValue) {
+            errors.push({ id: 'components.Input.error.validation.max' });
           }
           break;
         }
-        case 'minLength': {
-          if (value.length < validationValue) {
-            errors.push({ id: 'components.Input.error.validation.minLength' });
+        case 'min': {
+          if (parseInt(value, 10) < validationValue) {
+            errors.push({ id: 'components.Input.error.validation.min' });
           }
           break;
         }
         case 'required': {
           if (value.length === 0) {
+            console.log('ok');
             errors.push({ id: 'components.Input.error.validation.required' });
           }
           break;
@@ -122,7 +123,7 @@ class InputTextWithErrors extends React.Component { // eslint-disable-line react
   }
 }
 
-InputTextWithErrors.defaultProps = {
+InputNumberWithErrors.defaultProps = {
   customBootstrapClass: false,
   didCheckErrors: false,
   onBlur: false,
@@ -136,7 +137,7 @@ InputTextWithErrors.defaultProps = {
   validations: {},
 };
 
-InputTextWithErrors.propTypes = {
+InputNumberWithErrors.propTypes = {
   customBootstrapClass: PropTypes.oneOfType([
     PropTypes.bool,
     PropTypes.string,
@@ -154,7 +155,10 @@ InputTextWithErrors.propTypes = {
   onChange: PropTypes.func.isRequired,
   onFocus: PropTypes.func,
   validations: PropTypes.object,
-  value: PropTypes.string.isRequired,
+  value: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.string,
+  ]),
 };
 
-export default InputTextWithErrors;
+export default InputNumberWithErrors;

--- a/packages/strapi-helper-plugin/lib/src/components/InputNumberWithErrors/index.js
+++ b/packages/strapi-helper-plugin/lib/src/components/InputNumberWithErrors/index.js
@@ -50,31 +50,67 @@ class InputNumberWithErrors extends React.Component { // eslint-disable-line rea
   }
 
   render() {
-    const { autoFocus, errorsClassName, errorsStyle, inputClassName, inputStyle, name, onChange, onFocus, placeholder, value } = this.props;
+    const {
+      autoFocus,
+      deactivateErrorHighlight,
+      disabled,
+      errorsClassName,
+      errorsStyle,
+      inputClassName,
+      inputDescriptionClassName,
+      inputDescriptionStyle,
+      inputStyle,
+      labelClassName,
+      labelStyle,
+      name,
+      onChange,
+      onFocus,
+      placeholder,
+      style,
+      tabIndex,
+      value,
+    } = this.props;
     const handleBlur = isFunction(this.props.onBlur) ? this.props.onBlur : this.handleBlur;
-    
+
     return (
       <div className={cn(
           styles.container,
           this.props.customBootstrapClass || 'col-md-6',
-          this.props.className,
+          !isEmpty(this.props.className) && props.className,
         )}
+        style={style}
       >
-        <Label htmlFor={name} message={this.props.label && this.props.label.message || this.props.label} />
-        <InputNumber
+        <Label
+          className={labelClassName}
+          htmlFor={name}
+          message={this.props.label && this.props.label.message || this.props.label}
+          style={labelStyle}
+        />
+      <InputNumber
           autoFocus={autoFocus}
           className={inputClassName}
-          errors={this.state.errors}
+          disabled={disabled}
+          deactivateErrorHighlight={deactivateErrorHighlight}
+          error={!isEmpty(this.state.errors)}
           name={name}
           onBlur={handleBlur}
           onChange={onChange}
           onFocus={onFocus}
           placeholder={placeholder}
           style={inputStyle}
+          tabIndex={tabIndex}
           value={value}
         />
-        <InputDescription message={this.props.inputDescription && this.props.inputDescription.message || this.props.inputDescription} />
-        <InputErrors className={errorsClassName} style={errorsStyle} errors={this.state.errors} />
+        <InputDescription
+          className={inputDescriptionClassName}
+          message={this.props.inputDescription && this.props.inputDescription.message || this.props.inputDescription}
+          style={inputDescriptionStyle}
+        />
+        <InputErrors
+          className={errorsClassName}
+          errors={this.state.errors}
+          style={errorsStyle}
+        />
       </div>
     );
   }
@@ -124,41 +160,66 @@ class InputNumberWithErrors extends React.Component { // eslint-disable-line rea
 }
 
 InputNumberWithErrors.defaultProps = {
+  autoFocus: false,
+  className: '',
   customBootstrapClass: false,
+  deactivateErrorHighlight: false,
   didCheckErrors: false,
+  disabled: false,
   onBlur: false,
   onFocus: () => {},
   errors: [],
   errorsClassName: '',
   errorsStyle: {},
   inputClassName: '',
+  inputDescription: '',
+  inputDescriptionClassName: '',
+  inputDescriptionStyle: {},
   inputStyle: {},
+  labelClassName: '',
+  labelStyle: {},
   placeholder: 'app.utils.placeholder.defaultMessage',
+  style: {},
+  tabIndex: '0',
   validations: {},
 };
 
 InputNumberWithErrors.propTypes = {
+  autoFocus: PropTypes.bool,
+  className: PropTypes.string,
   customBootstrapClass: PropTypes.oneOfType([
     PropTypes.bool,
     PropTypes.string,
   ]),
+  deactivateErrorHighlight: PropTypes.bool,
   didCheckErrors: PropTypes.bool,
+  disabled: PropTypes.bool,
   errors: PropTypes.array,
   errorsClassName: PropTypes.string,
   errorsStyle: PropTypes.object,
   inputClassName: PropTypes.string,
+  inputDescription: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.func,
+    PropTypes.object,
+  ]),
+  inputDescriptionClassName: PropTypes.string,
+  inputDescriptionStyle: PropTypes.object,
   inputStyle: PropTypes.object,
+  labelClassName: PropTypes.string,
+  labelStyle: PropTypes.object,
   onBlur: PropTypes.oneOfType([
     PropTypes.bool,
     PropTypes.func,
   ]),
   onChange: PropTypes.func.isRequired,
   onFocus: PropTypes.func,
+  name: PropTypes.string.isRequired,
+  placeholder: PropTypes.string,
+  style: PropTypes.object,
+  tabIndex: PropTypes.string,
   validations: PropTypes.object,
-  value: PropTypes.oneOfType([
-    PropTypes.number,
-    PropTypes.string,
-  ]),
+  value: PropTypes.string.isRequired,
 };
 
 export default InputNumberWithErrors;

--- a/packages/strapi-helper-plugin/lib/src/components/InputNumberWithErrors/styles.scss
+++ b/packages/strapi-helper-plugin/lib/src/components/InputNumberWithErrors/styles.scss
@@ -1,0 +1,5 @@
+.container {
+  min-width: 200px;
+  margin-bottom: 1.5rem;
+  font-size: 1.3rem;
+}

--- a/packages/strapi-helper-plugin/lib/src/components/InputText/index.js
+++ b/packages/strapi-helper-plugin/lib/src/components/InputText/index.js
@@ -1,0 +1,66 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { isEmpty } from 'lodash';
+import { FormattedMessage } from 'react-intl';
+import cn from 'classnames';
+
+import styles from './styles.scss';
+
+function InputText(props) {
+  return (
+    <FormattedMessage id={props.placeholder} defaultMessage={props.placeholder}>
+      {(message) => (
+        <input
+          autoFocus={props.autoFocus}
+          className={cn(
+            styles.input,
+            'form-control',
+            !props.deactivateErrorHighlight && !isEmpty(props.errors) && 'is-invalid',
+            !isEmpty(props.className) && props.className,
+          )}
+          disabled={props.disabled}
+          id={props.name}
+          name={props.name}
+          onBlur={props.onBlur}
+          onChange={props.onChange}
+          onFocus={props.onFocus}
+          placeholder={message}
+          style={props.style}
+          tabIndex={props.tabIndex}
+          value={props.value}
+        />
+      )}
+    </FormattedMessage>
+  )
+}
+
+InputText.defaultProps = {
+  autoFocus: false,
+  className: '',
+  deactivateErrorHighlight: false,
+  disabled: false,
+  errors: [],
+  onBlur: () => {},
+  onFocus: () => {},
+  placeholder: 'app.utils.placeholder.defaultMessage',
+  style: {},
+  tabIndex: '0',
+};
+
+InputText.propTypes = {
+  autoFocus: PropTypes.bool,
+  className: PropTypes.string,
+  deactivateErrorHighlight: PropTypes.bool,
+  disabled: PropTypes.bool,
+  errors: PropTypes.array,
+  onBlur: PropTypes.func,
+  onChange: PropTypes.func.isRequired,
+  onFocus: PropTypes.func,
+  name: PropTypes.string.isRequired,
+  placeholder: PropTypes.string,
+  style: PropTypes.object,
+  tabIndex: PropTypes.string,
+  value: PropTypes.string.isRequired,
+};
+
+export default InputText;

--- a/packages/strapi-helper-plugin/lib/src/components/InputText/index.js
+++ b/packages/strapi-helper-plugin/lib/src/components/InputText/index.js
@@ -15,7 +15,7 @@ function InputText(props) {
           className={cn(
             styles.input,
             'form-control',
-            !props.deactivateErrorHighlight && !isEmpty(props.errors) && 'is-invalid',
+            !props.deactivateErrorHighlight && props.error && 'is-invalid',
             !isEmpty(props.className) && props.className,
           )}
           disabled={props.disabled}
@@ -40,7 +40,7 @@ InputText.defaultProps = {
   className: '',
   deactivateErrorHighlight: false,
   disabled: false,
-  errors: [],
+  error: false,
   onBlur: () => {},
   onFocus: () => {},
   placeholder: 'app.utils.placeholder.defaultMessage',
@@ -53,7 +53,7 @@ InputText.propTypes = {
   className: PropTypes.string,
   deactivateErrorHighlight: PropTypes.bool,
   disabled: PropTypes.bool,
-  errors: PropTypes.array,
+  errors: PropTypes.bool,
   onBlur: PropTypes.func,
   onChange: PropTypes.func.isRequired,
   onFocus: PropTypes.func,

--- a/packages/strapi-helper-plugin/lib/src/components/InputText/styles.scss
+++ b/packages/strapi-helper-plugin/lib/src/components/InputText/styles.scss
@@ -1,0 +1,12 @@
+.input {
+  height: 3.4rem;
+  margin-top: .9rem;
+  padding-left: 1rem;
+  background-size: 0 !important;
+  border: 1px solid #E3E9F3;
+  border-radius: 0.25rem;
+  line-height: 3.4rem;
+  font-size: 1.3rem;
+  font-family: 'Lato' !important;
+  box-shadow: 0px 1px 1px rgba(104, 118, 142, 0.05);
+}

--- a/packages/strapi-helper-plugin/lib/src/components/InputTextWithErrors/index.js
+++ b/packages/strapi-helper-plugin/lib/src/components/InputTextWithErrors/index.js
@@ -50,31 +50,67 @@ class InputTextWithErrors extends React.Component { // eslint-disable-line react
   }
 
   render() {
-    const { autoFocus, errorsClassName, errorsStyle, inputClassName, inputStyle, name, onChange, onFocus, placeholder, value } = this.props;
+    const {
+      autoFocus,
+      deactivateErrorHighlight,
+      disabled,
+      errorsClassName,
+      errorsStyle,
+      inputClassName,
+      inputDescriptionClassName,
+      inputDescriptionStyle,
+      inputStyle,
+      labelClassName,
+      labelStyle,
+      name,
+      onChange,
+      onFocus,
+      placeholder,
+      style,
+      tabIndex,
+      value,
+    } = this.props;
     const handleBlur = isFunction(this.props.onBlur) ? this.props.onBlur : this.handleBlur;
 
     return (
       <div className={cn(
           styles.container,
           this.props.customBootstrapClass || 'col-md-6',
-          this.props.className,
+          !isEmpty(this.props.className) && props.className,
         )}
+        style={style}
       >
-        <Label htmlFor={name} message={this.props.label && this.props.label.message || this.props.label} />
+        <Label
+          className={labelClassName}
+          htmlFor={name}
+          message={this.props.label && this.props.label.message || this.props.label}
+          style={labelStyle}
+        />
         <InputText
           autoFocus={autoFocus}
           className={inputClassName}
-          errors={this.state.errors}
+          disabled={disabled}
+          deactivateErrorHighlight={deactivateErrorHighlight}
+          error={!isEmpty(this.state.errors)}
           name={name}
           onBlur={handleBlur}
           onChange={onChange}
           onFocus={onFocus}
           placeholder={placeholder}
           style={inputStyle}
+          tabIndex={tabIndex}
           value={value}
         />
-        <InputDescription message={this.props.inputDescription && this.props.inputDescription.message || this.props.inputDescription} />
-        <InputErrors className={errorsClassName} style={errorsStyle} errors={this.state.errors} />
+        <InputDescription
+          className={inputDescriptionClassName}
+          message={this.props.inputDescription && this.props.inputDescription.message || this.props.inputDescription}
+          style={inputDescriptionStyle}
+        />
+        <InputErrors
+          className={errorsClassName}
+          errors={this.state.errors}
+          style={errorsStyle}
+        />
       </div>
     );
   }
@@ -123,36 +159,64 @@ class InputTextWithErrors extends React.Component { // eslint-disable-line react
 }
 
 InputTextWithErrors.defaultProps = {
+  autoFocus: false,
+  className: '',
   customBootstrapClass: false,
+  deactivateErrorHighlight: false,
   didCheckErrors: false,
+  disabled: false,
   onBlur: false,
   onFocus: () => {},
   errors: [],
   errorsClassName: '',
   errorsStyle: {},
   inputClassName: '',
+  inputDescription: '',
+  inputDescriptionClassName: '',
+  inputDescriptionStyle: {},
   inputStyle: {},
+  labelClassName: '',
+  labelStyle: {},
   placeholder: 'app.utils.placeholder.defaultMessage',
+  style: {},
+  tabIndex: '0',
   validations: {},
 };
 
 InputTextWithErrors.propTypes = {
+  autoFocus: PropTypes.bool,
+  className: PropTypes.string,
   customBootstrapClass: PropTypes.oneOfType([
     PropTypes.bool,
     PropTypes.string,
   ]),
+  deactivateErrorHighlight: PropTypes.bool,
   didCheckErrors: PropTypes.bool,
+  disabled: PropTypes.bool,
   errors: PropTypes.array,
   errorsClassName: PropTypes.string,
   errorsStyle: PropTypes.object,
   inputClassName: PropTypes.string,
+  inputDescription: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.func,
+    PropTypes.object,
+  ]),
+  inputDescriptionClassName: PropTypes.string,
+  inputDescriptionStyle: PropTypes.object,
   inputStyle: PropTypes.object,
+  labelClassName: PropTypes.string,
+  labelStyle: PropTypes.object,
   onBlur: PropTypes.oneOfType([
     PropTypes.bool,
     PropTypes.func,
   ]),
   onChange: PropTypes.func.isRequired,
   onFocus: PropTypes.func,
+  name: PropTypes.string.isRequired,
+  placeholder: PropTypes.string,
+  style: PropTypes.object,
+  tabIndex: PropTypes.string,
   validations: PropTypes.object,
   value: PropTypes.string.isRequired,
 };

--- a/packages/strapi-helper-plugin/lib/src/components/InputTextWithErrors/index.js
+++ b/packages/strapi-helper-plugin/lib/src/components/InputTextWithErrors/index.js
@@ -1,0 +1,133 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { includes, isEmpty, mapKeys, reject } from 'lodash';
+import cn from 'classnames';
+
+// Design
+import Label from 'components/Label';
+import InputText from 'components/InputText';
+
+import styles from './styles.scss';
+
+class InputTextWithErrors extends React.Component { // eslint-disable-line react/prefer-stateless-function
+  state = { errors: [], hasInitialValue: false };
+
+  componentDidMount() {
+    const { value, errors } = this.props;
+
+    // Prevent the input from displaying an error when the user enters and leaves without filling it
+    if (value && !isEmpty(value)) {
+      this.setState({ hasInitialValue: true });
+    }
+
+    // Display input error if it already has some
+    if (!isEmpty(errors)) {
+      this.setState({ errors });
+    }
+  }
+
+  componentWillReceiveProps(nextProps) {
+    // Check if errors have been updated during validations
+    if (nextProps.didCheckErrors !== this.props.didCheckErrors) {
+      // Remove from the state the errors that have already been set
+      const errors = isEmpty(nextProps.errors) ? [] : nextProps.errors;
+      this.setState({ errors });
+    }
+  }
+
+  /**
+   * Set the errors depending on the validations given to the input
+   * @param  {Object} target
+   */
+  handleBlur = ({ target }) => {
+    // Prevent from displaying error if the input is initially isEmpty
+    if (!isEmpty(target.value) || this.state.hasInitialValue) {
+      const errors = this.validate(target.value);
+      this.setState({ errors, hasInitialValue: true });
+    }
+  }
+
+  render() {
+    const { autoFocus, inputClassName, name, onChange, placeholder, value } = this.props;
+
+    return (
+      <div className={cn(
+          styles.container,
+          this.props.customBootstrapClass || 'col-md-6',
+          this.props.className,
+        )}
+      >
+        <Label htmlFor={name} message={this.props.label && this.props.label.message || this.props.label} />
+        <InputText
+          autoFocus={autoFocus}
+          className={inputClassName}
+          errors={this.state.errors}
+          name={name}
+          onBlur={this.handleBlur}
+          onChange={onChange}
+          placeholder={placeholder}
+          value={value}
+        />
+      </div>
+    );
+  }
+
+  validate = (value) => {
+    const requiredError = { id: 'components.Input.error.validation.required' };
+    let errors = [];
+
+    mapKeys(this.props.validations, (validationValue, validationKey) => {
+      switch (validationKey) {
+        case 'maxLength': {
+          if (value.length > validationValue) {
+            errors.push({ id: 'components.Input.error.validation.maxLength' });
+          }
+          break;
+        }
+        case 'minLength': {
+          if (value.length < validationValue) {
+            errors.push({ id: 'components.Input.error.validation.minLength' });
+          }
+          break;
+        }
+        case 'required': {
+          if (value.length === 0) {
+            errors.push({ id: 'components.Input.error.validation.required' });
+          }
+          break;
+        }
+        default:
+          errors = [];
+      }
+    });
+
+    if (includes(errors, requiredError)) {
+      errors = reject(errors, (error) => error !== requiredError);
+    }
+
+    return errors;
+  }
+}
+
+InputTextWithErrors.defaultProps = {
+  customBootstrapClass: false,
+  didCheckErrors: false,
+  errors: [],
+  inputClassName: '',
+  placeholder: 'app.utils.placeholder.defaultMessage',
+  validations: {},
+};
+
+InputTextWithErrors.propTypes = {
+  customBootstrapClass: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.string,
+  ]),
+  didCheckErrors: PropTypes.bool,
+  errors: PropTypes.array,
+  inputClassName: PropTypes.string,
+  validations: PropTypes.object,
+  value: PropTypes.string.isRequired
+};
+
+export default InputTextWithErrors;

--- a/packages/strapi-helper-plugin/lib/src/components/InputTextWithErrors/index.js
+++ b/packages/strapi-helper-plugin/lib/src/components/InputTextWithErrors/index.js
@@ -1,10 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { includes, isEmpty, mapKeys, reject } from 'lodash';
+import { includes, isEmpty, isFunction, mapKeys, reject } from 'lodash';
 import cn from 'classnames';
 
 // Design
 import Label from 'components/Label';
+import InputDescription from 'components/InputDescription';
 import InputText from 'components/InputText';
 
 import styles from './styles.scss';
@@ -48,7 +49,8 @@ class InputTextWithErrors extends React.Component { // eslint-disable-line react
   }
 
   render() {
-    const { autoFocus, inputClassName, name, onChange, placeholder, value } = this.props;
+    const { autoFocus, inputClassName, name, onChange, onFocus, placeholder, value } = this.props;
+    const handleBlur = isFunction(this.props.onBlur) ? this.props.onBlur : this.handleBlur;
 
     return (
       <div className={cn(
@@ -63,11 +65,13 @@ class InputTextWithErrors extends React.Component { // eslint-disable-line react
           className={inputClassName}
           errors={this.state.errors}
           name={name}
-          onBlur={this.handleBlur}
+          onBlur={handleBlur}
           onChange={onChange}
+          onFocus={onFocus}
           placeholder={placeholder}
           value={value}
         />
+        <InputDescription message={this.props.inputDescription && this.props.inputDescription.message || this.props.inputDescription} />
       </div>
     );
   }
@@ -112,6 +116,8 @@ class InputTextWithErrors extends React.Component { // eslint-disable-line react
 InputTextWithErrors.defaultProps = {
   customBootstrapClass: false,
   didCheckErrors: false,
+  onBlur: false,
+  onFocus: () => {},
   errors: [],
   inputClassName: '',
   placeholder: 'app.utils.placeholder.defaultMessage',
@@ -126,6 +132,12 @@ InputTextWithErrors.propTypes = {
   didCheckErrors: PropTypes.bool,
   errors: PropTypes.array,
   inputClassName: PropTypes.string,
+  onBlur: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.func,
+  ]),
+  onChange: PropTypes.func.isRequired,
+  onFocus: PropTypes.func,
   validations: PropTypes.object,
   value: PropTypes.string.isRequired
 };

--- a/packages/strapi-helper-plugin/lib/src/components/InputTextWithErrors/index.js
+++ b/packages/strapi-helper-plugin/lib/src/components/InputTextWithErrors/index.js
@@ -6,6 +6,7 @@ import cn from 'classnames';
 // Design
 import Label from 'components/Label';
 import InputDescription from 'components/InputDescription';
+import InputErrors from 'components/InputErrors';
 import InputText from 'components/InputText';
 
 import styles from './styles.scss';
@@ -49,7 +50,7 @@ class InputTextWithErrors extends React.Component { // eslint-disable-line react
   }
 
   render() {
-    const { autoFocus, inputClassName, name, onChange, onFocus, placeholder, value } = this.props;
+    const { autoFocus, errorsClassName, errorsStyle, inputClassName, inputStyle, name, onChange, onFocus, placeholder, value } = this.props;
     const handleBlur = isFunction(this.props.onBlur) ? this.props.onBlur : this.handleBlur;
 
     return (
@@ -69,9 +70,11 @@ class InputTextWithErrors extends React.Component { // eslint-disable-line react
           onChange={onChange}
           onFocus={onFocus}
           placeholder={placeholder}
+          style={inputStyle}
           value={value}
         />
         <InputDescription message={this.props.inputDescription && this.props.inputDescription.message || this.props.inputDescription} />
+        <InputErrors className={errorsClassName} style={errorsStyle} errors={this.state.errors} />
       </div>
     );
   }
@@ -119,7 +122,10 @@ InputTextWithErrors.defaultProps = {
   onBlur: false,
   onFocus: () => {},
   errors: [],
+  errorsClassName: '',
+  errorsStyle: {},
   inputClassName: '',
+  inputStyle: {},
   placeholder: 'app.utils.placeholder.defaultMessage',
   validations: {},
 };
@@ -131,7 +137,10 @@ InputTextWithErrors.propTypes = {
   ]),
   didCheckErrors: PropTypes.bool,
   errors: PropTypes.array,
+  errorsClassName: PropTypes.string,
+  errorsStyle: PropTypes.object,
   inputClassName: PropTypes.string,
+  inputStyle: PropTypes.object,
   onBlur: PropTypes.oneOfType([
     PropTypes.bool,
     PropTypes.func,
@@ -139,7 +148,7 @@ InputTextWithErrors.propTypes = {
   onChange: PropTypes.func.isRequired,
   onFocus: PropTypes.func,
   validations: PropTypes.object,
-  value: PropTypes.string.isRequired
+  value: PropTypes.string.isRequired,
 };
 
 export default InputTextWithErrors;

--- a/packages/strapi-helper-plugin/lib/src/components/InputTextWithErrors/styles.scss
+++ b/packages/strapi-helper-plugin/lib/src/components/InputTextWithErrors/styles.scss
@@ -1,0 +1,5 @@
+.container {
+  min-width: 200px;
+  margin-bottom: 1.5rem;
+  font-size: 1.3rem;
+}

--- a/packages/strapi-helper-plugin/lib/src/components/Label/index.js
+++ b/packages/strapi-helper-plugin/lib/src/components/Label/index.js
@@ -9,16 +9,16 @@ import styles from './styles.scss';
 function Label(props) {
   let content = props.children;
 
-  if (typeof(props.value) === 'string') {
-    content = props.value;
+  if (typeof(props.message) === 'string') {
+    content = props.message;
   }
 
-  if (isObject(props.value) && props.value.id) {
-    content = <FormattedMessage id={props.value.id} defaultMessage=" " values={props.value.params} />;
+  if (isObject(props.message) && props.message.id) {
+    content = <FormattedMessage id={props.message.id} defaultMessage=" " messages={props.message.params} />;
   }
 
-  if (isFunction(props.value)) {
-    content = props.value();
+  if (isFunction(props.message)) {
+    content = props.message();
   }
 
   return (
@@ -35,16 +35,16 @@ function Label(props) {
 Label.defaultProps = {
   children: '',
   className: '',
+  htmlFor: '',
+  message: '',
   style: {},
-  values: '',
 };
 
 Label.propTypes = {
   children: PropTypes.node,
   className: PropTypes.string,
-  htmlFor: PropTypes.string.isRequired,
-  style: PropTypes.object,
-  values: PropTypes.oneOfType([
+  htmlFor: PropTypes.string,
+  message: PropTypes.oneOfType([
     PropTypes.func,
     PropTypes.string,
     PropTypes.shape({
@@ -52,6 +52,7 @@ Label.propTypes = {
       params: PropTypes.object,
     }),
   ]),
+  style: PropTypes.object,
 };
 
 export default Label;

--- a/packages/strapi-helper-plugin/lib/src/components/Label/index.js
+++ b/packages/strapi-helper-plugin/lib/src/components/Label/index.js
@@ -14,7 +14,7 @@ function Label(props) {
   }
 
   if (isObject(props.message) && props.message.id) {
-    content = <FormattedMessage id={props.message.id} defaultMessage=" " messages={props.message.params} />;
+    content = <FormattedMessage id={props.message.id} defaultMessage=" " values={props.message.params} />;
   }
 
   if (isFunction(props.message)) {

--- a/packages/strapi-helper-plugin/lib/src/components/Label/index.js
+++ b/packages/strapi-helper-plugin/lib/src/components/Label/index.js
@@ -1,0 +1,57 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+import { isFunction, isObject, upperFirst } from 'lodash';
+import cn from 'classnames';
+
+import styles from './styles.scss';
+
+function Label(props) {
+  let content = props.children;
+
+  if (typeof(props.value) === 'string') {
+    content = props.value;
+  }
+
+  if (isObject(props.value) && props.value.id) {
+    content = <FormattedMessage id={props.value.id} defaultMessage=" " values={props.value.params} />;
+  }
+
+  if (isFunction(props.value)) {
+    content = props.value();
+  }
+
+  return (
+    <label
+      className={cn(styles.label, props.className)}
+      htmlFor={props.htmlFor}
+      style={props.style}
+    >
+      {content}
+    </label>
+  );
+}
+
+Label.defaultProps = {
+  children: '',
+  className: '',
+  style: {},
+  values: '',
+};
+
+Label.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+  htmlFor: PropTypes.string.isRequired,
+  style: PropTypes.object,
+  values: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.string,
+    PropTypes.shape({
+      id: PropTypes.string,
+      params: PropTypes.object,
+    }),
+  ]),
+};
+
+export default Label;

--- a/packages/strapi-helper-plugin/lib/src/components/Label/styles.scss
+++ b/packages/strapi-helper-plugin/lib/src/components/Label/styles.scss
@@ -1,0 +1,4 @@
+.label {
+  margin-bottom: 0;
+  font-weight: 500;
+}


### PR DESCRIPTION
Created the main components in order to improve the Input library.

Now an Input is splitted into 4 components :
  -  Label 
  -  Input (for instance InputText which only renders an input type text with the correct design) 
  -  InputDescription
  -  InputErrors

Currently only `InputTextWithErrors` and `InputNumberWithErrors` are developed and may change.

Also the documentation regarding those new components has been written.
