### PR TITLE
Fixing dropdown background

### DIFF
--- a/packages/strapi-admin/admin/src/containers/Admin/Logout/components.js
+++ b/packages/strapi-admin/admin/src/containers/Admin/Logout/components.js
@@ -2,7 +2,6 @@ import styled from 'styled-components';
 
 const Wrapper = styled.div`
   position: relative;
-  min-width: 19rem;
   -webkit-font-smoothing: antialiased;
   > div {
     height: 6rem;
@@ -14,6 +13,7 @@ const Wrapper = styled.div`
       position: relative;
       z-index: 9;
       width: 100%;
+      padding-left: 20px;
       padding-right: 20px;
       background: white;
       border: none;


### PR DESCRIPTION


### What does it do?

Fixes the user dropdown size

<img width="1920" alt="Screenshot 2021-03-01 at 09 41 20 (2)" src="https://user-images.githubusercontent.com/3874873/109472566-920b3300-7a72-11eb-826e-d1d27d0b8ffe.png">
