### PR TITLE
File name as title for file cards

### DIFF
--- a/packages/strapi-plugin-upload/admin/src/components/Card/index.js
+++ b/packages/strapi-plugin-upload/admin/src/components/Card/index.js
@@ -51,7 +51,7 @@ const Card = ({
 
   return (
     <Wrapper
-      title={isDisabled ? formatMessage({ id: getTrad('list.assets.type-not-allowed') }) : null}
+      title={isDisabled ? formatMessage({ id: getTrad('list.assets.type-not-allowed') }) : name}
       onClick={handleClick}
     >
       <CardImgWrapper checked={checked} small={small}>
@@ -70,7 +70,7 @@ const Card = ({
       {!withoutFileInfo ? (
         <>
           <Flex>
-            <Title>{name}</Title>
+            <Title title={name}>{name}</Title>
             <Tag label={getType(fileType)} />
           </Flex>
           {!withoutFileInfo && (


### PR DESCRIPTION
### What does it do?

Added file name as title to the whole card if it's a valid type, and also on the displayed file name always.

### Why is it needed?

When having long file names it's hard for data entry people to see if it's the right file they are about to add since the name is being changed to partialname... after 19 characters. In our case it's a long ID that is to be matched and currently they have to click edit to see the actual name
