### PR TITLE
import model components from plugins

### DIFF
--- a/packages/strapi/lib/core/load-components.js
+++ b/packages/strapi/lib/core/load-components.js
@@ -4,10 +4,48 @@ const { join } = require('path');
 const _ = require('lodash');
 const { exists } = require('fs-extra');
 const loadFiles = require('../load/load-files');
+const findPackagePath = require('../load/package-path');
 
-module.exports = async strapi => {
-  const componentsDir = join(strapi.dir, 'components');
+module.exports = async ({ dir, config }) => {
+  const localComponents = await loadLocalComponents({ dir, config });
+  const components = await loadExternalComponents({
+    installedPlugins: config.installedPlugins,
+    config,
+  });
 
+  const componentsIntersection = _.intersection(Object.keys(loadExternalComponents), Object.keys(components));
+
+  if (components.length > 0) {
+    throw new Error(
+      `You have some local components with the same name as npm installed plugins:\n${componentsIntersection
+        .map(p => `- ${p}`)
+        .join('\n')}`
+    );
+  }
+
+  // check for conflicts
+  return _.merge(components, localComponents);
+};
+
+const loadLocalComponents = async ({ dir }) => {
+  const componentsDir = join(dir, 'components');
+  return loadComponents(componentsDir)
+};
+
+const loadExternalComponents = async ({ installedPlugins }) => {
+  let components = {};
+
+  for (let plugin of installedPlugins) {
+    const pluginPath = findPackagePath(`strapi-plugin-${plugin}`);
+    const componentsDir = join(pluginPath, 'components');
+    const component = await loadComponents(componentsDir);
+    _.merge(components,  component);
+  }
+
+  return components;
+};
+
+async function loadComponents(componentsDir) {
   if (!(await exists(componentsDir))) {
     return {};
   }
@@ -40,4 +78,4 @@ module.exports = async strapi => {
 
     return acc;
   }, {});
-};
+}


### PR DESCRIPTION
## What does it do?

Check if plugins have a components directory and add its in project's components (Based on the same import native plugin process.)

### Why is it needed?

It's very import to be able to create good modular plugins or community plugins. It’s weird to let developpers create model from a plugin but not a component. If we can't create components inside external plugin (ex: from npm), the plugin feature is very limited and can't be exploited. Exemple : you have a catalog plugin and a cart plugin, you need to have the same product component into both which is for example { product : (catalog product model relation from catalog plugin), qty: number }. It's not possible now from plugins.

### Related issue(s)/PR(s)

Related issue : https://github.com/strapi/strapi/issues/7640
