### PR TITLE
Prevent the ctb from breaking 

### DIFF
--- a/packages/strapi-plugin-content-type-builder/admin/src/containers/ModelPage/index.js
+++ b/packages/strapi-plugin-content-type-builder/admin/src/containers/ModelPage/index.js
@@ -26,6 +26,8 @@ import List from 'components/List';
 import NoTableWarning from 'components/NoTableWarning';
 import PluginLeftMenu from 'components/PluginLeftMenu';
 
+import forms from 'containers/Form/forms.json';
+
 import injectSaga from 'utils/injectSaga';
 import injectReducer from 'utils/injectReducer';
 
@@ -45,6 +47,9 @@ import saga from './sagas';
 import reducer from './reducer';
 import selectModelPage from './selectors';
 import styles from './styles.scss';
+
+// Array of attributes that the ctb can handle at the moment
+const availableAttributes = Object.keys(forms.attribute);
 
 /* eslint-disable jsx-a11y/no-static-element-interactions */
 /* eslint-disable react/jsx-wrap-multilines */
@@ -174,8 +179,8 @@ export class ModelPage extends React.Component { // eslint-disable-line react/pr
     const index = findIndex(this.props.modelPage.model.attributes, ['name', attributeName]);
     const attribute = this.props.modelPage.model.attributes[index];
 
-    // Remove enumeration type because it's not supported by this plugin for the moment.
-    if (attribute.params.type === 'enumeration') {
+    // Display a notification if the attribute is not present in the ones that the ctb handles
+    if (!includes(availableAttributes, attribute.params.type)) {
       return strapi.notification.info('content-type-builder.notification.info.enumeration');
     }
     const settingsType = attribute.params.type ? 'baseSettings' : 'defineRelation';
@@ -294,6 +299,7 @@ export class ModelPage extends React.Component { // eslint-disable-line react/pr
         onButtonClick={this.handleClickAddAttribute}
       />;
     const icoType = includes(this.props.match.params.modelName, '&source=') ? '' : 'pencil';
+
     return (
       <div className={styles.modelPage}>
         <div className="container-fluid">


### PR DESCRIPTION
Add a notification if a user tries to edit a field in the content type builder plugin that it cannot currently handle.

For example the enumeration or the array field
