### PR TITLE
Fix documentation typo

### DIFF
--- a/docs/3.0.0-beta.x/plugins/users-permissions.md
+++ b/docs/3.0.0-beta.x/plugins/users-permissions.md
@@ -9,7 +9,7 @@ To access the plugin admin panel, click on the **Users & Pemissions** link in th
 When this plugin is installed, it adds an access layer on your application.
 The plugin uses [`jwt token`](https://fr.wikipedia.org/wiki/JSON_Web_Token) to authenticate users.
 
-Each time an API request is sent, the server checks if an `Authorization` header is present and verifies if the user making the request has acces to the resource..
+Each time an API request is sent, the server checks if an `Authorization` header is present and verifies if the user making the request has access to the resource..
 
 To do so, your JWT contain your user ID and we are able to match the group your user is in and at the end to know if the group allows access to the route.
 


### PR DESCRIPTION
#### Description of what you did:
Fix spelling `acces` -> `access`

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [x] Documentation
- [ ] Framework
- [ ] Plugin

#### Manual testing done on the following databases:

- [x] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
