### PR TITLE
Re-add Google App Engine deployment docs

### DIFF
--- a/docs/3.0.0-beta.x/deployment/google-app-engine.md
+++ b/docs/3.0.0-beta.x/deployment/google-app-engine.md
@@ -1,0 +1,307 @@
+# Google App Engine
+
+In this guide we are going to:
+
+- Create a new Strapi project
+- Configure PostgreSQL for the production enviroment
+- Deploy the app to Google App Engine
+- Add the [Google Cloud Storage file uploading plugin](https://github.com/Lith/strapi-provider-upload-google-cloud-storage) by [@Lith](https://github.com/Lith)
+
+### New Strapi project
+
+:::: tabs
+
+::: tab yarn
+
+Use **yarn** to install the Strapi project (**recommended**). [Install yarn with these docs](https://yarnpkg.com/lang/en/docs/install/)
+
+```bash
+yarn create strapi-app my-project --quickstart
+```
+
+:::
+
+::: tab npx
+
+Use **npm/npx** to install the Strapi project
+
+```bash
+npx create-strapi-app my-project --quickstart
+```
+
+:::
+
+::::
+
+When the setup completes, register an admin user using the form which opens in the browser. This user will be only relevant in local development.
+
+The `sqlite` database is created at `.tmp/data.db`.
+
+Login, but don't add content types yet. Close the browser. Quit the running app.
+
+### Initial commit
+
+This may be a good point to commit the files in their initial state.
+
+```bash
+cd my-project
+git init
+git add .
+git commit -m first
+```
+
+### Install the Cloud SDK CLI tool
+
+[Cloud SDK: Command Line Interface](https://cloud.google.com/sdk/)
+
+### New App Engine project
+
+Create a new [App Engine](https://console.cloud.google.com/appengine/) project.
+
+Select the region, such as `europe-west`.
+
+- Language: Node JS
+- Environment: Standard (or Flexible)
+
+(_A note on performance and cost_: the `Standard Environment` is sufficient for development, but it may not be for production. Review the resources your application will need to determine the cost. When you sign up for Google App Engine, it offers a certain amount of free credits which will not be billed.)
+
+Create the project. Take note of the instance identifier, which is in the form of `<instance_id>:<region>:<instance_name>`.
+
+Check if `gcloud` lists the project:
+
+```bash
+gcloud projects list
+```
+
+Run `init` to authenticate the cli, and select current cloud project.
+
+```bash
+gcloud init
+```
+
+### Create the database (PostgreSQL)
+
+Create the [Cloud SQL database](https://cloud.google.com/sql/docs/postgres/create-manage-databases) which the app is going to use.
+
+Take note of the user name (default is `postgres`) and password.
+
+The first database will be created with the name `postgres`. This cannot be deleted.
+
+Create another database, named `strapi` for example. It may be useful to delete and and re-create this while you are experimenting with the application setup.
+
+### Create app.yaml and .gcloudignore
+
+Create the `app.yaml` file in the project root.
+
+Add `app.yaml` to `.gitignore`.
+
+The instance identifier looks like `myapi-123456:europe-west1:myapi`.
+
+The `myapi-123456` part is the project identifier. (The number is automatically added to short project names).
+
+The following is an example config for `Standard Environment` or `Flexible Environment`.
+
+:::: tabs
+
+::: tab Standard Environment
+
+```yaml
+runtime: nodejs10
+
+instance_class: F2
+
+env_variables:
+  HOST: '<project_id>.appspot.com'
+  NODE_ENV: 'production'
+  DATABASE_NAME: 'strapi'
+  DATABASE_USERNAME: 'postgres'
+  DATABASE_PASSWORD: '<password>'
+  INSTANCE_CONNECTION_NAME: '<instance_identifier>'
+
+beta_settings:
+  cloud_sql_instances: '<instance_identifier>'
+```
+
+:::
+
+::: tab Flexible Environment
+
+```yaml
+runtime: nodejs10
+
+env: flex
+
+env_variables:
+  HOST: '<project_id>.appspot.com'
+  NODE_ENV: 'production'
+  DATABASE_NAME: 'strapi'
+  DATABASE_USERNAME: 'postgres'
+  DATABASE_PASSWORD: '<password>'
+  INSTANCE_CONNECTION_NAME: '<instance_identifier>'
+
+beta_settings:
+  cloud_sql_instances: '<instance_identifier>'
+```
+
+:::
+
+::::
+
+Create `.gcloudignore` in the project root, include `app.yaml` here as well.
+
+```
+app.yaml
+.gcloudignore
+.git
+.gitignore
+node_modules/
+#!include:.gitignore
+```
+
+In the case of Strapi, the admin UI will have to be re-built after every deploy,
+and so we don't deploy local build artifacts, cache files and so on by including
+the `.gitignore` entries.
+
+### Configure the database
+
+The `PostgreSQL` database will need the `pg` package.
+
+```bash
+yarn add pg
+```
+
+[Google App Engine requires](https://cloud.google.com/sql/docs/postgres/connect-app-engine) to connect to the database using the unix socket path, not an IP and port.
+
+Edit `database.json`, and use the socket path as `host`.
+
+```
+config/environments/production/database.json
+```
+
+```json
+{
+  "defaultConnection": "default",
+  "connections": {
+    "default": {
+      "connector": "bookshelf",
+      "settings": {
+        "client": "postgres",
+        "host": "/cloudsql/${process.env.INSTANCE_CONNECTION_NAME}",
+        "database": "${process.env.DATABASE_NAME}",
+        "username": "${process.env.DATABASE_USERNAME}",
+        "password": "${process.env.DATABASE_PASSWORD}"
+      },
+      "options": {}
+    }
+  }
+}
+```
+
+Edit `server.json` to pick up the deployed hostname from the `HOST` variable in `app.yaml`.
+
+```
+config/environments/production/server.json
+```
+
+```json
+{
+  "host": "${process.env.HOST}",
+  "port": "${process.env.PORT || 1337}",
+  "production": true,
+  "proxy": {
+    "enabled": false
+  },
+  "cron": {
+    "enabled": false
+  },
+  "admin": {
+    "autoOpen": false
+  }
+}
+```
+
+### Auto-build after deploy
+
+After deployment, the admin UI has to be re-built. This generates the contents of the `build` folder on the server.
+
+In `package.json`, add the `gcp-build` command to `scripts`:
+
+```json
+{
+  "scripts": {
+    "gcp-build": "strapi build"
+  }
+}
+```
+
+### Deploy
+
+```bash
+gcloud app deploy app.yaml --project myapi-123456
+```
+
+Watch the logs:
+
+```bash
+gcloud app logs tail --project=myapi-123456 -s default
+```
+
+Open the admin page and register and admin user.
+
+```
+https://myapp-123456.appspot.com/admin/
+```
+
+### File uploading to Google Cloud Storage
+
+[Lith/strapi-provider-upload-google-cloud-storage](https://github.com/Lith/strapi-provider-upload-google-cloud-storage)
+
+```bash
+yarn add strapi-provider-upload-google-cloud-storage
+```
+
+Deploy so that the server app includes the dependency from `package.json`.
+
+Create a Google service account key.
+
+<https://console.cloud.google.com/apis/credentials/serviceaccountkey>
+
+Save the JSON credentials file.
+
+Plugins > File Upload > Settings > Production tab
+
+By default `localhost` is selected. Select the `Google Cloud Storage` plugin.
+
+Copy the JSON key and set the regions.
+
+Open the `Cloud Console > Storage > Browser` menu.
+
+Copy the bucket name to the plugin settings, the default is the app ID, such as `myapi-123456.appspot.com`.
+
+(Note that the `Access control` setting of the bucket has to be `Fine-grained`, which is the default.)
+
+Click `Save`, and it's ready to go!
+
+### Post-setup configuration
+
+**CORS**
+
+CORS is enabled by default, allowing `*` origin. You may want to limit the allowed origins.
+
+```
+config/environments/production/security.json
+```
+
+**Changing the admin url**
+
+```
+config/environments/production/server.json
+```
+
+```json
+{
+  "admin": {
+    "path": "/dashboard"
+  }
+}
+```

--- a/docs/3.0.0-beta.x/getting-started/deployment.md
+++ b/docs/3.0.0-beta.x/getting-started/deployment.md
@@ -47,6 +47,18 @@ Manual guides for deployment on various platforms, for One-click and docker plea
 </div>
 
 <div>
+	<InstallLink link="../deployment/google-app-engine">
+		<template #icon>
+			<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 24 24" version="1.1"><path d="M6.969 3L4.094 8.188l1.468 2.624L8.438 6h10.25L17 3zm8.75 4l2.969 4.906L13.625 21H17l5-9-2.781-5zM12 8c-2.207 0-4 1.793-4 4s1.793 4 4 4 4-1.793 4-4-1.793-4-4-4zM3.531 9.219L2 12l4.969 9H12.5l1.656-3h-5.75zM12 10c1.102 0 2 .898 2 2 0 1.102-.898 2-2 2-1.102 0-2-.898-2-2 0-1.102.898-2 2-2z" fill="#fff"/></svg>
+		</template>
+		<template #title>Google App Engine</template>
+		<template #description>
+			Manual step by step guide for deploying on GCP's App Engine
+		</template>
+	</InstallLink>
+</div>
+
+<div>
 	<InstallLink link="../deployment/heroku">
     <template #icon>
     <svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 5.12 5.12" preserveAspectRatio="xMinYMin meet"><path d="M3.068 4.415V2.382s.132-.487-1.63.2C1.436 2.6 1.436.7 1.436.7L2.01.697v1.2s1.61-.635 1.61.48v2.026h-.555zm.328-2.986h-.6c.22-.27.42-.73.42-.73h.63s-.108.3-.44.73zm-1.95 2.982V3.254l.58.58-.58.58z" fill="#fff"/></svg>


### PR DESCRIPTION
#### Description of what you did:

During the merge of the new Deployment docs this PR: https://github.com/strapi/strapi/pull/5088/files accidentally got skipped over, this new PR fixes that and merges in these GCP docs with the new deployment docs structure.