### PR TITLE
fix: enable prefix

### DIFF
--- a/packages/strapi/lib/middlewares/router/index.js
+++ b/packages/strapi/lib/middlewares/router/index.js
@@ -22,12 +22,20 @@ module.exports = strapi => {
 
     initialize() {
       _.forEach(strapi.config.routes, value => {
+        const configPrefix = _.get(
+          strapi.config,
+          'currentEnvironment.request.router.prefix',
+          null
+        );
+        const routePrefix = _.get(value, 'config.prefix', null);
+        if (routePrefix) {
+          value.path = routePrefix + value.path;
+        } else if (configPrefix) {
+          value.path = configPrefix + value.path;
+        }
+
         composeEndpoint(value, null, strapi.router);
       });
-
-      strapi.router.prefix(
-        _.get(strapi.config, 'currentEnvironment.request.router.prefix', '')
-      );
 
       if (!_.isEmpty(_.get(strapi.admin, 'config.routes', false))) {
         // Create router for admin.


### PR DESCRIPTION
#### Description:

Solution for prefix logic.

see [#1398](https://github.com/strapi/strapi/issues/1398), [#1323](https://github.com/strapi/strapi/issues/1323)

1. **/admin** is work
2. global prefix **(config/enviroments/\<env>/request/ -> router.prefix)** is work
3. router's preifx **(api/\<model>/config/routes.json -> routes.[route_name].config.prefix)** is work

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [ ] Documentation
- [x] Framework
- [ ] Plugin

#### Manual testing done on the following databases:

- [x] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
