### PR TITLE
Update policies documentation to include link to GraphQL doc

### DIFF
--- a/docs/3.0.0-beta.x/concepts/policies.md
+++ b/docs/3.0.0-beta.x/concepts/policies.md
@@ -56,6 +56,10 @@ You can access to any controllers, services or models thanks to the global varia
 
 To apply policies to a route, you need to associate an array of policies to it. There are two kinds of policies: global or scoped.
 
+::: warning
+To apply policies with GraphQL please see the [following guide](../plugins/graphql.md#execute-a-policy-before-a-resolver)
+:::
+
 ### Global policies
 
 The global policies can be associated to any routes in your project.


### PR DESCRIPTION
#### Description of what you did:

Added a link in the concept/policy documentation to the related GraphQL policy docs to clarify you need to edit the schema.graphql file to enable policies for GQL routes (Mutations as an example)

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [x] Documentation
- [ ] Framework
- [ ] Plugin

#### Manual testing done on the following databases:

- [x] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
