### PR TITLE
Heroku Error: self-signed certificate SSL fix

### DIFF
--- a/docs/3.0.0-beta.x/deployment/heroku.md
+++ b/docs/3.0.0-beta.x/deployment/heroku.md
@@ -213,7 +213,7 @@ Replace the contents of `database.json` with the following:
         "database": "${process.env.DATABASE_NAME}",
         "username": "${process.env.DATABASE_USERNAME}",
         "password": "${process.env.DATABASE_PASSWORD}",
-        "ssl": true
+        "ssl": { "rejectUnauthorized": false }
       },
       "options": {}
     }


### PR DESCRIPTION
Heroku Error: self-signed certificate SSL fix for PG '^8.0.0'. Setting SSL options to `"ssl": { "rejectUnauthorized": false }` enables SSL but does not reject self-signed certificate for Heroku deployment. The issue occurs when Heroku invokes node application but fails at SSL cert for PG ^8.0.0.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:
