### PR TITLE
Remove idAttribute and idAttributeType options because breaks strapi

### DIFF
--- a/packages/strapi-connector-bookshelf/lib/mount-models.js
+++ b/packages/strapi-connector-bookshelf/lib/mount-models.js
@@ -62,10 +62,8 @@ module.exports = ({ models, target }, ctx) => {
     definition.orm = 'bookshelf';
     definition.databaseName = getDatabaseName(connection);
     definition.client = _.get(connection.settings, 'client');
-    _.defaults(definition, {
-      primaryKey: 'id',
-      primaryKeyType: _.get(definition, 'options.idAttributeType', 'integer'),
-    });
+    definition.primaryKey = 'id';
+    definition.primaryKeyType = 'integer';
 
     // Use default timestamp column names if value is `true`
     if (_.get(definition, 'options.timestamps', false) === true) {
@@ -85,7 +83,6 @@ module.exports = ({ models, target }, ctx) => {
         requireFetch: false,
         tableName: definition.collectionName,
         hasTimestamps: _.get(definition, 'options.timestamps', false),
-        idAttribute: _.get(definition, 'options.idAttribute', 'id'),
         associations: [],
         defaults: Object.keys(definition.attributes).reduce((acc, current) => {
           if (definition.attributes[current].type && definition.attributes[current].default) {


### PR DESCRIPTION
Signed-off-by: Alexandre Bodin <bodin.alex@gmail.com>

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

Currently using the idAttribute and idAttributeType options can break strpai in many ways. We will reconsider a better approach in the future but right now it is preferable to remove the options and only work with a conventional `id`. 



Close https://github.com/strapi/strapi/issues/4084
Close https://github.com/strapi/strapi/issues/1762
