### PR TITLE
Prevent returning optimized image if it's larger than original

### DIFF
--- a/packages/strapi-plugin-upload/services/image-manipulation.js
+++ b/packages/strapi-plugin-upload/services/image-manipulation.js
@@ -70,23 +70,21 @@ const optimize = async buffer => {
 
   const sharpInstance = autoOrientation ? sharp(buffer).rotate() : sharp(buffer);
 
-  const optimized = await sharpInstance
+  return sharpInstance
     .toBuffer({ resolveWithObject: true })
-    .then(({ data, info }) => ({
-      buffer: data,
-      info: {
-        width: info.width,
-        height: info.height,
-        size: bytesToKbytes(info.size),
-      },
-    }))
+    .then(({ data, info }) => {
+      const output = buffer.length < data.length ? buffer : data;
+
+      return {
+        buffer: output,
+        info: {
+          width: info.width,
+          height: info.height,
+          size: bytesToKbytes(output.length),
+        },
+      };
+    })
     .catch(() => ({ buffer }));
-
-  if (bytesToKbytes(buffer.length) < optimized.info.size) {
-    return { buffer };
-  }
-
-  return optimized;
 };
 
 const BREAKPOINTS = {

--- a/packages/strapi-plugin-upload/services/image-manipulation.js
+++ b/packages/strapi-plugin-upload/services/image-manipulation.js
@@ -69,7 +69,8 @@ const optimize = async buffer => {
   }
 
   const sharpInstance = autoOrientation ? sharp(buffer).rotate() : sharp(buffer);
-  return sharpInstance
+
+  const optimized = await sharpInstance
     .toBuffer({ resolveWithObject: true })
     .then(({ data, info }) => ({
       buffer: data,
@@ -80,6 +81,12 @@ const optimize = async buffer => {
       },
     }))
     .catch(() => ({ buffer }));
+
+  if (bytesToKbytes(buffer.length) < optimized.info.size) {
+    return { buffer };
+  }
+
+  return optimized;
 };
 
 const BREAKPOINTS = {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Prevent returning optimized image if it's larger than the original. It's mostly visible on PNG images, and it's a known behavior of `sharp` https://github.com/lovell/sharp/issues/1110, https://github.com/lovell/sharp/issues/1017, https://github.com/lovell/sharp/issues/600, https://github.com/lovell/sharp/issues/478.

### Why is it needed?

When the user is uploading an already optimized image, or just the optimizer is unable to reduce the size, we should keep the image that is smaller.

### Related issue(s)/PR(s)

I didn't find any of them.
