### PR TITLE
Add RegExp as text type attribute validation option

### DIFF
--- a/packages/strapi-plugin-content-manager/admin/src/components/Inputs/index.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/Inputs/index.js
@@ -64,7 +64,16 @@ function Inputs({ autoFocus, keys, layout, name, onBlur }) {
     'default',
     'plugin',
     'enum',
+    'regex',
   ]);
+
+  if (attribute['regex']) {
+    const regex = new RegExp(attribute['regex'])
+    if (regex) {
+      validations['regex'] = regex
+    }
+  }
+
   const { description, visible } = metadatas;
   const value = get(modifiedData, keys, null);
 

--- a/packages/strapi-plugin-content-manager/admin/src/components/Inputs/index.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/Inputs/index.js
@@ -56,6 +56,7 @@ function Inputs({ autoFocus, keys, layout, name, onBlur }) {
   const metadatas = useMemo(() => get(layout, ['metadatas', name, 'edit'], {}), [layout, name]);
   const disabled = useMemo(() => !get(metadatas, 'editable', true), [metadatas]);
   const type = useMemo(() => get(attribute, 'type', null), [attribute]);
+  const regex = useMemo(() => get(attribute, 'regex', null), [attribute]);
   const validations = omit(attribute, [
     'type',
     'model',

--- a/packages/strapi-plugin-content-manager/admin/src/components/Inputs/index.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/Inputs/index.js
@@ -56,7 +56,7 @@ function Inputs({ autoFocus, keys, layout, name, onBlur }) {
   const metadatas = useMemo(() => get(layout, ['metadatas', name, 'edit'], {}), [layout, name]);
   const disabled = useMemo(() => !get(metadatas, 'editable', true), [metadatas]);
   const type = useMemo(() => get(attribute, 'type', null), [attribute]);
-  const regex = useMemo(() => get(attribute, 'regex', null), [attribute]);
+  const regexpString = useMemo(() => get(attribute, 'regex', null), [attribute]);
   const validations = omit(attribute, [
     'type',
     'model',
@@ -68,10 +68,11 @@ function Inputs({ autoFocus, keys, layout, name, onBlur }) {
     'regex',
   ]);
 
-  if (attribute['regex']) {
-    const regex = new RegExp(attribute['regex'])
-    if (regex) {
-      validations['regex'] = regex
+  if (regexpString) {
+    const regexp = new RegExp(regexpString);
+
+    if (regexp) {
+      validations.regex = regexp;
     }
   }
 

--- a/packages/strapi-plugin-content-manager/admin/src/containers/EditViewDataManagerProvider/utils/schema.js
+++ b/packages/strapi-plugin-content-manager/admin/src/containers/EditViewDataManagerProvider/utils/schema.js
@@ -168,6 +168,10 @@ const createYupSchema = (model, { components }) => {
 
 const createYupSchemaAttribute = (type, validations) => {
   let schema = yup.mixed();
+    
+  if (validations.regex) {
+    validations.regex = new RegExp(validations.regex)
+  }
 
   if (['string', 'uid', 'text', 'richtext', 'email', 'password', 'enumeration'].includes(type)) {
     schema = yup.string();

--- a/packages/strapi-plugin-content-manager/admin/src/containers/EditViewDataManagerProvider/utils/schema.js
+++ b/packages/strapi-plugin-content-manager/admin/src/containers/EditViewDataManagerProvider/utils/schema.js
@@ -168,9 +168,11 @@ const createYupSchema = (model, { components }) => {
 
 const createYupSchemaAttribute = (type, validations) => {
   let schema = yup.mixed();
-    
-  if (validations.regex) {
-    validations.regex = new RegExp(validations.regex)
+
+  let regex = get(validations, 'regex', null);
+  delete validations.regex;
+  if (regex) {
+    validations.regex = new RegExp(regex)
   }
 
   if (['string', 'uid', 'text', 'richtext', 'email', 'password', 'enumeration'].includes(type)) {

--- a/packages/strapi-plugin-content-manager/admin/src/containers/EditViewDataManagerProvider/utils/schema.js
+++ b/packages/strapi-plugin-content-manager/admin/src/containers/EditViewDataManagerProvider/utils/schema.js
@@ -171,8 +171,9 @@ const createYupSchemaAttribute = (type, validations) => {
 
   let regex = get(validations, 'regex', null);
   delete validations.regex;
+
   if (regex) {
-    validations.regex = new RegExp(regex)
+    validations.regex = new RegExp(regex);
   }
 
   if (['string', 'uid', 'text', 'richtext', 'email', 'password', 'enumeration'].includes(type)) {

--- a/packages/strapi-plugin-content-type-builder/admin/src/containers/FormModal/index.js
+++ b/packages/strapi-plugin-content-type-builder/admin/src/containers/FormModal/index.js
@@ -496,7 +496,14 @@ const FormModal = () => {
   };
 
   const handleChange = ({ target: { name, value, type, ...rest } }) => {
-    const namesThatCanResetToNullValue = ['enumName', 'max', 'min', 'maxLength', 'minLength'];
+    const namesThatCanResetToNullValue = [
+      'enumName',
+      'max',
+      'min',
+      'maxLength',
+      'minLength',
+      'regex',
+    ];
     let val;
 
     if (['default', ...namesThatCanResetToNullValue].includes(name) && value === '') {

--- a/packages/strapi-plugin-content-type-builder/admin/src/containers/FormModal/utils/forms.js
+++ b/packages/strapi-plugin-content-type-builder/admin/src/containers/FormModal/utils/forms.js
@@ -75,6 +75,17 @@ yup.addMethod(yup.array, 'matchesEnumRegex', function(message) {
   });
 });
 
+yup.addMethod(yup.string, 'isValidRegExpPattern', function(message) {
+              return this.test('isValidRegExpPattern', message, function(string) {
+                               return new RegExp(string) !== null;
+                               });
+              });
+yup.addMethod(yup.string, 'isValidRegExpPattern', function(message) {
+  return this.test('isValidRegExpPattern', message, function(string) {
+    return new RegExp(string) !== null;
+  });
+});
+
 const ATTRIBUTES_THAT_DONT_HAVE_MIN_MAX_SETTINGS = ['boolean', 'date', 'enumeration', 'media'];
 
 const forms = {
@@ -232,7 +243,10 @@ const forms = {
           return yup.object().shape({
             ...commonShape,
             ...fieldsThatSupportMaxAndMinLengthShape,
-            regex: yup.string().nullable(),
+            regex: yup
+              .string()
+              .isValidRegExpPattern(getTrad('error.validation.regex'))
+              .nullable(),
           });
         case 'number':
         case 'integer':

--- a/packages/strapi-plugin-content-type-builder/admin/src/containers/FormModal/utils/forms.js
+++ b/packages/strapi-plugin-content-type-builder/admin/src/containers/FormModal/utils/forms.js
@@ -80,11 +80,6 @@ yup.addMethod(yup.string, 'isValidRegExpPattern', function(message) {
     return new RegExp(string) !== null;
   });
 });
-yup.addMethod(yup.string, 'isValidRegExpPattern', function(message) {
-  return this.test('isValidRegExpPattern', message, function(string) {
-    return new RegExp(string) !== null;
-  });
-});
 
 const ATTRIBUTES_THAT_DONT_HAVE_MIN_MAX_SETTINGS = ['boolean', 'date', 'enumeration', 'media'];
 

--- a/packages/strapi-plugin-content-type-builder/admin/src/containers/FormModal/utils/forms.js
+++ b/packages/strapi-plugin-content-type-builder/admin/src/containers/FormModal/utils/forms.js
@@ -76,10 +76,10 @@ yup.addMethod(yup.array, 'matchesEnumRegex', function(message) {
 });
 
 yup.addMethod(yup.string, 'isValidRegExpPattern', function(message) {
-              return this.test('isValidRegExpPattern', message, function(string) {
-                               return new RegExp(string) !== null;
-                               });
-              });
+  return this.test('isValidRegExpPattern', message, function(string) {
+    return new RegExp(string) !== null;
+  });
+});
 yup.addMethod(yup.string, 'isValidRegExpPattern', function(message) {
   return this.test('isValidRegExpPattern', message, function(string) {
     return new RegExp(string) !== null;
@@ -415,14 +415,11 @@ const forms = {
               type: 'text',
               validations: {},
               description: {
-                id: getTrad(
-                  'form.attribute.item.text.regex.description'
-                ),
+                id: getTrad('form.attribute.item.text.regex.description'),
               },
             },
           ]);
-        }
-        else if (type === 'media') {
+        } else if (type === 'media') {
           items.splice(0, 1);
         } else if (type === 'boolean') {
           items.splice(0, 1, [

--- a/packages/strapi-plugin-content-type-builder/admin/src/containers/FormModal/utils/forms.js
+++ b/packages/strapi-plugin-content-type-builder/admin/src/containers/FormModal/utils/forms.js
@@ -228,6 +228,12 @@ const forms = {
               .hasNotEmptyValues('Empty strings are not allowed', dataToValidate.enum),
             enumName: yup.string().nullable(),
           });
+        case 'text':
+          return yup.object().shape({
+            ...commonShape,
+            ...fieldsThatSupportMaxAndMinLengthShape,
+            regex: yup.string().nullable(),
+          });
         case 'number':
         case 'integer':
         case 'biginteger':
@@ -384,7 +390,25 @@ const forms = {
           ]);
         }
 
-        if (type === 'media') {
+        if (type === 'text') {
+          items.splice(1, 0, [
+            {
+              autoFocus: false,
+              label: {
+                id: getTrad('form.attribute.item.text.regex'),
+              },
+              name: 'regex',
+              type: 'text',
+              validations: {},
+              description: {
+                id: getTrad(
+                  'form.attribute.item.text.regex.description'
+                ),
+              },
+            },
+          ]);
+        }
+        else if (type === 'media') {
           items.splice(0, 1);
         } else if (type === 'boolean') {
           items.splice(0, 1, [

--- a/packages/strapi-plugin-content-type-builder/admin/src/translations/en.json
+++ b/packages/strapi-plugin-content-type-builder/admin/src/translations/en.json
@@ -51,6 +51,7 @@
   "error.validation.enum-duplicate": "Duplicate values are not allowed",
   "error.validation.minSupMax": "Can't be superior",
   "error.validation.relation.targetAttribute-taken": "This name exists in the target",
+  "error.validation.regex": "Regex pattern is invalid",
   "form.attribute.component.option.add": "Add a component",
   "form.attribute.component.option.create.description": "A component is shared across types and components, it will be available and accessible everywhere.",
   "form.attribute.component.option.create": "Create a new component",
@@ -93,7 +94,8 @@
   "form.attribute.media.option.single.description": "Best for avatar, profile picture or cover",
   "form.attribute.media.option.single": "Single media",
   "form.attribute.settings.default": "Default value",
-  "form.attribute.text.option.long-text.description": "Best for descriptions, biography.  Exact search is disabled.",
+  "form.attribute.text.option.long-text.description": "Best for descriptions, biography. 
+Exact search is disabled.",
   "form.attribute.text.option.long-text": "Long text",
   "form.attribute.text.option.short-text.description": "Best for titles, names, links (URL). It also enables exact search on the field.",
   "form.attribute.text.option.short-text": "Short text",

--- a/packages/strapi-plugin-content-type-builder/admin/src/translations/en.json
+++ b/packages/strapi-plugin-content-type-builder/admin/src/translations/en.json
@@ -94,8 +94,7 @@
   "form.attribute.media.option.single.description": "Best for avatar, profile picture or cover",
   "form.attribute.media.option.single": "Single media",
   "form.attribute.settings.default": "Default value",
-  "form.attribute.text.option.long-text.description": "Best for descriptions, biography. 
-Exact search is disabled.",
+  "form.attribute.text.option.long-text.description": "Best for descriptions, biography. Exact search is disabled.",
   "form.attribute.text.option.long-text": "Long text",
   "form.attribute.text.option.short-text.description": "Best for titles, names, links (URL). It also enables exact search on the field.",
   "form.attribute.text.option.short-text": "Short text",

--- a/packages/strapi-plugin-content-type-builder/admin/src/translations/en.json
+++ b/packages/strapi-plugin-content-type-builder/admin/src/translations/en.json
@@ -70,6 +70,8 @@
   "form.attribute.item.enumeration.graphql": "Name override for GraphQL",
   "form.attribute.item.enumeration.placeholder": "Ex:\nmorning\nnoon\nevening",
   "form.attribute.item.enumeration.rules": "Values (one line per value)",
+  "form.attribute.item.text.regex": "RegExp pattern",
+  "form.attribute.item.text.regex.description": "The text of the regular expression",
   "form.attribute.item.maximum": "Maximum value",
   "form.attribute.item.maximumLength": "Maximum length",
   "form.attribute.item.minimum": "Minimum value",

--- a/packages/strapi-plugin-content-type-builder/controllers/validation/common.js
+++ b/packages/strapi-plugin-content-type-builder/controllers/validation/common.js
@@ -74,6 +74,12 @@ const areEnumValuesUnique = {
   },
 };
 
+const isValidRegExpPattern = {
+  name: 'isValidRegExpPattern',
+  message: '${path} must be a valid RexExp pattern string',
+  test: val => val === '' || new RegExp(val),
+};
+
 module.exports = {
   validators,
   areEnumValuesUnique,
@@ -84,4 +90,5 @@ module.exports = {
   isValidKey,
   isValidEnum,
   isValidUID,
+  isValidRegExpPattern,
 };

--- a/packages/strapi-plugin-content-type-builder/controllers/validation/types.js
+++ b/packages/strapi-plugin-content-type-builder/controllers/validation/types.js
@@ -9,6 +9,7 @@ const {
   isValidName,
   isValidEnum,
   isValidUID,
+  isValidRegExpPattern,
 } = require('./common');
 const { hasComponent } = require('../../utils/attributes');
 const { modelTypes, VALID_UID_TARGETS } = require('./constants');
@@ -94,7 +95,7 @@ const getTypeShape = (attribute, { modelType, attributes } = {}) => {
         unique: validators.unique,
         minLength: validators.minLength,
         maxLength: validators.maxLength,
-        regex: yup.string(),
+        regex: yup.string().test(isValidRegExpPattern),
       };
     }
     case 'richtext': {

--- a/packages/strapi-plugin-content-type-builder/controllers/validation/types.js
+++ b/packages/strapi-plugin-content-type-builder/controllers/validation/types.js
@@ -94,6 +94,7 @@ const getTypeShape = (attribute, { modelType, attributes } = {}) => {
         unique: validators.unique,
         minLength: validators.minLength,
         maxLength: validators.maxLength,
+        regex: yup.string(),
       };
     }
     case 'richtext': {

--- a/packages/strapi/lib/services/entity-validator/validators.js
+++ b/packages/strapi/lib/services/entity-validator/validators.js
@@ -48,7 +48,7 @@ const addMaxIntegerValidator = ({ max }, validator) =>
   _.isNumber(max) ? validator.max(_.toInteger(max)) : validator;
 
 /**
- * Adds min float/decimal validatore
+ * Adds min float/decimal validator
  * @param {Object} attribute model attribute
  * @param {Object} validator yup validator
  */
@@ -56,19 +56,28 @@ const addMinFloatValidator = ({ min }, validator) =>
   _.isNumber(min) ? validator.min(min) : validator;
 
 /**
- * Adds max float/decimal validatore
+ * Adds max float/decimal validator
  * @param {Object} attribute model attribute
  * @param {Object} validator yup validator
  */
 const addMaxFloatValidator = ({ max }, validator) =>
   _.isNumber(max) ? validator.max(max) : validator;
 
+/**
+ * Adds regex validator
+ * @param {Object} attribute model attribute
+ * @param {Object} validator yup validator
+ */
+const addStringRegexValidator = ({ regex }, validator) =>
+  _.isUndefined(regex) ? validator : validator.matches(new RegExp(regex));
+
 /* Type validators */
 
 const stringValidator = composeValidators(
   () => yup.string().strict(),
   addMinLengthValidator,
-  addMaxLengthValidator
+  addMaxLengthValidator,
+  addStringRegexValidator
 );
 
 const emailValidator = composeValidators(stringValidator, (attr, validator) => validator.email());


### PR DESCRIPTION
Signed-off-by: yacir dev.yassir@gmail.com

FIX #1493

WIP: If it LGTY, translations should be added before merge.

#### Description of what you did:
#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [ ] 💅 Enhancement
- [x] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [ ] Documentation
- [x] Framework
- [x] Plugin

#### Manual testing done on the following databases:

- [ ] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite

#### Result:
<img width="972" alt="Capture d’écran 2020-01-07 à 12 57 59" src="https://user-images.githubusercontent.com/2587473/71893997-5b2add00-314d-11ea-9ba3-ce11cd8046be.png">
