### PR TITLE
Add intl support in logout component

### DIFF
--- a/packages/strapi-admin/admin/src/components/Logout/index.js
+++ b/packages/strapi-admin/admin/src/components/Logout/index.js
@@ -41,16 +41,10 @@ class Logout extends React.Component { // eslint-disable-line react/prefer-state
           </DropdownToggle>
           <DropdownMenu className={styles.dropDownContent}>
             <DropdownItem onClick={this.handleGoTo} className={styles.item}>
-              <FormattedMessage
-                id="app.components.Logout.profile"
-                defaultMessage="Profile"
-              />
+              <FormattedMessage id="app.components.Logout.profile" />
             </DropdownItem>
             <DropdownItem onClick={this.handleLogout}>
-              <FormattedMessage
-                id="app.components.Logout.logout"
-                defaultMessage="Logout"
-              />
+              <FormattedMessage id="app.components.Logout.logout" />
               <i className="fa fa-sign-out" />
             </DropdownItem>
           </DropdownMenu>

--- a/packages/strapi-admin/admin/src/components/Logout/index.js
+++ b/packages/strapi-admin/admin/src/components/Logout/index.js
@@ -5,6 +5,7 @@
 */
 
 import React from 'react';
+import { FormattedMessage } from 'react-intl';
 import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import { ButtonDropdown, DropdownItem, DropdownMenu, DropdownToggle } from 'reactstrap';
@@ -40,10 +41,16 @@ class Logout extends React.Component { // eslint-disable-line react/prefer-state
           </DropdownToggle>
           <DropdownMenu className={styles.dropDownContent}>
             <DropdownItem onClick={this.handleGoTo} className={styles.item}>
-              Profile
+              <FormattedMessage
+                id="app.components.Logout.profile"
+                defaultMessage="Profile"
+              />
             </DropdownItem>
             <DropdownItem onClick={this.handleLogout}>
-              Logout
+              <FormattedMessage
+                id="app.components.Logout.logout"
+                defaultMessage="Logout"
+              />
               <i className="fa fa-sign-out" />
             </DropdownItem>
           </DropdownMenu>

--- a/packages/strapi-admin/admin/src/containers/AdminPage/index.js
+++ b/packages/strapi-admin/admin/src/containers/AdminPage/index.js
@@ -256,6 +256,7 @@ AdminPage.propTypes = {
   blockApp: PropTypes.bool.isRequired,
   disableGlobalOverlayBlocker: PropTypes.func.isRequired,
   enableGlobalOverlayBlocker: PropTypes.func.isRequired,
+  getAdminData: PropTypes.func.isRequired,
   hasUserPlugin: PropTypes.bool,
   history: PropTypes.object.isRequired,
   isAppLoading: PropTypes.bool,

--- a/packages/strapi-admin/admin/src/translations/ar.json
+++ b/packages/strapi-admin/admin/src/translations/ar.json
@@ -75,6 +75,8 @@
   "app.components.ListPluginsPage.description": "قائمة الإضافيات المثبتة في المشروع.",
   "app.components.ListPluginsPage.helmet.title": "قائمة الإضافات",
   "app.components.ListPluginsPage.title": "الإضافات",
+  "app.components.Logout.profile": "الملف الشخصي",
+  "app.components.Logout.logout": "الخروج",
   "app.components.NotFoundPage.back": "العودة للرئيسية",
   "app.components.NotFoundPage.description": "لا يوجد",
   "app.components.Official": "الرسمية",

--- a/packages/strapi-admin/admin/src/translations/de.json
+++ b/packages/strapi-admin/admin/src/translations/de.json
@@ -75,6 +75,8 @@
   "app.components.LeftMenuLinkContainer.plugins": "Plugins",
   "app.components.ListPluginsPage.description": "Liste aller im Projekt installierten Plugins.",
   "app.components.ListPluginsPage.helmet.title": "Plugins anzeigen",
+  "app.components.Logout.profile": "Profil",
+  "app.components.Logout.logout": "Ausloggen",
   "app.components.ListPluginsPage.title": "Plugins",
   "app.components.NotFoundPage.back": "Zurück zur Homepage",
   "app.components.NotFoundPage.description": "Nicht gefunden",

--- a/packages/strapi-admin/admin/src/translations/en.json
+++ b/packages/strapi-admin/admin/src/translations/en.json
@@ -75,6 +75,8 @@
   "app.components.ListPluginsPage.description": "List of the installed plugins in the project.",
   "app.components.ListPluginsPage.helmet.title": "List plugins",
   "app.components.ListPluginsPage.title": "Plugins",
+  "app.components.Logout.profile": "Profile",
+  "app.components.Logout.logout": "Logout",
   "app.components.NotFoundPage.back": "Back to homepage",
   "app.components.NotFoundPage.description": "Not Found",
   "app.components.Official": "Official",

--- a/packages/strapi-admin/admin/src/translations/es.json
+++ b/packages/strapi-admin/admin/src/translations/es.json
@@ -75,6 +75,8 @@
   "app.components.ListPluginsPage.description": "Lista de los plugins instalados en el proyecto.",
   "app.components.ListPluginsPage.helmet.title": "Lista de plugins",
   "app.components.ListPluginsPage.title": "Plugins",
+  "app.components.Logout.profile": "Perfil",
+  "app.components.Logout.logout": "Cerrar sesión",
   "app.components.NotFoundPage.back": "Volver a la página de inicio",
   "app.components.NotFoundPage.description": "No encontrado",
   "app.components.Official": "Oficial",

--- a/packages/strapi-admin/admin/src/translations/fr.json
+++ b/packages/strapi-admin/admin/src/translations/fr.json
@@ -75,6 +75,8 @@
   "app.components.LeftMenuLinkContainer.plugins": "Plugins",
   "app.components.ListPluginsPage.description": "Liste des plugins installés dans le projet.",
   "app.components.ListPluginsPage.helmet.title": "List plugins",
+  "app.components.Logout.profile": "Profil",
+  "app.components.Logout.logout": "Connectez - Out",
   "app.components.ListPluginsPage.title": "Plugins",
   "app.components.NotFoundPage.back": "Retourner à la page d'accueil",
   "app.components.NotFoundPage.description": "Page introuvable",

--- a/packages/strapi-admin/admin/src/translations/it.json
+++ b/packages/strapi-admin/admin/src/translations/it.json
@@ -75,6 +75,8 @@
   "app.components.ListPluginsPage.description": "Lista dei plugin installati nel progetto.",
   "app.components.ListPluginsPage.helmet.title": "Lista plugin",
   "app.components.ListPluginsPage.title": "Plugins",
+  "app.components.Logout.profile": "Profilo",
+  "app.components.Logout.logout": "Disconnettersi",
   "app.components.NotFoundPage.back": "Torna alla home",
   "app.components.NotFoundPage.description": "Non trovato",
   "app.components.Official": "Ufficiale",

--- a/packages/strapi-admin/admin/src/translations/ja.json
+++ b/packages/strapi-admin/admin/src/translations/ja.json
@@ -75,6 +75,8 @@
   "app.components.ListPluginsPage.description": "このプロジェクトでインストールされたプラグイン一覧",
   "app.components.ListPluginsPage.helmet.title": "プラグイン一覧",
   "app.components.ListPluginsPage.title": "プラグイン",
+  "app.components.Logout.profile": "プロフィール",
+  "app.components.Logout.logout": "ログアウト",
   "app.components.NotFoundPage.back": "ホームページに戻る",
   "app.components.NotFoundPage.description": "見つかりません",
   "app.components.Official": "オフィシャル",

--- a/packages/strapi-admin/admin/src/translations/ko.json
+++ b/packages/strapi-admin/admin/src/translations/ko.json
@@ -74,6 +74,8 @@
   "app.components.ListPluginsPage.description": "이 프로젝트에 설치된 플러그인 목록입니다.",
   "app.components.ListPluginsPage.helmet.title": "플러그인 목록",
   "app.components.ListPluginsPage.title": "플러그인",
+  "app.components.Logout.profile": "옆모습",
+  "app.components.Logout.logout": "로그 아웃",
   "app.components.NotFoundPage.back": "홈으로 돌아가기",
   "app.components.NotFoundPage.description": "찾을 수 없는 페이지입니다.",
   "app.components.Official": "공식",

--- a/packages/strapi-admin/admin/src/translations/nl.json
+++ b/packages/strapi-admin/admin/src/translations/nl.json
@@ -75,6 +75,8 @@
   "app.components.ListPluginsPage.description": "Lijst van alle plugins voor dit project",
   "app.components.ListPluginsPage.helmet.title": "Alle extensies",
   "app.components.ListPluginsPage.title": "Extensies",
+  "app.components.Logout.profile": "Profil",
+  "app.components.Logout.logout": "Log ud",
   "app.components.NotFoundPage.back": "Terug naar home pagina",
   "app.components.NotFoundPage.description": "Niets gevonden",
   "app.components.Official": "Officieel",

--- a/packages/strapi-admin/admin/src/translations/pl.json
+++ b/packages/strapi-admin/admin/src/translations/pl.json
@@ -75,6 +75,8 @@
   "app.components.ListPluginsPage.description": "Lista zainstalowanych wtyczek w projekcie.",
   "app.components.ListPluginsPage.helmet.title": "Lista wtyczek",
   "app.components.ListPluginsPage.title": "Wtyczki",
+  "app.components.Logout.profile": "Profil",
+  "app.components.Logout.logout": "Wyloguj",
   "app.components.NotFoundPage.back": "Powrót do strony głównej",
   "app.components.NotFoundPage.description": "Nie znaleziono",
   "app.components.Official": "Oficjalna",

--- a/packages/strapi-admin/admin/src/translations/pt-BR.json
+++ b/packages/strapi-admin/admin/src/translations/pt-BR.json
@@ -75,6 +75,8 @@
   "app.components.ListPluginsPage.description": "Lista de extensões instaladas no projeto.",
   "app.components.ListPluginsPage.helmet.title": "Lista de extensões",
   "app.components.ListPluginsPage.title": "Extensões",
+  "app.components.Logout.profile": "Perfil",
+  "app.components.Logout.logout": "Sair",
   "app.components.NotFoundPage.back": "Voltar à página inicial",
   "app.components.NotFoundPage.description": "Não encontrado",
   "app.components.Official": "Oficial",

--- a/packages/strapi-admin/admin/src/translations/pt.json
+++ b/packages/strapi-admin/admin/src/translations/pt.json
@@ -75,6 +75,8 @@
   "app.components.ListPluginsPage.description": "Lista de extensões instaladas no projecto.",
   "app.components.ListPluginsPage.helmet.title": "Lista de extensões",
   "app.components.ListPluginsPage.title": "Extensões",
+  "app.components.Logout.profile": "Perfil",
+  "app.components.Logout.logout": "Sair",
   "app.components.NotFoundPage.back": "Voltar à página inicial",
   "app.components.NotFoundPage.description": "Não encontrado",
   "app.components.Official": "Oficial",

--- a/packages/strapi-admin/admin/src/translations/ru.json
+++ b/packages/strapi-admin/admin/src/translations/ru.json
@@ -75,6 +75,8 @@
   "app.components.ListPluginsPage.description": "Список установленых плагинов.",
   "app.components.ListPluginsPage.helmet.title": "Список плагинов",
   "app.components.ListPluginsPage.title": "Плагины",
+  "app.components.Logout.profile": "Профиль",
+  "app.components.Logout.logout": "Выйти",
   "app.components.NotFoundPage.back": "Вернуться на главную",
   "app.components.NotFoundPage.description": "Не найдено",
   "app.components.Official": "Официальный",

--- a/packages/strapi-admin/admin/src/translations/tr.json
+++ b/packages/strapi-admin/admin/src/translations/tr.json
@@ -75,6 +75,8 @@
   "app.components.ListPluginsPage.description": "Projedeki yüklenen eklentiler.",
   "app.components.ListPluginsPage.helmet.title": "Eklenti Listesi",
   "app.components.ListPluginsPage.title": "Etklentiler",
+  "app.components.Logout.profile": "Profil",
+  "app.components.Logout.logout": "Çıkış Yap",
   "app.components.NotFoundPage.back": "Anasayfaya geri dön",
   "app.components.NotFoundPage.description": "Bulunamadı",
   "app.components.Official": "Resmi",

--- a/packages/strapi-admin/admin/src/translations/zh-Hans.json
+++ b/packages/strapi-admin/admin/src/translations/zh-Hans.json
@@ -72,6 +72,8 @@
   "app.components.ListPluginsPage.description": "项目中已安装的插件列表",
   "app.components.ListPluginsPage.helmet.title": "插件列表",
   "app.components.ListPluginsPage.title": "插件",
+  "app.components.Logout.profile": "轮廓",
+  "app.components.Logout.logout": "登出",
   "app.components.NotFoundPage.back": "返回主页",
   "app.components.NotFoundPage.description": "没有找到",
   "app.components.Official": "官方",

--- a/packages/strapi-admin/admin/src/translations/zh.json
+++ b/packages/strapi-admin/admin/src/translations/zh.json
@@ -75,6 +75,8 @@
   "app.components.ListPluginsPage.description": "這個專案安裝的擴充功能列表",
   "app.components.ListPluginsPage.helmet.title": "擴充功能列表",
   "app.components.ListPluginsPage.title": "擴充功能",
+  "app.components.Logout.profile": "輪廓",
+  "app.components.Logout.logout": "登出",
   "app.components.NotFoundPage.back": "回到主頁",
   "app.components.NotFoundPage.description": "找不到此頁面",
   "app.components.Official": "官方",


### PR DESCRIPTION
<!-- ⚠️ Your PR title will appear in the changelogs please make it short detailed and understandable for all. -->

<!-- Uncomment the correct contribution type. !-->

My PR is a:
💅 Enhancement

Main update on the:
Admin

<!-- Write a short description of what your PR does and link the concerned issues of your update. -->
In Logout component "Profile" and "Logout" strings were replaced with `<FormattedMessage />`. `app.components.Logout.profile` and `app.components.Logout.logout` translation keys were defined in all locale files.

<!-- ⚠️ Please link issue(s) you close / fix by using GitHub keywords https://help.github.com/articles/closing-issues-using-keywords/ !-->
