### PR TITLE
Fix project generation with wrong node engine spec

### DIFF
--- a/packages/strapi-generate-new/lib/resources/json/package.json.js
+++ b/packages/strapi-generate-new/lib/resources/json/package.json.js
@@ -42,7 +42,7 @@ module.exports = opts => {
       uuid: uuid,
     },
     engines: {
-      node: '>=10.0.0',
+      node: '>=10.16.0 <=14.x.x',
       npm: '>=6.0.0',
     },
     license: 'MIT',

--- a/packages/strapi-generate-plugin/json/package.json.js
+++ b/packages/strapi-generate-plugin/json/package.json.js
@@ -37,7 +37,7 @@ module.exports = scope => {
       },
     ],
     engines: {
-      node: '>=10.0.0',
+      node: '>=10.16.0 <=14.x.x',
       npm: '>=6.0.0',
     },
     license: scope.license || 'MIT',


### PR DESCRIPTION
Signed-off-by: Derrick Mehaffy <derrickmehaffy@gmail.com>

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Projects were being generated with the node engine `>=10.0.0` and it was causing issues deploying on heroku which watches this to figure out which version of node to install

### Why is it needed?

We don't support node v15

### Related issue(s)/PR(s)

https://forum.strapi.io/t/how-do-i-connect-heroku-to-strapi/703/5
