### PR TITLE
Adding support for more Date, Time, Datetime, and Timestamp options

### DIFF
--- a/packages/strapi-hook-bookshelf/lib/index.js
+++ b/packages/strapi-hook-bookshelf/lib/index.js
@@ -435,10 +435,35 @@ module.exports = function(strapi) {
                             type = 'decimal(10,2)';
                             break;
                           case 'date':
+                            type = 'date';
                           case 'time':
+                            type = 'time';
                           case 'datetime':
+                            switch(definition.client) {
+                              case 'pg':
+                                type = 'timestamp';
+                                break;
+                              case 'sqlite3':
+                                type = 'datetime';
+                                break;
+                              default:
+                                type = 'datetime';
+                                break;
+                            }
+                            break;
                           case 'timestamp':
-                            type = definition.client === 'pg' ? 'timestamp with time zone' : 'timestamp DEFAULT CURRENT_TIMESTAMP';
+                            switch(definition.client) {
+                              case 'pg':
+                                type = 'timestamp with time zone';
+                                break;
+                              case 'sqlite3':
+                                // This may need to be changed to a SQLite Function
+                                type = 'timestamp DEFAULT CURRENT_TIMESTAMP';
+                                break;
+                              default:
+                                type = 'timestamp DEFAULT CURRENT_TIMESTAMP';
+                                break;
+                            }
                             break;
                           case 'timestampUpdate':
                             switch(definition.client) {
@@ -446,6 +471,7 @@ module.exports = function(strapi) {
                                 type = 'timestamp with time zone';
                                 break;
                               case 'sqlite3':
+                                // This may need to be changed to a SQLite Function
                                 type = 'timestamp DEFAULT CURRENT_TIMESTAMP';
                                 break;
                               default:

--- a/packages/strapi-hook-bookshelf/lib/index.js
+++ b/packages/strapi-hook-bookshelf/lib/index.js
@@ -436,8 +436,10 @@ module.exports = function(strapi) {
                             break;
                           case 'date':
                             type = 'date';
+                            break;
                           case 'time':
                             type = 'time';
+                            break;
                           case 'datetime':
                             switch(definition.client) {
                               case 'pg':

--- a/packages/strapi-hook-mongoose/lib/utils/index.js
+++ b/packages/strapi-hook-mongoose/lib/utils/index.js
@@ -27,8 +27,9 @@ module.exports = (mongoose = new Mongoose()) => {
         case 'binary':
           return 'Buffer';
         case 'date':
-        case 'datetime':
+        // There is no "Time" type in mongo used as an alias for datetime
         case 'time':
+        case 'datetime':
         case 'timestamp':
           return Date;
         case 'decimal':


### PR DESCRIPTION
Adding the following options (at the moment only backend support):

- Date
- Time
- Datetime
- Timestamp (with automated values for create / update)

What is done so far:

- [x] Adding all options to Mongoose
- [x] Adding all options to Bookshelf
- [ ] Testing Bookshelf DBs
- [ ] ~~Testing Mongo~~ Not needed as mongo doesn't support time only
- [ ] ~~Add options to AdminUI~~ Out of PR scope until beta PR is merged

#### My PR is a:
- [ ] 💥 Breaking change
- [x] 🐛 Bug fix #2497
- [ ] 💅 Enhancement
- [x] 🚀 New feature

#### Main update on the:
- [ ] Admin
- [ ] Documentation
- [ ] Framework
- [x] Plugin

<!-- Please note that all databases should be tested and confirmed to be working prior to the PR being merged. -->
#### Manual testing done on the following databases:
- [ ] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
