### PR TITLE
translation improvement

### DIFF
--- a/packages/strapi-plugin-users-permissions/admin/src/translations/pl.json
+++ b/packages/strapi-plugin-users-permissions/admin/src/translations/pl.json
@@ -10,7 +10,7 @@
   "EditForm.inputToggle.label.email": "Jedno konto na adres email",
   "EditForm.inputToggle.label.email-confirmation": "Zezwól na potwierdzenie adresu email",
   "EditForm.inputToggle.label.email-confirmation-redirection": "url przekierowania",
-  "EditForm.inputToggle.label.email-reset-password": "Straona resetowania hasła",
+  "EditForm.inputToggle.label.email-reset-password": "Strona resetowania hasła",
   "EditForm.inputToggle.label.sign-up": "Rejestracja",
   "HeaderNav.link.advancedSettings": "Zaawansowane",
   "HeaderNav.link.emailTemplates": "Szablony e-mail",


### PR DESCRIPTION
"EditForm.inputToggle.label.email-reset-password": "Straona resetowania hasła"   <--- should be "Strona resetowania hasła"
