### PR TITLE
[I18n/rbac] add additional infos in delete modal

### DIFF
--- a/packages/strapi-helper-plugin/lib/src/components/InjectionZone/InjectionZone.js
+++ b/packages/strapi-helper-plugin/lib/src/components/InjectionZone/InjectionZone.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import useInjectionZone from './useInjectionZone';
+
+const InjectionZone = ({ area, ...props }) => {
+  const compos = useInjectionZone(area);
+
+  if (!compos) {
+    return null;
+  }
+
+  return compos.map(compo => <compo.Component key={compo.name} {...props} />);
+};
+
+InjectionZone.propTypes = {
+  area: PropTypes.string.isRequired,
+};
+
+export default InjectionZone;

--- a/packages/strapi-helper-plugin/lib/src/components/InjectionZone/InjectionZoneList.js
+++ b/packages/strapi-helper-plugin/lib/src/components/InjectionZone/InjectionZoneList.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import useInjectionZone from './useInjectionZone';
+
+const List = styled.ul``;
+
+const ListItem = styled.li`
+  font-size: ${p => p.theme.main.sizes.fonts.md};
+
+  &::marker {
+    color: ${p => p.theme.main.colors.grey};
+  }
+`;
+
+const InjectionZoneList = ({ area, ...props }) => {
+  const compos = useInjectionZone(area);
+
+  if (!compos) {
+    return null;
+  }
+
+  return (
+    <List>
+      {compos.map(compo => (
+        <ListItem key={compo.name}>
+          <compo.Component {...props} />
+        </ListItem>
+      ))}
+    </List>
+  );
+};
+
+InjectionZoneList.propTypes = {
+  area: PropTypes.string.isRequired,
+};
+
+export default InjectionZoneList;

--- a/packages/strapi-helper-plugin/lib/src/components/InjectionZone/InjectionZoneList.js
+++ b/packages/strapi-helper-plugin/lib/src/components/InjectionZone/InjectionZoneList.js
@@ -3,8 +3,6 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import useInjectionZone from './useInjectionZone';
 
