### PR TITLE
Change implementation for create/remove symlinks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ git clone git@github.com:strapi/strapi.git
 ```
 
 #### 3. ⏳ Installation
- 
+
 Go to the root of the repository.
 ```bash
 cd strapi

--- a/package.json
+++ b/package.json
@@ -25,8 +25,9 @@
     "strapi-lint": "file:packages/strapi-lint"
   },
   "scripts": {
-    "clean": "npm run removesymlinkdependencies && npx rimraf package-lock.json && npx rimraf packages/*/package-lock.json",
-    "clean:all": "npm run removesymlinkdependencies && npx rimraf package-lock.json && npx rimraf packages/*/package-lock.json && npx rimraf packages/*/node_modules",
+    "preclean:all": "npm install",
+    "clean": "npm run removesymlinkdependencies && npx rimraf {.,packages/*}/package-lock.json",
+    "clean:all": "npm run removesymlinkdependencies && npx rimraf {.,packages/*}/package-lock.json packages/*/node_modules",
     "doc": "node ./scripts/documentation.js",
     "release": "npm run clean:all && npm install && npm run createsymlinkdependencies && lerna exec --concurrency 1 -- npm install && npm run removesymlinkdependencies && node ./scripts/publish.js $TAG",
     "createsymlinkdependencies": "node ./scripts/createSymlinkDependencies.js",

--- a/scripts/createSymlinkDependencies.js
+++ b/scripts/createSymlinkDependencies.js
@@ -1,24 +1,10 @@
-const fs = require('fs');
-const path = require('path');
+/**
+ * Set all `strapi-*` dependencies as local
+ */
 
-try {
-  const packages = fs.readdirSync(path.resolve(process.cwd(),'packages'), 'utf8');
+const shell = require('shelljs');
 
-  packages.filter(pkg => pkg.indexOf('strapi') !== -1).forEach(pkg => {
-    const packageJSON = JSON.parse(fs.readFileSync(path.resolve(process.cwd(), 'packages', pkg, 'package.json'), 'utf8'));
-
-    Object.keys(packageJSON.dependencies || []).filter(dependency => dependency.indexOf('strapi-') !== -1).forEach(dependency => {
-      packageJSON.dependencies[dependency] = 'file:../' + dependency;
-    });
-
-    if (packageJSON.devDependencies) {
-      Object.keys(packageJSON.devDependencies || []).filter(devDependency => devDependency.indexOf('strapi-') !== -1).forEach(devDependency => {
-        packageJSON.devDependencies[devDependency] = 'file:../' + devDependency;
-      });
-    }
-
-    fs.writeFileSync(path.resolve(process.cwd(), 'packages', pkg, 'package.json'), JSON.stringify(packageJSON, null, 2), 'utf8');
+shell.ls('./packages/strapi*/package.json')
+  .forEach(file => {
+    shell.sed('-i', /^(\s*"(strapi-[a-z-]*)":\s*").*(",?\s*)$/, '$1file:../$2$3', file);
   });
-} catch (error) {
-  console.error(error);
-}


### PR DESCRIPTION
From JavaScript to BASH significantly reducing LOC making simple understand what is happening.

<!-- ⚠️ Your PR title will appear in the changelogs please make it short detailed and understandable for all. -->

<!-- Uncomment the correct contribution type. !-->
---
My PR is a: 💅 Enhancement
<!-- 🚀 New feature -->
Main update on the: Framework
<!-- Plugin -->

<!-- Write a short description of what your PR does and link the concerned issues of your update. -->
## Description
In my process of understanding the operation to publish a new version, I came across with the `createsymlinkdependencies` & `removesymlinkdependencies` scripts. 

Upon understanding its purpose, I realized all that JS logic can be reduced in a line with the command `sed`. So, I create this PR to show how the implementation would be.

## Pros
- The obvious code reduction seeks less mental waste in understanding the purpose. Now includes comments explaining what the script does 😛 
- Although I have not made measurements, it is highly probable that there will be a reduction in execution time.
- With this implementation, create and removing don't produce "false changes" with EOL. Attached screenshot below.

## Risks
~~I know all the core developers are working on MacOS, and I know there are an incompatibility issue for inline replacements with `sed`. Although this could be easily solve installing the GNU version (`brew install gnu-sed --with-default-names`), I decided add a "extra-step" (create and remove backup files) with the intention to have a transparent implementation. However, **I have not tested if works on MacOS** (I don't have one 😋)~~

~~**This will not work under Windows** without BASH; meaning an Windows user should install an Unix environment like Cygwin, WSL a VMs, or similar. (I'm pro-promote this).~~

Changed to use `shelljs` to make it multi-platform.

## How it was tested
I run the task `npm run createsymlinkdependencies` both in the original and this implementation and checked there were no differences in the result. The ones that were there is because of the difference of the EOF in some files. Attached screenshots and the result of the outputs.

## Additional comments
This is a result of what I saw and what I know, but I have the feeling that this can be done using `lerna`.. From what I've seen so far, this is precisely the problem that seeks to solve. I will keep this in mind.

---

### Proofs
* Results of running `createsymlinkdependencies` and then `removesymlinkdependencies`. On the left this PR; on the right the code from this repository (the differences are just on EOLs)
![createandremove](https://user-images.githubusercontent.com/5768813/44961020-69207c00-aecf-11e8-933b-7cefb60420da.png)

* `npm run createsymlinkdependencies`
![createsymllink](https://user-images.githubusercontent.com/5768813/44960895-602eab00-aecd-11e8-8e8c-761435ec1ef7.png)

* ` npm run removesymlinkdependencies`
![removesymlink](https://user-images.githubusercontent.com/5768813/44960897-6b81d680-aecd-11e8-8395-f10bbb42be10.png)

* Outputs: https://gist.github.com/maturanomx/a74220c694d71f1ddb1476b4ce1dad99