### PR TITLE
Ignore private fields input on user register

### DIFF
--- a/packages/strapi-plugin-users-permissions/config/schema.graphql.js
+++ b/packages/strapi-plugin-users-permissions/config/schema.graphql.js
@@ -36,6 +36,12 @@ module.exports = {
       type: String
     }
 
+    input UsersPermissionsRegisterInput {
+      username: String!
+      email: String!
+      password: String!
+    }
+
     input UsersPermissionsLoginInput {
       identifier: String!
       password: String!
@@ -56,7 +62,7 @@ module.exports = {
   `,
   mutation: `
     login(input: UsersPermissionsLoginInput!): UsersPermissionsLoginPayload!
-    register(input: UserInput!): UsersPermissionsLoginPayload!
+    register(input: UsersPermissionsRegisterInput!): UsersPermissionsLoginPayload!
     forgotPassword(email: String!): ForgotPassword
     changePassword(password: String!, passwordConfirmation: String!, code: String!): UsersPermissionsLoginPayload
     emailConfirmation(confirmation: String!): UsersPermissionsLoginPayload

--- a/packages/strapi-plugin-users-permissions/test/users-graphql.test.e2e.js
+++ b/packages/strapi-plugin-users-permissions/test/users-graphql.test.e2e.js
@@ -31,7 +31,7 @@ describe('Test Graphql Users API End to End', () => {
     test('Register a user', async () => {
       const res = await graphqlQuery({
         query: /* GraphQL */ `
-          mutation register($input: UserInput!) {
+          mutation register($input: UsersPermissionsRegisterInput!) {
             register(input: $input) {
               jwt
               user {


### PR DESCRIPTION
Fixes #5834 

- Ignore private fields before passing input to resolver

PS: I'm only using GraphQL so I don't know if the same bug could be used to exploit the REST API.
