### PR TITLE
Fix for getting a Role from the GraphQL API

### DIFF
--- a/packages/strapi-plugin-users-permissions/config/schema.graphql.js
+++ b/packages/strapi-plugin-users-permissions/config/schema.graphql.js
@@ -60,7 +60,7 @@ module.exports = {
       role: {
         resolverOf: 'plugins::users-permissions.userspermissions.getRole',
         resolver: async (obj, options, { context }) => {
-          context.params = { ...context.params, ...options.input };
+          context.params = { ...context.params, ...options };
 
           await strapi.plugins['users-permissions'].controllers.userspermissions.getRole(context);
 


### PR DESCRIPTION
#### Description of what you did:

While developing an ACL layer on my frontend, I noticed the `role` query throws an error. 

```
Undefined binding(s) detected when compiling SELECT. Undefined column(s): [id] query: select `users-permissions_role`.* from `users-permissions_role` where `id` = ? limit ?"
```

This is because the resolver was expecting a `input` from the GraphQL query, but only a ID is allowed.