### PR TITLE
Fixing create-quickstart-project.js file to correctly parse --no-run command line argument on Windows

### DIFF
--- a/packages/strapi-generate-new/lib/create-quickstart-project.js
+++ b/packages/strapi-generate-new/lib/create-quickstart-project.js
@@ -21,7 +21,9 @@ module.exports = async function createQuickStartProject(scope) {
 
   await createProject(scope, configuration);
 
-  if (scope.runQuickstartApp !== true) return;
+  if (scope.runQuickstartApp !== true) {
+    process.exit(1);
+  }
 
   try {
     await trackUsage({ event: 'willBuildAdmin', scope });


### PR DESCRIPTION
…command line argument on Windows

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch) 
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/docs/contribguide/CONTRIBUTING.md
-->

#### Description of what you did:

Fixing create-quickstart-project.js file to correctly parse "--no-run" command line argument on Windows. #5759

