### PR TITLE
fix shadow crud breaking build when resolvers are not defined in a plugin

### DIFF
--- a/docs/3.0.0-beta.x/plugins/graphql.md
+++ b/docs/3.0.0-beta.x/plugins/graphql.md
@@ -263,6 +263,10 @@ query {
 
 To simplify and automate the build of the GraphQL schema, we introduced the Shadow CRUD feature. It automatically generates the type definition, queries, mutations and resolvers based on your models. The feature also lets you make complex query with many arguments such as `limit`, `sort`, `start` and `where`.
 
+::: tip NOTE
+If you use a local plugin, the controller methods of your plugin are not created by default. In order for the Shadow CRUD to work you have to define them in your controllers for each of your models. You can find examples of controllers `findOne`, `find`, `create`, `update` and `delete` there : [Core controllers](../concepts/controllers.html#core-controllers).
+:::
+
 ### Example
 
 If you've generated an API called `Restaurant` using the CLI `strapi generate:api restaurant` or the administration panel, your model looks like this:
@@ -517,7 +521,7 @@ module.exports = {
   `,
   mutation: `
     attachRestaurantToChef(id: ID, chefID: ID): Restaurant!
-  `
+  `,
   resolver: {
     Query: {
       restaurant: {

--- a/packages/strapi-plugin-graphql/services/resolvers-builder.js
+++ b/packages/strapi-plugin-graphql/services/resolvers-builder.js
@@ -7,8 +7,15 @@
 const _ = require('lodash');
 const compose = require('koa-compose');
 
-const { convertToParams, convertToQuery, amountLimiting } = require('./utils');
 const { policy: policyUtils } = require('strapi-utils');
+const {
+  convertToParams,
+  convertToQuery,
+  amountLimiting,
+  getAction,
+  getActionDetails,
+  isResolvablePath,
+} = require('./utils');
 
 const buildMutation = (mutationName, config) => {
   const { resolver, resolverOf, transformOutput = _.identity } = config;
@@ -147,70 +154,9 @@ const buildQueryContext = ({ options, graphqlContext }) => {
   return { ctx, opts };
 };
 
-const getAction = resolver => {
-  if (!_.isString(resolver)) {
-    throw new Error(`Error building query. Expected a string, got ${resolver}`);
-  }
-
-  const actionDetails = getActionDetails(resolver);
-  const actionFn = getActionFn(actionDetails);
-
-  if (!actionFn) {
-    throw new Error(
-      `[GraphQL] Cannot find action "${resolver}". Check your graphql configurations.`
-    );
-  }
-
-  return actionFn;
-};
-
-const getActionFn = details => {
-  const { controller, action, plugin, api } = details;
-
-  if (plugin) {
-    return _.get(strapi.plugins, [_.toLower(plugin), 'controllers', _.toLower(controller), action]);
-  }
-
-  return _.get(strapi.api, [_.toLower(api), 'controllers', _.toLower(controller), action]);
-};
-
-const getActionDetails = resolver => {
-  if (resolver.startsWith('plugins::')) {
-    const [, path] = resolver.split('::');
-    const [plugin, controller, action] = path.split('.');
-
-    return { plugin, controller, action };
-  }
-
-  if (resolver.startsWith('application::')) {
-    const [, path] = resolver.split('::');
-    const [api, controller, action] = path.split('.');
-
-    return { api, controller, action };
-  }
-
-  const args = resolver.split('.');
-
-  if (args.length === 3) {
-    const [api, controller, action] = args;
-    return { api, controller, action };
-  }
-
-  // if direct api access
-  if (args.length === 2) {
-    const [controller, action] = args;
-    return { api: controller, controller, action };
-  }
-
-  throw new Error(
-    `[GraphQL] Could not find action for resolver "${resolver}". Check your graphql configurations.`
-  );
-};
-
 /**
  * Checks if a resolverPath (resolver or resovlerOf) might be resolved
  */
-const isResolvablePath = path => _.isString(path) && !_.isEmpty(path);
 
 const getPolicies = config => {
   const { resolver, policies = [], resolverOf } = config;


### PR DESCRIPTION
fix #4224 

#### Description of what you did:
- Checks if the resolver exists before trying to add it the graphql schema. If it doesn't exist, it doesn't add it to the schema.
- Moved some functions in utils
