### PR TITLE
I think lifecycle hooks should be inside lifecycles object

### DIFF
--- a/docs/3.0.0-beta.x/guides/slug.md
+++ b/docs/3.0.0-beta.x/guides/slug.md
@@ -63,18 +63,20 @@ When it's done, you have to update the life cycle of the **Article** Content Typ
 const slugify = require('slugify');
 
 module.exports = {
-  beforeSave: async model => {
-    if (model.title) {
-      model.slug = slugify(model.title);
-    }
-  },
-  beforeUpdate: async model => {
-    if (model.getUpdate() && model.getUpdate().title) {
-      model.update({
-        slug: slugify(model.getUpdate().title),
-      });
-    }
-  },
+  lifecycles: {
+    beforeCreate: async model => {
+      if (model.title) {
+        model.slug = slugify(model.title);
+      }
+    },
+    beforeUpdate: async model => {
+      if (model.getUpdate() && model.getUpdate().title) {
+        model.update({
+          slug: slugify(model.getUpdate().title),
+        });
+      }
+    },
+  }
 };
 ```
 


### PR DESCRIPTION
The example provided in docs didn't work for me, the changes I made did work.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch) 
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/docs/contribguide/CONTRIBUTING.md
-->

#### Description of what you did:
I moved hooks into `lifecycles` object and changed `beforeSave` to `beforeCreate` as I couldn't find `beforeSave` in Lifecycle hooks doc