### PR TITLE
Generic localhost address for Dockerized Strapi apps

### DIFF
--- a/packages/strapi-generate-new/files/config/environments/development/server.json
+++ b/packages/strapi-generate-new/files/config/environments/development/server.json
@@ -1,5 +1,5 @@
 {
-  "host": "localhost",
+  "host": "${process.env.HOST || process.env.HOSTNAME || 'localhost'}",
   "port": 1337,
   "autoReload": {
     "enabled": true

--- a/packages/strapi-generate-new/files/config/environments/production/server.json
+++ b/packages/strapi-generate-new/files/config/environments/production/server.json
@@ -1,5 +1,5 @@
 {
-  "host": "localhost",
+  "host": "${process.env.HOST || process.env.HOSTNAME || 'localhost'}",
   "port": "${process.env.PORT || 1337}",
   "autoReload": {
     "enabled": false

--- a/packages/strapi-generate-new/files/config/environments/staging/server.json
+++ b/packages/strapi-generate-new/files/config/environments/staging/server.json
@@ -1,5 +1,5 @@
 {
-  "host": "localhost",
+  "host": "${process.env.HOST || process.env.HOSTNAME || 'localhost'}",
   "port": "${process.env.PORT || 1337}",
   "autoReload": {
     "enabled": false


### PR DESCRIPTION
<!-- ⚠️ Your PR title will appear in the changelogs please make it short detailed and understandable for all. -->

<!-- Uncomment the correct contribution type. !-->

My PR is a:
<!-- 💥 Breaking change -->
<!-- 🐛 Bug fix -->
💅 Enhancement
<!-- 🚀 New feature -->

Main update on the:
<!-- Admin -->
<!-- Documentation -->
Framework
<!-- Plugin -->

<!-- Write a short description of what your PR does and link the concerned issues of your update. -->
This changes allows to run Strapi into a Docker container and expose the app to host via 0.0.0.0:1337 address. We can then access Strapi on host by using http://localhost:1337.