### PR TITLE
Add default value for 'preload' option to HSTS

### DIFF
--- a/packages/strapi/lib/middlewares/hsts/defaults.json
+++ b/packages/strapi/lib/middlewares/hsts/defaults.json
@@ -2,6 +2,7 @@
   "hsts": {
     "enabled": true,
     "maxAge": 31536000,
-    "includeSubDomains": true
+    "includeSubDomains": true,
+    "preload": true
   }
 }

--- a/packages/strapi/lib/middlewares/hsts/defaults.json
+++ b/packages/strapi/lib/middlewares/hsts/defaults.json
@@ -3,6 +3,6 @@
     "enabled": true,
     "maxAge": 31536000,
     "includeSubDomains": true,
-    "preload": true
+    "preload": false
   }
 }


### PR DESCRIPTION
### What does it do?

Add a default value for the key 'preload' to the HSTS middleware, which is `true`.

### Why is it needed?

koa-lusca added this option in this commit https://github.com/koajs/koa-lusca/commit/db56267f84d5504d93bda312e9f4e36e01179ba1 and I'd like to use it.
