### PR TITLE
[GraphQL] Make plural definition as required

### DIFF
--- a/packages/strapi-plugin-graphql/services/type-builder.js
+++ b/packages/strapi-plugin-graphql/services/type-builder.js
@@ -127,7 +127,7 @@ module.exports = {
           return '[ID]';
         }
 
-        return `[${globalId}]`;
+        return `[${globalId}!]`;
       }
 
       if (rootType === 'mutation') {

--- a/packages/strapi-plugin-graphql/services/type-builder.js
+++ b/packages/strapi-plugin-graphql/services/type-builder.js
@@ -127,7 +127,7 @@ module.exports = {
           return '[ID]';
         }
 
-        return `[${globalId}!]`;
+        return `[${globalId}!]!`;
       }
 
       if (rootType === 'mutation') {

--- a/packages/strapi-plugin-graphql/services/type-definitions.js
+++ b/packages/strapi-plugin-graphql/services/type-definitions.js
@@ -461,7 +461,7 @@ const buildCollectionType = model => {
       const resolver = buildQuery(pluralName, resolverOpts);
       _.merge(localSchema, {
         query: {
-          [`${pluralName}${FIND_QUERY_ARGUMENTS}`]: `[${model.globalId}]`,
+          [`${pluralName}${FIND_QUERY_ARGUMENTS}`]: `[${model.globalId}!]!`,
         },
         resolvers: {
           Query: {


### PR DESCRIPTION
From https://github.com/strapi/strapi/pull/7056

~~This might be breaking change. Because some plural fields are null in mongoose and this will emit error.~~
~~So filling null fields with empty array `[]` is needed after merge this PR.~~
(Edit)
~~Plural with no result returns empty array on version `3.4.1`, but current master returns null.~~
(Edit)
On version `3.4.4` graphql does not returning null on plural. It works well.

### SideEffects?
I couldn't find side-effects. (I've forked this plugin and used it for 1 month)

### What does it do?

Make GraphQL plural definition as required.

### Why is it needed?

To avoid unnecessary if statement on Typescript with CodeGenerator.

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/pull/7056
