### PR TITLE
Fix socketPath connection setting's variable name

### DIFF
--- a/packages/strapi-hook-knex/lib/index.js
+++ b/packages/strapi-hook-knex/lib/index.js
@@ -94,7 +94,7 @@ module.exports = strapi => {
             charset: _.get(connection.settings, 'charset'),
             schema: _.get(connection.settings, 'schema', 'public'),
             port: _.get(connection.settings, 'port'),
-            socket: _.get(connection.settings, 'socketPath'),
+            socketPath: _.get(connection.settings, 'socketPath'),
             ssl: _.get(connection.settings, 'ssl', false),
             timezone: _.get(connection.settings, 'timezone', 'utc'),
             filename: _.get(connection.settings, 'filename', '.tmp/data.db')


### PR DESCRIPTION
Hey. I noticed that the property name for socketPath from config is mapped to the wrong name before initializing Knex connection. Because of it I could not deploy app to google app engine and use mysql database.

My PR is a:

- [ ] 💥 Breaking change
- [X] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [ ] Documentation
- [X] Framework
- [ ] Plugin

#### Manual testing done on the following databases:

- [ ] Not applicable
- [ ] MongoDB
- [X] MySQL
- [ ] Postgres
- [ ] SQLite
