### PR TITLE
#919 FIX: Mongoose POST API should include relations

### DIFF
--- a/packages/strapi-generate-api/templates/mongoose/service.template
+++ b/packages/strapi-generate-api/templates/mongoose/service.template
@@ -48,7 +48,7 @@ module.exports = {
    */
 
   add: async (values) => {
-    const data = await <%= globalID %>.create(_.omit(values, _.keys(_.groupBy(strapi.models.<%= id %>.associations, 'alias'))));
+    const data = await <%= globalID %>.create(values);
     await strapi.hook.mongoose.manageRelations('<%= id %>', _.merge(_.clone(data), { values }));
     return data;
   },


### PR DESCRIPTION
For some reason, relations were omitted from `values` object in previous versions. So I just removed the `lodash` function that filtered `values`. Hope it won't have any negative impact on other issues.