### PR TITLE
Add delete function in store

### DIFF
--- a/packages/strapi/lib/services/__tests__/core-store.test.js
+++ b/packages/strapi/lib/services/__tests__/core-store.test.js
@@ -1,0 +1,136 @@
+'use strict';
+const { createCoreStore } = require('../core-store');
+
+const data = {
+  key: 'testKey',
+  value: 'testValue',
+};
+const queryRes = {
+  id: 1,
+  key: 'testKey',
+  value: 'testValue',
+  type: 'string',
+  environment: '',
+  tag: '',
+};
+
+const where = {
+  key: 'plugin_testName_testKey',
+  environment: 'test',
+  tag: '',
+};
+
+describe('Core Store', () => {
+  test.only('Set key in empty store', async () => {
+    const fakeEmptyDBQuery = {
+      findOne: jest.fn(() => Promise.resolve()),
+      update: jest.fn(() => Promise.resolve(queryRes)),
+      create: jest.fn(() => Promise.resolve(queryRes)),
+      delete: jest.fn(() => Promise.resolve()),
+    };
+    const fakeEmptyDB = {
+      query: jest.fn(() => fakeEmptyDBQuery),
+    };
+    const emptyTestStore = createCoreStore({
+      environment: 'test',
+      db: fakeEmptyDB,
+    });
+    const store = emptyTestStore({
+      environment: 'test',
+      type: 'plugin',
+      name: 'testName',
+    });
+    const rest = await store.set(data);
+    expect(fakeEmptyDB.query).toHaveBeenCalledTimes(2);
+    expect(fakeEmptyDBQuery.findOne).toHaveBeenCalledWith(where);
+    expect(fakeEmptyDBQuery.create).toHaveBeenCalledWith({
+      ...where,
+      value: JSON.stringify('testValue'),
+      type: 'string',
+    });
+    expect(rest).toEqual(undefined);
+  });
+
+  test.only('Set key in not empty store', async () => {
+    const fakeNotEmptyDBQuery = {
+      findOne: jest.fn(() => Promise.resolve(queryRes)),
+      update: jest.fn(() => Promise.resolve(queryRes)),
+      create: jest.fn(() => Promise.resolve(queryRes)),
+      delete: jest.fn(() => Promise.resolve()),
+    };
+    const fakeNotEmptyDB = {
+      query: jest.fn(() => fakeNotEmptyDBQuery),
+    };
+    const notEmptyTestStore = createCoreStore({
+      environment: 'test',
+      db: fakeNotEmptyDB,
+    });
+    const store = notEmptyTestStore({
+      environment: 'test',
+      type: 'plugin',
+      name: 'testName',
+    });
+    const rest = await store.set(data);
+    expect(fakeNotEmptyDB.query).toHaveBeenCalledTimes(2);
+    expect(fakeNotEmptyDBQuery.findOne).toHaveBeenCalledWith(where);
+    expect(fakeNotEmptyDBQuery.update).toHaveBeenCalledWith(
+      { id: queryRes.id },
+      {
+        ...queryRes,
+        value: JSON.stringify('testValue'),
+      }
+    );
+    expect(rest).toEqual(undefined);
+  });
+
+  test.only('Delete key from empty store', async () => {
+    const fakeEmptyDBQuery = {
+      findOne: jest.fn(() => Promise.resolve()),
+      update: jest.fn(() => Promise.resolve(queryRes)),
+      create: jest.fn(() => Promise.resolve(queryRes)),
+      delete: jest.fn(() => Promise.resolve()),
+    };
+    const fakeEmptyDB = {
+      query: jest.fn(() => fakeEmptyDBQuery),
+    };
+    const emptyTestStore = createCoreStore({
+      environment: 'test',
+      db: fakeEmptyDB,
+    });
+    const store = emptyTestStore({
+      environment: 'test',
+      type: 'plugin',
+      name: 'testName',
+    });
+    const rest = await store.delete(data);
+    expect(fakeEmptyDB.query).toHaveBeenCalledTimes(1);
+    expect(fakeEmptyDBQuery.findOne).toHaveBeenCalledWith(where);
+    expect(rest).toEqual(undefined);
+  });
+
+  test.only('Delete key from not empty store', async () => {
+    const fakeNotEmptyDBQuery = {
+      findOne: jest.fn(() => Promise.resolve(queryRes)),
+      update: jest.fn(() => Promise.resolve(queryRes)),
+      create: jest.fn(() => Promise.resolve(queryRes)),
+      delete: jest.fn(() => Promise.resolve()),
+    };
+    const fakeNotEmptyDB = {
+      query: jest.fn(() => fakeNotEmptyDBQuery),
+    };
+    const notEmptyTestStore = createCoreStore({
+      environment: 'test',
+      db: fakeNotEmptyDB,
+    });
+    const store = notEmptyTestStore({
+      environment: 'test',
+      type: 'plugin',
+      name: 'testName',
+    });
+    const rest = await store.delete(data);
+    expect(fakeNotEmptyDB.query).toHaveBeenCalledTimes(2);
+    expect(fakeNotEmptyDBQuery.findOne).toHaveBeenCalledWith(where);
+    expect(fakeNotEmptyDBQuery.delete).toHaveBeenCalledWith({ id: queryRes.id });
+    expect(rest).toEqual(undefined);
+  });
+});

