### PR TITLE
Update fadeOut animation min-width property for Onboarding Videos button

### DIFF
--- a/packages/strapi-admin/admin/src/containers/Onboarding/styles.scss
+++ b/packages/strapi-admin/admin/src/containers/Onboarding/styles.scss
@@ -111,6 +111,7 @@
   100% {
     opacity: 0;
     width: 0;
+    min-width: 0;
     height: 0;
   }
 }


### PR DESCRIPTION
Fixes #3006 Fixes #3000

#### Description:
Adds a "min-width" property to the "fadeOut" animation in the Onboarding Videos button component.

`/strapi/packages/strapi-admin/admin/src/containers/Onboarding/styles.scss`

#### My PR is a:
- [ ] 💥 Breaking change
- [X] 🐛 Bug fix #3006 Bug fix #3000
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:
- [X] Admin
- [ ] Documentation
- [ ] Framework
- [ ] Plugin

#### Manual testing done on the following databases:
- [X] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
