### PR TITLE
plugin-documentation: added enum for associations

### DIFF
--- a/packages/strapi-plugin-documentation/services/Documentation.js
+++ b/packages/strapi-plugin-documentation/services/Documentation.js
@@ -348,7 +348,7 @@ module.exports = {
         }
 
         if (isField) {
-          acc.properties[curr] = { type: this.getType(attribute.type) };
+          acc.properties[curr] = { type: this.getType(attribute.type), enum: attribute.enum };
         } else {
           const newGetter = getter.slice();
           newGetter.splice(newGetter.length - 1, 1, 'associations');


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

It adds missing enums for associations.

Example. Before:

```  
"components": {
    "schemas": {
      "Post": {
        "properties": {
          // ...fields
          "employee": {
            "properties": {
              "id": {
                "type": "string"
              },
             // enum of collection Employee. generated as string
              "location": {
                "type": "string",
              },
            }
          },
          // high-level enum (generated correctly)
          "language": {
            "type": "string",
            "default": "RU",
            "enum": [
              "RU",
              "EN"
            ]
          },
        }
      },
    }
  },
```

after:

```
"components": {
    "schemas": {
      "Post": {
        "properties": {
          // ...fields
          "employee": {
            "properties": {
              "id": {
                "type": "string"
              },
             // enum of Employee. generated correctly
              "location": {
                "type": "string",
                "enum": [
                  "SAINT_PETERSBURG",
                  "MOSCOW",
                  "KALININGRAD",
                ]
              },
            }
          },
          // high-level enum (generated correctly)
          "language": {
            "type": "string",
            "default": "RU",
            "enum": [
              "RU",
              "EN"
            ]
          },
        }
      },
    }
  },
```


### Why is it needed?

1. I do not see any reason why enum should be 'string'
2. We use swagger api to generate TS types. Current behavior leads to an type issue
`language: 'string'` not equal to `language: 'RU' | 'EN'`

### Related issue(s)/PR(s)

No related issues
