### PR TITLE
Changes the App Engine HOST variable to '0.0.0.0'

### DIFF
--- a/docs/3.0.0-beta.x/deployment/google-app-engine.md
+++ b/docs/3.0.0-beta.x/deployment/google-app-engine.md
@@ -111,7 +111,7 @@ runtime: nodejs10
 instance_class: F2
 
 env_variables:
-  HOST: '<project_id>.appspot.com'
+  HOST: '0.0.0.0'
   NODE_ENV: 'production'
   DATABASE_NAME: 'strapi'
   DATABASE_USERNAME: 'postgres'
@@ -132,7 +132,7 @@ runtime: nodejs10
 env: flex
 
 env_variables:
-  HOST: '<project_id>.appspot.com'
+  HOST: '0.0.0.0'
   NODE_ENV: 'production'
   DATABASE_NAME: 'strapi'
   DATABASE_USERNAME: 'postgres'


### PR DESCRIPTION
This changes documentation for the App Engine Deployment. Specifically the example `app.yaml` file.

Setting the `HOST` variable to one that has `*.appspot.com` domain seems to be causing connectivity issues for multiple people - https://github.com/strapi/strapi/issues/3433#issuecomment-621764964
My first deployment spawned 10 App Engine instances because of starting/connectivity problem.

The solution is simply setting `0.0.0.0`.

