### PR TITLE
docs: Update "environments" to "env"

### DIFF
--- a/docs/3.0.0-beta.x/concepts/file-structure.md
+++ b/docs/3.0.0-beta.x/concepts/file-structure.md
@@ -12,7 +12,7 @@ By default, your project's structure will look like this:
     - [`/services`](./services.md): contains the API's custom services.
 - `/build`: contains your admin panel UI build.
 - [`/config`](./configurations.md)
-  - [`/environments`](./configurations.md#environments): contains the project's configurations per environment.
+  - [`/env`](./configurations.md#environments): contains the project's configurations per environment.
     - `/**`
       - `/development`
         - [`custom.json`](./configurations.md#custom): contains the custom configurations for this environment.


### PR DESCRIPTION
I was trying to have multiple environments for my app by following this  [guide](https://strapi.io/documentation/3.0.0-beta.x/concepts/file-structure.html) It wasn't working until I found this guide https://strapi.io/documentation/v3.x/concepts/configurations.html#environments where it uses "env" instead of "environments".

What's the final name? I could update the other docs to use the correct term. I want to help

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch) 
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/docs/contribguide/CONTRIBUTING.md
-->

#### Description of what you did:
