### PR TITLE
Fix init reset password permission

### DIFF
--- a/packages/strapi-plugin-users-permissions/services/UsersPermissions.js
+++ b/packages/strapi-plugin-users-permissions/services/UsersPermissions.js
@@ -22,7 +22,7 @@ const DEFAULT_PERMISSIONS = [
     type: 'users-permissions',
     roleType: 'public',
   },
-  { action: 'changepassword', controller: 'auth', type: 'users-permissions', roleType: 'public' },
+  { action: 'resetPassword', controller: 'auth', type: 'users-permissions', roleType: 'public' },
   { action: 'init', controller: 'userspermissions', type: null, roleType: null },
   { action: 'me', controller: 'user', type: 'users-permissions', roleType: null },
   { action: 'autoreload', controller: null, type: null, roleType: null },


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch) 
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/docs/contribguide/CONTRIBUTING.md
-->

#### Description of what you did:
When the `changepassword` function has been renamed `resetpassword`.
the init permissions hasn't been updated?
So the function has been no longer available by default for the public role.

close #6440
