### PR TITLE
Fix SelectWrapper stack order

### DIFF
--- a/packages/strapi-plugin-content-manager/admin/src/components/SelectWrapper/components.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/SelectWrapper/components.js
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 const Wrapper = styled.div`
   position: relative;
   margin-bottom: 27px;
+  z-index: 2;
 
   label {
     width: 100%;


### PR DESCRIPTION
Signed-off-by: James Alvarez <jp@domainwink.com>

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

Fixed the stack order of SelectWrapper by giving it `z-index: 2;`. 

See screenshot below:

<img width="866" alt="Screen Shot 2020-03-02 at 3 18 36 AM" src="https://user-images.githubusercontent.com/8105211/75632203-d502b280-5c34-11ea-8d48-d90e96c9eece.png">
