### PR TITLE
Set group default mainField not id unless no attributes

### DIFF
--- a/packages/strapi-plugin-content-manager/services/utils/configuration/attributes.js
+++ b/packages/strapi-plugin-content-manager/services/utils/configuration/attributes.js
@@ -12,6 +12,8 @@ const isSortable = (schema, name) => {
     return false;
   }
 
+  if (schema.modelType === 'group' && name === 'id') return false;
+
   const attribute = schema.attributes[name];
   if (NON_SORTABLES.includes(attribute.type)) {
     return false;

--- a/packages/strapi-plugin-content-manager/services/utils/configuration/index.js
+++ b/packages/strapi-plugin-content-manager/services/utils/configuration/index.js
@@ -9,7 +9,7 @@ async function createDefaultConfiguration(model) {
   const schema = formatContentTypeSchema(model);
 
   return {
-    settings: await createDefaultSettings(),
+    settings: await createDefaultSettings(schema),
     metadatas: await createDefaultMetadatas(schema),
     layouts: await createDefaultLayouts(schema),
   };


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

Group mainField (field displayed in the editView on top of a collapsed group) should not be the id if there are valid attributes to display

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [ ] Documentation
- [ ] Framework
- [ ] Plugin

#### Manual testing done on the following databases:

- [ ] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
