### PR TITLE
Allow customized _id on models (GraphQL plugin, Controller generator findOne, associations)

### DIFF
--- a/docs/3.x.x/guides/graphql.md
+++ b/docs/3.x.x/guides/graphql.md
@@ -248,7 +248,7 @@ The generated GraphQL type and queries will be:
 ```
 // Post's Type definition
 type Post {
-  _id: String
+  _id: ID
   created_at: String
   updated_at: String
   title: String
@@ -259,7 +259,7 @@ type Post {
 // Queries to retrieve one or multiple posts.
 type Query {
   posts(sort: String, limit: Int, start: Int, where: JSON): [Post]
-  post(id: String!): Post
+  post(id: ID!): Post
 }
 
 // Mutations to create, update or delete a post.

--- a/docs/3.x.x/guides/models.md
+++ b/docs/3.x.x/guides/models.md
@@ -49,6 +49,27 @@ The following types are currently available:
   - `json`
   - `email`
 
+## Primary key attribute
+
+When using a MongoDB connection, your model gets an _id: ID_ primary key by default: you dont have to add it on the attributes.
+
+However if you need to customize it, for example to change the _id type, you can add it and make the needed changes.
+
+For a given `Article` model, to have a `String` on the _id:
+
+**Path —** `./api/article/models/Article.settings.json`.
+```json
+{
+  ...,
+  "attributes": {
+    "_id": {
+      "type": "string",
+      "configurable": false
+    },
+  }
+}
+```
+
 #### Validations
 
 You can apply basic validations to the attributes. The following supported validations are *only supported by MongoDB* connection.

--- a/packages/strapi-generate-api/templates/mongoose/controller.template
+++ b/packages/strapi-generate-api/templates/mongoose/controller.template
@@ -29,11 +29,10 @@ module.exports = {
    */
 
   findOne: async (ctx) => {
-    if (!ctx.params._id.match(/^[0-9a-fA-F]{24}$/)) {
+    const data = await strapi.services.<%= id %>.fetch(ctx.params);
+    if (!data)
       return ctx.notFound();
-    }
-
-    return strapi.services.<%= id %>.fetch(ctx.params);
+    return data;
   },
 
   /**

--- a/packages/strapi-hook-mongoose/lib/index.js
+++ b/packages/strapi-hook-mongoose/lib/index.js
@@ -311,12 +311,15 @@ module.exports = function (strapi) {
                 definition.loadedModel[name].type = utils(instance).convertType(details.type);
               }
 
+              const customKey = details.model ? (details.plugin ? strapi.plugins[details.plugin].models[details.model].attributes['_id'] : strapi.models[details.model].attributes["_id"]) : null;
+
               switch (verbose) {
                 case 'hasOne': {
                   const ref = details.plugin ? strapi.plugins[details.plugin].models[details.model].globalId : strapi.models[details.model].globalId;
+                  const keyType = customKey ? utils(instance).convertType(customKey.type) : instance.Schema.Types.ObjectId;
 
                   definition.loadedModel[name] = {
-                    type: instance.Schema.Types.ObjectId,
+                    type: keyType,
                     ref
                   };
                   break;
@@ -336,8 +339,9 @@ module.exports = function (strapi) {
                     // Set this info to be able to see if this field is a real database's field.
                     details.isVirtual = true;
                   } else {
+                    const keyType = customKey ? utils(instance).convertType(customKey.type) : instance.Schema.Types.ObjectId;
                     definition.loadedModel[name] = [{
-                      type: instance.Schema.Types.ObjectId,
+                      type: keyType,
                       ref
                     }];
                   }
@@ -358,8 +362,9 @@ module.exports = function (strapi) {
                     // Set this info to be able to see if this field is a real database's field.
                     details.isVirtual = true;
                   } else {
+                    const keyType = customKey ? utils(instance).convertType(customKey.type) : instance.Schema.Types.ObjectId;
                     definition.loadedModel[name] = {
-                      type: instance.Schema.Types.ObjectId,
+                      type: keyType,
                       ref
                     };
                   }
@@ -381,8 +386,9 @@ module.exports = function (strapi) {
                     // Set this info to be able to see if this field is a real database's field.
                     details.isVirtual = true;
                   } else {
+                    const keyType = customKey ? utils(instance).convertType(customKey.type) : instance.Schema.Types.ObjectId;
                     definition.loadedModel[name] = [{
-                      type: instance.Schema.Types.ObjectId,
+                      type: keyType,
                       ref
                     }];
                   }
@@ -422,7 +428,7 @@ module.exports = function (strapi) {
                     kind: String,
                     [details.filter]: String,
                     ref: {
-                      type: instance.Schema.Types.ObjectId,
+                      type: String,
                       refPath: `${name}.kind`
                     }
                   };
@@ -433,7 +439,7 @@ module.exports = function (strapi) {
                     kind: String,
                     [details.filter]: String,
                     ref: {
-                      type: instance.Schema.Types.ObjectId,
+                      type: String,
                       refPath: `${name}.kind`
                     }
                   }];

--- a/packages/strapi-plugin-graphql/services/Resolvers.js
+++ b/packages/strapi-plugin-graphql/services/Resolvers.js
@@ -42,10 +42,15 @@ module.exports = {
         ? strapi.plugins[plugin].models[name]
         : strapi.models[name];
 
+      // Primary key can be customized so get its type
+      const keyType = model.attributes[model.primaryKey] ? Types.convertType({
+        definition: model.attributes[model.primaryKey]
+      }) : 'ID';
+
       // Setup initial state with default attribute that should be displayed
       // but these attributes are not properly defined in the models.
       const initialState = {
-        [model.primaryKey]: 'ID!',
+        [model.primaryKey]: `${keyType}!`,
       };
 
       const globalId = model.globalId;
@@ -162,7 +167,7 @@ module.exports = {
         if (_.isFunction(queries[type])) {
           if (type === 'singular') {
             Object.assign(acc.query, {
-              [`${pluralize.singular(name)}(id: ID!)`]: model.globalId,
+              [`${pluralize.singular(name)}(id: ${keyType}!)`]: model.globalId,
             });
           } else {
             Object.assign(acc.query, {


### PR DESCRIPTION
My PR is a:
<!-- 💥 Breaking change -->
<!-- 🐛 Bug fix -->
💅 Enhancement 
<!-- 🚀 New feature -->

Main update on the:
<!-- Admin -->
<!-- Documentation -->
<!-- Framework -->
Plugin

<!-- Write a short description of what your PR does and link the concerned issues of your update. -->

Current GraphQL plugin builds the query resolvers with a fixed `id: ID` on all models. That means, if the user makes customizations for any given API model to have an id field from different type, a String for example, like this:

```
{
  "connection": "default",
  "collectionName": "blog",
  "info": {
    "name": "blog",
  },
  "options": {
    "timestamps": true,
  },
  "attributes": {
    "_id": {
      "type": "string",
      "configurable": false
    },
   ...,
    "text": {
      "default": "",
      "type": "text",
      "required": true
    }
  }
}
```
When trying to query with GraphQL like this: 

```
query {
    blog(id: "the_id_value") {
         title
         text
    }
}
```
you will get an error saying something like `ID expected but received String`


## Solution

This PR adds support for fixing that. It fetches the model defined `primaryKey` to use its type.

Also, there is a little modification on the `strapi-generate-api`  generator, as it adds a check on the format by default via a regex, which is not correct if using a string in its place.

## Screenshot

![seleccion_001](https://user-images.githubusercontent.com/517228/47931076-8b714e80-deac-11e8-9790-90c881efc774.jpg)

Close https://github.com/strapi/strapi/issues/2244
