### PR TITLE
Adding more reserved model names based on SQL syntax

### DIFF
--- a/packages/strapi-plugin-content-type-builder/admin/src/containers/FormModal/utils/reservedNames.js
+++ b/packages/strapi-plugin-content-type-builder/admin/src/containers/FormModal/utils/reservedNames.js
@@ -10,12 +10,35 @@ const JS_BUILT_IN_OBJECTS = [
   'object',
   'symbol',
 ];
+
+const DB_RESERVED_SYNTAX = [
+  'call',
+  'case',
+  'cast',
+  'character',
+  'exclusive',
+  'global',
+  'language',
+  'national',
+  'natural',
+  'order',
+  'procedure',
+  'return',
+  'space',
+  'transaction',
+  'trigger',
+  'work',
+  'zone',
+
+];
+
 const RESERVED_NAMES = [
   'admin',
   'series',
   'file',
   'news',
   ...JS_BUILT_IN_OBJECTS,
+  ...DB_RESERVED_SYNTAX,
 ];
 
 export default RESERVED_NAMES;

--- a/packages/strapi-plugin-content-type-builder/admin/src/containers/FormModal/utils/reservedNames.js
+++ b/packages/strapi-plugin-content-type-builder/admin/src/containers/FormModal/utils/reservedNames.js
@@ -29,7 +29,6 @@ const DB_RESERVED_SYNTAX = [
   'trigger',
   'work',
   'zone',
-
 ];
 
 const RESERVED_NAMES = [


### PR DESCRIPTION
#### Description of what you did:

Adding more reserved model name words relating to SQL specific syntax. Using the following list to grab a few that might be used to create models: https://docs.actian.com/psql/psqlv13/index.html#page/sqlref%2Fsqlkword.htm%23ww79654

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix #4983
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [ ] Documentation
- [ ] Framework
- [x] Plugin

#### Manual testing done on the following databases:

- [ ] Not applicable
- [ ] MongoDB
- [x] MySQL
- [ ] Postgres
- [x] SQLite
