### PR TITLE
add search plugin

### DIFF
--- a/packages/strapi-search-plugin/README.md
+++ b/packages/strapi-search-plugin/README.md
@@ -1,0 +1,5 @@
+# Strapi search plugin
+
+## Description
+
+Strapi search plugin provides /search endpoint that can be used to find content type fields which contain search string

--- a/packages/strapi-search-plugin/config/routes.json
+++ b/packages/strapi-search-plugin/config/routes.json
@@ -1,0 +1,13 @@
+{
+  "routes": [
+    {
+      "method": "POST",
+      "path": "/search",
+      "handler": "Search.search",
+      "config": {
+        "policies": []
+      }
+    }
+  ]
+}
+

--- a/packages/strapi-search-plugin/controllers/Search.js
+++ b/packages/strapi-search-plugin/controllers/Search.js
@@ -1,0 +1,24 @@
+const getAsyncSearchableData = async (contentType, searchQuery) => {
+  const result = await strapi.query(contentType).search({ _q: searchQuery });
+  return result.map(item => ({ ...item, __contentType: contentType }));
+};
+
+const fetchAsyncSearchableData = async (contentTypes, searchQuery) => {
+  const requests = contentTypes.map(contentType => {
+    return getAsyncSearchableData(contentType, searchQuery);
+  });
+  return Promise.all(requests);
+};
+
+module.exports = {
+  async search(ctx) {
+    console.log(strapi.contentTypes)
+    const body = JSON.parse(ctx.request.body);
+    const searchQuery = body.searchQuery;
+    const searchableContentTypes = Object.entries(strapi.contentTypes)
+      .filter(([_key, value]) => value.options.searchable)
+      .map(([_key, value]) => value.info.name);
+
+    return fetchAsyncSearchableData(searchableContentTypes, searchQuery);
+  }
+};


### PR DESCRIPTION


#### Description of what you did:
Strapi search plugin provides /search endpoint that can be used to find content type fields which contain search string