### PR TITLE
Prevent from uninstalling the upload plugin in the admin panel

### DIFF
--- a/packages/strapi-plugin-upload/package.json
+++ b/packages/strapi-plugin-upload/package.json
@@ -5,7 +5,8 @@
   "strapi": {
     "name": "Media Library",
     "icon": "cloud-upload-alt",
-    "description": "upload.plugin.description"
+    "description": "upload.plugin.description",
+    "required": true
   },
   "scripts": {
     "test": "echo \"no tests yet\""


### PR DESCRIPTION
Signed-off-by: soupette <cyril.lpz@gmail.com>

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch) 
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/docs/contribguide/CONTRIBUTING.md
-->

#### Description of what you did:

This PR fixes #7572 by preventing users from uninstalling the upload plugin from the administration panel.