### PR TITLE
Added 0.0.0.0 to Deployment Configuration Doc

### DIFF
--- a/docs/3.0.0-beta.x/guides/deployment.md
+++ b/docs/3.0.0-beta.x/guides/deployment.md
@@ -16,7 +16,7 @@ Update the `production` settings with the IP or domain name where the project wi
 
 ```js
 {
-  "host": "domain.io", // IP or domain
+  "host": "domain.io", // IP or domain or 0.0.0.0
   "port": 1337
 }
 ```
@@ -30,7 +30,7 @@ If you are passing a number of configuration item values via environment variabl
 
 ```js
 {
-  "host": "${process.env.APP_HOST || '127.0.0.1'}",
+  "host": "${process.env.APP_HOST || '0.0.0.0'}",
   "port": "${process.env.NODE_PORT || 1337}"
 }
 ```


### PR DESCRIPTION
There was a problem in Heroku when using the default "localhost". We must change it to "0.0.0.0". We can help others by adding this to the documentation so they don't have to invest much time to find the solution like me.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:
