### PR TITLE
Docker link had a closing bracket at the end

### DIFF
--- a/docs/3.x.x/guides/deployment.md
+++ b/docs/3.x.x/guides/deployment.md
@@ -3,7 +3,7 @@
 ### Docker
 
 ::: tip
-You can also deploy using [Docker](https://hub.docker.com/r/strapi/strapi])
+You can also deploy using [Docker](https://hub.docker.com/r/strapi/strapi)
 :::
 
 The method below describes regular deployment using the built-in mechanisms.


### PR DESCRIPTION
<!-- ⚠️ Your PR title will appear in the changelogs please make it short detailed and understandable for all. -->

<!-- Uncomment the correct contribution type. !-->

**My PR is a:**
- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix #issueNumber
- [x] 💅 Enhancement
- [ ] 🚀 New feature

**Main update on the:**
- [ ] Admin
- [x] Documentation
- [ ] Framework
- [ ] Plugin

<!-- Please note that all databases should be tested and confirmed to be working prior to the PR being merged. -->
**Manual testing done on the following databases:**
- [x] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres

<!-- Write a short description of what your PR does and link the concerned issues of your update. -->
**Description:**
The Docker [link](https://strapi.io/documentation/3.x.x/guides/deployment.html) had a typo at the end which sent users to Docker's 404 page instead of strapi page.

<!-- ⚠️ Please link issue(s) you close / fix by using GitHub keywords https://help.github.com/articles/closing-issues-using-keywords/ !-->
