### PR TITLE
Remove idAttribute and idAttributeType from docs

### DIFF
--- a/docs/3.0.0-beta.x/guides/models.md
+++ b/docs/3.0.0-beta.x/guides/models.md
@@ -31,8 +31,6 @@ The info key on the model-json states information about the model. This informat
 
 The options key on the model-json states.
 
-- `idAttribute`: This tells the model which attribute to expect as the unique identifier for each database row (typically an auto-incrementing primary key named 'id'). _Only valid for strapi-hook-bookshelf_
-- `idAttributeType`: Data type of `idAttribute`, accepted list of value below. _Only valid for strapi-hook-bookshelf_
 - `timestamps`: This tells the model which attributes to use for timestamps. Accepts either `boolean` or `Array` of strings where first element is create date and second element is update date. Default value when set to `true` for Bookshelf is `["created_at", "updated_at"]` and for MongoDB is `["createdAt", "updatedAt"]`.
 - `uuid` : Boolean to enable UUID support on MySQL, you will need to set the `idAttributeType` to `uuid` as well and install the `bookshelf-uuid` package. To load the package you can see [this example](../configurations/configurations.md#bookshelf-mongoose).
 


### PR DESCRIPTION
#### Description of what you did:

Removed idAttribute and idAttributeType from docs to prevent confusion as there is far too much hard coded `id` links within the project to support this.

Until these are fixed, removing from docs.

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [x] Documentation
- [ ] Framework
- [ ] Plugin

#### Manual testing done on the following databases:

- [x] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
