### PR TITLE
Fix X-Powered-By header setup and panel support for it

### DIFF
--- a/docs/3.x.x/configurations/configurations.md
+++ b/docs/3.x.x/configurations/configurations.md
@@ -339,6 +339,9 @@ The session doesn't work with `mongo` as a client. The package that we should us
   - `enabled` (boolean): Enable or not GZIP response compression.
  - `responseTime`
   - `enabled` (boolean): Enable or not `X-Response-Time header` to response. Default value: `false`.
+ - `poweredBy`
+  - `enabled` (boolean): Enable or not `X-Powered-By` header to response. Default value: depends on the environment.
+  - `value` (string): The value of the header. Default value: `Strapi <strapi.io>`
 
 ***
 

--- a/packages/strapi-generate-new/files/config/environments/development/response.json
+++ b/packages/strapi-generate-new/files/config/environments/development/response.json
@@ -4,5 +4,9 @@
   },
   "responseTime": {
     "enabled": false
+  },
+  "poweredBy": {
+    "enabled": true,
+    "value": "Strapi <strapi.io>"
   }
 }

--- a/packages/strapi-generate-new/files/config/environments/production/response.json
+++ b/packages/strapi-generate-new/files/config/environments/production/response.json
@@ -4,5 +4,8 @@
   },
   "responseTime": {
     "enabled": false
+  },
+  "poweredBy": {
+    "enabled": false
   }
 }

--- a/packages/strapi-generate-new/files/config/environments/staging/response.json
+++ b/packages/strapi-generate-new/files/config/environments/staging/response.json
@@ -4,5 +4,8 @@
   },
   "responseTime": {
     "enabled": false
+  },
+  "poweredBy": {
+    "enabled": false
   }
 }

--- a/packages/strapi-plugin-settings-manager/admin/src/components/WithFormSection/config.json
+++ b/packages/strapi-plugin-settings-manager/admin/src/components/WithFormSection/config.json
@@ -4,5 +4,5 @@
   "databases.connections.${name}.settings.host": "col-md-12",
   "database.connections.settings.host": "col-md-12",
   "database.connections.settings.port": "col-md-6",
-  "showInputLabel": ["form.response.item.gzip.enabled", "form.response.item.responseTime.enabled"]
+  "showInputLabel": ["form.response.item.gzip.enabled", "form.response.item.responseTime.enabled", "form.response.item.poweredBy.enabled"]
 }

--- a/packages/strapi-plugin-settings-manager/admin/src/translations/ar.json
+++ b/packages/strapi-plugin-settings-manager/admin/src/translations/ar.json
@@ -48,6 +48,7 @@
   "form.response.description": "قم بتكوين إعدادات الاستجابة الخاصة بك.",
   "form.response.item.gzip.enabled": "Gzip",
   "form.response.item.responseTime.enabled": "وقت الاستجابة",
+  "form.response.item.poweredBy.enabled": "Powered by",
   "form.response.name": "الإستجابة",
   "form.security.description": "تكوين إعدادات الأمان الخاصة بك.",
   "form.security.item.cors": "Cors",

--- a/packages/strapi-plugin-settings-manager/admin/src/translations/de.json
+++ b/packages/strapi-plugin-settings-manager/admin/src/translations/de.json
@@ -48,6 +48,7 @@
   "form.response.description": "Verwalte deine Antworteinstellungen.",
   "form.response.item.gzip.enabled": "Gzip",
   "form.response.item.responseTime.enabled": "Antwortzeit",
+  "form.response.item.poweredBy.enabled": "Powered by",
   "form.response.name": "Antwort",
   "form.security.description": "Verwalte deine Sicherheitseinstellungen.",
   "form.security.item.cors": "Cors",

--- a/packages/strapi-plugin-settings-manager/admin/src/translations/en.json
+++ b/packages/strapi-plugin-settings-manager/admin/src/translations/en.json
@@ -48,6 +48,7 @@
   "form.response.description": "Configure your response settings.",
   "form.response.item.gzip.enabled": "Gzip",
   "form.response.item.responseTime.enabled": "Response Time",
+  "form.response.item.poweredBy.enabled": "Powered by",
   "form.response.name": "Response",
   "form.security.description": "Configure your security settings.",
   "form.security.item.cors": "Cors",

--- a/packages/strapi-plugin-settings-manager/admin/src/translations/es.json
+++ b/packages/strapi-plugin-settings-manager/admin/src/translations/es.json
@@ -48,6 +48,7 @@
   "form.response.description": "Configurar las opciones de respuesta.",
   "form.response.item.gzip.enabled": "Gzip",
   "form.response.item.responseTime.enabled": "Tiempo de respuesta",
