### PR TITLE
Enable customization of decimal types.

### DIFF
--- a/packages/strapi-hook-bookshelf/lib/buildDatabaseSchema.js
+++ b/packages/strapi-hook-bookshelf/lib/buildDatabaseSchema.js
@@ -387,6 +387,7 @@ const getType = ({ definition, attribute, name, tableExists = false }) => {
         return null;
     }
   }
+  let customTypes = strapi.config.customTypes || {};
 
   switch (attribute.type) {
     case 'uuid':
@@ -407,9 +408,9 @@ const getType = ({ definition, attribute, name, tableExists = false }) => {
       if (client === 'sqlite3') return 'bigint(53)'; // no choice until the sqlite3 package supports returning strings for big integers
       return 'bigint';
     case 'float':
-      return client === 'pg' ? 'double precision' : 'double';
+      return customTypes[attribute.type] || (client === 'pg' ?  'double precision' : 'double');
     case 'decimal':
-      return 'decimal(10,2)';
+      return customTypes[attribute.type] || 'decimal(10,2)';
     // TODO: split time types as they should be different
     case 'date':
     case 'time':


### PR DESCRIPTION
#### Description of change:

This change allows setting the database type for decimals which is useful for setting a custom precision.
The type can be set in the config json of the strapi installation.
Relevant feature request: #1330

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [ ] 💅 Enhancement
- [x] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [ ] Documentation
- [ ] Framework
- [ ] Plugin

#### Manual testing done on the following databases:

- [ ] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [x] Postgres
- [ ] SQLite
