### PR TITLE
Provide default for plugin config if not provided by the plugin itself

### DIFF
--- a/packages/strapi-plugin-users-permissions/middlewares/users-permissions/index.js
+++ b/packages/strapi-plugin-users-permissions/middlewares/users-permissions/index.js
@@ -28,6 +28,9 @@ module.exports = strapi => {
 
       if (strapi.plugins) {
         _.forEach(strapi.plugins, (plugin, name) => {
+          if ( ! plugin.config ) {
+            plugin.config = {}
+          }
           _.forEach(plugin.config.routes, value => {
             if (_.get(value.config, 'policies')) {
               value.config.policies.unshift('plugins.users-permissions.permissions');


### PR DESCRIPTION
<!-- ⚠️ Your PR title will appear in the changelogs please make it short detailed and understandable for all. -->

<!-- Uncomment the correct contribution type. !-->

**My PR is a:**
- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix #issueNumber
- [x] 💅 Enhancement
- [ ] 🚀 New feature

**Main update on the:**
- [ ] Admin
- [ ] Documentation
- [ ] Framework
- [x] Plugin

<!-- Please note that all databases should be tested and confirmed to be working prior to the PR being merged. -->
**Manual testing done on the following databases:**
- [ ] Not applicable
- [ ] MongoDB
- [x] MySQL
- [ ] Postgres

<!-- Write a short description of what your PR does and link the concerned issues of your update. -->
**Description:**

<!-- ⚠️ Please link issue(s) you close / fix by using GitHub keywords https://help.github.com/articles/closing-issues-using-keywords/ !-->

When using the GraphQL plugin (though I did later realise that it is one that doesn't install properly from the admin panel), it causes Strapi to error out when trying to start, It should probably not do that just because a plugin doesn't provide a config, and should  either default to something instead, or not try and load the plugin in the first place because it doesn't have the required stuff.

I've done a PR but not bothered how it is implemented just highlighting the problem.

`TypeError: Cannot read property 'routes' of undefined
    at _.forEach (/plugins/users-permissions/middlewares/users-permissions/index.js:32:35)`
