### PR TITLE
Fixes the updatedAt or updated_at field bug when updating an entry from the admin panel

### DIFF
--- a/packages/strapi-helper-plugin/lib/internals/eslint/.eslintrc.json
+++ b/packages/strapi-helper-plugin/lib/internals/eslint/.eslintrc.json
@@ -93,6 +93,7 @@
     "react/require-default-props": 2,
     "no-undef": 0,
     "react/no-array-index-key": 0,
+    "react/sort-comp": 0,
     "react/jsx-handler-names": [
       2,
       {

--- a/packages/strapi-plugin-content-manager/admin/src/containers/EditPage/saga.js
+++ b/packages/strapi-plugin-content-manager/admin/src/containers/EditPage/saga.js
@@ -41,6 +41,16 @@ function* dataGet(action) {
       call(request, '/content-manager/layout', { method: 'GET', params }),
     ];
     const pluginHeaderTitle = yield call(templateObject, { mainField: action.mainField }, response);
+
+    // Remove the updated_at field so it is updated correctly when using Postgres or MySQL db
+    if (response.updated_at) {
+      delete response.updated_at;
+    }
+
+    // Remove the updatedAt field so it is updated correctly when using MongoDB
+    if (response.updatedAt) {
+      delete response.updatedAt;
+    }
     yield put(getDataSucceeded(action.id, response, pluginHeaderTitle.mainField));
     yield put(getLayoutSucceeded(layout));
   } catch(err) {


### PR DESCRIPTION
My PR is a:
🐛 Bug fix

Main update on the:
Plugin: `content-manager`

In order to make it work properly we need to remove the `updatedAt` or `updated_at` attribute from the data received, so the backend updates it correctly.
