### PR TITLE
fix: GraphQL Aggregation Bookshelf `where` condition aren't applied to groupBy

### DIFF
--- a/packages/strapi-plugin-graphql/services/build-aggregation.js
+++ b/packages/strapi-plugin-graphql/services/build-aggregation.js
@@ -252,15 +252,15 @@ const preProcessGroupByData = function({ result, fieldKey, filters }) {
  */
 const createGroupByFieldsResolver = function(model, fields) {
   const resolver = async (filters, options, context, fieldResolver, fieldKey) => {
-    const params = {
+    const params = convertRestQueryParams({
       ...convertToParams(_.omit(filters, 'where')),
       ...convertToQuery(filters.where),
-    };
+    });
 
     if (model.orm === 'mongoose') {
       const result = await buildQuery({
         model,
-        filters: convertRestQueryParams(params),
+        filters: params,
         aggregate: true,
       }).group({
         _id: `$${fieldKey === 'id' ? model.primaryKey : fieldKey}`,
@@ -276,7 +276,7 @@ const createGroupByFieldsResolver = function(model, fields) {
     if (model.orm === 'bookshelf') {
       return model
         .query(qb => {
-          buildQuery({ model, filters: convertRestQueryParams(params) })(qb);
+          buildQuery({ model, filters: params })(qb);
           qb.groupBy(fieldKey);
           qb.select(fieldKey);
         })

--- a/packages/strapi-plugin-graphql/services/build-aggregation.js
+++ b/packages/strapi-plugin-graphql/services/build-aggregation.js
@@ -194,8 +194,8 @@ const createAggregationFieldsResolver = function(model, fields, operation, typeC
       if (model.orm === 'bookshelf') {
         return model
           .query(qb => {
-            // apply filters without pagination limit
-            buildQuery({ model, filters: _.omit(filters, ['limit']) })(qb);
+            // apply filters
+            buildQuery({ model, filters })(qb);
 
             // `sum, avg, min, max` pass nicely to knex :->
             qb[operation](`${fieldKey} as ${operation}_${fieldKey}`);
@@ -276,7 +276,7 @@ const createGroupByFieldsResolver = function(model, fields) {
     if (model.orm === 'bookshelf') {
       return model
         .query(qb => {
-          buildQuery({ model, filters })(qb);
+          buildQuery({ model, filters: convertRestQueryParams(params) })(qb);
           qb.groupBy(fieldKey);
           qb.select(fieldKey);
         })


### PR DESCRIPTION
#### Description of what you did:
I discovered a bug that filters conditions aren't applied to `groupBy`.

Original's `filters` are raw GraphQL's filters object, eg:
```filters = { limit: 100, start: 0, where: { country: "France" } }```
We need convert it to Strapi's ORM filter object, eg 
```filters = { _limit: 100, _start:0, where: [ { field: "country", operator: "eq", value: "France" } ] }```