### PR TITLE
feat/omitFilenamesPrefix-configuration (PURPOSAL)

### DIFF
--- a/docs/3.0.0-beta.x/concepts/configurations.md
+++ b/docs/3.0.0-beta.x/concepts/configurations.md
@@ -35,6 +35,7 @@ Contains the main configurations relative to your project.
 - `public`
   - `path` (string): Path to the public folder. Default value: `./public`.
   - `maxAge` (integer): Cache-control max-age directive in ms. Default value: `60000`.
+- `omitFilenamesPrefix` (string): filename prefix which will be omitted when setting global `strapi` object. By default all filenames inside `/api/controllers`, `/api/services` and `/api/models` will be accessible in global objects: `strapi.controllers`, `strapi.services`, `strapi.models`. For instance file `/api/services/Foo` will be accessible through: `strapi.services.foo`. In some cases you may not want that, then just set `"omitFilenamesPrefix": "_"` (or another key). Files named e.g `/api/controllers/_Foo` will be omitted from `strapi` object.
 
 ## Custom
 

--- a/packages/strapi/lib/Strapi.js
+++ b/packages/strapi/lib/Strapi.js
@@ -334,7 +334,6 @@ class Strapi extends EventEmitter {
 
     const [
       config,
-      api,
       admin,
       plugins,
       middlewares,
@@ -343,7 +342,6 @@ class Strapi extends EventEmitter {
       components,
     ] = await Promise.all([
       loadConfig(this),
-      loadApis(this),
       loadAdmin(this),
       loadPlugins(this),
       loadMiddlewares(this),
@@ -353,6 +351,9 @@ class Strapi extends EventEmitter {
     ]);
 
     _.merge(this.config, config);
+
+    // api is loaded later, because depends on config
+    const api = await loadApis(this);
 
     this.api = api;
     this.admin = admin;

--- a/packages/strapi/lib/core/load-apis.js
+++ b/packages/strapi/lib/core/load-apis.js
@@ -6,8 +6,9 @@ const _ = require('lodash');
 const loadFiles = require('../load/load-files');
 const loadConfig = require('../load/load-config-files');
 
-module.exports = async ({ dir }) => {
+module.exports = async ({ dir, config }) => {
   const apiDir = join(dir, 'api');
+  const omitFilenamesPrefix = _.get(config, 'omitFilenamesPrefix', '');
 
   if (!existsSync(apiDir)) {
     throw new Error(
@@ -15,7 +16,14 @@ module.exports = async ({ dir }) => {
     );
   }
 
-  const apis = await loadFiles(apiDir, '*/!(config)/**/*.*(js|json)');
+  const filenamPrefix = omitFilenamesPrefix
+    ? `[!${omitFilenamesPrefix}]*`
+    : '*';
+
+  const apis = await loadFiles(
+    apiDir,
+    `*/!(config)/**/${filenamPrefix}.*(js|json)`
+  );
   const apiConfigs = await loadConfig(apiDir, '*/config/**/*.*(js|json)');
 
   return _.merge(apis, apiConfigs);


### PR DESCRIPTION
Hello there,
Few days ago I asked question on slack if there is a way to omit some files from strapi folders which not be accessible from `strapi` object. And there isn't. Here's my purposal of doing this. I may move this config in other place, name it differently or do it in other way, just need guides.

**Use case:**
I like to keep my service/controller files clean as possible. Each function as separate file, just imported to controller/service, like so:

```
- /api
-- /MyModel
--- /services
---- /MyModel.js
---- /Foo.js
```

but `foo` is accessible through: `strapi.services.foo`

with this PR, there will be possible to set omitted prefix, like `_`, and then _Foo will not be accessible through `strapi.services` object.
 
#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [ ] Documentation
- [x] Framework
- [ ] Plugin

#### Manual testing done on the following databases:

- [x] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
