### PR TITLE
Upgrade graphql-tools package to use GraphQL v15

### DIFF
--- a/packages/strapi-plugin-graphql/package.json
+++ b/packages/strapi-plugin-graphql/package.json
@@ -19,7 +19,7 @@
     "graphql-depth-limit": "^1.1.0",
     "graphql-iso-date": "^3.6.1",
     "graphql-playground-middleware-koa": "^1.6.20",
-    "graphql-tools": "4.0.6",
+    "graphql-tools": "4.0.8",
     "graphql-type-json": "0.3.2",
     "graphql-type-long": "^0.1.1",
     "graphql-upload": "11.0.0",


### PR DESCRIPTION
update `graphql-tools` package to **4.0.8** to use **GraphQL v15** syntaxes.

related to #8374