### PR TITLE
Fix toJSON verification inside bookshelf for content-manager

### DIFF
--- a/packages/strapi-plugin-content-manager/config/queries/bookshelf.js
+++ b/packages/strapi-plugin-content-manager/config/queries/bookshelf.js
@@ -44,7 +44,7 @@ module.exports = {
         withRelated: populate || this.associations.map(x => x.alias)
       });
 
-    const data = record ? record.toJSON() : record;
+    const data = record.toJSON ? record.toJSON() : record;
 
     // Retrieve data manually.
     if (_.isEmpty(populate)) {


### PR DESCRIPTION
My PR is a:
🐛 Bug fix

Main update on the:
Plugin

Little fix to change the verification of the data with `toJSON` (as it makes with the `create` function)