### PR TITLE
Fix Creating a user in AdminUI does not properly set provider to 'local'

### DIFF
--- a/packages/strapi-plugin-users-permissions/controllers/User.js
+++ b/packages/strapi-plugin-users-permissions/controllers/User.js
@@ -91,6 +91,8 @@ module.exports = {
       ctx.request.body.role = defaultRole._id || defaultRole.id;
     }
 
+    ctx.request.body.provider = 'local';
+
     try {
       const data = await strapi.plugins['users-permissions'].services.user.add(ctx.request.body);
       // Send 201 `created`


### PR DESCRIPTION
My PR is a: 🐛 Bug fix 

Main update on the: Admin

`Issue summary`
Creating a user through the API sets provider to 'local' but do the same through the Admin UI sets the provider to '-'.
See also ISSUE #1787.

`Commit summary`
Creating a user through the API and the Admin UI is not managed by the same function.
We have to set the provider to 'local' in the create function of the User.js file.
