### PR TITLE
Fixed removeKeyInObject function

### DIFF
--- a/packages/strapi-plugin-content-manager/admin/src/utils/removeKeyInObject.js
+++ b/packages/strapi-plugin-content-manager/admin/src/utils/removeKeyInObject.js
@@ -11,6 +11,12 @@ const removeKeyInObject = (obj, keyToRemove) => {
     }
 
     if (Array.isArray(value)) {
+      if (Array.isArray(acc)) {
+        acc[current] = removeKeyInObject(value, keyToRemove);
+
+        return acc;
+      }
+
       return { ...acc, [current]: value.map(obj => removeKeyInObject(obj, keyToRemove)) };
     }
 

--- a/packages/strapi-plugin-content-manager/admin/src/utils/tests/removeKeyInObject.test.js
+++ b/packages/strapi-plugin-content-manager/admin/src/utils/tests/removeKeyInObject.test.js
@@ -1,5 +1,35 @@
 import removeKeyInObject from '../removeKeyInObject';
 
+const testGeoJson = {
+  type: 'GeometryCollection',
+  geometries: [
+    {
+      type: 'Polygon',
+      coordinates: [
+        [
+          [10.5213132, 43.93323823637245],
+          [10.473529288411845, 43.926382621922876],
+          [10.433048976879297, 43.9068638108183],
+          [10.406046931858038, 43.87766379644947],
+          [10.396621893557642, 43.8432384146332],
+          [10.40617984638903, 43.80883288661175],
+          [10.433236946877438, 43.779680803655985],
+          [10.473662203601545, 43.760209924123394],
+          [10.5213132, 43.753374163627555],
+          [10.568964196398454, 43.760209924123394],
+          [10.609389453122565, 43.779680803655985],
+          [10.636446553610973, 43.80883288661175],
+          [10.64600450644236, 43.8432384146332],
+          [10.636579468141962, 43.87766379644947],
+          [10.609577423120705, 43.9068638108183],
+          [10.569097111588155, 43.926382621922876],
+          [10.5213132, 43.93323823637245],
+        ],
+      ],
+    },
+  ],
+};
+
 describe('CONTENT MANAGER | utils | removeKeyInObject', () => {
   it('should remove the specified key in a given object', () => {
     const data = {
@@ -62,6 +92,7 @@ describe('CONTENT MANAGER | utils | removeKeyInObject', () => {
           },
         ],
       },
+      test_json: testGeoJson,
     };
 
     const expected = {
@@ -120,6 +151,7 @@ describe('CONTENT MANAGER | utils | removeKeyInObject', () => {
           },
         ],
       },
+      test_json: testGeoJson,
     };
 
     expect(removeKeyInObject(data, '__temp_key__')).toEqual(expected);


### PR DESCRIPTION
### What does it do?

Fixes the bug in function removed specified key in object. 

### Why is it needed?

Previously, after the function array of arrays would be returned as array of objects. This PR fixes this bug.

### Related issue(s)/PR(s)

#8994