### PR TITLE
[i18n] fixing add locale params

### DIFF
--- a/packages/strapi-plugin-i18n/admin/src/components/ModalCreate/index.js
+++ b/packages/strapi-plugin-i18n/admin/src/components/ModalCreate/index.js
@@ -40,7 +40,7 @@ const ModalCreate = ({ onClose, isOpened }) => {
       <Formik
         initialValues={{ code: defaultOption.label, displayName: defaultOption.value }}
         onSubmit={values =>
-          addLocale({ code: values.code, name: values.displayName }).then(onClose)}
+          addLocale({ code: values.code, name: values.displayName, isDefault: false }).then(onClose)}
         validationSchema={localeFormSchema}
       >
         {({ handleSubmit, errors }) => (

--- a/packages/strapi-plugin-i18n/admin/src/hooks/useAddLocale/index.js
+++ b/packages/strapi-plugin-i18n/admin/src/hooks/useAddLocale/index.js
@@ -2,13 +2,14 @@ import { request } from 'strapi-helper-plugin';
 import { useMutation, useQueryClient } from 'react-query';
 import { getTrad } from '../../utils';
 
-const addLocale = async ({ code, name }) => {
+const addLocale = async ({ code, name, isDefault }) => {
   try {
     const data = await request(`/i18n/locales`, {
       method: 'POST',
       body: {
         name,
         code,
+        isDefault,
       },
     });
 


### PR DESCRIPTION

### What does it do?

Add `isDefault` to the POST request when adding a locale to a project
