### PR TITLE
Let developers decide, whether they would like to pluralize collection labels (in menu) or not

### DIFF
--- a/packages/strapi-plugin-content-manager/services/ContentTypes.js
+++ b/packages/strapi-plugin-content-manager/services/ContentTypes.js
@@ -18,8 +18,14 @@ const toUID = (name, plugin) => {
 const formatContentTypeLabel = contentType => {
   const { kind } = contentType;
   const name = _.get(contentType, ['info', 'name'], contentType.modelName);
+  const pluralizeCollections = strapi.config.get(
+    "server.admin.contentManager.pluralizeCollectionLabels",
+    true
+  );
 
-  return kind === 'singleType' ? _.upperFirst(name) : _.upperFirst(pluralize(name));
+  return kind === "singleType" || !pluralizeCollections
+    ? _.upperFirst(name)
+    : _.upperFirst(pluralize(name));
 };
 
 const HIDDEN_CONTENT_TYPES = [


### PR DESCRIPTION
Signed-off-by: Sebastian Trebunak <trebunak.sebastian@gmail.com>

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch) 
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/docs/contribguide/CONTRIBUTING.md
-->

#### Description of what you did:

So there is this RFC [Request — Collection Display names pluralizing problems](https://github.com/strapi/rfcs/issues/18), which describes pain for non-english collection type display names.

I've basically came with the most primitive solution for us (admins/devs) in order to satisfy our clients needs of consistency and readability of collection names inside of dashboard. This PR includes a new environment variable `pluralizeCollectionLabels` support. Environment variable should be set inside of `config/server.js` file:

```js
module.exports = ({ env }) => ({
  host: env("HOST", "0.0.0.0"),
  port: env.int("PORT", 1337),
  admin: {
    auth: {
      secret: env("ADMIN_JWT_SECRET"),
    },
    contentManager: {
      pluralizeCollectionLabels: false,
    },
  },
});
```

When developer set this variable to `false`, during process of collection types labels construction (at left panel), the plurazile package will not be used.

If this env variable is not set (or set to true), nothing is changed in strapi's current behaviour.

I hope you will like it (even as a temporary solution, in case you would like to come with some other/better solution). In case you will, then please, let me know and I will add relevant documentation page/text.

Thanks!  