### PR TITLE
Fix Local Upload Provider URL

### DIFF
--- a/packages/strapi-provider-upload-local/lib/index.js
+++ b/packages/strapi-provider-upload-local/lib/index.js
@@ -21,7 +21,7 @@ module.exports = {
               return reject(err);
             }
 
-            file.url = `/uploads/${file.hash}${file.ext}`;
+            file.url = `${strapi.config.url}/uploads/${file.hash}${file.ext}`;
 
             resolve();
           });


### PR DESCRIPTION
#### Description of what you did:

`strapi-provider-upload-local` provides a `path` to a field labeled `url`. Added protocol and FQDN so value is a `url`.

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [ ] Documentation
- [x] Framework
- [ ] Plugin

#### Manual testing done on the following databases:

- [ ] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [x] Postgres
- [x] SQLite
