### PR TITLE
Add Academy link to the 'Join the community' card in the homepage

### DIFF
--- a/packages/strapi-admin/admin/src/containers/HomePage/SocialLink.js
+++ b/packages/strapi-admin/admin/src/containers/HomePage/SocialLink.js
@@ -28,6 +28,7 @@ function getSrc(name) {
     case 'Twitter':
       return Twitter;
     case 'Forum':
+    case 'Academy':
       return Forum;
     default:
       return Gh;

--- a/packages/strapi-admin/admin/src/containers/HomePage/index.js
+++ b/packages/strapi-admin/admin/src/containers/HomePage/index.js
@@ -55,6 +55,10 @@ const SOCIAL_LINKS = [
     name: 'Forum',
     link: 'https://forum.strapi.io',
   },
+  {
+    name: 'Academy',
+    link: 'https://academy.strapi.io',
+  },
 ];
 
 const HomePage = ({ global: { plugins }, history: { push } }) => {


### PR DESCRIPTION
#### Description of what you did:

I added a link to the academy in the "Join the community" card in the homepage

<img width="388" alt="Capture d’écran 2020-10-13 à 14 52 53" src="https://user-images.githubusercontent.com/17828745/95862861-c7351400-0d63-11eb-9ad4-bcfdb14e9482.png">

