### PR TITLE
Fix mongoose ObjectId to string at GraphQL plugin

### DIFF
--- a/packages/strapi-plugin-graphql/services/Resolvers.js
+++ b/packages/strapi-plugin-graphql/services/Resolvers.js
@@ -56,6 +56,19 @@ module.exports = {
       if (!acc.resolver[globalId]) {
         acc.resolver[globalId] = {};
       }
+      
+      // Add resolver to primaryKey defined in the models
+      Object.assign(acc.resolver[globalId], {
+        _id: (obj, options, context) => {
+          // eslint-disable-line no-unused-vars
+          if (typeof obj._id === 'object') { 
+            if (Object.prototype.hasOwnProperty.call(obj._id, 'id') && (typeof obj._id.id === 'object')) {
+              return obj._id.id.toString('hex');
+            }
+          }
+          return obj._id || obj.id;
+        },
+      });
 
       // Add timestamps attributes.
       if (_.get(model, 'options.timestamps') === true) {

--- a/packages/strapi-plugin-graphql/services/Resolvers.js
+++ b/packages/strapi-plugin-graphql/services/Resolvers.js
@@ -59,14 +59,14 @@ module.exports = {
       
       // Add resolver to primaryKey defined in the models
       Object.assign(acc.resolver[globalId], {
-        _id: (obj, options, context) => {
+        [model.primaryKey]: (obj, options, context) => {
           // eslint-disable-line no-unused-vars
-          if (typeof obj._id === 'object') { 
-            if (Object.prototype.hasOwnProperty.call(obj._id, 'id') && (typeof obj._id.id === 'object')) {
-              return obj._id.id.toString('hex');
+          if (typeof obj[model.primaryKey] === 'object') { 
+            if (Object.prototype.hasOwnProperty.call(obj[model.primaryKey], 'id') && (typeof obj[model.primaryKey].id === 'object')) {
+              return obj[model.primaryKey].id.toString('hex');
             }
           }
-          return obj._id || obj.id;
+          return obj[model.primaryKey];
         },
       });
 


### PR DESCRIPTION
<!-- ⚠️ Your PR title will appear in the changelogs please make it short detailed and understandable for all. -->

<!-- Uncomment the correct contribution type. !-->

My PR is a:
🐛 Bug fix

Main update on the:
Plugin: graphql

<!-- Write a short description of what your PR does and link the concerned issues of your update. -->
When find some data from MongoDB, **Mongoose** retrieve collection primary key `_id` as `ObjectId`. [Mongoose ObjectId](https://docs.mongodb.com/manual/reference/method/ObjectId/) [MongoDB ObjectId](https://docs.mongodb.com/manual/reference/method/ObjectId/).
Because of this when graphql plugin tries convert `_id` to `ID` schema type, I have this error:

![graphql-error](https://user-images.githubusercontent.com/1368287/47608155-de0bc000-d9ff-11e8-9167-2095f6cbd96d.png)


To fix this I add a custom resolver that's check if `_id` is an object and if it has `id` property inside of. After this I transform your value to hex. 
