### PR TITLE
#6954 Possible mistake about database file name in the docs (version …

### DIFF
--- a/docs/v3.x/guides/databases.md
+++ b/docs/v3.x/guides/databases.md
@@ -311,7 +311,7 @@ Please note the `<password>` after your `username`. In this example, after `mong
 
 #### 5. Update and replace your existing `/database.js` config file for the appropriate environment (development | production).
 
-Replace the contents of `/database.json` with the following and replace **< password >** with the password of the user of your database you created earlier:
+Replace the contents of `/database.js` with the following and replace **< password >** with the password of the user of your database you created earlier:
 
 `Path: ./config/database.js`.
 
@@ -339,9 +339,9 @@ DATABASE_URI=mongodb://paulbocuse:<password>@strapidatabase-shard-00-00-fxxx6c.m
 ```
 
 ::: warning NOTE
-The above configuration will create a database called `strapi`, the _default database_ Strapi sets for any **MongoDB** database. If you would like to name your database something else, add the following **key:value pair** into your **"settings":** located in your `database.json` file.
+The above configuration will create a database called `strapi`, the _default database_ Strapi sets for any **MongoDB** database. If you would like to name your database something else, add the following **key:value pair** into your **settings:** located in your `database.js` file.
 
-`"database": "my-database-name"`
+`database: "my-database-name"`
 
 :::
 

--- a/docs/v3.x/guides/databases.md
+++ b/docs/v3.x/guides/databases.md
@@ -341,7 +341,7 @@ DATABASE_URI=mongodb://paulbocuse:<password>@strapidatabase-shard-00-00-fxxx6c.m
 ::: warning NOTE
 The above configuration will create a database called `strapi`, the _default database_ Strapi sets for any **MongoDB** database. If you would like to name your database something else, add the following **key:value pair** into your **settings:** located in your `database.js` file.
 
-`database: "my-database-name"`
+`database: 'my-database-name'`
 
 :::
 


### PR DESCRIPTION
- fix #6954 

#### Description of what you did:
I have changed the confusing file names to **database.js** from **database.json** and removed unnecessary double quotes since it is a JavaScript file.
