### PR TITLE
Prevent 0 value being coerced to false when passed via prop

### DIFF
--- a/packages/strapi-helper-plugin/lib/src/components/InputNumberWithErrors/index.js
+++ b/packages/strapi-helper-plugin/lib/src/components/InputNumberWithErrors/index.js
@@ -119,7 +119,7 @@ class InputNumberWithErrors extends React.Component {
           style={inputStyle}
           tabIndex={tabIndex}
           step={step}
-          value={value}
+          value={value && Number(value)}
         />
         <InputDescription
           className={inputDescriptionClassName}
@@ -164,7 +164,7 @@ InputNumberWithErrors.defaultProps = {
   style: {},
   tabIndex: '0',
   validations: {},
-  value: 0,
+  value: null,
 };
 
 InputNumberWithErrors.propTypes = {
@@ -209,7 +209,7 @@ InputNumberWithErrors.propTypes = {
   style: PropTypes.object,
   tabIndex: PropTypes.string,
   validations: PropTypes.object,
-  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  value: PropTypes.number,
 };
 
 export default InputNumberWithErrors;

--- a/packages/strapi-plugin-content-type-builder/admin/src/components/CustomCheckbox/index.js
+++ b/packages/strapi-plugin-content-type-builder/admin/src/components/CustomCheckbox/index.js
@@ -15,7 +15,10 @@ import StyledCustomCheckbox from './StyledCustomCheckbox';
 class CustomCheckbox extends React.Component {
   // eslint-disable-line react/prefer-stateless-function
   state = {
-    isChecked: this.props.value !== null && this.props.value !== undefined,
+    isChecked:
+      this.props.value !== null &&
+      this.props.value !== undefined &&
+      !isNaN(this.props.value),
   };
 
   handleChange = ({ target: { checked } }) => {
@@ -66,7 +69,7 @@ class CustomCheckbox extends React.Component {
             errors={errors}
             name={name}
             onChange={this.handleInputNumberChange}
-            value={value || ''}
+            value={value}
           />
         )}
       </StyledCustomCheckbox>


### PR DESCRIPTION
#### Description of what you did:

This PR fixes issue #3832. 
It prevents 0 values being coerced as falsey when passed to the InputNumber component

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [ ] Documentation
- [ ] Framework
- [x] Plugin

#### Manual testing done on the following databases:

- [x] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
