### PR TITLE
Fix model rename not using the right api name to persist files

### DIFF
--- a/packages/strapi-plugin-content-type-builder/controllers/ContentTypeBuilder.js
+++ b/packages/strapi-plugin-content-type-builder/controllers/ContentTypeBuilder.js
@@ -175,7 +175,7 @@ module.exports = {
         if (plugin) {
           await Service.writeModel(name, modelJSON, { plugin });
         } else {
-          await Service.writeModel(name, modelJSON, { api: modelData.apiName });
+          await Service.writeModel(name, modelJSON, { api: name !== model ? name.toLowerCase() : modelData.apiName});
         }
 
         ctx.send({ ok: true });


### PR DESCRIPTION

#### Description:

Fix model rename not using the right api name to persist files

<!-- Uncomment the correct contribution type. !-->

#### My PR is a:
- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:
- [ ] Admin
- [ ] Documentation
- [ ] Framework
- [x] Plugin

<!-- Please note that all databases should be tested and confirmed to be working prior to the PR being merged. -->
#### Manual testing done on the following databases:
- [x] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
