### PR TITLE
ASC/DESC sort filters needs to be uppercase

### DIFF
--- a/docs/3.x.x/guides/filters.md
+++ b/docs/3.x.x/guides/filters.md
@@ -49,8 +49,8 @@ Sort according to a specific field.
 
 Sort users by email.
 
- - ASC: `GET /users?_sort=email:asc`
- - DESC: `GET /users?_sort=email:desc`
+ - ASC: `GET /users?_sort=email:ASC`
+ - DESC: `GET /users?_sort=email:DESC`
 
 ### Limit
 


### PR DESCRIPTION
Otherwise I would get error 500 on latest strapi (`3.0.0-alpha.15`) which doesn't explain why
