### PR TITLE
Fixes errors in content types with two or more word in the name

### DIFF
--- a/packages/strapi-plugin-content-type-builder/controllers/ContentTypeBuilder.js
+++ b/packages/strapi-plugin-content-type-builder/controllers/ContentTypeBuilder.js
@@ -162,7 +162,7 @@ module.exports = {
   deleteModel: async ctx => {
     const { model } = ctx.params;
 
-    if (!_.get(strapi.models, model)) return ctx.badRequest(null, [{ messages: [{ id: 'request.error.model.unknow' }] }]);
+    if (!_.get(strapi.models, _.toLower(model))) return ctx.badRequest(null, [{ messages: [{ id: 'request.error.model.unknow' }] }]);
 
     strapi.reload.isWatching = false;
 

--- a/packages/strapi-plugin-content-type-builder/services/ContentTypeBuilder.js
+++ b/packages/strapi-plugin-content-type-builder/services/ContentTypeBuilder.js
@@ -203,11 +203,11 @@ module.exports = {
         switch (relation.nature) {
           case 'oneToOne':
           case 'manyToOne':
-            attr.model = relation.target;
+            attr.model = relation.target.toLowerCase();
             break;
           case 'manyToMany':
           case 'oneToMany':
-            attr.collection = relation.target;
+            attr.collection = relation.target.toLowerCase();
             break;
           default:
         }
@@ -255,10 +255,10 @@ module.exports = {
       Object.keys(models).forEach(name => {
         const relationsToDelete = _.get(plugin ? strapi.plugins[plugin].models[name] : strapi.models[name], 'associations', []).filter(association => {
           if (source) {
-            return association[association.type] === model && association.plugin === source;
+            return association[association.type] === _.toLower(model) && association.plugin === source;
           }
 
-          return association[association.type] === model;
+          return association[association.type] === _.toLower(model);
         });
 
         if (!_.isEmpty(relationsToDelete)) {
@@ -326,10 +326,10 @@ module.exports = {
       Object.keys(models).forEach(name => {
         const relationsToCreate = attributes.filter(attribute => {
           if (plugin) {
-            return _.get(attribute, 'params.target') === name && _.get(attribute, 'params.pluginValue') === plugin;
+            return _.toLower(_.get(attribute, 'params.target')) === name && _.get(attribute, 'params.pluginValue') === plugin;
           }
 
-          return _.get(attribute, 'params.target') === name && _.isEmpty(_.get(attribute, 'params.pluginValue', ''));
+          return _.toLower(_.get(attribute, 'params.target')) === name && _.isEmpty(_.get(attribute, 'params.pluginValue', ''));
         });
 
         if (!_.isEmpty(relationsToCreate)) {


### PR DESCRIPTION
You have an error in Content Type Builder plugin. When you have content type named with two ore more words (for example productionCompany),  you cannot add relation and delete this content type. 

I fixed these errors in the code below ;-)

