### PR TITLE
Fix multi API controller

### DIFF
--- a/packages/strapi-plugin-users-permissions/services/UsersPermissions.js
+++ b/packages/strapi-plugin-users-permissions/services/UsersPermissions.js
@@ -116,7 +116,9 @@ module.exports = {
       }, {}));
 
     const appControllers = Object.keys(strapi.api || {}).reduce((acc, key) => {
-      acc.controllers[key] = generateActions(strapi.api[key].controllers[key]);
+      Object.keys(strapi.api[key].controllers).forEach((controller) => {
+        acc.controllers[controller] = generateActions(strapi.api[key].controllers[controller]);
+      });
 
       return acc;
     }, { controllers: {} });
@@ -203,7 +205,7 @@ module.exports = {
     const databasePermissions = await strapi.query('permission', 'users-permissions').find();
     const actions = databasePermissions
       .map(permission => `${permission.type}.${permission.controller}.${permission.action}`);
-    
+
 
     // Aggregate first level actions.
     const appActions = Object.keys(strapi.api || {}).reduce((acc, api) => {


### PR DESCRIPTION
<!-- ⚠️ Your PR title will appear in the changelogs please make it short detailed and understandable for all. -->

<!-- Uncomment the correct contribution type. !-->

My PR is a:  🐛 Bug fix 
<!-- 💅 Enhancement -->
<!-- 🚀 New feature -->

Main update on the: Plugin

When you try to create a new role, if you have 2 controllers in your api, just the controller that have the api name is handle. 