### PR TITLE
[WIP] Save application logs in .log file

### DIFF
--- a/packages/strapi-utils/lib/logger.js
+++ b/packages/strapi-utils/lib/logger.js
@@ -1,26 +1,60 @@
-'use strict';
+"use strict";
 
 /**
  * Logger.
  */
 
-const pino = require('pino');
-const _ = require('lodash');
 
-const logLevels = ['fatal', 'error', 'warn', 'info', 'debug', 'trace'];
+const fs = require("fs");
+const path = require("path");
+const _ = require("lodash");
+const pino = require("pino");
+
+const logLevels = ["fatal", "error", "warn", "info", "debug", "trace"];
 
 function getLogLevel() {
-  if (_.isString(process.env.STRAPI_LOG_LEVEL) && _.includes(logLevels, process.env.STRAPI_LOG_LEVEL.toLowerCase())) {
+  if (
+    _.isString(process.env.STRAPI_LOG_LEVEL) &&
+    _.includes(logLevels, process.env.STRAPI_LOG_LEVEL.toLowerCase())
+  ) {
     return process.env.STRAPI_LOG_LEVEL;
   }
-  return 'debug';
+  return "debug";
 }
+
+const logTypes = ["stdout", "file"];
+function getLogType() {
+  if (
+    _.isString(process.env.STRAPI_LOG_TYPE) &&
+    _.includes(logTypes, process.env.STRAPI_LOG_TYPE.toLowerCase())
+  ) {
+    return process.env.STRAPI_LOG_TYPE;
+  }
+  return "stdout";
+}
+
+function parseLogPath(defaultLogFilename = "strapi.log") {
+  if (_.isString(process.env.STRAPI_LOG_PATH)) {
+    return path.parse(process.env.STRAPI_LOG_PATH);
+  }
+  return path.parse(path.join(__dirname, defaultLogFilename));
+}
+
+function getLogDir() {
+  return parseLogPath().dir;
+}
+
+function getLogBase() {
+  return parseLogPath().base;
+}
+
+const logFile = path.join(getLogDir(), getLogBase());
 
 function getBool(envVar, defaultValue) {
   if (_.isBoolean(envVar)) return envVar;
   if (_.isString(envVar)) {
-    if (envVar === 'true') return true;
-    if (envVar === 'false') return false;
+    if (envVar === "true") return true;
+    if (envVar === "false") return false;
   }
   return defaultValue;
 }
@@ -34,14 +68,32 @@ const loggerConfig = {
 
 const pretty = pino.pretty({
   formatter: (logs, options) => {
-    return `${options.asColoredText({ level: 10 }, `[${new Date().toISOString()}]`)} ${options.prefix.toLowerCase()} ${logs.msg}`;
+    return `${options.asColoredText(
+      { level: 10 },
+      `[${new Date().toISOString()}]`
+    )} ${options.prefix.toLowerCase()} ${logs.msg}`;
   }
 });
 
-pretty.pipe(process.stdout);
-
-const logger = getBool(process.env.STRAPI_LOG_PRETTY_PRINT, true) ?
-  pino(loggerConfig, pretty):
-  pino(loggerConfig);
+let logger;
+switch (getLogType()) {
+  case "stdout":
+    pretty.pipe(process.stdout);
+    logger = getBool(process.env.STRAPI_LOG_PRETTY_PRINT, true)
+      ? pino(loggerConfig, pretty)
+      : pino(loggerConfig);
+    break;
+  case "file":
+    pretty.pipe(fs.createWriteStream(logFile, { flags: "a" }));
+    logger = getBool(process.env.STRAPI_LOG_PRETTY_PRINT, true)
+      ? pino(loggerConfig, pretty)
+      : pino(loggerConfig, fs.createWriteStream(logFile, { flags: "a" }));
+    break;
+  default:
+    pretty.pipe(process.stdout);
+    logger = getBool(process.env.STRAPI_LOG_PRETTY_PRINT, true)
+      ? pino(loggerConfig, pretty)
+      : pino(loggerConfig);
+}
 
 module.exports = logger;

--- a/packages/strapi-utils/lib/logger.js
+++ b/packages/strapi-utils/lib/logger.js
@@ -1,16 +1,16 @@
-"use strict";
+'use strict';
 
 /**
  * Logger.
  */
 
 
-const fs = require("fs");
-const path = require("path");
-const _ = require("lodash");
-const pino = require("pino");
+const fs = require('fs');
+const path = require('path');
+const _ = require('lodash');
+const pino = require('pino');
 
-const logLevels = ["fatal", "error", "warn", "info", "debug", "trace"];
+const logLevels = ['fatal', 'error', 'warn', 'info', 'debug', 'trace'];
 
 function getLogLevel() {
   if (
@@ -19,10 +19,10 @@ function getLogLevel() {
   ) {
     return process.env.STRAPI_LOG_LEVEL;
   }
-  return "debug";
+  return 'debug';
 }
 
-const logTypes = ["stdout", "file"];
+const logTypes = ['stdout', 'file'];
 function getLogType() {
   if (
     _.isString(process.env.STRAPI_LOG_TYPE) &&
@@ -30,10 +30,10 @@ function getLogType() {
   ) {
     return process.env.STRAPI_LOG_TYPE;
   }
-  return "stdout";
+  return 'stdout';
 }
 
-function parseLogPath(defaultLogFilename = "strapi.log") {
+function parseLogPath(defaultLogFilename = 'strapi.log') {
   if (_.isString(process.env.STRAPI_LOG_PATH)) {
     return path.parse(process.env.STRAPI_LOG_PATH);
   }
@@ -53,8 +53,8 @@ const logFile = path.join(getLogDir(), getLogBase());
 function getBool(envVar, defaultValue) {
   if (_.isBoolean(envVar)) return envVar;
   if (_.isString(envVar)) {
-    if (envVar === "true") return true;
-    if (envVar === "false") return false;
+    if (envVar === 'true') return true;
+    if (envVar === 'false') return false;
   }
   return defaultValue;
 }
@@ -77,17 +77,17 @@ const pretty = pino.pretty({
 
 let logger;
 switch (getLogType()) {
-  case "stdout":
+  case 'stdout':
     pretty.pipe(process.stdout);
     logger = getBool(process.env.STRAPI_LOG_PRETTY_PRINT, true)
       ? pino(loggerConfig, pretty)
       : pino(loggerConfig);
     break;
-  case "file":
-    pretty.pipe(fs.createWriteStream(logFile, { flags: "a" }));
+  case 'file':
+    pretty.pipe(fs.createWriteStream(logFile, { flags: 'a' }));
     logger = getBool(process.env.STRAPI_LOG_PRETTY_PRINT, true)
       ? pino(loggerConfig, pretty)
-      : pino(loggerConfig, fs.createWriteStream(logFile, { flags: "a" }));
+      : pino(loggerConfig, fs.createWriteStream(logFile, { flags: 'a' }));
     break;
   default:
     pretty.pipe(process.stdout);


### PR DESCRIPTION
My PR is a 🚀 New feature for issue #1427.
Main update on the pino logger.

**Demand:**
@Thyvo said:
> I would like to write my console output (info to error) to written into a logfile.
> I already tried the code below to write the output to a file, unfortunately, nothing gets written to the file.

@derrickmehaffy 
> I would also be interested in this...

**Implementation:**
I used the pino v4 (v5 is the current version) to be compatible with current strapi packages.
I updated /home/entwicklerfr/dev/strapi/packages/strapi-utils/lib/logger.js.

Adding two new environment variables:
- STRAPI_LOG_TYPE (optional)
  - 'stdout'
  - 'file'

If not set or set to 'stdout', **same behaviour** as current one (logs written in stdout).  
If set to 'file', see below.  

_Note:
I only implement 2 mono streams which don't run in the same time.  
In other words, it's either one or the other._

- STRAPI_LOG_PATH (optional)
   - **full path** name of the log file, '/tmp/my-project.log' for sample

If not set and STRAPI_LOG_TYPE set to 'file', logs written to 'strapi.log' in current directory (path.join(__dirname, 'strapi.log')) by default.  
If set and STRAPI_LOG_TYPE set to 'file', logs written to the set path.  
Writting is done in append mode.
 
_Note:
Only one variable could have been enough (STRAPI_LOG_PATH), but in case of a third future option like multi-streams files by log level it will be necessary to have STRAPI_LOG_TYPE to set "multi' option for example.  
The same for writting in 'stdout' and 'file' at the same time. It could be option 'both'._

**Examples:**  
Data written in log file for a database not started:  

**(1) Settings:**
process.env.STRAPI_LOG_TYPE="file";
process.env.STRAPI_LOG_PRETTY_PRINT=false;
process.env.STRAPI_LOG_PATH="/tmp/strapi.log";

{"level":20,"msg":"⛔️ Server wasn't able to start properly.","pid":6027,"hostname":"ew-pc","v":1}

**(2) Settings:**
process.env.STRAPI_LOG_TYPE="stdout";
process.env.STRAPI_LOG_PRETTY_PRINT=true;
OR
process.env.STRAPI_LOG_PRETTY_PRINT=true;

$ strapi start
[2018-10-22T12:13:56.561Z] debug ⛔️ Server wasn't able to start properly.
[2018-10-22T12:13:56.561Z] error Make sure your MongoDB database is running...
Make sure your MongoDB database is running...
