### PR TITLE
Update docs for hook.json javascript config object

### DIFF
--- a/docs/3.0.0-beta.x/concepts/hooks.md
+++ b/docs/3.0.0-beta.x/concepts/hooks.md
@@ -82,9 +82,11 @@ To activate and configure your hook with custom options, you need to edit your `
 ```javascript
 {
   ...
-  "hook-name": {
-    "enabled": true,
-    ...
+  "settings": {
+    "hook-name": {
+      "enabled": true,
+      ...
+    }
   }
 }
 ```


### PR DESCRIPTION
Specify that to enable a hook, that hook object must exist within a `settings` object
