### PR TITLE
Fix #660: Allow side menu to scroll when content requires it

### DIFF
--- a/packages/strapi-admin/admin/src/components/LeftMenuLinkContainer/styles.scss
+++ b/packages/strapi-admin/admin/src/components/LeftMenuLinkContainer/styles.scss
@@ -3,6 +3,12 @@
 
 .leftMenuLinkContainer { /* stylelint-ignore */
   padding-top: .6rem;
+  position: absolute;
+  top: 60px;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  overflow-y: scroll;
 }
 
 .title {


### PR DESCRIPTION
Depending on screen resolution, when adding many content types the side
menu can't fit them all. This commit simply uses absolute positioning
and overflow-y: auto to allow vertical scrolling when it's needed.

