### PR TITLE
add attribute definition for timestamp fields

### DIFF
--- a/packages/strapi-hook-mongoose/lib/index.js
+++ b/packages/strapi-hook-mongoose/lib/index.js
@@ -136,6 +136,9 @@ module.exports = function(strapi) {
               // This is not an error if the file is not found.
             }
 
+            // BUG: this is NO OP!
+            // Object.key takes a single parameter: this looks like it should be
+            // Object.keys(options).forEach( key => instance.set(key, options[key]))
             Object.keys(options, key => instance.set(key, options[key]));
 
             const mountModels = (models, target, plugin = false) => {
@@ -336,6 +339,21 @@ module.exports = function(strapi) {
                           : false,
                       );
                     }
+                    // add attribute definition for timestamp fields
+                    if (_.get(definition, 'options.timestamps')) {
+                      // either array or false
+                      definition.attributes[
+                        _.get(definition, 'options.timestamps[0]')
+                      ] = {
+                        type: 'timestamp',
+                      };
+                      definition.attributes[
+                        _.get(definition, 'options.timestamps[1]')
+                      ] = {
+                        type: 'timestampUpdate',
+                      };
+                    }
+                    
                     collection.schema.set(
                       'minimize',
                       _.get(definition, 'options.minimize', false) === true,
@@ -791,7 +809,7 @@ module.exports = function(strapi) {
             result.value = _.castArray(value);
             break;
           default:
-            result = undefined;
+            result = undefined; // BUG: result is const
         }
 
         return result;


### PR DESCRIPTION
fix #3595 

#### Description of what you did:

This commit adds the attribute definition for timestamp fields to allAttributes for mongodb. 
It allows querying by updatedAt or createdAt.

I've also marked two potential code smells/bugs

#### My PR is a:

- [ ] 💥 Breaking change
- [X] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [ ] Documentation
- [ ] Framework
- [X] Plugin `strapi-hook-mongoose`

#### Manual testing done on the following databases:

- [ ] Not applicable
- [X] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite

I couldn't properly test because:

- strapi's code formatting allows trailing commas in argument lists, which VSCode automatically and silently removes. It's the first time I see such a weird code convention, and it looks like a bug to me to write: `console.log(whatever,)`. I don't know how to provide a clean commit which respects your code conventions, I had to redo my edits directly in github!
- I don't know how to test my update from the source repo. I did test it by patching my node_modules on `3.0.0-alpha-26.2`