+  "form.response.item.poweredBy.enabled": "Powered by",
   "form.response.name": "Respuesta",
   "form.security.description": "Configurar las opciones de seguridad.",
   "form.security.item.cors": "Cors",

--- a/packages/strapi-plugin-settings-manager/admin/src/translations/fr.json
+++ b/packages/strapi-plugin-settings-manager/admin/src/translations/fr.json
@@ -48,6 +48,7 @@
   "form.response.description": "Configuration des réponses.",
   "form.response.item.gzip.enabled": "Gzip",
   "form.response.item.responseTime.enabled": "Temps de réponse",
+  "form.response.item.poweredBy.enabled": "Powered by",
   "form.response.name": "Réponse",
   "form.security.description": "Configurations de sécurité.",
   "form.security.item.cors": "Cors",

--- a/packages/strapi-plugin-settings-manager/admin/src/translations/it.json
+++ b/packages/strapi-plugin-settings-manager/admin/src/translations/it.json
@@ -48,6 +48,7 @@
   "form.response.description": "Configurare la tua risposta impostazioni.",
   "form.response.item.gzip.enabled": "Gzip",
   "form.response.item.responseTime.enabled": "Il Tempo Di Risposta",
+  "form.response.item.poweredBy.enabled": "Powered by",
   "form.response.name": "Risposta",
   "form.security.description": "Configurare le impostazioni di sicurezza.",
   "form.security.item.cors": "Cors",

--- a/packages/strapi-plugin-settings-manager/admin/src/translations/ja.json
+++ b/packages/strapi-plugin-settings-manager/admin/src/translations/ja.json
@@ -48,6 +48,7 @@
   "form.response.description": "レスポンス設定を構成します。",
   "form.response.item.gzip.enabled": "Gzip",
   "form.response.item.responseTime.enabled": "Response Time",
+  "form.response.item.poweredBy.enabled": "Powered by",
   "form.response.name": "レスポンス",
   "form.security.description": "セキュリティ設定を構成します。",
   "form.security.item.cors": "Cors",

--- a/packages/strapi-plugin-settings-manager/admin/src/translations/ko.json
+++ b/packages/strapi-plugin-settings-manager/admin/src/translations/ko.json
@@ -48,6 +48,7 @@
   "form.response.description": "응답(response) 환경을 설정하세요.",
   "form.response.item.gzip.enabled": "Gzip",
   "form.response.item.responseTime.enabled": "응답 시간 (Response Time)",
+  "form.response.item.poweredBy.enabled": "Powered by",
   "form.response.name": "응답 (Response)",
   "form.security.description": "보안 환경을 설정하세요.",
   "form.security.item.cors": "Cors",

--- a/packages/strapi-plugin-settings-manager/admin/src/translations/nl.json
+++ b/packages/strapi-plugin-settings-manager/admin/src/translations/nl.json
@@ -48,6 +48,7 @@
   "form.response.description": "Configureer je response instellingen.",
   "form.response.item.gzip.enabled": "Gzip",
   "form.response.item.responseTime.enabled": "Response Tijd",
+  "form.response.item.poweredBy.enabled": "Powered by",
   "form.response.name": "Response",
   "form.security.description": "Configureer je beveiliging instellingen.",
   "form.security.item.cors": "Cors",

--- a/packages/strapi-plugin-settings-manager/admin/src/translations/pl.json
+++ b/packages/strapi-plugin-settings-manager/admin/src/translations/pl.json
@@ -48,6 +48,7 @@
   "form.response.description": "Konfiguruj ustawienia odpowiedzi.",
   "form.response.item.gzip.enabled": "Gzip",
   "form.response.item.responseTime.enabled": "Czas odpowiedzi",
+  "form.response.item.poweredBy.enabled": "Powered by",
   "form.response.name": "Odpowiedzi",
   "form.security.description": "Konfiguruj ustawienia bezpieczeństwa.",
   "form.security.item.cors": "Cors",

--- a/packages/strapi-plugin-settings-manager/admin/src/translations/pt-BR.json
+++ b/packages/strapi-plugin-settings-manager/admin/src/translations/pt-BR.json
@@ -48,6 +48,7 @@
   "form.response.description": "Defina as suas configurações de resposta.",
   "form.response.item.gzip.enabled": "Gzip",
   "form.response.item.responseTime.enabled": "Tempo de resposta",
+  "form.response.item.poweredBy.enabled": "Powered by",
   "form.response.name": "Resposta",
   "form.security.description": "Defina as suas configurações de segurança.",
   "form.security.item.cors": "CORS",

--- a/packages/strapi-plugin-settings-manager/admin/src/translations/pt.json
+++ b/packages/strapi-plugin-settings-manager/admin/src/translations/pt.json
@@ -48,6 +48,7 @@
   "form.response.description": "Configure as suas definições de resposta.",
   "form.response.item.gzip.enabled": "Gzip",
   "form.response.item.responseTime.enabled": "Tempo de resposta",
