### PR TITLE
Rebuilt command in migration guide was wrong

### DIFF
--- a/docs/v3.x/migration-guide/migration-guide-3.0.x-to-3.1.x.md
+++ b/docs/v3.x/migration-guide/migration-guide-3.0.x-to-3.1.x.md
@@ -146,7 +146,7 @@ Rebuild the admin panel with one of the following commands:
 ```bash
 yarn build --clean
 # or
-npm run build -- --clean
+npm run build --clean
 ```
 
 🎉 Congrats, your application has been migrated!


### PR DESCRIPTION
## Context

I was migrating a version of  strapi on a project. Saw on [that](https://strapi.io/documentation/v3.x/migration-guide/migration-guide-3.0.x-to-3.1.x.html#_5-rebuild-the-admin-panel) step that the command for npm contain an empty flag `--`.

So I quickly updated it in case it was an error.

Good work to all the team for the job btw.