### PR TITLE
Support models icon

### DIFF
--- a/packages/strapi-admin/admin/src/containers/LeftMenu/utils/generateModelsLinks.js
+++ b/packages/strapi-admin/admin/src/containers/LeftMenu/utils/generateModelsLinks.js
@@ -5,7 +5,7 @@ const generateLinks = links => {
     .filter(link => link.isDisplayed)
     .map(link => {
       return {
-        icon: 'circle',
+        icon: link.info.icon || 'circle',
         destination: `/plugins/content-manager/${link.kind}/${link.uid}`,
         isDisplayed: false,
         label: link.info.label,

--- a/packages/strapi-admin/admin/src/containers/LeftMenu/utils/tests/generateModelsLinks.test.js
+++ b/packages/strapi-admin/admin/src/containers/LeftMenu/utils/tests/generateModelsLinks.test.js
@@ -164,5 +164,47 @@ describe('ADMIN | LeftMenu | utils', () => {
 
       expect(generateModelsLinks(data)).toEqual(expected);
     });
+    
+    it('should detect custom icons', () => {
+      const data = [
+        {
+          isDisplayed: true,
+          kind: 'collectionType',
+          uid: 'application::address.address',
+          info: {
+            label: 'Addresses',
+            icon: 'cog'
+          },
+        },
+      ];
+
+      const expected = {
+        collectionTypesSectionLinks: [
+          {
+            icon: 'cog',
+            destination: '/plugins/content-manager/collectionType/application::address.address',
+            isDisplayed: false,
+            label: 'Addresses',
+            permissions: [
+              {
+                action: 'plugins::content-manager.explorer.create',
+                subject: 'application::address.address',
+              },
+              {
+                action: 'plugins::content-manager.explorer.read',
+                subject: 'application::address.address',
+              },
+              {
+                action: 'plugins::content-manager.explorer.update',
+                subject: 'application::address.address',
+              },
+            ],
+          },
+        ],
+        singleTypesSectionLinks: [],
+      };
+
+      expect(generateModelsLinks(data)).toEqual(expected);
+    });
   });
 });


### PR DESCRIPTION
### What does it do?

This small change allow to customize the admin menu with icons for models

![image](https://user-images.githubusercontent.com/3911343/102687002-fb0d3980-41eb-11eb-8421-d35862324c22.png)


To use it, simply add an `icon` to your model info (same syntax as components)
```json
{
  "kind": "collectionType",
  "collectionName": "deliverers",
  "info": {
    "name": "Livreurs",
    "icon": "calendar-minus"
  },
  "options": {},
  "attributes": {}
}
```

### Why is it needed?

This is just an opiniated improvement of admin UX. We can go further by implementing the icon picker (used in component creation) into the model creation/edition processes

