### PR TITLE
Reset password will send informing email in case user.provider != local

### DIFF
--- a/packages/strapi-plugin-users-permissions/admin/src/translations/en.json
+++ b/packages/strapi-plugin-users-permissions/admin/src/translations/en.json
@@ -36,6 +36,7 @@
   "Email.template.email_confirmation": "Email address confirmation",
   "Email.template.reset_password": "Reset password",
   "Email.template.success_register": "Registration successful",
+  "Email.template.account_using_external_provider": "Account using external provider",
   "HeaderNav.link.advancedSettings": "Advanced settings",
   "HeaderNav.link.emailTemplates": "Email templates",
   "HeaderNav.link.providers": "Providers",

--- a/packages/strapi-plugin-users-permissions/config/functions/bootstrap.js
+++ b/packages/strapi-plugin-users-permissions/config/functions/bootstrap.js
@@ -148,6 +148,23 @@ module.exports = async () => {
 <p>Thanks.</p>`,
         },
       },
+      account_using_external_provider: {
+        display: "Email.template.account_using_external_provider",
+        icon: "sync",
+        options: {
+          from: {
+            name: "Administration Panel",
+            email: "no-reply@slub.ro"
+          },
+          response_email: "",
+          object: "Reset password",
+          message: `<p>We heard that you lost your password. Sorry about that!</p>
+        
+<p>You register using <%= PROVIDER %>. Could you try to sign in again using  <%= PROVIDER %>
+
+<p>Thanks.</p>`
+        }
+      },
     };
 
     await pluginStore.set({ key: 'email', value });


### PR DESCRIPTION

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch) 
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/docs/contribguide/CONTRIBUTING.md
-->

#### Description of what you did:

Hi,

**This is a proposal of a possible feature**

The idea would be not to send a reset token email when the user provider is different than local.
In this case, we would send an email to inform the user that he should sign in using the provider he previous used.


