### PR TITLE
Fix default values on create entity.

### DIFF
--- a/packages/strapi/lib/services/__tests__/entity-service.test.js
+++ b/packages/strapi/lib/services/__tests__/entity-service.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const createEntityService = require('../entity-service');
+const createEntityValidator = require('../entity-validator');
 const { EventEmitter } = require('events');
 
 describe('Entity service', () => {
@@ -56,15 +57,121 @@ describe('Entity service', () => {
         eventHub: new EventEmitter(),
       });
 
-      await expect(
-        instance.create({ data: {} }, { model: 'test-model' })
-      ).rejects.toThrow('Single type entry can only be created once');
+      await expect(instance.create({ data: {} }, { model: 'test-model' })).rejects.toThrow(
+        'Single type entry can only be created once'
+      );
 
       expect(fakeDB.getModel).toHaveBeenCalledTimes(1);
       expect(fakeDB.getModel).toHaveBeenCalledWith('test-model');
 
       expect(fakeDB.query).toHaveBeenCalledWith('test-model');
       expect(fakeQuery.count).toHaveBeenCalled();
+    });
+
+    describe('assign default values', () => {
+      let instance;
+
+      beforeAll(() => {
+        const strapi = {
+          errors: {
+            badRequest: jest.fn((_, errors) => errors),
+          },
+        };
+
+        const entityValidator = createEntityValidator({ strapi });
+
+        const fakeQuery = {
+          count: jest.fn(() => 0),
+          create: jest.fn(data => data),
+        };
+
+        const fakeModel = {
+          kind: 'contentType',
+          modelName: 'test-model',
+          attributes: {
+            attrStringDefaultRequired: { type: 'string', default: 'default value', required: true },
+            attrStringDefault: { type: 'string', default: 'default value' },
+            attrBoolDefaultRequired: { type: 'boolean', default: true, required: true },
+            attrBoolDefault: { type: 'boolean', default: true },
+            attrIntDefaultRequired: { type: 'integer', default: 1, required: true },
+            attrIntDefault: { type: 'integer', default: 1 },
+            attrEnumDefaultRequired: {
+              type: 'enumeration',
+              enum: ['a', 'b', 'c'],
+              default: 'a',
+              required: true,
+            },
+            attrEnumDefault: {
+              type: 'enumeration',
+              enum: ['a', 'b', 'c'],
+              default: 'b',
+            },
+          },
+        };
+
+        const fakeDB = {
+          getModel: jest.fn(() => fakeModel),
+          query: jest.fn(() => fakeQuery),
+        };
+
+        instance = createEntityService({
+          db: fakeDB,
+          eventHub: new EventEmitter(),
+          entityValidator,
+        });
+      });
+
+      test('should create record with all default attributes', async () => {
+        const data = {};
+
+        await expect(instance.create({ data }, { model: 'test-model' })).resolves.toMatchObject({
+          attrStringDefaultRequired: 'default value',
+          attrStringDefault: 'default value',
+          attrBoolDefaultRequired: true,
+          attrBoolDefault: true,
+          attrIntDefaultRequired: 1,
+          attrIntDefault: 1,
+          attrEnumDefaultRequired: 'a',
+          attrEnumDefault: 'b',
+        });
+      });
+
+      test('should create record with default and required attributes', async () => {
+        const data = {
+          attrStringDefault: 'my value',
+          attrBoolDefault: false,
+          attrIntDefault: 2,
+          attrEnumDefault: 'c',
+        };
+
+        await expect(instance.create({ data }, { model: 'test-model' })).resolves.toMatchObject({
+          attrStringDefault: 'my value',
+          attrBoolDefault: false,
+          attrIntDefault: 2,
+          attrEnumDefault: 'c',
+          attrStringDefaultRequired: 'default value',
+          attrBoolDefaultRequired: true,
+          attrIntDefaultRequired: 1,
+          attrEnumDefaultRequired: 'a',
+        });
+      });
+
+      test('should create record with provided data', async () => {
+        const data = {
+          attrStringDefaultRequired: 'my value',
+          attrStringDefault: 'my value',
+          attrBoolDefaultRequired: true,
+          attrBoolDefault: true,
+          attrIntDefaultRequired: 10,
+          attrIntDefault: 10,
+          attrEnumDefaultRequired: 'c',
+          attrEnumDefault: 'a',
+        };
+
+        await expect(instance.create({ data }, { model: 'test-model' })).resolves.toMatchObject(
+          data
+        );
+      });
     });
   });
 });

