### PR TITLE
Fix custom mutation returning null and not executing policies

### DIFF
--- a/packages/strapi-plugin-graphql/services/Mutation.js
+++ b/packages/strapi-plugin-graphql/services/Mutation.js
@@ -23,7 +23,7 @@ module.exports = {
     // Extract custom resolver or type description.
     const { resolver: handler = {} } = _schema;
 
-    const queryName = `${action}${_.capitalize(name)}`;
+    const queryName = action ? `${action}${_.capitalize(name)}` : `${name}`;
 
     // Retrieve policies.
     const policies = _.get(handler, `Mutation.${queryName}.policies`, []);

--- a/packages/strapi-plugin-graphql/services/Mutation.js
+++ b/packages/strapi-plugin-graphql/services/Mutation.js
@@ -192,7 +192,7 @@ module.exports = {
 
       // Resolver can be a function. Be also a native resolver or a controller's action.
       if (_.isFunction(resolver)) {
-        context.params = Query.convertToParams(options.input.where || {}, (plugin ? strapi.plugins[plugin].models[name] : strapi.models[name]).primaryKey);
+        context.params = Query.convertToParams(options.input.where || {}, (action && (plugin ? strapi.plugins[plugin].models[name] : strapi.models[name]).primaryKey));
         context.request.body = options.input.data || {};
 
         if (isController) {
@@ -206,9 +206,11 @@ module.exports = {
 
           const body = values && values.toJSON ? values.toJSON() : values;
 
-          return {
-            [pluralize.singular(name)]: body,
-          };
+          return action
+          ? {
+            [pluralize.singular(name)]: body
+          }
+          : body;
         }
 
         return resolver.call(null, obj, options, context);


### PR DESCRIPTION
<!-- ⚠️ Your PR title will appear in the changelogs please make it short detailed and understandable for all. -->

<!-- Write a short description of what your PR does and link the concerned issues of your update. -->
<!-- ⚠️ Please link issue(s) you close / fix by using GitHub keywords https://help.github.com/articles/closing-issues-using-keywords/ !-->
#### Description:
**The fix address the following issues:**
- Custom mutation resolvers defined as string will return null ([screenshot](https://github.com/strapi/strapi/issues/2766#issuecomment-463129085))
- Policies defined for custom resolvers won't execute 

**Steps to reproduce:** 
1. In `schema.graphql` add a custom resolver:
```
resolver: {
    Mutation: {
      upsertPost: {
        policies: ['global.isLoggedIn'],
        resolver: 'Post.createOrUpdate'
      }
    }
  }
```
2. Add the controller action returning a sample data according to your schema
3. `strapi generate:policy isLoggedIn`
4. Execute the mutation

<!-- Uncomment the correct contribution type. !-->

#### My PR is a:
- [ ] 💥 Breaking change
- [x] 🐛 Bug fix #1887 #2766
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:
- [ ] Admin
- [ ] Documentation
- [ ] Framework
- [x] Plugin

<!-- Please note that all databases should be tested and confirmed to be working prior to the PR being merged. -->
#### Manual testing done on the following databases:
- [ ] Not applicable
- [x] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
