### PR TITLE
Remove content builder links from content manager in non development environments

### DIFF
--- a/packages/strapi-plugin-content-type-builder/admin/src/InjectedComponents/ContentManager/EditSettingViewButton.js
+++ b/packages/strapi-plugin-content-type-builder/admin/src/InjectedComponents/ContentManager/EditSettingViewButton.js
@@ -14,7 +14,7 @@ import getTrad from '../../utils/getTrad';
 
 // Create link from content-type-builder to content-manager
 function EditViewButton(props) {
-  const { emitEvent, formatMessage } = useGlobalContext();
+  const { currentEnvironment, emitEvent, formatMessage } = useGlobalContext();
   // Retrieve URL from props
   const { modifiedData, componentSlug, type } = get(
     props,
@@ -40,6 +40,10 @@ function EditViewButton(props) {
     emitEvent('willEditEditLayout');
     props.push(`${baseUrl}/${suffixUrl}`);
   };
+
+  if (currentEnvironment !== 'development') {
+    return null;
+  }
 
   if (props.getModelName() === 'strapi::administrator') {
     return null;

--- a/packages/strapi-plugin-content-type-builder/admin/src/InjectedComponents/ContentManager/EditViewLink.js
+++ b/packages/strapi-plugin-content-type-builder/admin/src/InjectedComponents/ContentManager/EditViewLink.js
@@ -10,9 +10,13 @@ import { LiLink, useGlobalContext } from 'strapi-helper-plugin';
 
 // Create link from content-type-builder to content-manager
 function EditViewLink(props) {
-  const { emitEvent } = useGlobalContext();
+  const { currentEnvironment, emitEvent } = useGlobalContext();
   // Retrieve URL from props
   const url = `/plugins/content-type-builder/content-types/${props.getModelName()}`;
+
+  if (currentEnvironment !== 'development') {
+    return null;
+  }
 
   if (props.getModelName() === 'strapi::administrator') {
     return null;


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:
This PR removes the injected links components in the content manager when the user is not in development environments as it might be confusing for the user. The content builder is still in read only in these environments.

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [ ] Documentation
- [ ] Framework
- [ ] Plugin

#### Manual testing done on the following databases:

- [ ] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
