### PR TITLE
Fix autocomplete issue in Chrome. Fixes #7666

### DIFF
--- a/packages/strapi-admin/admin/src/containers/ProfilePage/utils/form.js
+++ b/packages/strapi-admin/admin/src/containers/ProfilePage/utils/form.js
@@ -28,11 +28,13 @@ const form = {
     label: 'Auth.form.username.label',
     placeholder: 'e.g. John_Doe',
     type: 'text',
+    autoComplete: 'no',
     validations: {},
   },
   password: {
     label: 'Auth.form.password.label',
     type: 'password',
+    autoComplete: 'new-password',
     validations: {},
   },
   confirmPassword: {

--- a/packages/strapi-admin/admin/src/containers/Users/EditPage/utils/form.js
+++ b/packages/strapi-admin/admin/src/containers/Users/EditPage/utils/form.js
@@ -28,11 +28,13 @@ const form = {
     label: 'Auth.form.username.label',
     placeholder: 'e.g. John_Doe',
     type: 'text',
+    autoComplete: 'no',
     validations: {},
   },
   password: {
     label: 'Auth.form.password.label',
     type: 'password',
+    autoComplete: 'new-password',
     validations: {},
   },
   confirmPassword: {


### PR DESCRIPTION
Signed-off-by: richardgrey <richie.grey@gmail.com>

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch) 
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/docs/contribguide/CONTRIBUTING.md
-->

#### Description of what you did:

This PR fixes #7666 

The fix is a simple setting `autocomplete` attribute to `new-password`. For `username` setting this attribute to `no` telling the browser that this field should be autocompleted as a field called "no". Basically, using unique value switching off the autocomplete. 
