### PR TITLE
Stringify json input for pg to support arrays

### DIFF
--- a/packages/strapi-hook-bookshelf/lib/mount-models.js
+++ b/packages/strapi-hook-bookshelf/lib/mount-models.js
@@ -887,17 +887,13 @@ module.exports = ({ models, target, plugin = false }, ctx) => {
   return Promise.all(updates);
 };
 
-const castValueFromType = (type, value, definition) => {
+const castValueFromType = (type, value, /* definition */) => {
   // do not cast null values
   if (value === null) return null;
 
   switch (type) {
-    case 'json': {
-      if (definition.client === 'mysql' || definition.client === 'sqlite3') {
-        return JSON.stringify(value);
-      }
-      return value;
-    }
+    case 'json':
+      return JSON.stringify(value);
     // TODO: handle real date format 1970-01-01
     // TODO: handle real time format 12:00:00
     case 'time':

--- a/packages/strapi-plugin-content-manager/test/types/json.test.e2e.js
+++ b/packages/strapi-plugin-content-manager/test/types/json.test.e2e.js
@@ -35,6 +35,27 @@ describe('Test type json', () => {
     });
   });
 
+  test('Create entry with array value input JSON', async () => {
+    const inputValue = [
+      {
+        key: 'value',
+      },
+      {
+        key: 'value',
+      },
+    ];
+    const res = await rq.post('/content-manager/explorer/withjson', {
+      body: {
+        field: inputValue,
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toMatchObject({
+      field: inputValue,
+    });
+  });
+
   test('Create entry with value input Formdata', async () => {
     const inputValue = {
       number: '12',


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

Add support for json array : `[{"key": "value"}]` to pg
Fix https://github.com/strapi/strapi/issues/2882
<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [X] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [ ] Documentation
- [X] Framework
- [ ] Plugin

#### Manual testing done on the following databases:

- [ ] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
