### PR TITLE
Update sqlite table migration query to escape column names

### DIFF
--- a/packages/strapi-connector-bookshelf/lib/buildDatabaseSchema.js
+++ b/packages/strapi-connector-bookshelf/lib/buildDatabaseSchema.js
@@ -304,11 +304,7 @@ module.exports = async ({ ORM, loadedModel, definition, connection, model }) => 
 
         const allAttrs = ['id', ...attrs];
 
-        await trx.raw(`INSERT INTO ?? (${allAttrs.join(', ')}) ??`, [
-          table,
-          trx.select(allAttrs).from(tmpTable),
-        ]);
-
+        await trx.insert(qb => qb.select(allAttrs).from(tmpTable)).into(table);
         await trx.schema.dropTableIfExists(tmpTable);
       };
 


### PR DESCRIPTION
Fix #4983
