### PR TITLE
Add MIME accept metadata field for media upload input

### DIFF
--- a/packages/strapi-helper-plugin/lib/src/components/InputFile/index.js
+++ b/packages/strapi-helper-plugin/lib/src/components/InputFile/index.js
@@ -113,7 +113,7 @@ class InputFile extends React.Component {
   };
 
   render() {
-    const { multiple, name, onChange, value } = this.props;
+    const { accept, multiple, name, onChange, value } = this.props;
 
     return (
       <Wrapper>
@@ -138,6 +138,7 @@ class InputFile extends React.Component {
           />
           <label style={{ marginBottom: 0, width: '100%' }}>
             <input
+              accept={accept}
               className="inputFile"
               multiple={multiple}
               name={name}
@@ -173,6 +174,7 @@ InputFile.defaultProps = {
 };
 
 InputFile.propTypes = {
+  accept: PropTypes.string,
   error: PropTypes.bool,
   multiple: PropTypes.bool,
   name: PropTypes.string.isRequired,

--- a/packages/strapi-plugin-content-manager/admin/src/components/CustomTable/TableHeader.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/CustomTable/TableHeader.js
@@ -61,7 +61,6 @@ function TableHeader({ headers, isBulkable }) {
             >
               <span className={header.sortable ? 'sortable' : ''}>
                 {header.label}
-
                 {sortBy === header.name && (
                   <Arrow className={`${sortOrder === 'ASC' && 'isAsc'}`} />
                 )}

--- a/packages/strapi-plugin-content-manager/admin/src/components/InputFileWithErrors/InputFile.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/InputFileWithErrors/InputFile.js
@@ -11,6 +11,7 @@ function InputFile({
   name,
   value,
   setLabel,
+  accept,
 }) {
   useEffect(() => {
     dispatch({
@@ -20,6 +21,7 @@ function InputFile({
 
   return (
     <Input
+      accept={accept}
       multiple={multiple}
       error={error}
       name={name}
@@ -38,6 +40,7 @@ function InputFile({
 }
 
 InputFile.defaultProps = {
+  accept: null,
   dispatch: () => {},
   error: false,
   multiple: false,
@@ -47,6 +50,7 @@ InputFile.defaultProps = {
 };
 
 InputFile.propTypes = {
+  accept: PropTypes.string,
   dispatch: PropTypes.func,
   error: PropTypes.bool,
   multiple: PropTypes.bool,

--- a/packages/strapi-plugin-content-manager/admin/src/components/InputFileWithErrors/index.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/InputFileWithErrors/index.js
@@ -13,6 +13,7 @@ import InputFile from './InputFile';
 import Container from './Container';
 
 function InputFileWithErrors({
+  accept,
   className,
   error: inputError,
   inputDescription,
@@ -60,6 +61,7 @@ function InputFileWithErrors({
 
             <InputFile
               {...props}
+              accept={accept}
               error={hasError}
               onChange={onChange}
               value={value}
@@ -80,6 +82,7 @@ function InputFileWithErrors({
 }
 
 InputFileWithErrors.defaultProps = {
+  accept: null,
   className: '',
   error: null,
   inputDescription: '',
@@ -91,6 +94,7 @@ InputFileWithErrors.defaultProps = {
 };
 
 InputFileWithErrors.propTypes = {
+  accept: PropTypes.string,
   className: PropTypes.string,
   error: PropTypes.string,
   inputDescription: PropTypes.oneOfType([

--- a/packages/strapi-plugin-content-manager/services/utils/configuration/metadatas.js
+++ b/packages/strapi-plugin-content-manager/services/utils/configuration/metadatas.js
@@ -62,6 +62,7 @@ function createDefaultMetadata(schema, name) {
       'visible',
       'editable',
       'mainField',
+      'accept',
     ])
   );
 


### PR DESCRIPTION
#### Description of what you did:

Adds a metadata field for media upload inputs, as described in [this roadmap item](https://portal.productboard.com/strapi/1-public-roadmap/c/54-restrict-types-of-files-uploaded).

This allows us to form inputs like `<input type="file" accept="image/jpeg,image/png" />`, which restricts the type of media that can be uploaded to Strapi. The default is as it was before (unrestricted).

This PR does _not_ include UI for setting the accept metadata (I tested by doing this programmatically). It is just a small refactor of the file upload components to make future work possible.

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [ ] Documentation
- [ ] Framework
- [x] Plugin

#### Manual testing done on the following databases:

- [ ] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [x] Postgres
- [ ] SQLite