+  "form.response.item.poweredBy.enabled": "Powered by",
   "form.response.name": "Resposta",
   "form.security.description": "Configure as suas definições de segurança.",
   "form.security.item.cors": "Cors",

--- a/packages/strapi-plugin-settings-manager/admin/src/translations/ru.json
+++ b/packages/strapi-plugin-settings-manager/admin/src/translations/ru.json
@@ -48,6 +48,7 @@
   "form.response.description": "Задайте настройки ответа.",
   "form.response.item.gzip.enabled": "Gzip",
   "form.response.item.responseTime.enabled": "Время ответа",
+  "form.response.item.poweredBy.enabled": "Powered by",
   "form.response.name": "Ответ",
   "form.security.description": "Задайте настройки безопасности.",
   "form.security.item.cors": "Cors",

--- a/packages/strapi-plugin-settings-manager/admin/src/translations/tr.json
+++ b/packages/strapi-plugin-settings-manager/admin/src/translations/tr.json
@@ -48,6 +48,7 @@
   "form.response.description": "Yanıt ayarlarınızı yapılandırın.",
   "form.response.item.gzip.enabled": "Gzip",
   "form.response.item.responseTime.enabled": "Tepki Süresi",
+  "form.response.item.poweredBy.enabled": "Powered by",
   "form.response.name": "Cevap",
   "form.security.description": "Güvenlik ayarlarınızı yapılandırın.",
   "form.security.item.cors": "Cors",

--- a/packages/strapi-plugin-settings-manager/admin/src/translations/zh-Hans.json
+++ b/packages/strapi-plugin-settings-manager/admin/src/translations/zh-Hans.json
@@ -47,6 +47,7 @@
   "form.response.description": "配置您的响应设置。",
   "form.response.item.gzip.enabled": "Gzip",
   "form.response.item.responseTime.enabled": "Response Time",
+  "form.response.item.poweredBy.enabled": "Powered by",
   "form.response.name": "Response",
   "form.security.description": "配置安全设置。",
   "form.security.item.cors": "Cors",

--- a/packages/strapi-plugin-settings-manager/admin/src/translations/zh.json
+++ b/packages/strapi-plugin-settings-manager/admin/src/translations/zh.json
@@ -48,6 +48,7 @@
   "form.response.description": "調整回應設定",
   "form.response.item.gzip.enabled": "Gzip",
   "form.response.item.responseTime.enabled": "回應時間",
+  "form.response.item.poweredBy.enabled": "Powered by",
   "form.response.name": "回應",
   "form.security.description": "調整安全性設定",
   "form.security.item.cors": "跨域資源共享 (Cors)",

--- a/packages/strapi-plugin-settings-manager/services/SettingsManager.js
+++ b/packages/strapi-plugin-settings-manager/services/SettingsManager.js
@@ -207,6 +207,15 @@ module.exports = {
             validations: {
               required: true
             }
+          },
+          {
+            name: 'form.response.item.poweredBy.enabled',
+            target: 'response.poweredBy.enabled',
+            type: 'boolean',
+            value: _.get(strapi.config, `environments.${env}.response.poweredBy.enabled`, null),
+            validations: {
+              required: true
+            }
           }
         ]
       }

--- a/packages/strapi/lib/middlewares/responses/index.js
+++ b/packages/strapi/lib/middlewares/responses/index.js
@@ -22,8 +22,8 @@ module.exports = () => {
         }
 
         // Set X-Powered-By header.
-        if (_.get(strapi.config, 'X-Powered-By.enabled', true)) {
-          ctx.set('X-Powered-By', 'Strapi <strapi.io>');
+        if (_.get(strapi.config.currentEnvironment.response, 'poweredBy.enabled', null)) {
+          ctx.set('X-Powered-By', _.get(strapi.config.currentEnvironment.response, 'poweredBy.value'));
         }
       });
       cb();


### PR DESCRIPTION
**My PR is a:**
- [ ] 💥 Breaking change
- [x] 🐛 Bug fix #2646
- [x] 💅 Enhancement
- [ ] 🚀 New feature

**Main update on the:**
- [x] Admin
- [ ] Documentation
- [x] Framework
- [ ] Plugin

**Manual testing done on the follow databases:**
- [ ] Not applicable
- [x] MongoDB
- [ ] MySQL
- [ ] Postgres

**Description:**
It allows to disable or change the "X-Powered-By" header in the response. Also in the management panel.

![shoot](https://user-images.githubusercontent.com/2753855/51549399-a7144180-1e6a-11e9-8370-0bf58250f7aa.png)

Fixes #2646