### PR TITLE
Fix `strapi -v` and `strapi --version` options

### DIFF
--- a/packages/strapi/bin/strapi.js
+++ b/packages/strapi/bin/strapi.js
@@ -64,7 +64,7 @@ program.helpOption('-h, --help', 'Display help for command');
 program.addHelpCommand('help [command]', 'Display help for command');
 
 // `$ strapi version` (--version synonym)
-program.option('-v, --version', 'Output the version number');
+program.version(packageJSON.version, '-v, --version', 'Output the version number');
 program
   .command('version')
   .description('Output your version of Strapi')


### PR DESCRIPTION
### What does it do?

When running the docker container I got weird output when initializing the container. This was caused by the fact that it runs `strapi -v` and this option no longer works. It seems it broke in c81af9a1d0b16cdc83cf1a0b73bd3012ebb80476 where `program.version(...)` got replaced with `program.option(...)` without an associated `.command(...)` to execute the option. I have changed `.option()` to `.version()`.

### Why is it needed?

To get `strapi -v` and `strapi --version` to work again.

### Related issue(s)/PR(s)

It seems noone noticed.