### PR TITLE
Update index.js

### DIFF
--- a/packages/strapi-provider-upload-aws-s3/lib/index.js
+++ b/packages/strapi-provider-upload-aws-s3/lib/index.js
@@ -26,6 +26,7 @@ module.exports = {
               Key: `${path}${file.hash}${file.ext}`,
               Body: Buffer.from(file.buffer, 'binary'),
               ACL: 'public-read',
+              Bucket: config.params.Bucket,
               ContentType: file.mime,
               ...customParams,
             },


### PR DESCRIPTION
Amazon S3 API requests to have a Bucket key in the parameters.

Ex : 

https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/s3-example-creating-buckets.html
Uploading a File to an Amazon S3 Bucket

// call S3 to retrieve upload file to specified bucket
var uploadParams = {Bucket: process.argv[2], Key: '', Body: ''};

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Add the Bucket Key in parameters

### Why is it needed?

Fix the issue the error Missing required key 'Bucket' in params during Upload

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
