### PR TITLE
Update Providers.js for Facebook Auth to prevent new user to be blocked on registration

### DIFF
--- a/packages/strapi-plugin-users-permissions/services/Providers.js
+++ b/packages/strapi-plugin-users-permissions/services/Providers.js
@@ -178,7 +178,7 @@ const getProfile = async (provider, query, callback) => {
             callback(err);
           } else {
             callback(null, {
-              username: body.name,
+              username: body.name + '#' + body.id,
               email: body.email,
             });
           }


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:
Issue: https://github.com/strapi/strapi/issues/4998

So I've replaced the facebook callback username by user.name + user.id.
It prevent new users with an already known name to be blocked as registration using Facebook Auth.

Since you only use the user email to find a user, it won't give any bugs or incorrect login attempts in the future
https://github.com/strapi/strapi/blob/master/packages/strapi-plugin-users-permissions/services/Providers.js#L44
``
const users = await strapi.query('user', 'users-permissions').find({
          email: profile.email,
        });
``

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [ ] Documentation
- [ ] Framework
- [x] Plugin

#### Manual testing done on the following databases:

- [ ] Not applicable
- [x] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite