### PR TITLE
update mongoose to 5.10.5

### DIFF
--- a/packages/strapi-connector-mongoose/package.json
+++ b/packages/strapi-connector-mongoose/package.json
@@ -16,7 +16,7 @@
   "main": "./lib",
   "dependencies": {
     "lodash": "4.17.19",
-    "mongoose": "5.8.0",
+    "mongoose": "5.10.5",
     "mongoose-float": "^1.0.4",
     "mongoose-long": "^0.2.1",
     "pluralize": "^8.0.0",


### PR DESCRIPTION
includes new features
like MongoDB driver 3.6 for full MongoDB 4.4 support & many other

Signed-off-by: Akash P <aksdevac@gmail.com>

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch) 
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/docs/contribguide/CONTRIBUTING.md
-->

#### Description of what you did:
Updated mongoose to current latest as there are many improvements after `5.8.0` & no breaking changes.