### PR TITLE
Allow different envrionment names on config load

### DIFF
--- a/packages/strapi/lib/load/__tests__/check-reserved-filename.test.js
+++ b/packages/strapi/lib/load/__tests__/check-reserved-filename.test.js
@@ -1,0 +1,27 @@
+const checkReservedFilename = require('../check-reserved-filename');
+
+describe('check-reserved-filename', () => {
+  const table = [
+    // matches
+    ['config/functions.json', true],
+    ['config/functions/bootstrapi.js', true],
+    ['config/layout.json', true],
+    ['config/hook.json', true],
+    ['config/middleware.json', true],
+    ['config/environments/test/database.json', true],
+    ['config/environments/development/request.json', true],
+    ['config/environments/production/server.json', true],
+    ['config/environments/staging/response.json', true],
+    ['config/environments/qa/security.json', true],
+
+    // dont match
+    ['config/application.json', false],
+    ['config/custom.json', false],
+    ['config/environments/qa/custom.json', false],
+    ['config/environments/qa/other.json', false],
+  ];
+
+  test.each(table)('Path %s should return %s', (path, expected) => {
+    expect(checkReservedFilename(path)).toBe(expected);
+  });
+});

--- a/packages/strapi/lib/load/check-reserved-filename.js
+++ b/packages/strapi/lib/load/check-reserved-filename.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const _ = require('lodash');
+const minimatch = require('minimatch');
+
+const envMatcher = new minimatch.Minimatch(
+  'config/environments/*/+(request|database|server|security|response).+(json|js)'
+);
+
+// files to load with filename key
+const prefixedPaths = [
+  'functions',
+  'policies',
+  'locales',
+  'hook',
+  'middleware',
+  'language',
+  'queries',
+  'layout',
+];
+
+module.exports = function checkReservedFilenames(file) {
+  if (envMatcher.match(file)) return true;
+  return _.some(prefixedPaths, e => file.indexOf(`config/${e}`) >= 0)
+    ? true
+    : false;
+};

--- a/packages/strapi/lib/load/load-config-files.js
+++ b/packages/strapi/lib/load/load-config-files.js
@@ -1,6 +1,8 @@
-const _ = require('lodash');
+'use strict';
+
 const loadFiles = require('./load-files');
 const requireFileAndParse = require('./require-file-parse');
+const checkReservedFilename = require('./check-reserved-filename');
 
 /**
  * @param {string} dir - directory from which to load configs
@@ -9,38 +11,11 @@ const requireFileAndParse = require('./require-file-parse');
 const laodConfigFiles = (dir, pattern = 'config/**/*.+(js|json)') =>
   loadFiles(dir, pattern, {
     requireFn: requireFileAndParse,
-    shouldUseFileNameAsKey,
+    shouldUseFileNameAsKey: checkReservedFilename,
     globArgs: {
       // used to load .init.json at first startup
-      dot: true
+      dot: true,
     },
   });
-
-const shouldUseFileNameAsKey = file => {
-  return _.some(prefixedPaths, e => file.indexOf(`config/${e}`) >= 0)
-    ? true
-    : false;
-};
-
-// files to load with filename key
-const prefixedPaths = [
-  ...['staging', 'production', 'development'].reduce((acc, env) => {
-    return acc.concat(
-      `environments/${env}/database`,
-      `environments/${env}/security`,
-      `environments/${env}/request`,
-      `environments/${env}/response`,
-      `environments/${env}/server`
-    );
-  }, []),
-  'functions',
-  'policies',
-  'locales',
-  'hook',
-  'middleware',
-  'language',
-  'queries',
-  'layout',
-];
 
 module.exports = laodConfigFiles;

--- a/packages/strapi/lib/load/load-files.js
+++ b/packages/strapi/lib/load/load-files.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const path = require('path');
 const glob = require('./glob');
 const _ = require('lodash');

--- a/packages/strapi/package.json
+++ b/packages/strapi/package.json
@@ -38,6 +38,7 @@
     "koa-session": "^5.5.1",
     "koa-static": "^4.0.1",
     "lodash": "^4.17.5",
+    "minimatch": "^3.0.4",
     "node-fetch": "^1.7.3",
     "node-machine-id": "^1.1.10",
     "node-schedule": "^1.2.0",


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

Fixes #3449 when starting an app with a different env than dev/prod or staging it broke because it didn't load correctly the env files in environments/*/

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [X] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [ ] Documentation
- [X] Framework
- [ ] Plugin

#### Manual testing done on the following databases:

- [X] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
