### PR TITLE
Fix TypeError: action.value[0] is undefined

### DIFF
--- a/packages/strapi-plugin-content-manager/admin/src/components/SelectWrapper/index.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/SelectWrapper/index.js
@@ -183,7 +183,9 @@ function SelectWrapper({
   };
 
   const handleAddRelation = value => {
-    addRelation({ target: { name, value } });
+    if (!isEmpty(value)) {
+      addRelation({ target: { name, value } });
+    }
   };
 
   const handleMenuOpen = () => {

--- a/packages/strapi-plugin-content-manager/admin/src/containers/EditViewDataManagerProvider/reducer.js
+++ b/packages/strapi-plugin-content-manager/admin/src/containers/EditViewDataManagerProvider/reducer.js
@@ -63,7 +63,7 @@ const reducer = (state, action) => {
         });
     case 'ADD_RELATION':
       return state.updateIn(['modifiedData', ...action.keys], list => {
-        if (!action.value) {
+        if (!Array.isArray(action.value) || !action.value.length) {
           return list;
         }
 


### PR DESCRIPTION
This commit fixes an error that occurs when an ADD_RELATION action is
called with an empty value from a relationship field.

To be extra safe, the fix is applied both in the component and the
reducer.

- Add isEmpty check in SelectWrapper component when adding relations.
- Add array check in reducer function for ADD_RELATION.

Fix #9500

### What does it do?

- Add an extra check to the `action.value` item, thereby avoiding reading from an `undefined` object.

It might be the [`react-select` `onChange`](https://github.com/strapi/strapi/blob/cd809720ba002cb74e33b93b9b2abbc121aac6c9/packages/strapi-plugin-content-manager/admin/src/components/SelectMany/index.js#L85) event that sends empty values to the reducer when hitting the backspace key. Because the select box is an external dependency, changing the reducer was the easiest fix I could come up with.

### Why is it needed?

It fixes the issue described in #9500.

### How to test it?

Described in #9500

### Related issue(s)/PR(s)

#9500