### PR TITLE
auth-request.md Postman parameters type

### DIFF
--- a/docs/3.0.0-beta.x/guides/auth-request.md
+++ b/docs/3.0.0-beta.x/guides/auth-request.md
@@ -83,7 +83,7 @@ console.log(data);
 
 ::: tab Postman
 
-If you are using **Postman** for example you will have to set the `body` as `raw` with the `JSON (application/json)` type.
+If you are using **Postman** for example you will have to set the `parameters` with the `x-www-form-urlencoded` type.
 
 ```json
 {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch) 
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/docs/contribguide/CONTRIBUTING.md
-->

#### Description of what you did:
I have struggled to request the JWT until I found out that the x-www-form-urlencoded is the right body type for the parameters.
Please double check that this is the required postman request for getting the JWT from /auth/local for specific users. 
Thanks.
