### PR TITLE
Update customize-admin in beta documentation

### DIFF
--- a/docs/3.0.0-beta.x/advanced/customize-admin.md
+++ b/docs/3.0.0-beta.x/advanced/customize-admin.md
@@ -33,6 +33,20 @@ The panel will be available through [http://localhost:1337/dashboard](http://loc
 
 **_Currently not available_**
 
+### Styles
+
+Admin part can be easily found in `./node_modules/strapi-admin/src/`.
+
+For example, to change the top-left displayed admin panel's color, `./node_modules/strapi-admin/admin/src/components/LeftMenuHeader/styles.scss` should be overriden by `./admin/src/components/LeftMenuHeader/styles.scss` with your own styles.
+
+Thus, you are replacing the files that would normally be in `node_modules/strapi-admin/admin/src` and directing them to `admin/src/some/file/path`.
+
+To apply your changes you need to rebuild your admin panel
+
+```
+npm run build
+```
+
 ### Logo
 
 To change the top-left displayed admin panel's logo, add your custom image at `./admin/src/assets/images/logo-strapi.png`.

--- a/docs/3.0.0-beta.x/advanced/customize-admin.md
+++ b/docs/3.0.0-beta.x/advanced/customize-admin.md
@@ -35,7 +35,7 @@ The panel will be available through [http://localhost:1337/dashboard](http://loc
 
 ### Styles
 
-Admin part can be easily found in `./node_modules/strapi-admin/src/`.
+The AdminUI package source can be easily found in `./node_modules/strapi-admin/src/`.
 
 For example, to change the top-left displayed admin panel's color, `./node_modules/strapi-admin/admin/src/components/LeftMenuHeader/styles.scss` should be overriden by `./admin/src/components/LeftMenuHeader/styles.scss` with your own styles.
 


### PR DESCRIPTION
#### Description of what you did:

Hello. I am currently working on Strapi. After migrating from alpha to beta version, we do not have `admin` directory anymore. I wanted to customize some styles of Admin panel, but the beta documentation does not provide it in details. Therefore, I would like to update it based on my figured solution, it would help beginners in the same case.

fixes #3604 

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [x] Documentation
- [ ] Framework
- [ ] Plugin

#### Manual testing done on the following databases:

- [ ] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
