### PR TITLE
Add confirmationToken to user for email confirmation

### DIFF
--- a/docs/v3.x/migration-guide/README.md
+++ b/docs/v3.x/migration-guide/README.md
@@ -17,7 +17,8 @@ If you were upgrading from the `3.0.0-beta.19.5` to `3.2.0`, here are the follow
 
 ## V3 guides
 
-- [Migration guide from 3.1.x to 3.2.x](migration-guide-3.1.x-to-3.2.x.md)
+- [Migration guide from 3.2.3 to 3.2.4](migration-guide-3.2.3-to-3.2.4.md)
+- [Migration guide from 3.1.x to 3.2.3](migration-guide-3.1.x-to-3.2.x.md)
 - [Migration guide from 3.0.x to 3.1.x](migration-guide-3.0.x-to-3.1.x.md)
 
 ## Beta guides

--- a/docs/v3.x/migration-guide/migration-guide-3.1.x-to-3.2.x.md
+++ b/docs/v3.x/migration-guide/migration-guide-3.1.x-to-3.2.x.md
@@ -1,4 +1,4 @@
-# Migration guide from 3.1.x to 3.2.x
+# Migration guide from 3.1.x to 3.2.3
 
 **Make sure your server is not running until the end of the migration**
 

--- a/docs/v3.x/migration-guide/migration-guide-3.2.3-to-3.2.4.md
+++ b/docs/v3.x/migration-guide/migration-guide-3.2.3-to-3.2.4.md
@@ -1,0 +1,49 @@
+# Migration guide from 3.2.3 to 3.2.4
+
+**Make sure your server is not running until the end of the migration**
+
+:::warning
+If you are using **extensions** to create custom code or modifying existing code, you will need to update your code and compare your version to the new changes on the repository.
+<br>
+Not updating your **extensions** can break your app in unexpected ways that we cannot predict.
+:::
+
+## Disclaimer
+
+This version requires a migration in the following cases:
+
+- You have extended the **Users-Permissions** **User** model and have the file `./extensions/users-permissions/models/User.settings.json`.
+
+Otherwise you can follow the basic [version update guide](../guides/update-version.md).
+
+## Migration
+
+To fix a security issue, we have added a `confirmationToken` attribute in the **User** model.
+If you have extended the model in any way, you will need to add the new attribute to the model in `./extensions/users-permissions/models/User.settings.json` following this example:
+
+**Before**:
+
+```json
+{
+  "attributes": {
+    //...
+  }
+}
+```
+
+**After**:
+
+```json
+{
+  "attributes": {
+    //...
+    "confirmationToken": {
+      "type": "string",
+      "configurable": false,
+      "private": true
+    }
+  }
+}
+```
+
+That's it now you can follow the basic [version update guide](../guides/update-version.md).

