### PR TITLE
Add Render as a deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@
 Strapi is a free and open-source headless CMS delivering your content anywhere you need.
 
 - **Keep control over your data**. With Strapi, you know where your data is stored, and you keep full control at all times.
-- **Self-hosted**. You can host and scale Strapi projects the way you want. You can choose any hosting platform you want: AWS, Netlify, Heroku, a VPS, or a dedicated server. You can scale as you grow, 100% independent.
+- **Self-hosted**. You can host and scale Strapi projects the way you want. You can choose any hosting platform you want: AWS, Render, Netlify, Heroku, a VPS, or a dedicated server. You can scale as you grow, 100% independent.
 - **Database agnostic**. You can choose the database you prefer. Strapi works with SQL & NoSQL databases: MongoDB, PostgreSQL, MySQL, MariaDB, and SQLite.
 - **Customizable**. You can quickly build your logic by fully customizing APIs, routes, or plugins to fit your needs perfectly.
 

--- a/README.md
+++ b/README.md
@@ -12,18 +12,21 @@
     <img src="https://assets.strapi.io/uploads/deploy_button_platform_sh_d032f646a7.png"  />
   </a>
 
-<a href="https://marketplace.digitalocean.com/apps/strapi">
-<img src="https://assets.strapi.io/uploads/deploy_button_Digital_Ocean_fe2c286222.png" />
-</a>
+  <a href="https://marketplace.digitalocean.com/apps/strapi">
+    <img src="https://assets.strapi.io/uploads/deploy_button_Digital_Ocean_fe2c286222.png" />
+  </a>
 
-<a href="https://www.heroku.com/deploy/?template=https://github.com/strapi/strapi-heroku-template">
-<img src="https://assets.strapi.io/uploads/Deploy_button_heroku_b1043fc67d.png" />
-</a>
+  <a href="https://www.heroku.com/deploy/?template=https://github.com/strapi/strapi-heroku-template">
+    <img src="https://assets.strapi.io/uploads/Deploy_button_heroku_b1043fc67d.png" />
+  </a>
 
-<a href="https://fastandcomfy.io/strapi/">
-<img src="https://assets.strapi.io/uploads/deploy_button_fastandcomfy_7cb9319189.png" />
-</a>
-
+  <a href="https://fastandcomfy.io/strapi/">
+    <img src="https://assets.strapi.io/uploads/deploy_button_fastandcomfy_7cb9319189.png" />
+  </a>
+  
+  <a href="https://render.com/docs/deploy-strapi">
+    <img src="https://assets.strapi.io/uploads/deploy_render_e076b6f23a.png" height="44" />
+  </a>
 </p>
 
 <p align="center">

--- a/docs/v3.x/deployment/render.md
+++ b/docs/v3.x/deployment/render.md
@@ -1,8 +1,8 @@
 # Render
 
