### PR TITLE
Fixes initial setup on a linux server.

### DIFF
--- a/packages/strapi-admin/scripts/preSetup.js
+++ b/packages/strapi-admin/scripts/preSetup.js
@@ -25,6 +25,20 @@ shell.exec(`cd "${appPath}" && npm install --ignore-scripts`, {
   silent
 });
 
+// Install all the dependencies of the plugins.
+shell.exec(`
+  cd ${appPath}/admin/plugins
+
+  for d in */ ; do
+      echo $d
+      cd $d
+      npm i
+      cd ../
+  done
+`, {
+  silent
+});
+
 // Install the administration dependencies.
 shell.exec(`cd "${path.resolve(appPath, 'admin')}" && npm install`, {
   silent


### PR DESCRIPTION
Installing strapi on a linux server with `npm run setup` causes issues because internal dependancies of the plugins are missing. This PR makes sure all the plugins have their dependancies installed.

My PR is a:
🐛 Bug fix #1840

Main update on the:
Admin

As shown in the issue #1840 Installing strapi on a linux server with `npm run setup` causes issues because internal dependancies of the plugins are missing. This PR makes sure all the plugins have their dependancies installed.
