### PR TITLE
Add npm install as last step of migration guide

### DIFF
--- a/docs/3.x.x/en/migration/migration-guide-alpha-10-to-alpha-11.md
+++ b/docs/3.x.x/en/migration/migration-guide-alpha-10-to-alpha-11.md
@@ -43,5 +43,8 @@ Copy the fields and relations you had in your `/plugins/users-permissions/models
 
 Then, delete your old `plugins` folder and replace it by the new one.
 
+## Update the Dependencies
+
+Now let's update the dependencies in your `package.json` we edited earlier. Simply run `npm install`:
 
 That's all, you have now upgraded to Strapi `alpha.11`.


### PR DESCRIPTION
<!-- ⚠️ Your PR title will appear in the changelogs please make it short detailed and understandable for all. -->

<!-- Uncomment the correct contribution type. !-->

My PR is a:
<!-- 💥 Breaking change -->
🐛 Bug fix
<!-- 💅 Enhancement -->
<!-- 🚀 New feature -->

Main update on the:
<!-- Admin -->
Documentation
<!-- Framework -->
<!-- Plugin -->

<!-- Write a short description of what your PR does and link the concerned issues of your update. -->

For me, copying the files from the newly generated strapi environment was not sufficient. When I started the strapi after following the guide, 
I got the following error: 
```
/home/xxx/Dev/Projects/xxx/server/node_modules/mongodb/lib/mongo_client.js:804
          throw err;
          ^

TypeError: Cannot read property 'globalId' of undefined

```
I guess this was the case because strapi-mongoose was not upgraded.  I don't know if I'm blind or did not read the migration guide carefully enough, but for me a `npm install` at the end did the trick and upgraded it.
Maybe this is helpful for you