### PR TITLE
Allow for loading namespaced dependencies

### DIFF
--- a/packages/strapi/lib/utils/get-prefixed-dependencies.js
+++ b/packages/strapi/lib/utils/get-prefixed-dependencies.js
@@ -1,5 +1,5 @@
 module.exports = (prefix, pkgJSON) => {
   return Object.keys(pkgJSON.dependencies)
-    .filter(d => d.startsWith(prefix) && d.length > prefix.length)
+    .filter(d => (d.includes(`/${prefix}`) || d.startsWith(prefix)) && d.length > prefix.length)
     .map(pkgName => pkgName.substring(prefix.length + 1));
 };


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

This change makes the dependency loader match dependencies with names such as:
- `@mycorp/strapi-plugin-foo`

... in addition to the existing match against:
- `strapi-plugin-foo`

A similar way of solving this problem was already done for email and upload providers:
https://github.com/strapi/strapi/pull/4371/files

### What does it do?

I've changed the depedency loader's string matching to also match against strings that include a `/` + the desired prefix, meaning `@company/strapi-plugin-` names will match a query for prefix `strapi-plugin-`.

### Why is it needed?

We want to be able to load plug-ins with npm package names such as `@company/strapi-plugin-foo`.
