### PR TITLE
The public folder path shouldn't be hard-coded in "strapi-provider-upload-local"

### DIFF
--- a/packages/strapi-provider-upload-local/lib/index.js
+++ b/packages/strapi-provider-upload-local/lib/index.js
@@ -16,7 +16,7 @@ module.exports = {
       upload: (file) => {
         return new Promise((resolve, reject) => {
           // write file in public/assets folder
-          fs.writeFile(path.join(strapi.config.appPath, 'public', `uploads/${file.hash}${file.ext}`), file.buffer, (err) => {
+          fs.writeFile(path.join(strapi.config.public.path, `/uploads/${file.hash}${file.ext}`), file.buffer, (err) => {
             if (err) {
               return reject(err);
             }
@@ -29,7 +29,7 @@ module.exports = {
       },
       delete: (file) => {
         return new Promise((resolve, reject) => {
-          const filePath = path.join(strapi.config.appPath, 'public', `uploads/${file.hash}${file.ext}`);
+          const filePath = path.join(strapi.config.public.path, `/uploads/${file.hash}${file.ext}`);
 
           if (!fs.existsSync(filePath)) {
             return resolve('File doesn\'t exist');


### PR DESCRIPTION
<!-- ⚠️ Your PR title will appear in the changelogs please make it short detailed and understandable for all. -->

<!-- Write a short description of what your PR does and link the concerned issues of your update. -->
<!-- ⚠️ Please link issue(s) you close / fix by using GitHub keywords https://help.github.com/articles/closing-issues-using-keywords/ !-->
#### Description:

the public folder path shouldn't be hard-coded, it needs to follow the "strapi.config.public.path" value.
I faced this issue on my current project where i have a custom path for the "public" folder for development, replacing:
```
path.join(strapi.config.appPath, 'public', `uploads/${file.hash}${file.ext}`)
```
with
```
path.join(strapi.config.public.path, `/uploads/${file.hash}${file.ext}`)
```
solved my problem, so i need to notify you on this issue.

<!-- Uncomment the correct contribution type. !-->

#### My PR is a:
- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:
- [ ] Admin
- [ ] Documentation
- [ ] Framework
- [x] Plugin

<!-- Please note that all databases should be tested and confirmed to be working prior to the PR being merged. -->
#### Manual testing done on the following databases:
- [x] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
