### PR TITLE
add more reserved words to the list

### DIFF
--- a/packages/strapi-database/lib/constants/index.js
+++ b/packages/strapi-database/lib/constants/index.js
@@ -3,7 +3,37 @@
 // contentTypes and components reserved names
 const RESERVED_MODEL_NAMES = ['admin', 'boolean', 'date', 'date-time', 'time', 'upload'];
 // attribute reserved names
-const RESERVED_ATTRIBUTE_NAMES = ['_id', 'id', 'length', 'attributes', 'relations', 'changed'];
+const RESERVED_ATTRIBUTE_NAMES = [
+  '_id',
+  'id',
+  'length',
+  'attributes',
+  'relations',
+  'changed',
+  'created_by',
+  'updated_by',
+  '_posts', // list found here https://mongoosejs.com/docs/api.html#schema_Schema.reserved
+  '_pres',
+  'collection',
+  'emit',
+  'errors',
+  'get',
+  'init',
+  'isModified',
+  'isNew',
+  'listeners',
+  'modelName',
+  'on',
+  'once',
+  'populated',
+  'prototype',
+  'remove',
+  'removeListener',
+  'save',
+  'schema',
+  'toObject',
+  'validate',
+];
 
 module.exports = {
   RESERVED_MODEL_NAMES,


### PR DESCRIPTION
fix #6614 

#### Description of what you did:
- Add more words to the reserved words list. New words come from mongoose doc: https://mongoosejs.com/docs/api.html#schema_Schema.reserved