### PR TITLE
Update users-permissions plugin config to export the /permissions endpoint

### DIFF
--- a/packages/strapi-plugin-users-permissions/config/routes.json
+++ b/packages/strapi-plugin-users-permissions/config/routes.json
@@ -37,6 +37,14 @@
     },
     {
       "method": "GET",
+      "path": "/permissions",
+      "handler": "UsersPermissions.getPermissions",
+      "config": {
+          "policies": []
+      }
+    },
+    {
+      "method": "GET",
       "path": "/policies",
       "handler": "UsersPermissions.getPolicies",
       "config": {


### PR DESCRIPTION
<!-- ⚠️ Your PR title will appear in the changelogs please make it short detailed and understandable for all. -->
  
**My PR is a:**
- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix #issueNumber
- [X] 💅 Enhancement
- [ ] 🚀 New feature

**Main update on the:**
- [X] Admin
- [ ] Documentation
- [ ] Framework
- [ ] Plugin

<!-- Please note that all databases should be tested and confirmed to be working prior to the PR being merged. -->
**Manual testing done on the follow databases:**
- [ ] Not applicable
- [X] MongoDB
- [ ] MySQL
- [ ] Postgres

<!-- Write a short description of what your PR does and link the concerned issues of your update. -->
**Description:**
This pull request adds the missing '/permissions/permissions' endpoint needed by the Add Role form in the plugin's admin page, when creating a new role.

