### PR TITLE
Easily use MySQL project in development mode

### DIFF
--- a/packages/strapi-generate-new/json/package.json.js
+++ b/packages/strapi-generate-new/json/package.json.js
@@ -16,6 +16,19 @@ const uuid = require('uuid/v4');
 module.exports = scope => {
   const cliPkg = scope.strapiPackageJSON || {};
 
+  // Let us install additional dependencies on a specific version.
+  // Ex: it allows us to install the right version of knex.
+  const additionalsDependencies = _.isArray(scope.additionalsDependencies) ?
+    scope.additionalsDependencies.reduce((acc, current) => {
+      const pkg = current.split('@');
+      const name = pkg[0];
+      const version = pkg[1] || 'latest';
+
+      acc[name] = name.indexOf('strapi') !== -1 ? getDependencyVersion(cliPkg, 'strapi') : version;
+
+      return acc;
+    }, {}) : {};
+
   // Finally, return the JSON.
   return _.merge(scope.appPackageJSON || {}, {
     'name': scope.name,
@@ -37,12 +50,13 @@ module.exports = scope => {
       'eslint-plugin-import': '^2.2.0',
       'eslint-plugin-react': '^6.8.0'
     },
-    'dependencies': {
+    'dependencies': Object.assign({}, {
       'lodash': '4.x.x',
       'strapi': getDependencyVersion(cliPkg, 'strapi'),
       [scope.client.connector]: getDependencyVersion(cliPkg, 'strapi'),
+    }, additionalsDependencies, {
       [scope.client.module]: scope.client.version
-    },
+    }),
     'author': {
       'name': scope.author || 'A Strapi developer',
       'email': scope.email || '',

--- a/packages/strapi-generate-new/lib/after.js
+++ b/packages/strapi-generate-new/lib/after.js
@@ -35,8 +35,8 @@ module.exports = (scope, cb) => {
 
   const availableDependencies = [];
   const dependencies = _.get(packageJSON, 'dependencies');
-  const strapiDependencies = Object.keys(dependencies).filter(key => key.indexOf('strapi') !== -1 && key.indexOf('strapi-bookshelf') === -1);
-  const othersDependencies = Object.keys(dependencies).filter(key => key.indexOf('strapi') === -1  || key.indexOf('strapi-bookshelf') !== -1);
+  const strapiDependencies = Object.keys(dependencies).filter(key => key.indexOf('strapi') !== -1);
+  const othersDependencies = Object.keys(dependencies).filter(key => key.indexOf('strapi') === -1);
 
   // Verify if the dependencies are available into the global
   _.forEach(strapiDependencies, (key) => {
@@ -56,6 +56,7 @@ module.exports = (scope, cb) => {
   logger.info('Installing dependencies...');
   if (!_.isEmpty(othersDependencies)) {
     npm.install({
+      dir: scope.rootPath,
       dependencies: othersDependencies,
       loglevel: 'silent',
       production: true,

--- a/packages/strapi-generate-new/lib/before.js
+++ b/packages/strapi-generate-new/lib/before.js
@@ -237,7 +237,7 @@ module.exports = (scope, cb) => {
             cmd += ` ${scope.client.module}`;
           }
 
-          if (scope.client.connector === 'strapi-bookshelf') {
+          if (scope.developerMode === true && scope.client.connector === 'strapi-bookshelf') {
             cmd += ` strapi-knex@alpha`;
 
             scope.additionalsDependencies = ['strapi-knex', 'knex'];
@@ -248,7 +248,7 @@ module.exports = (scope, cb) => {
               const lock = require(path.join(`${scope.tmpPath}`,`/node_modules/`,`${scope.client.module}/package.json`));
               scope.client.version = lock.version;
 
-              if (scope.client.connector === 'strapi-bookshelf') {
+              if (scope.developerMode === true && scope.client.connector === 'strapi-bookshelf') {
                 const knexVersion = require(path.join(`${scope.tmpPath}`,`/node_modules/`,`knex/package.json`));
                 scope.additionalsDependencies[1] = `knex@${knexVersion.version || 'latest'}`;
               }

--- a/packages/strapi-generate-new/lib/before.js
+++ b/packages/strapi-generate-new/lib/before.js
@@ -232,14 +232,26 @@ module.exports = (scope, cb) => {
         }),
         new Promise(resolve => {
           let cmd = `npm install --prefix "${scope.tmpPath}" ${scope.client.connector}@alpha`;
+
           if (scope.client.module) {
             cmd += ` ${scope.client.module}`;
+          }
+
+          if (scope.client.connector === 'strapi-bookshelf') {
+            cmd += ` strapi-knex@alpha`;
+
+            scope.additionalsDependencies = ['strapi-knex', 'knex'];
           }
 
           exec(cmd, () => {
             if (scope.client.module) {
               const lock = require(path.join(`${scope.tmpPath}`,`/node_modules/`,`${scope.client.module}/package.json`));
               scope.client.version = lock.version;
+
+              if (scope.client.connector === 'strapi-bookshelf') {
+                const knexVersion = require(path.join(`${scope.tmpPath}`,`/node_modules/`,`knex/package.json`));
+                scope.additionalsDependencies[1] = `knex@${knexVersion.version || 'latest'}`;
+              }
             }
 
             resolve();

--- a/packages/strapi-generate-new/lib/index.js
+++ b/packages/strapi-generate-new/lib/index.js
@@ -68,6 +68,11 @@ module.exports = {
     // Empty public directory.
     'public/uploads': {
       folder: {}
+    },
+
+    // Empty node_modules directory.
+    'node_modules': {
+      folder: {}
     }
   }
 };


### PR DESCRIPTION
This PR fixes some issues in development mode when we're creating a project with a SQL database.

- It auto-installs the right version of `strapi-knex` and `knex` when you're choosing a SQL database.
- It creates the symlinks to the global dependencies if you've setup the monorepo.
- It forces to install the dependency at the root of the project (to avoid the well-know knex issue)
- It installs the exact same version of `knex` than the `bookshelf` dependency.