### PR TITLE
Fix content-manager build

### DIFF
--- a/packages/strapi-plugin-content-manager/admin/src/containers/ListPage/index.js
+++ b/packages/strapi-plugin-content-manager/admin/src/containers/ListPage/index.js
@@ -20,7 +20,7 @@ import { makeSelectModels, makeSelectSchema } from 'containers/App/selectors';
 // or strapi/packages/strapi-helper-plugin/lib/src
 import PageFooter from 'components/PageFooter';
 import PluginHeader from 'components/PluginHeader';
-import PopUpWarning from 'components/PopUpWarning/Loadable';
+import PopUpWarning from 'components/PopUpWarning';
 
 // Components from the plugin itself
 import AddFilterCTA from 'components/AddFilterCTA';

--- a/packages/strapi-plugin-graphql/services/GraphQL.js
+++ b/packages/strapi-plugin-graphql/services/GraphQL.js
@@ -624,7 +624,6 @@ module.exports = {
                   break;
                   // falls through
                 }
-                  break;
                 default:
                   // Where.
                   queryOpts.query = strapi.utils.models.convertParams(name, {


### PR DESCRIPTION
My PR is a:
🐛 Bug fix

Main update on the:
Plugin

Remove Loadable import with `PopUpWarning` components that always keeps the `loading` state instead of being mounted.

FYI: it's the reason why we could see `Loading...` after the table in the list view of the `content-manager` plugin.
