### PR TITLE
Change search logic

### DIFF
--- a/packages/strapi-connector-bookshelf/lib/buildDatabaseSchema.js
+++ b/packages/strapi-connector-bookshelf/lib/buildDatabaseSchema.js
@@ -111,63 +111,6 @@ module.exports = async ({ ORM, loadedModel, definition, connection, model }) => 
   const createOrUpdateTable = async (table, attributes) => {
     const tableExists = await ORM.knex.schema.hasTable(table);
 
-    const generateIndexes = async table => {
-      try {
-        const connection = strapi.config.connections[definition.connection];
-        let columns = Object.keys(attributes).filter(attribute =>
-          ['string', 'text'].includes(attributes[attribute].type)
-        );
-
-        if (!columns.length) {
-          // No text columns founds, exit from creating Fulltext Index
-          return;
-        }
-
-        switch (connection.settings.client) {
-          case 'mysql':
-            columns = columns.map(attribute => `\`${attribute}\``).join(',');
-
-            // Create fulltext indexes for every column.
-            await ORM.knex.raw(
-              `CREATE FULLTEXT INDEX SEARCH_${_.toUpper(
-                _.snakeCase(table)
-              )} ON \`${table}\` (${columns})`
-            );
-            break;
-          case 'pg': {
-            // Enable extension to allow GIN indexes.
-            await ORM.knex.raw('CREATE EXTENSION IF NOT EXISTS pg_trgm');
-
-            // Create GIN indexes for every column.
-            const indexes = columns.map(column => {
-              const indexName = `${_.snakeCase(table)}_${column}`;
-              const attribute = _.toLower(column) === column ? column : `"${column}"`;
-
-              return ORM.knex.raw(
-                `CREATE INDEX IF NOT EXISTS search_${_.toLower(
-                  indexName
-                )} ON "${table}" USING gin(${attribute} gin_trgm_ops)`
-              );
-            });
-
-            await Promise.all(indexes);
-            break;
-          }
-        }
-      } catch (e) {
-        // Handle duplicate errors.
-        if (e.errno !== 1061 && e.code !== '42P07') {
-          if (_.get(connection, 'options.debug') === true) {
-            console.log(e);
-          }
-
-          strapi.log.warn(
-            `The SQL database indexes haven't been generated successfully. Please enable the debug mode for more details.`
-          );
-        }
-      }
-    };
-
     const buildColumns = (tbl, columns, opts = {}) => {
       const { tableExists, alter = false } = opts;
 
@@ -219,7 +162,6 @@ module.exports = async ({ ORM, loadedModel, definition, connection, model }) => 
 
     if (!tableExists) {
       await createTable(table);
-      await generateIndexes(table);
       await storeTable(table, attributes);
       return;
     }
@@ -248,9 +190,6 @@ module.exports = async ({ ORM, loadedModel, definition, connection, model }) => 
         createColumns(tbl, columnsToAdd, { tableExists });
       });
     }
