### PR TITLE
Fix url encoding for local upload provider

### DIFF
--- a/packages/strapi-plugin-upload/package.json
+++ b/packages/strapi-plugin-upload/package.json
@@ -13,7 +13,6 @@
   "dependencies": {
     "byte-size": "^6.2.0",
     "cropperjs": "^1.5.6",
-    "filenamify": "4.1.0",
     "immer": "^6.0.2",
     "immutable": "^3.8.2",
     "is-valid-domain": "0.0.14",

--- a/packages/strapi-plugin-upload/services/Upload.js
+++ b/packages/strapi-plugin-upload/services/Upload.js
@@ -11,14 +11,14 @@ const path = require('path');
 const crypto = require('crypto');
 const _ = require('lodash');
 const util = require('util');
-const filenamify = require('filenamify');
+const { nameToSlug } = require('strapi-utils');
 const mime = require('mime-types');
 
 const { bytesToKbytes } = require('../utils/file');
 
 const randomSuffix = () => crypto.randomBytes(5).toString('hex');
 const generateFileName = name => {
-  const baseName = filenamify(name, { replacement: '_' }).replace(/\s/g, '_');
+  const baseName = nameToSlug(name, { separator: '_', lowercase: false });
 
   return `${baseName}_${randomSuffix()}`;
 };

--- a/packages/strapi-plugin-upload/services/__tests__/upload.test.js
+++ b/packages/strapi-plugin-upload/services/__tests__/upload.test.js
@@ -18,6 +18,22 @@ describe('Upload service', () => {
       });
     });
 
+    test('Replaces reserved and unsafe characters for URLs and files in hash', () => {
+      const fileData = {
+        filename: 'File%&Näme\\<>:"|?*.png',
+        type: 'image/png',
+        size: 1000 * 1000,
+      };
+
+      expect(uploadService.formatFileInfo(fileData)).toMatchObject({
+        name: 'File%&Näme\\<>:"|?*',
+        hash: expect.stringContaining('File_and_Naeme'),
+        ext: '.png',
+        mime: 'image/png',
+        size: 1000,
+      });
+    });
+
     test('Overrides name with fileInfo', () => {
       const fileData = {
         filename: 'File Name.png',

--- a/packages/strapi-utils/lib/stringFormatting.js
+++ b/packages/strapi-utils/lib/stringFormatting.js
@@ -2,7 +2,7 @@
 
 const slugify = require('@sindresorhus/slugify');
 
-const nameToSlug = name => slugify(name, { separator: '-' });
+const nameToSlug = (name, options = { separator: '-' }) => slugify(name, options);
 
 const nameToCollectionName = name => slugify(name, { separator: '_' });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8033,20 +8033,6 @@ filed-mimefix@^0.1.3:
   dependencies:
     mime "^1.4.0"
 
-filename-reserved-regex@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz#abf73dfab735d045440abfea2d91f389ebbfa229"
-  integrity sha1-q/c9+rc10EVECr/qLZHzieu/oik=
-
-filenamify@4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/filenamify/-/filenamify-4.1.0.tgz#54d110810ae74eebfe115c1b995bd07e03cf2184"
-  integrity sha512-KQV/uJDI9VQgN7sHH1Zbk6+42cD6mnQ2HONzkXUfPJ+K2FC8GZ1dpewbbHw0Sz8Tf5k3EVdHVayM4DoAwWlmtg==
-  dependencies:
-    filename-reserved-regex "^2.0.0"
-    strip-outer "^1.0.1"
-    trim-repeated "^1.0.0"
-
 filesize@^4.1.2:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/filesize/-/filesize-4.2.1.tgz#ab1cb2069db5d415911c1a13e144c0e743bc89bc"
@@ -11810,11 +11796,6 @@ lodash@4.17.10:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
   integrity sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==
-
-lodash@4.17.11:
-  version "4.17.11"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
-  integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
 lodash@4.17.12:
   version "4.17.12"
@@ -17578,13 +17559,6 @@ strip-json-comments@~2.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
 
-strip-outer@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/strip-outer/-/strip-outer-1.0.1.tgz#b2fd2abf6604b9d1e6013057195df836b8a9d631"
-  integrity sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==
-  dependencies:
-    escape-string-regexp "^1.0.2"
-
 strong-log-transformer@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/strong-log-transformer/-/strong-log-transformer-2.1.0.tgz#0f5ed78d325e0421ac6f90f7f10e691d6ae3ae10"
@@ -18235,13 +18209,6 @@ trim-off-newlines@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz#9f9ba9d9efa8764c387698bcbfeb2c848f11adb3"
   integrity sha1-n5up2e+odkw4dpi8v+sshI8RrbM=
-
-trim-repeated@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/trim-repeated/-/trim-repeated-1.0.0.tgz#e3646a2ea4e891312bf7eace6cfb05380bc01c21"
-  integrity sha1-42RqLqTokTEr9+rObPsFOAvAHCE=
-  dependencies:
-    escape-string-regexp "^1.0.2"
 
 trim-trailing-lines@^1.0.0:
   version "1.1.3"


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Problem description
Using the local upload provider with the new media library introduced in beta.20, images with a name that contains reserved characters such as `%` are not displayed properly any more, as the image URL is not encoded and now contains the image name as well.

#### Description of what you did:
This changes the upload function of the local upload provider to encode the URL of uploaded images with `encodeURI()`.