### PR TITLE
Add ObjectId toString function to index.js

### DIFF
--- a/packages/strapi-hook-mongoose/lib/index.js
+++ b/packages/strapi-hook-mongoose/lib/index.js
@@ -19,6 +19,12 @@ const { models: utilsModels }  = require('strapi-utils');
 const utils = require('./utils/');
 const relations = require('./relations');
 
+// ObjectId toString
+const { ObjectId } = mongoose.Types;
+ObjectId.prototype.valueOf = function () {
+  return this.toString()
+}
+
 /**
  * Mongoose hook
  */


### PR DESCRIPTION
My PR is a:
  🐛 Bug fix

Main update on the:
  Plugin

It lets GraphQL plugin to use id attributes and retrive it as String.
Currently GraphQL plugin throws and error when trying to retrieve id for models.

`
"errors": [
    {
      "message": "ID cannot represent value: { _bsontype: \"ObjectID\", id: <Buffer 5b cc 6e b3 d4 5f 6f 07 be de 6d fa> }",
...
`