### PR TITLE
Fix error with polymorphic relations when the attribute name is different to related

### DIFF
--- a/packages/strapi-connector-bookshelf/lib/mount-models.js
+++ b/packages/strapi-connector-bookshelf/lib/mount-models.js
@@ -417,10 +417,9 @@ module.exports = async ({ models, target }, ctx, { selfFinalize = false } = {}) 
             qb.where(qb => {
               for (const modelAndFields of morphModelsAndFields) {
                 qb.orWhere(qb => {
-                  qb.where({ related_type: modelAndFields.collectionName }).whereIn(
-                    'field',
-                    modelAndFields.relatedFields
-                  );
+                  qb.where({
+                    [`${morphAttrInfo.name}_type`]: modelAndFields.collectionName,
+                  }).whereIn('field', modelAndFields.relatedFields);
                 });
               }
             });


### PR DESCRIPTION

### What does it do?
Use the polymorphic attribute info to name the type field correctly.

Currently, It is  hardcoded to `related_type`


### Why is it needed?

Fix error with polymorphic relations when the attribute name is different to `related`


### Related issue(s)/PR(s)
Look at the last comment of the issue
https://github.com/strapi/strapi/issues/5348