### PR TITLE
Replace _id by id for user API and generated API

### DIFF
--- a/examples/getstarted/api/post/config/routes.json
+++ b/examples/getstarted/api/post/config/routes.json
@@ -18,7 +18,7 @@
     },
     {
       "method": "GET",
-      "path": "/posts/:_id",
+      "path": "/posts/:id",
       "handler": "Post.findOne",
       "config": {
         "policies": []
@@ -34,7 +34,7 @@
     },
     {
       "method": "PUT",
-      "path": "/posts/:_id",
+      "path": "/posts/:id",
       "handler": "Post.update",
       "config": {
         "policies": []
@@ -42,7 +42,7 @@
     },
     {
       "method": "DELETE",
-      "path": "/posts/:_id",
+      "path": "/posts/:id",
       "handler": "Post.delete",
       "config": {
         "policies": []

--- a/examples/getstarted/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/examples/getstarted/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "05/22/2019 6:18:29 PM"
+    "x-generation-date": "06/13/2019 3:56:01 PM"
   },
   "x-strapi-config": {
     "path": "/documentation",
@@ -2917,7 +2917,7 @@
         "parameters": []
       }
     },
-    "/users/{_id}": {
+    "/users/{id}": {
       "get": {
         "deprecated": false,
         "description": "Retrieve a single user depending on his id",
@@ -2969,7 +2969,7 @@
         ],
         "parameters": [
           {
-            "name": "_id",
+            "name": "id",
             "in": "path",
             "description": "",
             "deprecated": false,
@@ -3031,7 +3031,7 @@
         ],
         "parameters": [
           {
-            "name": "_id",
+            "name": "id",
             "in": "path",
             "description": "",
             "deprecated": false,
@@ -3108,7 +3108,7 @@
         ],
         "parameters": [
           {
-            "name": "_id",
+            "name": "id",
             "in": "path",
             "description": "",
             "deprecated": false,

--- a/examples/getstarted/extensions/users-permissions/documentation/1.0.0/users-permissions-User.json
+++ b/examples/getstarted/extensions/users-permissions/documentation/1.0.0/users-permissions-User.json
@@ -895,7 +895,7 @@
         "parameters": []
       }
     },
-    "/users/{_id}": {
+    "/users/{id}": {
       "get": {
         "deprecated": false,
         "description": "Retrieve a single user depending on his id",
@@ -947,7 +947,7 @@
         ],
         "parameters": [
           {
-            "name": "_id",
+            "name": "id",
             "in": "path",
             "description": "",
             "deprecated": false,
@@ -1009,7 +1009,7 @@
         ],
         "parameters": [
           {
-            "name": "_id",
+            "name": "id",
             "in": "path",
             "description": "",
             "deprecated": false,
@@ -1086,7 +1086,7 @@
         ],
         "parameters": [
           {
-            "name": "_id",
+            "name": "id",
             "in": "path",
             "description": "",
             "deprecated": false,

--- a/packages/strapi-generate-api/json/routes.json.js
+++ b/packages/strapi-generate-api/json/routes.json.js
@@ -16,9 +16,6 @@ const _ = require('lodash');
 
 module.exports = scope => {
   function generateRoutes() {
-    const tokenID =
-      scope.args.tpl && scope.args.tpl !== 'mongoose' ? 'id' : '_id';
-
     const routes = {
       routes: [
         {
@@ -39,7 +36,7 @@ module.exports = scope => {
         },
         {
           method: 'GET',
-          path: '/' + scope.idPluralized + '/:' + tokenID,
+          path: '/' + scope.idPluralized + '/:id',
           handler: scope.globalID + '.findOne',
           config: {
             policies: [],
@@ -55,7 +52,7 @@ module.exports = scope => {
         },
         {
           method: 'PUT',
-          path: '/' + scope.idPluralized + '/:' + tokenID,
+          path: '/' + scope.idPluralized + '/:id',
           handler: scope.globalID + '.update',
           config: {
             policies: [],
@@ -63,7 +60,7 @@ module.exports = scope => {
         },
         {
           method: 'DELETE',
-          path: '/' + scope.idPluralized + '/:' + tokenID,
+          path: '/' + scope.idPluralized + '/:id',
           handler: scope.globalID + '.delete',
           config: {
             policies: [],

--- a/packages/strapi-plugin-upload/config/routes.json
+++ b/packages/strapi-plugin-upload/config/routes.json
@@ -65,7 +65,7 @@
     },
     {
       "method": "GET",
-      "path": "/files/:_id",
+      "path": "/files/:id",
       "handler": "Upload.findOne",
       "config": {
         "policies": [],
@@ -91,7 +91,7 @@
     },
     {
       "method": "DELETE",
-      "path": "/files/:_id",
+      "path": "/files/:id",
       "handler": "Upload.destroy",
       "config": {
         "policies": [],

--- a/packages/strapi-plugin-users-permissions/config/routes.json
+++ b/packages/strapi-plugin-users-permissions/config/routes.json
@@ -317,7 +317,7 @@
     },
     {
       "method": "GET",
-      "path": "/users/:_id",
+      "path": "/users/:id",
       "handler": "User.findOne",
       "config": {
         "policies": [],
@@ -341,7 +341,7 @@
     },
     {
       "method": "PUT",
-      "path": "/users/:_id",
+      "path": "/users/:id",
       "handler": "User.update",
       "config": {
         "policies": [],
@@ -356,7 +356,7 @@
     },
     {
       "method": "DELETE",
-      "path": "/users/:_id",
+      "path": "/users/:id",
       "handler": "User.destroy",
       "config": {
         "policies": [],

--- a/packages/strapi-plugin-users-permissions/controllers/User.js
+++ b/packages/strapi-plugin-users-permissions/controllers/User.js
@@ -17,7 +17,7 @@ module.exports = {
    */
 
   find: async (ctx, next, { populate } = {}) => {
-    let users;  
+    let users;
 
     if (_.has(ctx.query, '_q')) {
       // use core strapi query to search for users
@@ -169,7 +169,7 @@ module.exports = {
 
   destroy: async (ctx) => {
     const data = await strapi.plugins['users-permissions'].services.user.remove(ctx.params);
-    
+
     // Send 200 `ok`
     ctx.send(data);
   },


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

When you use SQL database (using bookshelf) the route param you send during the findOne, update and delete is `_id` so SQL database doesn't use it.

`id` will work for mongo and sql databases.

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix #3429
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [ ] Documentation
- [x] Framework
- [ ] Plugin

#### Manual testing done on the following databases:

- [ ] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
