### PR TITLE
Fix wrong flag for Swedish

### DIFF
--- a/packages/strapi-admin/admin/src/containers/LocaleToggle/index.js
+++ b/packages/strapi-admin/admin/src/containers/LocaleToggle/index.js
@@ -49,6 +49,8 @@ export class LocaleToggle extends React.Component {
         return 'https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/3.1.0/flags/4x3/cz.svg';
       case 'ms':
         return 'https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/3.1.0/flags/4x3/my.svg';
+      case 'sv':
+        return 'https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/3.1.0/flags/4x3/se.svg';
       default:
         return `https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/3.1.0/flags/4x3/${locale}.svg`;
     }

--- a/packages/strapi-admin/admin/src/containers/LocaleToggle/tests/index.test.js
+++ b/packages/strapi-admin/admin/src/containers/LocaleToggle/tests/index.test.js
@@ -117,6 +117,15 @@ describe('<LocaleToggle />', () => {
       );
     });
 
+    it('should return the se flag', () => {
+      const renderedComponent = shallow(<LocaleToggle {...props} />);
+      const { getFlagUrl } = renderedComponent.instance();
+
+      expect(getFlagUrl('sv')).toEqual(
+        'https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/3.1.0/flags/4x3/se.svg'
+      );
+    });
+
     it('should return the locale flag', () => {
       const renderedComponent = shallow(<LocaleToggle {...props} />);
       const { getFlagUrl } = renderedComponent.instance();


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch) 
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/docs/contribguide/CONTRIBUTING.md
-->

#### Description of what you did:
Fixes #6912 — Add another `case` for Swedish since the language code (`sv`) is different than the country code (`se`). 
