### PR TITLE
[WIP] Handle not exists directory on file upload

### DIFF
--- a/packages/strapi-plugin-upload/config/functions/bootstrap.js
+++ b/packages/strapi-plugin-upload/config/functions/bootstrap.js
@@ -51,6 +51,30 @@ module.exports = async cb => {
           });
 
           await pluginStore.set({key: 'provider', value});
+
+          const dirPath = `${strapi.config.appPath}/public/uploads`;
+   
+          try {
+            // Check if directory exists
+            await new Promise((resolve, reject) => fs.exists(dirPath, (exists) => {
+              if (exists) {
+                resolve();
+              } else {
+                // Create directory if not exists
+                fs.mkdir(dirPath, {recursive: true}, (err) => {
+                  if (err) {
+                    return reject(err);
+                  }
+
+                  resolve();
+                });
+              }
+            });
+          } catch (err) {
+            strapi.log.error(`Can't access to the public folder`);
+            strapi.log.warn(`Please change access mode / owner to the public folder`);
+            strapi.stop();  
+          }
         }
       } catch (err) {
         strapi.log.error(`Can't load ${config.provider} upload provider.`);

--- a/packages/strapi-plugin-upload/config/functions/bootstrap.js
+++ b/packages/strapi-plugin-upload/config/functions/bootstrap.js
@@ -69,7 +69,7 @@ module.exports = async cb => {
                   resolve();
                 });
               }
