### PR TITLE
Fix strapi blog url

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -132,7 +132,7 @@ module.exports = {
       },
       {
         text: 'Blog',
-        link: 'https://blog.strapi.io',
+        link: 'https://strapi.io/blog',
       },
       {
         text: 'Tutorials',

--- a/docs/3.0.0-beta.x/getting-started/quick-start-tutorial.md
+++ b/docs/3.0.0-beta.x/getting-started/quick-start-tutorial.md
@@ -145,7 +145,7 @@ You are now ready to create a new **Administrator** and new front-end **User**.
 
 ## 2. Create an Administrator and front-end User
 
-The first step is to create an **Administrator** (or "root user") for your project. An **Administrator** has all administrator privileges and access rights. (You can read more about why **Administrators** and front-end **Users** are separate [here](https://blog.strapi.io/why-we-split-the-management-of-the-admin-users-and-end-users/).)
+The first step is to create an **Administrator** (or "root user") for your project. An **Administrator** has all administrator privileges and access rights. (You can read more about why **Administrators** and front-end **Users** are separate [here](https://strapi.io/blog/why-we-split-the-management-of-the-admin-users-and-end-users/).)
 
 You need to complete the following fields:
 
@@ -632,7 +632,7 @@ If you would like to see the route of any specific **Content Type**, you need to
 ::: tip CONGRATULATIONS
 👏 Congratulations, you have now completed the **Strapi Getting Started Tutorial**. Where to go next?
 
-- Learn how to use Strapi with React ([Gatsby](https://blog.strapi.io/building-a-static-website-using-gatsby-and-strapi) or [Next.js](https://blog.strapi.io/strapi-next-setup/)) or Vue.js ([Nuxt.js](https://blog.strapi.io/cooking-a-deliveroo-clone-with-nuxt-vue-js-graphql-strapi-and-stripe-setup-part-1-7/)).
+- Learn how to use Strapi with React ([Gatsby](https://strapi.io/blog/building-a-static-website-using-gatsby-and-strapi) or [Next.js](https://strapi.io/blog/strapi-next-setup/)) or Vue.js ([Nuxt.js](https://strapi.io/blog/cooking-a-deliveroo-clone-with-nuxt-vue-js-graphql-strapi-and-stripe-setup-part-1-7/)).
 - Read the **concepts** to deep dive into Strapi.
 - Get help on [Github Discussions](https://github.com/strapi/strapi/discussions).
 - Read the [source code](https://github.com/strapi/strapi), [contribute](https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md) or [give a star](https://github.com/strapi/strapi) on GitHub.

--- a/docs/3.0.0-beta.x/getting-started/quick-start.md
+++ b/docs/3.0.0-beta.x/getting-started/quick-start.md
@@ -118,7 +118,7 @@ Here we are! The list of **restaurants** is accessible at [`http://localhost:133
 ::: tip CONGRATULATIONS
 👏 Congratulations, you have now completed the **Strapi Quick Start**. Where to go next?
 
-- Learn how to use Strapi with React ([Gatsby](https://blog.strapi.io/building-a-static-website-using-gatsby-and-strapi) or [Next.js](https://blog.strapi.io/strapi-next-setup/)) or Vue.js ([Nuxt.js](https://blog.strapi.io/cooking-a-deliveroo-clone-with-nuxt-vue-js-graphql-strapi-and-stripe-setup-part-1-7/)).
+- Learn how to use Strapi with React ([Gatsby](https://strapi.io/blog/building-a-static-website-using-gatsby-and-strapi) or [Next.js](https://strapi.io/blog/strapi-next-setup/)) or Vue.js ([Nuxt.js](https://strapi.io/blog/cooking-a-deliveroo-clone-with-nuxt-vue-js-graphql-strapi-and-stripe-setup-part-1-7/)).
 - Read the **concepts** and do the [Tutorial](quick-start-tutorial.md) to deep dive into Strapi.
 - Get help on [Github Discussions](https://github.com/strapi/strapi/discussions).
 - Read the [source code](https://github.com/strapi/strapi), [contribute](https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md) or [give a star](https://github.com/strapi/strapi) on GitHub.

--- a/docs/v3.x/getting-started/quick-start-tutorial.md
+++ b/docs/v3.x/getting-started/quick-start-tutorial.md
@@ -145,7 +145,7 @@ You are now ready to create a new **Administrator** and new front-end **User**.
 
 ## 2. Create an Administrator and front-end User
 
-The first step is to create an **Administrator** (or "root user") for your project. An **Administrator** has all administrator privileges and access rights. (You can read more about why **Administrators** and front-end **Users** are separate [here](https://blog.strapi.io/why-we-split-the-management-of-the-admin-users-and-end-users/).)
+The first step is to create an **Administrator** (or "root user") for your project. An **Administrator** has all administrator privileges and access rights. (You can read more about why **Administrators** and front-end **Users** are separate [here](https://strapi.io/blog/why-we-split-the-management-of-the-admin-users-and-end-users/).)
 
 You need to complete the following fields:
 
@@ -631,7 +631,7 @@ If you would like to see the route of any specific **Content Type**, you need to
 ::: tip CONGRATULATIONS
 👏 Congratulations, you have now completed the **Strapi Getting Started Tutorial**. Where to go next?
 
-- Learn how to use Strapi with React ([Gatsby](https://blog.strapi.io/building-a-static-website-using-gatsby-and-strapi) or [Next.js](https://blog.strapi.io/strapi-next-setup/)) or Vue.js ([Nuxt.js](https://blog.strapi.io/cooking-a-deliveroo-clone-with-nuxt-vue-js-graphql-strapi-and-stripe-setup-part-1-7/)).
+- Learn how to use Strapi with React ([Gatsby](https://strapi.io/blog/building-a-static-website-using-gatsby-and-strapi) or [Next.js](https://strapi.io/blog/strapi-next-setup/)) or Vue.js ([Nuxt.js](https://strapi.io/blog/cooking-a-deliveroo-clone-with-nuxt-vue-js-graphql-strapi-and-stripe-setup-part-1-7/)).
 - Read the **concepts** to deep dive into Strapi.
 - Get help on [Github Discussions](https://github.com/strapi/strapi/discussions).
 - Read the [source code](https://github.com/strapi/strapi), [contribute](https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md) or [give a star](https://github.com/strapi/strapi) on GitHub.

--- a/docs/v3.x/getting-started/quick-start.md
+++ b/docs/v3.x/getting-started/quick-start.md
@@ -118,7 +118,7 @@ Here we are! The list of **restaurants** is accessible at [`http://localhost:133
 ::: tip CONGRATULATIONS
 👏 Congratulations, you have now completed the **Strapi Quick Start**. Where to go next?
 
-- Learn how to use Strapi with React ([Gatsby](https://blog.strapi.io/building-a-static-website-using-gatsby-and-strapi) or [Next.js](https://blog.strapi.io/strapi-next-setup/)) or Vue.js ([Nuxt.js](https://blog.strapi.io/cooking-a-deliveroo-clone-with-nuxt-vue-js-graphql-strapi-and-stripe-setup-part-1-7/)).
+- Learn how to use Strapi with React ([Gatsby](https://strapi.io/blog/building-a-static-website-using-gatsby-and-strapi) or [Next.js](https://strapi.io/blog/strapi-next-setup/)) or Vue.js ([Nuxt.js](https://strapi.io/blog/cooking-a-deliveroo-clone-with-nuxt-vue-js-graphql-strapi-and-stripe-setup-part-1-7/)).
 - Read the **concepts** and do the [Tutorial](quick-start-tutorial.md) to deep dive into Strapi.
 - Get help on [Github Discussions](https://github.com/strapi/strapi/discussions).
 - Read the [source code](https://github.com/strapi/strapi), [contribute](https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md) or [give a star](https://github.com/strapi/strapi) on GitHub.

--- a/packages/strapi-admin/admin/src/containers/HomePage/BlogPost.js
+++ b/packages/strapi-admin/admin/src/containers/HomePage/BlogPost.js
@@ -20,13 +20,11 @@ const BlogPost = ({ error, isFirst, isLoading, title, content, link }) => {
     <a
       rel="noopener noreferrer"
       target="_blank"
-      href={`https://blog.strapi.io/${link}`}
+      href={`https://strapi.io/blog/${link}`}
       style={{ color: '#333740' }}
     >
       <h2>{title}</h2>
-      <p style={{ marginTop: 17, marginBottom: isFirst ? 32 : 10 }}>
-        {content}
-      </p>
+      <p style={{ marginTop: 17, marginBottom: isFirst ? 32 : 10 }}>{content}</p>
     </a>
   );
 };

--- a/packages/strapi-admin/admin/src/containers/HomePage/index.js
+++ b/packages/strapi-admin/admin/src/containers/HomePage/index.js
@@ -73,7 +73,7 @@ const HomePage = ({ global: { plugins }, history: { push } }) => {
   const linkProps = hasAlreadyCreatedContentTypes
     ? {
         id: 'app.components.HomePage.button.blog',
-        href: 'https://blog.strapi.io/',
+        href: 'https://strapi.io/blog/',
         onClick: () => {},
         type: 'blog',
         target: '_blank',


### PR DESCRIPTION
#### Description of what you did:

The URL of the blog changed from `blog.strapi.io` to `strapi.io/blog`
There is a 301 redirection from the old one to the new one.
So I'm updating documentation links to the new one to don't have 301 redirection for nothing.