### PR TITLE
Add POST route /auth/send-email-confirmation

### DIFF
--- a/docs/3.0.0-beta.x/plugins/users-permissions.md
+++ b/docs/3.0.0-beta.x/plugins/users-permissions.md
@@ -222,6 +222,34 @@ axios
 });
 ```
 
+### Email validation
+
+This action send an email to a user with the link to confirm the user.
+
+#### Usage
+
+- email is the user email.
+
+```js
+import axios from 'axios';
+
+// Example of a function that send a confirmation email
+async function your_function() {
+  try {
+    await axios
+      .post(`http://localhost:1337/auth/send-email-confirmation`, {
+        email: 'user@strapi.io'
+      })
+    // Handle success.
+    console.log('Your user received an email')
+  } catch (err) {
+    // Handle error.
+    console.err('An error occured:', err)
+  }
+}
+},
+```
+
 ## User object in Strapi context
 
 The `user` object is available to successfully authenticated requests.

--- a/docs/3.0.0-beta.x/plugins/users-permissions.md
+++ b/docs/3.0.0-beta.x/plugins/users-permissions.md
@@ -209,17 +209,16 @@ axios
   .post('http://localhost:1337/auth/reset-password', {
     code: 'privateCode',
     password: 'myNewPassword',
-    passwordConfirmation: 'myNewPassword'
+    passwordConfirmation: 'myNewPassword',
   })
   .then(response => {
     // Handle success.
-    console.log('Your user\'s password has been changed.');
+    console.log("Your user's password has been changed.");
   })
   .catch(error => {
     // Handle error.
     console.log('An error occurred:', error);
   });
-});
 ```
 
 ### Email validation
@@ -233,21 +232,19 @@ This action send an email to a user with the link to confirm the user.
 ```js
 import axios from 'axios';
 
-// Example of a function that send a confirmation email
-async function your_function() {
-  try {
-    await axios
-      .post(`http://localhost:1337/auth/send-email-confirmation`, {
-        email: 'user@strapi.io'
-      })
+// Request API.
+axios
+  .post(`http://localhost:1337/auth/send-email-confirmation`, {
+    email: 'user@strapi.io',
+  })
+  .then(response => {
     // Handle success.
-    console.log('Your user received an email')
-  } catch (err) {
+    console.log('Your user received an email');
+  })
+  .catch(error => {
     // Handle error.
-    console.err('An error occured:', err)
-  }
-}
-},
+    console.err('An error occured:', err);
+  });
 ```
 
 ## User object in Strapi context

--- a/packages/strapi-plugin-users-permissions/config/routes.json
+++ b/packages/strapi-plugin-users-permissions/config/routes.json
@@ -286,6 +286,20 @@
       }
     },
     {
+      "method": "POST",
+      "path": "/auth/send-email-confirmation",
+      "handler": "Auth.sendEmailConfirmation",
+      "config": {
+        "policies": [],
+        "prefix": "",
+        "description": "Send a confirmation email to user",
+        "tag": {
+          "plugin": "users-permissions",
+          "name": "User"
+        }
+      }
+    },
+    {
       "method": "GET",
       "path": "/users",
       "handler": "User.find",

--- a/packages/strapi-plugin-users-permissions/controllers/Auth.js
+++ b/packages/strapi-plugin-users-permissions/controllers/Auth.js
@@ -589,4 +589,80 @@ module.exports = {
 
     ctx.redirect(settings.email_confirmation_redirection || '/');
   },
+
+  async sendEmailConfirmation(ctx) {
+    const pluginStore = await strapi.store({
+      environment: '',
+      type: 'plugin',
+      name: 'users-permissions',
+    });
+
+    const params = _.assign(ctx.request.body);
+
+    if (!params.email) {
+      return ctx.badRequest('missing.email');
+    }
+
+    const isEmail = emailRegExp.test(params.email);
+
+    if (isEmail) {
+      params.email = params.email.toLowerCase();
+    } else {
+      return ctx.badRequest('wrong.email');
+    }
+
+    const user = await strapi.query('user', 'users-permissions').findOne({
+      email: params.email
+    });
+
+    if (user.confirmed) {
+      return ctx.badRequest('already.confirmed');
+    }
+
+    if (user.blocked) {
+      return ctx.badRequest('blocked.user');
+    }
+
+    const jwt = strapi.plugins['users-permissions'].services.jwt.issue(
+      _.pick(user.toJSON ? user.toJSON() : user, ['id'])
+    );
+
+    const settings = await pluginStore.get({ key: 'email' }).then(storeEmail => {
+      try {
+        return storeEmail['email_confirmation'].options;
+      } catch (err) {
+        return {};
+      }
+    });
+
+    settings.message = await strapi.plugins['users-permissions'].services.userspermissions.template(settings.message, {
+      URL: new URL('/auth/email-confirmation', strapi.config.url).toString(),
+      USER: _.omit(user.toJSON ? user.toJSON() : user, ['password', 'resetPasswordToken', 'role', 'provider']),
+      CODE: jwt
+    });
+
+    settings.object = await strapi.plugins['users-permissions'].services.userspermissions.template(settings.object, {
+      USER: _.omit(user.toJSON ? user.toJSON() : user, ['password', 'resetPasswordToken', 'role', 'provider']),
+    });
+
+    try {
+      await strapi.plugins['email'].services.email.send({
+        to: (user.toJSON ? user.toJSON() : user).email,
+        from:
+          settings.from.email && settings.from.name
+            ? `"${settings.from.name}" <${settings.from.email}>`
+            : undefined,
+        replyTo: settings.response_email,
+        subject: settings.object,
+        text: settings.message,
+        html: settings.message
+      });
+      ctx.send({
+        email: (user.toJSON ? user.toJSON() : user).email,
+        sent: true
+      });
+    } catch (err) {
+      return ctx.badRequest(null, err);
+    }
+  },
 };

--- a/packages/strapi-plugin-users-permissions/documentation/1.0.0/overrides/users-permissions-User.json
+++ b/packages/strapi-plugin-users-permissions/documentation/1.0.0/overrides/users-permissions-User.json
@@ -53,6 +53,47 @@
         "security": []
       }
     },
+    "/auth/send-email-confirmation": {
+      "post": {
+        "security": [],
+        "externalDocs": {
+          "description": "Find out more in the strapi's documentation",
+          "url": "https://strapi.io/documentation/guides/authentication.html#usage"
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully sent email",
+            "content": {
+              "application/json": {
+                "email": {
+                  "type": "string"
+                },
+                "sent": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "description": "",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "required": ["email"],
+                "properties": {
+                  "email": {
+                    "type": "string",
+                    "minLength": 6
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/users-permissions/search/{id}": {
       "get": {
         "summary": "Retrieve a list of users by searching for their username or email",


### PR DESCRIPTION
#### Description of what you did:

 Add POST route /auth/send-email-confirmation to call sendEmailConfirmation function of plugin users-permissions.
In case the user didn't received the confirm email, this function trigger a new call, based on the email given.

This feature send a badRequest in case of null email, wrong email, or if user has already been verified.

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [ ] 💅 Enhancement
- [x] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [ ] Documentation
- [ ] Framework
- [x] Plugin

#### Manual testing done on the following databases:

- [x] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
