### PR TITLE
Fix typos with the `module.exports` examples.

### DIFF
--- a/docs/v3.x/admin-panel/deploy.md
+++ b/docs/v3.x/admin-panel/deploy.md
@@ -22,7 +22,7 @@ module.exports = ({ env }) => ({
   admin: {
     url: '/dashboard', // We change the path to access to the admin (highly recommended for security reasons).
   },
-};
+});
 ```
 
 **You have to rebuild the administration panel to make this work.** [Build instructions](./customization.md#build).
@@ -42,7 +42,7 @@ module.exports = ({ env }) => ({
     url: '/', // Note: The administration will be accessible from the root of the domain (ex: http://yourfrontend.com/)
     serveAdminPanel: false, // http://yourbackend.com will not serve any static admin files
   },
-};
+});
 ```
 
 After running `yarn build` with this configuration, the folder `build` will be created/overwritten. You can then use this folder to serve it from another server with the domain of your choice (ex: `http://youfrontend.com`).


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch) 
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/docs/contribguide/CONTRIBUTING.md
-->

#### Description of what you did:
The `module.exports` example code is missing a closing parenthesis at the end of each example. Added the closing parenthesis.
