### PR TITLE
docs: fix 404 link on services.md

### DIFF
--- a/docs/v3.x/concepts/services.md
+++ b/docs/v3.x/concepts/services.md
@@ -39,7 +39,7 @@ module.exports = {
 ```
 
 - `params` (object): this represent filters for your find request.<br>
-  The object follow the URL query format, [refer to this documentation.](../content-api/parameters.html).
+  The object follow the URL query format, [refer to this documentation.](../content-api/parameters.md).
 
 ```json
 {
@@ -75,7 +75,7 @@ module.exports = {
 ```
 
 - `params` (object): this represent filters for your find request.<br>
-  The object follow the URL query format, [refer to this documentation.](../content-api/parameters.html).
+  The object follow the URL query format, [refer to this documentation.](../content-api/parameters.md).
 
 ```json
 {
@@ -110,7 +110,7 @@ module.exports = {
 ```
 
 - `params` (object): this represent filters for your find request.<br>
-  The object follow the URL query format, [refer to this documentation.](../content-api/parameters.html).
+  The object follow the URL query format, [refer to this documentation.](../content-api/parameters.md).
 
 ```json
 {
@@ -229,7 +229,7 @@ module.exports = {
 ```
 
 - `params` (object): this represent filters for your find request.<br>
-  The object follow the URL query format, [refer to this documentation.](../content-api/parameters.html).
+  The object follow the URL query format, [refer to this documentation.](../content-api/parameters.md).
 
 ```json
 {
@@ -261,7 +261,7 @@ module.exports = {
 ```
 
 - `params` (object): this represent filters for your find request.<br>
-  The object follow the URL query format, [refer to this documentation.](../content-api/parameters.html).
+  The object follow the URL query format, [refer to this documentation.](../content-api/parameters.md).
 
 ```json
 {


### PR DESCRIPTION
Signed-off-by: Diego Albitres <diego.albitres@gmail.com>

#### Description of what you did:

Fixed a [404](https://strapi.io/documentation/v3.x/concepts/content-api/parameters.html) on [Extending a Model Service](https://strapi.io/documentation/v3.x/concepts/services.html#core-services). 