### PR TITLE
Erroneous double quote syntax error

### DIFF
--- a/docs/3.0.0-beta.x/plugins/documentation.md
+++ b/docs/3.0.0-beta.x/plugins/documentation.md
@@ -101,7 +101,7 @@ Here are the file that needs to be created in order to change the documentation 
   },
   "x-strapi-config": {
     "path": "/documentation",
-    "showGeneratedFiles": true",
+    "showGeneratedFiles": true,
     "pluginsForWhichToGenerateDoc": [
       "email",
       "upload",


### PR DESCRIPTION
Erroneous double quote in custom  extensions/documentation/config/settings.json example

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:
Removed a a double quote to make the JSON parse.
