### PR TITLE
Fix singularName resolver for GraphQL findOne action

### DIFF
--- a/packages/strapi-plugin-graphql/services/type-definitions.js
+++ b/packages/strapi-plugin-graphql/services/type-definitions.js
@@ -373,7 +373,7 @@ const buildCollectionType = model => {
   if (isQueryEnabled(_schema, singularName)) {
     const resolverOpts = {
       resolver: `${uid}.findOne`,
-      ..._.get(_schema, `resolver.Query.${pluralName}`, {}),
+      ..._.get(_schema, `resolver.Query.${singularName}`, {}),
     };
     if (actionExists(resolverOpts)) {
       _.merge(localSchema, {


### PR DESCRIPTION
Fixed the GraphQL resolver, so that findOne uses the singular collectionType name instead of the plural name.

Currently the singular query resolver is ignored and the plural resolver is used. Which makes adding policies or custom resolvers to singular GraphQL queries impossible.