### PR TITLE
Execute bootstrap during startup

### DIFF
--- a/packages/strapi/lib/Strapi.js
+++ b/packages/strapi/lib/Strapi.js
@@ -293,6 +293,9 @@ class Strapi {
       logger: this.log,
       configuration: this.config.get('server.webhooks', {}),
     });
+    
+    // Run bootstrap functions
+    await this.runBootstrapFunctions();
 
     // Init core store
     this.models['core_store'] = coreStoreModel(this.config);
@@ -326,7 +329,7 @@ class Strapi {
     await initializeMiddlewares.call(this);
     await initializeHooks.call(this);
 
-    await this.runBootstrapFunctions();
+
     await this.freeze();
 
     this.isLoaded = true;


### PR DESCRIPTION
Bootstrap can be executed even before models and stores are initialized.

Reason: I need a script to be executed, which retrieves config from a remote server, retrieves secure string, etc.,
