### PR TITLE
Set the fetch limit to 100 by default and add a default param

### DIFF
--- a/packages/strapi-utils/lib/convertRestQueryParams.js
+++ b/packages/strapi-utils/lib/convertRestQueryParams.js
@@ -5,23 +5,20 @@
 
 const _ = require('lodash');
 
-const defaults = {
-  start: 0,
-  limit: 10,
-};
-
 /**
  * Global convertor
  * @param {Object} params
  */
-const convertRestQueryParams = (params = {}) => {
+const convertRestQueryParams = (params = {}, defaults = {}) => {
   if (typeof params !== 'object' || params === null) {
     throw new Error(
-      `convertRestQueryParams expected an object got ${object === null ? 'null' : typeof object}`
+      `convertRestQueryParams expected an object got ${
+        params === null ? 'null' : typeof params
+      }`
     );
   }
 
-  let finalParams = { ...defaults };
+  let finalParams = Object.assign({ start: 0, limit: 100 }, defaults);
 
   if (Object.keys(params).length === 0) {
     return finalParams;
@@ -55,7 +52,9 @@ const convertRestQueryParams = (params = {}) => {
  */
 const convertSortQueryParams = sortQuery => {
   if (typeof sortQuery !== 'string') {
-    throw new Error(`convertSortQueryParams expected a string, got ${typeof sortQuery}`);
+    throw new Error(
+      `convertSortQueryParams expected a string, got ${typeof sortQuery}`
+    );
   }
 
   const sortKeys = [];
@@ -88,7 +87,9 @@ const convertStartQueryParams = startQuery => {
   const startAsANumber = _.toNumber(startQuery);
 
   if (!_.isInteger(startAsANumber) || startAsANumber < 0) {
-    throw new Error(`convertStartQueryParams expected a positive integer got ${startAsANumber}`);
+    throw new Error(
+      `convertStartQueryParams expected a positive integer got ${startAsANumber}`
+    );
   }
 
   return {
@@ -103,8 +104,13 @@ const convertStartQueryParams = startQuery => {
 const convertLimitQueryParams = limitQuery => {
   const limitAsANumber = _.toNumber(limitQuery);
 
-  if (!_.isInteger(limitAsANumber) || (limitAsANumber !== -1 && limitAsANumber < 0)) {
-    throw new Error(`convertLimitQueryParams expected a positive integer got ${limitAsANumber}`);
+  if (
+    !_.isInteger(limitAsANumber) ||
+    (limitAsANumber !== -1 && limitAsANumber < 0)
+  ) {
+    throw new Error(
+      `convertLimitQueryParams expected a positive integer got ${limitAsANumber}`
+    );
   }
 
   return {


### PR DESCRIPTION
#### Description:
Set back the limit to 100 in rest queries


#### My PR is a:
- [ ] 💥 Breaking change
- [x] 🐛 Bug fix #issueNumber
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:
- [ ] Admin
- [ ] Documentation
- [x] Framework
- [ ] Plugin

#### Manual testing done on the following databases:
- [ ] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [X] Postgres
- [ ] SQLite
