### PR TITLE
(doc) fix collection name in many-to-many example

### DIFF
--- a/docs/3.x.x/en/guides/models.md
+++ b/docs/3.x.x/en/guides/models.md
@@ -271,7 +271,7 @@ A `product` can be related to many `categories`, so a `category` can have many `
 {
   "attributes": {
     "categories": {
-      "collection": "product",
+      "collection": "category",
       "via": "products",
       "dominant": true
     }
@@ -286,7 +286,7 @@ A `product` can be related to many `categories`, so a `category` can have many `
 {
   "attributes": {
     "products": {
-      "collection": "category",
+      "collection": "product",
       "via": "categories"
     }
   }


### PR DESCRIPTION
Not sure if I understand the example correctly, but with the given config it does not work for me.
Shouldn't be the collection names the other way round?

