### PR TITLE
Allow sending username instead of identifier

### DIFF
--- a/packages/strapi-plugin-users-permissions/controllers/Auth.js
+++ b/packages/strapi-plugin-users-permissions/controllers/Auth.js
@@ -32,6 +32,7 @@ module.exports = {
       }
 
       // The identifier is required.
+      params.identifier = params.identifier ? params.identifier : params.username;
       if (!params.identifier) {
         return ctx.badRequest(
           null,


### PR DESCRIPTION
#### Description:

Simple fix to allow users to send:
```
{
    "username": "testuser",
    "password": "somepassword"
}
```

Instead of the typical identifer/password which is not a common API authentication scheme.

<!-- Uncomment the correct contribution type. !-->

#### My PR is a:
- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix #issueNumber
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:
- [ ] Admin
- [ ] Documentation
- [ ] Framework
- [x] Plugin - User Permissions

<!-- Please note that all databases should be tested and confirmed to be working prior to the PR being merged. -->
#### Manual testing done on the following databases:
- [x] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
