### PR TITLE
Include yarn.lock in packages .gitignore

### DIFF
--- a/packages/strapi-admin/.gitignore
+++ b/packages/strapi-admin/.gitignore
@@ -3,6 +3,7 @@ coverage
 node_modules
 stats.json
 package-lock.json
+yarn.lock
 
 # Cruft
 .DS_Store

--- a/packages/strapi-admin/admin/.gitignore
+++ b/packages/strapi-admin/admin/.gitignore
@@ -5,6 +5,7 @@ manifest.json
 plugins.json
 stats.json
 package-lock.json
+yarn.lock
 
 # Cruft
 .DS_Store

--- a/packages/strapi-email-mailgun/.gitignore
+++ b/packages/strapi-email-mailgun/.gitignore
@@ -93,3 +93,4 @@ build
 node_modules
 .node_history
 package-lock.json
+yarn.lock

--- a/packages/strapi-email-sendgrid/.gitignore
+++ b/packages/strapi-email-sendgrid/.gitignore
@@ -93,3 +93,4 @@ build
 node_modules
 .node_history
 package-lock.json
+yarn.lock

--- a/packages/strapi-email-sendmail/.gitignore
+++ b/packages/strapi-email-sendmail/.gitignore
@@ -93,3 +93,4 @@ build
 node_modules
 .node_history
 package-lock.json
+yarn.lock

--- a/packages/strapi-generate-admin/.gitignore
+++ b/packages/strapi-generate-admin/.gitignore
@@ -92,6 +92,7 @@ build
 node_modules
 .node_history
 package-lock.json
+yarn.lock
 
 
 ############################

--- a/packages/strapi-generate-admin/files/.gitignore
+++ b/packages/strapi-generate-admin/files/.gitignore
@@ -3,6 +3,7 @@ coverage
 node_modules
 stats.json
 package-lock.json
+yarn.lock
 
 # Cruft
 .DS_Store

--- a/packages/strapi-generate-api/.gitignore
+++ b/packages/strapi-generate-api/.gitignore
@@ -93,6 +93,7 @@ build
 node_modules
 .node_history
 package-lock.json
+yarn.lock
 
 
 ############################

--- a/packages/strapi-generate-controller/.gitignore
+++ b/packages/strapi-generate-controller/.gitignore
@@ -93,6 +93,7 @@ build
 node_modules
 .node_history
 package-lock.json
+yarn.lock
 
 
 ############################

--- a/packages/strapi-generate-model/.gitignore
+++ b/packages/strapi-generate-model/.gitignore
@@ -93,6 +93,7 @@ build
 node_modules
 .node_history
 package-lock.json
+yarn.lock
 
 
 ############################

--- a/packages/strapi-generate-new/.gitignore
+++ b/packages/strapi-generate-new/.gitignore
@@ -92,6 +92,7 @@ build
 node_modules
 .node_history
 package-lock.json
+yarn.lock
 
 
 ############################

--- a/packages/strapi-generate-plugin/.gitignore
+++ b/packages/strapi-generate-plugin/.gitignore
@@ -93,6 +93,7 @@ build
 node_modules
 .node_history
 package-lock.json
+yarn.lock
 
 
 ############################

--- a/packages/strapi-generate-policy/.gitignore
+++ b/packages/strapi-generate-policy/.gitignore
@@ -93,6 +93,7 @@ build
 node_modules
 .node_history
 package-lock.json
+yarn.lock
 
 
 ############################

--- a/packages/strapi-generate-service/.gitignore
+++ b/packages/strapi-generate-service/.gitignore
@@ -93,6 +93,7 @@ build
 node_modules
 .node_history
 package-lock.json
+yarn.lock
 
 
 ############################

--- a/packages/strapi-generate/.gitignore
+++ b/packages/strapi-generate/.gitignore
@@ -93,6 +93,7 @@ build
 node_modules
 .node_history
 package-lock.json
+yarn.lock
 
 
 ############################

