### PR TITLE
Added comment to improve linting of generated service files

### DIFF
--- a/packages/strapi-generate-api/templates/bookshelf/service.template
+++ b/packages/strapi-generate-api/templates/bookshelf/service.template
@@ -1,3 +1,4 @@
+/* global <%= globalID %> */
 'use strict';
 
 /**


### PR DESCRIPTION
<!-- ⚠️ Your PR title will appear in the changelogs please make it short detailed and understandable for all. -->

<!-- Uncomment the correct contribution type. !-->

My PR is a:
- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix #issueNumber
- [*] 💅 Enhancement
- [ ] 🚀 New feature

Main update on the:
- [ ] Admin
- [ ] Documentation
- [*] Framework
- [ ] Plugin

<!-- Write a short description of what your PR does and link the concerned issues of your update. -->
It's a very small thing, but the generated code constantly breaks lint because it complains that the Model object (which is in scope of the service) is not declared. This just hints to eslint and IDE that it is declared elsewhere.

<!-- ⚠️ Please link issue(s) you close / fix by using GitHub keywords https://help.github.com/articles/closing-issues-using-keywords/ !-->
