### PR TITLE
feat(generate-new): processing database connection by CLI arguments

### DIFF
--- a/packages/strapi-generate-new/lib/before.js
+++ b/packages/strapi-generate-new/lib/before.js
@@ -28,12 +28,14 @@ const logger = require('strapi-utils').logger;
 
 module.exports = (scope, cb) => {
   // App info.
+  const hasDatabaseConfig = !!scope.database;
   _.defaults(scope, {
     name: scope.name === '.' || !scope.name ? scope.name : path.basename(process.cwd()),
     author: process.env.USER || 'A Strapi developer',
     email: process.env.EMAIL || '',
     year: (new Date()).getFullYear(),
-    license: 'MIT'
+    license: 'MIT',
+    database: {}
   });
 
   // Make changes to the rootPath where the Strapi project will be created.
@@ -51,7 +53,9 @@ module.exports = (scope, cb) => {
 
   logger.info('Let\s configurate the connection to your database:');
 
-  scope.database = {};
+  if (hasDatabaseConfig) {
+    logger.info(`Database determined by CLI args: ${scope.database.settings.client}`);
+  }
 
   const connectionValidation = () => {
     const databaseChoices = [
@@ -98,6 +102,7 @@ module.exports = (scope, cb) => {
     inquirer
     .prompt([
       {
+        when: !hasDatabaseConfig,
         type: 'list',
         prefix: '',
         name: 'client',
@@ -111,20 +116,29 @@ module.exports = (scope, cb) => {
       }
     ])
     .then(answers => {
+
+      if (hasDatabaseConfig) {
+        const databaseChoice = _.find(databaseChoices, ['value.database', scope.database.settings.client]);
+        answers.client = {
+          ...databaseChoice.value
+        };
+      } else {
+        _.assign(scope.database, {
+          connector: answers.client.connector,
+          settings: {
+            client: answers.client.database
+          },
+          options: {}
+        });
+      }
       scope.client = answers.client;
-      _.assign(scope.database, {
-        connector: answers.client.connector,
-        settings: {
-          client: answers.client.database
-        },
-        options: {}
-      });
 
       const asyncFn = [
         new Promise(resolve => {
           inquirer
           .prompt([
             {
+              when: !hasDatabaseConfig,
               type: 'input',
               prefix: '',
               name: 'name',
@@ -132,6 +146,7 @@ module.exports = (scope, cb) => {
               default: _.get(scope.database, 'database', 'strapi')
             },
             {
+              when: !hasDatabaseConfig,
               type: 'input',
               prefix: '',
               name: 'host',
@@ -139,6 +154,7 @@ module.exports = (scope, cb) => {
               default: _.get(scope.database, 'host', 'localhost')
             },
             {
+              when: !hasDatabaseConfig,
               type: 'input',
               prefix: '',
               name: 'port',
@@ -160,6 +176,7 @@ module.exports = (scope, cb) => {
               }
             },
             {
+              when: !hasDatabaseConfig,
               type: 'input',
               prefix: '',
               name: 'username',
@@ -167,6 +184,7 @@ module.exports = (scope, cb) => {
               default: _.get(scope.database, 'username', undefined)
             },
             {
+              when: !hasDatabaseConfig,
               type: 'input',
               prefix: '',
               name: 'password',
@@ -175,6 +193,11 @@ module.exports = (scope, cb) => {
             }
           ])
           .then(answers => {
+
+            if (hasDatabaseConfig) {
+              answers = _.omit(scope.database.settings, ['client'])
+            }
+
             scope.database.settings.host = answers.host;
             scope.database.settings.port = answers.port;
             scope.database.settings.database = answers.name;

--- a/packages/strapi/bin/strapi-new.js
+++ b/packages/strapi/bin/strapi-new.js
@@ -9,6 +9,9 @@
 // Node.js core.
 const path = require('path');
 
+// Public node modules.
+const _ = require('lodash');
+
 // Master of ceremonies for generators.
 const generate = require('strapi-generate');
 
@@ -38,6 +41,20 @@ module.exports = function (name, cliArguments) {
     strapiPackageJSON: packageJSON,
     developerMode
   };
+
+  if (_.values(_.omit(cliArguments, ['dev'])).length) {
+    scope.database = {
+      settings: {
+        client: cliArguments.dbtype,
+        host: cliArguments.dbhost,
+        port: cliArguments.dbport,
+        database: cliArguments.dbname,
+        username: cliArguments.dbusername,
+        password: cliArguments.dbpassword
+      },
+      options: {}
+    }
+  }
 
   // Return the scope and the response (`error` or `success`).
   return generate(scope, {

--- a/packages/strapi/bin/strapi.js
+++ b/packages/strapi/bin/strapi.js
@@ -51,7 +51,13 @@ program
 program
   .command('new')
   .option('-d, --dev', 'Development mode')
-  .description('create a new application ')
+  .option('--dbtype <dbtype>', 'Database type')
+  .option('--dbhost <dbhost>', 'Database host')
+  .option('--dbport <dbport>', 'Database port')
+  .option('--dbname <dbname>', 'Database name')
+  .option('--dbusername <dbusername>', 'Database username')
+  .option('--dbpassword <dbpassword>', 'Database password')
+  .description('create a new application')
   .action(require('./strapi-new'));
 
 // `$ strapi start`


### PR DESCRIPTION
For #489,
`strapi new myApp --dbtype mongo --dbhost localhost --dbport 27017 --dbname strapi --dbusername user --dbpassword password`