### PR TITLE
Stringify boolean to detect Yarn or npm

### DIFF
--- a/packages/strapi-generate-new/lib/utils/usage.js
+++ b/packages/strapi-generate-new/lib/utils/usage.js
@@ -93,7 +93,7 @@ function trackUsage({ event, scope, error }) {
         node_version: process.version,
         version: scope.strapiVersion,
         docker: scope.docker,
-        useYarn: scope.useYarn,
+        useYarn: scope.useYarn.toString(),
       },
     });
   } catch (err) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -14597,7 +14597,7 @@ react-input-autosize@^2.2.2:
   dependencies:
     prop-types "^15.5.8"
 
-react-intl@^4.5.0:
+react-intl@4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/react-intl/-/react-intl-4.5.0.tgz#f1ea00eb393b1a0e33850819b5ce8947abed187e"
   integrity sha512-CQuFR9vjUYOjzxsm7KaVRdM4hKOyMNY2ejvniZCbz3Ni3jMbjfTgcXYmxqYBn0lenMaFg3G2ol7HKkoy2YSXlQ==


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch) 
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/docs/contribguide/CONTRIBUTING.md
-->

#### Description of what you did:

To improve the product, we need to know if the users prefer using Yarn or npm. To make sure it'll pass all our security protections in our telemetry tools we need to stringify the value instead of using boolean.