### PR TITLE
Remove graphql special condition for delete request

### DIFF
--- a/packages/strapi-plugin-graphql/services/Mutation.js
+++ b/packages/strapi-plugin-graphql/services/Mutation.js
@@ -43,17 +43,24 @@ module.exports = {
       const resolver = _.get(handler, `Mutation.${queryName}.resolver`);
 
       if (_.isString(resolver) || _.isPlainObject(resolver)) {
-        const { handler = resolver } = _.isPlainObject(resolver) ? resolver : {};
+        const { handler = resolver } = _.isPlainObject(resolver)
+          ? resolver
+          : {};
 
         // Retrieve the controller's action to be executed.
         const [name, action] = handler.split('.');
 
         const controller = plugin
-          ? _.get(strapi.plugins, `${plugin}.controllers.${_.toLower(name)}.${action}`)
+          ? _.get(
+              strapi.plugins,
+              `${plugin}.controllers.${_.toLower(name)}.${action}`
+            )
           : _.get(strapi.controllers, `${_.toLower(name)}.${action}`);
 
         if (!controller) {
-          return new Error(`Cannot find the controller's action ${name}.${action}`);
+          return new Error(
+            `Cannot find the controller's action ${name}.${action}`
+          );
         }
 
         // We're going to return a controller instead.
@@ -81,13 +88,17 @@ module.exports = {
       // We're going to return a controller instead.
       isController = true;
 
-      const controllers = plugin ? strapi.plugins[plugin].controllers : strapi.controllers;
+      const controllers = plugin
+        ? strapi.plugins[plugin].controllers
+        : strapi.controllers;
 
       // Try to find the controller that should be related to this model.
       const controller = _.get(controllers, `${name}.${action}`);
 
       if (!controller) {
-        return new Error(`Cannot find the controller's action ${name}.${action}`);
+        return new Error(
+          `Cannot find the controller's action ${name}.${action}`
+        );
       }
 
       // Push global policy to make sure the permissions will work as expected.
@@ -96,7 +107,7 @@ module.exports = {
         policyUtils.globalPolicy(
           undefined,
           {
-            handler: `${name}.${action === 'delete' ? 'destroy' : action}`,
+            handler: `${name}.${action}`,
           },
           undefined,
           plugin
@@ -121,11 +132,16 @@ module.exports = {
       const [name, action] = resolverOf.split('.');
 
       const controller = plugin
-        ? _.get(strapi.plugins, `${plugin}.controllers.${_.toLower(name)}.${action}`)
+        ? _.get(
+            strapi.plugins,
+            `${plugin}.controllers.${_.toLower(name)}.${action}`
+          )
         : _.get(strapi.controllers, `${_.toLower(name)}.${action}`);
 
       if (!controller) {
-        return new Error(`Cannot find the controller's action ${name}.${action}`);
+        return new Error(
+          `Cannot find the controller's action ${name}.${action}`
+        );
       }
 
       policiesFn[0] = policyUtils.globalPolicy(
@@ -144,7 +160,13 @@ module.exports = {
 
     // Populate policies.
     policies.forEach(policy =>
-      policyUtils.get(policy, plugin, policiesFn, `GraphQL query "${queryName}"`, name)
+      policyUtils.get(
+        policy,
+        plugin,
+        policiesFn,
+        `GraphQL query "${queryName}"`,
+        name
+      )
     );
 
     return async (obj, options, { context }) => {
@@ -159,7 +181,10 @@ module.exports = {
       const policy = await strapi.koaMiddlewares.compose(policiesFn)(ctx);
 
       // Policy doesn't always return errors but they update the current context.
-      if (_.isError(ctx.request.graphql) || _.get(ctx.request.graphql, 'isBoom')) {
+      if (
+        _.isError(ctx.request.graphql) ||
+        _.get(ctx.request.graphql, 'isBoom')
+      ) {
         return ctx.request.graphql;
       }
 
@@ -172,7 +197,8 @@ module.exports = {
       if (_.isFunction(resolver)) {
         context.params = Query.convertToParams(
           options.input.where || {},
-          (plugin ? strapi.plugins[plugin].models[name] : strapi.models[name]).primaryKey
+          (plugin ? strapi.plugins[plugin].models[name] : strapi.models[name])
+            .primaryKey
         );
         context.request.body = options.input.data || {};
 


### PR DESCRIPTION


#### Description:

If we make delete **GraphQL** request, this 
```
 policiesFn.push(
        policyUtils.globalPolicy(
          undefined,
          {
            handler: `${name}.${action === 'delete' ? 'destroy' : action}`,
          },
          undefined,
          plugin
        )
      );
```

replace "delete" on "destroy". 
In the beta version it is not necessary 

**Note**: test **graphqlCrud.test.e2e.js / Delete Posts** does not see this bug, because as running under admin rights.

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [ ] Documentation
- [ ] Framework
- [x] Plugin

#### Manual testing done on the following databases:

- [x] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
