### PR TITLE
Updated links in docs to referenced document pages

### DIFF
--- a/docs/3.0.0-beta.x/guides/custom-data-response.md
+++ b/docs/3.0.0-beta.x/guides/custom-data-response.md
@@ -6,9 +6,9 @@ In this guide we will see how you can customize your API's response..
 
 To be able to update the default data response you have first to understand how it works.
 
-When you create a content type, it generates an API with the following list of [endpoints](../content-api/endpoint).
+When you create a content type, it generates an API with the following list of [endpoints](../content-api/api-endpoints.md).
 
-Each of these endpoint triggers a controller action. Here is the list of [controller actions](../concepts/controller.md) that exist by default when a content type is created.
+Each of these endpoint triggers a controller action. Here is the list of [controller actions](../concepts/controllers.md) that exist by default when a content type is created.
 
 If you check the controller file of your generated API `./api/{content-type}/controller/{Content-Type}.js`, you will see an empty file. It is because all the default logic is managed by Strapi. But you can override these actions with your own code.
 


### PR DESCRIPTION
Found some broken links to document pages.

#### Description of what you did:
The first two links of this page were broken. https://strapi.io/documentation/3.0.0-beta.x/guides/custom-data-response.html#introduction
Now, these are linking to .html pages, here the extension is .md - I presume the html pages are generated based on these .md pages which will fix the issue? Correct?