### PR TITLE
Updates the url of the settings button for Content Manager PluginCard

### DIFF
--- a/packages/strapi-admin/admin/src/components/PluginCard/index.js
+++ b/packages/strapi-admin/admin/src/components/PluginCard/index.js
@@ -63,7 +63,7 @@ class PluginCard extends React.Component {
   handleClickSettings = e => {
     const settingsPath =
       this.props.plugin.id === 'content-manager'
-        ? '/plugins/content-manager/ctm-configurations'
+        ? '/plugins/content-manager/ctm-configurations/models'
         : `/plugins/${this.props.plugin.id}/configurations/${this.props.currentEnvironment}`;
 
     e.preventDefault();


### PR DESCRIPTION
#### Description of what you did:

Updates the url of the settings button for Content Manager PluginCard. This PR fixes the bug reported in #4104.

The PR is ready to merge.

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [x] Admin
- [ ] Documentation
- [ ] Framework
- [ ] Plugin

#### Manual testing done on the following databases:

- [x] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
