### PR TITLE
Fix AWS SES not working in eu-central-1 region

### DIFF
--- a/packages/strapi-provider-email-amazon-ses/package.json
+++ b/packages/strapi-provider-email-amazon-ses/package.json
@@ -15,7 +15,7 @@
   "main": "./lib",
   "dependencies": {
     "lodash": "^4.17.11",
-    "node-ses": "^2.2.0"
+    "node-ses": "^3.0.0"
   },
   "author": {
     "email": "nikolay@tsenkov.net",


### PR DESCRIPTION
Fixes #5852

#### Description of what you did:

Just updated the dependency to `node-ses`, as I had to fix the issue there: https://github.com/aheckmann/node-ses/pull/60

