### PR TITLE
Automatically register any model virtual fields and declaratively add bookshelf plugins

### DIFF
--- a/packages/strapi-generate-model/templates/bookshelf/model.settings.template
+++ b/packages/strapi-generate-model/templates/bookshelf/model.settings.template
@@ -8,7 +8,11 @@
   "options": {
     "increments": true,
     "timestamps": true,
-    "comment": ""
+    "comment": "",
+    "plugins": [
+      "visibility",
+      "pagination"
+    ]
   },
   "attributes": {
     <%= attributes %>

--- a/packages/strapi-hook-bookshelf/lib/index.js
+++ b/packages/strapi-hook-bookshelf/lib/index.js
@@ -66,9 +66,8 @@ module.exports = function(strapi) {
         }
 
         // Load plugins
-        if (_.get(connection, 'options.plugins', true) !== false) {
-          ORM.plugin('visibility');
-          ORM.plugin('pagination');
+        if (_.get(connection, 'options.plugins', null) !== null) {
+          _.forEach(connection.options.plugins, plugin => ORM.plugin(plugin));
         }
 
         const mountModels = (models, target, plugin = false) => {
@@ -108,7 +107,8 @@ module.exports = function(strapi) {
                 }
 
                 return acc;
-              }, {})
+              }, {}),
+              virtuals: _.get(definition, 'virtuals', {}) // Register any model virtuals (https://github.com/bookshelf/bookshelf/wiki/Plugin:-Virtuals)
             }, definition.options);
 
             if (_.isString(_.get(connection, 'options.pivot_prefix'))) {

--- a/packages/strapi-hook-bookshelf/lib/index.js
+++ b/packages/strapi-hook-bookshelf/lib/index.js
@@ -69,6 +69,10 @@ module.exports = function(strapi) {
         if (_.get(connection, 'options.plugins', null) !== null) {
           _.forEach(connection.options.plugins, plugin => ORM.plugin(plugin));
         }
+        // backwards compartibility. Will be remove in future release
+        ORM.plugin('visibility');
+        ORM.plugin('pagination');
+
 
         const mountModels = (models, target, plugin = false) => {
           // Parse every authenticated model.


### PR DESCRIPTION
<!-- ⚠️ Your PR title will appear in the changelogs please make it short detailed and understandable for all. -->

<!-- Uncomment the correct contribution type. !-->

**My PR is a:**
- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix #issueNumber
- [x] 💅 Enhancement
- [x] 🚀 New feature

**Main update on the:**
- [ ] Admin
- [ ] Documentation
- [x] Framework
- [ ] Plugin

<!-- Please note that all databases should be tested and confirmed to be working prior to the PR being merged. -->
**Manual testing done on the following databases:**
- [ ] Not applicable
- [ ] MongoDB
- [x] MySQL
- [x] Postgres

Sometimes you might want to compute additional values on your model based on other values. Maybe you want to generate a fullName property, based on a firstName and lastName? The virtuals plugin helps you to easily achieve this type of behaviour. This PR adds support for adding virtuals to bookshelf models.

Additionally, this PR completes the declarative bookshelf plugin installation feature.

More: https://github.com/bookshelf/bookshelf/wiki/Plugin:-Virtuals

<!-- ⚠️ Please link issue(s) you close / fix by using GitHub keywords https://help.github.com/articles/closing-issues-using-keywords/ !-->
Fixes https://github.com/strapi/strapi/issues/1826 via the `bookshelf-uuid` plugin