### PR TITLE
DOC: Reference the configuration options for SQL databases from the Databases guide

### DIFF
--- a/docs/v3.x/guides/databases.md
+++ b/docs/v3.x/guides/databases.md
@@ -41,6 +41,13 @@ This will create a new project and launch it in the browser.
 The [Quick Start Guide](../getting-started/quick-start.md) is a complete step-by-step tutorial
 :::
 
+## Other SQL Databases (PostgreSQL, MySQL)
+Refer to the [configuration section](../concepts/configurations.md#database) for all supported options to setup Strapi with your SQL database.
+
+::: tip
+Most cloud service providers offer a managed SQL database service, which is a hassle-free way to get your database up and running. To get up and running locally, you might want to try using a Docker container.
+:::
+
 ## MongoDB Installation
 
 ### Install MongoDB locally


### PR DESCRIPTION
Hello, and thanks for building Strapi, we're using it for our next-gen website and it looks very promising.

I started my project using the quickstart option, but quickly wanted to move on to my PostgreSQL instance to get a setup as close to production as possible (also, I had to use Docker anyway since I have Node v14 on my machine, and well docker-compose just works). So I wen through the configuration to change my database settings, and looked at the documentation to find the relevant parameters. Having two pages with the same title made it difficult for me to find the right options since the guide page does not talk about PostgreSQL or MySQL. This PR aims to add the missing link between the two pages.

#### Description of what you did:
Added a section in the Databases guide referring to the configuration options for SQL databases.