### PR TITLE
[i18n] add a locale from the ISO list

### DIFF
--- a/packages/strapi-plugin-i18n/admin/src/components/ModalCreate/BaseForm.js
+++ b/packages/strapi-plugin-i18n/admin/src/components/ModalCreate/BaseForm.js
@@ -10,7 +10,7 @@ import { getTrad } from '../../utils';
 
 const BaseForm = ({ options, defaultOption }) => {
   const { formatMessage } = useIntl();
-  const { values, handleChange } = useFormikContext();
+  const { values, handleChange, setFieldValue } = useFormikContext();
 
   return (
     <Row>
@@ -18,7 +18,7 @@ const BaseForm = ({ options, defaultOption }) => {
         <span id="locale-code">
           <Label htmlFor="">
             {formatMessage({
-              id: getTrad('Settings.locales.modal.edit.locales.label'),
+              id: getTrad('Settings.locales.modal.locales.label'),
             })}
           </Label>
         </span>
@@ -27,9 +27,13 @@ const BaseForm = ({ options, defaultOption }) => {
           aria-labelledby="locale-code"
           options={options}
           defaultValue={defaultOption}
-          isDisabled
+          onChange={selection => {
+            setFieldValue('displayName', selection.value);
+            setFieldValue('code', selection.label);
+          }}
         />
       </Col>
+
       <Col>
         <Inputs
           label={formatMessage({
@@ -62,10 +66,10 @@ BaseForm.defaultProps = {
 
 BaseForm.propTypes = {
   options: PropTypes.arrayOf(
-    PropTypes.exact({ value: PropTypes.number.isRequired, label: PropTypes.string.isRequired })
+    PropTypes.exact({ value: PropTypes.string.isRequired, label: PropTypes.string.isRequired })
   ).isRequired,
   defaultOption: PropTypes.exact({
-    value: PropTypes.number.isRequired,
+    value: PropTypes.string.isRequired,
     label: PropTypes.string.isRequired,
   }),
 };

--- a/packages/strapi-plugin-i18n/admin/src/hooks/useAddLocale/index.js
+++ b/packages/strapi-plugin-i18n/admin/src/hooks/useAddLocale/index.js
@@ -1,0 +1,41 @@
+import { request } from 'strapi-helper-plugin';
+import { useMutation, useQueryClient } from 'react-query';
+import { getTrad } from '../../utils';
+
+const addLocale = async ({ code, name }) => {
+  try {
+    const data = await request(`/i18n/locales`, {
+      method: 'POST',
+      body: {
+        name,
+        code,
+      },
+    });
+
+    strapi.notification.toggle({
+      type: 'success',
+      message: { id: getTrad('Settings.locales.modal.create.success') },
+    });
+
+    return data;
+  } catch (e) {
+    strapi.notification.toggle({
+      type: 'warning',
+      message: { id: 'notification.error' },
+    });
+
+    return e;
+  }
+};
+
+const useAddLocale = () => {
+  const queryClient = useQueryClient();
+
+  const { isLoading, mutateAsync } = useMutation(addLocale, {
+    onSuccess: data => queryClient.setQueryData(['locales', { id: data.id }], data),
+  });
+
+  return { isAdding: isLoading, addLocale: mutateAsync };
+};
+
+export default useAddLocale;

--- a/packages/strapi-plugin-i18n/admin/src/schemas.js
+++ b/packages/strapi-plugin-i18n/admin/src/schemas.js
@@ -1,7 +1,7 @@
 import { object, string } from 'yup';
 
 const localeFormSchema = object().shape({
-  displayName: string().max(50, 'Settings.locales.modal.create.locales.displayName.error'),
+  displayName: string().max(50, 'Settings.locales.modal.locales.displayName.error'),
 });
 
 export default localeFormSchema;

--- a/packages/strapi-plugin-i18n/admin/src/translations/en.json
+++ b/packages/strapi-plugin-i18n/admin/src/translations/en.json
@@ -30,18 +30,15 @@
   "Settings.locales.modal.delete.success": "Locale successfully deleted",
   "Settings.locales.modal.edit.confirmation": "Finish",
   "Settings.locales.modal.edit.success": "Locale successfully edited",
-  "Settings.locales.modal.edit.locales.label": "Locales",
-  "Settings.locales.modal.edit.locales.displayName": "Locale display name",
-  "Settings.locales.modal.edit.locales.displayName.description":"Locale will be displayed under that name in the administration panel",
   "Settings.locales.modal.edit.tab.label":"Navigating between the I18N base settings and advanced settings",
   "Settings.locales.modal.base": "Base settings",
   "Settings.locales.modal.advanced": "Advanced settings",
-
+  "Settings.locales.modal.create.defaultLocales.loading": "Loading the available locales...",
   "Settings.locales.modal.create.confirmation": "Add locale",
   "Settings.locales.modal.create.success": "Locale successfully added",
-  "Settings.locales.modal.create.locales.label": "Locales",
-  "Settings.locales.modal.create.locales.displayName": "Locale display name",
+  "Settings.locales.modal.locales.label": "Locales",
+  "Settings.locales.modal.locales.displayName": "Locale display name",
   "Settings.locales.modal.locales.displayName.error": "The locale display name can only be less than 50 characters.",
-  "Settings.locales.modal.create.locales.displayName.description":"Locale will be displayed under that name in the administration panel",
+  "Settings.locales.modal.locales.displayName.description":"Locale will be displayed under that name in the administration panel",
   "Settings.locales.modal.create.tab.label":"Navigating between the I18N base settings and advanced settings"
 }


### PR DESCRIPTION


### What does it do?

Allows to add a locale from the iso list.

### How to test

- Log in the dashboard
- Go to settings (left side menu)
- Select "Internationalisation" in the sub-left menu
- Click the "Add a locale" button
- Play with the form
- Validate at some point
- After adding a locale, make sure the new locale is listed in the list
