### PR TITLE
[WIP] Feature enabled/disable plugins on load

### DIFF
--- a/packages/strapi/lib/core/load-plugins.js
+++ b/packages/strapi/lib/core/load-plugins.js
@@ -37,8 +37,7 @@ const loadLocalPlugins = async ({ dir, config }) => {
   const plugins = {};
 
   for (const plugin of readdirSync(pluginsDir)) {
-    if (typeof config.plugins[plugin] !== 'undefined' && config.plugins[plugin].enabled === false)
-      continue;
+    if (_.isUndefined(config.plugins[plugin]) && config.plugins[plugin].enabled === false) continue;
 
     const pluginDir = join(pluginsDir, plugin);
 
@@ -57,8 +56,7 @@ const loadPlugins = async ({ installedPlugins, config }) => {
   let plugins = {};
 
   for (let plugin of installedPlugins) {
-    if (typeof config.plugins[plugin] !== 'undefined' && config.plugins[plugin].enabled === false)
-      continue;
+    if (_.isUndefined(config.plugins[plugin]) && config.plugins[plugin].enabled === false) continue;
 
     const pluginPath = findPackagePath(`strapi-plugin-${plugin}`);
 

--- a/packages/strapi/lib/core/load-plugins.js
+++ b/packages/strapi/lib/core/load-plugins.js
@@ -45,6 +45,9 @@ const loadPlugins = async ({ installedPlugins, config }) => {
   let plugins = {};
 
   for (let plugin of installedPlugins) {
+    if (typeof config.plugins[plugin] !== 'undefined' && config.plugins[plugin].enabled === false)
+      continue;
+
     const pluginPath = findPackagePath(`strapi-plugin-${plugin}`);
 
     const files = await loadFiles(


### PR DESCRIPTION
In the bootstrap of my private strapi plugin there is some interaction with a database and with an external service. When not having the right env variables or a database setup locally, Strapi won't start properly if the local plugin is enabled. In my case the plugin is worthless and only throws a lot of errors (this because it is linked to Lifecycle hooks). So I was looking for an option to disable a plugin without deleting the local folder or removing it from the `package.json`. I couldn't find such an option, so I gave it a try myself. 

I do believe this is essential for having more community plugins, it's better to handle this centralized through the core then individually in a plugin. I would like to hear what you guys think about this, I'm open to suggestions. 

#### Description of what I did:
Added the possibility to disable a (local)plugin in the `plugins.js` config, for example:
```js
module.exports = ({ env }) => ({
  plugin: {
    enabled: false,
  }
});
```

**Help needed**
Still trying to figure out the correct way to disable the front-end loading/building of the plugins admin elements.


#### To Do:

- [x] Disable back-end plugin load
- [ ] Disable front-end plugin load 
- [ ] Add docs