### PR TITLE
Add config options for AutoOpen by default

### DIFF
--- a/packages/strapi-generate-new/files/config/environments/development/server.json
+++ b/packages/strapi-generate-new/files/config/environments/development/server.json
@@ -9,5 +9,8 @@
   },
   "cron": {
     "enabled": false
+  },
+  "admin": {
+    "autoOpen": true
   }
 }

--- a/packages/strapi-generate-new/files/config/environments/production/server.json
+++ b/packages/strapi-generate-new/files/config/environments/production/server.json
@@ -9,5 +9,8 @@
   },
   "cron": {
     "enabled": false
+  },
+  "admin": {
+    "autoOpen": false
   }
 }

--- a/packages/strapi-generate-new/files/config/environments/staging/server.json
+++ b/packages/strapi-generate-new/files/config/environments/staging/server.json
@@ -9,5 +9,8 @@
   },
   "cron": {
     "enabled": false
+  },
+  "admin": {
+    "autoOpen": false
   }
 }


### PR DESCRIPTION
My PR is a:
💅 Enhancement

Main update on the:
Framework

Added the config options for the autoOpen option to the server.js configs by default on generation to make it easier to find and change.

Personally I think it should be disabled by default on development, on most environments it does not refresh the current tab and instead opens up a new one. Very frustrating when you are trying to add models using the content-type builder or directly editing files while the server is running. Every time it auto-restarts it opens a new tab.

@Aurelsicoko thoughts on this? If you agree we can disable it by default I'll push the change.
