### PR TITLE
feat: add "create new" functonality to SelectMany

### DIFF
--- a/packages/strapi-plugin-content-manager/admin/src/components/SelectMany/components.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/SelectMany/components.js
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { Link } from 'react-router-dom';
 
 const ListWrapper = styled.div`
   overflow: hidden;
@@ -145,4 +146,8 @@ const Li = styled.li`
   }
 `;
 
-export { ListShadow, ListWrapper, Li };
+const AddNewLink = styled(Link)`
+  text-decoration: none;
+`;
+
+export { AddNewLink, ListShadow, ListWrapper, Li };

--- a/packages/strapi-plugin-content-manager/admin/src/components/SelectMany/index.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/SelectMany/index.js
@@ -6,7 +6,7 @@ import { useDrop } from 'react-dnd';
 import Select, { createFilter } from 'react-select';
 import ItemTypes from '../../utils/ItemTypes';
 
-import { ListShadow, ListWrapper } from './components';
+import { AddNewLink, ListShadow, ListWrapper } from './components';
 import ListItem from './ListItem';
 
 function SelectMany({
@@ -22,7 +22,11 @@ function SelectMany({
   onMenuScrollToBottom,
   onRemove,
   options,
+  pathname,
   placeholder,
+  relationType,
+  sourceId,
+  sourceModel,
   targetModel,
   value,
 }) {
@@ -107,12 +111,33 @@ function SelectMany({
         )}
         {!isEmpty(value) && value.length > 4 && <ListShadow />}
       </ListWrapper>
+
+      <div style={{ marginBottom: 18 }} />
+
+      {sourceId &&
+        sourceModel &&
+        relationType === 'oneToMany' &&
+        sourceId !== 'create' && (
+        <AddNewLink
+          to={{
+            pathname: `/plugins/content-manager/${targetModel}/create`,
+            search: `redirectUrl=${pathname}`,
+            state: {
+              [`preselected_${sourceModel}`]: sourceId,
+            },
+          }}
+        >
+            Create new
+        </AddNewLink>
+      )}
     </>
   );
 }
 
 SelectMany.defaultProps = {
   move: () => {},
+  sourceId: null,
+  sourceModel: null,
   value: null,
 };
 
@@ -129,7 +154,11 @@ SelectMany.propTypes = {
   onMenuScrollToBottom: PropTypes.func.isRequired,
   onRemove: PropTypes.func.isRequired,
   options: PropTypes.array.isRequired,
+  pathname: PropTypes.string.isRequired,
   placeholder: PropTypes.node.isRequired,
+  relationType: PropTypes.string.isRequired,
+  sourceId: PropTypes.string,
+  sourceModel: PropTypes.string,
   targetModel: PropTypes.string.isRequired,
   value: PropTypes.array,
 };

--- a/packages/strapi-plugin-content-manager/admin/src/containers/EditView/index.js
+++ b/packages/strapi-plugin-content-manager/admin/src/containers/EditView/index.js
@@ -32,6 +32,9 @@ const EditView = ({
   components,
   currentEnvironment,
   layouts,
+  match: {
+    params: { id },
+  },
   plugins,
   slug,
 }) => {
@@ -262,6 +265,8 @@ const EditView = ({
                           key={relationName}
                           name={relationName}
                           relationsType={relation.relationType}
+                          sourceId={id}
+                          sourceModel={slug}
                         />
                       );
                     })}
@@ -309,6 +314,11 @@ EditView.propTypes = {
   components: PropTypes.array.isRequired,
   emitEvent: PropTypes.func,
   layouts: PropTypes.object.isRequired,
+  match: PropTypes.shape({
+    params: PropTypes.shape({
+      id: PropTypes.string.isRequired,
+    }).isRequired,
+  }).isRequired,
   slug: PropTypes.string.isRequired,
   plugins: PropTypes.object,
 };


### PR DESCRIPTION


<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

This PR introduces a "Create new" link to the SelectMany component provided the following are true:

- The relation is of type "oneToMany" (that is, "Belongs to many" in the content type builder, or a bidirectional relation).
- The item has already been created and is being edited.

This enables a simpler workflow: previously, one would have to go to the ListView of the related model, create a new entry, save it, go back to the item we were editing, and associate the newly created entry to the item.

Now, the user can click the "Create new" link, create the new item, and it will be automatically associated to the source item. When the use saves it, they will be redirected back to the EditView of the source item.

This only works on "Belongs to many" relations, and not in "Has many", because the association is made from the target model's creation view, and not from the source model's edit view. Therefore, we need the relation to be bidirectional.

I'm marking this PR as a draft because it is untested, undocumented, and un-i18n'd. I wanted to receive some feedback on this feature before putting more work into it. The new link is also not styled at all, which I'm not sure if is okay for the project.

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [ ] 💅 Enhancement
- [X] 🚀 New feature

#### Main update on the:

- [X] Admin
- [ ] Documentation
- [ ] Framework
- [ ] Plugin

#### Manual testing done on the following databases:

- [X] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite

Thanks for your time.