### PR TITLE
Custom widget for a Field API

### DIFF
--- a/packages/strapi-plugin-content-manager/admin/src/components/Inputs/index.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/Inputs/index.js
@@ -89,6 +89,7 @@ function Inputs({
   const metadatas = useMemo(() => get(layout, ['metadatas', name, 'edit'], {}), [layout, name]);
   const disabled = useMemo(() => !get(metadatas, 'editable', true), [metadatas]);
   const type = useMemo(() => get(attribute, 'type', null), [attribute]);
+  const widget = useMemo(() => get(attribute, 'widget', null), [attribute]);
   const regexpString = useMemo(() => get(attribute, 'regex', null), [attribute]);
   const temporaryErrorIdUntilBuffetjsSupportsFormattedMessage = 'app.utils.defaultMessage';
   const errorId = useMemo(() => {
@@ -108,7 +109,7 @@ function Inputs({
   const validations = useMemo(() => omit(attribute, validationsToOmit), [attribute]);
   const isRequired = useMemo(() => get(validations, ['required'], false), [validations]);
   const inputType = useMemo(() => {
-    return getInputType(type);
+    return getInputType(widget ? widget : type);
   }, [type]);
   const inputValue = useMemo(() => {
     // Fix for input file multipe


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch) 
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/docs/contribguide/CONTRIBUTING.md
-->

#### Description of what you did:
Add "widget" to the strapi-plugin-content-manager.

User can create custom field, same as here:
https://strapi.io/documentation/v3.x/guides/registering-a-field-in-admin.html#introduction

But instead of change "type" in model.settings.json, he can add "widget" field instead.
In that case user can create new input types for old fields, i.e.: "json" or "string" without changing anything in the model or database. Multiple input widgets for one field type can be created.

Example `page.settings.json`:
```javascript
{
  "kind": "collectionType",
  "collectionName": "pages",
  "info": {
    "name": "Page"
  },
  "options": {
    "increments": true,
    "timestamps": true
  },
  "attributes": {
    "text": {
      "type": "wysiwyg",
      "widget": "ckeditor"    <------ new option
    }
  }
}

```
