### PR TITLE
Beta.18.x migration guide add mongoose tabs

### DIFF
--- a/docs/3.0.0-beta.x/migration-guide/migration-guide-beta.17-to-beta.18.md
+++ b/docs/3.0.0-beta.x/migration-guide/migration-guide-beta.17-to-beta.18.md
@@ -19,6 +19,10 @@ Starting from beta.18 the database packages have been changed to allow future ch
 
 Update your package.json accordingly:
 
+:::: tabs
+
+::: tab bookshelf
+
 **Before**
 
 ```json
@@ -46,19 +50,67 @@ Update your package.json accordingly:
 {
   //...
   "dependencies": {
-    "strapi": "3.0.0-beta.18",
-    "strapi-admin": "3.0.0-beta.18",
-    "strapi-connector-bookshelf": "3.0.0-beta.18",
-    "strapi-plugin-content-manager": "3.0.0-beta.18",
-    "strapi-plugin-content-type-builder": "3.0.0-beta.18",
-    "strapi-plugin-email": "3.0.0-beta.18",
-    "strapi-plugin-graphql": "3.0.0-beta.18",
-    "strapi-plugin-upload": "3.0.0-beta.18",
-    "strapi-plugin-users-permissions": "3.0.0-beta.18",
-    "strapi-utils": "3.0.0-beta.18"
+    "strapi": "3.0.0-beta.18.3",
+    "strapi-admin": "3.0.0-beta.18.3",
+    "strapi-connector-bookshelf": "3.0.0-beta.18.3",
+    "strapi-plugin-content-manager": "3.0.0-beta.18.3",
+    "strapi-plugin-content-type-builder": "3.0.0-beta.18.3",
+    "strapi-plugin-email": "3.0.0-beta.18.3",
+    "strapi-plugin-graphql": "3.0.0-beta.18.3",
+    "strapi-plugin-upload": "3.0.0-beta.18.3",
+    "strapi-plugin-users-permissions": "3.0.0-beta.18.3",
+    "strapi-utils": "3.0.0-beta.18.3"
   }
 }
 ```
+
+:::
+
+::: tab mongoose
+
+**Before**
+
+```json
+{
+  //...
+  "dependencies": {
+    "strapi": "3.0.0-beta.17.4",
+    "strapi-admin": "3.0.0-beta.17.4",
+    "strapi-hook-mongoose": "3.0.0-beta.17.4", // rename to strapi-connector-mongoose
+    "strapi-plugin-content-manager": "3.0.0-beta.17.4",
+    "strapi-plugin-content-type-builder": "3.0.0-beta.17.4",
+    "strapi-plugin-email": "3.0.0-beta.17.4",
+    "strapi-plugin-graphql": "3.0.0-beta.17.4",
+    "strapi-plugin-upload": "3.0.0-beta.17.4",
+    "strapi-plugin-users-permissions": "3.0.0-beta.17.4",
+    "strapi-utils": "3.0.0-beta.17.4"
+  }
+}
+```
+
+**After**
+
+```json
+{
+  //...
+  "dependencies": {
+    "strapi": "3.0.0-beta.18.3",
+    "strapi-admin": "3.0.0-beta.18.3",
+    "strapi-connector-mongoose": "3.0.0-beta.18.3",
+    "strapi-plugin-content-manager": "3.0.0-beta.18.3",
+    "strapi-plugin-content-type-builder": "3.0.0-beta.18.3",
+    "strapi-plugin-email": "3.0.0-beta.18.3",
+    "strapi-plugin-graphql": "3.0.0-beta.18.3",
+    "strapi-plugin-upload": "3.0.0-beta.18.3",
+    "strapi-plugin-users-permissions": "3.0.0-beta.18.3",
+    "strapi-utils": "3.0.0-beta.18.3"
+  }
+}
+```
+
+:::
+
+::::
 
 Then run either `yarn install` or `npm install`.
 
@@ -67,6 +119,10 @@ Then run either `yarn install` or `npm install`.
 Now that you have installed the new database package. You need to update your `database.json` configuration files located in `./config/environments/{env}/database.json`.
 
 You can now only use the connector name instead of the complete package name.
+
+:::: tabs
+
+::: tab bookshelf
 
 **Before**
 
