### PR TITLE
better error handling in email

### DIFF
--- a/docs/v3.x/deployment/amazon-aws.md
+++ b/docs/v3.x/deployment/amazon-aws.md
@@ -330,7 +330,7 @@ module.exports = ({ env }) => ({
 This plugin will allow configurations for each active environment.
 
 ```bash
-npm install strapi-provider-upload-aws-s3@beta
+npm install strapi-provider-upload-aws-s3
 ```
 
 #### 4. Push your local changes to your project's GitHub repository.

--- a/docs/v3.x/plugins/email.md
+++ b/docs/v3.x/plugins/email.md
@@ -35,7 +35,7 @@ To install a new provider run:
 ::: tab yarn
 
 ```
-yarn add strapi-provider-email-sendgrid@beta --save
+yarn add strapi-provider-email-sendgrid --save
 ```
 
 :::
@@ -43,7 +43,7 @@ yarn add strapi-provider-email-sendgrid@beta --save
 ::: tab npm
 
 ```
-npm install strapi-provider-email-sendgrid@beta --save
+npm install strapi-provider-email-sendgrid --save
 ```
 
 :::

--- a/packages/strapi-plugin-email/controllers/Email.js
+++ b/packages/strapi-plugin-email/controllers/Email.js
@@ -8,7 +8,15 @@
 module.exports = {
   send: async ctx => {
     let options = ctx.request.body;
-    await strapi.plugins.email.services.email.send(options);
+    try {
+      await strapi.plugins.email.services.email.send(options);
+    } catch (e) {
+      if (e.statusCode === 400) {
+        return ctx.badRequest(e.message);
+      } else {
+        throw new Error(`Couldn't send email: ${e.message}.`);
+      }
+    }
 
     // Send 200 `ok`
     ctx.send({});

--- a/packages/strapi-provider-email-amazon-ses/lib/index.js
+++ b/packages/strapi-provider-email-amazon-ses/lib/index.js
@@ -26,7 +26,7 @@ module.exports = {
 
           client.sendEmail(removeUndefined(msg), function(err) {
             if (err) {
-              reject([{ messages: [{ id: 'Auth.form.error.email.invalid' }] }]);
+              reject(err);
             } else {
               resolve();
             }

--- a/packages/strapi-provider-email-mailgun/lib/index.js
+++ b/packages/strapi-provider-email-mailgun/lib/index.js
@@ -29,7 +29,7 @@ module.exports = {
 
           mailgun.messages().send(removeUndefined(msg), function(err) {
             if (err) {
-              reject([{ messages: [{ id: 'Auth.form.error.email.invalid' }] }]);
+              reject(err);
             } else {
               resolve();
             }

--- a/packages/strapi-provider-email-sendgrid/lib/index.js
+++ b/packages/strapi-provider-email-sendgrid/lib/index.js
@@ -26,7 +26,7 @@ module.exports = {
 
           sendgrid.send(removeUndefined(msg), function(err) {
             if (err) {
-              reject([{ messages: [{ id: 'Auth.form.error.email.invalid' }] }]);
+              reject(err);
             } else {
               resolve();
             }

--- a/packages/strapi-provider-email-sendmail/lib/index.js
+++ b/packages/strapi-provider-email-sendmail/lib/index.js
@@ -28,7 +28,7 @@ module.exports = {
 
           sendmail(removeUndefined(msg), err => {
             if (err) {
-              reject([{ messages: [{ id: 'Auth.form.error.email.invalid' }] }]);
+              reject(err);
             } else {
               resolve();
             }


### PR DESCRIPTION
fix #6543

**What I did**
- log correctly the error from the provider on server side and send a 500 to user.
- send 400 error to user in case the error concerns the resquest (bad email for example). Only on `strapi-provider-email-mailgun` for the moment.

**What should be done in the future**
- Each provider should handler its own errors by adding a statusCode to the error it throws. 400 if it concerns a bad request, 500 if it's something else. Won't be done in the PR as it takes time and is not a priority.