### PR TITLE
Update documentation of the section plugin Google Cloud Storage

### DIFF
--- a/docs/3.0.0-beta.x/deployment/google-app-engine.md
+++ b/docs/3.0.0-beta.x/deployment/google-app-engine.md
@@ -262,25 +262,7 @@ yarn add strapi-provider-upload-google-cloud-storage
 
 Deploy so that the server app includes the dependency from `package.json`.
 
-Create a Google service account key.
-
-<https://console.cloud.google.com/apis/credentials/serviceaccountkey>
-
-Save the JSON credentials file.
-
-Plugins > File Upload > Settings > Production tab
-
-By default `localhost` is selected. Select the `Google Cloud Storage` plugin.
-
-Copy the JSON key and set the regions.
-
-Open the `Cloud Console > Storage > Browser` menu.
-
-Copy the bucket name to the plugin settings, the default is the app ID, such as `myapi-123456.appspot.com`.
-
-(Note that the `Access control` setting of the bucket has to be `Fine-grained`, which is the default.)
-
-Click `Save`, and it's ready to go!
+Follow the [documentation of the plugin](https://github.com/Lith/strapi-provider-upload-google-cloud-storage/blob/master/README.md) for the full configuration.
 
 ### Post-setup configuration
 

--- a/docs/v3.x/deployment/google-app-engine.md
+++ b/docs/v3.x/deployment/google-app-engine.md
@@ -237,34 +237,7 @@ yarn add strapi-provider-upload-google-cloud-storage
 
 Deploy so that the server app includes the dependency from `package.json`.
 
-Create a Google service account key.
-
-<https://console.cloud.google.com/apis/credentials/serviceaccountkey>
-
-Save the JSON credentials file.
-
-Open the JSON credentials file, copy all the content and set an environment variable named as `GCS_SERVICE_ACCOUNT`
-
-Create a settings.json file in below path
-
-```
-./extensions/upload/config/settings.json
-```
-
-Paste in the code below, replace `###YOUR BUCKET NAME###` with your bucket name such as `myapi-123456.appspot.com`
-
-```
-{
-  "provider": "google-cloud-storage",
-  "providerOptions": {
-    "serviceAccount": "${process.env.GCS_SERVICE_ACCOUNT}",
-    "bucketName": "###YOUR BUCKET NAME###",
-    "baseUrl": "https://storage.googleapis.com/###YOUR BUCKET NAME###"
-  }
-}
-```
-
-(Note that the `Access control` setting of the bucket has to be `Fine-grained`, which is the default.)
+Follow the [documentation of the plugin](https://github.com/Lith/strapi-provider-upload-google-cloud-storage/blob/master/README.md) for the full configuration.
 
 ### Post-setup configuration
 


### PR DESCRIPTION
Hello,

Some people are writing issue about misunderstood in the `google cloud storage` section for the deployment with Google App Engine.
In order to avoid further mistake, I prefer than the documentation provide a redirection to the full documentation of the plugin.

Thanks,