### PR TITLE
Update docker-compose examples

### DIFF
--- a/docs/v3.x/installation/docker.md
+++ b/docs/v3.x/installation/docker.md
@@ -46,6 +46,8 @@ services:
       - ./app:/srv/app
     ports:
       - '1337:1337'
+    depends_on:
+      - postgres
 
   postgres:
     image: postgres
@@ -78,6 +80,8 @@ services:
       - ./app:/srv/app
     ports:
       - '1337:1337'
+    depends_on:
+      - mongo
 
   mongo:
     image: mongo

--- a/docs/v3.x/installation/docker.md
+++ b/docs/v3.x/installation/docker.md
@@ -89,7 +89,7 @@ services:
       MONGO_INITDB_ROOT_USERNAME: strapi
       MONGO_INITDB_ROOT_PASSWORD: strapi
     volumes:
-      - ./data/db:/data/db
+      - ./db:/data/db
     ports:
       - '27017:27017'
 ```

--- a/docs/v3.x/installation/docker.md
+++ b/docs/v3.x/installation/docker.md
@@ -89,7 +89,7 @@ services:
       MONGO_INITDB_ROOT_USERNAME: strapi
       MONGO_INITDB_ROOT_PASSWORD: strapi
     volumes:
-      - ./db:/data/db
+      - ./data:/data/db
 ```
 
 :::

--- a/docs/v3.x/installation/docker.md
+++ b/docs/v3.x/installation/docker.md
@@ -57,8 +57,6 @@ services:
       POSTGRES_PASSWORD: strapi
     volumes:
       - ./data:/var/lib/postgresql/data
-    ports:
-      - '5432:5432'
 ```
 
 :::
@@ -92,8 +90,6 @@ services:
       MONGO_INITDB_ROOT_PASSWORD: strapi
     volumes:
       - ./db:/data/db
-    ports:
-      - '27017:27017'
 ```
 
 :::

--- a/docs/v3.x/installation/docker.md
+++ b/docs/v3.x/installation/docker.md
@@ -21,7 +21,7 @@ services:
   strapi:
     image: strapi/strapi
     volumes:
-      - ./:/srv/app
+      - ./app:/srv/app
     ports:
       - '1337:1337'
 ```

--- a/docs/v3.x/installation/docker.md
+++ b/docs/v3.x/installation/docker.md
@@ -42,8 +42,6 @@ services:
       DATABASE_PORT: 5432
       DATABASE_USERNAME: strapi
       DATABASE_PASSWORD: strapi
-    links:
-      - postgres:postgres
     volumes:
       - ./app:/srv/app
     ports:
@@ -76,8 +74,6 @@ services:
       DATABASE_PORT: 27017
       DATABASE_USERNAME: strapi
       DATABASE_PASSWORD: strapi
-    links:
-      - mongo:mongo
     volumes:
       - ./app:/srv/app
     ports:

--- a/docs/v3.x/installation/docker.md
+++ b/docs/v3.x/installation/docker.md
@@ -52,6 +52,7 @@ services:
   postgres:
     image: postgres
     environment:
+      POSTGRES_DB: strapi
       POSTGRES_USER: strapi
       POSTGRES_PASSWORD: strapi
     volumes:
@@ -86,6 +87,7 @@ services:
   mongo:
     image: mongo
     environment:
+      MONGO_INITDB_DATABASE: strapi
       MONGO_INITDB_ROOT_USERNAME: strapi
       MONGO_INITDB_ROOT_PASSWORD: strapi
     volumes:


### PR DESCRIPTION
This PR only affects the documentation and is ready to be merged.

#### Description of what this PR changed:

1. **Changed volume for strapi in SQLite from `./:/srv/app` to `./app:/srv/app`**

   Both the PostgreSQL and MongoDB strapi service binds to `./app` instead of `./`, so this feels more uniform. It's also better to keep strapi into the `./app` folder and not mixed up with the docker-compose file here.

2. **Removed `links` option for strapi service in PostgreSQL and MongoDB**

   Since docker-compose v3, the `links` option became a legacy feature and may eventually be removed, [as mentioned in the official Docker docs over here](https://docs.docker.com/compose/compose-file/#links). Since docker-compose joins services/containers into the same network, they can already communicate to each other, as quoted from the previous docker docs link:

   > Links are not required to enable services to communicate - by default, any service can reach any other service at that service’s name.

   In addition, the docker compose examples for [postgresql](https://github.com/strapi/strapi-docker/blob/master/examples/postgresql/docker-compose.yml) and [mongodb](https://github.com/strapi/strapi-docker/blob/master/examples/mongo/docker-compose.yml) in the strapi-docker repo also seems to be more up-to-date in terms of docker compose v3 format, so I do believe having more updated format over here will be more consistent overall.

3. **Add `depends_on` option for strapi service in PostgreSQL and MongoDB**

   This option is also used in the postgresql & mongodb docker compose example in strapi-docker. Since Strapi also often mentions the database needs to be up beforehand, this option added does seem more fitting. Just in case the reviewer is not sure what `depends_on` does, basically docker-compose will recognize that "strapi" service depends on the "postgres" or "mongo" service, so it will wait until the database service start first before starting strapi (there are some caveats, but it's explained in the official docs). [More info on this option in the official Docker docs here](https://docs.docker.com/compose/compose-file/#depends_on)

4. **Changed volume for strapi in MongoDB from `./data/db:/data/db` to `./db:/data/db`**

   Since based on other tabs, strapi resides on `./app` of the base directory, postgres on `./data`, I think it's also more uniform to have mongo to reside on `./db` rather than nested in `./data/db`. Once again this `./db` approach is also used in the [mongodb compose example in strapi-docker](https://github.com/strapi/strapi-docker/blob/master/examples/mongo/docker-compose.yml) so it'll be more consistent as well.

---

The following changes are more for clarity in my personal opinion, so if you guys deem them not necessary, I can revert these changes if you guys want me to.

5. **Add `POSTGRES_DB` and `MONGO_INITDB_DATABASE` environment variables**

   These are also used in the strapi-docker examples to show a database is initialized with the name "strapi", as seen [here (postgres)](https://github.com/strapi/strapi-docker/blob/master/examples/postgresql/docker-compose.yml#L30) and [here (mongodb)](https://github.com/strapi/strapi-docker/blob/master/examples/mongo/docker-compose.yml#L26). This is just to match how for postgres, `DATABASE_USERNAME` corresponds to `POSTGRES_USER` and `DATABASE_PASSWORD` to `POSTGRES_PASSWORD`. Even though for the [Postgres docker image](https://hub.docker.com/_/postgres) it will automatically set `POSTGRES_DB` to the value of `POSTGRES_USER` if it's not set, but I feel like setting it here will be clearer rather than hoping the user know the postgres image does this under the hood.

6. **Remove exposed ports for databases**

   Since the strapi service can already reach the database service, be it postgresql or mongodb, via the docker network, there is no need to expose the database port to the host machine. This is of course unless they have a database management application in their machine and wants to use `localhost:5432` or `localhost:27017` to access the database. However for security purpose and in case someone does use this compose file in production, I believe it's best to not expose it until they opt-in to do so. The postgres example in strapi-docker also doesn't expose the port, though the mongodb one does. I do plan to create a pull request at strapi-docker if all these are approved over here.

---

I have tested the updated compose file & there are no issues. If you guys wish to have the docker-compose logs for verification, do let me know so I can provide it, probably via pastebin since it's pretty lengthy.  I do understand reviewing pull requests can be a long process, so I hope I gave sufficient details on what I changed and the reasoning behind the changes. Do let me know as well if you need any clarifications. Cheers