### PR TITLE
Fix #5337 - suppress rewrite config in db without changes

### DIFF
--- a/packages/strapi-plugin-content-manager/services/utils/store.js
+++ b/packages/strapi-plugin-content-manager/services/utils/store.js
@@ -37,7 +37,7 @@ const setModelConfiguration = async (key, value) => {
     }
   });
 
-  if(_.isEqual(currentConfig, storedConfig) == false) {
+  if(!_.isEqual(currentConfig, storedConfig)) {
     return getStore().set({
       key: configurationKey(key),
       value: currentConfig,

--- a/packages/strapi-plugin-content-manager/services/utils/store.js
+++ b/packages/strapi-plugin-content-manager/services/utils/store.js
@@ -37,13 +37,13 @@ const setModelConfiguration = async (key, value) => {
     }
   });
 
-  if(JSON.stringify(currentConfig) != JSON.stringify(storedConfig)) {
+  if(_.isEqual(currentConfig, storedConfig) == false) {
     return getStore().set({
       key: configurationKey(key),
       value: currentConfig,
     });
   }
- 
+
 };
 
 const deleteKey = key => {

--- a/packages/strapi-plugin-content-manager/services/utils/store.js
+++ b/packages/strapi-plugin-content-manager/services/utils/store.js
@@ -29,18 +29,21 @@ const getModelConfiguration = async key => {
 };
 
 const setModelConfiguration = async (key, value) => {
-  const config = (await getStore().get({ key: configurationKey(key) })) || {};
-
+  const storedConfig = (await getStore().get({ key: configurationKey(key) })) || {};
+  const currentConfig = { ...storedConfig };
   Object.keys(value).forEach(key => {
     if (value[key] !== null && value[key] !== undefined) {
-      _.set(config, key, value[key]);
+      _.set(currentConfig, key, value[key]);
     }
   });
 
-  return getStore().set({
-    key: configurationKey(key),
-    value: config,
-  });
+  if(JSON.stringify(currentConfig) != JSON.stringify(storedConfig)) {
+    return getStore().set({
+      key: configurationKey(key),
+      value: currentConfig,
+    });
+  }
+ 
 };
 
 const deleteKey = key => {


### PR DESCRIPTION
Now Strapi rewrite all 'plugin_content_manager_configuration_content_types' keys in "core_store" database table on each restart.
I add comparison of stored config with generated, and skip unnecessary write config to database, when there are no changes.
fixes #5367

Signed-off-by murznn@gmail.com