### PR TITLE
Update link version in left menu and fix typo in strapi-generate-new

### DIFF
--- a/packages/strapi-admin/admin/src/components/LeftMenuFooter/index.js
+++ b/packages/strapi-admin/admin/src/components/LeftMenuFooter/index.js
@@ -15,10 +15,8 @@ defineMessages(messages);
 function LeftMenuFooter({ version }) { // eslint-disable-line react/prefer-stateless-function
   return (
     <div className={styles.leftMenuFooter}>
-      <div>
-        <FormattedMessage {...messages.poweredBy} />
-        <a href="https://strapi.io" target="_blank">v{version}</a>
-      </div>
+      <FormattedMessage {...messages.poweredBy} />
+      <a href={`https://github.com/strapi/strapi/releases/tag/v${version}`} target="_blank">v{version}</a>
     </div>
   );
 }

--- a/packages/strapi-generate-new/lib/index.js
+++ b/packages/strapi-generate-new/lib/index.js
@@ -47,7 +47,7 @@ module.exports = {
 
     // Copy Markdown files with some information.
     'README.md': {
-      template: 'CLI.md'
+      template: 'README.md'
     },
 
     // Empty API directory.


### PR DESCRIPTION
- Update link of version in leftMenuFooter : redirect now to changelog on github.
- Fix typo in strapi-generate-new.


My PR is a:
🐛 Bug fix
💅 Enhancement

Main update on the:
Admin

Close #2197