### PR TITLE
Showing local time in admin panel content manager 

### DIFF
--- a/packages/strapi-helper-plugin/lib/src/components/InputDate/index.js
+++ b/packages/strapi-helper-plugin/lib/src/components/InputDate/index.js
@@ -51,7 +51,7 @@ function InputDate(props) {
           ref={props.inputRef}
           tabIndex={props.tabIndex}
           timeFormat='HH:mm:ss'
-          utc={true}
+          utc={false}
           value={value}
           style={props.style}
         />

--- a/packages/strapi-helper-plugin/lib/src/components/InputDate/index.js
+++ b/packages/strapi-helper-plugin/lib/src/components/InputDate/index.js
@@ -17,9 +17,8 @@ import styles from './styles.scss';
 
 /* eslint-disable react/jsx-boolean-value */
 function InputDate(props) {
-  const value = isObject(props.value) && props.value._isAMomentObject === true ? props.value : moment(props.value);
+  const value = isObject(props.value) && props.value._isAMomentObject === true ? props.value.local() : moment.utc(props.value).local();
   const formattedPlaceholder = props.placeholder === '' ? 'app.utils.placeholder.defaultMessage' : props.placeholder;
-
   return (
     <FormattedMessage id={formattedPlaceholder} defaultMessage={formattedPlaceholder}>
       {(placeholder) => (

--- a/packages/strapi-plugin-content-manager/admin/src/components/TableRow/index.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/TableRow/index.js
@@ -55,8 +55,7 @@ class TableRow extends React.Component {
 
         const date = value && isObject(value) && value._isAMomentObject === true ?
           value :
-          moment(value);
-
+          moment.utc(value).local();
         return date.format('YYYY-MM-DD HH:mm:ss');
       }
       case 'password':

--- a/packages/strapi-plugin-content-manager/admin/src/components/TableRow/index.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/TableRow/index.js
@@ -55,7 +55,7 @@ class TableRow extends React.Component {
 
         const date = value && isObject(value) && value._isAMomentObject === true ?
           value :
-          moment.utc(value);
+          moment(value);
 
         return date.format('YYYY-MM-DD HH:mm:ss');
       }

--- a/packages/strapi-plugin-content-manager/admin/src/containers/EditPage/saga.js
+++ b/packages/strapi-plugin-content-manager/admin/src/containers/EditPage/saga.js
@@ -96,7 +96,7 @@ export function* submit(action) {
           cleanedData = record[current];
           break;
         case 'date':
-          cleanedData = record[current] && record[current]._isAMomentObject === true ? record[current].format('YYYY-MM-DD HH:mm:ss') : record[current];
+          cleanedData = record[current] && record[current]._isAMomentObject === true ? record[current].valueOf() : record[current];
           break;
         default:
           cleanedData = cleanData(record[current], 'value', 'id');

--- a/packages/strapi-plugin-content-manager/admin/src/containers/EditPage/saga.js
+++ b/packages/strapi-plugin-content-manager/admin/src/containers/EditPage/saga.js
@@ -96,7 +96,7 @@ export function* submit(action) {
           cleanedData = record[current];
           break;
         case 'date':
-          cleanedData = record[current] && record[current]._isAMomentObject === true ? record[current].valueOf() : record[current];
+          cleanedData = record[current] && record[current]._isAMomentObject === true ? record[current].utc().format('YYYY-MM-DD HH:mm:ss') : record[current];
           break;
         default:
           cleanedData = cleanData(record[current], 'value', 'id');


### PR DESCRIPTION
#### Description:
The admin panel is showing the date with a wrong timezone #2811 . The reason is that the EditPage's saga convert the date to a format not respecting to timezone. So my thought is to use timestamp or a ISO-8601 date format string. 

However, some DBs are not supporting those formats, etc. mysql datetime is using ISO-9075. Can anyone modify this part for the DBs not saving date in timestamp?

#### My PR is a:
- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix #issueNumber
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:
- [ ] Admin
- [ ] Documentation
- [ ] Framework
- [x] Plugin

#### Manual testing done on the following databases:
- [ ] Not applicable
- [x] MongoDB
- [ ] MySQL
- [ ] Postgres
- [x] SQLite
