### PR TITLE
Remove version key from root package.json of the monorepo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "private": true,
-  "version": "3.0.0-alpha.26.2",
   "dependencies": {},
   "devDependencies": {
     "babel-eslint": "^10.0.1",


### PR DESCRIPTION
#### Description of what you did:

The version key in the root `package.jons` file is not necessary? We can remove it.

#### My PR is a:
- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [X] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:
- [ ] Admin
- [ ] Documentation
- [X] Framework
- [ ] Plugin

#### Manual testing done on the following databases:
- [X] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
