### PR TITLE
Improve InputToggle to show all possible DB states

### DIFF
--- a/packages/strapi-helper-plugin/lib/src/components/InputToggle/index.js
+++ b/packages/strapi-helper-plugin/lib/src/components/InputToggle/index.js
@@ -10,27 +10,36 @@ import { isEmpty } from 'lodash';
 import styles from './styles.scss';
 
 class InputToggle extends React.Component {
-  handleClick = (e) => {
+  state = {
+    value: this.props.value
+  }
+
+  handleClick(value) {
+
+    // // Make value de-selectable (nullable) when clicking again on same value.
+    // if (value === this.state.value)
+    //   value = null;
+
     const target = {
       name: this.props.name,
       type: 'toggle',
-      value: e.target.id.includes('__ON__'),
+      value
     };
 
+    this.setState({ value });
     this.props.onChange({ target });
   }
 
   render() {
+    const value = this.state.value;
     const {
       autoFocus,
       className,
       disabled,
       deactivateErrorHighlight,
       error,
-      name,
       style,
-      tabIndex,
-      value,
+      tabIndex
     } = this.props;
 
     return (
@@ -39,16 +48,15 @@ class InputToggle extends React.Component {
           'btn-group',
           styles.inputToggleContainer,
           !isEmpty(className) && className,
-          !deactivateErrorHighlight && error && styles.error,
+          !deactivateErrorHighlight && error && styles.error
         )}
         style={style}
       >
         <button
           autoFocus={autoFocus}
           disabled={disabled}
-          className={cn('btn', !value && styles.gradientOff)}
-          id={`__OFF__${name}`}
-          onClick={this.handleClick}
+          className = {cn('btn', value !== null && !value && styles.gradientOff)}
+          onClick={this.handleClick.bind(this, false)}
           tabIndex={tabIndex}
           type="button"
         >
@@ -57,8 +65,7 @@ class InputToggle extends React.Component {
         <button
           disabled={disabled}
           className={cn('btn', value && styles.gradientOn)}
-          id={`__ON__${name}`}
-          onClick={this.handleClick}
+          onClick={this.handleClick.bind(this, true)}
           type="button"
         >
           ON
@@ -76,7 +83,7 @@ InputToggle.defaultProps = {
   error: false,
   style: {},
   tabIndex: '0',
-  value: true,
+  value: null
 };
 
 InputToggle.propTypes = {
@@ -89,7 +96,7 @@ InputToggle.propTypes = {
   onChange: PropTypes.func.isRequired,
   style: PropTypes.object,
   tabIndex: PropTypes.string,
-  value: PropTypes.bool,
+  value: PropTypes.bool
 };
 
 export default InputToggle;

--- a/packages/strapi-helper-plugin/lib/src/components/InputToggle/styles.scss
+++ b/packages/strapi-helper-plugin/lib/src/components/InputToggle/styles.scss
@@ -1,13 +1,13 @@
 .gradientOff {
   background-image: linear-gradient( to bottom right, #F65A1D, #F68E0E );
   color: white !important;
-  z-index: 0!important;
-  
+  z-index: 0 !important;
+
   &:active, :hover {
     box-shadow: inset -1px 1px 3px rgba(0,0,0,0.1);
     background-image: linear-gradient( to bottom right, #F65A1D, #F68E0E );
     color: white !important;
-    z-index: 0!important;
+    z-index: 0 !important;
   }
 }
 
@@ -18,7 +18,7 @@
   &:active, :hover {
     background-image: linear-gradient( to bottom right, #005EEA, #0097F6);
     color: white !important;
-    z-index: 0!important;
+    z-index: 0 !important;
   }
 }
 
@@ -33,19 +33,25 @@
     border-radius: 0.25rem;
     color: #CED3DB;
     background-color: white;
-    box-shadow: 0px 1px 1px rgba(104, 118, 142, 0.05);
+    box-shadow: 0 1px 1px rgba(104, 118, 142, 0.05);
     font-weight: 600;
     font-size: 1.2rem;
     letter-spacing: 0.1rem;
-    font-family: Lato;
+    font-family: Lato, sans-serif;
     line-height: 3.4rem;
     cursor: pointer;
-    &:first-of-type {
-      border-right: none;
+
+    // Default middle border
+    &:last-child {
+      border-left: 1px solid #E3E9F3;
     }
-    &:nth-of-type(2) {
+
+    // Middle border when true or false
+    &.gradientOn,
+    &.gradientOff ~ button {
       border-left: none;
     }
+
     &:hover {
       z-index: 0 !important;
     }
@@ -59,15 +65,17 @@
   }
 }
 
+// Error can only occur if field isRequired but user didn't set a value
 .error {
   > button {
+    border: 1px solid #FF203C;
+
     &:first-child {
-      border: 1px solid #ff203c !important;
-      border-right: 0 !important;
+      border-right: 0;
     }
+
     &:last-child {
-      border: 1px solid #ff203c !important;
-      border-left: 0 !important;
+      border-left: 1px solid #E3E9F3;
     }
   }
 }


### PR DESCRIPTION
#### Description of what you did:

Fixes the InputToggle aspect of https://github.com/strapi/strapi/issues/4059, allowing this toggle to accurately show all possible DB states (false, true, null). If null, both "OFF" and "ON" are gray boxes indicating value is not defined.

WIP because 1.) I left lines 19-21 for Strapi team to see functionality both with and without this, and 2.) to verify styles look good.

I've verified functionality of this component, but couldn't get styles to load properly in my small setup for this component, and I'm waiting to set up a dev env for Strapi given that will change significantly soon. Please confirm the styles look ok when testing. They should be good.

@Aurelsicoko Please try with and without lines 19-21, so you can see functionality both ways, and please let me know if styles are all ok. 


#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [ ] Documentation
- [ ] Framework
- [x] Plugin

#### Manual testing done on the following databases:

- [x] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
