### PR TITLE
Users Permissions: preserve icon column width, centered icons

### DIFF
--- a/packages/strapi-plugin-users-permissions/admin/src/components/ListRow/styles.scss
+++ b/packages/strapi-plugin-users-permissions/admin/src/components/ListRow/styles.scss
@@ -1,18 +1,18 @@
 .listRow {
-
 }
 
-.container { /* stylelint-disable */
-  margin: 0 3.2rem 0 1.9rem ;
+.container {
+  /* stylelint-disable */
+  margin: 0 3.2rem 0 1.9rem;
   padding: 0 1.4rem 0 0rem;
-  border-bottom: 1px solid rgba(14,22,34,0.04);
+  border-bottom: 1px solid rgba(14, 22, 34, 0.04);
   color: #333740;
   font-size: 1.3rem;
   > div {
     padding: 0;
     align-self: center;
   }
-  > div:first-child{
+  > div:first-child {
     padding-left: 1.4rem;
   }
   > div:last-child {
@@ -28,6 +28,8 @@
   > div:first-child {
     width: 17px;
     padding-top: 2px;
+    flex-shrink: 0;
+    text-align: center;
     > i {
       font-size: 15px;
     }
@@ -42,13 +44,13 @@
 }
 
 .li {
-  margin-top: 0!important;
+  margin-top: 0 !important;
   position: relative;
   height: 5.4rem;
   line-height: 5.4rem;
   cursor: pointer;
   &:hover {
-    background-color: #F7F8F8;
+    background-color: #f7f8f8;
   }
 
   div {

--- a/packages/strapi-plugin-users-permissions/admin/src/components/ListRow/styles.scss
+++ b/packages/strapi-plugin-users-permissions/admin/src/components/ListRow/styles.scss
@@ -1,18 +1,18 @@
 .listRow {
+
 }
 
-.container {
-  /* stylelint-disable */
+.container {/* stylelint-disable */
   margin: 0 3.2rem 0 1.9rem;
   padding: 0 1.4rem 0 0rem;
-  border-bottom: 1px solid rgba(14, 22, 34, 0.04);
+  border-bottom: 1px solid rgba(14,22,34,0.04);
   color: #333740;
   font-size: 1.3rem;
   > div {
     padding: 0;
     align-self: center;
   }
-  > div:first-child {
+  > div:first-child{
     padding-left: 1.4rem;
   }
   > div:last-child {
@@ -44,13 +44,13 @@
 }
 
 .li {
-  margin-top: 0 !important;
+  margin-top: 0!important;
   position: relative;
   height: 5.4rem;
   line-height: 5.4rem;
   cursor: pointer;
   &:hover {
-    background-color: #f7f8f8;
+    background-color: #F7F8F8;
   }
 
   div {

--- a/packages/strapi-plugin-users-permissions/admin/src/components/ListRow/styles.scss
+++ b/packages/strapi-plugin-users-permissions/admin/src/components/ListRow/styles.scss
@@ -2,8 +2,8 @@
 
 }
 
-.container {/* stylelint-disable */
-  margin: 0 3.2rem 0 1.9rem;
+.container { /* stylelint-disable */
+  margin: 0 3.2rem 0 1.9rem ;
   padding: 0 1.4rem 0 0rem;
   border-bottom: 1px solid rgba(14,22,34,0.04);
   color: #333740;


### PR DESCRIPTION
#### Description of what you did:

This PR improves the icon column in the user permission table (f.e. email templates). Before FA icons were trimmed on smaller screen resolutions. 
Before:
<img width="113" alt="Screenshot 2019-09-30 at 15 38 47" src="https://user-images.githubusercontent.com/12811012/65884127-91abcb80-e398-11e9-95d3-61034cb166fe.png">
After:
<img width="99" alt="Screenshot 2019-09-30 at 15 39 33" src="https://user-images.githubusercontent.com/12811012/65884128-91abcb80-e398-11e9-9251-e4a6c7d80af5.png">


#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [x] Admin
- [ ] Documentation
- [ ] Framework
- [x] Plugin

#### Manual testing done on the following databases:

- [x] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
