### PR TITLE
Fix links wrong documentation version

### DIFF
--- a/docs/v3.x/migration-guide/migration-guide-alpha.26-to-beta.md
+++ b/docs/v3.x/migration-guide/migration-guide-alpha.26-to-beta.md
@@ -241,7 +241,7 @@ module.exports = () => {};
 
 One of our main objectives for the `beta` is to make it easier and quicker to upgrade to more recent versions of Strapi. This is why moving forward, plugins will be located in the `node_modules` folder.
 
-[Read more](../concepts/file-structure.md)
+[Read more](../../3.0.0-beta.x/concepts/file-structure.md)
 
 Let's start by creating a new folder called `./extensions`. This folder needs to exist even if it's empty. You may use a `.gitkeep` file to ensure the folder isn't deleted from the repository (if it's empty) when cloning. [More details](https://davidwalsh.name/git-empty-directory).
 
@@ -540,7 +540,7 @@ The only difference is that the admin of a local plugin is ignored for the momen
 In the `beta`, we are introducing the `Core API`, which is replacing the templates that were generated before.
 
 Now when you create a new model your `controller` and `service` will be empty modules and will be used to override the default behaviors.
-Read more about [controllers](../concepts/controllers.md) or [services](../concepts/services.md)
+Read more about [controllers](../3.0.0-beta.x/concepts/controllers.md) or [services](../3.0.0-beta.x/concepts/services.md)
 
 To migrate, you will only have to delete the methods you haven't modified or created from your `controllers` and `services`
 

--- a/docs/v3.x/migration-guide/migration-guide-beta.15-to-beta.16.md
+++ b/docs/v3.x/migration-guide/migration-guide-beta.15-to-beta.16.md
@@ -90,7 +90,7 @@ To make sure a Wysiwyg field stays the same when deploying, we introduced the `r
 
 ### Custom controllers and services
 
-If you are using [core services](../concepts/services.md), you previously needed to call `result.toJSON()` or `result.toObject()` to get a plain javascript object. This is not the case anymore, you will now receive a simple object directly.
+If you are using [core services](../../3.0.0-beta.x/concepts/services.md), you previously needed to call `result.toJSON()` or `result.toObject()` to get a plain javascript object. This is not the case anymore, you will now receive a simple object directly.
 
 **Before**:
 
@@ -113,9 +113,9 @@ module.exports = {
 };
 ```
 
-The same modification was made to `strapi.query()`. Read more about **Queries** [here](../concepts/queries.md).
+The same modification was made to `strapi.query()`. Read more about **Queries** [here](../../3.0.0-beta.x/concepts/queries.md).
 
-Keep in mind that if you are running custom ORM queries with Bookshelf or Mongoose you will still have to call `toJSON` or `toObject`. Check out this section about [custom queries](../concepts/queries.md#api-reference).
+Keep in mind that if you are running custom ORM queries with Bookshelf or Mongoose you will still have to call `toJSON` or `toObject`. Check out this section about [custom queries](../../3.0.0-beta.x/concepts/queries.md#api-reference).
 
 ### Bootstrap function
 
@@ -167,7 +167,7 @@ module.exports = () => {};
 
 ### Custom hooks
 
-If you have custom [hooks](../concepts/hooks.md) in your project, the `initialize` function will not receive a callback anymore. You can either use an async function, return a promise or simply run a synchronous function.
+If you have custom [hooks](../../3.0.0-beta.x/concepts/hooks.md) in your project, the `initialize` function will not receive a callback anymore. You can either use an async function, return a promise or simply run a synchronous function.
 
 **Before**
 

--- a/docs/v3.x/migration-guide/migration-guide-beta.19-to-beta.20.md
+++ b/docs/v3.x/migration-guide/migration-guide-beta.19-to-beta.20.md
@@ -38,13 +38,13 @@ To allow customizations, the server will now serve the files in your `./public` 
 
 From now on, if you don't have any `index.html` file in your `./public` folder, the server will render the default Strapi homepage.
 
-You can now also disable this behavior with the `public.defaultIndex` option. Read the documentation [here](../concepts/configurations.md#application).
+You can now also disable this behavior with the `public.defaultIndex` option. Read the documentation [here](../../3.0.0-beta.x/concepts/configurations.md#application).
 
 ## Upload plugin settings
 
 A lot of our users have been requesting that we move some back-end specific configurations to files. While implementing the media library feature, we decided to move the upload plugin settings to files.
 
-This means that you now have to configure your provider directly in the files. You can read the documentation [here](../plugins/upload.md#using-a-provider) to update.
+This means that you now have to configure your provider directly in the files. You can read the documentation [here](../../3.0.0-beta.x/plugins/upload.md#using-a-provider) to update.
 
 ## MongoDB Media relation changes
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch) 
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/docs/contribguide/CONTRIBUTING.md
-->

#### Description of what you did:
In migration guide, some links were relative so pointing to the wrong version of the documentation.
I fix this issue.
close #6776 
