### PR TITLE
Fix "npm run strapi"

### DIFF
--- a/packages/strapi-generate-new/json/package.json.js
+++ b/packages/strapi-generate-new/json/package.json.js
@@ -39,7 +39,7 @@ module.exports = scope => {
     'scripts': {
       'setup': 'cd admin && npm run setup', // Ready to deploy setup
       'start': 'node server.js',
-      'strapi': 'node_modules/strapi/bin/strapi.js', // Allow to use `npm run strapi` CLI,
+      'strapi': 'node node_modules/strapi/bin/strapi.js start', // Allow to use `npm run strapi` CLI,
       'lint': 'node_modules/.bin/eslint api/**/*.js config/**/*.js plugins/**/*.js',
       'postinstall': 'node node_modules/strapi/lib/utils/post-install.js'
     },


### PR DESCRIPTION
My PR is a:
<!-- 💥 Breaking change -->
🐛 Bug fix
<!-- 💅 Enhancement -->
<!-- 🚀 New feature -->

Main update on the:
<!-- Admin -->
<!-- Documentation -->
Framework
<!-- Plugin -->

<!-- Write a short description of what your PR does and link the concerned issues of your update. -->
Fix `npm run strapi` to run strapi via node_modules.