### PR TITLE
[i18n] add locale dropdown in listview filters

### DIFF
--- a/packages/strapi-helper-plugin/lib/src/components/InjectionZone/index.js
+++ b/packages/strapi-helper-plugin/lib/src/components/InjectionZone/index.js
@@ -4,8 +4,9 @@ import useStrapi from '../../hooks/useStrapi';
 
 const InjectionZone = ({ area, ...props }) => {
   const { strapi: globalStrapi } = useStrapi();
-  const [plugin, page, position] = area.split('.');
-  const plugin = globalStrapi.getPlugin(plugin);
+
+  const [pluginName, page, position] = area.split('.');
+  const plugin = globalStrapi.getPlugin(pluginName);
 
   if (!plugin) {
     return null;

--- a/packages/strapi-helper-plugin/lib/src/components/InjectionZone/index.js
+++ b/packages/strapi-helper-plugin/lib/src/components/InjectionZone/index.js
@@ -4,10 +4,14 @@ import useStrapi from '../../hooks/useStrapi';
 
 const InjectionZone = ({ area, ...props }) => {
   const { strapi: globalStrapi } = useStrapi();
-
   const [plugin, page, position] = area.split('.');
-  const cmPlugin = globalStrapi.getPlugin(plugin);
-  const compos = cmPlugin.getInjectedComponents(page, position);
+  const plugin = globalStrapi.getPlugin(plugin);
+
+  if (!plugin) {
+    return null;
+  }
+
+  const compos = plugin.getInjectedComponents(page, position);
 
   return compos.map(compo => <compo.Component key={compo.name} {...props} />);
 };

--- a/packages/strapi-helper-plugin/lib/src/components/InjectionZone/index.js
+++ b/packages/strapi-helper-plugin/lib/src/components/InjectionZone/index.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import useStrapi from '../../hooks/useStrapi';
+
+const InjectionZone = ({ area, ...props }) => {
+  const { strapi: globalStrapi } = useStrapi();
+
+  const [plugin, page, position] = area.split('.');
+  const cmPlugin = globalStrapi.getPlugin(plugin);
+  const compos = cmPlugin.getInjectedComponents(page, position);
+
+  return compos.map(compo => <compo.Component key={compo.name} {...props} />);
+};
+
+InjectionZone.propTypes = {
+  area: PropTypes.string.isRequired,
+};
+
+export default InjectionZone;

--- a/packages/strapi-helper-plugin/lib/src/index.js
+++ b/packages/strapi-helper-plugin/lib/src/index.js
@@ -27,6 +27,7 @@ export { default as InputAddon } from './components/InputAddon';
 export { default as EmptyState } from './components/EmptyState';
 export * from './components/Tabs';
 export * from './components/Select';
+export {default as InjectionZone} from './components/InjectionZone';
 
 export { default as InputAddonWithErrors } from './components/InputAddonWithErrors';
 export { default as InputCheckbox } from './components/InputCheckbox';

--- a/packages/strapi-plugin-content-manager/admin/src/containers/ListView/FieldPicker/index.js
+++ b/packages/strapi-plugin-content-manager/admin/src/containers/ListView/FieldPicker/index.js
@@ -16,7 +16,7 @@ const FieldPicker = ({ displayedHeaders, items, onChange, onClickReset, slug }) 
         renderButtonContent={isOpen => (
           <Flex>
             <div>
-              <FontAwesomeIcon icon="cog" style={{ marginRighte: 10 }} />
+              <FontAwesomeIcon icon="cog" style={{ marginRight: 10 }} />
             </div>
             <Padded left size="sm">
               <Carret fill={isOpen ? '#007eff' : '#292b2c'} isUp={isOpen} />

--- a/packages/strapi-plugin-content-manager/admin/src/containers/ListView/index.js
+++ b/packages/strapi-plugin-content-manager/admin/src/containers/ListView/index.js
@@ -6,6 +6,7 @@ import { get, isEmpty } from 'lodash';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { useHistory, useLocation } from 'react-router-dom';
 import { Header } from '@buffetjs/custom';
+import { Flex, Padded } from '@buffetjs/core';
 import isEqual from 'react-fast-compare';
 import { stringify } from 'qs';
 import {
@@ -14,6 +15,7 @@ import {
   CheckPermissions,
   useGlobalContext,
   useUserPermissions,
+  InjectionZone,
 } from 'strapi-helper-plugin';
 import pluginId from '../../pluginId';
 import pluginPermissions from '../../permissions';
@@ -54,7 +56,6 @@ import makeSelectListView from './selectors';
 import { getAllAllowedHeaders, getFirstSortableHeader } from './utils';
 
 /* eslint-disable react/no-array-index-key */
-
 function ListView({
   didDeleteData,
   entriesToDelete,
@@ -392,7 +393,7 @@ function ListView({
           {canRead && (
             <Wrapper>
               <div className="row" style={{ marginBottom: '5px' }}>
-                <div className="col-10">
+                <div className="col-9">
                   <div className="row" style={{ marginLeft: 0, marginRight: 0 }}>
                     {isFilterable && (
                       <>
@@ -419,16 +420,23 @@ function ListView({
                     )}
                   </div>
                 </div>
-                <div className="col-2">
-                  <CheckPermissions permissions={pluginPermissions.collectionTypesConfigurations}>
-                    <FieldPicker
-                      displayedHeaders={displayedHeaders}
-                      items={allAllowedHeaders}
-                      onChange={handleChangeListLabels}
-                      onClickReset={onResetListHeaders}
-                      slug={slug}
-                    />
-                  </CheckPermissions>
+
+                <div className="col-3">
+                  <Flex justifyContent="flex-end">
+                    <Padded right size="sm">
+                      <InjectionZone area={`${pluginId}.listView.actions`} />
+                    </Padded>
+
+                    <CheckPermissions permissions={pluginPermissions.collectionTypesConfigurations}>
+                      <FieldPicker
+                        displayedHeaders={displayedHeaders}
+                        items={allAllowedHeaders}
+                        onChange={handleChangeListLabels}
+                        onClickReset={onResetListHeaders}
+                        slug={slug}
+                      />
+                    </CheckPermissions>
+                  </Flex>
                 </div>
               </div>
               <div className="row" style={{ paddingTop: '12px' }}>

--- a/packages/strapi-plugin-content-manager/admin/src/index.js
+++ b/packages/strapi-plugin-content-manager/admin/src/index.js
@@ -32,6 +32,7 @@ export default strapi => {
         key: 'content-manager.link',
       },
     ],
+    injectionZones: { listView: { actions: [] } },
     isReady: true,
     isRequired: pluginPkg.strapi.required || false,
     layout: null,

--- a/packages/strapi-plugin-i18n/admin/src/components/LocalePicker/index.js
+++ b/packages/strapi-plugin-i18n/admin/src/components/LocalePicker/index.js
@@ -1,0 +1,74 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+import { Picker, Padded, Text, Flex } from '@buffetjs/core';
+import { Carret } from 'strapi-helper-plugin';
+import styled from 'styled-components';
+
+const List = styled.ul`
+  list-style-type: none;
+  padding: 0;
+  margin: 0;
+`;
+
+const ListItem = styled.li`
+  padding: ${props => props.theme.main.sizes.paddings.xs};
+  margin: 0;
+
+  &:hover {
+    background: ${props => props.theme.main.colors.lightGrey};
+  }
+`;
+
+const EllipsisParagraph = styled(Text)`
+  width: ${props => props.width};
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+  text-align: left;
+`;
+
+const LocalePicker = () => {
+  const locales = useSelector(state => state.get('i18n_locales').locales);
+  const [selected, setSelected] = React.useState(locales && locales[0]);
+
+  if (!locales || locales.length === 0) {
+    return null;
+  }
+
+  return (
+    <Picker
+      position="right"
+      renderButtonContent={isOpen => (
+        <Flex>
+          <EllipsisParagraph width="20ch">{selected.name}</EllipsisParagraph>
+
+          <Padded left size="sm">
+            <Carret fill={isOpen ? '#007eff' : '#292b2c'} isUp={isOpen} />
+          </Padded>
+        </Flex>
+      )}
+      renderSectionContent={onToggle => {
+        const handleClick = locale => {
+          setSelected(locale);
+          onToggle();
+        };
+
+        return (
+          <Padded top left right bottom>
+            <List>
+              {locales.map(locale => (
+                <ListItem key={locale.id}>
+                  <button onClick={() => handleClick(locale)} type="button">
+                    <EllipsisParagraph width="200px">{locale.name}</EllipsisParagraph>
+                  </button>
+                </ListItem>
+              ))}
+            </List>
+          </Padded>
+        );
+      }}
+    />
+  );
+};
+
+export default LocalePicker;

--- a/packages/strapi-plugin-i18n/admin/src/components/LocalePicker/index.js
+++ b/packages/strapi-plugin-i18n/admin/src/components/LocalePicker/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useSelector } from 'react-redux';
 import { Picker, Padded, Text, Flex } from '@buffetjs/core';
 import { Carret } from 'strapi-helper-plugin';
@@ -29,7 +29,7 @@ const EllipsisParagraph = styled(Text)`
 
 const LocalePicker = () => {
   const locales = useSelector(state => state.get('i18n_locales').locales);
-  const [selected, setSelected] = React.useState(locales && locales[0]);
+  const [selected, setSelected] = useState(locales && locales[0]);
 
   if (!locales || locales.length === 0) {
     return null;

--- a/packages/strapi-plugin-i18n/admin/src/index.js
+++ b/packages/strapi-plugin-i18n/admin/src/index.js
@@ -14,6 +14,7 @@ import mutateCTBContentTypeSchema from './utils/mutateCTBContentTypeSchema';
 import LOCALIZED_FIELDS from './utils/localizedFields';
 import Initializer from './containers/Initializer';
 import i18nReducers from './hooks/reducers';
+import LocalePicker from './components/LocalePicker'
 
 export default strapi => {
   const pluginDescription = pluginPkg.strapi.description || pluginPkg.description;
@@ -52,6 +53,14 @@ export default strapi => {
     reducers: i18nReducers,
     boot(app) {
       const ctbPlugin = app.getPlugin('content-type-builder');
+      const cmPlugin = app.getPlugin('content-manager');
+
+      if (cmPlugin) {
+        cmPlugin.injectComponent('listView', 'actions', {
+          name: 'i18n-locale-filter',
+          Component: LocalePicker,
+        });
+      }
 
       if (ctbPlugin) {
         const ctbFormsAPI = ctbPlugin.apis.forms;

--- a/packages/strapi-plugin-i18n/admin/src/utils/tests/mutateCTBContentTypeSchema.test.js
+++ b/packages/strapi-plugin-i18n/admin/src/utils/tests/mutateCTBContentTypeSchema.test.js
@@ -117,7 +117,7 @@ describe('i18n | utils ', () => {
         attributes: {
           cover: {
             type: 'media',
-            pluginOptions: { pluginA: { ok: true } },
+            pluginOptions: { pluginA: { ok: true }, i18n: { localized: true } },
           },
           name: {
             type: 'text',


### PR DESCRIPTION

### What does it do?

Adds a locale dropdown next to the "settings" option in ListView


### How to test it?

Make sure to have locales set in I18N settings. (at least one)

- Login the application
- On the left sidebar, select a content type
- You're not on the List view of that content type. You should see a dropdown listing the available locales

<img width="1920" alt="Screenshot 2021-03-04 at 10 27 57 (2)" src="https://user-images.githubusercontent.com/3874873/109942265-4fe12c00-7cd4-11eb-93d0-6390543430d1.png">
