### PR TITLE
Update upload.md

### DIFF
--- a/docs/v3.x/plugins/upload.md
+++ b/docs/v3.x/plugins/upload.md
@@ -296,7 +296,7 @@ In our second example, you can upload and attach multiple pictures to the restau
 
 By default Strapi provides a provider that uploads files to a local directory. You might want to upload your files to another provider like AWS S3.
 
-You can check all the available providers developed by the community on npmjs.org - [Providers list](https://www.npmjs.com/search?q=strapi-provider-upload-)
+You can check all the available providers developed by the community on npmjs.org - [Providers list](https://www.npmjs.com/search?q=strapi-provider-upload-&ranking=popularity)
 
 To install a new provider run:
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch) 
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/docs/contribguide/CONTRIBUTING.md
-->

#### Description of what you did:
Update upload.md to show the official and most populair provider first in the list. When using without the ranking param the offical packages are not shown in the top, probably due to having a lot of issues (linked to main repo) and thus low quality according to npmjs.com.
