### PR TITLE
Add map and series to RESERVED_NAMES in CTB

### DIFF
--- a/packages/strapi-plugin-content-type-builder/admin/src/containers/FormModal/utils/reservedNames.js
+++ b/packages/strapi-plugin-content-type-builder/admin/src/containers/FormModal/utils/reservedNames.js
@@ -1,14 +1,21 @@
 const JS_BUILT_IN_OBJECTS = [
-  'object',
-  'function',
   'boolean',
-  'symbol',
-  'error',
-  'infinity',
-  'number',
-  'math',
   'date',
+  'error',
+  'function',
+  'infinity',
+  'map',
+  'math',
+  'number',
+  'object',
+  'symbol',
 ];
-const RESERVED_NAMES = ['admin', 'series', 'file', ...JS_BUILT_IN_OBJECTS];
+const RESERVED_NAMES = [
+  'admin',
+  'series',
+  'file',
+  'news',
+  ...JS_BUILT_IN_OBJECTS,
+];
 
 export default RESERVED_NAMES;


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:
This PR prevents a user from creating a content type called either `map` or `series` in the ctb as it can break their project.

fix #4875 
fix #4470

#### My PR is a:

- [ ] 💥 Breaking change
- [X] 🐛 Bug fix 
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [ ] Documentation
- [ ] Framework
- [ ] Plugin

#### Manual testing done on the following databases:

- [ ] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
