### PR TITLE
Fix bug on conditional code

### DIFF
--- a/packages/strapi/lib/core/configurations.js
+++ b/packages/strapi/lib/core/configurations.js
@@ -331,7 +331,7 @@ module.exports.app = async function() {
     `${this.config.url}/${get(this.config.currentEnvironment.server, 'admin.path', 'admin')}`;
 
   // proxy settings
-  this.config.proxy = get(this.config.currentEnvironment, 'server.proxy' || {});
+  this.config.proxy = get(this.config.currentEnvironment, 'server.proxy', {});
 
   // check if SSL enabled and construct proxy url
   function getProxyUrl(ssl, url) {
@@ -385,7 +385,7 @@ const enableHookNestedDependencies = function (name, flattenHooksConfig, force =
 const isAdminInDevMode = function () {
   try {
     fs.accessSync(path.resolve(this.config.appPath, 'admin', 'admin', 'build', 'index.html'), fs.constants.R_OK | fs.constants.W_OK);
-    
+
     return true;
   } catch (e) {
     return false;


### PR DESCRIPTION
My PR is a:
<!-- 💥 Breaking change -->
 🐛 Bug fix
<!-- 💅 Enhancement -->
<!-- 🚀 New feature -->

Main update on the:
<!-- Admin -->
<!-- Documentation -->
 Framework
<!-- Plugin -->

<!-- Write a short description of what your PR does and link the concerned issues of your update. -->
----
`'server.proxy' || {}` is **always** returning `server.proxy`. The real intention is pass `{}` as default value for `_.get`.