-
-    // Generate indexes for new attributes.
-    await generateIndexes(table, columnsToAdd);
 
     let previousAttributes;
     try {
@@ -310,7 +249,6 @@ module.exports = async ({ ORM, loadedModel, definition, connection, model }) => 
 
       try {
         await ORM.knex.transaction(trx => rebuildTable(trx));
-        await generateIndexes(table);
       } catch (err) {
         if (err.message.includes('UNIQUE constraint failed')) {
           strapi.log.error(

--- a/packages/strapi-connector-bookshelf/lib/queries.js
+++ b/packages/strapi-connector-bookshelf/lib/queries.js
@@ -655,7 +655,7 @@ const buildSearchQuery = (qb, model, params) => {
   const query = params._q;
 
   const associations = model.associations.map(x => x.alias);
-  const stringTypes = ['string', 'text', 'uid', 'email', 'enumeration', 'richtext', 'password'];
+  const stringTypes = ['string', 'text', 'uid', 'email', 'enumeration', 'richtext'];
   const numberTypes = ['biginteger', 'integer', 'decimal', 'float'];
 
   const searchColumns = Object.keys(model._attributes)

--- a/packages/strapi-connector-bookshelf/lib/queries.js
+++ b/packages/strapi-connector-bookshelf/lib/queries.js
@@ -4,7 +4,12 @@
  */
 
 const _ = require('lodash');
-const { convertRestQueryParams, buildQuery, models: modelUtils } = require('strapi-utils');
+const {
+  convertRestQueryParams,
+  buildQuery,
+  models: modelUtils,
+  escapeQuery,
+} = require('strapi-utils');
 
 module.exports = function createQueryBuilder({ model, modelKey, strapi }) {
   /* Utils */
@@ -650,52 +655,41 @@ const buildSearchQuery = (qb, model, params) => {
   const query = params._q;
 
   const associations = model.associations.map(x => x.alias);
+  const stringTypes = ['string', 'text', 'uid', 'email', 'enumeration', 'richtext', 'password'];
+  const numberTypes = ['biginteger', 'integer', 'decimal', 'float'];
 
-  const searchText = Object.keys(model._attributes)
-    .filter(attribute => attribute !== model.primaryKey && !associations.includes(attribute))
-    .filter(attribute => ['string', 'text'].includes(model._attributes[attribute].type));
-
-  const searchInt = Object.keys(model._attributes)
-    .filter(attribute => attribute !== model.primaryKey && !associations.includes(attribute))
-    .filter(attribute =>
-      ['integer', 'decimal', 'float'].includes(model._attributes[attribute].type)
-    );
-
-  const searchBool = Object.keys(model._attributes)
-    .filter(attribute => attribute !== model.primaryKey && !associations.includes(attribute))
-    .filter(attribute => ['boolean'].includes(model._attributes[attribute].type));
+  const searchColumns = Object.keys(model._attributes)
+    .filter(attribute => !associations.includes(attribute))
+    .filter(attribute => stringTypes.includes(model._attributes[attribute].type));
 
   if (!_.isNaN(_.toNumber(query))) {
-    searchInt.forEach(attribute => {
-      qb.orWhere(attribute, _.toNumber(query));
-    });
+    const numberColumns = Object.keys(model._attributes)
+      .filter(attribute => !associations.includes(attribute))
+      .filter(attribute => numberTypes.includes(model._attributes[attribute].type));
+    searchColumns.push(...numberColumns);
   }
 
-  if (query === 'true' || query === 'false') {
-    searchBool.forEach(attribute => {
-      qb.orWhere(attribute, _.toNumber(query === 'true'));
-    });
+  if ([...numberTypes, ...stringTypes].includes(model.primaryKeyType)) {
+    searchColumns.push(model.primaryKey);
   }
 
   // Search in columns with text using index.
   switch (model.client) {
-    case 'sqlite3': {
-      searchText.forEach(attr => qb.orWhereRaw(`${attr} LIKE ?`, `%${query}%`));
-      break;
-    }
-    case 'mysql':
-      qb.orWhereRaw(`MATCH(${searchText.join(',')}) AGAINST(? IN BOOLEAN MODE)`, `*${query}*`);
-      break;
-    case 'pg': {
-      const searchQuery = searchText.map(attribute =>
-        _.toLower(attribute) === attribute
-          ? `to_tsvector(coalesce(${attribute}, ''))`
-          : `to_tsvector(coalesce("${attribute}", ''))`
+    case 'pg':
+      searchColumns.forEach(attr =>
+        qb.orWhereRaw(`"${attr}"::text ILIKE ?`, `%${escapeQuery(query, '*%\\')}%`)
       );
-
-      qb.orWhereRaw(`${searchQuery.join(' || ')} @@ plainto_tsquery(?)`, query);
       break;
-    }
+    case 'sqlite3':
+      searchColumns.forEach(attr =>
+        qb.orWhereRaw(`"${attr}" LIKE ? ESCAPE '\\'`, `%${escapeQuery(query, '*%\\')}%`)
+      );
+      break;
+    case 'mysql':
+      searchColumns.forEach(attr =>
+        qb.orWhereRaw(`\`${attr}\` LIKE ?`, `%${escapeQuery(query, '*%\\')}%`)
+      );
+      break;
   }
 };
 

--- a/packages/strapi-connector-mongoose/lib/index.js
+++ b/packages/strapi-connector-mongoose/lib/index.js
@@ -105,7 +105,7 @@ module.exports = function(strapi) {
         }
 
         try {
-          const version = (await instance.connection.db.admin().serverInfo()).version;
+          const { version } = await instance.connection.db.admin().serverInfo();
           instance.mongoDBVersion = version;
         } catch {
           instance.mongoDBVersion = null;

--- a/packages/strapi-connector-mongoose/lib/index.js
+++ b/packages/strapi-connector-mongoose/lib/index.js
@@ -104,6 +104,13 @@ module.exports = function(strapi) {
           throw err;
         }
 
+        try {
+          const version = (await instance.connection.db.admin().serverInfo()).version;
+          instance.mongoDBVersion = version;
+        } catch {
+          instance.mongoDBVersion = null;
+        }
+
         const initFunctionPath = path.resolve(
           strapi.config.appPath,
           'config',

--- a/packages/strapi-connector-mongoose/lib/queries.js
+++ b/packages/strapi-connector-mongoose/lib/queries.js
@@ -4,6 +4,7 @@
  */
 
 const _ = require('lodash');
+var semver = require('semver');
 const { convertRestQueryParams, buildQuery, models: modelUtils } = require('strapi-utils');
 
 const { findComponentByGlobalId } = require('./utils/helpers');
@@ -516,25 +517,34 @@ module.exports = ({ model, modelKey, strapi }) => {
 const buildSearchOr = (model, query) => {
   return Object.keys(model.attributes).reduce((acc, curr) => {
     switch (model.attributes[curr].type) {
+      case 'biginteger':
       case 'integer':
       case 'float':
       case 'decimal':
         if (!_.isNaN(_.toNumber(query))) {
-          return acc.concat({ [curr]: query });
+          const mongoVersion = model.db.base.mongoDBVersion;
+          if (semver.valid(mongoVersion) && semver.gt(mongoVersion, '4.2.0')) {
+            return acc.concat({
+              $expr: {
+                $regexMatch: {
+                  input: { $toString: `$${curr}` },
+                  regex: _.escapeRegExp(query),
+                },
+              },
+            });
+          } else {
+            return acc.concat({ [curr]: query });
+          }
         }
-
         return acc;
       case 'string':
       case 'text':
       case 'password':
+      case 'richtext':
+      case 'email':
+      case 'enumeration':
       case 'uid':
-        return acc.concat({ [curr]: { $regex: query, $options: 'i' } });
-      case 'boolean':
-        if (query === 'true' || query === 'false') {
-          return acc.concat({ [curr]: query === 'true' });
-        }
-
-        return acc;
+        return acc.concat({ [curr]: { $regex: _.escapeRegExp(query), $options: 'i' } });
       default:
         return acc;
     }

--- a/packages/strapi-connector-mongoose/lib/queries.js
+++ b/packages/strapi-connector-mongoose/lib/queries.js
@@ -540,7 +540,6 @@ const buildSearchOr = (model, query) => {
         return acc;
       case 'string':
       case 'text':
-      case 'password':
       case 'richtext':
       case 'email':
       case 'enumeration':

--- a/packages/strapi-connector-mongoose/lib/queries.js
+++ b/packages/strapi-connector-mongoose/lib/queries.js
@@ -8,6 +8,7 @@ var semver = require('semver');
 const { convertRestQueryParams, buildQuery, models: modelUtils } = require('strapi-utils');
 
 const { findComponentByGlobalId } = require('./utils/helpers');
+const utils = require('./utils')();
 
 const hasPK = (obj, model) => _.has(obj, model.primaryKey) || _.has(obj, 'id');
 const getPK = (obj, model) => (_.has(obj, model.primaryKey) ? obj[model.primaryKey] : obj.id);
@@ -515,7 +516,7 @@ module.exports = ({ model, modelKey, strapi }) => {
 };
 
 const buildSearchOr = (model, query) => {
-  return Object.keys(model.attributes).reduce((acc, curr) => {
+  const searchOr = Object.keys(model.attributes).reduce((acc, curr) => {
     switch (model.attributes[curr].type) {
       case 'biginteger':
       case 'integer':
@@ -549,6 +550,12 @@ const buildSearchOr = (model, query) => {
         return acc;
     }
   }, []);
+
+  if (utils.isMongoId(query)) {
+    searchOr.push({ _id: query });
+  }
+
+  return searchOr;
 };
 
 function validateRepeatableInput(value, { key, min, max, required }) {

--- a/packages/strapi-connector-mongoose/package.json
+++ b/packages/strapi-connector-mongoose/package.json
@@ -20,6 +20,7 @@
     "mongoose-float": "^1.0.4",
     "mongoose-long": "^0.2.1",
     "pluralize": "^7.0.0",
+    "semver": "^7.3.2",
     "strapi-utils": "3.0.0-beta.20.1"
   },
   "author": {

--- a/packages/strapi-utils/lib/__tests__/stringFormatting.test.js
+++ b/packages/strapi-utils/lib/__tests__/stringFormatting.test.js
@@ -1,0 +1,25 @@
+const { escapeQuery } = require('../stringFormatting');
+
+describe('Escape Query', () => {
+  const testData = [
+    // [query, charsToEscape, escapeChar, expectedResult]
+    ['123', '[%\\', '\\', '123'],
+    ['12%3', '[%\\', '\\', '12\\%3'],
+    ['1[2%3', '[%\\', '\\', '1\\[2\\%3'],
+    ['1\\23', '[%\\', '\\', '1\\\\23'],
+    ['123\\', '[%\\', '\\', '123\\\\'],
+    ['\\', '[%\\', '\\', '\\\\'],
+    ['123', '[%\\', '+', '123'],
+    ['12%3', '[%\\', '+', '12+%3'],
+    ['1[2%3', '[%\\', '+', '1+[2+%3'],
+    ['1\\23', '[%\\', '+', '1+\\23'],
+  ];
+
+  test.each(testData)(
+    'Escaping %s from %s with %s',
+    (query, charsToEscape, escapeChar, expectedResult) => {
+      const result = escapeQuery(query, charsToEscape, escapeChar);
+      expect(result).toEqual(expectedResult);
+    }
+  );
+});

--- a/packages/strapi-utils/lib/index.js
+++ b/packages/strapi-utils/lib/index.js
@@ -15,7 +15,7 @@ const models = require('./models');
 const policy = require('./policy');
 const templateConfiguration = require('./templateConfiguration');
 const { yup, formatYupErrors } = require('./validators');
-const { nameToSlug, nameToCollectionName } = require('./stringFormatting');
+const { nameToSlug, nameToCollectionName, escapeQuery } = require('./stringFormatting');
 
 module.exports = {
   yup,
@@ -32,4 +32,5 @@ module.exports = {
   parseType,
   nameToSlug,
   nameToCollectionName,
+  escapeQuery,
 };

--- a/packages/strapi-utils/lib/stringFormatting.js
+++ b/packages/strapi-utils/lib/stringFormatting.js
@@ -6,13 +6,13 @@ const nameToSlug = name => slugify(name, { separator: '-' });
 
 const nameToCollectionName = name => slugify(name, { separator: '_' });
 
-const escapeQuery = (query, charsToEscape, espaceChar = '\\') => {
+const escapeQuery = (query, charsToEscape, escapeChar = '\\') => {
   return query
     .split('')
     .reduce(
       (escapedQuery, char) =>
         charsToEscape.includes(char)
-          ? `${escapedQuery}${espaceChar}${char}`
+          ? `${escapedQuery}${escapeChar}${char}`
           : `${escapedQuery}${char}`,
       ''
     );

--- a/packages/strapi-utils/lib/stringFormatting.js
+++ b/packages/strapi-utils/lib/stringFormatting.js
@@ -6,7 +6,20 @@ const nameToSlug = name => slugify(name, { separator: '-' });
 
 const nameToCollectionName = name => slugify(name, { separator: '_' });
 
+const escapeQuery = (query, charsToEscape, espaceChar = '\\') => {
+  return query
+    .split('')
+    .reduce(
+      (escapedQuery, char) =>
+        charsToEscape.includes(char)
+          ? `${escapedQuery}${espaceChar}${char}`
+          : `${escapedQuery}${char}`,
+      ''
+    );
+};
+
 module.exports = {
   nameToSlug,
   nameToCollectionName,
+  escapeQuery,
 };

--- a/packages/strapi/__tests__/search.test.e2e.js
+++ b/packages/strapi/__tests__/search.test.e2e.js
@@ -44,9 +44,6 @@ const bedModel = {
     fabricThickness: {
       type: 'float',
     },
-    editPassword: {
-      type: 'password',
-    },
   },
 };
 
@@ -63,7 +60,6 @@ const bedFixtures = [
     serialNumber: 2908199405091998,
     peopleNumber: 5,
     fabricThickness: 1.54567,
-    editPassword: 'secretpassword',
   },
   {
     // will have id=2
@@ -77,7 +73,6 @@ const bedFixtures = [
     serialNumber: 1111111111111111,
     peopleNumber: 1,
     fabricThickness: 1.0001,
-    editPassword: 'subtileandhiddenpassword',
   },
   {
     // will have id=3
@@ -92,7 +87,6 @@ const bedFixtures = [
     serialNumber: null,
     peopleNumber: null,
     fabricThickness: null,
-    editPassword: null,
   },
   {
     // will have id=4
@@ -106,7 +100,6 @@ const bedFixtures = [
     serialNumber: null,
     peopleNumber: null,
     fabricThickness: null,
-    editPassword: null,
   },
 ];
 

--- a/packages/strapi/__tests__/search.test.e2e.js
+++ b/packages/strapi/__tests__/search.test.e2e.js
@@ -1,0 +1,210 @@
+// Test an API with all the possible filed types and simple filterings (no deep filtering, no relations)
+const { registerAndLogin } = require('../../../test/helpers/auth');
+const createModelsUtils = require('../../../test/helpers/models');
+const { createAuthRequest } = require('../../../test/helpers/request');
+
+const databaseName = process.argv
+  .find(arg => arg.startsWith('--database='))
+  .replace('--database=', '');
+
+let rq;
+let modelsUtils;
+let data = {
+  beds: [],
+};
+
+const bedModel = {
+  name: 'bed',
+  kind: 'collectionType',
+  attributes: {
+    name: {
+      type: 'string',
+    },
+    weight: {
+      type: 'decimal',
+    },
+    shortDescription: {
+      type: 'text',
+    },
+    description: {
+      type: 'richtext',
+    },
+    sku: {
+      type: 'uid',
+    },
+    savEmail: {
+      type: 'email',
+    },
+    type: {
+      enum: ['spring', 'foam', 'feather'],
+      type: 'enumeration',
+    },
+    serialNumber: {
+      type: 'biginteger',
+    },
+    peopleNumber: {
+      type: 'integer',
+    },
+    fabricThickness: {
+      type: 'float',
+    },
+    editPassword: {
+      type: 'password',
+    },
+  },
+};
+
+const bedFixtures = [
+  {
+    // will have id=1
+    name: 'Sleepy Bed',
+    weight: 12.4,
+    shortDescription: 'Is a good bed to sleep in.',
+    description: '**Is a very good bed to sleep in.** We promise.',
+    sku: 'sleepybed_0152',
+    savEmail: 'sav@bed.fr',
+    type: 'foam',
+    serialNumber: 2908199405091998,
+    peopleNumber: 5,
+    fabricThickness: 1.54567,
+    editPassword: 'secretpassword',
+  },
+  {
+    // will have id=2
+    name: 'Tired Bed',
+    weight: 11.1,
+    shortDescription: 'You will never wake up again.',
+    description: '**You will never wake up again.** Never.',
+    sku: 'tiredbed_0001',
+    savEmail: 'sav@sleep.fr',
+    type: 'feather',
+    serialNumber: 1111111111111111,
+    peopleNumber: 1,
+    fabricThickness: 1.0001,
+    editPassword: 'subtileandhiddenpassword',
+  },
+  {
+    // will have id=3
+    // other beds don't contain any 3 in order to find only Zombie Bed when searching 3
+    name: 'Zombie Bed',
+    weight: null,
+    shortDescription: null,
+    description: null,
+    sku: null,
+    savEmail: null,
+    type: null,
+    serialNumber: null,
+    peopleNumber: null,
+    fabricThickness: null,
+    editPassword: null,
+  },
+  {
+    // will have id=4
+    name: 'a*b_c%d\\e+f',
+    weight: null,
+    shortDescription: null,
+    description: null,
+    sku: null,
+    savEmail: null,
+    type: null,
+    serialNumber: null,
+    peopleNumber: null,
+    fabricThickness: null,
+    editPassword: null,
+  },
+];
+
+async function createFixtures() {
+  for (let bedFixture of bedFixtures) {
+    const res = await rq({
+      method: 'POST',
+      url: '/beds',
+      body: bedFixture,
+    });
+
+    data.beds.push(res.body);
+  }
+}
+
+async function deleteFixtures() {
+  for (let bed of data.beds) {
+    await rq({
+      method: 'DELETE',
+      url: `/beds/${bed.id}`,
+    });
+  }
+}
+
+describe('Search query', () => {
+  beforeAll(async () => {
+    const token = await registerAndLogin();
+    rq = createAuthRequest(token);
+
+    modelsUtils = createModelsUtils({ rq });
+    await modelsUtils.createContentTypes([bedModel]);
+    await createFixtures();
+  }, 60000);
+
+  afterAll(async () => {
+    await deleteFixtures();
+    await modelsUtils.deleteContentTypes(['bed']);
+  }, 60000);
+
+  test('search for "id"', async () => {
+    if (databaseName === 'mongo') return; // functionnality not available for mongo, we skip test
+
+    const res = await rq({
+      method: 'GET',
+      url: '/content-manager/explorer/application::bed.bed',
+      qs: {
+        _q: 3,
+      },
+    });
+
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body.length).toBe(1);
+    expect(res.body[0]).toMatchObject(data.beds[2]);
+  });
+
+  test.each(Object.keys(bedFixtures[0]))('search that target column %p', async columnName => {
+    const res = await rq({
+      method: 'GET',
+      url: '/content-manager/explorer/application::bed.bed',
+      qs: {
+        _q: bedFixtures[0][columnName],
+      },
+    });
+
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body.length).toBe(1);
+    expect(res.body[0]).toMatchObject(data.beds[0]);
+  });
+
+  test('search with an empty query', async () => {
+    const res = await rq({
+      method: 'GET',
+      url: '/content-manager/explorer/application::bed.bed',
+      qs: {
+        _q: '',
+      },
+    });
+
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body.length).toBe(4);
+    expect(res.body).toEqual(expect.arrayContaining(data.beds));
+  });
+
+  test('search with special characters', async () => {
+    const res = await rq({
+      method: 'GET',
+      url: '/content-manager/explorer/application::bed.bed',
+      qs: {
+        _q: data.beds[3].name,
+      },
+    });
+
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body.length).toBe(1);
+    expect(res.body[0]).toMatchObject(data.beds[3]);
+  });
+});

--- a/packages/strapi/__tests__/search.test.e2e.js
+++ b/packages/strapi/__tests__/search.test.e2e.js
@@ -3,10 +3,6 @@ const { registerAndLogin } = require('../../../test/helpers/auth');
 const createModelsUtils = require('../../../test/helpers/models');
 const { createAuthRequest } = require('../../../test/helpers/request');
 
-const databaseName = process.argv
-  .find(arg => arg.startsWith('--database='))
-  .replace('--database=', '');
-
 let rq;
 let modelsUtils;
 let data = {
@@ -151,13 +147,11 @@ describe('Search query', () => {
   }, 60000);
 
   test('search for "id"', async () => {
-    if (databaseName === 'mongo') return; // functionnality not available for mongo, we skip test
-
     const res = await rq({
       method: 'GET',
       url: '/content-manager/explorer/application::bed.bed',
       qs: {
-        _q: 3,
+        _q: data.beds[2].id,
       },
     });
 

--- a/test/e2e.js
+++ b/test/e2e.js
@@ -37,8 +37,8 @@ const databases = {
   },
 };
 
-const test = async (databaseName, args) => {
-  return execa('yarn', ['-s', 'test:e2e', ...args.split(' '), `--database=${databaseName}`], {
+const test = async args => {
+  return execa('yarn', ['-s', 'test:e2e', ...args.split(' ')], {
     stdio: 'inherit',
     cwd: path.resolve(__dirname, '..'),
     env: {
@@ -47,7 +47,7 @@ const test = async (databaseName, args) => {
   });
 };
 
-const main = async (databaseName, database, args) => {
+const main = async (database, args) => {
   try {
     await cleanTestApp(appName);
     await generateTestApp({ appName, database });
@@ -55,7 +55,7 @@ const main = async (databaseName, database, args) => {
 
     await waitOn({ resources: ['http://localhost:1337'] });
 
-    await test(databaseName, args).catch(() => {
+    await test(args).catch(() => {
       testAppProcess.kill();
       process.stdout.write('Tests failed\n', () => {
         process.exit(1);
@@ -87,7 +87,7 @@ yargs
     argv => {
       const { database, _: args } = argv;
 
-      main(database, databases[database], args.join(' '));
+      main(databases[database], args.join(' '));
     }
   )
   .help().argv;

--- a/test/e2e.js
+++ b/test/e2e.js
@@ -37,8 +37,8 @@ const databases = {
   },
 };
 
-const test = async args => {
-  return execa('yarn', ['-s', 'test:e2e', ...args.split(' ')], {
+const test = async (databaseName, args) => {
+  return execa('yarn', ['-s', 'test:e2e', ...args.split(' '), `--database=${databaseName}`], {
     stdio: 'inherit',
     cwd: path.resolve(__dirname, '..'),
     env: {
@@ -47,7 +47,7 @@ const test = async args => {
   });
 };
 
-const main = async (database, args) => {
+const main = async (databaseName, database, args) => {
   try {
     await cleanTestApp(appName);
     await generateTestApp({ appName, database });
@@ -55,7 +55,7 @@ const main = async (database, args) => {
 
     await waitOn({ resources: ['http://localhost:1337'] });
 
-    await test(args).catch(() => {
+    await test(databaseName, args).catch(() => {
       testAppProcess.kill();
       process.stdout.write('Tests failed\n', () => {
         process.exit(1);
@@ -87,7 +87,7 @@ yargs
     argv => {
       const { database, _: args } = argv;
 
-      main(databases[database], args.join(' '));
+      main(database, databases[database], args.join(' '));
     }
   )
   .help().argv;

--- a/yarn.lock
+++ b/yarn.lock
@@ -16405,6 +16405,11 @@ semver@^7.1.3:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.1.3.tgz#e4345ce73071c53f336445cfc19efb1c311df2a6"
   integrity sha512-ekM0zfiA9SCBlsKa2X1hxyxiI4L3B6EbVJkkdgQXnSEEaHlGdvyodMruTiulSRWMMB4NeIuYNMC9rTKTz97GxA==
 
+semver@^7.3.2:
+  version "7.3.2"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
+  integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
+
 send@0.17.1:
   version "0.17.1"
   resolved "https://registry.yarnpkg.com/send/-/send-0.17.1.tgz#c1d8b059f7900f7466dd4938bdc44e11ddb376c8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -16405,11 +16405,6 @@ semver@^7.1.3:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.1.3.tgz#e4345ce73071c53f336445cfc19efb1c311df2a6"
   integrity sha512-ekM0zfiA9SCBlsKa2X1hxyxiI4L3B6EbVJkkdgQXnSEEaHlGdvyodMruTiulSRWMMB4NeIuYNMC9rTKTz97GxA==
 
-semver@^7.3.2:
-  version "7.3.2"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
-  integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
-
 send@0.17.1:
   version "0.17.1"
   resolved "https://registry.yarnpkg.com/send/-/send-0.17.1.tgz#c1d8b059f7900f7466dd4938bdc44e11ddb376c8"


### PR DESCRIPTION
The search logic was not the same for every database (it was most often a semantic search which requires that the query contains full words).

Now the search is a simple LIKE search were we are looking for data that **contains** the query. 

**New feature:**
When the query is a number, the search was looking for an exact match.
Now I propose that it searches as if numbers were string so the query `12` would find an entry were a field is the number `123`.
This feature has an impact on the performance and I'm asking if the impact is acceptable or not.
Here are my performance results :

|Test nb|Database|Nb of requests|Kind of requests|Using new feature|Duration (sec)|Duration/request (ms)|
|---|---|---|---|---|---|---|
|1|postgres|600|half string, half number|no|79|131|
|2|postgres|600|half string, half number|yes|89|148|
|3|mongo|600|half string, half number|no|47|78|
|4|mongo|600|half string, half number|yes|73|121|
|5|mysql|600|half string, half number|no|30|50|
|6|mysql|600|half string, half number|yes|30|50|
|7|postgres|300|number|no|41|136|
|8|postgres|300|number|yes|50|166|
|9|mongo|300|number|no|24|80|
|10|mongo|300|number|yes|50|166|
|11|mysql|300|number|no|17|56|
|12|mysql|300|number|yes|16|53|

**Note:** The tests were made on the same dataset. The dataset had 50 000 entries. The number of results per request were limited to 100. Most of the time there were more than 100 results.

The impact on postgres databases is real but limited (x1.2) and the impact on mongo databases is real (x2).
We can see that in general, mongo is more rapid than postgres. With this feature, mongo is as fast (or as slow) as postgres.
The performance impact can only be seen when there is a search for a **number**. Otherwise there is no impact.

**My opinion**:
Considering: 
- that the impact is seen only on mongo databases when the search is a number
- that the rapidity is still good (166ms/request, as good as with postgres)
- that it's an internal API for the admin panel that is not supposed to be used outside
- that the user of the admin panel wont notice the difference
- that the developer can implement his/her own search route

I think it's better to have this feature