-            });
+            }));
           } catch (err) {
             strapi.log.error(`Can't access to the public folder`);
             strapi.log.warn(`Please change access mode / owner to the public folder`);

--- a/packages/strapi-provider-upload-local/lib/index.js
+++ b/packages/strapi-provider-upload-local/lib/index.js
@@ -13,9 +13,9 @@ module.exports = {
   name: 'Local server',
   init: (config) => {
     // write file in public/assets folder
-    const write = (file, path) => {
+    const write = (file, dirPath) => {
       return new Promise((resolve, reject) => {
-        fs.writeFile(path.join(path, `${file.hash}${file.ext}`), file.buffer, (err) => {
+        fs.writeFile(path.join(dirPath, `${file.hash}${file.ext}`), file.buffer, (err) => {
           if (err) {
             return reject(err);
           }
@@ -30,20 +30,20 @@ module.exports = {
     return {
       upload: (file) => {
         return new Promise((resolve, reject) => {
-          const path = path.join(strapi.config.appPath, 'public', 'uploads');
-
+          const dirPath = path.join(strapi.config.appPath, 'public', 'uploads');
+          
           // Check if directory exists
-          fs.exists(path, (exists) => {
+          fs.exists(dirPath, (exists) => {
             if (exists) {
-              resolve(write(file, path));
+              resolve(write(file, dirPath));
             } else {
               // Create directory if not exists
-              fs.mkdir(path, {recursive: true}, (err) => {
+              fs.mkdir(dirPath, {recursive: true}, (err) => {
                 if (err) {
                   return reject(err);
                 }
 
-                resolve(write(file, path));
+                resolve(write(file, dirPath));
               });
             }
           });

--- a/packages/strapi-provider-upload-local/lib/index.js
+++ b/packages/strapi-provider-upload-local/lib/index.js
@@ -12,6 +12,7 @@ module.exports = {
   provider: 'local',
   name: 'Local server',
   init: (config) => {
+    // write file in public/assets folder
     const write = (file, path) => {
       return new Promise((resolve, reject) => {
         fs.writeFile(path.join(path, `${file.hash}${file.ext}`), file.buffer, (err) => {
@@ -31,11 +32,12 @@ module.exports = {
         return new Promise((resolve, reject) => {
           const path = path.join(strapi.config.appPath, 'public', 'uploads');
 
-          // write file in public/assets folder
+          // Check if directory exists
           fs.exists(path, (exists) => {
             if (exists) {
               resolve(write(file, path));
             } else {
+              // Create directory if not exists
               fs.mkdir(path, {recursive: true}, (err) => {
                 if (err) {
                   return reject(err);

--- a/packages/strapi-provider-upload-local/lib/index.js
+++ b/packages/strapi-provider-upload-local/lib/index.js
@@ -12,43 +12,19 @@ module.exports = {
   provider: 'local',
   name: 'Local server',
   init: (config) => {
-    // write file in public/assets folder
-    const write = (file, dirPath) => {
-      return new Promise((resolve, reject) => {
-        fs.writeFile(path.join(dirPath, `${file.hash}${file.ext}`), file.buffer, (err) => {
-          if (err) {
-            return reject(err);
-          }
-
-          file.url = `/uploads/${file.hash}${file.ext}`;
-
-          resolve();
-        });
-      });
-    };
-
     return {
       upload: (file) => {
         return new Promise((resolve, reject) => {
-          const dirPath = path.join(strapi.config.appPath, 'public', 'uploads');
-          
-          // Check if directory exists
-          fs.exists(dirPath, (exists) => {
-            if (exists) {
-              resolve(write(file, dirPath));
-            } else {
-              // Create directory if not exists
-              fs.mkdir(dirPath, {recursive: true}, (err) => {
-                if (err) {
-                  return reject(err);
-                }
-
-                resolve(write(file, dirPath));
-              });
+          // write file in public/assets folder
+          fs.writeFile(path.join(strapi.config.appPath, 'public', `uploads/${file.hash}${file.ext}`), file.buffer, (err) => {
+            if (err) {
+              return reject(err);
             }
+
+            file.url = `/uploads/${file.hash}${file.ext}`;
+
+            resolve();
           });
-          
-          
         });
       },
       delete: (file) => {

--- a/packages/strapi-provider-upload-local/lib/index.js
+++ b/packages/strapi-provider-upload-local/lib/index.js
@@ -14,7 +14,7 @@ module.exports = {
   init: (config) => {
     const write = (file, path) => {
       return new Promise((resolve, reject) => {
-        fs.writeFile(, path.join(path, `${file.hash}${file.ext}`)), file.buffer, (err) => {
+        fs.writeFile(path.join(path, `${file.hash}${file.ext}`)), file.buffer, (err) => {
           if (err) {
             return reject(err);
           }

--- a/packages/strapi-provider-upload-local/lib/index.js
+++ b/packages/strapi-provider-upload-local/lib/index.js
@@ -32,11 +32,7 @@ module.exports = {
           const path = path.join(strapi.config.appPath, 'public', 'uploads');
 
           // write file in public/assets folder
-          fs.exists(path, (err, exists) => {
-            if (err) {
-              return reject(err);
-            }
-
+          fs.exists(path, (exists) => {
             if (exists) {
               resolve(write(file, path));
             } else {

--- a/packages/strapi-provider-upload-local/lib/index.js
+++ b/packages/strapi-provider-upload-local/lib/index.js
@@ -14,7 +14,7 @@ module.exports = {
   init: (config) => {
     const write = (file, path) => {
       return new Promise((resolve, reject) => {
-        fs.writeFile(path.join(path, `${file.hash}${file.ext}`)), file.buffer, (err) => {
+        fs.writeFile(path.join(path, `${file.hash}${file.ext}`), file.buffer, (err) => {
           if (err) {
             return reject(err);
           }


### PR DESCRIPTION
Currently local provider doesn't check if category exists, so if public or public/upload doesn't exist local provider return err

POST /upload return 500 in this case.

So I handle this case and create directory if it doesn't exist.

#### My PR is a:
- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:
- [ ] Admin
- [ ] Documentation
- [ ] Framework
- [x] Plugin

<!-- Please note that all databases should be tested and confirmed to be working prior to the PR being merged. -->
#### Manual testing done on the following databases:
- [x] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [x] SQLite
