### PR TITLE
Add HAProxy proxy documentation

### DIFF
--- a/docs/3.0.0-beta.x/deployment/haproxy-proxy.md
+++ b/docs/3.0.0-beta.x/deployment/haproxy-proxy.md
@@ -28,7 +28,7 @@ This config is using the sub-domain that is dedicated to Strapi only. It will re
 
 Example Domain: `api.example.com`
 
-Path: `/etc/haproxy/haproxy.cfg`
+**Path —** `/etc/haproxy/haproxy.cfg`
 
 ```
 global
@@ -94,7 +94,7 @@ HAProxy **cannot** serve static content, the below example is proxying frontend 
 
 Example Domain: `example.com/api`
 
-Path: `/etc/haproxy/haproxy.cfg`
+**Path —** `/etc/haproxy/haproxy.cfg`
 
 ```
 global
@@ -171,7 +171,7 @@ Example API Domain: `example.com/api`
 
 Example Admin Domain: `example.com/dashboard`
 
-Path: `/etc/haproxy/haproxy.cfg`
+**Path —** `/etc/haproxy/haproxy.cfg`
 
 ```
 global
@@ -252,7 +252,7 @@ In order to take full advantage of a proxied Strapi application you will need to
 
 Example Domain: `api.example.com`
 
-Path: `config/server.js`
+**Path —** `config/server.js`
 
 ```js
 module.exports = ({ env }) => ({
@@ -272,7 +272,7 @@ module.exports = ({ env }) => ({
 
 Example Domain: `example.com/api`
 
-Path: `config/server.js`
+**Path —** `config/server.js`
 
 ```js
 module.exports = ({ env }) => ({
@@ -294,7 +294,7 @@ Example API Domain: `example.com/api`
 
 Example Admin Domain: `example.com/dashboard`
 
-Path: `config/server.js`
+**Path —** `config/server.js`
 
 ```js
 module.exports = ({ env }) => ({

--- a/docs/3.0.0-beta.x/deployment/haproxy-proxy.md
+++ b/docs/3.0.0-beta.x/deployment/haproxy-proxy.md
@@ -4,7 +4,11 @@ As Strapi does not handle SSL directly and hosting a Node.js service on the "edg
 
 ## Configuration
 
+The below examples are more or less acting as an "SSL termination" proxy, meaning that HAProxy is only accepting the requests on SSL and proxying to other backend services such as Strapi or other web servers. **HAProxy cannot serve static content** and as such it is usually used to handle multi-server deployments in a failover or load-balance situtation. The examples provided below are based around everything existing on the same server, but could easily be tweaked for multi-server deployments.
+
 ### HAProxy
+
+As mentioned previously the following examples are either proxying all requests directly to Strapi or are splitting requests between Strapi and some other backend web server such as Nginx, Apache, or others.
 
 Below are 3 example HAProxy configurations:
 
@@ -18,14 +22,60 @@ Below are 3 example HAProxy configurations:
 
 #### Sub-Domain
 
+This config is using the sub-domain that is dedicated to Strapi only. It will redirect normal HTTP traffic over to SSL and proxies all requests (both api and admin) to the Strapi server running on the server.
+
 ---
 
 Example Domain: `api.example.com`
 
-Path: ``
+Path: `/etc/haproxy/haproxy.cfg`
 
 ```
+global
+        log /dev/log    local0
+        log /dev/log    local1 notice
+        chroot /var/lib/haproxy
+        stats socket /run/haproxy/admin.sock mode 660 level admin expose-fd listeners
+        stats timeout 30s
+        user haproxy
+        group haproxy
+        daemon
 
+        # Default SSL material locations
+        ca-base /etc/ssl/certs
+        crt-base /etc/ssl/private
+
+        # See: https://ssl-config.mozilla.org/#server=haproxy&server-version=2.0.3&config=intermediate
+        ssl-default-bind-ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA3$
+        ssl-default-bind-ciphersuites TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256
+        ssl-default-bind-options ssl-min-ver TLSv1.2 no-tls-tickets
+
+defaults
+        log     global
+        mode    http
+        option  httplog
+        option  dontlognull
+        timeout connect 5000
+        timeout client  50000
+        timeout server  50000
+        errorfile 400 /etc/haproxy/errors/400.http
+        errorfile 403 /etc/haproxy/errors/403.http
+        errorfile 408 /etc/haproxy/errors/408.http
+        errorfile 500 /etc/haproxy/errors/500.http
+        errorfile 502 /etc/haproxy/errors/502.http
+        errorfile 503 /etc/haproxy/errors/503.http
+        errorfile 504 /etc/haproxy/errors/504.http
+
+# Everything above this line is HAProxy defaults
+
+frontend api.example.com
+        bind *:80
+        bind *:443 ssl crt /path/to/your/cert
+        http-request redirect scheme https unless { ssl_fc }
+        default_backend strapi-backend
+
+backend strapi-backend
+        server local 127.0.0.1:1337
 ```
 
 ::::
@@ -34,17 +84,72 @@ Path: ``
 
 #### Sub-Folder Unified
 
+This config is using a sub-folder that is dedicated to Strapi only. It will redirect normal HTTP traffic over to SSL and proxies the "frontend" to `localhost:8080`, but proxies all strapi requests on the `example.com/api` sub-path to the locally running Strapi application.
+
 ::: warning
-Please note that this config is not focused on the frontend hosting, you will most likely need to adjust this to your frontend software requirements, it is only being shown here as an example.
+HAProxy **cannot** serve static content, the below example is proxying frontend traffic to some other web server running on the localhost port 8080
 :::
 
 ---
 
 Example Domain: `example.com/api`
 
-Path: ``
+Path: `/etc/haproxy/haproxy.cfg`
 
 ```
+global
+        log /dev/log    local0
+        log /dev/log    local1 notice
+        chroot /var/lib/haproxy
+        stats socket /run/haproxy/admin.sock mode 660 level admin expose-fd listeners
+        stats timeout 30s
+        user haproxy
+        group haproxy
+        daemon
+
+        # Default SSL material locations
+        ca-base /etc/ssl/certs
+        crt-base /etc/ssl/private
+
+        # See: https://ssl-config.mozilla.org/#server=haproxy&server-version=2.0.3&config=intermediate
+        ssl-default-bind-ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA3$
+        ssl-default-bind-ciphersuites TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256
+        ssl-default-bind-options ssl-min-ver TLSv1.2 no-tls-tickets
+
+defaults
+        log     global
+        mode    http
+        option  httplog
+        option  dontlognull
+        timeout connect 5000
+        timeout client  50000
+        timeout server  50000
+        errorfile 400 /etc/haproxy/errors/400.http
+        errorfile 403 /etc/haproxy/errors/403.http
+        errorfile 408 /etc/haproxy/errors/408.http
+        errorfile 500 /etc/haproxy/errors/500.http
+        errorfile 502 /etc/haproxy/errors/502.http
+        errorfile 503 /etc/haproxy/errors/503.http
+        errorfile 504 /etc/haproxy/errors/504.http
+
+# Everything above this line is HAProxy defaults
+
+frontend example.com
+        bind *:80
+        bind *:443 ssl crt /path/to/your/cert
+        http-request redirect scheme https unless { ssl_fc }
+        acl api path_beg /api
+        use_backend strapi-backend if api
+        default_backend default-backend
+
+backend default-backend
+        # HAProxy -cannot- serve static content on it's own
+        # This example is relaying traffic to some other backend webserver
+        server somewebserver 127.0.0.1:8080
+
+backend strapi-backend
+        http-request set-path "%[path,regsub(^/api/,/)]"
+        server local 127.0.0.1:1337
 
 ```
 
@@ -53,6 +158,8 @@ Path: ``
 :::: tab Sub-Folder-Split
 
 #### Sub-Folder Split
+
+This config is using a sub-folder that is dedicated to Strapi only. It will redirect normal HTTP traffic over to SSL and proxies the "frontend" to `localhost:8080`, but proxies all strapi api requests on the `example.com/api` sub-path to the locally running Strapi application. Likewise it will proxy all admin requests on the `example.com/dashboard` sub-path.
 
 ::: warning
 Please note that this config is not focused on the frontend hosting, you will most likely need to adjust this to your frontend software requirements, it is only being shown here as an example.
@@ -64,10 +171,67 @@ Example API Domain: `example.com/api`
 
 Example Admin Domain: `example.com/dashboard`
 
-Path: ``
+Path: `/etc/haproxy/haproxy.cfg`
 
 ```
+global
+        log /dev/log    local0
+        log /dev/log    local1 notice
+        chroot /var/lib/haproxy
+        stats socket /run/haproxy/admin.sock mode 660 level admin expose-fd listeners
+        stats timeout 30s
+        user haproxy
+        group haproxy
+        daemon
 
+        # Default SSL material locations
+        ca-base /etc/ssl/certs
+        crt-base /etc/ssl/private
+
+        # See: https://ssl-config.mozilla.org/#server=haproxy&server-version=2.0.3&config=intermediate
+        ssl-default-bind-ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA3$
+        ssl-default-bind-ciphersuites TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256
+        ssl-default-bind-options ssl-min-ver TLSv1.2 no-tls-tickets
+
+defaults
+        log     global
+        mode    http
+        option  httplog
+        option  dontlognull
+        timeout connect 5000
+        timeout client  50000
+        timeout server  50000
+        errorfile 400 /etc/haproxy/errors/400.http
+        errorfile 403 /etc/haproxy/errors/403.http
+        errorfile 408 /etc/haproxy/errors/408.http
+        errorfile 500 /etc/haproxy/errors/500.http
+        errorfile 502 /etc/haproxy/errors/502.http
+        errorfile 503 /etc/haproxy/errors/503.http
+        errorfile 504 /etc/haproxy/errors/504.http
+
+# Everything above this line is HAProxy defaults
+
+frontend example.com
+        bind *:80
+        bind *:443 ssl crt /path/to/your/cert
+        http-request redirect scheme https unless { ssl_fc }
+        acl api path_beg /api
+        acl dashboard path_beg /dashboard
+        use_backend strapi-api-backend if api
+        use_backend strapi-dashboard-backend if dashboard
+        default_backend default-backend
+
+backend default-backend
+        # HAProxy -cannot- serve static content on it's own
+        # This example is relaying traffic to some other backend webserver
+        server somewebserver 127.0.0.1:8080
+
+backend strapi-api-backend
+        http-request set-path "%[path,regsub(^/api/,/)]"
+        server local 127.0.0.1:1337
+
+backend strapi-dashboard-backend
+        server local 127.0.0.1:1337
 ```
 
 ::::

--- a/docs/3.0.0-beta.x/deployment/haproxy-proxy.md
+++ b/docs/3.0.0-beta.x/deployment/haproxy-proxy.md
@@ -1,0 +1,148 @@
+# HAProxy Proxying
+
+As Strapi does not handle SSL directly and hosting a Node.js service on the "edge" network is not a secure solution it is recommended that you use some sort of proxy application such as Nginx, Apache, HAProxy, Traefik, or others. Below you will find some sample configurations for HAProxy, naturally these configs may not suit all environments and you will likely need to adjust them to fit your needs.
+
+## Configuration
+
+### HAProxy
+
+Below are 3 example HAProxy configurations:
+
+- Sub-domain based such as `api.example.com`
+- Sub-folder based with both the API and Admin on the same sub-folder such as `example.com/api` and `example.com/api/admin`
+- Sub-folder based with split API and Admin such as `example.com/api` and `example.com/dashboard`
+
+::::: tabs
+
+:::: tab Sub-Domain
+
+#### Sub-Domain
+
+---
+
+Example Domain: `api.example.com`
+
+Path: ``
+
+```
+
+```
+
+::::
+
+:::: tab Sub-Folder-Unified
+
+#### Sub-Folder Unified
+
+::: warning
+Please note that this config is not focused on the frontend hosting, you will most likely need to adjust this to your frontend software requirements, it is only being shown here as an example.
+:::
+
+---
+
+Example Domain: `example.com/api`
+
+Path: ``
+
+```
+
+```
+
+::::
+
+:::: tab Sub-Folder-Split
+
+#### Sub-Folder Split
+
+::: warning
+Please note that this config is not focused on the frontend hosting, you will most likely need to adjust this to your frontend software requirements, it is only being shown here as an example.
+:::
+
+---
+
+Example API Domain: `example.com/api`
+
+Example Admin Domain: `example.com/dashboard`
+
+Path: ``
+
+```
+
+```
+
+::::
+
+:::::
+
+### Strapi Server
+
+In order to take full advantage of a proxied Strapi application you will need to configure Strapi to make it aware of the upstream proxy. Like with the above HAProxy configurations there are 3 matching examples. To read more about this server configuration file please see the [server configuration concept](../concepts/configurations.md#server) documentation.
+
+::::: tabs
+
+:::: tab Sub-Domain
+
+#### Sub-Domain Strapi config
+
+---
+
+Example Domain: `api.example.com`
+
+Path: `config/server.js`
+
+```js
+module.exports = ({ env }) => ({
+  host: env('HOST', '0.0.0.0'),
+  port: env.int('PORT', 1337),
+  url: 'https://api.example.com',
+});
+```
+
+::::
+
+:::: tab Sub-Folder-Unified
+
+#### Sub-Folder Unified Strapi config
+
+---
+
+Example Domain: `example.com/api`
+
+Path: `config/server.js`
+
+```js
+module.exports = ({ env }) => ({
+  host: env('HOST', '0.0.0.0'),
+  port: env.int('PORT', 1337),
+  url: 'https://example.com/api',
+});
+```
+
+::::
+
+:::: tab Sub-Folder-Split
+
+#### Sub-Folder Split Strapi config
+
+---
+
+Example API Domain: `example.com/api`
+
+Example Admin Domain: `example.com/dashboard`
+
+Path: `config/server.js`
+
+```js
+module.exports = ({ env }) => ({
+  host: env('HOST', '0.0.0.0'),
+  port: env.int('PORT', 1337),
+  url: 'https://example.com/api',
+  admin: {
+    url: 'https://example.com/dashboard',
+  },
+});
+```
+
+::::
+
+:::::

--- a/docs/3.0.0-beta.x/getting-started/deployment.md
+++ b/docs/3.0.0-beta.x/getting-started/deployment.md
@@ -29,7 +29,7 @@ Manual guides for deployment on various platforms, for One-click and docker plea
     </template>
 		<template #title>Azure</template>
 		<template #description>
-			Step by step guide for deploying on Azure web app
+			Step by step guide for deploying on Azure
 		</template>
 	</InstallLink>
 </div>

--- a/docs/3.0.0-beta.x/getting-started/deployment.md
+++ b/docs/3.0.0-beta.x/getting-started/deployment.md
@@ -87,6 +87,18 @@ Additional guides for optional software additions that compliment or improve the
 </div>
 
 <div>
+	<InstallLink link="../deployment/haproxy-proxy">
+    <template #icon>
+    HAP
+    </template>
+		<template #title>HAProxy</template>
+		<template #description>
+			Overview of proxying Strapi with HAProxy
+		</template>
+	</InstallLink>
+</div>
+
+<div>
 	<InstallLink link="../deployment/nginx-proxy">
     <template #icon>
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="-35.5 26 32 32" width="64" height="64"><path d="M-33.442 42.023v-7.637a.68.68 0 0 1 .385-.651l13.173-7.608c.237-.148.503-.178.74-.03l13.232 7.637a.71.71 0 0 1 .355.651V49.63a.71.71 0 0 1-.355.651l-11.367 6.57a56.27 56.27 0 0 1-1.806 1.036c-.266.148-.533.148-.8 0l-13.202-7.608c-.237-.148-.355-.326-.355-.622v-7.637z" fill="#fff"/><path d="M-24.118 39.18v8.9c0 1.006-.8 1.894-1.865 1.865-.65-.03-1.154-.296-1.5-.858-.178-.266-.237-.562-.237-.888V35.836c0-.83.503-1.42 1.154-1.687s1.302-.207 1.954 0c.622.178 1.095.562 1.5 1.036l7.874 9.443c.03.03.06.09.118.148v-9c0-.947.65-1.687 1.57-1.776 1.154-.148 1.924.68 2.042 1.54v12.6c0 .7-.326 1.214-.918 1.54-.444.237-.918.296-1.42.266a3.23 3.23 0 0 1-1.954-.829c-.296-.266-.503-.592-.77-.888l-7.49-8.97c0-.03-.03-.06-.06-.09z" fill="#3498DB"/></svg>


### PR DESCRIPTION
#### Description of what you did:

**This should not be merged until after:** #6134 

Currently missing a proper SVG logo, if the design team want to redraw the current HAProxy logo to add in. I am not terribly skilled in graphical editing enough to get their complex logo added. Example logo can be grabbed here: https://www.vectorlogo.zone/logos/haproxy/index.html
