### PR TITLE
Maintain strapi-provider-email-nodemailer

### DIFF
--- a/packages/strapi-provider-email-nodemailer/LICENSE
+++ b/packages/strapi-provider-email-nodemailer/LICENSE
@@ -1,0 +1,22 @@
+Copyright (c) 2015-present Strapi Solutions SAS
+
+Portions of the Strapi software are licensed as follows:
+
+* All software that resides under an "ee/" directory (the “EE Software”), if that directory exists, is licensed under the license defined in "ee/LICENSE".
+
+* All software outside of the above-mentioned directories or restrictions above is available under the "MIT Expat" license as set forth below.
+
+MIT Expat License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/strapi-provider-email-nodemailer/README.md
+++ b/packages/strapi-provider-email-nodemailer/README.md
@@ -1,0 +1,151 @@
+# strapi-provider-email-nodemailer
+
+## Resources
+
+- [License](LICENSE)
+
+## Links
+
+- [Strapi website](http://strapi.io/)
+- [Strapi community on Slack](http://slack.strapi.io)
+- [Strapi news on Twitter](https://twitter.com/strapijs)
+
+## Prerequisites
+
+You need to have the plugin `strapi-plugin-email` installed in your Strapi project.
+
+## Installation
+
+```bash
+# using yarn
+yarn add strapi-provider-email-nodemailer
+
+# using npm
+npm install strapi-provider-email-nodemailer --save
+```
+
+## Example
+
+**Path -** `config/plugins.js`
+
+```js
+module.exports = ({ env }) => ({
+  email: {
+    provider: 'nodemailer',
+    providerOptions: {
+      host: env('SMTP_HOST', 'smtp.example.com'),
+      port: env('SMTP_PORT', 587),
+      auth: {
+        user: env('SMTP_USERNAME'),
+        pass: env('SMTP_PASSWORD'),
+      },
+      // ... any custom nodemailer options
+    },
+    settings: {
+      defaultFrom: 'hello@example.com',
+      defaultReplyTo: 'hello@example.com',
+    },
+  },
+});
+```
+
+Check out the available options for nodemailer: https://nodemailer.com/about/
+
+### Development mode
+
+You can override the default configurations for specific environments. E.g. for
+`NODE_ENV=development` in **config/env/development/plugins.js**:
+
+```js
+module.exports = ({ env }) => ({
+  email: {
+    provider: 'nodemailer',
+    providerOptions: {
+      host: 'localhost',
+      port: 1025,
+      ignoreTLS: true,
+    },
+  },
+});
+```
+
+The above setting is useful for local development with
+[maildev](https://github.com/maildev/maildev).
+
+### Custom authentication mechanisms
+
+It is also possible to use custom authentication methods.
+Here is an example for a NTLM authentication:
+
+```js
+const nodemailerNTLMAuth = require('nodemailer-ntlm-auth');
+
+module.exports = ({ env }) => ({
+  email: {
+    provider: 'nodemailer',
+    providerOptions: {
+      host: env('SMTP_HOST', 'smtp.example.com'),
+      port: env('SMTP_PORT', 587),
+      auth: {
+        type: 'custom',
+        method: 'NTLM',
+        user: env('SMTP_USERNAME'),
+        pass: env('SMTP_PASSWORD'),
+      },
+      customAuth: {
+        NTLM: nodemailerNTLMAuth,
+      },
+    },
+    settings: {
+      defaultFrom: 'hello@example.com',
+      defaultReplyTo: 'hello@example.com',
+    },
+  },
+});
+```
+
+## Usage
+
+To send an email from anywhere inside Strapi:
+
+```js
+await strapi.plugins['email'].services.email.send({
+  to: 'someone@example.com',
+  from: 'someone2@example.com',
+  subject: 'Hello world',
+  text: 'Hello world',
+  html: `<h4>Hello world</h4>`,
+});
+```
+
+The following fields are supported:
+
+| Field       | Description                                                       |
+| ----------- | ----------------------------------------------------------------- |
+| from        | Email address of the sender                                       |
+| to          | Comma separated list or an array of recipients                    |
+| replyTo     | Email address to which replies are sent                           |
+| cc          | Comma separated list or an array of recipients                    |
+| bcc         | Comma separated list or an array of recipients                    |
+| subject     | Subject of the email                                              |
+| text        | Plaintext version of the message                                  |
+| html        | HTML version of the message                                       |
+| attachments | Array of objects See: https://nodemailer.com/message/attachments/ |
+
+## Troubleshooting
+
+Check your firewall to ensure that requests are allowed. If it doesn't work with
+
+```js
+port: 465,
+secure: true
+```
+
+try using
+
+```js
+port: 587,
+secure: false
+```
+
+to test if it works correctly.

--- a/packages/strapi-provider-email-nodemailer/lib/index.js
+++ b/packages/strapi-provider-email-nodemailer/lib/index.js
@@ -4,11 +4,20 @@
  * Module dependencies
  */
 
-/* eslint-disable import/no-unresolved */
-/* eslint-disable prefer-template */
-// Public node modules.
 const _ = require('lodash');
 const nodemailer = require('nodemailer');
+
+const emailFields = [
+  'from',
+  'replyTo',
+  'to',
+  'cc',
+  'bcc',
+  'subject',
+  'text',
+  'html',
+  'attachments',
+];
 
 module.exports = {
   provider: 'nodemailer',
@@ -19,31 +28,14 @@ module.exports = {
 
     return {
       send: options => {
-        return new Promise((resolve, reject) => {
-          // Default values.
-          options = _.isObject(options) ? options : {};
-          options.from = options.from || settings.defaultFrom;
-          options.replyTo = options.replyTo || settings.defaultReplyTo;
-          options.text = options.text || options.html;
-          options.html = options.html || options.text;
+        // Default values.
+        options = _.isObject(options) ? options : {};
+        options.from = options.from || settings.defaultFrom;
+        options.replyTo = options.replyTo || settings.defaultReplyTo;
+        options.text = options.text || options.html;
+        options.html = options.html || options.text;
 
-          const msg = [
-            'from',
-            'replyTo',
-            'to',
-            'cc',
-            'bcc',
-            'subject',
-            'text',
-            'html',
-            'attachments',
-          ];
-
-          transporter
-            .sendMail(_.pick(options, msg))
-            .then(resolve)
-            .catch(error => reject(error));
-        });
+        return transporter.sendMail(_.pick(options, emailFields));
       },
     };
   },

--- a/packages/strapi-provider-email-nodemailer/lib/index.js
+++ b/packages/strapi-provider-email-nodemailer/lib/index.js
@@ -1,0 +1,50 @@
+'use strict';
+
+/**
+ * Module dependencies
+ */
+
+/* eslint-disable import/no-unresolved */
+/* eslint-disable prefer-template */
+// Public node modules.
+const _ = require('lodash');
+const nodemailer = require('nodemailer');
+
+module.exports = {
+  provider: 'nodemailer',
+  name: 'Nodemailer',
+
+  init: (providerOptions = {}, settings = {}) => {
+    const transporter = nodemailer.createTransport(providerOptions);
+
+    return {
+      send: options => {
+        return new Promise((resolve, reject) => {
+          // Default values.
+          options = _.isObject(options) ? options : {};
+          options.from = options.from || settings.defaultFrom;
+          options.replyTo = options.replyTo || settings.defaultReplyTo;
+          options.text = options.text || options.html;
+          options.html = options.html || options.text;
+
+          const msg = [
+            'from',
+            'replyTo',
+            'to',
+            'cc',
+            'bcc',
+            'subject',
+            'text',
+            'html',
+            'attachments',
+          ];
+
+          transporter
+            .sendMail(_.pick(options, msg))
+            .then(resolve)
+            .catch(error => reject(error));
+        });
+      },
+    };
+  },
+};

--- a/packages/strapi-provider-email-nodemailer/lib/index.js
+++ b/packages/strapi-provider-email-nodemailer/lib/index.js
@@ -29,13 +29,15 @@ module.exports = {
     return {
       send: options => {
         // Default values.
-        options = _.isObject(options) ? options : {};
-        options.from = options.from || settings.defaultFrom;
-        options.replyTo = options.replyTo || settings.defaultReplyTo;
-        options.text = options.text || options.html;
-        options.html = options.html || options.text;
+        const emailOptions = {
+          ..._.pick(options, emailFields),
+          from: options.from || settings.defaultFrom,
+          replyTo: options.replyTo || settings.defaultReplyTo,
+          text: options.text || options.html,
+          html: options.html || options.text,
+        };
 
-        return transporter.sendMail(_.pick(options, emailFields));
+        return transporter.sendMail(emailOptions);
       },
     };
   },

--- a/packages/strapi-provider-email-nodemailer/package.json
+++ b/packages/strapi-provider-email-nodemailer/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "strapi-provider-email-nodemailer",
+  "version": "3.2.5",
+  "description": "Nodemailer provider for Strapi 3",
+  "main": "./lib",
+  "directories": {
+    "lib": "./lib"
+  },
+  "dependencies": {
+    "lodash": "4.17.19",
+    "nodemailer": "6.3.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/strapi/strapi.git"
+  },
+  "keywords": [
+    "Strapi",
+    "Email",
+    "Provider",
+    "Strapi 3"
+  ],
+  "author": {
+    "name": "Yurii Tykhomyrov"
+  },
+  "contributors": [
+    {
+      "name": "Veit Bjarsch",
+      "email": "vb@poweruplink.com",
+      "url": "https://poweruplink.com"
+    },
+    {
+      "name": "Saunved Mutalik"
+    },
+    {
+      "name": "Robert Schäfer",
+      "email": "git@roschaefer.de"
+    }
+  ],
+  "maintainers": [
+    {
+      "name": "Strapi team",
+      "email": "hi@strapi.io",
+      "url": "http://strapi.io"
+    }
+  ],
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/strapi/strapi/issues"
+  },
+  "homepage": "https://github.com/strapi/strapi/tree/master/packages/strapi-provider-email-nodemailer"
+}

--- a/packages/strapi-provider-email-nodemailer/package.json
+++ b/packages/strapi-provider-email-nodemailer/package.json
@@ -2,6 +2,13 @@
   "name": "strapi-provider-email-nodemailer",
   "version": "3.2.5",
   "description": "Nodemailer provider for Strapi 3",
+  "homepage": "http://strapi.io",
+  "keywords": [
+    "strapi",
+    "email",
+    "provider",
+    "nodemailer"
+  ],
   "main": "./lib",
   "directories": {
     "lib": "./lib"
@@ -14,14 +21,11 @@
     "type": "git",
     "url": "https://github.com/strapi/strapi.git"
   },
-  "keywords": [
-    "Strapi",
-    "Email",
-    "Provider",
-    "Strapi 3"
-  ],
   "author": {
     "name": "Yurii Tykhomyrov"
+  },
+  "scripts": {
+    "test": "echo \"no tests yet\""
   },
   "contributors": [
     {
@@ -44,9 +48,8 @@
       "url": "http://strapi.io"
     }
   ],
-  "license": "MIT",
+  "license": "SEE LICENSE IN LICENSE",
   "bugs": {
     "url": "https://github.com/strapi/strapi/issues"
-  },
-  "homepage": "https://github.com/strapi/strapi/tree/master/packages/strapi-provider-email-nodemailer"
+  }
 }

--- a/packages/strapi-provider-email-nodemailer/package.json
+++ b/packages/strapi-provider-email-nodemailer/package.json
@@ -24,6 +24,9 @@
   "author": {
     "name": "Yurii Tykhomyrov"
   },
+  "strapi": {
+    "isProvider": true
+  },
   "scripts": {
     "test": "echo \"no tests yet\""
   },

--- a/packages/strapi-provider-email-nodemailer/package.json
+++ b/packages/strapi-provider-email-nodemailer/package.json
@@ -51,5 +51,9 @@
   "license": "SEE LICENSE IN LICENSE",
   "bugs": {
     "url": "https://github.com/strapi/strapi/issues"
+  },
+  "engines": {
+    "node": ">=10.16.0 <=14.x.x",
+    "npm": ">=6.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9632,10 +9632,10 @@ immediate@~3.0.5:
   resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"
   integrity sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=
 
-immer@^7.0.8:
-  version "7.0.9"
-  resolved "https://registry.yarnpkg.com/immer/-/immer-7.0.9.tgz#28e7552c21d39dd76feccd2b800b7bc86ee4a62e"
-  integrity sha512-Vs/gxoM4DqNAYR7pugIxi0Xc8XAun/uy7AQu4fLLqaTBHxjOP9pJ266Q9MWA/ly4z6rAFZbvViOtihxUZ7O28A==
+immer@^7.0.14:
+  version "7.0.14"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-7.0.14.tgz#3e605f8584b15a9520d2f2f3fda9441cc9170d25"
+  integrity sha512-BxCs6pJwhgSEUEOZjywW7OA8DXVzfHjkBelSEl0A+nEu0+zS4cFVdNOONvt55N4WOm8Pu4xqSPYxhm1Lv2iBBA==
 
 immutable@^3.8.2:
   version "3.8.2"
@@ -13199,6 +13199,11 @@ nodemailer-shared@1.1.0:
   integrity sha1-z1mU4v0mjQD1zw+nZ6CBae2wfsA=
   dependencies:
     nodemailer-fetch "1.6.0"
+
+nodemailer@6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/nodemailer/-/nodemailer-6.3.0.tgz#a89b0c62d3937bdcdeecbf55687bd7911b627e12"
+  integrity sha512-TEHBNBPHv7Ie/0o3HXnb7xrPSSQmH1dXwQKRaMKDBGt/ZN54lvDVujP6hKkO/vjkIYL9rK8kHSG11+G42Nhxuw==
 
 noop-logger@^0.1.1:
   version "0.1.1"


### PR DESCRIPTION
### What does it do?

This will merge repository https://github.com/yutikom/strapi-provider-email-nodemailer/ into this mono repo under
```
packages/strapi-provider-email-nodemailer
```

~I followed this [suggestion](https://stackoverflow.com/a/61450995) and ran the following commands:~

### Why is it needed?

In summer I opened [issue 6998](https://github.com/strapi/strapi/issues/6998) because I had a terrible developer experience from a multitude of unmaintained or outdated 3rd party libraries for email delivery through SMTP. As explained in the issue, we made `strapi-provider-email-nodemailer` compatible with version 3.

I think the best idea would be to incorporate the library into the main strapi mono repository, so it does not get out of sync and stays maintained. Strapi is already maintaining several proprietary email providers including Mailgun, Sendgrid and Amazon: https://github.com/strapi/strapi/tree/master/packages

So why not SMTP? SMTP is not proprietary and it's better for data privacy and GDPR. Developer experience gets improved because less headache but also because most people have an email account already.

See the isssue for more details.

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/issues/6998

### TODOs
- [ ] @yutikom needs to make @strapi a package owner of https://www.npmjs.com/package/strapi-provider-email-nodemailer
- [ ] update CI/CD pipeline of strapi to push the package to npm


close #6998 