### PR TITLE
Fix VK OAuth not working

### DIFF
--- a/packages/strapi-plugin-users-permissions/services/Providers.js
+++ b/packages/strapi-plugin-users-permissions/services/Providers.js
@@ -328,7 +328,7 @@ const getProfile = async (provider, query, callback) => {
 
       vk.query()
         .get('users.get')
-        .qs({ access_token, id: query.raw.user_id, v: '5.013' })
+        .qs({ access_token, id: query.raw.user_id, v: '5.122' })
         .request((err, res, body) => {
           if (err) {
             callback(err);


### PR DESCRIPTION
Bumped VK provider API version. Prior to this VK OAuth used to fail silently without creating a user. As it turned out - VK API responded with `versions prior to 5.21 are not supported`.