### PR TITLE
Fix error 500 when user trying to signin with bad credentials

### DIFF
--- a/packages/strapi-plugin-users-permissions/controllers/Auth.js
+++ b/packages/strapi-plugin-users-permissions/controllers/Auth.js
@@ -52,12 +52,12 @@ module.exports = {
       // Check if the user exists.
       const user = await strapi.query('user', 'users-permissions').findOne(query, ['role']);
 
-      if (_.get(await store.get({key: 'advanced'}), 'email_confirmation') && user && user.confirmed !== true) {
-        return ctx.badRequest(null, ctx.request.admin ? [{ messages: [{ id: 'Auth.form.error.confirmed' }] }] : 'Your account email is not confirmed.');
-      }
-
       if (!user) {
         return ctx.badRequest(null, ctx.request.admin ? [{ messages: [{ id: 'Auth.form.error.invalid' }] }] : 'Identifier or password invalid.');
+      }
+      
+      if (_.get(await store.get({key: 'advanced'}), 'email_confirmation') && user.confirmed !== true) {
+        return ctx.badRequest(null, ctx.request.admin ? [{ messages: [{ id: 'Auth.form.error.confirmed' }] }] : 'Your account email is not confirmed.');
       }
 
       if (user.blocked === true) {

--- a/packages/strapi-plugin-users-permissions/controllers/Auth.js
+++ b/packages/strapi-plugin-users-permissions/controllers/Auth.js
@@ -52,7 +52,7 @@ module.exports = {
       // Check if the user exists.
       const user = await strapi.query('user', 'users-permissions').findOne(query, ['role']);
 
-      if (_.get(await store.get({key: 'advanced'}), 'email_confirmation') && user.confirmed !== true) {
+      if (_.get(await store.get({key: 'advanced'}), 'email_confirmation') && user && user.confirmed !== true) {
         return ctx.badRequest(null, ctx.request.admin ? [{ messages: [{ id: 'Auth.form.error.confirmed' }] }] : 'Your account email is not confirmed.');
       }
 


### PR DESCRIPTION
<!-- ⚠️ Your PR title will appear in the changelogs please make it short detailed and understandable for all. -->

<!-- Uncomment the correct contribution type. !-->

My PR is a:
<!-- 💥 Breaking change -->
🐛 Bug fix
<!-- 💅 Enhancement -->
<!-- 🚀 New feature -->

Main update on the:
<!-- Admin -->
<!-- Documentation -->
<!-- Framework -->
Plugin

<!-- Write a short description of what your PR does and link the concerned issues of your update. -->

Step 1) Enable the email confirmation
Step 2) Signin with bad credentials on `/auth/local` POST

An 500 error comes up instead of the expected 400 response

```
TypeError: Cannot read property 'confirmed' of null
at callback (/usr/src/api/plugins/users-permissions/controllers/Auth.js:59:83)
```
Expected : 
```
{
    "statusCode": 400,
    "error": "Bad Request",
    "message": "Identifier or password invalid."
}
```
