### PR TITLE
[Docs] Add missing if statement to guide on slug generation

### DIFF
--- a/docs/v3.x/guides/slug.md
+++ b/docs/v3.x/guides/slug.md
@@ -70,7 +70,9 @@ module.exports = {
       }
     },
     beforeUpdate: async (params, data) => {
-      data.slug = slugify(data.title);
+      if (data.title) {
+        data.slug = slugify(data.title);
+      }
     },
   },
 };


### PR DESCRIPTION
### Description
After following [this guide](https://strapi.io/documentation/v3.x/guides/slug.html#auto-create-update-the-slug-attribute), I was receiving server errors in my app when attempting to publish content whose content type had an automatically generated slug. I found that the lack of if statement generates runtime errors.

### What does it do?

I added an if statement to the code snippet.

### Why is it needed?

Generates errors on other events that invoke the lifecycle method.

### Related issue(s)/PR(s)

N/A
