### PR TITLE
Update inquirer version to resolve Windows cli hang

### DIFF
--- a/packages/strapi-generate-new/package.json
+++ b/packages/strapi-generate-new/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "enpeem": "^2.2.0",
     "fs-extra": "^4.0.0",
-    "inquirer": "^4.0.2",
+    "inquirer": "^6.2.1",
     "listr": "^0.14.1",
     "lodash": "^4.17.5",
     "ora": "^2.1.0",

--- a/packages/strapi-hook-bookshelf/package.json
+++ b/packages/strapi-hook-bookshelf/package.json
@@ -17,7 +17,7 @@
   "main": "./lib",
   "dependencies": {
     "bookshelf": "^0.12.1",
-    "inquirer": "^5.2.0",
+    "inquirer": "^6.2.1",
     "lodash": "^4.17.5",
     "pluralize": "^6.0.0",
     "rimraf": "^2.6.2",


### PR DESCRIPTION
<!-- ⚠️ Your PR title will appear in the changelogs please make it short detailed and understandable for all. -->

<!-- Uncomment the correct contribution type. !-->

My PR is a:
- [ ] 💥 Breaking change
- [x] 🐛 Bug fix #1281
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

Main update on the:
- [ ] Admin
- [ ] Documentation
- [x] Framework
- [ ] Plugin

<!-- Write a short description of what your PR does and link the concerned issues of your update. -->

As reported in the issue #1281 creating a new project hangs in the windows CLI.  Updating the inquirer dependency appears to resolve this.  I have tested this locally and it doesn't appear that inquirer is utilized extensively so I don't believe this will be a breaking change.

<!-- ⚠️ Please link issue(s) you close / fix by using GitHub keywords https://help.github.com/articles/closing-issues-using-keywords/ !-->

Closes #1281
