### PR TITLE
Check if ref is set before checking toJSON

### DIFF
--- a/packages/strapi-connector-mongoose/lib/mount-models.js
+++ b/packages/strapi-connector-mongoose/lib/mount-models.js
@@ -229,7 +229,8 @@ module.exports = ({ models, target, plugin = false }, ctx) => {
     const refToStrapiRef = obj => {
       const ref = obj.ref;
 
-      let plainData = typeof ref.toJSON === 'function' ? ref.toJSON() : ref;
+      let plainData =
+        ref && typeof ref.toJSON === 'function' ? ref.toJSON() : ref;
 
       if (typeof plainData !== 'object') return ref;
 


### PR DESCRIPTION
#### Description of what you did:
Fix #5129 
Check if `ref` is set before calling toJSON to prevent doing toJSON on a null object.

#### My PR is a:

- [ ] 💥 Breaking change
- [X] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [ ] Documentation
- [x] Framework
- [ ] Plugin

#### Manual testing done on the following databases:

- [ ] Not applicable
- [X] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
