### PR TITLE
Update minimum webpack version for strapi-admin

### DIFF
--- a/packages/strapi-admin/package.json
+++ b/packages/strapi-admin/package.json
@@ -79,7 +79,7 @@
     "terser-webpack-plugin": "^1.2.3",
     "url-loader": "^1.1.2",
     "video-react": "^0.13.2",
-    "webpack": "^4.29.6",
+    "webpack": "^4.40.1",
     "webpackbar": "^3.2.0",
     "yup": "^0.27.0"
   },
@@ -102,7 +102,7 @@
   "license": "MIT",
   "gitHead": "c85658a19b8fef0f3164c19693a45db305dc07a9",
   "devDependencies": {
-    "webpack": "^4.29.6",
+    "webpack": "^4.40.1",
     "webpack-cli": "^3.3.2",
     "webpack-dev-server": "^3.4.1"
   }


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

Webpack v4.40.0 had a bug that caused a create to fail with this error:

```
Error: Conflict: Multiple assets emit to the same filename
```

This ups the minimum version constraint to v4.40.1.

Ref #3981 Closes #3982 

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [x] Admin
- [ ] Documentation
- [ ] Framework
- [ ] Plugin

#### Manual testing done on the following databases:

- [x] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
