### PR TITLE
Add/input toggle

### DIFF
--- a/docs/3.x.x/en/plugin-development/ui-components.md
+++ b/docs/3.x.x/en/plugin-development/ui-components.md
@@ -444,6 +444,25 @@ InputText Component
 
 ***
 
+## InputToggle
+
+Input type: 'toggle' component
+
+| Property | Type | Required | Description |
+| -------- | ---- | -------- | ----------- |
+| autoFocus | bool | no | Sets the input's autoFocus |
+| className | string | no | custom className for the input |
+| deactivateErrorHighlight | bool | no | Allow to deactivate the red border on the input when there is an error |
+| disabled | bool | no | Disables the input |
+| error | bool | no | Sets the red border on the input |
+| onChange | func | yes | Handler to modify the input's value |
+| name | string | yes | The name of the input |
+| style | object | no | Input's style property |
+| tabIndex | string | no | Input's tabIndex |
+| value | bool | yes | Input's value |
+
+***
+
 ## InputNumberWithErrors
 
 Please refer to the [InputTextWithErrors](#InputTextWithErrors) documentation.
@@ -551,6 +570,42 @@ Component integrates Label, InputText, InputDescription and InputErrors.
     }
   }
 ```
+
+***
+
+## InputToggleWithErrors
+
+Component integrates Label, InputToggle, InputDescription and InputErrors.
+
+| Property | Type | Required | Description |
+| -------- | ---- | -------- | ----------- |
+| autoFocus | bool | no | Sets the input's autoFocus |
+| className | string | no | Overrides the container className |
+| customBootstrapClass | string | no | Allows to override the input bootstrap col system |
+| deactivateErrorHighlight | bool | no | Allow to deactivate the red border on the input when there is an error |
+| didCheckErrors | bool | no | Use this props to display errors after submitting a form. |
+| disabled | bool | no | Disables the input |
+| errors | array | no | Array of errors |
+| errorsClassName | string | no | Overrides the InputErrors' className |
+| errorsStyle | object | no | Overrides the InputErrors' style |
+| inputClassName | string | no | Overrides the InputText's className |
+| inputDescription | string or object or func | no | Sets the input's description |
+| inputDescriptionClassName | string | no | Overrides the InputDescription's className |
+| inputDescriptionStyle | object | no | Overrides the InputDescription's style|
+| inputStyle | object | no | Overrides the InputText's style |
+| label | string or func or object | no sets the input's label |
+| labelClassName | string | no | Overrides the Label's className |
+| labelStyle | object | no | Overrides the Label's style |
+| onChange | func | yes | Handler to modify the input's value |
+| name | string | yes | The name of the input |
+| style | object | no | Overrides the container style |
+| tabIndex | string | no | Input's tabIndex |
+| validations | object | no | Input's validations |
+| value | string | yes | Input's value |
+
+### Usage
+
+Please refer to the [InputTextWithErrors](#InputTextWithErrors) documentation.
 
 ***
 

--- a/docs/3.x.x/en/plugin-development/ui-components.md
+++ b/docs/3.x.x/en/plugin-development/ui-components.md
@@ -534,10 +534,8 @@ Component integrates Label, InputText, InputDescription and InputErrors.
     render() {
       const { didCheckErrors, errors, foo } = this.state;
       const inputDescription = {
-        message: {
-          id: 'my-plugin.inputFoo.description',
-          params: { bar: 'Something' }
-        }
+        id: 'my-plugin.inputFoo.description',
+        params: { bar: 'Something' },
       };
 
       // This can also works (it's the same behavior for the label)
@@ -555,10 +553,10 @@ Component integrates Label, InputText, InputDescription and InputErrors.
                 inputDescription={inputDescription}
                 name="foo"
                 onChange={this.handleChange}
-                label={{ message: {
+                label={{
                   id: 'my-plugin.inputFoo.label',
                   params: { name: <a href="strapi.io" target="_blank">Click me</a> }
-                }}}
+                }}
                 value={foo}
                 validations={{ required: true }}
               />

--- a/packages/strapi-helper-plugin/lib/src/components/InputNumber/index.js
+++ b/packages/strapi-helper-plugin/lib/src/components/InputNumber/index.js
@@ -15,7 +15,7 @@ function InputNumber(props) {
           className={cn(
             styles.input,
             'form-control',
-            !props.deactivateErrorHighlight && !isEmpty(props.errors) && 'is-invalid',
+            !props.deactivateErrorHighlight && props.error && 'is-invalid',
             !isEmpty(props.className) && props.className,
           )}
           disabled={props.disabled}
@@ -40,7 +40,7 @@ InputNumber.defaultProps = {
   className: '',
   deactivateErrorHighlight: false,
   disabled: false,
-  errors: [],
+  error: false,
   onBlur: () => {},
   onFocus: () => {},
   placeholder: 'app.utils.placeholder.defaultMessage',
@@ -53,7 +53,7 @@ InputNumber.propTypes = {
   className: PropTypes.string,
   deactivateErrorHighlight: PropTypes.bool,
   disabled: PropTypes.bool,
-  errors: PropTypes.array,
+  error: PropTypes.bool,
   onBlur: PropTypes.func,
   onChange: PropTypes.func.isRequired,
   onFocus: PropTypes.func,

--- a/packages/strapi-helper-plugin/lib/src/components/InputNumberWithErrors/index.js
+++ b/packages/strapi-helper-plugin/lib/src/components/InputNumberWithErrors/index.js
@@ -83,7 +83,7 @@ class InputNumberWithErrors extends React.Component { // eslint-disable-line rea
         <Label
           className={labelClassName}
           htmlFor={name}
-          message={this.props.label && this.props.label.message || this.props.label}
+          message={this.props.label}
           style={labelStyle}
         />
         <InputNumber
@@ -103,7 +103,7 @@ class InputNumberWithErrors extends React.Component { // eslint-disable-line rea
         />
         <InputDescription
           className={inputDescriptionClassName}
-          message={this.props.inputDescription && this.props.inputDescription.message || this.props.inputDescription}
+          message={this.props.inputDescription}
           style={inputDescriptionStyle}
         />
         <InputErrors
@@ -200,10 +200,8 @@ InputNumberWithErrors.propTypes = {
     PropTypes.string,
     PropTypes.func,
     PropTypes.shape({
-      message: PropTypes.shape({
-        id: PropTypes.string,
-        params: PropTypes.object,
-      }),
+      id: PropTypes.string,
+      params: PropTypes.object,
     }),
   ]),
   inputDescriptionClassName: PropTypes.string,
@@ -213,10 +211,8 @@ InputNumberWithErrors.propTypes = {
     PropTypes.string,
     PropTypes.func,
     PropTypes.shape({
-      message: PropTypes.shape({
-        id: PropTypes.string,
-        params: PropTypes.object,
-      }),
+      id: PropTypes.string,
+      params: PropTypes.object,
     }),
   ]),
   labelClassName: PropTypes.string,

--- a/packages/strapi-helper-plugin/lib/src/components/InputNumberWithErrors/index.js
+++ b/packages/strapi-helper-plugin/lib/src/components/InputNumberWithErrors/index.js
@@ -75,8 +75,8 @@ class InputNumberWithErrors extends React.Component { // eslint-disable-line rea
     return (
       <div className={cn(
           styles.container,
-          this.props.customBootstrapClass || 'col-md-6',
-          !isEmpty(this.props.className) && props.className,
+          this.props.customBootstrapClass,
+          !isEmpty(this.props.className) && this.props.className,
         )}
         style={style}
       >
@@ -162,7 +162,7 @@ class InputNumberWithErrors extends React.Component { // eslint-disable-line rea
 InputNumberWithErrors.defaultProps = {
   autoFocus: false,
   className: '',
-  customBootstrapClass: false,
+  customBootstrapClass: 'col-md-6',
   deactivateErrorHighlight: false,
   didCheckErrors: false,
   disabled: false,
@@ -176,6 +176,7 @@ InputNumberWithErrors.defaultProps = {
   inputDescriptionClassName: '',
   inputDescriptionStyle: {},
   inputStyle: {},
+  label: '',
   labelClassName: '',
   labelStyle: {},
   placeholder: 'app.utils.placeholder.defaultMessage',
@@ -187,10 +188,7 @@ InputNumberWithErrors.defaultProps = {
 InputNumberWithErrors.propTypes = {
   autoFocus: PropTypes.bool,
   className: PropTypes.string,
-  customBootstrapClass: PropTypes.oneOfType([
-    PropTypes.bool,
-    PropTypes.string,
-  ]),
+  customBootstrapClass: PropTypes.string,
   deactivateErrorHighlight: PropTypes.bool,
   didCheckErrors: PropTypes.bool,
   disabled: PropTypes.bool,
@@ -201,20 +199,35 @@ InputNumberWithErrors.propTypes = {
   inputDescription: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.func,
-    PropTypes.object,
+    PropTypes.shape({
+      message: PropTypes.shape({
+        id: PropTypes.string,
+        params: PropTypes.object,
+      }),
+    }),
   ]),
   inputDescriptionClassName: PropTypes.string,
   inputDescriptionStyle: PropTypes.object,
   inputStyle: PropTypes.object,
+  label: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.func,
+    PropTypes.shape({
+      message: PropTypes.shape({
+        id: PropTypes.string,
+        params: PropTypes.object,
+      }),
+    }),
+  ]),
   labelClassName: PropTypes.string,
   labelStyle: PropTypes.object,
+  name: PropTypes.string.isRequired,
   onBlur: PropTypes.oneOfType([
     PropTypes.bool,
     PropTypes.func,
   ]),
   onChange: PropTypes.func.isRequired,
   onFocus: PropTypes.func,
-  name: PropTypes.string.isRequired,
   placeholder: PropTypes.string,
   style: PropTypes.object,
   tabIndex: PropTypes.string,

--- a/packages/strapi-helper-plugin/lib/src/components/InputText/index.js
+++ b/packages/strapi-helper-plugin/lib/src/components/InputText/index.js
@@ -53,7 +53,7 @@ InputText.propTypes = {
   className: PropTypes.string,
   deactivateErrorHighlight: PropTypes.bool,
   disabled: PropTypes.bool,
-  errors: PropTypes.bool,
+  error: PropTypes.bool,
   onBlur: PropTypes.func,
   onChange: PropTypes.func.isRequired,
   onFocus: PropTypes.func,

--- a/packages/strapi-helper-plugin/lib/src/components/InputTextWithErrors/index.js
+++ b/packages/strapi-helper-plugin/lib/src/components/InputTextWithErrors/index.js
@@ -83,7 +83,7 @@ class InputTextWithErrors extends React.Component { // eslint-disable-line react
         <Label
           className={labelClassName}
           htmlFor={name}
-          message={this.props.label && this.props.label.message || this.props.label}
+          message={this.props.label}
           style={labelStyle}
         />
         <InputText
@@ -103,7 +103,7 @@ class InputTextWithErrors extends React.Component { // eslint-disable-line react
         />
         <InputDescription
           className={inputDescriptionClassName}
-          message={this.props.inputDescription && this.props.inputDescription.message || this.props.inputDescription}
+          message={this.props.inputDescription}
           style={inputDescriptionStyle}
         />
         <InputErrors
@@ -199,10 +199,8 @@ InputTextWithErrors.propTypes = {
     PropTypes.string,
     PropTypes.func,
     PropTypes.shape({
-      message: PropTypes.shape({
-        id: PropTypes.string,
-        params: PropTypes.object,
-      }),
+      id: PropTypes.string,
+      params: PropTypes.object,
     }),
   ]),
   inputDescriptionClassName: PropTypes.string,
@@ -212,10 +210,8 @@ InputTextWithErrors.propTypes = {
     PropTypes.string,
     PropTypes.func,
     PropTypes.shape({
-      message: PropTypes.shape({
-        id: PropTypes.string,
-        params: PropTypes.object,
-      }),
+      id: PropTypes.string,
+      params: PropTypes.object,
     }),
   ]),
   labelClassName: PropTypes.string,

--- a/packages/strapi-helper-plugin/lib/src/components/InputToggle/index.js
+++ b/packages/strapi-helper-plugin/lib/src/components/InputToggle/index.js
@@ -37,7 +37,6 @@ class InputToggle extends React.Component {
           'btn-group',
           styles.inputToggleContainer,
           !isEmpty(className) && className,
-          disabled && styles.disabled,
           !deactivateErrorHighlight && error && styles.error,
         )}
         style={style}
@@ -79,7 +78,7 @@ InputToggle.defaultProps = {
 };
 
 InputToggle.propTypes = {
-  autoFocus: false,
+  autoFocus: PropTypes.bool,
   className: PropTypes.string,
   deactivateErrorHighlight: PropTypes.bool,
   disabled: PropTypes.bool,

--- a/packages/strapi-helper-plugin/lib/src/components/InputToggle/index.js
+++ b/packages/strapi-helper-plugin/lib/src/components/InputToggle/index.js
@@ -1,0 +1,94 @@
+/**
+ * InputToggle
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import cn from 'classnames';
+import { isEmpty } from 'lodash';
+
+import styles from './styles.scss';
+
+class InputToggle extends React.Component {
+  handleClick = (e) => {
+    const target = {
+      name: this.props.name,
+      type: 'toggle',
+      value: e.target.id === 'on',
+    };
+
+    this.props.onChange({ target });
+  }
+
+  render() {
+    const {
+      autoFocus,
+      className,
+      disabled,
+      deactivateErrorHighlight,
+      error,
+      style,
+      tabIndex,
+      value,
+    } = this.props;
+
+    return (
+      <div className={cn(
+          'btn-group',
+          styles.inputToggleContainer,
+          !isEmpty(className) && className,
+          disabled && styles.disabled,
+          !deactivateErrorHighlight && error && styles.error,
+        )}
+        style={style}
+      >
+        <button
+          autoFocus={autoFocus}
+          disabled={disabled}
+          className={cn('btn', !value && styles.gradientOff)}
+          id="off"
+          onClick={this.handleClick}
+          tabIndex={tabIndex}
+          type="button"
+        >
+          OFF
+        </button>
+        <button
+          disabled={disabled}
+          className={cn('btn', value && styles.gradientOn)}
+          id="on"
+          onClick={this.handleClick}
+          type="button"
+        >
+          ON
+        </button>
+      </div>
+    );
+  }
+}
+
+InputToggle.defaultProps = {
+  autoFocus: false,
+  className: '',
+  deactivateErrorHighlight: false,
+  disabled: false,
+  error: false,
+  style: {},
+  tabIndex: '0',
+  value: true,
+};
+
+InputToggle.propTypes = {
+  autoFocus: false,
+  className: PropTypes.string,
+  deactivateErrorHighlight: PropTypes.bool,
+  disabled: PropTypes.bool,
+  error: PropTypes.bool,
+  name: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
+  style: PropTypes.object,
+  tabIndex: PropTypes.string,
+  value: PropTypes.bool,
+};
+
+export default InputToggle;

--- a/packages/strapi-helper-plugin/lib/src/components/InputToggle/styles.scss
+++ b/packages/strapi-helper-plugin/lib/src/components/InputToggle/styles.scss
@@ -1,0 +1,61 @@
+.gradientOff {
+  background-image: linear-gradient( to bottom right, #F65A1D, #F68E0E );
+  color: white !important;
+  box-shadow: inset -1px 1px 3px rgba(0,0,0,0.1);
+}
+
+.gradientOn {
+  background-image: linear-gradient( to bottom right, #005EEA, #0097F6);
+  color: white !important;
+  box-shadow: inset 1px 1px 3px rgba(0,0,0,0.1);
+}
+
+.inputToggleContainer {
+  padding-top: 9px;
+  > button {
+    width: 5.3rem;
+    height: 3.4rem;
+    margin-bottom: 2.8rem;
+    padding: 0;
+    border: 1px solid #E3E9F3;
+    border-radius: 0.25rem;
+    color: #CED3DB;
+    background-color: white;
+    box-shadow: 0px 1px 1px rgba(104, 118, 142, 0.05);
+    font-weight: 600;
+    font-size: 1.2rem;
+    letter-spacing: 0.1rem;
+    font-family: Lato;
+    line-height: 3.4rem;
+    cursor: pointer;
+    &:first-of-type {
+      border-right: none;
+    }
+    &:nth-of-type(2) {
+      border-left: none;
+    }
+    &:hover {
+      z-index: 0 !important;
+    }
+    &:focus {
+      outline: 0;
+      box-shadow: 0 0 0;
+    }
+    &:disabled {
+      cursor: not-allowed;
+    }
+  }
+}
+
+.error {
+  > button {
+    &:first-child {
+      border: 1px solid #ff203c !important;
+      border-right: 0 !important;
+    }
+    &:last-child {
+      border: 1px solid #ff203c !important;
+      border-left: 0 !important;
+    }
+  }
+}

--- a/packages/strapi-helper-plugin/lib/src/components/InputToggleWithErrors/index.js
+++ b/packages/strapi-helper-plugin/lib/src/components/InputToggleWithErrors/index.js
@@ -1,30 +1,29 @@
+/**
+ *
+ * InputToggleWithErrors
+ *
+ */
+
 import React from 'react';
 import PropTypes from 'prop-types';
-import { includes, isEmpty, isFunction, mapKeys, reject } from 'lodash';
 import cn from 'classnames';
-
+import { isEmpty } from 'lodash';
 // Design
 import Label from 'components/Label';
 import InputDescription from 'components/InputDescription';
 import InputErrors from 'components/InputErrors';
-import InputText from 'components/InputText';
+import InputToggle from 'components/InputToggle';
 
 import styles from './styles.scss';
 
-class InputTextWithErrors extends React.Component { // eslint-disable-line react/prefer-stateless-function
-  state = { errors: [], hasInitialValue: false };
-
+class InputToggleWithErrors extends React.Component {
+  state = { errors: [] }
   componentDidMount() {
-    const { value, errors } = this.props;
-
-    // Prevent the input from displaying an error when the user enters and leaves without filling it
-    if (value && !isEmpty(value)) {
-      this.setState({ hasInitialValue: true });
-    }
+    const { errors } = this.props;
 
     // Display input error if it already has some
     if (!isEmpty(errors)) {
-      this.setState({ errors });
+      this.setState({ errors })
     }
   }
 
@@ -37,73 +36,61 @@ class InputTextWithErrors extends React.Component { // eslint-disable-line react
     }
   }
 
-  /**
-   * Set the errors depending on the validations given to the input
-   * @param  {Object} target
-   */
-  handleBlur = ({ target }) => {
-    // Prevent from displaying error if the input is initially isEmpty
-    if (!isEmpty(target.value) || this.state.hasInitialValue) {
-      const errors = this.validate(target.value);
-      this.setState({ errors, hasInitialValue: true });
-    }
-  }
-
   render() {
     const {
       autoFocus,
+      className,
+      customBootstrapClass,
       deactivateErrorHighlight,
       disabled,
       errorsClassName,
       errorsStyle,
       inputClassName,
+      inputDescription,
       inputDescriptionClassName,
       inputDescriptionStyle,
       inputStyle,
+      label,
       labelClassName,
       labelStyle,
       name,
       onChange,
-      onFocus,
-      placeholder,
       style,
       tabIndex,
       value,
     } = this.props;
-    const handleBlur = isFunction(this.props.onBlur) ? this.props.onBlur : this.handleBlur;
 
     return (
       <div className={cn(
           styles.container,
-          this.props.customBootstrapClass,
-          !isEmpty(this.props.className) && this.props.className,
+          customBootstrapClass,
+          !isEmpty(className) && className,
         )}
         style={style}
       >
-        <Label
-          className={labelClassName}
-          htmlFor={name}
-          message={this.props.label && this.props.label.message || this.props.label}
-          style={labelStyle}
-        />
-        <InputText
+        <div className={styles.toggleLabel}>
+          <Label
+            className={cn(!isEmpty(labelClassName) && labelClassName)}
+            htmlFor={name}
+            message={label && label.message || label}
+            style={labelStyle}
+            />
+        </div>
+        <InputToggle
           autoFocus={autoFocus}
           className={inputClassName}
-          disabled={disabled}
           deactivateErrorHighlight={deactivateErrorHighlight}
+          disabled={disabled}
           error={!isEmpty(this.state.errors)}
           name={name}
-          onBlur={handleBlur}
           onChange={onChange}
-          onFocus={onFocus}
-          placeholder={placeholder}
           style={inputStyle}
           tabIndex={tabIndex}
           value={value}
         />
         <InputDescription
           className={inputDescriptionClassName}
-          message={this.props.inputDescription && this.props.inputDescription.message || this.props.inputDescription}
+          message={inputDescription && inputDescription.message || inputDescription}
           style={inputDescriptionStyle}
         />
         <InputErrors
@@ -114,59 +101,15 @@ class InputTextWithErrors extends React.Component { // eslint-disable-line react
       </div>
     );
   }
-
-  validate = (value) => {
-    const requiredError = { id: 'components.Input.error.validation.required' };
-    let errors = [];
-
-    mapKeys(this.props.validations, (validationValue, validationKey) => {
-      switch (validationKey) {
-        case 'maxLength': {
-          if (value.length > validationValue) {
-            errors.push({ id: 'components.Input.error.validation.maxLength' });
-          }
-          break;
-        }
-        case 'minLength': {
-          if (value.length < validationValue) {
-            errors.push({ id: 'components.Input.error.validation.minLength' });
-          }
-          break;
-        }
-        case 'required': {
-          if (value.length === 0) {
-            errors.push({ id: 'components.Input.error.validation.required' });
-          }
-          break;
-        }
-        case 'regex': {
-          if (!new RegExp(validationValue).test(value)) {
-            errors.push({ id: 'components.Input.error.validation.regex' });
-          }
-          break;
-        }
-        default:
-          errors = [];
-      }
-    });
-
-    if (includes(errors, requiredError)) {
-      errors = reject(errors, (error) => error !== requiredError);
-    }
-
-    return errors;
-  }
 }
 
-InputTextWithErrors.defaultProps = {
+InputToggleWithErrors.defaultProps = {
   autoFocus: false,
   className: '',
   customBootstrapClass: 'col-md-6',
   deactivateErrorHighlight: false,
   didCheckErrors: false,
   disabled: false,
-  onBlur: false,
-  onFocus: () => {},
   errors: [],
   errorsClassName: '',
   errorsStyle: {},
@@ -178,13 +121,12 @@ InputTextWithErrors.defaultProps = {
   label: '',
   labelClassName: '',
   labelStyle: {},
-  placeholder: 'app.utils.placeholder.defaultMessage',
   style: {},
   tabIndex: '0',
-  validations: {},
+  value: true,
 };
 
-InputTextWithErrors.propTypes = {
+InputToggleWithErrors.propTypes = {
   autoFocus: PropTypes.bool,
   className: PropTypes.string,
   customBootstrapClass: PropTypes.string,
@@ -221,17 +163,10 @@ InputTextWithErrors.propTypes = {
   labelClassName: PropTypes.string,
   labelStyle: PropTypes.object,
   name: PropTypes.string.isRequired,
-  onBlur: PropTypes.oneOfType([
-    PropTypes.bool,
-    PropTypes.func,
-  ]),
   onChange: PropTypes.func.isRequired,
-  onFocus: PropTypes.func,
-  placeholder: PropTypes.string,
   style: PropTypes.object,
   tabIndex: PropTypes.string,
-  validations: PropTypes.object,
-  value: PropTypes.string.isRequired,
+  value: PropTypes.bool,
 };
 
-export default InputTextWithErrors;
+export default InputToggleWithErrors;

--- a/packages/strapi-helper-plugin/lib/src/components/InputToggleWithErrors/index.js
+++ b/packages/strapi-helper-plugin/lib/src/components/InputToggleWithErrors/index.js
@@ -72,7 +72,7 @@ class InputToggleWithErrors extends React.Component {
           <Label
             className={cn(!isEmpty(labelClassName) && labelClassName)}
             htmlFor={name}
-            message={label && label.message || label}
+            message={label}
             style={labelStyle}
             />
         </div>
@@ -90,7 +90,7 @@ class InputToggleWithErrors extends React.Component {
         />
         <InputDescription
           className={inputDescriptionClassName}
-          message={inputDescription && inputDescription.message || inputDescription}
+          message={inputDescription}
           style={inputDescriptionStyle}
         />
         <InputErrors
@@ -141,10 +141,8 @@ InputToggleWithErrors.propTypes = {
     PropTypes.string,
     PropTypes.func,
     PropTypes.shape({
-      message: PropTypes.shape({
-        id: PropTypes.string,
-        params: PropTypes.object,
-      }),
+      id: PropTypes.string,
+      params: PropTypes.object,
     }),
   ]),
   inputDescriptionClassName: PropTypes.string,

--- a/packages/strapi-helper-plugin/lib/src/components/InputToggleWithErrors/styles.scss
+++ b/packages/strapi-helper-plugin/lib/src/components/InputToggleWithErrors/styles.scss
@@ -1,0 +1,9 @@
+.container {
+  margin-bottom: 1.5rem;
+  font-size: 1.3rem;
+}
+
+.toggleLabel {
+  margin-bottom: 0 !important;
+  font-weight: 500 !important;
+}

--- a/packages/strapi-helper-plugin/lib/src/components/InputsIndex/index.js
+++ b/packages/strapi-helper-plugin/lib/src/components/InputsIndex/index.js
@@ -1,0 +1,36 @@
+/**
+ *
+ * InputsIndex references all the input with errors available
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+// Design
+import InputNumberWithErrors from 'components/InputNumberWithErrors';
+import InputTextWithErrors from 'components/InputTextWithErrors';
+import InputToggleWithErrors from 'components/InputToggleWithErrors';
+
+const inputs = {
+  number: InputNumberWithErrors,
+  string: InputTextWithErrors,
+  text: InputTextWithErrors,
+  toggle: InputToggleWithErrors,
+};
+
+function InputsIndex(props) {
+  const Input = inputs[props.type] || <div />;
+
+  return <Input {...props} />;
+}
+
+InputsIndex.propTypes = {
+  type: PropTypes.string.isRequired,
+};
+
+export default InputsIndex;
+export {
+  InputNumberWithErrors,
+  InputTextWithErrors,
+  InputToggleWithErrors,
+};


### PR DESCRIPTION
Created these components
- InputToggle : simple input toggle
- InputToggleWithErrors : input that wraps Label, InputDescription, InputErrors
- InputsIndex : component that references all the inputs available so you need only one import when you have multiples inputs of different type

Correct InputNumber and InputText props so it's more efficient