### PR TITLE
Temporary fix for GraphQL variables not being loaded

### DIFF
--- a/packages/strapi-plugin-graphql/package.json
+++ b/packages/strapi-plugin-graphql/package.json
@@ -14,7 +14,7 @@
     "apollo-server-koa": "^2.5.0",
     "dataloader": "^1.4.0",
     "glob": "^7.1.4",
-    "graphql": "^14.3.0",
+    "graphql": "14.3.1",
     "graphql-depth-limit": "^1.1.0",
     "graphql-playground-middleware-koa": "^1.6.12",
     "graphql-tools": "^4.0.4",


### PR DESCRIPTION
#### Description of what you did:

Fix for variables in GraphQL with latest version, hard coded to 14.3.1 version instead of allowing npm/yarn to install the latest.

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix #3537
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [ ] Documentation
- [ ] Framework
- [x] Plugin

#### Manual testing done on the following databases:

- [ ] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
