### PR TITLE
docs: DE Abbrechen does not mean reset

### DIFF
--- a/packages/strapi-plugin-content-manager/admin/src/translations/de.json
+++ b/packages/strapi-plugin-content-manager/admin/src/translations/de.json
@@ -32,7 +32,7 @@
   "containers.Edit.clickToJump": "Klicke, um zu einem Eintrag zu springen",
   "containers.Edit.delete": "Löschen",
   "containers.Edit.editing": "Bearbeite...",
-  "containers.Edit.reset": "Abbrechen",
+  "containers.Edit.reset": "Zurücksetzen",
   "containers.Edit.returnList": "Zu Liste zurückkehren",
   "containers.Edit.seeDetails": "Details",
   "containers.Edit.submit": "Speichern",


### PR DESCRIPTION
#### Description of what you did:

Abbrechen means cancel. Which implies the user would get back to the list view, while editing a single item.
Zurücksetzen means to revert back - reset. :)