### PR TITLE
Allow only same type when replacing asset

### DIFF
--- a/packages/strapi-plugin-content-manager/admin/src/containers/Initializer/index.js
+++ b/packages/strapi-plugin-content-manager/admin/src/containers/Initializer/index.js
@@ -17,6 +17,8 @@ const Initializer = ({ updatePlugin }) => {
   useEffect(() => {
     const getData = async () => {
       // When updating this we also need to update the content-type-builder/admin/src/containers/DataManager/index.js => updateAppMenu
+      // And also the upload/admin/src/containers/Initializer/index.js since the plugin needs to retrieve it's own model in order to get the timestamps
+      // options for the filter and sort components
       // since it uses the exact same method...
       const requestURL = `/${pluginId}/content-types`;
 

--- a/packages/strapi-plugin-upload/admin/src/components/EditForm/index.js
+++ b/packages/strapi-plugin-upload/admin/src/components/EditForm/index.js
@@ -62,7 +62,7 @@ const EditForm = forwardRef(
       get(fileToEdit, ['file', 'type'], null) || get(fileToEdit, ['file', 'mime'], '');
     const isImg = isImageType(mimeType);
     const isVideo = isVideoType(mimeType);
-    const canCrop = isImg && !mimeType.includes('svg');
+    const canCrop = isImg && !mimeType.includes('svg') && !mimeType.includes('gif');
     const aRef = useRef();
     const imgRef = useRef();
     const inputRef = useRef();

--- a/packages/strapi-plugin-upload/admin/src/components/EditForm/index.js
+++ b/packages/strapi-plugin-upload/admin/src/components/EditForm/index.js
@@ -63,7 +63,6 @@ const EditForm = forwardRef(
     const isImg = isImageType(mimeType);
     const isVideo = isVideoType(mimeType);
     const canCrop = isImg && !mimeType.includes('svg');
-
     const aRef = useRef();
     const imgRef = useRef();
     const inputRef = useRef();
@@ -330,6 +329,16 @@ const EditForm = forwardRef(
             multiple={false}
             onChange={handleChange}
             style={{ display: 'none' }}
+            accept={mimeType
+              .split('/')
+              .map((v, i) => {
+                if (i === 1) {
+                  return '*';
+                }
+
+                return v;
+              })
+              .join('/')}
           />
           <button type="submit" style={{ display: 'none' }}>
             hidden button to make to get the native form event

--- a/packages/strapi-plugin-upload/admin/src/components/FiltersPicker/FiltersCard/index.js
+++ b/packages/strapi-plugin-upload/admin/src/components/FiltersPicker/FiltersCard/index.js
@@ -1,11 +1,10 @@
-import React, { useReducer, useEffect, useRef } from 'react';
+import React, { useReducer } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import { Select } from '@buffetjs/core';
-
-import { getFilterType, request } from 'strapi-helper-plugin';
-import { getTrad } from '../../../utils';
-
+import { getFilterType, useGlobalContext } from 'strapi-helper-plugin';
+import { getTrad, getFileModelTimestamps } from '../../../utils';
+import init from './init';
 import reducer, { initialState } from './reducer';
 
 import Wrapper from './Wrapper';
@@ -14,20 +13,9 @@ import FilterButton from './FilterButton';
 import FilterInput from './FilterInput';
 
 const FiltersCard = ({ onChange, filters }) => {
-  // Not using the hook from buffet.js because it appears that when the component is closed we the hooks returns false
-  // Until we make a PR on @buffetjs/hooks I rather use this custom one
-  const isMounted = useRef(true);
-  const [state, dispatch] = useReducer(reducer, initialState);
-
-  useEffect(() => {
-    if (isMounted.current) {
-      fetchTimestampNames();
-    }
-
-    return () => (isMounted.current = false);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isMounted]);
-
+  const { plugins } = useGlobalContext();
+  const timestamps = getFileModelTimestamps(plugins);
+  const [state, dispatch] = useReducer(reducer, initialState, () => init(initialState, timestamps));
   const { name, filter, filtersForm, value } = state.toJS();
 
   const type = filtersForm[name].type;
@@ -69,25 +57,6 @@ const FiltersCard = ({ onChange, filters }) => {
         </option>
       );
     });
-  };
-
-  const fetchTimestampNames = async () => {
-    try {
-      const result = await request('/content-manager/content-types/plugins::upload.file', {
-        method: 'GET',
-      });
-
-      if (isMounted.current) {
-        dispatch({
-          type: 'HANDLE_CUSTOM_TIMESTAMPS',
-          timestamps: result.data.contentType.schema.options.timestamps,
-        });
-      }
-    } catch (err) {
-      if (isMounted.current) {
-        strapi.notification.error('notification.error');
-      }
-    }
   };
 
   return (

--- a/packages/strapi-plugin-upload/admin/src/components/FiltersPicker/FiltersCard/init.js
+++ b/packages/strapi-plugin-upload/admin/src/components/FiltersPicker/FiltersCard/init.js
@@ -1,0 +1,21 @@
+const init = (initialState, timestamps) => {
+  const [created_at, updated_at] = timestamps;
+
+  return initialState
+    .update('name', () => created_at)
+    .updateIn(['filtersForm'], object => {
+      return object.keySeq().reduce((acc, current) => {
+        if (current === 'created_at' && created_at !== 'created_at') {
+          return acc.set(created_at, object.get('created_at')).remove('created_at');
+        }
+
+        if (current === 'updated_at' && updated_at !== 'updated_at') {
+          return acc.set(updated_at, object.get('updated_at')).remove('updated_at');
+        }
+
+        return acc;
+      }, object);
+    });
+};
+
+export default init;

--- a/packages/strapi-plugin-upload/admin/src/components/FiltersPicker/FiltersCard/reducer.js
+++ b/packages/strapi-plugin-upload/admin/src/components/FiltersPicker/FiltersCard/reducer.js
@@ -27,27 +27,6 @@ function reducer(state, action) {
 
       return state.update(name, () => value);
     }
-    case 'HANDLE_CUSTOM_TIMESTAMPS': {
-      const {
-        timestamps: [created_at, updated_at],
-      } = action;
-
-      return state
-        .update('name', () => created_at)
-        .updateIn(['filtersForm'], object => {
-          return object.keySeq().reduce((acc, current) => {
-            if (current === 'created_at' && created_at !== 'created_at') {
-              return acc.set(created_at, object.get('created_at')).remove('created_at');
-            }
-
-            if (current === 'updated_at' && updated_at !== 'updated_at') {
-              return acc.set(updated_at, object.get('updated_at')).remove('updated_at');
-            }
-
-            return acc;
-          }, object);
-        });
-    }
     case 'RESET_FORM':
       return initialState
         .set(

--- a/packages/strapi-plugin-upload/admin/src/components/FiltersPicker/FiltersCard/tests/init.test.js
+++ b/packages/strapi-plugin-upload/admin/src/components/FiltersPicker/FiltersCard/tests/init.test.js
@@ -1,0 +1,66 @@
+import { fromJS } from 'immutable';
+import init from '../init';
+
+describe('UPLOAD | components | FiltersPicker | FilersCard | init', () => {
+  it('should set the initialState correctly with the retrieved timestamps', () => {
+    const state = fromJS({
+      name: 'created_at',
+      filter: '=',
+      value: 'test',
+      filtersForm: {
+        created_at: {
+          type: 'datetime',
+          defaultFilter: '=',
+          defaultValue: 'test1',
+        },
+        updated_at: {
+          type: 'datetime',
+          defaultFilter: '=',
+          defaultValue: 'test2',
+        },
+        size: {
+          type: 'integer',
+          defaultFilter: '=',
+          defaultValue: '0KB',
+        },
+        mime: {
+          type: 'enum',
+          defaultFilter: '_contains',
+          defaultValue: 'image',
+        },
+      },
+    });
+
+    const timestamps = ['createdAtCustom', 'updatedAtCustom'];
+
+    const expected = fromJS({
+      name: 'createdAtCustom',
+      filter: '=',
+      value: 'test',
+      filtersForm: {
+        createdAtCustom: {
+          type: 'datetime',
+          defaultFilter: '=',
+          defaultValue: 'test1',
+        },
+        updatedAtCustom: {
+          type: 'datetime',
+          defaultFilter: '=',
+          defaultValue: 'test2',
+        },
+        size: {
+          type: 'integer',
+          defaultFilter: '=',
+          defaultValue: '0KB',
+        },
+        mime: {
+          type: 'enum',
+          defaultFilter: '_contains',
+          defaultValue: 'image',
+        },
+      },
+    });
+
+    expect(init(state, timestamps)).toEqual(expected);
+  });
+});

--- a/packages/strapi-plugin-upload/admin/src/components/FiltersPicker/FiltersCard/tests/reducer.test.js
+++ b/packages/strapi-plugin-upload/admin/src/components/FiltersPicker/FiltersCard/tests/reducer.test.js
@@ -1,4 +1,3 @@
-import { fromJS } from 'immutable';
 import reducer, { initialState } from '../reducer';
 
 describe('Upload | components | FiltersCard | reducer', () => {
@@ -30,70 +29,6 @@ describe('Upload | components | FiltersCard | reducer', () => {
     const expected = state.set('filter', '>');
 
     expect(actual).toEqual(expected);
-  });
-  it('should return the updated filters form with custom timestamps', () => {
-    const state = fromJS({
-      name: 'created_at',
-      filter: '=',
-      value: 'test',
-      filtersForm: {
-        created_at: {
-          type: 'datetime',
-          defaultFilter: '=',
-          defaultValue: 'test1',
-        },
-        updated_at: {
-          type: 'datetime',
-          defaultFilter: '=',
-          defaultValue: 'test2',
-        },
-        size: {
-          type: 'integer',
-          defaultFilter: '=',
-          defaultValue: '0KB',
-        },
-        mime: {
-          type: 'enum',
-          defaultFilter: '_contains',
-          defaultValue: 'image',
-        },
-      },
-    });
-
-    const action = {
-      type: 'HANDLE_CUSTOM_TIMESTAMPS',
-      timestamps: ['createdAtCustom', 'updatedAtCustom'],
-    };
-
-    const expected = fromJS({
-      name: 'createdAtCustom',
-      filter: '=',
-      value: 'test',
-      filtersForm: {
-        createdAtCustom: {
-          type: 'datetime',
-          defaultFilter: '=',
-          defaultValue: 'test1',
-        },
-        updatedAtCustom: {
-          type: 'datetime',
-          defaultFilter: '=',
-          defaultValue: 'test2',
-        },
-        size: {
-          type: 'integer',
-          defaultFilter: '=',
-          defaultValue: '0KB',
-        },
-        mime: {
-          type: 'enum',
-          defaultFilter: '_contains',
-          defaultValue: 'image',
-        },
-      },
-    });
-
-    expect(reducer(state, action)).toEqual(expected);
   });
 
   it('should return the initialState on reset', () => {

--- a/packages/strapi-plugin-upload/admin/src/components/SortPicker/index.js
+++ b/packages/strapi-plugin-upload/admin/src/components/SortPicker/index.js
@@ -1,21 +1,23 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
-
+import { useGlobalContext } from 'strapi-helper-plugin';
 import { Carret } from '@buffetjs/icons';
-import { getTrad } from '../../utils';
+import { getTrad, getFileModelTimestamps } from '../../utils';
 
 import SortList from '../SortList';
 import Picker from '../Picker';
 
 const SortPicker = ({ onChange, value }) => {
+  const { plugins } = useGlobalContext();
+  const [created_at, updated_at] = getFileModelTimestamps(plugins);
   const orders = {
-    created_at_desc: 'created_at:DESC',
-    created_at_asc: 'created_at:ASC',
+    created_at_desc: `${created_at}:DESC`,
+    created_at_asc: `${created_at}:ASC`,
     name_asc: 'name:ASC',
     name_desc: 'name:DESC',
-    updated_at_desc: 'updated_at:DESC',
-    updated_at_asc: 'updated_at:ASC',
+    updated_at_desc: `${updated_at}:DESC`,
+    updated_at_asc: `${updated_at}:ASC`,
   };
 
   return (

--- a/packages/strapi-plugin-upload/admin/src/containers/HomePage/index.js
+++ b/packages/strapi-plugin-upload/admin/src/containers/HomePage/index.js
@@ -53,6 +53,10 @@ const HomePage = () => {
   const debouncedSearch = useDebounce(searchValue, 300);
 
   useEffect(() => {
+    return () => (isMounted.current = false);
+  }, []);
+
+  useEffect(() => {
     handleChangeParams({ target: { name: '_q', value: debouncedSearch } });
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -61,7 +65,6 @@ const HomePage = () => {
   useEffect(() => {
     fetchListData();
 
-    return () => (isMounted.current = false);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [search]);
 

--- a/packages/strapi-plugin-upload/admin/src/containers/Initializer/index.js
+++ b/packages/strapi-plugin-upload/admin/src/containers/Initializer/index.js
@@ -1,0 +1,41 @@
+/**
+ *
+ * Initializer
+ *
+ */
+
+import { useEffect, useRef } from 'react';
+import PropTypes from 'prop-types';
+import { request } from 'strapi-helper-plugin';
+import pluginId from '../../pluginId';
+
+const Initializer = ({ updatePlugin }) => {
+  const ref = useRef();
+  ref.current = updatePlugin;
+
+  useEffect(() => {
+    const getData = async () => {
+      const requestURL = '/content-manager/content-types';
+
+      try {
+        const { data } = await request(requestURL, { method: 'GET' });
+        const fileModel = data.find(model => model.uid === 'plugins::upload.file');
+
+        ref.current(pluginId, 'fileModel', fileModel);
+        ref.current(pluginId, 'isReady', true);
+      } catch (err) {
+        strapi.notification.error('content-manager.error.model.fetch');
+      }
+    };
+
+    getData();
+  }, []);
+
+  return null;
+};
+
+Initializer.propTypes = {
+  updatePlugin: PropTypes.func.isRequired,
+};
+
+export default Initializer;

--- a/packages/strapi-plugin-upload/admin/src/containers/ModalStepper/index.js
+++ b/packages/strapi-plugin-upload/admin/src/containers/ModalStepper/index.js
@@ -322,7 +322,7 @@ const ModalStepper = ({
       }
     }
 
-    if (!isEqual(initialFileToEdit, fileToEdit)) {
+    if (!isEqual(initialFileToEdit, fileToEdit) && currentStep === 'edit') {
       // eslint-disable-next-line no-alert
       const confirm = window.confirm(
         formatMessage({ id: getTrad('window.confirm.close-modal.file') })

--- a/packages/strapi-plugin-upload/admin/src/index.js
+++ b/packages/strapi-plugin-upload/admin/src/index.js
@@ -8,6 +8,7 @@
 import pluginPkg from '../../package.json';
 import pluginLogo from './assets/images/logo.svg';
 import App from './containers/App';
+import Initializer from './containers/Initializer';
 import SettingsPage from './containers/SettingsPage';
 import InputMedia from './components/InputMedia';
 
@@ -21,11 +22,12 @@ export default strapi => {
     blockerComponent: null,
     blockerComponentProps: {},
     description: pluginDescription,
+    fileModel: null,
     icon: pluginPkg.strapi.icon,
     id: pluginId,
-    initializer: null,
+    initializer: Initializer,
     injectedComponents: [],
-    isReady: true,
+    isReady: false,
     isRequired: pluginPkg.strapi.required || false,
     layout: null,
     lifecycles: null,

--- a/packages/strapi-plugin-upload/admin/src/utils/getFileModelTimestamps.js
+++ b/packages/strapi-plugin-upload/admin/src/utils/getFileModelTimestamps.js
@@ -1,0 +1,14 @@
+import { get } from 'lodash';
+import pluginId from '../pluginId';
+
+const getFileModelTimestamps = plugins => {
+  const timestamps = get(
+    plugins,
+    [pluginId, 'fileModel', 'schema', 'options', 'timestamps'],
+    ['created_at', 'updated_at']
+  );
+
+  return timestamps;
+};
+
+export default getFileModelTimestamps;

--- a/packages/strapi-plugin-upload/admin/src/utils/index.js
+++ b/packages/strapi-plugin-upload/admin/src/utils/index.js
@@ -9,6 +9,7 @@ export { default as formatFileForEditing } from './formatFileForEditing';
 export { default as generatePageFromStart } from './generatePageFromStart';
 export { default as generateStartFromPage } from './generateStartFromPage';
 export { default as getExtension } from './getExtension';
+export { default as getFileModelTimestamps } from './getFileModelTimestamps';
 export { default as getFilesToDownload } from './getFilesToDownload';
 export { default as getRequestUrl } from './getRequestUrl';
 export { default as getTrad } from './getTrad';

--- a/packages/strapi-plugin-upload/admin/src/utils/tests/getFileModelTimestamps.test.js
+++ b/packages/strapi-plugin-upload/admin/src/utils/tests/getFileModelTimestamps.test.js
@@ -1,0 +1,35 @@
+import getFileModelTimestamps from '../getFileModelTimestamps';
+
+describe('UPLOAD | utils | getFileModelTimestamps', () => {
+  it('should retrieve the timestamps of the model file from the plugins object', () => {
+    const plugins = {
+      ctb: {
+        ok: true,
+      },
+      upload: {
+        ok: true,
+        fileModel: {
+          uid: 'plugins::upload.file',
+          schema: {
+            attributes: {},
+            options: {
+              timestamps: ['createdAt', 'updatedAt'],
+            },
+          },
+        },
+      },
+    };
+
+    const expected = ['createdAt', 'updatedAt'];
+
+    expect(getFileModelTimestamps(plugins)).toEqual(expected);
+  });
+
+  it('should return the default timestamps', () => {
+    const plugins = null;
+
+    const expected = ['created_at', 'updated_at'];
+
+    expect(getFileModelTimestamps(plugins)).toEqual(expected);
+  });
+});


### PR DESCRIPTION
Signed-off-by: soupette <cyril.lpz@gmail.com>

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:
This PR improves:
- the filtercard by retrieving the timestamps directly from the plugin's model
- add the timestamps to the sort component
- fix the isMounted in the homepage
- Prevents from replacing a file with a one that has a different type
- Prevents from cropping a GIF