### PR TITLE
Allow models to be hidden from admin interface

### DIFF
--- a/packages/strapi-plugin-content-manager/services/ContentTypes.js
+++ b/packages/strapi-plugin-content-manager/services/ContentTypes.js
@@ -60,7 +60,10 @@ const formatContentType = contentType => {
     name: _.get(contentType, ['info', 'name']),
     apiID: contentType.modelName,
     label: formatContentTypeLabel(contentType),
-    isDisplayed: HIDDEN_CONTENT_TYPES.includes(contentType.uid) ? false : true,
+    isDisplayed:
+      HIDDEN_CONTENT_TYPES.includes(contentType.uid) || _.get(contentType, ['info', 'hidden'])
+        ? false
+        : true,
     schema: {
       ...formatContentTypeSchema(contentType),
       kind: contentType.kind || 'collectionType',


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch) 
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/docs/contribguide/CONTRIBUTING.md
-->

#### Description of what you did:

I added a hidden flag to the info key on the model-json state. Setting it as `true` will stop the model from being displayed in the admin interface.