### PR TITLE
Fix favicon link in docs

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -17,7 +17,7 @@ module.exports = {
       'link',
       {
         rel: 'icon',
-        href: 'https://strapi.io/favicon.ico',
+        href: 'https://strapi.io/assets/favicon-32x32.png',
       },
     ],
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch) 
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/docs/contribguide/CONTRIBUTING.md
-->

#### Description of what you did:

Just fixed the favicon link on documentation. Right now it isn't loading because it can't find the icon on [`https://strapi.io/favicon.ico`](https://strapi.io/favicon.ico).

![image](https://user-images.githubusercontent.com/7624090/89749135-2f2d5c80-da8c-11ea-9e17-47270b38b7d2.png)