### PR TITLE
Fit Left menu + scrollbars

### DIFF
--- a/packages/strapi-admin/admin/src/components/GlobalStyle/index.js
+++ b/packages/strapi-admin/admin/src/components/GlobalStyle/index.js
@@ -137,6 +137,39 @@ const GlobalStyle = createGlobalStyle`
   }
 
 
+  // scrollbar
+  ::-webkit-scrollbar {
+    width: 9px;
+  }
+
+  ::-webkit-scrollbar-track {
+    background-color: #eee;
+  }
+
+  ::-webkit-scrollbar-track:hover {
+    background-color: #ddd;
+  }
+
+  ::-webkit-scrollbar-thumb {
+    background-color: #ccc;
+    border-radius: 0.5rem;
+  }
+
+  ::-webkit-scrollbar-thumb:hover {
+    background-color: #bbb;
+  }
+
+  ::-webkit-scrollbar-button {
+    display: none;
+  }
+
+  // firefox scrollbar
+  * {
+    scrollbar-color: #bbb #eee;
+    scrollbar-width: thin;
+  }
+
+
 `;
 
 export default GlobalStyle;

--- a/packages/strapi-admin/admin/src/components/LeftMenuLinkContainer/MenuSection.js
+++ b/packages/strapi-admin/admin/src/components/LeftMenuLinkContainer/MenuSection.js
@@ -1,0 +1,17 @@
+import styled from 'styled-components';
+
+const LeftMenuSection = styled.div`
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+
+  &:first-child {
+    overflow: hidden;
+    min-height: 175px;
+    height: auto;
+    flex: 0 1 auto;
+  }
+`;
+
+export default LeftMenuSection;

--- a/packages/strapi-admin/admin/src/components/LeftMenuLinkContainer/Wrapper.js
+++ b/packages/strapi-admin/admin/src/components/LeftMenuLinkContainer/Wrapper.js
@@ -11,6 +11,8 @@ const Wrapper = styled.div`
   overflow-y: auto;
   height: calc(100vh - (${props => props.theme.main.sizes.leftMenu.height} + 10.2rem));
   box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
 
   .title {
     padding-left: 2rem;

--- a/packages/strapi-admin/admin/src/components/LeftMenuLinkContainer/index.js
+++ b/packages/strapi-admin/admin/src/components/LeftMenuLinkContainer/index.js
@@ -5,6 +5,7 @@ import { get, snakeCase, isEmpty } from 'lodash';
 
 import { SETTINGS_BASE_URL } from '../../config';
 import Wrapper from './Wrapper';
+import MenuSection from './MenuSection';
 import messages from './messages.json';
 
 import LeftMenuLinkSection from '../LeftMenuLinkSection';
@@ -19,6 +20,7 @@ const LeftMenuLinkContainer = ({ plugins }) => {
         acc[snakeCase(section.name)] = {
           name: section.name,
           searchable: true,
+          shrink: true,
           links: get(acc[snakeCase(section.name)], 'links', []).concat(
             section.links
               .filter(link => link.isDisplayed !== false)
@@ -50,49 +52,58 @@ const LeftMenuLinkContainer = ({ plugins }) => {
       };
     });
 
-  const menu = {
-    ...contentTypesSections,
-    plugins: {
-      searchable: false,
-      name: 'plugins',
-      emptyLinksListMessage: messages.noPluginsInstalled.id,
-      links: pluginsLinks,
+  const menus = [
+    contentTypesSections,
+    {
+      plugins: {
+        searchable: false,
+        name: 'plugins',
+        emptyLinksListMessage: messages.noPluginsInstalled.id,
+        links: pluginsLinks,
+      },
+      general: {
+        searchable: false,
+        name: 'general',
+        links: [
+          {
+            icon: 'list',
+            label: messages.listPlugins.id,
+            destination: '/list-plugins',
+          },
+          {
+            icon: 'shopping-basket',
+            label: messages.installNewPlugin.id,
+            destination: '/marketplace',
+          },
+          {
+            icon: 'cog',
+            label: messages.settings.id,
+            destination: SETTINGS_BASE_URL || '/settings',
+          },
+        ],
+      },
     },
-    general: {
-      searchable: false,
-      name: 'general',
-      links: [
-        {
-          icon: 'list',
-          label: messages.listPlugins.id,
-          destination: '/list-plugins',
-        },
-        {
-          icon: 'shopping-basket',
-          label: messages.installNewPlugin.id,
-          destination: '/marketplace',
-        },
-        {
-          icon: 'cog',
-          label: messages.settings.id,
-          destination: SETTINGS_BASE_URL || '/settings',
-        },
-      ],
-    },
-  };
+  ];
 
   return (
     <Wrapper>
-      {Object.keys(menu).map(current => (
-        <LeftMenuLinkSection
-          key={current}
-          links={menu[current].links}
-          section={current}
-          location={location}
-          searchable={menu[current].searchable}
-          emptyLinksListMessage={menu[current].emptyLinksListMessage}
-        />
-      ))}
+      {menus.map(
+        section => (
+          <MenuSection>
+            {Object.entries(section).map(([key, value]) => (
+              <LeftMenuLinkSection
+                key={key}
+                shrink={value.shrink}
+                links={value.links}
+                section={key}
+                location={location}
+                searchable={value.searchable}
+                emptyLinksListMessage={value.emptyLinksListMessage}
+              />
+            ))}
+          </MenuSection>
+        )
+      )}
     </Wrapper>
   );
 };

--- a/packages/strapi-admin/admin/src/components/LeftMenuLinkSection/LeftMenuListLink.js
+++ b/packages/strapi-admin/admin/src/components/LeftMenuLinkSection/LeftMenuListLink.js
@@ -1,9 +1,18 @@
 import styled from 'styled-components';
 
 const LeftMenuListLink = styled.div`
