### PR TITLE
Fix image populate

### DIFF
--- a/packages/strapi-hook-mongoose/lib/index.js
+++ b/packages/strapi-hook-mongoose/lib/index.js
@@ -160,6 +160,28 @@ module.exports = function (strapi) {
                             } else {
                               this._mongooseOptions.populate[association.alias].path = `${association.alias}.ref`;
                             }
+                          } else {
+                            if (!this._mongooseOptions.populate) {
+                              this._mongooseOptions.populate = {};
+                            }
+
+                            // Images are not displayed in populated data.
+                            // We automaticaly populate morph relations.
+                            if (association.nature === 'oneToManyMorph' || association.nature === 'manyToManyMorph') {
+                              this._mongooseOptions.populate[association.alias] = {
+                                path: association.alias,
+                                match: {
+                                  [`${association.via}.${association.filter}`]: association.alias,
+                                  [`${association.via}.kind`]: definition.globalId
+                                },
+                                options: {
+                                  sort: '-createdAt'
+                                },
+                                select: undefined,
+                                model: undefined,
+                                _docs: {}
+                              };
+                            }
                           }
                           next();
                         });

--- a/packages/strapi-hook-mongoose/lib/index.js
+++ b/packages/strapi-hook-mongoose/lib/index.js
@@ -166,7 +166,7 @@ module.exports = function (strapi) {
                             }
 
                             // Images are not displayed in populated data.
-                            // We automaticaly populate morph relations.
+                            // We automatically populate morph relations.
                             if (association.nature === 'oneToManyMorph' || association.nature === 'manyToManyMorph') {
                               this._mongooseOptions.populate[association.alias] = {
                                 path: association.alias,


### PR DESCRIPTION
<!-- ⚠️ Your PR title will appear in the changelogs please make it short detailed and understandable for all. -->

<!-- Uncomment the correct contribution type. !-->

**My PR is a:**
- [ ] 💥 Breaking change
- [x] 🐛 Bug fix #2118
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

**Main update on the:**
- [ ] Admin
- [ ] Documentation
- [x] Framework
- [ ] Plugin

<!-- Please note that all databases should be tested and confirmed to be working prior to the PR being merged. -->
**Manual testing done on the following databases:**
- [ ] Not applicable
- [x] MongoDB
- [ ] MySQL
- [ ] Postgres

<!-- Write a short description of what your PR does and link the concerned issues of your update. -->
**Description:**

When you receive populated data, morph relations are omit and it's not good for media (images)
So now we auto populate morph relations. You will receive images.

<!-- ⚠️ Please link issue(s) you close / fix by using GitHub keywords https://help.github.com/articles/closing-issues-using-keywords/ !-->
