### PR TITLE
Fix spelling mistake

### DIFF
--- a/docs/3.x.x/guides/filters.md
+++ b/docs/3.x.x/guides/filters.md
@@ -85,7 +85,7 @@ Requests system can be implemented in custom code sections.
 To extract the filters from an JavaScript object or a request, you need to call the [`strapi.utils.models.convertParams` helper](../api-reference/reference.md#strapiutils).
 
 ::: note
-The returned objects is formatted according to the ORM used by the model.
+The returned objects are formatted according to the ORM used by the model.
 :::
 
 #### Example


### PR DESCRIPTION
change line 88 from "[...] returned objects is formatted [...]" to "[...] returned objects are formatted [...]"

<!-- ⚠️ Your PR title will appear in the changelogs please make it short detailed and understandable for all. -->

<!-- Uncomment the correct contribution type. !-->

My PR is a:
- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix #issueNumber
- [X] 💅 Enhancement
- [ ] 🚀 New feature

Main update on the:
- [ ] Admin
- [X] Documentation
- [ ] Framework
- [ ] Plugin

<!-- Write a short description of what your PR does and link the concerned issues of your update. -->
Fix spelling mistake in documentation, chapter filters, line 88 from "[...] returned objects is formatted [...]" to "[...] returned objects are formatted [...]"

<!-- ⚠️ Please link issue(s) you close / fix by using GitHub keywords https://help.github.com/articles/closing-issues-using-keywords/ !-->
