### PR TITLE
Remove auto-sync indexes for mongodb from production envs

### DIFF
--- a/packages/strapi-connector-mongoose/lib/mount-models.js
+++ b/packages/strapi-connector-mongoose/lib/mount-models.js
@@ -278,8 +278,7 @@ module.exports = ({ models, target }, ctx) => {
     // Instantiate model.
     const Model = instance.model(definition.globalId, schema, definition.collectionName);
 
-    // Ensure indexes are synced with the model, prevent duplicate index errors
-    Model.syncIndexes(null, () => {
+    const handleIndexesErrors = () => {
       Model.on('index', error => {
         if (error) {
           if (error.code === 11000) {
@@ -291,7 +290,17 @@ module.exports = ({ models, target }, ctx) => {
           }
         }
       });
-    });
+    };
+
+    // Only sync indexes in development env while it's not possible to create complex indexes directly from models
+    // In other environments it will simply create missing indexes (those defined in the models but not present in db)
+    if (strapi.app.env === 'development') {
+      // Ensure indexes are synced with the model, prevent duplicate index errors
+      // Side-effect: Delete all the indexes not present in the model.json
+      Model.syncIndexes(null, handleIndexesErrors);
+    } else {
+      handleIndexesErrors();
+    }
 
     // Expose ORM functions through the `target` object.
     target[model] = _.assign(Model, target[model]);


### PR DESCRIPTION
resolves #5682 

#### Description of what you did:
https://github.com/strapi/strapi/pull/5612 forced MongoDB indexes to be synced with the JSON model.
However, this pr caused some breaking changes for peoples using manually created indexes.
After discussing it in #5682 and while it's not possible to create compound indexes in models.json, the `syncIndex` will now be executed only in a development environment.