### PR TITLE
Improve strapi new

### DIFF
--- a/docs/3.x.x/cli/CLI.md
+++ b/docs/3.x.x/cli/CLI.md
@@ -10,7 +10,7 @@ Create a new project
 ```bash
 strapi new <name>
 
-options: [--dev|--dbclient=<dbclient> --dbhost=<dbhost> --dbport=<dbport> --dbname=<dbname> --dbusername=<dbusername> --dbpassword=<dbpassword> --dbssl=<dbssl> --dbauth=<dbauth>]
+options: [--dev|--debug|--dbclient=<dbclient> --dbhost=<dbhost> --dbport=<dbport> --dbname=<dbname> --dbusername=<dbusername> --dbpassword=<dbpassword> --dbssl=<dbssl> --dbauth=<dbauth>]
 ```
 
 - **strapi new &#60;name&#62;**<br/>
@@ -18,6 +18,9 @@ options: [--dev|--dbclient=<dbclient> --dbhost=<dbhost> --dbport=<dbport> --dbna
 
 - **strapi new &#60;name&#62; --dev**<br/>
   Generates a new project called **&#60;name&#62;** and creates symlinks for the `./admin` folder and each plugin inside the `./plugin` folder. It means that the Strapi's development workflow has been set up on the machine earlier.
+
+- **strapi new &#60;name&#62; --debug**<br/>
+  Will display the full error message if one is fired during the database connection.
 
 - **strapi new &#60;name&#62; --dbclient=&#60;dbclient&#62; --dbhost=&#60;dbhost&#62; --dbport=&#60;dbport&#62; --dbname=&#60;dbname&#62; --dbusername=&#60;dbusername&#62; --dbpassword=&#60;dbpassword&#62; --dbssl=&#60;dbssl&#62; --dbauth=&#60;dbauth&#62;**<br/>
   Generates a new project called **&#60;name&#62;** and skip the interactive database configuration and initilize with these options.

--- a/packages/strapi-generate-new/lib/before.js
+++ b/packages/strapi-generate-new/lib/before.js
@@ -226,6 +226,7 @@ module.exports = (scope, cb) => {
             }
 
             let cmd = `${packageCmd} ${scope.client.connector}@${scope.strapiPackageJSON.version}`;
+            let linkNodeModulesCommand = `cd ${scope.tmpPath} && npm link ${scope.client.connector}`;
 
             if (scope.client.module) {
               cmd += ` ${scope.client.module}`;
@@ -233,6 +234,7 @@ module.exports = (scope, cb) => {
 
             if (scope.client.connector === 'strapi-hook-bookshelf') {
               cmd += ` strapi-hook-knex@${scope.strapiPackageJSON.version}`;
+              linkNodeModulesCommand += ` && npm link strapi-hook-knex`;
 
               scope.additionalsDependencies = ['strapi-hook-knex', 'knex'];
             }
@@ -248,7 +250,13 @@ module.exports = (scope, cb) => {
                 }
               }
 
-              resolve();
+              if (scope.developerMode) {
+                exec(linkNodeModulesCommand, () => {
+                  resolve();
+                });
+              } else {
+                resolve();
+              }
             });
           })
         ];

--- a/packages/strapi-generate-new/lib/before.js
+++ b/packages/strapi-generate-new/lib/before.js
@@ -266,8 +266,8 @@ module.exports = (scope, cb) => {
             try {
               require(path.join(`${scope.tmpPath}`, '/node_modules/', `${scope.client.connector}/lib/utils/connectivity.js`))(scope, cb.success, connectionValidation);
             } catch(err) {
-              shell.rm('-r', scope.tmpPath);
               console.log(err);
+              shell.rm('-r', scope.tmpPath);
               cb.error();
             }
           });

--- a/packages/strapi-hook-bookshelf/lib/utils/connectivity.js
+++ b/packages/strapi-hook-bookshelf/lib/utils/connectivity.js
@@ -1,12 +1,24 @@
 'use strict';
 
