### PR TITLE
Mailgun: possibility to configure api host

### DIFF
--- a/packages/strapi-provider-email-mailgun/lib/index.js
+++ b/packages/strapi-provider-email-mailgun/lib/index.js
@@ -27,6 +27,10 @@ module.exports = {
       label: 'Mailgun API Key',
       type: 'text'
     },
+    mailgun_api_host: {
+      label: 'Mailgun API Host',
+      type: 'text'
+    },
     mailgun_domain: {
       label: 'Mailgun Domain',
       type: 'text'
@@ -36,6 +40,7 @@ module.exports = {
 
     const mailgun = mailgunFactory({
       apiKey: config.mailgun_api_key,
+      host: config.mailgun_api_host,
       domain: config.mailgun_domain,
       mute: false
     });


### PR DESCRIPTION
#### Description of what you did:

Mailgun has two api endpoints: api.eu.mailgun.net and api.mailgun.net (default). We should have possibility to configure it.

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [X] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [ ] Documentation
- [ ] Framework
- [X] Plugin

#### Manual testing done on the following databases:

- [X] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
