### PR TITLE
Update models.md

### DIFF
--- a/docs/3.x.x/guides/models.md
+++ b/docs/3.x.x/guides/models.md
@@ -25,8 +25,8 @@ The info key on the model-json states information about the model. This informat
 
 ## Model options
 The options key on the model-json states.
-   - `idAttribute`: This tells the model which attribute to expect as the unique identifier for each database row (typically an auto-incrementing primary key named 'id').
-   - `idAttributeType`: Data type of `idAttribute`, accepted list of value bellow:
+   - `idAttribute`: This tells the model which attribute to expect as the unique identifier for each database row (typically an auto-incrementing primary key named 'id'). _Only valid for strapi-hook-bookshelf_
+   - `idAttributeType`: Data type of `idAttribute`, accepted list of value bellow. _Only valid for strapi-hook-bookshelf_
 
 ## Define the attributes
 


### PR DESCRIPTION
The Model options specified are only used on strapi-hook-bookshelf. State it clearly

<!-- ⚠️ Your PR title will appear in the changelogs please make it short detailed and understandable for all. -->

<!-- Uncomment the correct contribution type. !-->

My PR is a:
<!-- 💥 Breaking change -->
<!-- 🐛 Bug fix -->
 💅 Enhancement 
<!-- 🚀 New feature -->

Main update on the:
<!-- Admin -->
Documentation
<!-- Framework -->
<!-- Plugin -->

The Model options on the Guides should clearly state that they are only valid when using bookshelf as the data handler.