### PR TITLE
send the value of all fields to the input component

### DIFF
--- a/packages/strapi-plugin-content-manager/admin/src/components/Inputs/index.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/Inputs/index.js
@@ -80,6 +80,7 @@ function Inputs({
   readableFields,
   shouldNotRunValidations,
   value,
+  valueAllFields,
 }) {
   const {
     strapi: { fieldApi },
@@ -299,6 +300,7 @@ function Inputs({
             validations={validations}
             value={inputValue}
             withDefaultValue={false}
+            valueAllFields={valueAllFields}
           />
         );
       }}
@@ -312,6 +314,7 @@ Inputs.defaultProps = {
   formErrors: {},
   onBlur: null,
   value: null,
+  valueAllFields: {},
 };
 
 Inputs.propTypes = {
@@ -329,6 +332,7 @@ Inputs.propTypes = {
   readableFields: PropTypes.array.isRequired,
   shouldNotRunValidations: PropTypes.bool.isRequired,
   value: PropTypes.any,
+  valueAllFields: PropTypes.any,
 };
 
 const Memoized = memo(Inputs, isEqual);

--- a/packages/strapi-plugin-content-manager/admin/src/components/Inputs/utils/select.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/Inputs/utils/select.js
@@ -26,6 +26,8 @@ function useSelect(keys) {
 
   const value = get(modifiedData, keys, null);
 
+  const valueAllFields = modifiedData;
+
   return {
     allowedFields,
     currentContentTypeLayout,
@@ -35,6 +37,7 @@ function useSelect(keys) {
     readableFields,
     shouldNotRunValidations,
     value,
+    valueAllFields,
   };
 }
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

The only thing that is done in this pull request is that in addition to the value of an input, the value of other fields is also sent to the component.

### Why is it needed?

In custome fields that are created through plugins, sometimes the data of other fields of that form are needed, now which we can access them.

### Related issue(s)/PR(s)

This issue has already been discussed in the [forum](https://forum.strapi.io/t/get-all-model-in-custom-field/795/4) with a more complete explanation.
