### PR TITLE
Add init option to strapi-plugin-sentry

### DIFF
--- a/packages/strapi-plugin-sentry/README.md
+++ b/packages/strapi-plugin-sentry/README.md
@@ -11,10 +11,11 @@ The official plugin to track Strapi errors with Sentry.
 
 ## Configuration
 
-| property       | type (default) | description                                                                                                    |
-| -------------- | -------------- | -------------------------------------------------------------------------------------------------------------- |
-| `dsn`          | string (null)  | Your Sentry data source name ([see Sentry docs](https://docs.sentry.io/product/sentry-basics/dsn-explainer/)). |
-| `sendMetadata` | boolean (true) | Whether the plugin should attach additional information (like OS, browser, etc.) to the events sent to Sentry. |
+| property       | type (default)   | description                                                                                                                                                                              |
+| -------------- | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `dsn`          | string (`null`)  | Your Sentry data source name ([see Sentry docs](https://docs.sentry.io/product/sentry-basics/dsn-explainer/)).                                                                           |
+| `sendMetadata` | boolean (`true`) | Whether the plugin should attach additional information (like OS, browser, etc.) to the events sent to Sentry.                                                                           |
+| `init`         | object (`{}`)    | A config object that is passed directly to Sentry during the `Sentry.init()`. See all available options [on Sentry's docs](https://docs.sentry.io/platforms/node/configuration/options/) |
 
 **Example**
 

--- a/packages/strapi-plugin-sentry/config/settings.json
+++ b/packages/strapi-plugin-sentry/config/settings.json
@@ -1,4 +1,5 @@
 {
   "dsn": null,
-  "sendMetadata": true
+  "sendMetadata": true,
+  "init": {}
 }

--- a/packages/strapi-plugin-sentry/services/sentry.js
+++ b/packages/strapi-plugin-sentry/services/sentry.js
@@ -30,6 +30,7 @@ const createSentryService = () => {
           Sentry.init({
             dsn: settings.dsn,
             environment: strapi.config.environment,
+            ...settings.init,
           });
           // Store the successfully initialized Sentry instance
           instance = Sentry;


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Adds a new `init` option to strapi-plugin-sentry. It allows users to customize their Sentry instance
