### PR TITLE
Removes misleading documentation

### DIFF
--- a/docs/v3.x/plugins/users-permissions.md
+++ b/docs/v3.x/plugins/users-permissions.md
@@ -748,7 +748,6 @@ You can update these templates under **Plugins** > **Roles & Permissions** > **E
 - `USER` (object)
   - `username`
   - `email`
-  - ...and any other field that you added manually in the model.
 - `TOKEN` corresponds to the token generated to be able to reset the password.
 - `URL` is the link where the user will be redirected after clicking on it in the email.
 
@@ -757,7 +756,6 @@ You can update these templates under **Plugins** > **Roles & Permissions** > **E
 - `USER` (object)
   - `username`
   - `email`
-  - ...and any other field that you added manually in the model.
 - `CODE` corresponds to the CODE generated to be able confirm the user email.
 - `URL` is the Strapi backend URL that confirms the code (by default `/auth/email-confirmation`).
 


### PR DESCRIPTION
#### Description of what you did:

removes misleading documentation around which fields on the USER model can be used in the email templates, as at this commit: https://github.com/strapi/strapi/pull/6629/commits/ccb428e04f9d19aee2fc4d54210684c3ceca6f98#diff-bbc9dda26221803c32574c89c58bdb24R6

only email and username may be referenced in the email template

