### PR TITLE
strapi-upload-cloudinary - Fix upload for videos and other format

### DIFF
--- a/packages/strapi-provider-upload-cloudinary/lib/index.js
+++ b/packages/strapi-provider-upload-cloudinary/lib/index.js
@@ -37,7 +37,7 @@ module.exports = {
     return {
       upload (file) {
         return new Promise((resolve, reject) => {
-          const upload_stream = cloudinary.uploader.upload_stream({}, (err, image) => {
+          const upload_stream = cloudinary.uploader.upload_stream({ resource_type: "auto" }, (err, image) => {
             if (err) {
               return reject(err);
             }


### PR DESCRIPTION
<!-- ⚠️ Your PR title will appear in the changelogs please make it short detailed and understandable for all. -->

<!-- Uncomment the correct contribution type. !-->

My PR is a:
- [ ] 💥 Breaking change
- [x] 🐛 Bug fix #2389
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

Main update on the:
- [ ] Admin
- [ ] Documentation
- [ ] Framework
- [x] Plugin

<!-- Write a short description of what your PR does and link the concerned issues of your update. -->

Fixes issue #2389 by setting `resource_type` to `auto` which automatically detects the file type. By doing this, any file format will be accepted by Cloudinary such as videos, pdf, documents and more.

Thanks!

<!-- ⚠️ Please link issue(s) you close / fix by using GitHub keywords https://help.github.com/articles/closing-issues-using-keywords/ !-->
