### PR TITLE
Added information about body and files to request docs

### DIFF
--- a/docs/3.0.0-beta.x/concepts/requests-responses.md
+++ b/docs/3.0.0-beta.x/concepts/requests-responses.md
@@ -4,6 +4,8 @@
 
 The context object (`ctx`) contains all the requests related information. They are accessible through `ctx.request`, from [controllers](controllers.md) and [policies](policies.md).
 
+Strapi passes the `body` on `ctx.request.body` and `files` through `ctx.request.files`
+
 For more information, please refer to the [Koa request documentation](http://koajs.com/#request).
 
 ## Responses


### PR DESCRIPTION
#### Description of what you did:

These paths to body and files differ from Koa's typical pathing, adding them to the docs temporarily until the docs are reworked.
