### PR TITLE
Warn of non-standard NODE_ENV when creating new app

### DIFF
--- a/packages/strapi-generate-new/lib/before.js
+++ b/packages/strapi-generate-new/lib/before.js
@@ -18,7 +18,6 @@ const shell = require('shelljs');
 // Logger.
 const logger = require('strapi-utils').logger;
 
-
 /**
  * This `before` function is run before generating targets.
  * Validate, configure defaults, get extra dependencies, etc.
@@ -273,4 +272,3 @@ module.exports = (scope, cb) => {
 
   connectionValidation();
 };
-

--- a/packages/strapi-generate-new/lib/before.js
+++ b/packages/strapi-generate-new/lib/before.js
@@ -18,6 +18,7 @@ const shell = require('shelljs');
 // Logger.
 const logger = require('strapi-utils').logger;
 
+
 /**
  * This `before` function is run before generating targets.
  * Validate, configure defaults, get extra dependencies, etc.
@@ -29,6 +30,16 @@ const logger = require('strapi-utils').logger;
 module.exports = (scope, cb) => {
   // App info.
   const hasDatabaseConfig = !!scope.database;
+  const standardEnvironments = [
+    'development',
+    'production',
+    'test'
+  ];
+  const nonStandardEnvironment = process.env.NODE_ENV && !standardEnvironments.includes(process.env.NODE_ENV);
+
+  if (nonStandardEnvironment) {
+    logger.warn(`A non-standard NODE_ENV has been detected (${process.env.NODE_ENV}). This may cause Strapi to behave in an unexpected manner.`);
+  }
 
   _.defaults(scope, {
     name: scope.name === '.' || !scope.name ? scope.name : path.basename(process.cwd()),
@@ -262,3 +273,4 @@ module.exports = (scope, cb) => {
 
   connectionValidation();
 };
+


### PR DESCRIPTION
I created this issue some time ago: #698 

After creating a brand-new app via `strapi new`, `strapi start` would fail spectacularly, and with a non-helpful error message.

It seems I wasn't the only one, as a handful of other users have run into a similar (or the same) problem.

This small change just warns the user of a non-standard `NODE_ENV` value (mine was set in my `.bashrc`) during `strapi_start`.