### PR TITLE
Add --no-run and --use-npm to CLI docs

### DIFF
--- a/docs/3.0.0-beta.x/cli/CLI.md
+++ b/docs/3.0.0-beta.x/cli/CLI.md
@@ -9,7 +9,7 @@ Create a new project.
 ```bash
 strapi new <name>
 
-options: [--debug|--quickstart|--dbclient=<dbclient> --dbhost=<dbhost> --dbport=<dbport> --dbname=<dbname> --dbusername=<dbusername> --dbpassword=<dbpassword> --dbssl=<dbssl> --dbauth=<dbauth> --dbforce]
+options: [--no-run|--use-npm|--debug|--quickstart|--dbclient=<dbclient> --dbhost=<dbhost> --dbport=<dbport> --dbname=<dbname> --dbusername=<dbusername> --dbpassword=<dbpassword> --dbssl=<dbssl> --dbauth=<dbauth> --dbforce]
 ```
 
 - **strapi new &#60;name&#62;**<br/>
@@ -20,6 +20,9 @@ options: [--debug|--quickstart|--dbclient=<dbclient> --dbhost=<dbhost> --dbport=
 
 - **strapi new &#60;name&#62; --quickstart**<br/>
   Use the quickstart system to create your app.
+  
+- **strapi new &#60;name&#62; --quickstart --no-run**<br/>
+  Use the quickstart system to create your app, and do not start the application after creation.
 
 - **strapi new &#60;name&#62; --dbclient=&#60;dbclient&#62; --dbhost=&#60;dbhost&#62; --dbport=&#60;dbport&#62; --dbname=&#60;dbname&#62; --dbusername=&#60;dbusername&#62; --dbpassword=&#60;dbpassword&#62; --dbssl=&#60;dbssl&#62; --dbauth=&#60;dbauth&#62; --dbforce**<br/>
 


### PR DESCRIPTION
Not sure if you want to call-out that it will leverage yarn if/when possible (if npm flag is not set).

Did notice other APIs need an update, but unsure how `---tpl` relates to new cli. I assume it's been refactored into `--extend`, but unsure.