### PR TITLE
[i18n/rbac] initialize with the first authorized locale

### DIFF
--- a/packages/strapi-plugin-i18n/admin/src/components/LocalePicker/index.js
+++ b/packages/strapi-plugin-i18n/admin/src/components/LocalePicker/index.js
@@ -85,13 +85,19 @@ const LocalePicker = () => {
         return (
           <Padded top left right bottom>
             <List>
-              {locales.map(locale => (
-                <ListItem key={locale.id}>
-                  <button onClick={() => handleClick(locale)} type="button">
-                    <EllipsisParagraph width="200px">{locale.name}</EllipsisParagraph>
-                  </button>
-                </ListItem>
-              ))}
+              {locales.map(locale => {
+                if (locale.id === selected.id) {
+                  return null;
+                }
+
+                return (
+                  <ListItem key={locale.id}>
+                    <button onClick={() => handleClick(locale)} type="button">
+                      <EllipsisParagraph width="200px">{locale.name}</EllipsisParagraph>
+                    </button>
+                  </ListItem>
+                );
+              })}
             </List>
           </Padded>
         );

--- a/packages/strapi-plugin-i18n/admin/src/middlewares/localeQueryParamsMiddleware.js
+++ b/packages/strapi-plugin-i18n/admin/src/middlewares/localeQueryParamsMiddleware.js
@@ -14,9 +14,10 @@ const localeQueryParamsMiddleware = () => ({ getState }) => next => action => {
 
   const store = getState();
   const { locales } = store.get('i18n_locales');
-  const { userPermissions } = store.get('permissionsManager');
+  const { collectionTypesRelatedPermissions } = store.get('permissionsManager');
+  const ctPermissions = collectionTypesRelatedPermissions[action.contentType.uid];
 
-  const defaultLocale = getDefaultLocale(action.contentType.uid, userPermissions, locales);
+  const defaultLocale = getDefaultLocale(ctPermissions, locales);
 
   if (!action.initialParams.plugins) {
     action.initialParams.plugins = {

--- a/packages/strapi-plugin-i18n/admin/src/middlewares/localeQueryParamsMiddleware.js
+++ b/packages/strapi-plugin-i18n/admin/src/middlewares/localeQueryParamsMiddleware.js
@@ -1,6 +1,7 @@
 import get from 'lodash/get';
+import getDefaultLocale from '../utils/getDefaultLocale';
 
-const localeQueryParamsMiddleware = () => () => next => action => {
+const localeQueryParamsMiddleware = () => ({ getState }) => next => action => {
   if (action.type !== 'ContentManager/ListView/SET_LIST_LAYOUT ') {
     return next(action);
   }
@@ -11,16 +12,22 @@ const localeQueryParamsMiddleware = () => () => next => action => {
     return next(action);
   }
 
+  const store = getState();
+  const { locales } = store.get('i18n_locales');
+  const { userPermissions } = store.get('permissionsManager');
+
+  const defaultLocale = getDefaultLocale(action.contentType.uid, userPermissions, locales);
+
   if (!action.initialParams.plugins) {
     action.initialParams.plugins = {
-      i18n: { locale: 'en' },
+      i18n: { locale: defaultLocale },
     };
 
     return next(action);
   }
 
   if (!get(action, 'initialParams.plugins.i18n.locale')) {
-    action.initialParams.plugins.i18n = { locale: 'en' };
+    action.initialParams.plugins.i18n = { locale: defaultLocale };
 
     return next(action);
   }

--- a/packages/strapi-plugin-i18n/admin/src/middlewares/tests/localeQueryParamsMiddleware.test.js
+++ b/packages/strapi-plugin-i18n/admin/src/middlewares/tests/localeQueryParamsMiddleware.test.js
@@ -8,6 +8,12 @@ describe('localeQueryParamsMiddleware', () => {
 
     store.set('i18n_locales', { locales: [] });
     store.set('permissionsManager', { userPermissions: [] });
+    store.set('permissionsManager', {
+      collectionTypesRelatedPermissions: {
+        'plugins::content-manager.explorer.read': [],
+        'plugins::content-manager.explorer.create': [],
+      },
+    });
 
     getState = () => store;
   });

--- a/packages/strapi-plugin-i18n/admin/src/middlewares/tests/localeQueryParamsMiddleware.test.js
+++ b/packages/strapi-plugin-i18n/admin/src/middlewares/tests/localeQueryParamsMiddleware.test.js
@@ -1,8 +1,19 @@
 import localeQueryParamsMiddleware from '../localeQueryParamsMiddleware';
 
 describe('localeQueryParamsMiddleware', () => {
+  let getState;
+
+  beforeEach(() => {
+    const store = new Map();
+
+    store.set('i18n_locales', { locales: [] });
+    store.set('permissionsManager', { userPermissions: [] });
+
+    getState = () => store;
+  });
+
   it('does nothing on unknown actions', () => {
-    const middleware = localeQueryParamsMiddleware()();
+    const middleware = localeQueryParamsMiddleware()({ getState });
     const nextFn = jest.fn();
     const action = { type: 'UNKNOWN' };
 
@@ -15,7 +26,7 @@ describe('localeQueryParamsMiddleware', () => {
   });
 
   it('does nothing when there s no i18n.localized key in the action', () => {
-    const middleware = localeQueryParamsMiddleware()();
+    const middleware = localeQueryParamsMiddleware()({ getState });
     const nextFn = jest.fn();
     const action = {
       type: 'ContentManager/ListView/SET_LIST_LAYOUT ',
@@ -35,7 +46,7 @@ describe('localeQueryParamsMiddleware', () => {
   });
 
   it('creates a plugins key with a locale when initialParams does not have a plugins key and the field is localized', () => {
-    const middleware = localeQueryParamsMiddleware()();
+    const middleware = localeQueryParamsMiddleware()({ getState });
     const nextFn = jest.fn();
     const action = {
       type: 'ContentManager/ListView/SET_LIST_LAYOUT ',
@@ -52,13 +63,13 @@ describe('localeQueryParamsMiddleware', () => {
     expect(nextFn).toBeCalledWith(action);
     expect(action).toEqual({
       contentType: { pluginOptions: { i18n: { localized: true } } },
-      initialParams: { plugins: { i18n: { locale: 'en' } } },
+      initialParams: { plugins: { i18n: { locale: null } } },
       type: 'ContentManager/ListView/SET_LIST_LAYOUT ',
     });
   });
 
   it('adds a key to plugins with a locale when initialParams has a plugins key and the field is localized', () => {
-    const middleware = localeQueryParamsMiddleware()();
+    const middleware = localeQueryParamsMiddleware()({ getState });
     const nextFn = jest.fn();
     const action = {
       type: 'ContentManager/ListView/SET_LIST_LAYOUT ',
@@ -79,7 +90,7 @@ describe('localeQueryParamsMiddleware', () => {
     expect(nextFn).toBeCalledWith(action);
     expect(action).toEqual({
       contentType: { pluginOptions: { i18n: { localized: true } } },
-      initialParams: { plugins: { i18n: { locale: 'en' }, hello: 'world' } },
+      initialParams: { plugins: { i18n: { locale: null }, hello: 'world' } },
       type: 'ContentManager/ListView/SET_LIST_LAYOUT ',
     });
   });

--- a/packages/strapi-plugin-i18n/admin/src/utils/getDefaultLocale.js
+++ b/packages/strapi-plugin-i18n/admin/src/utils/getDefaultLocale.js
@@ -12,10 +12,10 @@ const hasLocalePermission = (permission, localeCode) => {
 
 const getFirstLocale = permission => {
   if (permission) {
-    const firstAuthorizedForReadNonDefaultLocale = permission.properties.locales[0];
+    const firstAuthorizedNonDefaultLocale = permission.properties.locales[0];
 
-    if (firstAuthorizedForReadNonDefaultLocale) {
-      return firstAuthorizedForReadNonDefaultLocale;
+    if (firstAuthorizedNonDefaultLocale) {
+      return firstAuthorizedNonDefaultLocale;
     }
   }
 

--- a/packages/strapi-plugin-i18n/admin/src/utils/getDefaultLocale.js
+++ b/packages/strapi-plugin-i18n/admin/src/utils/getDefaultLocale.js
@@ -1,0 +1,60 @@
+const hasLocalePermission = (permission, localeCode) => {
+  if (permission) {
+    const hasPermission = permission.properties.locales.includes(localeCode);
+
+    if (hasPermission) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
+const hasPermissionForLocale = (readPermission, createPermission, localeCode) => {
+  if (hasLocalePermission(readPermission, localeCode)) {
+    return true;
+  }
+
+  if (hasLocalePermission(createPermission, localeCode)) {
+    return true;
+  }
+
+  return false;
+};
+
+const getFirstLocale = permission => {
+  if (permission) {
+    const firstAuthorizedForReadNonDefaultLocale = permission.properties.locales[0];
+
+    if (firstAuthorizedForReadNonDefaultLocale) {
+      return firstAuthorizedForReadNonDefaultLocale;
+    }
+  }
+
+  return null;
+};
+
+/**
+ * Entry point of the module
+ */
+const getDefaultLocale = (contentType, userPermissions, locales = []) => {
+  const locale = locales.find(locale => locale.isDefault);
+  const ctPermissions = userPermissions.filter(permission => permission.subject === contentType);
+
+  const readPermission = ctPermissions.find(permission => permission.action.includes('.read'));
+  const createPermission = ctPermissions.find(permission => permission.action.includes('.create'));
+
+  if (locale && hasPermissionForLocale(readPermission, createPermission, locale.code)) {
+    return locale.code;
+  }
+
+  const firstAuthorizedForReadNonDefaultLocale = getFirstLocale(readPermission);
+
+  if (firstAuthorizedForReadNonDefaultLocale) {
+    return firstAuthorizedForReadNonDefaultLocale;
+  }
+
+  return getFirstLocale(createPermission);
+};
+
+export default getDefaultLocale;

--- a/packages/strapi-plugin-i18n/admin/src/utils/getDefaultLocale.js
+++ b/packages/strapi-plugin-i18n/admin/src/utils/getDefaultLocale.js
@@ -10,18 +10,6 @@ const hasLocalePermission = (permission, localeCode) => {
   return false;
 };
 
-const hasPermissionForLocale = (readPermission, createPermission, localeCode) => {
-  if (hasLocalePermission(readPermission, localeCode)) {
-    return true;
-  }
-
-  if (hasLocalePermission(createPermission, localeCode)) {
-    return true;
-  }
-
-  return false;
-};
-
 const getFirstLocale = permission => {
   if (permission) {
     const firstAuthorizedForReadNonDefaultLocale = permission.properties.locales[0];
@@ -38,16 +26,26 @@ const getFirstLocale = permission => {
  * Entry point of the module
  */
 const getDefaultLocale = (contentType, userPermissions, locales = []) => {
-  const locale = locales.find(locale => locale.isDefault);
+  const defaultLocale = locales.find(locale => locale.isDefault);
+
+  if (!defaultLocale) {
+    return null;
+  }
+
   const ctPermissions = userPermissions.filter(permission => permission.subject === contentType);
 
   const readPermission = ctPermissions.find(permission => permission.action.includes('.read'));
   const createPermission = ctPermissions.find(permission => permission.action.includes('.create'));
 
-  if (locale && hasPermissionForLocale(readPermission, createPermission, locale.code)) {
-    return locale.code;
+  if (hasLocalePermission(readPermission, defaultLocale.code)) {
+    return defaultLocale.code;
   }
 
+  if (hasLocalePermission(createPermission, defaultLocale.code)) {
+    return defaultLocale.code;
+  }
+
+  // When the default locale is not authorized, we return the first authorized locale
   const firstAuthorizedForReadNonDefaultLocale = getFirstLocale(readPermission);
 
   if (firstAuthorizedForReadNonDefaultLocale) {

--- a/packages/strapi-plugin-i18n/admin/src/utils/tests/getDefaultLocale.test.js
+++ b/packages/strapi-plugin-i18n/admin/src/utils/tests/getDefaultLocale.test.js
@@ -1,0 +1,352 @@
+import getDefaultLocale from '../getDefaultLocale';
+
+describe('getDefaultLocale', () => {
+  it('gives fr-FR when it s the default locale and that it has read access to it', () => {
+    const locales = [
+      {
+        id: 1,
+        name: 'English',
+        code: 'en',
+        created_at: '2021-03-09T14:57:03.016Z',
+        updated_at: '2021-03-09T14:57:03.016Z',
+        isDefault: false,
+      },
+      {
+        id: 2,
+        name: 'French (France) (fr-FR)',
+        code: 'fr-FR',
+        created_at: '2021-03-09T15:03:06.992Z',
+        updated_at: '2021-03-17T13:01:03.569Z',
+        isDefault: true,
+      },
+    ];
+
+    const userPermissions = [
+      {
+        id: 1324,
+        action: 'plugins::i18n.locale.read',
+        subject: null,
+        properties: {},
+        conditions: [],
+      },
+      {
+        id: 1325,
+        action: 'plugins::content-manager.explorer.create',
+        subject: 'application::address.address',
+        properties: {
+          fields: [
+            'postal_coder',
+            'categories',
+            'cover',
+            'images',
+            'city',
+            'likes',
+            'json',
+            'slug',
+          ],
+          locales: [],
+        },
+        conditions: [],
+      },
+      {
+        id: 1326,
+        action: 'plugins::content-manager.explorer.read',
+        subject: 'application::address.address',
+        properties: {
+          fields: [],
+          locales: ['en', 'fr-FR'],
+        },
+        conditions: [],
+      },
+    ];
+
+    const expected = 'fr-FR';
+    const actual = getDefaultLocale('application::address.address', userPermissions, locales);
+
+    expect(actual).toEqual(expected);
+  });
+
+  it('gives fr-FR when it s the default locale and that it has create access to it', () => {
+    const locales = [
+      {
+        id: 1,
+        name: 'English',
+        code: 'en',
+        created_at: '2021-03-09T14:57:03.016Z',
+        updated_at: '2021-03-09T14:57:03.016Z',
+        isDefault: false,
+      },
+      {
+        id: 2,
+        name: 'French (France) (fr-FR)',
+        code: 'fr-FR',
+        created_at: '2021-03-09T15:03:06.992Z',
+        updated_at: '2021-03-17T13:01:03.569Z',
+        isDefault: true,
+      },
+    ];
+
+    const userPermissions = [
+      {
+        id: 1324,
+        action: 'plugins::i18n.locale.read',
+        subject: null,
+        properties: {},
+        conditions: [],
+      },
+      {
+        id: 1325,
+        action: 'plugins::content-manager.explorer.create',
+        subject: 'application::address.address',
+        properties: {
+          fields: [
+            'postal_coder',
+            'categories',
+            'cover',
+            'images',
+            'city',
+            'likes',
+            'json',
+            'slug',
+          ],
+          locales: ['fr-FR'],
+        },
+        conditions: [],
+      },
+      {
+        id: 1326,
+        action: 'plugins::content-manager.explorer.read',
+        subject: 'application::address.address',
+        properties: {
+          fields: [],
+          locales: ['en'],
+        },
+        conditions: [],
+      },
+    ];
+
+    const expected = 'fr-FR';
+    const actual = getDefaultLocale('application::address.address', userPermissions, locales);
+
+    expect(actual).toEqual(expected);
+  });
+
+  it('gives gives the first locale with read permission ("en") when the locale is allowed', () => {
+    const locales = [
+      {
+        id: 1,
+        name: 'English',
+        code: 'en',
+        created_at: '2021-03-09T14:57:03.016Z',
+        updated_at: '2021-03-09T14:57:03.016Z',
+        isDefault: false,
+      },
+      {
+        id: 2,
+        name: 'French (France) (fr-FR)',
+        code: 'fr-FR',
+        created_at: '2021-03-09T15:03:06.992Z',
+        updated_at: '2021-03-17T13:01:03.569Z',
+        isDefault: true,
+      },
+      {
+        id: 3,
+        name: 'Another lang',
+        code: 'de',
+        created_at: '2021-03-09T15:03:06.992Z',
+        updated_at: '2021-03-17T13:01:03.569Z',
+        isDefault: false,
+      },
+    ];
+
+    const userPermissions = [
+      {
+        id: 1324,
+        action: 'plugins::i18n.locale.read',
+        subject: null,
+        properties: {},
+        conditions: [],
+      },
+      {
+        id: 1325,
+        action: 'plugins::content-manager.explorer.create',
+        subject: 'application::address.address',
+        properties: {
+          fields: [
+            'postal_coder',
+            'categories',
+            'cover',
+            'images',
+            'city',
+            'likes',
+            'json',
+            'slug',
+          ],
+          locales: [],
+        },
+        conditions: [],
+      },
+      {
+        id: 1326,
+        action: 'plugins::content-manager.explorer.read',
+        subject: 'application::address.address',
+        properties: {
+          fields: [],
+          locales: ['en', 'de'],
+        },
+        conditions: [],
+      },
+    ];
+
+    const expected = 'en';
+    const actual = getDefaultLocale('application::address.address', userPermissions, locales);
+
+    expect(actual).toEqual(expected);
+  });
+
+  it('gives gives the first locale with create permission ("en") when the locale is allowed', () => {
+    const locales = [
+      {
+        id: 1,
+        name: 'English',
+        code: 'en',
+        created_at: '2021-03-09T14:57:03.016Z',
+        updated_at: '2021-03-09T14:57:03.016Z',
+        isDefault: false,
+      },
+      {
+        id: 2,
+        name: 'French (France) (fr-FR)',
+        code: 'fr-FR',
+        created_at: '2021-03-09T15:03:06.992Z',
+        updated_at: '2021-03-17T13:01:03.569Z',
+        isDefault: true,
+      },
+      {
+        id: 3,
+        name: 'Another lang',
+        code: 'de',
+        created_at: '2021-03-09T15:03:06.992Z',
+        updated_at: '2021-03-17T13:01:03.569Z',
+        isDefault: false,
+      },
+    ];
+
+    const userPermissions = [
+      {
+        id: 1324,
+        action: 'plugins::i18n.locale.read',
+        subject: null,
+        properties: {},
+        conditions: [],
+      },
+      {
+        id: 1325,
+        action: 'plugins::content-manager.explorer.create',
+        subject: 'application::address.address',
+        properties: {
+          fields: [
+            'postal_coder',
+            'categories',
+            'cover',
+            'images',
+            'city',
+            'likes',
+            'json',
+            'slug',
+          ],
+          locales: ['en', 'de'],
+        },
+        conditions: [],
+      },
+      {
+        id: 1326,
+        action: 'plugins::content-manager.explorer.read',
+        subject: 'application::address.address',
+        properties: {
+          fields: [],
+          locales: [],
+        },
+        conditions: [],
+      },
+    ];
+
+    const expected = 'en';
+    const actual = getDefaultLocale('application::address.address', userPermissions, locales);
+
+    expect(actual).toEqual(expected);
+  });
+
+  it('gives null when the user has no permission on any locale', () => {
+    const locales = [
+      {
+        id: 1,
+        name: 'English',
+        code: 'en',
+        created_at: '2021-03-09T14:57:03.016Z',
+        updated_at: '2021-03-09T14:57:03.016Z',
+        isDefault: false,
+      },
+      {
+        id: 2,
+        name: 'French (France) (fr-FR)',
+        code: 'fr-FR',
+        created_at: '2021-03-09T15:03:06.992Z',
+        updated_at: '2021-03-17T13:01:03.569Z',
+        isDefault: true,
+      },
+      {
+        id: 3,
+        name: 'Another lang',
+        code: 'de',
+        created_at: '2021-03-09T15:03:06.992Z',
+        updated_at: '2021-03-17T13:01:03.569Z',
+        isDefault: false,
+      },
+    ];
+
+    const userPermissions = [
+      {
+        id: 1324,
+        action: 'plugins::i18n.locale.read',
+        subject: null,
+        properties: {},
+        conditions: [],
+      },
+      {
+        id: 1325,
+        action: 'plugins::content-manager.explorer.create',
+        subject: 'application::address.address',
+        properties: {
+          fields: [
+            'postal_coder',
+            'categories',
+            'cover',
+            'images',
+            'city',
+            'likes',
+            'json',
+            'slug',
+          ],
+          locales: [],
+        },
+        conditions: [],
+      },
+      {
+        id: 1326,
+        action: 'plugins::content-manager.explorer.read',
+        subject: 'application::address.address',
+        properties: {
+          fields: [],
+          locales: [],
+        },
+        conditions: [],
+      },
+    ];
+
+    const expected = null;
+    const actual = getDefaultLocale('application::address.address', userPermissions, locales);
+
+    expect(actual).toEqual(expected);
+  });
+});

--- a/packages/strapi-plugin-i18n/admin/src/utils/tests/getDefaultLocale.test.js
+++ b/packages/strapi-plugin-i18n/admin/src/utils/tests/getDefaultLocale.test.js
@@ -21,47 +21,44 @@ describe('getDefaultLocale', () => {
       },
     ];
 
-    const userPermissions = [
-      {
-        id: 1324,
-        action: 'plugins::i18n.locale.read',
-        subject: null,
-        properties: {},
-        conditions: [],
-      },
-      {
-        id: 1325,
-        action: 'plugins::content-manager.explorer.create',
-        subject: 'application::address.address',
-        properties: {
-          fields: [
-            'postal_coder',
-            'categories',
-            'cover',
-            'images',
-            'city',
-            'likes',
-            'json',
-            'slug',
-          ],
-          locales: [],
+    const ctPermissions = {
+      'plugins::content-manager.explorer.create': [
+        {
+          id: 1325,
+          action: 'plugins::content-manager.explorer.create',
+          subject: 'application::address.address',
+          properties: {
+            fields: [
+              'postal_coder',
+              'categories',
+              'cover',
+              'images',
+              'city',
+              'likes',
+              'json',
+              'slug',
+            ],
+            locales: [],
+          },
+          conditions: [],
         },
-        conditions: [],
-      },
-      {
-        id: 1326,
-        action: 'plugins::content-manager.explorer.read',
-        subject: 'application::address.address',
-        properties: {
-          fields: [],
-          locales: ['en', 'fr-FR'],
+      ],
+      'plugins::content-manager.explorer.read': [
+        {
+          id: 1326,
+          action: 'plugins::content-manager.explorer.read',
+          subject: 'application::address.address',
+          properties: {
+            fields: [],
+            locales: ['en', 'fr-FR'],
+          },
+          conditions: [],
         },
-        conditions: [],
-      },
-    ];
+      ],
+    };
 
     const expected = 'fr-FR';
-    const actual = getDefaultLocale('application::address.address', userPermissions, locales);
+    const actual = getDefaultLocale(ctPermissions, locales);
 
     expect(actual).toEqual(expected);
   });
@@ -86,47 +83,44 @@ describe('getDefaultLocale', () => {
       },
     ];
 
-    const userPermissions = [
-      {
-        id: 1324,
-        action: 'plugins::i18n.locale.read',
-        subject: null,
-        properties: {},
-        conditions: [],
-      },
-      {
-        id: 1325,
-        action: 'plugins::content-manager.explorer.create',
-        subject: 'application::address.address',
-        properties: {
-          fields: [
-            'postal_coder',
-            'categories',
-            'cover',
-            'images',
-            'city',
-            'likes',
-            'json',
-            'slug',
-          ],
-          locales: ['fr-FR'],
+    const ctPermissions = {
+      'plugins::content-manager.explorer.create': [
+        {
+          id: 1325,
+          action: 'plugins::content-manager.explorer.create',
+          subject: 'application::address.address',
+          properties: {
+            fields: [
+              'postal_coder',
+              'categories',
+              'cover',
+              'images',
+              'city',
+              'likes',
+              'json',
+              'slug',
+            ],
+            locales: ['fr-FR'],
+          },
+          conditions: [],
         },
-        conditions: [],
-      },
-      {
-        id: 1326,
-        action: 'plugins::content-manager.explorer.read',
-        subject: 'application::address.address',
-        properties: {
-          fields: [],
-          locales: ['en'],
+      ],
+      'plugins::content-manager.explorer.read': [
+        {
+          id: 1326,
+          action: 'plugins::content-manager.explorer.read',
+          subject: 'application::address.address',
+          properties: {
+            fields: [],
+            locales: ['en'],
+          },
+          conditions: [],
         },
-        conditions: [],
-      },
-    ];
+      ],
+    };
 
     const expected = 'fr-FR';
-    const actual = getDefaultLocale('application::address.address', userPermissions, locales);
+    const actual = getDefaultLocale(ctPermissions, locales);
 
     expect(actual).toEqual(expected);
   });
@@ -159,47 +153,44 @@ describe('getDefaultLocale', () => {
       },
     ];
 
-    const userPermissions = [
-      {
-        id: 1324,
-        action: 'plugins::i18n.locale.read',
-        subject: null,
-        properties: {},
-        conditions: [],
-      },
-      {
-        id: 1325,
-        action: 'plugins::content-manager.explorer.create',
-        subject: 'application::address.address',
-        properties: {
-          fields: [
-            'postal_coder',
-            'categories',
-            'cover',
-            'images',
-            'city',
-            'likes',
-            'json',
-            'slug',
-          ],
-          locales: [],
+    const ctPermissions = {
+      'plugins::content-manager.explorer.create': [
+        {
+          id: 1325,
+          action: 'plugins::content-manager.explorer.create',
+          subject: 'application::address.address',
+          properties: {
+            fields: [
+              'postal_coder',
+              'categories',
+              'cover',
+              'images',
+              'city',
+              'likes',
+              'json',
+              'slug',
+            ],
+            locales: [],
+          },
+          conditions: [],
         },
-        conditions: [],
-      },
-      {
-        id: 1326,
-        action: 'plugins::content-manager.explorer.read',
-        subject: 'application::address.address',
-        properties: {
-          fields: [],
-          locales: ['en', 'de'],
+      ],
+      'plugins::content-manager.explorer.read': [
+        {
+          id: 1326,
+          action: 'plugins::content-manager.explorer.read',
+          subject: 'application::address.address',
+          properties: {
+            fields: [],
+            locales: ['en', 'de'],
+          },
+          conditions: [],
         },
-        conditions: [],
-      },
-    ];
+      ],
+    };
 
     const expected = 'en';
-    const actual = getDefaultLocale('application::address.address', userPermissions, locales);
+    const actual = getDefaultLocale(ctPermissions, locales);
 
     expect(actual).toEqual(expected);
   });
@@ -232,47 +223,44 @@ describe('getDefaultLocale', () => {
       },
     ];
 
-    const userPermissions = [
-      {
-        id: 1324,
-        action: 'plugins::i18n.locale.read',
-        subject: null,
-        properties: {},
-        conditions: [],
-      },
-      {
-        id: 1325,
-        action: 'plugins::content-manager.explorer.create',
-        subject: 'application::address.address',
-        properties: {
-          fields: [
-            'postal_coder',
-            'categories',
-            'cover',
-            'images',
-            'city',
-            'likes',
-            'json',
-            'slug',
-          ],
-          locales: ['en', 'de'],
+    const ctPermissions = {
+      'plugins::content-manager.explorer.create': [
+        {
+          id: 1325,
+          action: 'plugins::content-manager.explorer.create',
+          subject: 'application::address.address',
+          properties: {
+            fields: [
+              'postal_coder',
+              'categories',
+              'cover',
+              'images',
+              'city',
+              'likes',
+              'json',
+              'slug',
+            ],
+            locales: ['en', 'de'],
+          },
+          conditions: [],
         },
-        conditions: [],
-      },
-      {
-        id: 1326,
-        action: 'plugins::content-manager.explorer.read',
-        subject: 'application::address.address',
-        properties: {
-          fields: [],
-          locales: [],
+      ],
+      'plugins::content-manager.explorer.read': [
+        {
+          id: 1326,
+          action: 'plugins::content-manager.explorer.read',
+          subject: 'application::address.address',
+          properties: {
+            fields: [],
+            locales: [],
+          },
+          conditions: [],
         },
-        conditions: [],
-      },
-    ];
+      ],
+    };
 
     const expected = 'en';
-    const actual = getDefaultLocale('application::address.address', userPermissions, locales);
+    const actual = getDefaultLocale(ctPermissions, locales);
 
     expect(actual).toEqual(expected);
   });
@@ -305,47 +293,44 @@ describe('getDefaultLocale', () => {
       },
     ];
 
-    const userPermissions = [
-      {
-        id: 1324,
-        action: 'plugins::i18n.locale.read',
-        subject: null,
-        properties: {},
-        conditions: [],
-      },
-      {
-        id: 1325,
-        action: 'plugins::content-manager.explorer.create',
-        subject: 'application::address.address',
-        properties: {
-          fields: [
-            'postal_coder',
-            'categories',
-            'cover',
-            'images',
-            'city',
-            'likes',
-            'json',
-            'slug',
-          ],
-          locales: [],
+    const ctPermissions = {
+      'plugins::content-manager.explorer.create': [
+        {
+          id: 1325,
+          action: 'plugins::content-manager.explorer.create',
+          subject: 'application::address.address',
+          properties: {
+            fields: [
+              'postal_coder',
+              'categories',
+              'cover',
+              'images',
+              'city',
+              'likes',
+              'json',
+              'slug',
+            ],
+            locales: [],
+          },
+          conditions: [],
         },
-        conditions: [],
-      },
-      {
-        id: 1326,
-        action: 'plugins::content-manager.explorer.read',
-        subject: 'application::address.address',
-        properties: {
-          fields: [],
-          locales: [],
+      ],
+      'plugins::content-manager.explorer.read': [
+        {
+          id: 1326,
+          action: 'plugins::content-manager.explorer.read',
+          subject: 'application::address.address',
+          properties: {
+            fields: [],
+            locales: [],
+          },
+          conditions: [],
         },
-        conditions: [],
-      },
-    ];
+      ],
+    };
 
     const expected = null;
-    const actual = getDefaultLocale('application::address.address', userPermissions, locales);
+    const actual = getDefaultLocale(ctPermissions, locales);
 
     expect(actual).toEqual(expected);
   });


### PR DESCRIPTION

### What does it do?

Set the initial locale in the i18n middleware using the following rules (in that order):

- If a CT is allowed to be read and that it has the default locale on it, it returns the **default locale**
- If a CT is allowed to be created and that it has the default locale on it, it returns the **default locale**
- If a CT is allowed to be read and that it has NOT the default locale on it, it returns the **first allowed locale**
- If a CT is allowed to be created and that it has NOT the default locale on it, it returns the **first allowed locale**
- else, it returns null