### PR TITLE
Fix ORM Create FullText index error if no text colums founded

### DIFF
--- a/packages/strapi-hook-bookshelf/lib/index.js
+++ b/packages/strapi-hook-bookshelf/lib/index.js
@@ -461,6 +461,11 @@ module.exports = function(strapi) {
                         const connection = strapi.config.connections[definition.connection];
                         let columns = Object.keys(attributes).filter(attribute => ['string', 'text'].includes(attributes[attribute].type));
 
+                        if (!columns) {
+                          // No text columns founds, exit from creating Fulltext Index
+                          return;
+                        }
+
                         switch (connection.settings.client) {
                           case 'pg': {
                             // Enable extension to allow GIN indexes.


### PR DESCRIPTION
... If aren't text colums definend in the schema do not lanch the SQL to create the fulltext index that generate the following SQL Error:

> Error: ER_PARSE_ERROR: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near ')' at line 1
> ...
>  sql: 'CREATE FULLTEXT INDEX SEARCH_MY_TABLE ON `my_table` ()'

My PR is a:
🐛 Bug fix 

Main update on the:
Framework strapi-hook-bookshelf with Relational DBs such as MySql

New pull request from #1845

