### PR TITLE
Fix Bookshelf big integer - backend only

### DIFF
--- a/packages/strapi-hook-bookshelf/lib/index.js
+++ b/packages/strapi-hook-bookshelf/lib/index.js
@@ -422,8 +422,10 @@ module.exports = function(strapi) {
                           case 'email':
                             type = 'varchar(255)';
                             break;
-                          case 'integer':
                           case 'biginteger':
+                            type = definition.client === 'pg' ? 'bigint' : 'bigint(53)';
+                            break;
+                          case 'integer':
                             type = definition.client === 'pg' ? 'integer' : 'int';
                             break;
                           case 'float':


### PR DESCRIPTION
**My PR is a:**
- [ ] 💥 Breaking change
- [x] 🐛 Bug fix 
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

**Main update on the:**
- [ ] Admin
- [ ] Documentation
- [ ] Framework
- [x] Plugin

<!-- Please note that all databases should be tested and confirmed to be working prior to the PR being merged. -->
**Manual testing done on the following databases:**
- [ ] Not applicable
- [ ] MongoDB
- [x] MySQL
- [x] Postgres

This is a spin off of https://github.com/strapi/strapi/pull/2664 that only fixes the backend of bookshelf and doesn't add support for `big integer` on the frontend. Mongo wasn't checked as there was no existing code for big integer.