### PR TITLE
[i18n] Edit view RBAC management

### DIFF
--- a/packages/strapi-admin/admin/src/containers/LeftMenu/utils/generateModelsLinks.js
+++ b/packages/strapi-admin/admin/src/containers/LeftMenu/utils/generateModelsLinks.js
@@ -1,19 +1,25 @@
 import { chain, get } from 'lodash';
 
-const generateLinks = links => {
+const generateLinks = (links, type) => {
   return links
     .filter(link => link.isDisplayed)
     .map(link => {
+      const collectionTypesPermissions = [
+        { action: 'plugins::content-manager.explorer.create', subject: link.uid },
+        { action: 'plugins::content-manager.explorer.read', subject: link.uid },
+      ];
+      const singleTypesPermissions = [
+        { action: 'plugins::content-manager.explorer.read', subject: link.uid },
+      ];
+      const permissions =
+        type === 'collectionTypes' ? collectionTypesPermissions : singleTypesPermissions;
+
       return {
         icon: 'circle',
         destination: `/plugins/content-manager/${link.kind}/${link.uid}`,
         isDisplayed: false,
         label: link.info.label,
-        permissions: [
-          { action: 'plugins::content-manager.explorer.create', subject: link.uid },
-          { action: 'plugins::content-manager.explorer.read', subject: link.uid },
-          { action: 'plugins::content-manager.explorer.update', subject: link.uid },
-        ],
+        permissions,
       };
     });
 };
@@ -26,8 +32,11 @@ const generateModelsLinks = models => {
     .value();
 
   return {
-    collectionTypesSectionLinks: generateLinks(get(collectionTypes, 'links', [])),
-    singleTypesSectionLinks: generateLinks(get(singleTypes, 'links', [])),
+    collectionTypesSectionLinks: generateLinks(
+      get(collectionTypes, 'links', []),
+      'collectionTypes'
+    ),
+    singleTypesSectionLinks: generateLinks(get(singleTypes, 'links', []), 'singleTypes'),
   };
 };
 

--- a/packages/strapi-helper-plugin/lib/src/hooks/useUserPermissions/index.js
+++ b/packages/strapi-helper-plugin/lib/src/hooks/useUserPermissions/index.js
@@ -68,7 +68,7 @@ const useUserPermissions = (pluginPermissions, permissions) => {
     return () => {
       abortController.abort();
     };
-  }, [permissionNames]);
+  }, [permissionNames, currentUserPermissions]);
 
   // This function is used to synchronise the hook when used in dynamic components
   const setIsLoading = useCallback(() => {

--- a/packages/strapi-plugin-content-manager/admin/src/containers/EditView/index.js
+++ b/packages/strapi-plugin-content-manager/admin/src/containers/EditView/index.js
@@ -7,7 +7,6 @@ import {
   LiLink,
   LoadingIndicatorPage,
   CheckPermissions,
-  useUser,
   useUserPermissions,
   useGlobalContext,
 } from 'strapi-helper-plugin';
@@ -31,14 +30,14 @@ import DeleteLink from './DeleteLink';
 import InformationCard from './InformationCard';
 
 /* eslint-disable  react/no-array-index-key */
-const EditView = ({ isSingleType, goBack, layout, slug, state, id, origin }) => {
+const EditView = ({ isSingleType, goBack, layout, slug, state, id, origin, userPermissions }) => {
   const { currentEnvironment, plugins } = useGlobalContext();
   // Permissions
   const viewPermissions = useMemo(() => generatePermissionsObject(slug), [slug]);
   const { allowedActions, isLoading: isLoadingForPermissions } = useUserPermissions(
-    viewPermissions
+    viewPermissions,
+    userPermissions
   );
-  const { userPermissions } = useUser();
 
   // Here in case of a 403 response when fetching data we will either redirect to the previous page
   // Or to the homepage if there's no state in the history stack
@@ -274,6 +273,7 @@ EditView.defaultProps = {
   isSingleType: false,
   origin: null,
   state: {},
+  userPermissions: [],
 };
 
 EditView.propTypes = {
@@ -293,6 +293,7 @@ EditView.propTypes = {
   origin: PropTypes.string,
   state: PropTypes.object,
   slug: PropTypes.string.isRequired,
+  userPermissions: PropTypes.array,
 };
 
 export { EditView };

--- a/packages/strapi-plugin-content-manager/admin/src/containers/EditViewDataManagerProvider/index.js
+++ b/packages/strapi-plugin-content-manager/admin/src/containers/EditViewDataManagerProvider/index.js
@@ -14,7 +14,7 @@ import { cleanData, createYupSchema, getYupInnerErrors } from './utils';
 
 const EditViewDataManagerProvider = ({
   allLayoutData,
-  allowedActions: { canCreate, canRead, canUpdate },
+  allowedActions: { canRead, canUpdate },
   children,
   componentsDataStructure,
   contentTypeDataStructure,
@@ -57,22 +57,6 @@ const EditViewDataManagerProvider = ({
   const { emitEvent, formatMessage } = useGlobalContext();
   const emitEventRef = useRef(emitEvent);
 
-  const shouldRedirectToHomepageWhenCreatingEntry = useMemo(() => {
-    if (isLoadingForData) {
-      return false;
-    }
-
-    if (!isCreatingEntry) {
-      return false;
-    }
-
-    if (canCreate === false) {
-      return true;
-    }
-
-    return false;
-  }, [isCreatingEntry, canCreate, isLoadingForData]);
-
   const shouldRedirectToHomepageWhenEditingEntry = useMemo(() => {
     if (isLoadingForData) {
       return false;
@@ -102,12 +86,6 @@ const EditViewDataManagerProvider = ({
       strapi.notification.info(getTrad('permissions.not-allowed.update'));
     }
   }, [shouldRedirectToHomepageWhenEditingEntry]);
-
-  useEffect(() => {
-    if (shouldRedirectToHomepageWhenCreatingEntry) {
-      strapi.notification.info(getTrad('permissions.not-allowed.create'));
-    }
-  }, [shouldRedirectToHomepageWhenCreatingEntry]);
 
   useEffect(() => {
     dispatch({
@@ -445,11 +423,6 @@ const EditViewDataManagerProvider = ({
     }),
     []
   );
-
-  // Redirect the user to the homepage if he is not allowed to create a document
-  if (shouldRedirectToHomepageWhenCreatingEntry) {
-    return <Redirect to="/" />;
-  }
 
   // Redirect the user to the previous page if he is not allowed to read/update a document
   if (shouldRedirectToHomepageWhenEditingEntry) {

--- a/packages/strapi-plugin-content-manager/admin/src/containers/EditViewLayoutManager/index.js
+++ b/packages/strapi-plugin-content-manager/admin/src/containers/EditViewLayoutManager/index.js
@@ -1,8 +1,9 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
 import { LoadingIndicatorPage, useQueryParams } from 'strapi-helper-plugin';
 import EditView from '../EditView';
+import useSyncRbac from '../RBACManager/useSyncRbac';
 import { resetProps, setLayout } from './actions';
 import selectLayout from './selectors';
 
@@ -10,6 +11,8 @@ const EditViewLayoutManager = ({ layout, ...rest }) => {
   const currentLayout = useSelector(selectLayout);
   const dispatch = useDispatch();
   const [{ query }] = useQueryParams();
+  const queryWithPluginOptions = useMemo(() => ({ pluginOptions: { ...query } }), [query]);
+  const permissions = useSyncRbac(queryWithPluginOptions, rest.slug, 'editView');
 
   useEffect(() => {
     dispatch(setLayout(layout, query));
@@ -23,7 +26,7 @@ const EditViewLayoutManager = ({ layout, ...rest }) => {
     return <LoadingIndicatorPage />;
   }
 
-  return <EditView {...rest} layout={currentLayout} />;
+  return <EditView {...rest} layout={currentLayout} userPermissions={permissions} />;
 };
 
 EditViewLayoutManager.propTypes = {

--- a/packages/strapi-plugin-content-manager/admin/src/containers/ListView/ListViewLayout.js
+++ b/packages/strapi-plugin-content-manager/admin/src/containers/ListView/ListViewLayout.js
@@ -10,7 +10,7 @@ const ListViewLayout = ({ layout, ...props }) => {
   const dispatch = useDispatch();
   const initialParams = useSelector(state => state.get('content-manager_listView').initialParams);
   const [{ query }, setQuery] = useQueryParams(initialParams);
-  const permissions = useSyncRbac(query, props.slug);
+  const permissions = useSyncRbac(query, props.slug, 'listView');
 
   useEffect(() => {
     dispatch(setLayout(layout.contentType));

--- a/packages/strapi-plugin-content-manager/admin/src/containers/RBACManager/useSyncRbac.js
+++ b/packages/strapi-plugin-content-manager/admin/src/containers/RBACManager/useSyncRbac.js
@@ -8,7 +8,7 @@ const selectPermissions = state => state.get(`${pluginId}_rbacManager`).permissi
 const selectCollectionTypePermissions = state =>
   state.get('permissionsManager').collectionTypesRelatedPermissions;
 
-const useSyncRbac = (query, collectionTypeUID = 'listView') => {
+const useSyncRbac = (query, collectionTypeUID, containerName = 'listView') => {
   const collectionTypesRelatedPermissions = useSelector(selectCollectionTypePermissions);
   const permissions = useSelector(selectPermissions);
   const dispatch = useDispatch();
@@ -17,7 +17,7 @@ const useSyncRbac = (query, collectionTypeUID = 'listView') => {
 
   useEffect(() => {
     if (query && relatedPermissions) {
-      dispatch(setPermissions(relatedPermissions, query.pluginOptions, 'listView'));
+      dispatch(setPermissions(relatedPermissions, query.pluginOptions, containerName));
 
       return () => {
         dispatch(resetPermissions());
@@ -25,7 +25,7 @@ const useSyncRbac = (query, collectionTypeUID = 'listView') => {
     }
 
     return () => {};
-  }, [relatedPermissions, dispatch, query]);
+  }, [relatedPermissions, dispatch, query, containerName]);
 
   return permissions;
 };

--- a/packages/strapi-plugin-i18n/admin/src/middlewares/localePermissionMiddleware.js
+++ b/packages/strapi-plugin-i18n/admin/src/middlewares/localePermissionMiddleware.js
@@ -8,7 +8,7 @@ const localePermissionMiddleware = () => () => next => action => {
     return next(action);
   }
 
-  if (action.__meta__.containerName !== 'listView') {
+  if (!['editView', 'listView'].includes(action.__meta__.containerName)) {
     return next(action);
   }
 


### PR DESCRIPTION
What does it do?
It allows to switch from one locale to another in the edit view

Why is it needed?
In order to apply the correct permissions depending on the locale

How to test it?
In one terminal window clone the monorepo checkout the branch corresponding to #9535 PR's branch && start the getstarted app.
In another terminal checkout the i18n/editview-rbac-manager branch and start the webpack devServer

Related issue(s)/PR(s)

Waiting for #9697 to be merged