### PR TITLE
Fix #5302 - Uninstall plugin: function to delete folder with files

### DIFF
--- a/packages/strapi/lib/commands/uninstall.js
+++ b/packages/strapi/lib/commands/uninstall.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { join } = require('path');
-const { existsSync, rmdirSync } = require('fs-extra');
+const { existsSync, removeSync } = require('fs-extra');
 const ora = require('ora');
 const execa = require('execa');
 const inquirer = require('inquirer');
@@ -21,7 +21,7 @@ module.exports = async (plugins, { deleteFiles }) => {
   const loader = ora();
   const dir = process.cwd();
 
-  const pluginArgs = plugins.map(name => `strapi-plugin-${name}`);
+  const pluginArgs = plugins.map((name) => `strapi-plugin-${name}`);
 
   try {
     // verify should rebuild before removing the pacakge
@@ -49,7 +49,7 @@ module.exports = async (plugins, { deleteFiles }) => {
       for (let name of plugins) {
         const pluginDir = join(dir, 'extensions', name);
         if (existsSync(pluginDir)) {
-          rmdirSync();
+          removeSync(pluginDir);
         }
       }
       loader.succeed();


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:
Fix for #5302 - there were no argument with folder path to delete. And previously used function didn't delete folder with it's content. The new `removeSync` delete folder with all content.
Tested locally and works fine.

I don't see any tests for /lib/uninstall.js
Documentation needs no changes, imho.

**Before Merge:**  shouldn't it also delete this folders?
```
/extensions/user-permissions/documentation
/extensions/email/documentation/1.0.0 
/extensions/upload/documentation/1.0.0
```
I could add some code to delete this folders if plugin name === "documentation".

**FYI:** this is my first Open Source contribution. Any suggestions appreciated :)