### PR TITLE
Allow filter on a relation attribute

### DIFF
--- a/docs/3.x.x/en/guides/filters.md
+++ b/docs/3.x.x/en/guides/filters.md
@@ -48,6 +48,7 @@ Find posts written by a user having more than 12 years old.
 `GET /post?author.age_gt=12`
 
 > Note: You can't use filter to have specific results inside relation, like "Find users and only their posts older than yesterday" as example. If you need it, you can modify or create your own service ou use [GraphQL](./graphql.md#query-api).
+> <br>Warning: this filter isn't available for `upload` plugin
 
 ### Sort
 

--- a/docs/3.x.x/en/guides/filters.md
+++ b/docs/3.x.x/en/guides/filters.md
@@ -35,6 +35,20 @@ Find products having a price equal or greater than `3`.
 
 `GET /product?price_gte=3`
 
+#### Relations
+
+You can also use filters into a relation attribute which will be applied to the first level of the request.
+
+Find users having written a post named `Title`.
+
+`GET /user?posts.name=Title`
+
+Find posts written by a user having more than 12 years old.
+
+`GET /post?author.age_gt=12`
+
+> Note: You can't use filter to have specific results inside relation, like "Find users and only their posts older than yesterday" as example. If you need it, you can modify or create your own service ou use [GraphQL](./graphql.md#query-api).
+
 ### Sort
 
 Sort according to a specific field.

--- a/packages/strapi-bookshelf/lib/index.js
+++ b/packages/strapi-bookshelf/lib/index.js
@@ -406,7 +406,7 @@ module.exports = function(strapi) {
                         switch (connection.settings.client) {
                           case 'pg':
                             // Enable extension to allow GIN indexes.
-                            await ORM.knex.raw(`CREATE EXTENSION IF NOT EXISTS pg_trgm`);
+                            await ORM.knex.raw('CREATE EXTENSION IF NOT EXISTS pg_trgm');
 
                             // Create GIN indexes for every column.
                             const indexes = columns
@@ -437,7 +437,7 @@ module.exports = function(strapi) {
                             console.log(e);
                           }
 
-                          strapi.log.warn(`The SQL database indexes haven't been generated successfully. Please enable the debug mode for more details.`);
+                          strapi.log.warn('The SQL database indexes haven\'t been generated successfully. Please enable the debug mode for more details.');
                         }
                       }
                     };
@@ -946,21 +946,6 @@ module.exports = function(strapi) {
             value
           };
           break;
-        case '_sort':
-          result.key = `sort`;
-          result.value = {
-            key,
-            order: value.toUpperCase()
-          };
-          break;
-        case '_start':
-          result.key = `start`;
-          result.value = parseFloat(value);
-          break;
-        case '_limit':
-          result.key = `limit`;
-          result.value = parseFloat(value);
-          break;
         case '_contains':
         case '_containss':
           result.key = `where.${key}`;
@@ -975,6 +960,21 @@ module.exports = function(strapi) {
             symbol: 'IN',
             value,
           };
+          break;
+        case '_sort':
+          result.key = 'sort';
+          result.value = {
+            key,
+            order: value.toUpperCase()
+          };
+          break;
+        case '_start':
+          result.key = 'start';
+          result.value = parseFloat(value);
+          break;
+        case '_limit':
+          result.key = 'limit';
+          result.value = parseFloat(value);
           break;
         default:
           return undefined;

--- a/packages/strapi-bookshelf/lib/index.js
+++ b/packages/strapi-bookshelf/lib/index.js
@@ -569,25 +569,12 @@ module.exports = function(strapi) {
                       }
                     };
 
-                    const table = _.get(manyRelations, 'collectionName') ||
-                      _.map(
-                        _.sortBy(
-                          [
-                            collection.attributes[
-                              manyRelations.via
-                            ],
-                            manyRelations
-                          ],
-                          'collection'
-                        ),
-                        table => {
-                          return _.snakeCase(
-                            pluralize.plural(table.collection) +
-                              ' ' +
-                              pluralize.plural(table.via)
-                          );
-                        }
-                      ).join('__');
+                    const table =
+                      _.get(manyRelations, 'collectionName') ||
+                      utilsModels.getCollectionName(
+                        collection.attributes[manyRelations.via],
+                        manyRelations,
+                      );
 
                     await handler(table, attributes);
                   }
