### PR TITLE
Skip number conversion on string fields

### DIFF
--- a/packages/strapi-utils/lib/models.js
+++ b/packages/strapi-utils/lib/models.js
@@ -457,11 +457,25 @@ module.exports = {
     _.forEach(params, (value, key)  => {
       let result;
       let formattedValue;
-
-      // Check if the value if a valid candidate to be converted to a number value
-      formattedValue = isNumeric(value)
-        ? _.toNumber(value)
-        : value;
+      let modelAttributes = models[model]['attributes'];
+      let fieldType;
+      // Get the field type to later check if it's a string before number conversion
+      if (modelAttributes[key]) {
+        fieldType = modelAttributes[key]['type'];
+      } else {
+        let splitKey = key.split('_').pop();
+        if (modelAttributes[splitKey]) {
+          fieldType = modelAttributes[splitKey]['type'];
+        }
+      }
+      // Check if the value is a valid candidate to be converted to a number value
+      if (fieldType != 'string') {
+        formattedValue = isNumeric(value)
+          ? _.toNumber(value)
+          : value;
+      } else {
+        formattedValue = value;
+      }
 
       if (_.includes(['_start', '_limit'], key)) {
         result = convertor(formattedValue, key);


### PR DESCRIPTION
My PR is a:
🐛 Bug fix

Main update on the:
Framework

When attempting to use an equal filter on a string field whose value is all numbers, the item does not return. There's a statement in the models' `convertParams` util that automatically detects number-only values to change its type to number. This sets a condition around it to avoid string fields. Fixes #1524.
