### PR TITLE
Prevent lint run in docs

### DIFF
--- a/scripts/lint.js
+++ b/scripts/lint.js
@@ -31,6 +31,7 @@ const watcher = (label, pckgName) => {
 };
 
 const except = [
+  'docs',
   'jest.config.js',
   'scripts',
   'strapi-lint',


### PR DESCRIPTION
According with @soupette , we need to prevent lint run in docs. 
<!-- Uncomment the correct contribution type. !-->

My PR is a:
🐛 Bug fix
💅 Enhancement

Main update on the:
Framework


<!-- Write a short description of what your PR does and link the concerned issues of your update. -->
No issue concerned, lint will not pass in doc files.