@@ -706,25 +693,12 @@ module.exports = function(strapi) {
                     strapi.plugins[details.plugin].models[details.collection]:
                     strapi.models[details.collection];
 
-                  const collectionName = _.get(details, 'collectionName') ||
-                    _.map(
-                      _.sortBy(
-                        [
-                          collection.attributes[
-                            details.via
-                          ],
-                          details
-                        ],
-                        'collection'
-                      ),
-                      table => {
-                        return _.snakeCase(
-                          pluralize.plural(table.collection) +
-                            ' ' +
-                            pluralize.plural(table.via)
-                        );
-                      }
-                    ).join('__');
+                  const collectionName =
+                    _.get(details, 'collectionName') ||
+                    utilsModels.getCollectionName(
+                      collection.attributes[details.via],
+                      details,
+                    );
 
                   const relationship = _.clone(
                     collection.attributes[details.via]

--- a/packages/strapi-generate-api/templates/bookshelf/service.template
+++ b/packages/strapi-generate-api/templates/bookshelf/service.template
@@ -1,4 +1,5 @@
 'use strict';
+/* global <%= globalID %>*/
 
 /**
  * <%= filename %> service

--- a/packages/strapi-generate-api/templates/bookshelf/service.template
+++ b/packages/strapi-generate-api/templates/bookshelf/service.template
@@ -43,6 +43,43 @@ module.exports = {
         qb.orderBy(filters.sort.key, filters.sort.order);
       }
 
+      Object.keys(filters.relations).forEach(
+        (relationName) => {
+          const ast = <%= globalID %>.associations.find(a => a.alias === relationName);
+          if (ast) {
+            const relation = filters.relations[relationName];
+
+            qb.distinct();
+
+            if (ast.tableCollectionName) {
+              qb.innerJoin(
+                ast.tableCollectionName,
+                `${ast.tableCollectionName}.${<%= globalID %>.info.name}_${<%= globalID %>.primaryKey}`,
+                `${<%= globalID %>.collectionName}.${<%= globalID %>.primaryKey}`,
+              );
+              qb.innerJoin(
+                `${relationName}`,
+                `${relationName}.${<%= globalID %>.attributes[relationName].column}`,
+                `${ast.tableCollectionName}.${<%= globalID %>.attributes[relationName].attribute}_${<%= globalID %>.attributes[relationName].column}`,
+              );
+            } else {
+              if (ast.type === 'collection') {
+                qb.innerJoin(`${relationName}`, `${relationName}.${ast.via}`, `${<%= globalID %>.collectionName}.${<%= globalID %>.primaryKey}`);
+              } else if (ast.type === 'model') {
+                const model = strapi.models[ast.model];
+                qb.innerJoin(`${model.collectionName}`, `${model.collectionName}.${model.primaryKey}`, `${<%= globalID %>.collectionName}.${<%= globalID %>.primaryKey}`);
+              }
+            }
+
+            Object.keys(relation).forEach(
+              (filter) => {
+                qb.where(`${relationName}.${filter}`, `${relation[filter].symbol}`, `${relation[filter].value}`);
+              }
+            );
+          }
+        }
+      );
+
       qb.offset(filters.start);
       qb.limit(filters.limit);
     }).fetchAll({

--- a/packages/strapi-generate-api/templates/bookshelf/service.template
+++ b/packages/strapi-generate-api/templates/bookshelf/service.template
@@ -46,35 +46,40 @@ module.exports = {
 
       Object.keys(filters.relations).forEach(
         (relationName) => {
-          const ast = <%= globalID %>.associations.find(a => a.alias === relationName);
+          const ast = <%= globalID.toLowerCase() %>.associations.find(a => a.alias === relationName);
           if (ast) {
-            const relation = filters.relations[relationName];
+            const model = ast.plugin ?
+              strapi.plugins[ast.plugin].models[ast.model ? ast.model : ast.collection] :
+              strapi.models[ast.model ? ast.model : ast.collection];
 
             qb.distinct();
 
             if (ast.tableCollectionName) {
               qb.innerJoin(
                 ast.tableCollectionName,
-                `${ast.tableCollectionName}.${<%= globalID %>.info.name}_${<%= globalID %>.primaryKey}`,
-                `${<%= globalID %>.collectionName}.${<%= globalID %>.primaryKey}`,
+                `${ast.tableCollectionName}.${<%= globalID.toLowerCase() %>.info.name}_${<%= globalID.toLowerCase() %>.primaryKey}`,
+                `${<%= globalID.toLowerCase() %>.collectionName}.${<%= globalID.toLowerCase() %>.primaryKey}`,
               );
               qb.innerJoin(
                 `${relationName}`,
-                `${relationName}.${<%= globalID %>.attributes[relationName].column}`,
-                `${ast.tableCollectionName}.${<%= globalID %>.attributes[relationName].attribute}_${<%= globalID %>.attributes[relationName].column}`,
+                `${relationName}.${<%= globalID.toLowerCase() %>.attributes[relationName].column}`,
+                `${ast.tableCollectionName}.${<%= globalID.toLowerCase() %>.attributes[relationName].attribute}_${<%= globalID.toLowerCase() %>.attributes[relationName].column}`,
               );
             } else {
-              if (ast.type === 'collection') {
-                qb.innerJoin(`${relationName}`, `${relationName}.${ast.via}`, `${<%= globalID %>.collectionName}.${<%= globalID %>.primaryKey}`);
-              } else if (ast.type === 'model') {
-                const model = strapi.models[ast.model];
-                qb.innerJoin(`${model.collectionName}`, `${model.collectionName}.${model.primaryKey}`, `${<%= globalID %>.collectionName}.${<%= globalID %>.primaryKey}`);
-              }
+              const relationTable = model.collectionName;
+              const externalKey = ast.type === 'collection' ?
+                `${model.collectionName}.${ast.via}` :
+                `${model.collectionName}.${model.primaryKey}`;
+              const internalKey = !ast.dominant ? `${<%= globalID.toLowerCase() %>.collectionName}.${<%= globalID.toLowerCase() %>.primaryKey}` :
+                ast.via === <%= globalID.toLowerCase() %>.collectionName ? `${<%= globalID.toLowerCase() %>.collectionName}.${ast.alias}` : `${<%= globalID.toLowerCase() %>.collectionName}.${<%= globalID.toLowerCase() %>.primaryKey}`;
+
+              qb.innerJoin(relationTable, externalKey, internalKey);
             }
 
+            const relation = filters.relations[relationName];
             Object.keys(relation).forEach(
               (filter) => {
-                qb.where(`${relationName}.${filter}`, `${relation[filter].symbol}`, `${relation[filter].value}`);
+                qb.where(`${model.collectionName}.${filter}`, `${relation[filter].symbol}`, `${relation[filter].value}`);
               }
             );
           }

--- a/packages/strapi-generate-api/templates/bookshelf/service.template
+++ b/packages/strapi-generate-api/templates/bookshelf/service.template
@@ -33,7 +33,7 @@ module.exports = {
       _.forEach(filters.where, (where, key) => {
         if (_.isArray(where.value)) {
           for (const value in where.value) {
-            qb[value ? 'where' : 'orWhere'](key, where.symbol, where.value[value])
+            qb[value ? 'where' : 'orWhere'](key, where.symbol, where.value[value]);
           }
         } else {
           qb.where(key, where.symbol, where.value);
@@ -124,7 +124,7 @@ module.exports = {
       _.forEach(filters.where, (where, key) => {
         if (_.isArray(where.value)) {
           for (const value in where.value) {
-            qb[value ? 'where' : 'orWhere'](key, where.symbol, where.value[value])
+            qb[value ? 'where' : 'orWhere'](key, where.symbol, where.value[value]);
           }
         } else {
           qb.where(key, where.symbol, where.value);

--- a/packages/strapi-generate-api/templates/mongoose/service.template
+++ b/packages/strapi-generate-api/templates/mongoose/service.template
@@ -34,6 +34,7 @@ module.exports = {
             (ast.via === <%= globalID %>.collectionName ? ast.via : '_id') :
             (ast.via === <%= globalID %>.collectionName ? '_id' : ast.via);
 
+        // Add the juncture like the `.populate()` function
         acc.push({
           $lookup: {
             from,
@@ -43,11 +44,8 @@ module.exports = {
           }
         });
 
-        if (ast.type === 'collection' && ast.dominant) {
-          acc.push({
-            $replaceRoot: { newRoot: { $mergeObjects: [{ $arrayElemAt: [`$${ast.alias}`, 0] }, '$$ROOT'] } },
-          });
-        } else if (ast.type === 'model') {
+        // Unwind the relation's result if only one is expected
+        if (ast.type === 'model') {
           acc.push({
             $unwind: {
               path: `$${ast.alias}`,
@@ -56,6 +54,16 @@ module.exports = {
           });
         }
 
+        // Preserve relation field if it is empty
+        acc.push({
+          $addFields: {
+            [ast.alias]: {
+              $ifNull: [`$${ast.alias}`, null]
+            }
+          }
+        });
+
+        // Filtrate the result depending of params
         if (filters.relations) {
           Object.keys(filters.relations).forEach(
             (relationName) => {

--- a/packages/strapi-generate-api/templates/mongoose/service.template
+++ b/packages/strapi-generate-api/templates/mongoose/service.template
@@ -1,4 +1,5 @@
 'use strict';
+/* global <%= globalID %>*/
 
 /**
  * <%= filename %> service

--- a/packages/strapi-generate-api/templates/mongoose/service.template
+++ b/packages/strapi-generate-api/templates/mongoose/service.template
@@ -26,12 +26,13 @@ module.exports = {
     const populate = <%= globalID %>.associations
       .filter(ast => ast.autoPopulate)
       .reduce((acc, ast) => {
-        const from = ast.collection ? ast.collection : ast.model;
+        const from = ast.plugin ? `${ast.plugin}_${ast.model}` : ast.collection ? ast.collection : ast.model;
         const as = ast.alias;
-        const localField = !ast.dominant ? '_id' : ast.via === <%= globalID %>.collectionName ? '_id' : ast.alias;
-        const foreignField = ast.dominant ?
-           (ast.via === <%= globalID %>.collectionName ? ast.via : '_id') :
-           (ast.via === <%= globalID %>.collectionName ? '_id' : ast.via);
+        const localField = !ast.dominant ? '_id' : ast.via === <%= globalID %>.collectionName || ast.via === 'related' ? '_id' : ast.alias;
+        const foreignField = ast.filter ? `${ast.via}.ref` :
+          ast.dominant ?
+            (ast.via === <%= globalID %>.collectionName ? ast.via : '_id') :
+            (ast.via === <%= globalID %>.collectionName ? '_id' : ast.via);
 
         acc.push({
           $lookup: {
@@ -48,7 +49,10 @@ module.exports = {
           });
         } else if (ast.type === 'model') {
           acc.push({
-            $unwind: `$${ast.alias}`,
+            $unwind: {
+              path: `$${ast.alias}`,
+              preserveNullAndEmptyArrays: true
+            }
           });
         }
 

--- a/packages/strapi-generate-api/templates/mongoose/service.template
+++ b/packages/strapi-generate-api/templates/mongoose/service.template
@@ -20,19 +20,74 @@ module.exports = {
   fetchAll: (params) => {
     // Convert `params` object to filters compatible with Mongo.
     const filters = strapi.utils.models.convertParams('<%= globalID.toLowerCase() %>', params);
+
     // Select field to populate.
     const populate = <%= globalID %>.associations
-      .filter(ast => ast.autoPopulate !== false)
-      .map(ast => ast.alias)
-      .join(' ');
+      .filter(ast => ast.autoPopulate)
+      .reduce((acc, ast) => {
+        const from = ast.collection ? ast.collection : ast.model;
+        const as = ast.alias;
+        const localField = !ast.dominant ? '_id' : ast.via === <%= globalID %>.collectionName ? '_id' : ast.alias;
+        const foreignField = ast.dominant ?
+           (ast.via === <%= globalID %>.collectionName ? ast.via : '_id') :
+           (ast.via === <%= globalID %>.collectionName ? '_id' : ast.via)
 
-    return <%= globalID %>
-      .find()
-      .where(filters.where)
-      .sort(filters.sort)
+        acc.push({
+          $lookup: {
+            from,
+            localField,
+            foreignField,
+            as,
+          }
+        });
+
+        if (ast.type === 'collection' && ast.dominant) {
+          acc.push({
+            $replaceRoot: { newRoot: { $mergeObjects: [{ $arrayElemAt: [`$${ast.alias}`, 0] }, '$$ROOT'] } },
+          });
+        } else if (ast.type === 'model') {
+          acc.push({
+            $unwind: `$${ast.alias}`,
+          });
+        }
+
+        if (filters.relations) {
+          Object.keys(filters.relations).forEach(
+            (relationName) => {
+              if (ast.alias === relationName) {
+                const association = <%= globalID %>.associations.find(a => a.alias === relationName);
+                if (association) {
+                  const relation = filters.relations[relationName];
+
+                  Object.keys(relation).forEach(
+                    (filter) => {
+                      acc.push({
+                        $match: { [`${relationName}.${filter}`]: relation[filter] }
+                      });
+                    }
+                  );
+                }
+              }
+            }
+          );
+        }
+
+        return acc;
+      }, []);
+
+    const result = <%= globalID %>
+      .aggregate([
+        {
+          $match: filters.where
+        },
+        ...populate,
+      ])
       .skip(filters.start)
-      .limit(filters.limit)
-      .populate(populate);
+      .limit(filters.limit);
+
+    if (filters.sort) result.sort(filters.sort);
+
+    return result;
   },
 
   /**

--- a/packages/strapi-generate-api/templates/mongoose/service.template
+++ b/packages/strapi-generate-api/templates/mongoose/service.template
@@ -31,7 +31,7 @@ module.exports = {
         const localField = !ast.dominant ? '_id' : ast.via === <%= globalID %>.collectionName ? '_id' : ast.alias;
         const foreignField = ast.dominant ?
            (ast.via === <%= globalID %>.collectionName ? ast.via : '_id') :
-           (ast.via === <%= globalID %>.collectionName ? '_id' : ast.via)
+           (ast.via === <%= globalID %>.collectionName ? '_id' : ast.via);
 
         acc.push({
           $lookup: {

--- a/packages/strapi-mongoose/lib/index.js
+++ b/packages/strapi-mongoose/lib/index.js
@@ -486,19 +486,6 @@ module.exports = function (strapi) {
           result.key = `where.${key}.$gte`;
           result.value = value;
           break;
-        case '_sort':
-          result.key = `sort`;
-          result.value = (_.toLower(value) === 'desc') ? '-' : '';
-          result.value += key;
-          break;
-        case '_start':
-          result.key = `start`;
-          result.value = parseFloat(value);
-          break;
-        case '_limit':
-          result.key = `limit`;
-          result.value = parseFloat(value);
-          break;
         case '_contains':
           result.key = `where.${key}`;
           result.value = {
@@ -513,6 +500,19 @@ module.exports = function (strapi) {
         case '_in':
           result.key = `where.${key}.$in`;
           result.value = value;
+          break;
+        case '_sort':
+          result.key = 'sort';
+          result.value = (_.toLower(value) === 'desc') ? '-' : '';
+          result.value += key;
+          break;
+        case '_start':
+          result.key = 'start';
+          result.value = parseFloat(value);
+          break;
+        case '_limit':
+          result.key = 'limit';
+          result.value = parseFloat(value);
           break;
         default:
           result = undefined;

--- a/packages/strapi-utils/lib/models.js
+++ b/packages/strapi-utils/lib/models.js
@@ -505,13 +505,13 @@ module.exports = {
             relationAttribute.hasOwnProperty('model')
           )) {
             // Mysql stores boolean as 1 or 0
-            const field = models[relationAttribute.collection ? relationAttribute.collection : relationAttribute.model].attributes[relationKey]
+            const field = models[relationAttribute.collection ? relationAttribute.collection : relationAttribute.model].attributes[relationKey];
             if (client === 'mysql' && field.type && field.type === 'boolena') {
               formattedValue = value === 'true' ? '1' : '0';
             }
 
             result = convertor(formattedValue, type, relationKey);
-            result.key = result.key.replace('where.', `relations.${relationName}.`)
+            result.key = result.key.replace('where.', `relations.${relationName}.`);
           }
         } else {
           // Mysql stores boolean as 1 or 0

--- a/packages/strapi-utils/lib/models.js
+++ b/packages/strapi-utils/lib/models.js
@@ -9,11 +9,12 @@ const path = require('path');
 
 // Public node modules.
 const _ = require('lodash');
+const pluralize = require('pluralize');
 
 // Following this discussion https://stackoverflow.com/questions/18082/validate-decimal-numbers-in-javascript-isnumeric this function is the best implem to determine if a value is a valid number candidate
 const isNumeric = (value) => {
   return !isNaN(parseFloat(value)) && isFinite(value);
-}
+};
 
 /* eslint-disable prefer-template */
 /*
@@ -311,6 +312,17 @@ module.exports = {
     return _.get(strapi.models, collectionIdentity.toLowerCase() + '.orm');
   },
 
+
+  /**
+   * Return table name for a collection many-to-many
+   */
+  getCollectionName: (associationA, associationB) => {
+    return [associationA, associationB]
+      .sort((a, b) => a.collection < b.collection ? -1 : 1)
+      .map(table => _.snakeCase(`${pluralize.plural(table.collection)} ${pluralize.plural(table.via)}`))
+      .join('__');
+  },
+
   /**
    * Define associations key to models
    */
@@ -340,7 +352,7 @@ module.exports = {
 
       // Build associations object
       if (association.hasOwnProperty('collection') && association.collection !== '*') {
-        definition.associations.push({
+        const ast = {
           alias: key,
           type: 'collection',
           collection: association.collection,
@@ -350,7 +362,13 @@ module.exports = {
           dominant: details.dominant !== true,
           plugin: association.plugin || undefined,
           filter: details.filter,
-        });
+        };
+
+        if (infos.nature === 'manyToMany' && !association.plugin && definition.orm === 'bookshelf') {
+          ast.tableCollectionName = this.getCollectionName(association, details);
+        }
+
+        definition.associations.push(ast);
       } else if (association.hasOwnProperty('model') && association.model !== '*') {
         definition.associations.push({
           alias: key,

--- a/packages/strapi-utils/lib/models.js
+++ b/packages/strapi-utils/lib/models.js
@@ -469,20 +469,16 @@ module.exports = {
         const [attr, order = 'ASC'] = formattedValue.split(':');
         result = convertor(order, key, attr);
       } else {
-        const suffix = key.split('_');
+        let type = '=';
 
-        // Mysql stores boolean as 1 or 0
-        if (client === 'mysql' && _.get(models, [model, 'attributes', suffix, 'type']) === 'boolean') {
-          formattedValue = value === 'true' ? '1' : '0';
+        if (key.match(/_{1}(?:ne|lte?|gte?|containss?|in)/)) {
+          type = key.match(/_{1}(?:ne|lte?|gte?|containss?|in)/)[0];
+          key = key.replace(type, '');
         }
 
-        let type;
-
-        if (_.includes(['ne', 'lt', 'gt', 'lte', 'gte', 'contains', 'containss', 'in'], _.last(suffix))) {
-          type = `_${_.last(suffix)}`;
-          key = _.dropRight(suffix).join('_');
-        } else {
-          type = '=';
+        // Mysql stores boolean as 1 or 0
+        if (client === 'mysql' && _.get(models, [model, 'attributes', key, 'type']) === 'boolean') {
+          formattedValue = value === 'true' ? '1' : '0';
         }
 
         result = convertor(formattedValue, type, key);

--- a/packages/strapi-utils/package.json
+++ b/packages/strapi-utils/package.json
@@ -22,7 +22,8 @@
     "joi-json": "^2.0.1",
     "knex": "^0.13.0",
     "lodash": "^4.17.4",
-    "pino": "^4.7.1"
+    "pino": "^4.7.1",
+    "pluralize": "^6.0.0"
   },
   "author": {
     "email": "hi@strapi.io",


### PR DESCRIPTION
My PR is a:
🚀 New feature

Main update on the:
Framework

The goal of this PR is to allow to the user to add a filter about relation fields of the model.
As an example, like fetch specific users who have a article named 'test'.
(So it's not about getting all users and then only articles written and named 'test).

For the moment, the first commit are just about fix linting and improve actual filter detection.
More specially, with boolean and a attribute which contains "_" as `is_published` because the transformation for MySQL could contain the `suffix` filter and not the good `key`.

Fixes #1292 

TODO:

- [x] Detect a relation filter (pushed with next commit)
- [x] Add NoSQL logic (update template generated)
- [x] Add SQL logic (update template generated)
- [x] Check the GraphQL Query logic (and adapt if necessary)
- [x] Update docs
- [x] Manage `Morph`-relation (ex.: file/upload)
- [x] Make some tests!
