### PR TITLE
Remove .npmignore from generated files.

### DIFF
--- a/packages/strapi-generate-new/lib/index.js
+++ b/packages/strapi-generate-new/lib/index.js
@@ -38,9 +38,6 @@ module.exports = {
     '.editorconfig': {
       copy: 'editorconfig'
     },
-    '.npmignore': {
-      copy: 'npmignore'
-    },
     '.gitignore': {
       copy: 'gitignore'
     },


### PR DESCRIPTION
<!-- ⚠️ Your PR title will appear in the changelogs please make it short detailed and understandable for all. -->

<!-- Uncomment the correct contribution type. !-->

**My PR is a:**
- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix #issueNumber
- [x] 💅 Enhancement
- [ ] 🚀 New feature

**Main update on the:**
- [ ] Admin
- [ ] Documentation
- [x] Framework
- [ ] Plugin

**Description:**

I remove `.npmignore` from project generated files cause it's useless.
It make generated application cleaner.

Close #823
