### PR TITLE
Fix bad token for confirmation link

### DIFF
--- a/packages/strapi-plugin-users-permissions/controllers/Auth.js
+++ b/packages/strapi-plugin-users-permissions/controllers/Auth.js
@@ -56,7 +56,7 @@ module.exports = {
       if (!user) {
         return ctx.badRequest(null, ctx.request.admin ? [{ messages: [{ id: 'Auth.form.error.invalid' }] }] : 'Identifier or password invalid.');
       }
-      
+
       if (_.get(await store.get({key: 'advanced'}), 'email_confirmation') && !user.confirmed) {
         return ctx.badRequest(null, ctx.request.admin ? [{ messages: [{ id: 'Auth.form.error.confirmed' }] }] : 'Your account email is not confirmed.');
       }
@@ -196,7 +196,7 @@ module.exports = {
     settings.object = await strapi.plugins['users-permissions'].services.userspermissions.template(settings.object, {
       USER: _.omit(user.toJSON ? user.toJSON() : user, ['password', 'resetPasswordToken', 'role', 'provider'])
     });
-    
+
     try {
       // Send an email to the user.
       await strapi.plugins['email'].services.email.send({
@@ -345,7 +345,12 @@ module.exports = {
   emailConfirmation: async (ctx) => {
     const params = ctx.query;
 
-    const user = await strapi.plugins['users-permissions'].services.jwt.verify(params.confirmation);
+    let user;
+    try {
+      user = await strapi.plugins['users-permissions'].services.jwt.verify(params.confirmation);
+    } catch (err) {
+      return ctx.badRequest(null, 'This confirmation token is invalid.');
+    }
 
     await strapi.plugins['users-permissions'].services.user.edit(_.pick(user, ['_id', 'id']), {confirmed: true});
 


### PR DESCRIPTION
<!-- ⚠️ Your PR title will appear in the changelogs please make it short detailed and understandable for all. -->

<!-- Write a short description of what your PR does and link the concerned issues of your update. -->
<!-- ⚠️ Please link issue(s) you close / fix by using GitHub keywords https://help.github.com/articles/closing-issues-using-keywords/ !-->
#### Description:

When the route to confirm the email address is hited, if the token is wrong it fire a 500 error instead of a 400 error with a correct message.

<!-- Uncomment the correct contribution type. !-->

#### My PR is a:
- [ ] 💥 Breaking change
- [x] 🐛 Bug fix #2740
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:
- [ ] Admin
- [ ] Documentation
- [ ] Framework
- [x] Plugin

<!-- Please note that all databases should be tested and confirmed to be working prior to the PR being merged. -->
#### Manual testing done on the following databases:
- [x] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
