### PR TITLE
Update template links in services/controllers to new doc pages

### DIFF
--- a/packages/strapi-generate-api/templates/bookshelf/controller.template
+++ b/packages/strapi-generate-api/templates/bookshelf/controller.template
@@ -1,7 +1,7 @@
 'use strict';
 
 /**
- * Read the documentation (https://strapi.io/documentation/3.0.0-beta.x/guides/controllers.html#core-controllers)
+ * Read the documentation (https://strapi.io/documentation/3.0.0-beta.x/concepts/controllers.html#core-controllers)
  * to customize this controller
  */
 

--- a/packages/strapi-generate-api/templates/bookshelf/service.template
+++ b/packages/strapi-generate-api/templates/bookshelf/service.template
@@ -1,7 +1,7 @@
 'use strict';
 
 /**
- * Read the documentation (https://strapi.io/documentation/3.0.0-beta.x/guides/services.html#core-services)
+ * Read the documentation (https://strapi.io/documentation/3.0.0-beta.x/concepts/services.html#core-services)
  * to customize this service
  */
 


### PR DESCRIPTION
#### Description of what you did:

Updated the documentation links in the service and controller templates to point to the changed links

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [ ] Documentation
- [x] Framework
- [ ] Plugin

#### Manual testing done on the following databases:

- [x] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
