### PR TITLE
Configuration dump and restore cli

### DIFF
--- a/docs/3.0.0-beta.x/cli/CLI.md
+++ b/docs/3.0.0-beta.x/cli/CLI.md
@@ -78,6 +78,63 @@ options: [--no-optimization]
 - **strapi build --no-optimization**<br/>
   Builds the administration panel without minimizing the assets. The build duration is faster.
 
+## strapi configuration:dump|config:dump
+
+Dumps configurations to a file or stdout to help you migrate to production.
+
+The dump format will be a JSON array.
+
+```
+strapi configuration:dump
+
+Options:
+  -f, --file <file>  Output file, default output is stdout
+```
+
+**Examples**
+
+- `strapi configuration:dump -f dump.json`
+- `strapi config:dump --file dump.json`
+- `strapi config:dump > dump.json`
+
+All these examples are equivalent.
+
+::: warning
+When configuring your application you often enter credentials for thrid party services (e.g authentication providers), Be aware that those credentials will also be dumped into the output of this command.
+When you aren't sure of what you are doing, you should avoid commiting this into a versioning system and rather copy the dump to the environment you want to restore it into when needed.
+:::
+
+## strapi configuration:restore|config:restore
+
+Restore a configuration dump into your application.
+
+The input format must be a JSON array.
+
+```
+strapi configuration:restore
+
+Options:
+  -f, --file <file>          Input file, default input is stdin
+  -s, --strategy <strategy>  Strategy name, one of: "replace", "merge", "keep". Defaults to: "replace"
+```
+
+**Examples**
+
+- `strapi configuration:restore -f dump.json`
+- `strapi config:restore --file dump.json -s replace`
+- `cat dump.json | strapi config:restore`
+- `strapi config:restore < dump.json`
+
+All these examples are equivalent.
+
+**Strategies**
+
+When running the restore command, you can choose from three different strategies:
+
+- **replace**: Will create missing keys and replace existing ones.
+- **merge**: Will create missing keys and merge existing keys whith there new value.
+- **keep**: Will create missing keys and keep existing keys as is.
+
 ## strapi generate:api
 
 Scaffold a complete API with its configurations, controller, model and service.

--- a/docs/3.0.0-beta.x/cli/CLI.md
+++ b/docs/3.0.0-beta.x/cli/CLI.md
@@ -100,13 +100,18 @@ Options:
 All these examples are equivalent.
 
 ::: warning
-When configuring your application you often enter credentials for thrid party services (e.g authentication providers), Be aware that those credentials will also be dumped into the output of this command.
-When you aren't sure of what you are doing, you should avoid commiting this into a versioning system and rather copy the dump to the environment you want to restore it into when needed.
+When configuring your application you often enter credentials for thrid party services (e.g authentication providers). Be aware that those credentials will also be dumped into the output of this command.
+In case of doubt, you should avoid committing the dump file into a versioning system. Here are some methods you can explore:
+
+- Copy the file directly to the environment you want and run the restore command there.
+- Put the file in a secure location and download it at deploy time with the right credentials.
+- Encrypt the file before committing and decrypt it when running the restore command.
+
 :::
 
 ## strapi configuration:restore|config:restore
 
-Restore a configuration dump into your application.
+Restores a configuration dump into your application.
 
 The input format must be a JSON array.
 

--- a/packages/strapi/bin/strapi.js
+++ b/packages/strapi/bin/strapi.js
@@ -216,11 +216,13 @@ program
 
 program
   .command('configuration:dump')
+  .alias('config:dump')
   .option('-f, --file <file>', 'Output file, default output is stdout')
   .action(getLocalScript('configurationDump'));
 
 program
   .command('configuration:restore')
+  .alias('config:restore')
   .option('-f, --file <file>', 'Input file, default input is stdin')
   .option('-s, --strategy <strategy>', 'Strategy name, one of: "replace", "merge", "keep"')
   .action(getLocalScript('configurationRestore'));

--- a/packages/strapi/bin/strapi.js
+++ b/packages/strapi/bin/strapi.js
@@ -205,6 +205,11 @@ program
   .description('Starts the admin dev server')
   .action(getLocalScript('watchAdmin'));
 
+program
+  .command('configuration:dump')
+  .option('-f, --file <file>', 'file to output to')
+  .action(getLocalScript('configurationDump'));
+
 /**
  * Normalize help argument
  */

--- a/packages/strapi/bin/strapi.js
+++ b/packages/strapi/bin/strapi.js
@@ -49,7 +49,16 @@ const getLocalScript = name => (...args) => {
     process.exit(1);
   }
 
