### PR TITLE
Fix graphql me query on sql databases

### DIFF
--- a/packages/strapi-plugin-users-permissions/config/schema.graphql
+++ b/packages/strapi-plugin-users-permissions/config/schema.graphql
@@ -6,7 +6,7 @@ module.exports = {
   },
   definition: `
     type UsersPermissionsMe {
-      _id: ID!
+      id: ID!
       username: String!
       email: String!
       confirmed: Boolean
@@ -15,7 +15,7 @@ module.exports = {
     }
 
     type UsersPermissionsMeRole {
-      _id: ID!
+      id: ID!
       name: String!
       description: String
       type: String

--- a/packages/strapi-plugin-users-permissions/config/schema.graphql
+++ b/packages/strapi-plugin-users-permissions/config/schema.graphql
@@ -25,6 +25,11 @@ module.exports = {
     me: UsersPermissionsMe
   `,
   resolver: {
+    UsersPermissionsMe: {
+      id(obj) {
+        return obj.id || obj._id;
+      },
+    },
     Query: {
       me: {
         resolverOf: 'User.me',


### PR DESCRIPTION
#### Description of what you did:

The schema for GraphQL in the users-permission plugin was forcing the use of `_id` instead of the database agnostic `id`.

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix #2867 
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [ ] Documentation
- [ ] Framework
- [x] Plugin

#### Manual testing done on the following databases:

- [ ] Not applicable
- [x] MongoDB
- [x] MySQL
- [x] Postgres
- [x] SQLite
