### PR TITLE
Change names for timestamp fields in GraphQL plugin

### DIFF
--- a/packages/strapi-plugin-graphql/services/GraphQL.js
+++ b/packages/strapi-plugin-graphql/services/GraphQL.js
@@ -407,15 +407,15 @@ module.exports = {
       // Add timestamps attributes.
       if (_.get(model, 'options.timestamps') === true) {
         Object.assign(initialState, {
-          created_at: 'String',
-          updated_at: 'String'
+          createdAt: 'String',
+          updatedAt: 'String'
         });
 
         Object.assign(acc.resolver[globalId], {
-          created_at: (obj, options, context) => { // eslint-disable-line no-unused-vars
+          createdAt: (obj, options, context) => { // eslint-disable-line no-unused-vars
             return obj.createdAt || obj.created_at;
           },
-          updated_at: (obj, options, context) => { // eslint-disable-line no-unused-vars
+          updatedAt: (obj, options, context) => { // eslint-disable-line no-unused-vars
             return obj.updatedAt || obj.updated_at;
           }
         });


### PR DESCRIPTION
My PR is a:
💥 Breaking change

Main update on the:
Plugin

To respect the openCRUD after talking with @Aurelsicoko, I update the fields about timestamp to follow the camel case logic for the naming of fields.

FYI: I indicate this PR as a `breaking change` because it will generate errors for people already using GraphQL if they don't update their requests.