### PR TITLE
Fix crash caused by strapi-plugin-users-permissions

### DIFF
--- a/packages/strapi-plugin-users-permissions/services/UsersPermissions.js
+++ b/packages/strapi-plugin-users-permissions/services/UsersPermissions.js
@@ -130,7 +130,7 @@ module.exports = {
           },
         },
         (err, response, body) => {
-          if (response.statusCode !== 200 || err) {
+          if (err || response.statusCode !== 200) {
             return resolve([]);
           }
 


### PR DESCRIPTION


<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:
When request to https://marketplace.strapi.io/plugins occurs a connection error, the `response` was `undefined` which cause app crash.

```javascript
  getPlugins: (plugin, lang = 'en') => {
    return new Promise(resolve => {
      request(
        {
          uri: `https://marketplace.strapi.io/plugins?lang=${lang}`,
          json: true,
          headers: {
            'cache-control': 'max-age=3600',
          },
        },
        (err, response, body) => {
          if (response.statusCode !== 200 || err) { // when connection error occurs, response was undefined
            return resolve([]);
          }
```

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [ ] Documentation
- [ ] Framework
- [x] Plugin

#### Manual testing done on the following databases:

- [x] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
