### PR TITLE
Convert provider emails to lowercase for lookup

### DIFF
--- a/packages/strapi-plugin-users-permissions/services/Providers.js
+++ b/packages/strapi-plugin-users-permissions/services/Providers.js
@@ -45,7 +45,7 @@ const connect = (provider, query) => {
 
       try {
         const users = await strapi.query('user', 'users-permissions').find({
-          email: profile.email,
+          email: profile.email.toLowerCase(),
         });
 
         const advanced = await strapi
@@ -63,7 +63,7 @@ const connect = (provider, query) => {
           return resolve([
             null,
             [{ messages: [{ id: 'Auth.advanced.allow_register' }] }],
-            'Register action is actualy not available.',
+            'Register action is actually not available.',
           ]);
         }
 
@@ -88,6 +88,7 @@ const connect = (provider, query) => {
           .findOne({ type: advanced.default_role }, []);
 
         // Create the new user.
+        profile.email = profile.email.toLowerCase();
         const params = _.assign(profile, {
           provider: provider,
           role: defaultRole.id,

--- a/packages/strapi-plugin-users-permissions/services/Providers.js
+++ b/packages/strapi-plugin-users-permissions/services/Providers.js
@@ -45,8 +45,16 @@ const connect = (provider, query) => {
 
       try {
         const users = await strapi.query('user', 'users-permissions').find({
-          email: profile.email.toLowerCase(),
+          _where: {
+            _or: [{
+              email: profile.email.toLowerCase()
+            }, {
+              email: profile.email
+            }]
+          }
         });
+
+        // If exists as an upper case should we send another request to lowercase it?
 
         const advanced = await strapi
           .store({


### PR DESCRIPTION
Signed-off-by: Derrick Mehaffy <derrickmehaffy@gmail.com>

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch) 
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/docs/contribguide/CONTRIBUTING.md
-->

#### Description of what you did:

fixes #8235 

Converts lookup email to lowercase and ensures new email from provider is saved as lowercase

# Don't merge until major release as is a breaking change