### PR TITLE
Feat/time fields step

### DIFF
--- a/docs/3.0.0-beta.x/concepts/models.md
+++ b/docs/3.0.0-beta.x/concepts/models.md
@@ -166,6 +166,7 @@ If you're using SQL databases, you should use the native SQL constraints to appl
 - `index` (boolean) — adds an index on this property, this will create a [single field index](https://docs.mongodb.com/manual/indexes/#single-field) that will run in the background (_only supported by MongoDB_).
 - `max` (integer) — checks if the value is greater than or equal to the given minimum.
 - `min` (integer) — checks if the value is less than or equal to the given maximum.
+- `step` (integer) — for time and datetime content types defines step in minutes (value must be divisable by 60).
 
 **Security validations**
 To improve the Developer eXperience when developing or using the administration panel, the framework enhances the attributes with these "security validations":

--- a/packages/strapi-plugin-content-manager/admin/src/components/Inputs/index.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/Inputs/index.js
@@ -115,7 +115,9 @@ function Inputs({ autoFocus, keys, layout, name, onBlur }) {
 
   let step;
 
-  if (type === 'float' || type === 'decimal') {
+  if (type === 'datetime' || type === 'time') {
+    step = attribute.step;
+  } else if (type === 'float' || type === 'decimal') {
     step = 'any';
   } else {
     step = '1';

--- a/packages/strapi-plugin-content-type-builder/admin/src/containers/FormModal/index.js
+++ b/packages/strapi-plugin-content-type-builder/admin/src/containers/FormModal/index.js
@@ -1244,7 +1244,7 @@ const FormModal = () => {
                           } else if (input.name === 'uid') {
                             value = input.value;
                           } else {
-                            value = retrievedValue;
+                            value = retrievedValue || input.value || '';
                           }
 
                           // The addon input is not present in @buffetjs so we are using the old lib

--- a/packages/strapi-plugin-content-type-builder/admin/src/containers/FormModal/index.js
+++ b/packages/strapi-plugin-content-type-builder/admin/src/containers/FormModal/index.js
@@ -533,6 +533,9 @@ const FormModal = () => {
       // We store an array for the enum
     } else if (name === 'enum') {
       val = value.split('\n');
+    } else if (name === 'step') {
+      // step accepts number enum values
+      val = +value.split('\n');
     } else {
       val = value;
     }

--- a/packages/strapi-plugin-content-type-builder/admin/src/containers/FormModal/utils/forms.js
+++ b/packages/strapi-plugin-content-type-builder/admin/src/containers/FormModal/utils/forms.js
@@ -476,6 +476,10 @@ const forms = {
               disabled: data.type !== 'date',
             },
           ]);
+
+          if (data.type === 'datetime' || data.type === 'time') {
+            items.splice(1, 0, [fields.step]);
+          }
         }
 
         if (!ATTRIBUTES_THAT_DONT_HAVE_MIN_MAX_SETTINGS.includes(type)) {

--- a/packages/strapi-plugin-content-type-builder/admin/src/containers/FormModal/utils/staticFields.js
+++ b/packages/strapi-plugin-content-type-builder/admin/src/containers/FormModal/utils/staticFields.js
@@ -56,6 +56,17 @@ const fields = {
     },
     validations: {},
   },
+  step: {
+    autoFocus: false,
+    name: 'step',
+    type: 'select',
+    label: {
+      id: getTrad('form.attribute.item.timestep'),
+    },
+    options: [60, 30, 20, 15, 10, 5, 1],
+    value: 30,
+    validations: {},
+  },
   name: {
     autoFocus: true,
     name: 'name',

--- a/packages/strapi-plugin-content-type-builder/admin/src/translations/en.json
+++ b/packages/strapi-plugin-content-type-builder/admin/src/translations/en.json
@@ -69,6 +69,7 @@
   "form.attribute.item.maximumLength": "Maximum length",
   "form.attribute.item.minimum": "Minimum value",
   "form.attribute.item.minimumLength": "Minimum length",
+  "form.attribute.item.timestep": "Time picker step (minutes)",
   "form.attribute.item.number.type": "Number format",
   "form.attribute.item.number.type.biginteger": "big integer (ex: 123456789)",
   "form.attribute.item.number.type.decimal": "decimal (ex: 2.22)",

--- a/packages/strapi-plugin-content-type-builder/admin/src/translations/pl.json
+++ b/packages/strapi-plugin-content-type-builder/admin/src/translations/pl.json
@@ -19,6 +19,7 @@
   "form.attribute.item.maximumLength": "Maksymalna długość",
   "form.attribute.item.minimum": "Minimalna wartość",
   "form.attribute.item.minimumLength": "Minimalna długość",
+  "form.attribute.item.timestep": "Podziałka wyboru czasu (minuty)",
   "form.attribute.item.number.type": "Forma",
   "form.attribute.item.number.type.decimal": "dziesiętna (np: 2.22)",
   "form.attribute.item.number.type.float": "zmiennoprzecinkowa (np: 3.33333333)",

--- a/packages/strapi-plugin-content-type-builder/controllers/validation/types.js
+++ b/packages/strapi-plugin-content-type-builder/controllers/validation/types.js
@@ -127,13 +127,20 @@ const getTypeShape = (attribute, { modelType } = {}) => {
         max: yup.number(),
       };
     }
-    case 'time':
-    case 'datetime':
     case 'date': {
       return {
         default: yup.string(),
         required: validators.required,
         unique: validators.unique,
+      };
+    }
+    case 'time':
+    case 'datetime': {
+      return {
+        default: yup.string(),
+        required: validators.required,
+        unique: validators.unique,
+        step: yup.number(),
       };
     }
     case 'boolean': {


### PR DESCRIPTION
#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [x] Admin
- [ ] Documentation
- [ ] Framework
- [ ] Plugin

#### Manual testing done on the following databases:

- [x] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite

With this PR It will be pausible to set step for time and datetime fields through [Model]settings.json file or on frontend on field settings in advanced tab.