### PR TITLE
[WIP] Script to automatically cleanup any Strapi dev plugins sitting in the npm global modules.

### DIFF
--- a/destroy.sh
+++ b/destroy.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+echo ">  Uninstalling Strapi dev modules..."
+echo ""
+npm uninstall -g strapi-admin
+npm uninstall -g strapi-email-sendmail
+npm uninstall -g strapi-generate
+npm uninstall -g strapi-generate-admin
+npm uninstall -g strapi-generate-api
+npm uninstall -g strapi-generate-new
+npm uninstall -g strapi-helper-plugin
+npm uninstall -g strapi-hook-bookshelf
+npm uninstall -g strapi-hook-knex
+npm uninstall -g strapi-hook-mongoose
+npm uninstall -g strapi-lint
+npm uninstall -g strapi-plugin-content-manager
+npm uninstall -g strapi-plugin-content-type-builder
+npm uninstall -g strapi-plugin-email
+npm uninstall -g strapi-plugin-graphql
+npm uninstall -g strapi-plugin-settings-manager
+npm uninstall -g strapi-plugin-upload
+npm uninstall -g strapi-plugin-users-permissions
+npm uninstall -g strapi-upload-local
+npm uninstall -g strapi-utils
+echo ""
+echo ">  Please check below to see if any Strapi dev modules are still installed. If there are, uninstall them manually."
+echo ""
+npm list -g --depth=0

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "scripts": {
     "clean": "npm run removesymlinkdependencies && rm -rf package-lock.json && rm -rf packages/*/package-lock.json",
     "clean:all": "npm run removesymlinkdependencies && rm -rf package-lock.json && rm -rf packages/*/package-lock.json && rm -rf packages/*/node_modules",
+    "destroy": "bash destroy.sh",
     "doc": "node ./scripts/documentation.js",
     "release": "npm run clean:all && npm install && npm run createsymlinkdependencies && lerna exec --concurrency 1 -- npm install && npm run removesymlinkdependencies && node ./scripts/publish.js $TAG",
     "createsymlinkdependencies": "node ./scripts/createSymlinkDependencies.js",


### PR DESCRIPTION
My PR is a:
💅 Enhancement
🚀 New feature

Main update on the:
Framework

I had the annoying problem of having a whole lot of peer dependency warning come up when running `npm list -g --depth=0` due to the compiled Strapi dev plugins. It seemed that there were no cleanup scripts that uninstalled them from the npm global modules. I've gone ahead to create a simple bash script and a caller function in `package.json` to execute the bash script.

Simply run:

`npm run destroy`

and will cleanup all the Strapi dev plugins in the npm global modules.