### PR TITLE
Allow group mainField and defaultSortBy to be id

### DIFF
--- a/packages/strapi-plugin-content-manager/controllers/validation/model-configuration.js
+++ b/packages/strapi-plugin-content-manager/controllers/validation/model-configuration.js
@@ -45,12 +45,12 @@ const createSettingsSchema = (model, schema) => {
       // should be reset when the type changes
       mainField: yup
         .string()
-        .oneOf(validAttributes)
+        .oneOf(validAttributes.concat('id'))
         .default('id'),
       // should be reset when the type changes
       defaultSortBy: yup
         .string()
-        .oneOf(validAttributes)
+        .oneOf(validAttributes.concat('id'))
         .default('id'),
       defaultSortOrder: yup
         .string()


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:
Allow group mainField and defaultSortBy to be id
Fix https://github.com/strapi/strapi/issues/3969

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [ ] Documentation
- [ ] Framework
- [x] Plugin

#### Manual testing done on the following databases:

- [ ] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
