### PR TITLE
Add status code handler to health checks

### DIFF
--- a/packages/strapi-helper-plugin/lib/src/utils/request.js
+++ b/packages/strapi-helper-plugin/lib/src/utils/request.js
@@ -91,7 +91,10 @@ function serverRestartWatcher(response) {
         'Keep-Alive': false,
       },
     })
-      .then(() => {
+      .then(res => {
+        if (res.status >= 400) {
+          throw new Error('not available');
+        }
         // Hide the global OverlayBlocker
         strapi.unlockApp();
         resolve(response);


### PR DESCRIPTION
#### Description of what you did:

When strapi is behind a proxy (nginx) you will get a 502 which isn't right now and displays an error message

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [X] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [X] Admin
- [ ] Documentation
- [ ] Framework
- [ ] Plugin

#### Manual testing done on the following databases:

- [X] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