-[Render](https://render.com) and Strapi make a great match. With persistent disks and managed PostgreSQL databases, Render gives you multiple different ways to store your content. Render services come with fully managed SSL, so it's no longer necessary to set up a proxy server to secure your Strapi app. Since Render services are automatically restarted if they become unresponsive, you don't need to use a process manager like `pm2` either.
+This guide explains how to update an existing Strapi project so it can be deployed on [Render](https://render.com).
 
-This guide explains how to update an existing Strapi project so it can be deployed on Render. Visit [Render One-Click Deploy](../installation/render.html) to deploy an new Strapi project on Render in one click.
+With persistent disks and managed PostgreSQL databases, Render gives you multiple different ways to store your content. Render services come with fully managed SSL, so it's no longer necessary to set up a proxy server to secure your Strapi app. Since Render services are automatically restarted if they become unresponsive, you don't need to use a process manager like `pm2` either.
 
 ::: tip
 For more information consult [Render's Deploy Strapi guide](https://render.com/docs/deploy-strapi)
@@ -14,24 +14,13 @@ Visit [the Render dashboard](https://dashboard.render.com) to create an account 
 
 ### Step 2: Choose Your Content Storage Method
 
-You have two decisions to make:
+You have to choose which database system to use for storing structured content, and where to store uploaded media library files.
 
-1. Which database system to use for storing structured content
-2. Where to store uploaded media library files
+Below are descriptions of 3 approaches that make different trade-offs between scalability, availability, simplicity, and cost.
 
-Render is flexible enough to accommodate a variety of content storage options. Below are descrptions of three approaches that make different trade-offs between scalability, availability, simplicity, and cost.
-
-#### 2.1. SQLite and Uploads on Disk
-
-This option will use a [Render persistent disk](https://render.com/docs/disks) to store both a SQLite database file and uploaded media library files. This is a simple and inexpensive approach, appropriate if for example you're using Strapi as the data source for a static site generator. [Render's `strapi-sqlite` repo](https://github.com/render-examples/strapi-sqlite) demonstrates this approach.
-
-#### 2.2. Managed PostgreSQL and Uploads on Cloudinary
-
-If you're using Strapi as the backend for a website or app that dynamically fetches content, scalability and availability are more important. Use a [managed PostgreSQL database](https://render.com/docs/databases) and Cloudinary for uploads to get [horizontal scaling](#step-6-scale) and [zero downtime deploys](https://render.com/docs/zero-downtime-deploys). [Render's `strapi-postgres-cloudinary` repo](https://github.com/render-examples/strapi-postgres-cloudinary) demonstrates this approach.
-
-#### 2.3. Managed PostgreSQL and Uploads on Disk
-
-If you care about performance but can tolerate a few seconds of downtime when you deploy, you can cut costs compared to a paid Cloudinary plan with a hybrid approach. Use [managed PostgreSQL](https://render.com/docs/databases) for structured content and [block storage](https://render.com/docs/disks) for uploads. If your project doesn't use the media library you can remove the disk to get [horizontal scaling](#step-6-scale) and [zero downtime deploys](https://render.com/docs/zero-downtime-deploys). [Render's `strapi-postgres` repo](https://github.com/render-examples/strapi-postgres) demonstrates this approach.
+- **SQLite and Uploads on Disk**: this option will use a [Render persistent disk](https://render.com/docs/disks) to store both a SQLite database file and uploaded media library files. This is a simple and inexpensive approach, appropriate if, for example, you're using Strapi as the data source for a static site generator. See [Render's `strapi-sqlite` repository](https://github.com/render-examples/strapi-sqlite) for an example of this approach.
+- **Managed PostgreSQL and Uploads on Cloudinary**: if you're using Strapi as the backend for a website or app that dynamically fetches content, scalability and availability are more important. Use a [managed PostgreSQL database](https://render.com/docs/databases) and Cloudinary for uploads to get [horizontal scaling](#step-6-scale) and [zero downtime deploys](https://render.com/docs/zero-downtime-deploys). See [Render's `strapi-postgres-cloudinary` repository](https://github.com/render-examples/strapi-postgres-cloudinary) for an example of this approach.
+- **Managed PostgreSQL and Uploads on Disk**: if you care about performance but can tolerate a few seconds of downtime when you deploy, you can cut costs compared to a paid Cloudinary plan with a hybrid approach. Use [managed PostgreSQL](https://render.com/docs/databases) for structured content and [block storage](https://render.com/docs/disks) for uploads. If your project doesn't use the media library you can remove the disk to get [horizontal scaling](#step-6-scale) and [zero downtime deploys](https://render.com/docs/zero-downtime-deploys). See [Render's `strapi-postgres` repository](https://github.com/render-examples/strapi-postgres) for an example of this approach.
 
 ### Step 3: Add a render.yaml File
 
@@ -91,26 +80,10 @@ services:
         sync: false
       - key: CLOUDINARY_SECRET
         sync: false
-      - key: DATABASE_HOST
+      - key: DATABASE_URL
         fromDatabase:
           name: strapi
-          property: host
-      - key: DATABASE_PORT
-        fromDatabase:
-          name: strapi
-          property: port
-      - key: DATABASE_USER
-        fromDatabase:
-          name: strapi
-          property: user
-      - key: DATABASE_PASSWORD
-        fromDatabase:
-          name: strapi
-          property: password
-      - key: DATABASE_NAME
-        fromDatabase:
-          name: strapi
-          property: database
+          property: connectionString
       - key: JWT_SECRET
         generateValue: true
       - key: ADMIN_JWT_SECRET
@@ -143,26 +116,10 @@ services:
         value: 12.18.4
       - key: NODE_ENV
         value: production
-      - key: DATABASE_HOST
+      - key: DATABASE_URL
         fromDatabase:
           name: strapi
-          property: host
-      - key: DATABASE_PORT
-        fromDatabase:
-          name: strapi
-          property: port
-      - key: DATABASE_USER
-        fromDatabase:
-          name: strapi
-          property: user
-      - key: DATABASE_PASSWORD
-        fromDatabase:
-          name: strapi
-          property: password
-      - key: DATABASE_NAME
-        fromDatabase:
-          name: strapi
-          property: database
+          property: connectionString
       - key: JWT_SECRET
         generateValue: true
       - key: ADMIN_JWT_SECRET
@@ -181,11 +138,7 @@ Alternatively, you can manually configure your service and database in the Rende
 
 ### Step 4: Configure Strapi for Production
 
-Copy `config/env/production` and its contents from the example repo that corresponds to your [storage preference](#step-2-choose-your-content-storage-method):
-
-- [SQLite and Disk](https://github.com/render-examples/strapi-sqlite)
-- [PostgreSQL and Cloudinary](https://github.com/render-examples/strapi-postgres-cloudinary)
-- [PostgreSQL and Disk](https://github.com/render-examples/strapi-postgres)
+Copy `config/env/production` and its contents from the example repository that corresponds to your [storage preference](#step-2-choose-your-content-storage-method).
 
 If you attach a [custom domain](https://render.com/docs/custom-domains) to your Render service, use it as the `url` attribute in `server.js`.
 
@@ -198,18 +151,14 @@ The [Configuration doc](../concepts/configurations.html) has more info on config
 ### Step 5: Deploy
 
 1. Commit your changes and push them to GitHub or GitLab.
-2. In the Render dashboard select **YAML** in the side nav and then click the **New From YAML** button.
-3. Give Render permission to access your GitHub or GitLab repo if you haven't already.
-4. Select the repo and branch for your Strapi project and follow the prompts that appear. If you're using Cloudinary, you'll be asked to enter your account credentials as environment variables. Render encrypts environment variables and stores them securely.
+2. In the Render dashboard select **YAML** in the side navigation and click the **New From YAML** button.
+3. Give Render permission to access your GitHub or GitLab repository if you haven't already.
+4. Select the repository and branch for your Strapi project and follow the prompts that appear. If you're using Cloudinary, you'll be asked to enter your account credentials as environment variables. Render encrypts environment variables and stores them securely.
 
 ### Step 6: Scale
 
-For vertical scaling, upgrade your service to a plan with more CPU and RAM per instance. If you're using a managed database you can upgrade its plan as well. Visit [Render's pricing page](https://render.com/pricing) and consider the [recommended requirements](../getting-started/deployment.html#recommended-requirements) in choosing the best plan for your needs. To upgrade, just change [the `plan` field(s)](https://render.com/docs/yaml-spec#plans) in your `render.yaml` file.
+For vertical scaling, upgrade your service to a plan with more CPU and RAM per instance. If you're using a managed database you can upgrade its plan as well. Visit [Render's pricing page](https://render.com/pricing) and consider the [recommended requirements](../getting-started/deployment.html#recommended-requirements) in choosing the best plan for your needs. To upgrade, change [the `plan` field(s)](https://render.com/docs/yaml-spec#plans) in your `render.yaml` file.
 
-Render services without attached disks can be horizontally scaled. Add [a `numInstances` field](https://render.com/docs/yaml-spec#number-of-instances) in your `render.yaml` file to get multiple instances of your Strapi app running in parallel. Render automatically load balances requests among your instances.
+Render services without attached disks can be horizontally scaled. Add [a `numInstances` field](https://render.com/docs/yaml-spec#number-of-instances) in your `render.yaml` file to get multiple instances of your Strapi application running in parallel. Render automatically load balances requests among your instances.
 
 For manually-managed infrastructure you can change the plan and number of instances from the **Settings** tab in the Render dashboard.
-
-::: tip
-If you have a question, post it to [Render's community forum](https://community.render.com)
-:::

--- a/docs/v3.x/deployment/render.md
+++ b/docs/v3.x/deployment/render.md
@@ -1,0 +1,215 @@
+# Render
+
+[Render](https://render.com) and Strapi make a great match. With persistent disks and managed PostgreSQL databases, Render gives you multiple different ways to store your content. Render services come with fully managed SSL, so it's no longer necessary to set up a proxy server to secure your Strapi app. Since Render services are automatically restarted if they become unresponsive, you don't need to use a process manager like `pm2` either.
+
+This guide explains how to update an existing Strapi project so it can be deployed on Render. Visit [Render One-Click Deploy](../installation/render.html) to deploy an new Strapi project on Render in one click.
+
+::: tip
+For more information consult [Render's Deploy Strapi guide](https://render.com/docs/deploy-strapi)
+:::
+
+### Step 1: Create a Render Account
+
+Visit [the Render dashboard](https://dashboard.render.com) to create an account if you don't already have one.
+
+### Step 2: Choose Your Content Storage Method
+
+You have two decisions to make:
+
+1. Which database system to use for storing structured content
+2. Where to store uploaded media library files
+
+Render is flexible enough to accommodate a variety of content storage options. Below are descrptions of three approaches that make different trade-offs between scalability, availability, simplicity, and cost.
+
+#### 2.1. SQLite and Uploads on Disk
+
+This option will use a [Render persistent disk](https://render.com/docs/disks) to store both a SQLite database file and uploaded media library files. This is a simple and inexpensive approach, appropriate if for example you're using Strapi as the data source for a static site generator. [Render's `strapi-sqlite` repo](https://github.com/render-examples/strapi-sqlite) demonstrates this approach.
+
+#### 2.2. Managed PostgreSQL and Uploads on Cloudinary
+
+If you're using Strapi as the backend for a website or app that dynamically fetches content, scalability and availability are more important. Use a [managed PostgreSQL database](https://render.com/docs/databases) and Cloudinary for uploads to get [horizontal scaling](#step-6-scale) and [zero downtime deploys](https://render.com/docs/zero-downtime-deploys). [Render's `strapi-postgres-cloudinary` repo](https://github.com/render-examples/strapi-postgres-cloudinary) demonstrates this approach.
+
+#### 2.3. Managed PostgreSQL and Uploads on Disk
+
+If you care about performance but can tolerate a few seconds of downtime when you deploy, you can cut costs compared to a paid Cloudinary plan with a hybrid approach. Use [managed PostgreSQL](https://render.com/docs/databases) for structured content and [block storage](https://render.com/docs/disks) for uploads. If your project doesn't use the media library you can remove the disk to get [horizontal scaling](#step-6-scale) and [zero downtime deploys](https://render.com/docs/zero-downtime-deploys). [Render's `strapi-postgres` repo](https://github.com/render-examples/strapi-postgres) demonstrates this approach.
+
+### Step 3: Add a render.yaml File
+
+Select the [render.yaml file](https://render.com/docs/yaml-spec) that matches your storage preferences and add it to the root of your Strapi project.
+
+:::: tabs
+
+::: tab strapi-sqlite
+
+```yaml
+services:
+  - type: web
+    name: strapi
+    env: node
+    plan: starter
+    buildCommand: yarn install && yarn build
+    startCommand: rsync -a public/ /data/public/ && yarn start
+    healthCheckPath: /_health
+    disk:
+      name: strapi-data
+      mountPath: /data
+      sizeGB: 1
+    envVars:
+      - key: NODE_VERSION
+        value: 12.18.4
+      - key: NODE_ENV
+        value: production
+      - key: DATABASE_FILENAME
+        value: /data/strapi.db
+      - key: JWT_SECRET
+        generateValue: true
+      - key: ADMIN_JWT_SECRET
+        generateValue: true
+```
+
+:::
+
+::: tab strapi-postgres-cloudinary
+
+```yaml
+services:
+  - type: web
+    name: strapi
+    env: node
+    plan: starter
+    buildCommand: yarn install && yarn build
+    startCommand: yarn start
+    healthCheckPath: /_health
+    envVars:
+      - key: NODE_VERSION
+        value: 12.18.4
+      - key: NODE_ENV
+        value: production
+      - key: CLOUDINARY_NAME
+        sync: false
+      - key: CLOUDINARY_KEY
+        sync: false
+      - key: CLOUDINARY_SECRET
+        sync: false
+      - key: DATABASE_HOST
+        fromDatabase:
+          name: strapi
+          property: host
+      - key: DATABASE_PORT
+        fromDatabase:
+          name: strapi
+          property: port
+      - key: DATABASE_USER
+        fromDatabase:
+          name: strapi
+          property: user
+      - key: DATABASE_PASSWORD
+        fromDatabase:
+          name: strapi
+          property: password
+      - key: DATABASE_NAME
+        fromDatabase:
+          name: strapi
+          property: database
+      - key: JWT_SECRET
+        generateValue: true
+      - key: ADMIN_JWT_SECRET
+        generateValue: true
+
+databases:
+  - name: strapi
+    plan: starter
+```
+
+:::
+
+::: tab strapi-postgres
+
+```yaml
+services:
+  - type: web
+    name: strapi
+    env: node
+    plan: starter
+    buildCommand: yarn install && yarn build
+    startCommand: yarn start
+    healthCheckPath: /_health
+    disk:
+      name: strapi-uploads
+      mountPath: /opt/render/project/src/public/uploads
+      sizeGB: 1
+    envVars:
+      - key: NODE_VERSION
+        value: 12.18.4
+      - key: NODE_ENV
+        value: production
+      - key: DATABASE_HOST
+        fromDatabase:
+          name: strapi
+          property: host
+      - key: DATABASE_PORT
+        fromDatabase:
+          name: strapi
+          property: port
+      - key: DATABASE_USER
+        fromDatabase:
+          name: strapi
+          property: user
+      - key: DATABASE_PASSWORD
+        fromDatabase:
+          name: strapi
+          property: password
+      - key: DATABASE_NAME
+        fromDatabase:
+          name: strapi
+          property: database
+      - key: JWT_SECRET
+        generateValue: true
+      - key: ADMIN_JWT_SECRET
+        generateValue: true
+
+databases:
+  - name: strapi
+    plan: starter
+```
+
+:::
+
+::::
+
+Alternatively, you can manually configure your service and database in the Render dashboard, instead of using [infrastructure as code](https://render.com/docs/infrastructure-as-code).
+
+### Step 4: Configure Strapi for Production
+
+Copy `config/env/production` and its contents from the example repo that corresponds to your [storage preference](#step-2-choose-your-content-storage-method):
+
+- [SQLite and Disk](https://github.com/render-examples/strapi-sqlite)
+- [PostgreSQL and Cloudinary](https://github.com/render-examples/strapi-postgres-cloudinary)
+- [PostgreSQL and Disk](https://github.com/render-examples/strapi-postgres)
+
+If you attach a [custom domain](https://render.com/docs/custom-domains) to your Render service, use it as the `url` attribute in `server.js`.
+
+For PostgreSQL, install the `pg` package from npm. If you're using Cloudinary, install `strapi-provider-upload-cloudinary`.
+
+::: tip
+The [Configuration doc](../concepts/configurations.html) has more info on configuring Strapi
+:::
+
+### Step 5: Deploy
+
+1. Commit your changes and push them to GitHub or GitLab.
+2. In the Render dashboard select **YAML** in the side nav and then click the **New From YAML** button.
+3. Give Render permission to access your GitHub or GitLab repo if you haven't already.
+4. Select the repo and branch for your Strapi project and follow the prompts that appear. If you're using Cloudinary, you'll be asked to enter your account credentials as environment variables. Render encrypts environment variables and stores them securely.
+
+### Step 6: Scale
+
+For vertical scaling, upgrade your service to a plan with more CPU and RAM per instance. If you're using a managed database you can upgrade its plan as well. Visit [Render's pricing page](https://render.com/pricing) and consider the [recommended requirements](../getting-started/deployment.html#recommended-requirements) in choosing the best plan for your needs. To upgrade, just change [the `plan` field(s)](https://render.com/docs/yaml-spec#plans) in your `render.yaml` file.
+
+Render services without attached disks can be horizontally scaled. Add [a `numInstances` field](https://render.com/docs/yaml-spec#number-of-instances) in your `render.yaml` file to get multiple instances of your Strapi app running in parallel. Render automatically load balances requests among your instances.
+
+For manually-managed infrastructure you can change the plan and number of instances from the **Settings** tab in the Render dashboard.
+
+::: tip
+If you have a question, post it to [Render's community forum](https://community.render.com)
+:::

--- a/docs/v3.x/getting-started/deployment.md
+++ b/docs/v3.x/getting-started/deployment.md
@@ -1,6 +1,6 @@
 # Deployment
 
-Strapi gives you many possible deployment options for your project or application. Strapi can be deployed on traditional hosting servers or services such as Heroku, AWS, Azure and others. The following documentation covers how to develop locally with Strapi and deploy Strapi with various hosting options.
+Strapi gives you many possible deployment options for your project or application. Strapi can be deployed on traditional hosting servers or services such as Render, Heroku, AWS, Azure and others. The following documentation covers how to develop locally with Strapi and deploy Strapi with various hosting options.
 
 ::: tip
 Deploying **databases** along with Strapi is covered in the [Databases Guide](../guides/databases.md).
@@ -66,6 +66,18 @@ Manual guides for deployment on various platforms, for One-click and docker plea
 		<template #title>Heroku</template>
 		<template #description>
 			Step by step guide for deploying on Heroku
+		</template>
+	</InstallLink>
+</div>
+
+<div>
+	<InstallLink link="../deployment/render.html">
+		<template #icon>
+			<svg viewBox="21.7 21.7 181 181" xmlns="http://www.w3.org/2000/svg"><g><polygon class="st0" points="145 31.7 143 31.7 143 33.7 143 52.2 143 54.2 145 54.2 163.6 54.2 165.6 54.2 165.6 52.2 165.6 33.7 165.6 31.7 163.6 31.7" fill="#fff"/><path class="st0" d="M 85.2 31.7 C 78 31.7 71 33.1 64.4 35.9 C 58 38.6 52.3 42.5 47.4 47.4 C 42.5 52.3 38.6 58 35.9 64.4 C 33.1 71 31.7 78 31.7 85.2 L 31.7 163.6 L 31.7 165.6 L 33.7 165.6 L 52.3 165.6 L 54.3 165.6 L 54.3 163.6 L 54.3 84.9 C 54.7 76.8 58.1 69.2 63.8 63.6 C 69.6 57.9 77.2 54.6 85.3 54.3 L 126.5 54.3 L 128.5 54.3 L 128.5 52.3 L 128.5 33.7 L 128.5 31.7 L 126.5 31.7 L 85.2 31.7 Z" fill="#fff"/><polygon class="st0" points="182.1 105.9 180.1 105.9 180.1 107.9 180.1 126.5 180.1 128.5 182.1 128.5 200.7 128.5 202.7 128.5 202.7 126.5 202.7 107.9 202.7 105.9 200.7 105.9" fill="#fff"/><polygon class="st0" points="182.1 68.8 180.1 68.8 180.1 70.8 180.1 89.4 180.1 91.4 182.1 91.4 200.7 91.4 202.7 91.4 202.7 89.4 202.7 70.8 202.7 68.8 200.7 68.8" fill="#fff"/><polygon class="st0" points="200.7 31.7 182.1 31.7 180.1 31.7 180.1 33.7 180.1 52.2 180.1 54.2 182.1 54.2 200.7 54.2 202.7 54.2 202.7 52.2 202.7 33.7 202.7 31.7" fill="#fff"/><polygon class="st0" points="182.1 143 180.1 143 180.1 145 180.1 163.6 180.1 165.6 182.1 165.6 200.7 165.6 202.7 165.6 202.7 163.6 202.7 145 202.7 143 200.7 143" fill="#fff"/><polygon class="st0" points="182.1 180.1 180.1 180.1 180.1 182.1 180.1 200.7 180.1 202.7 182.1 202.7 200.7 202.7 202.7 202.7 202.7 200.7 202.7 182.1 202.7 180.1 200.7 180.1" fill="#fff"/><polygon class="st0" points="145 180.1 143 180.1 143 182.1 143 200.7 143 202.7 145 202.7 163.6 202.7 165.6 202.7 165.6 200.7 165.6 182.1 165.6 180.1 163.6 180.1" fill="#fff"/><polygon class="st0" points="107.9 180.3 105.9 180.3 105.9 182.3 105.9 200.9 105.9 202.9 107.9 202.9 126.5 202.9 128.5 202.9 128.5 200.9 128.5 182.3 128.5 180.3 126.5 180.3" fill="#fff"/><polygon class="st0" points="70.8 180.1 68.8 180.1 68.8 182.1 68.8 200.7 68.8 202.7 70.8 202.7 89.4 202.7 91.4 202.7 91.4 200.7 91.4 182.1 91.4 180.1 89.4 180.1" fill="#fff"/><polygon class="st0" points="33.7 180.1 31.7 180.1 31.7 182.1 31.7 200.7 31.7 202.7 33.7 202.7 52.2 202.7 54.2 202.7 54.2 200.7 54.2 182.1 54.2 180.1 52.2 180.1" fill="#fff"/></g></svg>
+		</template>
+		<template #title>Render</template>
+		<template #description>
+			Three different options for deploying on Render
 		</template>
 	</InstallLink>
 </div>

--- a/docs/v3.x/getting-started/installation.md
+++ b/docs/v3.x/getting-started/installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-Strapi gives you many possible installation options for your project or application. Strapi can be installed on your computer or services such as DigitalOcean, Amazon AWS, or Platform.sh. The following documentation covers many different options to install Strapi and getting started on using it.
+Strapi gives you many possible installation options for your project or application. Strapi can be installed on your computer or services such as Render, DigitalOcean, Amazon AWS, or Platform.sh. The following documentation covers many different options to install Strapi and getting started on using it.
 
 ::: tip
 For a more detailed overview of deployment please see the [related documentation](./deployment.md).
@@ -52,6 +52,18 @@ For a more detailed overview of deployment please see the [related documentation
 		<template #title>Platform.sh One-Click</template>
 		<template #description>
 			Your project setup in one click with Platform.sh
+		</template>
+	</InstallLink>
+</div>
+
+<div>
+	<InstallLink link="../installation/render.html">
+		<template #icon>
+			<svg viewBox="21.7 21.7 181 181" xmlns="http://www.w3.org/2000/svg"><g><polygon class="st0" points="145 31.7 143 31.7 143 33.7 143 52.2 143 54.2 145 54.2 163.6 54.2 165.6 54.2 165.6 52.2 165.6 33.7 165.6 31.7 163.6 31.7" fill="#fff"/><path class="st0" d="M 85.2 31.7 C 78 31.7 71 33.1 64.4 35.9 C 58 38.6 52.3 42.5 47.4 47.4 C 42.5 52.3 38.6 58 35.9 64.4 C 33.1 71 31.7 78 31.7 85.2 L 31.7 163.6 L 31.7 165.6 L 33.7 165.6 L 52.3 165.6 L 54.3 165.6 L 54.3 163.6 L 54.3 84.9 C 54.7 76.8 58.1 69.2 63.8 63.6 C 69.6 57.9 77.2 54.6 85.3 54.3 L 126.5 54.3 L 128.5 54.3 L 128.5 52.3 L 128.5 33.7 L 128.5 31.7 L 126.5 31.7 L 85.2 31.7 Z" fill="#fff"/><polygon class="st0" points="182.1 105.9 180.1 105.9 180.1 107.9 180.1 126.5 180.1 128.5 182.1 128.5 200.7 128.5 202.7 128.5 202.7 126.5 202.7 107.9 202.7 105.9 200.7 105.9" fill="#fff"/><polygon class="st0" points="182.1 68.8 180.1 68.8 180.1 70.8 180.1 89.4 180.1 91.4 182.1 91.4 200.7 91.4 202.7 91.4 202.7 89.4 202.7 70.8 202.7 68.8 200.7 68.8" fill="#fff"/><polygon class="st0" points="200.7 31.7 182.1 31.7 180.1 31.7 180.1 33.7 180.1 52.2 180.1 54.2 182.1 54.2 200.7 54.2 202.7 54.2 202.7 52.2 202.7 33.7 202.7 31.7" fill="#fff"/><polygon class="st0" points="182.1 143 180.1 143 180.1 145 180.1 163.6 180.1 165.6 182.1 165.6 200.7 165.6 202.7 165.6 202.7 163.6 202.7 145 202.7 143 200.7 143" fill="#fff"/><polygon class="st0" points="182.1 180.1 180.1 180.1 180.1 182.1 180.1 200.7 180.1 202.7 182.1 202.7 200.7 202.7 202.7 202.7 202.7 200.7 202.7 182.1 202.7 180.1 200.7 180.1" fill="#fff"/><polygon class="st0" points="145 180.1 143 180.1 143 182.1 143 200.7 143 202.7 145 202.7 163.6 202.7 165.6 202.7 165.6 200.7 165.6 182.1 165.6 180.1 163.6 180.1" fill="#fff"/><polygon class="st0" points="107.9 180.3 105.9 180.3 105.9 182.3 105.9 200.9 105.9 202.9 107.9 202.9 126.5 202.9 128.5 202.9 128.5 200.9 128.5 182.3 128.5 180.3 126.5 180.3" fill="#fff"/><polygon class="st0" points="70.8 180.1 68.8 180.1 68.8 182.1 68.8 200.7 68.8 202.7 70.8 202.7 89.4 202.7 91.4 202.7 91.4 200.7 91.4 182.1 91.4 180.1 89.4 180.1" fill="#fff"/><polygon class="st0" points="33.7 180.1 31.7 180.1 31.7 182.1 31.7 200.7 31.7 202.7 33.7 202.7 52.2 202.7 54.2 202.7 54.2 200.7 54.2 182.1 54.2 180.1 52.2 180.1" fill="#fff"/></g></svg>
+		</template>
+		<template #title>Render One-Click</template>
+		<template #description>
+			Deploy your project on Render in one click
 		</template>
 	</InstallLink>
 </div>

--- a/docs/v3.x/installation/render.md
+++ b/docs/v3.x/installation/render.md
@@ -1,0 +1,35 @@
+# Render One-Click Deploy
+
+[Render](https://render.com) and Strapi make a great match. With persistent disks and managed PostgreSQL databases, Render gives you multiple different ways to store your content. Render services come with fully managed SSL, so it's no longer necessary to set up a proxy server to secure your Strapi app. Since Render services are automatically restarted if they become unresponsive, you don't need to use a process manager like `pm2` either.
+
+This guide explains how to deploy a new Strapi project on Render in one click. Visit [the Render deployment guide](../deployment/render.html) to learn how to update an existing Strapi project so it can be deployed on Render.
+
+::: tip
+For more information consult [Render's Deploy Strapi guide](https://render.com/docs/deploy-strapi)
+:::
+
+### Step 1: Create a Render Account
+
+Visit [the Render dashboard](https://dashboard.render.com) to create an account if you don't already have one.
+
+### Step 2: Fork an Example Repo
+
+Render maintains three Strapi on Render example repos, which differ based on which database is used and where uploaded media library files are stored:
+
+1. [Strapi with SQLite and uploads on disk](https://github.com/render-examples/strapi-sqlite)
+2. [Strapi with PostgreSQL and uploads on Cloudinary](https://github.com/render-examples/strapi-postgres-cloudinary)
+3. [Strapi with PostgreSQL and uploads on disk](https://github.com/render-examples/strapi-postgres)
+
+Read [Render's Deploy Strapi guide](https://render.com/docs/deploy-strapi) to get help choosing the best option for your use case. Once you've chosen, fork the repo on GitHub so you have the flexibility to make your own changes.
+
+### Step 3: Deploy
+
+Click the **Deploy to Render** button in the repo's `README` file. Give Render permission to access your repo if you haven't already. If you're using Cloudinary, you'll be prompted to enter your account credentials as environment variables.
+
+### (Optional) Step 4: Use Development Mode
+
+Your Strapi app will be running in production mode. If you'd like the ability edit content types from the admin UI, you can change the value of `NODE_ENV` to `development` in the `render.yaml` file at the root of your forked repo. A more [typical workflow](https://render.com/docs/deploy-strapi#development-%E2%86%92-staging-%E2%86%92-production) would be to edit content types locally before pushing your changes to staging and production.
+
+::: tip
+If you have a question, post it to [Render's community forum](https://community.render.com)
+:::

--- a/docs/v3.x/installation/render.md
+++ b/docs/v3.x/installation/render.md
@@ -1,8 +1,8 @@
 # Render One-Click Deploy
 
-[Render](https://render.com) and Strapi make a great match. With persistent disks and managed PostgreSQL databases, Render gives you multiple different ways to store your content. Render services come with fully managed SSL, so it's no longer necessary to set up a proxy server to secure your Strapi app. Since Render services are automatically restarted if they become unresponsive, you don't need to use a process manager like `pm2` either.
+This guide explains how to deploy a new Strapi project on [Render](https://render.com) in one click.
 
-This guide explains how to deploy a new Strapi project on Render in one click. Visit [the Render deployment guide](../deployment/render.html) to learn how to update an existing Strapi project so it can be deployed on Render.
+With persistent disks and managed PostgreSQL databases, Render gives you multiple different ways to store your content. Render services come with fully managed SSL, so it's no longer necessary to set up a proxy server to secure your Strapi application. Since Render services are automatically restarted if they become unresponsive, you don't need to use a process manager like `pm2` either.
 
 ::: tip
 For more information consult [Render's Deploy Strapi guide](https://render.com/docs/deploy-strapi)
@@ -12,24 +12,20 @@ For more information consult [Render's Deploy Strapi guide](https://render.com/d
 
 Visit [the Render dashboard](https://dashboard.render.com) to create an account if you don't already have one.
 
-### Step 2: Fork an Example Repo
+### Step 2: Fork an Example Repository
 
-Render maintains three Strapi on Render example repos, which differ based on which database is used and where uploaded media library files are stored:
+Render maintains 3 Strapi on Render example repositories, which differ based on which database is used and where uploaded media library files are stored:
 
 1. [Strapi with SQLite and uploads on disk](https://github.com/render-examples/strapi-sqlite)
 2. [Strapi with PostgreSQL and uploads on Cloudinary](https://github.com/render-examples/strapi-postgres-cloudinary)
 3. [Strapi with PostgreSQL and uploads on disk](https://github.com/render-examples/strapi-postgres)
 
-Read [Render's Deploy Strapi guide](https://render.com/docs/deploy-strapi) to get help choosing the best option for your use case. Once you've chosen, fork the repo on GitHub so you have the flexibility to make your own changes.
+Read [Render's Deploy Strapi guide](https://render.com/docs/deploy-strapi) to get help choosing the best option for your use case. Once you've chosen, fork the repository on GitHub so you have the flexibility to make your own changes.
 
 ### Step 3: Deploy
 
-Click the **Deploy to Render** button in the repo's `README` file. Give Render permission to access your repo if you haven't already. If you're using Cloudinary, you'll be prompted to enter your account credentials as environment variables.
+Click the **Deploy to Render** button in the forked repository's `README` file. Give Render permission to access your repository if you haven't already. If you're using Cloudinary, you'll be prompted to enter your account credentials as environment variables. Render encrypts environment variables and stores them securely.
 
-### (Optional) Step 4: Use Development Mode
+### Step 4: Add Content Types
 
-Your Strapi app will be running in production mode. If you'd like the ability edit content types from the admin UI, you can change the value of `NODE_ENV` to `development` in the `render.yaml` file at the root of your forked repo. A more [typical workflow](https://render.com/docs/deploy-strapi#development-%E2%86%92-staging-%E2%86%92-production) would be to edit content types locally before pushing your changes to staging and production.
-
-::: tip
-If you have a question, post it to [Render's community forum](https://community.render.com)
-:::
+Your Strapi application on Render will be running in production mode, with `NODE_ENV=production`. To add or edit content types via the admin UI, you need to run Strapi locally in development mode. Clone the forked repository to your local machine, `cd` into it, and run `yarn install && yarn develop`. When you're ready, commit your changes and push them to your remote repository. Render will auto-deploy the changes to your production application. A [typical workflow](https://render.com/docs/deploy-strapi#development-%E2%86%92-staging-%E2%86%92-production) would also include a staging environment for testing.


### PR DESCRIPTION
I added docs on deploying Strapi to Render, as discussed with @derrickmehaffy and @malgamves: https://github.com/strapi/community-content/issues/166. Feedback is very welcome.

Would it be possible to add a "Deploy on Render" button at the top of the main README? I would've done it myself, but it looks like the button images need to be generated and uploaded to assets.strapi.io.
