### PR TITLE
plugin-documentation: added missed manyWay relation

### DIFF
--- a/packages/strapi-plugin-documentation/services/Documentation.js
+++ b/packages/strapi-plugin-documentation/services/Documentation.js
@@ -359,6 +359,7 @@ module.exports = {
           switch (relationNature) {
             case 'manyToMany':
             case 'oneToMany':
+            case 'manyWay':
             case 'manyToManyMorph':
               acc.properties[curr] = {
                 type: 'array',
@@ -573,6 +574,7 @@ module.exports = {
           switch (relationNature) {
             case 'manyToMany':
             case 'oneToMany':
+            case 'manyWay':
             case 'manyToManyMorph':
               acc.properties[current] = {
                 type: 'array',


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->
### What does it do?

It fixes generating of types in case of using 'manyWay' relation

### Why is it needed?

The plugin generates a single instance ref instead of an array for one-to-many (manyWay) relations.

### Related issue(s)/PR(s)

[#9280](https://github.com/strapi/strapi/issues/9280)
