### PR TITLE
Fix Korean translations for relation.manyToOne

### DIFF
--- a/packages/strapi-plugin-content-type-builder/admin/src/translations/ko.json
+++ b/packages/strapi-plugin-content-type-builder/admin/src/translations/ko.json
@@ -47,7 +47,7 @@
   "popUpWarning.bodyMessage.contentType.delete": "이 콘텐츠 타입을 삭제 하시겠습니까?",
   "relation.attributeName.placeholder": "Ex: author, category, tag",
   "relation.manyToMany": "N : N",
-  "relation.manyToOne": "N : 1",
+  "relation.manyToOne": "has many",
   "relation.manyWay": "has many",
   "relation.oneToMany": "1 : N",
   "relation.oneToOne": "1 : 1",


### PR DESCRIPTION
### What does it do?

It fixes Korean translations for `relation.manyToOne`

Previously shown as `Article N : 1 Comments` while it should show `Article 1 : N Comments`
Since en.json uses `has many` for this description, do the same for Korean translation

### Why is it needed?

Previous translation shows wrong description that might confuse the user.

This is the current description shown on Korean language setting:

<img width="1481" alt="스크린샷 2021-03-12 오전 8 20 21" src="https://user-images.githubusercontent.com/17202261/110869080-17ad9f00-830d-11eb-84d2-c3e3393aaf47.png">

This is the same description shown on English language setting:
<img width="1481" alt="스크린샷 2021-03-12 오전 8 20 02" src="https://user-images.githubusercontent.com/17202261/110869164-3c097b80-830d-11eb-9bf6-b49712367734.png">


### How to test it?

Tested on v3.5.3

### Related issue(s)/PR(s)

N/A
