### PR TITLE
Bugfix: graphql role query

### DIFF
--- a/packages/strapi-plugin-users-permissions/config/schema.graphql
+++ b/packages/strapi-plugin-users-permissions/config/schema.graphql
@@ -80,7 +80,7 @@ module.exports = {
         plugin: 'users-permissions',
         resolverOf: 'UsersPermissions.getRoles', // Apply the `getRoles` permissions on the resolver.
         resolver: async (obj, options, { context }) => {
-          context.params = {...context.params, ...options.input};
+          context.params = {...context.params, ...options};
 
           await strapi.plugins[
             'users-permissions'


### PR DESCRIPTION
Bugfix: the `role` graphql query always returns `authenticated` role

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [ ] Documentation
- [ ] Framework
- [x] Plugin

#### Manual testing done on the following databases:

- [ ] Not applicable
- [x] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
