### PR TITLE
Update of webpack configuration: fix #9442 

### DIFF
--- a/packages/strapi-admin/webpack.config.js
+++ b/packages/strapi-admin/webpack.config.js
@@ -192,9 +192,10 @@ module.exports = ({
         ENABLED_EE_FEATURES: JSON.stringify(options.features),
       }),
       new webpack.NormalModuleReplacementPlugin(/ee_else_ce(\.*)/, function(resource) {
-        const splitPath = resource.context.split(`${path.sep}src${path.sep}`);
-
-        let wantedPath = path.join(splitPath[0], 'src');
+        let wantedPath = path.join(
+          resource.context.substr(0, resource.context.lastIndexOf(`${path.sep}src${path.sep}`)),
+          'src'
+        );
 
         if (useEE) {
           resource.request = resource.request.replace(


### PR DESCRIPTION
### What does it do?

It fixes setting up the build path within the strapi-admin package.

### Why is it needed?

The current implementation splits the path of the project at the first occurrence of the string `src` in order to rebuild it later considering special behavior when building an ee edition application. This causes an issue when the full path of the project already contains a `src` directory, e.g. `~/projects/src/MyStrapiApp`.

The PR modifies the code in such a way, that the last occurrence of `src` within the path is chosen as split location.

### How to test it?

Sorry, I am just learning NodeJS development. I've tested it locally by altering a regular installation and then it worked for me.

