### PR TITLE
Fix search input extra scrollbar in Firefox

### DIFF
--- a/packages/strapi-plugin-content-manager/admin/src/components/Search/styles.scss
+++ b/packages/strapi-plugin-content-manager/admin/src/components/Search/styles.scss
@@ -3,7 +3,7 @@
   top: 0;
   display: flex;
   align-items: center;
-  overflow: auto;
+  overflow: hidden;
   min-width: 44rem;
   height: 6rem;
   padding-right: 20px;


### PR DESCRIPTION
My PR is a:
💅 Enhancement

Main update on the:
Admin / Content manager

#1563 Hidding an useless scrollbar appearing in firefox

Don't know the CMS well yet, but I wanted to help, keep up the good work 👌
