### PR TITLE
Fix warning for controlled input without onChange handler in WYSIWYG

### DIFF
--- a/packages/strapi-plugin-content-manager/admin/src/components/Wysiwyg/index.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/Wysiwyg/index.js
@@ -722,7 +722,7 @@ class Wysiwyg extends React.Component {
                 stripPastedStyles
                 tabIndex={this.props.tabIndex}
               />
-              <input className={styles.editorInput} value="" tabIndex="-1" />
+              <input className={styles.editorInput} tabIndex="-1" />
             </div>
           )}
           {!isFullscreen && (


### PR DESCRIPTION
<!-- ⚠️ Your PR title will appear in the changelogs please make it short detailed and understandable for all. -->

<!-- Uncomment the correct contribution type. !-->

My PR is a:
<!-- 💥 Breaking change -->
🐛 Bug fix
<!-- 💅 Enhancement -->
<!-- 🚀 New feature -->

Main update on the:
<!-- Admin -->
<!-- Documentation -->
<!-- Framework -->
Plugin
Fix warning for controlled input without onChange handler in WYSIWYG


<!-- Write a short description of what your PR does and link the concerned issues of your update. -->
