### PR TITLE
Remove Heroku button

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,22 +107,6 @@ This project is currently in **Beta**. Significant breaking changes are unlikely
 
 **[See more on our website](https://strapi.io/overview)**.
 
-### Try on Heroku
-
-You can also give it a try using Heroku in one click!
-
-<a href="https://heroku.com/deploy?template=https://github.com/strapi/strapi-heroku-app">
-  <img src="https://www.herokucdn.com/deploy/button.svg" alt="Deploy">
-</a>
-
-Be aware that the Content Type Builder won't work due to the restriction of writing files on the Heroku servers. If you would like to change/edit/add Content Types, you need to follow these steps:
-
-1. Click the button above and deploy your app
-2. Clone that repo by using `heroku git:clone -a` followed by your repo's name
-3. Go into the cloned projects' folder using `cd` followed by your repo's name
-4. Add the Heroku boilerplate as a remote by running `git remote add boilerplate https://github.com/strapi/strapi-heroku-app`
-5. Pull from this new origin by running `git pull boilerplate master`
-
 ## Contributing
 
 Please read our [Contributing Guide](./CONTRIBUTING.md) before submitting a Pull Request to the project.


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

In this PR I remove the Heroku button.
This button doesn't make sense.
The power of Strapi is the let you create your content types and then contribute you content and then offer you and API to consume your data where you want.
But in Heroku you can't create/update/remove content type. You can't do the first steps.
So please if you want to use Heroku to deploy your app, you will have to follow the [Heroku deployment documentation 📚](https://strapi.io/documentation/3.0.0-beta.x/guides/deployment.html#heroku).

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [x] Documentation
- [ ] Framework
- [ ] Plugin

#### Manual testing done on the following databases:

- [x] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