--- a/packages/strapi-helper-plugin/.gitignore
+++ b/packages/strapi-helper-plugin/.gitignore
@@ -5,6 +5,7 @@ build
 node_modules
 stats.json
 package-lock.json
+yarn.lock
 
 # Cruft
 .DS_Store

--- a/packages/strapi-hook-bookshelf/.gitignore
+++ b/packages/strapi-hook-bookshelf/.gitignore
@@ -93,3 +93,4 @@ build
 node_modules
 .node_history
 package-lock.json
+yarn.lock

--- a/packages/strapi-hook-ejs/.gitignore
+++ b/packages/strapi-hook-ejs/.gitignore
@@ -93,3 +93,4 @@ build
 node_modules
 .node_history
 package-lock.json
+yarn.lock

--- a/packages/strapi-hook-knex/.gitignore
+++ b/packages/strapi-hook-knex/.gitignore
@@ -93,3 +93,4 @@ build
 node_modules
 .node_history
 package-lock.json
+yarn.lock

--- a/packages/strapi-hook-mongoose/.gitignore
+++ b/packages/strapi-hook-mongoose/.gitignore
@@ -93,3 +93,4 @@ build
 node_modules
 .node_history
 package-lock.json
+yarn.lock

--- a/packages/strapi-hook-redis/.gitignore
+++ b/packages/strapi-hook-redis/.gitignore
@@ -93,3 +93,4 @@ build
 node_modules
 .node_history
 package-lock.json
+yarn.lock

--- a/packages/strapi-middleware-views/.gitignore
+++ b/packages/strapi-middleware-views/.gitignore
@@ -93,3 +93,4 @@ build
 node_modules
 .node_history
 package-lock.json
+yarn.lock

--- a/packages/strapi-plugin-content-manager/.gitignore
+++ b/packages/strapi-plugin-content-manager/.gitignore
@@ -4,6 +4,7 @@ node_modules
 stats.json
 config/layout.json
 package-lock.json
+yarn.lock
 
 # Cruft
 .DS_Store

--- a/packages/strapi-plugin-graphql/.gitignore
+++ b/packages/strapi-plugin-graphql/.gitignore
@@ -3,6 +3,7 @@ coverage
 node_modules
 stats.json
 package-lock.json
+yarn.lock
 
 # Cruft
 .DS_Store

--- a/packages/strapi-plugin-upload/.gitignore
+++ b/packages/strapi-plugin-upload/.gitignore
@@ -3,6 +3,7 @@ coverage
 node_modules
 stats.json
 package-lock.json
+yarn.lock
 
 # Cruft
 .DS_Store

--- a/packages/strapi-upload-aws-s3/.gitignore
+++ b/packages/strapi-upload-aws-s3/.gitignore
@@ -93,3 +93,4 @@ build
 node_modules
 .node_history
 package-lock.json
+yarn.lock

--- a/packages/strapi-upload-cloudinary/.gitignore
+++ b/packages/strapi-upload-cloudinary/.gitignore
@@ -1,6 +1,7 @@
 # Don't check auto-generated stuff into git
 node_modules
 package-lock.json
+yarn.lock
 
 # Cruft
 .DS_Store

--- a/packages/strapi-upload-local/.gitignore
+++ b/packages/strapi-upload-local/.gitignore
@@ -93,3 +93,4 @@ build
 node_modules
 .node_history
 package-lock.json
+yarn.lock

--- a/packages/strapi-utils/.gitignore
+++ b/packages/strapi-utils/.gitignore
@@ -93,3 +93,4 @@ build
 node_modules
 .node_history
 package-lock.json
+yarn.lock

--- a/packages/strapi/.gitignore
+++ b/packages/strapi/.gitignore
@@ -93,6 +93,7 @@ build
 node_modules
 .node_history
 package-lock.json
+yarn.lock
 
 
 ############################


### PR DESCRIPTION

My PR is a:
💅 Enhancement

Main update on the:
Plugin

I am sure this was intended was since line 118 of the main .gitignore has a wildcard match for yarn.lock - this is ignored as each package has it's own .gitignore file.

