### PR TITLE
Added timezone for cron jobs

### DIFF
--- a/docs/v3.x/concepts/configurations.md
+++ b/docs/v3.x/concepts/configurations.md
@@ -297,6 +297,27 @@ module.exports = {
 };
 ```
 
+If your CRON task is required to run based on a specific timezone then you can configure the task like below:
+
+```js
+module.exports = {
+  /**
+   * CRON task with timezone example.
+   * Every monday at 1am for Asia/Dhaka timezone.
+   * List of valid timezones: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List
+   */
+
+  '0 0 1 * * 1': {
+    task: () => {
+      // Add your own logic here (e.g. send a queue of email, create a database backup, etc.).
+    },
+    options: {
+      tz: 'Asia/Dhaka',
+    },
+  },
+};
+```
+
 ### Database ORM customization
 
 When present, they are loaded to let you customize your database connection instance, for example for adding some plugin, customizing parameters, etc.

--- a/docs/v3.x/guides/scheduled-publication.md
+++ b/docs/v3.x/guides/scheduled-publication.md
@@ -24,7 +24,7 @@ The goal will be to check every minute if there are draft articles that have a `
 
 To execute a function every minutes, we will use a CRON task.
 
-Here is the [full documentation](../concepts/configurations.md#cron-tasks) of this feature.
+Here is the [full documentation](../concepts/configurations.md#cron-tasks) of this feature. If your CRON task requires to run based on a specific timezone then do look into the full documentation.
 
 **Path —** `./config/functions/cron.js`
 

--- a/packages/strapi/lib/middlewares/cron/index.js
+++ b/packages/strapi/lib/middlewares/cron/index.js
@@ -20,8 +20,25 @@ module.exports = strapi => {
 
     initialize() {
       if (strapi.config.get('server.cron.enabled', false) === true) {
-        _.forEach(_.keys(strapi.config.get('functions.cron', {})), task => {
-          cron.scheduleJob(task, strapi.config.functions.cron[task]);
+        _.forEach(_.keys(strapi.config.get('functions.cron', {})), taskExpression => {
+          const taskValue = strapi.config.functions.cron[taskExpression];
+          const isFunctionValue = _.isFunction(taskValue);
+
+          if (isFunctionValue) {
+            cron.scheduleJob(taskExpression, strapi.config.functions.cron[taskExpression]);
+
+            return;
+          }
+
+          const options = _.get(strapi.config.functions.cron[taskExpression], 'options', {});
+
+          cron.scheduleJob(
+            {
+              rule: taskExpression,
+              ...options,
+            },
+            strapi.config.functions.cron[taskExpression]['task']
+          );
         });
       }
     },

--- a/packages/strapi/lib/middlewares/cron/index.js
+++ b/packages/strapi/lib/middlewares/cron/index.js
@@ -22,22 +22,19 @@ module.exports = strapi => {
       if (strapi.config.get('server.cron.enabled', false) === true) {
         _.forEach(_.keys(strapi.config.get('functions.cron', {})), taskExpression => {
           const taskValue = strapi.config.functions.cron[taskExpression];
-          const isFunctionValue = _.isFunction(taskValue);
 
-          if (isFunctionValue) {
-            cron.scheduleJob(taskExpression, strapi.config.functions.cron[taskExpression]);
-
-            return;
+          if (_.isFunction(taskValue)) {
+            return cron.scheduleJob(taskExpression, taskValue);
           }
 
-          const options = _.get(strapi.config.functions.cron[taskExpression], 'options', {});
+          const options = _.get(taskValue, 'options', {});
 
           cron.scheduleJob(
             {
               rule: taskExpression,
               ...options,
             },
-            strapi.config.functions.cron[taskExpression]['task']
+            taskValue.task
           );
         });
       }


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/docs/contribguide/CONTRIBUTING.md
-->

### What does it do?

I have added cron timezone configuration on the cron initialisation hook. Strapi uses `node-scheduler`, the way you add timezone with this library is mentioned [here](https://github.com/node-schedule/node-schedule/issues/217#issuecomment-478624773).  I implemented the timezone feature in a similar manner

### Why is it needed?

As mentioned in [3099](https://github.com/strapi/strapi/issues/3099)

### Related issue(s)/PR(s)

None
