### PR TITLE
Add documentation for making backend requests

### DIFF
--- a/docs/3.0.0-beta.x/plugin-development/frontend-development.md
+++ b/docs/3.0.0-beta.x/plugin-development/frontend-development.md
@@ -291,3 +291,12 @@ class Foo extends React.Component {
   }
 }
 ```
+### Backend requests
+When making requests as admin to plugin routes the authorization token needs to be included. The easiest way to accomplish this is to use _request_ method from _strapi-helper-plugin_ package.
+
+```js
+import { request } from 'strapi-helper-plugin';
+...
+const result = await request(url, { method: "GET" });
+```
+This method wraps the _fetch_ method from [whatwg-fetch](https://www.npmjs.com/package/whatwg-fetch) and populates some basic options automatically, including the authorization header. For more details inspect the [source code](https://github.com/strapi/strapi/blob/master/packages/strapi-helper-plugin/lib/src/utils/request.js) of the _request_ method.


### PR DESCRIPTION
There's no documentation about making authorized requests as admin from local plugins. This should fix it. Please be free to make any changes and clarifications.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:
I went through default plugin implementations and found out how they make requests to the backend. Then I documented my findings.