### PR TITLE
Fix broken link install plugin popup

### DIFF
--- a/packages/strapi-helper-plugin/lib/src/components/OverlayBlocker/index.js
+++ b/packages/strapi-helper-plugin/lib/src/components/OverlayBlocker/index.js
@@ -73,7 +73,7 @@ class OverlayBlocker extends React.Component {
       <div className="buttonContainer">
         <a
           className={cn('primary', 'btn')}
-          href="https://strapi.io/documentation/configurations/configurations.html#server"
+          href="https://strapi.io/documentation/v3.x/getting-started/introduction.html"
           target="_blank"
           rel="noopener noreferrer"
         >

--- a/packages/strapi-helper-plugin/lib/src/components/OverlayBlocker/index.js
+++ b/packages/strapi-helper-plugin/lib/src/components/OverlayBlocker/index.js
@@ -73,7 +73,7 @@ class OverlayBlocker extends React.Component {
       <div className="buttonContainer">
         <a
           className={cn('primary', 'btn')}
-          href="https://strapi.io/documentation/v3.x/getting-started/introduction.html"
+          href="https://strapi.io/documentation"
           target="_blank"
           rel="noopener noreferrer"
         >


### PR DESCRIPTION
New link for the button **Read the documentation** that pops up as overlay in Strapi. (plugin install blocker)

#### Description of what you did:
Fixed read the doc button link. #6669 
The button was broken with an old link. Replaced it with new link.