### PR TITLE
Catch error for auto open Google Chrome with AppleScript

### DIFF
--- a/packages/strapi/lib/utils/openBrowser.js
+++ b/packages/strapi/lib/utils/openBrowser.js
@@ -82,8 +82,7 @@ function startBrowserProcess(browser, url) {
       });
       return true;
     } catch (err) {
-      console.log(err);
-      // Ignore errors.
+      strapi.log.error('Failed to open Google Chrome with AppleScript');
     }
   }
 


### PR DESCRIPTION
Catch error for auto open browser

<!-- ⚠️ Your PR title will appear in the changelogs please make it short detailed and understandable for all. -->

<!-- Uncomment the correct contribution type. !-->

**My PR is a:**
- [ ] 💥 Breaking change
- [x] 🐛 Bug fix #issueNumber
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

**Main update on the:**
- [x] Admin
- [ ] Documentation
- [ ] Framework
- [ ] Plugin

<!-- Please note that all databases should be tested and confirmed to be working prior to the PR being merged. -->
**Manual testing done on the following databases:**
- [x] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres

<!-- Write a short description of what your PR does and link the concerned issues of your update. -->
**Description:**
Catch error for auto open Google Chrome with AppleScript
<!-- ⚠️ Please link issue(s) you close / fix by using GitHub keywords https://help.github.com/articles/closing-issues-using-keywords/ !-->
Fixes #2817 