### PR TITLE
Prevent .cache folders to impact the unit tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   name: 'Unit test',
   testMatch: ['**/packages/**/__tests__/?(*.)+(spec|test).js'],
+  modulePathIgnorePatterns: ['.cache'],
   transform: {},
 };


### PR DESCRIPTION
Add `.cache` pattern to excluded paths in `jest.config.js`