### PR TITLE
Fix a typo in the error key

### DIFF
--- a/packages/strapi-admin/admin/src/translations/de.json
+++ b/packages/strapi-admin/admin/src/translations/de.json
@@ -130,5 +130,5 @@
     "ResetPasswordToken": "Passwort-Token zurücksetzen",
     "Role": "Rolle",
     "New entry": "Neuer Eintrag",
-    "request.error.model.unknow": "Dieses Schema existiert nicht"
+    "request.error.model.unknown": "Dieses Schema existiert nicht"
   }

--- a/packages/strapi-admin/admin/src/translations/en.json
+++ b/packages/strapi-admin/admin/src/translations/en.json
@@ -156,7 +156,7 @@
   "ResetPasswordToken": "Reset Password Token",
   "Role": "Role",
   "New entry": "New entry",
-  "request.error.model.unknow": "This model doesn't exist",
+  "request.error.model.unknown": "This model doesn't exist",
   "Users": "Users",
   "Analytics": "Analytics"
 }

--- a/packages/strapi-admin/admin/src/translations/fr.json
+++ b/packages/strapi-admin/admin/src/translations/fr.json
@@ -154,5 +154,5 @@
   "ResetPasswordToken": "ResetPasswordToken",
   "Role": "Rôle",
   "New entry": "Nouvelle entrée",
-  "request.error.model.unknow": "Le model n'existe pas"
+  "request.error.model.unknown": "Le model n'existe pas"
 }

--- a/packages/strapi-admin/admin/src/translations/pl.json
+++ b/packages/strapi-admin/admin/src/translations/pl.json
@@ -133,5 +133,5 @@
   "ResetPasswordToken": "Token resetu hasła",
   "Role": "Rola",
   "New entry": "Nowy wpis",
-  "request.error.model.unknow": "Ten model nie istnieje"
+  "request.error.model.unknown": "Ten model nie istnieje"
 }

--- a/packages/strapi-admin/admin/src/translations/ru.json
+++ b/packages/strapi-admin/admin/src/translations/ru.json
@@ -153,7 +153,7 @@
     "ResetPasswordToken": "Сбросить токен пароля",
     "Role": "Роль",
     "New entry": "Новая запись",
-    "request.error.model.unknow": "Модель данных не существует",
+    "request.error.model.unknown": "Модель данных не существует",
     "Users": "Пользователи",
     "Analytics": "Аналитика"
   }

--- a/packages/strapi-admin/admin/src/translations/tr.json
+++ b/packages/strapi-admin/admin/src/translations/tr.json
@@ -156,7 +156,7 @@
   "ResetPasswordToken": "Şifre sıfırlama anahtarı",
   "Role": "Rol",
   "New entry": "Yeni kayıt",
-  "request.error.model.unknow": "Bu model bulunmamaktadır.",
+  "request.error.model.unknown": "Bu model bulunmamaktadır.",
   "Users": "Kullanıcılar",
   "Analytics": "Analizler"
 }

--- a/packages/strapi-admin/admin/src/translations/zh-Hans.json
+++ b/packages/strapi-admin/admin/src/translations/zh-Hans.json
@@ -156,7 +156,7 @@
   "ResetPasswordToken": "密码重置",
   "Role": "角色",
   "New entry": "新入口",
-  "request.error.model.unknow": "这个模型已不存在",
+  "request.error.model.unknown": "这个模型已不存在",
   "Users": "用户",
   "Analytics": "分析"
 }

--- a/packages/strapi-admin/admin/src/translations/zh.json
+++ b/packages/strapi-admin/admin/src/translations/zh.json
@@ -136,5 +136,5 @@
   "ResetPasswordToken": "重設密碼的 Token",
   "Role": "權限",
   "New entry": "新入口",
-  "request.error.model.unknow": "這個資料不存在"
+  "request.error.model.unknown": "這個資料不存在"
 }

--- a/packages/strapi-plugin-content-type-builder/controllers/ContentTypeBuilder.js
+++ b/packages/strapi-plugin-content-type-builder/controllers/ContentTypeBuilder.js
@@ -18,10 +18,10 @@ module.exports = {
 
     model = _.toLower(model);
 
-    if (!source && !_.get(strapi.models, model)) return ctx.badRequest(null, [{ messages: [{ id: 'request.error.model.unknow' }] }]);
+    if (!source && !_.get(strapi.models, model)) return ctx.badRequest(null, [{ messages: [{ id: 'request.error.model.unknown' }] }]);
 
     if (source && !_.get(strapi.plugins, [source, 'models', model])) {
-      return ctx.badRequest(null, [{ messages: [{ id: 'request.error.model.unknow' }] }]);
+      return ctx.badRequest(null, [{ messages: [{ id: 'request.error.model.unknown' }] }]);
     }
 
     ctx.send({ model: Service.getModel(model, source) });
@@ -91,7 +91,7 @@ module.exports = {
     if (!name) return ctx.badRequest(null, [{ messages: [{ id: 'request.error.name.missing' }] }]);
     if (!_.includes(Service.getConnections(), connection)) return ctx.badRequest(null, [{ messages: [{ id: 'request.error.connection.unknow' }] }]);
     if (strapi.models[_.toLower(name)] && name !== model) return ctx.badRequest(null, [{ messages: [{ id: 'request.error.model.exist' }] }]);
-    if (!strapi.models[_.toLower(model)] && plugin && !strapi.plugins[_.toLower(plugin)].models[_.toLower(model)]) return ctx.badRequest(null, [{ messages: [{ id: 'request.error.model.unknow' }] }]);
+    if (!strapi.models[_.toLower(model)] && plugin && !strapi.plugins[_.toLower(plugin)].models[_.toLower(model)]) return ctx.badRequest(null, [{ messages: [{ id: 'request.error.model.unknown' }] }]);
     if (!_.isNaN(parseFloat(name[0]))) return ctx.badRequest(null, [{ messages: [{ id: 'request.error.model.name' }] }]);
     if (plugin && !strapi.plugins[_.toLower(plugin)]) return ctx.badRequest(null, [{ message: [{ id: 'request.error.plugin.name' }] }]);
 
@@ -161,7 +161,7 @@ module.exports = {
   deleteModel: async ctx => {
     const { model } = ctx.params;
 
-    if (!_.get(strapi.models, model)) return ctx.badRequest(null, [{ messages: [{ id: 'request.error.model.unknow' }] }]);
+    if (!_.get(strapi.models, model)) return ctx.badRequest(null, [{ messages: [{ id: 'request.error.model.unknown' }] }]);
 
     strapi.reload.isWatching = false;
 


### PR DESCRIPTION
<!-- ⚠️ Your PR title will appear in the changelogs please make it short detailed and understandable for all. -->

<!-- Uncomment the correct contribution type. !-->

My PR is a:
- 💥 Breaking change?
- 💅 Enhancement

Main update on the:
Admin
<!-- Documentation -->
<!-- Framework -->
<!-- Plugin -->

<!-- Write a short description of what your PR does and link the concerned issues of your update. -->
This PR fixes a typo in one of the error strings.

Unsure if thi will be considered a breaking change, maybe someone is working on translations and will miss this?