### PR TITLE
Fix/#7197/Change custom populate state to own service

### DIFF
--- a/packages/strapi-plugin-users-permissions/config/policies/permissions.js
+++ b/packages/strapi-plugin-users-permissions/config/policies/permissions.js
@@ -16,7 +16,9 @@ module.exports = async (ctx, next) => {
         throw new Error('Invalid token: Token did not contain required fields');
       }
 
-      ctx.state.user = await strapi.plugins['users-permissions'].services.user.fetchState({ id });
+      ctx.state.user = await strapi.plugins[
+        'users-permissions'
+      ].services.user.fetchAuthenticatedUser(id);
     } catch (err) {
       return handleErrors(ctx, err, 'unauthorized');
     }

--- a/packages/strapi-plugin-users-permissions/config/policies/permissions.js
+++ b/packages/strapi-plugin-users-permissions/config/policies/permissions.js
@@ -16,8 +16,7 @@ module.exports = async (ctx, next) => {
         throw new Error('Invalid token: Token did not contain required fields');
       }
 
-      ctx.state.user = await strapi.plugins['users-permissions'].services.user.fetch({ id });
-
+      ctx.state.user = await strapi.plugins['users-permissions'].services.user.fetchState({ id });
     } catch (err) {
       return handleErrors(ctx, err, 'unauthorized');
     }

--- a/packages/strapi-plugin-users-permissions/config/policies/permissions.js
+++ b/packages/strapi-plugin-users-permissions/config/policies/permissions.js
@@ -16,6 +16,7 @@ module.exports = async (ctx, next) => {
         throw new Error('Invalid token: Token did not contain required fields');
       }
 
+      // fetch authenticated user
       ctx.state.user = await strapi.plugins[
         'users-permissions'
       ].services.user.fetchAuthenticatedUser(id);

--- a/packages/strapi-plugin-users-permissions/services/User.js
+++ b/packages/strapi-plugin-users-permissions/services/User.js
@@ -66,7 +66,7 @@ module.exports = {
   },
 
   /**
-   * Promise to fetch state user in header.
+   * Promise to fetch authenticated user.
    * @return {Promise}
    */
   fetchAuthenticatedUser(id) {

--- a/packages/strapi-plugin-users-permissions/services/User.js
+++ b/packages/strapi-plugin-users-permissions/services/User.js
@@ -69,8 +69,8 @@ module.exports = {
    * Promise to fetch state user in header.
    * @return {Promise}
    */
-  fetchState(params, populate = ['role']) {
-    return strapi.query('user', 'users-permissions').findOne(params, populate);
+  fetchAuthenticatedUser(id) {
+    return strapi.query('user', 'users-permissions').findOne({ id }, ['roles']);
   },
 
   /**

--- a/packages/strapi-plugin-users-permissions/services/User.js
+++ b/packages/strapi-plugin-users-permissions/services/User.js
@@ -61,7 +61,15 @@ module.exports = {
    * Promise to fetch a/an user.
    * @return {Promise}
    */
-  fetch(params, populate = ['role']) {
+  fetch(params, populate) {
+    return strapi.query('user', 'users-permissions').findOne(params, populate);
+  },
+
+  /**
+   * Promise to fetch state user in header.
+   * @return {Promise}
+   */
+  fetchState(params, populate = ['role']) {
     return strapi.query('user', 'users-permissions').findOne(params, populate);
   },
 


### PR DESCRIPTION
The service "fetch" is used to fetch user data from endpoints "/users/{id}" so only is showing the populated field "role" to avoid this issue, I change to an own service call "fetchState" in this way can still personalize the state user in the header and solve the current issue and allow full customization only for state.user

This commit lets the user change this rule by overwriting the file `/extensions/users-permissions/services/User.js` using the function `fetchState`

Fixes #7197
Relate PRs #6770 #4540

**My PR is a:**

- [ ]  💥 Breaking change
- [x]  🐛 Bug fix
- [ ]  💅 Enhancement
- [ ]  🚀 New feature

**Main update on the:**
- [ ]  Admin
- [ ]  Documentation
- [ ]  Framework
- [x]  Plugin

**Manual testing is done on the following databases:**

- [ ]  Not applicable
- [x]  MongoDB
- [ ]  MySQL
- [x]  Postgres
- [x]  SQLite
