### PR TITLE
Fix delete all

### DIFF
--- a/packages/strapi-utils/lib/models.js
+++ b/packages/strapi-utils/lib/models.js
@@ -584,7 +584,7 @@ module.exports = {
       };
     } else if (model.attributes[key]) {
       field = model.attributes[key];
-    } else {
+    } else if (typeof key === 'string') {
       // Remove the filter keyword at the end
       let splitKey = key.split('_').slice(0, -1);
       splitKey = splitKey.join('_');


### PR DESCRIPTION
<!-- ⚠️ Your PR title will appear in the changelogs please make it short detailed and understandable for all. -->

<!-- Uncomment the correct contribution type. !-->

My PR is a:
- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

Main update on the:
- [ ] Admin
- [ ] Documentation
- [x] Framework
- [ ] Plugin

When content manager use deleteAll function, it send `0` as url query and it breaks convertParams function cause it's not a `string`.
