### PR TITLE
[WIP] Add option to opt out of SSL Validation to Mongoose

### DIFF
--- a/packages/strapi-connector-mongoose/lib/utils/connectivity.js
+++ b/packages/strapi-connector-mongoose/lib/utils/connectivity.js
@@ -21,7 +21,7 @@ module.exports = async ({ connection }) => {
   }
 
   connectOptions.ssl = ssl ? true : false;
-  connectOptions.tlsInsecure = tlsInsecure ? false : true;
+  connectOptions.tlsInsecure = tlsInsecure ? true : false;
   connectOptions.useNewUrlParser = true;
   connectOptions.dbName = connection.settings.database;
 

--- a/packages/strapi-connector-mongoose/lib/utils/connectivity.js
+++ b/packages/strapi-connector-mongoose/lib/utils/connectivity.js
@@ -4,7 +4,7 @@ module.exports = async ({ connection }) => {
   const Mongoose = require('mongoose');
 
   const { username, password, srv } = connection.settings;
-  const { authenticationDatabase, ssl } = connection.options;
+  const { authenticationDatabase, ssl, tlsInsecure } = connection.options;
 
   const connectOptions = {};
 
@@ -21,6 +21,7 @@ module.exports = async ({ connection }) => {
   }
 
   connectOptions.ssl = ssl ? true : false;
+  connectOptions.tlsInsecure = tlsInsecure ? false : true;
   connectOptions.useNewUrlParser = true;
   connectOptions.dbName = connection.settings.database;
 
@@ -33,7 +34,7 @@ module.exports = async ({ connection }) => {
     () => {
       Mongoose.connection.close();
     },
-    error => {
+    (error) => {
       Mongoose.connection.close();
       throw error;
     }


### PR DESCRIPTION
Signed-off-by: Derrick Mehaffy <derrickmehaffy@gmail.com>

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Add an extra option to the mongoose connector for TLS validation

### Why is it needed?

Bypass CA validation for the database

### Related issue(s)/PR(s)

N/A
