### PR TITLE
Specify timezone for time value.

### DIFF
--- a/packages/strapi-plugin-content-manager/admin/src/containers/EditPage/index.js
+++ b/packages/strapi-plugin-content-manager/admin/src/containers/EditPage/index.js
@@ -227,7 +227,7 @@ export class EditPage extends React.Component {
     let value = e.target.value;
     // Check if date
     if (isObject(e.target.value) && e.target.value._isAMomentObject === true) {
-      value = moment(e.target.value).format('YYYY-MM-DD HH:mm:ss');
+      value = moment(e.target.value).format('YYYY-MM-DDTHH:mm:ss.SSSSZZ');
     } else if (['float', 'integer', 'biginteger', 'decimal'].indexOf(get(this.getSchema(), ['fields', e.target.name, 'type'])) !== -1) {
       value = toNumber(e.target.value);
     }


### PR DESCRIPTION
**My PR is a:**
🐛 Bug fix #1960 

**Main update on the:**
Plugin strapi-plugin-content-manager

Date value are now passed to inputDate component with a timezone offset in order to prevent multiple UTC recalculation.