### PR TITLE
removed text-transform from variable name

### DIFF
--- a/packages/strapi-plugin-content-type-builder/admin/src/components/ListRow/Wrapper.js
+++ b/packages/strapi-plugin-content-type-builder/admin/src/components/ListRow/Wrapper.js
@@ -43,7 +43,6 @@ const Wrapper = styled.tr`
     }}
     p {
       font-weight: 500;
-      text-transform: capitalize;
     }
   }
   td:last-child {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:
Hello There!
I was following the tutorial and realize that variable names are capitalized, which is a bit misleading.
So thought of removing that.

![image](https://user-images.githubusercontent.com/143546/75087111-6782c200-5562-11ea-8dec-c276cd79cc52.png)