### PR TITLE
Fix plugin documentation :  operationId & properties types & complete list of get parameters

### DIFF
--- a/packages/strapi-plugin-documentation/services/Documentation.js
+++ b/packages/strapi-plugin-documentation/services/Documentation.js
@@ -402,6 +402,7 @@ module.exports = {
       }
 
       const verbObject = {
+        operationId: controllerMethod + controllerName,
         deprecated: false,
         description: this.generateVerbDescription(
           verb,

--- a/packages/strapi-plugin-documentation/services/Documentation.js
+++ b/packages/strapi-plugin-documentation/services/Documentation.js
@@ -319,6 +319,16 @@ module.exports = {
     return `${formattedPluginName} - ${formattedName}`;
   },
 
+  // Get property : type and format
+  getProperty: function(type) {
+    const validTypes = ['string', 'integer', 'number', 'boolean'];
+    if (validTypes.includes(type)) {
+      return { type: this.getType(type) };
+    } else {
+      return { type: 'string', format: this.getType(type) };
+    }
+  },
+
   generateAssociationSchema: function(attributes, getter) {
     return Object.keys(attributes).reduce(
       (acc, curr) => {
@@ -330,7 +340,7 @@ module.exports = {
         }
 
         if (isField) {
-          acc.properties[curr] = { type: this.getType(attribute.type) };
+          acc.properties[curr] = this.getProperty(attribute.type);
         } else {
           const newGetter = getter.slice();
           newGetter.splice(newGetter.length - 1, 1, 'associations');


### PR DESCRIPTION
Description : 
This PR contains some fix of plugin-documentations to follow guidelines.
- Generate complete list of Get parameters available.
- Add OperationId field 
- Fix incorrect property type.

Reference : 
Fix #5773 