### PR TITLE
Fix content type generation with bookshelf.

### DIFF
--- a/packages/strapi-plugin-content-type-builder/services/ContentTypeBuilder.js
+++ b/packages/strapi-plugin-content-type-builder/services/ContentTypeBuilder.js
@@ -4,7 +4,7 @@ const path = require('path');
 const fs = require('fs');
 const _ = require('lodash');
 const generator = require('strapi-generate');
-const { fromJS } = require('immutable');
+const { fromJS, List, Map } = require('immutable');
 const Manager = require('../utils/Manager.js');
 const {
   createManager,
@@ -30,8 +30,8 @@ module.exports = {
       });
       const schemaPath = plugin ? ['models', 'plugins', plugin, model] : ['models', model];
       const keys = plugin ? `plugins.${plugin}.${model}.editDisplay` : `${model}.editDisplay`;
-      const prevList = state.getIn(['schema', ...schemaPath, 'editDisplay', 'fields']);
-      const prevFields =  Object.keys(state.getIn(['schema', ...schemaPath, 'editDisplay', 'availableFields']).toJS());
+      const prevList = state.getIn(['schema', ...schemaPath, 'editDisplay', 'fields'], List());
+      const prevFields =  Object.keys(state.getIn(['schema', ...schemaPath, 'editDisplay', 'availableFields'], Map()).toJS());
       const currentFields = Object.keys(attributes);
       const fieldsToRemove = _.difference(prevFields, currentFields);
       let newList = prevList;


### PR DESCRIPTION
BugFix in content-type-builder plugin service

My PR is a:
🐛 Bug fix 

Main update on the:
Plugin 

i was getting below error during new content type save
```
TypeError: Cannot read property 'toJS' of undefined
    at Object.appearance (/fakepath/api/plugins/content-type-builder/services/ContentTypeBuilder.js:101:71)

```
same error was on two places, it was caused by missing values in the immutable object so i added second parameter to empty List/Map.
