### PR TITLE
strapi-provider-upload-aws-s3 add ability to specify S3 prefix

### DIFF
--- a/packages/strapi-provider-upload-aws-s3/README.md
+++ b/packages/strapi-provider-upload-aws-s3/README.md
@@ -28,6 +28,44 @@ module.exports = ({ env }) => ({
 });
 ```
 
+### S3 prefix
+
+If you set the `s3Prefix` under `providerOptions` Strapi will save all files under a common prefix.
+This is useful if you have to use a shared S3 bucket.
+
+Normally Strapi will save files in S3 without any prefixes:
+
+```
+s3://test-shared-bucket/this-is-my-image.jpg
+```
+
+But if you as an example set `s3Prefix` to `strapi-images`, then files will be saved to:
+
+```
+s3://test-shared-bucket/strapi-images/this-is-my-image.jpg
+```
+
+**Example**
+
+```js
+module.exports = ({ env }) => ({
+  // ...
+  upload: {
+    provider: 'aws-s3',
+    providerOptions: {
+      accessKeyId: env('AWS_ACCESS_KEY_ID'),
+      secretAccessKey: env('AWS_ACCESS_SECRET'),
+      region: env('AWS_REGION'),
+      params: {
+        Bucket: env('AWS_BUCKET'),
+      },
+      s3Prefix: env('AWS_S3_PREFIX'),
+    },
+  },
+  // ...
+});
+```
+
 ## Resources
 
 - [License](LICENSE)

--- a/packages/strapi-provider-upload-aws-s3/lib/index.js
+++ b/packages/strapi-provider-upload-aws-s3/lib/index.js
@@ -9,18 +9,31 @@
 const _ = require('lodash');
 const AWS = require('aws-sdk');
 
+const getFilePath = (filePath, s3Prefix) => {
+  const path = filePath ? `${filePath}/` : '';
+  if (s3Prefix) {
+    return `${s3Prefix}${path}`;
+  }
+  return path;
+};
+
 module.exports = {
   init(config) {
+    // we create a new config so that we don't delete the s3Prefix from the original object
+    const newConfig = { ...config };
+    const s3Prefix = newConfig.s3Prefix ? `${newConfig.s3Prefix}/` : '';
+
+    delete newConfig.s3Prefix;
     const S3 = new AWS.S3({
       apiVersion: '2006-03-01',
-      ...config,
+      ...newConfig,
     });
 
     return {
       upload(file, customParams = {}) {
         return new Promise((resolve, reject) => {
           // upload file on S3 bucket
-          const path = file.path ? `${file.path}/` : '';
+          const path = getFilePath(file.path, s3Prefix);
           S3.upload(
             {
               Key: `${path}${file.hash}${file.ext}`,
@@ -45,7 +58,7 @@ module.exports = {
       delete(file, customParams = {}) {
         return new Promise((resolve, reject) => {
           // delete file on S3 bucket
-          const path = file.path ? `${file.path}/` : '';
+          const path = getFilePath(file.path, s3Prefix);
           S3.deleteObject(
             {
               Key: `${path}${file.hash}${file.ext}`,


### PR DESCRIPTION
### What does it do?

This change allows for the use of S3 prefix when using the S3 upload provider.

Example, you have an S3 bucket called `test-strapi`, but you don't want to
store files in the root of that bucket, instead you want to put all files under a
common prefix.

An example is shown in the documentation changes.

### Why is it needed?

This is useful if you have to use an S3 bucket which you're sharing with other apps.


### Related issue(s)/PR(s)

n/a