### PR TITLE
Add tests regarding missing translations

### DIFF
--- a/packages/strapi-admin/admin/src/translations/__tests__/translations.test.js
+++ b/packages/strapi-admin/admin/src/translations/__tests__/translations.test.js
@@ -1,0 +1,29 @@
+const fs = require('fs');
+const en = require('../en.json');
+
+const trads = fs
+  .readdirSync(`${__dirname}/../`)
+  .filter(filename => filename.match(/.*\.json$/))
+  .map(langFilename => langFilename.replace('.json', ''))
+  .filter(langName => langName !== 'en')
+  .reduce(
+    (trads, langName) => ({
+      ...trads,
+      [langName]: require(`../${langName}.json`), // eslint-disable-line import/no-dynamic-require, global-require
+    }),
+    {}
+  );
+
+xdescribe('translations', () => {
+  describe('all languages have same keys', () => {
+    const enKeys = Object.values(en).sort();
+
+    Object.entries(trads).forEach(([langName, lang]) => {
+      test(`"en" and "${langName}" have the same keys`, () => {
+        const langKeys = Object.keys(lang).sort();
+
+        expect(langKeys).toEqual(enKeys);
+      });
+    });
+  });
+});


### PR DESCRIPTION
References the following discussion: https://github.com/strapi/strapi/discussions/7284#discussioncomment-45838

## Description
I added tests regarding missing translations:
- assumes that english is the primary language
- fails when a language has missing keys
- fails when a language has extraneous keys

## Disclaimer
- the current state of translations breaks these new tests so I deactivated it (`xdescribe` instead of `describe`)

I understand the PR is not mergeable as is. I am open to suggestions :smile: 