### PR TITLE
Corrected and added "request.error.*.unknow" translations

### DIFF
--- a/packages/strapi-plugin-settings-manager/admin/src/translations/en.json
+++ b/packages/strapi-plugin-settings-manager/admin/src/translations/en.json
@@ -111,6 +111,7 @@
   "form.language.choose": "Choose a language:",
 
   "request.error.database.exist": "This connection already exists",
+  "request.error.database.unknow": "No such connection",
   "request.error.type.string": "A text is required.",
   "request.error.type.number": "A number is required.",
   "request.error.type.boolean": "A boolean is required.",

--- a/packages/strapi-plugin-settings-manager/admin/src/translations/pl.json
+++ b/packages/strapi-plugin-settings-manager/admin/src/translations/pl.json
@@ -111,6 +111,7 @@
   "form.language.choose": "Nazwa:",
 
   "request.error.database.exist": "Takie połączenie już istnieje",
+  "request.error.database.unknow": "Takie połączenie nie istnieje",
   "request.error.type.string": "Tekst jest wymagany.",
   "request.error.type.number": "Liczba jest wymagana.",
   "request.error.type.boolean": "Typ logiczny jest wymagany.",

--- a/packages/strapi-plugin-settings-manager/controllers/SettingsManager.js
+++ b/packages/strapi-plugin-settings-manager/controllers/SettingsManager.js
@@ -27,7 +27,7 @@ module.exports = {
     const Service = strapi.plugins['settings-manager'].services.settingsmanager;
     const { env } = ctx.params;
 
-    if (!env || _.isEmpty(_.find(Service.getEnvironments(), { name: env }))) return ctx.badRequest(null, [{ messages: [{ id: 'request.error.environment.unknown' }] }]);
+    if (!env || _.isEmpty(_.find(Service.getEnvironments(), { name: env }))) return ctx.badRequest(null, [{ messages: [{ id: 'request.error.environment.unknow' }] }]);
 
     ctx.send({ databases: Service.getDatabases(env) });
   },
@@ -36,7 +36,7 @@ module.exports = {
     const Service = strapi.plugins['settings-manager'].services.settingsmanager;
     const { name, env } = ctx.params;
 
-    if (!env || _.isEmpty(_.find(Service.getEnvironments(), { name: env }))) return ctx.badRequest(null, [{ messages: [{ id: 'request.error.environment.unknown' }] }]);
+    if (!env || _.isEmpty(_.find(Service.getEnvironments(), { name: env }))) return ctx.badRequest(null, [{ messages: [{ id: 'request.error.environment.unknow' }] }]);
     if (!name || _.isEmpty(_.find(Service.getDatabases(env), { name }))) return ctx.badRequest(null, [{ messages: [{ id: 'request.error.database.unknow' }] }]);
 
     const model = Service.databases(name, env);
@@ -57,7 +57,7 @@ module.exports = {
     const Service = strapi.plugins['settings-manager'].services.settingsmanager;
     const { slug, env } = ctx.params;
 
-    if (env && _.isEmpty(_.find(Service.getEnvironments(), { name: env }))) return ctx.badRequest(null, [{ messages: [{ id: 'request.error.environment.unknown' }] }]);
+    if (env && _.isEmpty(_.find(Service.getEnvironments(), { name: env }))) return ctx.badRequest(null, [{ messages: [{ id: 'request.error.environment.unknow' }] }]);
 
     _.has(Service, slug) ? ctx.send(await Service[slug](env)) : ctx.badRequest(null, [{ messages: [{ id: 'request.error.config' }] }]);
   },
@@ -67,7 +67,7 @@ module.exports = {
     const { slug, env } = ctx.params;
     let params = ctx.request.body;
 
-    if (env && _.isEmpty(_.find(Service.getEnvironments(), { name: env }))) return ctx.badRequest(null, [{ messages: [{ id: 'request.error.environment.unknown' }] }]);
+    if (env && _.isEmpty(_.find(Service.getEnvironments(), { name: env }))) return ctx.badRequest(null, [{ messages: [{ id: 'request.error.environment.unknow' }] }]);
 
     let model;
     if (_.has(Service, slug)) {
@@ -153,7 +153,7 @@ module.exports = {
     const { env } = ctx.params;
     let params = ctx.request.body;
 
-    if (!env || _.isEmpty(_.find(Service.getEnvironments(), { name: env }))) return ctx.badRequest(null, [{ messages: [{ id: 'request.error.environment.unknown' }] }]);
+    if (!env || _.isEmpty(_.find(Service.getEnvironments(), { name: env }))) return ctx.badRequest(null, [{ messages: [{ id: 'request.error.environment.unknow' }] }]);
 
     const [name] = _.keys(params.database.connections);
 
@@ -196,7 +196,7 @@ module.exports = {
     const { name, env } = ctx.params;
     let params = ctx.request.body;
 
-    if (!env || _.isEmpty(_.find(Service.getEnvironments(), { name: env }))) return ctx.badRequest(null, [{ messages: [{ id: 'request.error.environment.unknown' }] }]);
+    if (!env || _.isEmpty(_.find(Service.getEnvironments(), { name: env }))) return ctx.badRequest(null, [{ messages: [{ id: 'request.error.environment.unknow' }] }]);
     if (!name || _.isEmpty(_.find(Service.getDatabases(env), { name }))) return ctx.badRequest(null, [{ messages: [{ id: 'request.error.database.unknow' }] }]);
 
     const model = Service.databases(name, env);
@@ -304,7 +304,7 @@ module.exports = {
     const Service = strapi.plugins['settings-manager'].services.settingsmanager;
     const { name, env } = ctx.params;
 
-    if (!env || _.isEmpty(_.find(Service.getEnvironments(), { name: env }))) return ctx.badRequest(null, [{ messages: [{ id: 'request.error.environment.unknown' }] }]);
+    if (!env || _.isEmpty(_.find(Service.getEnvironments(), { name: env }))) return ctx.badRequest(null, [{ messages: [{ id: 'request.error.environment.unknow' }] }]);
     if (!name || _.isEmpty(_.find(Service.getDatabases(env), { name }))) return ctx.badRequest(null, [{ messages: [{ id: 'request.error.database.unknow' }] }]);
 
     const connections = _.clone(strapi.config.environments[env].database.connections);


### PR DESCRIPTION
While browsing through `./plugins/settings-manager/controllers/SettingsManager.js` I've found some issues with translation strings:
1. There was `request.error.environment.unknown` instead of `request.error.environment.unknow` (as in translation files). I corrected it.
2. There were no `request.error.database.unknow` string in translation files. I added lacking string and its translations to EN and PL files. Other files need updating.