### PR TITLE
Fix spaces path issues on npm run build --plugins

### DIFF
--- a/packages/strapi-admin/scripts/setup.js
+++ b/packages/strapi-admin/scripts/setup.js
@@ -5,7 +5,7 @@ const _ = require('lodash');
 shell.echo('');
 shell.echo('🕓  The setup process can take few minutes.');
 shell.echo('');
-shell.echo(`🔸  Administration Panel`);
+shell.echo('🔸  Administration Panel');
 shell.echo('📦  Installing packages...');
 
 const pwd = shell.pwd();
@@ -19,28 +19,28 @@ shell.rm('-rf', path.resolve(appPath, 'package-lock.json'));
 shell.rm('-rf', path.resolve(appPath, 'admin', 'package-lock.json'));
 
 // Install the project dependencies.
-shell.exec(`cd ${appPath} && npm install --ignore-scripts`, {
+shell.exec(`cd "${appPath}" && npm install --ignore-scripts`, {
   silent
 });
 
 // Install the administration dependencies.
-shell.exec(`cd ${path.resolve(appPath, 'admin')} && npm install`, {
+shell.exec(`cd "${path.resolve(appPath, 'admin')}" && npm install`, {
   silent
 });
 
 if (isDevelopmentMode) {
-  shell.exec(`cd ${path.resolve(appPath, 'admin')} && npm link strapi-helper-plugin && npm link strapi-utils`, {
+  shell.exec(`cd "${path.resolve(appPath, 'admin')}" && npm link strapi-helper-plugin && npm link strapi-utils`, {
     silent
   });
 } else {
-  shell.exec(`cd ${path.resolve(appPath, 'admin', 'node_modules', 'strapi-helper-plugin')} && npm install`, {
+  shell.exec(`cd "${path.resolve(appPath, 'admin', 'node_modules', 'strapi-helper-plugin')}" && npm install`, {
     silent
   });
 }
 
 shell.echo('🏗  Building...');
 
-const build = shell.exec(`cd ${path.resolve(appPath, 'admin')} && APP_PATH=${appPath} npm run build`, {
+const build = shell.exec(`cd "${path.resolve(appPath, 'admin')}" && APP_PATH="${appPath}" npm run build`, {
   silent
 });
 
@@ -58,23 +58,23 @@ if (process.env.npm_config_plugins === 'true') {
   shell.ls('* -d', plugins).forEach(function (plugin) {
     shell.echo(`🔸  Plugin - ${_.upperFirst(plugin)}`);
     shell.echo('📦  Installing packages...');
-    shell.exec(`cd ${path.resolve(plugins, plugin)} && npm install`, {
+    shell.exec(`cd "${path.resolve(plugins, plugin)}" && npm install`, {
       silent
     });
 
     if (isDevelopmentMode) {
-      shell.exec(`cd ${path.resolve(plugins, plugin)} && npm link strapi-helper-plugin`, {
+      shell.exec(`cd "${path.resolve(plugins, plugin)}" && npm link strapi-helper-plugin`, {
         silent
       });
     } else {
-      shell.exec(`cd ${path.resolve(plugins, plugin, 'node_modules', 'strapi-helper-plugin')} && npm install`, {
+      shell.exec(`cd "${path.resolve(plugins, plugin, 'node_modules', 'strapi-helper-plugin')}" && npm install`, {
         silent
       });
     }
 
     shell.echo('🏗  Building...');
 
-    const build = shell.exec(`cd ${path.resolve(plugins, plugin)} && APP_PATH=${appPath} npm run build`, {
+    const build = shell.exec(`cd "${path.resolve(plugins, plugin)}" && APP_PATH="${appPath}" npm run build`, {
       silent
     });
 

--- a/packages/strapi-bookshelf/lib/utils/connectivity.js
+++ b/packages/strapi-bookshelf/lib/utils/connectivity.js
@@ -18,7 +18,7 @@ module.exports = (scope, success, error) => {
   knex.raw('select 1+1 as result').then(() => {
     logger.info('The app has been connected to the database successfully');
     knex.destroy();
-    execSync(`rm -r ${scope.tmpPath}`);
+    execSync(`rm -r "${scope.tmpPath}"`);
 
     logger.info('Copying the dashboard...');
 

--- a/packages/strapi-mongoose/lib/utils/connectivity.js
+++ b/packages/strapi-mongoose/lib/utils/connectivity.js
@@ -32,7 +32,7 @@ module.exports = (scope, success, error) => {
 
     Mongoose.connection.close();
 
-    execSync(`rm -r ${scope.tmpPath}`);
+    execSync(`rm -r "${scope.tmpPath}"`);
 
     logger.info('Copying the dashboard...');
 

--- a/packages/strapi-redis/lib/utils/connectivity.js
+++ b/packages/strapi-redis/lib/utils/connectivity.js
@@ -26,7 +26,7 @@ module.exports = (scope, success, error) => {
 
     logger.info('The app has been connected to the database successfully!');
 
-    execSync(`rm -r ${scope.tmpPath}`);
+    execSync(`rm -r "${scope.tmpPath}"`);
 
     logger.info('Copying the dashboard...');
 


### PR DESCRIPTION
Now the `npm run build --plugins` works for me in paths with spaces.

Also fix spaces path issues on databases. I'm not sure if something else is missing, because when I try `strapi new myDevelopmentProject --dev` use the `strapi-mongoose` from npm.

Fix #709.