### PR TITLE
Fix REST api for content-types that start with "admin"

### DIFF
--- a/packages/strapi/lib/middlewares/public/index.js
+++ b/packages/strapi/lib/middlewares/public/index.js
@@ -81,16 +81,18 @@ module.exports = strapi => {
       if (!strapi.config.serveAdminPanel) return;
 
       const buildDir = path.resolve(strapi.dir, 'build');
+      const serveAdmin = ctx => {
+        ctx.type = 'html';
+        ctx.body = fs.createReadStream(path.join(buildDir + '/index.html'));
+      };
 
       strapi.router.get(
         `${strapi.config.admin.path}/*`,
         serveStatic(buildDir, { maxage: maxAge, defer: false, index: 'index.html' })
       );
 
-      strapi.router.get(`${strapi.config.admin.path}*`, ctx => {
-        ctx.type = 'html';
-        ctx.body = fs.createReadStream(path.join(buildDir + '/index.html'));
-      });
+      strapi.router.get(`${strapi.config.admin.path}`, serveAdmin);
+      strapi.router.get(`${strapi.config.admin.path}/*`, serveAdmin);
     },
   };
 };


### PR DESCRIPTION
fix #9017