### PR TITLE
Upload proxy - Using Header objects build-in entries function

### DIFF
--- a/packages/strapi-plugin-upload/controllers/proxy.js
+++ b/packages/strapi-plugin-upload/controllers/proxy.js
@@ -27,7 +27,7 @@ module.exports = {
         headers: _.omit(ctx.request.headers, ['origin', 'host', 'authorization']),
       });
 
-      for (var [key, value] of res.headers.entries()) {
+      for (const [key, value] of res.headers.entries()) {
         ctx.set(key, value);
       }
 

--- a/packages/strapi-plugin-upload/controllers/proxy.js
+++ b/packages/strapi-plugin-upload/controllers/proxy.js
@@ -27,9 +27,9 @@ module.exports = {
         headers: _.omit(ctx.request.headers, ['origin', 'host', 'authorization']),
       });
 
-      Object.entries(res.headers.raw()).forEach(([key, value]) => {
+      for (var [key, value] of res.headers.entries()) {
         ctx.set(key, value);
-      });
+      }
 
       ctx.status = res.status;
       ctx.body = res.body;


### PR DESCRIPTION
Found out that when using `res.headers.raw()` the header value would be wrapped in an array like: `['image/jpeg']`.

https://developer.mozilla.org/en-US/docs/Web/API/Headers/entries