### PR TITLE
[i18n] add filters from the start

### DIFF
--- a/packages/strapi-plugin-i18n/admin/src/components/ModalCreate/BaseForm.js
+++ b/packages/strapi-plugin-i18n/admin/src/components/ModalCreate/BaseForm.js
@@ -2,13 +2,19 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Label } from '@buffetjs/core';
 import { Inputs } from '@buffetjs/custom';
-import Select from 'react-select';
+import Select, { createFilter } from 'react-select';
 import { Col, Row } from 'reactstrap';
 import { useIntl } from 'react-intl';
 import { useTheme } from 'styled-components';
 import { BaselineAlignment, selectStyles, DropdownIndicator } from 'strapi-helper-plugin';
 import { useFormikContext } from 'formik';
 import { getTrad } from '../../utils';
+
+const reactSelectLocaleFilter = createFilter({
+  ignoreCase: true,
+  ignoreAccents: true,
+  matchFrom: 'start',
+});
 
 const BaseForm = ({ options, defaultOption }) => {
   const theme = useTheme();
@@ -34,6 +40,7 @@ const BaseForm = ({ options, defaultOption }) => {
           aria-labelledby="locale-code"
           options={options}
           defaultValue={defaultOption}
+          filterOption={reactSelectLocaleFilter}
           onChange={selection => {
             setFieldValue('displayName', selection.value);
             setFieldValue('code', selection.label);


### PR DESCRIPTION


### What does it do?

Allows to filter from the start in the I18N settings page when trying to add a new locale to the project

### Why is it needed?

Better UX

### How to test it?

- Log in the app
- Go on the Settings page (left sidebar)
- Select internationalization in the sub-left sidebar
- Click "Add a locale" button on the top right-hand corner
- Play with the locale dropdown
