### PR TITLE
Use idAttribute from schema to make CRUD operation in admin interface… 

### DIFF
--- a/packages/strapi-connector-bookshelf/lib/mount-models.js
+++ b/packages/strapi-connector-bookshelf/lib/mount-models.js
@@ -45,7 +45,7 @@ module.exports = ({ models, target, plugin = false }, ctx) => {
     definition.databaseName = getDatabaseName(connection);
     definition.client = _.get(connection.settings, 'client');
     _.defaults(definition, {
-      primaryKey: 'id',
+      primaryKey: _.get(definition, 'options.idAttribute', 'id'),
       primaryKeyType: _.get(definition, 'options.idAttributeType', 'integer'),
     });
 

--- a/packages/strapi-connector-bookshelf/lib/queries.js
+++ b/packages/strapi-connector-bookshelf/lib/queries.js
@@ -9,6 +9,7 @@ const {
   buildQuery,
   models: modelUtils,
 } = require('strapi-utils');
+const resolveParams = (params, idAttribute) => params.id ? { ..._.omit(params, 'id'), [idAttribute]: params.id } : params
 
 module.exports = function createQueryBuilder({ model, modelKey, strapi }) {
   /* Utils */
@@ -18,6 +19,8 @@ module.exports = function createQueryBuilder({ model, modelKey, strapi }) {
   const groupKeys = Object.keys(model.attributes).filter(key => {
     return model.attributes[key].type === 'group';
   });
+  const idAttribute = _.get(model, 'primaryKey', 'id');
+
 
   const timestamps = _.get(model, ['options', 'timestamps'], []);
 
@@ -109,7 +112,8 @@ module.exports = function createQueryBuilder({ model, modelKey, strapi }) {
   }
 
   async function update(params, values, { transacting } = {}) {
-    const entry = await model.forge(params).fetch({ transacting });
+    const modelForge =  await model.forge(params)
+    const entry = await model.forge(resolveParams(params, idAttribute)).fetch({ transacting });
 
     if (!entry) {
       const err = new Error('entry.notFound');

--- a/packages/strapi-connector-bookshelf/lib/queries.js
+++ b/packages/strapi-connector-bookshelf/lib/queries.js
@@ -112,7 +112,6 @@ module.exports = function createQueryBuilder({ model, modelKey, strapi }) {
   }
 
   async function update(params, values, { transacting } = {}) {
-    const modelForge =  await model.forge(params)
     const entry = await model.forge(resolveParams(params, idAttribute)).fetch({ transacting });
 
     if (!entry) {

--- a/packages/strapi-plugin-content-manager/admin/src/components/CustomTable/Row.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/CustomTable/Row.js
@@ -56,7 +56,7 @@ const getDisplayedValue = (type, value, name) => {
   }
 };
 
-function Row({ goTo, isBulkable, row, headers }) {
+function Row({ goTo, isBulkable, row, headers, idAttribute }) {
   const {
     entriesToDelete,
     onChangeBulk,
@@ -78,11 +78,12 @@ function Row({ goTo, isBulkable, row, headers }) {
       {isBulkable && (
         <td key="i" onClick={e => e.stopPropagation()}>
           <CustomInputCheckbox
-            name={row.id}
+            name={row[idAttribute]}
             onChange={onChangeBulk}
             value={
-              entriesToDelete.filter(id => toString(id) === toString(row.id))
-                .length > 0
+              entriesToDelete.filter(
+                id => toString(id) === toString(row[idAttribute])
+              ).length > 0
             }
           />
         </td>
@@ -109,14 +110,14 @@ function Row({ goTo, isBulkable, row, headers }) {
             {
               icoType: 'pencil',
               onClick: () => {
-                goTo(row.id);
+                goTo(row[idAttribute]);
               },
             },
             {
               id: row.id,
               icoType: 'trash',
               onClick: () => {
-                onClickDelete(row.id);
+                onClickDelete(row[idAttribute]);
               },
             },
           ]}
@@ -126,11 +127,16 @@ function Row({ goTo, isBulkable, row, headers }) {
   );
 }
 
+Row.defaultProps = {
+  idAttribute: 'id',
+};
+
 Row.propTypes = {
   goTo: PropTypes.func.isRequired,
   headers: PropTypes.array.isRequired,
   isBulkable: PropTypes.bool.isRequired,
   row: PropTypes.object.isRequired,
+  idAttribute: PropTypes.string,
 };
 
 export default withRouter(memo(Row));

--- a/packages/strapi-plugin-content-manager/admin/src/components/CustomTable/TableHeader.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/CustomTable/TableHeader.js
@@ -5,7 +5,7 @@ import { useListView } from '../../contexts/ListView';
 import CustomInputCheckbox from '../CustomInputCheckbox';
 import { Icon, Thead } from './styledComponents';
 
-function TableHeader({ headers, isBulkable }) {
+function TableHeader({ headers, isBulkable, idAttribute }) {
   const {
     data,
     entriesToDelete,
@@ -15,6 +15,7 @@ function TableHeader({ headers, isBulkable }) {
     searchParams: { _sort },
   } = useListView();
   const [sortBy, sortOrder] = _sort.split(':');
+  const onChangeSelectAll = () => onChangeBulkSelectall({ idAttribute });
 
   return (
     <Thead isBulkable={isBulkable}>
@@ -25,7 +26,7 @@ function TableHeader({ headers, isBulkable }) {
               entriesToDelete={entriesToDelete}
               isAll
               name="all"
-              onChange={onChangeBulkSelectall}
+              onChange={onChangeSelectAll}
               value={
                 data.length === entriesToDelete.length &&
                 entriesToDelete.length > 0
@@ -78,11 +79,13 @@ function TableHeader({ headers, isBulkable }) {
 TableHeader.defaultProps = {
   isBulkable: true,
   headers: [],
+  idAttribute: 'id',
 };
 
 TableHeader.propTypes = {
   headers: PropTypes.array,
   isBulkable: PropTypes.bool,
+  idAttribute: PropTypes.string,
 };
 
 export default memo(TableHeader);

--- a/packages/strapi-plugin-content-manager/admin/src/components/CustomTable/index.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/CustomTable/index.js
@@ -17,6 +17,7 @@ function CustomTable({
     location: { pathname, search },
     push,
   },
+  idAttribute,
   isBulkable,
 }) {
   const {
@@ -58,11 +59,11 @@ function CustomTable({
       data.map(row => {
         return (
           <TableRow
-            key={row.id}
+            key={row[idAttribute]}
             onClick={e => {
               e.preventDefault();
               e.stopPropagation();
-              handleGoTo(row.id);
+              handleGoTo(row[idAttribute]);
             }}
           >
             <Row
@@ -70,6 +71,7 @@ function CustomTable({
               headers={headers}
               row={row}
               goTo={handleGoTo}
+              idAttribute={idAttribute}
             />
           </TableRow>
         );
@@ -78,7 +80,11 @@ function CustomTable({
 
   return (
     <Table className="table">
-      <TableHeader headers={headers} isBulkable={isBulkable} />
+      <TableHeader
+        headers={headers}
+        isBulkable={isBulkable}
+        idAttribute={idAttribute}
+      />
       <tbody>
         {entriesToDelete.length > 0 && (
           <ActionCollapse colSpan={colSpanLength} />
@@ -94,6 +100,7 @@ CustomTable.defaultProps = {
   headers: [],
   isBulkable: true,
   slug: '',
+  idAttribute: 'id',
 };
 
 CustomTable.propTypes = {
@@ -108,6 +115,7 @@ CustomTable.propTypes = {
   }).isRequired,
   isBulkable: PropTypes.bool,
   slug: PropTypes.string,
+  idAttribute: PropTypes.string,
 };
 
 export default withRouter(memo(CustomTable));

--- a/packages/strapi-plugin-content-manager/admin/src/components/SelectMany/index.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/SelectMany/index.js
@@ -26,11 +26,12 @@ function SelectMany({
   source,
   targetModel,
   value,
+  idAttribute,
 }) {
   const [, drop] = useDrop({ accept: ItemTypes.RELATION });
   const findRelation = id => {
     const relation = value.filter(c => {
-      return `${c.id}` === `${id}`;
+      return `${c[idAttribute]}` === `${id}`;
     })[0];
 
     return {
@@ -64,7 +65,9 @@ function SelectMany({
         filterOption={(candidate, input) => {
           if (!isEmpty(value)) {
             const isSelected =
-              value.findIndex(item => item.id === candidate.value.id) !== -1;
+              value.findIndex(
+                item => item[idAttribute] === candidate.value.id
+              ) !== -1;
             if (isSelected) {
               return false;
             }
@@ -93,7 +96,7 @@ function SelectMany({
           <ul>
             {value.map((data, index) => (
               <ListItem
-                key={data.id}
+                key={data[idAttribute]}
                 data={data}
                 findRelation={findRelation}
                 mainField={mainField}
@@ -116,6 +119,7 @@ SelectMany.defaultProps = {
   move: () => {},
   source: 'content-manager',
   value: null,
+  idAttribute: 'id',
 };
 
 SelectMany.propTypes = {
@@ -135,6 +139,7 @@ SelectMany.propTypes = {
   source: PropTypes.string,
   targetModel: PropTypes.string.isRequired,
   value: PropTypes.array,
+  idAttribute: PropTypes.string,
 };
 
 export default memo(SelectMany);

--- a/packages/strapi-plugin-content-manager/admin/src/containers/ListView/actions.js
+++ b/packages/strapi-plugin-content-manager/admin/src/containers/ListView/actions.js
@@ -36,9 +36,10 @@ export function onChangeBulk({ target: { name, value } }) {
   };
 }
 
-export function onChangeBulkSelectall() {
+export function onChangeBulkSelectall({ idAttribute }) {
   return {
     type: ON_CHANGE_BULK_SELECT_ALL,
+    idAttribute,
   };
 }
 

--- a/packages/strapi-plugin-content-manager/admin/src/containers/ListView/index.js
+++ b/packages/strapi-plugin-content-manager/admin/src/containers/ListView/index.js
@@ -127,6 +127,8 @@ function ListView({
   const getMetaDatas = (path = []) =>
     get(layouts, [slug, 'metadatas', ...path], {});
   const getListLayout = () => get(layouts, [slug, 'layouts', 'list'], []);
+  const getIdAttribute = () =>
+    get(layouts, [slug, 'schema', 'options', 'idAttribute'], 'id');
   const getAllLabels = () => {
     return sortBy(
       Object.keys(getMetaDatas())
@@ -378,6 +380,7 @@ function ListView({
                   isBulkable={getLayoutSettingRef.current('bulkable')}
                   onChangeParams={handleChangeParams}
                   slug={slug}
+                  idAttribute={getIdAttribute()}
                 />
                 <Footer />
               </div>

--- a/packages/strapi-plugin-content-manager/admin/src/containers/ListView/reducer.js
+++ b/packages/strapi-plugin-content-manager/admin/src/containers/ListView/reducer.js
@@ -49,7 +49,9 @@ function listViewReducer(state = initialState, action) {
           return List([]);
         }
 
-        return state.get('data').map(value => toString(value.id));
+        return state
+          .get('data')
+          .map(value => toString(value[action.idAttribute]));
       });
     case ON_DELETE_DATA_SUCCEEDED:
       return state

--- a/packages/strapi-plugin-content-manager/services/ContentManager.js
+++ b/packages/strapi-plugin-content-manager/services/ContentManager.js
@@ -2,6 +2,8 @@
 
 const _ = require('lodash');
 const uploadFiles = require('../utils/upload-files');
+const getIdAttribute = (model, source) =>
+  _.get(strapi.query(model, source), 'primaryKey', 'id');
 /**
  * A set of functions called "actions" for `ContentManager`
  */
@@ -33,31 +35,34 @@ module.exports = {
 
   async createMultipart(data, { files = {}, model, source } = {}) {
     const entry = await strapi.query(model, source).create(data);
+    const idAttribute = getIdAttribute(model, source);
 
     await uploadFiles(entry, files, { model, source });
 
-    return strapi.query(model, source).findOne({ id: entry.id });
+    return strapi.query(model, source).findOne({ id: entry[idAttribute] });
   },
 
   async create(data, { files, model, source } = {}) {
     const entry = await strapi.query(model, source).create(data);
+    const idAttribute = getIdAttribute(model, source);
 
     if (files) {
       await uploadFiles(entry, files, { model, source });
-      return strapi.query(model, source).findOne({ id: entry.id });
+      return strapi.query(model, source).findOne({ id: entry[idAttribute] });
     }
 
     return entry;
   },
 
   async edit(params, data, { model, source, files } = {}) {
+    const idAttribute = getIdAttribute(model, source);
     const entry = await strapi
       .query(model, source)
       .update({ id: params.id }, data);
 
     if (files) {
       await uploadFiles(entry, files, { model, source });
-      return strapi.query(model, source).findOne({ id: entry.id });
+      return strapi.query(model, source).findOne({ id: entry[idAttribute] });
     }
 
     return entry;

--- a/packages/strapi-plugin-content-manager/services/ContentTypes.js
+++ b/packages/strapi-plugin-content-manager/services/ContentTypes.js
@@ -55,45 +55,42 @@ module.exports = {
 
   formatContentTypeSchema(contentType) {
     const { associations, allAttributes } = contentType;
-    return {
-      ...pickSchemaFields(contentType),
-      attributes: {
-        id: {
-          type: contentType.primaryKeyType,
-        },
-        ...Object.keys(allAttributes).reduce((acc, key) => {
-          const attribute = allAttributes[key];
-          const assoc = associations.find(assoc => assoc.alias === key);
+    const schemaFields = pickSchemaFields(contentType);
+    const attributes = Object.keys(allAttributes).reduce((acc, key) => {
+      const attribute = allAttributes[key];
+      const assoc = associations.find(assoc => assoc.alias === key);
 
-          if (assoc) {
-            const { plugin } = attribute;
-            let targetEntity = attribute.model || attribute.collection;
+      if (assoc) {
+        const { plugin } = attribute;
+        let targetEntity = attribute.model || attribute.collection;
 
-            if (plugin === 'upload' && targetEntity === 'file') {
-              acc[key] = {
-                type: 'media',
-                multiple: attribute.collection ? true : false,
-                required: attribute.required ? true : false,
-              };
-            } else {
-              acc[key] = {
-                ...attribute,
-                type: 'relation',
-                targetModel: targetEntity,
-                relationType: assoc.nature,
-              };
-            }
-          } else {
-            if (attribute.type === 'timestampUpdate') {
-              attribute.type = 'timestamp';
-            }
+        if (plugin === 'upload' && targetEntity === 'file') {
+          acc[key] = {
+            type: 'media',
+            multiple: attribute.collection ? true : false,
+            required: attribute.required ? true : false,
+          };
+        } else {
+          acc[key] = {
+            ...attribute,
+            type: 'relation',
+            targetModel: targetEntity,
+            relationType: assoc.nature,
+          };
+        }
+      } else {
+        if (attribute.type === 'timestampUpdate') {
+          attribute.type = 'timestamp';
+        }
 
-            acc[key] = attribute;
-          }
-          return acc;
-        }, {}),
-      },
+        acc[key] = attribute;
+      }
+      return acc;
+    }, {});
+    attributes[contentType.primaryKey] = {
+      type: contentType.primaryKeyType,
     };
+    return { ...schemaFields, attributes };
   },
 
   findContentTypeModel({ uid, source }) {

--- a/packages/strapi-plugin-content-manager/services/utils/configuration/__tests__/attributes.test.js
+++ b/packages/strapi-plugin-content-manager/services/utils/configuration/__tests__/attributes.test.js
@@ -1,9 +1,10 @@
 const { isSortable, isVisible } = require('../attributes');
 
-const createMockSchema = (attrs, timestamps = true) => {
+const createMockSchema = (attrs, { timestamps = true, options } = {}) => {
   return {
     options: {
       timestamps: timestamps ? ['createdAt', 'updatedAt'] : false,
+      ...options,
     },
     attributes: {
       id: {
@@ -28,12 +29,32 @@ describe('attributesUtils', () => {
   describe('isSortable', () => {
     test('The id attribute is always sortable', () => {
       expect(isSortable(createMockSchema({}), 'id')).toBe(true);
+      const customIdSchema = createMockSchema(
+        {
+          customId: {
+            type: 'integer',
+          },
+        },
+        {
+          options: {
+            idAttribute: 'customId',
+            idAttributeType: 'integer',
+          },
+        }
+      );
+      expect(isSortable(customIdSchema, 'customId')).toBe(true);
     });
 
     test('Timestamps are sortable', () => {
-      expect(isSortable(createMockSchema({}, true), 'createdAt')).toBe(true);
-      expect(isSortable(createMockSchema({}, true), 'updatedAt')).toBe(true);
-      expect(isSortable(createMockSchema({}, false), 'createdAt')).toBe(false);
+      expect(
+        isSortable(createMockSchema({}, { timestamps: true }), 'createdAt')
+      ).toBe(true);
+      expect(
+        isSortable(createMockSchema({}, { timestamps: true }), 'updatedAt')
+      ).toBe(true);
+      expect(
+        isSortable(createMockSchema({}, { timestamps: false }), 'createdAt')
+      ).toBe(false);
     });
 
     test('Group fields are not sortable', () => {

--- a/packages/strapi-plugin-content-manager/services/utils/configuration/attributes.js
+++ b/packages/strapi-plugin-content-manager/services/utils/configuration/attributes.js
@@ -18,12 +18,16 @@ const isListable = (schema, name) => {
   return true;
 };
 
+const getIdAttribute = schema =>
+  _.get(schema, ['options', 'idAttribute'], 'id');
+const isIdAttribute = (schema, name) => name === getIdAttribute(schema);
+
 const isSortable = (schema, name) => {
   if (!_.has(schema.attributes, name)) {
     return false;
   }
 
-  if (schema.modelType === 'group' && name === 'id') return false;
+  if (schema.modelType === 'group' && isIdAttribute(schema, name)) return false;
 
   const attribute = schema.attributes[name];
   if (NON_SORTABLES.includes(attribute.type)) {
@@ -42,7 +46,7 @@ const isVisible = (schema, name) => {
     return false;
   }
 
-  if (isTimestamp(schema, name) || name === 'id') {
+  if (isTimestamp(schema, name) || isIdAttribute(schema, name)) {
     return false;
   }
 

--- a/packages/strapi-plugin-content-manager/utils/upload-files.js
+++ b/packages/strapi-plugin-content-manager/utils/upload-files.js
@@ -44,9 +44,10 @@ module.exports = async (entry, files, { model, source }) => {
     const [path, field] = [_.initial(parts), _.last(parts)];
 
     const { model, source } = findModelFromUploadPath(path);
+    const idAttribute = getIdAttribute(model, source)
 
     if (model) {
-      const id = _.get(entry, path.concat('id'));
+      const id = _.get(entry, path.concat(idAttribute));
       return uploadService.uploadToEntity(
         { id, model: model },
         { [field]: files },

--- a/packages/strapi-plugin-content-manager/utils/upload-files.js
+++ b/packages/strapi-plugin-content-manager/utils/upload-files.js
@@ -3,6 +3,7 @@
 const _ = require('lodash');
 
 module.exports = async (entry, files, { model, source }) => {
+  const getIdAttribute = (model, source) => _.get(strapi.query(model, source), 'primaryKey', 'id')
   const entity = strapi.getModel(model, source);
 
   if (!_.has(strapi.plugins, 'upload')) return entry;

--- a/packages/strapi/lib/core-api/service.js
+++ b/packages/strapi/lib/core-api/service.js
@@ -21,7 +21,7 @@ module.exports = ({ model, strapi }) => {
      * @return {Promise}
      */
     find(params, populate) {
-      return strapi.query(model).find(params), populate);
+      return strapi.query(model).find(params, populate);
     },
 
     /**
@@ -31,7 +31,7 @@ module.exports = ({ model, strapi }) => {
      */
 
     findOne(params, populate) {
-      return strapi.query(model).findOne(params), populate);
+      return strapi.query(model).findOne(params, populate);
     },
 
     /**

--- a/packages/strapi/lib/core-api/service.js
+++ b/packages/strapi/lib/core-api/service.js
@@ -3,7 +3,6 @@
 const _ = require('lodash');
 const uploadFiles = require('./utils/upload-files');
 const getIdAttribute = model => _.get(strapi.query(model), 'primaryKey', 'id');
-const resolveParams = (params, idAttribute) => params.id ? { ..._.omit(params, 'id'), [idAttribute]: params.id } : params
 
 /**
  * default service
@@ -22,7 +21,7 @@ module.exports = ({ model, strapi }) => {
      * @return {Promise}
      */
     find(params, populate) {
-      return strapi.query(model).find(resolveParams(params, getIdAttribute(model)), populate);
+      return strapi.query(model).find(params), populate);
     },
 
     /**
@@ -32,7 +31,7 @@ module.exports = ({ model, strapi }) => {
      */
 
     findOne(params, populate) {
-      return strapi.query(model).findOne(resolveParams(params, getIdAttribute(model)), populate);
+      return strapi.query(model).findOne(params), populate);
     },
 
     /**
@@ -42,7 +41,7 @@ module.exports = ({ model, strapi }) => {
      */
 
     count(params) {
-      return strapi.query(model).count(resolveParams(params, getIdAttribute(model)));
+      return strapi.query(model).count(params);
     },
 
     /**
@@ -70,11 +69,11 @@ module.exports = ({ model, strapi }) => {
      */
 
     async update(params, data, { files } = {}) {
-      const idAttribute = getIdAttribute(model);
-      const entry = await strapi.query(model).update(resolveParams(params, idAttribute), data);
+      const entry = await strapi.query(model).update(params, data);
 
       if (files) {
         await this.uploadFiles(entry, files, { model });
+        const idAttribute = getIdAttribute(model);
         return this.findOne({ id: entry[idAttribute] });
       }
 
@@ -88,7 +87,7 @@ module.exports = ({ model, strapi }) => {
      */
 
     delete(params) {
-      return strapi.query(model).delete(resolveParams(params, getIdAttribute(model)));
+      return strapi.query(model).delete(params);
     },
 
     /**
@@ -98,7 +97,7 @@ module.exports = ({ model, strapi }) => {
      */
 
     search(params) {
-      return strapi.query(model).search(resolveParams(params, getIdAttribute(model)));
+      return strapi.query(model).search(params);
     },
 
     /**
@@ -107,7 +106,7 @@ module.exports = ({ model, strapi }) => {
      * @return {Promise}
      */
     countSearch(params) {
-      return strapi.query(model).countSearch(resolveParams(params, getIdAttribute(model)));
+      return strapi.query(model).countSearch(params);
     },
   };
 };

--- a/packages/strapi/lib/core-api/service.js
+++ b/packages/strapi/lib/core-api/service.js
@@ -1,6 +1,8 @@
 'use strict';
 
+const _ = require('lodash');
 const uploadFiles = require('./utils/upload-files');
+const resolveParams = (params, idAttribute) => params.id ? { ..._.omit(params, 'id'), [idAttribute]: params.id } : params
 
 /**
  * default service
@@ -19,7 +21,7 @@ module.exports = ({ model, strapi }) => {
      * @return {Promise}
      */
     find(params, populate) {
-      return strapi.query(model).find(params, populate);
+      return strapi.query(model).find(resolveParams(params, getIdAttribute(model)), populate);
     },
 
     /**
@@ -29,7 +31,7 @@ module.exports = ({ model, strapi }) => {
      */
 
     findOne(params, populate) {
-      return strapi.query(model).findOne(params, populate);
+      return strapi.query(model).findOne(resolveParams(params, getIdAttribute(model)), populate);
     },
 
     /**
@@ -39,7 +41,7 @@ module.exports = ({ model, strapi }) => {
      */
 
     count(params) {
-      return strapi.query(model).count(params);
+      return strapi.query(model).count(resolveParams(params, getIdAttribute(model)));
     },
 
     /**
@@ -53,7 +55,8 @@ module.exports = ({ model, strapi }) => {
 
       if (files) {
         await this.uploadFiles(entry, files, { model });
-        return this.findOne({ id: entry.id });
+        const idAttribute = getIdAttribute(model);
+        return this.findOne({ id: entry[idAttribute] });
       }
 
       return entry;
@@ -66,11 +69,12 @@ module.exports = ({ model, strapi }) => {
      */
 
     async update(params, data, { files } = {}) {
-      const entry = await strapi.query(model).update(params, data);
+      const idAttribute = getIdAttribute(model);
+      const entry = await strapi.query(model).update(resolveParams(params, idAttribute), data);
 
       if (files) {
         await this.uploadFiles(entry, files, { model });
-        return this.findOne({ id: entry.id });
+        return this.findOne({ id: entry[idAttribute] });
       }
 
       return entry;
@@ -83,7 +87,7 @@ module.exports = ({ model, strapi }) => {
      */
 
     delete(params) {
-      return strapi.query(model).delete(params);
+      return strapi.query(model).delete(resolveParams(params, getIdAttribute(model)));
     },
 
     /**
@@ -93,7 +97,7 @@ module.exports = ({ model, strapi }) => {
      */
 
     search(params) {
-      return strapi.query(model).search(params);
+      return strapi.query(model).search(resolveParams(params, getIdAttribute(model)));
     },
 
     /**
@@ -102,7 +106,7 @@ module.exports = ({ model, strapi }) => {
      * @return {Promise}
      */
     countSearch(params) {
-      return strapi.query(model).countSearch(params);
+      return strapi.query(model).countSearch(resolveParams(params, getIdAttribute(model)));
     },
   };
 };

--- a/packages/strapi/lib/core-api/service.js
+++ b/packages/strapi/lib/core-api/service.js
@@ -2,6 +2,7 @@
 
 const _ = require('lodash');
 const uploadFiles = require('./utils/upload-files');
+const getIdAttribute = model => _.get(strapi.query(model), 'primaryKey', 'id');
 const resolveParams = (params, idAttribute) => params.id ? { ..._.omit(params, 'id'), [idAttribute]: params.id } : params
 
 /**


### PR DESCRIPTION
#### Description of what you did:

I've made an option to import databases where tables are not using 'id' property as PK. As you still couldn't create custom id in content manager, but you could use properties `idAttribute` and `idAttributeType` to describe your PK name in `options` section of your model. And then you could simply use admin interface for CRUD operations create, read, list, update and delete. 
This is much simplifying import of existed database without requiring to create additional duplicated id field or change it. Because I think usually people migrating to Strapi when they already have some another language or framework that has shared access to DB - (you won't need to edit your old code to make Strapi working with your existed database schema).

To get more about this bug/feature, please check out this issue: https://github.com/strapi/strapi/issues/4084 

#### My PR is a:

- [ ] 💥 Breaking change
- [X] 🐛 Bug fix #4084
- [X] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [X] Admin
- [ ] Documentation
- [ ] Framework
- [X] Plugin

#### Manual testing done on the following databases:

- [ ] Not applicable
- [ ] MongoDB
- [X] MySQL
- [ ] Postgres
- [ ] SQLite