### PR TITLE
Force plugins version equal to strapi version

### DIFF
--- a/packages/strapi-generate-new/lib/after.js
+++ b/packages/strapi-generate-new/lib/after.js
@@ -112,7 +112,7 @@ module.exports = (scope, cb) => {
     // Install each plugin.
     defaultPlugins.forEach(defaultPlugin => {
       try {
-        execSync(`node ${strapiBin} install ${defaultPlugin.name} ${scope.developerMode && defaultPlugin.core ? '--dev' : ''}`);
+        execSync(`node ${strapiBin} install ${defaultPlugin.name}@${packageJSON.version} ${scope.developerMode && defaultPlugin.core ? '--dev' : ''}`);
         logger.info(`The plugin ${defaultPlugin.name} has been successfully installed.`);
       } catch (error) {
         logger.error(`An error occurred during ${defaultPlugin.name} plugin installation.`);

--- a/packages/strapi/bin/strapi-install.js
+++ b/packages/strapi/bin/strapi-install.js
@@ -22,9 +22,19 @@ const { cli, logger } = require('strapi-utils');
 
 module.exports = function (plugin, cliArguments) {
   // Define variables.
+  let pluginVersion = 'alpha';
+  let pluginName = plugin;
   const pluginPrefix = 'strapi-plugin-';
-  const pluginID = `${pluginPrefix}${plugin}`;
-  const pluginPath = `./plugins/${plugin}`;
+  if (plugin.indexOf('@') !== -1) {
+    //version specified
+    const components = plugin.split('@');
+    pluginVersion = components[1];
+    pluginName = components[0];
+  }
+
+  const pluginPrefix = 'strapi-plugin-';
+  const pluginID = `${pluginPrefix}${pluginName}`;
+  const pluginPath = `./plugins/${pluginName}`;
 
   // Check that we're in a valid Strapi project.
   if (!cli.isStrapiApp()) {
@@ -55,7 +65,7 @@ module.exports = function (plugin, cliArguments) {
     logger.debug('Installing the plugin from npm registry.');
 
     // Install the plugin from the npm registry.
-    exec(`npm install ${pluginID}@alpha --ignore-scripts --no-save --prefix ${pluginPath}`, (err) => {
+    exec(`npm install ${pluginID}@${pluginVersion} --ignore-scripts --no-save --prefix ${pluginPath}`, (err) => {
       if (err) {
         logger.error(`An error occurred during plugin installation. \nPlease make sure this plugin is available on npm: https://www.npmjs.com/package/${pluginID}`);
         process.exit(1);


### PR DESCRIPTION
My PR is a:
💅 Enhancement

Main update on the:
Framework

Often the installation of plugins of a different version than the (globally) installed strapi version can leads to problem (I've experimented this with 12.2 version - installed strapi version 12.1.3, in which the plugins stopped working on new projects).
This PR try to solve this by adding the ability to strapi-install to install a specific version (content-manager@3.0.0-alpha...) and by providing this info in the first plugin installation (reading from package.json)

