### PR TITLE
fix: remove duplicate rest api in plugin routes

### DIFF
--- a/packages/strapi/lib/core/load-modules.js
+++ b/packages/strapi/lib/core/load-modules.js
@@ -40,7 +40,10 @@ module.exports = async strapi => {
   _.mergeWith(plugins, extensions.merges, (objValue, srcValue, key) => {
     // concat routes
     if (_.isArray(srcValue) && _.isArray(objValue) && key === 'routes') {
-      return srcValue.concat(objValue);
+      const merged = srcValue.concat(objValue);
+      return _.uniqWith(merged, (x, y) =>
+        (x.method === y.method) && (x.handler === y.handler)
+      );
     }
   });
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

this fix will remove duplicate routes when creating a new routes.json in the extensions plugin folder.

#### Examples

`/extensions/users-permissions/config/routes.json`

![image](https://user-images.githubusercontent.com/53975050/107146889-6d450380-697d-11eb-88f5-edf667f0c43e.png)

#### Before
![image](https://user-images.githubusercontent.com/53975050/107146815-0b849980-697d-11eb-9bb1-b4eb10be28e2.png)
![image](https://user-images.githubusercontent.com/53975050/107146447-e4c56380-697a-11eb-86f4-636da87d90dc.png)

#### After
![image](https://user-images.githubusercontent.com/53975050/107146949-e3496a80-697d-11eb-9627-2126be4f8f80.png)
![image](https://user-images.githubusercontent.com/53975050/107146958-f0665980-697d-11eb-8328-e08f8c7df65d.png)


#### Side Effect
1 handler can only bound to 1 path, EXCEPT with a different method.

##### Examples :

Handler `Auth.callback` will only bound to path `/auth/local` and path `/auth/:provider/callback` will not recognized.
```json
{
  "routes": [
    {
      "method": "POST",
      "path": "/auth/local",
      "handler": "Auth.callback",
      "config": {}
    },
   {
      "method": "POST",
      "path": "/auth/:provider/callback",
      "handler": "Auth.callback",
      "config": {}
    }
  ]
}
```

But, if we change path `/auth/:provider/callback` to GET method, it will be recognized.

```json
{
  "routes": [
    {
      "method": "POST",
      "path": "/auth/local",
      "handler": "Auth.callback",
      "config": {}
    },
   {
      "method": "GET",
      "path": "/auth/:provider/callback",
      "handler": "Auth.callback",
      "config": {}
    }
  ]
}
```
