### PR TITLE
Added missing forgotPassword, changePassword and emailConfirmation mutations/resolvers

### DIFF
--- a/packages/strapi-plugin-users-permissions/controllers/Auth.js
+++ b/packages/strapi-plugin-users-permissions/controllers/Auth.js
@@ -568,28 +568,39 @@ module.exports = {
     }
   },
 
-  async emailConfirmation(ctx) {
+  async emailConfirmation(ctx, returnUser) {
     const params = ctx.query;
 
     const decodedToken = await strapi.plugins['users-permissions'].services.jwt.verify(
       params.confirmation
     );
 
-    await strapi.plugins['users-permissions'].services.user.edit(
+    let user = await strapi.plugins['users-permissions'].services.user.edit(
       { id: decodedToken.id },
       { confirmed: true }
     );
 
-    const settings = await strapi
-      .store({
-        environment: '',
-        type: 'plugin',
-        name: 'users-permissions',
-        key: 'advanced',
-      })
-      .get();
+    if(returnUser) {
+      ctx.send({
+        jwt: strapi.plugins['users-permissions'].services.jwt.issue({
+          id: user.id
+        }),
+        user: sanitizeEntity(user.toJSON ? user.toJSON() : user, {
+          model: strapi.query('user', 'users-permissions').model
+        })
+      });
+    } else {
+      const settings = await strapi
+        .store({
+          environment: '',
+          type: 'plugin',
+          name: 'users-permissions',
+          key: 'advanced',
+        })
+        .get();
 
-    ctx.redirect(settings.email_confirmation_redirection || '/');
+      ctx.redirect(settings.email_confirmation_redirection || '/');
+    }
   },
 
   async sendEmailConfirmation(ctx) {


### PR DESCRIPTION
In regard to: https://github.com/strapi/strapi/issues/5524

#### Description of what you did:

- Added missing forgotPassword, changePassword and emailConfirmation mutations/resolvers. 
- Made a slight adjustment to the emailConfirmation controller function in Auth.js to return a UsersPermissionsLoginPayload when using GraphQL 