### PR TITLE
Fix missing connector in generated database.json files

### DIFF
--- a/packages/strapi-generate-new/lib/resources/json/database.json.js
+++ b/packages/strapi-generate-new/lib/resources/json/database.json.js
@@ -1,5 +1,4 @@
 'use strict';
-const { merge } = require('lodash');
 
 module.exports = ({ connection, env }) => {
   // Production/Staging Template
@@ -26,10 +25,11 @@ module.exports = ({ connection, env }) => {
     return {
       defaultConnection: 'default',
       connections: {
-        default: merge({
+        default: {
+          connector: connection.connector,
           settings: settingsBase,
           options: optionsBase,
-        }),
+        },
       },
     };
   }


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

When generating a new strapi application the database.json file generated for `production`and `staging` didn't contain the connector field.

Fixes #3600 
<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [X] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [ ] Documentation
- [X] Framework
- [ ] Plugin

#### Manual testing done on the following databases:

- [X] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
