### PR TITLE
Specify MongoDB >= 2.6

### DIFF
--- a/docs/3.x.x/en/getting-started/installation.md
+++ b/docs/3.x.x/en/getting-started/installation.md
@@ -6,7 +6,7 @@ Installation is very easy and only takes a few seconds.
 
 Please make sure your computer/server meets the following requirements:
  - [Node.js](https://nodejs.org) >= 9: Node.js is a server platform which runs JavaScript. Installation guide [here](https://nodejs.org/en/download/).
- - [MongoDB](https://www.mongodb.com/): MongoDB is a powerful document store. Installation guide [here](https://www.mongodb.com/download-center?j#community).
+ - [MongoDB](https://www.mongodb.com/) >= 2.6: MongoDB is a powerful document store. Installation guide [here](https://www.mongodb.com/download-center?j#community).
 
 ## Setup
 


### PR DESCRIPTION
Need to use MongoDB >= 2.6 otherwise get wire version errors on start:
```
UnhandledPromiseRejectionWarning: MongoError: Server at 127.0.0.1:27017 reports wire version 0, but this version of Node.js Driver requires at least 2 (MongoDB2.6).
```

<!-- ⚠️ Your PR title will appear in the changelogs please make it short detailed and understandable for all. -->

<!-- Uncomment the correct contribution type. !-->

My PR is a:
<!-- 💥 Breaking change -->
<!-- 🐛 Bug fix -->
 💅 Enhancement
<!-- 🚀 New feature -->

Main update on the:
<!-- Admin -->
Documentation
<!-- Framework -->
<!-- Plugin -->

Older versions of MongoDB (installed by default on many versions of Debian, Ubuntu, etc.) may cause Strapi to crash mysteriously on start.