### PR TITLE
Fix wrong query generation with bookshelf

### DIFF
--- a/packages/strapi-connector-bookshelf/lib/populate.js
+++ b/packages/strapi-connector-bookshelf/lib/populate.js
@@ -210,7 +210,7 @@ const formatPopulateOptions = (definition, { withRelated, publicationState } = {
       prefix = `${newKey}.`;
 
       _.extend(acc, {
-        [newKey]: pq.extendWithPopulateQueries(obj[key], {
+        [newKey]: pq.extendWithPopulateQueries([obj[newKey], acc[newKey]], {
           publicationState: { query: publicationState, model: tmpModel },
         }),
       });
@@ -238,9 +238,14 @@ const formatPolymorphicPopulate = ({ assoc, prefix = '', publicationState }) => 
   const path = `${prefix}${assoc.alias}.${model.collectionName}`;
 
   return {
-    [path]: pq.extendWithPopulateQueries(qb => {
-      qb.orderBy('created_at', 'desc');
-    }, populateOptions),
+    [path]: pq.extendWithPopulateQueries(
+      [
+        qb => {
+          qb.orderBy('created_at', 'desc');
+        },
+      ],
+      populateOptions
+    ),
   };
 };
 

--- a/packages/strapi-connector-bookshelf/lib/utils/populate-queries.js
+++ b/packages/strapi-connector-bookshelf/lib/utils/populate-queries.js
@@ -78,17 +78,15 @@ const bindPopulateQueries = (paths, options) => {
 
 /**
  * Extend the behavior of an already existing populate query, and bind generated (from options) ones to it
- * @param fn
+ * @param fns
  * @param options
  * @returns {function(...[*]=)}
  */
-const extendWithPopulateQueries = (fn, options) => {
+const extendWithPopulateQueries = (fns, options) => {
   const queries = toQueries(options);
 
   return qb => {
-    if (_.isFunction(fn)) {
-      fn(qb);
-    }
+    fns.filter(_.isFunction).forEach(fn => fn(qb));
     runPopulateQueries(queries, qb);
   };
 };


### PR DESCRIPTION
fix #8225 

Fix wrong behaviour from bookshelf's populate which was extending custom populate queries for each part of the deep path instead of only extending the full path and binding populate queries to the rest.

The fix consist of **extending** the original query only for the full path. **Binding** only populate queries otherwise. 