### PR TITLE
3.0.0-alpha.12.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "version": "3.0.0-alpha.12.5",
+  "version": "3.0.0-alpha.12.6",
   "dependencies": {},
   "devDependencies": {
     "assert": "~1.3.0",

--- a/packages/strapi-admin/package.json
+++ b/packages/strapi-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-admin",
-  "version": "3.0.0-alpha.12.5",
+  "version": "3.0.0-alpha.12.6",
   "description": "Strapi Admin",
   "repository": {
     "type": "git",
@@ -31,8 +31,8 @@
   },
   "devDependencies": {
     "sanitize.css": "^4.1.0",
-    "strapi-helper-plugin": "3.0.0-alpha.12.5",
-    "strapi-utils": "3.0.0-alpha.12.5"
+    "strapi-helper-plugin": "3.0.0-alpha.12.6",
+    "strapi-utils": "3.0.0-alpha.12.6"
   },
   "author": {
     "name": "Strapi",

--- a/packages/strapi-bookshelf/package.json
+++ b/packages/strapi-bookshelf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-bookshelf",
-  "version": "3.0.0-alpha.12.5",
+  "version": "3.0.0-alpha.12.6",
   "description": "Bookshelf hook for the Strapi framework",
   "homepage": "http://strapi.io",
   "keywords": [
@@ -20,8 +20,8 @@
     "inquirer": "^5.2.0",
     "lodash": "^4.17.4",
     "pluralize": "^6.0.0",
-    "strapi-knex": "3.0.0-alpha.12.5",
-    "strapi-utils": "3.0.0-alpha.12.5"
+    "strapi-knex": "3.0.0-alpha.12.6",
+    "strapi-utils": "3.0.0-alpha.12.6"
   },
   "strapi": {
     "isHook": true,

--- a/packages/strapi-ejs/package.json
+++ b/packages/strapi-ejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-ejs",
-  "version": "3.0.0-alpha.12.5",
+  "version": "3.0.0-alpha.12.6",
   "description": "EJS hook for the Strapi framework",
   "homepage": "http://strapi.io",
   "keywords": [

--- a/packages/strapi-email-mailgun/package.json
+++ b/packages/strapi-email-mailgun/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-email-mailgun",
-  "version": "3.0.0-alpha.12.5",
+  "version": "3.0.0-alpha.12.6",
   "description": "Mailgun provider for strapi email plugin",
   "homepage": "http://strapi.io",
   "keywords": [

--- a/packages/strapi-email-sendgrid/package.json
+++ b/packages/strapi-email-sendgrid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-email-sendgrid",
-  "version": "3.0.0-alpha.12.5",
+  "version": "3.0.0-alpha.12.6",
   "description": "Sendgrid provider for strapi email",
   "homepage": "http://strapi.io",
   "keywords": [

--- a/packages/strapi-email-sendmail/package.json
+++ b/packages/strapi-email-sendmail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-email-sendmail",
-  "version": "3.0.0-alpha.12.5",
+  "version": "3.0.0-alpha.12.6",
   "description": "Sendmail provider for strapi email",
   "homepage": "http://strapi.io",
   "keywords": [

--- a/packages/strapi-generate-admin/package.json
+++ b/packages/strapi-generate-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-generate-admin",
-  "version": "3.0.0-alpha.12.5",
+  "version": "3.0.0-alpha.12.6",
   "description": "Generate the default admin panel for a Strapi application.",
   "homepage": "http://strapi.io",
   "keywords": [
@@ -15,7 +15,7 @@
   "dependencies": {
     "fs-extra": "^4.0.1",
     "lodash": "^4.17.4",
-    "strapi-admin": "3.0.0-alpha.12.5"
+    "strapi-admin": "3.0.0-alpha.12.6"
   },
   "author": {
     "email": "hi@strapi.io",

--- a/packages/strapi-generate-api/package.json
+++ b/packages/strapi-generate-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-generate-api",
-  "version": "3.0.0-alpha.12.5",
+  "version": "3.0.0-alpha.12.6",
   "description": "Generate an API for a Strapi application.",
   "homepage": "http://strapi.io",
   "keywords": [

--- a/packages/strapi-generate-controller/package.json
+++ b/packages/strapi-generate-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-generate-controller",
-  "version": "3.0.0-alpha.12.5",
+  "version": "3.0.0-alpha.12.6",
   "description": "Generate a controller for a Strapi API.",
   "homepage": "http://strapi.io",
   "keywords": [

--- a/packages/strapi-generate-model/package.json
+++ b/packages/strapi-generate-model/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-generate-model",
-  "version": "3.0.0-alpha.12.5",
+  "version": "3.0.0-alpha.12.6",
   "description": "Generate a model for a Strapi API.",
   "homepage": "http://strapi.io",
   "keywords": [

--- a/packages/strapi-generate-new/package.json
+++ b/packages/strapi-generate-new/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-generate-new",
-  "version": "3.0.0-alpha.12.5",
+  "version": "3.0.0-alpha.12.6",
   "description": "Generate a new Strapi application.",
   "homepage": "http://strapi.io",
   "keywords": [
@@ -17,7 +17,7 @@
     "fs-extra": "^4.0.0",
     "inquirer": "^4.0.2",
     "lodash": "^4.17.4",
-    "strapi-utils": "3.0.0-alpha.12.5",
+    "strapi-utils": "3.0.0-alpha.12.6",
     "uuid": "^3.1.0"
   },
   "scripts": {

--- a/packages/strapi-generate-plugin/package.json
+++ b/packages/strapi-generate-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-generate-plugin",
-  "version": "3.0.0-alpha.12.5",
+  "version": "3.0.0-alpha.12.6",
   "description": "Generate an plugin for a Strapi application.",
   "homepage": "http://strapi.io",
   "keywords": [

--- a/packages/strapi-generate-policy/package.json
+++ b/packages/strapi-generate-policy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-generate-policy",
-  "version": "3.0.0-alpha.12.5",
+  "version": "3.0.0-alpha.12.6",
   "description": "Generate a policy for a Strapi API.",
   "homepage": "http://strapi.io",
   "keywords": [

--- a/packages/strapi-generate-service/package.json
+++ b/packages/strapi-generate-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-generate-service",
-  "version": "3.0.0-alpha.12.5",
+  "version": "3.0.0-alpha.12.6",
   "description": "Generate a service for a Strapi API.",
   "homepage": "http://strapi.io",
   "keywords": [

--- a/packages/strapi-generate/package.json
+++ b/packages/strapi-generate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-generate",
-  "version": "3.0.0-alpha.12.5",
+  "version": "3.0.0-alpha.12.6",
   "description": "Master of ceremonies for the Strapi generators.",
   "homepage": "http://strapi.io",
   "keywords": [
@@ -17,7 +17,7 @@
     "fs-extra": "^4.0.0",
     "lodash": "^4.17.4",
     "reportback": "^2.0.1",
-    "strapi-utils": "3.0.0-alpha.12.5"
+    "strapi-utils": "3.0.0-alpha.12.6"
   },
   "author": {
     "name": "Strapi team",

--- a/packages/strapi-helper-plugin/package.json
+++ b/packages/strapi-helper-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-helper-plugin",
-  "version": "3.0.0-alpha.12.5",
+  "version": "3.0.0-alpha.12.6",
   "description": "Helper for Strapi plugins development",
   "engines": {
     "node": ">= 9.0.0",

--- a/packages/strapi-knex/package.json
+++ b/packages/strapi-knex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-knex",
-  "version": "3.0.0-alpha.12.5",
+  "version": "3.0.0-alpha.12.6",
   "description": "Knex hook for the Strapi framework",
   "homepage": "http://strapi.io",
   "keywords": [

--- a/packages/strapi-lint/package.json
+++ b/packages/strapi-lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-lint",
-  "version": "3.0.0-alpha.12.5",
+  "version": "3.0.0-alpha.12.6",
   "description": "Strapi eslint and prettier configurations",
   "directories": {
     "lib": "lib"

--- a/packages/strapi-middleware-views/package.json
+++ b/packages/strapi-middleware-views/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-middleware-views",
-  "version": "3.0.0-alpha.12.5",
+  "version": "3.0.0-alpha.12.6",
   "description": "Views hook to enable server-side rendering for the Strapi framework",
   "homepage": "http://strapi.io",
   "keywords": [

--- a/packages/strapi-mongoose/package.json
+++ b/packages/strapi-mongoose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-mongoose",
-  "version": "3.0.0-alpha.12.5",
+  "version": "3.0.0-alpha.12.6",
   "description": "Mongoose hook for the Strapi framework",
   "homepage": "http://strapi.io",
   "keywords": [
@@ -19,7 +19,7 @@
     "mongoose": "^5.0.16",
     "mongoose-float": "^1.0.2",
     "pluralize": "^6.0.0",
-    "strapi-utils": "3.0.0-alpha.12.5"
+    "strapi-utils": "3.0.0-alpha.12.6"
   },
   "strapi": {
     "isHook": true

--- a/packages/strapi-plugin-content-manager/package.json
+++ b/packages/strapi-plugin-content-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-plugin-content-manager",
-  "version": "3.0.0-alpha.12.5",
+  "version": "3.0.0-alpha.12.6",
   "description": "A powerful UI to easily manage your data.",
   "strapi": {
     "name": "Content Manager",
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "react-select": "^1.0.0-rc.5",
-    "strapi-helper-plugin": "3.0.0-alpha.12.5"
+    "strapi-helper-plugin": "3.0.0-alpha.12.6"
   },
   "author": {
     "name": "Strapi team",

--- a/packages/strapi-plugin-content-type-builder/package.json
+++ b/packages/strapi-plugin-content-type-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-plugin-content-type-builder",
-  "version": "3.0.0-alpha.12.5",
+  "version": "3.0.0-alpha.12.6",
   "description": "Strapi plugin to create content type (API).",
   "strapi": {
     "name": "Content Type Builder",
@@ -23,11 +23,11 @@
   },
   "dependencies": {
     "pluralize": "^7.0.0",
-    "strapi-generate": "3.0.0-alpha.12.5",
-    "strapi-generate-api": "3.0.0-alpha.12.5"
+    "strapi-generate": "3.0.0-alpha.12.6",
+    "strapi-generate-api": "3.0.0-alpha.12.6"
   },
   "devDependencies": {
-    "strapi-helper-plugin": "3.0.0-alpha.12.5"
+    "strapi-helper-plugin": "3.0.0-alpha.12.6"
   },
   "author": {
     "name": "Strapi team",

--- a/packages/strapi-plugin-email/package.json
+++ b/packages/strapi-plugin-email/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-plugin-email",
-  "version": "3.0.0-alpha.12.5",
+  "version": "3.0.0-alpha.12.6",
   "description": "This is the description of the plugin.",
   "strapi": {
     "name": "Email",
@@ -22,11 +22,11 @@
     "prepublishOnly": "IS_MONOREPO=true npm run build"
   },
   "dependencies": {
-    "strapi-email-sendmail": "3.0.0-alpha.12.5"
+    "strapi-email-sendmail": "3.0.0-alpha.12.6"
   },
   "devDependencies": {
     "react-copy-to-clipboard": "5.0.1",
-    "strapi-helper-plugin": "3.0.0-alpha.12.5"
+    "strapi-helper-plugin": "3.0.0-alpha.12.6"
   },
   "author": {
     "name": "Strapi team",

--- a/packages/strapi-plugin-graphql/package.json
+++ b/packages/strapi-plugin-graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-plugin-graphql",
-  "version": "3.0.0-alpha.12.5",
+  "version": "3.0.0-alpha.12.6",
   "description": "This is the description of the plugin.",
   "strapi": {
     "name": "graphql",
@@ -29,7 +29,7 @@
     "graphql-tools": "^2.23.1",
     "graphql-type-json": "^0.2.0",
     "pluralize": "^7.0.0",
-    "strapi-utils": "3.0.0-alpha.12.5"
+    "strapi-utils": "3.0.0-alpha.12.6"
   },
   "author": {
     "name": "A Strapi developer",

--- a/packages/strapi-plugin-settings-manager/package.json
+++ b/packages/strapi-plugin-settings-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-plugin-settings-manager",
-  "version": "3.0.0-alpha.12.5",
+  "version": "3.0.0-alpha.12.6",
   "description": "Strapi plugin to manage settings.",
   "strapi": {
     "name": "Settings Manager",
@@ -25,7 +25,7 @@
   "devDependencies": {
     "flag-icon-css": "^2.8.0",
     "react-select": "^1.0.0-rc.5",
-    "strapi-helper-plugin": "3.0.0-alpha.12.5"
+    "strapi-helper-plugin": "3.0.0-alpha.12.6"
   },
   "author": {
     "name": "Strapi team",

--- a/packages/strapi-plugin-upload/package.json
+++ b/packages/strapi-plugin-upload/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-plugin-upload",
-  "version": "3.0.0-alpha.12.5",
+  "version": "3.0.0-alpha.12.6",
   "description": "This is the description of the plugin.",
   "strapi": {
     "name": "Files Upload",
@@ -23,12 +23,12 @@
   },
   "dependencies": {
     "react-copy-to-clipboard": "^5.0.1",
-    "strapi-upload-local": "3.0.0-alpha.12.5",
+    "strapi-upload-local": "3.0.0-alpha.12.6",
     "stream-to-array": "^2.3.0",
     "uuid": "^3.2.1"
   },
   "devDependencies": {
-    "strapi-helper-plugin": "3.0.0-alpha.12.5"
+    "strapi-helper-plugin": "3.0.0-alpha.12.6"
   },
   "author": {
     "name": "A Strapi developer",

--- a/packages/strapi-plugin-users-permissions/package.json
+++ b/packages/strapi-plugin-users-permissions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-plugin-users-permissions",
-  "version": "3.0.0-alpha.12.5",
+  "version": "3.0.0-alpha.12.6",
   "description": "Protect your API with a full-authentication process based on JWT",
   "strapi": {
     "name": "Roles & Permissions",
@@ -31,7 +31,7 @@
     "uuid": "^3.1.0"
   },
   "devDependencies": {
-    "strapi-helper-plugin": "3.0.0-alpha.12.5"
+    "strapi-helper-plugin": "3.0.0-alpha.12.6"
   },
   "author": {
     "name": "Strapi team",

--- a/packages/strapi-redis/package.json
+++ b/packages/strapi-redis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-redis",
-  "version": "3.0.0-alpha.12.5",
+  "version": "3.0.0-alpha.12.6",
   "description": "Redis hook for the Strapi framework",
   "homepage": "http://strapi.io",
   "keywords": [
@@ -18,7 +18,7 @@
     "ioredis": "^3.1.2",
     "lodash": "^4.17.4",
     "stack-trace": "0.0.10",
-    "strapi-utils": "3.0.0-alpha.12.5"
+    "strapi-utils": "3.0.0-alpha.12.6"
   },
   "strapi": {
     "isHook": true

--- a/packages/strapi-upload-aws-s3/package.json
+++ b/packages/strapi-upload-aws-s3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-upload-aws-s3",
-  "version": "3.0.0-alpha.12.5",
+  "version": "3.0.0-alpha.12.6",
   "description": "AWS S3 provider for strapi upload",
   "homepage": "http://strapi.io",
   "keywords": [

--- a/packages/strapi-upload-cloudinary/package.json
+++ b/packages/strapi-upload-cloudinary/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-upload-cloudinary",
-  "version": "3.0.0-alpha.12.5",
+  "version": "3.0.0-alpha.12.6",
   "description": "Cloudinary provider for strapi upload",
   "homepage": "http://strapi.io",
   "keywords": [

--- a/packages/strapi-upload-local/package.json
+++ b/packages/strapi-upload-local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-upload-local",
-  "version": "3.0.0-alpha.12.5",
+  "version": "3.0.0-alpha.12.6",
   "description": "Local provider for strapi upload",
   "homepage": "http://strapi.io",
   "keywords": [

--- a/packages/strapi-upload-rackspace/package.json
+++ b/packages/strapi-upload-rackspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-upload-rackspace",
-  "version": "3.0.0-alpha.12.5",
+  "version": "3.0.0-alpha.12.6",
   "description": "Rackspace provider for strapi upload",
   "main": "./lib",
   "scripts": {

--- a/packages/strapi-utils/package.json
+++ b/packages/strapi-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-utils",
-  "version": "3.0.0-alpha.12.5",
+  "version": "3.0.0-alpha.12.6",
   "description": "Shared utilities for the Strapi packages",
   "homepage": "http://strapi.io",
   "keywords": [

--- a/packages/strapi/package.json
+++ b/packages/strapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi",
-  "version": "3.0.0-alpha.12.5",
+  "version": "3.0.0-alpha.12.6",
   "description": "An open source solution to create and manage your own API. It provides a powerful dashboard and features to make your life easier.",
   "homepage": "http://strapi.io",
   "keywords": [
@@ -55,16 +55,16 @@
     "rimraf": "^2.6.2",
     "semver": "^5.4.1",
     "stack-trace": "0.0.10",
-    "strapi-generate": "3.0.0-alpha.12.5",
-    "strapi-generate-admin": "3.0.0-alpha.12.5",
-    "strapi-generate-api": "3.0.0-alpha.12.5",
-    "strapi-generate-controller": "3.0.0-alpha.12.5",
-    "strapi-generate-model": "3.0.0-alpha.12.5",
-    "strapi-generate-new": "3.0.0-alpha.12.5",
-    "strapi-generate-plugin": "3.0.0-alpha.12.5",
-    "strapi-generate-policy": "3.0.0-alpha.12.5",
-    "strapi-generate-service": "3.0.0-alpha.12.5",
-    "strapi-utils": "3.0.0-alpha.12.5"
+    "strapi-generate": "3.0.0-alpha.12.6",
+    "strapi-generate-admin": "3.0.0-alpha.12.6",
+    "strapi-generate-api": "3.0.0-alpha.12.6",
+    "strapi-generate-controller": "3.0.0-alpha.12.6",
+    "strapi-generate-model": "3.0.0-alpha.12.6",
+    "strapi-generate-new": "3.0.0-alpha.12.6",
+    "strapi-generate-plugin": "3.0.0-alpha.12.6",
+    "strapi-generate-policy": "3.0.0-alpha.12.6",
+    "strapi-generate-service": "3.0.0-alpha.12.6",
+    "strapi-utils": "3.0.0-alpha.12.6"
   },
   "author": {
     "email": "hi@strapi.io",


### PR DESCRIPTION
Migration guide: https://github.com/strapi/strapi/wiki/migration-guide-alpha.12.5-to-alpha.12.6

Changelog: https://github.com/strapi/strapi/releases/tag/3.0.0-alpha.12.6