### PR TITLE
Lifecycle pre callbacks can be cancelled

### DIFF
--- a/packages/strapi-hook-mongoose/lib/mount-models.js
+++ b/packages/strapi-hook-mongoose/lib/mount-models.js
@@ -128,7 +128,7 @@ module.exports = ({ models, target, plugin = false }, ctx) => {
       const fn = preLifecycle[key];
 
       if (_.isFunction(target[model.toLowerCase()][fn])) {
-        schema.pre(key, function(next) {
+        schema.pre(key, function() {
           return target[model.toLowerCase()]
             [fn](this);
         });

--- a/packages/strapi-hook-mongoose/lib/mount-models.js
+++ b/packages/strapi-hook-mongoose/lib/mount-models.js
@@ -130,8 +130,7 @@ module.exports = ({ models, target, plugin = false }, ctx) => {
       if (_.isFunction(target[model.toLowerCase()][fn])) {
         schema.pre(key, function(next) {
           return target[model.toLowerCase()]
-            [fn](this)
-            .then(next);
+            [fn](this);
         });
       }
     });

--- a/packages/strapi-hook-mongoose/lib/mount-models.js
+++ b/packages/strapi-hook-mongoose/lib/mount-models.js
@@ -129,10 +129,9 @@ module.exports = ({ models, target, plugin = false }, ctx) => {
 
       if (_.isFunction(target[model.toLowerCase()][fn])) {
         schema.pre(key, function(next) {
-          target[model.toLowerCase()]
+          return target[model.toLowerCase()]
             [fn](this)
-            .then(next)
-            .catch(err => strapi.log.error(err));
+            .then(next);
         });
       }
     });


### PR DESCRIPTION
In case that any Lifecycle pre callback returns Promise.reject it will be caught by Admin UI showing error banner.
It allows custom validations with Lifecycle callbacks as well
Admin UI will show saving process without it in case of error inside Lifecycle callback just writing error message in log.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [ ] Documentation
- [x] Framework
- [ ] Plugin

#### Manual testing done on the following databases:

- [ ] Not applicable
- [x] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
