### PR TITLE
fix: count and totalCount on GraphQL queries

### DIFF
--- a/packages/strapi-generate-api/templates/mongoose/controller.template
+++ b/packages/strapi-generate-api/templates/mongoose/controller.template
@@ -15,11 +15,7 @@ module.exports = {
    */
 
   find: async (ctx, next, { populate } = {}) => {
-    if (ctx.query._q) {
-      return strapi.services.<%= id %>.search(ctx.query);
-    } else {
-      return strapi.services.<%= id %>.fetchAll(ctx.query, populate);
-    }
+    return strapi.services.<%= id %>.fetchAll(ctx.query, populate);
   },
 
   /**

--- a/packages/strapi-generate-api/templates/mongoose/service.template
+++ b/packages/strapi-generate-api/templates/mongoose/service.template
@@ -12,6 +12,45 @@
 const _ = require('lodash');
 const { convertRestQueryParams, buildQuery } = require('strapi-utils');
 
+// helper for building search filters
+const getSearchFilters = function getSearchFilters(params) {
+  // Convert `params` object to filters compatible with Mongo.
+  const filters = strapi.utils.models.convertParams('<%= globalID.toLowerCase() %>', params);
+
+  const $or = Object.keys(<%= globalID %>.attributes).reduce((acc, curr) => {
+    switch (<%= globalID %>.attributes[curr].type) {
+      case 'integer':
+      case 'float':
+      case 'decimal':
+        if (!_.isNaN(_.toNumber(params._q))) {
+          return acc.concat({ [curr]: params._q });
+        }
+
+        return acc;
+      case 'string':
+      case 'text':
+      case 'password':
+        return acc.concat({ [curr]: { $regex: params._q, $options: 'i' } });
+      case 'boolean':
+        if (params._q === 'true' || params._q === 'false') {
+          return acc.concat({ [curr]: params._q === 'true' });
+        }
+
+        return acc;
+      default:
+        return acc;
+    }
+  }, []);
+
+  // Adjust where object for search queries
+  if (filters.where._q) {
+    delete filters.where._q;
+    filters.where = { $or, ...filters.where };
+  }
+
+  return filters;
+};
+
 module.exports = {
 
   /**
@@ -57,14 +96,19 @@ module.exports = {
    * @return {Promise}
    */
 
-  count: (params) => {
-    const filters = convertRestQueryParams(params);
+  count: async (params, limit = 0) => {
+    const { where } = getSearchFilters(params);
 
-    return buildQuery({
-      model: <%= globalID %>,
-      filters: { where: filters.where },
-    })
-      .count()
+    // Filter on where
+    let filtered = <%= globalID %>.find(where);
+
+    // Add limit if necessary
+    if (limit > 0) {
+      filtered = filtered.limit(limit);
+    }
+
+    // Return count
+    return filtered.countDocuments();
   },
 
   /**
@@ -154,44 +198,20 @@ module.exports = {
    */
 
   search: async (params) => {
-    // Convert `params` object to filters compatible with Mongo.
-    const filters = strapi.utils.models.convertParams('<%= globalID.toLowerCase() %>', params);
     // Select field to populate.
     const populate = <%= globalID %>.associations
       .filter(ast => ast.autoPopulate !== false)
       .map(ast => ast.alias)
       .join(' ');
 
-    const $or = Object.keys(<%= globalID %>.attributes).reduce((acc, curr) => {
-      switch (<%= globalID %>.attributes[curr].type) {
-        case 'integer':
-        case 'float':
-        case 'decimal':
-          if (!_.isNaN(_.toNumber(params._q))) {
-            return acc.concat({ [curr]: params._q });
-          }
-
-          return acc;
-        case 'string':
-        case 'text':
-        case 'password':
-          return acc.concat({ [curr]: { $regex: params._q, $options: 'i' } });
-        case 'boolean':
-          if (params._q === 'true' || params._q === 'false') {
-            return acc.concat({ [curr]: params._q === 'true' });
-          }
-
-          return acc;
-        default:
-          return acc;
-      }
-    }, []);
+    // Get search filters
+    const filters = getSearchFilters(params);
 
     return <%= globalID %>
-      .find({ $or })
+      .find(filters.where )
       .sort(filters.sort)
       .skip(filters.start)
       .limit(filters.limit)
       .populate(populate);
-  }
+  },
 };

