### PR TITLE
Fix model name with whitespace on keyboard content-builder form submission

### DIFF
--- a/packages/strapi-plugin-content-type-builder/admin/src/containers/Form/index.js
+++ b/packages/strapi-plugin-content-type-builder/admin/src/containers/Form/index.js
@@ -451,7 +451,7 @@ export class Form extends React.Component { // eslint-disable-line react/prefer-
     }
   }
 
-  handleSubmit = (e, redirectToChoose = false) => {
+  handleSubmit = (e, redirectToChoose = true) => {
     e.preventDefault();
     const hashArray = split(this.props.hash, ('::'));
     const valueToReplace = includes(this.props.hash, '#create') ? '#create' : '#edit';
@@ -526,12 +526,9 @@ export class Form extends React.Component { // eslint-disable-line react/prefer-
   }
 
   renderModalBodyChooseAttributes = () => {
-    const attributesDisplay = forms.attributesDisplay.items;
-
-    // Don't display the media field if the upload plugin isn't installed
-    if (!has(this.context.plugins.toJS(), 'upload')) {
-      attributesDisplay.splice(8, 1);
-    }
+    const attributesDisplay = has(this.context.plugins.toJS(), 'upload')
+      ? forms.attributesDisplay.items
+      : forms.attributesDisplay.items.filter(obj => obj.type !== 'media'); // Don't display the media field if the upload plugin isn't installed
 
     return (
       map(attributesDisplay, (attribute, key) => (

--- a/packages/strapi-plugin-content-type-builder/admin/src/containers/Form/index.js
+++ b/packages/strapi-plugin-content-type-builder/admin/src/containers/Form/index.js
@@ -143,7 +143,7 @@ export class Form extends React.Component { // eslint-disable-line react/prefer-
     }
 
     // Check if user is adding a relation with the same content type
-    
+
     if (includes(this.props.hash, 'attributerelation') && this.props.modifiedDataAttribute.params.target === this.props.modelName && get(this.props.modifiedDataAttribute, ['params', 'nature'], '') !== 'oneWay') {
       // Insert two attributes
       this.props.addAttributeRelationToContentType(this.props.modifiedDataAttribute);
@@ -418,7 +418,7 @@ export class Form extends React.Component { // eslint-disable-line react/prefer-
     if (includes(this.props.hash, 'choose')) {
       const { nodeToFocus } = this.state;
       let toAdd = 0;
-  
+
       switch(e.keyCode) {
         case 37: // Left arrow
         case 39: // Right arrow
@@ -446,17 +446,16 @@ export class Form extends React.Component { // eslint-disable-line react/prefer-
           toAdd = 0;
           break;
       }
-  
+
       this.setState(prevState => ({ nodeToFocus: prevState.nodeToFocus + toAdd }));
     }
   }
 
-  handleSubmit = (e, redirectToChoose = true) => {
+  handleSubmit = (e, redirectToChoose = false) => {
     e.preventDefault();
     const hashArray = split(this.props.hash, ('::'));
     const valueToReplace = includes(this.props.hash, '#create') ? '#create' : '#edit';
     const contentTypeName = replace(hashArray[0], valueToReplace, '');
-
     let cbSuccess;
     let dataSucces = null;
     let cbFail;
@@ -466,7 +465,7 @@ export class Form extends React.Component { // eslint-disable-line react/prefer-
         // Check if the user is editing the attribute
         const isAttribute = includes(hashArray[1], 'attribute');
         cbSuccess = isAttribute ? () => this.editTempContentTypeAttribute(redirectToChoose) : this.createContentType;
-        dataSucces = isAttribute ? null : this.props.modifiedDataEdit;
+        dataSucces = isAttribute ? null : this.getModelWithCamelCaseName(this.props.modifiedDataEdit);
         cbFail = isAttribute ? () => this.editContentTypeAttribute(redirectToChoose) : this.contentTypeEdit;
         return this.testContentType(contentTypeName, cbSuccess, dataSucces, cbFail);
       }
@@ -476,9 +475,22 @@ export class Form extends React.Component { // eslint-disable-line react/prefer-
         return this.testContentType(contentTypeName, cbSuccess, dataSucces, cbFail);
       }
       default: {
-        return this.createContentType(this.props.modifiedData);
+        return this.createContentType(
+          this.getModelWithCamelCaseName(this.props.modifiedData)
+        );
       }
     }
+  }
+
+  getModelWithCamelCaseName = (model = {}) => {
+    if (isEmpty(model) || isEmpty(model.name)) {
+      return;
+    }
+
+    return {
+      ...model,
+      name: camelCase(model.name),
+    };
   }
 
   initComponent = (props, condition) => {
@@ -514,9 +526,12 @@ export class Form extends React.Component { // eslint-disable-line react/prefer-
   }
 
   renderModalBodyChooseAttributes = () => {
-    const attributesDisplay = has(this.context.plugins.toJS(), 'upload') 
-      ? forms.attributesDisplay.items
-      : forms.attributesDisplay.items.filter(obj => obj.type !== 'media'); // Don't display the media field if the upload plugin isn't installed
+    const attributesDisplay = forms.attributesDisplay.items;
+
+    // Don't display the media field if the upload plugin isn't installed
+    if (!has(this.context.plugins.toJS(), 'upload')) {
+      attributesDisplay.splice(8, 1);
+    }
 
     return (
       map(attributesDisplay, (attribute, key) => (


### PR DESCRIPTION
My PR is a:
🐛 Bug fix #1897 

Main update on the:
Update of the `strapi-plugin-content-type-builder`

Model name is camelCased only on input blur, a `getModelWithCamelCaseName` function has been added and is used for model object on form submission (create and edit) in order to prevent model name with whitespaces.
