### PR TITLE
Fix for SQLite #2879

### DIFF
--- a/packages/strapi-plugin-users-permissions/config/policies/permissions.js
+++ b/packages/strapi-plugin-users-permissions/config/policies/permissions.js
@@ -32,11 +32,11 @@ module.exports = async (ctx, next) => {
       name: 'users-permissions'
     });
 
-    if (_.get(await store.get({key: 'advanced'}), 'email_confirmation') && ctx.state.user.confirmed !== true) {
+    if (_.get(await store.get({key: 'advanced'}), 'email_confirmation') && !ctx.state.user.confirmed) {
       return handleErrors(ctx, 'Your account email is not confirmed.', 'unauthorized');
     }
 
-    if (ctx.state.user.blocked === true) {
+    if (ctx.state.user.blocked) {
       return handleErrors(ctx, 'Your account has been blocked by the administrator.', 'unauthorized');
     }
   }

--- a/packages/strapi-plugin-users-permissions/controllers/Auth.js
+++ b/packages/strapi-plugin-users-permissions/controllers/Auth.js
@@ -57,11 +57,11 @@ module.exports = {
         return ctx.badRequest(null, ctx.request.admin ? [{ messages: [{ id: 'Auth.form.error.invalid' }] }] : 'Identifier or password invalid.');
       }
       
-      if (_.get(await store.get({key: 'advanced'}), 'email_confirmation') && user.confirmed !== true) {
+      if (_.get(await store.get({key: 'advanced'}), 'email_confirmation') && !user.confirmed) {
         return ctx.badRequest(null, ctx.request.admin ? [{ messages: [{ id: 'Auth.form.error.confirmed' }] }] : 'Your account email is not confirmed.');
       }
 
-      if (user.blocked === true) {
+      if (user.blocked) {
         return ctx.badRequest(null, ctx.request.admin ? [{ messages: [{ id: 'Auth.form.error.blocked' }] }] : 'Your account has been blocked by the administrator.');
       }
 


### PR DESCRIPTION

#### Description:
SQLite doesn't support boolean fields, so I replace strict check for enable type conversation 

#### My PR is a:
- [ ] 💥 Breaking change
- [x] 🐛 Bug fix #2879 
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:
- [ ] Admin
- [ ] Documentation
- [ ] Framework
- [x] Plugin

#### Manual testing done on the following databases:
- [ ] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [x] SQLite
