### PR TITLE
Update draft.md

### DIFF
--- a/docs/v3.x/guides/draft.md
+++ b/docs/v3.x/guides/draft.md
@@ -86,7 +86,7 @@ Here we want to force it to fetch articles that have status equal to `published`
 The way to do that is to set `ctx.query.status` to `published`.
 It will force the filter of the query.
 
-**Path —** `./api/restaurant/controller/Restaurant.js`
+**Path —** `./api/article/controller/Article.js`
 
 ```js
 const { sanitizeEntity } = require('strapi-utils');


### PR DESCRIPTION
#### Description of what you did:
Hello, strapi Teams,

I have found a mistype on documentation.
![image](https://user-images.githubusercontent.com/10557621/88269468-5d611d00-ccd4-11ea-97c2-23ac46b2811a.png)

Although an other section uses `./api/article/controller/Article.js`, but on 'Apply our changes' section, it was wrote `./api/restaurant/controller/Restaurant.js`. 

So I fixed the wrong path text. :)