### PR TITLE
Update upload.md

### DIFF
--- a/docs/v3.x/plugins/upload.md
+++ b/docs/v3.x/plugins/upload.md
@@ -107,6 +107,9 @@ To upload files that will be linked to a specific entry.
 - `source` (optional): The name of the plugin where the model is located.
 - `field`: The field of the entry which the file(s) will be precisely linked to.
 
+note: please note that you need to append a formdata called 'source' with value 'users-permissions' in order to upload pictures to the internal user collection type.
+
+
 ### Examples
 
 The `Restaurant` model attributes:


### PR DESCRIPTION


#### Description of what you did:

I enhanced a small thing in the upload documentation which got me stuck for ages. I Clarified how people can upload files related to the collection type "User" entry. 

For some reason the User collection type requires the following formData to be appended to the request.
**formData.append('source', 'users-permissions')** 

If this formdata is not present on the request it'll throw an error "Cannot read property 'associations' of undefined". 

For other collection types it all just works fine. The User collection type requires the extra formdata to get it working.

I think it's very useful for people since it got me and a lot of my team members stuck for a while. 