### PR TITLE
Add migration guide

### DIFF
--- a/docs/v3.x/migration-guide/README.md
+++ b/docs/v3.x/migration-guide/README.md
@@ -17,6 +17,7 @@ If you were upgrading from the `3.0.0-beta.19.5` to `3.2.0`, here are the follow
 
 ## V3 guides
 
+- [Migration guide from 3.2.3 to 3.2.4](migration-guide-3.2.5-to-3.3.0.md)
 - [Migration guide from 3.2.3 to 3.2.4](migration-guide-3.2.3-to-3.2.4.md)
 - [Migration guide from 3.1.x to 3.2.3](migration-guide-3.1.x-to-3.2.x.md)
 - [Migration guide from 3.0.x to 3.1.x](migration-guide-3.0.x-to-3.1.x.md)

--- a/docs/v3.x/migration-guide/README.md
+++ b/docs/v3.x/migration-guide/README.md
@@ -17,7 +17,7 @@ If you were upgrading from the `3.0.0-beta.19.5` to `3.2.0`, here are the follow
 
 ## V3 guides
 
-- [Migration guide from 3.2.3 to 3.2.4](migration-guide-3.2.5-to-3.3.0.md)
+- [Migration guide from 3.2.5 to 3.3.0](migration-guide-3.2.5-to-3.3.0.md)
 - [Migration guide from 3.2.3 to 3.2.4](migration-guide-3.2.3-to-3.2.4.md)
 - [Migration guide from 3.1.x to 3.2.3](migration-guide-3.1.x-to-3.2.x.md)
 - [Migration guide from 3.0.x to 3.1.x](migration-guide-3.0.x-to-3.1.x.md)

--- a/docs/v3.x/migration-guide/migration-guide-3.2.5-to-3.3.0.md
+++ b/docs/v3.x/migration-guide/migration-guide-3.2.5-to-3.3.0.md
@@ -1,0 +1,41 @@
+# Migration guide from 3.2.5 to 3.3.0
+
+**Make sure your server is not running until the end of the migration**
+
+:::warning
+If you are using **extensions** to create custom code or modifying existing code, you will need to update your code and compare your version to the new changes on the repository.
+<br>
+Not updating your **extensions** can break your app in unexpected ways that we cannot predict.
+:::
+
+## Disclaimer
+
+This version requires a migration in the following cases:
+
+- You have extended the **Strapi-admin** **admin/src/config.js** file, so you have `./admin/src/config.js`.
+
+Otherwise you can follow the basic [version update guide](../guides/update-version.md).
+
+## Migration
+
+To invite users upgrading their application, we have introduced an application details page.
+If you have extended the config file in any way, you will need to add the new constant to your extension in `./admin/src/config.js`
+
+**Before**:
+
+```js
+export const LOGIN_LOGO = null;
+export const SHOW_TUTORIALS = true;
+export const SETTINGS_BASE_URL = '/settings';
+```
+
+**After**:
+
+```js
+export const LOGIN_LOGO = null;
+export const SHOW_TUTORIALS = true;
+export const SETTINGS_BASE_URL = '/settings';
+export const STRAPI_UPDATE_NOTIF = true;
+```
+
+That's it, now you can follow the basic [version update guide](../guides/update-version.md).


### PR DESCRIPTION
Signed-off-by: soupette <cyril.lpz@gmail.com>


### What does it do?

This PR adds the migration guide for 3.2.5 to 3.3

### Why is it needed?

So users can migrate

