### PR TITLE
Fix carret for modal edit/create locale dropdown

### DIFF
--- a/packages/strapi-helper-plugin/lib/src/components/Select/index.js
+++ b/packages/strapi-helper-plugin/lib/src/components/Select/index.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import ReactSelect, { components } from 'react-select';
 import PropTypes from 'prop-types';
-import { Carret } from '@buffetjs/icons';
+import Carret from '../Carret';
 import { useTheme } from 'styled-components';
 import getStyles from './styles';
 
-const DropdownIndicator = props => {
+export const DropdownIndicator = props => {
   const theme = useTheme();
 
   return (

--- a/packages/strapi-plugin-i18n/admin/src/components/ModalCreate/BaseForm.js
+++ b/packages/strapi-plugin-i18n/admin/src/components/ModalCreate/BaseForm.js
@@ -6,7 +6,7 @@ import Select from 'react-select';
 import { Col, Row } from 'reactstrap';
 import { useIntl } from 'react-intl';
 import { useTheme } from 'styled-components';
-import { BaselineAlignment, selectStyles } from 'strapi-helper-plugin';
+import { BaselineAlignment, selectStyles, DropdownIndicator } from 'strapi-helper-plugin';
 import { useFormikContext } from 'formik';
 import { getTrad } from '../../utils';
 
@@ -38,6 +38,7 @@ const BaseForm = ({ options, defaultOption }) => {
             setFieldValue('displayName', selection.value);
             setFieldValue('code', selection.label);
           }}
+          components={{ DropdownIndicator }}
           styles={{
             ...styles,
             control: (base, state) => ({ ...base, ...styles.control(base, state), height: '34px' }),

--- a/packages/strapi-plugin-i18n/admin/src/components/ModalEdit/BaseForm.js
+++ b/packages/strapi-plugin-i18n/admin/src/components/ModalEdit/BaseForm.js
@@ -6,7 +6,7 @@ import Select from 'react-select';
 import { Col, Row } from 'reactstrap';
 import { useIntl } from 'react-intl';
 import { useTheme } from 'styled-components';
-import { BaselineAlignment, selectStyles } from 'strapi-helper-plugin';
+import { BaselineAlignment, selectStyles, DropdownIndicator } from 'strapi-helper-plugin';
 import { useFormikContext } from 'formik';
 import { getTrad } from '../../utils';
 
@@ -34,6 +34,7 @@ const BaseForm = ({ options, defaultOption }) => {
           options={options}
           defaultValue={defaultOption}
           isDisabled
+          components={{ DropdownIndicator }}
           styles={{
             ...styles,
             control: (base, state) => ({ ...base, ...styles.control(base, state), height: '34px' }),


### PR DESCRIPTION


### What does it do?

Fixes the carret in the ModalCreate / ModalEdit

![Screenshot 2021-03-05 at 11 25 50](https://user-images.githubusercontent.com/3874873/110102852-8e92e700-7da5-11eb-817a-379e5c6aa2e9.png)
