### PR TITLE
Prevent fall through in the model search method when a plugin is spec…

### DIFF
--- a/packages/strapi-database/lib/database-manager.js
+++ b/packages/strapi-database/lib/database-manager.js
@@ -108,11 +108,11 @@ class DatabaseManager {
       return _.get(strapi.admin, ['models', key]);
     }
 
-    return (
-      _.get(strapi.plugins, [plugin, 'models', key]) ||
-      _.get(strapi, ['models', key]) ||
-      _.get(strapi, ['components', key])
-    );
+    if (plugin) {
+      return _.get(strapi.plugins, [plugin, 'models', key]);
+    }
+
+    return _.get(strapi, ['models', key]) || _.get(strapi, ['components', key]);
   }
 
   getModelByCollectionName(collectionName) {


### PR DESCRIPTION
The implementation of the `getModel` method of `DatabaseManager` in the `strapi-database` package could cause bugs that are hard to find.

**Explanation:** currently, if somebody calls `strapi.query('modelName', 'pluginName')`, searching for the model goes like this:
```
return (
      _.get(strapi.plugins, [plugin, 'models', key]) ||
      _.get(strapi, ['models', key]) ||
      _.get(strapi, ['components', key])
    );
```
It means that if `strapi.plugins.models[plugin]` does not exist, search falls through to `strapi.models` and `strapi.components`.

So, let's say, we've got the component with the model `icon` and the plugin `some-plugin` with the model `icon`.

If we have made a simple typo in our code:
```
strapi.query('icon', 'some-olagin').find({});
```
instead of exception (which would be a logical result of this query), we are going to access the model of the component `icon`. 

This type of behavior is really illogical and produces bugs that are worth many hours of code digging.

So the best solution is to prevent this fall-through behavior when the plugin name is specified.
