### PR TITLE
🐛fix createDocObject in documentation plugin

### DIFF
--- a/packages/strapi-plugin-documentation/services/Documentation.js
+++ b/packages/strapi-plugin-documentation/services/Documentation.js
@@ -195,7 +195,14 @@ module.exports = {
   },
 
   createDocObject: array => {
-    return array.reduce((acc, curr) => _.merge(acc, curr), {});
+    return _.sortBy(array, t => t.tags[0] && t.tags[0].name).reduce((acc, curr) => {
+      function customizer(objValue, srcValue) {
+        if (_.isArray(objValue)) {
+          return objValue.concat(srcValue);
+        }
+      }
+      return _.mergeWith(acc, curr, customizer);
+    }, {});
   },
 
   deleteDocumentation: async function(version = this.getDocumentationVersion()) {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch) 
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/docs/contribguide/CONTRIBUTING.md
-->

#### Description of what you did:

Fixes #7509

I modify edit `createDocObject` function
- sort array before merge
- replace `merge` with `mergeWith` with customizer to concat array instea

createDocObject function generate invalid doc due to
1. falsy `doc.tags` array, namely tags array get override when merge instead of concat elements
2.  wrong order of elements in doc object, which matters because of how `areObjectsEquals` function is defined

Note: sort array by tags[0].name might not be such a good idea, but i don't see better option without modifying item in array