### PR TITLE
Fix count method w/ D&P filters on MongoDB

### DIFF
--- a/packages/strapi-connector-mongoose/lib/queries.js
+++ b/packages/strapi-connector-mongoose/lib/queries.js
@@ -513,11 +513,12 @@ module.exports = ({ model, strapi }) => {
   }
 
   function countSearch(params) {
-    const { where } = convertRestQueryParams(_.omit(params, '_q'));
+    const countParams = omit(['_sort', '_limit', '_start', '_q'], params);
+    const filters = convertRestQueryParams(countParams);
 
     return buildQuery({
       model,
-      filters: { where },
+      filters,
       searchParam: params._q,
     }).count();
   }

--- a/packages/strapi-connector-mongoose/lib/queries.js
+++ b/packages/strapi-connector-mongoose/lib/queries.js
@@ -4,7 +4,7 @@
  */
 
 const _ = require('lodash');
-const { prop } = require('lodash/fp');
+const { prop, omit } = require('lodash/fp');
 const { convertRestQueryParams, buildQuery } = require('strapi-utils');
 const { contentTypes: contentTypesUtils } = require('strapi-utils');
 const mongoose = require('mongoose');
@@ -417,7 +417,8 @@ module.exports = ({ model, strapi }) => {
   }
 
   function count(params) {
-    const filters = convertRestQueryParams(params);
+    const countParams = omit(['_sort', '_limit', '_start'], params);
+    const filters = convertRestQueryParams(countParams);
 
     return buildQuery({ model, filters }).count();
   }

--- a/packages/strapi-connector-mongoose/lib/queries.js
+++ b/packages/strapi-connector-mongoose/lib/queries.js
@@ -419,10 +419,7 @@ module.exports = ({ model, strapi }) => {
   function count(params) {
     const filters = convertRestQueryParams(params);
 
-    return buildQuery({
-      model,
-      filters: { where: filters.where },
-    }).count();
+    return buildQuery({ model, filters }).count();
   }
 
   async function create(values) {

--- a/packages/strapi/tests/publication-state.test.e2e.js
+++ b/packages/strapi/tests/publication-state.test.e2e.js
@@ -165,11 +165,21 @@ describe('Publication State', () => {
   }, 60000);
 
   describe.each(['default', 'live', 'preview'])('Mode: "%s"', mode => {
-    test.each(['country', 'category', 'product'])('For %s', async modelName => {
-      const url = `/${pluralizedModels[modelName]}${getQueryFromMode(mode)}`;
-      const res = await rq({ method: 'GET', url });
+    describe.each(['country', 'category', 'product'])('For %s', modelName => {
+      const baseUrl = `/${pluralizedModels[modelName]}`;
+      const query = getQueryFromMode(mode);
 
-      expect(res.body).toHaveLength(lengthFor(modelName, { mode }));
+      test('Can get entries', async () => {
+        const res = await rq({ method: 'GET', url: `${baseUrl}${query}` });
+
+        expect(res.body).toHaveLength(lengthFor(modelName, { mode }));
+      });
+
+      test('Can count entries', async () => {
+        const res = await rq({ method: 'GET', url: `${baseUrl}/count${query}` });
+
+        expect(res.body).toBe(lengthFor(modelName, { mode }));
+      });
     });
   });
 


### PR DESCRIPTION
Fix a bug where calling the `query().count()` method on mongoose don't take the `publicationState` filter into account.

fix #9092