### PR TITLE
Fix deep delete relation for oneWay and when there is no relations

### DIFF
--- a/packages/strapi-generate-api/templates/mongoose/service.template
+++ b/packages/strapi-generate-api/templates/mongoose/service.template
@@ -129,6 +129,10 @@ module.exports = {
 
     await Promise.all(
       <%= globalID %>.associations.map(async association => {
+        if (!association.via || !data._id) {
+          return true;
+        }
+
         const search = _.endsWith(association.nature, 'One') || association.nature === 'oneToMany' ? { [association.via]: data._id } : { [association.via]: { $in: [data._id] } };
         const update = _.endsWith(association.nature, 'One') || association.nature === 'oneToMany' ? { [association.via]: null } : { $pull: { [association.via]: data._id } };
 


### PR DESCRIPTION
<!-- ⚠️ Your PR title will appear in the changelogs please make it short detailed and understandable for all. -->

<!-- Uncomment the correct contribution type. !-->

My PR is a: 🐛 Bug fix #1483
Main update on the: Framework
<!-- Plugin -->

`$pull` object on delete data has an error when `data._id` is null (because there is no relations) and where `association.via` value is null (because oneWay relation has no key in the other model)

So we don't have to check relations in this two case.
