### PR TITLE
Fix migration when disabling dp on sqlite

### DIFF
--- a/packages/strapi-connector-bookshelf/lib/build-database-schema.js
+++ b/packages/strapi-connector-bookshelf/lib/build-database-schema.js
@@ -9,10 +9,7 @@ const { getManyRelations } = require('./utils/associations');
 const createMigrationRunner = require('./migrations/create-migration-runner');
 const draftPublishMigration = require('./migrations/draft-publish-migration');
 
-const migrateSchemas = async (
-  { ORM, loadedModel, definition, connection, model },
-  migrationInfos
-) => {
+const migrateSchemas = async ({ ORM, loadedModel, definition, connection, model }, context) => {
   // Add created_at and updated_at field if timestamp option is true
   if (loadedModel.hasTimestamps) {
     definition.attributes[loadedModel.hasTimestamps[0]] = { type: 'currentTimestamp' };
@@ -29,7 +26,7 @@ const migrateSchemas = async (
         ORM,
         model,
       },
-      migrationInfos
+      context
     );
   }
 
@@ -56,7 +53,7 @@ const migrateSchemas = async (
           ORM,
           model,
         },
-        migrationInfos
+        context
       );
     }
   }
@@ -94,7 +91,7 @@ const migrateSchemas = async (
 
       const table = manyRelation.tableCollectionName;
       if (connection.options && connection.options.autoMigration !== false) {
-        await createOrUpdateTable({ table, attributes, definition, ORM, model }, migrationInfos);
+        await createOrUpdateTable({ table, attributes, definition, ORM, model }, context);
       }
     }
   }
