### PR TITLE
Make the unit tests on the file system platform agnostic

### DIFF
--- a/packages/strapi/lib/core/__tests__/fs.test.js
+++ b/packages/strapi/lib/core/__tests__/fs.test.js
@@ -1,6 +1,8 @@
 const fs = require('../fs');
 const fse = require('fs-extra');
 
+const path = require('path');
+
 jest.mock('fs-extra');
 
 describe('Strapi fs utils', () => {
@@ -23,8 +25,8 @@ describe('Strapi fs utils', () => {
 
       await strapiFS.writeAppFile('test', content);
 
-      expect(fse.ensureFile).toHaveBeenCalledWith('/tmp/test');
-      expect(fse.writeFile).toHaveBeenCalledWith('/tmp/test', content);
+      expect(fse.ensureFile).toHaveBeenCalledWith(path.join('\\', 'tmp', 'test'));
+      expect(fse.writeFile).toHaveBeenCalledWith(path.join('\\', 'tmp', 'test'), content);
     });
 
     test('Normalize the path to avoid relative access to folders in parent directories', async () => {
@@ -34,8 +36,8 @@ describe('Strapi fs utils', () => {
 
       await strapiFS.writeAppFile('../../test', content);
 
-      expect(fse.ensureFile).toHaveBeenCalledWith('/tmp/test');
-      expect(fse.writeFile).toHaveBeenCalledWith('/tmp/test', content);
+      expect(fse.ensureFile).toHaveBeenCalledWith(path.join('\\', 'tmp', 'test'));
+      expect(fse.writeFile).toHaveBeenCalledWith(path.join('\\', 'tmp', 'test'), content);
     });
 
     test('Works with array path', async () => {
@@ -45,8 +47,11 @@ describe('Strapi fs utils', () => {
 
       await strapiFS.writeAppFile(['test', 'sub', 'path'], content);
 
-      expect(fse.ensureFile).toHaveBeenCalledWith('/tmp/test/sub/path');
-      expect(fse.writeFile).toHaveBeenCalledWith('/tmp/test/sub/path', content);
+      expect(fse.ensureFile).toHaveBeenCalledWith(path.join('\\', 'tmp', 'test', 'sub', 'path'));
+      expect(fse.writeFile).toHaveBeenCalledWith(
+        path.join('\\', 'tmp', 'test', 'sub', 'path'),
+        content
+      );
     });
   });
 
@@ -58,11 +63,7 @@ describe('Strapi fs utils', () => {
 
       strapiFS.writeAppFile = jest.fn(() => Promise.resolve());
 
-      await strapiFS.writePluginFile(
-        'users-permissions',
-        ['test', 'sub', 'path'],
-        content
-      );
+      await strapiFS.writePluginFile('users-permissions', ['test', 'sub', 'path'], content);
 
       expect(strapiFS.writeAppFile).toHaveBeenCalledWith(
         'extensions/users-permissions/test/sub/path',


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

The unit tests on the file system were failing on Windows platforms as they were assuming / as path separator. Amended them to use path.combine so that they're independent from the platform they're running on. 