### PR TITLE
Fix validations for custom field types

### DIFF
--- a/packages/strapi/lib/services/__tests__/entity-validator.test.js
+++ b/packages/strapi/lib/services/__tests__/entity-validator.test.js
@@ -102,6 +102,25 @@ describe('Entity validator', () => {
           });
         });
       });
+
+      it('Supports custom field types', async () => {
+        const model = {
+          attributes: {
+            uuid: {
+              type: 'uuid',
+            },
+          },
+        };
+
+        const input = { uuid: '2479d6d7-2497-478d-8a34-a9e8ce45f8a7' };
+
+        expect.hasAssertions();
+
+        const data = await entityValidator.validateEntityCreation(model, input);
+        expect(data).toEqual({
+          uuid: '2479d6d7-2497-478d-8a34-a9e8ce45f8a7',
+        });
+      });
     });
 
     describe('String validator', () => {
@@ -334,6 +353,25 @@ describe('Entity validator', () => {
           { isDraft: true }
         );
         expect(data).toEqual({ title: null });
+      });
+
+      it('Supports custom field types', async () => {
+        const model = {
+          attributes: {
+            uuid: {
+              type: 'uuid',
+            },
+          },
+        };
+
+        const input = { uuid: '2479d6d7-2497-478d-8a34-a9e8ce45f8a7' };
+
+        expect.hasAssertions();
+
+        const data = await entityValidator.validateEntityCreation(model, input, { isDraft: true });
+        expect(data).toEqual({
+          uuid: '2479d6d7-2497-478d-8a34-a9e8ce45f8a7',
+        });
       });
     });
 

--- a/packages/strapi/lib/services/entity-validator/index.js
+++ b/packages/strapi/lib/services/entity-validator/index.js
@@ -126,7 +126,13 @@ const createRelationValidator = createOrUpdate => (attr, data, { isDraft }) => {
 const createSimpleAttributeValidator = createOrUpdate => (attr, { isDraft }) => {
   let validator;
 
-  validator = validators[attr.type](attr, { isDraft });
+  if (attr.type in validators) {
+    validator = validators[attr.type](attr, { isDraft });
+  } else {
+    // No validators specified - fall back to mixed
+    validator = yup.mixed();
+  }
+
   validator = addRequiredValidation(createOrUpdate)(!isDraft && attr.required, validator);
 
   return validator;


### PR DESCRIPTION
Fixes #8294 

With the new draft/publish system, models with custom field types could no longer be saved.
(Custom field types described [here](https://strapi.io/documentation/v3.x/plugin-development/frontend-field-api.html#registering-a-new-field))

When trying to create or update a model with an un-handled attribute type, the API would give a 500 internal server error, as no validator exists for this attribute type.

This PR handles the case where a custom validator is not available for a specific attribute type, and instead of throwing an error, falls back to using a mixed type validator.