### PR TITLE
Fix graphql amountLimit must be used when no limit is provided

### DIFF
--- a/packages/strapi-plugin-graphql/services/Query.js
+++ b/packages/strapi-plugin-graphql/services/Query.js
@@ -52,15 +52,13 @@ module.exports = {
   amountLimiting: (params = {}) => {
     const { amountLimit } = strapi.plugins.graphql.config;
 
-    if (!params.limit) return params;
+    if(!amountLimit) return params; // not sure if this is needed
 
-    if (params.limit === -1) {
+    if (!params.limit || params.limit === -1 || params.limit > amountLimit) { // combined lines which return same
       params.limit = amountLimit;
     } else if (params.limit < 0) {
       params.limit = 0;
-    } else if (params.limit > amountLimit) {
-      params.limit = amountLimit;
-    }
+    } 
 
     return params;
   },

--- a/packages/strapi-plugin-graphql/services/Query.js
+++ b/packages/strapi-plugin-graphql/services/Query.js
@@ -52,9 +52,9 @@ module.exports = {
   amountLimiting: (params = {}) => {
     const { amountLimit } = strapi.plugins.graphql.config;
 
-    if(!amountLimit) return params; // not sure if this is needed
+    if(!amountLimit) return params;
 
-    if (!params.limit || params.limit === -1 || params.limit > amountLimit) { // combined lines which return same
+    if (!params.limit || params.limit === -1 || params.limit > amountLimit) {
       params.limit = amountLimit;
     } else if (params.limit < 0) {
       params.limit = 0;


### PR DESCRIPTION
#### Description of what you did:
This issue fixes #3648 If no limit is provided and `amountLimit` is set it still sends default 100 records. After this fix, if amountLimit is set to 20 it will only return 20 records

Ready for merge

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [ ] Documentation
- [ ] Framework
- [X] Plugin

#### Manual testing done on the following databases:

- [ ] Not applicable
- [ ] MongoDB
- [X] MySQL
- [ ] Postgres
- [ ] SQLite
