### PR TITLE
Fix fetch user mongoose

### DIFF
--- a/packages/strapi-plugin-users-permissions/config/queries/mongoose.js
+++ b/packages/strapi-plugin-users-permissions/config/queries/mongoose.js
@@ -12,9 +12,9 @@ module.exports = {
 
     const result = this.aggregate(aggregateStages);
 
-    if (_.has(filters, 'start')) result.skip(filters.start);
-    if (_.has(filters, 'limit')) result.limit(filters.limit);
-    if (_.has(filters, 'sort')) result.sort(filters.sort);
+    if (_.has(filters, 'start') && filters.start) result.skip(filters.start);
+    if (_.has(filters, 'limit') && filters.limit) result.limit(filters.limit);
+    if (_.has(filters, 'sort') && filters.sort) result.sort(filters.sort);
 
     return result;
   },


### PR DESCRIPTION
<!-- ⚠️ Your PR title will appear in the changelogs please make it short detailed and understandable for all. -->

<!-- Uncomment the correct contribution type. !-->

My PR is a:
- [ ] 💥 Breaking change
- [x] 🐛 Bug fix #issueNumber
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

Main update on the:
- [ ] Admin
- [ ] Documentation
- [ ] Framework
- [x] Plugin

When user API fetch user, it sort on empty string and Mongoose fail the request `MongoError: $sort stage must have at least one sort key`
So I apply filters only if the key exist and is not empty.
