### PR TITLE
fixed: try requiring global strapi's utils when failed from local for graphql plugin

### DIFF
--- a/packages/strapi-plugin-graphql/hooks/graphql/index.js
+++ b/packages/strapi-plugin-graphql/hooks/graphql/index.js
@@ -22,13 +22,26 @@ module.exports = strapi => {
       strapi.config.hook.load.after.push('graphql');
 
       // Load core utils.
-      const utils = require(path.resolve(
-        strapi.config.appPath,
-        'node_modules',
-        'strapi',
-        'lib',
-        'utils',
-      ));
+      let utils = null;
+      // try requiring from local node_module
+      try {
+        utils = require(path.resolve(
+          strapi.config.appPath,
+          'node_modules',
+          'strapi',
+          'lib',
+          'utils',
+        ));
+      } catch {
+        // if error, require from global node_module
+        utils = require(path.resolve(
+          process.env._.replace('bin/strapi', 'lib/'),
+          'node_modules',
+          'strapi',
+          'lib',
+          'utils',
+        ));
+      }
 
       // Set '*.graphql' files configurations in the global variable.
       await Promise.all([


### PR DESCRIPTION
<!-- ⚠️ Your PR title will appear in the changelogs please make it short detailed and understandable for all. -->

<!-- Uncomment the correct contribution type. !-->

My PR is a:
- [ ] 💥 Breaking change
- [x] 🐛 Bug fix #1612 
- [ ] 💅 Enhancement
- [ ] 🚀 New feature


Main update on the:
- [ ] Admin
- [ ] Documentation
- [ ] Framework
- [x] Plugin

<!-- Write a short description of what your PR does and link the concerned issues of your update. -->
Plugin GraphQL requires strapi's core utils in its hook but only referring to the local node_module (`strapi.config.appPath` equal to cwd ). When first installing strapi globally without `npm install` later, it comes to the error issue #1612 concerned.
<!-- ⚠️ Please link issue(s) you close / fix by using GitHub keywords https://help.github.com/articles/closing-issues-using-keywords/ !-->
 