### PR TITLE
Change admin UI's default language to English if browser's preferred language is not found

### DIFF
--- a/packages/strapi-admin/admin/src/containers/LanguageProvider/reducer.js
+++ b/packages/strapi-admin/admin/src/containers/LanguageProvider/reducer.js
@@ -5,7 +5,7 @@
  */
 
 import { fromJS } from 'immutable';
-import { first, get, includes, split } from 'lodash';
+import { get, includes, split } from 'lodash';
 
 // Import supported languages from the translations folder
 import trads from '../../translations';
@@ -33,7 +33,7 @@ if (!foundLanguage) {
 }
 
 const initialState = fromJS({
-  locale: foundLanguage || first(languages) || 'en',
+  locale: foundLanguage || 'en',
 });
 
 function languageProviderReducer(state = initialState, action) {


### PR DESCRIPTION
#### Description of what you did:

Previously admin panels language defaulted to Arabic if browsers preferred language was not supported. 
I think it definitely should be English, so I changed that.

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [x] Admin
- [ ] Documentation
- [ ] Framework
- [ ] Plugin

#### Manual testing done on the following databases:

- [x] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
