### PR TITLE
Update Strapi-Bookshelf to properly store long float values

### DIFF
--- a/packages/strapi-bookshelf/lib/index.js
+++ b/packages/strapi-bookshelf/lib/index.js
@@ -353,8 +353,10 @@ module.exports = function(strapi) {
                             type = definition.client === 'pg' ? 'integer' : 'int';
                             break;
                           case 'float':
+                            type = 'double';
+                            break;
                           case 'decimal':
-                            type = attribute.type;
+                            type = 'decimal';
                             break;
                           case 'date':
                           case 'time':

--- a/packages/strapi-bookshelf/lib/index.js
+++ b/packages/strapi-bookshelf/lib/index.js
@@ -353,7 +353,7 @@ module.exports = function(strapi) {
                             type = definition.client === 'pg' ? 'integer' : 'int';
                             break;
                           case 'float':
-                            type = 'double';
+                            type = definition.client === 'pg' ? 'double precision' : 'double';
                             break;
                           case 'decimal':
                             type = 'decimal';


### PR DESCRIPTION
<!-- ⚠️ Your PR title will appear in the changelogs please make it short detailed and understandable for all. -->

<!-- Uncomment the correct contribution type. !-->

My PR is a:
<!-- 💥 Breaking change -->
🐛 Bug fix
<!-- 💅 Enhancement -->
<!-- 🚀 New feature -->

Main update on the:
<!-- Admin -->
<!-- Documentation -->
<!-- Framework -->
Plugin

<!-- Write a short description of what your PR does and link the concerned issues of your update. -->
Update MySQL float data type from `float` to `double` to properly store large float values.