-  return require(cmdPath)(...args);
+  const script = require(cmdPath);
+
+  Promise.resolve()
+    .then(() => {
+      return script(...args);
+    })
+    .catch(error => {
+      console.error(`Error while running command ${name}: ${error.message}`);
+      process.exit(1);
+    });
 };
 
 /**
@@ -207,8 +216,14 @@ program
 
 program
   .command('configuration:dump')
-  .option('-f, --file <file>', 'file to output to')
+  .option('-f, --file <file>', 'Output file, default output is stdout')
   .action(getLocalScript('configurationDump'));
+
+program
+  .command('configuration:restore')
+  .option('-f, --file <file>', 'Input file, default input is stdin')
+  .option('-s, --strategy <strategy>', 'Strategy name, one of: "replace", "merge", "keep"')
+  .action(getLocalScript('configurationRestore'));
 
 /**
  * Normalize help argument

--- a/packages/strapi/lib/Strapi.js
+++ b/packages/strapi/lib/Strapi.js
@@ -297,6 +297,7 @@ class Strapi {
 
     await this.runBootstrapFunctions();
     await this.freeze();
+    return this;
   }
 
   async startWebhooks() {

--- a/packages/strapi/lib/Strapi.js
+++ b/packages/strapi/lib/Strapi.js
@@ -234,8 +234,6 @@ class Strapi {
   }
 
   async load() {
-    this.isLoaded = true;
-
     this.app.use(async (ctx, next) => {
       if (ctx.request.url === '/_health' && ctx.request.method === 'HEAD') {
         ctx.set('strapi', 'You are so French!');
@@ -297,6 +295,9 @@ class Strapi {
 
     await this.runBootstrapFunctions();
     await this.freeze();
+
+    this.isLoaded = true;
+
     return this;
   }
 

--- a/packages/strapi/lib/commands/configurationDump.js
+++ b/packages/strapi/lib/commands/configurationDump.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const fs = require('fs');
+const { logger } = require('strapi-utils');
+const loadConfiguration = require('../core/app-configuration');
+const strapi = require('../index');
+
+module.exports = async function({ file }) {
+  const output = file ? fs.createWriteStream(file) : process.stdout;
+
+  output.write('this is a test');
+
+  const app = strapi();
+
+  await app.load();
+
+  const confs = await app.query('core_store').find({
+    key_contains: 'plugin',
+  });
+
+  console.log(confs);
+
+  output.write('\n');
+  output.end();
+};

--- a/packages/strapi/lib/commands/configurationDump.js
+++ b/packages/strapi/lib/commands/configurationDump.js
@@ -1,25 +1,52 @@
 'use strict';
 
 const fs = require('fs');
-const { logger } = require('strapi-utils');
-const loadConfiguration = require('../core/app-configuration');
 const strapi = require('../index');
 
+const CHUNK_SIZE = 100;
+
+/**
+ * Will dump configurations to a file or stdout
+ * @param {string} file filepath to use as output
+ */
 module.exports = async function({ file }) {
   const output = file ? fs.createWriteStream(file) : process.stdout;
-
-  output.write('this is a test');
 
   const app = strapi();
 
   await app.load();
 
-  const confs = await app.query('core_store').find({
-    key_contains: 'plugin',
-  });
+  const count = await app.query('core_store').count();
 
-  console.log(confs);
+  const exportData = [];
 
+  const pageCount = Math.ceil(count / 100);
+
+  for (let page = 0; page < pageCount; page++) {
+    const results = await app
+      .query('core_store')
+      .find({ _limit: CHUNK_SIZE, _start: page * CHUNK_SIZE });
+
+    results
+      .filter(result => result.key.startsWith('plugin_'))
+      .forEach(result => {
+        exportData.push({
+          key: result.key,
+          value: result.value,
+          type: result.type,
+          environment: result.environment,
+          tag: result.tag,
+        });
+      });
+  }
+
+  output.write(JSON.stringify(exportData));
   output.write('\n');
   output.end();
+
+  // log success only when writting to file
+  if (file) {
+    console.log(`Successfully exported ${exportData.length} configuration entries`);
+  }
+  process.exit(0);
 };

