### PR TITLE
Support available locales without `en`

### DIFF
--- a/packages/strapi-admin/admin/src/i18n.js
+++ b/packages/strapi-admin/admin/src/i18n.js
@@ -12,6 +12,6 @@
 
 import translationMessages, { languageNativeNames } from './translations';
 
-const languages = Object.keys(translationMessages);
+const languages = Object.keys(languageNativeNames);
 
 export { languages, translationMessages, languageNativeNames };


### PR DESCRIPTION
When `en` locale is not one of the available languages, but we still need it as a fallback. We can keep `en` in `translationMessages` but remove it from `languageNativeNames`.
