### PR TITLE
strapi-plugin-graphql: Fix nested queries in graphql

### DIFF
--- a/packages/strapi-plugin-graphql/services/data-loaders.js
+++ b/packages/strapi-plugin-graphql/services/data-loaders.js
@@ -140,6 +140,9 @@ module.exports = {
 
     const ref = strapi.getModel(modelUID);
     const ast = ref.associations.find(ast => ast.alias === query.alias);
+    const include = ref.associations
+      .filter(assoc => assoc.nature == 'manyWay')
+      .map(assoc => assoc.alias);
 
     const ids = _.chain(query.ids)
       .filter(id => !_.isEmpty(id) || _.isInteger(id)) // Only keep valid ids
@@ -156,7 +159,7 @@ module.exports = {
 
     // Run query and remove duplicated ID.
     return strapi.entityService.find(
-      { params, populate: ast ? [query.alias] : [] },
+      { params, populate: ast ? [query.alias, ...include] : [] },
       { model: modelUID }
     );
   },

--- a/packages/strapi-plugin-graphql/services/type-definitions.js
+++ b/packages/strapi-plugin-graphql/services/type-definitions.js
@@ -181,8 +181,7 @@ const buildAssocResolvers = model => {
         case 'oneToManyMorph':
         case 'manyMorphToOne':
         case 'manyMorphToMany':
-        case 'manyToManyMorph':
-        case 'manyWay': {
+        case 'manyToManyMorph': {
           resolver[association.alias] = async obj => {
             if (obj[association.alias]) {
               return assignOptions(obj[association.alias], obj);


### PR DESCRIPTION
### What does it do?

This change reverts the change made by #7959 and adds some new logic to include any `manyWay` associations when retrieving data via graphql.

### Why is it needed?

Prior to #7959 `manyWay` associations weren't being populated, I think due to the lack of a foreign key, this caused errors due to a field containing `undefined` (because `association.via` is `undefined` for `manyWay` associations).
#7959 fixed this but broke nested queries by bypassing that logic.

### Related issue(s)/PR(s)

Fixes #5608 which was introduced in #7959.
Also addresses #4353 issue that #7959 was resolving.
