### PR TITLE
Show error.message || error on failed command

### DIFF
--- a/packages/strapi/bin/strapi.js
+++ b/packages/strapi/bin/strapi.js
@@ -56,7 +56,7 @@ const getLocalScript = name => (...args) => {
       return script(...args);
     })
     .catch(error => {
-      console.error(`Error while running command ${name}: ${error.message}`);
+      console.error(`Error while running command ${name}: ${error.message || error}`);
       process.exit(1);
     });
 };


### PR DESCRIPTION
Some exceptions, like module inclusion errors, don't generate nice
Error objects with message defined. This causes hard-to-debug failures.
When encountering an error with no message, show the whole Error object.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch) 
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/docs/contribguide/CONTRIBUTING.md
-->

#### Description of what you did:
In the `strapi` executable if a subcommand throws an error the driver prints `error.message`. But some errors don't have a `message` and this leads to a bad error message in the console. I print `error.message || error` instead.