### PR TITLE
Use https:// in package.json and README.md files

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -8,19 +8,19 @@ In the interest of fostering an open and welcoming environment, we as contributo
 
 Examples of behavior that contributes to creating a positive environment include:
 
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
 
 Examples of unacceptable behavior by participants include:
 
-* The use of sexualized language or imagery and unwelcome sexual attention or advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or electronic address, without explicit permission
-* Other conduct which could reasonably be considered inappropriate in a professional setting
+- The use of sexualized language or imagery and unwelcome sexual attention or advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
 
 ## Our Responsibilities
 
@@ -40,7 +40,7 @@ Project maintainers who do not follow or enforce the Code of Conduct in good fai
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [https://contributor-covenant.org/version/1/4][version]
 
-[homepage]: http://contributor-covenant.org
-[version]: http://contributor-covenant.org/version/1/4/
+[homepage]: https://contributor-covenant.org
+[version]: https://contributor-covenant.org/version/1/4/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,7 +152,7 @@ $ node test/e2e.js --db=mysql
 
 ### Repository Organization
 
-We chose to to use a monorepo design that exploits [Yarn Workspaces](https://yarnpkg.com/en/docs/workspaces) in the way [React](https://github.com/facebook/react/tree/master/packages) or [Babel](https://github.com/babel/babel/tree/master/packages) does. This allows the community to easily maintain the whole ecosystem, keep it up-to-date and consistent.
+We chose to use a monorepo design that exploits [Yarn Workspaces](https://yarnpkg.com/en/docs/workspaces) in the way [React](https://github.com/facebook/react/tree/master/packages) or [Babel](https://github.com/babel/babel/tree/master/packages) does. This allows the community to easily maintain the whole ecosystem, keep it up-to-date and consistent.
 
 We do our best to keep the master branch as clean as possible, with tests passing at all times. However, it may happen that the master branch moves faster than the release cycle. Therefore check the [releases on npm](https://www.npmjs.com/package/strapi) so that you're always up-to-date with the latest stable version.
 
@@ -163,7 +163,7 @@ Before submitting an issue you need to make sure:
 - You are experiencing a concrete technical issue with Strapi.
 - You have already searched for related [issues](https://github.com/strapi/strapi/issues), and found none open (if you found a related _closed_ issue, please link to it from your post).
 - You are not asking a question about how to use Strapi or about whether or not Strapi has a certain feature. For general help using Strapi, you may:
-  - Refer to [the official Strapi documentation](http://strapi.io).
+  - Refer to [the official Strapi documentation](https://strapi.io).
   - Ask a member of the community in the [Strapi Slack Community](https://slack.strapi.io/).
   - Ask a question on [our community forum](https://forum.strapi.io).
 - Your issue title is concise, on-topic and polite.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
   <a href="https://travis-ci.org/strapi/strapi">
     <img src="https://travis-ci.org/strapi/strapi.svg?branch=master" alt="Travis Build Status" />
   </a>
-  <a href="http://slack.strapi.io">
+  <a href="https://slack.strapi.io">
     <img src="https://slack.strapi.io/badge.svg" alt="Strapi on Slack" />
   </a>
 </p>
@@ -136,7 +136,7 @@ Please read our [Contributing Guide](./CONTRIBUTING.md) before submitting a Pull
 
 For general help using Strapi, please refer to [the official Strapi documentation](https://strapi.io/documentation/). For additional help, you can use one of these channels to ask a question:
 
-- [Slack](http://slack.strapi.io) (For live discussion with the Community and Strapi team)
+- [Slack](https://slack.strapi.io) (For live discussion with the Community and Strapi team)
 - [GitHub](https://github.com/strapi/strapi) (Bug reports, Contributions)
 - [Community Forum](https://forum.strapi.io) (Questions and Discussions)
 - [Academy](https://academy.strapi.io) (Learn the fundamentals of Strapi)

--- a/package.json
+++ b/package.json
@@ -82,13 +82,13 @@
   "author": {
     "email": "hi@strapi.io",
     "name": "Strapi Solutions",
-    "url": "http://strapi.io"
+    "url": "https://strapi.io"
   },
   "maintainers": [
     {
       "name": "Strapi Solutions",
       "email": "hi@strapi.io",
-      "url": "http://strapi.io"
+      "url": "https://strapi.io"
     }
   ],
   "repository": {

--- a/packages/create-strapi-app/package.json
+++ b/packages/create-strapi-app/package.json
@@ -3,7 +3,7 @@
   "version": "3.4.5",
   "description": "Generate a new Strapi application.",
   "license": "SEE LICENSE IN LICENSE",
-  "homepage": "http://strapi.io",
+  "homepage": "https://strapi.io",
   "keywords": [
     "create-strapi-app",
     "create",
@@ -29,7 +29,7 @@
   "author": {
     "email": "hi@strapi.io",
     "name": "Strapi team",
-    "url": "http://strapi.io"
+    "url": "https://strapi.io"
   },
   "repository": {
     "type": "git",

--- a/packages/strapi-connector-bookshelf/README.md
+++ b/packages/strapi-connector-bookshelf/README.md
@@ -4,7 +4,7 @@
 [![npm downloads](https://img.shields.io/npm/dm/strapi-connector-bookshelf.svg)](https://www.npmjs.org/package/strapi-connector-bookshelf)
 [![npm dependencies](https://david-dm.org/strapi/strapi-connector-bookshelf.svg)](https://david-dm.org/strapi/strapi-connector-bookshelf)
 [![Build status](https://travis-ci.org/strapi/strapi-connector-bookshelf.svg?branch=master)](https://travis-ci.org/strapi/strapi-connector-bookshelf)
-[![Slack status](https://slack.strapi.io/badge.svg)](http://slack.strapi.io)
+[![Slack status](https://slack.strapi.io/badge.svg)](https://slack.strapi.io)
 
 This built-in connector allows you to use the [Bookshelf ORM](http://bookshelfjs.org/) using the `strapi-connector-knex` connector.
 
@@ -18,6 +18,6 @@ It is designed to work well with SQLite3, PostgreSQL, MySQL, MariaDB, Microsoft 
 
 ## Links
 
-- [Strapi website](http://strapi.io/)
-- [Strapi community on Slack](http://slack.strapi.io)
+- [Strapi website](https://strapi.io/)
+- [Strapi community on Slack](https://slack.strapi.io)
 - [Strapi news on Twitter](https://twitter.com/strapijs)

--- a/packages/strapi-connector-bookshelf/package.json
+++ b/packages/strapi-connector-bookshelf/package.json
@@ -2,7 +2,7 @@
   "name": "strapi-connector-bookshelf",
   "version": "3.4.5",
   "description": "Bookshelf hook for the Strapi framework",
-  "homepage": "http://strapi.io",
+  "homepage": "https://strapi.io",
   "keywords": [
     "bookshelf",
     "hook",
@@ -39,13 +39,13 @@
   "author": {
     "email": "hi@strapi.io",
     "name": "Strapi team",
-    "url": "http://strapi.io"
+    "url": "https://strapi.io"
   },
   "maintainers": [
     {
       "name": "Strapi team",
       "email": "hi@strapi.io",
-      "url": "http://strapi.io"
+      "url": "https://strapi.io"
     }
   ],
   "repository": {

--- a/packages/strapi-connector-mongoose/README.md
+++ b/packages/strapi-connector-mongoose/README.md
@@ -4,7 +4,7 @@
 [![npm downloads](https://img.shields.io/npm/dm/strapi-connector-mongoose.svg)](https://www.npmjs.org/package/strapi-connector-mongoose)
 [![npm dependencies](https://david-dm.org/strapi/strapi-connector-mongoose.svg)](https://david-dm.org/strapi/strapi-connector-mongoose)
 [![Build status](https://travis-ci.org/strapi/strapi-connector-mongoose.svg?branch=master)](https://travis-ci.org/strapi/strapi-connector-mongoose)
-[![Slack status](https://slack.strapi.io/badge.svg)](http://slack.strapi.io)
+[![Slack status](https://slack.strapi.io/badge.svg)](https://slack.strapi.io)
 
 This built-in connector allows you to use the [Mongoose ORM](http://mongoosejs.com/).
 
@@ -16,6 +16,6 @@ This built-in connector allows you to use the [Mongoose ORM](http://mongoosejs.c
 
 ## Links
 
-- [Strapi website](http://strapi.io/)
-- [Strapi community on Slack](http://slack.strapi.io)
+- [Strapi website](https://strapi.io/)
+- [Strapi community on Slack](https://slack.strapi.io)
 - [Strapi news on Twitter](https://twitter.com/strapijs)

--- a/packages/strapi-connector-mongoose/package.json
+++ b/packages/strapi-connector-mongoose/package.json
@@ -2,7 +2,7 @@
   "name": "strapi-connector-mongoose",
   "version": "3.4.5",
   "description": "Mongoose hook for the Strapi framework",
-  "homepage": "http://strapi.io",
+  "homepage": "https://strapi.io",
   "keywords": [
     "mongoose",
     "hook",
@@ -26,13 +26,13 @@
   "author": {
     "email": "hi@strapi.io",
     "name": "Strapi team",
-    "url": "http://strapi.io"
+    "url": "https://strapi.io"
   },
   "maintainers": [
     {
       "name": "Strapi team",
       "email": "hi@strapi.io",
-      "url": "http://strapi.io"
+      "url": "https://strapi.io"
     }
   ],
   "repository": {

--- a/packages/strapi-database/README.md
+++ b/packages/strapi-database/README.md
@@ -4,7 +4,7 @@
 [![npm downloads](https://img.shields.io/npm/dm/strapi-database.svg)](https://www.npmjs.org/package/strapi-database)
 [![npm dependencies](https://david-dm.org/strapi/strapi-database.svg)](https://david-dm.org/strapi/strapi-database)
 [![Build status](https://travis-ci.org/strapi/strapi-database.svg?branch=master)](https://travis-ci.org/strapi/strapi-database)
-[![Slack status](https://slack.strapi.io/badge.svg)](http://slack.strapi.io)
+[![Slack status](https://slack.strapi.io/badge.svg)](https://slack.strapi.io)
 
 This package is strapi's database handling layer. It is responsible for orchestrating database connectors and implementing the logic of strapi's data structures.
 
@@ -16,7 +16,7 @@ This package is not meant to be used as a standalone module.
 
 ## Links
 
-- [Strapi documentation](http://strapi.io/documentation)
-- [Strapi website](http://strapi.io/)
-- [Strapi community on Slack](http://slack.strapi.io)
+- [Strapi documentation](https://strapi.io/documentation)
+- [Strapi website](https://strapi.io/)
+- [Strapi community on Slack](https://slack.strapi.io)
 - [Strapi news on Twitter](https://twitter.com/strapijs)

--- a/packages/strapi-database/package.json
+++ b/packages/strapi-database/package.json
@@ -2,7 +2,7 @@
   "name": "strapi-database",
   "version": "3.4.5",
   "description": "Strapi's database layer",
-  "homepage": "http://strapi.io",
+  "homepage": "https://strapi.io",
   "main": "./lib/index.js",
   "scripts": {
     "test": "echo \"no tests yet\""
@@ -13,7 +13,7 @@
   "author": {
     "name": "Strapi team",
     "email": "hi@strapi.io",
-    "url": "http://strapi.io"
+    "url": "https://strapi.io"
   },
   "repository": {
     "type": "git",

--- a/packages/strapi-generate-api/README.md
+++ b/packages/strapi-generate-api/README.md
@@ -4,7 +4,7 @@
 [![npm downloads](https://img.shields.io/npm/dm/strapi-generate-api.svg)](https://www.npmjs.org/package/strapi-generate-api)
 [![npm dependencies](https://david-dm.org/strapi/strapi-generate-api.svg)](https://david-dm.org/strapi/strapi-generate-api)
 [![Build status](https://travis-ci.org/strapi/strapi-generate-api.svg?branch=master)](https://travis-ci.org/strapi/strapi-generate-api)
-[![Slack status](https://slack.strapi.io/badge.svg)](http://slack.strapi.io)
+[![Slack status](https://slack.strapi.io/badge.svg)](https://slack.strapi.io)
 
 This Strapi generator contains all the default files for a new API.
 
@@ -20,6 +20,6 @@ $ strapi generate:api apiName
 
 ## Links
 
-- [Strapi website](http://strapi.io/)
-- [Strapi community on Slack](http://slack.strapi.io)
+- [Strapi website](https://strapi.io/)
+- [Strapi community on Slack](https://slack.strapi.io)
 - [Strapi news on Twitter](https://twitter.com/strapijs)

--- a/packages/strapi-generate-api/package.json
+++ b/packages/strapi-generate-api/package.json
@@ -2,7 +2,7 @@
   "name": "strapi-generate-api",
   "version": "3.4.5",
   "description": "Generate an API for a Strapi application.",
-  "homepage": "http://strapi.io",
+  "homepage": "https://strapi.io",
   "keywords": [
     "generate",
     "generator",
@@ -23,13 +23,13 @@
   "author": {
     "email": "hi@strapi.io",
     "name": "Strapi team",
-    "url": "http://strapi.io"
+    "url": "https://strapi.io"
   },
   "maintainers": [
     {
       "name": "Strapi team",
       "email": "hi@strapi.io",
-      "url": "http://strapi.io"
+      "url": "https://strapi.io"
     }
   ],
   "repository": {

--- a/packages/strapi-generate-controller/README.md
+++ b/packages/strapi-generate-controller/README.md
@@ -4,7 +4,7 @@
 [![npm downloads](https://img.shields.io/npm/dm/strapi-generate-controller.svg)](https://www.npmjs.org/package/strapi-generate-controller)
 [![npm dependencies](https://david-dm.org/strapi/strapi-generate-controller.svg)](https://david-dm.org/strapi/strapi-generate-controller)
 [![Build status](https://travis-ci.org/strapi/strapi-generate-controller.svg?branch=master)](https://travis-ci.org/strapi/strapi-generate-controller)
-[![Slack status](https://slack.strapi.io/badge.svg)](http://slack.strapi.io)
+[![Slack status](https://slack.strapi.io/badge.svg)](https://slack.strapi.io)
 
 This Strapi generator contains the default files for a controller.
 
@@ -26,6 +26,6 @@ $ strapi generate:controller group user
 
 ## Links
 
-- [Strapi website](http://strapi.io/)
-- [Strapi community on Slack](http://slack.strapi.io)
+- [Strapi website](https://strapi.io/)
+- [Strapi community on Slack](https://slack.strapi.io)
 - [Strapi news on Twitter](https://twitter.com/strapijs)

--- a/packages/strapi-generate-controller/package.json
+++ b/packages/strapi-generate-controller/package.json
@@ -2,7 +2,7 @@
   "name": "strapi-generate-controller",
   "version": "3.4.5",
   "description": "Generate a controller for a Strapi API.",
-  "homepage": "http://strapi.io",
+  "homepage": "https://strapi.io",
   "keywords": [
     "controller",
     "generate",
@@ -23,13 +23,13 @@
   "author": {
     "email": "hi@strapi.io",
     "name": "Strapi team",
-    "url": "http://strapi.io"
+    "url": "https://strapi.io"
   },
   "maintainers": [
     {
       "name": "Strapi team",
       "email": "hi@strapi.io",
-      "url": "http://strapi.io"
+      "url": "https://strapi.io"
     }
   ],
   "repository": {

--- a/packages/strapi-generate-model/README.md
+++ b/packages/strapi-generate-model/README.md
@@ -4,7 +4,7 @@
 [![npm downloads](https://img.shields.io/npm/dm/strapi-generate-model.svg)](https://www.npmjs.org/package/strapi-generate-model)
 [![npm dependencies](https://david-dm.org/strapi/strapi-generate-model.svg)](https://david-dm.org/strapi/strapi-generate-model)
 [![Build status](https://travis-ci.org/strapi/strapi-generate-model.svg?branch=master)](https://travis-ci.org/strapi/strapi-generate-model)
-[![Slack status](https://slack.strapi.io/badge.svg)](http://slack.strapi.io)
+[![Slack status](https://slack.strapi.io/badge.svg)](https://slack.strapi.io)
 
 This Strapi generator contains the default files for a model.
 
@@ -26,6 +26,6 @@ $ strapi generate:model group user
 
 ## Links
 
-- [Strapi website](http://strapi.io/)
-- [Strapi community on Slack](http://slack.strapi.io)
+- [Strapi website](https://strapi.io/)
+- [Strapi community on Slack](https://slack.strapi.io)
 - [Strapi news on Twitter](https://twitter.com/strapijs)

--- a/packages/strapi-generate-model/package.json
+++ b/packages/strapi-generate-model/package.json
@@ -2,7 +2,7 @@
   "name": "strapi-generate-model",
   "version": "3.4.5",
   "description": "Generate a model for a Strapi API.",
-  "homepage": "http://strapi.io",
+  "homepage": "https://strapi.io",
   "keywords": [
     "generate",
     "generator",
@@ -24,13 +24,13 @@
   "author": {
     "email": "hi@strapi.io",
     "name": "Strapi team",
-    "url": "http://strapi.io"
+    "url": "https://strapi.io"
   },
   "maintainers": [
     {
       "name": "Strapi team",
       "email": "hi@strapi.io",
-      "url": "http://strapi.io"
+      "url": "https://strapi.io"
     }
   ],
   "repository": {

--- a/packages/strapi-generate-new/README.md
+++ b/packages/strapi-generate-new/README.md
@@ -4,7 +4,7 @@
 [![npm downloads](https://img.shields.io/npm/dm/strapi-generate-new.svg)](https://www.npmjs.org/package/strapi-generate-new)
 [![npm dependencies](https://david-dm.org/strapi/strapi-generate-new.svg)](https://david-dm.org/strapi/strapi-generate-new)
 [![Build status](https://travis-ci.org/strapi/strapi-generate-new.svg?branch=master)](https://travis-ci.org/strapi/strapi-generate-new)
-[![Slack status](https://slack.strapi.io/badge.svg)](http://slack.strapi.io)
+[![Slack status](https://slack.strapi.io/badge.svg)](https://slack.strapi.io)
 
 This Strapi generator contains all the default files for a new Strapi application.
 
@@ -20,6 +20,6 @@ $ strapi new <myAppName>
 
 ## Links
 
-- [Strapi website](http://strapi.io/)
-- [Strapi community on Slack](http://slack.strapi.io)
+- [Strapi website](https://strapi.io/)
+- [Strapi community on Slack](https://slack.strapi.io)
 - [Strapi news on Twitter](https://twitter.com/strapijs)

--- a/packages/strapi-generate-new/package.json
+++ b/packages/strapi-generate-new/package.json
@@ -2,7 +2,7 @@
   "name": "strapi-generate-new",
   "version": "3.4.5",
   "description": "Generate a new Strapi application.",
-  "homepage": "http://strapi.io",
+  "homepage": "https://strapi.io",
   "keywords": [
     "generate",
     "generator",
@@ -32,13 +32,13 @@
   "author": {
     "email": "hi@strapi.io",
     "name": "Strapi team",
-    "url": "http://strapi.io"
+    "url": "https://strapi.io"
   },
   "maintainers": [
     {
       "name": "Strapi team",
       "email": "hi@strapi.io",
-      "url": "http://strapi.io"
+      "url": "https://strapi.io"
     }
   ],
   "repository": {

--- a/packages/strapi-generate-plugin/README.md
+++ b/packages/strapi-generate-plugin/README.md
@@ -4,7 +4,7 @@
 [![npm downloads](https://img.shields.io/npm/dm/strapi-generate-plugin.svg)](https://www.npmjs.org/package/strapi-generate-plugin)
 [![npm dependencies](https://david-dm.org/strapi/strapi-generate-plugin.svg)](https://david-dm.org/strapi/strapi-generate-plugin)
 [![Build status](https://travis-ci.org/strapi/strapi-generate-plugin.svg?branch=master)](https://travis-ci.org/strapi/strapi-generate-plugin)
-[![Slack status](https://slack.strapi.io/badge.svg)](http://slack.strapi.io)
+[![Slack status](https://slack.strapi.io/badge.svg)](https://slack.strapi.io)
 
 This Strapi generator contains all the default files for a new plugin.
 
@@ -20,6 +20,6 @@ $ strapi generate:plugin pluginName
 
 ## Links
 
-- [Strapi website](http://strapi.io/)
-- [Strapi community on Slack](http://slack.strapi.io)
+- [Strapi website](https://strapi.io/)
+- [Strapi community on Slack](https://slack.strapi.io)
 - [Strapi news on Twitter](https://twitter.com/strapijs)

--- a/packages/strapi-generate-plugin/package.json
+++ b/packages/strapi-generate-plugin/package.json
@@ -2,7 +2,7 @@
   "name": "strapi-generate-plugin",
   "version": "3.4.5",
   "description": "Generate an plugin for a Strapi application.",
-  "homepage": "http://strapi.io",
+  "homepage": "https://strapi.io",
   "keywords": [
     "generate",
     "generator",
@@ -23,13 +23,13 @@
   "author": {
     "email": "hi@strapi.io",
     "name": "Strapi team",
-    "url": "http://strapi.io"
+    "url": "https://strapi.io"
   },
   "maintainers": [
     {
       "name": "Strapi team",
       "email": "hi@strapi.io",
-      "url": "http://strapi.io"
+      "url": "https://strapi.io"
     }
   ],
   "repository": {

--- a/packages/strapi-generate-policy/README.md
+++ b/packages/strapi-generate-policy/README.md
@@ -4,7 +4,7 @@
 [![npm downloads](https://img.shields.io/npm/dm/strapi-generate-policy.svg)](https://www.npmjs.org/package/strapi-generate-policy)
 [![npm dependencies](https://david-dm.org/strapi/strapi-generate-policy.svg)](https://david-dm.org/strapi/strapi-generate-policy)
 [![Build status](https://travis-ci.org/strapi/strapi-generate-policy.svg?branch=master)](https://travis-ci.org/strapi/strapi-generate-policy)
-[![Slack status](https://slack.strapi.io/badge.svg)](http://slack.strapi.io)
+[![Slack status](https://slack.strapi.io/badge.svg)](https://slack.strapi.io)
 
 This Strapi generator contains the default files for a policy.
 
@@ -26,6 +26,6 @@ $ strapi generate:policy isAuthenticated user
 
 ## Links
 
-- [Strapi website](http://strapi.io/)
-- [Strapi community on Slack](http://slack.strapi.io)
+- [Strapi website](https://strapi.io/)
+- [Strapi community on Slack](https://slack.strapi.io)
 - [Strapi news on Twitter](https://twitter.com/strapijs)

--- a/packages/strapi-generate-policy/package.json
+++ b/packages/strapi-generate-policy/package.json
@@ -2,7 +2,7 @@
   "name": "strapi-generate-policy",
   "version": "3.4.5",
   "description": "Generate a policy for a Strapi API.",
-  "homepage": "http://strapi.io",
+  "homepage": "https://strapi.io",
   "keywords": [
     "generate",
     "generator",
@@ -23,13 +23,13 @@
   "author": {
     "email": "hi@strapi.io",
     "name": "Strapi team",
-    "url": "http://strapi.io"
+    "url": "https://strapi.io"
   },
   "maintainers": [
     {
       "name": "Strapi team",
       "email": "hi@strapi.io",
-      "url": "http://strapi.io"
+      "url": "https://strapi.io"
     }
   ],
   "repository": {

--- a/packages/strapi-generate-service/README.md
+++ b/packages/strapi-generate-service/README.md
@@ -4,7 +4,7 @@
 [![npm downloads](https://img.shields.io/npm/dm/strapi-generate-service.svg)](https://www.npmjs.org/package/strapi-generate-service)
 [![npm dependencies](https://david-dm.org/strapi/strapi-generate-service.svg)](https://david-dm.org/strapi/strapi-generate-service)
 [![Build status](https://travis-ci.org/strapi/strapi-generate-service.svg?branch=master)](https://travis-ci.org/strapi/strapi-generate-service)
-[![Slack status](https://slack.strapi.io/badge.svg)](http://slack.strapi.io)
+[![Slack status](https://slack.strapi.io/badge.svg)](https://slack.strapi.io)
 
 This Strapi generator contains the default files for a service.
 
@@ -26,6 +26,6 @@ $ strapi generate:service sendEmail email
 
 ## Links
 
-- [Strapi website](http://strapi.io/)
-- [Strapi community on Slack](http://slack.strapi.io)
+- [Strapi website](https://strapi.io/)
+- [Strapi community on Slack](https://slack.strapi.io)
 - [Strapi news on Twitter](https://twitter.com/strapijs)

--- a/packages/strapi-generate-service/package.json
+++ b/packages/strapi-generate-service/package.json
@@ -2,7 +2,7 @@
   "name": "strapi-generate-service",
   "version": "3.4.5",
   "description": "Generate a service for a Strapi API.",
-  "homepage": "http://strapi.io",
+  "homepage": "https://strapi.io",
   "keywords": [
     "generate",
     "generator",
@@ -23,13 +23,13 @@
   "author": {
     "email": "hi@strapi.io",
     "name": "Strapi team",
-    "url": "http://strapi.io"
+    "url": "https://strapi.io"
   },
   "maintainers": [
     {
       "name": "Strapi team",
       "email": "hi@strapi.io",
-      "url": "http://strapi.io"
+      "url": "https://strapi.io"
     }
   ],
   "repository": {

--- a/packages/strapi-generate/README.md
+++ b/packages/strapi-generate/README.md
@@ -4,7 +4,7 @@
 [![npm downloads](https://img.shields.io/npm/dm/strapi-generate.svg)](https://www.npmjs.org/package/strapi-generate)
 [![npm dependencies](https://david-dm.org/strapi/strapi-generate.svg)](https://david-dm.org/strapi/strapi-generate)
 [![Build status](https://travis-ci.org/strapi/strapi-generate.svg?branch=master)](https://travis-ci.org/strapi/strapi-generate)
-[![Slack status](https://slack.strapi.io/badge.svg)](http://slack.strapi.io)
+[![Slack status](https://slack.strapi.io/badge.svg)](https://slack.strapi.io)
 
 Master of ceremonies for generators in the Strapi CLI.
 
@@ -20,6 +20,6 @@ $ strapi generate:something
 
 ## Links
 
-- [Strapi website](http://strapi.io/)
-- [Strapi community on Slack](http://slack.strapi.io)
+- [Strapi website](https://strapi.io/)
+- [Strapi community on Slack](https://slack.strapi.io)
 - [Strapi news on Twitter](https://twitter.com/strapijs)

--- a/packages/strapi-generate/package.json
+++ b/packages/strapi-generate/package.json
@@ -2,7 +2,7 @@
   "name": "strapi-generate",
   "version": "3.4.5",
   "description": "Master of ceremonies for the Strapi generators.",
-  "homepage": "http://strapi.io",
+  "homepage": "https://strapi.io",
   "keywords": [
     "generate",
     "generator",
@@ -25,13 +25,13 @@
   "author": {
     "name": "Strapi team",
     "email": "hi@strapi.io",
-    "url": "http://strapi.io"
+    "url": "https://strapi.io"
   },
   "maintainers": [
     {
       "name": "Strapi team",
       "email": "hi@strapi.io",
-      "url": "http://strapi.io"
+      "url": "https://strapi.io"
     }
   ],
   "repository": {

--- a/packages/strapi-helper-plugin/lib/src/components/BlockerComponent/index.js
+++ b/packages/strapi-helper-plugin/lib/src/components/BlockerComponent/index.js
@@ -69,7 +69,7 @@ const renderButton = () => (
   <ButtonWrapper>
     <a
       className={cn('primary', 'btn')}
-      href="http://strapi.io"
+      href="https://strapi.io"
       target="_blank"
       rel="noopener noreferrer"
     >

--- a/packages/strapi-helper-plugin/package.json
+++ b/packages/strapi-helper-plugin/package.json
@@ -12,7 +12,7 @@
   "author": {
     "email": "hi@strapi.io",
     "name": "Strapi team",
-    "url": "http://strapi.io"
+    "url": "https://strapi.io"
   },
   "main": "dist/strapi-helper-plugin.cjs.min.js",
   "module": "dist/strapi-helper-plugin.esm.min.js",
@@ -20,7 +20,7 @@
     {
       "name": "Strapi team",
       "email": "hi@strapi.io",
-      "url": "http://strapi.io"
+      "url": "https://strapi.io"
     }
   ],
   "license": "SEE LICENSE IN LICENSE",

--- a/packages/strapi-hook-ejs/README.md
+++ b/packages/strapi-hook-ejs/README.md
@@ -4,7 +4,7 @@
 [![npm downloads](https://img.shields.io/npm/dm/strapi-ejs.svg)](https://www.npmjs.org/package/strapi-ejs)
 [![npm dependencies](https://david-dm.org/strapi/strapi-ejs.svg)](https://david-dm.org/strapi/strapi-ejs)
 [![Build status](https://travis-ci.org/strapi/strapi-ejs.svg?branch=master)](https://travis-ci.org/strapi/strapi)
-[![Slack status](https://slack.strapi.io/badge.svg)](http://slack.strapi.io)
+[![Slack status](https://slack.strapi.io/badge.svg)](https://slack.strapi.io)
 
 This built-in hook allows you to use the EJS template engine with custom options.
 
@@ -50,6 +50,6 @@ This will render the `views/home.ejs` file and you will have access to `<%= titl
 
 ## Links
 
-- [Strapi website](http://strapi.io/)
-- [Strapi community on Slack](http://slack.strapi.io)
+- [Strapi website](https://strapi.io/)
+- [Strapi community on Slack](https://slack.strapi.io)
 - [Strapi news on Twitter](https://twitter.com/strapijs)

--- a/packages/strapi-hook-ejs/package.json
+++ b/packages/strapi-hook-ejs/package.json
@@ -2,7 +2,7 @@
   "name": "strapi-hook-ejs",
   "version": "3.4.5",
   "description": "EJS hook for the Strapi framework",
-  "homepage": "http://strapi.io",
+  "homepage": "https://strapi.io",
   "keywords": [
     "ejs",
     "hook",
@@ -22,13 +22,13 @@
   "author": {
     "email": "hi@strapi.io",
     "name": "Strapi team",
-    "url": "http://strapi.io"
+    "url": "https://strapi.io"
   },
   "maintainers": [
     {
       "name": "Strapi team",
       "email": "hi@strapi.io",
-      "url": "http://strapi.io"
+      "url": "https://strapi.io"
     }
   ],
   "repository": {

--- a/packages/strapi-hook-redis/README.md
+++ b/packages/strapi-hook-redis/README.md
@@ -4,7 +4,7 @@
 [![npm downloads](https://img.shields.io/npm/dm/strapi-redis.svg)](https://www.npmjs.org/package/strapi-redis)
 [![npm dependencies](https://david-dm.org/strapi/strapi-redis.svg)](https://david-dm.org/strapi/strapi-redis)
 [![Build status](https://travis-ci.org/strapi/strapi-redis.svg?branch=master)](https://travis-ci.org/strapi/strapi-redis)
-[![Slack status](https://slack.strapi.io/badge.svg)](http://slack.strapi.io)
+[![Slack status](https://slack.strapi.io/badge.svg)](https://slack.strapi.io)
 
 This built-in hook allows you to use [Redis](https://redis.io/) as a databases connection. Redis is an open source (BSD licensed), in-memory data structure store, used as a database, cache and message broker.
 
@@ -18,6 +18,6 @@ We developed this hook to use Redis as cache database for our Strapi apps.
 
 ## Links
 
-- [Strapi website](http://strapi.io/)
-- [Strapi community on Slack](http://slack.strapi.io)
+- [Strapi website](https://strapi.io/)
+- [Strapi community on Slack](https://slack.strapi.io)
 - [Strapi news on Twitter](https://twitter.com/strapijs)

--- a/packages/strapi-hook-redis/package.json
+++ b/packages/strapi-hook-redis/package.json
@@ -2,7 +2,7 @@
   "name": "strapi-hook-redis",
   "version": "3.4.5",
   "description": "Redis hook for the Strapi framework",
-  "homepage": "http://strapi.io",
+  "homepage": "https://strapi.io",
   "keywords": [
     "redis",
     "hook",
@@ -24,13 +24,13 @@
   "author": {
     "email": "hi@strapi.io",
     "name": "Strapi team",
-    "url": "http://strapi.io"
+    "url": "https://strapi.io"
   },
   "maintainers": [
     {
       "name": "Strapi team",
       "email": "hi@strapi.io",
-      "url": "http://strapi.io"
+      "url": "https://strapi.io"
     }
   ],
   "repository": {

--- a/packages/strapi-middleware-views/README.md
+++ b/packages/strapi-middleware-views/README.md
@@ -4,7 +4,7 @@
 [![npm downloads](https://img.shields.io/npm/dm/strapi-middleware-views.svg)](https://www.npmjs.org/package/strapi-middleware-views)
 [![npm dependencies](https://david-dm.org/strapi/strapi-middleware-views.svg)](https://david-dm.org/strapi/strapi-middleware-views)
 [![Build status](https://travis-ci.org/strapi/strapi-middleware-views.svg?branch=master)](https://travis-ci.org/strapi/strapi-middleware-views)
-[![Slack status](https://slack.strapi.io/badge.svg)](http://slack.strapi.io)
+[![Slack status](https://slack.strapi.io/badge.svg)](https://slack.strapi.io)
 
 Views middleware to enable server-side rendering for the Strapi framework. It will let you use [koa-views](https://www.npmjs.com/package/koa-views) and [consolidate](https://github.com/tj/consolidate.js/).
 
@@ -14,6 +14,6 @@ Views middleware to enable server-side rendering for the Strapi framework. It wi
 
 ## Links
 
-- [Strapi website](http://strapi.io/)
-- [Strapi community on Slack](http://slack.strapi.io)
+- [Strapi website](https://strapi.io/)
+- [Strapi community on Slack](https://slack.strapi.io)
 - [Strapi news on Twitter](https://twitter.com/strapijs)

--- a/packages/strapi-middleware-views/package.json
+++ b/packages/strapi-middleware-views/package.json
@@ -2,7 +2,7 @@
   "name": "strapi-middleware-views",
   "version": "3.4.5",
   "description": "Views middleware to enable server-side rendering for the Strapi framework",
-  "homepage": "http://strapi.io",
+  "homepage": "https://strapi.io",
   "keywords": [
     "redis",
     "hook",
@@ -22,13 +22,13 @@
   "author": {
     "email": "hi@strapi.io",
     "name": "Strapi team",
-    "url": "http://strapi.io"
+    "url": "https://strapi.io"
   },
   "maintainers": [
     {
       "name": "Strapi team",
       "email": "hi@strapi.io",
-      "url": "http://strapi.io"
+      "url": "https://strapi.io"
     }
   ],
   "repository": {

--- a/packages/strapi-plugin-content-manager/package.json
+++ b/packages/strapi-plugin-content-manager/package.json
@@ -53,13 +53,13 @@
   "author": {
     "name": "Strapi team",
     "email": "hi@strapi.io",
-    "url": "http://strapi.io"
+    "url": "https://strapi.io"
   },
   "maintainers": [
     {
       "name": "Strapi team",
       "email": "hi@strapi.io",
-      "url": "http://strapi.io"
+      "url": "https://strapi.io"
     }
   ],
   "repository": {

--- a/packages/strapi-plugin-content-type-builder/package.json
+++ b/packages/strapi-plugin-content-type-builder/package.json
@@ -38,13 +38,13 @@
   "author": {
     "name": "Strapi team",
     "email": "hi@strapi.io",
-    "url": "http://strapi.io"
+    "url": "https://strapi.io"
   },
   "maintainers": [
     {
       "name": "Strapi team",
       "email": "hi@strapi.io",
-      "url": "http://strapi.io"
+      "url": "https://strapi.io"
     }
   ],
   "repository": {

--- a/packages/strapi-plugin-documentation/package.json
+++ b/packages/strapi-plugin-documentation/package.json
@@ -41,13 +41,13 @@
   "author": {
     "name": "soupette",
     "email": "hi@strapi.io",
-    "url": "http://strapi.io"
+    "url": "https://strapi.io"
   },
   "maintainers": [
     {
       "name": "Strapi",
       "email": "hi@strapi.io",
-      "url": "http://strapi.io"
+      "url": "https://strapi.io"
     },
     {
       "name": "soupette",

--- a/packages/strapi-plugin-email/package.json
+++ b/packages/strapi-plugin-email/package.json
@@ -23,13 +23,13 @@
   "author": {
     "name": "Strapi team",
     "email": "hi@strapi.io",
-    "url": "http://strapi.io"
+    "url": "https://strapi.io"
   },
   "maintainers": [
     {
       "name": "Strapi team",
       "email": "hi@strapi.io",
-      "url": "http://strapi.io"
+      "url": "https://strapi.io"
     }
   ],
   "repository": {

--- a/packages/strapi-plugin-users-permissions/package.json
+++ b/packages/strapi-plugin-users-permissions/package.json
@@ -45,13 +45,13 @@
   "author": {
     "name": "Strapi team",
     "email": "hi@strapi.io",
-    "url": "http://strapi.io"
+    "url": "https://strapi.io"
   },
   "maintainers": [
     {
       "name": "Strapi team",
       "email": "hi@strapi.io",
-      "url": "http://strapi.io"
+      "url": "https://strapi.io"
     }
   ],
   "repository": {

--- a/packages/strapi-provider-email-amazon-ses/README.md
+++ b/packages/strapi-provider-email-amazon-ses/README.md
@@ -6,8 +6,8 @@
 
 ## Links
 
-- [Strapi website](http://strapi.io/)
-- [Strapi community on Slack](http://slack.strapi.io)
+- [Strapi website](https://strapi.io/)
+- [Strapi community on Slack](https://slack.strapi.io)
 - [Strapi news on Twitter](https://twitter.com/strapijs)
 
 ## Prerequisites

--- a/packages/strapi-provider-email-amazon-ses/package.json
+++ b/packages/strapi-provider-email-amazon-ses/package.json
@@ -2,7 +2,7 @@
   "name": "strapi-provider-email-amazon-ses",
   "version": "3.4.5",
   "description": "Amazon SES provider for strapi email",
-  "homepage": "http://strapi.io",
+  "homepage": "https://strapi.io",
   "keywords": [
     "email",
     "strapi",
@@ -25,7 +25,7 @@
     {
       "name": "Strapi team",
       "email": "hi@strapi.io",
-      "url": "http://strapi.io"
+      "url": "https://strapi.io"
     }
   ],
   "repository": {

--- a/packages/strapi-provider-email-mailgun/README.md
+++ b/packages/strapi-provider-email-mailgun/README.md
@@ -6,8 +6,8 @@
 
 ## Links
 
-- [Strapi website](http://strapi.io/)
-- [Strapi community on Slack](http://slack.strapi.io)
+- [Strapi website](https://strapi.io/)
+- [Strapi community on Slack](https://slack.strapi.io)
 - [Strapi news on Twitter](https://twitter.com/strapijs)
 
 ## Prerequisites

--- a/packages/strapi-provider-email-mailgun/package.json
+++ b/packages/strapi-provider-email-mailgun/package.json
@@ -2,7 +2,7 @@
   "name": "strapi-provider-email-mailgun",
   "version": "3.4.5",
   "description": "Mailgun provider for strapi email plugin",
-  "homepage": "http://strapi.io",
+  "homepage": "https://strapi.io",
   "keywords": [
     "email",
     "strapi",
@@ -22,13 +22,13 @@
   "author": {
     "email": "hi@strapi.io",
     "name": "Strapi team",
-    "url": "http://strapi.io"
+    "url": "https://strapi.io"
   },
   "maintainers": [
     {
       "name": "Strapi team",
       "email": "hi@strapi.io",
-      "url": "http://strapi.io"
+      "url": "https://strapi.io"
     }
   ],
   "repository": {

--- a/packages/strapi-provider-email-nodemailer/README.md
+++ b/packages/strapi-provider-email-nodemailer/README.md
@@ -6,8 +6,8 @@
 
 ## Links
 
-- [Strapi website](http://strapi.io/)
-- [Strapi community on Slack](http://slack.strapi.io)
+- [Strapi website](https://strapi.io/)
+- [Strapi community on Slack](https://slack.strapi.io)
 - [Strapi news on Twitter](https://twitter.com/strapijs)
 
 ## Prerequisites

--- a/packages/strapi-provider-email-nodemailer/package.json
+++ b/packages/strapi-provider-email-nodemailer/package.json
@@ -2,7 +2,7 @@
   "name": "strapi-provider-email-nodemailer",
   "version": "3.4.5",
   "description": "Nodemailer provider for Strapi 3",
-  "homepage": "http://strapi.io",
+  "homepage": "https://strapi.io",
   "keywords": [
     "strapi",
     "email",
@@ -48,7 +48,7 @@
     {
       "name": "Strapi team",
       "email": "hi@strapi.io",
-      "url": "http://strapi.io"
+      "url": "https://strapi.io"
     }
   ],
   "license": "SEE LICENSE IN LICENSE",

--- a/packages/strapi-provider-email-sendgrid/README.md
+++ b/packages/strapi-provider-email-sendgrid/README.md
@@ -6,8 +6,8 @@
 
 ## Links
 
-- [Strapi website](http://strapi.io/)
-- [Strapi community on Slack](http://slack.strapi.io)
+- [Strapi website](https://strapi.io/)
+- [Strapi community on Slack](https://slack.strapi.io)
 - [Strapi news on Twitter](https://twitter.com/strapijs)
 
 ## Prerequisites

--- a/packages/strapi-provider-email-sendgrid/package.json
+++ b/packages/strapi-provider-email-sendgrid/package.json
@@ -2,7 +2,7 @@
   "name": "strapi-provider-email-sendgrid",
   "version": "3.4.5",
   "description": "Sendgrid provider for strapi email",
-  "homepage": "http://strapi.io",
+  "homepage": "https://strapi.io",
   "keywords": [
     "email",
     "strapi",
@@ -22,13 +22,13 @@
   "author": {
     "email": "hi@strapi.io",
     "name": "Strapi team",
-    "url": "http://strapi.io"
+    "url": "https://strapi.io"
   },
   "maintainers": [
     {
       "name": "Strapi team",
       "email": "hi@strapi.io",
-      "url": "http://strapi.io"
+      "url": "https://strapi.io"
     }
   ],
   "repository": {

--- a/packages/strapi-provider-email-sendmail/README.md
+++ b/packages/strapi-provider-email-sendmail/README.md
@@ -6,8 +6,8 @@
 
 ## Links
 
-- [Strapi website](http://strapi.io/)
-- [Strapi community on Slack](http://slack.strapi.io)
+- [Strapi website](https://strapi.io/)
+- [Strapi community on Slack](https://slack.strapi.io)
 - [Strapi news on Twitter](https://twitter.com/strapijs)
 
 ## Prerequisites

--- a/packages/strapi-provider-email-sendmail/package.json
+++ b/packages/strapi-provider-email-sendmail/package.json
@@ -2,7 +2,7 @@
   "name": "strapi-provider-email-sendmail",
   "version": "3.4.5",
   "description": "Sendmail provider for strapi email",
-  "homepage": "http://strapi.io",
+  "homepage": "https://strapi.io",
   "keywords": [
     "email",
     "strapi"
@@ -21,13 +21,13 @@
   "author": {
     "email": "hi@strapi.io",
     "name": "Strapi team",
-    "url": "http://strapi.io"
+    "url": "https://strapi.io"
   },
   "maintainers": [
     {
       "name": "Strapi team",
       "email": "hi@strapi.io",
-      "url": "http://strapi.io"
+      "url": "https://strapi.io"
     }
   ],
   "repository": {

--- a/packages/strapi-provider-upload-aws-s3/README.md
+++ b/packages/strapi-provider-upload-aws-s3/README.md
@@ -34,6 +34,6 @@ module.exports = ({ env }) => ({
 
 ## Links
 
-- [Strapi website](http://strapi.io/)
-- [Strapi community on Slack](http://slack.strapi.io)
+- [Strapi website](https://strapi.io/)
+- [Strapi community on Slack](https://slack.strapi.io)
 - [Strapi news on Twitter](https://twitter.com/strapijs)

--- a/packages/strapi-provider-upload-aws-s3/package.json
+++ b/packages/strapi-provider-upload-aws-s3/package.json
@@ -2,7 +2,7 @@
   "name": "strapi-provider-upload-aws-s3",
   "version": "3.4.5",
   "description": "AWS S3 provider for strapi upload",
-  "homepage": "http://strapi.io",
+  "homepage": "https://strapi.io",
   "keywords": [
     "upload",
     "aws",
@@ -23,13 +23,13 @@
   "author": {
     "email": "hi@strapi.io",
     "name": "Strapi team",
-    "url": "http://strapi.io"
+    "url": "https://strapi.io"
   },
   "maintainers": [
     {
       "name": "Strapi team",
       "email": "hi@strapi.io",
-      "url": "http://strapi.io"
+      "url": "https://strapi.io"
     }
   ],
   "repository": {

--- a/packages/strapi-provider-upload-cloudinary/README.md
+++ b/packages/strapi-provider-upload-cloudinary/README.md
@@ -31,6 +31,6 @@ module.exports = ({ env }) => ({
 
 ## Links
 
-- [Strapi website](http://strapi.io/)
-- [Strapi community on Slack](http://slack.strapi.io)
+- [Strapi website](https://strapi.io/)
+- [Strapi community on Slack](https://slack.strapi.io)
 - [Strapi news on Twitter](https://twitter.com/strapijs)

--- a/packages/strapi-provider-upload-cloudinary/package.json
+++ b/packages/strapi-provider-upload-cloudinary/package.json
@@ -2,7 +2,7 @@
   "name": "strapi-provider-upload-cloudinary",
   "version": "3.4.5",
   "description": "Cloudinary provider for strapi upload",
-  "homepage": "http://strapi.io",
+  "homepage": "https://strapi.io",
   "keywords": [
     "upload",
     "cloudinary",
@@ -31,7 +31,7 @@
     {
       "name": "Strapi team",
       "email": "hi@strapi.io",
-      "url": "http://strapi.io"
+      "url": "https://strapi.io"
     }
   ],
   "repository": {

--- a/packages/strapi-provider-upload-local/README.md
+++ b/packages/strapi-provider-upload-local/README.md
@@ -25,6 +25,6 @@ The `sizeLimit` parameter must be a number. Be aware that the unit is in bytes, 
 
 ## Links
 
-- [Strapi website](http://strapi.io/)
-- [Strapi community on Slack](http://slack.strapi.io)
+- [Strapi website](https://strapi.io/)
+- [Strapi community on Slack](https://slack.strapi.io)
 - [Strapi news on Twitter](https://twitter.com/strapijs)

--- a/packages/strapi-provider-upload-local/package.json
+++ b/packages/strapi-provider-upload-local/package.json
@@ -2,7 +2,7 @@
   "name": "strapi-provider-upload-local",
   "version": "3.4.5",
   "description": "Local provider for strapi upload",
-  "homepage": "http://strapi.io",
+  "homepage": "https://strapi.io",
   "keywords": [
     "upload",
     "strapi"
@@ -17,13 +17,13 @@
   "author": {
     "email": "hi@strapi.io",
     "name": "Strapi team",
-    "url": "http://strapi.io"
+    "url": "https://strapi.io"
   },
   "maintainers": [
     {
       "name": "Strapi team",
       "email": "hi@strapi.io",
-      "url": "http://strapi.io"
+      "url": "https://strapi.io"
     }
   ],
   "repository": {

--- a/packages/strapi-provider-upload-rackspace/README.md
+++ b/packages/strapi-provider-upload-rackspace/README.md
@@ -32,6 +32,6 @@ module.exports = ({ env }) => ({
 
 ## Links
 
-- [Strapi website](http://strapi.io/)
-- [Strapi community on Slack](http://slack.strapi.io)
+- [Strapi website](https://strapi.io/)
+- [Strapi community on Slack](https://slack.strapi.io)
 - [Strapi news on Twitter](https://twitter.com/strapijs)

--- a/packages/strapi-utils/README.md
+++ b/packages/strapi-utils/README.md
@@ -4,7 +4,7 @@
 [![npm downloads](https://img.shields.io/npm/dm/strapi-utils.svg)](https://www.npmjs.org/package/strapi-utils)
 [![npm dependencies](https://david-dm.org/strapi/strapi-utils.svg)](https://david-dm.org/strapi/strapi-utils)
 [![Build status](https://travis-ci.org/strapi/strapi-utils.svg?branch=master)](https://travis-ci.org/strapi/strapi-utils)
-[![Slack status](https://slack.strapi.io/badge.svg)](http://slack.strapi.io)
+[![Slack status](https://slack.strapi.io/badge.svg)](https://slack.strapi.io)
 
 Shared utilities between Strapi packages.
 
@@ -14,6 +14,6 @@ Shared utilities between Strapi packages.
 
 ## Links
 
-- [Strapi website](http://strapi.io/)
-- [Strapi community on Slack](http://slack.strapi.io)
+- [Strapi website](https://strapi.io/)
+- [Strapi community on Slack](https://slack.strapi.io)
 - [Strapi news on Twitter](https://twitter.com/strapijs)

--- a/packages/strapi-utils/package.json
+++ b/packages/strapi-utils/package.json
@@ -2,7 +2,7 @@
   "name": "strapi-utils",
   "version": "3.4.5",
   "description": "Shared utilities for the Strapi packages",
-  "homepage": "http://strapi.io",
+  "homepage": "https://strapi.io",
   "keywords": [
     "strapi",
     "utilities",
@@ -24,13 +24,13 @@
   "author": {
     "email": "hi@strapi.io",
     "name": "Strapi team",
-    "url": "http://strapi.io"
+    "url": "https://strapi.io"
   },
   "maintainers": [
     {
       "name": "Strapi team",
       "email": "hi@strapi.io",
-      "url": "http://strapi.io"
+      "url": "https://strapi.io"
     }
   ],
   "repository": {

--- a/packages/strapi/README.md
+++ b/packages/strapi/README.md
@@ -4,7 +4,7 @@
 [![npm downloads](https://img.shields.io/npm/dm/strapi.svg)](https://www.npmjs.org/package/strapi)
 [![npm dependencies](https://david-dm.org/strapi/strapi.svg)](https://david-dm.org/strapi/strapi)
 [![Build status](https://travis-ci.org/strapi/strapi.svg?branch=master)](https://travis-ci.org/strapi/strapi)
-[![Slack status](https://slack.strapi.io/badge.svg)](http://slack.strapi.io)
+[![Slack status](https://slack.strapi.io/badge.svg)](https://slack.strapi.io)
 
 The Strapi HTTP layer sits on top of [Koa](http://koajs.com/). Its ensemble of small modules work together to provide simplicity, maintainability, and structural conventions to Node.js applications.
 
@@ -14,6 +14,6 @@ The Strapi HTTP layer sits on top of [Koa](http://koajs.com/). Its ensemble of s
 
 ## Links
 
-- [Strapi website](http://strapi.io/)
-- [Strapi community on Slack](http://slack.strapi.io)
+- [Strapi website](https://strapi.io/)
+- [Strapi community on Slack](https://slack.strapi.io)
 - [Strapi news on Twitter](https://twitter.com/strapijs)

--- a/packages/strapi/package.json
+++ b/packages/strapi/package.json
@@ -2,7 +2,7 @@
   "name": "strapi",
   "version": "3.4.5",
   "description": "An open source headless CMS solution to create and manage your own API. It provides a powerful dashboard and features to make your life easier. Databases supported: MongoDB, MySQL, MariaDB, PostgreSQL, SQLite",
-  "homepage": "http://strapi.io",
+  "homepage": "https://strapi.io",
   "directories": {
     "lib": "./lib",
     "bin": "./bin"
@@ -72,13 +72,13 @@
   "author": {
     "email": "hi@strapi.io",
     "name": "Strapi team",
-    "url": "http://strapi.io"
+    "url": "https://strapi.io"
   },
   "maintainers": [
     {
       "name": "Strapi team",
       "email": "hi@strapi.io",
-      "url": "http://strapi.io"
+      "url": "https://strapi.io"
     }
   ],
   "repository": {


### PR DESCRIPTION
I noticed that at several places http://strapi.io was used instead of https://strapi.io. Here is patch that fixes this, as well as other urls.