### PR TITLE
feature: accept user-defined logger from opts

### DIFF
--- a/packages/strapi/lib/Strapi.js
+++ b/packages/strapi/lib/Strapi.js
@@ -42,7 +42,7 @@ class Strapi {
     this.router = new Router();
 
     // Logger.
-    this.log = logger;
+    this.log = opts.logger || logger;
 
     // Utils.
     this.utils = {


### PR DESCRIPTION
I propose that Strapi accepts a custom logger implementation from outside, mainly for the reason that I'd like to define my own transports and controls for pino instead of the hardcoded behaviour from `strapi-utils`

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:
