### PR TITLE
Fix undefined filter value Error (#8490)

### DIFF
--- a/packages/strapi-utils/lib/build-query.js
+++ b/packages/strapi-utils/lib/build-query.js
@@ -111,16 +111,16 @@ const hasDeepFilters = ({ where = [], sort = [] }, { minDepth = 1 } = {}) => {
 
 const normalizeWhereClauses = (whereClauses, { model }) => {
   return whereClauses
-    .filter(({ value }) => !_.isNull(value))
-    .map(({ field, operator, value }) => {
-      if (_.isUndefined(value)) {
-        const err = new Error(
-          `The value of field: '${field}', in your where filter, is undefined.`
-        );
-        err.status = 400;
-        throw err;
+    .filter(({ field, value }) => {
+      if (_.isNull(value)) {
+        return false;
+      } else if (_.isUndefined(value)) {
+        strapi.log.warn(`The value of field: '${field}', in your where filter, is undefined.`);
+        return false;
       }
-
+      return true;
+    })
+    .map(({ field, operator, value }) => {
       if (BOOLEAN_OPERATORS.includes(operator)) {
         return {
           field,


### PR DESCRIPTION
### What does it do?

Replaces the Error (when having `undefined` as value in a where filter) with an warning `strapi.log.warn`.

### Why is it needed?

Fixes/gives a solution for the discussion in #8490.

### How to test it?
1.
```js
return strapi.query('category').findOne({ id: undefined });
```
Returns 200, but gives an warning in the logs: _The value of field: 'id', in your where filter, is undefined._

2.
```js
return strapi.query('category').findOne({ unknownField: 1 });
```
Returns 400: _Your filters contain a field 'unknownField' that doesn't appear on your model definition nor it's relations_

3.
```js
return strapi.query('category').findOne({ undefinedUnknownField: undefined });
```
~Returns 400: The field 'undefinedUnknownField' in your where filter has undefined as value.
And~ gives warning in the logs: _The value of field: 'undefinedUnknownField', in your where filter, is undefined._

### Related issue(s)/PR(s)

#8201
#8490