### PR TITLE
Fix column name for many to many relations

### DIFF
--- a/packages/strapi-hook-bookshelf/lib/buildQuery.js
+++ b/packages/strapi-hook-bookshelf/lib/buildQuery.js
@@ -83,7 +83,7 @@ const buildJoinsAndFilter = (qb, model, whereClauses) => {
       const joinTableAlias = generateAlias(assoc.tableCollectionName);
       qb.leftJoin(
         `${assoc.tableCollectionName} AS ${joinTableAlias}`,
-        `${joinTableAlias}.${singular(originInfo.model.collectionName)}_${
+        `${joinTableAlias}.${singular(originInfo.model.globalId.toLowerCase())}_${
           originInfo.model.attributes[assoc.alias].column
         }`,
         `${originInfo.alias}.${originInfo.model.primaryKey}`
@@ -91,7 +91,7 @@ const buildJoinsAndFilter = (qb, model, whereClauses) => {
 
       qb.leftJoin(
         `${destinationInfo.model.collectionName} AS ${destinationInfo.alias}`,
-        `${joinTableAlias}.${singular(destinationInfo.model.collectionName)}_${
+        `${joinTableAlias}.${singular(destinationInfo.model.globalId.toLowerCase())}_${
           destinationInfo.model.primaryKey
         }`,
         `${destinationInfo.alias}.${destinationInfo.model.primaryKey}`


### PR DESCRIPTION
> ⚠️ We have stopped merging PRs for now to the Strapi core.<br><br>
> The reason is that we are developing new architecture for the admin panel and for the plugins.<br>
> This new architecture will provide stability of the Strapi core as we approach the release of Beta.<br>
> We appreciate and welcome all your contributions, but until further notice, please do not submit a PR as it will not be merged.<br>
> Furthermore, you will have to rewrite it based on the new architecture.


<!-- ⚠️ Your PR title will appear in the changelogs please make it short detailed and understandable for all. -->

<!-- Write a short description of what your PR does and link the concerned issues of your update. -->
<!-- ⚠️ Please link issue(s) you close / fix by using GitHub keywords https://help.github.com/articles/closing-issues-using-keywords/ !-->
#### Description:

Fix the column name use for relations many to many.

<!-- Uncomment the correct contribution type. !-->

#### My PR is a:
- [ ] 💥 Breaking change
- [x] 🐛 Bug fix #3144
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:
- [ ] Admin
- [ ] Documentation
- [x] Framework
- [ ] Plugin

<!-- Please note that all databases should be tested and confirmed to be working prior to the PR being merged. -->
#### Manual testing done on the following databases:
- [ ] Not applicable
- [ ] MongoDB
- [x] MySQL
- [ ] Postgres
- [ ] SQLite
