### PR TITLE
Fix sanitizeEntity's includeFields usage

### DIFF
--- a/packages/strapi-utils/lib/sanitize-entity.js
+++ b/packages/strapi-utils/lib/sanitize-entity.js
@@ -59,8 +59,10 @@ const sanitizeEntity = (dataSource, options) => {
       return { ...acc, [key]: nextVal };
     }
 
+    const isAllowedField = !includeFields || allowedFieldsHasKey;
+
     // Dynamic zones
-    if (attribute && attribute.type === 'dynamiczone' && value !== null && allowedFieldsHasKey) {
+    if (attribute && attribute.type === 'dynamiczone' && value !== null && isAllowedField) {
       const nextVal = value.map(elem =>
         sanitizeEntity(elem, {
           model: strapi.getModel(elem.__component),
@@ -70,8 +72,8 @@ const sanitizeEntity = (dataSource, options) => {
       );
       return { ...acc, [key]: nextVal };
     }
+
     // Other fields
-    const isAllowedField = !includeFields || allowedFieldsHasKey;
     if (isAllowedField) {
       return { ...acc, [key]: value };
     }


### PR DESCRIPTION
Fix #7335 

In sanitizeEntity, setting `includeFields` to `null` should indicates "all fields".
It was not the case before thus creating issues with `allowedFieldsHasKey` checks for dynamic zones.