### PR TITLE
Use correct file name with original extension

### DIFF
--- a/packages/strapi-plugin-upload/services/Upload.js
+++ b/packages/strapi-plugin-upload/services/Upload.js
@@ -33,10 +33,11 @@ const combineFilters = params => {
 
 module.exports = {
   formatFileInfo({ filename, type, size }, fileInfo = {}, metas = {}) {
-    const ext = '.' + mime.extension(type) || path.extname(filename);
+    const fileExt = path.extname(filename) || '';
+    const ext = fileExt && '.' + fileExt || '';
     const baseName = path.basename(filename, path.extname(filename));
 
-    const usedName = fileInfo.name || baseName;
+    const usedName = fileInfo.name || filename;
 
     const entity = {
       name: usedName,


### PR DESCRIPTION
Original file extension should not be replaced by mime type.
Also filename should include its extension (To keep compatibility for prior versions and having a minimal impact on existing providers)
Also it will allow to have filename without extension in specific cases when a user wish.
