### PR TITLE
Virtual model fields

### DIFF
--- a/examples/getstarted/api/address/models/Address.js
+++ b/examples/getstarted/api/address/models/Address.js
@@ -5,12 +5,14 @@
  */
 
 module.exports = {
-  afterFind(result) {
-    // update array of results
-    result = result.map(strapi.services.address.setTitle);
-  },
-  afterFindOne(result) {
-    // update one item
-    strapi.services.address.setTitle(result);
+  lifecycles: {
+    afterFind(result) {
+      // update array of results
+      result = result.map(strapi.services.address.setTitle);
+    },
+    afterFindOne(result) {
+      // update one item
+      strapi.services.address.setTitle(result);
+    },
   },
 };

--- a/examples/getstarted/api/address/models/Address.js
+++ b/examples/getstarted/api/address/models/Address.js
@@ -4,4 +4,13 @@
  * Lifecycle callbacks for the `Address` model.
  */
 
-module.exports = {};
+module.exports = {
+  afterFind(result) {
+    // update array of results
+    result = result.map(strapi.services.address.setTitle);
+  },
+  afterFindOne(result) {
+    // update one item
+    strapi.services.address.setTitle(result);
+  },
+};

--- a/examples/getstarted/api/address/models/Address.settings.json
+++ b/examples/getstarted/api/address/models/Address.settings.json
@@ -21,6 +21,10 @@
     "postal_coder": {
       "type": "string"
     },
+    "title": {
+      "type": "string",
+      "virtual": true
+    },
     "categories": {
       "collection": "category",
       "via": "addresses",

--- a/examples/getstarted/api/address/services/Address.js
+++ b/examples/getstarted/api/address/services/Address.js
@@ -5,4 +5,12 @@
  * to customize this service
  */
 
-module.exports = {};
+module.exports = {
+  setTitle(data) {
+    const { city, postal_coder } = data;
+    data.title = [city, postal_coder].filter(Boolean).join(' ');
+    console.log(data);
+    // we need to return data, because we will update array of entities with map
+    return data;
+  },
+};

--- a/packages/strapi-connector-bookshelf/lib/buildDatabaseSchema.js
+++ b/packages/strapi-connector-bookshelf/lib/buildDatabaseSchema.js
@@ -108,7 +108,13 @@ module.exports = async ({ ORM, loadedModel, definition, connection, model }) => 
   }
 
   // Equilize database tables
-  const createOrUpdateTable = async (table, attributes) => {
+  const createOrUpdateTable = async (table, rawAttributes) => {
+    const attributes = _.cloneDeep(rawAttributes);
+
+    for (const key in attributes) {
+      if (attributes[key].virtual) delete attributes[key];
+    }
+
     const tableExists = await ORM.knex.schema.hasTable(table);
 
     const buildColumns = (tbl, columns, opts = {}) => {

--- a/packages/strapi-database/lib/utils/lifecycles.js
+++ b/packages/strapi-database/lib/utils/lifecycles.js
@@ -3,8 +3,8 @@
 const _ = require('lodash');
 
 const executeLifecycle = async (lifecycle, model, ...args) => {
-  if (lifecycle in model) {
-    await model[lifecycle](...args);
+  if (_.has(model, `lifecycles.${lifecycle}`)) {
+    await model.lifecycles[lifecycle](...args);
   }
 };
 

--- a/packages/strapi-database/lib/utils/lifecycles.js
+++ b/packages/strapi-database/lib/utils/lifecycles.js
@@ -3,8 +3,8 @@
 const _ = require('lodash');
 
 const executeLifecycle = async (lifecycle, model, ...args) => {
-  if (_.has(model, `lifecycles.${lifecycle}`)) {
-    await model.lifecycles[lifecycle](...args);
+  if (lifecycle in model) {
+    await model[lifecycle](...args);
   }
 };
 

--- a/packages/strapi-plugin-content-type-builder/controllers/validation/types.js
+++ b/packages/strapi-plugin-content-type-builder/controllers/validation/types.js
@@ -34,6 +34,7 @@ const getTypeValidator = (attribute, { types, modelType, attributes }) => {
       .string()
       .oneOf(types)
       .required(),
+    virtual: yup.boolean(),
     configurable: yup.boolean().nullable(),
     private: yup.boolean().nullable(),
     ...getTypeShape(attribute, { modelType, attributes }),


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch) 
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/docs/contribguide/CONTRIBUTING.md
-->

#### Description of what you did:

Basically I've wanted to implement exactly what @wysher was trying to document in #6433. However from what I could tell there was no way to have an attribute field that doesn't generate a column in the database. So to achieve that I implemented a "virtual" field attribute. When it's set to true the database will not try to create a column for it.

Master branch also for some reason didn't have the lifecycles working correctly so I had to quickly fix that to make this work. I've added an example in the address model of the getstarted example.

I'm not sure if this is the ideal implementation, but it's the only way I could think of. Also this currently only works with bookshelf. I don't have any experience with mongoose so it's better if someone else does it if they deem this a good addition.

Overall I think this is very useful. Doesn't add too much to API functionality, however it was really needed for me for the admin panel. Since before this it's only possible to display the actual fields in the database, which is often not what you want.