### PR TITLE
fix #5351 Uncapitalize field names in interface to match code

### DIFF
--- a/packages/strapi-plugin-content-type-builder/admin/src/components/ListRow/Wrapper.js
+++ b/packages/strapi-plugin-content-type-builder/admin/src/components/ListRow/Wrapper.js
@@ -43,7 +43,6 @@ const Wrapper = styled.tr`
     }}
     p {
       font-weight: 500;
-      text-transform: capitalize;
     }
   }
   td:last-child {


### PR DESCRIPTION
 All field names in Strapi model fields list are capitalized via css rule, even they starts with lowercase letter, this confuse developers. This small fix is disable capitalizing of field name in interface.

fix #5351

Signed-off-by: Alexey Murz Korepov <murznn@gmail.com>
