### PR TITLE
Add `!` flag for GraphQL and non-nullable field

### DIFF
--- a/packages/strapi-plugin-graphql/services/GraphQL.js
+++ b/packages/strapi-plugin-graphql/services/GraphQL.js
@@ -135,19 +135,29 @@ module.exports = {
   convertType: (definition = {}) => {
     // Type.
     if (definition.type) {
+      let type = 'String';
+
       switch (definition.type) {
         case 'string':
         case 'text':
-          return 'String';
+          type = 'String';
+          break;
         case 'boolean':
-          return 'Boolean';
+          type = 'Boolean';
+          break;
         case 'integer':
-          return 'Int';
+          type = 'Int';
+          break;
         case 'float':
-          return 'Float';
-        default:
-          return 'String';
+          type = 'Float';
+          break;
       }
+
+      if (definition.required) {
+        type += '!';
+      }
+
+      return type;
     }
 
     const ref = definition.model || definition.collection;
@@ -394,7 +404,7 @@ module.exports = {
       // Setup initial state with default attribute that should be displayed
       // but these attributes are not properly defined in the models.
       const initialState = {
-        [model.primaryKey]: 'String'
+        [model.primaryKey]: 'String!'
       };
 
       const globalId = model.globalId;
@@ -407,8 +417,8 @@ module.exports = {
       // Add timestamps attributes.
       if (_.get(model, 'options.timestamps') === true) {
         Object.assign(initialState, {
-          createdAt: 'String',
-          updatedAt: 'String'
+          createdAt: 'String!',
+          updatedAt: 'String!'
         });
 
         Object.assign(acc.resolver[globalId], {


### PR DESCRIPTION
My PR is a:
💅 Enhancement

Main update on the:
Plugin

In order to follow the GraphQL spec, this PR add the flag `!` for a type when the field must be a non-nullable (because it's required).
