### PR TITLE
Add warning messages to Alpha docs

### DIFF
--- a/docs/3.0.0-alpha.x/getting-started/introduction.md
+++ b/docs/3.0.0-alpha.x/getting-started/introduction.md
@@ -10,6 +10,12 @@ Users love Strapi because it is open source, MIT licensed, fully customizable an
 
 ### Get Started
 
+::: danger
+
+The Alpha version of Strapi is no longer supported, please use the Beta version. You can find the relevant [documentation here](https://strapi.io/documentation/).
+
+:::
+
 You are invited to get started using Strapi. You may explore Strapi by:
 
 1. A [Quick Start Guide](../getting-started/quick-start.html) for more intermediate to advanced developers.

--- a/docs/3.0.0-alpha.x/getting-started/quick-start-tutorial.md
+++ b/docs/3.0.0-alpha.x/getting-started/quick-start-tutorial.md
@@ -1,5 +1,11 @@
 # Tutorial
 
+::: danger
+
+The Alpha version of Strapi is no longer supported, please use the Beta version. You can find the relevant [documentation here](https://strapi.io/documentation/).
+
+:::
+
 This Tutorial is written for developers who prefer a more detailed step-by-step introduction. (A less detailed introduction can be found at [Quick Start Guide](/3.0.0-alpha.x/getting-started/quick-start.html).)
 
 <div class="video-container">

--- a/docs/3.0.0-alpha.x/getting-started/quick-start.md
+++ b/docs/3.0.0-alpha.x/getting-started/quick-start.md
@@ -1,5 +1,11 @@
 # Quick Start Guide
 
+::: danger
+
+The Alpha version of Strapi is no longer supported, please use the Beta version. You can find the relevant [documentation here](https://strapi.io/documentation/).
+
+:::
+
 Get ready to make Strapi up and running in **less than 5 minutes** 🚀
 
 <div class="video-container">


### PR DESCRIPTION
#### Description of what you did:

Adding warning messages to new users not to use the Alpha version. Based on feedback the deprecated notice at the top of the docs didn't quite get the point across.

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [x] Documentation
- [ ] Framework
- [ ] Plugin

#### Manual testing done on the following databases:

- [x] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
