### PR TITLE
Fix default config usage ejs

### DIFF
--- a/packages/strapi-hook-ejs/lib/index.js
+++ b/packages/strapi-hook-ejs/lib/index.js
@@ -33,13 +33,13 @@ module.exports = function(strapi) {
      * Initialize the hook
      */
 
-    initialize: () => {
+    initialize () {
       // Force cache mode in production
       if (strapi.config.environment === 'production') {
         strapi.config.hook.settings.ejs.cache = true;
       }
 
-      render(strapi.app, strapi.config.hook.settings.ejs);
+      render(strapi.app, Object.assign(this.defaults, strapi.config.hook.settings.ejs));
 
       strapi.app.context.render = co.wrap(strapi.app.context.render);
     },


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

Default `ejs` hook configs are not used.
Strapi only send `strapi.config.hook.settings.ejs` that represent hook config in the app.
And the `root` option is managed in default settings of the hook.

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [ ] Documentation
- [x] Framework
- [ ] Plugin

#### Manual testing done on the following databases:

- [x] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
