### PR TITLE
Add api and extensions gitkeep

### DIFF
--- a/packages/strapi-generate-new/lib/index.js
+++ b/packages/strapi-generate-new/lib/index.js
@@ -68,6 +68,10 @@ module.exports = {
     'extensions': {
       folder: {}
     },
+    
+    'extensions/.gitkeep': {
+      copy: 'gitkeep'
+    },
 
     // Empty public directory.
     'public': {

--- a/packages/strapi-generate-new/lib/index.js
+++ b/packages/strapi-generate-new/lib/index.js
@@ -60,6 +60,10 @@ module.exports = {
       folder: {}
     },
 
+    'api/.gitkeep': {
+      copy: 'gitkeep'
+    },
+
     // Empty plugins directory.
     'extensions': {
       folder: {}


### PR DESCRIPTION
#### Description:

Add  a .gitkeep file in the api folder to make sure we can deploy an empty strapi project via git

#### My PR is a:
- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix #issueNumber
- [X] 💅 Enhancementa
- [ ] 🚀 New feature

#### Main update on the:
- [ ] Admin
- [ ] Documentation
- [X] Framework
- [ ] Plugin

<!-- Please note that all databases should be tested and confirmed to be working prior to the PR being merged. -->
#### Manual testing done on the following databases:
- [X] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
