### PR TITLE
Fix missing `pluralize` dependency

### DIFF
--- a/packages/strapi-plugin-content-manager/package.json
+++ b/packages/strapi-plugin-content-manager/package.json
@@ -51,5 +51,8 @@
     "node": ">= 9.0.0",
     "npm": ">= 5.0.0"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "pluralize": "^7.0.0"
+  }
 }


### PR DESCRIPTION
<!-- ⚠️ Your PR title will appear in the changelogs please make it short detailed and understandable for all. -->

<!-- Uncomment the correct contribution type. !-->

My PR is a: 🐛 Bug fix
<!-- 💅 Enhancement -->
<!-- 🚀 New feature -->

Main update on the: Plugin

<!-- Write a short description of what your PR does and link the concerned issues of your update. -->
`content-manager` is using `pluralize` as dependency but is not declared in their `package.json` file, this ends with this output when trying to run the application:

```
debug ⛔️ Server wasn't able to start properly.
error Cannot find module 'pluralize'
```

This PR add the dependency trying to fix that.