### PR TITLE
fix: add URL from node.js url module

### DIFF
--- a/packages/strapi/lib/core/bootstrap.js
+++ b/packages/strapi/lib/core/bootstrap.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
+const { URL } = require('url');
 
 const { createController, createService } = require('../core-api');
 const getURLFromSegments = require('../utils/url-from-segments');


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [x] Admin
- [ ] Documentation
- [ ] Framework
- [ ] Plugin

#### Manual testing done on the following databases:

- [ ] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite

Hello. I installed strapi from npm , and can't start it. I found that https://github.com/strapi/strapi/blob/master/packages/strapi/lib/core/bootstrap.js#L321 need URL that didn't declare before, so got "reference error" and i declare it from node.js module, After that all build and start without errors, i think so. Please check my PR. Kindly regards and "long live to Belarus")