### PR TITLE
docs: docker-compose postgres example clarification

### DIFF
--- a/docs/3.0.0-beta.x/installation/docker.md
+++ b/docs/3.0.0-beta.x/installation/docker.md
@@ -54,6 +54,7 @@ services:
     environment:
       POSTGRES_USER: strapi
       POSTGRES_PASSWORD: strapi
+      POSTGRES_DB: strapi
     volumes:
       - ./data:/var/lib/postgresql/data
     ports:


### PR DESCRIPTION
While the default DB in postgres if `POSTGRES_DB` is not supplied is the `POSTGRES_USER` [[reference](https://hub.docker.com/_/postgres)], I believe it's more readable to the developer to have this explicitly declared, as it can be confusing - especially since almost every naming choice in this project defaults to `strapi`

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Describe the technical changes you did.

### Why is it needed?

Describe the issue you are solving.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
