### PR TITLE
Fix forcefully resolving policy names as lowercase

### DIFF
--- a/packages/strapi-utils/lib/policy.js
+++ b/packages/strapi-utils/lib/policy.js
@@ -66,7 +66,7 @@ const PLUGIN_PREFIX = 'plugins::';
 const APPLICATION_PREFIX = 'application::';
 
 const getPolicyIn = (container, policy) => {
-  return _.get(container, ['config', 'policies', _.toLower(policy)]);
+  return _.get(container, ['config', 'policies', policy]);
 };
 
 const policyExistsIn = (container, policy) => {


### PR DESCRIPTION
#### Description of what you did:

fixes #6288 

Removed the forceful resolving of policies as lowercase and instead uses the direct name of the file.
