### PR TITLE
Fix get timestamp in the admin

### DIFF
--- a/packages/strapi-hook-bookshelf/lib/index.js
+++ b/packages/strapi-hook-bookshelf/lib/index.js
@@ -86,6 +86,16 @@ module.exports = function(strapi) {
               primaryKey: 'id',
               primaryKeyType: _.get(definition, 'options.idAttributeType', 'integer')
             });
+
+            // Use default timestamp column names if value is `true`
+            if (_.get(definition, 'options.timestamps', false) === true) {
+              _.set(definition, 'options.timestamps', ['created_at', 'updated_at']);
+            }
+            // Use false for values other than `Boolean` or `Array`
+            if (!_.isArray(_.get(definition, 'options.timestamps')) && !_.isBoolean(_.get(definition, 'options.timestamps'))) {
+              _.set(definition, 'options.timestamps', false);
+            }
+
             // Register the final model for Bookshelf.
             const loadedModel = _.assign({
               tableName: definition.collectionName,
@@ -100,14 +110,7 @@ module.exports = function(strapi) {
                 return acc;
               }, {})
             }, definition.options);
-            // Use default timestamp column names if value is `true`
-            if (_.get(loadedModel, 'hasTimestamps') === true) {
-              _.set(loadedModel, 'hasTimestamps', ['created_at', 'updated_at']);
-            }
-            // Use false for values other than `Boolean` or `Array`
-            if (!_.isArray(_.get(loadedModel, 'hasTimestamps')) && !_.isBoolean(_.get(loadedModel, 'hasTimestamps'))) {
-              _.set(loadedModel, 'hasTimestamps', false);
-            }
+
             if (_.isString(_.get(connection, 'options.pivot_prefix'))) {
               loadedModel.toJSON = function(options = {}) {
                 const { shallow = false, omitPivot = false } = options;

--- a/packages/strapi-hook-mongoose/lib/index.js
+++ b/packages/strapi-hook-mongoose/lib/index.js
@@ -216,6 +216,7 @@ module.exports = function (strapi) {
                   collection.schema.set('timestamps', timestamps);
                 } else {
                   collection.schema.set('timestamps', _.get(definition, 'options.timestamps') === true);
+                  _.set(definition, 'options.timestamps', _.get(definition, 'options.timestamps') === true ? ['createdAt', 'updatedAt'] : false);
                 }
                 collection.schema.set('minimize', _.get(definition, 'options.minimize', false) === true);
 

--- a/packages/strapi-plugin-content-manager/config/functions/bootstrap.js
+++ b/packages/strapi-plugin-content-manager/config/functions/bootstrap.js
@@ -17,7 +17,7 @@ const pickData = (model) => _.pick(model, [
   'globalId',
   'globalName',
   'orm',
-  'options.timestamps',
+  'options',
   'loadedModel',
   'primaryKey',
   'associations'
@@ -381,6 +381,12 @@ module.exports = async cb => {
       const currentFields = _.get(prevSchema.models, fieldsPath, []);
       currentFields.push(attr.name);
       _.set(prevSchema.models, fieldsPath, currentFields);
+    });
+
+    schemaApis.map((model) => {
+      const isPlugin = model.includes('plugins.');
+      _.set(prevSchema.models[model], 'info', _.get(!isPlugin ? strapi.models[model] : strapi[model], 'info'));
+      _.set(prevSchema.models[model], 'options', _.get(!isPlugin ? strapi.models[model] : strapi[model], 'options'));
     });
 
     await pluginStore.set({ key: 'schema', value: prevSchema });


### PR DESCRIPTION
<!-- ⚠️ Your PR title will appear in the changelogs please make it short detailed and understandable for all. -->

<!-- Uncomment the correct contribution type. !-->

**My PR is a:**
- [ ] 💥 Breaking change
- [x] 🐛 Bug fix #2663
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

**Main update on the:**
- [ ] Admin
- [ ] Documentation
- [x] Framework
- [ ] Plugin

<!-- Please note that all databases should be tested and confirmed to be working prior to the PR being merged. -->
**Manual testing done on the follow databases:**
- [ ] Not applicable
- [x] MongoDB
- [x] MySQL
- [x] Postgres

<!-- Write a short description of what your PR does and link the concerned issues of your update. -->
**Description:**

Timestamp key name was not send to the content manager to omit the correct keys during the update of one entry.
So I fix the way we give the correct information to the content manager.

<!-- ⚠️ Please link issue(s) you close / fix by using GitHub keywords https://help.github.com/articles/closing-issues-using-keywords/ !-->
