### PR TITLE
Assume selection is text when creating a link

### DIFF
--- a/packages/strapi-plugin-content-manager/admin/src/components/Wysiwyg/constants.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/Wysiwyg/constants.js
@@ -82,7 +82,7 @@ export const CONTROLS = [
       className: 'link',
       hideLabel: true,
       handler: 'addContent',
-      text: '[text](textToReplace)',
+      text: '[textToReplace](link)',
     },
     {
       label: 'quotes',

--- a/packages/strapi-plugin-content-manager/admin/src/components/Wysiwyg/helpers.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/Wysiwyg/helpers.js
@@ -55,9 +55,9 @@ export function getBlockContent(style) {
       };
     case 'LINK':
       return {
-        innerContent: 'link',
-        endReplacer: ')',
-        startReplacer: '[text](',
+        innerContent: 'text',
+        endReplacer: ']',
+        startReplacer: '[',
       };
     default:
       return {


### PR DESCRIPTION
Fixes #7890

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch) 
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/docs/contribguide/CONTRIBUTING.md
-->

#### Description of what you did:
Title says it all, when replacing a selection, assume the selection is text and not a link; as per the issue