### PR TITLE
[i18n] fix typo on permissions

### DIFF
--- a/packages/strapi-plugin-i18n/admin/src/permissions.js
+++ b/packages/strapi-plugin-i18n/admin/src/permissions.js
@@ -6,7 +6,7 @@ const i18nPermissions = {
   create: [{ action: 'plugins::i18n.locale.create', subject: null }],
   delete: [{ action: 'plugins::i18n.locale.delete', subject: null }],
   update: [{ action: 'plugins::i18n.locale.update', subject: null }],
-  read: [{ action: 'plugins:i18n.locale.read', subject: null }],
+  read: [{ action: 'plugins::i18n.locale.read', subject: null }],
 };
 
 export default i18nPermissions;


### PR DESCRIPTION
### What does it do?

It fixes permissions on read for the locale settings