--- a/packages/strapi-generate-api/templates/mongoose/service.template
+++ b/packages/strapi-generate-api/templates/mongoose/service.template
@@ -12,45 +12,6 @@
 const _ = require('lodash');
 const { convertRestQueryParams, buildQuery } = require('strapi-utils');
 
-// helper for building search filters
-const getSearchFilters = function getSearchFilters(params) {
-  // Convert `params` object to filters compatible with Mongo.
-  const filters = strapi.utils.models.convertParams('<%= globalID.toLowerCase() %>', params);
-
-  const $or = Object.keys(<%= globalID %>.attributes).reduce((acc, curr) => {
-    switch (<%= globalID %>.attributes[curr].type) {
-      case 'integer':
-      case 'float':
-      case 'decimal':
-        if (!_.isNaN(_.toNumber(params._q))) {
-          return acc.concat({ [curr]: params._q });
-        }
-
-        return acc;
-      case 'string':
-      case 'text':
-      case 'password':
-        return acc.concat({ [curr]: { $regex: params._q, $options: 'i' } });
-      case 'boolean':
-        if (params._q === 'true' || params._q === 'false') {
-          return acc.concat({ [curr]: params._q === 'true' });
-        }
-
-        return acc;
-      default:
-        return acc;
-    }
-  }, []);
-
-  // Adjust where object for search queries
-  if (filters.where._q) {
-    delete filters.where._q;
-    filters.where = { $or, ...filters.where };
-  }
-
-  return filters;
-};
-
 module.exports = {
 
   /**
@@ -92,23 +53,28 @@ module.exports = {
 
   /**
    * Promise to count <%= humanizeIdPluralized %>.
-   *
+   * @param {Object} params - rest params for the query
+   * @param {Boolean} limited - optional, to limit the count result
    * @return {Promise}
    */
 
-  count: async (params, limit = 0) => {
-    const { where } = getSearchFilters(params);
+  count: (params, limited = false) => {
+    const filters = convertRestQueryParams(params);
 
-    // Filter on where
-    let filtered = <%= globalID %>.find(where);
+    // Set query options
+    const queryOptions = {
+      model: <%= globalID %>,
+      filters: { where: filters.where },
+    };
 
-    // Add limit if necessary
-    if (limit > 0) {
-      filtered = filtered.limit(limit);
+    // Limit the result if needed (e.g. for GraphQL count aggregator)
+    if (limited) {
+      queryOptions.filters.limit = filters.limit;
+      queryOptions.filters.start = filters.start;
     }
 
-    // Return count
-    return filtered.countDocuments();
+    return buildQuery(queryOptions)
+      .count()
   },
 
   /**
@@ -191,27 +157,21 @@ module.exports = {
     return data;
   },
 
-  /**
-   * Promise to search a/an <%= id %>.
-   *
-   * @return {Promise}
-   */
+    /**
+     * DEPRECATED - for compatibility reasons only, use fetchAll instead, that handles the _q search parameter now
+     *
+     * Promise to search a/an <%= id %>.
+     *
+     * @return {Promise}
+     */
 
-  search: async (params) => {
-    // Select field to populate.
-    const populate = <%= globalID %>.associations
-      .filter(ast => ast.autoPopulate !== false)
-      .map(ast => ast.alias)
-      .join(' ');
+    search: async (params) => {
+      // Select field to populate.
+      const populate = <%= globalID %>.associations
+        .filter(ast => ast.autoPopulate !== false)
+        .map(ast => ast.alias)
 
-    // Get search filters
-    const filters = getSearchFilters(params);
-
-    return <%= globalID %>
-      .find(filters.where )
-      .sort(filters.sort)
-      .skip(filters.start)
-      .limit(filters.limit)
-      .populate(populate);
-  },
+      // Call fetchAll
+      return module.exports.fetchAll(params, populate);
+    }
 };

--- a/packages/strapi-hook-mongoose/lib/buildQuery.js
+++ b/packages/strapi-hook-mongoose/lib/buildQuery.js
@@ -46,7 +46,7 @@ const getFindCriteria = (model, filters) => {
     ...whereSearch,
     ...(wheres.length > 0 ? { $and: wheres } : {})
   };
-}
+};
 
 /**
  * Builds a simple find query when there are no deep filters

--- a/packages/strapi-hook-mongoose/lib/buildQuery.js
+++ b/packages/strapi-hook-mongoose/lib/buildQuery.js
@@ -27,25 +27,33 @@ const buildQuery = ({ model, filters = {}, populate = [], aggregate = false } = 
  * @return {string}
  */
 const getSearchFieldOperator = function(type, value) {
-  let operator = 'eq';
+  let operator = "ignore"; // types that are not suitable for search
   switch (type) {
-    case 'integer':
-    case 'float':
-    case 'decimal':
+    case "biginteger":
+    case "integer":
+    case "float":
+    case "decimal":
       if (_.isNaN(_.toNumber(value))) {
-        operator = 'ignore'; // value is not numeric
+        operator = "ignore"; // value is not numeric
+      } else {
+        operator = "eq";
       }
       break;
-    case 'string':
-    case 'text':
-    case 'password':
-    case 'enumeration':
-      //return acc.concat({ [curr]: { $regex: params._q, $options: 'i' } });
-      operator = 'contains';
+    case "string":
+    case "text":
+    case "password":
+    case "enumeration":
+    case "email":
+      operator = "contains";
       break;
-    case 'boolean':
-      if (value !== 'true' && value !== 'false') {
-        operator = 'ignore'; // value is not boolean
+    case "boolean":
+      if (value === "true" && value === "false") {
+        operator = "eq";
+      }
+      break;
+    case "binary":
+      if (value === 1 && value === 0) {
+        operator = "eq";
       }
       break;
   }

--- a/packages/strapi-hook-mongoose/lib/buildQuery.js
+++ b/packages/strapi-hook-mongoose/lib/buildQuery.js
@@ -52,7 +52,7 @@ const getSearchFieldOperator = function(type, value) {
       }
       break;
     case "binary":
-      if (value === 1 && value === 0) {
+      if (value === '1' && value === '0') {
         operator = "eq";
       }
       break;

--- a/packages/strapi-hook-mongoose/lib/buildQuery.js
+++ b/packages/strapi-hook-mongoose/lib/buildQuery.js
@@ -5,7 +5,7 @@ const utils = require('./utils')();
  * Build a mongo query
  * @param {Object} options - Query options
  * @param {Object} options.model - The model you are querying
- * @param {Object} options.filers - An object with the possible filters (start, limit, sort, where)
+ * @param {Object} options.filters - An object with the possible filters (start, limit, sort, where)
  * @param {Object} options.populate - An array of paths to populate
  * @param {boolean} options.aggregate - Force aggregate function to use group by feature
  */
@@ -29,11 +29,12 @@ const getFindCriteria = (model, filters) => {
   let whereSearch = {};
 
   // Handle special search attribute "_q"
-  if (searchObject = where.find(item => item.field === '_q' )) {
+  const searchObject = where.find(item => item.field === '_q' );
+  if (searchObject) {
     const fields = Object.keys(model.attributes);
     whereSearch = {
       $or: fields.map(val => buildWhereClause({ field: val, operator: 'contains', value: searchObject.value })),
-    }
+    };
     // Remove search entry from where
     const searchIndex = where.findIndex(item => item.field === '_q' );
     where.splice(searchIndex, 1);
@@ -41,18 +42,17 @@ const getFindCriteria = (model, filters) => {
 
   // Build object for find method and return it
   const wheres = where.map(buildWhereClause);
-  const findCriteria = {
+  return {
     ...whereSearch,
     ...(wheres.length > 0 ? { $and: wheres } : {})
   };
-  return findCriteria;
 }
 
 /**
  * Builds a simple find query when there are no deep filters
  * @param {Object} options - Query options
  * @param {Object} options.model - The model you are querying
- * @param {Object} options.filers - An object with the possible filters (start, limit, sort, where)
+ * @param {Object} options.filters - An object with the possible filters (start, limit, sort, where)
  * @param {Object} options.populate - An array of paths to populate
  */
 const buildSimpleQuery = ({ model, filters, populate }) => {
@@ -73,7 +73,7 @@ const buildSimpleQuery = ({ model, filters, populate }) => {
  * Builds a deep aggregate query when there are deep filters
  * @param {Object} options - Query options
  * @param {Object} options.model - The model you are querying
- * @param {Object} options.filers - An object with the possible filters (start, limit, sort, where)
+ * @param {Object} options.filters - An object with the possible filters (start, limit, sort, where)
  * @param {Object} options.populate - An array of paths to populate
  */
 const buildDeepQuery = ({ model, filters, populate }) => {

--- a/packages/strapi-hook-mongoose/lib/buildQuery.js
+++ b/packages/strapi-hook-mongoose/lib/buildQuery.js
@@ -72,7 +72,7 @@ const getFindCriteria = (model, filters) => {
         if (operator === 'ignore') {
           return null;
         }
-        return buildWhereClause({ field, operator, value: searchObject.value })
+        return buildWhereClause({ field, operator, value: searchObject.value });
 
       }).filter(item => item !== null && item !== undefined)
     };

--- a/packages/strapi-plugin-graphql/services/Aggregator.js
+++ b/packages/strapi-plugin-graphql/services/Aggregator.js
@@ -339,7 +339,7 @@ const formatConnectionAggregator = function(fields, model) {
       count: async (obj, options, context) => {
         // Call count function from service object with limit
         return strapi.services[model.modelName.toLowerCase()]
-          .count(undoWhereConversion(obj.where), obj.limit);
+          .count({...undoWhereConversion(obj.where), _limit: obj.limit, _start: obj.start}, true);
       },
       totalCount: async (obj, options, context) => {
         // Call count function from service object

--- a/packages/strapi-plugin-graphql/services/Aggregator.js
+++ b/packages/strapi-plugin-graphql/services/Aggregator.js
@@ -300,7 +300,7 @@ const formatConnectionGroupBy = function(fields, model, name) {
  *
  * @param whereArg
  */
-const undoWhereConversion = function(whereArg) {
+const undoWhereConversion = function(whereArg = []) {
   const converted = {};
   whereArg.forEach(where => {
     // Ignore operator for equal

--- a/packages/strapi-utils/lib/buildQuery.js
+++ b/packages/strapi-utils/lib/buildQuery.js
@@ -32,7 +32,7 @@ const getAssociationFromFieldKey = ({ model, field }) => {
       continue;
     }
 
-    if (!assoc && (!isAttribute(tmpModel, part) || i !== fieldParts.length - 1)) {
+    if (field != '_q' && !assoc && (!isAttribute(tmpModel, part) || i !== fieldParts.length - 1)) {
       const err = new Error(
         `Your filters contain a field '${field}' that doesn't appear on your model definition nor it's relations`
       );


### PR DESCRIPTION
<!-- ⚠️ Your PR title will appear in the changelogs please make it short detailed and understandable for all. -->

<!-- Write a short description of what your PR does and link the concerned issues of your update. -->
<!-- ⚠️ Please link issue(s) you close / fix by using GitHub keywords https://help.github.com/articles/closing-issues-using-keywords/ !-->
#### Description:
The fields `count` and `totalCount` of type `aggregate` in GraphQl queries ending in `Connection` are not working correctly. As soon as there is the search param '_q' set, the query fails with an error message: "Your filters contain a field '_q' that doesn't appear on your model definition nor it's relations".

The issue was fixed by using the count function from the model's service object in `strapi-generate-api/templates/mongoose/service.template`, later generate to `/api/**/services/` in `/strapi-plugin-graphql/services/Aggregator.js`. 
The service's count function was improved to handle the "_q" parameter correctly and uses the same function from search to generate the $or query, which is now its own function `getSearchFilters`.


<!-- Uncomment the correct contribution type. !-->

#### My PR is a:
- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:
- [ ] Admin
- [ ] Documentation
- [ ] Framework
- [x] Plugin

<!-- Please note that all databases should be tested and confirmed to be working prior to the PR being merged. -->
#### Manual testing done on the following databases:
- [ ] Not applicable
- [x] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite

Seems to be related to the following issues: #2666 #3187 #2151
