### PR TITLE
typo fix for `below` text link

### DIFF
--- a/docs/v3.x/concepts/models.md
+++ b/docs/v3.x/concepts/models.md
@@ -113,7 +113,7 @@ Additional settings can be set on models:
 - `connection` (string) - Connection name which must be used. Default value: `default`.
 - `collectionName` (string) - Collection name (or table name) in which the data should be stored.
 - `globalId` (string) - Global variable name for this model (case-sensitive) - _only for Content Types_
-- `attributes` (object) - Define the data structure of your model. Find available options [bellow](#define-the-attributes).
+- `attributes` (object) - Define the data structure of your model. Find available options [below](#define-the-attributes).
 
 **Path —** `Restaurant.settings.json`.
 


### PR DESCRIPTION
Read to merge

#### Description of what you did:
fixed typo in `bellow` text link