### PR TITLE
Fix mongo preview when array is missing

### DIFF
--- a/packages/strapi-connector-mongoose/lib/buildQuery.js
+++ b/packages/strapi-connector-mongoose/lib/buildQuery.js
@@ -412,7 +412,7 @@ const buildLookupMatch = ({ assoc, assocModel, filters = {} }) => {
         $match: {
           $and: defaultMatches.concat({
             $expr: {
-              $in: ['$_id', '$$localAlias'],
+              $in: ['$_id', { $ifNull: ['$$localAlias', []] }],
             },
           }),
         },
@@ -424,7 +424,7 @@ const buildLookupMatch = ({ assoc, assocModel, filters = {} }) => {
           $match: {
             $and: defaultMatches.concat({
               $expr: {
-                $in: ['$_id', '$$localAlias'],
+                $in: ['$_id', { $ifNull: ['$$localAlias', []] }],
               },
             }),
           },
@@ -435,7 +435,7 @@ const buildLookupMatch = ({ assoc, assocModel, filters = {} }) => {
         $match: {
           $and: defaultMatches.concat({
             $expr: {
-              $in: ['$$localId', `$${assoc.via}`],
+              $in: ['$$localId', { $ifNull: [`$${assoc.via}`, []] }],
             },
           }),
         },

--- a/packages/strapi-connector-mongoose/lib/queries.js
+++ b/packages/strapi-connector-mongoose/lib/queries.js
@@ -550,7 +550,11 @@ module.exports = ({ model, strapi }) => {
           return model
             .aggregate()
             .match({ [model.primaryKey]: { $in: entitiesIds.map(mongoose.Types.ObjectId) } })
-            .project({ _id: 0, id: '$_id', count: { $size: `$${assoc.alias}` } });
+            .project({
+              _id: 0,
+              id: '$_id',
+              count: { $size: { $ifNull: [`$${assoc.alias}`, []] } },
+            });
         }
         const assocModel = strapi.db.getModelByAssoc(assoc);
         return assocModel


### PR DESCRIPTION
When a many-to-many or a many-way relation is added to a model while some entity already exist, the existing entities are not updated with an empty array, resulting in some bugs.
I fixed the queries, is it enough or should we make sure the empty arrays are added ?