### PR TITLE
Change enum regex message for special characters

### DIFF
--- a/packages/strapi-plugin-content-type-builder/admin/src/translations/en.json
+++ b/packages/strapi-plugin-content-type-builder/admin/src/translations/en.json
@@ -39,7 +39,7 @@
   "error.validation.minSupMax": "Can't be superior",
   "error.validation.regex": "The value does not match the regex.",
   "error.validation.regex.name": "Name should start with alphabetical characters. Underscores and numbers  only are allowed after.",
-  "error.validation.regex.values": "Values should not start with a number or a special character.",
+  "error.validation.regex.values": "Values should not start with a number nor contain a special character.",
   "error.validation.required": "This value input is required.",
   "form.attribute.info.no-space-allowed": "No space is allowed for the name of the attribute",
   "form.attribute.item.appearance.description": "Otherwise, the value will be editable through a basic textarea field",

--- a/packages/strapi-plugin-content-type-builder/admin/src/translations/fr.json
+++ b/packages/strapi-plugin-content-type-builder/admin/src/translations/fr.json
@@ -38,7 +38,7 @@
   "error.validation.minSupMax": "Ne peut pas être plus grand",
   "error.validation.regex": "La valeur ne correspond pas au format attendu.",
   "error.validation.regex.name": "Le nom doit commencer par une lettre. Seulement les chiffres et les underscores sont autorisés après.",
-  "error.validation.regex.values": "Les valeurs ne peuvent pas commencer par un nombre ou un caractère spécial",
+  "error.validation.regex.values": "Les valeurs ne doivent pas commencer par un nombre ou un caractere special.",
   "error.validation.required": "Ce champ est obligatoire.",
   "form.attribute.info.no-space-allowed": "Les espaces ne sont pas autorisés pour les noms du champ",
   "form.attribute.item.appearance.description": "Sinon, il sera editable à partir d'une simple zone de texte",


### PR DESCRIPTION
### Description of what you did:

Changed the regex message to clarify that special characters are not accepted in an enum value based on graphql docs

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix #4250
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [x] Admin
- [ ] Documentation
- [ ] Framework
- [ ] Plugin

#### Manual testing done on the following databases:

- [x] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
