### PR TITLE
Prevent user registration with confirmed status

### DIFF
--- a/packages/strapi-plugin-users-permissions/controllers/Auth.js
+++ b/packages/strapi-plugin-users-permissions/controllers/Auth.js
@@ -395,7 +395,7 @@ module.exports = {
     }
 
     const params = {
-      ..._.pick(ctx.request.body, ['username', 'email', 'password']),
+      ..._.omit(ctx.request.body, ['confirmed', 'resetPasswordToken']),
       provider: 'local',
     };
 


### PR DESCRIPTION
Pull request https://github.com/strapi/strapi/pull/6072 aimed to add security by preventing user creation with email confirmation already enable. By limiting user params to 'username', 'email', 'password', the current code do not allow adding custom field to user entity anymore. This may breaks existing applications that have added required custom fields into user model.

Having required custom fields into user model that are now ignored leads code to throw an error that is catch line 566 and leads to `Username already taken` error which is in this situation inaccurate

#### Description of what you did:
Remove "confirmed" params off the registration payload instead of keeping only "username", "email", "password" params.