### PR TITLE
Fix WYSIWYG state

### DIFF
--- a/packages/strapi-plugin-content-manager/admin/src/components/Wysiwyg/index.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/Wysiwyg/index.js
@@ -207,9 +207,9 @@ class Wysiwyg extends React.Component {
         () => {
           this.focus();
           // Update the parent reducer
-          this.sendData(newEditorState);
         }
       );
+      this.sendData(newEditorState);
       return;
     }
 
@@ -220,10 +220,9 @@ class Wysiwyg extends React.Component {
       },
       () => {
         this.focus();
-        // Update the parent reducer
-        this.sendData(newEditorState);
       }
     );
+    this.sendData(newEditorState);
     return;
   };
 


### PR DESCRIPTION
Signed-off-by: HichamELBSI <elabbassih@gmail.com>

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Move the call to the sendData function outside the setState callback. The function sendData compare `prevState` and `currentState`. If we call the sendData in the setState callback, we compare `currentState` vs `currentState`.

### Why is it needed?

Describe the issue you are solving.

### How to test it?

1. Create a content-type with a Rich Text field.
2. Create a new entry of that content-type.
3. Edit the entry you just created.
4. Select some text in the Rich Text field and click one of the formatting buttons (e.g. Bold).
5. You should be able to save the entry.

### Related issue(s)/PR(s)

fix https://github.com/strapi/strapi/issues/9589
