### PR TITLE
[i18n/rbac] show locale picker even when not authorized

### DIFF
--- a/packages/strapi-plugin-content-manager/admin/src/containers/ListView/index.js
+++ b/packages/strapi-plugin-content-manager/admin/src/containers/ListView/index.js
@@ -362,6 +362,15 @@ function ListView({
           {isSearchable && canRead && (
             <Search changeParams={setQuery} initValue={_q} model={label} value={_q} />
           )}
+
+          {!canRead && (
+            <Flex justifyContent="flex-end">
+              <Padded right size="sm">
+                <InjectionZone area={`${pluginId}.listView.actions`} />
+              </Padded>
+            </Flex>
+          )}
+
           {canRead && (
             <Wrapper>
               <div className="row" style={{ marginBottom: '5px' }}>


### PR DESCRIPTION

### What does it do?

Shows the locale dropdown even when the user doesn't have the locale activated so that they can switch language.

![2021-03-19 09 05 05](https://user-images.githubusercontent.com/3874873/111749756-869d7180-8892-11eb-9ea1-845a012974ef.gif)
