### PR TITLE
fix: don't show unique attribute for rich text fields #5305

### DIFF
--- a/packages/strapi-plugin-content-type-builder/admin/src/containers/FormModal/utils/forms.js
+++ b/packages/strapi-plugin-content-type-builder/admin/src/containers/FormModal/utils/forms.js
@@ -476,6 +476,8 @@ const forms = {
               disabled: data.type !== 'date',
             },
           ]);
+        } else if (type === 'richtext') {
+          items.splice(4, 1);
         }
 
         if (!ATTRIBUTES_THAT_DONT_HAVE_MIN_MAX_SETTINGS.includes(type)) {


### PR DESCRIPTION
Bugfix: don't show unique attribute for rich text fields
fixes #5305

My PR is a:
 🐛 Bug fix

Main update on the:
 Admin

Manual testing done on the following databases:
 MongoDB