### PR TITLE
Split logic cleanly between visible & writable attributes

### DIFF
--- a/packages/strapi-connector-bookshelf/lib/mount-models.js
+++ b/packages/strapi-connector-bookshelf/lib/mount-models.js
@@ -69,6 +69,8 @@ module.exports = async ({ models, target }, ctx, { selfFinalize = false } = {}) 
         definition.attributes[PUBLISHED_AT_ATTRIBUTE] = {
           type: 'datetime',
           configurable: false,
+          writable: true,
+          visible: false,
         };
       }
 
@@ -79,6 +81,7 @@ module.exports = async ({ models, target }, ctx, { selfFinalize = false } = {}) 
         plugin: 'admin',
         configurable: false,
         writable: false,
+        visible: false,
         private: isPrivate,
       };
 
@@ -87,6 +90,7 @@ module.exports = async ({ models, target }, ctx, { selfFinalize = false } = {}) 
         plugin: 'admin',
         configurable: false,
         writable: false,
+        visible: false,
         private: isPrivate,
       };
     }

--- a/packages/strapi-connector-mongoose/lib/mount-models.js
+++ b/packages/strapi-connector-mongoose/lib/mount-models.js
@@ -44,6 +44,8 @@ module.exports = async ({ models, target }, ctx) => {
         definition.attributes[PUBLISHED_AT_ATTRIBUTE] = {
           type: 'datetime',
           configurable: false,
+          writable: true,
+          visible: false,
         };
       }
 
@@ -54,6 +56,7 @@ module.exports = async ({ models, target }, ctx) => {
         plugin: 'admin',
         configurable: false,
         writable: false,
+        visible: false,
         private: isPrivate,
       };
 
@@ -62,6 +65,7 @@ module.exports = async ({ models, target }, ctx) => {
         plugin: 'admin',
         configurable: false,
         writable: false,
+        visible: false,
         private: isPrivate,
       };
     }

--- a/packages/strapi-database/lib/queries/relations-counts-queries.js
+++ b/packages/strapi-database/lib/queries/relations-counts-queries.js
@@ -2,7 +2,7 @@
 
 const { prop, assoc } = require('lodash/fp');
 const { MANY_RELATIONS } = require('strapi-utils').relations.constants;
