### PR TITLE
Fix content manager json parsing strategy

### DIFF
--- a/examples/getstarted/api/articles/models/Articles.settings.json
+++ b/examples/getstarted/api/articles/models/Articles.settings.json
@@ -14,15 +14,21 @@
     "comment": ""
   },
   "attributes": {
-    "content2": {
+    "title": {
+      "type": "string"
+    },
+    "content": {
       "type": "text"
+    },
+    "published": {
+      "type": "boolean"
+    },
+    "value": {
+      "type": "integer"
     },
     "posts": {
       "collection": "post",
       "via": "articles"
-    },
-    "title": {
-      "type": "string"
     },
     "image": {
       "model": "file",

--- a/examples/getstarted/config/environments/development/database.js
+++ b/examples/getstarted/config/environments/development/database.js
@@ -22,6 +22,19 @@ const postgres = {
   options: {},
 };
 
+const mysql = {
+  connector: 'strapi-hook-bookshelf',
+  settings: {
+    client: 'mysql',
+    database: 'strapi',
+    username: 'strapi',
+    password: 'strapi',
+    port: 3306,
+    host: 'localhost',
+  },
+  options: {},
+};
+
 const mongo = {
   connector: 'strapi-hook-mongoose',
   settings: {
@@ -35,6 +48,7 @@ const mongo = {
 };
 
 const db = {
+  mysql,
   sqlite,
   postgres,
   mongo,

--- a/examples/getstarted/exports/graphql/schema.graphql
+++ b/examples/getstarted/exports/graphql/schema.graphql
@@ -2,16 +2,20 @@ type Articles {
   id: ID!
   created_at: DateTime!
   updated_at: DateTime!
-  content2: String
   title: String
+  content: String
+  published: Boolean
+  value: Int
   image: UploadFile
   posts(sort: String, limit: Int, start: Int, where: JSON): [Post]
 }
 
 input ArticlesInput {
-  content2: String
-  posts: [ID]
   title: String
+  content: String
+  published: Boolean
+  value: Int
+  posts: [ID]
   image: ID
 }
 
@@ -85,9 +89,11 @@ type deleteUserPayload {
 }
 
 input editArticlesInput {
-  content2: String
-  posts: [ID]
   title: String
+  content: String
+  published: Boolean
+  value: Int
+  posts: [ID]
   image: ID
 }
 

--- a/examples/getstarted/package.json
+++ b/examples/getstarted/package.json
@@ -14,6 +14,7 @@
     "lodash": "^4.17.5",
     "pg": "^7.10.0",
     "sqlite3": "^4.0.6",
+    "mysql": "^2.17.1",
     "strapi": "3.0.0-beta.10",
     "strapi-admin": "3.0.0-beta.10",
     "strapi-hook-bookshelf": "3.0.0-beta.10",

--- a/packages/strapi-plugin-content-manager/services/ContentManager.js
+++ b/packages/strapi-plugin-content-manager/services/ContentManager.js
@@ -77,7 +77,7 @@ module.exports = {
       const parser = value => {
         try {
           const parsed = JSON.parse(value);
-          // if we parse a a value and it is still a string leave it as is
+          // if we parse a value and it is still a string leave it as is
           if (typeof parsed !== 'string') {
             value = parsed;
           }

--- a/packages/strapi-plugin-content-manager/services/ContentManager.js
+++ b/packages/strapi-plugin-content-manager/services/ContentManager.js
@@ -77,8 +77,8 @@ module.exports = {
       const parser = value => {
         try {
           const parsed = JSON.parse(value);
-          // do not modify initial value if it is string except 'null'
-          if (_.isObject(parsed) || _.isNull(parsed)) {
+          // if we parse a a value and it is still a string leave it as is
+          if (typeof parsed !== 'string') {
             value = parsed;
           }
         } catch (e) {
@@ -140,7 +140,7 @@ module.exports = {
         try {
           const parsed = JSON.parse(value);
           // do not modify initial value if it is string except 'null'
-          if (_.isObject(parsed) || _.isNull(parsed)) {
+          if (typeof parsed !== 'string') {
             value = parsed;
           }
         } catch (e) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3515,7 +3515,7 @@ big.js@^5.2.2:
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
   integrity sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==
 
-bignumber.js@^7.0.0:
+bignumber.js@7.2.1, bignumber.js@^7.0.0:
   version "7.2.1"
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-7.2.1.tgz#80c048759d826800807c4bfd521e50edbba57a5f"
   integrity sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ==
@@ -11834,6 +11834,16 @@ mute-stream@~0.0.4:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
 
+mysql@^2.17.1:
+  version "2.17.1"
+  resolved "https://registry.yarnpkg.com/mysql/-/mysql-2.17.1.tgz#62bba4a039a9b2f73638cd1652ce50fc6f682899"
+  integrity sha512-7vMqHQ673SAk5C8fOzTG2LpPcf3bNt0oL3sFpxPEEFp1mdlDcrLK0On7z8ZYKaaHrHwNcQ/MTUz7/oobZ2OyyA==
+  dependencies:
+    bignumber.js "7.2.1"
+    readable-stream "2.3.6"
+    safe-buffer "5.1.2"
+    sqlstring "2.3.1"
+
 mz@^2.4.0, mz@^2.6.0, mz@^2.7.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/mz/-/mz-2.7.0.tgz#95008057a56cafadc2bc63dde7f9ff6955948e32"
@@ -15004,7 +15014,7 @@ read@1, read@~1.0.1:
   dependencies:
     mute-stream "~0.0.4"
 
-"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.0, readable-stream@^2.3.3, readable-stream@^2.3.5, readable-stream@^2.3.6, readable-stream@~2.3.6:
+"readable-stream@1 || 2", readable-stream@2.3.6, readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.0, readable-stream@^2.3.3, readable-stream@^2.3.5, readable-stream@^2.3.6, readable-stream@~2.3.6:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
   integrity sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==
@@ -16806,6 +16816,11 @@ sqlite3@^4.0.6:
     nan "^2.12.1"
     node-pre-gyp "^0.11.0"
     request "^2.87.0"
+
+sqlstring@2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/sqlstring/-/sqlstring-2.3.1.tgz#475393ff9e91479aea62dcaf0ca3d14983a7fb40"
+  integrity sha1-R1OT/56RR5rqYtyvDKPRSYOn+0A=
 
 squeak@^1.0.0:
   version "1.3.0"


### PR DESCRIPTION
#### Description of what you did:

The PR #3356 introduced bugs when parsing booleans and numbers. I'm changing the strategy to use the parsed value correctly and only ignore it if the parsed value is a string.

Fix #3588

#### My PR is a:

- [ ] 💥 Breaking change
- [X] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [ ] Documentation
- [ ] Framework
- [X] Plugin

#### Manual testing done on the following databases:

- [ ] Not applicable
- [ ] MongoDB
- [X] MySQL
- [] Postgres
- [X] SQLite
