### PR TITLE
Center logo

### DIFF
--- a/packages/strapi-admin/admin/src/components/LeftMenuHeader/styles.scss
+++ b/packages/strapi-admin/admin/src/components/LeftMenuHeader/styles.scss
@@ -20,7 +20,7 @@
 
   background-image: url('../../assets/images/logo-strapi.png');
   background-repeat: no-repeat;
-  background-position: 55px 17px;
+  background-position: center center;
   background-size: auto 3rem;
 }
 


### PR DESCRIPTION
`center center` logo background position so that we don't have to use logos with a specific height and width.

