### PR TITLE
Replaced "skip" by "start" for bookshelf service search

### DIFF
--- a/packages/strapi-generate-api/templates/bookshelf/service.template
+++ b/packages/strapi-generate-api/templates/bookshelf/service.template
@@ -195,8 +195,8 @@ module.exports = {
         qb.orderBy(filters.sort.key, filters.sort.order);
       }
 
-      if (filters.skip) {
-        qb.offset(_.toNumber(filters.skip));
+      if (filters.start) {
+        qb.offset(_.toNumber(filters.start));
       }
 
       if (filters.limit) {


### PR DESCRIPTION
> ⚠️ We have stopped merging PRs for now to the Strapi core.<br><br>
> The reason is that we are developing new architecture for the admin panel and for the plugins.<br>
> This new architecture will provide stability of the Strapi core as we approach the release of Beta.<br>
> We appreciate and welcome all your contributions, but until further notice, please do not submit a PR as it will not be merged.<br>
> Furthermore, you will have to rewrite it based on the new architecture.


<!-- ⚠️ Your PR title will appear in the changelogs please make it short detailed and understandable for all. -->

<!-- Write a short description of what your PR does and link the concerned issues of your update. -->
<!-- ⚠️ Please link issue(s) you close / fix by using GitHub keywords https://help.github.com/articles/closing-issues-using-keywords/ !-->
#### Description:
This PR is about fixing a bug in bookshelf for _start parameters in API calls.
As specified in the documentation : https://strapi.io/documentation/3.x.x/guides/filters.html#available-operators

The current code is trying to get the filter Skip instead of Start (Skip doesnt exists btw).


<!-- Uncomment the correct contribution type. !-->

#### My PR is a:
- [ ] 💥 Breaking change
- [x ] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:
- [ ] Admin
- [ ] Documentation
- [x ] Framework
- [ ] Plugin

#### Manual testing done on the following databases:
- [ ] Not applicable
- [ ] MongoDB
- [ x] MySQL
- [ ] Postgres
- [ ] SQLite
