### PR TITLE
Remove API prefix 

### DIFF
--- a/docs/3.x.x/en/configurations/configurations.md
+++ b/docs/3.x.x/en/configurations/configurations.md
@@ -297,8 +297,6 @@ Most of the application's configurations are defined by environment. It means th
  - `parser`
   - `enabled`(boolean): Enable or disable parser. Default value: `true`.
   - `multipart` (boolean): Enable or disable multipart bodies parsing. Default value: `true`.
- - `router`
-  - `prefix` (string): API url prefix (eg. `/v1`).
 
 > Note: The session doesn't work with `mongo` as a client. The package that we should use is broken for now.
 

--- a/packages/strapi-generate-new/files/config/environments/development/request.json
+++ b/packages/strapi-generate-new/files/config/environments/development/request.json
@@ -19,8 +19,5 @@
   "parser": {
     "enabled": true,
     "multipart": true
-  },
-  "router": {
-    "prefix": ""
   }
 }

--- a/packages/strapi-generate-new/files/config/environments/production/request.json
+++ b/packages/strapi-generate-new/files/config/environments/production/request.json
@@ -19,8 +19,5 @@
   "parser": {
     "enabled": true,
     "multipart": true
-  },
-  "router": {
-    "prefix": ""
   }
 }

--- a/packages/strapi-generate-new/files/config/environments/staging/request.json
+++ b/packages/strapi-generate-new/files/config/environments/staging/request.json
@@ -19,8 +19,5 @@
   "parser": {
     "enabled": true,
     "multipart": true
-  },
-  "router": {
-    "prefix": ""
   }
 }


### PR DESCRIPTION
<!-- ⚠️ Your PR title will appear in the changelogs please make it short detailed and understandable for all. -->

<!-- Uncomment the correct contribution type. !-->

My PR is a: 💅 Enhancement 
Main update on the: Framework

Actually we allow by default an router option `prefix` because it was possible by the router we use in Strapi. But it cause issues with Public files and Admin so we chose to remove the possibility to prefix all routes. 

Related issue #1323