### PR TITLE
Support STRAPI_UUID_PREFIX env var

### DIFF
--- a/packages/strapi-generate-new/lib/index.js
+++ b/packages/strapi-generate-new/lib/index.js
@@ -23,10 +23,7 @@ module.exports = (projectDirectory, cliArguments) => {
 
   const rootPath = resolve(projectDirectory);
 
-  const tmpPath = join(
-    os.tmpdir(),
-    `strapi${crypto.randomBytes(6).toString('hex')}`
-  );
+  const tmpPath = join(os.tmpdir(), `strapi${crypto.randomBytes(6).toString('hex')}`);
 
   const useNpm = cliArguments.useNpm !== undefined;
 
@@ -40,7 +37,7 @@ module.exports = (projectDirectory, cliArguments) => {
     debug: cliArguments.debug !== undefined,
     quick: cliArguments.quickstart !== undefined,
     docker: process.env.DOCKER === 'true',
-    uuid: uuid(),
+    uuid: (process.env.STRAPI_UUID_PREFIX || '') + uuid(),
     deviceId: machineIdSync(),
     tmpPath,
     // use yarn if available and --use-npm isn't true


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch) 
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/docs/contribguide/CONTRIBUTING.md
-->

#### Description of what you did:

We need to differentiate One-click deploy buttons from other installations. That's the reason why we would like to introduce a way to prefix the `uuid` generated for each project. We do so by using an environment variable called `STRAPI_UUID_PREFIX`.

Then, each One-click deployment script will have to use the environment variable to prefix the uuid.
