### PR TITLE
Create a custom field in the Content-Type Builder from a user's plugin

### DIFF
--- a/packages/strapi-admin/admin/src/utils/FieldApi.js
+++ b/packages/strapi-admin/admin/src/utils/FieldApi.js
@@ -27,13 +27,13 @@ class FieldApi {
   };
 
   registerField = field => {
-    const { type, Component } = field;
+    const { type, Component, collectionType, icon, pluginId } = field;
 
     invariant(Component, 'A Component must be provided');
     invariant(type, 'A type must be provided');
     invariant(this.fields[type] === undefined, 'A similar field already exists');
 
-    this.fields[type] = { Component };
+    this.fields[type] = { Component, collectionType, icon, pluginId };
   };
 
   removeField = type => {

--- a/packages/strapi-plugin-content-manager/admin/src/components/Inputs/index.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/Inputs/index.js
@@ -88,7 +88,9 @@ function Inputs({
   const attribute = useMemo(() => get(layout, ['schema', 'attributes', name], {}), [layout, name]);
   const metadatas = useMemo(() => get(layout, ['metadatas', name, 'edit'], {}), [layout, name]);
   const disabled = useMemo(() => !get(metadatas, 'editable', true), [metadatas]);
-  const type = useMemo(() => get(attribute, 'type', null), [attribute]);
+  const type = useMemo(() => get(attribute, 'inputType', get(attribute, 'type', null)), [
+    attribute,
+  ]);
   const regexpString = useMemo(() => get(attribute, 'regex', null), [attribute]);
   const temporaryErrorIdUntilBuffetjsSupportsFormattedMessage = 'app.utils.defaultMessage';
   const errorId = useMemo(() => {

--- a/packages/strapi-plugin-content-type-builder/admin/src/components/AttributeOption/index.js
+++ b/packages/strapi-plugin-content-type-builder/admin/src/components/AttributeOption/index.js
@@ -4,24 +4,38 @@
  *
  */
 
-import React, { forwardRef, useEffect, useImperativeHandle, useRef } from 'react';
+import React, { forwardRef, useEffect, useImperativeHandle, useMemo, useRef } from 'react';
 import { AttributeIcon } from '@buffetjs/core';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import { useHistory } from 'react-router-dom';
-import { useGlobalContext, useQuery } from 'strapi-helper-plugin';
+import { useGlobalContext, useQuery, useStrapi } from 'strapi-helper-plugin';
 import getTrad from '../../utils/getTrad';
 import makeSearch from '../../utils/makeSearch';
 import Button from './Button';
 import Card from './Card';
+import CustomIcon from '../CustomAttributeIcon';
 
 const AttributeOption = forwardRef(({ tabIndex, type }, ref) => {
+  const {
+    strapi: { fieldApi },
+  } = useStrapi();
   const buttonRef = useRef();
   const tabRef = useRef();
   const query = useQuery();
   const { push } = useHistory();
   const { emitEvent } = useGlobalContext();
+  // eslint-disable-next-line no-mixed-operators
+  const customField = useMemo(() => (type && fieldApi.getField(type)) || {}, [fieldApi, type]);
+
   tabRef.current = tabIndex;
+
+  const CustomAttributeIcon = props =>
+    customField && customField.icon ? (
+      <CustomIcon icon={customField.icon} {...props} />
+    ) : (
+      <AttributeIcon type={type} {...props} />
+    );
 
   useImperativeHandle(ref, () => ({
     focus: () => {
@@ -101,11 +115,11 @@ const AttributeOption = forwardRef(({ tabIndex, type }, ref) => {
     <div className="col-6">
       <Button ref={buttonRef} type="button" onClick={handleClick}>
         <Card>
-          <AttributeIcon type={type} style={{ marginRight: 10 }} className="attributeIcon" />
-          <FormattedMessage id={getTrad(`attribute.${type}`)}>
+          <CustomAttributeIcon style={{ marginRight: 10 }} className="attributeIcon" />
+          <FormattedMessage id={getTrad(`attribute.${type}`, customField.pluginId)}>
             {message => <span className="attributeType">{message}</span>}
           </FormattedMessage>
-          <FormattedMessage id={getTrad(`attribute.${type}.description`)} />
+          <FormattedMessage id={getTrad(`attribute.${type}.description`, customField.pluginId)} />
         </Card>
       </Button>
     </div>

--- a/packages/strapi-plugin-content-type-builder/admin/src/components/CustomAttributeIcon/StyledCustomAttributeIcon.js
+++ b/packages/strapi-plugin-content-type-builder/admin/src/components/CustomAttributeIcon/StyledCustomAttributeIcon.js
@@ -1,0 +1,24 @@
+/**
+ *
+ * StyledCustomAttributeIcon
+ *
+ */
+
+import styled from 'styled-components';
+
+const StyledCustomAttributeIcon = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  height: 20px;
+  width: 35px;
+  padding: 0;
+  background-color: #666666;
+  border-radius: 2px;
+
+  > svg {
+    align-self: center;
+  }
+`;
+
+export default StyledCustomAttributeIcon;

--- a/packages/strapi-plugin-content-type-builder/admin/src/components/CustomAttributeIcon/index.js
+++ b/packages/strapi-plugin-content-type-builder/admin/src/components/CustomAttributeIcon/index.js
@@ -1,0 +1,31 @@
+/**
+ *
+ * CustomAttributeIcon
+ *
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faPlug } from '@fortawesome/free-solid-svg-icons';
+import StyledCustomAttributeIcon from './StyledCustomAttributeIcon';
+
+const CustomAttributeIcon = ({ icon, className, ...rest }) => {
+  return (
+    <StyledCustomAttributeIcon {...rest}>
+      <FontAwesomeIcon icon={icon || faPlug} style={{ color: 'white' }} className={className} />
+    </StyledCustomAttributeIcon>
+  );
+};
+
+CustomAttributeIcon.defaultProps = {
+  icon: null,
+  className: '',
+};
+
+CustomAttributeIcon.propTypes = {
+  icon: PropTypes.object,
+  className: PropTypes.string,
+};
+
+export default CustomAttributeIcon;

--- a/packages/strapi-plugin-content-type-builder/admin/src/containers/DataManagerProvider/index.js
+++ b/packages/strapi-plugin-content-type-builder/admin/src/containers/DataManagerProvider/index.js
@@ -6,6 +6,7 @@ import {
   LoadingIndicatorPage,
   useGlobalContext,
   PopUpWarning,
+  useStrapi,
 } from 'strapi-helper-plugin';
 import { useHistory, useLocation, useRouteMatch, Redirect } from 'react-router-dom';
 import DataManagerContext from '../../contexts/DataManagerContext';
@@ -28,6 +29,7 @@ import {
   formatMainDataType,
   getCreatedAndModifiedComponents,
   sortContentType,
+  mapCustomInputTypesToCollectionTypes,
 } from './utils/cleanData';
 
 const DataManagerProvider = ({ allIcons, children }) => {
@@ -41,6 +43,9 @@ const DataManagerProvider = ({ allIcons, children }) => {
     formatMessage,
     menu,
   } = useGlobalContext();
+  const {
+    strapi: { fieldApi },
+  } = useStrapi();
   const {
     components,
     contentTypes,
@@ -403,7 +408,7 @@ const DataManagerProvider = ({ allIcons, children }) => {
   const submitData = async additionalContentTypeData => {
     try {
       const isCreating = get(modifiedData, [firstKeyToMainSchema, 'isTemporary'], false);
-      const body = {
+      let body = {
         components: getComponentsToPost(
           modifiedData.components,
           components,
@@ -424,6 +429,7 @@ const DataManagerProvider = ({ allIcons, children }) => {
 
         emitEvent('willSaveComponent');
       }
+      body = mapCustomInputTypesToCollectionTypes(body, fieldApi);
 
       const method = isCreating ? 'POST' : 'PUT';
 

--- a/packages/strapi-plugin-content-type-builder/admin/src/containers/FormModal/utils/attributes.js
+++ b/packages/strapi-plugin-content-type-builder/admin/src/containers/FormModal/utils/attributes.js
@@ -1,4 +1,4 @@
-const getAttributes = (dataTarget = '', targetUid, nestedComponents) => {
+const getAttributes = (dataTarget = '', targetUid, nestedComponents, customFields = []) => {
   const defaultAttributes = [
     [
       'text',
@@ -28,6 +28,15 @@ const getAttributes = (dataTarget = '', targetUid, nestedComponents) => {
 
   if (canAddComponentInAnotherComponent) {
     items.push(['component']);
+  }
+
+  if (customFields.length) {
+    const alreadyPresentFields = items.flat();
+    const uniqueCustomFields = customFields.filter(field => !alreadyPresentFields.includes(field));
+
+    if (uniqueCustomFields.length) {
+      items.push(uniqueCustomFields);
+    }
   }
 
   return items;

--- a/packages/strapi-plugin-content-type-builder/admin/src/utils/convertAttrObjToArray.js
+++ b/packages/strapi-plugin-content-type-builder/admin/src/utils/convertAttrObjToArray.js
@@ -1,6 +1,8 @@
 const convertAttrObjToArray = attributes => {
   return Object.keys(attributes).map((key, index) => {
-    return { ...attributes[key], name: key, index };
+    const type = attributes[key].inputType || attributes[key].type;
+
+    return Object.assign({}, attributes[key], { name: key, index, type });
   });
 };
 

--- a/packages/strapi-plugin-content-type-builder/admin/src/utils/getTrad.js
+++ b/packages/strapi-plugin-content-type-builder/admin/src/utils/getTrad.js
@@ -1,5 +1,5 @@
 import pluginId from '../pluginId';
 
-const getTrad = id => `${pluginId}.${id}`;
+const getTrad = (id, prefix = pluginId) => `${prefix}.${id}`;
 
 export default getTrad;

--- a/packages/strapi-plugin-content-type-builder/controllers/validation/types.js
+++ b/packages/strapi-plugin-content-type-builder/controllers/validation/types.js
@@ -114,6 +114,7 @@ const getTypeShape = (attribute, { modelType, attributes } = {}) => {
         minLength: validators.minLength,
         maxLength: validators.maxLength,
         regex: yup.string().test(isValidRegExpPattern),
+        inputType: yup.string(),
       };
     }
     case 'richtext': {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

This proposal adds the ability to create custom input fields in the Content-Type Builder, directly from a custom plugin. It was largely inspired by the way to register (update) an existing field through the Admin Field API. In order to make it work:
- I modified the Admin Field API (documentation updated in PR)
- I modified the Content-Type Builder DataManager to handle custom field types on the front-end
- I modified the Content Manager form builder (`Inputs`) to display custom inputs
- I modified the Content-Type Builder Text Validator to handle custom input types on the back-end

### Why is it needed?

The `type` value is used in both the [Inputs component](./packages/strapi-plugin-content-manager/admin/src/components/Inputs/index.js) and as the `kind` property in the [ORM validators](./packages/strapi-plugin-content-type-builder/controllers/validation/types.js), which made it impossible to create a custom field without adding the custom type in Strapi source code manually.
This proposal introduces a new hidden field for the `text` type: `inputType`. It is stored silently by the server while the data `type` is still saved like before. The `inputType` is served as the custom field `type` attribute to the front-end application. This way, it is possible to segregate `type` as a back-end property and as a distinct front-end attribute.

### Related issue(s)/PR(s)

fix #7593
doc #8515