### PR TITLE
[i18n] don't add locale in settings when it already exists

### DIFF
--- a/packages/strapi-plugin-i18n/admin/src/hooks/useAddLocale/index.js
+++ b/packages/strapi-plugin-i18n/admin/src/hooks/useAddLocale/index.js
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { request } from 'strapi-helper-plugin';
 import { useDispatch } from 'react-redux';
+import get from 'lodash/get';
 import { getTrad } from '../../utils';
 import { ADD_LOCALE } from '../constants';
 
@@ -22,10 +23,19 @@ const addLocale = async ({ code, name, isDefault }) => {
 
     return data;
   } catch (e) {
-    strapi.notification.toggle({
-      type: 'warning',
-      message: { id: 'notification.error' },
-    });
+    const message = get(e, 'response.payload.message', null);
+
+    if (message && message.includes('already exists')) {
+      strapi.notification.toggle({
+        type: 'warning',
+        message: { id: getTrad('Settings.locales.modal.create.alreadyExist') },
+      });
+    } else {
+      strapi.notification.toggle({
+        type: 'warning',
+        message: { id: 'notification.error' },
+      });
+    }
 
     throw e;
   }

--- a/packages/strapi-plugin-i18n/admin/src/hooks/useAddLocale/index.js
+++ b/packages/strapi-plugin-i18n/admin/src/hooks/useAddLocale/index.js
@@ -27,7 +27,7 @@ const addLocale = async ({ code, name, isDefault }) => {
       message: { id: 'notification.error' },
     });
 
-    return e;
+    throw e;
   }
 };
 

--- a/packages/strapi-plugin-i18n/admin/src/translations/en.json
+++ b/packages/strapi-plugin-i18n/admin/src/translations/en.json
@@ -39,6 +39,7 @@
   "Settings.locales.modal.create.defaultLocales.loading": "Loading the available locales...",
   "Settings.locales.modal.create.confirmation": "Add locale",
   "Settings.locales.modal.create.success": "Locale successfully added",
+  "Settings.locales.modal.create.alreadyExist": "This locale already exists",
   "Settings.locales.modal.locales.label": "Locales",
   "Settings.locales.modal.edit.locales.label": "Locales",
   "Settings.locales.modal.locales.displayName": "Locale display name",


### PR DESCRIPTION
### What does it do?

Does not add a line in the array when the locale already exists and show an explicit toast about that