### PR TITLE
Fix GraphQL ShadowCRUD with plugins

### DIFF
--- a/packages/strapi-plugin-graphql/config/settings.json
+++ b/packages/strapi-plugin-graphql/config/settings.json
@@ -5,5 +5,6 @@
   "playgroundAlways": false,
   "depthLimit": 7,
   "amountLimit": 100,
-  "shareEnabled": false
+  "shareEnabled": false,
+  "enablePlugins": true
 }

--- a/packages/strapi-plugin-graphql/hooks/graphql/index.js
+++ b/packages/strapi-plugin-graphql/hooks/graphql/index.js
@@ -67,7 +67,10 @@ module.exports = strapi => {
         return attachMetadataToResolvers(schema, { plugin: key });
       });
 
-      const baseSchema = mergeSchemas([...apisSchemas, ...pluginsSchemas, ...extensionsSchemas]);
+      const enablePlugins = strapi.plugins.graphql.config.enablePlugins !== false;
+      const baseSchema = enablePlugins
+        ? mergeSchemas([...apisSchemas, ...pluginsSchemas, ...extensionsSchemas])
+        : mergeSchemas(apisSchemas);
 
       // save the final schema in the plugin's config
       _.set(strapi, ['plugins', 'graphql', 'config', '_schema', 'graphql'], baseSchema);

--- a/packages/strapi-plugin-graphql/services/schema-generator.js
+++ b/packages/strapi-plugin-graphql/services/schema-generator.js
@@ -48,7 +48,7 @@ const generateSchema = () => {
     pluginCRUD.resolvers
   );
 
-  const extraResolvers = diffResolvers(_schema.resolver, builtResolvers);
+  const extraResolvers = diffResolvers(builtResolvers, _schema.resolver);
 
   const resolvers = _.merge({}, builtResolvers, buildResolvers(extraResolvers));
 

--- a/packages/strapi-plugin-graphql/services/type-builder.js
+++ b/packages/strapi-plugin-graphql/services/type-builder.js
@@ -15,6 +15,7 @@ const GraphQLLong = require('graphql-type-long');
 
 const Time = require('../types/time');
 const { toSingular, toInputName } = require('./naming');
+const { createDefaultSchema } = require('./utils');
 
 const isScalarAttribute = ({ type }) => type && !['component', 'dynamiczone'].includes(type);
 
@@ -195,6 +196,9 @@ module.exports = {
    */
 
   addPolymorphicUnionType(definition) {
+    if (definition.trim().length === 0) {
+      return createDefaultSchema();
+    }
     const types = graphql
       .parse(definition)
       .definitions.filter(def => def.kind === 'ObjectTypeDefinition' && def.name.value !== 'Query')

--- a/packages/strapi-plugin-graphql/services/utils.js
+++ b/packages/strapi-plugin-graphql/services/utils.js
@@ -28,7 +28,7 @@ const createDefaultSchema = () => ({
   resolvers: {},
 });
 
-const diffResolvers = (object, base) => {
+const diffResolvers = (base, object = {}) => {
   let newObj = {};
 
   Object.keys(object).forEach(type => {


### PR DESCRIPTION
Addresses #5312 because disabling shadowCRUD would break schemas inside plugins which required generated definitions. ShadowCRUD is now enabled _only_ for plugins if you disable it for your own models. And there's a separate option to disable the GraphQL schema's in plugins entirely, allowing users to build their own schema from scratch.

Some util functions were adjusted to handle empty/nullish values if users are lacking mutations because they're starting with an empty schema.

Tests are a todo because I'm still relatively new to strapi and no idea how to setup a test that spans multiple plugins. 