### PR TITLE
Remove mandatory fields from User update

### DIFF
--- a/packages/strapi-plugin-users-permissions/controllers/User.js
+++ b/packages/strapi-plugin-users-permissions/controllers/User.js
@@ -170,23 +170,37 @@ module.exports = {
     const { id } = ctx.params;
     const { email, username, password } = ctx.request.body;
 
-    const userWithSameUsername = await strapi
-      .query('user', 'users-permissions')
-      .findOne({ username });
-
-    if (userWithSameUsername && userWithSameUsername.id != id) {
-      return ctx.badRequest(
-        null,
-        ctx.request.admin
-          ? adminError({
-              message: 'Auth.form.error.username.taken',
-              field: ['username'],
-            })
-          : 'username.alreadyTaken.'
-      );
+    if(ctx.request.body.hasOwnProperty('username') && !username) {
+      return ctx.badRequest('missing.username')
     }
 
-    if (advancedConfigs.unique_email) {
+    if(ctx.request.body.hasOwnProperty('email') && !email) {
+      return ctx.badRequest('missing.email')
+    }
+
+    if(ctx.request.body.hasOwnProperty('password') && !password) {
+      return ctx.badRequest('missing.password')
+    }
+
+    if (username) {
+      const userWithSameUsername = await strapi
+        .query('user', 'users-permissions')
+        .findOne({ username });
+
+      if (userWithSameUsername && userWithSameUsername.id != id) {
+        return ctx.badRequest(
+          null,
+          ctx.request.admin
+            ? adminError({
+                message: 'Auth.form.error.username.taken',
+                field: ['username'],
+              })
+            : 'username.alreadyTaken.'
+        );
+      }
+    }
+
+    if (email && advancedConfigs.unique_email) {
       const userWithSameEmail = await strapi
         .query('user', 'users-permissions')
         .findOne({ email });
@@ -212,7 +226,7 @@ module.exports = {
       ...ctx.request.body,
     };
 
-    if (password != null && password === user.password) {
+    if (password && password === user.password) {
       delete updateData.password;
     }
 

--- a/packages/strapi-plugin-users-permissions/controllers/User.js
+++ b/packages/strapi-plugin-users-permissions/controllers/User.js
@@ -170,10 +170,6 @@ module.exports = {
     const { id } = ctx.params;
     const { email, username, password } = ctx.request.body;
 
-    if (!email) return ctx.badRequest('missing.email');
-    if (!username) return ctx.badRequest('missing.username');
-    if (!password) return ctx.badRequest('missing.password');
-
     const userWithSameUsername = await strapi
       .query('user', 'users-permissions')
       .findOne({ username });
@@ -216,7 +212,7 @@ module.exports = {
       ...ctx.request.body,
     };
 
-    if (password === user.password) {
+    if (password != null && password === user.password) {
       delete updateData.password;
     }
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:
After 3.0.0-beta16, the update User endpoint required `email`, `username` and `password` in the body. This came at an inconvenience since we don't usually store passwords on the client-side.

This PR removes the mandatory checks in the request body and now reverts back to the previous behaviour.

Issue: [https://github.com/strapi/strapi/issues/3959](url)

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [ ] Documentation
- [ ] Framework
- [x] Plugin

#### Manual testing done on the following databases:

- [ ] Not applicable
- [x] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
