### PR TITLE
Content Manager relations bypass author permissions

### DIFF
--- a/packages/strapi-plugin-content-manager/controllers/relations.js
+++ b/packages/strapi-plugin-content-manager/controllers/relations.js
@@ -10,6 +10,7 @@ module.exports = {
     const { model, targetField } = ctx.params;
     const { _component, ...query } = ctx.request.query;
     const { idsToOmit } = ctx.request.body;
+    const { userAbility } = ctx.state;
 
     if (!targetField) {
       return ctx.badRequest();
@@ -38,13 +39,15 @@ module.exports = {
     }
 
     const entityManager = getService('entity-manager');
+    const permissionChecker = getService('permission-checker').create({ userAbility, model });
+    const permissionQuery = permissionChecker.buildReadQuery(query);
 
     let entities = [];
 
     if (has('_q', ctx.request.query)) {
-      entities = await entityManager.search(query, target.uid);
+      entities = await entityManager.search(permissionQuery, target.uid);
     } else {
-      entities = await entityManager.find(query, target.uid);
+      entities = await entityManager.find(permissionQuery, target.uid);
     }
 
     if (!entities) {


### PR DESCRIPTION
Hey, guys our `strapi-plugin-content-manager/controllers/relations.js` has security concern, it shows entities which author should not see. I fixed it according to `strapi-plugin-content-manager/controllers/collection-types.js`

### What does it do?

Adds security check

### Why is it needed?

In related field dropdown author can see foreign entities, which is insecure.

### How to test it?

Create content type with relations
Create Admin account
Create Author account, and configure it to see only own content
Create content with Admin account
Go to Author account and see insecure Admin content

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
