### PR TITLE
Custom timestamp column names in database

### DIFF
--- a/docs/3.x.x/guides/models.md
+++ b/docs/3.x.x/guides/models.md
@@ -27,6 +27,7 @@ The info key on the model-json states information about the model. This informat
 The options key on the model-json states.
    - `idAttribute`: This tells the model which attribute to expect as the unique identifier for each database row (typically an auto-incrementing primary key named 'id'). _Only valid for strapi-hook-bookshelf_
    - `idAttributeType`: Data type of `idAttribute`, accepted list of value bellow. _Only valid for strapi-hook-bookshelf_
+   - `timestamps`: This tells the model which attributes to use for timestamps. Accepts either `boolean` or `Array` of strings where frist element is create data and second elemtent is update date. Default value when set to `true` for Bookshelf is `["created_at", "updated_at"]` and for MongoDB is `["createdAt", "updatedAt"]`.
 
 ## Define the attributes
 

--- a/packages/strapi-hook-bookshelf/lib/index.js
+++ b/packages/strapi-hook-bookshelf/lib/index.js
@@ -105,7 +105,7 @@ module.exports = function(strapi) {
               _.set(loadedModel, 'hasTimestamps', ['created_at', 'updated_at']);
             }
             // Use false for values other than `Boolean` or `Array`
