### PR TITLE
Schedule cron from plugins

### DIFF
--- a/packages/strapi/lib/middlewares/cron/index.js
+++ b/packages/strapi/lib/middlewares/cron/index.js
@@ -19,43 +19,33 @@ module.exports = strapi => {
      */
 
     initialize() {
+      const scheduleTask = (taskExpression, taskValue) => {
+        if (_.isFunction(taskValue)) {
+          return cron.scheduleJob(taskExpression, taskValue);
+        }
+
+        const options = _.get(taskValue, 'options', {});
+
+        cron.scheduleJob(
+          {
+            rule: taskExpression,
+            ...options,
+          },
+          taskValue.task,
+        );
+      };
+
       if (strapi.config.get('server.cron.enabled', false) === true) {
-        _.forEach(_.keys(strapi.config.get('functions.cron', {})), taskExpression => {
-          const taskValue = strapi.config.functions.cron[taskExpression];
-
-          if (_.isFunction(taskValue)) {
-            return cron.scheduleJob(taskExpression, taskValue);
-          }
-
-          const options = _.get(taskValue, 'options', {});
-
-          cron.scheduleJob(
-            {
-              rule: taskExpression,
-              ...options,
-            },
-            taskValue.task
-          );
+        _.forEach(_.entries(strapi.config.get('functions.cron', {})), ([taskExpression, taskValue]) => {
+          scheduleTask(taskExpression, taskValue);
         });
 
         _.forEach(_.keys(strapi.plugins), pluginName => {
-          const pluginCron = strapi.plugins[pluginName].config.functions.cron;
+          const pluginCron = _.get(strapi.plugins[pluginName], ['config', 'functions', 'cron']);
 
           if (pluginCron) {
             _.forEach(_.entries(pluginCron), ([taskExpression, taskValue]) => {
-              if (_.isFunction(taskValue)) {
-                return cron.scheduleJob(taskExpression, taskValue);
-              }
-
-              const options = _.get(taskValue, 'options', {});
-
-              cron.scheduleJob(
-                {
-                  rule: taskExpression,
-                  ...options,
-                },
-                taskValue.task
-              );
+              scheduleTask(taskExpression, taskValue);
             });
           }
         });
@@ -63,3 +53,4 @@ module.exports = strapi => {
     },
   };
 };
+

--- a/packages/strapi/lib/middlewares/cron/index.js
+++ b/packages/strapi/lib/middlewares/cron/index.js
@@ -37,6 +37,28 @@ module.exports = strapi => {
             taskValue.task
           );
         });
+
+        _.forEach(_.keys(strapi.plugins), pluginName => {
+          const pluginCron = strapi.plugins[pluginName].config.functions.cron;
+
+          if (pluginCron) {
+            _.forEach(_.entries(pluginCron), ([taskExpression, taskValue]) => {
+              if (_.isFunction(taskValue)) {
+                return cron.scheduleJob(taskExpression, taskValue);
+              }
+
+              const options = _.get(taskValue, 'options', {});
+
+              cron.scheduleJob(
+                {
+                  rule: taskExpression,
+                  ...options,
+                },
+                taskValue.task
+              );
+            });
+          }
+        });
       }
     },
   };


### PR DESCRIPTION
### What does it do?

Check for cron jobs from plugins in the cron middleware. If they exists; schedule them.

### Why is it needed?

Say you have a twitter or instagram feed plugin, it would be handy to add a cron task directly in the plugin to fetch the feed every x hours e.g. Also I think it will open up room for more enhanced plugins to be written.

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/issues/9437