### PR TITLE
handle toggle i18n on CT and fields

### DIFF
--- a/packages/strapi-plugin-content-type-builder/controllers/validation/__tests__/component.test.js
+++ b/packages/strapi-plugin-content-type-builder/controllers/validation/__tests__/component.test.js
@@ -1,0 +1,91 @@
+'use strict';
+
+const componentValidation = require('../component');
+
+describe('Component validator', () => {
+  global.strapi = {
+    contentTypes: {},
+    plugins: {
+      'content-type-builder': {
+        services: {
+          builder: {
+            getReservedNames() {
+              return {
+                models: [],
+                attributes: ['thisIsReserved'],
+              };
+            },
+          },
+        },
+      },
+    },
+  };
+
+  describe.each(['validateComponentInput', 'validateUpdateComponentInput'])('%p', method => {
+    test('can validate a regular component', async () => {
+      const input = {
+        components: [],
+        component: {
+          category: 'default',
+          name: 'mycompo',
+          icon: 'american-sign-language-interpreting',
+          attributes: {
+            title: {
+              type: 'string',
+            },
+          },
+        },
+      };
+
+      expect.assertions(1);
+
+      await componentValidation[method](input).then(data => {
+        expect(data).toBe(input);
+      });
+    });
+
+    test('can use custom keys in attributes', async () => {
+      const input = {
+        components: [],
+        component: {
+          category: 'default',
+          name: 'mycompo',
+          icon: 'american-sign-language-interpreting',
+          attributes: {
+            title: {
+              type: 'string',
+              myCustomKey: true,
+            },
+          },
+        },
+      };
+
+      expect.assertions(1);
+
+      await componentValidation[method](input).then(data => {
+        expect(data).toBe(input);
+      });
+    });
+
+    test('cannot use custom keys at root', async () => {
+      const input = {
+        myCustomKey: true,
+        components: [],
+        component: {
+          category: 'default',
+          name: 'mycompo',
+          icon: 'american-sign-language-interpreting',
+          attributes: {
+            title: {
+              type: 'string',
+            },
+          },
+        },
+      };
+
+      expect.assertions(1);
+
+      await expect(componentValidation[method](input)).rejects.toBeDefined();
+    });
+  });
+});

--- a/packages/strapi-plugin-content-type-builder/controllers/validation/__tests__/content-type.test.js
+++ b/packages/strapi-plugin-content-type-builder/controllers/validation/__tests__/content-type.test.js
@@ -85,6 +85,32 @@ describe('Content type validator', () => {
     });
   });
 
