### PR TITLE
Infinite pagination when count is zero fix

### DIFF
--- a/packages/strapi-helper-plugin/lib/src/components/GlobalPagination/index.js
+++ b/packages/strapi-helper-plugin/lib/src/components/GlobalPagination/index.js
@@ -12,7 +12,7 @@ import styles from './styles.scss';
 
 /* eslint-disable jsx-a11y/anchor-is-valid */
 class GlobalPagination extends React.Component {
-  getLastPageNumber = () => Math.ceil(this.props.count / this.props.params._limit);
+  getLastPageNumber = () => Math.ceil(this.props.count / this.props.params._limit) || 1;
 
   handleDotsClick = (e) => e.preventDefault();
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:
Added `1` as a default return value for our `getLastPageNumber` method. If the result of `Math.Ceil` returns `0` and we know that when there is no items we shouldn't be able to navigate between pages and since `0` evaluates to false, we can use the or logical operator and return `1` as our last page.

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [X] 🐛 Bug fix #3846
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [ ] Documentation
- [ ] Framework
- [X] Plugin

#### Manual testing done on the following databases:

- [X] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
