### PR TITLE
Add display name to display a user friendly name for content types on admin menu

### DIFF
--- a/packages/strapi-plugin-content-manager/admin/src/bootstrap.js
+++ b/packages/strapi-plugin-content-manager/admin/src/bootstrap.js
@@ -10,7 +10,7 @@ const bootstrap = plugin =>
           {
             name: 'Content Types',
             links: map(omit(models.models.models, 'plugins'), (model, key) => ({
-              label: model.labelPlural || model.label || key,
+              label: model.info.displayName || model.labelPlural || model.label || key,
               destination: key,
             })),
           },

--- a/packages/strapi-plugin-content-type-builder/admin/src/containers/App/actions.js
+++ b/packages/strapi-plugin-content-type-builder/admin/src/containers/App/actions.js
@@ -124,7 +124,7 @@ export function getData() {
 
 export function getDataSucceeded({ allModels, models }, connections) {
   const initialData = allModels.reduce((acc, current) => {
-    acc[current.name] = pick(current, ['name', 'collectionName', 'connection', 'description', 'mainField']);
+    acc[current.name] = pick(current, ['name', 'collectionName', 'connection', 'displayName', 'description', 'mainField']);
     const attributes = OrderedMap(buildModelAttributes(current.attributes));
     set(acc, [current.name, 'attributes'], attributes);
 

--- a/packages/strapi-plugin-content-type-builder/admin/src/containers/App/reducer.js
+++ b/packages/strapi-plugin-content-type-builder/admin/src/containers/App/reducer.js
@@ -47,6 +47,7 @@ export const initialState = fromJS({
   newContentType: {
     collectionName: '',
     connection: '',
+    displayName: '',
     description: '',
     mainField: '',
     name: '',
@@ -55,6 +56,7 @@ export const initialState = fromJS({
   newContentTypeClone: {
     collectionName: '',
     connection: '',
+    displayName: '',
     description: '',
     mainField: '',
     name: '',

--- a/packages/strapi-plugin-content-type-builder/admin/src/containers/App/saga.js
+++ b/packages/strapi-plugin-content-type-builder/admin/src/containers/App/saga.js
@@ -77,7 +77,7 @@ export function* submitCT({
       const oldContentTypeNameIndex = appMenu[0].links.findIndex(el => el.destination === oldContentTypeName);
       const updatedLink = {
         destination: name.toLowerCase(),
-        label: capitalize(pluralize(name)),
+        label: body.displayName || capitalize(pluralize(name)),
       };
       appMenu[0].links.splice(oldContentTypeNameIndex, 1, updatedLink);
       appMenu[0].links = sortBy(appMenu[0].links, 'label');
@@ -111,7 +111,7 @@ export function* submitTempCT({ body, context: { emitEvent, plugins, updatePlugi
     const appMenu = get(appPlugins, ['content-manager', 'leftMenuSections'], []);
     const newLink = {
       destination: name.toLowerCase(),
-      label: capitalize(pluralize(name)),
+      label: body.displayName || capitalize(pluralize(name)),
     };
     appMenu[0].links.push(newLink);
     appMenu[0].links = sortBy(appMenu[0].links, 'label');

--- a/packages/strapi-plugin-content-type-builder/admin/src/containers/HomePage/index.js
+++ b/packages/strapi-plugin-content-type-builder/admin/src/containers/HomePage/index.js
@@ -128,6 +128,7 @@ HomePage.propTypes = {
   newContentType: PropTypes.shape({
     collectionName: PropTypes.string,
     connection: PropTypes.string,
+    displayName: PropTypes.string,
     description: PropTypes.string,
     mainField: PropTypes.string,
     name: PropTypes.string,

--- a/packages/strapi-plugin-content-type-builder/admin/src/containers/ModelForm/forms.json
+++ b/packages/strapi-plugin-content-type-builder/admin/src/containers/ModelForm/forms.json
@@ -4,12 +4,23 @@
       {
         "customBootstrapClass": "col-md-6 offset-md-6 mr-md-5",
         "label": {
+          "id": "content-type-builder.form.contentType.item.displayName"
+        },
+        "name": "displayName",
+        "value": "",
+        "type": "string",
+        "autoFocus": true,
+        "placeholder": "content-type-builder.form.contentType.item.displayName.placeholder",
+        "validations": {}
+      },
+      {
+        "customBootstrapClass": "col-md-6 offset-md-6 mr-md-5",
+        "label": {
           "id": "content-type-builder.form.contentType.item.name"
         },
         "name": "name",
         "value": "",
         "type": "string",
-        "autoFocus": true,
         "validations": {
           "required": true
         },

--- a/packages/strapi-plugin-content-type-builder/admin/src/translations/ar.json
+++ b/packages/strapi-plugin-content-type-builder/admin/src/translations/ar.json
@@ -69,6 +69,8 @@
   "form.contentType.item.collectionName": "اسم المجموعة ( collection )",
   "form.contentType.item.collectionName.inputDescription": "من المفيد أن يختلف اسم نوع المحتوى واسم الجدول الخاص بك",
   "form.contentType.item.connections": "الأتصال",
+  "form.contentType.item.displayName": "اسم العرض",
+  "form.contentType.item.displayName.placeholder": "اسم العرض المخصص",
   "form.contentType.item.description": "الوصف",
   "form.contentType.item.description.placeholder": "اكتب وصفك الصغير هنا...",
   "form.contentType.item.name": "الأسم",

--- a/packages/strapi-plugin-content-type-builder/admin/src/translations/de.json
+++ b/packages/strapi-plugin-content-type-builder/admin/src/translations/de.json
@@ -68,6 +68,8 @@
   "form.button.save": "Speichern",
   "form.contentType.item.collectionName": "Name des Dokuments in der Datenbank",
   "form.contentType.item.collectionName.inputDescription": "Nützlich, wenn Inhaltstyp und Datenbankname unterschiedlich sind",
+  "form.contentType.item.displayName": "Anzeigename",
+  "form.contentType.item.displayName.placeholder": "Name der benutzerdefinierten Anzeige",
   "form.contentType.item.connections": "Verbindung",
   "form.contentType.item.description": "Beschreibung",
   "form.contentType.item.description.placeholder": "Beschreibe deinen Inhaltstyp",

--- a/packages/strapi-plugin-content-type-builder/admin/src/translations/en.json
+++ b/packages/strapi-plugin-content-type-builder/admin/src/translations/en.json
@@ -72,6 +72,8 @@
   "form.contentType.item.collectionName": "Collection Name",
   "form.contentType.item.collectionName.inputDescription": "Useful when the name of your Content Type and your table name differ",
   "form.contentType.item.connections": "Connection",
+  "form.contentType.item.displayName": "Display Name",
+  "form.contentType.item.displayName.placeholder": "Custom display name",
   "form.contentType.item.description": "Description",
   "form.contentType.item.description.placeholder": "Write your little description here...",
   "form.contentType.item.name": "Name",

--- a/packages/strapi-plugin-content-type-builder/admin/src/translations/es.json
+++ b/packages/strapi-plugin-content-type-builder/admin/src/translations/es.json
@@ -69,6 +69,8 @@
   "form.contentType.item.collectionName": "Nombre de la colección",
   "form.contentType.item.collectionName.inputDescription": "Útil cuando el nombre de su tipo de contenido y el nombre de su tabla difieren",
   "form.contentType.item.connections": "Conexión",
+  "form.contentType.item.displayName": "Nombre para mostrar",
+  "form.contentType.item.displayName.placeholder": "Nombre para mostrar personalizado",
   "form.contentType.item.description": "Descripción",
   "form.contentType.item.description.placeholder": "Escribe aquí tu breve descripción...",
   "form.contentType.item.name": "Nombre",

--- a/packages/strapi-plugin-content-type-builder/admin/src/translations/fr.json
+++ b/packages/strapi-plugin-content-type-builder/admin/src/translations/fr.json
@@ -70,6 +70,8 @@
   "form.contentType.item.collectionName": "Nom de la Collection",
   "form.contentType.item.collectionName.inputDescription": "Pratique quand le Nom de votre Modèle et de votre table sont différents",
   "form.contentType.item.connections": "Connexion",
+  "form.contentType.item.displayName": "Afficher un nom",
+  "form.contentType.item.displayName.placeholder": "Nom d'affichage personnalisé",
   "form.contentType.item.description": "Description",
   "form.contentType.item.description.placeholder": "Ecrivez votre petite description ici...",
   "form.contentType.item.name": "Nom",

--- a/packages/strapi-plugin-content-type-builder/admin/src/translations/it.json
+++ b/packages/strapi-plugin-content-type-builder/admin/src/translations/it.json
@@ -68,6 +68,8 @@
   "form.button.save": "Salva",
   "form.contentType.item.collectionName": "Nome Della Collezione",
   "form.contentType.item.collectionName.inputDescription": "Utile quando il nome del Tipo di Contenuto e il nome della tabella differiscono",
+  "form.contentType.item.displayName": "Nome da visualizzare",
+  "form.contentType.item.displayName.placeholder": "Nome visualizzato personalizzato",
   "form.contentType.item.connections": "Collegamento",
   "form.contentType.item.description": "Descrizione",
   "form.contentType.item.description.placeholder": "Scrivi la tua piccola descrizione qui...",

--- a/packages/strapi-plugin-content-type-builder/admin/src/translations/ja.json
+++ b/packages/strapi-plugin-content-type-builder/admin/src/translations/ja.json
@@ -69,6 +69,8 @@
   "form.contentType.item.collectionName": "コレクション名",
   "form.contentType.item.collectionName.inputDescription": "コンテンツタイプの名前とテーブル名が異なる場合に便利です",
   "form.contentType.item.connections": "接続",
+  "form.contentType.item.displayName": "表示名",
+  "form.contentType.item.displayName.placeholder": "カスタム表示名",
   "form.contentType.item.description": "説明文",
   "form.contentType.item.description.placeholder": "ここに簡単な説明を書いてください...",
   "form.contentType.item.name": "名前",

--- a/packages/strapi-plugin-content-type-builder/admin/src/translations/ko.json
+++ b/packages/strapi-plugin-content-type-builder/admin/src/translations/ko.json
@@ -69,6 +69,8 @@
   "form.contentType.item.collectionName": "컬렉션 이름",
   "form.contentType.item.collectionName.inputDescription": "콘텐츠 타입 이름과 테이블 이름이 다를 경우 유용합니다.",
   "form.contentType.item.connections": "연결",
+  "form.contentType.item.displayName": "표시 이름",
+  "form.contentType.item.displayName.placeholder": "사용자 정의 표시 이름",
   "form.contentType.item.description": "설명",
   "form.contentType.item.description.placeholder": "간략한 설명을 작성하세요.",
   "form.contentType.item.name": "이름",

--- a/packages/strapi-plugin-content-type-builder/admin/src/translations/nl.json
+++ b/packages/strapi-plugin-content-type-builder/admin/src/translations/nl.json
@@ -69,6 +69,8 @@
   "form.contentType.item.collectionName": "Collectie naam",
   "form.contentType.item.collectionName.inputDescription": "Handig als de naam van je Content Type en je tabel verschillen",
   "form.contentType.item.connections": "Verbinding",
+  "form.contentType.item.displayName": "Weergavenaam",
+  "form.contentType.item.displayName.placeholder": "Aangepaste weergavenaam",
   "form.contentType.item.description": "Beschrijving",
   "form.contentType.item.description.placeholder": "Schrijf je korte beschrijving hier...",
   "form.contentType.item.name": "Naam",

--- a/packages/strapi-plugin-content-type-builder/admin/src/translations/pl.json
+++ b/packages/strapi-plugin-content-type-builder/admin/src/translations/pl.json
@@ -69,6 +69,8 @@
   "form.contentType.item.collectionName": "Kolekcja",
   "form.contentType.item.collectionName.inputDescription": "Przydatne kiedy nazwa modelu jest inna niż nazwa tabeli w bazie danych",
   "form.contentType.item.connections": "Połączenie",
+  "form.contentType.item.displayName": "Wyświetlana nazwa",
+  "form.contentType.item.displayName.placeholder": "Niestandardowa nazwa wyświetlana",
   "form.contentType.item.description": "Opis",
   "form.contentType.item.description.placeholder": "Wpisz krótki opis tutaj...",
   "form.contentType.item.name": "Nazwa",

--- a/packages/strapi-plugin-content-type-builder/admin/src/translations/pt-BR.json
+++ b/packages/strapi-plugin-content-type-builder/admin/src/translations/pt-BR.json
@@ -69,6 +69,8 @@
   "form.contentType.item.collectionName": "Nome da coleção",
   "form.contentType.item.collectionName.inputDescription": "Útil quando o nome do seu Tipo de Conteúdo e o nome da sua tabela diferem",
   "form.contentType.item.connections": "Conexões",
+  "form.contentType.item.displayName": "Mostrar nome",
+  "form.contentType.item.displayName.placeholder": "Nome de exibição personalizado",
   "form.contentType.item.description": "Descrição",
   "form.contentType.item.description.placeholder": "Escreva sua pequena descrição aqui...",
   "form.contentType.item.name": "Nome",

--- a/packages/strapi-plugin-content-type-builder/admin/src/translations/pt.json
+++ b/packages/strapi-plugin-content-type-builder/admin/src/translations/pt.json
@@ -69,6 +69,8 @@
   "form.contentType.item.collectionName": "Nome da coleção",
   "form.contentType.item.collectionName.inputDescription": "Útil quando o nome do seu Tipo de Conteúdo e o nome da sua tabela diferem",
   "form.contentType.item.connections": "Conexão",
+  "form.contentType.item.displayName": "Mostrar nome",
+  "form.contentType.item.displayName.placeholder": "Nome de exibição personalizado",
   "form.contentType.item.description": "Descrição",
   "form.contentType.item.description.placeholder": "Escreva sua pequena descrição aqui...",
   "form.contentType.item.name": "Nome",

--- a/packages/strapi-plugin-content-type-builder/admin/src/translations/ru.json
+++ b/packages/strapi-plugin-content-type-builder/admin/src/translations/ru.json
@@ -69,6 +69,8 @@
   "form.contentType.item.collectionName": "Название коллекции",
   "form.contentType.item.collectionName.inputDescription": "Полезно, когда название вашего Типа Контента и название вашей таблицы различаются",
   "form.contentType.item.connections": "Соединение",
+  "form.contentType.item.displayName": "Отображаемое имя",
+  "form.contentType.item.displayName.placeholder": "Пользовательское отображаемое имя",
   "form.contentType.item.description": "Описание",
   "form.contentType.item.description.placeholder": "Добавьте короткое описание...",
   "form.contentType.item.name": "Название",

--- a/packages/strapi-plugin-content-type-builder/admin/src/translations/tr.json
+++ b/packages/strapi-plugin-content-type-builder/admin/src/translations/tr.json
@@ -69,6 +69,8 @@
   "form.contentType.item.collectionName": "Koleksiyon Adı",
   "form.contentType.item.collectionName.inputDescription": "İçerik Türünüzün adı ve tablonuzun adı farklı olduğunda kullanışlıdır.",
   "form.contentType.item.connections": "Bağlantı",
+  "form.contentType.item.displayName": "Ekran adı",
+  "form.contentType.item.displayName.placeholder": "Özel görünen ad",
   "form.contentType.item.description": "Açıklama",
   "form.contentType.item.description.placeholder": "Küçük açıklama yaz...",
   "form.contentType.item.name": "İsim",

--- a/packages/strapi-plugin-content-type-builder/admin/src/translations/zh-Hans.json
+++ b/packages/strapi-plugin-content-type-builder/admin/src/translations/zh-Hans.json
@@ -68,6 +68,8 @@
   "form.contentType.item.collectionName": "Collection Name",
   "form.contentType.item.collectionName.inputDescription": "当你的Content Type和你的数据库表名不一样的时候",
   "form.contentType.item.connections": "连接",
+  "form.contentType.item.displayName": "显示名称",
+  "form.contentType.item.displayName.placeholder": "自定义显示名称",
   "form.contentType.item.description": "描述",
   "form.contentType.item.description.placeholder": "在这里写下你的描述...",
   "form.contentType.item.name": "名称",

--- a/packages/strapi-plugin-content-type-builder/admin/src/translations/zh.json
+++ b/packages/strapi-plugin-content-type-builder/admin/src/translations/zh.json
@@ -69,6 +69,8 @@
   "form.contentType.item.collectionName": "群組名稱",
   "form.contentType.item.collectionName.inputDescription": "當您的資料結構和資料庫欄位不一樣時很有用",
   "form.contentType.item.connections": "連線",
+  "form.contentType.item.displayName": "顯示名稱",
+  "form.contentType.item.displayName.placeholder": "自定義顯示名稱",
   "form.contentType.item.description": "說明",
   "form.contentType.item.description.placeholder": "請在這裡寫一些說明...",
   "form.contentType.item.name": "名稱",

--- a/packages/strapi-plugin-content-type-builder/controllers/ContentTypeBuilder.js
+++ b/packages/strapi-plugin-content-type-builder/controllers/ContentTypeBuilder.js
@@ -44,7 +44,7 @@ module.exports = {
   },
 
   createModel: async ctx => {
-    const { name, description, connection, collectionName, attributes = [], plugin } = ctx.request.body;
+    const { name, displayName, description, connection, collectionName, attributes = [], plugin } = ctx.request.body;
 
     if (!name) return ctx.badRequest(null, [{ messages: [{ id: 'request.error.name.missing' }] }]);
     if (!_.includes(Service.getConnections(), connection)) return ctx.badRequest(null, [{ messages: [{ id: 'request.error.connection.unknow' }] }]);
@@ -69,6 +69,8 @@ module.exports = {
 
     try {
       const modelJSON = _.cloneDeep(require(modelFilePath));
+
+      modelJSON.info.displayName = displayName;
 
       modelJSON.attributes = formatedAttributes;
 
@@ -107,7 +109,7 @@ module.exports = {
 
   updateModel: async ctx => {
     const { model } = ctx.params;
-    const { name, description, mainField, connection, collectionName, attributes = [], plugin } = ctx.request.body;
+    const { name, displayName, description, mainField, connection, collectionName, attributes = [], plugin } = ctx.request.body;
 
     if (!name) return ctx.badRequest(null, [{ messages: [{ id: 'request.error.name.missing' }] }]);
     if (!_.includes(Service.getConnections(), connection)) return ctx.badRequest(null, [{ messages: [{ id: 'request.error.connection.unknow' }] }]);
@@ -141,6 +143,7 @@ module.exports = {
       modelJSON.collectionName = collectionName;
       modelJSON.info = {
         name,
+        displayName,
         description: _description
       };
       modelJSON.attributes = formatedAttributes;

--- a/packages/strapi-plugin-content-type-builder/services/ContentTypeBuilder.js
+++ b/packages/strapi-plugin-content-type-builder/services/ContentTypeBuilder.js
@@ -133,6 +133,7 @@ module.exports = {
       models.push({
         icon: 'fa-cube',
         name: _.get(model, 'info.name', 'model.name.missing'),
+        displayName: _.get(model, 'info.displayName', 'model.displayName.missing'),
         description: _.get(model, 'info.description', 'model.description.missing'),
         fields: _.keys(model.attributes).length,
         isTemporary: false,
@@ -148,6 +149,7 @@ module.exports = {
         acc.push({
           icon: 'fa-cube',
           name: _.get(model, 'info.name', 'model.name.missing'),
+          displayName: _.get(model, 'info.displayName', 'model.displayName.missing'),
           description: _.get(model, 'info.description', 'model.description.missing'),
           fields: _.keys(model.attributes).length,
           source: current,
@@ -213,6 +215,7 @@ module.exports = {
 
     return {
       name: _.get(model, 'info.name', 'model.name.missing'),
+      displayName: _.get(model, 'info.displayName', 'model.displayName.missing'),
       description: _.get(model, 'info.description', 'model.description.missing'),
       mainField: _.get(model, 'info.mainField', ''),
       connection: model.connection,


### PR DESCRIPTION
Add display name to display a business friendly name for content types on admin menu

#### Description:
Currently strapi always automatically rename `My Sample Model`  to `Mysamplemodels` which is not user-friendly.

There are several issues related to this, for example: https://github.com/strapi/strapi/issues/1736

I added an additional field on the new model creation screen called "displayName" to allow admin to define a user-friendly display name for the model. The user-friendly display name will be shown in the admin menu.

Here is the screenshot:
![image](https://user-images.githubusercontent.com/4420274/55212588-48e34200-51be-11e9-8fa0-c4bc3c358bf1.png)

See previously closed PR for details: https://github.com/strapi/strapi/pull/3043

#### My PR is a:
- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix #issueNumber
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:
- [x] Admin
- [ ] Documentation
- [ ] Framework
- [ ] Plugin

<!-- Please note that all databases should be tested and confirmed to be working prior to the PR being merged. -->
#### Manual testing done on the following databases:
- [ ] Not applicable
- [x] MongoDB
- [x] MySQL
- [ ] Postgres
- [ ] SQLite
