### PR TITLE
Add option to enable GraphQL playground anywhere

### DIFF
--- a/packages/strapi-plugin-graphql/config/settings.json
+++ b/packages/strapi-plugin-graphql/config/settings.json
@@ -1,5 +1,6 @@
 {
   "endpoint": "/graphql",
   "shadowCRUD": true,
+  "playgroundAlways": false,
   "depthLimit": 7
 }

--- a/packages/strapi-plugin-graphql/hooks/graphql/index.js
+++ b/packages/strapi-plugin-graphql/hooks/graphql/index.js
@@ -123,7 +123,7 @@ module.exports = strapi => {
       })(ctx, next));
 
       // Disable GraphQL Playground in production environment.
-      if (strapi.config.environment !== 'production') {
+      if (strapi.config.environment !== 'production' || strapi.plugins.graphql.config.playgroundAlways) {
         router.get('/playground', koaPlayground({ endpoint: strapi.plugins.graphql.config.endpoint}));
       }
 


### PR DESCRIPTION
My PR is a:
🚀 New feature

Main update on the:
Plugin

Fix for #1392 
It add an option `playgroundAlways` to force the availability of the GraphQL Playground IDE, whatever the environment.