### PR TITLE
temporary define mongoose 5.10.6 as workaround for #8066

### DIFF
--- a/packages/strapi-plugin-users-permissions/package.json
+++ b/packages/strapi-plugin-users-permissions/package.json
@@ -33,6 +33,9 @@
     "strapi-utils": "3.1.6",
     "uuid": "^3.1.0"
   },
+  "resolutions": {
+    "mongoose": "5.10.6"
+  },
   "devDependencies": {
     "koa": "^2.8.0"
   },


### PR DESCRIPTION
Mongoose 5.10.7 has a regression affecting core parts, used in koa2-ratelimit

Signed-off-by: Jonas De Kegel <jonas@fluid.desi>

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch) 
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/docs/contribguide/CONTRIBUTING.md
-->

#### Description of what you did:
Define mongoose 5.10.6 as a direct dependency of `strapi-plugin-users-permissions` so that 5.10.6 (instead of 5.10.7) is used in koa2-ratelimit.
Workaround as requested by @derrickmehaffy until https://github.com/Automattic/mongoose/issues/9449 (upstream) is resolved