### PR TITLE
Fix validation of Date and Time field types for Mongoose connector #5777

### DIFF
--- a/packages/strapi-connector-mongoose/lib/utils/index.js
+++ b/packages/strapi-connector-mongoose/lib/utils/index.js
@@ -32,14 +32,18 @@ module.exports = (mongoose = Mongoose) => {
       case 'time':
         return {
           type: String,
-          validate: value => parseType({ type: 'time', value }),
-          set: value => parseType({ type: 'time', value }),
+          validate: value =>
+            (!attr.required && _.isNil(value)) || parseType({ type: 'time', value }),
+          set: value =>
+            !attr.required && _.isNil(value) ? value : parseType({ type: 'time', value }),
         };
       case 'date':
         return {
           type: String,
-          validate: value => parseType({ type: 'date', value }),
-          set: value => parseType({ type: 'date', value }),
+          validate: value =>
+            (!attr.required && _.isNil(value)) || parseType({ type: 'date', value }),
+          set: value =>
+            !attr.required && _.isNil(value) ? value : parseType({ type: 'date', value }),
         };
       case 'datetime':
         return {


### PR DESCRIPTION
Signed-off-by: richardgrey richie.grey@gmail.com

#### Description of what you did:

This PR fixes #5777 

This changes will allow setting an empty value (null, undefined) for fields of type Date/Time through the API.

In the admin panel, it's still not possible to clear the value of Date or Time fields. It is on buffet/core DatePicker component and has related [feature request](https://github.com/strapi/buffet/issues/97) to be able to clear the value of such inputs.