+  describe('validateContentTypeInput', () => {
+    test('Can use custom keys', async () => {
+      const input = {
+        contentType: {
+          name: 'test',
+          attributes: {
+            views: {
+              type: 'integer',
+              myCustomKey: 10000,
+            },
+            title: {
+              type: 'string',
+              myCustomKey: true,
+            },
+          },
+        },
+      };
+
+      expect.assertions(1);
+
+      await validateContentTypeInput(input).then(data => {
+        expect(data.contentType.attributes).toBe(input.contentType.attributes);
+      });
+    });
+  });
+
   describe('validateUpdateContentTypeInput', () => {
     test('Deletes empty defaults', async () => {
       const data = {
@@ -149,6 +175,30 @@ describe('Content type validator', () => {
 
       await validateUpdateContentTypeInput(data).then(() => {
         expect(data.contentType.attributes.slug.targetField).toBeUndefined();
+      });
+    });
+
+    test('Can use custom keys', async () => {
+      const input = {
+        contentType: {
+          name: 'test',
+          attributes: {
+            views: {
+              type: 'integer',
+              myCustomKey: 10000,
+            },
+            title: {
+              type: 'string',
+              myCustomKey: true,
+            },
+          },
+        },
+      };
+
+      expect.assertions(1);
+
+      await validateUpdateContentTypeInput(input).then(data => {
+        expect(data.contentType.attributes).toBe(input.contentType.attributes);
       });
     });
   });

--- a/packages/strapi-plugin-content-type-builder/controllers/validation/__tests__/types.test.js
+++ b/packages/strapi-plugin-content-type-builder/controllers/validation/__tests__/types.test.js
@@ -3,6 +3,46 @@
 const getTypeValidator = require('../types');
 
 describe('Type validators', () => {
+  describe.each(['collectionType', 'singleType'])('mixed type', kind => {
+    test('pluginOptions can be used', () => {
+      const attributes = {
+        title: {
+          type: 'string',
+          pluginOptions: {
+            i18n: {
+              localized: false,
+            },
+          },
+        },
+      };
+
+      const validator = getTypeValidator(attributes.title, {
+        types: ['string'],
+        modelType: kind,
+        attributes,
+      });
+
+      expect(validator.isValidSync(attributes.title)).toBe(true);
+    });
+
+    test('can use custom keys', () => {
+      const attributes = {
+        title: {
+          type: 'string',
+          myCustomKey: true,
+        },
+      };
+
+      const validator = getTypeValidator(attributes.title, {
+        types: ['string'],
+        modelType: kind,
+        attributes,
+      });
+
+      expect(validator.isValidSync(attributes.title)).toBe(true);
+    });
+  });
+
   describe('UID type validator', () => {
     test('Target field can be null', () => {
       const attributes = {

--- a/packages/strapi-plugin-content-type-builder/controllers/validation/model-schema.js
+++ b/packages/strapi-plugin-content-type-builder/controllers/validation/model-schema.js
@@ -16,6 +16,7 @@ const createSchema = (types, relations, { modelType } = {}) => {
       .required('name.required'),
     description: yup.string(),
     draftAndPublish: yup.boolean(),
+    pluginOptions: yup.object(),
     connection: yup.string(),
     collectionName: yup
       .string()
@@ -45,16 +46,13 @@ const createAttributesValidator = ({ types, modelType, relations }) => {
           }
 
           if (_.has(attribute, 'type')) {
-            return getTypeValidator(attribute, { types, modelType, attributes })
-              .test(isValidKey(key))
-              .noUnknown();
+            return getTypeValidator(attribute, { types, modelType, attributes }).test(
+              isValidKey(key)
+            );
           }
 
           if (_.has(attribute, 'target')) {
-            return yup
-              .object(getRelationValidator(attribute, relations))
-              .test(isValidKey(key))
-              .noUnknown();
+            return yup.object(getRelationValidator(attribute, relations)).test(isValidKey(key));
           }
 
           return typeOrRelationValidator;

--- a/packages/strapi-plugin-content-type-builder/controllers/validation/relations.js
+++ b/packages/strapi-plugin-content-type-builder/controllers/validation/relations.js
@@ -51,5 +51,6 @@ module.exports = (obj, validNatures) => {
           .nullable(),
     targetColumnName: yup.string().nullable(),
     private: yup.boolean().nullable(),
+    pluginOptions: yup.object(),
   };
 };

--- a/packages/strapi-plugin-content-type-builder/controllers/validation/types.js
+++ b/packages/strapi-plugin-content-type-builder/controllers/validation/types.js
@@ -36,6 +36,7 @@ const getTypeValidator = (attribute, { types, modelType, attributes }) => {
       .required(),
     configurable: yup.boolean().nullable(),
     private: yup.boolean().nullable(),
+    pluginOptions: yup.object(),
     ...getTypeShape(attribute, { modelType, attributes }),
   });
 };

--- a/packages/strapi-plugin-content-type-builder/services/Components.js
+++ b/packages/strapi-plugin-content-type-builder/services/Components.js
@@ -24,6 +24,7 @@ const formatComponent = component => {
       description: _.get(info, 'description', ''),
       connection,
       collectionName,
+      pluginOptions: component.pluginOptions,
       attributes: formatAttributes(component),
     },
   };

--- a/packages/strapi-plugin-content-type-builder/services/ContentTypes.js
+++ b/packages/strapi-plugin-content-type-builder/services/ContentTypes.js
@@ -49,6 +49,7 @@ const formatContentType = contentType => {
       name: getformattedName(contentType),
       description: _.get(info, 'description', ''),
       draftAndPublish: contentTypesUtils.hasDraftAndPublish({ options }),
+      pluginOptions: contentType.pluginOptions,
       connection,
       kind: kind || 'collectionType',
       collectionName,

--- a/packages/strapi-plugin-content-type-builder/services/__tests__/__snapshots__/content-types.test.js.snap
+++ b/packages/strapi-plugin-content-type-builder/services/__tests__/__snapshots__/content-types.test.js.snap
@@ -16,6 +16,11 @@ Object {
     "draftAndPublish": false,
     "kind": "singleType",
     "name": "My name",
+    "pluginOptions": Object {
+      "content-manager": Object {
+        "visible": true,
+      },
+    },
     "restrictRelationsTo": null,
     "visible": true,
   },

--- a/packages/strapi-plugin-content-type-builder/services/__tests__/content-types.test.js
+++ b/packages/strapi-plugin-content-type-builder/services/__tests__/content-types.test.js
@@ -18,6 +18,11 @@ describe('Content types service', () => {
       options: {
         draftAndPublish: false,
       },
+      pluginOptions: {
+        'content-manager': {
+          visible: true,
+        },
+      },
       attributes: {
         title: {
           type: 'string',

--- a/packages/strapi-plugin-content-type-builder/services/schema-builder/component-builder.js
+++ b/packages/strapi-plugin-content-type-builder/services/schema-builder/component-builder.js
@@ -52,6 +52,7 @@ module.exports = function createComponentBuilder() {
         .set(['info', 'name'], infos.name)
         .set(['info', 'icon'], infos.icon)
         .set(['info', 'description'], infos.description)
+        .set('pluginOptions', infos.pluginOptions)
         .setAttributes(this.convertAttributes(infos.attributes));
 
       if (this.components.size === 0) {
@@ -101,6 +102,7 @@ module.exports = function createComponentBuilder() {
         .set(['info', 'name'], infos.name)
         .set(['info', 'icon'], infos.icon)
         .set(['info', 'description'], infos.description)
+        .set('pluginOptions', infos.pluginOptions)
         .setAttributes(this.convertAttributes(newAttributes));
 
       if (newUID !== uid) {

--- a/packages/strapi-plugin-content-type-builder/services/schema-builder/content-type-builder.js
+++ b/packages/strapi-plugin-content-type-builder/services/schema-builder/content-type-builder.js
@@ -86,6 +86,7 @@ module.exports = function createComponentBuilder() {
           timestamps: true,
           draftAndPublish: infos.draftAndPublish || false,
         })
+        .set('pluginOptions', infos.pluginOptions)
         .setAttributes(this.convertAttributes(infos.attributes));
 
       Object.keys(infos.attributes).forEach(key => {
@@ -188,6 +189,7 @@ module.exports = function createComponentBuilder() {
         .set(['info', 'name'], infos.name)
         .set(['info', 'description'], infos.description)
         .set(['options', 'draftAndPublish'], infos.draftAndPublish || false)
+        .set('pluginOptions', infos.pluginOptions)
         .setAttributes(this.convertAttributes(newAttributes));
 
       return contentType;

--- a/packages/strapi-plugin-content-type-builder/tests/components.test.e2e.js
+++ b/packages/strapi-plugin-content-type-builder/tests/components.test.e2e.js
@@ -52,9 +52,19 @@ describe('Content Type Builder - Components', () => {
             category: 'default',
             icon: 'default',
             name: 'Some Component',
+            pluginOptions: {
+              pluginName: {
+                option: true,
+              },
+            },
             attributes: {
               title: {
                 type: 'string',
+                pluginOptions: {
+                  pluginName: {
+                    option: true,
+                  },
+                },
               },
               pic: {
                 type: 'media',
@@ -152,9 +162,19 @@ describe('Content Type Builder - Components', () => {
             description: '',
             connection: 'default',
             collectionName: 'components_default_some_components',
+            pluginOptions: {
+              pluginName: {
+                option: true,
+              },
+            },
             attributes: {
               title: {
                 type: 'string',
+                pluginOptions: {
+                  pluginName: {
+                    option: true,
+                  },
+                },
               },
               pic: {
                 type: 'media',
@@ -212,6 +232,11 @@ describe('Content Type Builder - Components', () => {
             icon: 'default',
             name: 'New Component',
             attributes: {},
+            pluginOptions: {
+              pluginName: {
+                option: false,
+              },
+            },
           },
         },
       });
@@ -236,6 +261,11 @@ describe('Content Type Builder - Components', () => {
           uid: 'default.some-component',
           schema: {
             name: 'New Component',
+            pluginOptions: {
+              pluginName: {
+                option: false,
+              },
+            },
           },
         },
       });

--- a/packages/strapi-plugin-content-type-builder/tests/content-types.test.e2e.js
+++ b/packages/strapi-plugin-content-type-builder/tests/content-types.test.e2e.js
@@ -51,9 +51,19 @@ describe('Content Type Builder - Content types', () => {
         body: {
           contentType: {
             name: 'Test Collection Type',
+            pluginOptions: {
+              i18n: {
+                localized: true,
+              },
+            },
             attributes: {
               title: {
                 type: 'string',
+                pluginOptions: {
+                  i18n: {
+                    localized: true,
+                  },
+                },
               },
             },
           },
@@ -125,9 +135,19 @@ describe('Content Type Builder - Content types', () => {
           contentType: {
             kind: 'singleType',
             name: 'Test Single Type',
+            pluginOptions: {
+              i18n: {
+                localized: true,
+              },
+            },
             attributes: {
               title: {
                 type: 'string',
+                pluginOptions: {
+                  i18n: {
+                    localized: true,
+                  },
+                },
               },
             },
           },

--- a/test/__snapshots__/all.test.e2e.js.snap
+++ b/test/__snapshots__/all.test.e2e.js.snap
@@ -317,6 +317,11 @@ Object {
     "schema": Object {
       "attributes": Object {
         "title": Object {
+          "pluginOptions": Object {
+            "i18n": Object {
+              "localized": true,
+            },
+          },
           "type": "string",
         },
       },
@@ -326,6 +331,11 @@ Object {
       "draftAndPublish": false,
       "kind": "collectionType",
       "name": "Test Collection Type",
+      "pluginOptions": Object {
+        "i18n": Object {
+          "localized": true,
+        },
+      },
       "restrictRelationsTo": null,
       "visible": true,
     },
@@ -365,6 +375,11 @@ Object {
     "schema": Object {
       "attributes": Object {
         "title": Object {
+          "pluginOptions": Object {
+            "i18n": Object {
+              "localized": true,
+            },
+          },
           "type": "string",
         },
       },
@@ -374,6 +389,11 @@ Object {
       "draftAndPublish": false,
       "kind": "singleType",
       "name": "Test Single Type",
+      "pluginOptions": Object {
+        "i18n": Object {
+          "localized": true,
+        },
+      },
       "restrictRelationsTo": null,
       "visible": true,
     },


### PR DESCRIPTION
Ability to toggle i18n for an CT and for fields.
Ability to add custom keys in the attributes schema (such as "index" for mongo) : based on discussion #8022