### PR TITLE
check if `strapi start` runs inside a strapi project

### DIFF
--- a/packages/strapi/bin/strapi-start.js
+++ b/packages/strapi/bin/strapi-start.js
@@ -27,6 +27,11 @@ const { cli, logger } = require('strapi-utils');
  */
 
 module.exports = function() {
+  // Check that we're in a valid Strapi project.
+  if (!cli.isStrapiApp()) {
+    return logger.error('This command can only be used inside a Strapi project.');
+  }
+  
   try {
     const strapi = function () {
       try {


### PR DESCRIPTION
Added a little check if `strapi start`runs inside a strapi project

Closes #481 