-  max-height: 180px;
+  box-sizing: border-box;
+  min-height: 3.7rem;
+  flex-shrink: 0;
   margin-bottom: 0.1rem;
   overflow: auto;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+
+  ${props =>
+    props.shrink &&
+    `
+    flex-shrink: 1;
+  `}
 `;
 
 export default LeftMenuListLink;

--- a/packages/strapi-admin/admin/src/components/LeftMenuLinkSection/index.js
+++ b/packages/strapi-admin/admin/src/components/LeftMenuLinkSection/index.js
@@ -10,7 +10,14 @@ import LeftMenuListLink from './LeftMenuListLink';
 import EmptyLinksList from './EmptyLinksList';
 import EmptyLinksListWrapper from './EmptyLinksListWrapper';
 
-const LeftMenuLinksSection = ({ section, searchable, location, links, emptyLinksListMessage }) => {
+const LeftMenuLinksSection = ({
+  section,
+  searchable,
+  location,
+  links,
+  emptyLinksListMessage,
+  shrink,
+}) => {
   const [search, setSearch] = useState('');
 
   const filteredList = sortBy(
@@ -39,7 +46,7 @@ const LeftMenuLinksSection = ({ section, searchable, location, links, emptyLinks
         setSearch={setSearch}
         search={search}
       />
-      <LeftMenuListLink>
+      <LeftMenuListLink shrink={shrink}>
         {filteredList.length > 0 ? (
           filteredList.map((link, index) => (
             <LeftMenuLink
@@ -64,9 +71,14 @@ const LeftMenuLinksSection = ({ section, searchable, location, links, emptyLinks
   );
 };
 
+LeftMenuLinksSection.defaultProps = {
+  shrink: false,
+};
+
 LeftMenuLinksSection.propTypes = {
   section: PropTypes.string.isRequired,
   searchable: PropTypes.bool.isRequired,
+  shrink: PropTypes.bool,
   location: PropTypes.shape({
     pathname: PropTypes.string,
   }).isRequired,

--- a/packages/strapi-admin/admin/src/containers/LeftMenu/Wrapper.js
+++ b/packages/strapi-admin/admin/src/containers/LeftMenu/Wrapper.js
@@ -15,6 +15,29 @@ const Wrapper = styled.div`
   height: 100vh;
   width: ${props => props.theme.main.sizes.leftMenu.width};
   background: ${props => props.theme.main.colors.strapi['blue-darker']};
+
+  // scrollbar overrides
+  * {
+    ::-webkit-scrollbar {
+      width: 7px;
+    }
+
+    ::-webkit-scrollbar-track,
+    ::-webkit-scrollbar-track:hover {
+      background-color: rgba(255, 255, 255, 0.1);
+    }
+
+    ::-webkit-scrollbar-thumb {
+      background-color: rgba(255, 255, 255, 0.3);
+    }
+
+    ::-webkit-scrollbar-thumb:hover {
+      background-color: rgba(255, 255, 255, 0.5);
+    }
+
+    // firefox
+    scrollbar-color: rgba(255, 255, 255, 0.5) rgba(255, 255, 255, 0.1);
+  }
 `;
 
 Wrapper.defaultProps = {

--- a/packages/strapi-plugin-content-manager/admin/src/components/SelectMany/components.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/SelectMany/components.js
@@ -1,7 +1,6 @@
 import styled from 'styled-components';
 
 const ListWrapper = styled.div`
-  overflow: hidden;
   max-height: 116px;
 
   > ul {


### PR DESCRIPTION
#### Description of what you did

This PR contains 3 different things I did in Admin UI

1. Fit Left menu items to available space.
With strapi@beta.18.9 I found that content type has max-height which looks good on small screens, but on FHD it makes dificult to use. With this commit I allow sections to grow/shrink depends on available space. 

2. Added custom scrollbars (different for light and dark app sections). Default scrollbars are just to big, especially in Left Menu and small sections like relations in entry view.

3. added scrollbar to many relation list in entry view.

Ad. 2 & 3. Scrollbar colors may be different. I'm waiting for suggestions

Some screenshots:

**Menu Before**
![menu-before-long](https://user-images.githubusercontent.com/16906868/75918707-83d50780-5e5c-11ea-8e6f-6225dd3e5467.png)

Short
![menu-before-short](https://user-images.githubusercontent.com/16906868/75918710-85063480-5e5c-11ea-82cb-d16f39e89437.png)

**Menu After**
![menu-after-long](https://user-images.githubusercontent.com/16906868/75918774-a404c680-5e5c-11ea-81e8-e3db8744fce5.png)

short
![menu-after-short](https://user-images.githubusercontent.com/16906868/75919058-29887680-5e5d-11ea-938d-b3f753366c7e.png)

**Scrollbars Before**
![scrollbars-before](https://user-images.githubusercontent.com/16906868/75919513-fe525700-5e5d-11ea-8a41-ee325f52a9d9.png)

**Scrollbars After**
![scrollbars-after](https://user-images.githubusercontent.com/16906868/75919536-09a58280-5e5e-11ea-91f8-d198e2ac7a29.png)

**Relations list in entry view - before**
![relations-list-before](https://user-images.githubusercontent.com/16906868/75919698-4b362d80-5e5e-11ea-8478-fded3ff696dc.png)

**Relations list in entry view - after**
![relations-list-after](https://user-images.githubusercontent.com/16906868/75919752-63a64800-5e5e-11ea-9b04-0ca80aa19ad4.png)