--- a/packages/strapi/lib/services/__tests__/entity-validator.test.js
+++ b/packages/strapi/lib/services/__tests__/entity-validator.test.js
@@ -240,12 +240,30 @@ describe('Entity validator', () => {
             type: 'string',
             default: 'test',
           },
+          testDate: {
+            type: 'date',
+            required: true,
+            default: '2020-04-01T04:00:00.000Z',
+          },
+          testJSON: {
+            type: 'date',
+            required: true,
+            default: {
+              foo: 1,
+              bar: 2,
+            },
+          },
         },
       };
 
       await expect(entityValidator.validateEntity(model, {})).resolves.toMatchObject({
         title: 'New',
         type: 'test',
+        testDate: '2020-04-01T04:00:00.000Z',
+        testJSON: {
+          foo: 1,
+          bar: 2,
+        },
       });
     });
   });

--- a/packages/strapi/lib/services/__tests__/entity-validator.test.js
+++ b/packages/strapi/lib/services/__tests__/entity-validator.test.js
@@ -217,5 +217,36 @@ describe('Entity validator', () => {
       const data = await entityValidator.validateEntity(model, input);
       expect(data).toEqual(input);
     });
+
+    test('Assign default values', async () => {
+      const errors = {
+        badRequest: jest.fn(),
+      };
+
+      const entityValidator = createEntityValidator({
+        strapi: {
+          errors,
+        },
+      });
+
+      const model = {
+        attributes: {
+          title: {
+            type: 'string',
+            required: true,
+            default: 'New',
+          },
+          type: {
+            type: 'string',
+            default: 'test',
+          },
+        },
+      };
+
+      await expect(entityValidator.validateEntity(model, {})).resolves.toMatchObject({
+        title: 'New',
+        type: 'test',
+      });
+    });
   });
 });

--- a/packages/strapi/lib/services/entity-validator/index.js
+++ b/packages/strapi/lib/services/entity-validator/index.js
@@ -59,7 +59,11 @@ const createValidator = model => {
 
         const { required } = attr;
 
-        const validator = createAttributeValidator(attr).nullable();
+        let validator = createAttributeValidator(attr).nullable();
+
+        if (_.has(attr, 'default')) {
+          validator = validator.default(attr.default);
+        }
 
         if (required) {
           return validator.notNil();

--- a/packages/strapi/lib/services/entity-validator/validators.js
+++ b/packages/strapi/lib/services/entity-validator/validators.js
@@ -66,7 +66,7 @@ const addMaxFloatValidator = ({ max }, validator) =>
 /* Type validators */
 
 const stringValidator = composeValidators(
-  () => yup.string().strict(),
+  () => yup.string().transform((val, originalVal) => originalVal),
   addMinLengthValidator,
   addMaxLengthValidator
 );


### PR DESCRIPTION
## Description of what you did:

### Bug description
When a model has an attribute with `default: true` and `required: true` and you use public API (POST /entitity) to create record it will return `400 ValidationError`, example:

**Model settings example**
```JSON
{
  "kind": "collectionType",
  "attributes": {
    "someAttr": {
      "type": "string"
    },
    "testAttr": {
      "type": "boolean",
      "default": true,
      "required": true
    }
  }
}
```

**Request:**
```HTTP
POST /entity HTTP/1.1
Content-Type: application/json
{
	"someAttr": "test"
}
```

**Response:**
```JSON
{
    "statusCode": 400,
    "error": "Bad Request",
    "message": "ValidationError",
    "data": {
            "testAttr": [
                "testAttr must be defined."
            ]
        }
    }
}
```
### Expected result
It should create record with default values, provided in model settings.
### What was done
I predefined default attributes in `packages/strapi/lib/services/entity-service.js` in `create` func  if attribute is not defined.

Also, this should fix issue #5645