### PR TITLE
Add missing command to digitalocean.md

### DIFF
--- a/docs/3.0.0-beta.x/deployment/digitalocean.md
+++ b/docs/3.0.0-beta.x/deployment/digitalocean.md
@@ -344,6 +344,7 @@ pm2 save
 [PM2] Saving current process list...
 [PM2] Successfully saved in /home/your-name/.pm2/dump.pm2
 
+systemctl start pm2-your-name
 ```
 
 - **OPTIONAL**: You can test to see if the script above works whenever your system reboots with the `sudo reboot` command. You will need to login again with your **non-root user** and then run `pm2 list` and `systemctl status pm2-your-name` to verify everything is working.


### PR DESCRIPTION
The command 'systemctl start pm2-your-name' was missing in the end of the PM2 section.
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:
The command 'systemctl start pm2-your-name' was missing in the end of the PM2 section. Ready to be merged.