### PR TITLE
Remove soft hyphen (U+00AD) from reset password email subject line

### DIFF
--- a/packages/strapi-admin/controllers/Auth.js
+++ b/packages/strapi-admin/controllers/Auth.js
@@ -327,7 +327,7 @@ module.exports = {
         email: 'no-reply@strapi.io',
       },
       response_email: '',
-      object: '­Reset password',
+      object: 'Reset password',
       message: `<p>We heard that you lost your password. Sorry about that!</p>
 
 <p>But don’t worry! You can use the following link to reset your password:</p>

--- a/packages/strapi-plugin-users-permissions/config/functions/bootstrap.js
+++ b/packages/strapi-plugin-users-permissions/config/functions/bootstrap.js
@@ -126,7 +126,7 @@ module.exports = async () => {
             email: 'no-reply@strapi.io',
           },
           response_email: '',
-          object: '­Reset password',
+          object: 'Reset password',
           message: `<p>We heard that you lost your password. Sorry about that!</p>
 
 <p>But don’t worry! You can use the following link to reset your password:</p>


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

Remove soft hypen (https://graphemica.com/00AD) from the reset password email subject lines. It's not visible in the browser, but appears in my IDE as well as in Outlook or other non-browser-based email clients.

![image](https://user-images.githubusercontent.com/83678/72207312-0c8b8480-3466-11ea-94c3-affed1e7310e.png)

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [ ] Documentation
- [ ] Framework
- [x] Plugin

#### Manual testing done on the following databases:

- [x] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
