### PR TITLE
Await on server listen on start to ensure server is ready before return

### DIFF
--- a/packages/strapi/lib/Strapi.js
+++ b/packages/strapi/lib/Strapi.js
@@ -144,7 +144,7 @@ class Strapi {
       this.app.use(this.router.routes()).use(this.router.allowedMethods());
 
       // Launch server.
-      this.listen(cb);
+      await this.listen(cb);
     } catch (err) {
       this.stopWithError(err);
     }


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch) 
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/docs/contribguide/CONTRIBUTING.md
-->

#### Description of what you did:
I await the listen koa to return the thread only when the server has started.

The callback is a bit ambiguous because is called when the server is destroyed not initialised.

If you prefer the behaviour of not await, please let me know.

Thanks in advance. 