### PR TITLE
Do not set default timestamp value for date types

### DIFF
--- a/packages/strapi-hook-bookshelf/lib/buildDatabaseSchema.js
+++ b/packages/strapi-hook-bookshelf/lib/buildDatabaseSchema.js
@@ -412,6 +412,11 @@ const getType = ({ definition, attribute, name, tableExists = false }) => {
     case 'date':
     case 'time':
     case 'datetime':
+      if (client === 'pg') {
+        return 'timestamp with time zone';
+      }
+
+      return 'timestamp';
     case 'timestamp':
       if (client === 'pg') {
         return 'timestamp with time zone';


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

This will leave date types with default null except for created_at and updated_at. this isn't ideal for now because we still set any timestamp with a default time but it isn't a user interface field and will be changed later on

Fix #2300

Replaces the PR #4019

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [X] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [ ] Documentation
- [x] Framework
- [ ] Plugin

#### Manual testing done on the following databases:

- [ ] Not applicable
- [ ] MongoDB
- [x] MySQL
- [x] Postgres
- [x] SQLite
