### PR TITLE
Allow browser options while using watch-admin

### DIFF
--- a/docs/v3.x/cli/CLI.md
+++ b/docs/v3.x/cli/CLI.md
@@ -40,7 +40,7 @@ Strapi modifies/creates files at runtime and needs to restart when new files are
 
 ```
 strapi develop
-options: [--no-build |--watch-admin ]
+options: [--no-build |--watch-admin |--browser ]
 ```
 
 - **strapi develop**<br/>
@@ -49,6 +49,8 @@ options: [--no-build |--watch-admin ]
   Starts your application with the autoReload enabled and skip the administration panel build process
 - **strapi develop --watch-admin**<br/>
   Starts your application with the autoReload enabled and the front-end development server. It allows you to customize the administration panel.
+- **strapi develop --watch-admin --browser 'google chrome'**<br/>
+  Starts your application with the autoReload enabled and the front-end development server. It allows you to customize the administration panel. Provide a browser name to use instead of the default one, `false` means stop opening the browser.
 
 ::: tip
 You should never use this command to run a Strapi application in production.

--- a/packages/strapi-admin/index.js
+++ b/packages/strapi-admin/index.js
@@ -233,7 +233,7 @@ async function createCacheDir(dir) {
   );
 }
 
-async function watchAdmin({ dir, host, port, options }) {
+async function watchAdmin({ dir, host, port, browser, options }) {
   // Create the cache dir containing the front-end files.
   await createCacheDir(dir);
 
@@ -253,7 +253,7 @@ async function watchAdmin({ dir, host, port, options }) {
     clientLogLevel: 'silent',
     hot: true,
     quiet: true,
-    open: true,
+    open: browser === 'true' ? true : browser,
     publicPath: options.publicPath,
     historyApiFallback: {
       index: options.publicPath,

--- a/packages/strapi/bin/strapi.js
+++ b/packages/strapi/bin/strapi.js
@@ -127,6 +127,7 @@ program
   .alias('dev')
   .option('--no-build', 'Disable build', false)
   .option('--watch-admin', 'Enable watch', true)
+  .option('--browser <name>', 'Open the browser', true)
   .description('Start your Strapi application in development mode')
   .action(getLocalScript('develop'));
 
@@ -211,6 +212,7 @@ program
 //   `$ strapi watch-admin`
 program
   .command('watch-admin')
+  .option('--browser <name>', 'Open the browser', true)
   .description('Starts the admin dev server')
   .action(getLocalScript('watchAdmin'));
 

--- a/packages/strapi/lib/commands/develop.js
+++ b/packages/strapi/lib/commands/develop.js
@@ -16,7 +16,7 @@ const strapi = require('../index');
  * `$ strapi develop`
  *
  */
-module.exports = async function({ build, watchAdmin }) {
+module.exports = async function({ build, watchAdmin, browser }) {
   const dir = process.cwd();
   const config = loadConfiguration(dir);
 
@@ -39,7 +39,7 @@ module.exports = async function({ build, watchAdmin }) {
     if (cluster.isMaster) {
       if (watchAdmin) {
         try {
-          execa('npm', ['run', '-s', 'strapi', 'watch-admin'], {
+          execa('npm', ['run', '-s', 'strapi', 'watch-admin', '--', '--browser', browser], {
             stdio: 'inherit',
           });
         } catch (err) {

--- a/packages/strapi/lib/commands/watchAdmin.js
+++ b/packages/strapi/lib/commands/watchAdmin.js
@@ -9,7 +9,7 @@ const { getConfigUrls, getAbsoluteServerUrl } = require('strapi-utils');
 
 const addSlash = require('../utils/addSlash');
 
-module.exports = async function() {
+module.exports = async function({ browser }) {
   const dir = process.cwd();
 
   const config = loadConfiguration(dir);
@@ -24,6 +24,7 @@ module.exports = async function() {
     dir,
     port: adminPort,
     host: adminHost,
+    browser,
     options: {
       backend: getAbsoluteServerUrl(config, true),
       publicPath: addSlash(adminPath),


### PR DESCRIPTION
```
strapi develop --watch-admin   //open the default browser
strapi develop --watch-admin --browser false   //do not open any browser
strapi develop --watch-admin --browser 'google chrome' //open Google Chrome
strapi develop --watch-admin --browser Firefox //open Firefox
```