### PR TITLE
Fix loose oneWay relation on update content type

### DIFF
--- a/packages/strapi-plugin-content-type-builder/controllers/ContentTypeBuilder.js
+++ b/packages/strapi-plugin-content-type-builder/controllers/ContentTypeBuilder.js
@@ -169,7 +169,7 @@ module.exports = {
 
     strapi.reload.isWatching = false;
 
-    const clearRelationsErrors = Service.clearRelations(model);
+    const clearRelationsErrors = Service.clearRelations(model, undefined, true);
 
     if (!_.isEmpty(clearRelationsErrors)) {
       return ctx.badRequest(null, [{ messages: clearRelationsErrors }]);

--- a/packages/strapi-plugin-content-type-builder/services/ContentTypeBuilder.js
+++ b/packages/strapi-plugin-content-type-builder/services/ContentTypeBuilder.js
@@ -241,7 +241,7 @@ module.exports = {
     return [attributesNotConfigurable, errors];
   },
 
-  clearRelations: (model, source) => {
+  clearRelations: (model, source, force) => {
     const errors = [];
     const structure = {
       models: strapi.models,
@@ -259,10 +259,10 @@ module.exports = {
       Object.keys(models).forEach(name => {
         const relationsToDelete = _.get(plugin ? strapi.plugins[plugin].models[name] : strapi.models[name], 'associations', []).filter(association => {
           if (source) {
-            return association[association.type] === model && association.plugin === source;
+            return association[association.type] === model && association.plugin === source && (association.nature !== 'oneWay' || force);
           }
 
-          return association[association.type] === model;
+          return association[association.type] === model && (association.nature !== 'oneWay' || force);
         });
 
         if (!_.isEmpty(relationsToDelete)) {


### PR DESCRIPTION
<!-- ⚠️ Your PR title will appear in the changelogs please make it short detailed and understandable for all. -->

<!-- Uncomment the correct contribution type. !-->

My PR is a: 🐛 Bug fix
<!-- 💅 Enhancement -->
<!-- 🚀 New feature -->

Main update on the: Plugin

Not clear oneWay relation on model update.

Fix #1477
<!-- Write a short description of what your PR does and link the concerned issues of your update. -->
