### PR TITLE
Use the MongoDB setting useUnifiedTopology when testing connection

### DIFF
--- a/packages/strapi-connector-mongoose/lib/utils/connectivity.js
+++ b/packages/strapi-connector-mongoose/lib/utils/connectivity.js
@@ -23,6 +23,7 @@ module.exports = async ({ connection }) => {
   connectOptions.ssl = ssl ? true : false;
   connectOptions.useNewUrlParser = true;
   connectOptions.dbName = connection.settings.database;
+  connectOptions.useUnifiedTopology = true;
 
   return Mongoose.connect(
     `mongodb${srv ? '+srv' : ''}://${connection.settings.host}${


### PR DESCRIPTION
### What does it do?

Uses the `useUnifiedTopology` option when creating a new project with MongoDB

### Why is it needed?

Prevents the following warning when creating a new project (we already enable this setting normally, just not during the connection test)


> (node:44216) DeprecationWarning: current Server Discovery and Monitoring engine is deprecated, and will be removed in a future version. To use the new Server Discover and Monitoring engine, pass option { useUnifiedTopology: true } to the MongoClient constructor.
> (Use node --trace-deprecation ... to show where the warning was created)

### How to test it?

Create a new project selecting a custom MongoDB install, notice the lack of a warning message.

### Related issue(s)/PR(s)

fixes: #9198
