### PR TITLE
Add database timezone config options to documentation

### DIFF
--- a/docs/3.0.0-beta.x/concepts/configurations.md
+++ b/docs/3.0.0-beta.x/concepts/configurations.md
@@ -212,7 +212,7 @@ You can access the config of the current environment through `strapi.config.curr
       - `username` (string): Username used to establish the connection.
       - `password` (string): Password used to establish the connection.
       - `options` (object): List of additional options used by the connector.
-      - `timezone` (string): Set the default behavior for local time. Default value: `utc`.
+      - `timezone` (string): Set the default behavior for local time. Default value: `utc` [Timezone options](https://www.php.net/manual/en/timezones.php).
       - `schema` (string): Set the default database schema. **Used only for Postgres DB**
       - `ssl` (boolean): For ssl database connection.
     - `options` Options used for database connection.


### PR DESCRIPTION
#### Description of what you did:

Added example link to php standard timezones for use with the database config option for timezone.

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [x] Documentation
- [ ] Framework
- [ ] Plugin

#### Manual testing done on the following databases:

- [ ] Not applicable
- [ ] MongoDB
- [x] MySQL
- [ ] Postgres
- [x] SQLite
