### PR TITLE
Fix display of falsey values in component banner

### DIFF
--- a/packages/strapi-plugin-content-manager/admin/src/components/RepeatableComponent/Banner.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/RepeatableComponent/Banner.js
@@ -50,7 +50,8 @@ const Banner = forwardRef(
 
           <FormattedMessage id={`${pluginId}.containers.Edit.pluginHeader.title.new`}>
             {msg => {
-              return <div style={{ display }}>{displayedValue || msg}</div>;
+              // The displayed value may be "falsey" when the main field is a number or boolean
+              return <div style={{ display }}>{displayedValue ?? msg}</div>;
             }}
           </FormattedMessage>
           <div className="cta-wrapper" style={{ display }}>


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Display the "new component" message if the displayed value is strictly `null` or `undefined`, and display valid "falsey" values otherwise.

### Why is it needed?

The repeatable component banner displays the main field from the component, or a "new component" message if the component is not yet created. It shows the "new component" message when the value of the component's main field is "falsey". However, if the main field of the component is a number, boolean, or string, then perfectly valid values such as `0` and `false` are overridden by the "new component" message.

### How to test it?

Create a component and configure the "main" field to be a number field. Create a component instance with the value of that field as `0`. It should display "0" instead of the "new component" message in the banner.

