### PR TITLE
Add option to select uuid type for id by default

### DIFF
--- a/packages/strapi-connector-bookshelf/lib/mount-models.js
+++ b/packages/strapi-connector-bookshelf/lib/mount-models.js
@@ -64,7 +64,7 @@ module.exports = ({ models, target }, ctx) => {
     definition.client = _.get(connection.settings, 'client');
     _.defaults(definition, {
       primaryKey: 'id',
-      primaryKeyType: _.get(definition, 'options.idAttributeType', 'integer'),
+      primaryKeyType: _.get(definition, 'options.idAttributeType', _.get(connection.options, 'idAttributeType', 'integer')),
     });
 
     // Use default timestamp column names if value is `true`


### PR DESCRIPTION
example:
```json
{
  "defaultConnection": "default",
  "connections": {
    "default": {
      "connector": "bookshelf",
      "settings": {
        "client": "postgres",
        "database": "dbname",
        "host": "127.0.0.1",
        "port": 5432,
        "username": "postgres",
        "password": "password"
      },
      "options": {
        "idAttributeType": "uuid"
      }
    }
  }
}
```

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:
