### PR TITLE
Update migration-guide-beta.18-to-beta.19.md

### DIFF
--- a/docs/3.0.0-beta.x/migration-guide/migration-guide-beta.18-to-beta.19.md
+++ b/docs/3.0.0-beta.x/migration-guide/migration-guide-beta.18-to-beta.19.md
@@ -14,16 +14,16 @@ Update your package.json accordingly:
 {
   //...
   "dependencies": {
-    "strapi": "3.0.0-beta.19",
-    "strapi-admin": "3.0.0-beta.19",
-    "strapi-connector-bookshelf": "3.0.0-beta.19",
-    "strapi-plugin-content-manager": "3.0.0-beta.19",
-    "strapi-plugin-content-type-builder": "3.0.0-beta.19",
-    "strapi-plugin-email": "3.0.0-beta.19",
-    "strapi-plugin-graphql": "3.0.0-beta.19",
-    "strapi-plugin-upload": "3.0.0-beta.19",
-    "strapi-plugin-users-permissions": "3.0.0-beta.19",
-    "strapi-utils": "3.0.0-beta.19"
+    "strapi": "3.0.0-beta.19.3",
+    "strapi-admin": "3.0.0-beta.19.3",
+    "strapi-connector-bookshelf": "3.0.0-beta.19.3",
+    "strapi-plugin-content-manager": "3.0.0-beta.19.3",
+    "strapi-plugin-content-type-builder": "3.0.0-beta.19.3",
+    "strapi-plugin-email": "3.0.0-beta.19.3",
+    "strapi-plugin-graphql": "3.0.0-beta.19.3",
+    "strapi-plugin-upload": "3.0.0-beta.19.3",
+    "strapi-plugin-users-permissions": "3.0.0-beta.19.3",
+    "strapi-utils": "3.0.0-beta.19.3"
   }
 }
 ```


### PR DESCRIPTION
New syntax is working only in "3.0.0-beta.19.3".
Maybe add "strapi-connector-mongoose": "3.0.0-beta.19.3", if someone uses mongodb.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:
