### PR TITLE
Fix wrong message when username exists (#9787)

### DIFF
--- a/packages/strapi-plugin-users-permissions/controllers/Auth.js
+++ b/packages/strapi-plugin-users-permissions/controllers/Auth.js
@@ -483,6 +483,21 @@ module.exports = {
       );
     }
 
+    // Check username existancy
+    const usernameExists = await strapi.query('user', 'users-permissions').findOne({
+      username: params.username,
+    });
+
+    if (usernameExists) {
+      return ctx.badRequest(
+        null,
+        formatError({
+          id: 'Auth.form.error.username.taken',
+          message: 'Username already taken',
+        })
+      );
+    }
+
     try {
       if (!settings.email_confirmation) {
         params.confirmed = true;
@@ -511,14 +526,10 @@ module.exports = {
         user: sanitizedUser,
       });
     } catch (err) {
-      const adminError = _.includes(err.message, 'username')
-        ? {
-            id: 'Auth.form.error.username.taken',
-            message: 'Username already taken',
-          }
-        : { id: 'Auth.form.error.email.taken', message: 'Email already taken' };
-
-      ctx.badRequest(null, formatError(adminError));
+      ctx.badRequest(
+        null,
+        formatError({ id: 'Auth.form.error.email.taken', message: 'Email already taken' })
+      );
     }
   },
 


### PR DESCRIPTION
### What does it do?

Fixes issue #9787 #5479

### Why is it needed?

Wrong message was shown when username already exists (shown as email duplicate)

### How to test it?

Register an user account, then register another one with same username and different email.

```
POST http://localhost:1337/auth/local/register
{
    "username": "johndoe",
    "email": "johndoe@email.com",
    "password": "abcd1234"
}
```

2nd request

```
POST http://localhost:1337/auth/local/register
{
    "username": "johndoe",
    "email": "johndoe2@email.com",
    "password": "abcd1234"
}
```

check error message 'Username already taken' is shown.


### Related issue(s)/PR(s)

#9787 #5479