### PR TITLE
Make the beta docs more clear, depreciated notice

### DIFF
--- a/docs/.vuepress/theme/components/Navbar.vue
+++ b/docs/.vuepress/theme/components/Navbar.vue
@@ -1,90 +1,86 @@
 <template>
   <header class="navbar">
-    <SidebarButton @toggle-sidebar="$emit('toggle-sidebar')"/>
+    <SidebarButton @toggle-sidebar="$emit('toggle-sidebar')" />
 
-    <router-link
-      :to="$localePath"
-      class="home-link"
-    >
+    <router-link :to="$localePath" class="home-link">
       <img
         class="logo"
         v-if="$site.themeConfig.logo"
         :src="$withBase($site.themeConfig.logo)"
         :alt="$siteTitle"
-      >
+      />
       <span
         ref="siteName"
         class="site-name"
         v-if="$siteTitle"
         :class="{ 'can-hide': $site.themeConfig.logo }"
-      >{{ $siteTitle }}</span>
+        >{{ $siteTitle }}</span
+      >
     </router-link>
 
-    <span
-      class="deprecated"
-      v-if="isBeta">
-      Beta docs -
-      <router-link
-        :to="$localePath"
-        class="home-link"
-      >
-        current version
-      </router-link>
+    <span class="deprecated" v-if="isBeta">
+      Beta docs (deprecated) - View the
+      <router-link :to="$localePath" class="home-link"> current version </router-link>
     </span>
 
     <div
       class="links"
-      :style="linksWrapMaxWidth ? {
-        'max-width': linksWrapMaxWidth + 'px'
-      } : {}"
+      :style="
+        linksWrapMaxWidth
+          ? {
+              'max-width': linksWrapMaxWidth + 'px',
+            }
+          : {}
+      "
     >
-      <AlgoliaSearchBox
-        :options="algolia"
-      />
-      <NavLinks class="can-hide"/>
+      <AlgoliaSearchBox :options="algolia" />
+      <NavLinks class="can-hide" />
     </div>
   </header>
 </template>
 
 <script>
-import AlgoliaSearchBox from '@theme/components/AlgoliaSearchBox'
-import SearchBox from '@SearchBox'
-import SidebarButton from '@parent-theme/components/SidebarButton.vue'
-import NavLinks from '@parent-theme/components/NavLinks.vue'
+import AlgoliaSearchBox from '@theme/components/AlgoliaSearchBox';
+import SearchBox from '@SearchBox';
+import SidebarButton from '@parent-theme/components/SidebarButton.vue';
+import NavLinks from '@parent-theme/components/NavLinks.vue';
 export default {
-  components: { SidebarButton, NavLinks, AlgoliaSearchBox, SearchBox},
-  data () {
+  components: { SidebarButton, NavLinks, AlgoliaSearchBox, SearchBox },
+  data() {
     return {
       linksWrapMaxWidth: null,
-      isBeta: false
-    }
+      isBeta: false,
+    };
   },
-  mounted () {
-    const MOBILE_DESKTOP_BREAKPOINT = 719 // refer to config.styl
-    const NAVBAR_VERTICAL_PADDING = parseInt(css(this.$el, 'paddingLeft')) + parseInt(css(this.$el, 'paddingRight'))
+  mounted() {
+    const MOBILE_DESKTOP_BREAKPOINT = 719; // refer to config.styl
+    const NAVBAR_VERTICAL_PADDING =
+      parseInt(css(this.$el, 'paddingLeft')) + parseInt(css(this.$el, 'paddingRight'));
     const handleLinksWrapWidth = () => {
       if (document.documentElement.clientWidth < MOBILE_DESKTOP_BREAKPOINT) {
-        this.linksWrapMaxWidth = null
+        this.linksWrapMaxWidth = null;
       } else {
-        this.linksWrapMaxWidth = this.$el.offsetWidth - NAVBAR_VERTICAL_PADDING
-          - (this.$refs.siteName && this.$refs.siteName.offsetWidth || 0)
+        this.linksWrapMaxWidth =
+          this.$el.offsetWidth -
+          NAVBAR_VERTICAL_PADDING -
+          ((this.$refs.siteName && this.$refs.siteName.offsetWidth) || 0);
       }
-    }
-    handleLinksWrapWidth()
-    window.addEventListener('resize', handleLinksWrapWidth, false)
-    this.isBeta = /documentation\/3.0.0-beta.x/.test(window.location.href)
+    };
+    handleLinksWrapWidth();
+    window.addEventListener('resize', handleLinksWrapWidth, false);
+    this.isBeta = /documentation\/3.0.0-beta.x/.test(window.location.href);
   },
   computed: {
-    algolia () {
-      return this.$themeLocaleConfig.algolia || this.$site.themeConfig.algolia || {}
-    }
-  }
-}
-function css (el, property) {
+    algolia() {
+      return this.$themeLocaleConfig.algolia || this.$site.themeConfig.algolia || {};
+    },
+  },
+};
+function css(el, property) {
   // NOTE: Known bug, will return 'auto' if style value is 'auto'
-  const win = el.ownerDocument.defaultView
+  const win = el.ownerDocument.defaultView;
   // null means not to return pseudo styles
-  return win.getComputedStyle(el, null)[property]
+  return win.getComputedStyle(el, null)[property];
 }
 </script>
 


### PR DESCRIPTION
Signed-off-by: Derrick Mehaffy <derrickmehaffy@gmail.com>

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Make it more clear the user is viewing old documentation.

Old:
![image](https://user-images.githubusercontent.com/8593673/99280919-22d54000-27ef-11eb-887e-0be5739c46ac.png)

This PR:
![image](https://user-images.githubusercontent.com/8593673/99280948-2ec10200-27ef-11eb-9ba5-2298ddcbbfcb.png)



### Why is it needed?

Temporary until we can remove the beta docs

### Related issue(s)/PR(s)

N/A
