### PR TITLE
change english lang by default | add russian lang

### DIFF
--- a/packages/strapi-admin/admin/src/config/languages.json
+++ b/packages/strapi-admin/admin/src/config/languages.json
@@ -1,3 +1,3 @@
 {
-  "languages": ["ar", "en", "es", "fr", "de", "it", "ko", "nl", "pl", "pt", "pt-BR", "tr", "zh", "zh-Hans"]
+  "languages": ["en", "ar", "es", "fr", "de", "it", "ko", "nl", "pl", "pt", "pt-BR", "ru", "tr", "zh", "zh-Hans"]
 }


### PR DESCRIPTION
My PR is a:
💅 Enhancement

Main update on the:
Admin

At this moment after installation by default admin is in arabian language, what is a little confuse. I change it on English.

Also we have a Russian language translate, but don't have a possibility choose it.

<img width="1315" alt="strapi-default-lang" src="https://user-images.githubusercontent.com/7899637/47389658-08b6f980-d71e-11e8-8679-b936b0389526.png">
