### PR TITLE
Load sentry as first middleware

### DIFF
--- a/docs/v3.x/guides/error-catching.md
+++ b/docs/v3.x/guides/error-catching.md
@@ -65,14 +65,15 @@ It's important to call `throw(error);` to avoid stopping the middleware stack. I
 
 ## Configure the middleware
 
-Make sure your middleware is added at the end of the middleware stack.
+Make sure your middleware is added at the beginning of the middleware stack.
 
 **Path —** `./config/middleware.js`
 
 ```js
 module.exports = {
   load: {
-    after: ['parser', 'router', 'sentry'],
+    before: ['sentry', 'responseTime', 'logger', ...],
+    ...
   },
 };
 ```


### PR DESCRIPTION
In order to catch errors from the other middlewares, it is important to have sentry middleware loaded at the beginning.
If let's say responseTime middleware would throw an error, sentry would not be able to pick it up if it's not loaded before.