-const List = styled.ul``;
-
 const ListItem = styled.li`
   font-size: ${p => p.theme.main.sizes.fonts.md};
 
@@ -21,13 +19,13 @@ const InjectionZoneList = ({ area, ...props }) => {
   }
 
   return (
-    <List>
+    <ul>
       {compos.map(compo => (
         <ListItem key={compo.name}>
           <compo.Component {...props} />
         </ListItem>
       ))}
-    </List>
+    </ul>
   );
 };
 

--- a/packages/strapi-helper-plugin/lib/src/components/InjectionZone/index.js
+++ b/packages/strapi-helper-plugin/lib/src/components/InjectionZone/index.js
@@ -1,24 +1,2 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import useStrapi from '../../hooks/useStrapi';
-
-const InjectionZone = ({ area, ...props }) => {
-  const { strapi: globalStrapi } = useStrapi();
-
-  const [pluginName, page, position] = area.split('.');
-  const plugin = globalStrapi.getPlugin(pluginName);
-
-  if (!plugin) {
-    return null;
-  }
-
-  const compos = plugin.getInjectedComponents(page, position);
-
-  return compos.map(compo => <compo.Component key={compo.name} {...props} />);
-};
-
-InjectionZone.propTypes = {
-  area: PropTypes.string.isRequired,
-};
-
-export default InjectionZone;
+export { default as InjectionZone } from './InjectionZone';
+export { default as InjectionZoneList } from './InjectionZoneList';

--- a/packages/strapi-helper-plugin/lib/src/components/InjectionZone/useInjectionZone.js
+++ b/packages/strapi-helper-plugin/lib/src/components/InjectionZone/useInjectionZone.js
@@ -1,0 +1,16 @@
+import useStrapi from '../../hooks/useStrapi';
+
+const useInjectionZone = area => {
+  const { strapi: globalStrapi } = useStrapi();
+
+  const [pluginName, page, position] = area.split('.');
+  const plugin = globalStrapi.getPlugin(pluginName);
+
+  if (!plugin) {
+    return null;
+  }
+
+  return plugin.getInjectedComponents(page, position);
+};
+
+export default useInjectionZone;

--- a/packages/strapi-helper-plugin/lib/src/components/PopUpWarning/index.js
+++ b/packages/strapi-helper-plugin/lib/src/components/PopUpWarning/index.js
@@ -24,6 +24,7 @@ function PopUpWarning({
   onlyConfirmButton,
   popUpWarningType,
   toggleModal,
+  children,
   ...rest
 }) {
   const handleToggle = e => {
@@ -77,6 +78,7 @@ function PopUpWarning({
             </Text>
           </Padded>
         )}
+        {children}
       </Body>
       <StyledFooter>
         {map(footerButtons, button => {

--- a/packages/strapi-helper-plugin/lib/src/index.js
+++ b/packages/strapi-helper-plugin/lib/src/index.js
@@ -28,7 +28,7 @@ export { default as InputAddon } from './components/InputAddon';
 export { default as EmptyState } from './components/EmptyState';
 export * from './components/Tabs';
 export * from './components/Select';
-export { default as InjectionZone } from './components/InjectionZone';
+export * from './components/InjectionZone';
 
 export { default as InputAddonWithErrors } from './components/InputAddonWithErrors';
 export { default as InputCheckbox } from './components/InputCheckbox';

--- a/packages/strapi-plugin-content-manager/admin/src/containers/ListView/index.js
+++ b/packages/strapi-plugin-content-manager/admin/src/containers/ListView/index.js
@@ -467,7 +467,9 @@ function ListView({
           onConfirm={handleConfirmDeleteAllData}
           onClosed={handleModalClose}
           isConfirmButtonLoading={showModalConfirmButtonLoading}
-        />
+        >
+          <InjectionZoneList area={`${pluginId}.listView.deleteModalAdditionalInfos`} />
+        </PopUpWarning>
       </ListViewProvider>
     </>
   );

--- a/packages/strapi-plugin-content-manager/admin/src/containers/ListView/index.js
+++ b/packages/strapi-plugin-content-manager/admin/src/containers/ListView/index.js
@@ -15,6 +15,7 @@ import {
   CheckPermissions,
   useGlobalContext,
   InjectionZone,
+  InjectionZoneList,
   useQueryParams,
 } from 'strapi-helper-plugin';
 import pluginId from '../../pluginId';
@@ -449,7 +450,9 @@ function ListView({
           popUpWarningType="danger"
           onClosed={handleModalClose}
           isConfirmButtonLoading={showModalConfirmButtonLoading}
-        />
+        >
+          <InjectionZoneList area={`${pluginId}.listView.deleteModalAdditionalInfos`} />
+        </PopUpWarning>
         <PopUpWarning
           isOpen={showWarningDeleteAll}
           toggleModal={toggleModalDeleteAll}

--- a/packages/strapi-plugin-content-manager/admin/src/index.js
+++ b/packages/strapi-plugin-content-manager/admin/src/index.js
@@ -34,7 +34,7 @@ export default strapi => {
     ],
     injectionZones: {
       editView: { informations: [] },
-      listView: { actions: [] },
+      listView: { actions: [], deleteModalAdditionalInfos: [] },
     },
     isReady: true,
     isRequired: pluginPkg.strapi.required || false,

--- a/packages/strapi-plugin-i18n/admin/src/components/DeleteModalAdditionalInfos/index.js
+++ b/packages/strapi-plugin-i18n/admin/src/components/DeleteModalAdditionalInfos/index.js
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { FormattedMessage } from 'react-intl';
+import { getTrad } from '../../utils';
+
+const DeleteModalAdditionalInfos = () => {
+  return (
+    <span>
+      <FormattedMessage
+        id={getTrad('Settings.list.actions.deleteAdditionalInfos')}
+        values={{
+          em: chunks => <em>{chunks}</em>,
+        }}
+      />
+    </span>
+  );
+};
+
+export default DeleteModalAdditionalInfos;

--- a/packages/strapi-plugin-i18n/admin/src/index.js
+++ b/packages/strapi-plugin-i18n/admin/src/index.js
@@ -16,6 +16,7 @@ import { getTrad } from './utils';
 import mutateCTBContentTypeSchema from './utils/mutateCTBContentTypeSchema';
 import LOCALIZED_FIELDS from './utils/localizedFields';
 import i18nReducers from './hooks/reducers';
+import DeleteModalAdditionalInfos from './components/DeleteModalAdditionalInfos';
 
 export default strapi => {
   const pluginDescription = pluginPkg.strapi.description || pluginPkg.description;
@@ -64,6 +65,11 @@ export default strapi => {
         cmPlugin.injectComponent('listView', 'actions', {
           name: 'i18n-locale-filter',
           Component: LocalePicker,
+        });
+
+        cmPlugin.injectComponent('listView', 'deleteModalAdditionalInfos', {
+          name: 'i18n-delete-bullets-in-modal',
+          Component: DeleteModalAdditionalInfos,
         });
       }
 

--- a/packages/strapi-plugin-i18n/admin/src/translations/en.json
+++ b/packages/strapi-plugin-i18n/admin/src/translations/en.json
@@ -25,6 +25,7 @@
   "Settings.list.actions.add": "Add a locale",
   "Settings.list.actions.edit": "Edit a locale",
   "Settings.list.actions.delete": "Delete a locale",
+  "Settings.list.actions.deleteAdditionalInfos": "This will delete the active locale versions <em>(from Internationalization)</em>",
   "Settings.locales.list.title.singular": "{number} Locale",
   "Settings.locales.list.title.plural": "{number} Locales",
   "Settings.locales.row.default-locale": "Default locale",


### PR DESCRIPTION

### What does it do?

- Creates an `InjectionZoneList` component for list-based injection zone (semantic)
- Modify the `PopupWarning` so that it accepts children in its body in order to enhance it with injection zones
- Configure an Injection zone in the content-manager-plugin in order to show addition information there
- Create a component in plugin i18n that will be injected in the delete modal injection zone of the content-manager

<img width="478" alt="Screenshot 2021-03-22 at 10 02 24" src="https://user-images.githubusercontent.com/3874873/111966069-c5cbfc80-8af6-11eb-8bb4-9a6b4f615386.png">
