### PR TITLE
Fix for UPPERCASE / camelCase names

### DIFF
--- a/packages/strapi-plugin-documentation/services/Documentation.js
+++ b/packages/strapi-plugin-documentation/services/Documentation.js
@@ -514,7 +514,7 @@ module.exports = {
           const getter =
             currentAssociation.plugin !== undefined
               ? ['plugins', currentAssociation.plugin, 'models', name, 'attributes']
-              : ['models', name, 'attributes'];
+              : ['models', name.toLowerCase(), 'attributes'];
           const associationAttributes = _.get(strapi, getter);
           const associationSchema = this.generateAssociationSchema(associationAttributes, getter);
 


### PR DESCRIPTION
#### Description:

Fix for UPPERCASE / camelCase names in "model" or "collection" field when generate documentation

#### My PR is a:
- [ ] 💥 Breaking change
- [x] 🐛 Bug fix 
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:
- [ ] Admin
- [ ] Documentation
- [ ] Framework
- [x] Plugin

#### Manual testing done on the following databases:
- [x] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [x] SQLite
