### PR TITLE
Add sqlite details to unit testing guide

### DIFF
--- a/docs/v3.x/guides/unit-testing.md
+++ b/docs/v3.x/guides/unit-testing.md
@@ -17,14 +17,16 @@ In this example we will use [Jest](https://jestjs.io/) Testing Framework with a 
 
 `Supertest` allows you to test all the `api` routes as they were instances of [http.Server](https://nodejs.org/api/http.html#http_class_http_server)
 
+`sqlite3` is used to create an on-disk database that is created and deleted between tests.
+
 :::: tabs
 
 ::: tab yarn
-`yarn add jest supertest`
+`yarn add --dev jest supertest sqlite3`
 :::
 
 ::: tab npm
-`npm install jest supertest`
+`npm install jest supertest sqlite3 --save-dev`
 :::
 ::::
 
@@ -85,7 +87,7 @@ The whole file will look like this:
         "useNullAsDefault": true,
         "pool": {
           "min": 0,
-          "max": 15
+          "max": 1
         }
       }
     }


### PR DESCRIPTION
## Description of what you did:

Added `sqlite3` to the list of modules to install for testing, as the guide assumes it is there. In the configuration I also dropped the pool size to 1; I was consistently hitting sqlite3 database lock errors until I did this.