### PR TITLE
Allow Array type in the backend

### DIFF
--- a/packages/strapi-mongoose/lib/utils/index.js
+++ b/packages/strapi-mongoose/lib/utils/index.js
@@ -19,32 +19,31 @@ module.exports = mongoose => {
   return {
     convertType: mongooseType => {
       switch (mongooseType.toLowerCase()) {
-        case 'string':
-        case 'password':
-        case 'text':
-        case 'email':
-          return 'String';
-        case 'integer':
-        case 'biginteger':
-          return 'Number';
-        case 'float':
-        case 'decimal':
-          return 'Float';
-        case 'date':
-        case 'time':
-        case 'datetime':
-        case 'timestamp':
-          return Date;
         case 'boolean':
           return 'Boolean';
         case 'binary':
           return 'Buffer';
-        case 'uuid':
-          return 'ObjectId';
-        case 'enumeration':
-          return 'String';
+        case 'date':
+        case 'datetime':
+        case 'time':
+        case 'timestamp':
+          return Date;
+        case 'decimal':
+        case 'float':
+          return 'Float';
         case 'json':
           return 'Mixed';
+        case 'biginteger':
+        case 'integer':
+          return 'Number';
+        case 'uuid':
+          return 'ObjectId';
+        case 'email':
+        case 'enumeration':
+        case 'password':
+        case 'string':
+        case 'text':
+          return 'String';
         default:
 
       }

--- a/packages/strapi-mongoose/lib/utils/index.js
+++ b/packages/strapi-mongoose/lib/utils/index.js
@@ -19,6 +19,8 @@ module.exports = mongoose => {
   return {
     convertType: mongooseType => {
       switch (mongooseType.toLowerCase()) {
+        case 'array':
+          return 'Array';
         case 'boolean':
           return 'Boolean';
         case 'binary':


### PR DESCRIPTION
Also, sort types alphabetically.
You can see the two commits separately.

Reference: https://github.com/strapi/strapi/issues/784#issuecomment-373649898