### PR TITLE
Fixed issue #4138 - Cannot remove default value for number type in group

### DIFF
--- a/packages/strapi-plugin-content-type-builder/controllers/validation/types.js
+++ b/packages/strapi-plugin-content-type-builder/controllers/validation/types.js
@@ -92,7 +92,14 @@ const getTypeShape = obj => {
     }
     case 'integer': {
       return {
-        default: yup.number().integer(),
+        default: yup.mixed().test(
+          value =>
+            value === '' ||
+            yup
+              .number()
+              .integer()
+              .isValidSync(value)
+        ),
         required: validators.required,
         unique: validators.unique,
         min: yup.number().integer(),
@@ -119,7 +126,9 @@ const getTypeShape = obj => {
     }
     case 'float': {
       return {
-        default: yup.number(),
+        default: yup
+          .mixed()
+          .test(value => value === '' || yup.number().isValidSync(value)),
         required: validators.required,
         unique: validators.unique,
         min: yup.number(),
@@ -128,7 +137,9 @@ const getTypeShape = obj => {
     }
     case 'decimal': {
       return {
-        default: yup.number(),
+        default: yup
+          .mixed()
+          .test(value => value === '' || yup.number().isValidSync(value)),
         required: validators.required,
         unique: validators.unique,
         min: yup.number(),


### PR DESCRIPTION
#### Description of what you did:
Fixed issue with validation on the default for numbers in groups.  It now allows a zero-length string.

#### My PR is a:

- [ ] 💥 Breaking change
- [x ] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [x ] Admin
- [ ] Documentation
- [ ] Framework
- [ ] Plugin

#### Manual testing done on the following databases:

- [x] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
