### PR TITLE
Encode the URL before fetching it.

### DIFF
--- a/packages/strapi-plugin-upload/controllers/proxy.js
+++ b/packages/strapi-plugin-upload/controllers/proxy.js
@@ -23,7 +23,7 @@ module.exports = {
     }
 
     try {
-      const res = await fetch(ctx.query.url, {
+      const res = await fetch(new URL(ctx.query.url), {
         headers: _.omit(ctx.request.headers, ['origin', 'host', 'authorization']),
       });
 

--- a/packages/strapi-plugin-upload/test/proxy.test.e2e.js
+++ b/packages/strapi-plugin-upload/test/proxy.test.e2e.js
@@ -1,0 +1,42 @@
+'use strict';
+
+// Helpers.
+const { registerAndLogin } = require('../../../test/helpers/auth');
+const { createAuthRequest } = require('../../../test/helpers/request');
+
+let rq;
+
+describe('Upload plugin end to end tests', () => {
+  beforeAll(async () => {
+    const token = await registerAndLogin();
+    rq = createAuthRequest(token);
+  }, 60000);
+
+  describe('GET /upload/proxy => Proxy the file', () => {
+    test('Return the remote URL', async () => {
+      const res = await rq.get('/upload/proxy', {
+        qs: {
+          url: 'https://strapi.io/'
+        },
+      });
+      expect(res.statusCode).toBe(200);
+    });
+
+    test('Accept an url with utf-8 characters', async () => {
+      const res = await rq.get('/upload/proxy', {
+        qs: {
+          url: 'https://strapi.io/?foo=网'
+        },
+      });
+
+      expect(res.statusCode).toBe(200);
+    });
+
+    test('Return 400 with an invalid url', async () => {
+      const res = await rq.get('/upload/proxy');
+
+      expect(res.statusCode).toBe(400);
+      expect(res.body).toEqual('Invalid URL');
+    });
+  });
+});


### PR DESCRIPTION
If the URL we were fetching via the proxy had utf-8 characters, the proxy returned a 500 "Request path contains unescaped characters". 

Before fetching the URL, we now encode it.

I added a few tests (the utf-8 characters one is failing on master, as expected). I used strapi.io as the proxied url, not really happy about it as it relies on an external service. If you have a better idea, tell me.