### PR TITLE
Find file to edit in all available files

### DIFF
--- a/packages/strapi-plugin-upload/admin/src/containers/InputModalStepperProvider/reducer.js
+++ b/packages/strapi-plugin-upload/admin/src/containers/InputModalStepperProvider/reducer.js
@@ -211,7 +211,7 @@ const reducer = (state, action) =>
       }
       case 'SET_FILE_TO_EDIT': {
         draftState.fileToEdit = formatFileForEditing(
-          state.files.find(file => file.id.toString() === action.fileId.toString())
+          [...state.files, ...state.selectedFiles].find(file => file.id.toString() === action.fileId.toString())
         );
         break;
       }

--- a/packages/strapi-plugin-upload/admin/src/containers/InputModalStepperProvider/tests/reducer.test.js
+++ b/packages/strapi-plugin-upload/admin/src/containers/InputModalStepperProvider/tests/reducer.test.js
@@ -2046,6 +2046,7 @@ describe('UPLOAD | containers | ModalStepper | reducer', () => {
       const state = {
         currentStep: 'test',
         fileToEdit: null,
+        selectedFiles: [],
         files: [
           {
             id: 13252341,
@@ -2060,7 +2061,63 @@ describe('UPLOAD | containers | ModalStepper | reducer', () => {
       };
       const expected = {
         currentStep: 'test',
+        selectedFiles: [],
         files: [
+          {
+            id: 13252341,
+            alternativeText: 'My first picture',
+            caption: null,
+            name: 'picture1',
+            updated_at: '2020-03-30T10:48:26+02:00',
+            created_at: '2020-03-30T10:48:26+02:00',
+          },
+          { id: 5564723, alternativeText: 'My second picture', caption: '', name: '' },
+        ],
+        fileToEdit: {
+          id: 13252341,
+          abortController: new AbortController(),
+          file: {
+            name: 'picture1',
+            created_at: '2020-03-30T10:48:26+02:00',
+          },
+          fileInfo: {
+            alternativeText: 'My first picture',
+            caption: null,
+            name: 'picture1',
+          },
+          hasError: false,
+          errorMessage: null,
+          isUploading: false,
+        },
+      };
+
+      expect(reducer(state, action)).toEqual(expected);
+    });
+    it('should add a selected file to edit', () => {
+      const action = {
+        type: 'SET_FILE_TO_EDIT',
+        fileId: 13252341,
+      };
+      const state = {
+        currentStep: 'test',
+        fileToEdit: null,
+        files: [],
+        selectedFiles: [
+          {
+            id: 13252341,
+            alternativeText: 'My first picture',
+            caption: null,
+            name: 'picture1',
+            updated_at: '2020-03-30T10:48:26+02:00',
+            created_at: '2020-03-30T10:48:26+02:00',
+          },
+          { id: 5564723, alternativeText: 'My second picture', caption: '', name: '' },
+        ],
+      };
+      const expected = {
+        currentStep: 'test',
+        files: [],
+        selectedFiles: [
           {
             id: 13252341,
             alternativeText: 'My first picture',


### PR DESCRIPTION
If a file is selected, but not loaded in the 'files' array of the state, it can't be found and you will get an error after clicking on the edit icon.

This PR will make sure it will look in both the 'files' and the 'selectedFiles' arrays for the given file id.

This resolves https://github.com/strapi/strapi/issues/7458