### PR TITLE
Force relationnal updates to be done before main model update

### DIFF
--- a/packages/strapi-hook-bookshelf/lib/relations.js
+++ b/packages/strapi-hook-bookshelf/lib/relations.js
@@ -240,22 +240,18 @@ module.exports = {
       return acc;
     }, {});
 
-    if (!_.isEmpty(values)) {
-      relationUpdates.push(
-        this
-          .forge({
-            [this.primaryKey]: getValuePrimaryKey(params, this.primaryKey)
-          })
-          .save(values, {
-            patch: true
-          })
-      );
-    } else {
-      relationUpdates.push(Promise.resolve(_.assign(response, params.values)));
-    }
-
-    // Update virtuals fields.
+    // Update fields in other collections.
     await Promise.all(relationUpdates);
+
+    if (!_.isEmpty(values)) {
+      await this
+        .forge({
+          [this.primaryKey]: getValuePrimaryKey(params, this.primaryKey)
+        })
+        .save(values, {
+          patch: true
+        });
+    }
 
     return await this
       .forge({


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

The updates on relation were executed in concurrency with the update of the model data. This should cause issue at first sight but some of the relational updates clear some of the main model columns for certain relations (e.g https://github.com/strapi/strapi/issues/3565) 

This Fix should probably fix quite a few issues we have add with relations not appearing randomly (image upload for example)

Fixes https://github.com/strapi/strapi/issues/3565

#### My PR is a:

- [ ] 💥 Breaking change
- [X] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [ ] Documentation
- [X] Framework
- [ ] Plugin

#### Manual testing done on the following databases:

- [ ] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [X] SQLite
