### PR TITLE
Fix repository url in strapi-admin/package.json

### DIFF
--- a/packages/strapi-admin/package.json
+++ b/packages/strapi-admin/package.json
@@ -4,7 +4,7 @@
   "description": "Strapi Admin",
   "repository": {
     "type": "git",
-    "url": "git://github.com/strapi/strapi-admin.git"
+    "url": "git://github.com/strapi/strapi.git"
   },
   "scripts": {
     "test": "echo \"no tests yet\"",


### PR DESCRIPTION
This minor change fixes the repository.url field in strapi-admin/package.json.