### PR TITLE
Clean up template and remove keys that would break bookshelf/knex

### DIFF
--- a/packages/strapi-generate-new/lib/resources/json/database.json.js
+++ b/packages/strapi-generate-new/lib/resources/json/database.json.js
@@ -3,23 +3,17 @@
 module.exports = ({ connection, env }) => {
   // Production/Staging Template
   if (['production', 'staging'].includes(env)) {
-    // All available settings (bookshelf and mongoose)
     const settingsBase = {
       client: connection.settings.client,
       host: "${process.env.DATABASE_HOST || '127.0.0.1'}",
       port: '${process.env.DATABASE_PORT || 27017}',
-      srv: '${process.env.DATABASE_SRV || false}',
       database: "${process.env.DATABASE_NAME || 'strapi'}",
       username: "${process.env.DATABASE_USERNAME || ''}",
       password: "${process.env.DATABASE_PASSWORD || ''}",
-      ssl: '${process.env.DATABASE_SSL || false}',
     };
 
-    // All available options (bookshelf and mongoose)
     const optionsBase = {
-      ssl: '${process.env.DATABASE_SSL || false}',
-      authenticationDatabase:
-        "${process.env.DATABASE_AUTHENTICATION_DATABASE || ''}",
+      debug: false,
     };
 
     return {

--- a/packages/strapi-generate-new/lib/resources/json/database.json.js
+++ b/packages/strapi-generate-new/lib/resources/json/database.json.js
@@ -12,9 +12,7 @@ module.exports = ({ connection, env }) => {
       password: "${process.env.DATABASE_PASSWORD || ''}",
     };
 
-    const optionsBase = {
-      debug: false,
-    };
+    const optionsBase = {};
 
     return {
       defaultConnection: 'default',


### PR DESCRIPTION
#### Description of what you did:

Some options provided in the staging and production template would break knex from connecting due to it throwing errors instead of ignoring keys it doesn't support.

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix #3891 
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [ ] Documentation
- [x] Framework
- [ ] Plugin

#### Manual testing done on the following databases:

- [x] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
