### PR TITLE
Allow null values on manyToMany and manyWay to set empty array

### DIFF
--- a/packages/strapi-hook-mongoose/lib/relations.js
+++ b/packages/strapi-hook-mongoose/lib/relations.js
@@ -159,7 +159,7 @@ module.exports = {
                     return _.set(
                       acc,
                       current,
-                      property.map(val => val[assocModel.primaryKey] || val)
+                      property ? property.map(val => val[assocModel.primaryKey] || val) : property
                     );
                   }
 
@@ -187,12 +187,12 @@ module.exports = {
                       return assocModel.updateMany(
                         {
                           [assocModel.primaryKey]: {
-                            $in: property.map(
+                            $in: property ? property.map(
                               val =>
                                 new mongoose.Types.ObjectId(
                                   val[assocModel.primaryKey] || val
                                 )
-                            ),
+                            ) : property,
                           },
                         },
                         {

--- a/packages/strapi-plugin-graphql/services/Resolvers.js
+++ b/packages/strapi-plugin-graphql/services/Resolvers.js
@@ -172,9 +172,7 @@ const buildAssocResolvers = (model, name, { plugin }) => {
               _.set(
                 queryOpts,
                 ['query', ref.primaryKey],
-                obj[association.alias].map(val => val[ref.primaryKey] || val) ||
-                  []
-              );
+                (obj[association.alias] ? obj[association.alias].map(val => val[ref.primaryKey] || val) : []));
             } else {
               _.set(queryOpts, ['query', association.via], obj[ref.primaryKey]);
             }


### PR DESCRIPTION
Fixes: #4109 

#### Description of what you did:
Fixes possibility to set null values for manyToMany and manyWay relation types.

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [ ] Documentation
- [x] Framework
- [ ] Plugin

#### Manual testing done on the following databases:

- [ ] Not applicable
- [X] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite