### PR TITLE
[WIP] Using custom primaryKey column name.

### DIFF
--- a/packages/strapi-hook-bookshelf/lib/index.js
+++ b/packages/strapi-hook-bookshelf/lib/index.js
@@ -83,7 +83,7 @@ module.exports = function(strapi) {
             definition.orm = 'bookshelf';
             definition.client = _.get(connection.settings, 'client');
             _.defaults(definition, {
-              primaryKey: 'id',
+              primaryKey: _.get(definition, 'options.idAttribute', 'id'),
               primaryKeyType: _.get(definition, 'options.idAttributeType', 'integer')
             });
             // Register the final model for Bookshelf.

--- a/packages/strapi-plugin-content-manager/admin/src/components/TableRow/index.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/TableRow/index.js
@@ -75,7 +75,7 @@ class TableRow extends React.Component {
       <IcoContainer
         icons={[
           { icoType: 'pencil', onClick: this.handleClick },
-          { id: this.props.record.id, icoType: 'trash', onClick: this.props.onDelete },
+          { id: this.props.record[this.props.primaryKey], icoType: 'trash', onClick: this.props.onDelete },
         ]}
       />
     </td>
@@ -106,7 +106,7 @@ class TableRow extends React.Component {
       return (
         <td onClick={(e) => e.stopPropagation()} key="i">
           <CustomInputCheckbox
-            name={this.props.record.id}
+            name={this.props.record[this.props.primaryKey]}
             onChange={this.props.onChange}
             value={this.props.value}
           />
@@ -136,6 +136,7 @@ TableRow.propTypes = {
   headers: PropTypes.array.isRequired,
   onChange: PropTypes.func.isRequired,
   onDelete: PropTypes.func,
+  primaryKey: PropTypes.string,
   record: PropTypes.object.isRequired,
   redirectUrl: PropTypes.string.isRequired,
   value: PropTypes.bool,
@@ -144,6 +145,7 @@ TableRow.propTypes = {
 TableRow.defaultProps = {
   enableBulkActions: true,
   onDelete: () => {},
+  primaryKey: 'id',
   value: false,
 };
 

--- a/packages/strapi-plugin-content-manager/admin/src/containers/EditPage/saga.js
+++ b/packages/strapi-plugin-content-manager/admin/src/containers/EditPage/saga.js
@@ -50,8 +50,11 @@ function* deleteData() {
   try {
     const currentModelName = yield select(makeSelectModelName());
     const record = yield select(makeSelectRecord());
-    const id = record.id || record._id;
     const source = yield select(makeSelectSource());
+    const schema = yield select(makeSelectSchema());
+
+    const primaryKey = get(schema, ['models', currentModelName, 'primaryKey'], null);
+    const id = record[primaryKey];
     const requestUrl = `/content-manager/explorer/${currentModelName}/${id}`;
 
     yield call(request, requestUrl, { method: 'DELETE', params: { source } });
@@ -120,7 +123,8 @@ export function* submit() {
     //   console.log(pair[0]+ ', '+ pair[1]);
     // }
 
-    const id = isCreating ? '' : record.id || record._id;
+    const primaryKey = get(schema, ['models', currentModelName, 'primaryKey'], null);
+    const id = isCreating ? '' : record[primaryKey];
     const params = { source };
     // Change the request helper default headers so we can pass a FormData
     const headers = {

--- a/packages/strapi-plugin-content-manager/services/ContentManager.js
+++ b/packages/strapi-plugin-content-manager/services/ContentManager.js
@@ -49,8 +49,9 @@ module.exports = {
   },
 
   fetch: async (params, source, populate, raw = true) => {
+    const primaryKey = strapi.query(params.model, source).primaryKey;
     return await strapi.query(params.model, source).findOne({
-      id: params.id
+      [primaryKey]: params.id
     }, populate, raw);
   },
 
@@ -103,6 +104,8 @@ module.exports = {
   },
 
   edit: async (params, values, source) => {
+    const primaryKey = strapi.query(params.model, source).primaryKey;
+
     // Multipart/form-data.
     if (values.hasOwnProperty('fields') && values.hasOwnProperty('files')) {
       // Silent recursive parser.
@@ -132,7 +135,7 @@ module.exports = {
 
       // Update JSON fields.
       await strapi.query(params.model, source).update({
-        id: params.id,
+        [primaryKey]: params.id,
         values
       });
 
@@ -143,13 +146,13 @@ module.exports = {
       }
 
       return strapi.query(params.model, source).findOne({
-        id: params.id
+        [primaryKey]: params.id
       });
     }
 
     // Raw JSON.
     return strapi.query(params.model, source).update({
-      id: params.id,
+      [primaryKey]: params.id,
       values
     });
   },
@@ -158,7 +161,7 @@ module.exports = {
     const query = strapi.query(params.model, source);
     const primaryKey = query.primaryKey;
     const response = await query.findOne({
-      id: params.id
+      [primaryKey]: params.id
     });
 
     params[primaryKey] = response[primaryKey];


### PR DESCRIPTION
<!-- ⚠️ Your PR title will appear in the changelogs please make it short detailed and understandable for all. -->

<!-- Uncomment the correct contribution type. !-->

My PR is a:
- [ ] 💥 Breaking change
- [x] 🐛 Bug fix #1762
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

Main update on the:
- [ ] Admin
- [ ] Documentation
- [ ] Framework
- [x] Plugin

<!-- Write a short description of what your PR does and link the concerned issues of your update. -->
This PR is towards removing all the hard coded primary key column and using `primaryKey` attribute value defined in `model.settings.json` file.

### Here are some of the known issues you can help with:

**[React] Checkbox Toggle Issue:**
The toggle stops working when we change the primary key column name to something other than `id`. But it works as expected when the column name is unchanged.

<img width="100%" alt="screenshot 2019-01-08 at 6 00 46 pm" src="https://user-images.githubusercontent.com/13115490/50830972-7531b400-136f-11e9-8268-12a1f3624d11.png">
<br />

**[Nodejs] Multiple Delete:**
For models with primaryKey column name other than `id`, when multiple records are selected for deletion in the `content-manager` plugin, it fails to do so with the following error. But it works as expected when the column name is unchanged.

```
Error: Undefined binding(s) detected when compiling DEL query: delete from "songs" where "id" in (?)
    at QueryCompiler_PG.toSQL (/node_modules/knex/lib/query/compiler.js:131:13)
    at Builder.toSQL (/node_modules/knex/lib/query/builder.js:115:44)
    at /node_modules/knex/lib/runner.js:56:32
From previous event:
    at Runner.run (/node_modules/knex/lib/runner.js:51:31)
    at Builder.Target.then (/node_modules/knex/lib/interface.js:35:43)
    at Child.<anonymous> (/strapi/packages/strapi-hook-bookshelf/node_modules/bookshelf/lib/model.js:1236:19)
    at runCallback (timers.js:705:18)
    at tryOnImmediate (timers.js:676:5)
    at processImmediate (timers.js:658:5)
    at process.topLevelDomainCallback (domain.js:120:23)
```
<br />

**[React] Singe Delete Error**
For models with primary key column name other than `id`, when deleting a record using the  🗑 icon on the left side of the table list view, the record is visible even after successful deletion. A simple refresh makes it disappear from the list. But it works as expected when the column name is unchanged.

I'm new to React, any help in the right direction would be appreciated.

### Manual Testing
Will update it as moving forward with the changes in this PR.
- [x] Postgres
- [ ] MySQL
- [ ] MongoDB

<!-- ⚠️ Please link issue(s) you close / fix by using GitHub keywords https://help.github.com/articles/closing-issues-using-keywords/ !-->
