### PR TITLE
fix(plugin-graphql): Fix association resolver for `manyWay` nature.

### DIFF
--- a/packages/strapi-plugin-graphql/services/type-definitions.js
+++ b/packages/strapi-plugin-graphql/services/type-definitions.js
@@ -143,7 +143,8 @@ const buildAssocResolvers = model => {
         case 'oneToManyMorph':
         case 'manyMorphToOne':
         case 'manyMorphToMany':
-        case 'manyToManyMorph': {
+        case 'manyToManyMorph':
+        case 'manyWay': {
           resolver[association.alias] = async obj => {
             if (obj[association.alias]) {
               return obj[association.alias];


### PR DESCRIPTION
This fixes strapi/strapi#4353 and all its duplicates.

### Detailed description of the problem:
As said by @abanchev [here](https://github.com/strapi/strapi/issues/4353#issuecomment-616209971) the problem is at file services/type-definitions.js near line 184:
```
if (
    ((association.nature === 'manyToMany' && association.dominant) ||
    association.nature === 'manyWay') &&
    _.has(obj, association.alias) // if populated
) { ... } else {
    _.set(queryOpts, ['query', association.via], obj[targetModel.primaryKey]);
}
```
It turns out that in the case of a 3+ level nested query, the third level will not work because the obj is not populated with the `association.alias` so it enters the else block and add the `association.via` in the query. But the problem is that `association.via` for `manyWay` is `undefined`. This will propagate and the code will be looking for something like `undefined_id` and throw the known error message:

> Your filters contain a field 'undefined' that doesn't appear on your model definition nor it's relations

You can reproduce it in this repo that I have prepared: https://github.com/danieldspx/strapi-graphql-example (See the README)

**The cause for this problem**: As we all know well, if you want to fetch such a nested content like this (with the API endpoint), you need to overwrite your controller (see this [stackoverflow awnser](https://stackoverflow.com/questions/59085678/strapi-cms-fetch-nested-content)). For the GraphQL we do not have something like this. Overwriting your controller will not affect the GraphQL way of fetching the content, thus the problem persist independent of your controller (I have tested this). 

### Description of my solution:
As you can see I added one line in the switch case and then the problem is fixed because it fetches de data for the `association.alias` and everything works perfectly and you can go as many deepness levels as you want (as long you respect your depthLimit). **This does not break other relations nature**.

