### PR TITLE
Allow deleting file that is already deleted in Cloudinary

### DIFF
--- a/packages/strapi-provider-upload-cloudinary/lib/index.js
+++ b/packages/strapi-provider-upload-cloudinary/lib/index.js
@@ -57,7 +57,7 @@ module.exports = {
             ...customConfig,
           });
 
-          if (response.result !== 'ok') {
+          if (response.result !== 'ok' && response.result !== 'not found') {
             throw errors.unknownError(`Error deleting on cloudinary: ${response.result}`);
           }
         } catch (error) {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/docs/contribguide/CONTRIBUTING.md
-->

### What does it do?

Handle the case with strapi-provider-upload-cloudinary when trying to delete a file that is already deleted in Cloudinary. Cloudinary responds with `{ result: 'not found' }` when trying to delete a non-existent file. This is added as an extra condition to be checked in strapi-provider-upload-cloudinary before throwing an error.

### Why is it needed?

When using strapi-provider-upload-cloudinary and the file is already deleted in Cloudinary, that file cannot be deleted from the Strapi UI and throws an internal server error.

### Related issue(s)/PR(s)

Fix #5729 Cannot delete file already deleted in Cloudinary
