### PR TITLE
graphql subscriptions support

### DIFF
--- a/packages/strapi-plugin-graphql/package.json
+++ b/packages/strapi-plugin-graphql/package.json
@@ -21,7 +21,8 @@
     "test": "echo \"no tests yet\""
   },
   "dependencies": {
-    "apollo-server-koa": "^2.0.7",
+    "apollo-server-cache-redis": "^0.3.1",
+    "apollo-server-koa": "^2.4.8",
     "dataloader": "^1.4.0",
     "glob": "^7.1.3",
     "graphql": "^14.1.0",
@@ -32,7 +33,8 @@
     "graphql-type-json": "^0.2.1",
     "graphql-type-long": "^0.1.1",
     "pluralize": "^7.0.0",
-    "strapi-utils": "3.0.0-alpha.26"
+    "strapi-utils": "3.0.0-alpha.26",
+    "subscriptions-transport-ws": "^0.9.16"
   },
   "devDependencies": {
     "cross-env": "^5.2.0",

--- a/packages/strapi-plugin-graphql/services/Mutation.js
+++ b/packages/strapi-plugin-graphql/services/Mutation.js
@@ -147,7 +147,12 @@ module.exports = {
       policyUtils.get(policy, plugin, policiesFn, `GraphQL query "${queryName}"`, name)
     );
 
-    return async (obj, options, { context }) => {
+    return async (obj, options, context) => {
+      context = Object.assign(context.context || context, {
+        request: {},
+        send: (res) => {context.body = res}
+      });
+
       // Hack to be able to handle permissions for each query.
       const ctx = Object.assign(_.clone(context), {
         request: Object.assign(_.clone(context.request), {

--- a/packages/strapi-plugin-graphql/services/Mutation.js
+++ b/packages/strapi-plugin-graphql/services/Mutation.js
@@ -148,14 +148,11 @@ module.exports = {
     );
 
     return async (obj, options, context) => {
-      context = Object.assign(context.context || context, {
-        request: {},
-        send: (res) => { context.body = res; }
-      });
-
-      // Hack to be able to handle permissions for each query.
-      const ctx = Object.assign(_.clone(context), {
-        request: Object.assign(_.clone(context.request), {
+      const ctx = Object.assign({
+        send: (res) => { ctx.body = res; }
+      },
+      _.clone(context.context || context), {
+        request: Object.assign(_.clone(context.context ? context.context.request : {}), {
           graphql: null,
         }),
       });

--- a/packages/strapi-plugin-graphql/services/Mutation.js
+++ b/packages/strapi-plugin-graphql/services/Mutation.js
@@ -150,7 +150,7 @@ module.exports = {
     return async (obj, options, context) => {
       context = Object.assign(context.context || context, {
         request: {},
-        send: (res) => {context.body = res}
+        send: (res) => { context.body = res; }
       });
 
       // Hack to be able to handle permissions for each query.

--- a/packages/strapi-plugin-graphql/services/Query.js
+++ b/packages/strapi-plugin-graphql/services/Query.js
@@ -219,9 +219,12 @@ module.exports = {
       policyUtils.get(policy, plugin, policiesFn, `GraphQL query "${queryName}"`, name)
     );
 
-    return async (obj, options = {}, { context }) => {
+    return async (obj, options = {}, context) => {
       const _options = _.cloneDeep(options);
-
+      context = Object.assign(context.context || context, {
+        request: {},
+        send: (res) => {context.body = res}
+      });
       // Hack to be able to handle permissions for each query.
       const ctx = Object.assign(_.clone(context), {
         request: Object.assign(_.clone(context.request), {

--- a/packages/strapi-plugin-graphql/services/Query.js
+++ b/packages/strapi-plugin-graphql/services/Query.js
@@ -221,13 +221,13 @@ module.exports = {
 
     return async (obj, options = {}, context) => {
       const _options = _.cloneDeep(options);
-      context = Object.assign(context.context || context, {
-        request: {},
-        send: (res) => { context.body = res; }
-      });
+
       // Hack to be able to handle permissions for each query.
-      const ctx = Object.assign(_.clone(context), {
-        request: Object.assign(_.clone(context.request), {
+      const ctx = Object.assign({
+        send: (res) => { ctx.body = res; }
+      },
+      _.clone(context.context || context), {
+        request: Object.assign(_.clone(context.context ? context.context.request : {}), {
           graphql: null,
         }),
       });

--- a/packages/strapi-plugin-graphql/services/Query.js
+++ b/packages/strapi-plugin-graphql/services/Query.js
@@ -223,7 +223,7 @@ module.exports = {
       const _options = _.cloneDeep(options);
       context = Object.assign(context.context || context, {
         request: {},
-        send: (res) => {context.body = res}
+        send: (res) => { context.body = res; }
       });
       // Hack to be able to handle permissions for each query.
       const ctx = Object.assign(_.clone(context), {

--- a/packages/strapi-plugin-graphql/services/Resolvers.js
+++ b/packages/strapi-plugin-graphql/services/Resolvers.js
@@ -306,12 +306,12 @@ const buildShadowCRUD = (models, plugin) => {
             subscriptionDefinition = {
               [`${subscriptionName}`]: `${subscriptionName}Payload`,
             };
-          break;
+            break;
           default:
             subscriptionDefinition = {
               [`${subscriptionName}(id: ID!)`]: `${subscriptionName}Payload`,
             };
-          break;
+            break;
         }
 
         // Assign subscription definition to global definition.

--- a/packages/strapi-plugin-graphql/services/Schema.js
+++ b/packages/strapi-plugin-graphql/services/Schema.js
@@ -131,8 +131,8 @@ const schemaBuilder = {
    */
 
   generateSchema: function() {
-    // Generate type definition and query/mutation for models.
-    let shadowCRUD = { definition: '', query: '', mutation: '', resolver: '' };
+    // Generate type definition and query/mutation for models. @
+    let shadowCRUD = { definition: '', query: '', mutation: '', subscription: '', resolver: '' };
 
     // build defaults schemas if shadowCRUD is enabled
     if (strapi.plugins.graphql.config.shadowCRUD !== false) {
@@ -140,7 +140,7 @@ const schemaBuilder = {
 
       const modelCruds = Resolvers.buildShadowCRUD(models);
       shadowCRUD = Object.keys(strapi.plugins).reduce((acc, plugin) => {
-        const { definition, query, mutation, resolver } = Resolvers.buildShadowCRUD(
+        const { definition, query, mutation, subscription, resolver } = Resolvers.buildShadowCRUD(
           Object.keys(strapi.plugins[plugin].models),
           plugin
         );
@@ -152,6 +152,7 @@ const schemaBuilder = {
           query,
           resolver,
           mutation,
+          subscription
         });
       }, modelCruds);
     }
@@ -161,6 +162,7 @@ const schemaBuilder = {
       definition,
       query,
       mutation,
+      subscription,
       resolver = {},
     } = strapi.plugins.graphql.config._schema.graphql;
 
@@ -181,6 +183,10 @@ const schemaBuilder = {
         if (acc[type][resolver] === false) {
           delete acc[type][resolver];
 
+          return acc;
+        }
+
+        if (type === 'Subscription') {
           return acc;
         }
 
@@ -229,6 +235,8 @@ const schemaBuilder = {
         this.formatGQL(shadowCRUD.query, resolver.Query, null, 'query')}${query}}
       type Mutation {${shadowCRUD.mutation &&
         this.formatGQL(shadowCRUD.mutation, resolver.Mutation, null, 'mutation')}${mutation}}
+      type Subscription {${shadowCRUD.subscription &&
+        this.formatGQL(shadowCRUD.subscription, resolver.Subscription, null, 'subscription')}${subscription}}
       ${Types.addCustomScalar(resolvers)}
       ${Types.addInput()}
       ${polymorphicDef}

--- a/packages/strapi-plugin-graphql/services/Subscription.js
+++ b/packages/strapi-plugin-graphql/services/Subscription.js
@@ -8,12 +8,11 @@
 
 const _ = require('lodash');
 const policyUtils = require('strapi-utils').policy;
-const Query = require('./Query.js');
-/* eslint-disable no-unused-vars */
-
 const { RedisPubSub } = require('graphql-redis-subscriptions');
 const { PubSub } = require('graphql-subscriptions');
 const Redis = require('ioredis');
+const Query = require('./Query.js');
+/* eslint-disable no-unused-vars */
 
 const options = {
   host: process.env.REDIS_HOST,
@@ -74,7 +73,7 @@ module.exports = {
         policyName = 'destroy';
         break;
       default:
-        policyName = policyName;
+        policyName = queryName;
         break;
     }
 
@@ -119,7 +118,7 @@ module.exports = {
                 }
               }
             });
-          }
+          };
           break;
         case 'beforeFetchAll':
         case 'afterFetchAll':
@@ -132,7 +131,7 @@ module.exports = {
                 [`${name}`]: obj.models.map(x => {
                   var model = {
                     ...x.attributes
-                  }
+                  };
                   _.keys(x.relations).map(y => {
                     model[y] = x.attributes || x.relations[y].models.map(z => z.attributes);
                   });
@@ -141,7 +140,7 @@ module.exports = {
                 })
               }
             });
-          }
+          };
           break;
         default:
           model[action] = async (obj) => {
@@ -156,7 +155,7 @@ module.exports = {
                 }
               }
             });
-          }
+          };
           break;
       }
 
@@ -172,7 +171,7 @@ module.exports = {
           default:
             return pubsub.asyncIterator(`${queryName}_${ctx.params.id}`);
         }
-      }
+      };
     })();
 
     if (strapi.plugins['users-permissions']) {
@@ -189,7 +188,7 @@ module.exports = {
       subscribe: async (obj, options, context) => {
         context = Object.assign(context.context || context, {
           request: {},
-          send: (res) => { context.body = res }
+          send: (res) => { context.body = res; }
         });
 
         // Hack to be able to handle permissions for each subscription.
@@ -225,6 +224,6 @@ module.exports = {
         // Hopefully Resolver can be a promise.
         return resolver;
       }
-    }
+    };
   }
 };

--- a/packages/strapi-plugin-graphql/services/Subscription.js
+++ b/packages/strapi-plugin-graphql/services/Subscription.js
@@ -186,14 +186,11 @@ module.exports = {
     return {
       resolverOf,
       subscribe: async (obj, options, context) => {
-        context = Object.assign(context.context || context, {
-          request: {},
-          send: (res) => { context.body = res; }
-        });
-
-        // Hack to be able to handle permissions for each subscription.
-        const ctx = Object.assign(_.clone(context), {
-          request: Object.assign(_.clone(context.request), {
+        const ctx = Object.assign({
+          send: (res) => { ctx.body = res; }
+        },
+        _.clone(context.context || context), {
+          request: Object.assign(_.clone(context.context ? context.context.request : {}), {
             graphql: null,
           }),
         });

--- a/packages/strapi-plugin-graphql/services/Subscription.js
+++ b/packages/strapi-plugin-graphql/services/Subscription.js
@@ -1,0 +1,230 @@
+'use strict';
+
+/**
+ * Subscription.js service
+ *
+ * @description: A set of functions similar to controller's actions to avoid code duplication.
+ */
+
+const _ = require('lodash');
+const policyUtils = require('strapi-utils').policy;
+const Query = require('./Query.js');
+/* eslint-disable no-unused-vars */
+
+const { RedisPubSub } = require('graphql-redis-subscriptions');
+const { PubSub } = require('graphql-subscriptions');
+const Redis = require('ioredis');
+
+const options = {
+  host: process.env.REDIS_HOST,
+  port: process.env.REDIS_PORT,
+  password: process.env.REDIS_PASSWORD,
+  db: 1,
+  retry_strategy: options => {
+    // reconnect after
+    return Math.max(options.attempt * 100, 3000);
+  }
+};
+
+const pubsub =
+['production', 'staging'].indexOf(process.env.NODE_ENV) >= 0 &&
+process.env.REDIS_HOST ?
+new RedisPubSub({
+  publisher: new Redis(options),
+  subscriber: new Redis(options)
+}) :
+new PubSub();
+
+module.exports = {
+  /**
+   * Execute policies before the specified resolver.
+   *
+   * @return Promise or Error.
+   */
+
+  composeSubscriptionResolver: function (_schema, plugin, name, action) {
+    // Extract custom resolver or type description.
+    const { resolver: handler = {} } = _schema;
+
+    const queryName = `${action}${_.capitalize(name)}`;
+    const resolverOf = `${_.capitalize(name)}.${action}`;
+
+    let policyName;
+    switch (action) {
+      case 'beforeFetchAll':
+      case 'afterFetchAll':
+        policyName = 'find';
+        break;
+      case 'beforeFetch':
+      case 'afterFetch':
+        policyName = 'findone';
+        break;
+      case 'beforeCreate':
+      case 'afterCreate':
+      case 'beforeSave':
+      case 'afterSave':
+        policyName = 'create';
+        break;
+      case 'beforeUpdate':
+      case 'afterUpdate':
+        policyName = 'update';
+        break;
+      case 'beforeDestroy':
+      case 'afterDestroy':
+        policyName = 'destroy';
+        break;
+      default:
+        policyName = policyName;
+        break;
+    }
+
+    // Retrieve policies.
+    const policies = _.get(handler, `Subscription.${action}.policies`, []);
+    const models = plugin ? strapi.plugins[plugin].models : strapi.models;
+
+    const policiesFn = [];
+
+    // Retrieve resolver. It could be the custom resolver of the user
+    // or the shadow CRUD resolver (aka Content-Manager).
+    const resolver = (() => {
+      
+
+      const model = models[name];
+
+      // Push global policy to make sure the permissions will work as expected.
+      // We're trying to detect the model name.
+      policiesFn.push(
+        policyUtils.globalPolicy(
+          undefined,
+          {
+            handler: `${name}.${policyName}`,
+          },
+          undefined,
+          plugin
+        )
+      );
+
+      switch (action) {
+        case 'beforeCreate':
+        case 'afterCreate':
+          model[action] = async (obj) => {
+            if (!obj.attributes)
+              return;
+
+            pubsub.publish(`${queryName}`, {
+              [`${queryName}`]: {
+                [`${name}`]: {
+                  ...obj.attributes,
+                  ...obj.relations
+                }
+              }
+            });
+          }
+          break;
+        case 'beforeFetchAll':
+        case 'afterFetchAll':
+          model[action] = async (obj) => {
+            if (!obj.models.length)
+              return;
+
+            pubsub.publish(`${queryName}`, {
+              [`${queryName}`]: {
+                [`${name}`]: obj.models.map(x => {
+                  var model = {
+                    ...x.attributes
+                  }
+                  _.keys(x.relations).map(y => {
+                    model[y] = x.attributes || x.relations[y].models.map(z => z.attributes);
+                  });
+
+                  return model;
+                })
+              }
+            });
+          }
+          break;
+        default:
+          model[action] = async (obj) => {
+            if (!obj.attributes)
+              return;
+
+            pubsub.publish(`${queryName}_${obj.attributes.id}`, {
+              [`${queryName}`]: {
+                [`${name}`]: {
+                  ...obj.attributes,
+                  ...obj.relations
+                }
+              }
+            });
+          }
+          break;
+      }
+
+      // Make the query compatible with our model by
+      // setting in the context the parameters.
+      return (ctx, next) => {
+        switch (action) {
+          case 'beforeCreate':
+          case 'afterCreate':
+          case 'beforeFetchAll':
+          case 'afterFetchAll':
+            return pubsub.asyncIterator(`${queryName}`);
+          default:
+            return pubsub.asyncIterator(`${queryName}_${ctx.params.id}`);
+        }
+      }
+    })();
+
+    if (strapi.plugins['users-permissions']) {
+      policies.push('plugins.users-permissions.permissions');
+    }
+
+    // Populate policies.
+    policies.forEach(policy => {
+      policyUtils.get(policy, plugin, policiesFn, `GraphQL query "${policyName}"`, name);
+    });
+
+    return {
+      resolverOf,
+      subscribe: async (obj, options, context) => {
+        context = Object.assign(context.context || context, {
+          request: {},
+          send: (res) => { context.body = res }
+        });
+
+        // Hack to be able to handle permissions for each subscription.
+        const ctx = Object.assign(_.clone(context), {
+          request: Object.assign(_.clone(context.request), {
+            graphql: null,
+          }),
+        });
+
+        // Execute policies stack.
+        const policy = await strapi.koaMiddlewares.compose(policiesFn)(ctx);
+
+        // Policy doesn't always return errors but they update the current context.
+        if (_.isError(ctx.request.graphql) || _.get(ctx.request.graphql, 'isBoom')) {
+          return ctx.request.graphql;
+        }
+
+        // Something went wrong in the policy.
+        if (policy) {
+          return policy;
+        }
+
+        // Resolver can only be a function.
+        if (_.isFunction(resolver)) {
+          ctx.params = Query.convertToParams(
+            options || {},
+            (plugin ? strapi.plugins[plugin].models[name] : strapi.models[name]).primaryKey
+          );
+
+          return resolver(ctx);
+        }
+
+        // Hopefully Resolver can be a promise.
+        return resolver;
+      }
+    }
+  }
+};

--- a/packages/strapi-plugin-graphql/services/Types.js
+++ b/packages/strapi-plugin-graphql/services/Types.js
@@ -255,6 +255,29 @@ module.exports = {
           model.globalId
         } }
         `;
+
+      case 'beforeFetchAll':
+      case 'afterFetchAll':
+        return `
+          type ${type}${payloadName} { ${pluralize.singular(name)}: [${
+          model.globalId
+        }] }
+        `;
+      case 'beforeCreate':
+      case 'afterCreate':
+      case 'beforeSave':
+      case 'afterSave':
+      case 'beforeFetch':
+      case 'afterFetch':
+      case 'beforeUpdate':
+      case 'afterUpdate':
+      case 'beforeDestroy':
+      case 'afterDestroy':
+        return `
+          type ${type}${payloadName} { ${pluralize.singular(name)}: ${
+          model.globalId
+        } }
+        `;
       default:
       // Nothing
     }

--- a/packages/strapi-plugin-users-permissions/config/policies/permissions.js
+++ b/packages/strapi-plugin-users-permissions/config/policies/permissions.js
@@ -1,7 +1,7 @@
 const _ = require('lodash');
 
 module.exports = async (ctx, next) => {
-  let role;
+  let role = ctx.state && ctx.state.user ? ctx.state.user.role : undefined;
 
   if (ctx.request && ctx.request.header && ctx.request.header.authorization) {
     try {


### PR DESCRIPTION
#### My PR is a:
- [x] 💥 Breaking change
- [ ] 🐛 Bug fix #issueNumber
- [x] 💅 Enhancement
- [x] 🚀 New feature

#### Main update on the:
- [ ] Admin
- [ ] Documentation
- [ ] Framework
- [x] Plugin

<!-- Please note that all databases should be tested and confirmed to be working prior to the PR being merged. -->
#### Manual testing done on the following databases:
- [ ] Not applicable
- [x] MongoDB
- [x] MySQL
- [ ] Postgres
- [x] SQLite


So here is my $ contribution for the Strapi framework :)  The PR includes:
- subscriptions via graphql over websockets
- included shadowCRUD logic, so that everything gets auto generated
- policy checks
- fixes for missing context object while using ws
- custom schema.graphql is also being applied and custom policies are being picked up from each model and plugin path

All of the events are being generated by the models lifecycle callbacks and action policy is being applied as follows:

1. find
- beforeFetchAll
- afterFetchAll
2. findone
- beforeFetch
- afterFetch
3. create
- beforeCreate
- afterCreate
- beforeSave
- afterSave
4. update
- beforeUpdate
- afterUpdate
5. destroy
- beforeDestroy
- afterDestroy

> Please note, to work with WS in production environment, you have to use REDIS (or other mem cache), so for that reason I have left some of the code that picks up REDIS env variables, and the code decides which caching mechanism to use.

> Another thing to point is, that when using sockets, no headers are being sent via the request, so for that reason I had to rewrite some bits where ctx is being used, but more importantly, you have to pass your authorisation token via "connectionParams" as shown [in this example](https://www.apollographql.com/docs/react/advanced/subscriptions#authentication)

Finally I was about to wait with the PR for the next major change on the framework, but I saw many others trying to work this out and decided to give it a go, so you don't spent time developing this feature while I already did 😎 