### PR TITLE
Handle template download error

### DIFF
--- a/packages/strapi-generate-new/lib/utils/merge-template.js
+++ b/packages/strapi-generate-new/lib/utils/merge-template.js
@@ -155,6 +155,9 @@ async function downloadGithubRepo(repoInfo, templatePath) {
   const { user, project } = repoInfo;
   const codeload = `https://codeload.github.com/${user}/${project}/tar.gz/master`;
   const response = await fetch(codeload);
+  if (!response.ok) {
+    throw Error(`Could not download the ${chalk.green(`${user}/${project}`)} repository`);
+  }
 
   await new Promise(resolve => {
     response.body.pipe(tar.extract({ strip: 1, cwd: templatePath })).on('close', resolve);


### PR DESCRIPTION
#### Description of what you did:

Better error management during the installation of templates. We use `node-fetch` to download the templates from GitHub, and it only throws an error if there is a network error. I added an additional check to make sure the status of the download was ok.

This has an effect when:

* The user enters a repo that doesn't exist
* The user enters a private repo

Before this fix, the error message was quite obscure. It only failed while uncompressing the downloaded files with `tar`.
