### PR TITLE
Add support for bookshelf plugin loading

### DIFF
--- a/docs/3.0.0-beta.x/configurations/configurations.md
+++ b/docs/3.0.0-beta.x/configurations/configurations.md
@@ -147,6 +147,18 @@ module.exports = (mongoose, connection) => {
 };
 ```
 
+Another example would be using the `bookshelf-uuid` plugin for MySQL, you can register it like this:
+
+**Path —** `./config/functions/bookshelf.js`.
+
+```js
+'use strict';
+
+module.exports = (bookshelf, connection) => {
+  bookshelf.plugin(require('bookshelf-uuid'));
+};
+```
+
 ---
 
 ## Locales

--- a/docs/3.0.0-beta.x/guides/models.md
+++ b/docs/3.0.0-beta.x/guides/models.md
@@ -34,6 +34,7 @@ The options key on the model-json states.
 - `idAttribute`: This tells the model which attribute to expect as the unique identifier for each database row (typically an auto-incrementing primary key named 'id'). _Only valid for strapi-hook-bookshelf_
 - `idAttributeType`: Data type of `idAttribute`, accepted list of value below. _Only valid for strapi-hook-bookshelf_
 - `timestamps`: This tells the model which attributes to use for timestamps. Accepts either `boolean` or `Array` of strings where first element is create data and second element is update date. Default value when set to `true` for Bookshelf is `["created_at", "updated_at"]` and for MongoDB is `["createdAt", "updatedAt"]`.
+- `uuid` : Boolean to enable UUID support on MySQL, you will need to set the `idAttributeType` to `uuid` as well and install the `bookshelf-uuid` package. To load the package you can see [this example](../configurations/configurations.md#bookshelf-mongoose).
 
 ## Define the attributes
 

--- a/packages/strapi-hook-bookshelf/lib/mount-models.js
+++ b/packages/strapi-hook-bookshelf/lib/mount-models.js
@@ -692,6 +692,9 @@ module.exports = ({ models, target, plugin = false }, ctx) => {
 
       // Initialize lifecycle callbacks.
       loadedModel.initialize = function() {
+        // Load bookshelf plugin arguments from model options
+        this.constructor.__super__.initialize.apply(this, arguments);
+
         const lifecycle = {
           creating: 'beforeCreate',
           created: 'afterCreate',

--- a/packages/strapi-hook-bookshelf/package.json
+++ b/packages/strapi-hook-bookshelf/package.json
@@ -17,7 +17,6 @@
   "main": "./lib",
   "dependencies": {
     "bookshelf": "^0.15.1",
-    "bookshelf-uuid": "^1.0.1",
     "date-fns": "^1.30.1",
     "inquirer": "^6.3.1",
     "lodash": "^4.17.11",

--- a/packages/strapi-hook-bookshelf/package.json
+++ b/packages/strapi-hook-bookshelf/package.json
@@ -17,6 +17,7 @@
   "main": "./lib",
   "dependencies": {
     "bookshelf": "^0.15.1",
+    "bookshelf-uuid": "^1.0.1",
     "date-fns": "^1.30.1",
     "inquirer": "^6.3.1",
     "lodash": "^4.17.11",


### PR DESCRIPTION
#### Description of what you did:

~~Adding bookshelf-uuid to generate UUIDs for MySQL as it doesn't have a simple way to generate UUIDv4 IDs.~~

Generic loading of bookshelf plugins like `bookshelf-uuid` support

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix #1826
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [ ] Documentation
- [ ] Framework
- [x] Plugin

#### Manual testing done on the following databases:

- [ ] Not applicable
- [ ] MongoDB
- [x] MySQL
- [ ] Postgres
- [ ] SQLite
