### PR TITLE
Fix typo in model relations docs

### DIFF
--- a/docs/3.0.0-beta.x/concepts/models.md
+++ b/docs/3.0.0-beta.x/concepts/models.md
@@ -341,7 +341,7 @@ xhr.send(
 
 ::: tab "One-to-Many" id="one-to-many"
 
-One-to-Many relationships are useful when an entry can be liked to multiple entries of another Content Type. And an entry of the other Content Type can be linked to only one entry.
+One-to-Many relationships are useful when an entry can be linked to multiple entries of another Content Type. And an entry of the other Content Type can be linked to only one entry.
 
 #### Example
 
@@ -400,7 +400,7 @@ xhr.send(
 
 ::: tab "Many-to-Many" id="many-to-many"
 
-Many-to-Many relationships are useful when an entry can be liked to multiple entries of another Content Type. And an entry of the other Content Type can be linked to many entries.
+Many-to-Many relationships are useful when an entry can be linked to multiple entries of another Content Type. And an entry of the other Content Type can be linked to many entries.
 
 #### Example
 


### PR DESCRIPTION
Fixed a typo in model relation docs:
`liked` -> `linked`