### PR TITLE
Changed the mount path of postgres

### DIFF
--- a/docs/3.0.0-beta.x/installation/docker.md
+++ b/docs/3.0.0-beta.x/installation/docker.md
@@ -55,7 +55,7 @@ services:
       POSTGRES_USER: strapi
       POSTGRES_PASSWORD: strapi
     volumes:
-      - ./data:/data/postgres
+      - ./data:/var/lib/postgresql/data
     ports:
       - '5432:5432'
 ```


### PR DESCRIPTION
Updated to proper mount path of postgres data so users will not loose data on rebuild

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

I have tried the original docker compose file for postgres, all is working fine and I have been using it for weeks until I recreate my docker containers, all my data is gone due to invalid mount point of data. I changed it to the proper location and my data now persists even i recreate my containers using --force-recreate
