### PR TITLE
Clarified upload proxy error messages

### DIFF
--- a/packages/strapi-plugin-upload/controllers/proxy.js
+++ b/packages/strapi-plugin-upload/controllers/proxy.js
@@ -10,11 +10,11 @@ module.exports = {
       const url = new URL(ctx.query.url);
 
       if (!['http:', 'https:'].includes(url.protocol)) {
-        throw new Error('Invalid URL');
+        throw new Error('Unexpected url protocol');
       }
 
       if (!isValidDomain(url.hostname)) {
-        throw new Error('Invalid URL');
+        throw new Error('Invalid url hostname');
       }
     } catch (err) {
       ctx.status = 400;


### PR DESCRIPTION
Error messages was unclear. As a developer, you could save a lot of time, with a more specific error-message.