### PR TITLE
WIP: Adds BackendUrlFetcher for fetching the backend URL from a local file

### DIFF
--- a/packages/strapi-admin/admin/src/BackendUrlFetcher.js
+++ b/packages/strapi-admin/admin/src/BackendUrlFetcher.js
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react';
+import 'whatwg-fetch';
+
+export default ({ children, configUrl }) => {
+  const [hasFetched, setHasFetched] = useState();
+
+  useEffect(() => {
+    if (hasFetched) return;
+    const originalBackendUrl = strapi.backendURL;
+    strapi.backendURL = null;
+
+    const fetchBackendUrl = async () => {
+      try {
+        const response = await fetch(configUrl);
+        const newBackendUrl = await response.text();
+
+        // just do a simple check to verify that what we got was indeed a valid URL
+        if (!newBackendUrl.startsWith('http')) throw new Error('Probably not a backend URL');
+
+        strapi.backendURL = newBackendUrl;
+      } catch (error) {
+        // no backend url found - using original url
+        strapi.backendURL = originalBackendUrl;
+      }
+      setHasFetched(true);
+    };
+
+    fetchBackendUrl();
+  });
+
+  if (!hasFetched) return null;
+
+  return children;
+};

--- a/packages/strapi-admin/admin/src/app.js
+++ b/packages/strapi-admin/admin/src/app.js
@@ -40,6 +40,7 @@ import getInjectors from './utils/reducerInjectors';
 import injectReducer from './utils/injectReducer';
 import injectSaga from './utils/injectSaga';
 import Strapi from './utils/Strapi';
+import BackendUrlFetcher from './BackendUrlFetcher';
 
 // Import root component
 import App from './containers/App';
@@ -200,7 +201,11 @@ const render = messages => {
         <Fonts />
         <LanguageProvider messages={messages}>
           <BrowserRouter basename={basename}>
-            <App store={store} />
+            <BackendUrlFetcher
+              configUrl={'/backend-url' /* where should the relative url come from? environment? */}
+            >
+              <App store={store} />
+            </BackendUrlFetcher>
           </BrowserRouter>
         </LanguageProvider>
       </StrapiProvider>


### PR DESCRIPTION
This makes Strapi Admin Panel configurable on deploy instead of using the backend url defined at build time.

This is not a finished feature - but rather a proof of concept.

TODO:
- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.


### What does it do?

Adds a guard for the Admin Panel that waits for a file to be fetched, which can contain a URL for the backend.

### Why is it needed?

Lets us define the backend URL on deployment, instead of on build. That means we can deploy the same build artefact in multiple setups.

### Related issue(s)/PR(s)
At least #8246 and #9395.

