### PR TITLE
Fix/auto reload

### DIFF
--- a/packages/strapi-plugin-content-type-builder/controllers/ContentTypeBuilder.js
+++ b/packages/strapi-plugin-content-type-builder/controllers/ContentTypeBuilder.js
@@ -188,7 +188,7 @@ module.exports = {
 
   autoReload: async ctx => {
     ctx.send({
-      autoReload: _.get(strapi.config.environments, 'development.server.autoReload', false),
+      autoReload: _.get(strapi.config.currentEnvironment, 'server.autoReload', { enabled: false })
     });
   },
 

--- a/packages/strapi-plugin-settings-manager/admin/src/requirements.js
+++ b/packages/strapi-plugin-settings-manager/admin/src/requirements.js
@@ -3,7 +3,7 @@ import request from 'utils/request';
 const shouldRenderCompo = (plugin) => new Promise((resolve, reject) => {
   request('/settings-manager/autoReload')
     .then(response => {
-      plugin.preventComponentRendering = !response.autoReload;
+      plugin.preventComponentRendering = !response.autoReload.enabled;
       plugin.blockerComponentProps = {
         blockerComponentTitle: 'components.AutoReloadBlocker.header',
         blockerComponentDescription: 'components.AutoReloadBlocker.description',

--- a/packages/strapi-plugin-settings-manager/controllers/SettingsManager.js
+++ b/packages/strapi-plugin-settings-manager/controllers/SettingsManager.js
@@ -334,8 +334,8 @@ module.exports = {
 
   autoReload: async ctx => {
     ctx.send({
-      autoReload: _.get(strapi.config.environments, 'development.server.autoReload', false),
-      environment: strapi.config.environment,
+      autoReload: _.get(strapi.config.currentEnvironment, 'server.autoReload', { enabled: false }),
+      environment: strapi.config.environment
     });
   }
 };


### PR DESCRIPTION
My PR is a:
🐛 Bug fix

Main update on the:
Plugins: settings-manager, content-type-builder

- Using `strapi.config.currentEnvironment` to get configuration
- Default parameter is an object according to the default configuration
- Use the `enabled` boolean on the autoReload endpoint (settings-manager)