### PR TITLE
Fix email confirmation redirect

### DIFF
--- a/packages/strapi-plugin-users-permissions/config/schema.graphql.js
+++ b/packages/strapi-plugin-users-permissions/config/schema.graphql.js
@@ -249,6 +249,7 @@ module.exports = {
 
           await strapi.plugins['users-permissions'].controllers.auth.emailConfirmation(
             context,
+            null,
             true
           );
           let output = context.body.toJSON ? context.body.toJSON() : context.body;

--- a/packages/strapi-plugin-users-permissions/controllers/Auth.js
+++ b/packages/strapi-plugin-users-permissions/controllers/Auth.js
@@ -568,7 +568,7 @@ module.exports = {
     }
   },
 
-  async emailConfirmation(ctx, returnUser) {
+  async emailConfirmation(ctx, next, returnUser) {
     const params = ctx.query;
 
     const decodedToken = await strapi.plugins['users-permissions'].services.jwt.verify(


### PR DESCRIPTION
Fixes #5816

#5580 changed the signature of the `emailConfirmation` endpoint by adding the `returnUser` argument, which in that PR got introduced to disable the frontend redirect after confirming the email via the GraphQL endpoint.

However, when using the REST API, the second argument for the `emailConfirmation` endpoint is always the `next` callback. Therefore #5580 caused the frontend redirect to break when using REST.

