### PR TITLE
Use the idAttribute from model options if present

### DIFF
--- a/packages/strapi-hook-bookshelf/lib/index.js
+++ b/packages/strapi-hook-bookshelf/lib/index.js
@@ -110,7 +110,7 @@ module.exports = function(strapi) {
               definition.databaseName = getDatabaseName(connection);
               definition.client = _.get(connection.settings, 'client');
               _.defaults(definition, {
-                primaryKey: 'id',
+                primaryKey: _.get(definition, 'options.idAttribute', 'id'),
                 primaryKeyType: _.get(
                   definition,
                   'options.idAttributeType',
@@ -352,9 +352,9 @@ module.exports = function(strapi) {
                         const model = findModelByAssoc({ assoc });
 
                         return {
-                          [`${prefix}${assoc.alias}.${
-                            model.collectionName
-                          }`]: function(query) {
+                          [`${prefix}${assoc.alias}.${model.collectionName}`]: function(
+                            query
+                          ) {
                             query.orderBy('created_at', 'desc');
                           },
                         };
@@ -602,9 +602,7 @@ module.exports = function(strapi) {
                     const columnName = details.plugin
                       ? _.get(
                           strapi.plugins,
-                          `${details.plugin}.models.${
-                            details.model
-                          }.attributes.${FK}.columnName`,
+                          `${details.plugin}.models.${details.model}.attributes.${FK}.columnName`,
                           FK
                         )
                       : _.get(


### PR DESCRIPTION
This should hopefully fix #1762

#### Description of what you did:

The idAttribute value gets translated to the primaryKey field when the
model is parsed, but the code which did this was ignoring the
idAttribute field and always hard-coding it to "id". This change uses
the idAttribute value if it is present but otherwise defaults to "id".

There aren't any tests in that package currently and the change is quite deep in a larger function, so I didn't add any. If you prefer I could try to add some.

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [ ] Documentation
- [ ] Framework
- [x] Plugin

#### Manual testing done on the following databases:

- [ ] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [x] Postgres
- [ ] SQLite
