### PR TITLE
FIX - Update regex error value for English translation

### DIFF
--- a/packages/strapi-helper-plugin/lib/src/testUtils/commonTrads.json
+++ b/packages/strapi-helper-plugin/lib/src/testUtils/commonTrads.json
@@ -116,7 +116,7 @@
   "components.Input.error.validation.min": "The value is too low.",
   "components.Input.error.validation.minLength": "The value is too short.",
   "components.Input.error.validation.minSupMax": "Can't be superior",
-  "components.Input.error.validation.regex": "The value not match the regex.",
+  "components.Input.error.validation.regex": "The value does not match the regex.",
   "components.Input.error.validation.required": "This value is required.",
   "components.ListRow.empty": "There is no data to be shown.",
   "components.OverlayBlocker.description": "You're using a feature that needs the server to restart. Please wait until the server is up.",

--- a/packages/strapi-plugin-content-manager/admin/src/translations/en.json
+++ b/packages/strapi-plugin-content-manager/admin/src/translations/en.json
@@ -121,7 +121,7 @@
   "error.validation.min": "The value is too low.",
   "error.validation.minLength": "The value is too short.",
   "error.validation.minSupMax": "Can't be superior",
-  "error.validation.regex": "The value not match the regex.",
+  "error.validation.regex": "The value does not match the regex.",
   "error.validation.required": "This value input is required.",
 
   "form.Input.bulkActions": "Enable bulk actions",

--- a/test/config/front/testUtils/commonTrads.json
+++ b/test/config/front/testUtils/commonTrads.json
@@ -116,7 +116,7 @@
   "components.Input.error.validation.min": "The value is too low.",
   "components.Input.error.validation.minLength": "The value is too short.",
   "components.Input.error.validation.minSupMax": "Can't be superior",
-  "components.Input.error.validation.regex": "The value not match the regex.",
+  "components.Input.error.validation.regex": "The value does not match the regex.",
   "components.Input.error.validation.required": "This value is required.",
   "components.ListRow.empty": "There is no data to be shown.",
   "components.OverlayBlocker.description": "You're using a feature that needs the server to restart. Please wait until the server is up.",


### PR DESCRIPTION
#### Description of what you did:

A simple update of the English translations so the error makes a bit more sense. 
