### PR TITLE
fix graphql responses when extending UsersPermissionsMe

### DIFF
--- a/packages/strapi-plugin-users-permissions/controllers/User.js
+++ b/packages/strapi-plugin-users-permissions/controllers/User.js
@@ -48,7 +48,12 @@ module.exports = {
       return ctx.badRequest(null, [{ messages: [{ id: 'No authorization header was found' }] }]);
     }
 
-    const data = sanitizeUser(user);
+    const { id } = user;
+    let data = await strapi.plugins['users-permissions'].services.user.fetch({
+        id
+    });
+
+    data = sanitizeUser(data);
     ctx.send(data);
   },
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

If someone wants to extend UsersPermissionsMe with custom fields it works as long as the fields are not relations, if there are relations graphql returns an error when you try to read the custom field. The code just fills the user object properly by making a query.
