### PR TITLE
Update koa2-ratelimit to latest version

### DIFF
--- a/packages/strapi-plugin-users-permissions/package.json
+++ b/packages/strapi-plugin-users-permissions/package.json
@@ -18,7 +18,7 @@
     "immutable": "^3.8.2",
     "invariant": "^2.2.1",
     "jsonwebtoken": "^8.1.0",
-    "koa2-ratelimit": "^0.6.1",
+    "koa2-ratelimit": "^0.9.0",
     "lodash": "^4.17.11",
     "purest": "^2.0.1",
     "react": "^16.0.0",


### PR DESCRIPTION
#### Description of what you did:

`npm audit` is throwing some vulnerabilities coming from `koa2-ratelimit` package. Testing updating to the latest version `0.9.0`

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [ ] Documentation
- [ ] Framework
- [x] Plugin

#### Manual testing done on the following databases:

- [ ] Not applicable
- [ ] MongoDB
- [x] MySQL
- [x] Postgres
- [x] SQLite
