### PR TITLE
Only use keys from settings.json to create documentation files

### DIFF
--- a/packages/strapi/lib/Strapi.js
+++ b/packages/strapi/lib/Strapi.js
@@ -266,8 +266,9 @@ class Strapi extends EventEmitter {
      * Handle plugin extensions
      */
     // merge extensions config folders
-    _.mergeWith(this.plugins, extensions.merges, (objValue, srcValue) => {
-      if (_.isArray(srcValue) && _.isArray(objValue)) {
+    _.mergeWith(this.plugins, extensions.merges, (objValue, srcValue, key) => {
+      // concat routes
+      if (_.isArray(srcValue) && _.isArray(objValue) && key === 'routes') {
         return srcValue.concat(objValue);
       }
     });


### PR DESCRIPTION
#### Description of what you did:

- Make sure to only use the right keys in the documentation file.
- Fix the extensions config merge strategy (only concat array for routes)

Fixes #3455

#### My PR is a:

- [ ] 💥 Breaking change
- [X] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [ ] Documentation
- [ ] Framework
- [X] Plugin

#### Manual testing done on the following databases:

- [X] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
