### PR TITLE
Preventing parse-type.test.js Date test from failure due to Time Zone differences

### DIFF
--- a/packages/strapi-utils/lib/__tests__/parse-type.test.js
+++ b/packages/strapi-utils/lib/__tests__/parse-type.test.js
@@ -1,4 +1,5 @@
 const parseType = require('../parse-type');
+const format = require('date-fns/format');
 
 describe('parseType', () => {
   describe('boolean', () => {
@@ -50,7 +51,10 @@ describe('parseType', () => {
 
       expect(parseType({ type: 'date', value: '2018-11-02' })).toBe('2018-11-02');
 
-      expect(parseType({ type: 'date', value: '2019-04-21T00:00:00.000Z' })).toBe('2019-04-21');
+      const isoDateFormat = new Date().toISOString();
+      const expectedDateFormat = format(new Date(isoDateFormat), 'yyyy-MM-dd');
+
+      expect(parseType({ type: 'date', value: isoDateFormat })).toBe(expectedDateFormat);
     });
 
     it('Throws on invalid formator dates', () => {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

Preventing parse-type.test.js Date test from failure due to Time Zone differences

`Summary of all failing tests
 FAIL  packages/strapi-utils/lib/__tests__/parse-type.test.js (19.811s)
  ● parseType › Date › Supports ISO formats and always returns the right format

    expect(received).toBe(expected) // Object.is equality

    Expected: "2019-04-21"
    Received: "2019-04-20"

      52 |       expect(parseType({ type: 'date', value: '2018-11-02' })).toBe('2018-11-02');
      53 | 
    > 54 |       expect(parseType({ type: 'date', value: '2019-04-21T00:00:00.000Z' })).toBe('2019-04-21');
         |                                                                              ^
      55 |     });
      56 | 
      57 |     it('Throws on invalid formator dates', () => {

      at Object.<anonymous> (packages/strapi-utils/lib/__tests__/parse-type.test.js:54:78)`


