### PR TITLE
Fix typo in documentation of Many-to-Many relationship in model.md

### DIFF
--- a/docs/3.0.0-beta.x/concepts/models.md
+++ b/docs/3.0.0-beta.x/concepts/models.md
@@ -349,7 +349,7 @@ xhr.send(
 
 ::: tab "Many-to-Many" id="many-to-many"
 
-One-to-Many relationships are usefull when an entry can be liked to multiple entries of an other Content Type. And an entry of the other Content Type can be linked to many entries.
+Many-to-Many relationships are usefull when an entry can be liked to multiple entries of an other Content Type. And an entry of the other Content Type can be linked to many entries.
 
 #### Example
 


### PR DESCRIPTION
## Description of what you did:
There is a typo in Many-to-Many Relationship section. It should be `Many-to-Many` instead of `One-to-Many`.

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [X] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [X] Documentation
- [ ] Framework
- [ ] Plugin

#### Manual testing done on the following databases:

- [X] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
