### PR TITLE
allow POST requests to pass in 'role' in the JSON

### DIFF
--- a/packages/strapi-plugin-users-permissions/controllers/Auth.js
+++ b/packages/strapi-plugin-users-permissions/controllers/Auth.js
@@ -444,9 +444,11 @@ module.exports = {
       );
     }
 
+    const roleType = params.role || settings.default_role
+
     const role = await strapi
-      .query('role', 'users-permissions')
-      .findOne({ type: settings.default_role }, []);
+    query('role', 'users-permissions')
+      .findOne({ type: roleType }, []);
 
     if (!role) {
       return ctx.badRequest(
@@ -580,9 +582,9 @@ module.exports = {
     } catch (err) {
       const adminError = _.includes(err.message, 'username')
         ? {
-            id: 'Auth.form.error.username.taken',
-            message: 'Username already taken',
-          }
+          id: 'Auth.form.error.username.taken',
+          message: 'Username already taken',
+        }
         : { id: 'Auth.form.error.email.taken', message: 'Email already taken' };
 
       ctx.badRequest(null, formatError(adminError));


### PR DESCRIPTION
This allows for post requests to automatically add the users to a pre-existing role setup in the admin panel, thereby allowing for programmatic creation of roles when creating accounts.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

I allowed for the role to be passed in (optionally) on post requests for creating users so that the front end can more easily create predefined users. I'd be happy to update the docs if this is an acceptable PR.

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [X] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [ ] Documentation
- [ ] Framework
- [X] Plugin

#### Manual testing done on the following databases:

I tested this on my local build using Mongo Atlas.

- [X] Not applicable
- [X] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
