### PR TITLE
support admin ui general - plugins page, custom define setting button

### DIFF
--- a/examples/getstarted/plugins/myplugin/admin/src/index.js
+++ b/examples/getstarted/plugins/myplugin/admin/src/index.js
@@ -15,6 +15,7 @@ export default strapi => {
     injectedComponents: [],
     isReady: true,
     isRequired: pluginPkg.strapi.required || false,
+    withSetting: pluginPkg.strapi.setting || false,
     leftMenuLinks: [],
     leftMenuSections: [],
     mainComponent: null,

--- a/packages/strapi-admin/admin/src/components/PluginCard/index.js
+++ b/packages/strapi-admin/admin/src/components/PluginCard/index.js
@@ -93,7 +93,7 @@ class PluginCard extends React.Component {
       : 'app.components.PluginCard.Button.label.download';
 
     // Display settings link for a selection of plugins.
-    const settingsComponent = this.props.plugin.withSetting && (
+    const settingsComponent = this.props.withSetting && (
       <div className="settings" onClick={this.handleClickSettings}>
         <FontAwesomeIcon icon="cog" />
         <FormattedMessage id="app.components.PluginCard.settings" />
@@ -231,6 +231,7 @@ PluginCard.propTypes = {
   history: PropTypes.object.isRequired,
   isAlreadyInstalled: PropTypes.bool,
   plugin: PropTypes.object,
+  withSetting: PropTypes.bool,
 };
 
 export default PluginCard;

--- a/packages/strapi-admin/admin/src/components/PluginCard/index.js
+++ b/packages/strapi-admin/admin/src/components/PluginCard/index.js
@@ -11,8 +11,6 @@ import { Button, PopUpWarning } from 'strapi-helper-plugin';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import Wrapper from './Wrapper';
 
-const PLUGINS_WITH_CONFIG = ['email', 'upload'];
-
 /* eslint-disable react/no-unused-state */
 class PluginCard extends React.Component {
   state = {
@@ -95,9 +93,7 @@ class PluginCard extends React.Component {
       : 'app.components.PluginCard.Button.label.download';
 
     // Display settings link for a selection of plugins.
-    const settingsComponent = PLUGINS_WITH_CONFIG.includes(
-      this.props.plugin.id
-    ) && (
+    const settingsComponent = this.props.plugin.withSetting && (
       <div className="settings" onClick={this.handleClickSettings}>
         <FontAwesomeIcon icon="cog" />
         <FormattedMessage id="app.components.PluginCard.settings" />

--- a/packages/strapi-admin/admin/src/containers/InstalledPluginsPage/Row.js
+++ b/packages/strapi-admin/admin/src/containers/InstalledPluginsPage/Row.js
@@ -10,15 +10,14 @@ import CustomRow from './CustomRow';
 import LogoContainer from './Logo';
 
 // TODO: remove the upload plugin when the media lib feature is merged.
-const PLUGINS_WITH_CONFIG = ['email', 'upload'];
 
-const Row = ({ logo, name, description, isRequired, id, icon, onConfirm }) => {
+const Row = ({ logo, name, description, isRequired, withSetting, id, icon, onConfirm }) => {
   const { currentEnvironment, formatMessage } = useGlobalContext();
   const [isOpen, setIsOpen] = useState(false);
   const { push } = useHistory();
   const links = [];
 
-  if (PLUGINS_WITH_CONFIG.includes(id)) {
+  if (withSetting) {
     links.push({
       icon: <FontAwesomeIcon icon={faCog} />,
       onClick: () => {
@@ -93,6 +92,7 @@ const Row = ({ logo, name, description, isRequired, id, icon, onConfirm }) => {
 Row.defaultProps = {
   icon: 'plug',
   isRequired: false,
+  withSetting: false,
   logo: null,
   onConfirm: () => {},
 };
@@ -102,6 +102,7 @@ Row.propTypes = {
   icon: PropTypes.string,
   id: PropTypes.string.isRequired,
   isRequired: PropTypes.bool,
+  withSetting: PropTypes.bool,
   logo: PropTypes.string,
   name: PropTypes.string.isRequired,
   onConfirm: PropTypes.func,

--- a/packages/strapi-admin/admin/src/containers/InstalledPluginsPage/utils/generateRows.js
+++ b/packages/strapi-admin/admin/src/containers/InstalledPluginsPage/utils/generateRows.js
@@ -2,13 +2,14 @@ import { sortBy } from 'lodash';
 
 const generateRows = (obj, onConfirm) => {
   const rows = Object.values(obj).map(
-    ({ name, pluginLogo, id, description, isRequired, icon }) => {
+    ({ name, pluginLogo, id, description, isRequired, withSetting, icon }) => {
       return {
         name,
         logo: pluginLogo,
         id,
         description,
         isRequired,
+        withSetting,
         icon,
         onConfirm,
       };

--- a/packages/strapi-admin/admin/src/containers/InstalledPluginsPage/utils/generateRows.js
+++ b/packages/strapi-admin/admin/src/containers/InstalledPluginsPage/utils/generateRows.js
@@ -9,7 +9,7 @@ const generateRows = (obj, onConfirm) => {
         id,
         description,
         isRequired,
-        withSetting,
+        withSetting: withSetting || false,
         icon,
         onConfirm,
       };

--- a/packages/strapi-admin/admin/src/containers/InstalledPluginsPage/utils/tests/generateRows.test.js
+++ b/packages/strapi-admin/admin/src/containers/InstalledPluginsPage/utils/tests/generateRows.test.js
@@ -14,6 +14,7 @@ describe('ADMIN | container | InstalledPlugins | utils | generateRows', () => {
         icon: null,
         description: 'test test',
         foo: 'bar',
+        withSetting: false,
         isRequired: false,
       },
       ctb: {
@@ -23,6 +24,7 @@ describe('ADMIN | container | InstalledPlugins | utils | generateRows', () => {
         icon: 'plug',
         description: 'test',
         foo: 'bar',
+        withSetting: true,
         isRequired: true,
       },
     };
@@ -36,6 +38,7 @@ describe('ADMIN | container | InstalledPlugins | utils | generateRows', () => {
         icon: 'plug',
         description: 'test',
         onConfirm,
+        withSetting: true,
         isRequired: true,
       },
       {
@@ -45,6 +48,7 @@ describe('ADMIN | container | InstalledPlugins | utils | generateRows', () => {
         icon: null,
         description: 'test test',
         onConfirm,
+        withSetting: false,
         isRequired: false,
       },
     ];

--- a/packages/strapi-admin/admin/src/containers/MarketplacePage/index.js
+++ b/packages/strapi-admin/admin/src/containers/MarketplacePage/index.js
@@ -74,6 +74,7 @@ const MarketPlacePage = ({ history }) => {
                 history={history}
                 plugin={plugin}
                 showSupportUsButton={false}
+                withSetting={plugins[plugin.id].withSetting || false}
                 isAlreadyInstalled={plugins[plugin.id] !== undefined}
               />
             );

--- a/packages/strapi-generate-plugin/files/admin/src/index.js
+++ b/packages/strapi-generate-plugin/files/admin/src/index.js
@@ -18,6 +18,7 @@ export default strapi => {
     injectedComponents: [],
     isReady: false,
     isRequired: pluginPkg.strapi.required || false,
+    withSetting: pluginPkg.strapi.setting || false,
     layout: null,
     lifecycles,
     leftMenuLinks: [],

--- a/packages/strapi-generate-plugin/json/package.json.js
+++ b/packages/strapi-generate-plugin/json/package.json.js
@@ -22,6 +22,7 @@ module.exports = scope => {
       name: scope.id,
       icon: 'plug',
       description: `Description of ${scope.id} plugin.`,
+      setting: false
     },
     dependencies: {},
     author: {

--- a/packages/strapi-plugin-content-manager/admin/src/index.js
+++ b/packages/strapi-plugin-content-manager/admin/src/index.js
@@ -19,6 +19,7 @@ export default strapi => {
     injectedComponents: [],
     isReady: false,
     isRequired: pluginPkg.strapi.required || false,
+    withSetting: pluginPkg.strapi.setting || false,
     layout: null,
     lifecycles,
     leftMenuLinks: [],

--- a/packages/strapi-plugin-content-type-builder/admin/src/index.js
+++ b/packages/strapi-plugin-content-type-builder/admin/src/index.js
@@ -39,6 +39,7 @@ export default strapi => {
       },
     ],
     isRequired: pluginPkg.strapi.required || false,
+    withSetting: pluginPkg.strapi.setting || false,
     layout: null,
     lifecycles,
     leftMenuLinks: [],

--- a/packages/strapi-plugin-documentation/admin/src/index.js
+++ b/packages/strapi-plugin-documentation/admin/src/index.js
@@ -19,6 +19,7 @@ export default strapi => {
     injectedComponents: [],
     isReady: false,
     isRequired: pluginPkg.strapi.required || false,
+    withSetting: pluginPkg.strapi.setting || false,
     layout: null,
     lifecycles,
     leftMenuLinks: [],

--- a/packages/strapi-plugin-email/admin/src/index.js
+++ b/packages/strapi-plugin-email/admin/src/index.js
@@ -19,6 +19,7 @@ export default strapi => {
     initializer: Initializer,
     injectedComponents: [],
     isRequired: pluginPkg.strapi.required || false,
+    withSetting: pluginPkg.strapi.setting || false,
     layout: null,
     lifecycles,
     leftMenuLinks: [],

--- a/packages/strapi-plugin-email/package.json
+++ b/packages/strapi-plugin-email/package.json
@@ -6,7 +6,8 @@
     "name": "Email",
     "icon": "paper-plane",
     "description": "email.plugin.description",
-    "required": true
+    "required": true,
+    "setting": true
   },
   "scripts": {
     "test": "echo \"no tests yet\""

--- a/packages/strapi-plugin-graphql/admin/src/index.js
+++ b/packages/strapi-plugin-graphql/admin/src/index.js
@@ -16,6 +16,7 @@ export default strapi => {
     initializer: () => null,
     injectedComponents: [],
     isRequired: pluginPkg.strapi.required || false,
+    withSetting: pluginPkg.strapi.setting || false,
     layout: null,
     lifecycles: () => {},
     leftMenuLinks: [],

--- a/packages/strapi-plugin-upload/admin/src/index.js
+++ b/packages/strapi-plugin-upload/admin/src/index.js
@@ -18,6 +18,7 @@ export default strapi => {
     initializer: Initializer,
     injectedComponents: [],
     isRequired: pluginPkg.strapi.required || false,
+    withSetting: pluginPkg.strapi.setting || false,
     layout: null,
     lifecycles,
     leftMenuLinks: [],

--- a/packages/strapi-plugin-upload/package.json
+++ b/packages/strapi-plugin-upload/package.json
@@ -5,7 +5,8 @@
   "strapi": {
     "name": "Files Upload",
     "icon": "cloud-upload-alt",
-    "description": "upload.plugin.description"
+    "description": "upload.plugin.description",
+    "setting": true
   },
   "scripts": {
     "test": "echo \"no tests yet\""

--- a/packages/strapi-plugin-users-permissions/admin/src/index.js
+++ b/packages/strapi-plugin-users-permissions/admin/src/index.js
@@ -20,6 +20,7 @@ export default strapi => {
     initializer: Initializer,
     injectedComponents: [],
     isRequired: pluginPkg.strapi.required || false,
+    withSetting: pluginPkg.strapi.setting || false,
     layout,
     lifecycles,
     leftMenuLinks: [],


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:
The office strapi-admin ,we can't define setting link button in gerneral -plugins page route: [/admin/list-plugins]

this merge request support plugins page ,we can defined custom plugins link to plugin setting page,
like upload and  email plugin.

Configuration method: same as email and upload plugin package.json
```json
"strapi": {
    "name": "Email",
    "icon": "paper-plane",
    "description": "email.plugin.description",
    "required": true,
    "setting": true
  }

we can defined key: `setting` to enable this feature.

Hope to adopt  ^_^
``` 