### PR TITLE
Fix strapi new without db args

### DIFF
--- a/packages/strapi-generate-new/lib/before.js
+++ b/packages/strapi-generate-new/lib/before.js
@@ -29,6 +29,7 @@ const logger = require('strapi-utils').logger;
 module.exports = (scope, cb) => {
   // App info.
   const hasDatabaseConfig = !!scope.database;
+
   _.defaults(scope, {
     name: scope.name === '.' || !scope.name ? scope.name : path.basename(process.cwd()),
     author: process.env.USER || 'A Strapi developer',
@@ -116,7 +117,6 @@ module.exports = (scope, cb) => {
       }
     ])
     .then(answers => {
-
       if (hasDatabaseConfig) {
         const databaseChoice = _.find(databaseChoices, ['value.database', scope.database.settings.client]);
         answers.client = {

--- a/packages/strapi/bin/strapi-new.js
+++ b/packages/strapi/bin/strapi-new.js
@@ -42,7 +42,15 @@ module.exports = function (name, cliArguments) {
     developerMode
   };
 
-  if (_.values(_.omit(cliArguments, ['dev'])).length) {
+  const dbArguments = ['dbclient', 'dbhost', 'dbport', 'dbname', 'dbusername', 'dbpassword'];
+  const matchingDbArguments = _.intersection(_.keys(cliArguments), dbArguments);
+
+  if (matchingDbArguments.length) {
+    if (matchingDbArguments.length !== dbArguments.length) {
+      logger.warn(`Some database arguments are missing. Required arguments list: ${dbArguments}`);
+      return process.exit(1);
+    }
+
     scope.database = {
       settings: {
         client: cliArguments.dbclient,


### PR DESCRIPTION
Stop project creation if one of db argument is missing
Better detection for using db arguments

