### PR TITLE
Fix getting a User with an unknown id

### DIFF
--- a/packages/strapi/lib/middlewares/boom/index.js
+++ b/packages/strapi/lib/middlewares/boom/index.js
@@ -95,8 +95,8 @@ module.exports = strapi => {
         }
 
         // Format `ctx.body` and `ctx.status`.
-        ctx.status = ctx.body.isBoom ? ctx.body.output.statusCode : ctx.status;
         ctx.body = ctx.body.isBoom ? ctx.body.output.payload : ctx.body;
+        ctx.status = ctx.body.isBoom ? ctx.body.output.statusCode : ctx.status;
       });
     },
 


### PR DESCRIPTION
ready to be merged

#### Description of what you did:
If status is set to 204, 205 or 304, ctx.body is set to null by koa causing a NPE on the next line (cf https://github.com/koajs/koa/blob/eda27608f7d39ede86d7b402aae64b1867ce31c6/lib/response.js#L92 and https://github.com/jshttp/statuses/blob/5b319c2bca7034943a43a5b4b3268866221661e1/index.js#L42)
A simple solution is to switch the two lines.

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix #5132
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [ ] Documentation
- [x] Framework
- [ ] Plugin

#### Manual testing done on the following databases:

- [ ] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
