### PR TITLE
Fix permissions scope for Instagram OAuth

### DIFF
--- a/packages/strapi-plugin-users-permissions/config/functions/bootstrap.js
+++ b/packages/strapi-plugin-users-permissions/config/functions/bootstrap.js
@@ -75,6 +75,7 @@ module.exports = async () => {
       key: '',
       secret: '',
       callback: `${strapi.config.server.url}/auth/instagram/callback`,
+      scope: ['user_profile'],
     },
     vk: {
       enabled: false,


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:
There was no authentication scope was set for Instagram. So Instagram throws the next error:
```
{"error_type": "OAuthException", "code": 400, "error_message": "Invalid scope: []"}
```

Currently it supports two variants of scope: `user_profile` & `user_media`. The first one is required to perform authentication & to get basic user information.