### PR TITLE
Update Heroku guide to set NODE_ENV to production

### DIFF
--- a/docs/v3.x/deployment/heroku.md
+++ b/docs/v3.x/deployment/heroku.md
@@ -198,9 +198,9 @@ With yarn:
 yarn add pg-connection-string
 ```
 
-#### 4. Create your Heroku database config file
+#### 4. Create your Heroku database config file for production
 
-Create a new `database.js` in a new [env](../concepts/configurations.html#environments) folder. By default Heroku applies the `NODE_ENV` environment variable as production. When you run locally you should be using the `./config/database.js` which should be set to use SQLite.
+Create a new `database.js` in a new [env](../concepts/configurations.html#environments) folder. When you run locally you should be using the `./config/database.js` which should be set to use SQLite.
 
 `Path: ./config/env/production/database.js`
 
@@ -227,6 +227,12 @@ module.exports = ({ env }) => ({
     },
   },
 });
+```
+
+We also need to set the `NODE_ENV` variable on Heroku to `production` to ensure this new database configuration file is used.
+
+```bash
+heroku config:set NODE_ENV=production
 ```
 
 #### 5. Install the `pg` node module


### PR DESCRIPTION
Signed-off-by: Derrick Mehaffy <derrickmehaffy@gmail.com>

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Fixes usage of PG on Heroku so it doesn't use the SQLite database

### Why is it needed?

Heroku doesn't set `NODE_ENV` by default to production anymore

### Related issue(s)/PR(s)

N/A
