### PR TITLE
Change validateEntity to validateEntityCreation

### DIFF
--- a/docs/v3.x/concepts/services.md
+++ b/docs/v3.x/concepts/services.md
@@ -139,7 +139,7 @@ module.exports = {
    */
 
   async create(data, { files } = {}) {
-    const validData = await strapi.entityValidator.validateEntity(strapi.models.restaurant, data);
+    const validData = await strapi.entityValidator.validateEntityCreation(strapi.models.restaurant, data);
     const entry = await strapi.query('restaurant').create(validData);
 
     if (files) {


### PR DESCRIPTION
Fix bug **_strapi.entityValidator.validateEntity_** is not a function

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/docs/contribguide/CONTRIBUTING.md
-->

### What does it do?

Fix so that the document show the correct function name. **validateEntityCreation** instead of **validateEntity**

### Why is it needed?

It seems that the validateEntity function no longer exists or it was renamed to validateEntityCreation but the document wasn't updated.

### Related issue(s)/PR(s)

No
