### PR TITLE
Return HTTP 403 (not 401) if user is not allowed to perform an operation

### DIFF
--- a/packages/strapi-plugin-users-permissions/config/policies/permissions.js
+++ b/packages/strapi-plugin-users-permissions/config/policies/permissions.js
@@ -39,7 +39,7 @@ module.exports = async (ctx, next) => {
   }, []);
 
   if (!permission) {
-    ctx.unauthorized();
+    ctx.forbidden();
 
     return ctx.request.graphql = ctx.body;
   }


### PR DESCRIPTION
<!-- ⚠️ Your PR title will appear in the changelogs please make it short detailed and understandable for all. -->

<!-- Uncomment the correct contribution type. !-->

My PR is an 💅 Enhancement

Main update on the: Plugin (strapi-plugin-user-permissions)

HTTP code which is returned when current user does not have enough permissions to perform an operation was changed from 401 (Unauthorized) to 403 (Forbidden) which is more suitable in this case.
<!-- Write a short description of what your PR does and link the concerned issues of your update. -->
