### PR TITLE
Load TypeScript config files.

### DIFF
--- a/packages/strapi/lib/core/app-configuration/config-loader.js
+++ b/packages/strapi/lib/core/app-configuration/config-loader.js
@@ -23,6 +23,7 @@ const loadFile = file => {
   const ext = path.extname(file);
 
   switch (ext) {
+    case '.ts':
     case '.js':
       return loadJsFile(file);
     case '.json':


### PR DESCRIPTION
This would make writing the files in the `config` directory in TypeScript very easy.

I run a custom `server.ts` to start strapi with `strapi().start()` in it. I start this process with `node-ts` which is standard for development.

I made this change and I could replace a `.js` file with a `.ts` and it would be loaded.

### What does it do?

Load config files from the config dir like js files.

### Why is it needed?

Writing everything in TypeScript

### Related issue(s)/PR(s)

No.