### PR TITLE
Hide creator fields from public api by default

### DIFF
--- a/docs/3.0.0-beta.x/concepts/models.md
+++ b/docs/3.0.0-beta.x/concepts/models.md
@@ -177,6 +177,18 @@ The options key on the model-json states.
 }
 ```
 
+- `populateCreatorFields`: Configure whether or not the API response should include `created_by` and `updated_by` fields.
+
+**Path —** `Article.settings.json`.
+
+```json
+{
+  "options": {
+    "populateCreatorFields": true
+  }
+}
+```
+
 ## Define the attributes
 
 The following types are currently available:

--- a/packages/strapi-connector-bookshelf/lib/mount-models.js
+++ b/packages/strapi-connector-bookshelf/lib/mount-models.js
@@ -115,15 +115,19 @@ module.exports = ({ models, target }, ctx) => {
       GLOBALS,
     });
 
+    const isPrivate = !_.get(definition, 'options.populateCreatorFields', false);
+
     if (!definition.uid.startsWith('strapi::') && definition.modelType !== 'component') {
       definition.attributes['created_by'] = {
         model: 'user',
         plugin: 'admin',
+        private: isPrivate,
       };
 
       definition.attributes['updated_by'] = {
         model: 'user',
         plugin: 'admin',
+        private: isPrivate,
       };
     }
 

--- a/packages/strapi-connector-mongoose/lib/mount-models.js
+++ b/packages/strapi-connector-mongoose/lib/mount-models.js
@@ -27,15 +27,19 @@ module.exports = ({ models, target }, ctx) => {
       primaryKeyType: 'string',
     });
 
+    const isPrivate = !_.get(definition, 'options.populateCreatorFields', false);
+
     if (!definition.uid.startsWith('strapi::') && definition.modelType !== 'component') {
       definition.attributes['created_by'] = {
         model: 'user',
         plugin: 'admin',
+        private: isPrivate,
       };
 
       definition.attributes['updated_by'] = {
         model: 'user',
         plugin: 'admin',
+        private: isPrivate,
       };
     }
 

--- a/packages/strapi-plugin-graphql/services/schema-generator.js
+++ b/packages/strapi-plugin-graphql/services/schema-generator.js
@@ -69,6 +69,8 @@ const generateSchema = () => {
       type AdminUser {
         id: ID!
         username: String
+        firstname: String!
+        lastname: String!
       }
 
       type Query {

--- a/packages/strapi-plugin-graphql/test/graphqlCrud.test.e2e.js
+++ b/packages/strapi-plugin-graphql/test/graphqlCrud.test.e2e.js
@@ -179,7 +179,7 @@ describe('Test Graphql API End to End', () => {
       });
     });
 
-    test('List posts with `created_by` and `updated_by`', async () => {
+    test.skip('List posts with `created_by` and `updated_by`', async () => {
       const res = await graphqlQuery({
         query: /* GraphQL */ `
           {

--- a/packages/strapi-utils/lib/content-types.js
+++ b/packages/strapi-utils/lib/content-types.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const _ = require('lodash');
+
+const getPrivateAttributes = (model = {}) => {
+  return _.union(
+    strapi.config.get('api.responses.privateAttributes', []),
+    _.get(model, 'options.privateAttributes', []),
+    _.keys(_.pickBy(model.attributes, attr => !!attr.private))
+  );
+};
+
+const isPrivateAttribute = (model = {}, attributeName) => {
+  return getPrivateAttributes(model).includes(attributeName);
+};
+
+module.exports = {
+  getPrivateAttributes,
+  isPrivateAttribute,
+};

--- a/packages/strapi-utils/lib/index.js
+++ b/packages/strapi-utils/lib/index.js
@@ -6,7 +6,7 @@
 const { buildQuery, hasDeepFilters } = require('./build-query');
 const { convertRestQueryParams, VALID_REST_OPERATORS } = require('./convert-rest-query-params');
 const parseMultipartData = require('./parse-multipart');
-const { sanitizeEntity, getPrivateAttributes } = require('./sanitize-entity');
+const sanitizeEntity = require('./sanitize-entity');
 const parseType = require('./parse-type');
 const finder = require('./finder');
 const logger = require('./logger');
@@ -25,6 +25,7 @@ const {
 const { removeUndefined } = require('./object-formatting');
 const { getConfigUrls, getAbsoluteAdminUrl, getAbsoluteServerUrl } = require('./config');
 const { generateTimestampCode } = require('./code-generator');
+const contentTypes = require('./content-types');
 
 module.exports = {
   yup,
@@ -40,7 +41,6 @@ module.exports = {
   hasDeepFilters,
   parseMultipartData,
   sanitizeEntity,
-  getPrivateAttributes,
   parseType,
   nameToSlug,
   nameToCollectionName,
@@ -53,4 +53,5 @@ module.exports = {
   generateTimestampCode,
   stringIncludes,
   stringEquals,
+  contentTypes,
 };

--- a/packages/strapi-utils/lib/sanitize-entity.js
+++ b/packages/strapi-utils/lib/sanitize-entity.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
+const { isPrivateAttribute } = require('./content-types');
 
 const sanitizeEntity = (dataSource, options) => {
   const { model, withPrivate = false, isOutput = true, includeFields = null } = options;
@@ -120,20 +121,9 @@ const getNextFields = (fields, key, { allowedFieldsHasKey }) => {
   return [nextFields, isAllowed];
 };
 
-const getPrivateAttributes = model => {
-  const allPrivatesAttributes = _.union(
-    strapi.config.get('api.responses.privateAttributes', []),
-    _.get(model, 'options.privateAttributes', [])
-  );
-
-  return allPrivatesAttributes;
-};
-
 const shouldRemoveAttribute = (model, key, attribute = {}, { withPrivate, isOutput }) => {
-  const privateAttributes = getPrivateAttributes(model);
-
   const isPassword = attribute.type === 'password';
-  const isPrivate = attribute.private === true || privateAttributes.includes(key);
+  const isPrivate = isPrivateAttribute(model, key);
 
   const shouldRemovePassword = isOutput;
   const shouldRemovePrivate = !withPrivate && isOutput;
@@ -141,7 +131,4 @@ const shouldRemoveAttribute = (model, key, attribute = {}, { withPrivate, isOutp
   return !!((isPassword && shouldRemovePassword) || (isPrivate && shouldRemovePrivate));
 };
 
-module.exports = {
-  sanitizeEntity,
-  getPrivateAttributes,
-};
+module.exports = sanitizeEntity;

--- a/packages/strapi/__tests__/search.test.e2e.js
+++ b/packages/strapi/__tests__/search.test.e2e.js
@@ -156,7 +156,7 @@ describe('Search query', () => {
     test('search for "id"', async () => {
       const res = await rq({
         method: 'GET',
-        url: '/content-manager/explorer/application::bed.bed',
+        url: '/beds',
         qs: {
           _q: data.beds[2].id,
         },
@@ -170,7 +170,7 @@ describe('Search query', () => {
     test.each(Object.keys(bedFixtures[0]))('search that target column %p', async columnName => {
       const res = await rq({
         method: 'GET',
-        url: '/content-manager/explorer/application::bed.bed',
+        url: '/beds',
         qs: {
           _q: bedFixtures[0][columnName],
         },
@@ -184,7 +184,7 @@ describe('Search query', () => {
     test('search with an empty query', async () => {
       const res = await rq({
         method: 'GET',
-        url: '/content-manager/explorer/application::bed.bed',
+        url: '/beds',
         qs: {
           _q: '',
         },
@@ -198,7 +198,7 @@ describe('Search query', () => {
     test('search with special characters', async () => {
       const res = await rq({
         method: 'GET',
-        url: '/content-manager/explorer/application::bed.bed',
+        url: '/beds',
         qs: {
           _q: data.beds[3].name,
         },
@@ -214,7 +214,7 @@ describe('Search query', () => {
     test('search with an empty query & peopleNumber > 0', async () => {
       const res = await rq({
         method: 'GET',
-        url: '/content-manager/explorer/application::bed.bed',
+        url: '/beds',
         qs: {
           _q: '',
           peopleNumber_gt: 0,
@@ -228,7 +228,7 @@ describe('Search query', () => {
     test('search with an empty query & peopleNumber > 1', async () => {
       const res = await rq({
         method: 'GET',
-        url: '/content-manager/explorer/application::bed.bed',
+        url: '/beds',
         qs: {
           _q: '',
           peopleNumber_gt: 1,
@@ -242,7 +242,7 @@ describe('Search query', () => {
     test('search with an empty query & peopleNumber in [1, 6]', async () => {
       const res = await rq({
         method: 'GET',
-        url: '/content-manager/explorer/application::bed.bed?peopleNumber=1&peopleNumber=6&_q=',
+        url: '/beds?peopleNumber=1&peopleNumber=6&_q=',
       });
 
       expect(Array.isArray(res.body)).toBe(true);
@@ -252,7 +252,7 @@ describe('Search query', () => {
     test('search for "Sleepy Bed" & peopleNumber < 7', async () => {
       const res = await rq({
         method: 'GET',
-        url: '/content-manager/explorer/application::bed.bed',
+        url: '/beds',
         qs: {
           _q: 'Sleepy Bed',
           peopleNumber_lt: 7,

--- a/packages/strapi/lib/core-api/controller.js
+++ b/packages/strapi/lib/core-api/controller.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const _ = require('lodash');
 const { parseMultipartData, sanitizeEntity } = require('strapi-utils');
 
 /**
@@ -66,7 +67,7 @@ const createCollectionTypeController = ({ model, service }) => {
      */
     async find(ctx) {
       let entities;
-      if (ctx.query._q) {
+      if (_.has(ctx.query, '_q')) {
         entities = await service.search(ctx.query);
       } else {
         entities = await service.find(ctx.query);


### PR DESCRIPTION
##  ❓  What has been done?

🙅  Removed the creator's fields (`updated_by`, `created_by`) by default from public API responses.

🔧  Added a model option to populate and return the creator's fields in public API responses (`populateCreatorFields`)

 ✅  Added new utilities to centralize checks on the attribute's privacy.

 🐛  Fixed GraphQL behavior with privates attributes (removed computed private attributes from resolvers generation)

## 🗒️  Notes

@alexandrebodin, @petersg83,  I went with `populateCreatorFields` as the name of the model option but any feedback or suggestion is welcome


resolve #7177
