### PR TITLE
fix:repeat-upload-the-same-file - clear file input after trigger event

### DIFF
--- a/packages/strapi-helper-plugin/lib/src/components/InputFile/index.js
+++ b/packages/strapi-helper-plugin/lib/src/components/InputFile/index.js
@@ -59,7 +59,8 @@ class InputFile extends React.Component {
       type: 'file',
       value,
     };
-
+    
+    this.inputFile.value = '';
     this.setState({ isUploading: !this.state.isUploading });
     this.props.onChange({ target });
   }


### PR DESCRIPTION
<!-- ⚠️ Your PR title will appear in the changelogs please make it short detailed and understandable for all. -->

<!-- Uncomment the correct contribution type. !-->

My PR is a:
<!-- 💥 Breaking change -->
🐛 Bug fix
<!-- 💅 Enhancement -->
<!-- 🚀 New feature -->

Main update on the:
<!-- Admin -->
<!-- Documentation -->
<!-- Framework -->
Plugin

<!-- Write a short description of what your PR does and link the concerned issues of your update. -->

To reproduce bug:

* attach file to any type
* remove this file
* attach again the same file
* File not be attached, but files array is empty