### PR TITLE
Fix the GraphQL where parser

### DIFF
--- a/packages/strapi-plugin-graphql/services/resolvers-builder.js
+++ b/packages/strapi-plugin-graphql/services/resolvers-builder.js
@@ -152,7 +152,7 @@ const buildQueryContext = ({ options, graphqlContext }) => {
 
   ctx.query = {
     ...convertToParams(_.omit(opts, 'where')),
-    ...convertToQuery(opts.where),
+    ...convertToQuery({ _where: opts.where }),
   };
 
   ctx.params = convertToParams(opts);


### PR DESCRIPTION
Signed-off-by: Abdón Rodríguez Davila <a@abdonrd.com>

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Fix the GraphQL where parser

### Why is it needed?

If not, the `convertToQuery` didn't work:

https://github.com/strapi/strapi/blob/512538a2b8a3eca852b945e392f78cf839d40049/packages/strapi-plugin-graphql/services/utils.js#L58-L75

Because the `QUERY_OPERATORS` is:

https://github.com/strapi/strapi/blob/512538a2b8a3eca852b945e392f78cf839d40049/packages/strapi-utils/lib/convert-rest-query-params.js#L14

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
