### PR TITLE
Fix incorrect graphql config var

### DIFF
--- a/packages/strapi-plugin-graphql/services/schema-generator.js
+++ b/packages/strapi-plugin-graphql/services/schema-generator.js
@@ -24,7 +24,7 @@ const { buildQuery, buildMutation } = require('./resolvers-builder');
  */
 
 const generateSchema = () => {
-  const isFederated = _.get(strapi.plugins.graphql.config, 'isFederated', false);
+  const isFederated = _.get(strapi.plugins.graphql.config, 'federation', false);
   const shadowCRUDEnabled = strapi.plugins.graphql.config.shadowCRUD !== false;
 
   // Generate type definition and query/mutation for models.


### PR DESCRIPTION
As mentionned here https://github.com/strapi/strapi/pull/6146, we merged a PR that change the config name for the federation config for graphql. I'm reverting it the the original name here