### PR TITLE
if there are files

### DIFF
--- a/packages/strapi/lib/services/entity-service.js
+++ b/packages/strapi/lib/services/entity-service.js
@@ -84,7 +84,7 @@ module.exports = ({ db, eventHub, entityValidator }) => ({
 
     let entry = await db.query(model).create(validData);
 
-    if (files) {
+    if (Object.keys(files).length > 0) {
       await this.uploadFiles(entry, files, { model });
       entry = await this.findOne({ params: { id: entry.id } }, { model });
     }
@@ -115,7 +115,7 @@ module.exports = ({ db, eventHub, entityValidator }) => ({
 
     let entry = await db.query(model).update(params, validData);
 
-    if (files) {
+    if (Object.keys(files).length > 0) {
       await this.uploadFiles(entry, files, { model });
       entry = await this.findOne({ params: { id: entry.id } }, { model });
     }

--- a/packages/strapi/lib/services/entity-service.js
+++ b/packages/strapi/lib/services/entity-service.js
@@ -84,7 +84,7 @@ module.exports = ({ db, eventHub, entityValidator }) => ({
 
     let entry = await db.query(model).create(validData);
 
-    if (Object.keys(files).length > 0) {
+    if (files && Object.keys(files).length > 0) {
       await this.uploadFiles(entry, files, { model });
       entry = await this.findOne({ params: { id: entry.id } }, { model });
     }
@@ -115,7 +115,7 @@ module.exports = ({ db, eventHub, entityValidator }) => ({
 
     let entry = await db.query(model).update(params, validData);
 
-    if (Object.keys(files).length > 0) {
+    if (files && Object.keys(files).length > 0) {
       await this.uploadFiles(entry, files, { model });
       entry = await this.findOne({ params: { id: entry.id } }, { model });
     }


### PR DESCRIPTION
### What does it do?

The files variable is sent in as {}, so if (files) is always true

### Why is it needed?

Slight optimisation, found it when trying to figure out why my update hooks didn't keep the values, and it turned out it's because it's always entering the if statement and doing a findOne.


