### PR TITLE
Adding options to plugin upload for Cloudinary.

### DIFF
--- a/packages/strapi-plugin-upload/services/Upload.js
+++ b/packages/strapi-plugin-upload/services/Upload.js
@@ -77,7 +77,11 @@ module.exports = {
     // Execute upload function of the provider for all files.
     return Promise.all(
       files.map(async file => {
-        await actions.upload(file);
+        
+        // This should host the provider configuration
+        const options = {};
+
+        await actions.upload(file, options);
 
         // Remove buffer to don't save it.
         delete file.buffer;

--- a/packages/strapi-provider-upload-cloudinary/lib/index.js
+++ b/packages/strapi-provider-upload-cloudinary/lib/index.js
@@ -35,9 +35,10 @@ module.exports = {
     });
 
     return {
-      upload (file) {
+      upload (file, options) {
         return new Promise((resolve, reject) => {
-          const upload_stream = cloudinary.uploader.upload_stream({ resource_type: "auto" }, (err, image) => {
+          const opts = options.resource_type ? options : { resource_type: "auto", ...options };
+          const upload_stream = cloudinary.uploader.upload_stream(opts, (err, image) => {
             if (err) {
               return reject(err);
             }


### PR DESCRIPTION
> ⚠️ We have stopped merging PRs for now to the Strapi core.<br><br>
> The reason is that we are developing new architecture for the admin panel and for the plugins.<br>
> This new architecture will provide stability of the Strapi core as we approach the release of Beta.<br>
> We appreciate and welcome all your contributions, but until further notice, please do not submit a PR as it will not be merged.<br>
> Furthermore, you will have to rewrite it based on the new architecture.


<!-- ⚠️ Your PR title will appear in the changelogs please make it short detailed and understandable for all. -->

<!-- Write a short description of what your PR does and link the concerned issues of your update. -->
<!-- ⚠️ Please link issue(s) you close / fix by using GitHub keywords https://help.github.com/articles/closing-issues-using-keywords/ !-->
#### Description:
Cloudinary file upload is missing configuration options. This small change allow the user to easily create an option configuration that would be executed by Cloudinary:

```
const options = {
  transformation: { width: 800, height: 800, crop: "limit" },
  format: "jpg",
  quality: 80,
  folder: "my_folder"
};
```

Actually this is available just by hard coding the options, in future it would be great to move this into a configuration file or maybe into model.

<!-- Uncomment the correct contribution type. !-->

#### My PR is a:
- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix #issueNumber
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:
- [ ] Admin
- [ ] Documentation
- [ ] Framework
- [x] Plugin

<!-- Please note that all databases should be tested and confirmed to be working prior to the PR being merged. -->
#### Manual testing done on the following databases:
- [ ] Not applicable
- [x] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
