### PR TITLE
docs: update database configurations to match current implementation

### DIFF
--- a/docs/v3.x/concepts/configurations.md
+++ b/docs/v3.x/concepts/configurations.md
@@ -364,21 +364,20 @@ You can find [supported database and versions](../installation/cli.md#databases)
       - `database` (string): Database name.
       - `username` (string): Username used to establish the connection.
       - `password` (string): Password used to establish the connection.
-      - `options` (object): List of additional options used by the connector.
       - `timezone` (string): Set the default behavior for local time. Default value: `utc` [Timezone options](https://www.php.net/manual/en/timezones.php).
       - `schema` (string): Set the default database schema. **Used only for Postgres DB.**
       - `ssl` (boolean/object): For ssl database connection. Object is used to pass certificate files as strings.
     - `options` Options used for database connection.
       - `debug` (boolean): Show database exchanges and errors.
       - `autoMigration` (boolean): To disable auto tables/columns creation for SQL database.
-      - `pool` Options used for database connection pooling. For more information look at [Knex's pool config documentation](https://knexjs.org/#Installation-pooling).
-        - `min` (integer): Minimum number of connections to keep in the pool. Default value: `0`.
-        - `max` (integer): Maximum number of connections to keep in the pool. Default value: `10`.
-        - `acquireTimeoutMillis` (integer): Maximum time in milliseconds to wait for acquiring a connection from the pool. Default value: `2000` (2 seconds).
-        - `createTimeoutMillis` (integer): Maximum time in milliseconds to wait for creating a connection to be added to the pool. Default value: `2000` (2 seconds).
-        - `idleTimeoutMillis` (integer): Number of milliseconds to wait before destroying idle connections. Default value: `30000` (30 seconds).
-        - `reapIntervalMillis` (integer): How often to check for idle connections in milliseconds. Default value: `1000` (1 second).
-        - `createRetryIntervalMillis` (integer): How long to idle after a failed create before trying again in milliseconds. Default value: `200`.
+      - `pool` Options used for database connection pooling. For default value and more information, look at [Knex's pool config documentation](https://knexjs.org/#Installation-pooling).
+        - `min` (integer): Minimum number of connections to keep in the pool.
+        - `max` (integer): Maximum number of connections to keep in the pool.
+        - `acquireTimeoutMillis` (integer): Maximum time in milliseconds to wait for acquiring a connection from the pool.
+        - `createTimeoutMillis` (integer): Maximum time in milliseconds to wait for creating a connection to be added to the pool.
+        - `idleTimeoutMillis` (integer): Number of milliseconds to wait before destroying idle connections.
+        - `reapIntervalMillis` (integer): How often to check for idle connections in milliseconds.
+        - `createRetryIntervalMillis` (integer): How long to idle after a failed create before trying again in milliseconds.
 
 :::
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch) 
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/docs/contribguide/CONTRIBUTING.md
-->

#### Description of what you did:
Default values for pooling options is removed in #6469, so currently they are same as `knex` and `tarn`. And `settings.options` is not used anywhere, so I guess it is succeeded by `options`.