### PR TITLE
Fix beforeCreate lifecycle

### DIFF
--- a/packages/strapi-mongoose/package.json
+++ b/packages/strapi-mongoose/package.json
@@ -16,7 +16,7 @@
   "main": "./lib",
   "dependencies": {
     "lodash": "^4.17.4",
-    "mongoose": "^5.0.15",
+    "mongoose": "^5.0.16",
     "mongoose-float": "^1.0.2",
     "pluralize": "^6.0.0",
     "strapi-utils": "3.0.0-alpha.12"

--- a/packages/strapi-plugin-content-manager/config/queries/bookshelf.js
+++ b/packages/strapi-plugin-content-manager/config/queries/bookshelf.js
@@ -92,9 +92,9 @@ module.exports = {
 
     return module.exports.update.call(this, {
       [this.primaryKey]: entry[this.primaryKey],
-      values: _.merge({
+      values: _.assign({
         id: entry[this.primaryKey]
-      }, params.values)
+      }, params.values, entry)
     });
   },
 

--- a/packages/strapi-plugin-content-manager/config/queries/mongoose.js
+++ b/packages/strapi-plugin-content-manager/config/queries/mongoose.js
@@ -35,7 +35,7 @@ module.exports = {
       return acc;
     }, {});
 
-    const entry = await this.create(values)
+    const request = await this.create(values)
       .catch((err) => {
         const message = err.message.split('index:');
         const field = _.words(_.last(message).split('_')[0]);
@@ -44,11 +44,13 @@ module.exports = {
         throw error;
       });
 
+    const entry = request.toJSON ? request.toJSON() : request;
+
     return module.exports.update.call(this, {
       [this.primaryKey]: entry[this.primaryKey],
-      values: _.merge({
+      values: _.assign({
         id: entry[this.primaryKey]
-      }, params.values)
+      }, params.values, entry)
     });
   },
 


### PR DESCRIPTION
If you set a new value in the lifecycle function, it was always overridden due to the call of the update method to handle relations.