### PR TITLE
Fixing incorrect connector strings in docs

### DIFF
--- a/docs/3.0.0-beta.x/concepts/configurations.md
+++ b/docs/3.0.0-beta.x/concepts/configurations.md
@@ -203,7 +203,7 @@ You can access the config of the current environment through `strapi.config.curr
 - `defaultConnection` (string): Connection by default for models which are not related to a specific `connection`. Default value: `default`.
 - `connections` List of all available connections.
   - `default`
-    - `connector` (string): Connector used by the current connection. Will be `bookshelf`.
+    - `connector` (string): Connector used by the current connection. Will be `strapi-hook-bookshelf`.
     - `settings` Useful for external session stores such as Redis.
       - `client` (string): Database client to create the connection. `sqlite` or `postgres` or `mysql`.
       - `host` (string): Database host name. Default value: `localhost`.
@@ -234,7 +234,7 @@ You can access the config of the current environment through `strapi.config.curr
 - `defaultConnection` (string): Connection by default for models which are not related to a specific `connection`. Default value: `default`.
 - `connections` List of all available connections.
   - `default`
-    - `connector` (string): Connector used by the current connection. Will be `mongoose`.
+    - `connector` (string): Connector used by the current connection. Will be `strapi-hook-mongoose`.
     - `settings` Useful for external session stores such as Redis.
       - `client` (string): Database client to create the connection. Will be `mongo`.
       - `host` (string): Database host name. Default value: `localhost`.


### PR DESCRIPTION

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:
Updating the documentation, specifically:

On Beta 3.0.0.x, using database connector strings "bookshelf" and "mongoose" cause Strapi to fail on boot. Must prepend "strapi-hook-" to these to get them to work.