### PR TITLE
Allow empty default on group attributes

### DIFF
--- a/packages/strapi-plugin-content-type-builder/controllers/Groups.js
+++ b/packages/strapi-plugin-content-type-builder/controllers/Groups.js
@@ -1,6 +1,6 @@
 'use strict';
-
 const validateGroupInput = require('./validation/group');
+const _ = require('lodash');
 /**
  * Groups controller
  */
@@ -80,6 +80,15 @@ module.exports = {
 
     if (!group) {
       return ctx.send({ error: 'group.notFound' }, 404);
+    }
+
+    // convert zero length string on default attributes to undefined
+    if (_.has(body, 'attributes')) {
+      Object.keys(body.attributes).forEach(attribute => {
+        if (body.attributes[attribute].default === '') {
+          body.attributes[attribute].default = undefined;
+        }
+      });
     }
 
     try {


### PR DESCRIPTION
#### Description of what you did:
Fix issue #4138 - Cannot remove default value for number type in group.

Fixed by converting the zero-length string that is being submitted (from the frontend) to undefined.  This removes the default attribute and it then doesn't fail the validation checks as per issue #4138.

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [ ] Documentation
- [ ] Framework
- [x] Plugin

#### Manual testing done on the following databases:

- [x] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