@@ -212,10 +209,7 @@ const buildColType = ({ name, attribute, table, tableExists = false, definition,
 };
 
 // Equilize database tables
-const createOrUpdateTable = async (
-  { table, attributes, definition, ORM, model },
-  migrationInfos
-) => {
+const createOrUpdateTable = async ({ table, attributes, definition, ORM, model }, context) => {
   const tableExists = await ORM.knex.schema.hasTable(table);
 
   const createIdType = table => {
@@ -313,7 +307,7 @@ const createOrUpdateTable = async (
   );
 
   if (definition.client === 'sqlite3') {
-    if (columnsToAlter.length > 0 || migrationInfos.find(i => i.recreateSqliteTable)) {
+    if (columnsToAlter.length > 0 || context.recreateSqliteTable) {
       const tmpTable = `tmp_${table}`;
 
       const rebuildTable = async trx => {

--- a/packages/strapi-connector-bookshelf/lib/migrations/create-migration-runner.js
+++ b/packages/strapi-connector-bookshelf/lib/migrations/create-migration-runner.js
@@ -4,11 +4,14 @@ const _ = require('lodash');
 
 const createMigrationRunner = (migrationFunction, { hooks = [] } = {}) => {
   const beforeHook = async options => {
+    const migrationInfos = [];
     for (const migration of hooks) {
       if (_.isFunction(migration.before)) {
-        await migration.before(options);
+        const migrationInfo = await migration.before(options);
+        migrationInfos.push(migrationInfo);
       }
     }
+    return migrationInfos;
   };
 
   const afterHook = async options => {
@@ -20,8 +23,8 @@ const createMigrationRunner = (migrationFunction, { hooks = [] } = {}) => {
   };
 
   const run = async options => {
-    await beforeHook(options);
-    await migrationFunction(options);
+    const migrationInfos = await beforeHook(options);
+    await migrationFunction(options, migrationInfos);
     await afterHook(options);
   };
 

--- a/packages/strapi-connector-bookshelf/lib/migrations/create-migration-runner.js
+++ b/packages/strapi-connector-bookshelf/lib/migrations/create-migration-runner.js
@@ -2,30 +2,27 @@
 
 const _ = require('lodash');
 
-const createMigrationRunner = (migrationFunction, { hooks = [] } = {}) => {
-  const beforeHook = async options => {
-    const migrationInfos = [];
+const createMigrationRunner = (migrationFunction, { hooks = [] } = {}, context = {}) => {
+  const beforeHook = async (options, context) => {
     for (const migration of hooks) {
       if (_.isFunction(migration.before)) {
-        const migrationInfo = await migration.before(options);
-        migrationInfos.push(migrationInfo);
+        await migration.before(options, context);
       }
     }
-    return migrationInfos;
   };
 
-  const afterHook = async options => {
+  const afterHook = async (options, context) => {
     for (const migration of hooks.slice(0).reverse()) {
       if (_.isFunction(migration.after)) {
-        await migration.after(options);
+        await migration.after(options, context);
       }
     }
   };
 
   const run = async options => {
-    const migrationInfos = await beforeHook(options);
-    await migrationFunction(options, migrationInfos);
-    await afterHook(options);
+    await beforeHook(options, context);
+    await migrationFunction(options, context);
+    await afterHook(options, context);
   };
 
   return {

--- a/packages/strapi-connector-bookshelf/lib/migrations/draft-publish-migration.js
+++ b/packages/strapi-connector-bookshelf/lib/migrations/draft-publish-migration.js
@@ -23,8 +23,7 @@ const getDraftAndPublishMigrationWay = async ({ definition, ORM }) => {
   }
 };
 
-const before = async ({ definition, ORM }) => {
-  const migrationInfo = {};
+const before = async ({ definition, ORM }, context) => {
   const way = await getDraftAndPublishMigrationWay({ definition, ORM });
 
   if (way === 'disable') {
@@ -41,7 +40,7 @@ const before = async ({ definition, ORM }) => {
       if (definition.client === 'sqlite3') {
         // Bug when droping column with sqlite3 https://github.com/knex/knex/issues/631
         // Need to recreate the table
-        migrationInfo.recreateSqliteTable = true;
+        context.recreateSqliteTable = true;
       } else {
         await ORM.knex.schema.table(definition.collectionName, table => {
           table.dropColumn(PUBLISHED_AT_ATTRIBUTE);
@@ -49,8 +48,6 @@ const before = async ({ definition, ORM }) => {
       }
     }
   }
-
-  return migrationInfo;
 };
 
 const after = async ({ definition, ORM }) => {

--- a/packages/strapi-database/test/migration-draft-publish.test.e2e.js
+++ b/packages/strapi-database/test/migration-draft-publish.test.e2e.js
@@ -32,9 +32,11 @@ const dogModel = {
 const dogs = [
   {
     name: 'Nelson',
+    code: '1',
   },
   {
     name: 'Atos',
+    code: '2',
   },
 ];
 
@@ -152,7 +154,6 @@ describe('Migration - draft and publish', () => {
           body: dogToCreate,
         });
         expect(res.statusCode).toBe(400);
-        console.log('res.body');
       });
     });
   });

--- a/packages/strapi-database/test/migration-draft-publish.test.e2e.js
+++ b/packages/strapi-database/test/migration-draft-publish.test.e2e.js
@@ -18,6 +18,10 @@ const dogModel = {
     name: {
       type: 'string',
     },
+    code: {
+      type: 'string',
+      unique: true,
+    },
   },
   connection: 'default',
   name: 'dog',
@@ -130,6 +134,25 @@ describe('Migration - draft and publish', () => {
         expect(body.length).toBe(1);
         expect(body[0]).toMatchObject(_.pick(data.dogs[0], ['name']));
         expect(body[0].published_at).toBeUndefined();
+      });
+      test('Unique constraint is kept after disabling the feature', async () => {
+        const dogToCreate = { code: 'sameCode' };
+        let res = await rq({
+          method: 'POST',
+          url: `/content-manager/explorer/application::dog.dog/`,
+          body: dogToCreate,
+        });
+        expect(res.statusCode).toBe(200);
+        expect(res.body).toMatchObject(dogToCreate);
+        data.dogs.push(res.body);
+
+        res = await rq({
+          method: 'POST',
+          url: `/content-manager/explorer/application::dog.dog/`,
+          body: dogToCreate,
+        });
+        expect(res.statusCode).toBe(400);
+        console.log('res.body');
       });
     });
   });


### PR DESCRIPTION
After disabling _draft&publish_ with _sqlite_, the indexes were gone.
It's because of this bug: https://github.com/knex/knex/issues/631