### PR TITLE
Dockerfile for deploying locally modified APIs

### DIFF
--- a/packages/strapi-generate-new/files/Dockerfile
+++ b/packages/strapi-generate-new/files/Dockerfile
@@ -1,0 +1,37 @@
+# cloned from https://github.com/kriasoft/nodejs-api-starter/blob/master/Dockerfile
+FROM node:11.1.0-alpine
+
+ARG NODE_ENV=production
+ENV NODE_ENV=$NODE_ENV
+
+# Set a working directory
+WORKDIR /usr/src/app
+
+# Install native dependencies
+# RUN set -ex; \
+#   apk add --no-cache ...
+
+# Install Node.js dependencies
+COPY package.json yarn.lock ./
+COPY admin ./admin
+COPY plugins ./plugins
+
+RUN set -ex; \
+    if [ "$NODE_ENV" = "production" ]; then \
+    yarn install --no-cache --frozen-lockfile --production; \
+    elif [ "$NODE_ENV" = "test" ]; then \
+    touch yarn-error.log; \
+    mkdir -m 777 build; \
+    yarn install --no-cache --frozen-lockfile; \
+    chown -R node:node build node_modules package.json yarn.lock yarn-error.log; \
+    else \
+    touch yarn-error.log; \
+    mkdir -p -m 777 build node_modules /home/node/.cache/yarn; \
+    chown -R node:node build node_modules package.json yarn.lock yarn-error.log /home/node/.cache/yarn; \
+    fi;
+
+# Bundle app source
+COPY . .
+
+EXPOSE 1337
+CMD [ "npm", "start" ]


### PR DESCRIPTION
Dockerfile for deploying locally modified APIs

My PR is a:
- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix #issueNumber
- [x] 💅 Enhancement
- [ ] 🚀 New feature

Main update on the:
- [x] Framework
- [ ] Admin
- [ ] Documentation
- [ ] Plugin

<!-- Write a short description of what your PR does and link the concerned issues of your update. -->
Many developers work on their Strapi projects locally and then deploy changes to the production. the containerized project (https://github.com/strapi/strapi-docker) doesn't prepare any option for such use casse and only deploys a new clean instance of strapi which doesn't persist generated content types.
This docker file performs a standard and optimum way for such a purpose. Shaping the api in the local, committing changes into the repo and deploying it using docker.

I think it's not a bad idea to include it in the project. it saves time a lot.

<!-- ⚠️ Please link issue(s) you close / fix by using GitHub keywords https://help.github.com/articles/closing-issues-using-keywords/ !-->
