### PR TITLE
Fix the display of longer attribute descriptions

### DIFF
--- a/packages/strapi-plugin-content-type-builder/admin/src/components/AttributeCard/styles.scss
+++ b/packages/strapi-plugin-content-type-builder/admin/src/components/AttributeCard/styles.scss
@@ -13,6 +13,7 @@
   line-height: 4rem;
   box-shadow: 1px 1px 1px rgba(104, 118,145, 0.05);
   cursor: pointer;
+  
   &:hover, &:active, &:focus {
     background: #F7F7F7;
     outline: 0;
@@ -24,7 +25,11 @@
 
 .attributeCard {
   font-size: 1.3rem;
-  &:after{
+  display: flex;
+  align-items: center;
+  max-width: calc(100% - 18px);
+
+  &:after {
     content: '\f05d';
     position: absolute;
     top: 7px;
@@ -35,10 +40,11 @@
     -webkit-font-smoothing: antialiased;
   }
 
-  &:hover{
+  &:hover {
     background: none;
   }
-  > img{
+
+  > img {
     display: inline-block;
     height: 20px;
     width: 35px;
@@ -47,11 +53,17 @@
   }
 
   > span {
+    white-space: nowrap;
     color: #9EA7B8;
     font-size: 1.2rem;
     font-style: italic;
     font-weight: 400;
     -webkit-font-smoothing: antialiased;
+
+    &:last-child {
+      text-overflow: ellipsis;
+      overflow: hidden;
+    }
   }
 }
 


### PR DESCRIPTION
My PR is a:
- [ ] 💥 Breaking change
- [x] 🐛 Bug fix #2403
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

Main update on the:
- [ ] Admin
- [ ] Documentation
- [ ] Framework
- [x] Plugin

Added CSS `text-overflow: ellipsis;` to crop a longer description


<img width="365" alt="zrzut ekranu 2018-12-10 o 16 31 28" src="https://user-images.githubusercontent.com/28870390/49744687-a306d880-fc9d-11e8-9b27-d96018de9d5d.png">

fixes #2403 
