### PR TITLE
Returning a 404 status message when requested resource does not exist.

### DIFF
--- a/packages/strapi-plugin-upload/controllers/Upload.js
+++ b/packages/strapi-plugin-upload/controllers/Upload.js
@@ -179,7 +179,12 @@ module.exports = {
     );
 
     if (!data) {
-      return ctx.notFound('file.notFound');
+      const response = {
+        statusCode: 404,
+        error: 'File not found',
+        message: 'The requested resource does not exist.',
+      };
+      return ctx.send(response);
     }
 
     // if is local server upload, add backend host as prefix


### PR DESCRIPTION
#### Description of what you did:
Issue fix: #3551

When user requests for a resource which does not exist, it returns the following response:
```
 {
        statusCode: 404,
        error: 'File not found',
        message: 'The requested resource does not exist.',
 }
```
#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [ ] Documentation
- [ ] Framework
- [x] Plugin

#### Manual testing done on the following databases:

- [x] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
