### PR TITLE
Fix doc header's link blog & slack

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -64,6 +64,8 @@ module.exports = {
     ],
     repo: 'strapi/strapi',
     website: 'https://strapi.io',
+    slack: 'https://slack.strapi.io',
+    blog: 'https://blog.strapi.io',
     docsDir: 'docs',
     algolia: {
       apiKey: 'a93451de224096fb34471c8b8b049de7',


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

In the documentation **Blog** and **Slack** links in the header was not available.
So I added VuePress configurations to add them.
This PR fix #3559 issue

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [x] Documentation
- [ ] Framework
- [ ] Plugin

#### Manual testing done on the following databases:

- [x] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
