### PR TITLE
[i18n] add the locale column in the CM list view

### DIFF
--- a/packages/strapi-plugin-content-manager/admin/src/components/CustomTable/styledComponents.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/CustomTable/styledComponents.js
@@ -13,6 +13,9 @@ const Table = styled.table`
   td {
     border: none;
     padding: 0;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
   }
 
   th,

--- a/packages/strapi-plugin-i18n/admin/src/components/LocaleListCell/LocaleListCell.js
+++ b/packages/strapi-plugin-i18n/admin/src/components/LocaleListCell/LocaleListCell.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const propTypes = {
+  localizations: PropTypes.arrayOf(PropTypes.string).isRequired,
+  locales: PropTypes.arrayOf(
+    PropTypes.shape({
+      name: PropTypes.string.isRequired,
+      code: PropTypes.string.isRequired,
+      isDefault: PropTypes.bool,
+    })
+  ).isRequired,
+  locale: PropTypes.string.isRequired,
+};
+
+const mapToLocaleName = (locales, localeCode) =>
+  locales.find(({ code }) => code === localeCode).name;
+
+const LocaleListCell = ({ locales, locale: localCode, localizations }) => {
+  const allLocalesWithoutActual = localizations.filter(locale => locale !== localCode);
+  const defaultLocale = locales.find(locale => locale.isDefault);
+  const hasDefaultLocale = allLocalesWithoutActual.includes(defaultLocale.code);
+
+  if (hasDefaultLocale) {
+    const ctLocalesWithoutDefault = allLocalesWithoutActual.filter(locale => locale !== defaultLocale.code);
+    const ctLocalesNamesWithoutDefault = ctLocalesWithoutDefault.map(locale =>
+      mapToLocaleName(locales, locale)
+    );
+
+    ctLocalesNamesWithoutDefault.sort()
+
+    const ctLocalesNamesWithDefault = [
+      `${defaultLocale.name} (default)`,
+      ...ctLocalesNamesWithoutDefault,
+    ];
+
+    return <span>{ctLocalesNamesWithDefault.join(', ')}</span>;
+  }
+
+  const ctLocales = allLocalesWithoutActual.map(locale => mapToLocaleName(locales, locale));
+  ctLocales.sort()
+
+  return <span>{ctLocales.join(', ')}</span>;
+};
+
+LocaleListCell.propTypes = propTypes;
+export default LocaleListCell;

--- a/packages/strapi-plugin-i18n/admin/src/components/LocaleListCell/LocaleListCell.js
+++ b/packages/strapi-plugin-i18n/admin/src/components/LocaleListCell/LocaleListCell.js
@@ -1,7 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Tooltip } from '@buffetjs/styles';
 
 const propTypes = {
+  id: PropTypes.number.isRequired,
   localizations: PropTypes.arrayOf(
     PropTypes.shape({
       locale: PropTypes.string.isRequired,
@@ -14,38 +16,51 @@ const propTypes = {
       isDefault: PropTypes.bool,
     })
   ).isRequired,
-  locale: PropTypes.string.isRequired,
 };
 
 const mapToLocaleName = (locales, localeCode) =>
   locales.find(({ code }) => code === localeCode).name;
 
-const LocaleListCell = ({ locales, locale: localCode, localizations }) => {
+const LocaleListCell = ({ locales, localizations, id }) => {
   const localizationNames = localizations.map(locale => locale.locale);
-  const allLocalesWithoutActual = localizationNames.filter(locale => locale !== localCode);
   const defaultLocale = locales.find(locale => locale.isDefault);
-  const hasDefaultLocale = allLocalesWithoutActual.includes(defaultLocale.code);
+  const hasDefaultLocale = localizationNames.includes(defaultLocale.code);
+
+  let localesNames;
 
   if (hasDefaultLocale) {
-    const ctLocalesWithoutDefault = allLocalesWithoutActual.filter(locale => locale !== defaultLocale.code);
+    const ctLocalesWithoutDefault = localizationNames.filter(
+      locale => locale !== defaultLocale.code
+    );
     const ctLocalesNamesWithoutDefault = ctLocalesWithoutDefault.map(locale =>
       mapToLocaleName(locales, locale)
     );
 
-    ctLocalesNamesWithoutDefault.sort()
+    ctLocalesNamesWithoutDefault.sort();
 
     const ctLocalesNamesWithDefault = [
       `${defaultLocale.name} (default)`,
       ...ctLocalesNamesWithoutDefault,
     ];
 
-    return <span>{ctLocalesNamesWithDefault.join(', ')}</span>;
+    localesNames = ctLocalesNamesWithDefault.join(', ');
+  } else {
+    const ctLocales = localizationNames.map(locale => mapToLocaleName(locales, locale));
+    ctLocales.sort();
+
+    localesNames = ctLocales.join(', ');
   }
 
-  const ctLocales = allLocalesWithoutActual.map(locale => mapToLocaleName(locales, locale));
-  ctLocales.sort()
+  const elId = `entry-${id}__locale`;
 
-  return <span>{ctLocales.join(', ')}</span>;
+  return (
+    <div>
+      <span data-for={elId} data-tip={localesNames}>
+        {localesNames}
+      </span>
+      <Tooltip id={elId} place="top" delay={0} />
+    </div>
+  );
 };
 
 LocaleListCell.propTypes = propTypes;

--- a/packages/strapi-plugin-i18n/admin/src/components/LocaleListCell/LocaleListCell.js
+++ b/packages/strapi-plugin-i18n/admin/src/components/LocaleListCell/LocaleListCell.js
@@ -2,22 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Tooltip } from '@buffetjs/styles';
 
-const propTypes = {
-  id: PropTypes.number.isRequired,
-  localizations: PropTypes.arrayOf(
-    PropTypes.shape({
-      locale: PropTypes.string.isRequired,
-    })
-  ).isRequired,
-  locales: PropTypes.arrayOf(
-    PropTypes.shape({
-      name: PropTypes.string.isRequired,
-      code: PropTypes.string.isRequired,
-      isDefault: PropTypes.bool,
-    })
-  ).isRequired,
-};
-
 const mapToLocaleName = (locales, localeCode) =>
   locales.find(({ code }) => code === localeCode).name;
 
@@ -63,5 +47,20 @@ const LocaleListCell = ({ locales, localizations, id }) => {
   );
 };
 
-LocaleListCell.propTypes = propTypes;
+LocaleListCell.propTypes = {
+  id: PropTypes.number.isRequired,
+  localizations: PropTypes.arrayOf(
+    PropTypes.shape({
+      locale: PropTypes.string.isRequired,
+    })
+  ).isRequired,
+  locales: PropTypes.arrayOf(
+    PropTypes.shape({
+      name: PropTypes.string.isRequired,
+      code: PropTypes.string.isRequired,
+      isDefault: PropTypes.bool,
+    })
+  ).isRequired,
+};
+
 export default LocaleListCell;

--- a/packages/strapi-plugin-i18n/admin/src/components/LocaleListCell/LocaleListCell.js
+++ b/packages/strapi-plugin-i18n/admin/src/components/LocaleListCell/LocaleListCell.js
@@ -2,7 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const propTypes = {
-  localizations: PropTypes.arrayOf(PropTypes.string).isRequired,
+  localizations: PropTypes.arrayOf(
+    PropTypes.shape({
+      locale: PropTypes.string.isRequired,
+    })
+  ).isRequired,
   locales: PropTypes.arrayOf(
     PropTypes.shape({
       name: PropTypes.string.isRequired,
@@ -17,7 +21,8 @@ const mapToLocaleName = (locales, localeCode) =>
   locales.find(({ code }) => code === localeCode).name;
 
 const LocaleListCell = ({ locales, locale: localCode, localizations }) => {
-  const allLocalesWithoutActual = localizations.filter(locale => locale !== localCode);
+  const localizationNames = localizations.map(locale => locale.locale);
+  const allLocalesWithoutActual = localizationNames.filter(locale => locale !== localCode);
   const defaultLocale = locales.find(locale => locale.isDefault);
   const hasDefaultLocale = allLocalesWithoutActual.includes(defaultLocale.code);
 

--- a/packages/strapi-plugin-i18n/admin/src/components/LocaleListCell/tests/LocaleListCell.test.js
+++ b/packages/strapi-plugin-i18n/admin/src/components/LocaleListCell/tests/LocaleListCell.test.js
@@ -2,6 +2,10 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import LocaleListCell from '../LocaleListCell';
 
+jest.mock('@buffetjs/styles', () => ({
+  Tooltip: () => null,
+}));
+
 describe('LocaleListCell', () => {
   it('returns the default locale first, then the others sorted alphabetically', () => {
     const locales = [
@@ -34,7 +38,9 @@ describe('LocaleListCell', () => {
     const locale = 'en';
     const localizations = [{ locale: 'fr-FR' }, { locale: 'ar' }];
 
-    render(<LocaleListCell locales={locales} locale={locale} localizations={localizations} />);
+    render(
+      <LocaleListCell id={12} locales={locales} locale={locale} localizations={localizations} />
+    );
 
     expect(screen.getByText('French (default), Arabic')).toBeVisible();
   });
@@ -70,7 +76,9 @@ describe('LocaleListCell', () => {
     const locale = 'en';
     const localizations = [{ locale: 'ar' }];
 
-    render(<LocaleListCell locales={locales} locale={locale} localizations={localizations} />);
+    render(
+      <LocaleListCell id={12} locales={locales} locale={locale} localizations={localizations} />
+    );
 
     expect(screen.getByText('Arabic')).toBeVisible();
   });
@@ -106,7 +114,9 @@ describe('LocaleListCell', () => {
     const locale = 'fr-FR';
     const localizations = [{ locale: 'en' }, { locale: 'ar' }];
 
-    render(<LocaleListCell locales={locales} locale={locale} localizations={localizations} />);
+    render(
+      <LocaleListCell id={12} locales={locales} locale={locale} localizations={localizations} />
+    );
 
     expect(screen.getByText('Arabic, English')).toBeVisible();
   });

--- a/packages/strapi-plugin-i18n/admin/src/components/LocaleListCell/tests/LocaleListCell.test.js
+++ b/packages/strapi-plugin-i18n/admin/src/components/LocaleListCell/tests/LocaleListCell.test.js
@@ -32,11 +32,11 @@ describe('LocaleListCell', () => {
     ];
 
     const locale = 'en';
-    const localizations = ['fr-FR', 'ar'];
+    const localizations = [{ locale: 'fr-FR' }, { locale: 'ar' }];
 
     render(<LocaleListCell locales={locales} locale={locale} localizations={localizations} />);
 
-    expect(screen.getByText('French (default), Arabic')).toBeVisible()
+    expect(screen.getByText('French (default), Arabic')).toBeVisible();
   });
 
   it('returns the "ar" when there s 2 locales available', () => {
@@ -68,11 +68,11 @@ describe('LocaleListCell', () => {
     ];
 
     const locale = 'en';
-    const localizations = ['ar'];
+    const localizations = [{ locale: 'ar' }];
 
     render(<LocaleListCell locales={locales} locale={locale} localizations={localizations} />);
 
-    expect(screen.getByText('Arabic')).toBeVisible()
+    expect(screen.getByText('Arabic')).toBeVisible();
   });
 
   it('returns the "ar" and "en" locales  alphabetically sorted', () => {
@@ -104,10 +104,10 @@ describe('LocaleListCell', () => {
     ];
 
     const locale = 'fr-FR';
-    const localizations = ['en', 'ar'];
+    const localizations = [{ locale: 'en' }, { locale: 'ar' }];
 
     render(<LocaleListCell locales={locales} locale={locale} localizations={localizations} />);
 
-    expect(screen.getByText('Arabic, English')).toBeVisible()
+    expect(screen.getByText('Arabic, English')).toBeVisible();
   });
 });

--- a/packages/strapi-plugin-i18n/admin/src/components/LocaleListCell/tests/LocaleListCell.test.js
+++ b/packages/strapi-plugin-i18n/admin/src/components/LocaleListCell/tests/LocaleListCell.test.js
@@ -1,0 +1,113 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import LocaleListCell from '../LocaleListCell';
+
+describe('LocaleListCell', () => {
+  it('returns the default locale first, then the others sorted alphabetically', () => {
+    const locales = [
+      {
+        id: 1,
+        name: 'English',
+        code: 'en',
+        created_at: '2021-03-09T14:57:03.016Z',
+        updated_at: '2021-03-09T14:57:03.016Z',
+        isDefault: false,
+      },
+      {
+        id: 2,
+        name: 'French',
+        code: 'fr-FR',
+        created_at: '2021-03-09T15:03:06.992Z',
+        updated_at: '2021-03-17T13:01:03.569Z',
+        isDefault: true,
+      },
+      {
+        id: 3,
+        name: 'Arabic',
+        code: 'ar',
+        created_at: '2021-03-09T15:03:06.992Z',
+        updated_at: '2021-03-17T13:01:03.569Z',
+        isDefault: false,
+      },
+    ];
+
+    const locale = 'en';
+    const localizations = ['fr-FR', 'ar'];
+
+    render(<LocaleListCell locales={locales} locale={locale} localizations={localizations} />);
+
+    expect(screen.getByText('French (default), Arabic')).toBeVisible()
+  });
+
+  it('returns the "ar" when there s 2 locales available', () => {
+    const locales = [
+      {
+        id: 1,
+        name: 'English',
+        code: 'en',
+        created_at: '2021-03-09T14:57:03.016Z',
+        updated_at: '2021-03-09T14:57:03.016Z',
+        isDefault: false,
+      },
+      {
+        id: 2,
+        name: 'French',
+        code: 'fr-FR',
+        created_at: '2021-03-09T15:03:06.992Z',
+        updated_at: '2021-03-17T13:01:03.569Z',
+        isDefault: true,
+      },
+      {
+        id: 3,
+        name: 'Arabic',
+        code: 'ar',
+        created_at: '2021-03-09T15:03:06.992Z',
+        updated_at: '2021-03-17T13:01:03.569Z',
+        isDefault: false,
+      },
+    ];
+
+    const locale = 'en';
+    const localizations = ['ar'];
+
+    render(<LocaleListCell locales={locales} locale={locale} localizations={localizations} />);
+
+    expect(screen.getByText('Arabic')).toBeVisible()
+  });
+
+  it('returns the "ar" and "en" locales  alphabetically sorted', () => {
+    const locales = [
+      {
+        id: 1,
+        name: 'English',
+        code: 'en',
+        created_at: '2021-03-09T14:57:03.016Z',
+        updated_at: '2021-03-09T14:57:03.016Z',
+        isDefault: false,
+      },
+      {
+        id: 2,
+        name: 'French',
+        code: 'fr-FR',
+        created_at: '2021-03-09T15:03:06.992Z',
+        updated_at: '2021-03-17T13:01:03.569Z',
+        isDefault: true,
+      },
+      {
+        id: 3,
+        name: 'Arabic',
+        code: 'ar',
+        created_at: '2021-03-09T15:03:06.992Z',
+        updated_at: '2021-03-17T13:01:03.569Z',
+        isDefault: false,
+      },
+    ];
+
+    const locale = 'fr-FR';
+    const localizations = ['en', 'ar'];
+
+    render(<LocaleListCell locales={locales} locale={locale} localizations={localizations} />);
+
+    expect(screen.getByText('Arabic, English')).toBeVisible()
+  });
+});

--- a/packages/strapi-plugin-i18n/admin/src/middlewares/localeQueryParamsMiddleware.js
+++ b/packages/strapi-plugin-i18n/admin/src/middlewares/localeQueryParamsMiddleware.js
@@ -20,8 +20,6 @@ const localeQueryParamsMiddleware = () => ({ getState }) => next => action => {
   const ctPermissions = collectionTypesRelatedPermissions[action.contentType.uid];
   const defaultLocale = getDefaultLocale(ctPermissions, locales);
 
-  console.log('xxx', locales)
-
   const locale = {
     key: '__locale_key__',
     fieldSchema: { type: 'string' },

--- a/packages/strapi-plugin-i18n/admin/src/middlewares/localeQueryParamsMiddleware.js
+++ b/packages/strapi-plugin-i18n/admin/src/middlewares/localeQueryParamsMiddleware.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import get from 'lodash/get';
 import getDefaultLocale from '../utils/getDefaultLocale';
+import LocaleListCell from '../components/LocaleListCell/LocaleListCell';
 
 const localeQueryParamsMiddleware = () => ({ getState }) => next => action => {
   if (action.type !== 'ContentManager/ListView/SET_LIST_LAYOUT ') {
@@ -19,18 +20,14 @@ const localeQueryParamsMiddleware = () => ({ getState }) => next => action => {
   const ctPermissions = collectionTypesRelatedPermissions[action.contentType.uid];
   const defaultLocale = getDefaultLocale(ctPermissions, locales);
 
+  console.log('xxx', locales)
+
   const locale = {
     key: '__locale_key__',
     fieldSchema: { type: 'string' },
     metadatas: { label: 'Content available in', searchable: false, sortable: false },
     name: 'locales',
-    cellFormatter: props => {
-      const actualLocale = locales.find(({ code }) => code === props.locale);
-
-      console.log('lol', actualLocale)
-
-      return <div>TODO when backend is {actualLocale.name}</div>;
-    },
+    cellFormatter: props => <LocaleListCell {...props} locales={locales} />,
   };
 
   action.displayedHeaders = [...action.displayedHeaders, locale];

--- a/packages/strapi-plugin-i18n/admin/src/middlewares/localeQueryParamsMiddleware.js
+++ b/packages/strapi-plugin-i18n/admin/src/middlewares/localeQueryParamsMiddleware.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import get from 'lodash/get';
 import getDefaultLocale from '../utils/getDefaultLocale';
 
@@ -16,8 +17,23 @@ const localeQueryParamsMiddleware = () => ({ getState }) => next => action => {
   const { locales } = store.get('i18n_locales');
   const { collectionTypesRelatedPermissions } = store.get('permissionsManager');
   const ctPermissions = collectionTypesRelatedPermissions[action.contentType.uid];
-
   const defaultLocale = getDefaultLocale(ctPermissions, locales);
+
+  const locale = {
+    key: '__locale_key__',
+    fieldSchema: { type: 'string' },
+    metadatas: { label: 'Content available in', searchable: false, sortable: false },
+    name: 'locales',
+    cellFormatter: props => {
+      const actualLocale = locales.find(({ code }) => code === props.locale);
+
+      console.log('lol', actualLocale)
+
+      return <div>TODO when backend is {actualLocale.name}</div>;
+    },
+  };
+
+  action.displayedHeaders = [...action.displayedHeaders, locale];
 
   if (!action.initialParams.plugins) {
     action.initialParams.plugins = {

--- a/packages/strapi-plugin-i18n/admin/src/middlewares/tests/localeQueryParamsMiddleware.test.js
+++ b/packages/strapi-plugin-i18n/admin/src/middlewares/tests/localeQueryParamsMiddleware.test.js
@@ -56,6 +56,7 @@ describe('localeQueryParamsMiddleware', () => {
     const nextFn = jest.fn();
     const action = {
       type: 'ContentManager/ListView/SET_LIST_LAYOUT ',
+      displayedHeaders: [],
       contentType: {
         pluginOptions: {
           i18n: { localized: true },
@@ -67,11 +68,13 @@ describe('localeQueryParamsMiddleware', () => {
     middleware(nextFn)(action);
 
     expect(nextFn).toBeCalledWith(action);
-    expect(action).toEqual({
-      contentType: { pluginOptions: { i18n: { localized: true } } },
-      initialParams: { plugins: { i18n: { locale: null } } },
-      type: 'ContentManager/ListView/SET_LIST_LAYOUT ',
-    });
+    // The anonymous function of cellFormatter creates problem, because it's anonymous
+    // In our scenario, it's even more tricky because we use a closure in order to pass
+    // the locales.
+    // Stringifying the action allows us to have a name inside the expectation for the "cellFormatter" key
+    expect(JSON.stringify(action)).toBe(
+      '{"type":"ContentManager/ListView/SET_LIST_LAYOUT ","displayedHeaders":[{"key":"__locale_key__","fieldSchema":{"type":"string"},"metadatas":{"label":"Content available in","searchable":false,"sortable":false},"name":"locales"}],"contentType":{"pluginOptions":{"i18n":{"localized":true}}},"initialParams":{"plugins":{"i18n":{"locale":null}}}}'
+    );
   });
 
   it('adds a key to plugins with a locale when initialParams has a plugins key and the field is localized', () => {
@@ -79,6 +82,7 @@ describe('localeQueryParamsMiddleware', () => {
     const nextFn = jest.fn();
     const action = {
       type: 'ContentManager/ListView/SET_LIST_LAYOUT ',
+      displayedHeaders: [],
       contentType: {
         pluginOptions: {
           i18n: { localized: true },
@@ -94,10 +98,8 @@ describe('localeQueryParamsMiddleware', () => {
     middleware(nextFn)(action);
 
     expect(nextFn).toBeCalledWith(action);
-    expect(action).toEqual({
-      contentType: { pluginOptions: { i18n: { localized: true } } },
-      initialParams: { plugins: { i18n: { locale: null }, hello: 'world' } },
-      type: 'ContentManager/ListView/SET_LIST_LAYOUT ',
-    });
+    expect(JSON.stringify(action)).toBe(
+      '{"type":"ContentManager/ListView/SET_LIST_LAYOUT ","displayedHeaders":[{"key":"__locale_key__","fieldSchema":{"type":"string"},"metadatas":{"label":"Content available in","searchable":false,"sortable":false},"name":"locales"}],"contentType":{"pluginOptions":{"i18n":{"localized":true}}},"initialParams":{"plugins":{"hello":"world","i18n":{"locale":null}}}}'
+    );
   });
 });


### PR DESCRIPTION


### What does it do?

It adds a locale column using the `localeQueryParamsMiddleware` in i18n using the following rules:

- Show only the complementary to the actual locale (if I'm looking to "EN" entries, I don't show "En" in the list of locales of the row)
- The default locale is always the first and it has a `(default)` suffix
- Other locales are ordered in alphabetical order


<img width="1280" alt="Screenshot 2021-03-18 at 12 47 23" src="https://user-images.githubusercontent.com/3874873/111621573-6fa24500-87e8-11eb-9dc5-17fb25e977d0.png">

_NB: the weird name is based on a custom modification I did on my set to test i18n settings edition_