### PR TITLE
Fixing refresh when adding a new locale

### DIFF
--- a/packages/strapi-plugin-i18n/admin/src/components/LocaleList/index.js
+++ b/packages/strapi-plugin-i18n/admin/src/components/LocaleList/index.js
@@ -10,8 +10,9 @@ import LocaleRow from '../LocaleRow';
 import { getTrad } from '../../utils';
 import ModalEdit from '../ModalEdit';
 import ModalDelete from '../ModalDelete';
+import ModalCreate from '../ModalCreate';
 
-const LocaleList = ({ canUpdateLocale, canDeleteLocale, onToggleCreateModal }) => {
+const LocaleList = ({ canUpdateLocale, canDeleteLocale, onToggleCreateModal, isCreating }) => {
   const [localeToDelete, setLocaleToDelete] = useState();
   const [localeToEdit, setLocaleToEdit] = useState();
   const { locales, isLoading, refetch } = useLocales();
@@ -51,6 +52,7 @@ const LocaleList = ({ canUpdateLocale, canDeleteLocale, onToggleCreateModal }) =
           )}
         />
 
+        <ModalCreate isOpened={isCreating} onClose={onToggleCreateModal} onSuccess={refetch} />
         <ModalDelete localeToDelete={localeToDelete} onClose={closeModalToDelete} />
         <ModalEdit localeToEdit={localeToEdit} onClose={closeModalToEdit} locales={locales} />
       </>
@@ -75,6 +77,8 @@ const LocaleList = ({ canUpdateLocale, canDeleteLocale, onToggleCreateModal }) =
           />
         </ListButton>
       )}
+
+      <ModalCreate isOpened={isCreating} onClose={onToggleCreateModal} onSuccess={refetch} />
     </>
   );
 };
@@ -87,6 +91,7 @@ LocaleList.propTypes = {
   canUpdateLocale: PropTypes.bool.isRequired,
   canDeleteLocale: PropTypes.bool.isRequired,
   onToggleCreateModal: PropTypes.func,
+  isCreating: PropTypes.bool.isRequired,
 };
 
 export default LocaleList;

--- a/packages/strapi-plugin-i18n/admin/src/components/ModalCreate/index.js
+++ b/packages/strapi-plugin-i18n/admin/src/components/ModalCreate/index.js
@@ -12,7 +12,7 @@ import useAddLocale from '../../hooks/useAddLocale';
 import BaseForm from './BaseForm';
 import AdvancedForm from './AdvancedForm';
 
-const ModalCreate = ({ onClose, isOpened }) => {
+const ModalCreate = ({ onClose, isOpened, onSuccess }) => {
   const { defaultLocales, isLoading } = useDefaultLocales();
   const { isAdding, addLocale } = useAddLocale();
   const { formatMessage } = useIntl();
@@ -37,7 +37,7 @@ const ModalCreate = ({ onClose, isOpened }) => {
   const defaultOption = options[0];
 
   return (
-    <Modal isOpen={isOpened} onToggle={onClose}>
+    <Modal isOpen={isOpened} onToggle={onClose} withoverflow="true">
       <Formik
         initialValues={{
           code: defaultOption.label,
@@ -49,7 +49,10 @@ const ModalCreate = ({ onClose, isOpened }) => {
             code: values.code,
             name: values.displayName,
             isDefault: values.isDefault,
-          }).then(onClose)}
+          }).then(() => {
+            onSuccess();
+            onClose();
+          })}
         validationSchema={localeFormSchema}
       >
         {({ handleSubmit, errors }) => (
@@ -97,6 +100,7 @@ const ModalCreate = ({ onClose, isOpened }) => {
 ModalCreate.propTypes = {
   onClose: PropTypes.func.isRequired,
   isOpened: PropTypes.bool.isRequired,
+  onSuccess: PropTypes.func.isRequired,
 };
 
 export default ModalCreate;

--- a/packages/strapi-plugin-i18n/admin/src/containers/SettingsPage/LocaleSettingsPage.js
+++ b/packages/strapi-plugin-i18n/admin/src/containers/SettingsPage/LocaleSettingsPage.js
@@ -6,7 +6,6 @@ import { Header } from '@buffetjs/custom';
 import { Button } from '@buffetjs/core';
 import { getTrad } from '../../utils';
 import LocaleList from '../../components/LocaleList';
-import ModalCreate from '../../components/ModalCreate';
 
 const LocaleSettingsPage = ({
   canReadLocale,
@@ -53,10 +52,9 @@ const LocaleSettingsPage = ({
           canUpdateLocale={canUpdateLocale}
           canDeleteLocale={canDeleteLocale}
           onToggleCreateModal={handleToggleModalCreate}
+          isCreating={isOpenedCreateModal}
         />
       ) : null}
-
-      <ModalCreate isOpened={isOpenedCreateModal} onClose={handleToggleModalCreate} />
     </>
   );
 };


### PR DESCRIPTION

### What does it do?

Make sure to refresh the list of locales when adding a new one


### How to test it?

- Login
- Go the the settings on the left sidebar
- Select "Internationlization" on the sub-sidebar
- Click the "Add a locale" button
- Fill the form
- Click save 
- **The list of locales should be refreshed with the new lang**
