### PR TITLE
returning toLower on obj.ref

### DIFF
--- a/packages/strapi-hook-mongoose/lib/relations.js
+++ b/packages/strapi-hook-mongoose/lib/relations.js
@@ -208,7 +208,7 @@ module.exports = {
                 case 'manyMorphToOne': {
                   // Update the relational array.
                   acc[current] = property.map(obj => {
-                    const refModel = strapi.getModel(obj.ref, obj.source);
+                    const refModel = strapi.getModel(_.toLower(obj.ref), obj.source);
                     return {
                       ref: new mongoose.Types.ObjectId(obj.refId),
                       kind: obj.kind || refModel.globalId,


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

To fix the issue described [here](https://github.com/strapi/strapi/issues/4140), I added back the call toLower(obj.ref). The Upload Plugin documentation states ref should be the model name. We are passing the model name, which is capitalized, but the collection is lowercase. Without a refModel being returned, we are seeing exceptions being thrown when trying to access refModel.globalId. The previous version of this logic utilized .toLower() before accessing/passing obj.ref anywhere. I think this is something that needs to be added back to the plugin.

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [ ] Documentation
- [ ] Framework
- [x] Plugin

#### Manual testing done on the following databases:

- [ ] Not applicable
- [x] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
