### PR TITLE
Fix avoid write files if production mode

### DIFF
--- a/packages/strapi/lib/core/admin.js
+++ b/packages/strapi/lib/core/admin.js
@@ -66,6 +66,8 @@ module.exports = function() {
 
                 resolve();
               });
+            } else {
+              resolve();
             }
           });
         });


### PR DESCRIPTION
<!-- ⚠️ Your PR title will appear in the changelogs please make it short detailed and understandable for all. -->

<!-- Uncomment the correct contribution type. !-->

**My PR is a:**
- [ ] 💥 Breaking change
- [x] 🐛 Bug fix #2636
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

**Main update on the:**
- [ ] Admin
- [ ] Documentation
- [x] Framework
- [x] Plugin

<!-- Please note that all databases should be tested and confirmed to be working prior to the PR being merged. -->
**Manual testing done on the follow databases:**
- [x] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres

<!-- Write a short description of what your PR does and link the concerned issues of your update. -->
**Description:**

<!-- ⚠️ Please link issue(s) you close / fix by using GitHub keywords https://help.github.com/articles/closing-issues-using-keywords/ !-->

Fix avoid write files if production mode

⚠️ Right now the `npm start` command is broken for `production` & `staging` environments.