### PR TITLE
Allow to change index file from server.json

### DIFF
--- a/packages/strapi/lib/middlewares/public/index.js
+++ b/packages/strapi/lib/middlewares/public/index.js
@@ -33,7 +33,7 @@ module.exports = strapi => {
       );
 
       // Open the file.
-      const filename =
+      const filename = strapi.config.currentEnvironment.server.indexFile ||
         strapi.config.environment === 'development' ? 'index' : 'production';
 
       const index = fs.readFileSync(


### PR DESCRIPTION
If you want to place a specific file name to be interpreted as root you can configure it within config/environments/{environment}/server.json 

Example
```
{
  "host": "localhost",
  "port": "${process.env.PORT || 1337}",
  "production": true,
  "proxy": {
    "enabled": false
  },
  "cron": {
    "enabled": false
  },
  "admin": {
    "autoOpen": false,
    "path": "/admin"
  },
  "indexFile": "index"
}
```

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [ ] Documentation
- [x] Framework
- [ ] Plugin

#### Manual testing done on the following databases:

- [x] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
