### PR TITLE
Image Preview supporting SVG

### DIFF
--- a/packages/strapi-helper-plugin/lib/src/components/ImgPreview/index.js
+++ b/packages/strapi-helper-plugin/lib/src/components/ImgPreview/index.js
@@ -34,9 +34,7 @@ class ImgPreview extends React.Component {
       ? get(this.props.files, ['0', 'name'], '')
       : get(this.props.files, 'name');
     this.setState({
-      imgURL:
-        get(this.props.files, ['0', 'url'], '') ||
-        get(this.props.files, 'url', ''),
+      imgURL: get(this.props.files, ['0', 'url'], '') || get(this.props.files, 'url', ''),
       isImg: this.isPictureType(file),
     });
   }
@@ -56,8 +54,7 @@ class ImgPreview extends React.Component {
     if (
       nextProps.didDeleteFile !== this.props.didDeleteFile ||
       nextProps.position !== this.props.position ||
-      (size(nextProps.files) !== size(this.props.files) &&
-        !this.state.isInitValue)
+      (size(nextProps.files) !== size(this.props.files) && !this.state.isInitValue)
     ) {
       const file = nextProps.files[nextProps.position] || nextProps.files || '';
       this.generateImgURL(file);
@@ -96,8 +93,7 @@ class ImgPreview extends React.Component {
       reader.readAsDataURL(file);
     } else if (has(file, 'url')) {
       const isImg = this.isPictureType(file.name);
-      const imgURL =
-        file.url[0] === '/' ? `${strapi.backendURL}${file.url}` : file.url;
+      const imgURL = file.url[0] === '/' ? `${strapi.backendURL}${file.url}` : file.url;
 
       this.setState({ isImg, imgURL });
     } else {
@@ -150,7 +146,7 @@ class ImgPreview extends React.Component {
   };
 
   // TODO change logic to depend on the type
-  isPictureType = fileName => /\.(jpe?g|png|gif)$/i.test(fileName);
+  isPictureType = fileName => /\.(jpe?g|png|svg|gif)$/i.test(fileName);
 
   updateFilePosition = newPosition => {
     this.props.updateFilePosition(newPosition);

--- a/packages/strapi-plugin-content-manager/admin/src/components/InputFileWithErrors/ImgPreview/index.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/InputFileWithErrors/ImgPreview/index.js
@@ -156,7 +156,7 @@ class ImgPreview extends React.Component {
   };
 
   // TODO change logic to depend on the type
-  isPictureType = fileName => /\.(jpe?g|png|gif)$/i.test(fileName);
+  isPictureType = fileName => /\.(jpe?g|png|svg|gif)$/i.test(fileName);
 
   updateFilePosition = newPosition => {
     this.props.updateFilePosition(newPosition);


### PR DESCRIPTION
SVG (image/svg+xml ) is supported by all major browsers and heavily used across the web, multiple projects (strapi included) are relying on svg resources to deliver a responsive experience to their users.

This pull request is adding support for SVG medias inside the **Image Preview** component.

**Before:**
![image](https://user-images.githubusercontent.com/7511692/79399110-d3791980-7f58-11ea-95fe-dacdbe88a4d9.png)

**After:**
![image](https://user-images.githubusercontent.com/7511692/79398967-6f565580-7f58-11ea-990d-4919489dacfb.png)

Fixes #5788

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

- Changed `isPictureType` detection to include svg extension
- Manual tested using Firefox / Chrome.