### PR TITLE
Fix ssl interpretation for Mongo connection

### DIFF
--- a/packages/strapi-mongoose/lib/index.js
+++ b/packages/strapi-mongoose/lib/index.js
@@ -69,9 +69,9 @@ module.exports = function (strapi) {
           connectOptions.authSource = authenticationDatabase;
         }
 
-        connectOptions.ssl = Boolean(ssl);
+        connectOptions.ssl = ssl === true || ssl === 'true';
 
-        options.debug = Boolean(debug);
+        options.debug = debug === true || debug === 'true';
 
         instance.connect(uri || `mongodb://${host}:${port}/${database}`, connectOptions);
 


### PR DESCRIPTION
<!-- ⚠️ Your PR title will appear in the changelogs please make it short detailed and understandable for all. -->

<!-- Uncomment the correct contribution type. !-->

My PR is a:
<!-- 💥 Breaking change -->
🐛 Bug fix
<!-- 💅 Enhancement -->
<!-- 🚀 New feature -->

Main update on the:
<!-- Admin -->
<!-- Documentation -->
Framework
<!-- Plugin -->

<!-- Write a short description of what your PR does and link the concerned issues of your update. -->
This PR fixes the SSL connection which is set as true whereas it shouldn't if the `DATABASE_SSL` environment variable is not set in production.