### PR TITLE
No recipient email on register

### DIFF
--- a/packages/strapi-plugin-users-permissions/controllers/Auth.js
+++ b/packages/strapi-plugin-users-permissions/controllers/Auth.js
@@ -200,7 +200,7 @@ module.exports = {
     try {
       // Send an email to the user.
       await strapi.plugins['email'].services.email.send({
-        to: user.email,
+        to: user.attributes.email,
         from: (settings.from.email || settings.from.name) ? `"${settings.from.name}" <${settings.from.email}>` : undefined,
         replyTo: settings.response_email,
         subject: settings.object,


### PR DESCRIPTION
**My PR is a:**
- [ ] 💥 Breaking change
- [x] 🐛 Bug fix #2517 (maybe)
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

**Main update on the:**
- [ ] Admin
- [ ] Documentation
- [ ] Framework
- [x] Plugin

**Manual testing done on the following databases:**
- [ ] Not applicable
- [ ] MongoDB
- [x] MySQL
- [ ] Postgres

**Description:**

User doesn't have property email, but user.attributes contains property email.
