### PR TITLE
Fix: Plugins docs syntax error

### DIFF
--- a/docs/3.0.0-beta.x/plugins/documentation.md
+++ b/docs/3.0.0-beta.x/plugins/documentation.md
@@ -101,7 +101,7 @@ Here are the file that needs to be created in order to change the documentation 
   },
   "x-strapi-config": {
     "path": "/documentation",
-    "showGeneratedFiles": true",
+    "showGeneratedFiles": true,
     "pluginsForWhichToGenerateDoc": [
       "email",
       "upload",


### PR DESCRIPTION
Hello there,

Just a small fix for a syntax error in your plugins documentation
