### PR TITLE
Fix incorrect notification when copy media url to clipboard

### DIFF
--- a/packages/strapi-plugin-upload/admin/src/components/InputMedia/index.js
+++ b/packages/strapi-plugin-upload/admin/src/components/InputMedia/index.js
@@ -94,7 +94,7 @@ const InputMedia = ({ disabled, label, onChange, name, attribute, value, type, i
   };
 
   const handleCopy = () => {
-    strapi.notification.info(getTrad('notification.link-copied'));
+    strapi.notification.info('notification.link-copied');
   };
 
   const handleAllowDrop = e => e.preventDefault();


### PR DESCRIPTION
#### Description of what you did:

fix #7669 point 8

verified point 6 on strapi@3.2.1 and it looks good.

for point 5 and 7, not sure if need to fix because it is subjective. Let me know if strapi team wants a fix.
