### PR TITLE
Write the correct database configuration

### DIFF
--- a/packages/strapi-generate-new/lib/create-customized-project.js
+++ b/packages/strapi-generate-new/lib/create-customized-project.js
@@ -44,7 +44,7 @@ async function askDbInfosAndTest(scope) {
       dependencies: clientDependencies({ scope, client }),
     };
 
-    await testDatabaseConnection({
+    return testDatabaseConnection({
       scope,
       configuration,
     })
@@ -67,6 +67,7 @@ async function askDbInfosAndTest(scope) {
           });
         }
       )
+      .then(() => configuration)
       .catch(err => {
         if (retries < MAX_RETRIES - 1) {
           console.log();
@@ -88,8 +89,6 @@ async function askDbInfosAndTest(scope) {
           `️⛔️ Could not connect to your database after ${MAX_RETRIES} tries. Try to check your database configuration an retry.`
         );
       });
-
-    return configuration;
   }
 
   return loop();


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

When a database connection fails, the CLI proposes a retry.
If you succeed to connect to the database during this retry, the database information is written in the `./config/environments/development/database.json` is the info of the first try.
So it means it's the wrong info.

This PR fix that to use the last successful try info.

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix #4490
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [ ] Documentation
- [x] Framework
- [ ] Plugin

#### Manual testing done on the following databases:

- [x] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
