### PR TITLE
fix(ckeditor): add missing dependancy

### DIFF
--- a/docs/3.0.0-beta.x/guides/registering-a-field-in-admin.md
+++ b/docs/3.0.0-beta.x/guides/registering-a-field-in-admin.md
@@ -26,7 +26,7 @@ yarn run strapi generate:plugin wysiwyg
 
 ```bash
 cd my-app/plugins/wysiwyg
-yarn add @ckeditor/ckeditor5-react @ckeditor/ckeditor5-build-classic
+yarn add @ckeditor/ckeditor5-react @ckeditor/ckeditor5-build-classic styled-components
 ```
 
 4. Start your application with the front-end development mode:


### PR DESCRIPTION
The dependancy `styled-components` was missing in the docs. 

This PR adds the above
