### PR TITLE
Retrieve roles without populating users and permissions relations

### DIFF
--- a/packages/strapi-plugin-users-permissions/services/UsersPermissions.js
+++ b/packages/strapi-plugin-users-permissions/services/UsersPermissions.js
@@ -389,7 +389,9 @@ module.exports = {
       };
 
       // Retrieve roles
-      const roles = await strapi.query('role', 'users-permissions').find();
+      const roles = await strapi
+        .query('role', 'users-permissions')
+        .find({}, []);
 
       // We have to know the difference to add or remove
       // the permissions entries in the database.


### PR DESCRIPTION
#### Description of what you did:
Fix #4511 
In UsersPermissions bootstrap function, we are using the query builder to retrieve roles, it autopopulates permissions and users by default, which slow down the start of strapi when there is a big number of users or permissions in database.

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [ ] Documentation
- [ ] Framework
- [x] Plugin

#### Manual testing done on the following databases:

- [x] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