+// Core
+const path = require('path');
+
 // Public node modules
 const inquirer = require('inquirer');
 const rimraf = require('rimraf');
 
 module.exports = (scope, success, error) => {
-  // eslint-disable-next-line import/no-unresolved
-  const knex = require('knex')({
+  let knex;
+
+  try {
+    // eslint-disable-next-line import/no-unresolved
+    knex = require('knex');
+  } catch (err) {
+    // eslint-disable-next-line import/no-unresolved
+    knex = require(path.resolve(scope.tmpPath, 'node_modules', 'knex'));
+  }
+
+  knex = knex({
     client: scope.client.module,
     connection: Object.assign({}, scope.database.settings, {
       user: scope.database.settings.username
@@ -48,10 +60,16 @@ module.exports = (scope, success, error) => {
   })
     .catch((err) => {
       if (err.sql) {
-        console.log('⚠️ Server connection has failed! Make sure your database server is running.');
+        console.log('⚠️  Server connection has failed! Make sure your database server is running.');
       } else {
-        console.log(`⚠️ Database connection has failed! Make sure your "${scope.database.settings.database}" database exist.`);
+        console.log(`⚠️  Database connection has failed! Make sure your "${scope.database.settings.database}" database exist.`);
       }
+
+      if (scope.debug) {
+        console.log('🐛 Full error log:');
+        console.log(err);
+      }
+
       error();
     });
 };

--- a/packages/strapi-hook-mongoose/lib/utils/connectivity.js
+++ b/packages/strapi-hook-mongoose/lib/utils/connectivity.js
@@ -29,7 +29,13 @@ module.exports = (scope, success, error) => {
 
   Mongoose.connect(`mongodb${srv ? '+srv' : ''}://${scope.database.settings.host}${!srv ? `:${scope.database.settings.port}` : ''}/`, connectOptions, function (err) {
     if (err) {
-      console.log('⚠️ Database connection has failed! Make sure your database is running.');
+      console.log('⚠️  Database connection has failed! Make sure your database is running.');
+
+      if (scope.debug) {
+        console.log('🐛 Full error log:');
+        console.log(err);
+      }
+
       return error();
     }
 

--- a/packages/strapi/bin/strapi-new.js
+++ b/packages/strapi/bin/strapi-new.js
@@ -42,7 +42,8 @@ module.exports = function (name, cliArguments) {
     generatorType: 'new',
     name,
     strapiPackageJSON: packageJSON,
-    developerMode
+    developerMode,
+    debug: cliArguments.debug !== undefined
   };
 
   const dbArguments = ['dbclient', 'dbhost', 'dbport', 'dbname', 'dbusername', 'dbpassword'];

--- a/packages/strapi/bin/strapi.js
+++ b/packages/strapi/bin/strapi.js
@@ -53,6 +53,7 @@ program
 program
   .command('new')
   .option('-d, --dev', 'Development mode')
+  .option('--debug', 'Display database connection error')
   .option('--dbclient <dbclient>', 'Database client')
   .option('--dbhost <dbhost>', 'Database host')
   .option('--dbport <dbport>', 'Database port')


### PR DESCRIPTION
<!-- ⚠️ Your PR title will appear in the changelogs please make it short detailed and understandable for all. -->

<!-- Uncomment the correct contribution type. !-->

My PR is a:
- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix #issueNumber
- [x] 💅 Enhancement
- [ ] 🚀 New feature

Main update on the:
- [ ] Admin
- [ ] Documentation
- [x] Framework
- [ ] Plugin

**TODO:**
- [x] Simplify dev mode for database connection test
- [x] Add debug option to help to debug database connection test
- [x] Add documentation
- [x] Simplify database option fo Mongo database

**Description:**

Now when you are creating a new project in `--dev` mode, it use your local install of ORM you need to test the database connection (`connectivity.js` script). It will be more easy to develop code in the part of Strapi.

Some time errors are fired dureing the connection test to the database and error are not display (we force some specific messages). Now you can use `--debug` during your `strapi new` it will display the full error message. It will be usefull tu understand the issue you you have one.