### PR TITLE
Add DKIM support if dkim-private.pem exists

### DIFF
--- a/packages/strapi-provider-email-sendmail/lib/index.js
+++ b/packages/strapi-provider-email-sendmail/lib/index.js
@@ -1,13 +1,17 @@
 'use strict';
 
+const fs = require('fs');
 const sendmailFactory = require('sendmail');
 const { removeUndefined } = require('strapi-utils');
 
 module.exports = {
   init: (providerOptions = {}, settings = {}) => {
+    const dkimPrivateKey = fs.existsSync('./dkim-private.pem') ? fs.readFileSync('./dkim-private.pem', 'utf8') : null;
+    const dkim = dkimPrivateKey ? { privateKey: dkimPrivateKey, keySelector: 'default' } : false;
+    const thisProviderOptions = Object.assign({}, { dkim: dkim }, providerOptions);
     const sendmail = sendmailFactory({
       silent: true,
-      ...providerOptions,
+      ...thisProviderOptions,
     });
     return {
       send: options => {


### PR DESCRIPTION
Basically a check for existance of the `dkim-private.pem` file is performed, and if the file exists in the project root folder it will be used in provider option, except the case where different options are passed for provider.

Now, if user provides that key and everything is correctly set the result will be `dkim=pass (1024-bit key) or (2048-bit key)` in validations made by receiving email providers. Its tested!

More details I will provide in the same forum topic where this issue was started : https://forum.strapi.io/t/unsolved-problem-emails-goes-to-spam/512/7?u=soringfs

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/docs/contribguide/CONTRIBUTING.md
-->

### What does it do?

Describe the technical changes you did.

### Why is it needed?

Describe the issue you are solving.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
