### PR TITLE
Fixing service documentation and fixing DO referral link

### DIFF
--- a/docs/v3.x/concepts/services.md
+++ b/docs/v3.x/concepts/services.md
@@ -143,7 +143,7 @@ module.exports = {
       // automatically uploads the files based on the entry and the model
       await strapi.entityService.uploadFiles(entry, files, {
         model: 'restaurant',
-        // if you are using a plugin's model you will have to add the `plugin` key (plugin: 'users-permissions')
+        // if you are using a plugin's model you will have to add the `source` key (source: 'users-permissions')
       });
       return this.findOne({ id: entry.id });
     }
@@ -174,7 +174,7 @@ module.exports = {
       // automatically uploads the files based on the entry and the model
       await strapi.entityService.uploadFiles(entry, files, {
         model: 'restaurant',
-        // if you are using a plugin's model you will have to add the `plugin` key (plugin: 'users-permissions')
+        // if you are using a plugin's model you will have to add the `source` key (source: 'users-permissions')
       });
       return this.findOne({ id: entry.id });
     }

--- a/docs/v3.x/deployment/digitalocean.md
+++ b/docs/v3.x/deployment/digitalocean.md
@@ -8,7 +8,7 @@ Strapi does have a [One-Click](../installation/digitalocean-one-click.md) deploy
 
 ### DigitalOcean Install Requirements
 
-- You must have a [DigitalOcean account](https://m.do.co/c/30986c1ff595) before doing these steps.
+- If you don't have a DigitalOcean account you will need to create one, you can use [this referral link](https://try.digitalocean.com/strapi/) to get \$100 of free credits!
 
 ### Create a "Droplet"
 

--- a/docs/v3.x/installation/digitalocean-one-click.md
+++ b/docs/v3.x/installation/digitalocean-one-click.md
@@ -10,7 +10,7 @@ You can find the image generation [source code](https://github.com/strapi/one-cl
 
 ### Step 1: Create a DigitalOcean account
 
-If you don't have a DigitalOcean account you will need to create one, you can use [this referral link](https://m.do.co/c/30986c1ff595) to get \$100 of free credits!
+If you don't have a DigitalOcean account you will need to create one, you can use [this referral link](https://try.digitalocean.com/strapi/) to get \$100 of free credits!
 
 ### Step 2: Create a project
 


### PR DESCRIPTION
#### Description of what you did:

Fixed a typo on the create and update services that incorrectly referenced `plugin: users-permissions` instead of `source: users-permissions`

Changed the referral URL for the free $100 credits on both DigitalOcean docments.