@@ -104,6 +160,91 @@ You can now only use the connector name instead of the complete package name.
 }
 ```
 
+:::
+
+::: tab mongoose
+
+**Before**
+
+```json
+{
+  "defaultConnection": "default",
+  "connections": {
+    "default": {
+      "connector": "strapi-hook-mongoose",
+      "settings": {
+        //...
+      },
+      "options": {}
+    }
+  }
+}
+```
+
+**After**
+
+```json
+{
+  "defaultConnection": "default",
+  "connections": {
+    "default": {
+      "connector": "mongoose",
+      "settings": {
+        //...
+      },
+      "options": {
+        //...
+      }
+    }
+  }
+}
+```
+
+:::
+
+::::
+
+## Adding new root page files
+
+We created new home pages when your go to your api url.
+You will need to copy `index.html` and `production.html` into your `public` folder.
+You can find those two files [here](https://github.com/strapi/strapi/tree/master/packages/strapi-generate-new/lib/resources/files/public).
+
+## Updating `csp` options
+
+The admin panel contains certain assets that use `data:img;base64` images. To allow rendering of those assets you can update the files `./config/environments/{env}/security.json` as follows:
+
+**Before**
+
+```json
+{
+  "csp": {
+    "enabled": true,
+    "policy": [
+      {
+        "img-src": "'self' http:"
+      },
+      "block-all-mixed-content"
+    ]
+  }
+  //....
+}
+```
+
+**After**
+
+```json
+{
+  "csp": {
+    "enabled": true,
+    "policy": ["block-all-mixed-content"]
+  }
+  //....
+}
+```
+
+If you need more fine control you can also simply add the `data:` option to the `img-src` option.
+
 ## `ctx.state.user`
 
 Previously the ctx.state.user was populated with the user informations, its role and permissions. To avoid perfromance issues the role is the only populated relation on the user by default.
@@ -112,11 +253,11 @@ Previously the ctx.state.user was populated with the user informations, its role
 
 The file model has been updated. The `size` field is now a decimal number, allowing correct sorting behavior.
 
-You will need to clear some database indexes if you are using either Mysql or PostgreSQL.
+You will need to clear some database indexes if you are using either MySQL or PostgreSQL.
 
 :::: tabs
 
-::: tab Mysql
+::: tab MySQL
 
 Run the following statement in your database:
 
@@ -298,7 +439,7 @@ RENAME COLUMN group_id to component_id;
 
 :::
 
-::: tab Mysql
+::: tab MySQL
 
 ```sql
 -- renaming the table
@@ -342,7 +483,7 @@ RENAME TO components_new_table_name;
 ```
 
 :::
-::: tab Mysql
+::: tab MySQL
 
 ```sql
 -- renaming the table
@@ -462,47 +603,6 @@ db.getCollection('contentTypeCollection').update(
   { multi: true }
 );
 ```
-
-## Adding new root page files
-
-We created new home pages when your go to your api url.
-You will need to copy `index.html` and `production.html` into your `public` folder.
-You can find those two files [here](https://github.com/strapi/strapi/tree/master/packages/strapi-generate-new/lib/resources/files/public).
-
-## Updating `csp` options
-
-The admin panel contains certain assets that use `data:img;base64` images. To allow rendering of those assets you can update the files `./config/environments/{env}/security.json` as follows:
-
-**Before**
-
-```json
-{
-  "csp": {
-    "enabled": true,
-    "policy": [
-      {
-        "img-src": "'self' http:"
-      },
-      "block-all-mixed-content"
-    ]
-  }
-  //....
-}
-```
-
-**After**
-
-```json
-{
-  "csp": {
-    "enabled": true,
-    "policy": ["block-all-mixed-content"]
-  }
-  //....
-}
-```
-
-If you need more fine control you can also simply add the `data:` option to the `img-src` option.
 
 ## Rebuilding your administration panel
 


### PR DESCRIPTION
#### Description of what you did:

Added tabs for mongoose and restructured a bit (Moved comp/groups to the end to make the CSP and root pages changes clear for those that aren't using comp/groups)

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [x] Documentation
- [ ] Framework
- [ ] Plugin

#### Manual testing done on the following databases:

- [x] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
