### PR TITLE
Fix documentation generation when route has no config

### DIFF
--- a/packages/strapi-plugin-documentation/services/Documentation.js
+++ b/packages/strapi-plugin-documentation/services/Documentation.js
@@ -471,7 +471,7 @@ module.exports = {
           current.handler,
           key,
           endPoint.split('/')[1],
-          current.config.description
+          _.get(current, 'config.description')
         ),
         responses: this.generateResponses(verb, current, key),
         summary: '',


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

Fix the access to the `config.description` if the `config` key not exist.

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix #2533
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [ ] Documentation
- [ ] Framework
- [x] Plugin

#### Manual testing done on the following databases:

- [x] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
