### PR TITLE
Fix admin start

### DIFF
--- a/packages/strapi-helper-plugin/lib/internals/scripts/loadAdminConfigurations.js
+++ b/packages/strapi-helper-plugin/lib/internals/scripts/loadAdminConfigurations.js
@@ -19,6 +19,9 @@ if (!isSetup) {
     await strapi.load({
       environment: process.env.NODE_ENV,
     });
+
+    // Force exit process if an other process doen't exit during Strapi load.
+    process.exit();
   })();
 }
- 
+


### PR DESCRIPTION
<!-- ⚠️ Your PR title will appear in the changelogs please make it short detailed and understandable for all. -->

<!-- Uncomment the correct contribution type. !-->

My PR is a:  🐛 Bug fix
<!-- 💅 Enhancement -->
<!-- 🚀 New feature -->

Main update on the:  Admin
<!-- Documentation -->
<!-- Framework -->
<!-- Plugin -->

During `strapi.load` we load middlewares and hooks, they can start process witch need app kill to end. (like watcher and other things) So when the `load` function is complete I force the end of the script.

<!-- Write a short description of what your PR does and link the concerned issues of your update. -->
