### PR TITLE
Default placeholder for enums to false

### DIFF
--- a/packages/strapi-plugin-content-manager/admin/src/components/Inputs/index.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/Inputs/index.js
@@ -83,7 +83,6 @@ function Inputs({
     return null;
   }
   const inputErrors = get(errors, keys, []);
-  const withOptionPlaceholder = get(attribute, 'type', '') === 'enumeration';
 
   return (
     <InputsIndex
@@ -106,7 +105,7 @@ function Inputs({
       type={getInputType(type)}
       validations={validations}
       value={value}
-      withOptionPlaceholder={withOptionPlaceholder}
+      withOptionPlaceholder={false}
     />
   );
 }


### PR DESCRIPTION
#### Description of what you did:

Defaults enum's placeholder to false.

IMO all placeholders should default to an empty value unless set by the user.  The problem with placeholders is that they make it  more difficult to visually scan an entry to see which fields have data and which do not yet.

Current:
<img width="314" alt="enum placeholder" src="https://user-images.githubusercontent.com/41795874/64572083-716a8d00-d355-11e9-86e8-efa2937a858b.png">

Ideally, the initial value for enum would also be a null/empty value. (I don't know if this PR does that, but it does get rid of the default placeholder text so is a step in the right direction.) 

I think a good rule for inputs is that inputs should be null/empty, unless a user has explicitly set a placeholder or a default value.

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [ ] Documentation
- [ ] Framework
- [x] Plugin

#### Manual testing done on the following databases:

- [x] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
