### PR TITLE
Update Purest docs link

### DIFF
--- a/docs/v3.x/plugins/users-permissions.md
+++ b/docs/v3.x/plugins/users-permissions.md
@@ -649,7 +649,7 @@ case 'discord': {
 
 This code creates a `Purest` object that gives us a generic way to interact with the provider's REST API.
 
-For more specs on using the `Purest` module, please refer to the [Official Purest Documentation](https://github.com/simov/purest/tree/2.x)
+For more specs on using the `Purest` module, please refer to the [Official Purest Documentation](https://github.com/simov/purest)
 
 You may also want to take a look onto the numerous already made configurations [here](https://github.com/simov/purest-providers/blob/master/config/providers.json).
 


### PR DESCRIPTION
Strapi uses purest 3.1 but docs were linking to an old 2.x branch of purest.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch) 
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/docs/contribguide/CONTRIBUTING.md
-->

#### Description of what you did:
