### PR TITLE
Fix docker mounting point typo (/src/app)

### DIFF
--- a/docs/v3.x/installation/docker.md
+++ b/docs/v3.x/installation/docker.md
@@ -21,7 +21,7 @@ services:
   strapi:
     image: strapi/strapi
     volumes:
-      - ./app:/srv/app
+      - ./app:/src/app
     ports:
       - '1337:1337'
 ```

--- a/docs/v3.x/installation/docker.md
+++ b/docs/v3.x/installation/docker.md
@@ -43,7 +43,7 @@ services:
       DATABASE_USERNAME: strapi
       DATABASE_PASSWORD: strapi
     volumes:
-      - ./app:/srv/app
+      - ./app:/src/app
     ports:
       - '1337:1337'
     depends_on:
@@ -76,7 +76,7 @@ services:
       DATABASE_USERNAME: strapi
       DATABASE_PASSWORD: strapi
     volumes:
-      - ./app:/srv/app
+      - ./app:/src/app
     ports:
       - '1337:1337'
     depends_on:


### PR DESCRIPTION
#### Description of what you did:

Fixed typo from `/srv/app` to `src/app`.