### PR TITLE
Fix getDraftRelationsCount utility

### DIFF
--- a/packages/strapi-plugin-content-manager/admin/src/containers/EditView/Header/utils/getDraftRelations.js
+++ b/packages/strapi-plugin-content-manager/admin/src/containers/EditView/Header/utils/getDraftRelations.js
@@ -1,4 +1,4 @@
-import { get, has, isEmpty } from 'lodash';
+import { get, has, isEmpty, isNil } from 'lodash';
 
 const getDraftRelations = (data, ctSchema, components) => {
   const getDraftRelationsCount = (data, schema) =>
@@ -8,6 +8,10 @@ const getDraftRelations = (data, ctSchema, components) => {
       const isMorph = relationType.toLowerCase().includes('morph');
       const oneWayTypes = ['oneWay', 'oneToOne', 'manyToOne'];
       const currentData = data[current];
+
+      if (isNil(currentData)) {
+        return acc;
+      }
 
       if (type === 'dynamiczone') {
         currentData.forEach(curr => {
@@ -26,7 +30,7 @@ const getDraftRelations = (data, ctSchema, components) => {
           currentData.forEach(curr => {
             acc += getDraftRelationsCount(curr, compoSchema);
           });
-        } else if (currentData !== null) {
+        } else {
           acc += getDraftRelationsCount(currentData, compoSchema);
         }
       }


### PR DESCRIPTION
Signed-off-by: soupette <cyril.lpz@gmail.com>

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch) 
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/docs/contribguide/CONTRIBUTING.md
-->

#### Description of what you did:
This PR fixes an helper that retrieves the number of relations that are still in draft state.