### PR TITLE
Forcefully disable package-lock generation

### DIFF
--- a/packages/strapi-generate-new/files/.npmrc
+++ b/packages/strapi-generate-new/files/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false


### PR DESCRIPTION
#### Description:

Forces NPM to disable automatic generation of the `package-lock.json` that can cause problems for projects cloned from Github or other Git related repos.

<!-- Uncomment the correct contribution type. !-->

#### My PR is a:
- [ ] 💥 Breaking change
- [x] 🐛 Bug fix #2874
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:
- [ ] Admin
- [ ] Documentation
- [x] Framework
- [ ] Plugin

<!-- Please note that all databases should be tested and confirmed to be working prior to the PR being merged. -->
#### Manual testing done on the following databases:
- [x] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
