### PR TITLE
Update gitignore in example and in generate-new

### DIFF
--- a/examples/getstarted/.gitignore
+++ b/examples/getstarted/.gitignore
@@ -82,7 +82,6 @@ ssl
 nbproject
 public/uploads/*
 !public/uploads/.gitkeep
-.env
 
 ############################
 # Node.js
@@ -96,19 +95,21 @@ results
 node_modules
 .node_history
 
-
 ############################
-# Strapi
+# Tests
 ############################
 
 testApp
 coverage
 
-exports
+############################
+# Strapi
+############################
 
+.env
+license.txt
+exports
 *.cache
-
+build
 documentation
-exports
-
 .strapi-updater.json

--- a/packages/strapi-generate-new/lib/resources/dot-files/gitignore
+++ b/packages/strapi-generate-new/lib/resources/dot-files/gitignore
@@ -95,7 +95,6 @@ results
 node_modules
 .node_history
 
-
 ############################
 # Tests
 ############################
@@ -110,5 +109,6 @@ coverage
 .env
 license.txt
 exports
-.cache
+*.cache
 build
+.strapi-updater.json


### PR DESCRIPTION
`.strapi-updater.json` was in the `.gitignore` of the example app but not in the `.gitignore` generated by `generate-new`. Causing issues in some environments : https://forum.strapi.io/t/error-open-packages-api-strapi-updater-json-permission-denied/1255/2

Some other variables were different between the 2 gitignores, I harmonized them.
