### PR TITLE
fix(graphql): filter out orphaned relationships

### DIFF
--- a/packages/strapi-plugin-graphql/services/build-aggregation.js
+++ b/packages/strapi-plugin-graphql/services/build-aggregation.js
@@ -212,7 +212,7 @@ const createAggregationFieldsResolver = function(model, fields, operation, typeC
  * Correctly format the data returned by the group by
  */
 const preProcessGroupByData = function({ result, fieldKey, filters }) {
-  const _result = _.toArray(result);
+  const _result = _.toArray(result).filter(value => Boolean(value._id));
   return _.map(_result, value => {
     return {
       key: value._id.toString(),


### PR DESCRIPTION

#### Description of what you did:

We have entities that reference another entity that could be deleted. For performance reasons, any entity that is orphaned is cleaned at a later time, but this is breaking our graphql aggregation queries. This PR adds a simple existence filter on the `_id` field that exists when null as well. Maybe it might also be beneficial to allow grouping by null to check orphaned relationships?

Output from a log above converting the result to an array:

![image](https://user-images.githubusercontent.com/4655972/89609890-21d36080-d847-11ea-823c-e8a346b9c37e.png)


![image](https://user-images.githubusercontent.com/4655972/89609834-f781a300-d846-11ea-95c8-43204654fe9b.png)

Output from the graphql query:
```json
{
  "errors": [
    {
      "message": "Cannot read property 'toString' of null",
      "locations": [
        {
          "line": 4,
          "column": 7
        }
      ],
      "path": [
        "entriesConnection",
        "groupBy",
        "release"
      ],
      "extensions": {
        "code": "INTERNAL_SERVER_ERROR",
        "exception": {
          "stacktrace": [
            "TypeError: Cannot read property 'toString' of null",
            "    at /Users/me/git/proj/redacted/node_modules/strapi-plugin-graphql/services/build-aggregation.js:220:22",
            "    at arrayMap (/Users/me/git/proj/redacted/node_modules/strapi-plugin-graphql/node_modules/lodash/lodash.js:639:23)",
            "    at Function.map (/Users/me/git/proj/redacted/node_modules/strapi-plugin-graphql/node_modules/lodash/lodash.js:9554:14)",
            "    at preProcessGroupByData (/Users/me/git/proj/redacted/node_modules/strapi-plugin-graphql/services/build-aggregation.js:217:12)",
            "    at resolver (/Users/me/git/proj/redacted/node_modules/strapi-plugin-graphql/services/build-aggregation.js:274:14)",
            "    at processTicksAndRejections (internal/process/task_queues.js:93:5)"
          ]
        }
      }
    }
  ],
  "data": {
    "entriesConnection": {
      "groupBy": {
        "release": null
      }
    }
  }
}
```

