### PR TITLE
Multiple roles per user

### DIFF
--- a/packages/strapi-plugin-users-permissions/config/policies/permissions.js
+++ b/packages/strapi-plugin-users-permissions/config/policies/permissions.js
@@ -1,7 +1,7 @@
 const _ = require('lodash');
 
 module.exports = async (ctx, next) => {
-  let role;
+  let roles = [];
 
   if (ctx.request && ctx.request.header && ctx.request.header.authorization) {
     try {
@@ -16,7 +16,7 @@ module.exports = async (ctx, next) => {
       if (isAdmin) {
         ctx.state.admin = await strapi.query('administrator', 'admin').findOne({ id }, []);
       } else {
-        ctx.state.user = await strapi.query('user', 'users-permissions').findOne({ id }, ['role']);
+        ctx.state.user = await strapi.query('user', 'users-permissions').findOne({ id }, ['roles']);
       }
     } catch (err) {
       return handleErrors(ctx, err, 'unauthorized');
@@ -39,9 +39,9 @@ module.exports = async (ctx, next) => {
       return handleErrors(ctx, 'User Not Found', 'unauthorized');
     }
 
-    role = ctx.state.user.role;
+    roles = ctx.state.user.roles;
 
-    if (role.type === 'root') {
+    if (roles.some(r => r.type === 'root')) {
       return await next();
     }
 
@@ -68,29 +68,35 @@ module.exports = async (ctx, next) => {
   }
 
   // Retrieve `public` role.
-  if (!role) {
-    role = await strapi.query('role', 'users-permissions').findOne({ type: 'public' }, []);
+  if (!roles.length) {
+    roles = await strapi.query('role', 'users-permissions').findOne({ type: 'public' }, []);
   }
 
   const route = ctx.request.route;
-  const permission = await strapi.query('permission', 'users-permissions').findOne(
-    {
-      role: role.id,
-      type: route.plugin || 'application',
-      controller: route.controller,
-      action: route.action,
-      enabled: true,
-    },
-    []
-  );
+  const permissions = await strapi
+    .query('permission', 'users-permissions')
+    .find(
+      {
+        role_in: roles.map(r => r.id),
+        type: route.plugin || 'application',
+        controller: route.controller,
+        action: route.action,
+        enabled: true,
+      },
+      []
+    );
 
-  if (!permission) {
+  if (!permissions.length) {
     return handleErrors(ctx, undefined, 'forbidden');
   }
 
   // Execute the policies.
-  if (permission.policy) {
-    return await strapi.plugins['users-permissions'].config.policies[permission.policy](ctx, next);
+  const { policy } = permissions.find(p => p.policy) || {};
+  if (policy) {
+    return await strapi.plugins['users-permissions'].config.policies[policy](
+      ctx,
+      next
+    );
   }
 
   // Execute the action.

--- a/packages/strapi-plugin-users-permissions/config/schema.graphql.js
+++ b/packages/strapi-plugin-users-permissions/config/schema.graphql.js
@@ -26,7 +26,7 @@ module.exports = {
       email: String!
       confirmed: Boolean
       blocked: Boolean
-      role: UsersPermissionsMeRole
+      roles: [UsersPermissionsMeRole]
     }
 
     type UsersPermissionsMeRole {

--- a/packages/strapi-plugin-users-permissions/controllers/Auth.js
+++ b/packages/strapi-plugin-users-permissions/controllers/Auth.js
@@ -344,7 +344,7 @@ module.exports = {
         USER: _.omit(user.toJSON ? user.toJSON() : user, [
           'password',
           'resetPasswordToken',
-          'role',
+          'roles',
           'provider',
         ]),
       }
@@ -461,7 +461,7 @@ module.exports = {
       );
     }
 
-    params.role = role.id;
+    params.roles = [role.id];
     params.password = await strapi.plugins['users-permissions'].services.user.hashPassword(params);
 
     const user = await strapi.query('user', 'users-permissions').findOne({
@@ -515,7 +515,7 @@ module.exports = {
           USER: _.omit(user.toJSON ? user.toJSON() : user, [
             'password',
             'resetPasswordToken',
-            'role',
+            'roles',
             'provider',
           ]),
           CODE: jwt,
@@ -527,7 +527,7 @@ module.exports = {
           USER: _.omit(user.toJSON ? user.toJSON() : user, [
             'password',
             'resetPasswordToken',
-            'role',
+            'roles',
             'provider',
           ]),
         });
@@ -655,7 +655,7 @@ module.exports = {
         USER: _.omit(user.toJSON ? user.toJSON() : user, [
           'password',
           'resetPasswordToken',
-          'role',
+          'roles',
           'provider',
         ]),
         CODE: jwt,

--- a/packages/strapi-plugin-users-permissions/controllers/User.js
+++ b/packages/strapi-plugin-users-permissions/controllers/User.js
@@ -84,7 +84,7 @@ module.exports = {
       })
       .get();
 
-    const { email, username, password, role } = ctx.request.body;
+    const { email, username, password, roles } = ctx.request.body;
 
     if (!email) return ctx.badRequest('missing.email');
     if (!username) return ctx.badRequest('missing.username');
@@ -126,12 +126,12 @@ module.exports = {
       provider: 'local',
     };
 
-    if (!role) {
+    if (!roles || [].length) {
       const defaultRole = await strapi
         .query('role', 'users-permissions')
         .findOne({ type: advanced.default_role }, []);
 
-      user.role = defaultRole.id;
+      user.roles = [defaultRole.id];
     }
 
     try {

--- a/packages/strapi-plugin-users-permissions/models/Role.settings.json
+++ b/packages/strapi-plugin-users-permissions/models/Role.settings.json
@@ -28,7 +28,7 @@
     },
     "users": {
       "collection": "user",
-      "via": "role",
+      "via": "roles",
       "configurable": false,
       "plugin": "users-permissions"
     }

--- a/packages/strapi-plugin-users-permissions/models/User.settings.json
+++ b/packages/strapi-plugin-users-permissions/models/User.settings.json
@@ -50,6 +50,7 @@
       "collection": "role",
       "via": "users",
       "plugin": "users-permissions",
+      "dominant": true,
       "configurable": false
     }
   }

--- a/packages/strapi-plugin-users-permissions/models/User.settings.json
+++ b/packages/strapi-plugin-users-permissions/models/User.settings.json
@@ -46,8 +46,8 @@
       "default": false,
       "configurable": false
     },
-    "role": {
-      "model": "role",
+    "roles": {
+      "collection": "role",
       "via": "users",
       "plugin": "users-permissions",
       "configurable": false

--- a/packages/strapi-plugin-users-permissions/services/Providers.js
+++ b/packages/strapi-plugin-users-permissions/services/Providers.js
@@ -91,7 +91,7 @@ exports.connect = (provider, query) => {
         // Create the new user.
         const params = _.assign(profile, {
           provider: provider,
-          role: defaultRole.id,
+          roles: [defaultRole.id],
           confirmed: true,
         });
 

--- a/packages/strapi-plugin-users-permissions/test/roles-api.test.e2e.js
+++ b/packages/strapi-plugin-users-permissions/test/roles-api.test.e2e.js
@@ -11,10 +11,12 @@ let internals = {
     email: 'user1@strapi.io',
     password: 'test1234',
   },
-  role: {
-    name: 'Test Role',
-    description: 'Some random test role',
-  },
+  roles: [
+    {
+      name: 'Test Role',
+      description: 'Some random test role',
+    },
+  ],
 };
 
 /**
@@ -52,7 +54,7 @@ describe('Roles API', () => {
       method: 'POST',
       url: '/users-permissions/roles',
       body: {
-        ...internals.role,
+        ...internals.roles[0],
         permissions: [],
         users: [data.user],
       },
@@ -70,10 +72,10 @@ describe('Roles API', () => {
 
     expect(res.statusCode).toBe(200);
     expect(res.body.roles).toEqual(
-      expect.arrayContaining([expect.objectContaining(internals.role)])
+      expect.arrayContaining([expect.objectContaining(internals.roles[0])])
     );
 
-    data.role = res.body.roles.find(r => r.name === internals.role.name);
+    data.role = res.body.roles.find(r => r.name === internals.roles[0].name);
   });
 
   test('Delete Role', async () => {


### PR DESCRIPTION
#### Description of what you did:

This is a mirror of https://github.com/strapi/strapi/pull/4860 by @iicdii 

The previous PR was failing some checks and the author did not have the time to update. I have mirrored the PR to pass the checks.

> I made User and Role relationship N:N so that user can have more than one role.
> And I've done testing some cases.

- [x] Give user multiple roles in User content type menu.
- [x] Create role and assign role to user who already have role(s).
- [x] Delete role in Roles & Permission menu.
if user has no remain role, user will have a public role.
- [x] Request to http://localhost:1337/countries with user has two roles.
If any of the roles has permission to find country content-type, the request succeeds.
- [x] `yarn test:unit`