### PR TITLE
Avoid username capitalize

### DIFF
--- a/packages/strapi-admin/admin/src/components/Logout/styles.scss
+++ b/packages/strapi-admin/admin/src/components/Logout/styles.scss
@@ -20,7 +20,6 @@
       font-size: 14px;
       font-weight: 500;
       text-align: right;
-      text-transform: capitalize;
       cursor: pointer;
       &:hover {
         color: #333740;


### PR DESCRIPTION
I think it makes sense not to capitalize the usernames.
Example: I see `Abdonrd` instead of `abdonrd`.