### PR TITLE
strapi-plugin-upload: Read responsive breakpoints from config

### DIFF
--- a/packages/strapi-plugin-upload/services/image-manipulation.js
+++ b/packages/strapi-plugin-upload/services/image-manipulation.js
@@ -93,10 +93,7 @@ const DEFAULT_BREAKPOINTS = {
   small: 500,
 };
 
-const BREAKPOINTS = strapi.config.get(
-  "plugins.upload.breakpoints",
-  DEFAULT_BREAKPOINTS
-)
+const getBreakpoints = () => strapi.config.get('plugins.upload.breakpoints', DEFAULT_BREAKPOINTS);
 
 const generateResponsiveFormats = async file => {
   const {
@@ -111,9 +108,10 @@ const generateResponsiveFormats = async file => {
 
   const originalDimensions = await getDimensions(file.buffer);
 
+  const breakpoints = getBreakpoints();
   return Promise.all(
-    Object.keys(BREAKPOINTS).map(key => {
-      const breakpoint = BREAKPOINTS[key];
+    Object.keys(breakpoints).map(key => {
+      const breakpoint = breakpoints[key];
 
       if (breakpointSmallerThan(breakpoint, originalDimensions)) {
         return generateBreakpoint(key, { file, breakpoint, originalDimensions });

--- a/packages/strapi-plugin-upload/services/image-manipulation.js
+++ b/packages/strapi-plugin-upload/services/image-manipulation.js
@@ -87,11 +87,16 @@ const optimize = async buffer => {
     .catch(() => ({ buffer }));
 };
 
-const BREAKPOINTS = {
+const DEFAULT_BREAKPOINTS = {
   large: 1000,
   medium: 750,
   small: 500,
 };
+
+const BREAKPOINTS = strapi.config.get(
+  "plugins.upload.breakpoints",
+  DEFAULT_BREAKPOINTS
+)
 
 const generateResponsiveFormats = async file => {
   const {


### PR DESCRIPTION
### What does it do?

This PR changes the upload plugin to read the responsive image breakpoints from the config instead of being hardcoded.
The hardcoded values are still available as defaults if the config is not present.

### Why is it needed?

Currently adjusting the sizing or names of the responsive images requires overriding the entire `image-manipulation.js` file, which is prone to errors and breaking when upgrading.
