### PR TITLE
fix #5399 Strapi is not using the configured host when launching the server

### DIFF
--- a/packages/strapi/lib/Strapi.js
+++ b/packages/strapi/lib/Strapi.js
@@ -225,7 +225,7 @@ class Strapi extends EventEmitter {
       this.app.use(this.router.routes()).use(this.router.allowedMethods());
 
       // Launch server.
-      this.server.listen(this.config.port, async err => {
+      this.server.listen(this.config.port, this.config.host, async err => {
         if (err) return this.stopWithError(err);
 
         if (!isInitialised) {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:
Strapi does not the host value in the configuration when launching the server currently. Therefore, Node server listens on all interface when host value is omitted. This causes a problem when the user has other applications that run on the same port but different interfaces. 

Fix #5399. 