### PR TITLE
(Documentation) Add step to RDS setup that allows for connection from Strapi EC2 Instance

### DIFF
--- a/docs/3.0.0-beta.x/deployment/amazon-aws.md
+++ b/docs/3.0.0-beta.x/deployment/amazon-aws.md
@@ -131,6 +131,8 @@ Follow these steps to complete installation of a `PostgreSQL` database:
     - **Master username:** Keep as `postgres`, or change (optional)
     - `Uncheck` _Auto generate a password_, and then type in a new secret password.
 - **Connectivity**, and **Additional connectivity configuration**: Set `Publicly accessible` to `Yes`.
+- **Security** Edit the existing security group to use a new rule where 
+    - **Type:** `PostgresSQL`, **Protocol:** `TCP`, **Port Range** `54321`, **Source:** `0.0.0.0/0, ::/0`
 - **OPTIONAL:** Review any further options (**DB Instance size**, **Storage**, **Connectivity**), and modify to your project needs.
 - You need to give you Database a name. Under **Additional configuration**:
   - **Additional configuration**, and then **Initial database name:** Give your database a name, e.g. `strapi`.


### PR DESCRIPTION
In documentation for deploying project, RDS setup required adding an extra rule to the Security Group that enabled connection via PostgresSQL.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Adds necessary step to the RDS setup in the documentation

### Why is it needed?

Without this step my EC2 instance of strapi could not connect to the database hosted on the RDS

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
