### PR TITLE
fixed admin-tutorial broken link in heroku-deployment

### DIFF
--- a/docs/v3.x/deployment/heroku.md
+++ b/docs/v3.x/deployment/heroku.md
@@ -388,7 +388,7 @@ heroku open
 
 If you see the Strapi Welcome page, you have correctly set-up, configured and deployed your Strapi project on Heroku. You will now need to set-up your `admin user` as the production database is brand-new (and empty).
 
-You can now continue with the [Tutorial - Creating an Admin User](../getting-started/quick-start-tutorial.md#_3-create-an-admin-user), if you have any questions on how to proceed.
+You can now continue with the [Tutorial - Creating an Admin User](../getting-started/quick-start.md#_2-create-an-administrator-user), if you have any questions on how to proceed.
 
 ::: warning
 For security reasons, the Content Type Builder plugin is disabled in production. To update content structure, please make your changes locally and deploy again.


### PR DESCRIPTION
Signed-off-by: akhilmhdh <akhilmhdh@gmail.com>

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

- Fixed broken link inside heroku-deployment section 
- Link pointing towards the admin-user creation in quick start guide

### Why is it needed?

- Better doc
- Better user experience

### Related issue(s)/PR(s)

#8710 
