### PR TITLE
Fix input description styles

### DIFF
--- a/packages/strapi-helper-plugin/lib/src/components/InputDescription/styles.scss
+++ b/packages/strapi-helper-plugin/lib/src/components/InputDescription/styles.scss
@@ -1,7 +1,7 @@
 .inputDescriptionContainer {
   width: 100%;
-  margin-top: 1.3rem;
-  line-height: 1.5rem;
+  margin-top: 1rem;
+  line-height: 1.8rem;
 
   > small {
     color: #9EA7B8;

--- a/packages/strapi-helper-plugin/lib/src/components/InputDescription/styles.scss
+++ b/packages/strapi-helper-plugin/lib/src/components/InputDescription/styles.scss
@@ -1,7 +1,7 @@
 .inputDescriptionContainer {
-  width: 200%;
+  width: 100%;
   margin-top: 1.3rem;
-  line-height: 1.2rem;
+  line-height: 1.5rem;
 
   > small {
     color: #9EA7B8;


### PR DESCRIPTION
#### Description of what you did:

Fix styles so an input's description stays properly positioned beneath its input.

##### Before:

<img width="424" alt="strapi desc before" src="https://user-images.githubusercontent.com/41795874/64647172-0e85fe00-d408-11e9-8930-2531c6a4b832.png">

##### After (The color shows how wide it is and isn't part of the PR)

<img width="396" alt="strapi desc after" src="https://user-images.githubusercontent.com/41795874/64647337-5c9b0180-d408-11e9-90a6-6d6fb99ccc4b.png">


#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [ ] Documentation
- [ ] Framework
- [x] Plugin

#### Manual testing done on the following databases:

- [x] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
