### PR TITLE
converted password to a string before creating hash

### DIFF
--- a/packages/strapi-plugin-users-permissions/services/User.js
+++ b/packages/strapi-plugin-users-permissions/services/User.js
@@ -82,7 +82,7 @@ module.exports = {
       if (!user.password || this.isHashed(user.password)) {
         resolve(null);
       } else {
-        bcrypt.hash(user.password, 10, (err, hash) => {
+        bcrypt.hash(`${user.password}`, 10, (err, hash) => {
           resolve(hash);
         });
       }


### PR DESCRIPTION

My PR is a:
🐛 Bug fix

Main update on the:
strapi-plugin-users-permissions

When trying to set password a number then [this line](https://github.com/kelektiv/node.bcrypt.js/blob/0da3dc35317c1b720c347d7edfde20ce0745e2a8/bcrypt.js#L144) in bcrypt was throwing an error and returning hash as `undefined`, Hence the password was not set.

I converted password to a string before passing it into the hash function
