### PR TITLE
Ensure state has been updated before calling ref.current()

### DIFF
--- a/packages/strapi-plugin-content-manager/admin/src/components/SelectWrapper/index.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/SelectWrapper/index.js
@@ -107,17 +107,13 @@ function SelectWrapper({
       }
 
       return { ...prevState, _q: inputValue };
-    });
-
-    ref.current();
+    }, ref.current);
 
     return inputValue;
   };
 
   const onMenuScrollToBottom = () => {
-    setState(prevState => ({ ...prevState, _start: prevState._start + 1 }));
-
-    ref.current();
+    setState(prevState => ({ ...prevState, _start: prevState._start + 1 }), ref.current);
   };
   const isSingle = [
     'oneWay',


### PR DESCRIPTION
Calling `ref.current()` before ensuring that `setState` has completed can lead to a race condition because `setState` [does not always immediately update the component](https://reactjs.org/docs/react-component.html#setstate).

This can lead to the relationship drop downs incorrectly populating when typing long relation names. Moving the `ref.current` call to the callback of `setState` resolves this.

I suspect this fully fixes #4025, but I don't have a mongo environment to test with.

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [x] Admin
- [ ] Documentation
- [ ] Framework
- [ ] Plugin

#### Manual testing done on the following databases:

- [ ] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [x] Postgres
- [ ] SQLite
