### PR TITLE
Clean up node env during build as not required in docs

### DIFF
--- a/docs/3.0.0-beta.x/admin-panel/customization.md
+++ b/docs/3.0.0-beta.x/admin-panel/customization.md
@@ -209,7 +209,7 @@ you can build your admin panel with a specific configuration (located in the `./
 ::: tab "yarn" id="yarn-build-prod"
 
 ```
-NODE_ENV=production yarn build
+yarn build
 ```
 
 :::
@@ -217,7 +217,7 @@ NODE_ENV=production yarn build
 ::: tab "npm" id="npm-build-prod"
 
 ```
-NODE_ENV=production npm run build
+npm run build
 ```
 
 :::
@@ -225,7 +225,7 @@ NODE_ENV=production npm run build
 ::: tab "strapi" id="strapi-build-prod"
 
 ```
-NODE_ENV=production strapi build
+strapi build
 ```
 
 :::

--- a/docs/3.0.0-beta.x/guides/deployment.md
+++ b/docs/3.0.0-beta.x/guides/deployment.md
@@ -44,7 +44,7 @@ Before running your server in production you need to build your admin panel for 
 ::: tab "yarn" id="yarn-build"
 
 ```bash
-NODE_ENV=production yarn build
+yarn build
 ```
 
 :::
@@ -52,7 +52,7 @@ NODE_ENV=production yarn build
 ::: tab "npm" id="npm-build"
 
 ```bash
-NODE_ENV=production npm run build
+npm run build
 ```
 
 :::
@@ -456,7 +456,7 @@ Next, navigate to the `my-project` folder, the root for Strapi. You will need to
 ```bash
 cd ./my-project/
 npm install
-NODE_ENV=production npm run build
+npm run build
 ```
 
 Next, you need to install **PM2 Runtime** and configure the `ecosystem.config.js` file
@@ -965,7 +965,7 @@ Next, navigate to the `my-project` folder, the root for Strapi. You will now nee
 ```bash
 cd ./my-project/
 npm install
-NODE_ENV=production npm run build
+npm run build
 ```
 
 Strapi uses `Port: 1337` by default. You will need to configure your `ufw firewall` to allow access to this port, for testing and installation purposes. After you have installed and [configured NGINX](https://www.digitalocean.com/community/tutorials/how-to-install-nginx-on-ubuntu-18-04), you need to `sudo ufw deny 1337`, to close the port to outside traffic.


### PR DESCRIPTION
#### Description of what you did:

Removing `NODE_ENV` options during build as not needed and confusing users (also could cause issues?)

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [x] Documentation
- [ ] Framework
- [ ] Plugin

#### Manual testing done on the following databases:

- [x] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
