### PR TITLE
Update sharp module to 0.26.0

### DIFF
--- a/packages/strapi-plugin-upload/package.json
+++ b/packages/strapi-plugin-upload/package.json
@@ -29,7 +29,7 @@
     "react-router": "^5.0.0",
     "react-router-dom": "^5.0.0",
     "reactstrap": "8.4.1",
-    "sharp": "0.24.1",
+    "sharp": "0.26.0",
     "strapi-helper-plugin": "3.1.4",
     "strapi-provider-upload-local": "3.1.4",
     "strapi-utils": "3.1.4",


### PR DESCRIPTION
Related Issue https://github.com/lovell/sharp/issues/2352

I've faced an issue when building electron app with strapi.

Updating version of sharp solved the problem.

Please check and hope be merged soon.