### PR TITLE
Fix crash when database (SQL) options are not defined

### DIFF
--- a/packages/strapi-connector-bookshelf/lib/knex.js
+++ b/packages/strapi-connector-bookshelf/lib/knex.js
@@ -102,7 +102,7 @@ module.exports = strapi => {
           ...connection.options,
           debug: _.get(connection.options, 'debug', false),
           pool: {
-            min: _.get(connection.options.pool, 'min', 0),
+            min: _.get(connection.options, 'pool.min', 0),
           },
         },
         strapi.config.hook.settings.knex,


### PR DESCRIPTION
fix #9325