### PR TITLE
Fix missing _ in the convertParams graphql queries

### DIFF
--- a/packages/strapi-plugin-graphql/services/Query.js
+++ b/packages/strapi-plugin-graphql/services/Query.js
@@ -21,11 +21,9 @@ module.exports = {
 
   convertToParams: (params, primaryKey) => {
     return Object.keys(params).reduce((acc, current) => {
-      return Object.assign(acc, {
-        [`${
-          "id" === current ? primaryKey : current
-        }`]: params[current]
-      });
+      const key = current === 'id' ? primaryKey : `_${current}`;
+      acc[key] = params[current];
+      return acc;
     }, {});
   },
 


### PR DESCRIPTION
Fix convertParams that wasn't adding `_` in front of the params 

#### My PR is a:
- [ ] 💥 Breaking change
- [x] 🐛 Bug fix #issueNumber
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:
- [ ] Admin
- [ ] Documentation
- [x] Framework
- [ ] Plugin

