### PR TITLE
Update lanagues list label breaked on multi-line.

### DIFF
--- a/packages/strapi-plugin-settings-manager/admin/src/components/List/styles.scss
+++ b/packages/strapi-plugin-settings-manager/admin/src/components/List/styles.scss
@@ -113,14 +113,16 @@ button {
   margin-left: 1rem;
 }
 
-.flexed {
+.flexed,
+.label {
   display: flex;
 }
 
 .label {
+  align-items: center;
+  line-height: 1;
   width: 15rem;
   height: 5.2rem;
-  line-height: 5.2rem;
   margin-left: 5rem;
   color: #333740;
   font-weight: 600;


### PR DESCRIPTION
My PR is a:
🐛 Bug fix #1844 

Main update on the:
Update of `strapi-plugin-settings-manager`

Update lanagues list label break on multi-line.
Center vertically label with flexbox and decrease line-height in order to increase render of language name.

<img width="684" alt="capture d ecran 2018-09-18 1" src="https://user-images.githubusercontent.com/1331358/45665822-cbd56280-bae0-11e8-8d28-81017d9e8bc9.png">
