### PR TITLE
Update docs to show correct password-reset URL and fix formatting

### DIFF
--- a/docs/3.x.x/en/guides/authentication.md
+++ b/docs/3.x.x/en/guides/authentication.md
@@ -117,7 +117,8 @@ This action sends an email to a user with the link of you reset password page. T
 #### Usage
 
 - `email` is your user email.
-- `url` is the url link that user will receive.
+- `url` is the url link that user will receive. After the user triggers a new password reset, 
+it is used to redirect the user to the new-password form. 
 
 ```js
 $.ajax({
@@ -125,7 +126,7 @@ $.ajax({
   url: 'http://localhost:1337/auth/forgot-password',
   data: {
     email: 'user@strapi.io',
-    url: 'http://mon-site.com/rest-password'
+    url: 'http:/localhost:1337/admin/plugins/users-permissions/auth/reset-password'
   },
   done: function() {
     console.log('Your user received an email');
@@ -135,8 +136,6 @@ $.ajax({
   }
 });
 ```
-
-> Received link url format http://mon-site.com/rest-password?code=privateCode
 
 ## Reset user password.
 
@@ -165,7 +164,7 @@ $.ajax({
 ```
 
 ## User Object In Strapi Context
-The User object is available to successfully authenticated requests.
+The `user` object is available to successfully authenticated requests.
 
 #### Usage
 - The authenticated `user` object is a property of `ctx.state`.
@@ -189,10 +188,9 @@ The User object is available to successfully authenticated requests.
 
 ```
 
-
 ## Add a new provider
 
-To add a new provider on strapi, you will need to perform changes onto the following files:
+To add a new provider on Strapi, you will need to perform changes onto the following files:
 
 ```
 packages/strapi-plugin-users-permissions/services/Providers.js
@@ -203,7 +201,7 @@ packages/strapi-plugin-users-permissions/admin/src/translations/en.json
 
 We will go step by step.
 
-### Configure your Provider request
+### Configure your Provider Request
 First, we need to configure our new provider onto `Provider.js` file.
 
 Jump onto the `getProfile` function, you will see the list of currently available providers in the form of a `switch...case`.
@@ -212,9 +210,10 @@ As you can see, `getProfile` take three params:
 
 1. provider :: The name of the used provider as a string.
 2. query :: The query is the result of the provider callback.
-3. callback :: The callback function who will continue the internal strapi login logic.
+3. callback :: The callback function who will continue the internal Strapi login logic.
 
-Let's take the `discord` one as an example since it's not the easier, it should cover most of the case you may encounter trying to implement your own provider.
+Let's take the `discord` one as an example since it's not the easier, it should cover most of the case you 
+may encounter trying to implement your own provider.
 
 #### Configure your oauth generic information
 
@@ -239,9 +238,11 @@ Let's take the `discord` one as an example since it's not the easier, it should 
           }
         }
       });
+    }
 ```
 
-So here, you can see that we use a module called `Purest`. This module gives us with a generic way to interact with the REST API.
+So here, you can see that we use a module called `Purest`. This module gives us with a generic way to interact 
+with the REST API.
 
 To understand each value usage, and the templating syntax, I invite you to read the [Official Purest Documentation](https://github.com/simov/purest/tree/2.x)
 
@@ -265,17 +266,21 @@ You may also want to take a look onto the numerous already made configurations [
     }
 ```
 
-Here is the next part of our switch. Now that we have properly configured our provider, we want to use it to retrieve user information.
+Here is the next part of our switch. Now that we have properly configured our provider, we want to use it to retrieve 
+user information.
 
-Here you see the real power of `purest`, you can simply make a get request on the desired URL, using the `access_token` from the `query` parameter to authenticate.
+Here you see the real power of `purest`, you can simply make a get request on the desired URL, using the `access_token` 
+from the `query` parameter to authenticate.
 
 That way, you should be able to retrieve the user info you need.
 
-Now, you can simply call the `callback` function with the username and email of your user. That way, strapi will be able to retrieve your user from the database and log you in.
+Now, you can simply call the `callback` function with the username and email of your user. That way, strapi will be able 
+to retrieve your user from the database and log you in.
 
 #### Configure the new provider model onto database
 
-Now, we need to configure our 'model' for our new provider. That way, our settings can be stored in the database, and managed from the admin panel.
+Now, we need to configure our 'model' for our new provider. That way, our settings can be stored in the database, and 
+managed from the admin panel.
 
 Into: `packages/strapi-plugin-users-permissions/config/functions/bootstrap.js`
 
@@ -296,9 +301,8 @@ For our discord provider it will look like:
     },
 ```
 
-
-You have already done the hard part, now, we simply need to make our new provider available from the front side of our application. So let's do it!
-
+You have already done the hard part, now, we simply need to make our new provider available from the front 
+side of our application. So let's do it!
 
 <!-- #### Tests -->
 <!-- TODO Add documentation about how to configure unit test for the new provider -->
@@ -316,13 +320,12 @@ As for backend, we have a `switch...case` where we need to put our new provider 
 Add the corresponding translation into: `packages/strapi-plugin-users-permissions/admin/src/translations/en.json`
 
 ```js
-  "PopUpForm.Providers.discord.providerConfig.redirectURL": "The redirect URL to add in your Discord application configurations",
+  "PopUpForm.Providers.discord.providerConfig.redirectURL": "The redirect URL to add in your Discord config",
 ````
 
 These two change will set up the popup message who appear on the UI when we will configure our new provider.
 
 That's it, now you should be able to use your new provider.
-
 
 ## Email templates
 

--- a/docs/3.x.x/en/guides/authentication.md
+++ b/docs/3.x.x/en/guides/authentication.md
@@ -320,7 +320,7 @@ As for backend, we have a `switch...case` where we need to put our new provider 
 Add the corresponding translation into: `packages/strapi-plugin-users-permissions/admin/src/translations/en.json`
 
 ```js
-  "PopUpForm.Providers.discord.providerConfig.redirectURL": "The redirect URL to add in your Discord config",
+  "PopUpForm.Providers.discord.providerConfig.redirectURL": "The redirect URL to add in your Discord application configurations",
 ````
 
 These two change will set up the popup message who appear on the UI when we will configure our new provider.


### PR DESCRIPTION
My PR is an: 💅 Enhancement

Main update on the: Documentation

This PR fixes the (required) URL used for password-resets via the REST-API. It also fixes some small typos and code-formatting.