### PR TITLE
Fix lower() error when running on non-string column

### DIFF
--- a/packages/strapi-connector-bookshelf/lib/buildQuery.js
+++ b/packages/strapi-connector-bookshelf/lib/buildQuery.js
@@ -287,9 +287,9 @@ const buildWhereClause = ({ qb, field, operator, value }) => {
     case 'nin':
       return qb.whereNotIn(field, Array.isArray(value) ? value : [value]);
     case 'contains':
-      return qb.whereRaw('LOWER(??) LIKE LOWER(?)', [field, `%${value}%`]);
+      return qb.whereRaw(`${fieldLowerFn(qb)} LIKE LOWER(?)`, [field, `%${value}%`]);
     case 'ncontains':
-      return qb.whereRaw('LOWER(??) NOT LIKE LOWER(?)', [field, `%${value}%`]);
+      return qb.whereRaw(`${fieldLowerFn(qb)} NOT LIKE LOWER(?)`, [field, `%${value}%`]);
     case 'containss':
       return qb.where(field, 'like', `%${value}%`);
     case 'ncontainss':
@@ -301,6 +301,14 @@ const buildWhereClause = ({ qb, field, operator, value }) => {
     default:
       throw new Error(`Unhandled whereClause : ${field} ${operator} ${value}`);
   }
+};
+
+const fieldLowerFn = qb => {
+  // Postgres requires string to be passed
+  if (qb.client.config.client === 'pg') {
+    return 'LOWER(CAST(?? AS VARCHAR))';
+  }
+  return 'LOWER(??)';
 };
 
 const findAssoc = (model, key) => model.associations.find(assoc => assoc.alias === key);


### PR DESCRIPTION

### What does it do?
When using the `contains` (or `ncontains`) database filter, it casts column to `CHAR` datatype so calling `LOWER(string)` function doesn't throw an error when a passed value is an integer

### Why is it needed?
It crashed on the non-text field (e.g. `id`)

### Related issue(s)/PR(s)

Fixes https://github.com/strapi/strapi/issues/7854