### PR TITLE
fixed searchcontext filter in docs

### DIFF
--- a/docs/.vuepress/theme/SearchBox.vue
+++ b/docs/.vuepress/theme/SearchBox.vue
@@ -64,7 +64,7 @@ export default {
         if (res.length >= max) break
         const p = pages[i]
         // filter out results that do not match current ersion context
-        if (~p.path.slice(1).indexOf(searchContext)) continue
+        if (!~p.path.slice(1).indexOf(searchContext)) continue
         // filter out results that do not match current locale
         if (this.getPageLocalePath(p) !== localePath) continue
         if (matches(p)) {


### PR DESCRIPTION
<!-- ⚠️ Your PR title will appear in the changelogs please make it short detailed and understandable for all. -->

<!-- Uncomment the correct contribution type. !-->

My PR is a:
<!-- 💥 Breaking change -->
🐛 Bug fix
<!-- 💅 Enhancement -->
<!-- 🚀 New feature -->

Main update on the:
<!-- Admin -->
Documentation
<!-- Framework -->
<!-- Plugin -->

<!-- Write a short description of what your PR does and link the concerned issues of your update. -->

When preparing the first draft of the docs, I messed up with the filter for version context.
By default, Vue does not filter based on versions, so I had to build that feature into it.
Right now, the filter is reversed. If you are in the 3.x.x docs, you search for 1.x.x and vice versa.

This PR fixes that.