### PR TITLE
Fix to allow provider to be shown in the content manager

### DIFF
--- a/packages/strapi-plugin-users-permissions/config/layout.js
+++ b/packages/strapi-plugin-users-permissions/config/layout.js
@@ -13,9 +13,6 @@ module.exports = {
       email: {
         className: 'col-md-6'
       },
-      provider: {
-        className: 'd-none'
-      },
       resetPasswordToken: {
         className: 'd-none'
       },


### PR DESCRIPTION
My PR is a:
- [ ] 💥 Breaking change
- [x] 🐛 Bug fix https://github.com/strapi/strapi/issues/2467
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

Main update on the:
- [ ] Admin
- [ ] Documentation
- [ ] Framework
- [x] Plugin

The provider was not able to be added to the content manager schema to show in the list view, worked with @lauriejim to allow it to be shown.
