### PR TITLE
Need to update fetch() as well during migration to 3.0.0-alpha.26

### DIFF
--- a/docs/3.x.x/migration-guide/migration-guide-alpha.25-to-alpha.26.md
+++ b/docs/3.x.x/migration-guide/migration-guide-alpha.25-to-alpha.26.md
@@ -101,6 +101,22 @@ fetchAll: (params, populate) => {
 },
 ```
 
+Replace the `fetch` function by the following code.
+
+```js
+  fetch: (params) => {
+    // Select field to populate.
+    const populate = <%= globalID %>.associations
+      .filter(ast => ast.autoPopulate !== false)
+      .map(ast => ast.alias)
+      .join(' ');
+
+    return <%= globalID %>
+      .findOne(_.pick(params, _.keys(<%= globalID %>.schema.paths)))
+      .populate(populate);
+  },
+```
+
 Replace the `count` function by the following code.
 
 ```js
@@ -164,6 +180,22 @@ fetchAll: (params, populate) => {
     .fetchAll({ withRelated })
     .then(data => data.toJSON());
 },
+```
+
+Replace the `fetch` function by the following code.
+
+```js
+  fetch: (params) => {
+    // Select field to populate.
+    const populate = <%= globalID %>.associations
+      .filter(ast => ast.autoPopulate !== false)
+      .map(ast => ast.alias)
+      .join(' ');
+
+    return <%= globalID %>
+      .findOne(_.pick(params, _.keys(<%= globalID %>.schema.paths)))
+      .populate(populate);
+  },
 ```
 
 Replace the `count` function by the following code.


### PR DESCRIPTION
The `fetch()` method version `3.0.0-alpha.26` looked like the following:

 ````
 fetch: (params) => {
    // Select field to populate.
    const populate = <%= globalID %>.associations
      .filter(ast => ast.autoPopulate !== false)
      .map(ast => ast.alias);

    return <%= globalID %>.forge(_.pick(params, 'id')).fetch({
      withRelated: populate
    });
  },
````

However, this gave an error `<%= globalID %>.forge is not a function and upon further digging, I found that the `fetch()` method needs to be updated as well. This PR updates the documentation for the migration.