### PR TITLE
Fix delete info.mainFied in content type builder

### DIFF
--- a/packages/strapi-plugin-content-type-builder/controllers/ContentTypeBuilder.js
+++ b/packages/strapi-plugin-content-type-builder/controllers/ContentTypeBuilder.js
@@ -86,7 +86,7 @@ module.exports = {
 
   updateModel: async ctx => {
     const { model } = ctx.params;
-    const { name, description, connection, collectionName, attributes = [], plugin } = ctx.request.body;
+    const { name, description, mainField, connection, collectionName, attributes = [], plugin } = ctx.request.body;
 
     if (!name) return ctx.badRequest(null, [{ messages: [{ id: 'request.error.name.missing' }] }]);
     if (!_.includes(Service.getConnections(), connection)) return ctx.badRequest(null, [{ messages: [{ id: 'request.error.connection.unknow' }] }]);
@@ -121,6 +121,10 @@ module.exports = {
         description
       };
       modelJSON.attributes = formatedAttributes;
+
+      if (mainField) {
+        modelJSON.info.mainField = mainField;
+      }
 
       const clearRelationsErrors = Service.clearRelations(model, plugin);
 

--- a/packages/strapi-plugin-content-type-builder/services/ContentTypeBuilder.js
+++ b/packages/strapi-plugin-content-type-builder/services/ContentTypeBuilder.js
@@ -105,6 +105,7 @@ module.exports = {
     return {
       name: _.get(model, 'info.name', 'model.name.missing'),
       description: _.get(model, 'info.description', 'model.description.missing'),
+      mainField: _.get(model, 'info.mainField', ''),
       connection: model.connection,
       collectionName: model.collectionName,
       attributes: attributes


### PR DESCRIPTION
<!-- ⚠️ Your PR title will appear in the changelogs please make it short detailed and understandable for all. -->

<!-- Uncomment the correct contribution type. !-->

My PR is a:  🐛 Bug fix
<!-- 💅 Enhancement -->
<!-- 🚀 New feature -->

Main update on the:  Plugin

Fix loose info.mainField when update content type via content-type-builder
<!-- Write a short description of what your PR does and link the concerned issues of your update. -->

Related issue: #1301