### PR TITLE
Add onSchemaLoad lifecycle

### DIFF
--- a/examples/getstarted/api/restaurant/models/Restaurant.js
+++ b/examples/getstarted/api/restaurant/models/Restaurant.js
@@ -6,6 +6,9 @@
 
 module.exports = {
   lifecycles: {
+    onSchemaLoad(...args) {
+      // console.log('onLoad', ...args);
+    },
     beforeCreate(...args) {
       // console.log('beforeCreate', ...args);
     },

--- a/examples/getstarted/api/restaurant/models/Restaurant.js
+++ b/examples/getstarted/api/restaurant/models/Restaurant.js
@@ -7,7 +7,7 @@
 module.exports = {
   lifecycles: {
     onSchemaLoad(...args) {
-      // console.log('onLoad', ...args);
+      // console.log('onSchemaLoad', ...args);
     },
     beforeCreate(...args) {
       // console.log('beforeCreate', ...args);

--- a/packages/strapi-connector-bookshelf/lib/mount-models.js
+++ b/packages/strapi-connector-bookshelf/lib/mount-models.js
@@ -590,6 +590,11 @@ module.exports = ({ models, target }, ctx) => {
           'columnName'
         )
       );
+
+      if (_.isFunction(_.get(target, [model.toLowerCase(), 'lifecycles', 'onSchemaLoad']))) {
+        _.get(target, [model.toLowerCase(), 'lifecycles', 'onSchemaLoad'])(loadedModel);
+      }
+
       GLOBALS[definition.globalId] = ORM.Model.extend(loadedModel);
 
       // Expose ORM functions through the `strapi.models[xxx]`

--- a/packages/strapi-connector-mongoose/lib/mount-models.js
+++ b/packages/strapi-connector-mongoose/lib/mount-models.js
@@ -225,6 +225,10 @@ module.exports = ({ models, target }, ctx) => {
       },
     };
 
+    if (_.isFunction(_.get(target, [model.toLowerCase(), 'lifecycles', 'onSchemaLoad']))) {
+      _.get(target, [model.toLowerCase(), 'lifecycles', 'onSchemaLoad'])(schema);
+    }
+
     // Instantiate model.
     const Model = instance.model(definition.globalId, schema, definition.collectionName);
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:
Related to #5972 

This will allow for further customization of the schema using a callback in the `model.js` file.  

I'm unsure how to implement this into `bookshelf`.
Additionally, I'd like to know if this is fine as it is or if there is a better way to do this.

### TODO

 - [x] Add `onSchemaLoad` lifecycle to `model.js` file
 - [x] Call lifecycle from `strapi-connector-mongoose`
 - [x] Call lifecycle from `strapi-connector-bookshelf`
 - [ ] Add testing
 - [ ] Update docs