### PR TITLE
Remove Mongoose warning logs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,7 +15,7 @@
 - [ ] Plugin
 
 <!-- Please note that all databases should be tested and confirmed to be working prior to the PR being merged. -->
-**Manual testing done on the follow databases:**
+**Manual testing done on the following databases:**
 - [ ] Not applicable
 - [ ] MongoDB
 - [ ] MySQL

--- a/packages/strapi-generate-api/templates/mongoose/service.template
+++ b/packages/strapi-generate-api/templates/mongoose/service.template
@@ -64,7 +64,7 @@ module.exports = {
     const filters = strapi.utils.models.convertParams('<%= globalID.toLowerCase() %>', params);
 
     return <%= globalID %>
-      .count()
+      .countDocuments()
       .where(filters.where);
   },
 
@@ -98,7 +98,7 @@ module.exports = {
     const data = _.omit(values, <%= globalID %>.associations.map(a => a.alias));
 
     // Update entry with no-relational data.
-    const entry = await <%= globalID %>.update(params, data, { multi: true });
+    const entry = await <%= globalID %>.updateOne(params, data, { multi: true });
 
     // Update relational data and return the entry.
     return <%= globalID %>.updateRelations(Object.assign(params, { values: relations }));

--- a/packages/strapi-hook-mongoose/lib/index.js
+++ b/packages/strapi-hook-mongoose/lib/index.js
@@ -60,7 +60,9 @@ module.exports = function (strapi) {
 
         // Connect to mongo database
         const connectOptions = {};
-        const options = {};
+        const options = {
+          useFindAndModify: false
+        };
 
         if (!_.isEmpty(username)) {
           connectOptions.user = username;
@@ -77,6 +79,7 @@ module.exports = function (strapi) {
         connectOptions.ssl = ssl === true || ssl === 'true';
         connectOptions.useNewUrlParser = true;
         connectOptions.dbName = database;
+        connectOptions.useCreateIndex = true;
 
         options.debug = debug === true || debug === 'true';
 

--- a/packages/strapi-hook-mongoose/lib/relations.js
+++ b/packages/strapi-hook-mongoose/lib/relations.js
@@ -239,7 +239,7 @@ module.exports = {
 
     virtualFields.push(
       this
-        .update({
+        .updateOne({
           [this.primaryKey]: getValuePrimaryKey(params, this.primaryKey)
         }, values, {
           strict: false

--- a/packages/strapi-plugin-content-manager/config/queries/mongoose.js
+++ b/packages/strapi-plugin-content-manager/config/queries/mongoose.js
@@ -15,7 +15,7 @@ module.exports = {
   count: async function (params) {
     return Number(await this
       .where(params.where)
-      .count());
+      .countDocuments());
   },
 
   search: async function (params, populate) { // eslint-disable-line  no-unused-vars
@@ -81,7 +81,7 @@ module.exports = {
 
     return this
       .find({ $or })
-      .count();
+      .countDocuments();
   },
 
   findOne: async function (params, populate, raw = true) {
@@ -150,7 +150,7 @@ module.exports = {
 
   deleteMany: async function (params) {
     return this
-      .remove({
+      .deleteMany({
         [this.primaryKey]: {
           $in: params[this.primaryKey] || params.id
         }

--- a/packages/strapi-plugin-email/config/queries/mongoose.js
+++ b/packages/strapi-plugin-email/config/queries/mongoose.js
@@ -13,7 +13,7 @@ module.exports = {
 
   count: async function (params = {}) {
     return Number(await this
-      .count(params));
+      .countDocuments(params));
   },
 
   findOne: async function (params, populate) {
@@ -68,7 +68,7 @@ module.exports = {
       };
     }
 
-    return this.update(search, params, {
+    return this.updateOne(search, params, {
       strict: false
     })
       .catch((error) => {
@@ -82,7 +82,7 @@ module.exports = {
   delete: async function (params) {
     // Delete entry.
     return this
-      .remove({
+      .deleteOne({
         [this.primaryKey]: params[this.primaryKey] || params.id
       });
   },

--- a/packages/strapi-plugin-upload/config/queries/mongoose.js
+++ b/packages/strapi-plugin-upload/config/queries/mongoose.js
@@ -13,7 +13,7 @@ module.exports = {
 
   count: async function (params = {}) {
     return Number(await this
-      .count(params));
+      .countDocuments(params));
   },
 
   findOne: async function (params, populate) {
@@ -68,7 +68,7 @@ module.exports = {
       };
     }
 
-    return this.update(search, params, {
+    return this.updateOne(search, params, {
       strict: false
     })
       .catch((error) => {

--- a/packages/strapi-plugin-users-permissions/config/queries/mongoose.js
+++ b/packages/strapi-plugin-users-permissions/config/queries/mongoose.js
@@ -13,7 +13,7 @@ module.exports = {
 
   count: async function (params = {}) {
     return Number(await this
-      .count(params));
+      .countDocuments(params));
   },
 
   findOne: async function (params, populate) {
@@ -65,7 +65,7 @@ module.exports = {
       };
     }
 
-    return this.update(search, params, {
+    return this.updateOne(search, params, {
       strict: false
     })
       .catch((error) => {
@@ -79,7 +79,7 @@ module.exports = {
   delete: async function (params) {
     // Delete entry.
     return this
-      .remove({
+      .deleteOne({
         [this.primaryKey]: params[this.primaryKey] || params.id
       });
   },
@@ -87,7 +87,7 @@ module.exports = {
   deleteMany: async function (params) {
     // Delete entry.
     return this
-      .remove({
+      .deleteMany({
         [this.primaryKey]: {
           $in: params[this.primaryKey] || params.id
         }

--- a/packages/strapi/lib/core/store.js
+++ b/packages/strapi/lib/core/store.js
@@ -110,7 +110,7 @@ module.exports = function () {
           });
 
           strapi.models['core_store'].orm === 'mongoose'
-            ? await strapi.models['core_store'].update({ _id: data._id }, data, { strict: false })
+            ? await strapi.models['core_store'].updateOne({ _id: data._id }, data, { strict: false })
             : await strapi.models['core_store'].forge({ id: data.id }).save(data, { patch: true });
         } else {
           Object.assign(where, {


### PR DESCRIPTION
<!-- ⚠️ Your PR title will appear in the changelogs please make it short detailed and understandable for all. -->

<!-- Uncomment the correct contribution type. !-->

**My PR is a:**
- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix #issueNumber
- [x] 💅 Enhancement
- [ ] 🚀 New feature

**Main update on the:**
- [ ] Admin
- [ ] Documentation
- [x] Framework
- [ ] Plugin

<!-- Please note that all databases should be tested and confirmed to be working prior to the PR being merged. -->
**Manual testing done on the follow databases:**
- [ ] Not applicable
- [x] MongoDB
- [x] MySQL
- [ ] Postgres

<!-- Write a short description of what your PR does and link the concerned issues of your update. -->
**Description:**

This PR removes the warnings we had when using Strapi with MongoDB. I followed the [deprecated  guide](https://mongoosejs.com/docs/deprecations.html) given by the Mongoose team.

<!-- ⚠️ Please link issue(s) you close / fix by using GitHub keywords https://help.github.com/articles/closing-issues-using-keywords/ !-->
