### PR TITLE
bugfix 1992 - Unexpected key 'Key' found in params when deleting a fi…

### DIFF
--- a/packages/strapi-upload-aws-s3/lib/index.js
+++ b/packages/strapi-upload-aws-s3/lib/index.js
@@ -92,7 +92,7 @@ module.exports = {
         return new Promise((resolve, reject) => {
           // delete file on S3 bucket
           const path = file.path ? `${file.path}/` : '';
-          S3.deleteObjects({
+          S3.deleteObject({
             Key: `${path}${file.hash}${file.ext}`
           }, (err, data) => {
             if (err) {


### PR DESCRIPTION
…le from S3

My PR is a 🐛 **Bug fix**

Main update on the **strapi-upload-aws-s3 plugin**

> When @betomoretti tries to delete a file from the File Upload tab, it fails whith the following errors:
**_MissingRequiredParameter: Missing required key 'Delete' in params  
UnexpectedParameter: Unexpected key 'Key' found in params_**  
This is happening for the strapi-upload-aws-s3 plugin.

@yummyelin gives the solution.
For deleting ONE object, wee need to call S3.deleteObject and not S3.deleteObject**s**.

The modified file is "packages/strapi-upload-aws-s3/lib/index.js."

Here is the Amazon documentation:
https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#deleteObject-property