### PR TITLE
JWT ExpiresIn

### DIFF
--- a/Pacotes/strapi-plugin-users-permissões/Serviços/Jwt.js
+++ b/Pacotes/strapi-plugin-users-permissões/Serviços/Jwt.js
@@ -9,21 +9,6 @@
 const _ = require('lodash');
 const jwt = require('jsonwebtoken');
 
-/*
-Exemple: ../../../config/application.json
-{
-  "favicon": {
-      "path": "favicon.ico",
-      "maxAge": 86400000
-  },
-  "public": {
-      "path": "./public",
-      "maxAge": 60000
-  },
-  "jwtExpiresIn": "2h"
-}
-*/
-
 const { jwtExpiresIn } = require('../../../config/application.json');
 
 const defaultJwtOptions = { expiresIn: jwtExpiresIn == null ? '30d' : jwtExpiresIn };

--- a/docs/3.0.0-beta.x/guides/jwt-validation.md
+++ b/docs/3.0.0-beta.x/guides/jwt-validation.md
@@ -30,6 +30,24 @@ Here is the file we will have to customize: [permission.js](https://github.com/s
 
 Now we are ready to create our custom validation code.
 
+
+## JWT ExpiresIn
+To configure the JWT expiration time add the parameter jwtExpiresIn in 'config/application.json'
+```json
+{
+  "favicon": {
+      "path": "favicon.ico",
+      "maxAge": 86400000
+  },
+  "public": {
+      "path": "./public",
+      "maxAge": 60000
+  },
+  "jwtExpiresIn": "2h"
+}
+```
+- jwtExpiresIn: `30d` time in days or `2h` time in hours
+
 ## Write our own logic
 
 First we have to define where we write our code.

--- a/packages/strapi-plugin-users-permissions/services/Jwt.js
+++ b/packages/strapi-plugin-users-permissions/services/Jwt.js
@@ -9,7 +9,24 @@
 const _ = require('lodash');
 const jwt = require('jsonwebtoken');
 
-const defaultJwtOptions = { expiresIn: '30d' };
+/*
+Exemple: ../../../config/application.json
+{
+  "favicon": {
+      "path": "favicon.ico",
+      "maxAge": 86400000
+  },
+  "public": {
+      "path": "./public",
+      "maxAge": 60000
+  },
+  "jwtExpiresIn": "2h"
+}
+*/
+
+const { jwtExpiresIn } = require('../../../config/application.json');
+
+const defaultJwtOptions = { expiresIn: jwtExpiresIn == null ? '30d' : jwtExpiresIn };
 
 module.exports = {
   getToken(ctx) {


### PR DESCRIPTION
## JWT ExpiresIn
To configure the JWT expiration time add the parameter jwtExpiresIn in 'config/application.json'
```json
{
  "favicon": {
      "path": "favicon.ico",
      "maxAge": 86400000
  },
  "public": {
      "path": "./public",
      "maxAge": 60000
  },
  "jwtExpiresIn": "2h"
}
```
- jwtExpiresIn: `30d` time in days or `2h` time in hours

> Check if there is a parameter defined in '../../../config/application.json' for 'jwtExpiresIn'
if there is any value if it does not continue with the default value
 ```js
const { jwtExpiresIn } = require('../../../config/application.json');

const defaultJwtOptions = { expiresIn: jwtExpiresIn == null ? '30d' : jwtExpiresIn };
```