### PR TITLE
Deprecated providers

### DIFF
--- a/packages/strapi-plugin-email/config/functions/bootstrap.js
+++ b/packages/strapi-plugin-email/config/functions/bootstrap.js
@@ -26,7 +26,8 @@ module.exports = async cb => {
     fs.readdir(path.join(basePath, 'node_modules'), async (err, node_modules) => {
       // get all email providers
       const emails = _.filter(node_modules, (node_module) => {
-        return _.startsWith(node_module, ('strapi-provider-email'));
+        // DEPRECATED strapi-email-* will be remove in next version
+        return _.startsWith(node_module, 'strapi-provider-email') || _.startsWith(node_module, 'strapi-email');
       });
 
       // mount all providers to get configs

--- a/packages/strapi-plugin-upload/config/functions/bootstrap.js
+++ b/packages/strapi-plugin-upload/config/functions/bootstrap.js
@@ -26,7 +26,8 @@ module.exports = async cb => {
     fs.readdir(path.join(basePath, 'node_modules'), async (err, node_modules) => {
       // get all upload provider
       const uploads = _.filter(node_modules, (node_module) => {
-        return _.startsWith(node_module, ('strapi-provider-upload'));
+        // DEPRECATED strapi-upload-* will be remove in next version
+        return _.startsWith(node_module, 'strapi-provider-upload') || _.startsWith(node_module, 'strapi-upload');
       });
 
       // mount all providers to get configs


### PR DESCRIPTION
<!-- ⚠️ Your PR title will appear in the changelogs please make it short detailed and understandable for all. -->

<!-- Uncomment the correct contribution type. !-->

My PR is a:
- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix #issueNumber
- [x] 💅 Enhancement
- [ ] 🚀 New feature

Main update on the:
- [ ] Admin
- [ ] Documentation
- [ ] Framework
- [x] Plugin

Keep support of `strapi-email-*` and `strapi-upload-*` during few versions to let time to providers maintainers to make migration to `strapi-provider-email-*` and `strapi-provider-upload-*`.