### PR TITLE
Remove moveFocusToEnd in addContent and addBlock WYSIWYG methods.

### DIFF
--- a/packages/strapi-plugin-content-manager/admin/src/components/Wysiwyg/index.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/Wysiwyg/index.js
@@ -173,9 +173,7 @@ class Wysiwyg extends React.Component {
     if (selectedText !== '') {
       return this.setState(
         {
-          // Move the cursor to the end (this line forces the cursor to be at the end of the content)
-          // It may go at the end of the last block
-          editorState: EditorState.moveFocusToEnd(newEditorState),
+          editorState: newEditorState,
         },
         () => {
           this.focus();
@@ -309,7 +307,14 @@ class Wysiwyg extends React.Component {
     const newContentState = this.createNewContentStateFromBlock(newBlock);
     const newEditorState = this.createNewEditorState(newContentState, text);
 
-    return this.setState({ editorState: EditorState.moveFocusToEnd(newEditorState) });
+    return this.setState(
+      {
+        editorState: newEditorState,
+      },
+      () => {
+        this.focus();
+      },
+    );
   };
 
   /**


### PR DESCRIPTION
My PR is a:
🐛 Bug fix #985 

Main update on the:
Update of `strapi-plugin-content-manager`

Remove `moveFocusToEnd` in order to prevent cursor which going to the bottom of the textarea when user put text in `bold`, `italic`, `line-through` or add `header`.