### PR TITLE
Fix clean up of duplicate permissions

### DIFF
--- a/packages/strapi-plugin-users-permissions/services/UsersPermissions.js
+++ b/packages/strapi-plugin-users-permissions/services/UsersPermissions.js
@@ -317,10 +317,12 @@ module.exports = {
   initialize: async function (cb) {
     const roles = await strapi.query('role', 'users-permissions').count();
 
-    // It's has been already initialized.
+    // It has already been initialized.
     if (roles > 0) {
-      await this.removeDuplicate();
-      return await this.updatePermissions(cb);
+      return await this.updatePermissions(async () => {
+        await this.removeDuplicate();
+        cb();
+      });
     }
 
     // Create two first default roles.


### PR DESCRIPTION
## 🐛 Bug fix

## Main update on the:
Plugin

## Description
We had issues with getting duplicate permissions when deployed on Heroku. It seems this logic was in the wrong order.

To reproduce the bug:

- Deploy a new project to Heroku (free dyno, really slow)
- Let it populate permissions
- Restart dyno
- You now have duplicate permissions