### PR TITLE
Add support for login via cas - github.com/apereo/cas

### DIFF
--- a/packages/strapi-plugin-users-permissions/config/functions/bootstrap.js
+++ b/packages/strapi-plugin-users-permissions/config/functions/bootstrap.js
@@ -24,6 +24,15 @@ module.exports = async () => {
       enabled: true,
       icon: 'envelope',
     },
+    cas: {
+      enabled: false,
+      icon: 'book',
+      key: '',
+      secret: '',
+      callback: `${strapi.config.server.url}/auth/cas/callback`,
+      scope: ['openid email'], // scopes should be space delimited
+      subdomain: 'my.subdomain.com/cas',
+    },
     discord: {
       enabled: false,
       icon: 'discord',

--- a/packages/strapi-plugin-users-permissions/config/functions/bootstrap.js
+++ b/packages/strapi-plugin-users-permissions/config/functions/bootstrap.js
@@ -24,15 +24,6 @@ module.exports = async () => {
       enabled: true,
       icon: 'envelope',
     },
-    cas: {
-      enabled: false,
-      icon: 'book',
-      key: '',
-      secret: '',
-      callback: `${strapi.config.server.url}/auth/cas/callback`,
-      scope: ['openid email'], // scopes should be space delimited
-      subdomain: 'my.subdomain.com/cas',
-    },
     discord: {
       enabled: false,
       icon: 'discord',
@@ -138,6 +129,15 @@ module.exports = async () => {
       subdomain: 'my-tenant.eu',
       callback: `${strapi.config.server.url}/auth/auth0/callback`,
       scope: ['openid', 'email', 'profile'],
+    },
+    cas: {
+      enabled: false,
+      icon: 'book',
+      key: '',
+      secret: '',
+      callback: `${strapi.config.server.url}/auth/cas/callback`,
+      scope: ['openid email'], // scopes should be space delimited
+      subdomain: 'my.subdomain.com/cas',
     },
   };
   const prevGrantConfig = (await pluginStore.get({ key: 'grant' })) || {};

--- a/packages/strapi-plugin-users-permissions/services/Providers.js
+++ b/packages/strapi-plugin-users-permissions/services/Providers.js
@@ -569,7 +569,7 @@ const getProfile = async (provider, query, callback) => {
               ? body.attributes.strapiemail || body.attributes.email
               : body.strapiemail || body.email;
             if (!username || !email) {
-              console.log(
+              strapi.log.warn(
                 'CAS Response Body did not contain required attributes: ' + JSON.stringify(body)
               );
             }

--- a/packages/strapi-plugin-users-permissions/services/Providers.js
+++ b/packages/strapi-plugin-users-permissions/services/Providers.js
@@ -124,55 +124,6 @@ const getProfile = async (provider, query, callback) => {
     .get();
 
   switch (provider) {
-    case 'cas': {
-      const provider_url = 'https://' + _.get(grant['cas'], 'subdomain');
-      const cas = purest({
-        provider: 'cas',
-        config: {
-          cas: {
-            [provider_url]: {
-              __domain: {
-                auth: {
-                  auth: { bearer: '[0]' },
-                },
-              },
-              '{endpoint}': {
-                __path: {
-                  alias: '__default',
-                },
-              },
-            },
-          },
-        },
-      });
-      cas
-        .query()
-        .get('oidc/profile')
-        .auth(access_token)
-        .request((err, res, body) => {
-          if (err) {
-            callback(err);
-          } else {
-            // CAS attribute may be in body.attributes or "FLAT", depending on CAS config
-            const username = body.attributes
-              ? body.attributes.strapiusername || body.sub
-              : body.strapiusername || body.id || body.sub;
-            const email = body.attributes
-              ? body.attributes.strapiemail || body.attributes.email
-              : body.strapiemail || body.email;
-            if (!username || !email) {
-              console.log(
-                'CAS Response Body did not contain required attributes: ' + JSON.stringify(body)
-              );
-            }
-            callback(null, {
-              username,
-              email,
-            });
-          }
-        });
-      break;
-    }
     case 'discord': {
       const discord = purest({
         provider: 'discord',
@@ -573,6 +524,55 @@ const getProfile = async (provider, query, callback) => {
               body.username || body.nickname || body.name || body.email.split('@')[0];
             const email = body.email || `${username.replace(/\s+/g, '.')}@strapi.io`;
 
+            callback(null, {
+              username,
+              email,
+            });
+          }
+        });
+      break;
+    }
+    case 'cas': {
+      const provider_url = 'https://' + _.get(grant['cas'], 'subdomain');
+      const cas = purest({
+        provider: 'cas',
+        config: {
+          cas: {
+            [provider_url]: {
+              __domain: {
+                auth: {
+                  auth: { bearer: '[0]' },
+                },
+              },
+              '{endpoint}': {
+                __path: {
+                  alias: '__default',
+                },
+              },
+            },
+          },
+        },
+      });
+      cas
+        .query()
+        .get('oidc/profile')
+        .auth(access_token)
+        .request((err, res, body) => {
+          if (err) {
+            callback(err);
+          } else {
+            // CAS attribute may be in body.attributes or "FLAT", depending on CAS config
+            const username = body.attributes
+              ? body.attributes.strapiusername || body.id || body.sub
+              : body.strapiusername || body.id || body.sub;
+            const email = body.attributes
+              ? body.attributes.strapiemail || body.attributes.email
+              : body.strapiemail || body.email;
+            if (!username || !email) {
+              console.log(
+                'CAS Response Body did not contain required attributes: ' + JSON.stringify(body)
+              );
+            }
             callback(null, {
               username,
               email,


### PR DESCRIPTION
This adds support for CAS as an OIDC login provider. CAS is supported by grant but there isn't a central CAS server so the `subdomain` parameter is required to be in the grant context so the URLs can be generated. If I ran a CAS server for a company at `https://my.company.com/cas` then the subdomain would be `my.company.com/cas`.  The fact that subdomain includes the whole domain and possibly some extra non-domain stuff is because that is how it is done in grant (for CAS and several other providers). https://github.com/simov/grant/blob/master/config/oauth.json#L148

We are currently using this as a strapi extension by overriding these same files in the `extensions\users-permissions` folder.

Edited: removed some stuff that was no longer accurate. After this PR was made initially, another provider added support for subdomain which made this much simpler. 