### PR TITLE
Update README.md

### DIFF
--- a/packages/strapi-provider-email-mailgun/README.md
+++ b/packages/strapi-provider-email-mailgun/README.md
@@ -45,6 +45,7 @@ module.exports = ({ env }) => ({
     provider: 'mailgun',
     providerOptions: {
       apiKey: env('MAILGUN_API_KEY'),
+      domain: env('MAILGUN_DOMAIN'), //Required if you have an account with multiple domains
     },
     settings: {
       defaultFrom: 'myemail@protonmail.com',


### PR DESCRIPTION
Added extra settings on the mailgun config based on the mailgun usage overview.
You can check the doc, and it specify the domain parameter.
https://www.npmjs.com/package/mailgun-js#usage-overview

You need to specify the domain, otherwise the email won't be sent, but the API return success anyway. 
In my scenario I have a mailgun account with multiple domains and without this param the email was not sent. Don't know if a mailgun with a single domain works.

cc @alexandrebodin 
