### PR TITLE
Fix eslint inline condition error

### DIFF
--- a/packages/strapi-lint/lib/internals/eslint/front/.eslintrc.json
+++ b/packages/strapi-lint/lib/internals/eslint/front/.eslintrc.json
@@ -1,21 +1,13 @@
 {
   "parser": "babel-eslint",
-  "extends": [
-    "airbnb",
-    "prettier",
-    "eslint:recommended"
-  ],
+  "extends": ["airbnb", "prettier", "eslint:recommended"],
   "env": {
     "browser": true,
     "node": true,
     "mocha": true,
     "es6": true
   },
-  "plugins": [
-    "redux-saga",
-    "react",
-    "jsx-a11y"
-  ],
+  "plugins": ["redux-saga", "react", "jsx-a11y"],
   "parserOptions": {
     "ecmaVersion": 7,
     "sourceType": "module",
@@ -25,10 +17,7 @@
     }
   },
   "rules": {
-    "comma-dangle": [
-      2,
-      "always-multiline"
-    ],
+    "comma-dangle": [2, "always-multiline"],
     "import/newline-after-import": 0,
     "import/no-dynamic-require": 0,
     "import/no-extraneous-dependencies": 0,
@@ -38,14 +27,7 @@
     "import/order": [
       "error",
       {
-        "groups": [
-          "builtin",
-          "external",
-          "internal",
-          "parent",
-          "sibling",
-          "index"
-        ]
+        "groups": ["builtin", "external", "internal", "parent", "sibling", "index"]
       }
     ],
     "import/imports-first": 2,
@@ -53,7 +35,8 @@
       2,
       2,
       {
-        "SwitchCase": 1
+        "SwitchCase": 1,
+        "ignoredNodes": ["ConditionalExpression"]
       }
     ],
     "jsx-a11y/aria-props": 2,
@@ -76,10 +59,7 @@
     "class-methods-use-this": 0,
     "react/forbid-prop-types": 0,
     "react/react-in-jsx-scope": 0,
-    "react/jsx-first-prop-new-line": [
-      2,
-      "multiline"
-    ],
+    "react/jsx-first-prop-new-line": [2, "multiline"],
     "react/jsx-filename-extension": 0,
     "react/jsx-no-target-blank": 0,
     "react/no-did-mount-set-state": 0,

--- a/packages/strapi-lint/lib/internals/prettier/front/.prettierrc.js
+++ b/packages/strapi-lint/lib/internals/prettier/front/.prettierrc.js
@@ -5,7 +5,6 @@
 
 module.exports = {
   printWidth: 110,
-  parser: 'flow',
   useTabs: false,
   singleQuote: true,
   bracketSpacing: true,

--- a/packages/strapi-lint/lib/internals/prettier/index.js
+++ b/packages/strapi-lint/lib/internals/prettier/index.js
@@ -39,7 +39,7 @@ if (!backendFiles.length) {
 const runPrettier = (files, isFront = true) => {
   const prettierConfigFolder = isFront ? 'front' : 'back';
   const prettierConfigPath = require.resolve(`./${prettierConfigFolder}/.prettierrc`);
-
+  console.log({ files, prettierConfigFolder })
   files.forEach(file => {
     const options = prettier.resolveConfig.sync(file, {
       config: prettierConfigPath

--- a/packages/strapi-lint/lib/internals/prettier/index.js
+++ b/packages/strapi-lint/lib/internals/prettier/index.js
@@ -39,7 +39,7 @@ if (!backendFiles.length) {
 const runPrettier = (files, isFront = true) => {
   const prettierConfigFolder = isFront ? 'front' : 'back';
   const prettierConfigPath = require.resolve(`./${prettierConfigFolder}/.prettierrc`);
-  console.log({ files, prettierConfigFolder })
+
   files.forEach(file => {
     const options = prettier.resolveConfig.sync(file, {
       config: prettierConfigPath


### PR DESCRIPTION
<!-- ⚠️ Your PR title will appear in the changelogs please make it short detailed and understandable for all. -->

This PR fixes eslint for the indent rule that wasn't working with inline conditions.
With the PR you should be able to run `npm run prettier` in the framework and pass the lint pre-commit hook.
<!-- Uncomment the correct contribution type. !-->

My PR is a:
- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix 
- [x] 💅 Enhancement
- [ ] 🚀 New feature

Main update on the:
- [ ] Admin
- [ ] Documentation
- [x] Framework
- [ ] Plugin

<!-- Write a short description of what your PR does and link the concerned issues of your update. -->

<!-- ⚠️ Please link issue(s) you close / fix by using GitHub keywords https://help.github.com/articles/closing-issues-using-keywords/ !-->
