### PR TITLE
Add IF NOT EXISTS parameter for creating indexes with PG

### DIFF
--- a/packages/strapi-hook-bookshelf/lib/index.js
+++ b/packages/strapi-hook-bookshelf/lib/index.js
@@ -479,7 +479,7 @@ module.exports = function(strapi) {
                                   ? column
                                   : `"${column}"`;
 
-                                return ORM.knex.raw(`CREATE INDEX search_${_.toLower(indexName)} ON "${table}" USING gin(${attribute} gin_trgm_ops)`);
+                                return ORM.knex.raw(`CREATE INDEX IF NOT EXISTS search_${_.toLower(indexName)} ON "${table}" USING gin(${attribute} gin_trgm_ops)`);
                               });
 
                             await Promise.all(indexes);


### PR DESCRIPTION
My PR is an 💅 Enhancement. See #1850 issue posted by @jbergstroem.
Main update on the package strapi-hook-bookshelf.

Add IF NOT EXISTS parameter for creating indexes in postgresql case to avoid this type message :  

> 2018-08-30 23:01:50.060 UTC [146] ERROR:  relation "search_users_permissions_permission_type" already exists
> 2018-08-30 23:01:50.060 UTC [146] STATEMENT:  CREATE INDEX search_users_permissions_permission_type ON "users-permissions_permission" USING gin(type gin_trgm_ops)
> 