### PR TITLE
fix(EditViewDataManagerProvider): allow to reset number input

### DIFF
--- a/packages/strapi-plugin-content-manager/admin/src/containers/EditViewDataManagerProvider/index.js
+++ b/packages/strapi-plugin-content-manager/admin/src/containers/EditViewDataManagerProvider/index.js
@@ -203,6 +203,11 @@ const EditViewDataManagerProvider = ({
       inputValue = null;
     }
 
+    // Allow to reset number input
+    if (type === 'number' && value === '') {
+      inputValue = null;
+    }
+
     dispatch({
       type: 'ON_CHANGE',
       keys: name.split('.'),


### PR DESCRIPTION
Currently, when you add a value to a numeric field, there is no way to reset that value; after saving it, the backend will set it to 0.

This is because an empty string is being sent to the backend, and it parses it as zero. This PR explicitly sends null when leaving a numeric field blank, so that the backend interprets it correctly.