### PR TITLE
Fixes issue where GraphQL Mutations that use actions in plugins don't work

### DIFF
--- a/docs/3.0.0-beta.x/guides/graphql.md
+++ b/docs/3.0.0-beta.x/guides/graphql.md
@@ -492,7 +492,7 @@ module.exports = {
     Query: {
       post: {
         description: 'Return a single post',
-        policy: ['plugins.users-permissions.isAuthenticated', 'isOwner'], // Apply the 'isAuthenticated' policy of the `Users & Permissions` plugin, then the 'isOwner' policy before executing the resolver.
+        policies: ['plugins.users-permissions.isAuthenticated', 'isOwner'], // Apply the 'isAuthenticated' policy of the `Users & Permissions` plugin, then the 'isOwner' policy before executing the resolver.
       },
       posts: {
         description: 'Return a list of posts', // Add a description to the query.
@@ -504,7 +504,7 @@ module.exports = {
       },
       postsByTags: {
         description: 'Return the posts published by the author',
-        resolverOf: 'Post.findByTags', // Will apply the same policy on the custom resolver than the controller's action `findByTags`.
+        resolverOf: 'Post.findByTags', // Will apply the same policy on the custom resolver as the controller's action `findByTags`.
         resolver: (obj, options, ctx) => {
           // ctx is the context of the Koa request.
           await strapi.controllers.posts.findByTags(ctx);
@@ -516,7 +516,7 @@ module.exports = {
     Mutation: {
       attachPostToAuthor: {
         description: 'Attach a post to an author',
-        policy: ['plugins.users-permissions.isAuthenticated', 'isOwner'],
+        policies: ['plugins.users-permissions.isAuthenticated', 'isOwner'],
         resolver: 'Post.attachToAuthor'
       }
     }
@@ -677,7 +677,7 @@ module.exports = {
     Query: {
       posts: {
         description: 'Return a list of posts',
-        policy: [
+        policies: [
           'plugins.users-permissions.isAuthenticated',
           'isOwner',
           'global.logging',
@@ -687,7 +687,10 @@ module.exports = {
     Mutation: {
       createPost: {
         description: 'Create a new post',
-        policy: ['plugins.users-permissions.isAuthenticated', 'global.logging'],
+        policies: [
+          'plugins.users-permissions.isAuthenticated',
+          'global.logging',
+        ],
       },
     },
   },
@@ -782,7 +785,7 @@ module.exports = {
     Query: {
       posts: {
         description: 'Return a list of posts by author',
-        resolverOf: 'Post.find', // Will apply the same policy on the custom resolver than the controller's action `find` located in `Post.js`.
+        resolverOf: 'Post.find', // Will apply the same policy on the custom resolver as the controller's action `find` located in `Post.js`.
         resolver: (obj, options, context) => {
           // You can return a raw JSON object or a promise.
 

--- a/packages/strapi-plugin-graphql/services/Mutation.js
+++ b/packages/strapi-plugin-graphql/services/Mutation.js
@@ -29,9 +29,6 @@ module.exports = {
       queryName = action;
     }
 
-    // Retrieve policies.
-    const policies = _.get(handler, `Mutation.${queryName}.policies`, []);
-
     // Retrieve resolverOf.
     const resolverOf = _.get(handler, `Mutation.${queryName}.resolverOf`, '');
 
@@ -158,8 +155,19 @@ module.exports = {
       );
     }
 
+    // Retrieve policies.
+    let policies = [];
+
     if (strapi.plugins['users-permissions']) {
       policies.push('plugins.users-permissions.permissions');
+    }
+
+    // Retrieve policies.
+    if (_.get(handler, `Mutation.${queryName}.policies`)) {
+      policies = _.concat(
+        policies,
+        _.get(handler, `Mutation.${queryName}.policies`)
+      );
     }
 
     // Populate policies.

--- a/packages/strapi-plugin-graphql/services/Mutation.js
+++ b/packages/strapi-plugin-graphql/services/Mutation.js
@@ -23,10 +23,11 @@ module.exports = {
     // Extract custom resolver or type description.
     const { resolver: handler = {} } = _schema;
 
-    let queryName = `${action}${_.capitalize(name)}`;
-
+    let queryName;
     if (_.has(handler, `Mutation.${action}`)) {
       queryName = action;
+    } else {
+      queryName = `${action}${_.capitalize(name)}`;
     }
 
     // Retrieve policies.

--- a/packages/strapi-plugin-graphql/services/Mutation.js
+++ b/packages/strapi-plugin-graphql/services/Mutation.js
@@ -19,7 +19,7 @@ module.exports = {
    * @return Promise or Error.
    */
 
-  composeMutationResolver: function(_schema, plugin, name, action) {
+  composeMutationResolver: function({ _schema, plugin, name, action }) {
     // Extract custom resolver or type description.
     const { resolver: handler = {} } = _schema;
 

--- a/packages/strapi-plugin-graphql/services/Mutation.js
+++ b/packages/strapi-plugin-graphql/services/Mutation.js
@@ -29,6 +29,9 @@ module.exports = {
       queryName = action;
     }
 
+    // Retrieve policies.
+    const policies = _.get(handler, `Mutation.${queryName}.policies`, []);
+
     // Retrieve resolverOf.
     const resolverOf = _.get(handler, `Mutation.${queryName}.resolverOf`, '');
 
@@ -155,19 +158,8 @@ module.exports = {
       );
     }
 
-    // Retrieve policies.
-    let policies = [];
-
     if (strapi.plugins['users-permissions']) {
-      policies.push('plugins.users-permissions.permissions');
-    }
-
-    // Retrieve policies.
-    if (_.get(handler, `Mutation.${queryName}.policies`)) {
-      policies = _.concat(
-        policies,
-        _.get(handler, `Mutation.${queryName}.policies`)
-      );
+      policies.unshift('plugins.users-permissions.permissions');
     }
 
     // Populate policies.

--- a/packages/strapi-plugin-graphql/services/Mutation.js
+++ b/packages/strapi-plugin-graphql/services/Mutation.js
@@ -23,7 +23,11 @@ module.exports = {
     // Extract custom resolver or type description.
     const { resolver: handler = {} } = _schema;
 
-    const queryName = `${action}${_.capitalize(name)}`;
+    let queryName = `${action}${_.capitalize(name)}`;
+
+    if (_.has(handler, `Mutation.${action}`)) {
+      queryName = action;
+    }
 
     // Retrieve policies.
     const policies = _.get(handler, `Mutation.${queryName}.policies`, []);

--- a/packages/strapi-plugin-graphql/services/Query.js
+++ b/packages/strapi-plugin-graphql/services/Query.js
@@ -69,7 +69,7 @@ module.exports = {
    * @return Promise or Error.
    */
 
-  composeQueryResolver: function(_schema, plugin, name, isSingular) {
+  composeQueryResolver: function({ _schema, plugin, name, isSingular }) {
     const params = {
       model: name,
     };

--- a/packages/strapi-plugin-graphql/services/Query.js
+++ b/packages/strapi-plugin-graphql/services/Query.js
@@ -91,6 +91,9 @@ module.exports = {
         : pluralize.plural(name);
     }
 
+    // Retrieve policies.
+    const policies = _.get(handler, `Query.${queryName}.policies`, []);
+
     // Retrieve resolverOf.
     const resolverOf = _.get(handler, `Query.${queryName}.resolverOf`, '');
 
@@ -232,18 +235,8 @@ module.exports = {
       );
     }
 
-    // Retrieve policies.
-    let policies = [];
-
     if (strapi.plugins['users-permissions']) {
-      policies.push('plugins.users-permissions.permissions');
-    }
-
-    if (_.get(handler, `Query.${queryName}.policies`)) {
-      policies = _.concat(
-        policies,
-        _.get(handler, `Query.${queryName}.policies`)
-      );
+      policies.unshift('plugins.users-permissions.permissions');
     }
 
     // Populate policies.

--- a/packages/strapi-plugin-graphql/services/Query.js
+++ b/packages/strapi-plugin-graphql/services/Query.js
@@ -52,13 +52,13 @@ module.exports = {
   amountLimiting: (params = {}) => {
     const { amountLimit } = strapi.plugins.graphql.config;
 
-    if(!amountLimit) return params;
+    if (!amountLimit) return params;
 
     if (!params.limit || params.limit === -1 || params.limit > amountLimit) {
       params.limit = amountLimit;
     } else if (params.limit < 0) {
       params.limit = 0;
-    } 
+    }
 
     return params;
   },
@@ -90,9 +90,6 @@ module.exports = {
         ? pluralize.singular(name)
         : pluralize.plural(name);
     }
-
-    // Retrieve policies.
-    const policies = _.get(handler, `Query.${queryName}.policies`, []);
 
     // Retrieve resolverOf.
     const resolverOf = _.get(handler, `Query.${queryName}.resolverOf`, '');
@@ -235,8 +232,18 @@ module.exports = {
       );
     }
 
+    // Retrieve policies.
+    let policies = [];
+
     if (strapi.plugins['users-permissions']) {
       policies.push('plugins.users-permissions.permissions');
+    }
+
+    if (_.get(handler, `Query.${queryName}.policies`)) {
+      policies = _.concat(
+        policies,
+        _.get(handler, `Query.${queryName}.policies`)
+      );
     }
 
     // Populate policies.

--- a/packages/strapi-plugin-graphql/services/Schema.js
+++ b/packages/strapi-plugin-graphql/services/Schema.js
@@ -206,14 +206,20 @@ const schemaBuilder = {
 
           switch (type) {
             case 'Mutation': {
-              // TODO: Verify this...
-              const [name, action] = acc[type][resolver].split('.');
-              const normalizedName = _.toLower(name);
+              let name, action;
+              if (_.isString(acc[type][resolver])) {
+                [name, action] = acc[type][resolver].split('.');
+              } else if (
+                _.isPlainObject(acc[type][resolver]) &&
+                _.isString(acc[type][resolver].handler)
+              ) {
+                [name, action] = acc[type][resolver].handler.split('.');
+              }
 
               acc[type][resolver] = Mutation.composeMutationResolver({
                 _schema: strapi.plugins.graphql.config._schema.graphql,
                 plugin,
-                name: normalizedName,
+                name: _.toLower(name),
                 action,
               });
               break;

--- a/packages/strapi-plugin-graphql/services/Schema.js
+++ b/packages/strapi-plugin-graphql/services/Schema.js
@@ -210,22 +210,22 @@ const schemaBuilder = {
               const [name, action] = acc[type][resolver].split('.');
               const normalizedName = _.toLower(name);
 
-              acc[type][resolver] = Mutation.composeMutationResolver(
-                strapi.plugins.graphql.config._schema.graphql,
+              acc[type][resolver] = Mutation.composeMutationResolver({
+                _schema: strapi.plugins.graphql.config._schema.graphql,
                 plugin,
-                normalizedName,
-                action
-              );
+                name: normalizedName,
+                action,
+              });
               break;
             }
             case 'Query':
             default:
-              acc[type][resolver] = Query.composeQueryResolver(
-                strapi.plugins.graphql.config._schema.graphql,
+              acc[type][resolver] = Query.composeQueryResolver({
+                _schema: strapi.plugins.graphql.config._schema.graphql,
                 plugin,
-                resolver,
-                'force' // Avoid singular/pluralize and force query name.
-              );
+                name: resolver,
+                isSingular: 'force', // Avoid singular/pluralize and force query name.
+              });
               break;
           }
         }


### PR DESCRIPTION
### Note that this change relies on this PR:
### https://github.com/strapi/strapi/pull/3881

--------

#### Description of what you did:
The following GraphQL mutation definition now works, as it should:

```
// In schema.graphql
Mutation: {
  customMutation:
    resolver: {
      plugin: "custom-plugin",
      handler: "Post.customMutation"
    }
  }
}
```

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [ ] Documentation
- [ ] Framework
- [x] Plugin

#### Manual testing done on the following databases:

- [ ] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [x] Postgres
- [ ] SQLite
