### PR TITLE
Different parameter names from content-manager

### DIFF
--- a/packages/strapi-plugin-users-permissions/controllers/User.js
+++ b/packages/strapi-plugin-users-permissions/controllers/User.js
@@ -120,7 +120,7 @@ module.exports = {
       if (advancedConfigs.unique_email && ctx.request.body.email) {
         const users = await strapi.plugins['users-permissions'].services.user.fetchAll({ email: ctx.request.body.email });
 
-        if (users && _.find(users, user => (user.id || user._id).toString() !== ctx.params._id)) {
+        if (users && _.find(users, user => (user.id || user._id).toString() !== (ctx.params._id || ctx.params.id))) {
           return ctx.badRequest(null, ctx.request.admin ? [{ messages: [{ id: 'Auth.form.error.email.taken', field: ['email'] }] }] : 'Email is already taken.');
         }
       }
@@ -140,7 +140,7 @@ module.exports = {
           email: ctx.request.body.email
         });
 
-        if (user !== null && (user.id || user._id).toString() !== ctx.params._id) {
+        if (user !== null && (user.id || user._id).toString() !== (ctx.params._id || ctx.params.id)) {
           return ctx.badRequest(null, ctx.request.admin ? [{ messages: [{ id: 'Auth.form.error.email.taken', field: ['email'] }] }] : 'Email is already taken.');
         }
       }


### PR DESCRIPTION
The content-manager plugin routes use the parameter name id (:id) in routes for updating content from the admin portal. The user-permissions plugin uses _id  (:_id) as the parameter name in the routes. This causes a conflict as the content-manager calls the update function of the user controller with a different parameter.

<!-- ⚠️ Your PR title will appear in the changelogs please make it short detailed and understandable for all. -->

<!-- Uncomment the correct contribution type. !-->

**My PR is a:**
- [ ] 💥 Breaking change
- [x] 🐛 Bug fix #issueNumber
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

**Main update on the:**
- [ ] Admin
- [ ] Documentation
- [ ] Framework
- [x] Plugin

<!-- Please note that all databases should be tested and confirmed to be working prior to the PR being merged. -->
**Manual testing done on the follow databases:**
- [x] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres

<!-- Write a short description of what your PR does and link the concerned issues of your update. -->
**Description:**
The content-manager plugin routes use the parameter name id (:id) in routes for updating content from the admin portal. The user-permissions plugin uses _id  (:_id) as the parameter name in the routes. This causes a conflict as the content-manager calls the update function of the user controller with a different parameter. This PR is a fix for the conflict.

<!-- ⚠️ Please link issue(s) you close / fix by using GitHub keywords https://help.github.com/articles/closing-issues-using-keywords/ !-->
Closes #2641