### PR TITLE
Translations: Updated the 'terms' translations for 'de'

### DIFF
--- a/packages/strapi-admin/admin/src/translations/de.json
+++ b/packages/strapi-admin/admin/src/translations/de.json
@@ -162,7 +162,7 @@
   "HomePage.greetings": "Hallo {name}!",
 
   "Auth.advanced.allow_register": "",
-  "Auth.privacy-policy-agreement.terms": "Begriffe",
+  "Auth.privacy-policy-agreement.terms": "Nutzungsbedingungen",
   "Auth.privacy-policy-agreement.policy": "Datenschutzerklärung",
   "Auth.form.button.forgot-password": "E-Mail versenden",
   "Auth.form.button.forgot-password.success": "Erneut schicken",


### PR DESCRIPTION
"Terms and Conditions" are called "Allgemeine Geschäftsbedingungen" in German (often abbreviated as "AGB") or "Nutzungsbedingungen".

In the context of the admin sign-up of 'strapi' I'd go for the latter.
(Research results attached to the pull request)

The previous version "Begriffe" is wrong in this context as it is the literal translation of the word "term".