### PR TITLE
Add missing migration step mkdir extensions

### DIFF
--- a/docs/3.0.0-beta.x/migration-guide/migration-guide-alpha.26-to-beta.md
+++ b/docs/3.0.0-beta.x/migration-guide/migration-guide-alpha.26-to-beta.md
@@ -195,6 +195,8 @@ One of our main objectives for the `beta` is to make it easier and quicker to up
 
 [Read more](https://strapi.io/documentation/3.0.0-beta.x/concepts/concepts.html#files-structure)
 
+Let's start by creating a new folder called `./extensions`. This folder needs to exists even if empty. You can use a `.gitkeep` file to make sure the folder is versionned into your repository.
+
 ### Migrating non customized plugin
 
 If you installed a plugin but never modified any files inside `./plugins/pluginName/**/*`, you can remove the `./plugins/pluginName` folder.
@@ -663,15 +665,12 @@ If you only used the `administrator` role to give access to the admin panel to c
 
 If you haven't created any relation with the `User` model in your `Content Types` and don't use those users in your application business logic; you can remove every user you have migrated to the `strapi_administrator` collection.
 
-
 Finally, if you have chosen to migrate your previous admin users in the new `strapi_administrator` collection but your `User` model has at least one relation with another model, then you may need to keep both the `strapi_administrator` and `users-pemrissions_user` collection manually in sync.
-
 
 **Example**: Some of your application users can edit their profile and access the admin panel. If they change their email you need to make sure their `administrator` entity also changes email.
 ::: warning
 We really recommend separating you users from your administrators to avoid this situation which is not a good practice.
 :::
-
 
 ## Running your migrated project
 

--- a/docs/3.0.0-beta.x/migration-guide/migration-guide-alpha.26-to-beta.md
+++ b/docs/3.0.0-beta.x/migration-guide/migration-guide-alpha.26-to-beta.md
@@ -195,7 +195,7 @@ One of our main objectives for the `beta` is to make it easier and quicker to up
 
 [Read more](https://strapi.io/documentation/3.0.0-beta.x/concepts/concepts.html#files-structure)
 
-Let's start by creating a new folder called `./extensions`. This folder needs to exists even if empty. You can use a `.gitkeep` file to make sure the folder is versionned into your repository.
+Let's start by creating a new folder called `./extensions`. This folder needs to exist even if it's empty. You may use a `.gitkeep` file to ensure the folder isn't deleted from the repository (if it's empty) when cloning. [More details](https://davidwalsh.name/git-empty-directory).
 
 ### Migrating non customized plugin
 


### PR DESCRIPTION
<!--
⚠️ We have stopped merging new PRs, for now, into the Strapi core.
The reason is that we are developing a new architecture for both the admin panel and for the plugins.
This new architecture will provide stability to the Strapi core as we approach the release of Beta.
We appreciate and welcome all your contributions, but until further notice, please do not submit a PR as it will not be merged.
Furthermore, your pull request will have to be rewritten for the new architecture.
-->

<!--
Hello 👋 Thank you for submitting a pull request.

To help us to merge your PR please follow these bullet points:
- You wrote documentation
- You wrote tests
- Refer to the issue you are closing in your PR description - fix #issue
- Let us know if this PR is WIP or ready to merge
-->

#### Description of what you did:

Add `extensions` folder creating step in the migration guide

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:
- [ ] 💥 Breaking change
- [X] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:
- [ ] Admin
- [X] Documentation
- [ ] Framework
- [ ] Plugin

#### Manual testing done on the following databases:
- [X] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
