### PR TITLE
Fix typo in graphql plugin documentation

### DIFF
--- a/docs/3.0.0-beta.x/guides/graphql.md
+++ b/docs/3.0.0-beta.x/guides/graphql.md
@@ -29,7 +29,7 @@ npm run strapi install graphql
 ::: tab "strapi" id="strapi"
 
 ```
-strapi install documentation
+strapi install graphql
 ```
 
 :::


### PR DESCRIPTION
I don't think installing the documentation plugin will install graphql

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [x] Documentation
- [ ] Framework
- [ ] Plugin

#### Manual testing done on the following databases:

- [x] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
