### PR TITLE
Use limit=0 to require full data set

### DIFF
--- a/docs/3.0.0-alpha.x/guides/filters.md
+++ b/docs/3.0.0-alpha.x/guides/filters.md
@@ -103,7 +103,7 @@ Limit the result length to 30.
 
 `GET /users?_limit=30`
 
-You can require the full data set by passing a limit equal to `-1`
+You can require the full data set by passing a limit equal to `0`
 
 ### Start
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

Tiny update to the documentation for 3.0.0-alpha:

In the Filters section is stated that you need to use `_limit=-1` to get the full data set, but in fact it is `_limit=0`

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [x] Documentation
- [ ] Framework
- [ ] Plugin

#### Manual testing done on the following databases:

- [x] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
