### PR TITLE
Execute bootstrap during startup

### DIFF
--- a/packages/strapi/lib/Strapi.js
+++ b/packages/strapi/lib/Strapi.js
@@ -65,7 +65,7 @@ class Strapi {
     this.fs = createStrapiFs(this);
     this.eventHub = createEventHub();
 
-    this.requireProjectBootstrap();
+    
   }
 
   get EE() {
@@ -84,7 +84,7 @@ class Strapi {
     const bootstrapPath = path.resolve(this.dir, 'config/functions/bootstrap.js');
 
     if (fse.existsSync(bootstrapPath)) {
-      require(bootstrapPath);
+      await (require(bootstrapPath))();
     }
   }
 
@@ -187,6 +187,7 @@ class Strapi {
   async start(cb) {
     try {
       if (!this.isLoaded) {
+        this.requireProjectBootstrap();
         await this.load();
       }
 


### PR DESCRIPTION
1. Allow ./config/functions/bootstrap.js to handle async tasks 
2. Moved requireProjectBootstrap from constructor to start

I need to do some API calls and initialize some of the variables even before strapi comes up, this might be a requirement for the most users at times.



