### PR TITLE
Add force option when database not empty with bookshelf

### DIFF
--- a/docs/3.x.x/cli/CLI.md
+++ b/docs/3.x.x/cli/CLI.md
@@ -10,7 +10,7 @@ Create a new project
 ```bash
 strapi new <name>
 
-options: [--dev|--dbclient=<dbclient> --dbhost=<dbhost> --dbport=<dbport> --dbname=<dbname> --dbusername=<dbusername> --dbpassword=<dbpassword> --dbssl=<dbssl> --dbauth=<dbauth>]
+options: [--dev|--dbclient=<dbclient> --dbhost=<dbhost> --dbport=<dbport> --dbname=<dbname> --dbusername=<dbusername> --dbpassword=<dbpassword> --dbssl=<dbssl> --dbauth=<dbauth> --dbforce]
 ```
 
 - **strapi new &#60;name&#62;**<br/>
@@ -19,10 +19,11 @@ options: [--dev|--dbclient=<dbclient> --dbhost=<dbhost> --dbport=<dbport> --dbna
 - **strapi new &#60;name&#62; --dev**<br/>
   Generates a new project called **&#60;name&#62;** and creates symlinks for the `./admin` folder and each plugin inside the `./plugin` folder. It means that the Strapi's development workflow has been set up on the machine earlier.
 
-- **strapi new &#60;name&#62; --dbclient=&#60;dbclient&#62; --dbhost=&#60;dbhost&#62; --dbport=&#60;dbport&#62; --dbname=&#60;dbname&#62; --dbusername=&#60;dbusername&#62; --dbpassword=&#60;dbpassword&#62; --dbssl=&#60;dbssl&#62; --dbauth=&#60;dbauth&#62;**<br/>
+- **strapi new &#60;name&#62; --dbclient=&#60;dbclient&#62; --dbhost=&#60;dbhost&#62; --dbport=&#60;dbport&#62; --dbname=&#60;dbname&#62; --dbusername=&#60;dbusername&#62; --dbpassword=&#60;dbpassword&#62; --dbssl=&#60;dbssl&#62; --dbauth=&#60;dbauth&#62; --dbforce**<br/>
   Generates a new project called **&#60;name&#62;** and skip the interactive database configuration and initilize with these options.
   - **&#60;dbclient&#62;** can be `mongo`, `postgres`, `mysql`.
   - **&#60;dbssl&#62;** and **&#60;dbauth&#62;** are available only for `mongo` and are optional.
+  - **--dbforce** is only available for `postgres`, `mysql`, and is optional. 
 
 See the [CONTRIBUTING guide](https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md) for more details.
 

--- a/docs/3.x.x/cli/CLI.md
+++ b/docs/3.x.x/cli/CLI.md
@@ -23,7 +23,7 @@ options: [--dev|--dbclient=<dbclient> --dbhost=<dbhost> --dbport=<dbport> --dbna
   Generates a new project called **&#60;name&#62;** and skip the interactive database configuration and initilize with these options.
   - **&#60;dbclient&#62;** can be `mongo`, `postgres`, `mysql`.
   - **&#60;dbssl&#62;** and **&#60;dbauth&#62;** are available only for `mongo` and are optional.
-  - **--dbforce** is only available for `postgres`, `mysql`, and is optional. 
+  - **--dbforce** Allows you to overwrite content if the provided database is not empty. Only available for `postgres`, `mysql`, and is optional. 
 
 See the [CONTRIBUTING guide](https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md) for more details.
 

--- a/packages/strapi-hook-bookshelf/lib/utils/connectivity.js
+++ b/packages/strapi-hook-bookshelf/lib/utils/connectivity.js
@@ -27,7 +27,7 @@ module.exports = (scope, success, error) => {
       };
 
       if (tables.rows && tables.rows.length !== 0) {
-        if (scope.database.options.force) {
+        if (scope.dbforce) {
           next();
         } else {
           console.log('🤔 It seems that your database is not empty. Be aware that Strapi is going to automatically creates tables & columns, and might update columns which can corrupt data or cause data loss.');

--- a/packages/strapi-hook-bookshelf/lib/utils/connectivity.js
+++ b/packages/strapi-hook-bookshelf/lib/utils/connectivity.js
@@ -27,20 +27,24 @@ module.exports = (scope, success, error) => {
       };
 
       if (tables.rows && tables.rows.length !== 0) {
-        console.log('🤔 It seems that your database is not empty. Be aware that Strapi is going to automatically creates tables & columns, and might update columns which can corrupt data or cause data loss.');
+        if (scope.database.options.force) {
+          next();
+        } else {
+          console.log('🤔 It seems that your database is not empty. Be aware that Strapi is going to automatically creates tables & columns, and might update columns which can corrupt data or cause data loss.');
 
-        inquirer.prompt([{
-          type: 'confirm',
-          name: 'confirm',
-          message: `Are you sure you want to continue with the ${scope.database.settings.database} database:`,
-        }])
-          .then(({ confirm }) => {
-            if (confirm) {
-              next();
-            } else {
-              error();
-            }
-          });
+          inquirer.prompt([{
+            type: 'confirm',
+            name: 'confirm',
+            message: `Are you sure you want to continue with the ${scope.database.settings.database} database:`,
+          }])
+            .then(({ confirm }) => {
+              if (confirm) {
+                next();
+              } else {
+                error();
+              }
+            });
+        }
       } else {
         next();
       }

--- a/packages/strapi/bin/strapi-new.js
+++ b/packages/strapi/bin/strapi-new.js
@@ -54,7 +54,7 @@ module.exports = function (name, cliArguments) {
       return process.exit(1);
     }
 
-    const dbforce = cliArguments.dbforce !== undefined;
+    scope.dbforce = cliArguments.dbforce !== undefined;
 
     scope.database = {
       settings: {
@@ -67,8 +67,7 @@ module.exports = function (name, cliArguments) {
       },
       options: {
         authenticationDatabase: cliArguments.dbauth,
-        ssl: cliArguments.dbssl,
-        force: dbforce
+        ssl: cliArguments.dbssl
       }
     };
   }

--- a/packages/strapi/bin/strapi-new.js
+++ b/packages/strapi/bin/strapi-new.js
@@ -54,6 +54,8 @@ module.exports = function (name, cliArguments) {
       return process.exit(1);
     }
 
+    const dbforce = cliArguments.dbforce !== undefined;
+
     scope.database = {
       settings: {
         client: cliArguments.dbclient,
@@ -65,7 +67,8 @@ module.exports = function (name, cliArguments) {
       },
       options: {
         authenticationDatabase: cliArguments.dbauth,
-        ssl: cliArguments.dbssl
+        ssl: cliArguments.dbssl,
+        force: dbforce
       }
     };
   }

--- a/packages/strapi/bin/strapi.js
+++ b/packages/strapi/bin/strapi.js
@@ -61,6 +61,7 @@ program
   .option('--dbpassword <dbpassword>', 'Database password')
   .option('--dbssl <dbssl>', 'Database SSL')
   .option('--dbauth <dbauth>', 'Authentication Database')
+  .option('--dbforce', 'Overwrite database content if any')
   .description('create a new application')
   .action(require('./strapi-new'));
 


### PR DESCRIPTION
<!-- ⚠️ Your PR title will appear in the changelogs please make it short detailed and understandable for all. -->

<!-- Uncomment the correct contribution type. !-->

My PR is a:
- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix #issueNumber
- [x] 💅 Enhancement #2432 
- [ ] 🚀 New feature

Main update on the:
- [ ] Admin
- [x] Documentation
- [ ] Framework
- [x] Plugin

<!-- Write a short description of what your PR does and link the concerned issues of your update. -->
When there is data already present in either Postgres or MySQL database, the `strapi new` command prompts with an interactive prompt to either proceed or abort.

This PR adds an `--dbforce` option, if present it proceeds with the creation of the project even if there's content already present in the database.

<!-- ⚠️ Please link issue(s) you close / fix by using GitHub keywords https://help.github.com/articles/closing-issues-using-keywords/ !-->
