### PR TITLE
Fix typo in en.json

### DIFF
--- a/packages/strapi-plugin-content-type-builder/admin/src/translations/en.json
+++ b/packages/strapi-plugin-content-type-builder/admin/src/translations/en.json
@@ -22,7 +22,7 @@
   "button.attributes.add.another": "Add Another Field",
   "button.contentType.add": "Add a Content Type",
   "button.delete.title": "Delete",
-  "button.delete.label": "Make you sure you understand what you are doing",
+  "button.delete.label": "Make sure you understand what you are doing",
   "button.group.add": "Add a Group",
   "button.models.create": "Create a Content Type",
   "button.groups.create": "Create a Group",


### PR DESCRIPTION
#### Description of what you did:

Fixes `Make you sure you understand` to `Make sure you understand`.

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [ ] Documentation
- [ ] Framework
- [x] Plugin

#### Manual testing done on the following databases:

- [x] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
