### PR TITLE
Fix strapi-provider-upload-local readme

### DIFF
--- a/packages/strapi-provider-upload-local/README.md
+++ b/packages/strapi-provider-upload-local/README.md
@@ -2,7 +2,7 @@
 
 ## Configurations
 
-Your configuration is passed down to the cloudinary configuration. (e.g: `cloudinary.config(config)`). You can see the complete list of options [here](https://cloudinary.com/documentation/cloudinary_sdks#configuration_parameters)
+This provider has only one parameter: `sizeLimit`.
 
 **Example**
 
@@ -10,14 +10,14 @@ Your configuration is passed down to the cloudinary configuration. (e.g: `cloudi
 
 ```json
 {
-  "provider": "cloudinary",
+  "provider": "local",
   "providerOptions": {
     "sizeLimit": 100000
   }
 }
 ```
 
-The `sizeLimit` parameter must be a number. Be aware that the unit is in KB. When setting this value high, you should make sure to also configure the body parser middleware `maxFileSize` so the file can be sent and processed. Read more [here](https://strapi.io/documentation/v3.x/plugins/upload.html#configuration)
+The `sizeLimit` parameter must be a number. Be aware that the unit is in bytes, and the default is 1000000. When setting this value high, you should make sure to also configure the body parser middleware `maxFileSize` so the file can be sent and processed. Read more [here](https://strapi.io/documentation/v3.x/plugins/upload.html#configuration)
 
 ## Resources
 
@@ -28,7 +28,3 @@ The `sizeLimit` parameter must be a number. Be aware that the unit is in KB. Whe
 - [Strapi website](http://strapi.io/)
 - [Strapi community on Slack](http://slack.strapi.io)
 - [Strapi news on Twitter](https://twitter.com/strapijs)
-
-```
-
-```


### PR DESCRIPTION
#### Description of what you did:

Fixed the Readme docs of the strapi-provider-upload-local package.

They talked about Cloudinary, probably because of a copy and paste mistake.

I also wrote that the `sizeLimit` config value should be specified in bytes and not KB, since it seems to rely on [File.size](https://developer.mozilla.org/en-US/docs/Web/API/File/size)
