### PR TITLE
Support uid and uuid foreign keys in components

### DIFF
--- a/packages/strapi-connector-bookshelf/lib/generate-component-relations.js
+++ b/packages/strapi-connector-bookshelf/lib/generate-component-relations.js
@@ -86,10 +86,15 @@ const createComponentJoinTables = async ({ definition, ORM }) => {
         .notNullable();
       table.string('component_type').notNullable();
       table.integer('component_id').notNullable();
-      if (primaryKeyType === 'uuid') {
-        table.uuid(joinColumn).notNullable();
-      } else {
-        table.integer(joinColumn).unsigned().notNullable();
+      switch (primaryKeyType) {
+        case 'uuid':
+          table.string(joinColumn).notNullable();
+          break;
+        case 'uuid':
+          table.uuid(joinColumn).notNullable();
+          break;
+        default:
+          table.integer(joinColumn).unsigned().notNullable();
       }
 
       table

--- a/packages/strapi-connector-bookshelf/lib/generate-component-relations.js
+++ b/packages/strapi-connector-bookshelf/lib/generate-component-relations.js
@@ -87,7 +87,7 @@ const createComponentJoinTables = async ({ definition, ORM }) => {
       table.string('component_type').notNullable();
       table.integer('component_id').notNullable();
       switch (primaryKeyType) {
-        case 'uuid':
+        case 'uid':
           table.string(joinColumn).notNullable();
           break;
         case 'uuid':

--- a/packages/strapi-connector-bookshelf/lib/generate-component-relations.js
+++ b/packages/strapi-connector-bookshelf/lib/generate-component-relations.js
@@ -67,7 +67,7 @@ const createComponentModels = async ({ model, definition, ORM, GLOBALS }) => {
 };
 
 const createComponentJoinTables = async ({ definition, ORM }) => {
-  const { collectionName, primaryKey } = definition;
+  const { collectionName, primaryKey, primaryKeyType } = definition;
 
   const componentAttributes = getComponentAttributes(definition);
 
@@ -86,10 +86,11 @@ const createComponentJoinTables = async ({ definition, ORM }) => {
         .notNullable();
       table.string('component_type').notNullable();
       table.integer('component_id').notNullable();
-      table
-        .integer(joinColumn)
-        .unsigned()
-        .notNullable();
+      if (primaryKeyType === 'uuid') {
+        table.uuid(joinColumn).notNullable();
+      } else {
+        table.integer(joinColumn).unsigned().notNullable();
+      }
 
       table
         .foreign(joinColumn, `${joinColumn}_fk`)


### PR DESCRIPTION
Fix #4339

Checks the primary key type of the parent model and creates the component's foreign key type accordingly.