### PR TITLE
Update index.js

### DIFF
--- a/packages/strapi-provider-upload-cloudinary/lib/index.js
+++ b/packages/strapi-provider-upload-cloudinary/lib/index.js
@@ -61,7 +61,7 @@ module.exports = {
             throw errors.unknownError(`Error deleting on cloudinary: ${response.result}`);
           }
         } catch (error) {
-          throw errors.unknownError(`Error deleting on cloudinary: ${error.error.message}`);
+          throw errors.unknownError(`Error deleting on cloudinary: ${error.message}`);
         }
       },
     };


### PR DESCRIPTION
Fix `TypeError: Cannot read property 'message' of undefined` and use `error.message` directly instead of `error.error.message`

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch) 
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/docs/contribguide/CONTRIBUTING.md
-->

#### Description of what you did:
