### PR TITLE
Add null and not null filters

### DIFF
--- a/docs/3.0.0-beta.x/guides/filters.md
+++ b/docs/3.0.0-beta.x/guides/filters.md
@@ -31,6 +31,7 @@ Filters are used as a suffix of a field name:
 - `ncontains`: Doesn't contain
 - `containss`: Contains case sensitive
 - `ncontainss`: Doesn't contain case sensitive
+- `null`: Is null/Is not null
 
 #### Examples
 

--- a/docs/3.0.0-beta.x/guides/graphql.md
+++ b/docs/3.0.0-beta.x/guides/graphql.md
@@ -199,6 +199,7 @@ You can also apply different parameters to the query to make more complex querie
   - `<field>_containss`: Contains sensitive.
   - `<field>_in`: Matches any value in the array of values.
   - `<field>_nin`: Doesn't match any value in the array of values.
+  - `<field>_null`: Equals null/Not equals null
 
 Return the second decade of users which have an email that contains `@strapi.io` ordered by username.
 
@@ -694,7 +695,6 @@ module.exports = {
 ```
 
 In this example, the policy `isAuthenticated` located in the `users-permissions` plugin will be executed first. Then, the `isOwner` policy located in the `Post` API `./api/post/config/policies/isOwner.js`. Next, it will execute the `logging` policy located in `./config/policies/logging.js`. Finally, the resolver will be executed.
-
 
 ::: note
 There is no custom resolver in that case, so it will execute the default resolver (Post.find) provided by the Shadow CRUD feature.

--- a/docs/3.0.0-beta.x/guides/restapi.md
+++ b/docs/3.0.0-beta.x/guides/restapi.md
@@ -28,6 +28,7 @@ Easily filter results according to fields values.
  - `_containss`: Contains case sensitive
  - `_in`: Matches any value in the array of values
  - `_nin`: Doesn't match any value in the array of values
+ - `_null`: Equals null/Not equals null
 
 #### Examples
 

--- a/packages/strapi-hook-bookshelf/lib/buildQuery.js
+++ b/packages/strapi-hook-bookshelf/lib/buildQuery.js
@@ -245,6 +245,9 @@ const buildWhereClause = ({ qb, field, operator, value }) => {
       return qb.where(field, 'like', `%${value}%`);
     case 'ncontainss':
       return qb.whereNot(field, 'like', `%${value}%`);
+    case 'null': {
+      return value ? qb.whereNull(field) : qb.whereNotNull(field);
+    }
 
     default:
       throw new Error(`Unhandled whereClause : ${field} ${operator} ${value}`);

--- a/packages/strapi-hook-mongoose/lib/buildQuery.js
+++ b/packages/strapi-hook-mongoose/lib/buildQuery.js
@@ -438,6 +438,9 @@ const buildWhereClause = ({ field, operator, value }) => {
           $not: new RegExp(val),
         },
       };
+    case 'null': {
+      return value ? { [field]: { $eq: null } } : { [field]: { $ne: null } };
+    }
 
     default:
       throw new Error(`Unhandled whereClause : ${field} ${operator} ${value}`);

--- a/packages/strapi-plugin-graphql/test/graphqlCrud.test.e2e.js
+++ b/packages/strapi-plugin-graphql/test/graphqlCrud.test.e2e.js
@@ -25,6 +25,12 @@ const postModel = {
         type: 'biginteger',
       },
     },
+    {
+      name: 'nullable',
+      params: {
+        type: 'string',
+      },
+    },
   ],
   connection: 'default',
   name: 'post',
@@ -54,8 +60,8 @@ describe('Test Graphql API End to End', () => {
 
   describe('Test CRUD', () => {
     const postsPayload = [
-      { name: 'post 1', bigint: 1316130638171 },
-      { name: 'post 2', bigint: 1416130639261 },
+      { name: 'post 1', bigint: 1316130638171, nullable: 'value' },
+      { name: 'post 2', bigint: 1416130639261, nullable: null },
     ];
     let data = {
       posts: [],
@@ -69,6 +75,7 @@ describe('Test Graphql API End to End', () => {
               post {
                 name
                 bigint
+                nullable
               }
             }
           }
@@ -100,6 +107,7 @@ describe('Test Graphql API End to End', () => {
               id
               name
               bigint
+              nullable
             }
           }
         `,
@@ -126,6 +134,7 @@ describe('Test Graphql API End to End', () => {
               id
               name
               bigint
+              nullable
             }
           }
         `,
@@ -147,6 +156,7 @@ describe('Test Graphql API End to End', () => {
               id
               name
               bigint
+              nullable
             }
           }
         `,
@@ -168,6 +178,7 @@ describe('Test Graphql API End to End', () => {
               id
               name
               bigint
+              nullable
             }
           }
         `,
@@ -229,13 +240,25 @@ describe('Test Graphql API End to End', () => {
       ],
       [
         {
-          name_in: ['post 1', 'post 2'],
+          name_in: ['post 1', 'post 2', 'post 3'],
         },
         postsPayload,
       ],
       [
         {
           name_nin: ['post 2'],
+        },
+        [postsPayload[0]],
+      ],
+      [
+        {
+          nullable_null: true,
+        },
+        [postsPayload[1]],
+      ],
+      [
+        {
+          nullable_null: false,
         },
         [postsPayload[0]],
       ],
@@ -246,6 +269,7 @@ describe('Test Graphql API End to End', () => {
             posts(where: $where) {
               name
               bigint
+              nullable
             }
           }
         `,
@@ -278,6 +302,7 @@ describe('Test Graphql API End to End', () => {
               id
               name
               bigint
+              nullable
             }
           }
         `,

--- a/packages/strapi-utils/lib/__tests__/convertRestQueryParams.test.js
+++ b/packages/strapi-utils/lib/__tests__/convertRestQueryParams.test.js
@@ -365,5 +365,33 @@ describe('convertRestQueryParams', () => {
         ],
       });
     });
+
+    test('Null', () => {
+      expect(
+        convertRestQueryParams({ 'content.text_null': true })
+      ).toMatchObject({
+        where: [
+          {
+            field: 'content.text',
+            operator: 'null',
+            value: true,
+          },
+        ],
+      });
+    });
+
+    test('Not Null', () => {
+      expect(
+        convertRestQueryParams({ 'content.text_null': false })
+      ).toMatchObject({
+        where: [
+          {
+            field: 'content.text',
+            operator: 'null',
+            value: false,
+          },
+        ],
+      });
+    });
   });
 });

--- a/packages/strapi-utils/lib/buildQuery.js
+++ b/packages/strapi-utils/lib/buildQuery.js
@@ -66,7 +66,7 @@ const castValueToType = ({ type, value }) => {
         return false;
       }
 
-      return value;
+      return Boolean(value);
     }
     case 'integer':
     case 'biginteger':
@@ -79,6 +79,17 @@ const castValueToType = ({ type, value }) => {
   }
 };
 
+/**
+ * Cast basic values based on attribute type
+ * @param {Object} options - Options
+ * @param {string} options.type - type of the atribute
+ * @param {*} options.value - value tu cast
+ * @param {string} options.operator - name of operator
+ */
+const castValue = ({ type, value, operator}) => {
+  if (operator === 'null')  return castValueToType({ type: 'boolean', value })
+  return castValueToType({ type, value})
+}
 /**
  *
  * @param {Object} options - Options
@@ -109,8 +120,8 @@ const buildQuery = ({ model, filters = {}, ...rest }) => {
 
         // cast value or array of values
         const castedValue = Array.isArray(value)
-          ? value.map(val => castValueToType({ type, value: val }))
-          : castValueToType({ type, value: value });
+            ? value.map(val => castValue({ type, operator, value: val }))
+            : castValue({ type, operator, value: value });
 
         return { field, operator, value: castedValue };
       });

--- a/packages/strapi-utils/lib/convertRestQueryParams.js
+++ b/packages/strapi-utils/lib/convertRestQueryParams.js
@@ -132,6 +132,7 @@ const VALID_OPERATORS = [
   'lte',
   'gt',
   'gte',
+  'null',
 ];
 
 /**

--- a/packages/strapi/__tests__/filtering.test.e2e.js
+++ b/packages/strapi/__tests__/filtering.test.e2e.js
@@ -81,6 +81,14 @@ const productFixtures = [
     rank: 91,
     big_rank: 926372323421,
   },
+  {
+    name: 'Product 4',
+    description: 'Product description 4',
+    price: null,
+    decimal_field: 12.22,
+    rank: 99,
+    big_rank: 999999999999,
+  },
 ];
 
 async function createFixtures() {
@@ -191,6 +199,35 @@ describe('Filtering API', () => {
         expect(res.body).toEqual(
           expect.not.arrayContaining([data.products[0]])
         );
+      });
+    });
+
+    describe('Filter null', () => {
+      test('Should return only one match', async () => {
+        const res = await rq({
+          method: 'GET',
+          url: '/products',
+          qs: {
+            price_null: true,
+          },
+        });
+
+        expect(Array.isArray(res.body)).toBe(true);
+        expect(res.body.length).toBe(1);
+        expect(res.body[0]).toMatchObject(data.products[3]);
+      });
+
+      test('Should return three matches', async () => {
+        const res = await rq({
+          method: 'GET',
+          url: '/products',
+          qs: {
+            price_null: false,
+          },
+        });
+
+        expect(Array.isArray(res.body)).toBe(true);
+        expect(res.body.length).toBe(3);
       });
     });
 
@@ -985,11 +1022,14 @@ describe('Filtering API', () => {
         },
       });
 
-      expect(res.body).toEqual([
+      [
+        data.products[3],
         data.products[0],
         data.products[2],
         data.products[1],
-      ]);
+      ].forEach(expectedPost => {
+        expect(res.body).toEqual(expect.arrayContaining([expectedPost]));
+      });
     });
   });
 


### PR DESCRIPTION
#### Description of what you did:

This is working progress. @alexandrebodin ask me to open this, so he can help me on the development.

Knex (SQL) works. MongoDB not yet.

https://portal.productboard.com/strapi/1-public-roadmap/c/57-filter-on-null-value-in-the-generated-api

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [ ] Documentation
- [x] Framework
- [ ] Plugin

#### Manual testing done on the following databases:

- [ ] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [x] SQLite

