### PR TITLE
add strapi-plugin-email thai translation

### DIFF
--- a/packages/strapi-plugin-email/admin/src/translations/index.js
+++ b/packages/strapi-plugin-email/admin/src/translations/index.js
@@ -13,6 +13,7 @@ import pl from './pl.json';
 import ptBR from './pt-BR.json';
 import pt from './pt.json';
 import ru from './ru.json';
+import th from './th.json';
 import tr from './tr.json';
 import uk from './uk.json';
 import vi from './vi.json';
@@ -36,6 +37,7 @@ const trads = {
   'pt-BR': ptBR,
   pt,
   ru,
+  th,
   tr,
   uk,
   vi,

--- a/packages/strapi-plugin-email/admin/src/translations/th.json
+++ b/packages/strapi-plugin-email/admin/src/translations/th.json
@@ -1,0 +1,4 @@
+{
+  "plugin.description.long": "Send emails.",
+  "plugin.description.short": "Send emails."
+}

--- a/packages/strapi-plugin-email/admin/src/translations/th.json
+++ b/packages/strapi-plugin-email/admin/src/translations/th.json
@@ -1,4 +1,4 @@
 {
-  "plugin.description.long": "Send emails.",
-  "plugin.description.short": "Send emails."
+  "plugin.description.long": "ส่งอีเมล",
+  "plugin.description.short": "ส่งอีเมล"
 }


### PR DESCRIPTION
Add translations to a new language - Thai to **strapi-plugin-email**

If you are Thai and use Strapi, please join for discussion and contribute with us.
**[Strapi Thailand](https://www.facebook.com/groups/564370471172538)** Facebook group. See you there!