### PR TITLE
Remove platform check

### DIFF
--- a/packages/strapi-plugin-users-permissions/controllers/Auth.js
+++ b/packages/strapi-plugin-users-permissions/controllers/Auth.js
@@ -249,8 +249,7 @@ module.exports = {
       .get();
 
     const [requestPath] = ctx.request.url.split('?');
-    const provider =
-      process.platform === 'win32' ? requestPath.split('\\')[2] : requestPath.split('/')[2];
+    const provider = requestPath.split('/')[2];
 
     if (!_.get(grantConfig[provider], 'enabled')) {
       return ctx.badRequest(null, 'This provider is disabled.');


### PR DESCRIPTION
Fix #5861 

Hello. At Windows (10) when accessing provider at server route /connect/{provider} you receive following error: 
`{"statusCode":400,"error":"Bad Request","message":"This provider is disabled.","data":"This provider is disabled."}` even when the provider is enabled. 

This PR fixes it at Windows and should be ok at other platforms as well as the condition is not required.