### PR TITLE
fix typo "to access to"

### DIFF
--- a/packages/strapi-plugin-documentation/public/login.html
+++ b/packages/strapi-plugin-documentation/public/login.html
@@ -119,7 +119,7 @@
             <div class="row">
               <div class="col-lg-6 col-lg-offset-3 col-md-12">
                 <img alt="Strapi logo" class="logo" src="https://strapi.io/assets/images/logo_login.png">
-                <h2 class="sub-title">Enter the password to access to the documentation.</h2>
+                <h2 class="sub-title">Enter the password to access the documentation.</h2>
                 <form method="post" action="<%=actionUrl%>">
                   <span class="error">Wrong password...</span>
                   <label>Password</label>


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Quick fix for language on the /documentation/login page

### Why is it needed?

"to access to documentation" reads a little weird

### Related issue(s)/PR(s)

None that I know of.
