### PR TITLE
Update /_health to accept GET requests

### DIFF
--- a/packages/strapi/lib/Strapi.js
+++ b/packages/strapi/lib/Strapi.js
@@ -277,7 +277,7 @@ class Strapi {
 
   async load() {
     this.app.use(async (ctx, next) => {
-      if (ctx.request.url === '/_health' && ctx.request.method === 'HEAD') {
+      if (ctx.request.url === '/_health' && ['HEAD', 'GET'].includes(ctx.request.method)) {
         ctx.set('strapi', 'You are so French!');
         ctx.status = 204;
       } else {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch) 
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/docs/contribguide/CONTRIBUTING.md
-->

#### Description of what you did:

I updated the health check to handle both GET and HEAD requests, where before it only handled HEAD requests. 

#### More context:

I'm an engineer at Render, and recently worked on our [Deploy Strapi doc](https://render.com/docs/deploy-strapi) and Strapi example repos. Render uses health checks to enable zero downtime deploys, as described here: https://render.com/docs/zero-downtime-deploys. Our health checks use GET requests, so currently we're recommending that people deploying Strapi on Render create a file at `/public/healthz/index.html` with contents `OK`, and specify `/healthz` as their health check path. This is okay, but it would be cleaner if we could use the existing health check at `/_health`.

I imagine this could be helpful for Strapi users on other platforms as well.