-            if (!_.isArray(_.get(loadedModel, 'hasTimestamps')) || !_.isBoolean(_.get(loadedModel, 'hasTimestamps'))) {
+            if (!_.isArray(_.get(loadedModel, 'hasTimestamps')) && !_.isBoolean(_.get(loadedModel, 'hasTimestamps'))) {
               _.set(loadedModel, 'hasTimestamps', false);
             }
             if (_.isString(_.get(connection, 'options.pivot_prefix'))) {

--- a/packages/strapi-hook-bookshelf/lib/index.js
+++ b/packages/strapi-hook-bookshelf/lib/index.js
@@ -89,7 +89,7 @@ module.exports = function(strapi) {
             // Register the final model for Bookshelf.
             const loadedModel = _.assign({
               tableName: definition.collectionName,
-              hasTimestamps: _.get(definition, 'options.timestamps') === true,
+              hasTimestamps: _.get(definition, 'options.timestamps'),
               idAttribute: _.get(definition, 'options.idAttribute', 'id'),
               associations: [],
               defaults: Object.keys(definition.attributes).reduce((acc, current) => {
@@ -619,10 +619,10 @@ module.exports = function(strapi) {
 
                   // Add created_at and updated_at field if timestamp option is true
                   if (loadedModel.hasTimestamps) {
-                    definition.attributes['created_at'] = {
+                    definition.attributes[loadedModel.hasTimestamps[0]] = {
                       type: 'timestamp'
                     };
-                    definition.attributes['updated_at'] = {
+                    definition.attributes[loadedModel.hasTimestamps[1]] = {
                       type: 'timestampUpdate'
                     };
                   }
@@ -701,8 +701,8 @@ module.exports = function(strapi) {
 
                   // Remove from attributes (auto handled by bookshlef and not displayed on ctb)
                   if (loadedModel.hasTimestamps) {
-                    delete definition.attributes['created_at'];
-                    delete definition.attributes['updated_at'];
+                    delete definition.attributes[loadedModel.hasTimestamps[0]];
+                    delete definition.attributes[loadedModel.hasTimestamps[1]];
                   }
 
                   resolve();

--- a/packages/strapi-hook-mongoose/lib/index.js
+++ b/packages/strapi-hook-mongoose/lib/index.js
@@ -207,10 +207,16 @@ module.exports = function (strapi) {
                   });
                 });
 
-                let timestamps = {};
-                _.set(timestamps.createdAt, _.get(definition, 'options.timestamps[0]'));
-                _.set(timestamps.updatedAt, _.get(definition, 'options.timestamps[1]'));
-                collection.schema.set('timestamps', timestamps);
+                // Use provided timestamps if the elemnets in the array are string else use default.
+                if (_.isArray(_.get(definition, 'options.timestamps'))) {
+                  const timestamps = {
+                    createdAt: _.isString(_.get(definition, 'options.timestamps[0]')) ? _.get(definition, 'options.timestamps[0]') : 'createdAt',
+                    updatedAt: _.isString(_.get(definition, 'options.timestamps[1]')) ? _.get(definition, 'options.timestamps[1]') : 'updatedAt'
+                  };
+                  collection.schema.set('timestamps', timestamps);
+                } else {
+                  collection.schema.set('timestamps', _.get(definition, 'options.timestamps') === true);
+                }
                 collection.schema.set('minimize', _.get(definition, 'options.minimize', false) === true);
 
                 collection.schema.options.toObject = collection.schema.options.toJSON = {

--- a/packages/strapi-hook-mongoose/lib/index.js
+++ b/packages/strapi-hook-mongoose/lib/index.js
@@ -207,7 +207,10 @@ module.exports = function (strapi) {
                   });
                 });
 
-                collection.schema.set('timestamps', _.get(definition, 'options.timestamps') === true);
+                let timestamps = {};
+                _.set(timestamps.createdAt, _.get(definition, 'options.timestamps[0]'));
+                _.set(timestamps.updatedAt, _.get(definition, 'options.timestamps[1]'));
+                collection.schema.set('timestamps', timestamps);
                 collection.schema.set('minimize', _.get(definition, 'options.minimize', false) === true);
 
                 collection.schema.options.toObject = collection.schema.options.toJSON = {

--- a/packages/strapi-plugin-content-manager/admin/src/containers/EditPage/saga.js
+++ b/packages/strapi-plugin-content-manager/admin/src/containers/EditPage/saga.js
@@ -77,15 +77,10 @@ export function* submit() {
   let shouldAddTranslationSuffix = false;
   
   // Remove the updated_at & created_at fields so it is updated correctly when using Postgres or MySQL db
-  if (record.updated_at) {
-    delete record.created_at;
-    delete record.updated_at;
-  }
-
-  // Remove the updatedAt & createdAt fields so it is updated correctly when using MongoDB
-  if (record.updatedAt) {
-    delete record.createdAt;
-    delete record.updatedAt;
+  const timestamps = get(schema, ['models', currentModelName, 'options', 'timestamps'], null);
+  if (timestamps) {
+    delete record[timestamps[0]];
+    delete record[timestamps[1]];
   }
 
   try {

--- a/packages/strapi-plugin-content-manager/config/functions/bootstrap.js
+++ b/packages/strapi-plugin-content-manager/config/functions/bootstrap.js
@@ -85,6 +85,7 @@ module.exports = async cb => {
       pageEntries: 10,
       defaultSort: model.primaryKey,
       sort: 'ASC',
+      options: model.options,
       editDisplay: {
         availableFields: {},
         fields: [],

--- a/packages/strapi-plugin-content-manager/config/functions/bootstrap.js
+++ b/packages/strapi-plugin-content-manager/config/functions/bootstrap.js
@@ -17,6 +17,7 @@ const pickData = (model) => _.pick(model, [
   'globalId',
   'globalName',
   'orm',
+  'options.timestamps',
   'loadedModel',
   'primaryKey',
   'associations'
@@ -330,8 +331,9 @@ module.exports = async cb => {
     // Here we just need to add the data from the current schema Object
     apisToAdd.map(apiPath => {
       const api = _.get(schema.models, apiPath);
-      const { search, filters, bulkActions, pageEntries } = _.get(prevSchema, 'generalSettings');
+      const { search, filters, bulkActions, pageEntries, options } = _.get(prevSchema, 'generalSettings');
 
+      _.set(api, 'options', options);
       _.set(api, 'filters', filters);
       _.set(api, 'search', search);
       _.set(api, 'bulkActions', bulkActions);


### PR DESCRIPTION
<!-- ⚠️ Your PR title will appear in the changelogs please make it short detailed and understandable for all. -->

<!-- Uncomment the correct contribution type. !-->

My PR is a:
- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [ ] 💅 Enhancement
- [x] 🚀 New feature #998

Main update on the:
- [ ] Admin
- [x] Documentation
- [ ] Framework
- [x] Plugin

<!-- Write a short description of what your PR does and link the concerned issues of your update. -->
This PR adds the ability to change the default names for the timestamp columns. The current solution works with both the database hooks.

**Changes Made:**
The following packages were changed/updated in order to add this feature.
1. `strapi-hook-bookshelf`
2. `strapi-hook-mongoose`
3. `strapi-plugin-content-manager`

**How to defile the custom column names:**
In your model's `<modelName>.settings.json` add the following attribute in `options` object.
```javascript
{
    "options": {
        "timestamps": ["createdAt", "updatedAt"]
    }
}
```
Here the first element of the array is associated with the create timestamp and the second element of the array is associated with the update timestamp.

The attribute accepts either `boolean` or `Array` of strings. If nothing is provided default is set to `false`. If boolean value is set to `true` default for Bookshelf is `["created_at", "updated_at"]` and for MongoDB is `["createdAt", "updatedAt"]`. This takes care of the existing functionality.

<!-- ⚠️ Please link issue(s) you close / fix by using GitHub keywords https://help.github.com/articles/closing-issues-using-keywords/ !-->
