### PR TITLE
Fixing typo in translations/en.json.

### DIFF
--- a/packages/strapi-admin/admin/src/translations/en.json
+++ b/packages/strapi-admin/admin/src/translations/en.json
@@ -215,7 +215,7 @@
   "app.components.UpgradePlanModal.button": "LEARN MORE",
   "app.components.UpgradePlanModal.limit-reached": "You have reached the limit",
   "app.components.UpgradePlanModal.text-ce": "Community Edition",
-  "app.components.UpgradePlanModal.text-ee": "Entreprise Edition",
+  "app.components.UpgradePlanModal.text-ee": "Enterprise Edition",
   "app.components.UpgradePlanModal.text-power": "Unlock the full power",
   "app.components.UpgradePlanModal.text-strapi": "of Strapi by upgrading your plan to the",
   "app.components.Users.MagicLink.connect": "Send this link to the user for him to connect.",


### PR DESCRIPTION
"Enterprise" was incorrectly spelt as "Entreprise"

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch) 
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/docs/contribguide/CONTRIBUTING.md
-->

#### Description of what you did: 
I changed the spelling of "Enterprise" in packages/strapi-admin/admin/src/translations/en.json so that it is no longer spelt incorrectly. 
