### PR TITLE
Prune obsolete files relations on startup

### DIFF
--- a/packages/strapi-plugin-upload/config/functions/bootstrap.js
+++ b/packages/strapi-plugin-upload/config/functions/bootstrap.js
@@ -6,12 +6,11 @@
  */
 
 module.exports = async () => {
-  const type = 'plugin';
   const name = 'upload';
 
   // set plugin store
   const configurator = strapi.store({
-    type,
+    type: 'plugin',
     name,
     key: 'settings',
   });

--- a/packages/strapi-plugin-upload/config/functions/bootstrap.js
+++ b/packages/strapi-plugin-upload/config/functions/bootstrap.js
@@ -59,14 +59,18 @@ const pruneObsoleteRelations = async () => {
   const { upload: plugin } = strapi.plugins;
   const modelIsNotDefined = !plugin || !plugin.models || !plugin.models.file;
 
-  if (modelIsNotDefined || plugin.models.file.orm !== 'mongoose') {
-    return;
+  if (modelIsNotDefined) {
+    return Promise.resolve();
   }
 
   await strapi.query('file', 'upload').custom(pruneObsoleteRelationsQuery)();
 };
 
 const pruneObsoleteRelationsQuery = ({ model }) => {
+  if (model.orm !== 'mongoose') {
+    return Promise.resolve();
+  }
+
   const models = Array.from(strapi.db.models.values());
   const modelsId = models.map(model => model.globalId);
 

--- a/packages/strapi-plugin-upload/config/functions/bootstrap.js
+++ b/packages/strapi-plugin-upload/config/functions/bootstrap.js
@@ -6,12 +6,10 @@
  */
 
 module.exports = async () => {
-  const name = 'upload';
-
   // set plugin store
   const configurator = strapi.store({
     type: 'plugin',
-    name,
+    name: 'upload',
     key: 'settings',
   });
 
@@ -29,7 +27,7 @@ module.exports = async () => {
     });
   }
 
-  await pruneObsoleteRelations(name);
+  await pruneObsoleteRelations();
 };
 
 const createProvider = ({ provider, providerOptions }) => {
@@ -57,10 +55,11 @@ const baseProvider = {
   },
 };
 
-const pruneObsoleteRelations = async name => {
-  const { orm } = strapi.plugins[name].models.file;
+const pruneObsoleteRelations = async () => {
+  const { upload: plugin } = strapi.plugins;
+  const modelIsNotDefined = !plugin || !plugin.models || !plugin.models.file;
 
-  if (orm !== 'mongoose') {
+  if (modelIsNotDefined || plugin.models.file.orm !== 'mongoose') {
     return;
   }
 


### PR DESCRIPTION

Signed-off-by: Convly <jean-sebastien.herbaux@epitech.eu>

#### Description of what you did:

fix #4918

Currently, on MongoDB, deleting a content-type doesn't update the `related` field of the `upload_file` entries which can cause some issues (eg: #4918)

This PR introduces a new query ran in the bootstrap function of the `strapi-plugin-upload` package.
This query search for obsolete relations in the `upload_file` document and remove them.