### PR TITLE
Update heroku.md

### DIFF
--- a/docs/v3.x/deployment/heroku.md
+++ b/docs/v3.x/deployment/heroku.md
@@ -73,7 +73,7 @@ If you plan to use **MongoDB** with your project, [refer to the create a Strapi 
 Use **yarn** to install the Strapi project (**recommended**). [Install yarn with these docs](https://yarnpkg.com/lang/en/docs/install/)
 
 ```bash
-yarn create strapi-app my-project --quickstart
+yarn create strapi-app my-project
 ```
 
 :::
@@ -83,7 +83,7 @@ yarn create strapi-app my-project --quickstart
 Use **npm/npx** to install the Strapi project
 
 ```bash
-npx create-strapi-app my-project --quickstart
+npx create-strapi-app my-project
 ```
 
 :::


### PR DESCRIPTION
I have struggled with setting up PostgreSQL database on Heroku using this tutorial. It says that if you want to use PostgreSQL you should not use --quickstart option, however, since this is tutorial for NOT sqlite database, running npx with --quickstart then totally disables the developer to later change to postgesql as intended. Therefore, I would not suggest running the --quickstart option in this case.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch) 
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/docs/contribguide/CONTRIBUTING.md
-->

#### Description of what you did:

I have updated documentation by simple removing --quickstart option from creating a project, which should later on use Heroku PostgreSQL database. If you do this you are stack with Strapi configured for SQlite database, which cannot be used with Heroku.
