### PR TITLE
Wrap tsvector attributes with coalesce before join

### DIFF
--- a/packages/strapi-hook-bookshelf/lib/queries.js
+++ b/packages/strapi-hook-bookshelf/lib/queries.js
@@ -546,8 +546,8 @@ const buildSearchQuery = (qb, model, params) => {
     case 'pg': {
       const searchQuery = searchText.map(attribute =>
         _.toLower(attribute) === attribute
-          ? `to_tsvector(${attribute})`
-          : `to_tsvector("${attribute}")`
+          ? `to_tsvector(coalesce(${attribute}, ''))`
+          : `to_tsvector(coalesce("${attribute}", ''))`
       );
 
       qb.orWhereRaw(`${searchQuery.join(' || ')} @@ plainto_tsquery(?)`, query);


### PR DESCRIPTION
#### Description of what you did:
Columns are now wrapped in `coalesce` before joining the tsvectors because a single NULL would result in the entire tsvector being NULL. This used to result in unexpected behaviour where a single NULL would disable searching for relations in the content-manager when using postgres as the backend.

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [ ] Documentation
- [x] Framework
- [ ] Plugin

#### Manual testing done on the following databases:

- [ ] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [x] Postgres
- [ ] SQLite
