### PR TITLE
Fix filename reference

### DIFF
--- a/docs/3.x.x/en/advanced/customize-admin.md
+++ b/docs/3.x.x/en/advanced/customize-admin.md
@@ -25,7 +25,7 @@ The entire logic of the admin panel is located in a single folder named `./admin
 |        └─── translations  // Directory containing text messages for each supported languages
 └─── config
 |    └─── routes.json // Admin's API routes
-|    └─── admin.json // Admin's specific settings
+|    └─── layout.json // Admin's specific settings
 └─── controllers // Admin's API controllers
 └─── services // Admin's API services
 └─── packages.json // Admin's npm dependencies


### PR DESCRIPTION
<!-- ⚠️ Your PR title will appear in the changelogs please make it short detailed and understandable for all. -->

<!-- Uncomment the correct contribution type. !-->

My PR is a:
<!-- 💥 Breaking change -->
🐛 Bug fix
<!-- 💅 Enhancement -->
<!-- 🚀 New feature -->

Main update on the:
<!-- Admin -->
Documentation
<!-- Framework -->
<!-- Plugin -->

<!-- Write a short description of what your PR does and link the concerned issues of your update. -->
Asked [by Slack](https://strapi.slack.com/archives/C0BNGCDNH/p1530292003000009)"
![adminconfig](https://user-images.githubusercontent.com/5768813/42105479-161ede50-7b96-11e8-93cc-ecfa34faec4c.PNG)

Te docs mention a `/admin/config/admin.json` file. Instead there is a `/admin/config/layout.json` ... There are equivalents? Is a bug in the docs or in the directory structure?