### PR TITLE
Fix styling on content type builder left menu list

### DIFF
--- a/packages/strapi-plugin-content-type-builder/admin/src/components/LeftMenuSection/styles.scss
+++ b/packages/strapi-plugin-content-type-builder/admin/src/components/LeftMenuSection/styles.scss
@@ -5,5 +5,6 @@
     margin: 1rem 0 0 -1.5rem;
     padding: 0;
     font-size: 1.3rem;
+    list-style-type: none;
   }
 }


### PR DESCRIPTION
#### Description of what you did:

Previously the lists in the Content Type Builder (e.g. Content Types
section) had bullet points still. This was hard to see as they're a
similar colour to the background behind them, but could be seen more
clearly when the page had enough content to enable scrolling.

This fixes that issue.

Previous behaviour:

![2019-07-04 13 31 58](https://user-images.githubusercontent.com/1713859/60668284-81e91d80-9e63-11e9-8331-71105c197b1d.gif)

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [x] Admin
- [ ] Documentation
- [ ] Framework
- [ ] Plugin

#### Manual testing done on the following databases:

- [x] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
