### PR TITLE
Fix update user email

### DIFF
--- a/packages/strapi-plugin-users-permissions/controllers/User.js
+++ b/packages/strapi-plugin-users-permissions/controllers/User.js
@@ -120,7 +120,7 @@ module.exports = {
       if (advancedConfigs.unique_email && ctx.request.body.email) {
         const users = await strapi.plugins['users-permissions'].services.user.fetchAll({ email: ctx.request.body.email });
 
-        if (users && _.find(users, user => (user.id || user._id).toString() !== ctx.params._id)) {
+        if (users && _.find(users, user => (user.id || user._id).toString() !== (ctx.params.id || ctx.params._id))) {
           return ctx.badRequest(null, ctx.request.admin ? [{ messages: [{ id: 'Auth.form.error.email.taken', field: ['email'] }] }] : 'Email is already taken.');
         }
       }
@@ -140,7 +140,7 @@ module.exports = {
           email: ctx.request.body.email
         });
 
-        if (user !== null && (user.id || user._id).toString() !== ctx.params._id) {
+        if (user !== null && (user.id || user._id).toString() !== (ctx.params.id || ctx.params._id)) {
           return ctx.badRequest(null, ctx.request.admin ? [{ messages: [{ id: 'Auth.form.error.email.taken', field: ['email'] }] }] : 'Email is already taken.');
         }
       }


### PR DESCRIPTION
<!-- ⚠️ Your PR title will appear in the changelogs please make it short detailed and understandable for all. -->

<!-- Uncomment the correct contribution type. !-->

**My PR is a:**
- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix #2446
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

**Main update on the:**
- [ ] Admin
- [ ] Documentation
- [ ] Framework
- [ ] Plugin

<!-- Please note that all databases should be tested and confirmed to be working prior to the PR being merged. -->
**Manual testing done on the follow databases:**
- [ ] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres

<!-- Write a short description of what your PR does and link the concerned issues of your update. -->
**Description:**

It fixes the issue when you want to update a user without changing the email, and you have an error message because of the email is already used.

<!-- ⚠️ Please link issue(s) you close / fix by using GitHub keywords https://help.github.com/articles/closing-issues-using-keywords/ !-->
