### PR TITLE
add koa-range to support range headers for media streaming

### DIFF
--- a/packages/strapi/lib/Strapi.js
+++ b/packages/strapi/lib/Strapi.js
@@ -6,6 +6,7 @@ const path = require('path');
 const { EventEmitter } = require('events');
 const fse = require('fs-extra');
 const Koa = require('koa');
+const range = require('koa-range');
 const _ = require('lodash');
 const { logger, models } = require('strapi-utils');
 const utils = require('./utils');
@@ -228,14 +229,7 @@ class Strapi extends EventEmitter {
   async load() {
     await this.enhancer();
 
-    this.app.use(async (ctx, next) => {
-      if (ctx.request.url === '/_health' && ctx.request.method === 'HEAD') {
-        ctx.set('strapi', 'You are so French!');
-        ctx.status = 204;
-      } else {
-        await next();
-      }
-    });
+    this.app.use(range);
 
     const [
       config,

--- a/packages/strapi/package.json
+++ b/packages/strapi/package.json
@@ -37,6 +37,7 @@
     "koa-qs": "^2.0.0",
     "koa-session": "^5.5.1",
     "koa-static": "^4.0.1",
+    "koa-range": "^0.3.0",
     "lodash": "^4.17.5",
     "minimatch": "^3.0.4",
     "node-fetch": "^1.7.3",


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

Included koa-range (https://github.com/koajs/koa-range) into core strapi package to strapi provides range headers for media uploaded to strapi and requested for streaming (e.G. videos). 

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix #2246
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [ ] Documentation
- [X] Framework
- [ ] Plugin

#### Manual testing done on the following databases:

- [X] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
