### PR TITLE
Allow DATABASE_CLIENT env

### DIFF
--- a/examples/getstarted/config/environments/production/database.json
+++ b/examples/getstarted/config/environments/production/database.json
@@ -4,7 +4,7 @@
     "default": {
       "connector": "bookshelf",
       "settings": {
-        "client": "sqlite",
+        "client": "${process.env.DATABASE_CLIENT || 'sqlite'}",
         "host": "${process.env.DATABASE_HOST || '127.0.0.1'}",
         "port": "${process.env.DATABASE_PORT || 27017}",
         "database": "${process.env.DATABASE_NAME || 'strapi'}",


### PR DESCRIPTION
#### Description of what you did:

Adjusted the prod database configuration file to allow specifying the client as `mongo` (given other details appear to lean that way, specifically port fallback is 27017). Didn't go breaking change (fallback still `sqlite`), but could be adjusted as well).