### PR TITLE
Fix delete relations manyToMany mongoose

### DIFF
--- a/packages/strapi-mongoose/lib/relations.js
+++ b/packages/strapi-mongoose/lib/relations.js
@@ -135,8 +135,8 @@ module.exports = {
               toRemove.forEach(value => {
                 value = _.isString(value) ? { [this.primaryKey]: value } : value;
 
-                if (association.nature === 'manyToMany' && !_.isArray(params.values[this.primaryKey]) || params[this.primaryKey]) {
-                  value[details.via] = value[details.via].filter(x => x.toString() !== params.values[this.primaryKey].toString());
+                if (association.nature === 'manyToMany' && !_.isArray(params.values[this.primaryKey] || params[this.primaryKey])) {
+                  value[details.via] = value[details.via].filter(x => _.toString(x) !== _.toString(params.values[this.primaryKey] || params[this.primaryKey]));
                 } else {
                   value[details.via] = null;
                 }

--- a/packages/strapi-plugin-content-manager/services/ContentManager.js
+++ b/packages/strapi-plugin-content-manager/services/ContentManager.js
@@ -131,10 +131,13 @@ module.exports = {
   },
 
   delete: async (params, { source }) => {
-    const response = await strapi.query(params.model, source).findOne({
+    const query = strapi.query(params.model, source);
+    const primaryKey = query.primaryKey;
+    const response = await query.findOne({
       id: params.id
     });
 
+    params[primaryKey] = response[primaryKey];
     params.values = Object.keys(JSON.parse(JSON.stringify(response))).reduce((acc, current) => {
       const association = (strapi.models[params.model] || strapi.plugins[source].models[params.model]).associations.filter(x => x.alias === current)[0];
 

--- a/packages/strapi-plugin-graphql/services/GraphQL.js
+++ b/packages/strapi-plugin-graphql/services/GraphQL.js
@@ -624,7 +624,6 @@ module.exports = {
                   break;
                   // falls through
                 }
-                  break;
                 default:
                   // Where.
                   queryOpts.query = strapi.utils.models.convertParams(name, {

--- a/packages/strapi/lib/Strapi.js
+++ b/packages/strapi/lib/Strapi.js
@@ -383,6 +383,7 @@ class Strapi extends EventEmitter {
       {
         orm: connector,
         primaryKey: Model.primaryKey,
+        associations: Model.associations
       },
     );
 


### PR DESCRIPTION
<!-- ⚠️ Your PR title will appear in the changelogs please make it short detailed and understandable for all. -->

<!-- Uncomment the correct contribution type. !-->

My PR is a:  🐛 Bug fix
<!-- 💅 Enhancement -->
<!-- 🚀 New feature -->

Main update on the:  Framework
<!-- Plugin -->

When deleting entry that have a manyToMany relation, the reference was not deleted in the other entry.
<!-- Write a short description of what your PR does and link the concerned issues of your update. -->
