### PR TITLE
[Media Library] Get preview mime from thumbnail (to support video thumbnail)

### DIFF
--- a/packages/strapi-plugin-upload/admin/src/components/List/index.js
+++ b/packages/strapi-plugin-upload/admin/src/components/List/index.js
@@ -40,11 +40,11 @@ const List = ({
       <ListRow>
         {data.map(item => {
           const { id } = item;
-          const url = get(item, ['formats', 'small', 'url'], item.url);
+          const thumbnail = get(item, ['formats', 'small'], item);
           const isAllowed =
             allowedTypes.length > 0 ? allowedTypes.includes(getType(item.mime)) : true;
           const checked = selectedItems.findIndex(file => file.id === id) !== -1;
-          const fileUrl = prefixFileUrlWithBackendUrl(url);
+          const fileUrl = prefixFileUrlWithBackendUrl(thumbnail.url);
 
           return (
             <ListCell key={id}>
@@ -53,6 +53,7 @@ const List = ({
                 checked={checked}
                 {...item}
                 url={fileUrl}
+                mime={thumbnail.mime}
                 onClick={onCardClick}
                 small={smallCards}
               >


### PR DESCRIPTION
### What does it do?
It changes the way that `CardPreview` component determine mime type of media.

### Why is it needed?
I've created plugin that generates video thumbnail.

(In progress...)
https://github.com/darron1217/strapi-plugin-video-thumbnail

It generates thumbnail as `png` type.

Media Library regard it as video, so it tries to play it as a video even though it is an image.


Current Behavior
![스크린샷 2021-01-22 오후 5 28 41](https://user-images.githubusercontent.com/8064923/105466227-475e0480-5cd7-11eb-9ef4-8647450042d8.png)

After merge
![스크린샷 2021-01-22 오후 5 26 27](https://user-images.githubusercontent.com/8064923/105465977-f9490100-5cd6-11eb-864e-327f8219b312.png)


### SideEffects?
I couldn't find side effect of this PR.

Other file types also works fine after merge.
![스크린샷 2021-01-22 오후 5 31 07](https://user-images.githubusercontent.com/8064923/105466491-a3c12400-5cd7-11eb-9c2c-5d0913336e6e.png)
