### PR TITLE
Fix Input Number issue

### DIFF
--- a/packages/strapi-plugin-content-manager/admin/src/components/Inputs/index.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/Inputs/index.js
@@ -19,6 +19,7 @@ const getInputType = (type = '') => {
     case 'boolean':
       return 'bool';
     case 'biginteger':
+      return 'text';
     case 'decimal':
     case 'float':
     case 'integer':

--- a/packages/strapi-plugin-content-manager/admin/src/components/Inputs/index.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/Inputs/index.js
@@ -19,7 +19,6 @@ const getInputType = (type = '') => {
     case 'boolean':
       return 'bool';
     case 'biginteger':
-      return 'text';
     case 'decimal':
     case 'float':
     case 'integer':
@@ -123,11 +122,11 @@ function Inputs({
     let step;
 
     if (type === 'float' || type === 'decimal') {
-      step = 'any';
+      step = 0.1;
     } else if (type === 'time' || type === 'datetime') {
       step = 30;
     } else {
-      step = '1';
+      step = 1;
     }
 
     return step;


### PR DESCRIPTION
Signed-off-by: Eric Liu <eric@ericliu.page>

#### Description of what you did:

fix https://github.com/strapi/buffet/issues/136

1. ~~Changing from 'text' to 'number' input for 'biginteger'. So it will show the inc/dec arrows for bigingeter input.~~
2. Set 'step' to 0.1 instead of 'any' so the inc/dec arrows on Decimal and Float type can work properly.
3. Changing 'step' value to the specific number type
