### PR TITLE
"new" command supports mongo +srv prefix uri ( #1742 )

### DIFF
--- a/packages/strapi-generate-new/lib/before.js
+++ b/packages/strapi-generate-new/lib/before.js
@@ -142,10 +142,17 @@ module.exports = (scope, cb) => {
                   default: _.get(scope.database, 'host', '127.0.0.1')
                 },
                 {
+                  when: !hasDatabaseConfig && scope.client.database === 'mongo',
+                  type: 'boolean',
+                  name: 'srv',
+                  message: '+srv connection::',
+                  default: _.get(scope.database, 'srv', false)
+                },
+                {
                   when: !hasDatabaseConfig,
                   type: 'input',
                   name: 'port',
-                  message: 'Port:',
+                  message: 'Port(It will be ignored if you enable +srv):',
                   default: (answers) => { // eslint-disable-line no-unused-vars
                     if (_.get(scope.database, 'port')) {
                       return scope.database.port;
@@ -196,6 +203,7 @@ module.exports = (scope, cb) => {
                 }
 
                 scope.database.settings.host = answers.host;
+                scope.database.settings.srv = answers.srv;
                 scope.database.settings.port = answers.port;
                 scope.database.settings.database = answers.database;
                 scope.database.settings.username = answers.username;
@@ -251,6 +259,7 @@ module.exports = (scope, cb) => {
               require(path.join(`${scope.tmpPath}`, '/node_modules/', `${scope.client.connector}/lib/utils/connectivity.js`))(scope, cb.success, connectionValidation);
             } catch(err) {
               shell.rm('-r', scope.tmpPath);
+              console.log(err)
               cb.success();
             }
           });

--- a/packages/strapi-hook-mongoose/lib/utils/connectivity.js
+++ b/packages/strapi-hook-mongoose/lib/utils/connectivity.js
@@ -7,7 +7,7 @@ const path = require('path');
 module.exports = (scope, success, error) => {
   const Mongoose = require(path.resolve(`${scope.tmpPath}/node_modules/mongoose`));
 
-  const { username, password } = scope.database.settings;
+  const { username, password, srv } = scope.database.settings;
   const { authenticationDatabase, ssl } = scope.database.options;
 
   const connectOptions = {};
@@ -26,8 +26,9 @@ module.exports = (scope, success, error) => {
 
   connectOptions.ssl = ssl ? true : false;
   connectOptions.useNewUrlParser = true;
+  connectOptions.dbName = scope.database.settings.database;
 
-  Mongoose.connect(`mongodb://${scope.database.settings.host}:${scope.database.settings.port}/${scope.database.settings.database}`, connectOptions, function (err) {
+  Mongoose.connect(`mongodb${srv ? "+srv" : ""}://${scope.database.settings.host}:${!srv ? ":" + scope.database.settings.port : ""}/`, connectOptions, function (err) {
     if (err) {
       console.log('⚠️ Database connection has failed! Make sure your database is running.');
       return error();


### PR DESCRIPTION
<!-- ⚠️ Your PR title will appear in the changelogs please make it short detailed and understandable for all. -->

<!-- Uncomment the correct contribution type. !-->

My PR is a:
<!-- 💥 Breaking change -->
<!-- 🐛 Bug fix -->
<!-- 💅 Enhancement -->
🚀 New feature

Main update on the:
<!-- Admin -->
<!-- Documentation -->
Framework
<!-- Plugin -->

<!-- Write a short description of what your PR does and link the concerned issues of your update. -->
`strapi new ...` command support `mongodb+srv:` prefix.  Please detail of `mongobd+srv` is [here](https://docs.mongodb.com/manual/reference/connection-string/#dns-seedlist-connection-format).
related #432