### PR TITLE
Mongoose reconnect

### DIFF
--- a/packages/strapi-hook-mongoose/lib/index.js
+++ b/packages/strapi-hook-mongoose/lib/index.js
@@ -119,7 +119,6 @@ module.exports = function(strapi) {
           throw err;
         }
 
-
         const initFunctionPath = path.resolve(
           strapi.config.appPath,
           'config',

--- a/packages/strapi-hook-mongoose/lib/index.js
+++ b/packages/strapi-hook-mongoose/lib/index.js
@@ -88,7 +88,7 @@ module.exports = function(strapi) {
         connectOptions.useCreateIndex = true;
         connectOptions.useUnifiedTopology = useUnifiedTopology || 'false';
 
-        let connect = () => {
+        const connect = () => {
           /* FIXME: for now, mongoose doesn't support srv auth except the way including user/pass in URI.
            * https://github.com/Automattic/mongoose/issues/6881 */
           return instance.connect(

--- a/packages/strapi-hook-mongoose/lib/index.js
+++ b/packages/strapi-hook-mongoose/lib/index.js
@@ -88,7 +88,7 @@ module.exports = function(strapi) {
         connectOptions.useCreateIndex = true;
         connectOptions.useUnifiedTopology = useUnifiedTopology || 'false';
 
-        let connect = function() {
+        let connect = () => {
           /* FIXME: for now, mongoose doesn't support srv auth except the way including user/pass in URI.
            * https://github.com/Automattic/mongoose/issues/6881 */
           return instance.connect(

--- a/packages/strapi-hook-mongoose/lib/index.js
+++ b/packages/strapi-hook-mongoose/lib/index.js
@@ -89,8 +89,8 @@ module.exports = function(strapi) {
         connectOptions.dbName = database;
         connectOptions.useCreateIndex = true;
         connectOptions.useUnifiedTopology = useUnifiedTopology || 'false';
-        connectOptions.reconnectInterval = reconnectInterval || defaults.reconnectInterval;
-        connectOptions.reconnectTries = reconnectTries || defaults.reconnectTries;
+        connectOptions.reconnectInterval = reconnectInterval;
+        connectOptions.reconnectTries = reconnectTries;
 
         const connect = () => {
           /* FIXME: for now, mongoose doesn't support srv auth except the way including user/pass in URI.
@@ -107,7 +107,7 @@ module.exports = function(strapi) {
         try {
           await connect();
 
-          instance.connection.on('disconnected', function() {
+          instance.connection.on('disconnected', () => {
             setTimeout(function() {
               connect()
               .catch(function(e) {

--- a/packages/strapi-hook-mongoose/lib/index.js
+++ b/packages/strapi-hook-mongoose/lib/index.js
@@ -107,6 +107,7 @@ module.exports = function(strapi) {
             setTimeout(function() {
               connect()
               .catch(function(e) {
+                strapi.log.error(e.message);
               })
             }, 2000);
           })

--- a/packages/strapi-hook-mongoose/lib/index.js
+++ b/packages/strapi-hook-mongoose/lib/index.js
@@ -31,6 +31,8 @@ const defaults = {
   authenticationDatabase: '',
   ssl: false,
   debug: false,
+  reconnectInterval: 1000,
+  reconnectTries: 30
 };
 
 const isMongooseConnection = ({ connector }) =>
@@ -60,7 +62,7 @@ module.exports = function(strapi) {
         } = connection.settings;
 
         const uriOptions = uri ? url.parse(uri, true).query : {};
-        const { authenticationDatabase, ssl, debug } = _.defaults(
+        const { authenticationDatabase, ssl, debug, reconnectInterval, reconnectTries } = _.defaults(
           connection.options,
           uriOptions,
           strapi.config.hook.settings.mongoose
@@ -87,6 +89,8 @@ module.exports = function(strapi) {
         connectOptions.dbName = database;
         connectOptions.useCreateIndex = true;
         connectOptions.useUnifiedTopology = useUnifiedTopology || 'false';
+        connectOptions.reconnectInterval = reconnectInterval || defaults.reconnectInterval;
+        connectOptions.reconnectTries = reconnectTries || defaults.reconnectTries;
 
         const connect = () => {
           /* FIXME: for now, mongoose doesn't support srv auth except the way including user/pass in URI.
@@ -109,7 +113,7 @@ module.exports = function(strapi) {
               .catch(function(e) {
                 strapi.log.error(e.message);
               })
-            }, 2000);
+            }, reconnectInterval);
           })
 
         } catch (error) {


### PR DESCRIPTION
This patch will restore a lost connection to MongoDB.
Checked on both standalone and replica set environments.
Please, put an attention that mongoose option reconnectTries doesn't have an effect on replica set.
The only way to restore a connection in this case is to use Mongoose.connect call

Related to MongoError: server instance pool was destroyed #4188

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [ ] Documentation
- [x] Framework
- [ ] Plugin

#### Manual testing done on the following databases:

- [ ] Not applicable
- [x] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
