### PR TITLE
Fix #5854 - GraphQL implementation of updateRole and deleteRole fails

### DIFF
--- a/packages/strapi-plugin-users-permissions/config/schema.graphql.js
+++ b/packages/strapi-plugin-users-permissions/config/schema.graphql.js
@@ -104,9 +104,11 @@ module.exports = {
         description: 'Update an existing role',
         resolverOf: 'plugins::users-permissions.userspermissions.updateRole',
         resolver: async (obj, options, { context }) => {
+          context.params = { ...context.params, ...options.input };
+          context.params.role = context.params.id;
+
           await strapi.plugins['users-permissions'].controllers.userspermissions.updateRole(
-            context.params,
-            context.body
+            context
           );
 
           return { ok: true };
@@ -116,6 +118,9 @@ module.exports = {
         description: 'Delete an existing role',
         resolverOf: 'plugins::users-permissions.userspermissions.deleteRole',
         resolver: async (obj, options, { context }) => {
+          context.params = { ...context.params, ...options.input };
+          context.params.role = context.params.id;
+
           await strapi.plugins['users-permissions'].controllers.userspermissions.deleteRole(
             context
           );


### PR DESCRIPTION
Fix for #5854 Updated arguments sent from the to role GraphQL schema to the controller to match the expected format

Added code in the schema file for updateRole and deleteRole to supply the Id from the "where" of the request into the context as expected by the controller (which expects context.params.role). Additionally, the updateRole expects only the context as an argument.

Did not modify the controller as not to break any non-graphql implementation.

FYI - This is my first PR.

#5854 