### PR TITLE
Update target.js: Changed assignment of "ok" in "isValidTarget" function

### DIFF
--- a/packages/strapi-generate/lib/target.js
+++ b/packages/strapi-generate/lib/target.js
@@ -263,10 +263,8 @@ function parseTarget(target, scope, cb) {
  */
 
 function isValidTarget(target) {
-  let ok = true;
-
-  ok = ok && typeof target === 'object';
-
+  let ok = typeof target === 'object';
+  
   // Is using a helper.
   // Or is another generator def.
   ok = ok && (targetIsHelper(target) || _.has(target, 'targets'));


### PR DESCRIPTION
Hello,

### What does it do?
I changed the assignment of the `ok` variable. It used to be set by the following lines:
`let ok = true`
`ok = ok && typeof target === 'object';`
Due to the first line, `ok` is first set to `true` and therefore in the second line `ok` will just be set to the right operand of the AND-operation because `ok` is `true` at that time.

Therefore it is possible to consolidate these 2 lines in the following statement:
`let ok = typeof target === 'object';`
where `ok` is still set by what used to be the right operand of the AND-operation.

### Why is it needed?
There is no issue that is being solved, just reducing the complexity of the code.

### Related issue(s)/PR(s)
There are no related issues or PR's.

I hope this is clear enough and look forward to your comments.

Kind regards,
Florian