### PR TITLE
Add missing 'format' reserved model word.

### DIFF
--- a/packages/strapi-database/lib/constants/index.js
+++ b/packages/strapi-database/lib/constants/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 // contentTypes and components reserved names
-const RESERVED_MODEL_NAMES = ['admin', 'boolean', 'date', 'date-time', 'time', 'upload'];
+const RESERVED_MODEL_NAMES = ['admin', 'boolean', 'date', 'date-time', 'format', 'time', 'upload'];
 // attribute reserved names
 const RESERVED_ATTRIBUTE_NAMES = [
   '_id',

--- a/packages/strapi-database/lib/constants/index.js
+++ b/packages/strapi-database/lib/constants/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 // contentTypes and components reserved names
-const RESERVED_MODEL_NAMES = ['admin', 'boolean', 'date', 'date-time', 'format', 'time', 'upload'];
+const RESERVED_MODEL_NAMES = ['admin', 'boolean', 'date', 'date-time', 'time', 'upload'];
 // attribute reserved names
 const RESERVED_ATTRIBUTE_NAMES = [
   '_id',
@@ -33,6 +33,7 @@ const RESERVED_ATTRIBUTE_NAMES = [
   'schema',
   'toObject',
   'validate',
+  'format',
 ];
 
 module.exports = {


### PR DESCRIPTION
#### Description of what you did:

Fixed issue where user was allowed to create a model with reserved word 'format'. Creating this model would then break one-to-one relationships and cause an error: "Maximum call stack size exceeded."
