### PR TITLE
fix #4621 - rich text can't save Chinese

### DIFF
--- a/packages/strapi-plugin-content-manager/admin/src/components/Wysiwyg/index.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/Wysiwyg/index.js
@@ -582,8 +582,8 @@ class Wysiwyg extends React.Component {
     Modifier.replaceText(contentState, this.getSelection(), text);
 
   onChange = editorState => {
-    this.setState({ editorState });
     this.sendData(editorState);
+    this.setState({ editorState });
   };
 
   handleTab = e => {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->
Hello, I meet the same bug of issue #4621
The rich text field can't save the Chinese words input through IME.
Here is the gif of this issue.
![richtext-bug](https://user-images.githubusercontent.com/8390906/80279370-c960d300-872f-11ea-8137-dceb4045961d.gif)

I tried to add some logs to debug it. I find the problem is between the `setState` and `sendData` function of WYSLWYG component. I added the following piece of code.

```javascript
/**
   * Update the parent reducer
   * @param  {Map} editorState [description]
   */
  sendData = editorState => {
    console.log("editorState.getCurrentContext().getPlainText():", editorState.getCurrentContent().getPlainText())
    console.log("this.getEditorState().getCurrentContext().getPlainText():", this.getEditorState().getCurrentContent().getPlainText())
    console.log("this.getEditorState().getCurrentContext() equals editorState.getCurrentContext()?", this.getEditorState().getCurrentContent() === editorState.getCurrentContent())
    if (
      this.getEditorState().getCurrentContent() !==
        editorState.getCurrentContent() ||
      editorState.getLastChangeType() === 'remove-range'
    ) {
      this.props.onChange({
        target: {
          value: editorState.getCurrentContent().getPlainText(),
          name: this.props.name,
          type: 'textarea',
        },
      });
    } else return;
  };
```

Here is the logs when I execute the input operations as in the above gif.
![logs](https://user-images.githubusercontent.com/8390906/80279535-e77b0300-8730-11ea-8c75-392bef102507.png)

From the logs we can see that after the input event for "中文“ is triggered, when executing the `sendData` function the state of the component is already synchronized by the `setState` function.
I don't know whether there is any special intention to put `sendData` after the `setState` function. But in my opinion, it may be safer to put it before the `setState` function.

