### PR TITLE
[Fix]: 🐛 Strapi parser middleware, catch block error logging

### DIFF
--- a/packages/strapi/lib/middlewares/parser/index.js
+++ b/packages/strapi/lib/middlewares/parser/index.js
@@ -51,7 +51,7 @@ module.exports = strapi => {
           })(ctx, next);
           return res;
         } catch (e) {
-          if (e.message.includes('maxFileSize exceeded')) {
+          if ((e || {}).message && e.message.includes('maxFileSize exceeded')) {
             throw strapi.errors.entityTooLarge('FileTooBig', {
               errors: [
                 {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Throwing error inside of a controller (using plain javascript) results in a different error in parser middleware.
Before calling (`String.prototype.includes`) method on the `message` property on the error object, a check should be performed to see if the `message` property is defined on the error instance so no runtime `TypeError` is thrown.

### Why is it needed?

Throw statements from within the code resulted in a `TypeError` with stack trace leading to `Strapi` parser middleware.
Instead, error logging should have appropriate stack trace from within the file where the error is thrown from.

### How to test it?

> Just in custom controller code, instead of usual ctx.throw(400, "something") write throw "something"

Reference: https://github.com/strapi/strapi/issues/9356#issuecomment-783571349

### Related issue(s)/PR(s)

Related issue: #9356

### Additional notes?

No new test cases are provided. Even though this is a trivial change (and is just a safeguard from the runtime `TypeError`), I would be willing to provide new test cases but I would need some assistance of where those should be placed and how can this be thoroughly tested.
attn. @alexandrebodin @Convly 
