### PR TITLE
[Docs] Add instructions for cloning locally from Heroku

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ Be aware that one of the content type builder won't work due to the writing file
 1. Click the button above and deploy your app
 2. Clone that repo by using `heroku git:clone -a ` followed by your repo's name
 3. Go into the cloned projects' folder using `cd` followed by your repo's name
-4. Add the Heroku boilerplate as a remote by running `git remote add origin https://github.com/strapi/strapi-heroku-app`
-5. Pull from this new origin by running `git pull origin master`
+4. Add the Heroku boilerplate as a remote by running `git remote add boilerplate https://github.com/strapi/strapi-heroku-app`
+5. Pull from this new origin by running `git pull boilerplate master`
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -80,16 +80,21 @@ strapi start
 
 Congratulations, you made it! Enjoy 🎉
 
-<br>
+### Try on Heroku
 
-You can also give it a try using Heroku! Be aware that one of the content type builder won't work due to the writing files restriction on the Heroku servers. 
+You can also give it a try using Heroku in one click!
 
 <a href="https://heroku.com/deploy?template=https://github.com/strapi/strapi-heroku-app">
   <img src="https://www.herokucdn.com/deploy/button.svg" alt="Deploy">
 </a>
 
-<br>
+Be aware that one of the content type builder won't work due to the writing files restriction on the Heroku servers. If you do want to change content types, you need to follow these steps:
 
+1. Click the button above and deploy your app
+2. Clone that repo by using `heroku git:clone -a ` followed by your repo's name
+3. Go into the cloned projects' folder using `cd` followed by your repo's name
+4. Add the Heroku boilerplate as a remote by running `git remote add origin https://github.com/strapi/strapi-heroku-app`
+5. Pull from this new origin by running `git pull origin master`
 
 ## Features
 


### PR DESCRIPTION
Hi 👋 

I really love Strapi and have been using it for a few months. I think you have all done a great job!

My PR is an:  💅 Enhancement

Main update on the: Documentation

This took me ages of trial & error when I first started investigating Strapi. I nearly gave up several times because of my inexperience with both Strapi and Heroku. 

The only available instructions I found to be a bit difficult to follow (https://help.heroku.com/XOBUHLKQ/why-do-i-see-a-message-you-appear-to-have-cloned-an-empty-repository-when-using-heroku-git-clone).

I think this addition would help new adopters to get a more useful instance of Strapi running that would help them more easily evaluate the benefits of the content builder.