### PR TITLE
Requiring bootstrap.js before config loading

### DIFF
--- a/packages/strapi/lib/Strapi.js
+++ b/packages/strapi/lib/Strapi.js
@@ -4,6 +4,7 @@
 const http = require('http');
 const path = require('path');
 const { EventEmitter } = require('events');
+const fse = require('fs-extra');
 const Koa = require('koa');
 const _ = require('lodash');
 const { logger, models } = require('strapi-utils');
@@ -100,6 +101,17 @@ class Strapi extends EventEmitter {
     };
 
     this.fs = createStrapiFs(this);
+  }
+
+  requireProjectBootstrap() {
+    const bootstrapPath = path.resolve(
+      this.dir,
+      'config/functions/bootstrap.js'
+    );
+
+    if (fse.existsSync(bootstrapPath)) {
+      require(bootstrapPath);
+    }
   }
 
   async start(cb) {


### PR DESCRIPTION
#### Description of what you did:

In the alpha version when using the module `dotenv` in the bootstrap.js file it would allow the use of process.env.VAR in the config files. This happened because the templateParsing of the json files was executed after requiring all the files and not on file load like it is now on beta. 

To reenable this behavior without involving other changes this PR ensures bootstrap.js is required (not executed) just after the initialization of Strapi. 

This will also allow more global package loading if necessary.

We will be thinking about adding native support for dotenv and revamping the whole configuration system in a future release

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix (considering you could do sth in alpha and not in beta anymore)
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [ ] Documentation
- [x] Framework
- [ ] Plugin

#### Manual testing done on the following databases:

- [x] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
