### PR TITLE
Fix incorrect PostgreSQL data path in example doc

### DIFF
--- a/docs/3.0.0-beta.x/installation/docker.md
+++ b/docs/3.0.0-beta.x/installation/docker.md
@@ -55,7 +55,7 @@ services:
       POSTGRES_USER: strapi
       POSTGRES_PASSWORD: strapi
     volumes:
-      - ./data:/data/postgres
+      - ./data:/var/lib/postgresql/data
     ports:
       - '5432:5432'
 ```


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch) 
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/docs/contribguide/CONTRIBUTING.md
-->

#### Description of what you did:
Fixed the PostgreSQL data path to a correct one (`postgres` Docker image stores the database files in `/var/lib/postgresql/data`. The example documentation originally stated `/data/postgres` path, which is incorrect).