### PR TITLE
Fix missing populate in graphql queries

### DIFF
--- a/packages/strapi-plugin-graphql/services/Query.js
+++ b/packages/strapi-plugin-graphql/services/Query.js
@@ -263,7 +263,7 @@ module.exports = {
         });
 
         if (isController) {
-          const values = await resolver.call(null, ctx, null, { populate: [] });
+          const values = await resolver.call(null, ctx, null);
 
           if (ctx.body) {
             return ctx.body;


### PR DESCRIPTION

#### My PR is a:
- [ ] 💥 Breaking change
- [X] 🐛 Bug fix #3155 
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:
- [ ] Admin
- [ ] Documentation
- [X] Framework
- [ ] Plugin

<!-- Please note that all databases should be tested and confirmed to be working prior to the PR being merged. -->
#### Manual testing done on the following databases:
- [ ] Not applicable
- [X] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
