### PR TITLE
update: removed additional double hyphen ("--")

### DIFF
--- a/docs/3.0.0-beta.x/migration-guide/migration-guide-beta.19-to-beta.20.md
+++ b/docs/3.0.0-beta.x/migration-guide/migration-guide-beta.19-to-beta.20.md
@@ -212,6 +212,6 @@ Once your migration is done you can delete the `export.js` and `models.json` fil
 
 ## Rebuilding your administration panel
 
-You can run `yarn build --clean` or `npm run build -- --clean` to rebuild your admin panel with the newly installed version of strapi.
+You can run `yarn build --clean` or `npm run build --clean` to rebuild your admin panel with the newly installed version of strapi.
 
 Finally restart your server: `yarn develop` or `npm run develop`.


### PR DESCRIPTION
Removed a typo in the migration guide beta.19 to beta.20 that contains an additional double hyphen ("--") in the command `npm run build`

#### Description of what you did:
- The changes are made in the documentation itself and so there are no tests.
- I don't think there are any related issues 
- ready to be merged