### PR TITLE
Add count route on generated API

### DIFF
--- a/packages/strapi-generate-api/json/routes.json.js
+++ b/packages/strapi-generate-api/json/routes.json.js
@@ -34,6 +34,13 @@ module.exports = scope => {
           policies: []
         }
       }, {
+        method: 'GET',
+        path: '/' + scope.humanizeId + '/count',
+        handler: scope.globalID + '.count',
+        config: {
+          policies: []
+        }
+      }, {
         method: 'POST',
         path: '/' + scope.humanizeId,
         handler: scope.globalID + '.create',

--- a/packages/strapi-generate-api/templates/mongoose/controller.template
+++ b/packages/strapi-generate-api/templates/mongoose/controller.template
@@ -33,6 +33,16 @@ module.exports = {
   },
 
   /**
+   * Count <%= id %> records.
+   *
+   * @return {Number}
+   */
+
+  count: async (ctx) => {
+    return strapi.services.<%= id %>.count(ctx.query);
+  },
+
+  /**
    * Create a/an <%= id %> record.
    *
    * @return {Object}

--- a/packages/strapi-generate-api/templates/mongoose/service.template
+++ b/packages/strapi-generate-api/templates/mongoose/service.template
@@ -54,6 +54,21 @@ module.exports = {
   },
 
   /**
+   * Promise to count <%= humanizeIdPluralized %>.
+   *
+   * @return {Promise}
+   */
+
+  count: (params) => {
+    // Convert `params` object to filters compatible with Mongo.
+    const filters = strapi.utils.models.convertParams('<%= globalID.toLowerCase() %>', params);
+
+    return <%= globalID %>
+      .count()
+      .where(filters.where);
+  },
+
+  /**
    * Promise to add a/an <%= id %>.
    *
    * @return {Promise}


### PR DESCRIPTION
My PR is a: 💅 Enhancement

Main update on the:
strapi-generate-api 

This PR is to add document count to mongoose templates