### PR TITLE
fixes #8221 - fixed publish failing if non-repeateable component data is "null"

### DIFF
--- a/packages/strapi-plugin-content-manager/admin/src/containers/EditView/Header/utils/getDraftRelations.js
+++ b/packages/strapi-plugin-content-manager/admin/src/containers/EditView/Header/utils/getDraftRelations.js
@@ -26,7 +26,7 @@ const getDraftRelations = (data, ctSchema, components) => {
           currentData.forEach(curr => {
             acc += getDraftRelationsCount(curr, compoSchema);
           });
-        } else {
+        } else if (currentData !== null) {
           acc += getDraftRelationsCount(currentData, compoSchema);
         }
       }


### PR DESCRIPTION
Fixes #8220 

In #8221 I explained the problem thoroughly, but it was closed as it is a duplicate of 8220.

Basically `getDraftRelationsCount` is called with `null` as data, and then `Object.keys(data)` fails on [line 5](https://github.com/strapi/strapi/blob/master/packages/strapi-plugin-content-manager/admin/src/containers/EditView/Header/utils/getDraftRelations.js#L5)

I'm pretty sure this doesn't affect other functionalities.
