### PR TITLE
H1 shouldn't be present in a body WYSIWYG

### DIFF
--- a/packages/strapi-plugin-content-manager/admin/src/components/Wysiwyg/constants.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/Wysiwyg/constants.js
@@ -1,6 +1,5 @@
 export const SELECT_OPTIONS = [
   { id: 'components.Wysiwyg.selectOptions.title', value: '' },
-  { id: 'components.Wysiwyg.selectOptions.H1', value: '#' },
   { id: 'components.Wysiwyg.selectOptions.H2', value: '##' },
   { id: 'components.Wysiwyg.selectOptions.H3', value: '###' },
   { id: 'components.Wysiwyg.selectOptions.H4', value: '####' },


### PR DESCRIPTION
### What does it do?

This just removes the H1 as described here https://github.com/strapi/strapi/issues/8678

### Why is it needed?

There is never (or perhaps almost never) a time when having an H1 in the body of a wysiwyg is semantically correct. 

The title of the page is an H1, the rest should be H2-H6's.  

### Related issue

https://github.com/strapi/strapi/issues/8678