### PR TITLE
Preserve pool setttings when there is a schema

### DIFF
--- a/packages/strapi-connector-bookshelf/lib/knex.js
+++ b/packages/strapi-connector-bookshelf/lib/knex.js
@@ -178,8 +178,7 @@ module.exports = strapi => {
 
           if (_.isString(_.get(options.connection, 'schema'))) {
             options.pool = {
-              min: _.get(connection.options, 'pool.min') || 0,
-              max: _.get(connection.options, 'pool.max') || 10,
+              ...options.pool,
               afterCreate: (conn, cb) => {
                 conn.query(
                   `SET SESSION SCHEMA '${options.connection.schema}';`,


### PR DESCRIPTION
In the case where this is a schema defined, `options.pool` is reassigned ignoring the object constructed in a previous step (only preserving min and max, but not the other values such as `createTimeoutMillis` etc...  This change is to keep the other values intact.