### PR TITLE
Added a rule to not ignore files or folders called icon

### DIFF
--- a/packages/strapi-generate-new/lib/resources/dot-files/gitignore
+++ b/packages/strapi-generate-new/lib/resources/dot-files/gitignore
@@ -111,3 +111,4 @@ coverage
 exports
 .cache
 build
+!api/icon


### PR DESCRIPTION
 Added a rule to not ignore files or folders called icon if they appear in the api directory

This only affects case insensitive dev environments like MacOS using AFPS. This issue was discovered when trying to create a content-type called icon