--- a/packages/strapi/lib/commands/configurationDump.js
+++ b/packages/strapi/lib/commands/configurationDump.js
@@ -12,9 +12,7 @@ const CHUNK_SIZE = 100;
 module.exports = async function({ file }) {
   const output = file ? fs.createWriteStream(file) : process.stdout;
 
-  const app = strapi();
-
-  await app.load();
+  const app = await strapi().load();
 
   const count = await app.query('core_store').count();
 

--- a/packages/strapi/lib/commands/configurationDump.js
+++ b/packages/strapi/lib/commands/configurationDump.js
@@ -9,8 +9,8 @@ const CHUNK_SIZE = 100;
  * Will dump configurations to a file or stdout
  * @param {string} file filepath to use as output
  */
-module.exports = async function({ file }) {
-  const output = file ? fs.createWriteStream(file) : process.stdout;
+module.exports = async function({ file: filePath }) {
+  const output = filePath ? fs.createWriteStream(filePath) : process.stdout;
 
   const app = await strapi().load();
 
@@ -18,12 +18,12 @@ module.exports = async function({ file }) {
 
   const exportData = [];
 
-  const pageCount = Math.ceil(count / 100);
+  const pageCount = Math.ceil(count / CHUNK_SIZE);
 
   for (let page = 0; page < pageCount; page++) {
     const results = await app
       .query('core_store')
-      .find({ _limit: CHUNK_SIZE, _start: page * CHUNK_SIZE });
+      .find({ _limit: CHUNK_SIZE, _start: page * CHUNK_SIZE, _sort: 'key' });
 
     results
       .filter(result => result.key.startsWith('plugin_'))
@@ -43,7 +43,7 @@ module.exports = async function({ file }) {
   output.end();
 
   // log success only when writting to file
-  if (file) {
+  if (filePath) {
     console.log(`Successfully exported ${exportData.length} configuration entries`);
   }
   process.exit(0);

--- a/packages/strapi/lib/commands/configurationRestore.js
+++ b/packages/strapi/lib/commands/configurationRestore.js
@@ -1,0 +1,113 @@
+'use strict';
+
+const _ = require('lodash');
+const fs = require('fs');
+const strapi = require('../index');
+
+/**
+ * Will restore configurations. It reads from a file or stdin
+ * @param {string} file filepath to use as input
+ * @param {string} strategy import strategy. one of (replace, merge, keep, default: replace)
+ */
+module.exports = async function({ file, strategy = 'replace' }) {
+  const input = file ? fs.readFileSync(file) : await readStdin(process.stdin);
+
+  const app = strapi();
+  await app.load();
+
+  let dataToImport;
+  try {
+    dataToImport = JSON.parse(input);
+
+    if (!Array.isArray(dataToImport)) {
+      throw new Error(`Invalid input data. Expected a valid JSON array.`);
+    }
+  } catch (error) {
+    throw new Error(`Invalid input data: ${error.message}. Expected a valid JSON array.`);
+  }
+
+  const importer = createImporter(app.db, strategy);
+
+  for (const config of dataToImport) {
+    await importer.import(config);
+  }
+
+  console.log(`Successfully imported ${dataToImport.length} configuration entries`);
+  process.exit(0);
+};
+
+const readStdin = () => {
+  const { stdin } = process;
+  let result = '';
+
+  if (stdin.isTTY) return Promise.resolve(result);
+
+  return new Promise((resolve, reject) => {
+    stdin.setEncoding('utf8');
+    stdin.on('readable', () => {
+      let chunk;
+      while ((chunk = stdin.read())) {
+        result += chunk;
+      }
+    });
+
+    stdin.on('end', () => {
+      resolve(result);
+    });
+
+    stdin.on('error', reject);
+  });
+};
+
+const createImporter = (db, strategy) => {
+  switch (strategy) {
+    case 'replace':
+      return new ReplaceImporter(db);
+    case 'merge':
+      return new MergeImporter(db);
+    case 'keep':
+      return new KeepImporter(db);
+    default:
+      throw new Error(`No importer available for strategy "${strategy}"`);
+  }
+};
+
+function ReplaceImporter(db) {
+  return {
+    async import(conf) {
+      const matching = await db.query('core_store').count({ key: conf.key });
+      if (matching > 0) {
+        await db.query('core_store').update({ key: conf.key }, conf);
+      } else {
+        await db.query('core_store').create(conf);
+      }
+    },
+  };
+}
+
+function MergeImporter(db) {
+  return {
+    async import(conf) {
+      const existingConf = await db.query('core_store').find({ key: conf.key });
+      if (existingConf) {
+        await db.query('core_store').update({ key: conf.key }, _.merge(existingConf, conf));
+      } else {
+        await db.query('core_store').create(conf);
+      }
+    },
+  };
+}
+
+function KeepImporter(db) {
+  return {
+    async import(conf) {
+      const matching = await db.query('core_store').count({ key: conf.key });
+      if (matching > 0) {
+        // if configuration already exists do not overwrite it
+        return;
+      }
+
+      await db.query('core_store').create(conf);
+    },
+  };
+}

--- a/packages/strapi/lib/commands/configurationRestore.js
+++ b/packages/strapi/lib/commands/configurationRestore.js
@@ -12,8 +12,7 @@ const strapi = require('../index');
 module.exports = async function({ file, strategy = 'replace' }) {
   const input = file ? fs.readFileSync(file) : await readStdin(process.stdin);
 
-  const app = strapi();
-  await app.load();
+  const app = await strapi().load();
 
   let dataToImport;
   try {


### PR DESCRIPTION
#### Description of what you did:


Adds `strapi configuration:dump` and `strapi configuration:restore` commands. 

## What it does

This will dump the content of all core_store keys starting with `plugin_`. This encloses all the plugin configurations put not the internal strapi keys. 

## What it doesn't do

- This doesn't dump webhooks.
- This doesn't dump user-permissions or any other model data.
 