### PR TITLE
Don't force number conversion when field defined as "string"

### DIFF
--- a/packages/strapi-plugin-content-manager/services/ContentManager.js
+++ b/packages/strapi-plugin-content-manager/services/ContentManager.js
@@ -73,12 +73,21 @@ module.exports = {
   add: async (params, values, source) => {
     // Multipart/form-data.
     if (values.hasOwnProperty('fields') && values.hasOwnProperty('files')) {
+      // get model attributes
+      const { attributes: modelAttibutes } = strapi.models[params.model];
+
       // Silent recursive parser.
-      const parser = value => {
+      const parser = (value, name) => {
+        // check if the field is defined as type "string" in the model
+        const isTypeString =
+          name &&
+          modelAttibutes[name] &&
+          modelAttibutes[name].type === 'string';
+
         try {
           const parsed = JSON.parse(value);
           // if we parse a value and it is still a string leave it as is
-          if (typeof parsed !== 'string') {
+          if (typeof parsed !== 'string' && !isTypeString) {
             value = parsed;
           }
         } catch (e) {
@@ -92,7 +101,7 @@ module.exports = {
 
       // Parse stringify JSON data.
       values = Object.keys(values.fields).reduce((acc, current) => {
-        acc[current] = parser(values.fields[current]);
+        acc[current] = parser(values.fields[current], current);
 
         return acc;
       }, {});
@@ -135,12 +144,21 @@ module.exports = {
   edit: async (params, values, source) => {
     // Multipart/form-data.
     if (values.hasOwnProperty('fields') && values.hasOwnProperty('files')) {
+      // get model attributes
+      const { attributes: modelAttibutes } = strapi.models[params.model];
+
       // Silent recursive parser.
-      const parser = value => {
+      const parser = (value, name) => {
+        // check if the field is defined as type "string" in the model
+        const isTypeString =
+          name &&
+          modelAttibutes[name] &&
+          modelAttibutes[name].type === 'string';
+
         try {
           const parsed = JSON.parse(value);
           // do not modify initial value if it is string except 'null'
-          if (typeof parsed !== 'string') {
+          if (typeof parsed !== 'string' && !isTypeString) {
             value = parsed;
           }
         } catch (e) {
@@ -161,7 +179,7 @@ module.exports = {
 
       // Parse stringify JSON data.
       values = Object.keys(values.fields).reduce((acc, current) => {
-        acc[current] = parser(values.fields[current]);
+        acc[current] = parser(values.fields[current], current);
 
         return acc;
       }, {});


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:
fix #3569.
- check how the field is defined: if it's declared as `string`, do not `JSON.parse` it's value

Tests where on:
- Mariadb 10.4.6
- PostgreSQL 11.4

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [ ] Documentation
- [ ] Framework
- [x] Plugin

#### Manual testing done on the following databases:

- [ ] Not applicable
- [ ] MongoDB
- [x] MySQL
- [x] Postgres
- [ ] SQLite
