### PR TITLE
Feat/tmp connection

### DIFF
--- a/packages/strapi-bookshelf/lib/utils/connectivity.js
+++ b/packages/strapi-bookshelf/lib/utils/connectivity.js
@@ -8,7 +8,7 @@ const path = require('path');
 const logger = require('strapi-utils').logger;
 
 module.exports = (scope, success, error) => {
-  const knex  = require(path.resolve(`${scope.rootPath}/node_modules/knex`))({
+  const knex  = require(path.resolve(`${scope.tmpPath}/node_modules/knex`))({
     client: scope.client.module,
     connection: Object.assign({}, scope.database.settings, {
       user: scope.database.settings.username
@@ -18,7 +18,7 @@ module.exports = (scope, success, error) => {
   knex.raw('select 1+1 as result').then(() => {
     logger.info('The app has been connected to the database successfully');
     knex.destroy();
-    execSync(`rm -r ${scope.rootPath}`);
+    execSync(`rm -r ${scope.tmpPath}`);
 
     logger.info('Copying the dashboard...');
 

--- a/packages/strapi-generate-new/lib/before.js
+++ b/packages/strapi-generate-new/lib/before.js
@@ -41,6 +41,7 @@ module.exports = (scope, cb) => {
 
   // Make changes to the rootPath where the Strapi project will be created.
   scope.rootPath = path.resolve(process.cwd(), scope.name || '');
+  scope.tmpPath = path.resolve(process.cwd(), 'tmp');
 
   // Ensure we aren't going to inadvertently delete any files.
   try {
@@ -212,14 +213,14 @@ module.exports = (scope, cb) => {
           });
         }),
         new Promise(resolve => {
-          let cmd = `npm install --prefix "${scope.rootPath}" ${scope.client.connector}@alpha`;
+          let cmd = `npm install --prefix "${scope.tmpPath}" ${scope.client.connector}@alpha`;
           if (scope.client.module) {
             cmd += ` ${scope.client.module}`;
           }
 
           exec(cmd, () => {
             if (scope.client.module) {
-              const lock = require(path.join(`${scope.rootPath}`,`/node_modules/`,`${scope.client.module}/package.json`));
+              const lock = require(path.join(`${scope.tmpPath}`,`/node_modules/`,`${scope.client.module}/package.json`));
               scope.client.version = lock.version;
             }
 
@@ -231,9 +232,9 @@ module.exports = (scope, cb) => {
       Promise.all(asyncFn)
       .then(() => {
         try {
-          require(path.join(`${scope.rootPath}`,`/node_modules/`,`${scope.client.connector}/lib/utils/connectivity.js`))(scope, cb.success, connectionValidation);
+          require(path.join(`${scope.tmpPath}`,`/node_modules/`,`${scope.client.connector}/lib/utils/connectivity.js`))(scope, cb.success, connectionValidation);
         } catch(err) {
-          shell.rm('-r', scope.rootPath);
+          shell.rm('-r', scope.tmpPath);
           logger.info('Copying the dashboard...');
           cb.success();
         }

--- a/packages/strapi-generate-new/lib/before.js
+++ b/packages/strapi-generate-new/lib/before.js
@@ -45,7 +45,7 @@ module.exports = (scope, cb) => {
   // Ensure we aren't going to inadvertently delete any files.
   try {
     const files = fs.readdirSync(scope.rootPath);
-    if (files.length) {
+    if (files.length > 1) {
       return logger.error('`$ strapi new` can only be called in an empty directory.');
     }
   } catch (err) {

--- a/packages/strapi-mongoose/lib/utils/connectivity.js
+++ b/packages/strapi-mongoose/lib/utils/connectivity.js
@@ -8,7 +8,7 @@ const path = require('path');
 const logger = require('strapi-utils').logger;
 
 module.exports = (scope, success, error) => {
-  const Mongoose = require(path.resolve(`${scope.rootPath}/node_modules/mongoose`));
+  const Mongoose = require(path.resolve(`${scope.tmpPath}/node_modules/mongoose`));
 
   const { username, password } = scope.database.settings
   const connectOptions = {}
@@ -28,7 +28,7 @@ module.exports = (scope, success, error) => {
 
     Mongoose.connection.close();
 
-    execSync(`rm -r ${scope.rootPath}`);
+    execSync(`rm -r ${scope.tmpPath}`);
 
     logger.info('Copying the dashboard...');
 

--- a/packages/strapi-redis/lib/utils/connectivity.js
+++ b/packages/strapi-redis/lib/utils/connectivity.js
@@ -8,7 +8,7 @@ const path = require('path');
 const logger = require('strapi-utils').logger;
 
 module.exports = (scope, success, error) => {
-  const Redis = require(`${scope.rootPath}/node_modules/ioredis`);
+  const Redis = require(`${scope.tmpPath}/node_modules/ioredis`);
   const redis = new Redis({
     port: scope.database.settings.port,
     host: scope.database.settings.host,
@@ -26,7 +26,7 @@ module.exports = (scope, success, error) => {
 
     logger.info('The app has been connected to the database successfully!');
 
-    execSync(`rm -r ${scope.rootPath}`);
+    execSync(`rm -r ${scope.tmpPath}`);
 
     logger.info('Copying the dashboard...');
 


### PR DESCRIPTION
- Use `tmp` directory to install database connectivity tester.
- Check if the content of the `rootPath` folder has more than one file. Used for docker volume that is shared with the host.