### PR TITLE
Remove options pool for non sqlite3 clients

### DIFF
--- a/packages/strapi-connector-bookshelf/lib/knex.js
+++ b/packages/strapi-connector-bookshelf/lib/knex.js
@@ -99,30 +99,12 @@ module.exports = strapi => {
             timezone: _.get(connection.settings, 'timezone', 'utc'),
             filename: _.get(connection.settings, 'filename', '.tmp/data.db'),
           },
+          ...connection.options,
           debug: _.get(connection.options, 'debug', false),
-          acquireConnectionTimeout: _.get(connection.options, 'acquireConnectionTimeout'),
-          migrations: _.get(connection.options, 'migrations'),
-          useNullAsDefault: _.get(connection.options, 'useNullAsDefault'),
         },
         strapi.config.hook.settings.knex,
         defaultConfig
       );
-
-      if (connection.settings.client !== 'sqlite3') {
-        options.pool = {
-          min: _.get(connection.options, 'pool.min', 0),
-          max: _.get(connection.options, 'pool.max', 10),
-          acquireTimeoutMillis: _.get(connection.options, 'pool.acquireTimeoutMillis', 2000),
-          createTimeoutMillis: _.get(connection.options, 'pool.createTimeoutMillis', 2000),
-          idleTimeoutMillis: _.get(connection.options, 'pool.idleTimeoutMillis', 30000),
-          reapIntervalMillis: _.get(connection.options, 'pool.reapIntervalMillis', 1000),
-          createRetryIntervalMillis: _.get(
-            connection.options,
-            'pool.createRetryIntervalMillis',
-            200
-          ),
-        };
-      }
 
       // Resolve path to the directory containing the database file.
       const fileDirectory = options.connection.filename


### PR DESCRIPTION
#### Description of what you did:

This PR removes pool options specified for database client connections other than `sqlite3`.
This was done because the `pool` options had very low values, particularly the `acquireConnectionTimeout`, which was causing the connection to timeout.

I'm not sure why this removed code was there in the first place, but maybe to fast detect connection timeouts. 

Instead of updating the code to have more permissive values, I choose to remove the code, making the `knex` and `tarn` dependencies responsible to set the default options. 

In userland, it's still possible to set the poll options as before.

@derrickmehaffy I've did not found any tests concerning database connections, maybe `strapi` relies on e2e tests for this?  

fix #6335 