### PR TITLE
reload grant value into db when add/delete provider

### DIFF
--- a/packages/strapi-plugin-users-permissions/config/functions/bootstrap.js
+++ b/packages/strapi-plugin-users-permissions/config/functions/bootstrap.js
@@ -34,49 +34,52 @@ module.exports = async cb => {
     name: 'users-permissions'
   });
 
-  if (!await pluginStore.get({key: 'grant'})) {
-    const value = {
-      email: {
-        enabled: true,
-        icon: 'envelope'
-      },
-      facebook: {
-        enabled: false,
-        icon: 'facebook-official',
-        key: '',
-        secret: '',
-        callback: '/auth/facebook/callback',
-        scope: ['email']
-      },
-      google: {
-        enabled: false,
-        icon: 'google',
-        key: '',
-        secret: '',
-        callback: '/auth/google/callback',
-        scope: ['email']
-      },
-      github: {
-        enabled: false,
-        icon: 'github',
-        key: '',
-        secret: '',
-        redirect_uri: '/auth/github/callback',
-        scope: [
-          'user',
-          'user:email'
-        ]
-      },
-      twitter: {
-        enabled: false,
-        icon: 'twitter',
-        key: '',
-        secret: '',
-        callback: '/auth/twitter/callback'
-      }
-    };
-
-    await pluginStore.set({key: 'grant', value});
+  const grantValue = {
+    email: {
+      enabled: true,
+      icon: 'envelope'
+    },
+    facebook: {
+      enabled: false,
+      icon: 'facebook-official',
+      key: '',
+      secret: '',
+      callback: '/auth/facebook/callback',
+      scope: ['email']
+    },
+    google: {
+      enabled: false,
+      icon: 'google',
+      key: '',
+      secret: '',
+      callback: '/auth/google/callback',
+      scope: ['email']
+    },
+    github: {
+      enabled: false,
+      icon: 'github',
+      key: '',
+      secret: '',
+      redirect_uri: '/auth/github/callback',
+      scope: [
+        'user',
+        'user:email'
+      ]
+    },
+    twitter: {
+      enabled: false,
+      icon: 'twitter',
+      key: '',
+      secret: '',
+      callback: '/auth/twitter/callback'
+    }
+  };
+  const prevGrantValue = await pluginStore.get({key: 'grant'})
+  // store grant auth config to db
+  // when plugin_users-permissions_grant is not existed in db
+  // or we have added/deleted provider here.
+  if (!prevGrantValue || !_.isEqual(_.keys(prevGrantValue), _.keys(grantValue))) {
+    await pluginStore.set({key: 'grant', value: grantValue});
   }
 
   if (!await pluginStore.get({key: 'email'})) {


### PR DESCRIPTION
the users-permissions plugin will store the `grant auth provider config` into db in bootstrap.js
when the first time we start the server. 
https://github.com/strapi/strapi/blob/6b8f430872b248dcc7510c9a540fbd55c50116f3/packages/strapi-plugin-users-permissions/config/functions/bootstrap.js#L37

after that the grant config (`plugin_users-permissions_grant` in core_store) will not be able changed even if someone want to add one more provider using grant.
The only way he can do is to remove  `core_store.{key: plugin_users-permissions_grant}` record in db manually.

I think we may want to reload the grant config into db, when we change the provider config (here i only handle the situation of adding/removing a provider)

https://github.com/strapi/strapi/issues/891#issuecomment-380404414