### PR TITLE
fix count() result not a number

### DIFF
--- a/packages/strapi-connector-bookshelf/lib/queries.js
+++ b/packages/strapi-connector-bookshelf/lib/queries.js
@@ -68,7 +68,7 @@ module.exports = function createQueryBuilder({ model, modelKey, strapi }) {
   /**
    * Count entries based on filters
    */
-  async function count(params = {}) {
+  function count(params = {}) {
     const { where } = convertRestQueryParams(params);
 
     return model

--- a/packages/strapi-connector-bookshelf/lib/queries.js
+++ b/packages/strapi-connector-bookshelf/lib/queries.js
@@ -68,10 +68,13 @@ module.exports = function createQueryBuilder({ model, modelKey, strapi }) {
   /**
    * Count entries based on filters
    */
-  function count(params = {}) {
+  async function count(params = {}) {
     const { where } = convertRestQueryParams(params);
 
-    return model.query(buildQuery({ model, filters: { where } })).count();
+    return model
+      .query(buildQuery({ model, filters: { where } }))
+      .count()
+      .then(Number);
   }
 
   async function create(values, { transacting } = {}) {
@@ -187,7 +190,8 @@ module.exports = function createQueryBuilder({ model, modelKey, strapi }) {
       .query(qb => {
         buildSearchQuery(qb, model, params);
       })
-      .count();
+      .count()
+      .then(Number);
   }
 
   async function createComponents(entry, values, { transacting }) {


### PR DESCRIPTION
Fix a bug introduced by: https://github.com/strapi/strapi/pull/5814.
Bug : default users were not created because `roleCount` is a string when using postgresql.