### PR TITLE
Do not use npm v7 on new projects

### DIFF
--- a/packages/strapi-generate-new/lib/resources/json/package.json.js
+++ b/packages/strapi-generate-new/lib/resources/json/package.json.js
@@ -37,7 +37,7 @@ module.exports = opts => {
     },
     engines: {
       node: '>=10.16.0 <=14.x.x',
-      npm: '<=6.x.x',
+      npm: '^6.0.0',
     },
     license: 'MIT',
   };

--- a/packages/strapi-generate-new/lib/resources/json/package.json.js
+++ b/packages/strapi-generate-new/lib/resources/json/package.json.js
@@ -37,7 +37,7 @@ module.exports = opts => {
     },
     engines: {
       node: '>=10.16.0 <=14.x.x',
-      npm: '>=6.0.0',
+      npm: '<=6.x.x',
     },
     license: 'MIT',
   };


### PR DESCRIPTION
Signed-off-by: Derrick Mehaffy <derrickmehaffy@gmail.com>

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Sets the default npm version to npm v6 in the package.json engines

### Why is it needed?

There are currently some breaking changes in npm v7 which has now gone into general release. This should stop providers like Heroku from trying to use npm v7 by default

### Related issue(s)/PR(s)

Related to the following comment: https://github.com/strapi/strapi/issues/9206#issuecomment-773036382
fixes: #8786 
