### PR TITLE
Bump node-fetch to 2.6.1

### DIFF
--- a/packages/strapi-generate-new/package.json
+++ b/packages/strapi-generate-new/package.json
@@ -20,7 +20,7 @@
     "hosted-git-info": "3.0.5",
     "inquirer": "^6.3.1",
     "lodash": "4.17.19",
-    "node-fetch": "^1.7.3",
+    "node-fetch": "^2.6.1",
     "node-machine-id": "^1.1.10",
     "ora": "^3.4.0",
     "tar": "6.0.5",

--- a/packages/strapi-plugin-upload/package.json
+++ b/packages/strapi-plugin-upload/package.json
@@ -20,7 +20,7 @@
     "koa-range": "0.3.0",
     "koa-static": "^5.0.0",
     "lodash": "4.17.19",
-    "node-fetch": "2.6.0",
+    "node-fetch": "2.6.1",
     "react": "^16.13.1",
     "react-copy-to-clipboard": "^5.0.1",
     "react-dom": "^16.9.0",

--- a/packages/strapi/package.json
+++ b/packages/strapi/package.json
@@ -43,7 +43,7 @@
     "koa-session": "^6.0.0",
     "koa-static": "^5.0.0",
     "lodash": "4.17.19",
-    "node-fetch": "2.6.0",
+    "node-fetch": "2.6.1",
     "node-machine-id": "1.1.12",
     "node-schedule": "1.3.2",
     "opn": "^5.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10394,7 +10394,7 @@ is-stream-ended@^0.1.4:
   resolved "https://registry.yarnpkg.com/is-stream-ended/-/is-stream-ended-0.1.4.tgz#f50224e95e06bce0e356d440a4827cd35b267eda"
   integrity sha512-xj0XPvmr7bQFTvirqnFr50o0hQIh6ZItDqloxt5aJrR4NQsYeSsyFQERYGCAzfindAcnKjINnwEEgLx4IqVzQw==
 
-is-stream@^1.0.1, is-stream@^1.1.0:
+is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
@@ -13088,23 +13088,10 @@ node-fetch-npm@^2.0.2:
     json-parse-better-errors "^1.0.0"
     safe-buffer "^5.1.1"
 
-node-fetch@2.6.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
-  integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
-
 node-fetch@2.6.1, node-fetch@^2.1.2, node-fetch@^2.2.0, node-fetch@^2.3.0, node-fetch@^2.5.0, node-fetch@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
-
-node-fetch@^1.7.3:
-  version "1.7.3"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
-  integrity sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==
-  dependencies:
-    encoding "^0.1.11"
-    is-stream "^1.0.1"
 
 node-forge@^0.10.0:
   version "0.10.0"


### PR DESCRIPTION
node-fetch < 2.6.1 has a security vulnerability
(https://github.com/advisories/GHSA-w7rc-rwvf-8q5r)

This is a major version bump for strapi-plugin-upload (from 1.7.3), but
it does not look like strapi-plugin-upload is relying on any of the
functionality that has broken from 1.x to 2.x

This covers the same change in https://github.com/strapi/strapi/pull/7975, but for more than strapi-generate-new.

This also covers three dependabot PRs that were closed without merging:
* https://github.com/strapi/strapi/pull/7857
* https://github.com/strapi/strapi/pull/7837
* https://github.com/strapi/strapi/pull/7757

#### Description of what you did:

Bumped node-fetch in the packages that use it, to address a security vulnerability.

* strapi-generate-new: 1.7.3 -> 2.6.1
* strapi-plugin-upload: 2.6.0 -> 2.6.1
* strapi: 2.6.0 -> 2.6.1