### PR TITLE
load dotenv lib at start

### DIFF
--- a/packages/strapi/lib/Strapi.js
+++ b/packages/strapi/lib/Strapi.js
@@ -3,11 +3,7 @@
 // Dependencies.
 const dotenv = require('dotenv');
 
-if(process.env.ENV_PATH) {
-  dotenv.config({ path: process.env.ENV_PATH });
-} else {
-  dotenv.config();
-}
+dotenv.config({ path: process.env.ENV_PATH });
 
 const http = require('http');
 const path = require('path');

--- a/packages/strapi/lib/Strapi.js
+++ b/packages/strapi/lib/Strapi.js
@@ -1,6 +1,14 @@
 'use strict';
 
 // Dependencies.
+const dotenv = require('dotenv');
+
+if(process.env.ENV_PATH) {
+  dotenv.config({ path: process.env.ENV_PATH });
+} else {
+  dotenv.config();
+}
+
 const http = require('http');
 const path = require('path');
 const fse = require('fs-extra');

--- a/packages/strapi/lib/core/app-configuration/index.js
+++ b/packages/strapi/lib/core/app-configuration/index.js
@@ -1,8 +1,5 @@
 'use strict';
 
-const dotenv = require('dotenv');
-
-dotenv.config({ path: process.env.ENV_PATH });
 process.env.NODE_ENV = process.env.NODE_ENV || 'development';
 
 const os = require('os');


### PR DESCRIPTION
allows setting STRAPI_LOG_PRETTY_PRINT, STRAPI_LOG_LEVEL etc in env file

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch) 
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/docs/contribguide/CONTRIBUTING.md
-->

#### Description of what you did:
Load env vars from env file at starpi start, allows setting STRAPI_LOG_LEVEL, STRAPI_LOG_PRETTY_PRINT, STRAPI_LOG_TIMESTAMP etc related to #6693.

but it might not fix it as middleware config is overriding log level to 'debug', using default json file, not sure if I can use this env variable(STRAPI_LOG_LEVEL) in that logger middlerware's defaults json file, but it allows use of other vars like STRAPI_LOG_PRETTY_PRINT, STRAPI_LOG_TIMESTAMP & STRAPI_LOG_FORCE_COLOR