### PR TITLE
Add security and vulnerability reporting page

### DIFF
--- a/.github/ISSUE_TEMPLATE/SECURITY.md
+++ b/.github/ISSUE_TEMPLATE/SECURITY.md
@@ -1,6 +1,6 @@
 ---
 name: 🛡 Security
-about: Information on reporting security volnerabilities
+about: Information on reporting security vulnerabilities
 ---
 
 # Security Policy

--- a/.github/ISSUE_TEMPLATE/SECURITY.md
+++ b/.github/ISSUE_TEMPLATE/SECURITY.md
@@ -1,0 +1,26 @@
+---
+name: 🛡 Security
+about: Information on reporting security volnerabilities
+---
+
+# Security Policy
+
+## Supported Versions
+
+As of November 2019 (and until this document is updated), only the v3.0.0-beta tags of Strapi are supported for updates. Any previous versions are currently not supported and users are advised to use them "at their own risk".
+
+## Reporting a Vulnerability
+
+Please report (suspected) security vulnerabilities to
+**[security@strapi.io](mailto:security@strapi.io)** or via the [Strapi Slack](https://slack.strapi.io).
+
+When reporting a (suspected) security vulnerabilitie via slack please reach out to any of the following Strapi employees directly:
+
+- `@aureliengeorget`
+- `@alexandre`
+- `@lauriejim`
+- `@soupette`
+
+You will receive a response from us within 72 hours. If the issue is confirmed,
+we will release a patch as soon as possible depending on complexity
+but historically within a few days.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,0 +1,21 @@
+# Security Policy
+
+## Supported Versions
+
+As of November 2019 (and until this document is updated), only the v3.0.0-beta tags of Strapi are supported for updates. Any previous versions are currently not supported and users are advised to use them "at their own risk".
+
+## Reporting a Vulnerability
+
+Please report (suspected) security vulnerabilities to
+**[security@strapi.io](mailto:security@strapi.io)** or via the [Strapi Slack](https://slack.strapi.io).
+
+When reporting a (suspected) security vulnerabilitie via slack please reach out to any of the following Strapi employees directly:
+
+- `@aureliengeorget`
+- `@alexandre`
+- `@lauriejim`
+- `@soupette`
+
+You will receive a response from us within 72 hours. If the issue is confirmed,
+we will release a patch as soon as possible depending on complexity
+but historically within a few days.


### PR DESCRIPTION
#### Description of what you did:

Added Security page for reporting vulnerabilities directly to Strapi via email or slack.

It's likely the email address will need to be changed as it probably doesn't exist.

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [x] Documentation
- [ ] Framework
- [ ] Plugin

#### Manual testing done on the following databases:

- [x] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