--- a/packages/strapi/lib/services/__tests__/core-store.test.js
+++ b/packages/strapi/lib/services/__tests__/core-store.test.js
@@ -5,6 +5,7 @@ const data = {
   key: 'testKey',
   value: 'testValue',
 };
+
 const queryRes = {
   id: 1,
   key: 'testKey',

--- a/packages/strapi/lib/services/__tests__/core-store.test.js
+++ b/packages/strapi/lib/services/__tests__/core-store.test.js
@@ -22,7 +22,7 @@ const where = {
 };
 
 describe('Core Store', () => {
-  test.only('Set key in empty store', async () => {
+  test('Set key in empty store', async () => {
     const fakeEmptyDBQuery = {
       findOne: jest.fn(() => Promise.resolve()),
       update: jest.fn(() => Promise.resolve(queryRes)),
@@ -52,7 +52,7 @@ describe('Core Store', () => {
     expect(rest).toEqual(undefined);
   });
 
-  test.only('Set key in not empty store', async () => {
+  test('Set key in not empty store', async () => {
     const fakeNotEmptyDBQuery = {
       findOne: jest.fn(() => Promise.resolve(queryRes)),
       update: jest.fn(() => Promise.resolve(queryRes)),
@@ -84,7 +84,7 @@ describe('Core Store', () => {
     expect(rest).toEqual(undefined);
   });
 
-  test.only('Delete key from empty store', async () => {
+  test('Delete key from empty store', async () => {
     const fakeEmptyDBQuery = {
       findOne: jest.fn(() => Promise.resolve()),
       update: jest.fn(() => Promise.resolve(queryRes)),
@@ -109,7 +109,7 @@ describe('Core Store', () => {
     expect(rest).toEqual(undefined);
   });
 
-  test.only('Delete key from not empty store', async () => {
+  test('Delete key from not empty store', async () => {
     const fakeNotEmptyDBQuery = {
       findOne: jest.fn(() => Promise.resolve(queryRes)),
       update: jest.fn(() => Promise.resolve(queryRes)),

--- a/packages/strapi/lib/services/__tests__/core-store.test.js
+++ b/packages/strapi/lib/services/__tests__/core-store.test.js
@@ -105,7 +105,7 @@ describe('Core Store', () => {
     });
     const rest = await store.delete(data);
     expect(fakeEmptyDB.query).toHaveBeenCalledTimes(1);
-    expect(fakeEmptyDBQuery.findOne).toHaveBeenCalledWith(where);
+    expect(fakeEmptyDBQuery.delete).toHaveBeenCalledWith(where);
     expect(rest).toEqual(undefined);
   });
 
@@ -129,9 +129,8 @@ describe('Core Store', () => {
       name: 'testName',
     });
     const rest = await store.delete(data);
-    expect(fakeNotEmptyDB.query).toHaveBeenCalledTimes(2);
-    expect(fakeNotEmptyDBQuery.findOne).toHaveBeenCalledWith(where);
-    expect(fakeNotEmptyDBQuery.delete).toHaveBeenCalledWith({ id: queryRes.id });
+    expect(fakeNotEmptyDB.query).toHaveBeenCalledTimes(1);
+    expect(fakeNotEmptyDBQuery.delete).toHaveBeenCalledWith(where);
     expect(rest).toEqual(undefined);
   });
 });

--- a/packages/strapi/lib/services/core-store.js
+++ b/packages/strapi/lib/services/core-store.js
@@ -105,7 +105,7 @@ const createCoreStore = ({ environment: defaultEnv, db }) => {
       }
     }
 
-    async function del(params = {}) {
+    async function deleteFn(params = {}) {
       const { key, environment = defaultEnv, type, name, tag = '' } = Object.assign(
         {},
         source,
@@ -126,7 +126,7 @@ const createCoreStore = ({ environment: defaultEnv, db }) => {
     return {
       get,
       set,
-      del,
+      delete: deleteFn,
     };
   };
 };

--- a/packages/strapi/lib/services/core-store.js
+++ b/packages/strapi/lib/services/core-store.js
@@ -105,9 +105,28 @@ const createCoreStore = ({ environment: defaultEnv, db }) => {
       }
     }
 
+    async function del(params = {}) {
+      const { key, environment = defaultEnv, type, name, tag = '' } = Object.assign(
+        {},
+        source,
+        params
+      );
+      const prefix = `${type}${name ? `_${name}` : ''}`;
+      const where = {
+        key: `${prefix}_${key}`,
+        environment,
+        tag,
+      };
+      const data = await db.query('core_store').findOne(where);
+      if (data) {
+        await db.query('core_store').delete({ id: data.id });
+      }
+    }
+
     return {
       get,
       set,
+      del,
     };
   };
 };

--- a/packages/strapi/lib/services/core-store.js
+++ b/packages/strapi/lib/services/core-store.js
@@ -111,16 +111,16 @@ const createCoreStore = ({ environment: defaultEnv, db }) => {
         source,
         params
       );
+
       const prefix = `${type}${name ? `_${name}` : ''}`;
+
       const where = {
         key: `${prefix}_${key}`,
         environment,
         tag,
       };
-      const data = await db.query('core_store').findOne(where);
-      if (data) {
-        await db.query('core_store').delete({ id: data.id });
-      }
+
+      await db.query('core_store').delete(where);
     }
 
     return {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

This PR adds a `del` method to the CoreStore. I had to call it `del` as an error was raised when using `delete`

<img width="501" alt="Screenshot 2021-02-26 at 16 23 31" src="https://user-images.githubusercontent.com/33010418/109320506-5c86ff80-7850-11eb-89ed-51eeb23a93cc.png">


### Why is it needed?

For security and cleaning purposes, I would like to be able to delete a key from the store. 

### How to test it?

I could not find where to add store tests but I tested it locally in a plugin the following way:

```javascript
const pluginStore = () => strapi.store({
  environment: strapi.config.environment,
  type: 'plugin',
  name: 'myStore'
})
const key = { key: 'mykey', value: 'myvalue' }
await pluginStore().set(key)
const before = await pluginStore().get(key)
await pluginStore().del(key)
const after = await pluginStore().get(key)
console.log({ before, after })
```


### Related issue(s)/PR(s)

fixes: #9533
