### PR TITLE
Use non writables instead of static creator fields in fields logic

### DIFF
--- a/packages/strapi-plugin-content-manager/services/data-mapper.js
+++ b/packages/strapi-plugin-content-manager/services/data-mapper.js
@@ -54,13 +54,11 @@ const formatContentTypeLabel = contentType => {
 };
 
 const formatAttributes = model => {
-  const { CREATED_BY_ATTRIBUTE, UPDATED_BY_ATTRIBUTE } = contentTypesUtils.constants;
+  const { getWritableAttributes } = contentTypesUtils;
 
-  return Object.keys(model.attributes).reduce((acc, key) => {
-    if ([CREATED_BY_ATTRIBUTE, UPDATED_BY_ATTRIBUTE].includes(key)) {
-      return acc;
-    }
+  const pickWritableAttributes = pick(getWritableAttributes(model));
 
+  return Object.keys(pickWritableAttributes(model.attributes)).reduce((acc, key) => {
     acc[key] = formatAttribute(key, model.attributes[key], { model });
     return acc;
   }, {});

--- a/packages/strapi-utils/lib/sanitize-entity.js
+++ b/packages/strapi-utils/lib/sanitize-entity.js
@@ -1,14 +1,9 @@
 'use strict';
 
 const _ = require('lodash');
-const { constants, isPrivateAttribute } = require('./content-types');
+const { constants, isPrivateAttribute, getNonWritableAttributes } = require('./content-types');
 
-const {
-  ID_ATTRIBUTE,
-  PUBLISHED_AT_ATTRIBUTE,
-  CREATED_BY_ATTRIBUTE,
-  UPDATED_BY_ATTRIBUTE,
-} = constants;
+const { ID_ATTRIBUTE, PUBLISHED_AT_ATTRIBUTE } = constants;
 
 const sanitizeEntity = (dataSource, options) => {
   const { model, withPrivate = false, isOutput = true, includeFields = null } = options;
@@ -124,6 +119,7 @@ const STATIC_FIELDS = [ID_ATTRIBUTE, '__v'];
 
 const getAllowedFields = ({ includeFields, model, isOutput }) => {
   const { options, primaryKey } = model;
+  const nonWritableAttributes = getNonWritableAttributes(model);
 
   const timestamps = options.timestamps || [];
 
@@ -135,9 +131,8 @@ const getAllowedFields = ({ includeFields, model, isOutput }) => {
           timestamps,
           STATIC_FIELDS,
           COMPONENT_FIELDS,
-          CREATED_BY_ATTRIBUTE,
-          UPDATED_BY_ATTRIBUTE,
           PUBLISHED_AT_ATTRIBUTE,
+          ...nonWritableAttributes,
         ]
       : [primaryKey, STATIC_FIELDS, COMPONENT_FIELDS])
   );


### PR DESCRIPTION
Making sure sanitize entity & CM content types list uses non writables instead of old static fields