### PR TITLE
Docs update on migration guide for username constraint

### DIFF
--- a/docs/v3.x/migration-guide/migration-guide-3.0.x-to-3.1.x.md
+++ b/docs/v3.x/migration-guide/migration-guide-3.0.x-to-3.1.x.md
@@ -98,7 +98,13 @@ You're done!
 All currently logged in administrators will be disconnected from the app and will need to log in again.
 :::
 
-## 3. Migrate your custom admin panel plugins
+## 3. Update `username` constraint for administrators
+
+The `username` field is no longer required for administrator users.
+
+You will have to remove the `NOT NULL` constraint for this column in your database.
+
+## 4. Migrate your custom admin panel plugins
 
 If you don't have custom plugins, you can jump to the next section.
 
@@ -133,7 +139,7 @@ export default strapi => {
 };
 ```
 
-## 4. Rebuild the admin panel
+## 5. Rebuild the admin panel
 
 Rebuild the admin panel with one of the following commands:
 


### PR DESCRIPTION
#### Description of what you did:

The `username` field is no longer required.

So in the database, the `username` field has `NOT NULL` constraint.

In the 3.1.x the field is not in the form to create a new admin. 
So there is an issue when you create a new admin because of this constraint.

We should remove the `NOT NULL` constraint to be able to create a new admin.