### PR TITLE
[Rebased] Accept info fields when uploading file through GraphQL

### DIFF
--- a/packages/strapi-plugin-upload/config/schema.graphql.js
+++ b/packages/strapi-plugin-upload/config/schema.graphql.js
@@ -12,7 +12,7 @@ module.exports = {
     }
   `,
   mutation: `
-    upload(refId: ID, ref: String, field: String, source: String, file: Upload!): UploadFile!
+    upload(refId: ID, ref: String, field: String, source: String, info: FileInfoInput, file: Upload!): UploadFile!
     multipleUpload(refId: ID, ref: String, field: String, source: String, files: [Upload]!): [UploadFile]!
     updateFileInfo(id: ID!, info: FileInfoInput!): UploadFile!
   `,
@@ -29,8 +29,8 @@ module.exports = {
       upload: {
         description: 'Upload one file',
         resolverOf: 'plugins::upload.upload.upload',
-        resolver: async (obj, { file: upload, ...fields }) => {
-          const file = await formatFile(upload, fields);
+        resolver: async (obj, { file: upload, info, ...fields }) => {
+          const file = await formatFile(upload, info, fields);
 
           const uploadedFiles = await strapi.plugins.upload.services.upload.uploadFileAndPersist(
             file
@@ -44,7 +44,7 @@ module.exports = {
         description: 'Upload one file',
         resolverOf: 'plugins::upload.upload.upload',
         resolver: async (obj, { files: uploads, ...fields }) => {
-          const files = await Promise.all(uploads.map(upload => formatFile(upload, fields)));
+          const files = await Promise.all(uploads.map(upload => formatFile(upload, {}, fields)));
 
           const uploadService = strapi.plugins.upload.services.upload;
 
@@ -73,7 +73,7 @@ module.exports = {
   },
 };
 
-const formatFile = async (upload, metas) => {
+const formatFile = async (upload, extraInfo, metas) => {
   const { filename, mimetype, createReadStream } = await upload;
 
   const { optimize } = strapi.plugins.upload.services['image-manipulation'];
@@ -88,7 +88,7 @@ const formatFile = async (upload, metas) => {
       type: mimetype,
       size: buffer.length,
     },
-    {},
+    extraInfo,
     metas
   );
 

--- a/packages/strapi-plugin-upload/tests/graphqlUpload.test.e2e.js
+++ b/packages/strapi-plugin-upload/tests/graphqlUpload.test.e2e.js
@@ -197,4 +197,56 @@ describe('Upload plugin end to end tests', () => {
       },
     });
   });
+
+  test('Upload a single file with info', async () => {
+    const req = rq.post('/graphql');
+    const form = req.form();
+    form.append(
+      'operations',
+      JSON.stringify({
+        query: /* GraphQL */ `
+          mutation uploadFilesWithInfo($file: Upload!, $info: FileInfoInput) {
+            upload(file: $file, info: $info) {
+              id
+              name
+              alternativeText
+              caption
+            }
+          }
+        `,
+        variables: {
+          file: null,
+          info: {
+            alternativeText: 'alternative text test',
+            caption: 'caption test',
+          },
+        },
+      })
+    );
+
+    form.append(
+      'map',
+      JSON.stringify({
+        0: ['variables.file'],
+      })
+    );
+
+    form.append('0', fs.createReadStream(__dirname + '/rec.jpg'));
+
+    const res = await req;
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toMatchObject({
+      data: {
+        upload: {
+          id: expect.anything(),
+          name: 'rec.jpg',
+          alternativeText: 'alternative text test',
+          caption: 'caption test',
+        },
+      },
+    });
+
+    data.file = res.body.data.upload;
+  });
 });


### PR DESCRIPTION
Rebased version of https://github.com/strapi/strapi/pull/8494

# What does it do?
Accept info fields when uploading file through GraphQL

### Why is it needed?
To send http request lesser.

### Related issue(s)/PR(s)
closes #8493
