### PR TITLE
Fixed: Core store returned null instead of string

### DIFF
--- a/packages/strapi/lib/services/core-store.js
+++ b/packages/strapi/lib/services/core-store.js
@@ -52,7 +52,7 @@ const createCoreStore = ({ environment: defaultEnv, db }) => {
         return null;
       }
 
-      if (data.type === 'object' || data.type === 'array' || data.type === 'boolean') {
+      if (data.type === 'object' || data.type === 'array' || data.type === 'boolean' || data.type === 'string') {
         try {
           return JSON.parse(data.value);
         } catch (err) {
@@ -60,8 +60,6 @@ const createCoreStore = ({ environment: defaultEnv, db }) => {
         }
       } else if (data.type === 'number') {
         return parseFloat(data.value);
-      } else if (data.type === 'string') {
-        return data.value;
       } else {
         return null;
       }

--- a/packages/strapi/lib/services/core-store.js
+++ b/packages/strapi/lib/services/core-store.js
@@ -60,6 +60,8 @@ const createCoreStore = ({ environment: defaultEnv, db }) => {
         }
       } else if (data.type === 'number') {
         return parseFloat(data.value);
+      } else if (data.type === 'string') {
+        return data.value;
       } else {
         return null;
       }


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

Found a bug, that the `core-store` returns `null` when the stored `type` is `'string'`.
The problem only affected the `get` function.
Added string type to the condition above JSON.parse, now it is converted back to the original value and returned from `core-store.get`.
