### PR TITLE
Remove filterOption in SelectMany to enable searching in multiple select

### DIFF
--- a/packages/strapi-plugin-content-manager/admin/src/components/SelectMany/index.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/SelectMany/index.js
@@ -53,13 +53,6 @@ function SelectMany({
       <Select
         isDisabled={isDisabled}
         id={name}
-        filterOption={el => {
-          if (isEmpty(value)) {
-            return true;
-          }
-
-          return value.findIndex(obj => obj.id === el.value.id) === -1;
-        }}
         isLoading={isLoading}
         isMulti
         isSearchable


### PR DESCRIPTION
#### Description of what you did:
I removed `filterOption` in `SelectMany` component because it prevent multiple select's autocomplete doesn't work.
It might related to https://github.com/strapi/strapi/issues/4025

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [x] Admin
- [ ] Documentation
- [ ] Framework
- [ ] Plugin

#### Manual testing done on the following databases:

- [ ] Not applicable
- [x] MongoDB
- [x] MySQL
- [ ] Postgres
- [x] SQLite