-const { isWritableAttribute } = require('strapi-utils').contentTypes;
+const { isVisibleAttribute } = require('strapi-utils').contentTypes;
 
 const createRelationsCountsQuery = ({ model, fn, connectorQuery }) => {
   // fetch counter map
@@ -18,7 +18,7 @@ const createRelationsCountsQuery = ({ model, fn, connectorQuery }) => {
     model.associations
       .filter(assoc => !populate || populate.includes(assoc.alias))
       .forEach(assoc => {
-        if (MANY_RELATIONS.includes(assoc.nature) && isWritableAttribute(model, assoc.alias)) {
+        if (MANY_RELATIONS.includes(assoc.nature) && isVisibleAttribute(model, assoc.alias)) {
           return toCount.push(assoc);
         }
 

--- a/packages/strapi-plugin-content-manager/services/data-mapper.js
+++ b/packages/strapi-plugin-content-manager/services/data-mapper.js
@@ -54,11 +54,10 @@ const formatContentTypeLabel = contentType => {
 };
 
 const formatAttributes = model => {
-  const { getWritableAttributes } = contentTypesUtils;
+  const { getVisibleAttributes } = contentTypesUtils;
 
-  const pickWritableAttributes = pick(getWritableAttributes(model));
-
-  return Object.keys(pickWritableAttributes(model.attributes)).reduce((acc, key) => {
+  // only get attributes that can be seen in the auto generated Edit view or List view
+  return getVisibleAttributes(model).reduce((acc, key) => {
     acc[key] = formatAttribute(key, model.attributes[key], { model });
     return acc;
   }, {});

--- a/packages/strapi-plugin-content-type-builder/utils/attributes.js
+++ b/packages/strapi-plugin-content-type-builder/utils/attributes.js
@@ -41,6 +41,7 @@ const isRelation = attribute =>
 const formatAttributes = model => {
   const { getVisibleAttributes } = utils.contentTypes;
 
+  // only get attributes that can be seen in the CTB
   return getVisibleAttributes(model).reduce((acc, key) => {
     acc[key] = formatAttribute(key, model.attributes[key], { model });
     return acc;

--- a/packages/strapi-plugin-i18n/config/functions/register.js
+++ b/packages/strapi-plugin-i18n/config/functions/register.js
@@ -7,22 +7,21 @@ module.exports = () => {
   Object.values(strapi.contentTypes).forEach(model => {
     if (getService('content-types').isLocalized(model)) {
       _.set(model.attributes, 'localizations', {
-        writable: false,
+        writable: true,
         private: false,
         configurable: false,
+        visible: false,
         collection: model.modelName,
         populate: ['id', 'locale', 'published_at'],
       });
 
       _.set(model.attributes, 'locale', {
-        writable: false,
+        writable: true,
         private: false,
         configurable: false,
+        visible: false,
         type: 'string',
       });
-
-      const writableFields = _.get(model, 'coreApi.writableAttributes', []);
-      _.set(model, 'coreApi.writableAttributes', writableFields.concat('locale'));
     }
   });
 

--- a/packages/strapi-utils/lib/__tests__/content-types.test.js
+++ b/packages/strapi-utils/lib/__tests__/content-types.test.js
@@ -56,14 +56,14 @@ describe('Content types utils', () => {
           title: {
             type: 'string',
           },
-          [constants.CREATED_BY_ATTRIBUTE]: {
+          non_writable_field: {
             type: 'string',
             writable: false,
           },
         },
       });
 
-      expect(getNonWritableAttributes(model)).toEqual(['id', constants.CREATED_BY_ATTRIBUTE]);
+      expect(getNonWritableAttributes(model)).toEqual(['id', 'non_writable_field']);
     });
 
     test('Includes primaryKey', () => {
@@ -104,7 +104,7 @@ describe('Content types utils', () => {
           title: {
             type: 'string',
           },
-          [constants.PUBLISHED_AT_ATTRIBUTE]: {
+          invisible_field: {
             type: 'datetime',
             visible: false,
           },

--- a/packages/strapi-utils/lib/__tests__/content-types.test.js
+++ b/packages/strapi-utils/lib/__tests__/content-types.test.js
@@ -50,20 +50,20 @@ describe('Content types utils', () => {
   });
 
   describe('getNonWritableAttributes', () => {
-    test('Includes default fields', () => {
+    test('Includes non writable fields', () => {
       const model = createModel({
         attributes: {
           title: {
             type: 'string',
           },
+          [constants.CREATED_BY_ATTRIBUTE]: {
+            type: 'string',
+            writable: false,
+          },
         },
       });
 
-      expect(getNonWritableAttributes(model)).toEqual([
-        'id',
-        constants.CREATED_BY_ATTRIBUTE,
-        constants.UPDATED_BY_ATTRIBUTE,
-      ]);
+      expect(getNonWritableAttributes(model)).toEqual(['id', constants.CREATED_BY_ATTRIBUTE]);
     });
 
     test('Includes primaryKey', () => {
@@ -98,7 +98,7 @@ describe('Content types utils', () => {
   });
 
   describe('getVisibleAttributes', () => {
-    test('Excludes published_at', () => {
+    test('Excludes non visible fields', () => {
       const model = createModel({
         attributes: {
           title: {
@@ -106,26 +106,7 @@ describe('Content types utils', () => {
           },
           [constants.PUBLISHED_AT_ATTRIBUTE]: {
             type: 'datetime',
-          },
-        },
-      });
-
-      expect(getVisibleAttributes(model)).toEqual(['title']);
-    });
-
-    test('Excludes creator attributes', () => {
-      const model = createModel({
-        attributes: {
-          title: {
-            type: 'string',
-          },
-          [constants.CREATED_BY_ATTRIBUTE]: {
-            model: 'user',
-            plugin: 'admin',
-          },
-          [constants.UPDATED_BY_ATTRIBUTE]: {
-            model: 'user',
-            plugin: 'admin',
+            visible: false,
           },
         },
       });

--- a/packages/strapi-utils/lib/content-types.js
+++ b/packages/strapi-utils/lib/content-types.js
@@ -13,9 +13,6 @@ const DP_PUB_STATE_LIVE = 'live';
 const DP_PUB_STATE_PREVIEW = 'preview';
 const DP_PUB_STATES = [DP_PUB_STATE_LIVE, DP_PUB_STATE_PREVIEW];
 
-const NON_WRITABLE_ATTRIBUTES = [ID_ATTRIBUTE, CREATED_BY_ATTRIBUTE, UPDATED_BY_ATTRIBUTE];
-const NON_VISIBLE_ATTRIBUTES = [...NON_WRITABLE_ATTRIBUTES, PUBLISHED_AT_ATTRIBUTE];
-
 const constants = {
   ID_ATTRIBUTE,
   PUBLISHED_AT_ATTRIBUTE,
@@ -57,9 +54,12 @@ const getNonWritableAttributes = (model = {}) => {
     []
   );
 
-  return _.uniq(
-    NON_WRITABLE_ATTRIBUTES.concat(model.primaryKey, getTimestamps(model), nonWritableAttributes)
-  );
+  return _.uniq([
+    ID_ATTRIBUTE,
+    model.primaryKey,
+    ...getTimestamps(model),
+    ...nonWritableAttributes,
+  ]);
 };
 
 const getWritableAttributes = (model = {}) => {
@@ -71,16 +71,21 @@ const isWritableAttribute = (model, attributeName) => {
 };
 
 const getNonVisibleAttributes = model => {
-  return _.uniq([
-    model.primaryKey,
-    ...NON_VISIBLE_ATTRIBUTES,
-    ...getTimestamps(model),
-    ...getNonWritableAttributes(model),
-  ]);
+  const nonVisibleAttributes = _.reduce(
+    model.attributes,
+    (acc, attr, attrName) => (attr.visible === false ? acc.concat(attrName) : acc),
+    []
+  );
+
+  return _.uniq([ID_ATTRIBUTE, model.primaryKey, ...getTimestamps(model), ...nonVisibleAttributes]);
 };
 
 const getVisibleAttributes = model => {
   return _.difference(_.keys(model.attributes), getNonVisibleAttributes(model));
+};
+
+const isVisibleAttribute = (model, attributeName) => {
+  return getVisibleAttributes(model).includes(attributeName);
 };
 
 const hasDraftAndPublish = model => _.get(model, 'options.draftAndPublish', false) === true;
@@ -198,6 +203,7 @@ module.exports = {
   isWritableAttribute,
   getNonVisibleAttributes,
   getVisibleAttributes,
+  isVisibleAttribute,
   hasDraftAndPublish,
   isDraft,
   isSingleType,

--- a/packages/strapi-utils/lib/sanitize-entity.js
+++ b/packages/strapi-utils/lib/sanitize-entity.js
@@ -1,9 +1,15 @@
 'use strict';
 
 const _ = require('lodash');
-const { constants, isPrivateAttribute, getNonWritableAttributes } = require('./content-types');
+const {
+  constants,
+  isPrivateAttribute,
+  getNonWritableAttributes,
+  getNonVisibleAttributes,
+  getWritableAttributes,
+} = require('./content-types');
 
-const { ID_ATTRIBUTE, PUBLISHED_AT_ATTRIBUTE } = constants;
+const { ID_ATTRIBUTE } = constants;
 
 const sanitizeEntity = (dataSource, options) => {
   const { model, withPrivate = false, isOutput = true, includeFields = null } = options;
@@ -120,6 +126,11 @@ const STATIC_FIELDS = [ID_ATTRIBUTE, '__v'];
 const getAllowedFields = ({ includeFields, model, isOutput }) => {
   const { options, primaryKey } = model;
   const nonWritableAttributes = getNonWritableAttributes(model);
+  const nonVisibleAttributes = getNonVisibleAttributes(model);
+
+  const writableAttributes = getWritableAttributes(model);
+
+  const nonVisibleWritableAttributes = _.intersection(writableAttributes, nonVisibleAttributes);
 
   const timestamps = options.timestamps || [];
 
@@ -131,10 +142,10 @@ const getAllowedFields = ({ includeFields, model, isOutput }) => {
           timestamps,
           STATIC_FIELDS,
           COMPONENT_FIELDS,
-          PUBLISHED_AT_ATTRIBUTE,
           ...nonWritableAttributes,
+          ...nonVisibleAttributes,
         ]
-      : [primaryKey, STATIC_FIELDS, COMPONENT_FIELDS])
+      : [primaryKey, STATIC_FIELDS, COMPONENT_FIELDS, ...nonVisibleWritableAttributes])
   );
 };
 

--- a/packages/strapi/lib/core-api/service.js
+++ b/packages/strapi/lib/core-api/service.js
@@ -65,16 +65,8 @@ const createUtils = ({ model }) => {
   const { getNonWritableAttributes } = utils.contentTypes;
 
   return {
-    sanitizeInput: data => {
-      const nonWritableAttributes = getNonWritableAttributes(model);
-
-      const attributesToOmit = _.difference(
-        nonWritableAttributes,
-        _.get(model, 'coreApi.writableAttributes', [])
-      );
-
-      return _.omit(data, attributesToOmit);
-    },
+    // make sure too keep the call to getNonWritableAttributes dynamic
+    sanitizeInput: data => _.omit(data, getNonWritableAttributes(model)),
   };
 };
 


### PR DESCRIPTION
Generalize usage or visible & wirtable on attributes instead of using hardcoded properties