### PR TITLE
Fix SQL query where oneWay relationship is null

### DIFF
--- a/packages/strapi-plugin-content-manager/config/queries/bookshelf.js
+++ b/packages/strapi-plugin-content-manager/config/queries/bookshelf.js
@@ -8,8 +8,10 @@ module.exports = {
           for (const value in where.value) {
             qb[value ? 'where' : 'orWhere'](key, where.symbol, where.value[value]);
           }
+        } else if (_.isArray(where)) {
+          qb.where(key, 'IN', where);
         } else {
-          qb.where(key, where.symbol, where.value);
+          qb.where(key, where.symbol || 'IN', where.value);
         }
       });
 

--- a/packages/strapi-plugin-content-manager/config/queries/bookshelf.js
+++ b/packages/strapi-plugin-content-manager/config/queries/bookshelf.js
@@ -8,10 +8,8 @@ module.exports = {
           for (const value in where.value) {
             qb[value ? 'where' : 'orWhere'](key, where.symbol, where.value[value]);
           }
-        } else if (_.isArray(where)) {
-          qb.where(key, 'IN', where);
         } else {
-          qb.where(key, where.symbol || 'IN', where.value);
+          qb.where(key, where.symbol, where.value);
         }
       });
 

--- a/packages/strapi-plugin-content-manager/services/ContentManager.js
+++ b/packages/strapi-plugin-content-manager/services/ContentManager.js
@@ -10,14 +10,14 @@ module.exports = {
   fetchAll: async (params, query) => {
     const { limit, skip, sort, query : request, queryAttribute, source, populate = [] } = query;
     const filters = strapi.utils.models.convertParams(params.model, query);
-    const where = !_.isEmpty(request) ? request : filters.where;
+    const where = !_.isEmpty(request) ? strapi.utils.models.convertParams(params.model, request) : filters;
 
     // Find entries using `queries` system
     return await strapi.query(params.model, source).find({
       limit: limit || filters.limit,
       skip: skip || filters.start || 0,
       sort: sort || filters.sort,
-      where,
+      where: where.where,
       queryAttribute,
     }, populate);
   },

--- a/packages/strapi-plugin-content-manager/services/ContentManager.js
+++ b/packages/strapi-plugin-content-manager/services/ContentManager.js
@@ -10,14 +10,14 @@ module.exports = {
   fetchAll: async (params, query) => {
     const { limit, skip, sort, query : request, queryAttribute, source, populate = [] } = query;
     const filters = strapi.utils.models.convertParams(params.model, query);
-    const where = !_.isEmpty(request) ? strapi.utils.models.convertParams(params.model, request) : filters;
+    const { where = {} } = !_.isEmpty(request) ? strapi.utils.models.convertParams(params.model, request) : filters;
 
     // Find entries using `queries` system
     return await strapi.query(params.model, source).find({
       limit: limit || filters.limit,
       skip: skip || filters.start || 0,
       sort: sort || filters.sort,
-      where: where.where,
+      where,
       queryAttribute,
     }, populate);
   },

--- a/packages/strapi-plugin-graphql/services/Loaders.js
+++ b/packages/strapi-plugin-graphql/services/Loaders.js
@@ -143,7 +143,7 @@ module.exports = {
       limit: 100,
     };
 
-    params.query[query.alias] = _.uniq(query.ids.filter(x => !_.isEmpty(x)).map(x => x.toString()));
+    params.query[query.alias] = _.uniq(query.ids.filter(x => !_.isEmpty(x) || _.isInteger(x)).map(x => x.toString()));
 
     if (['id', '_id'].includes(query.alias)) {
       // However, we're applying a limit based on the number of entries we've to fetch.

--- a/packages/strapi-utils/lib/models.js
+++ b/packages/strapi-utils/lib/models.js
@@ -486,7 +486,7 @@ module.exports = {
         const suffix = key.split('_');
         // Mysql stores boolean as 1 or 0
         if (client === 'mysql' && _.get(models, [model, 'attributes', suffix, 'type']) === 'boolean') {
-          formattedValue = value === 'true' ? '1' : '0';
+          formattedValue = value.toString() === 'true' ? '1' : '0';
         }
 
         let type;


### PR DESCRIPTION
<!-- ⚠️ Your PR title will appear in the changelogs please make it short detailed and understandable for all. -->

<!-- Uncomment the correct contribution type. !-->

**My PR is a:**
- [ ] 💥 Breaking change
- [x] 🐛 Bug fix #issueNumber
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

**Main update on the:**
- [ ] Admin
- [ ] Documentation
- [ ] Framework
- [x] Plugin

<!-- Please note that all databases should be tested and confirmed to be working prior to the PR being merged. -->
**Manual testing done on the follow databases:**
- [ ] Not applicable
- [ ] MongoDB
- [x] MySQL
- [ ] Postgres

<!-- Write a short description of what your PR does and link the concerned issues of your update. -->
**Description:**

I fixed the SQL query that allows retrieving multiple entries through GraphQL, there was a bug when a oneWay relationship was null.

<!-- ⚠️ Please link issue(s) you close / fix by using GitHub keywords https://help.github.com/articles/closing-issues-using-keywords/ !-->
