### PR TITLE
Fix query building in user-permissions/services/Provider.js

### DIFF
--- a/packages/strapi-plugin-users-permissions/services/Providers.js
+++ b/packages/strapi-plugin-users-permissions/services/Providers.js
@@ -47,7 +47,10 @@ exports.connect = (provider, query) => {
       try {
         const users = await strapi.query('user', 'users-permissions').find({
           where: {
-            email: profile.email
+            email: {
+              symbol: '=',
+              value: profile.email
+            }
           }
         });
 
@@ -85,6 +88,7 @@ exports.connect = (provider, query) => {
 
         return resolve([createdUser, null]);
       } catch (err) {
+        strapi.log.error(err)
         reject([null, err]);
       }
     });

--- a/packages/strapi-plugin-users-permissions/services/Providers.js
+++ b/packages/strapi-plugin-users-permissions/services/Providers.js
@@ -83,7 +83,6 @@ exports.connect = (provider, query) => {
 
         return resolve([createdUser, null]);
       } catch (err) {
-        strapi.log.error(err);
         reject([null, err]);
       }
     });

--- a/packages/strapi-plugin-users-permissions/services/Providers.js
+++ b/packages/strapi-plugin-users-permissions/services/Providers.js
@@ -45,14 +45,9 @@ exports.connect = (provider, query) => {
       }
 
       try {
-        const users = await strapi.query('user', 'users-permissions').find({
-          where: {
-            email: {
-              symbol: '=',
-              value: profile.email
-            }
-          }
-        });
+        const users = await strapi.query('user', 'users-permissions').find(strapi.utils.models.convertParams('user', {
+          email: profile.email
+        }));
 
         const advanced = await strapi.store({
           environment: '',

--- a/packages/strapi-plugin-users-permissions/services/Providers.js
+++ b/packages/strapi-plugin-users-permissions/services/Providers.js
@@ -88,7 +88,7 @@ exports.connect = (provider, query) => {
 
         return resolve([createdUser, null]);
       } catch (err) {
-        strapi.log.error(err)
+        strapi.log.error(err);
         reject([null, err]);
       }
     });


### PR DESCRIPTION
<!-- ⚠️ Your PR title will appear in the changelogs please make it short detailed and understandable for all. -->

<!-- Uncomment the correct contribution type. !-->

My PR is a:
- [ ] 💥 Breaking change
- [x] 🐛 Bug fix #2536 
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

Main update on the:
- [ ] Admin
- [ ] Documentation
- [ ] Framework
- [x] Plugin

<!-- Write a short description of what your PR does and link the concerned issues of your update. -->
Fixes the parameters passed to the call to the `query` method in `user-permissions/services/Provider.js`. It specifies the symbol and value separately, instead of just passing a string.

<!-- ⚠️ Please link issue(s) you close / fix by using GitHub keywords https://help.github.com/articles/closing-issues-using-keywords/ !-->
