### PR TITLE
Remove unneeded modals when D&P is disabled

### DIFF
--- a/packages/strapi-plugin-content-manager/admin/src/containers/EditView/Header/index.js
+++ b/packages/strapi-plugin-content-manager/admin/src/containers/EditView/Header/index.js
@@ -26,12 +26,12 @@ const Header = ({
   initialData,
   isCreatingEntry,
   isSingleType,
-  status,
-  layout,
   hasDraftAndPublish,
+  layout,
   modifiedData,
   onPublish,
   onUnpublish,
+  status,
 }) => {
   const [showWarningUnpublish, setWarningUnpublish] = useState(false);
   const { formatMessage } = useIntl();
@@ -189,46 +189,49 @@ const Header = ({
   return (
     <>
       <PluginHeader {...headerProps} />
-
-      <ModalConfirm
-        isOpen={showWarningUnpublish}
-        toggle={toggleWarningPublish}
-        content={{
-          id: getTrad('popUpWarning.warning.unpublish'),
-          values: {
-            br: () => <br />,
-          },
-        }}
-        type="xwarning"
-        onConfirm={handleConfirmUnpublish}
-        onClosed={handleCloseModalUnpublish}
-      >
-        <Text>{formatMessage({ id: getTrad('popUpWarning.warning.unpublish-question') })}</Text>
-      </ModalConfirm>
-      <ModalConfirm
-        confirmButtonLabel={{
-          id: getTrad('popUpwarning.warning.has-draft-relations.button-confirm'),
-        }}
-        isOpen={showWarningDraftRelation}
-        toggle={toggleWarningDraftRelation}
-        onClosed={handleCloseModalPublish}
-        onConfirm={handleConfirmPublish}
-        type="success"
-        content={{
-          id: getTrad(`popUpwarning.warning.has-draft-relations.message.${contentIdSuffix}`),
-          values: {
-            count: draftRelationsCount,
-            b: chunks => (
-              <Text as="span" fontWeight="bold">
-                {chunks}
-              </Text>
-            ),
-            br: () => <br />,
-          },
-        }}
-      >
-        <Text>{formatMessage({ id: getTrad('popUpWarning.warning.publish-question') })}</Text>
-      </ModalConfirm>
+      {hasDraftAndPublish && (
+        <>
+          <ModalConfirm
+            isOpen={showWarningUnpublish}
+            toggle={toggleWarningPublish}
+            content={{
+              id: getTrad('popUpWarning.warning.unpublish'),
+              values: {
+                br: () => <br />,
+              },
+            }}
+            type="xwarning"
+            onConfirm={handleConfirmUnpublish}
+            onClosed={handleCloseModalUnpublish}
+          >
+            <Text>{formatMessage({ id: getTrad('popUpWarning.warning.unpublish-question') })}</Text>
+          </ModalConfirm>
+          <ModalConfirm
+            confirmButtonLabel={{
+              id: getTrad('popUpwarning.warning.has-draft-relations.button-confirm'),
+            }}
+            isOpen={showWarningDraftRelation}
+            toggle={toggleWarningDraftRelation}
+            onClosed={handleCloseModalPublish}
+            onConfirm={handleConfirmPublish}
+            type="success"
+            content={{
+              id: getTrad(`popUpwarning.warning.has-draft-relations.message.${contentIdSuffix}`),
+              values: {
+                count: draftRelationsCount,
+                b: chunks => (
+                  <Text as="span" fontWeight="bold">
+                    {chunks}
+                  </Text>
+                ),
+                br: () => <br />,
+              },
+            }}
+          >
+            <Text>{formatMessage({ id: getTrad('popUpWarning.warning.publish-question') })}</Text>
+          </ModalConfirm>
+        </>
+      )}
     </>
   );
 };


### PR DESCRIPTION
Signed-off-by: soupette <cyril.lpz@gmail.com>

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch) 
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/docs/contribguide/CONTRIBUTING.md
-->

#### Description of what you did:
This PR removes the D&P related modals when the feature is disabled on a content type.