### PR TITLE
Set dependency on knex to valid value in strapi-generate-new

### DIFF
--- a/packages/strapi-generate-new/lib/utils/db-client-dependencies.js
+++ b/packages/strapi-generate-new/lib/utils/db-client-dependencies.js
@@ -16,7 +16,7 @@ module.exports = ({ scope, client }) => {
     case 'mysql':
       return {
         'strapi-connector-bookshelf': scope.strapiVersion,
-        knex: '<0.20.0',
+        knex: '^0.20.0',
         [sqlClientModule[client]]: 'latest',
       };
     case 'mongo':


### PR DESCRIPTION
Signed-off-by: Jorrit Schippers <jorrit@ncode.nl>

### What does it do?

When running `yarn create strapi-app` a default package.json is created. This json file contains an outdated knex dependency, namely `<0.20.0`. `strapi-connector-bookshelf` and `examples/getstarted/package.json` are currently using `^0.20.0`.

### Why is it needed?

NPM 7 doesn't accept conflicting dependencies/peerDependencies anymore.

### Related issue(s)/PR(s)

Fixes #8786