### PR TITLE
fixes wrong column name on join table with manyToMany via user

### DIFF
--- a/packages/strapi-hook-bookshelf/lib/buildQuery.js
+++ b/packages/strapi-hook-bookshelf/lib/buildQuery.js
@@ -84,7 +84,7 @@ const buildJoinsAndFilter = (qb, model, whereClauses) => {
 
       qb.leftJoin(
         `${originInfo.model.databaseName}.${assoc.tableCollectionName} AS ${joinTableAlias}`,
-        `${joinTableAlias}.${singular(originInfo.model.globalId.toLowerCase())}_${
+        `${joinTableAlias}.${originInfo.model.info.name}_${
           originInfo.model.attributes[assoc.alias].column
         }`,
         `${originInfo.alias}.${originInfo.model.primaryKey}`
@@ -92,7 +92,7 @@ const buildJoinsAndFilter = (qb, model, whereClauses) => {
 
       qb.leftJoin(
         `${destinationInfo.model.databaseName}.${destinationInfo.model.collectionName} AS ${destinationInfo.alias}`,
-        `${joinTableAlias}.${singular(destinationInfo.model.globalId.toLowerCase())}_${
+        `${joinTableAlias}.${destinationInfo.model.info.name}_${
           destinationInfo.model.primaryKey
         }`,
         `${destinationInfo.alias}.${destinationInfo.model.primaryKey}`


### PR DESCRIPTION
#### My PR is a:
- [ ] 💥 Breaking change
- [x] 🐛 Bug fix #3144 over #3152 
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:
- [ ] Admin
- [ ] Documentation
- [ ] Framework
- [x] Plugin

<!-- Please note that all databases should be tested and confirmed to be working prior to the PR being merged. -->
#### Manual testing done on the following databases:
- [ ] Not applicable
- [ ] MongoDB
- [x] MySQL
- [ ] Postgres
- [x] SQLite

The new queryBuilder had a problem when doing a query manyToMany. The #3152 fixes the issue partially, but does not handle relations over plugins, especially users-permissions_user, which causes the queries to fail.
Not sure if this is the best way to go around it, but I've done my testing by switching the dominant flag vice versa and it seem to fix it in all cases