--- a/docs/v3.x/migration-guide/migration-guide-3.2.3-to-3.2.4.md
+++ b/docs/v3.x/migration-guide/migration-guide-3.2.3-to-3.2.4.md
@@ -46,4 +46,4 @@ If you have extended the model in any way, you will need to add the new attribut
 }
 ```
 
-That's it now you can follow the basic [version update guide](../guides/update-version.md).
+That's it, now you can follow the basic [version update guide](../guides/update-version.md).

--- a/examples/getstarted/extensions/users-permissions/models/User.settings.json
+++ b/examples/getstarted/extensions/users-permissions/models/User.settings.json
@@ -37,6 +37,11 @@
       "configurable": false,
       "private": true
     },
+    "confirmationToken": {
+      "type": "string",
+      "configurable": false,
+      "private": true
+    },
     "confirmed": {
       "type": "boolean",
       "default": false,

--- a/packages/strapi-plugin-users-permissions/controllers/Auth.js
+++ b/packages/strapi-plugin-users-permissions/controllers/Auth.js
@@ -525,19 +525,19 @@ module.exports = {
   async emailConfirmation(ctx, next, returnUser) {
     const { confirmation: confirmationToken } = ctx.query;
 
-    const { user: userServie, jwt: jwtService } = strapi.plugins['users-permissions'].services;
+    const { user: userService, jwt: jwtService } = strapi.plugins['users-permissions'].services;
 
     if (_.isEmpty(confirmationToken)) {
       return ctx.badRequest('token.invalid');
     }
 
-    const user = await userServie.fetch({ confirmationToken }, []);
+    const user = await userService.fetch({ confirmationToken }, []);
 
     if (!user) {
       return ctx.badRequest('token.invalid');
     }
 
-    await userServie.edit({ id: user.id }, { confirmed: true, confirmationToken: null });
+    await userService.edit({ id: user.id }, { confirmed: true, confirmationToken: null });
 
     if (returnUser) {
       ctx.send({

--- a/packages/strapi-plugin-users-permissions/controllers/Auth.js
+++ b/packages/strapi-plugin-users-permissions/controllers/Auth.js
@@ -10,7 +10,7 @@
 const crypto = require('crypto');
 const _ = require('lodash');
 const grant = require('grant-koa');
-const { sanitizeEntity, getAbsoluteServerUrl } = require('strapi-utils');
+const { sanitizeEntity } = require('strapi-utils');
 
 const emailRegExp = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
 const formatError = error => [
@@ -324,7 +324,9 @@ module.exports = {
       key: 'advanced',
     });
 
-    const userInfo = _.omit(user, ['password', 'resetPasswordToken', 'role', 'provider']);
+    const userInfo = sanitizeEntity(user, {
+      model: strapi.query('user', 'users-permissions').model,
+    });
 
     settings.message = await strapi.plugins['users-permissions'].services.userspermissions.template(
       settings.message,
@@ -387,7 +389,7 @@ module.exports = {
     }
 
     const params = {
-      ..._.omit(ctx.request.body, ['confirmed', 'resetPasswordToken']),
+      ..._.omit(ctx.request.body, ['confirmed', 'confirmationToken', 'resetPasswordToken']),
       provider: 'local',
     };
 
@@ -488,74 +490,26 @@ module.exports = {
 
       const user = await strapi.query('user', 'users-permissions').create(params);
 
-      const jwt = strapi.plugins['users-permissions'].services.jwt.issue(
-        _.pick(user.toJSON ? user.toJSON() : user, ['id'])
-      );
+      const sanitizedUser = sanitizeEntity(user, {
+        model: strapi.query('user', 'users-permissions').model,
+      });
 
       if (settings.email_confirmation) {
-        const settings = await pluginStore.get({ key: 'email' }).then(storeEmail => {
-          try {
-            return storeEmail['email_confirmation'].options;
-          } catch (error) {
-            return {};
-          }
-        });
-
-        settings.message = await strapi.plugins[
-          'users-permissions'
-        ].services.userspermissions.template(settings.message, {
-          URL: `${getAbsoluteServerUrl(strapi.config)}/auth/email-confirmation`,
-          USER: _.omit(user.toJSON ? user.toJSON() : user, [
-            'password',
-            'resetPasswordToken',
-            'role',
-            'provider',
-          ]),
-          CODE: jwt,
-        });
-
-        settings.object = await strapi.plugins[
-          'users-permissions'
-        ].services.userspermissions.template(settings.object, {
-          USER: _.omit(user.toJSON ? user.toJSON() : user, [
-            'password',
-            'resetPasswordToken',
-            'role',
-            'provider',
-          ]),
-        });
-
         try {
-          // Send an email to the user.
-          await strapi.plugins['email'].services.email.send({
-            to: (user.toJSON ? user.toJSON() : user).email,
-            from:
-              settings.from.email && settings.from.name
-                ? `${settings.from.name} <${settings.from.email}>`
-                : undefined,
-            replyTo: settings.response_email,
-            subject: settings.object,
-            text: settings.message,
-            html: settings.message,
-          });
+          await strapi.plugins['users-permissions'].services.user.sendConfirmationEmail(user);
         } catch (err) {
           return ctx.badRequest(null, err);
         }
+
+        return ctx.send({ user: sanitizedUser });
       }
 
-      const sanitizedUser = sanitizeEntity(user.toJSON ? user.toJSON() : user, {
-        model: strapi.query('user', 'users-permissions').model,
+      const jwt = strapi.plugins['users-permissions'].services.jwt.issue(_.pick(user, ['id']));
+
+      return ctx.send({
+        jwt,
+        user: sanitizedUser,
       });
-      if (settings.email_confirmation) {
-        ctx.send({
-          user: sanitizedUser,
-        });
-      } else {
-        ctx.send({
-          jwt,
-          user: sanitizedUser,
-        });
-      }
     } catch (err) {
       const adminError = _.includes(err.message, 'username')
         ? {
@@ -569,23 +523,26 @@ module.exports = {
   },
 
   async emailConfirmation(ctx, next, returnUser) {
-    const params = ctx.query;
+    const { confirmation: confirmationToken } = ctx.query;
 
-    const decodedToken = await strapi.plugins['users-permissions'].services.jwt.verify(
-      params.confirmation
-    );
+    const { user: userServie, jwt: jwtService } = strapi.plugins['users-permissions'].services;
 
-    let user = await strapi.plugins['users-permissions'].services.user.edit(
-      { id: decodedToken.id },
-      { confirmed: true }
-    );
+    if (_.isEmpty(confirmationToken)) {
+      return ctx.badRequest('token.invalid');
+    }
+
+    const user = await userServie.fetch({ confirmationToken }, []);
+
+    if (!user) {
+      return ctx.badRequest('token.invalid');
+    }
+
+    await userServie.edit({ id: user.id }, { confirmed: true, confirmationToken: null });
 
     if (returnUser) {
       ctx.send({
-        jwt: strapi.plugins['users-permissions'].services.jwt.issue({
-          id: user.id,
-        }),
-        user: sanitizeEntity(user.toJSON ? user.toJSON() : user, {
+        jwt: jwtService.issue({ id: user.id }),
+        user: sanitizeEntity(user, {
           model: strapi.query('user', 'users-permissions').model,
         }),
       });
@@ -604,12 +561,6 @@ module.exports = {
   },
 
   async sendEmailConfirmation(ctx) {
-    const pluginStore = await strapi.store({
-      environment: '',
-      type: 'plugin',
-      name: 'users-permissions',
-    });
-
     const params = _.assign(ctx.request.body);
 
     if (!params.email) {
@@ -636,50 +587,10 @@ module.exports = {
       return ctx.badRequest('blocked.user');
     }
 
-    const jwt = strapi.plugins['users-permissions'].services.jwt.issue(
-      _.pick(user.toJSON ? user.toJSON() : user, ['id'])
-    );
-
-    const settings = await pluginStore.get({ key: 'email' }).then(storeEmail => {
-      try {
-        return storeEmail['email_confirmation'].options;
-      } catch (err) {
-        return {};
-      }
-    });
-
-    const userInfo = _.omit(user, ['password', 'resetPasswordToken', 'role', 'provider']);
-
-    settings.message = await strapi.plugins['users-permissions'].services.userspermissions.template(
-      settings.message,
-      {
-        URL: `${getAbsoluteServerUrl(strapi.config)}/auth/email-confirmation`,
-        USER: userInfo,
-        CODE: jwt,
-      }
-    );
-
-    settings.object = await strapi.plugins['users-permissions'].services.userspermissions.template(
-      settings.object,
-      {
-        USER: userInfo,
-      }
-    );
-
     try {
-      await strapi.plugins['email'].services.email.send({
-        to: (user.toJSON ? user.toJSON() : user).email,
-        from:
-          settings.from.email && settings.from.name
-            ? `"${settings.from.name}" <${settings.from.email}>`
-            : undefined,
-        replyTo: settings.response_email,
-        subject: settings.object,
-        text: settings.message,
-        html: settings.message,
-      });
+      await strapi.plugins['users-permissions'].services.user.sendConfirmationEmail(user);
       ctx.send({
-        email: (user.toJSON ? user.toJSON() : user).email,
+        email: user.email,
         sent: true,
       });
     } catch (err) {

--- a/packages/strapi-plugin-users-permissions/models/User.config.js
+++ b/packages/strapi-plugin-users-permissions/models/User.config.js
@@ -3,6 +3,9 @@ module.exports = {
     resetPasswordToken: {
       hidden: true,
     },
+    confirmationToken: {
+      hidden: true,
+    },
     provider: {
       hidden: true,
     },

--- a/packages/strapi-plugin-users-permissions/models/User.settings.json
+++ b/packages/strapi-plugin-users-permissions/models/User.settings.json
@@ -37,6 +37,11 @@
       "configurable": false,
       "private": true
     },
+    "confirmationToken": {
+      "type": "string",
+      "configurable": false,
+      "private": true
+    },
     "confirmed": {
       "type": "boolean",
       "default": false,

--- a/packages/strapi-plugin-users-permissions/services/User.js
+++ b/packages/strapi-plugin-users-permissions/services/User.js
@@ -7,6 +7,9 @@
  */
 
 const bcrypt = require('bcryptjs');
+const crypto = require('crypto');
+
+const { sanitizeEntity, getAbsoluteServerUrl } = require('strapi-utils');
 
 module.exports = {
   /**
@@ -115,5 +118,47 @@ module.exports = {
 
   validatePassword(password, hash) {
     return bcrypt.compare(password, hash);
+  },
+
+  async sendConfirmationEmail(user) {
+    const userPermissionService = strapi.plugins['users-permissions'].services.userspermissions;
+    const pluginStore = await strapi.store({
+      environment: '',
+      type: 'plugin',
+      name: 'users-permissions',
+    });
+
+    const settings = await pluginStore
+      .get({ key: 'email' })
+      .then(storeEmail => storeEmail['email_confirmation'].options);
+
+    const userInfo = sanitizeEntity(user, {
+      model: strapi.query('user', 'users-permissions').model,
+    });
+
+    const confirmationToken = crypto.randomBytes(20).toString('hex');
+
+    await this.edit({ id: user.id }, { confirmationToken });
+
+    settings.message = await userPermissionService.template(settings.message, {
+      URL: `${getAbsoluteServerUrl(strapi.config)}/auth/email-confirmation`,
+      USER: userInfo,
+      CODE: confirmationToken,
+    });
+
+    settings.object = await userPermissionService.template(settings.object, { USER: userInfo });
+
+    // Send an email to the user.
+    await strapi.plugins['email'].services.email.send({
+      to: user.email,
+      from:
+        settings.from.email && settings.from.name
+          ? `${settings.from.name} <${settings.from.email}>`
+          : undefined,
+      replyTo: settings.response_email,
+      subject: settings.object,
+      text: settings.message,
+      html: settings.message,
+    });
   },
 };


### PR DESCRIPTION
Signed-off-by: Alexandre Bodin <bodin.alex@gmail.com>


### What does it do?

Adds a confirmationToken to use in the email confirmation instead of a valid jwt token.


We will need to explain how to add this field manually for users that did extend the User model. Will create a specific migration guide 