### PR TITLE
Update mount-models.js to check if dynamic zone field exists from returned mongo object

### DIFF
--- a/packages/strapi-connector-mongoose/lib/mount-models.js
+++ b/packages/strapi-connector-mongoose/lib/mount-models.js
@@ -212,14 +212,16 @@ module.exports = ({ models, target }, ctx) => {
           }
 
           if (type === 'dynamiczone') {
-            const components = returned[name].map(el => {
-              return {
-                __component: findComponentByGlobalId(el.kind).uid,
-                ...el.ref,
-              };
-            });
+            if(returned[name]){
+              const components = returned[name].map(el => {
+                return {
+                  __component: findComponentByGlobalId(el.kind).uid,
+                  ...el.ref,
+                };
+              });
 
-            returned[name] = components;
+              returned[name] = components;
+            }
           }
         });
       },


### PR DESCRIPTION
This is to ensure custom mongoose queries that exclude dynamic zone fields don't fail.

Fix issue: https://github.com/strapi/strapi/issues/6016

#### Simple check to see if a dynamic field zone exists on returned mongo object.
