### PR TITLE
Change Traditional Chinese flag in LocaleToggle

### DIFF
--- a/packages/strapi-admin/admin/src/containers/LocaleToggle/index.js
+++ b/packages/strapi-admin/admin/src/containers/LocaleToggle/index.js
@@ -35,6 +35,7 @@ export class LocaleToggle extends React.Component {
       case 'pt-BR':
         return 'https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/3.1.0/flags/4x3/br.svg';
       case 'zh':
+        return 'https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/3.1.0/flags/4x3/tw.svg';
       case 'zh-Hans':
         return 'https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/3.1.0/flags/4x3/cn.svg';
       case 'ar':

--- a/packages/strapi-admin/admin/src/containers/LocaleToggle/tests/index.test.js
+++ b/packages/strapi-admin/admin/src/containers/LocaleToggle/tests/index.test.js
@@ -42,7 +42,7 @@ describe('<LocaleToggle />', () => {
       const renderedComponent = shallow(<LocaleToggle {...props} />);
       const { getFlagUrl } = renderedComponent.instance();
   
-      expect(getFlagUrl('zh')).toEqual('https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/3.1.0/flags/4x3/cn.svg');
+      expect(getFlagUrl('zh')).toEqual('https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/3.1.0/flags/4x3/tw.svg');
       expect(getFlagUrl('zh-Hans')).toEqual('https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/3.1.0/flags/4x3/cn.svg');
     });
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

China uses Simplified Chinese (zh-Hans) instead of Traditional Chinese, so I changed the flag.
Most websites use the national flag of Taiwan (ROC) as a Traditional Chinese icon.

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [x] Admin
- [ ] Documentation
- [ ] Framework
- [ ] Plugin

#### Manual testing done on the following databases:

- [x] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
