### PR TITLE
feat(graphql): move to GraphQL Playground

### DIFF
--- a/docs/3.x.x/en/guides/graphql.md
+++ b/docs/3.x.x/en/guides/graphql.md
@@ -10,7 +10,7 @@ To get started with GraphQL in your app, please install the plugin first. To do 
 strapi install graphql
 ```
 
-Then, start your app and open your browser at [http://localhost:1337/graphiql](http://localhost:1337/graphiql). You should see the interface (GraphiQL) that will help you to write GraphQL query to explore your data.
+Then, start your app and open your browser at [http://localhost:1337/playground](http://localhost:1337/playground). You should see the interface (GraphQL Playground) that will help you to write GraphQL query to explore your data.
 
 > Install the [ModHeader](https://chrome.google.com/webstore/detail/modheader/idgpnmonknjnojddfkpgkljpfnnfcklj/related) extension to set the `Authorization` header in your request
 

--- a/packages/strapi-plugin-graphql/package.json
+++ b/packages/strapi-plugin-graphql/package.json
@@ -25,6 +25,7 @@
     "apollo-server-koa": "^1.3.3",
     "glob": "^7.1.2",
     "graphql": "^0.13.2",
+    "graphql-playground-middleware-koa": "^1.5.1",
     "graphql-tools": "^2.23.1",
     "graphql-type-json": "^0.2.0",
     "pluralize": "^7.0.0",


### PR DESCRIPTION
My PR is a:
💅 Enhancement

Main update on the: 
Plugin

The pull request is about to move from GraphiQL to [GraphQL Playground](https://github.com/prismagraphql/graphql-playground), which is really the best IDE for using GraphQL