### PR TITLE
[i18n] Migrate CollectionTypeFormWrapper and SingleTypeFormWrapper to redux

### DIFF
--- a/packages/strapi-plugin-content-manager/admin/src/containers/SingleTypeFormWrapper/index.js
+++ b/packages/strapi-plugin-content-manager/admin/src/containers/SingleTypeFormWrapper/index.js
@@ -1,7 +1,8 @@
-import { memo, useCallback, useEffect, useRef, useReducer, useState } from 'react';
+import { memo, useCallback, useEffect, useRef, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { get } from 'lodash';
 import { request, useGlobalContext } from 'strapi-helper-plugin';
+import { useSelector, useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
 import {
   createDefaultForm,
@@ -9,7 +10,16 @@ import {
   getTrad,
   removePasswordFieldsFromData,
 } from '../../utils';
-import { crudInitialState, crudReducer } from '../../sharedReducers';
+import {
+  getData,
+  getDataSucceeded,
+  initForm,
+  resetProps,
+  setDataStructures,
+  setStatus,
+  submitSucceeded,
+} from '../../sharedReducers/crudReducer/actions';
+import selectCrudReducer from '../../sharedReducers/crudReducer/selectors';
 import { getRequestUrl } from './utils';
 
 // This container is used to handle the CRUD
@@ -19,10 +29,14 @@ const SingleTypeFormWrapper = ({ allLayoutData, children, from, slug }) => {
   const emitEventRef = useRef(emitEvent);
   const [isCreatingEntry, setIsCreatingEntry] = useState(true);
 
-  const [
-    { componentsDataStructure, contentTypeDataStructure, data, isLoading, status },
-    dispatch,
-  ] = useReducer(crudReducer, crudInitialState);
+  const dispatch = useDispatch();
+  const {
+    componentsDataStructure,
+    contentTypeDataStructure,
+    data,
+    isLoading,
+    status,
+  } = useSelector(selectCrudReducer);
 
   const cleanReceivedData = useCallback(
     data => {
@@ -37,6 +51,12 @@ const SingleTypeFormWrapper = ({ allLayoutData, children, from, slug }) => {
     },
     [allLayoutData]
   );
+
+  useEffect(() => {
+    return () => {
+      dispatch(resetProps());
+    };
+  }, [dispatch]);
 
   useEffect(() => {
     const componentsDataStructure = Object.keys(allLayoutData.components).reduce((acc, current) => {
@@ -58,17 +78,14 @@ const SingleTypeFormWrapper = ({ allLayoutData, children, from, slug }) => {
       allLayoutData.contentType.attributes,
       allLayoutData.components
     );
+    const contentTypeDataStructureFormatted = formatComponentData(
+      contentTypeDataStructure,
+      allLayoutData.contentType,
+      allLayoutData.components
+    );
 
-    dispatch({
-      type: 'SET_DATA_STRUCTURES',
-      componentsDataStructure,
-      contentTypeDataStructure: formatComponentData(
-        contentTypeDataStructure,
-        allLayoutData.contentType,
-        allLayoutData.components
-      ),
-    });
-  }, [allLayoutData]);
+    dispatch(setDataStructures(componentsDataStructure, contentTypeDataStructureFormatted));
+  }, [allLayoutData, dispatch]);
 
   // Check if creation mode or editing mode
   useEffect(() => {
@@ -76,17 +93,15 @@ const SingleTypeFormWrapper = ({ allLayoutData, children, from, slug }) => {
     const { signal } = abortController;
 
     const fetchData = async signal => {
-      dispatch({ type: 'GET_DATA' });
+      dispatch(getData());
 
       setIsCreatingEntry(true);
 
       try {
         const data = await request(getRequestUrl(slug), { method: 'GET', signal });
 
-        dispatch({
-          type: 'GET_DATA_SUCCEEDED',
-          data: cleanReceivedData(data),
-        });
+        dispatch(getDataSucceeded(cleanReceivedData(data)));
+
         setIsCreatingEntry(false);
       } catch (err) {
         if (err.name === 'AbortError') {
@@ -97,7 +112,7 @@ const SingleTypeFormWrapper = ({ allLayoutData, children, from, slug }) => {
 
         // Creating a single type
         if (responseStatus === 404) {
-          dispatch({ type: 'INIT_FORM' });
+          dispatch(initForm());
         }
 
         if (responseStatus === 403) {
@@ -111,7 +126,7 @@ const SingleTypeFormWrapper = ({ allLayoutData, children, from, slug }) => {
     fetchData(signal);
 
     return () => abortController.abort();
-  }, [cleanReceivedData, from, push, slug]);
+  }, [cleanReceivedData, from, push, slug, dispatch]);
 
   const displayErrors = useCallback(err => {
     const errorPayload = err.response.payload;
@@ -155,15 +170,15 @@ const SingleTypeFormWrapper = ({ allLayoutData, children, from, slug }) => {
   const onDeleteSucceeded = useCallback(() => {
     setIsCreatingEntry(true);
 
-    dispatch({ type: 'INIT_FORM' });
-  }, []);
+    dispatch(initForm());
+  }, [dispatch]);
 
   const onPost = useCallback(
     async (body, trackerProperty) => {
       const endPoint = getRequestUrl(slug);
 
       try {
-        dispatch({ type: 'SET_STATUS', status: 'submit-pending' });
+        dispatch(setStatus('submit-pending'));
 
         const response = await request(endPoint, { method: 'PUT', body });
 
@@ -173,24 +188,26 @@ const SingleTypeFormWrapper = ({ allLayoutData, children, from, slug }) => {
           message: { id: getTrad('success.record.save') },
         });
 
-        dispatch({ type: 'SUBMIT_SUCCEEDED', data: cleanReceivedData(response) });
+        dispatch(submitSucceeded(cleanReceivedData(response)));
         setIsCreatingEntry(false);
-        dispatch({ type: 'SET_STATUS', status: 'resolved' });
+
+        dispatch(setStatus('resolved'));
       } catch (err) {
         emitEventRef.current('didNotCreateEntry', { error: err, trackerProperty });
 
         displayErrors(err);
-        dispatch({ type: 'SET_STATUS', status: 'resolved' });
+
+        dispatch(setStatus('resolved'));
       }
     },
-    [cleanReceivedData, displayErrors, slug]
+    [cleanReceivedData, displayErrors, slug, dispatch]
   );
   const onPublish = useCallback(async () => {
     try {
       emitEventRef.current('willPublishEntry');
       const endPoint = getRequestUrl(`${slug}/actions/publish`);
 
-      dispatch({ type: 'SET_STATUS', status: 'publish-pending' });
+      dispatch(setStatus('publish-pending'));
 
       const data = await request(endPoint, { method: 'POST' });
 
@@ -200,13 +217,15 @@ const SingleTypeFormWrapper = ({ allLayoutData, children, from, slug }) => {
         message: { id: getTrad('success.record.publish') },
       });
 
-      dispatch({ type: 'SUBMIT_SUCCEEDED', data: cleanReceivedData(data) });
-      dispatch({ type: 'SET_STATUS', status: 'resolved' });
+      dispatch(submitSucceeded(cleanReceivedData(data)));
+
+      dispatch(setStatus('resolved'));
     } catch (err) {
       displayErrors(err);
-      dispatch({ type: 'SET_STATUS', status: 'resolved' });
+
+      dispatch(setStatus('resolved'));
     }
-  }, [cleanReceivedData, displayErrors, slug]);
+  }, [cleanReceivedData, displayErrors, slug, dispatch]);
 
   const onPut = useCallback(
     async (body, trackerProperty) => {
@@ -215,7 +234,7 @@ const SingleTypeFormWrapper = ({ allLayoutData, children, from, slug }) => {
       try {
         emitEventRef.current('willEditEntry', trackerProperty);
 
-        dispatch({ type: 'SET_STATUS', status: 'submit-pending' });
+        dispatch(setStatus('submit-pending'));
 
         const response = await request(endPoint, { method: 'PUT', body });
 
@@ -226,22 +245,25 @@ const SingleTypeFormWrapper = ({ allLayoutData, children, from, slug }) => {
 
         emitEventRef.current('didEditEntry', { trackerProperty });
 
-        dispatch({ type: 'SUBMIT_SUCCEEDED', data: cleanReceivedData(response) });
-        dispatch({ type: 'SET_STATUS', status: 'resolved' });
+        dispatch(submitSucceeded(cleanReceivedData(response)));
+
+        dispatch(setStatus('resolved'));
       } catch (err) {
         displayErrors(err);
 
         emitEventRef.current('didNotEditEntry', { error: err, trackerProperty });
-        dispatch({ type: 'SET_STATUS', status: 'resolved' });
+
+        dispatch(setStatus('resolved'));
       }
     },
-    [cleanReceivedData, displayErrors, slug]
+    [cleanReceivedData, displayErrors, slug, dispatch]
   );
 
   // The publish and unpublish method could be refactored but let's leave the duplication for now
   const onUnpublish = useCallback(async () => {
     const endPoint = getRequestUrl(`${slug}/actions/unpublish`);
-    dispatch({ type: 'SET_STATUS', status: 'unpublish-pending' });
+
+    dispatch(setStatus('unpublish-pending'));
 
     try {
       emitEventRef.current('willUnpublishEntry');
@@ -251,13 +273,14 @@ const SingleTypeFormWrapper = ({ allLayoutData, children, from, slug }) => {
       emitEventRef.current('didUnpublishEntry');
       strapi.notification.success(getTrad('success.record.unpublish'));
 
-      dispatch({ type: 'SUBMIT_SUCCEEDED', data: cleanReceivedData(response) });
-      dispatch({ type: 'SET_STATUS', status: 'resolved' });
+      dispatch(submitSucceeded(cleanReceivedData(response)));
+
+      dispatch(setStatus('resolved'));
     } catch (err) {
-      dispatch({ type: 'SET_STATUS', status: 'resolved' });
+      dispatch(setStatus('resolved'));
       displayErrors(err);
     }
-  }, [cleanReceivedData, displayErrors, slug]);
+  }, [cleanReceivedData, displayErrors, slug, dispatch]);
 
   return children({
     componentsDataStructure,

--- a/packages/strapi-plugin-content-manager/admin/src/reducers.js
+++ b/packages/strapi-plugin-content-manager/admin/src/reducers.js
@@ -2,6 +2,7 @@ import mainReducer from './containers/Main/reducer';
 import editViewLayoutManagerReducer from './containers/EditViewLayoutManager/reducer';
 import listViewReducer from './containers/ListView/reducer';
 import rbacManagerReducer from './containers/RBACManager/reducer';
+import editViewCrudReducer from './sharedReducers/crudReducer/reducer';
 import pluginId from './pluginId';
 
 const reducers = {
@@ -9,6 +10,7 @@ const reducers = {
   [`${pluginId}_listView`]: listViewReducer,
   [`${pluginId}_rbacManager`]: rbacManagerReducer,
   [`${pluginId}_editViewLayoutManager`]: editViewLayoutManagerReducer,
+  [`${pluginId}_editViewCrudReducer`]: editViewCrudReducer,
 };
 
 export default reducers;

--- a/packages/strapi-plugin-content-manager/admin/src/sharedReducers/crudReducer/actions.js
+++ b/packages/strapi-plugin-content-manager/admin/src/sharedReducers/crudReducer/actions.js
@@ -1,0 +1,42 @@
+import {
+  GET_DATA,
+  GET_DATA_SUCCEEDED,
+  INIT_FORM,
+  RESET_PROPS,
+  SET_DATA_STRUCTURES,
+  SET_STATUS,
+  SUBMIT_SUCCEEDED,
+} from './constants';
+
+export const getData = () => {
+  return {
+    type: GET_DATA,
+  };
+};
+
+export const getDataSucceeded = data => ({
+  type: GET_DATA_SUCCEEDED,
+  data,
+});
+
+export const initForm = () => ({
+  type: INIT_FORM,
+});
+
+export const resetProps = () => ({ type: RESET_PROPS });
+
+export const setDataStructures = (componentsDataStructure, contentTypeDataStructure) => ({
+  type: SET_DATA_STRUCTURES,
+  componentsDataStructure,
+  contentTypeDataStructure,
+});
+
+export const setStatus = status => ({
+  type: SET_STATUS,
+  status,
+});
+
+export const submitSucceeded = data => ({
+  type: SUBMIT_SUCCEEDED,
+  data,
+});

--- a/packages/strapi-plugin-content-manager/admin/src/sharedReducers/crudReducer/constants.js
+++ b/packages/strapi-plugin-content-manager/admin/src/sharedReducers/crudReducer/constants.js
@@ -1,0 +1,7 @@
+export const GET_DATA = 'ContentManager/CrudReducer/GET_DATA';
+export const GET_DATA_SUCCEEDED = 'ContentManager/CrudReducer/GET_DATA_SUCCEEDED';
+export const INIT_FORM = 'ContentManager/CrudReducer/INIT_FORM';
+export const RESET_PROPS = 'ContentManager/CrudReducer/RESET_PROPS';
+export const SET_DATA_STRUCTURES = 'ContentManager/CrudReducer/SET_DATA_STRUCTURES';
+export const SET_STATUS = 'ContentManager/CrudReducer/SET_STATUS';
+export const SUBMIT_SUCCEEDED = 'ContentManager/CrudReducer/SUBMIT_SUCCEEDED';

--- a/packages/strapi-plugin-content-manager/admin/src/sharedReducers/crudReducer/index.js
+++ b/packages/strapi-plugin-content-manager/admin/src/sharedReducers/crudReducer/index.js
@@ -7,6 +7,16 @@ import produce from 'immer';
 // require us to add the dispatch to the array wich is not wanted. This refacto does not require us to
 // to do any of this.
 
+import {
+  GET_DATA,
+  GET_DATA_SUCCEEDED,
+  INIT_FORM,
+  RESET_PROPS,
+  SET_DATA_STRUCTURES,
+  SET_STATUS,
+  SUBMIT_SUCCEEDED,
+} from './constants';
+
 const crudInitialState = {
   componentsDataStructure: {},
   contentTypeDataStructure: {},
@@ -15,34 +25,37 @@ const crudInitialState = {
   status: 'resolved',
 };
 
-const crudReducer = (state, action) =>
+const crudReducer = (state = crudInitialState, action) =>
   produce(state, draftState => {
     switch (action.type) {
-      case 'GET_DATA': {
+      case GET_DATA: {
         draftState.isLoading = true;
         draftState.data = {};
         break;
       }
-      case 'GET_DATA_SUCCEEDED': {
+      case GET_DATA_SUCCEEDED: {
         draftState.isLoading = false;
         draftState.data = action.data;
         break;
       }
-      case 'INIT_FORM': {
+      case INIT_FORM: {
         draftState.isLoading = false;
         draftState.data = state.contentTypeDataStructure;
         break;
       }
-      case 'SET_DATA_STRUCTURES': {
+      case RESET_PROPS: {
+        return crudInitialState;
+      }
+      case SET_DATA_STRUCTURES: {
         draftState.componentsDataStructure = action.componentsDataStructure;
         draftState.contentTypeDataStructure = action.contentTypeDataStructure;
         break;
       }
-      case 'SET_STATUS': {
+      case SET_STATUS: {
         draftState.status = action.status;
         break;
       }
-      case 'SUBMIT_SUCCEEDED': {
+      case SUBMIT_SUCCEEDED: {
         draftState.data = action.data;
         break;
       }

--- a/packages/strapi-plugin-content-manager/admin/src/sharedReducers/crudReducer/reducer.js
+++ b/packages/strapi-plugin-content-manager/admin/src/sharedReducers/crudReducer/reducer.js
@@ -1,0 +1,68 @@
+/* eslint-disable consistent-return */
+import produce from 'immer';
+
+// NOTE: instead of creating a shared reducer here, we could also create a hook
+// that returns the dispatch and the state, however it will mess with the linter
+// and force us to either disable the linter for the hooks dependencies array rule or
+// require us to add the dispatch to the array wich is not wanted. This refacto does not require us to
+// to do any of this.
+
+import {
+  GET_DATA,
+  GET_DATA_SUCCEEDED,
+  INIT_FORM,
+  RESET_PROPS,
+  SET_DATA_STRUCTURES,
+  SET_STATUS,
+  SUBMIT_SUCCEEDED,
+} from './constants';
+
+const crudInitialState = {
+  componentsDataStructure: {},
+  contentTypeDataStructure: {},
+  isLoading: true,
+  data: {},
+  status: 'resolved',
+};
+
+const crudReducer = (state = crudInitialState, action) =>
+  produce(state, draftState => {
+    switch (action.type) {
+      case GET_DATA: {
+        draftState.isLoading = true;
+        draftState.data = {};
+        break;
+      }
+      case GET_DATA_SUCCEEDED: {
+        draftState.isLoading = false;
+        draftState.data = action.data;
+        break;
+      }
+      case INIT_FORM: {
+        draftState.isLoading = false;
+        draftState.data = state.contentTypeDataStructure;
+        break;
+      }
+      case RESET_PROPS: {
+        return crudInitialState;
+      }
+      case SET_DATA_STRUCTURES: {
+        draftState.componentsDataStructure = action.componentsDataStructure;
+        draftState.contentTypeDataStructure = action.contentTypeDataStructure;
+        break;
+      }
+      case SET_STATUS: {
+        draftState.status = action.status;
+        break;
+      }
+      case SUBMIT_SUCCEEDED: {
+        draftState.data = action.data;
+        break;
+      }
+      default:
+        return draftState;
+    }
+  });
+
+export default crudReducer;
+export { crudInitialState };

--- a/packages/strapi-plugin-content-manager/admin/src/sharedReducers/crudReducer/selectors.js
+++ b/packages/strapi-plugin-content-manager/admin/src/sharedReducers/crudReducer/selectors.js
@@ -1,0 +1,5 @@
+import pluginId from '../../pluginId';
+
+const selectCrudReducer = state => state.get(`${pluginId}_editViewCrudReducer`);
+
+export default selectCrudReducer;

--- a/packages/strapi-plugin-content-manager/admin/src/sharedReducers/crudReducer/tests/crudReducer.test.js
+++ b/packages/strapi-plugin-content-manager/admin/src/sharedReducers/crudReducer/tests/crudReducer.test.js
@@ -1,4 +1,12 @@
 import produce from 'immer';
+import {
+  GET_DATA,
+  GET_DATA_SUCCEEDED,
+  INIT_FORM,
+  SET_DATA_STRUCTURES,
+  SET_STATUS,
+  SUBMIT_SUCCEEDED,
+} from '../constants';
 import crudReducer from '../reducer';
 
 describe('CONTENT MANAGER | sharedReducers | crudReducer', () => {
@@ -23,7 +31,7 @@ describe('CONTENT MANAGER | sharedReducers | crudReducer', () => {
     state.data = null;
     state.componentsDataStructure = null;
 
-    const action = { type: 'GET_DATA' };
+    const action = { type: GET_DATA };
 
     const expected = produce(state, draft => {
       draft.isLoading = true;
@@ -35,7 +43,7 @@ describe('CONTENT MANAGER | sharedReducers | crudReducer', () => {
 
   it('should handle the GET_DATA_SUCCEEDED action correctly', () => {
     const action = {
-      type: 'GET_DATA_SUCCEEDED',
+      type: GET_DATA_SUCCEEDED,
       data: 'test',
     };
 
@@ -49,7 +57,7 @@ describe('CONTENT MANAGER | sharedReducers | crudReducer', () => {
 
   it('should handle the INIT_FORM action correctly', () => {
     const action = {
-      type: 'INIT_FORM',
+      type: INIT_FORM,
     };
     state.contentTypeDataStructure = { foo: 'bar' };
 
@@ -63,7 +71,7 @@ describe('CONTENT MANAGER | sharedReducers | crudReducer', () => {
 
   it('should handle the SET_DATA_STRUCTURES action correctly', () => {
     const action = {
-      type: 'SET_DATA_STRUCTURES',
+      type: SET_DATA_STRUCTURES,
       componentsDataStructure: { test: 'test' },
       contentTypeDataStructure: { foo: 'bar' },
     };
@@ -77,7 +85,7 @@ describe('CONTENT MANAGER | sharedReducers | crudReducer', () => {
   });
 
   it('should handle the SET_STATUS action correctly', () => {
-    const action = { type: 'SET_STATUS', status: 'pending' };
+    const action = { type: SET_STATUS, status: 'pending' };
 
     const expected = produce(state, draft => {
       draft.status = 'pending';
@@ -87,7 +95,7 @@ describe('CONTENT MANAGER | sharedReducers | crudReducer', () => {
   });
 
   it('should handle the SUBMIt_SUCCEEDED action correctly', () => {
-    const action = { type: 'SUBMIT_SUCCEEDED', data: 'test' };
+    const action = { type: SUBMIT_SUCCEEDED, data: 'test' };
 
     const expected = produce(state, draft => {
       draft.data = 'test';

--- a/packages/strapi-plugin-content-manager/admin/src/sharedReducers/crudReducer/tests/crudReducer.test.js
+++ b/packages/strapi-plugin-content-manager/admin/src/sharedReducers/crudReducer/tests/crudReducer.test.js
@@ -1,5 +1,5 @@
 import produce from 'immer';
-import crudReducer from '../crudReducer';
+import crudReducer from '../reducer';
 
 describe('CONTENT MANAGER | sharedReducers | crudReducer', () => {
   let state;


### PR DESCRIPTION
Signed-off-by: soupette <cyril.lpz@gmail.com>

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

It migrates the CRUD of the edit view to redux

### Why is it needed?

So a plugin can override the actions

### How to test it?

1. In one terminal window clone the monorepo checkout the branch corresponding to #9535 PR's branch && start the `getstarted` app.
2. In another terminal checkout the `i18n/edit-view-redux` branch and start the webpack `devServer` 

