### PR TITLE
Add a place for users to link their project in Issue Template

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -23,6 +23,7 @@ about: Create a report to help us improve 🤔.
 - **Strapi version**: <!-- Please make sure you are on the latest version -->
 - **Database**: 
 - **Operating system**: 
+- **(Optional) Link to your Project**: <!-- To speedup support, if you have your project on github/gitlab you can provide a link -->
 
 
 **What is the current behavior?**


### PR DESCRIPTION
<!-- ⚠️ Your PR title will appear in the changelogs please make it short detailed and understandable for all. -->

<!-- Uncomment the correct contribution type. !-->

My PR is a:
- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix #issueNumber
- [x] 💅 Enhancement
- [ ] 🚀 New feature

Main update on the:
- [ ] Admin
- [x] Documentation
- [ ] Framework
- [ ] Plugin

To hopefully help us debug issues, I've added a place in the bug template for users to provide a link to their Strapi project. This will hopefully allow us to clone and test ourselves and/or compare changes between their project and a fresh Strapi project.

<!-- ⚠️ Please link issue(s) you close / fix by using GitHub keywords https://help.github.com/articles/closing-issues-using-keywords/ !-->
