### PR TITLE
wrap updatePermissions map in _.attempt()

### DIFF
--- a/packages/strapi-plugin-users-permissions/services/UsersPermissions.js
+++ b/packages/strapi-plugin-users-permissions/services/UsersPermissions.js
@@ -259,10 +259,10 @@ module.exports = {
     const dbPermissions = await strapi
       .query('permission', 'users-permissions')
       .find({ _limit: -1 });
-    let permissionsFoundInDB = dbPermissions.map(
+    let permissionsFoundInDB = _.attempt(()=>dbPermissions.map(
       p => `${p.type}.${p.controller}.${p.action}.${p.role[primaryKey]}`
-    );
-    permissionsFoundInDB = _.uniq(permissionsFoundInDB);
+    ))
+    permissionsFoundInDB = _.isError(permissionsFoundInDB)?[]:_.uniq(permissionsFoundInDB);
 
     // Aggregate first level actions.
     const appActions = Object.keys(strapi.api || {}).reduce((acc, api) => {


### PR DESCRIPTION
### What does it do?

Wrapped mapping of found permissions in lodash's attempt (try-catch). Fallbacks to empty array in case _.attempt returns an error.

### Why is it needed?

To stop strapi from crashing when all documents don't match users-permissions' model.

### Related issue(s)/PR(s)

Most likely fixes [#6941](https://github.com/strapi/strapi/issues/6941)
