### PR TITLE
added filename to CardPreview

### DIFF
--- a/packages/strapi-plugin-upload/admin/src/components/CardPreview/index.js
+++ b/packages/strapi-plugin-upload/admin/src/components/CardPreview/index.js
@@ -1,15 +1,23 @@
-import React, { memo, useRef } from 'react';
 import PropTypes from 'prop-types';
-
-import { getType } from '../../utils';
-
+import React, { memo, useRef } from 'react';
+import styled from 'styled-components';
 import BrokenFile from '../../icons/BrokenFile';
+import { getType } from '../../utils';
 import FileIcon from '../FileIcon';
 import VideoPreview from '../VideoPreview';
-import Wrapper from './Wrapper';
 import Image from './Image';
+import Wrapper from './Wrapper';
 
-const CardPreview = ({ extension, hasError, hasIcon, url, previewUrl, type, withFileCaching }) => {
+const CardPreview = ({
+  extension,
+  hasError,
+  hasIcon,
+  url,
+  previewUrl,
+  type,
+  withFileCaching,
+  filename,
+}) => {
   const isFile = getType(type) === 'file';
   const isVideo = getType(type) === 'video';
   const cacheRef = useRef(performance.now());
@@ -25,7 +33,10 @@ const CardPreview = ({ extension, hasError, hasIcon, url, previewUrl, type, with
   if (isFile) {
     return (
       <Wrapper isFile>
-        <FileIcon ext={extension} />
+        <FileWrap>
+          <FileIcon ext={extension} />
+          {filename && <p>{filename}</p>}
+        </FileWrap>
       </Wrapper>
     );
   }
@@ -43,6 +54,15 @@ const CardPreview = ({ extension, hasError, hasIcon, url, previewUrl, type, with
   );
 };
 
+const FileWrap = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  max-width: 80%;
+  text-align: center;
+`;
+
 CardPreview.defaultProps = {
   extension: null,
   hasError: false,
@@ -51,6 +71,7 @@ CardPreview.defaultProps = {
   url: null,
   type: '',
   withFileCaching: true,
+  filename: '',
 };
 
 CardPreview.propTypes = {
@@ -61,6 +82,7 @@ CardPreview.propTypes = {
   url: PropTypes.string,
   type: PropTypes.string,
   withFileCaching: PropTypes.bool,
+  filename: PropTypes.string,
 };
 
 export default memo(CardPreview);

--- a/packages/strapi-plugin-upload/admin/src/components/InputMedia/InputFilePreview.js
+++ b/packages/strapi-plugin-upload/admin/src/components/InputMedia/InputFilePreview.js
@@ -1,8 +1,7 @@
-import React from 'react';
-import PropTypes from 'prop-types';
 import { get } from 'lodash';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { prefixFileUrlWithBackendUrl } from 'strapi-helper-plugin';
-
 import CardPreview from '../CardPreview';
 import Flex from '../Flex';
 import Chevron from './Chevron';
@@ -18,7 +17,13 @@ const InputFilePreview = ({ file, onClick, isSlider }) => {
       justifyContent="space-between"
     >
       {isSlider && <Chevron side="left" onClick={() => onClick(false)} />}
-      <CardPreview hasIcon url={fileUrl} type={file.mime} />
+      <CardPreview
+        hasIcon
+        url={fileUrl}
+        type={file.mime}
+        filename={file.name}
+        extension={file.ext.slice(1)}
+      />
       {isSlider && <Chevron side="right" onClick={() => onClick(true)} />}
     </Flex>
   );


### PR DESCRIPTION
### What does it do?
This PR adds the name of the file to the preview card on the file upload input, below the icon, when the input is of type *files*. I did this by introducing a new `filename` prop to the `CardPreview` component. Also fixed the icon not showing up correctly due to the missing `extension` prop on `CardPreview`.

### Why is it needed?

It makes it easier to navigate through multiple files. Up until now there was no easy way to tell which file you are on currently. See screenshots below:

**Before:**
![Screenshot_20210210_003122](https://user-images.githubusercontent.com/30611343/107445835-8399bd80-6b3d-11eb-83a4-42eb343bdfa9.png)
**After:**
![Screenshot_20210210_010504](https://user-images.githubusercontent.com/30611343/107445869-97ddba80-6b3d-11eb-986c-92e62967e4df.png)


### Related issue(s)/PR(s)

Resolves: https://github.com/strapi/strapi/issues/9322
