### PR TITLE
Expose mongoose connections

### DIFF
--- a/packages/strapi-connector-mongoose/lib/index.js
+++ b/packages/strapi-connector-mongoose/lib/index.js
@@ -125,6 +125,8 @@ module.exports = function(strapi) {
           connection,
         };
 
+        _.set(strapi, `connections.${connectionName}`, instance);
+
         return Promise.all([
           mountComponents(connectionName, ctx),
           mountApis(connectionName, ctx),


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

When a connection is open with Bookshelf we can access the Knex instance via `strapi.connections.default` and that lets you execute custom SQL queries.

Here is the code line https://github.com/strapi/strapi/blob/master/packages/strapi-connector-bookshelf/lib/knex.js#L227

But this not happen with Mongoose. This PR just apply the same logic to be able to execute custom requests to the MongDB database.

This PR will close #5199 
<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [ ] Documentation
- [x] Framework
- [ ] Plugin

#### Manual testing done on the following databases:

- [ ] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
