### PR TITLE
Add RTL support to WysiwygEditor

### DIFF
--- a/packages/strapi-plugin-content-manager/admin/src/components/WysiwygEditor/index.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/WysiwygEditor/index.js
@@ -6,6 +6,7 @@
 
 import React from 'react';
 import { Editor } from 'draft-js';
+import 'draft-js/dist/Draft.css';
 import PropTypes from 'prop-types';
 
 class WysiwygEditor extends React.Component {


### PR DESCRIPTION
When adding Arabic into the RichText fields of Strapi, the text will automatically be aligned to the right after this change. 

I cannot identify any change to the interface after this change other than this automation. 

To test, copy and paste some Arabic into a Rich Text field and it will align right automatically. 

Resolves: https://github.com/strapi/strapi/issues/9412