### PR TITLE
Extend email plugin to allow custom actions

### DIFF
--- a/docs/v3.x/plugins/email.md
+++ b/docs/v3.x/plugins/email.md
@@ -58,6 +58,26 @@ await strapi.plugins.email.services.email.sendTemplatedEmail(
 );
 ```
 
+### Custom actions via the `.action()` method
+
+The email plugin supports multiple providers, such as [Sendgrid](https://github.com/strapi/strapi/tree/master/packages/strapi-provider-email-sendgrid), [Mailjet](https://github.com/ijsto/strapi-provider-email-mailjet) and [others](https://github.com/strapi/awesome-strapi#email-providers).
+This means that there are virtually countless custom methods (API endpoints) a given email provider may be exposing.
+
+Via the `.action()` method you can access these custom methods based on the documentation of each email provider.
+
+**Example**
+
+```js
+await strapi.plugins.email.services.email.action({
+  type: 'createContactList',
+  name: 'People interested in jobs',
+});
+```
+
+The above will create an email contacts list on your Mailjet account.
+
+To read more about available action types and data you must pass in, please refer to each individual email provider's documentation.
+
 ## Configure the plugin
 
 By default Strapi provides a local email system ([sendmail](https://www.npmjs.com/package/sendmail)). If you want to use a third party to send emails, you need to install the correct provider module. Otherwise you can skip this part and continue to configure your provider.
@@ -138,7 +158,7 @@ Default template
 module.exports = {
   init: (providerOptions = {}, settings = {}) => {
     return {
-      send: async options => {},
+      send: async (options) => {},
     };
   },
 };

--- a/docs/v3.x/plugins/email.md
+++ b/docs/v3.x/plugins/email.md
@@ -158,7 +158,7 @@ Default template
 module.exports = {
   init: (providerOptions = {}, settings = {}) => {
     return {
-      send: async (options) => {},
+      send: async options => {},
     };
   },
 };

--- a/packages/strapi-plugin-email/controllers/Email.js
+++ b/packages/strapi-plugin-email/controllers/Email.js
@@ -6,6 +6,21 @@
  * @description: A set of functions called "actions" of the `email` plugin.
  */
 module.exports = {
+  action: async ctx => {
+    let options = ctx.request.body;
+    try {
+      await strapi.plugins.email.services.email.action(options);
+    } catch (e) {
+      if (e.statusCode === 400) {
+        return ctx.badRequest(e.message);
+      } else {
+        throw new Error(`Couldn't execute custom email action: ${e.message}.`);
+      }
+    }
+
+    // Send 200 `ok`
+    ctx.send({});
+  },
   send: async ctx => {
     let options = ctx.request.body;
     try {

--- a/packages/strapi-plugin-email/services/Email.js
+++ b/packages/strapi-plugin-email/services/Email.js
@@ -41,6 +41,7 @@ const sendTemplatedEmail = (emailOptions = {}, emailTemplate = {}, data = {}) =>
 };
 
 module.exports = {
+  action,
   getProviderConfig,
   send,
   sendTemplatedEmail,

--- a/packages/strapi-plugin-email/services/Email.js
+++ b/packages/strapi-plugin-email/services/Email.js
@@ -6,6 +6,9 @@ const getProviderConfig = () => {
   return strapi.plugins.email.config;
 };
 
+const action = async options => {
+  return strapi.plugins.email.provider.action(options);
+};
 const send = async options => {
   return strapi.plugins.email.provider.send(options);
 };


### PR DESCRIPTION
Hello Strapi, with this PR I would like to propose exposing an additional resolver to the email-plugin.

It appears that currently there's an issue as there's limited custom functionality possible.

Exposing a method that would allow plugin developers to add custom functionality such as managing email lists, contacts and potentially other concerns related to email providers, IMHO, would bring a big value to this plugin.

I have with this PR added a `strapi.plugins.email.provider.action(options)` resolver as well as brief documentation on how it could work.

If approved, you can expect an extend documentation with examples momentarily. Currently working with Mailjet provider, however, if approved happy to others as well.

🙌