### PR TITLE
Fix missing path field in upload entity

### DIFF
--- a/packages/strapi-plugin-upload/models/File.settings.json
+++ b/packages/strapi-plugin-upload/models/File.settings.json
@@ -51,6 +51,10 @@
       "configurable": false,
       "required": true
     },
+    "path": {
+      "type": "string",
+      "configurable": false
+    },
     "url": {
       "type": "string",
       "configurable": false,


### PR DESCRIPTION
### What does it do?
This PR adds the missing `path` field to the `upload_file` table so it can store the custom path set during upload.

### Why is it needed?
It wouldn't delete the main file when it was uploaded with a custom `path` set, only its thumbnails and responsive versions.
That was caused due to this missing field as the app couldn't find this file during the deletion process.

### Related issue(s)/PR(s)
Fixes https://github.com/strapi/strapi/issues/7770