### PR TITLE
Add button to copy permissions from a existing role

### DIFF
--- a/packages/strapi-admin/admin/src/translations/en.json
+++ b/packages/strapi-admin/admin/src/translations/en.json
@@ -105,6 +105,7 @@
   "Settings.permissions.users.listview.header.description.plural": "{number} users found",
   "Settings.permissions.users.listview.header.description.singular": "{number} user found",
   "Settings.permissions.users.listview.header.title": "Users",
+  "Settings.roles.copy-role": "Copy a existing role",
   "Settings.roles.create.description": "Define the rights given to the role",
   "Settings.roles.create.title": "Create a role",
   "Settings.roles.created": "Role created",

--- a/packages/strapi-admin/admin/src/translations/ko.json
+++ b/packages/strapi-admin/admin/src/translations/ko.json
@@ -46,6 +46,7 @@
   "Provider": "프로바이더(provider)",
   "ResetPasswordToken": "패스워트 토큰 재설정",
   "Role": "역할",
+  "Settings.roles.copy-role": "기존 권한 복사",
   "Username": "사용자 이름(Username)",
   "Users": "User",
   "Users & Permissions": "사용자 & 권한(permissions)",

--- a/packages/strapi-plugin-users-permissions/admin/src/components/Roles/RolePicker/Button.js
+++ b/packages/strapi-plugin-users-permissions/admin/src/components/Roles/RolePicker/Button.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Carret } from 'strapi-helper-plugin';
+
+const Button = ({ isOpen, label }) => {
+  return (
+    <>
+      {label}
+      <Carret isUp={isOpen} fill={isOpen ? '#007eff' : '#292b2c'} />
+    </>
+  );
+};
+
+Button.defaultProps = {
+  isOpen: false,
+  label: '',
+};
+
+Button.propTypes = {
+  isOpen: PropTypes.bool,
+  label: PropTypes.string,
+};
+
+export default Button;

--- a/packages/strapi-plugin-users-permissions/admin/src/components/Roles/RolePicker/List.js
+++ b/packages/strapi-plugin-users-permissions/admin/src/components/Roles/RolePicker/List.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import ListItem from './ListItem';
+import ListWrapper from './ListWrapper';
+
+const RoleList = ({ onClick, items, selectedItem }) => {
+  return (
+    <ListWrapper>
+      {items.map(item => {
+        return (
+          <ListItem
+            key={item.id}
+            label={item.name}
+            value={item.id}
+            onClick={onClick}
+            selectedItem={selectedItem}
+          />
+        );
+      })}
+    </ListWrapper>
+  );
+};
+
+RoleList.defaultProps = {
+  onClick: () => {},
+  items: [],
+  selectedItem: null,
+};
+
+RoleList.propTypes = {
+  onClick: PropTypes.func,
+  items: PropTypes.array,
+  selectedItem: PropTypes.string,
+};
+
+export default RoleList;

--- a/packages/strapi-plugin-users-permissions/admin/src/components/Roles/RolePicker/ListItem.js
+++ b/packages/strapi-plugin-users-permissions/admin/src/components/Roles/RolePicker/ListItem.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Text } from '@buffetjs/core';
+import StyledListItem from './StyledListItem';
+
+const ListItem = ({ onClick, selectedItem, label, value }) => {
+  const handleClick = () => {
+    onClick({ target: { value } });
+  };
+
+  return (
+    <StyledListItem isActive={selectedItem === value} onClick={handleClick}>
+      <Text lineHeight="27px">{label}</Text>
+    </StyledListItem>
+  );
+};
+
+ListItem.defaultProps = {
+  selectedItem: null,
+  label: '',
+  onClick: () => {},
+  value: null,
+};
+
+ListItem.propTypes = {
+  selectedItem: PropTypes.string,
+  label: PropTypes.string,
+  onClick: PropTypes.func,
+  value: PropTypes.string,
+};
+
+export default ListItem;

--- a/packages/strapi-plugin-users-permissions/admin/src/components/Roles/RolePicker/ListWrapper.js
+++ b/packages/strapi-plugin-users-permissions/admin/src/components/Roles/RolePicker/ListWrapper.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import styled from 'styled-components';
+import { themePropTypes } from 'strapi-helper-plugin';
+import { Text } from '@buffetjs/core';
+
+const ListWrapper = styled(props => <Text as="ul" fontSize="md" {...props} />)`
+  margin-bottom: 0;
+  padding: 0;
+  min-width: 230px;
+  list-style-type: none;
+  background-color: ${({ theme }) => theme.main.colors.white};
+`;
+
+ListWrapper.propTypes = {
+  ...themePropTypes,
+};
+
+export default ListWrapper;

--- a/packages/strapi-plugin-users-permissions/admin/src/components/Roles/RolePicker/StyledListItem.js
+++ b/packages/strapi-plugin-users-permissions/admin/src/components/Roles/RolePicker/StyledListItem.js
@@ -1,0 +1,30 @@
+import styled from 'styled-components';
+import PropTypes from 'prop-types';
+import { themePropTypes } from 'strapi-helper-plugin';
+
+/* eslint-disable indent */
+
+const StyledListItem = styled.li`
+  padding: 0 14px;
+  height: 27px;
+  &:hover {
+    cursor: pointer;
+    background-color: ${({ theme }) => theme.main.colors.mediumGrey};
+  }
+  ${({ isActive, theme }) =>
+    isActive &&
+    `
+    background-color: ${theme.main.colors.mediumGrey};
+  `}
+`;
+
+StyledListItem.defaultProps = {
+  isActive: false,
+};
+
+StyledListItem.propTypes = {
+  isActive: PropTypes.bool,
+  ...themePropTypes,
+};
+
+export default StyledListItem;

--- a/packages/strapi-plugin-users-permissions/admin/src/components/Roles/RolePicker/index.js
+++ b/packages/strapi-plugin-users-permissions/admin/src/components/Roles/RolePicker/index.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Picker } from '@buffetjs/core';
+import { request } from 'strapi-helper-plugin';
+import Button from './Button';
+import List from './List';
+import { useRolesList } from '../../../hooks';
+import pluginId from '../../../pluginId';
+
+const RolePicker = ({ onChange, value, label }) => {
+  const { roles } = useRolesList(true);
+  const handleChange = async ({ target: { value } }) => {
+    try {
+      const { role } = await request(`/${pluginId}/roles/${value}`, { method: 'GET' });
+      onChange(role);
+    } catch (err) {
+      console.error(err);
+      strapi.notification.toggle({
+        type: 'warning',
+        message: { id: 'notification.error' },
+      });
+    }
+  };
+
+  return (
+    <Picker
+      renderButtonContent={isOpen => <Button isOpen={isOpen} label={label} />}
+      renderSectionContent={onToggle => (
+        <List
+          items={roles}
+          selectedItem={value}
+          onClick={async e => {
+            await handleChange(e);
+            onToggle();
+          }}
+        />
+      )}
+    />
+  );
+};
+
+RolePicker.defaultProps = {
+  onChange: () => {},
+  value: '',
+  label: '',
+};
+
+RolePicker.propTypes = {
+  onChange: PropTypes.func,
+  value: PropTypes.string,
+  label: PropTypes.string,
+};
+
+export default RolePicker;

--- a/packages/strapi-plugin-users-permissions/admin/src/components/UsersPermissions/index.js
+++ b/packages/strapi-plugin-users-permissions/admin/src/components/UsersPermissions/index.js
@@ -10,6 +10,7 @@ import Permissions from '../Permissions';
 import reducer, { initialState } from './reducer';
 import { UsersPermissionsProvider } from '../../contexts/UsersPermissionsContext';
 import init from './init';
+import RolePicker from '../Roles/RolePicker';
 
 const UsersPermissions = forwardRef(({ permissions, routes, policies }, ref) => {
   const { formatMessage } = useIntl();
@@ -54,12 +55,31 @@ const UsersPermissions = forwardRef(({ permissions, routes, policies }, ref) => 
     });
   }, []);
 
+  const handleRoleChange = useCallback(role => {
+    dispatch({
+      type: 'ON_COPY_EXISTING_ROLE',
+      keys: Object.keys(role.permissions),
+      value: role.permissions,
+    });
+  }, []);
+
   const providerValue = {
     ...state,
     onChange: handleChange,
     onChangeSelectAll: handleChangeSelectAll,
     onSelectedAction: handleSelectedAction,
   };
+
+  const actions = [
+    <RolePicker
+      key="copy-role"
+      label={formatMessage({
+        id: 'Settings.roles.copy-role',
+        defaultMessage: 'Copy a existing role',
+      })}
+      onChange={handleRoleChange}
+    />,
+  ];
 
   return (
     <UsersPermissionsProvider value={providerValue}>
@@ -71,6 +91,7 @@ const UsersPermissions = forwardRef(({ permissions, routes, policies }, ref) => 
           subtitle={formatMessage({
             id: getTrad('Plugins.header.description'),
           })}
+          actions={actions}
         >
           <Padded left right size="xs">
             <Permissions />

--- a/packages/strapi-plugin-users-permissions/admin/src/components/UsersPermissions/reducer.js
+++ b/packages/strapi-plugin-users-permissions/admin/src/components/UsersPermissions/reducer.js
@@ -46,6 +46,10 @@ const reducer = (state, action) =>
         draftState.initialData = state.modifiedData;
         break;
       }
+      case 'ON_COPY_EXISTING_ROLE': {
+        set(draftState, ['modifiedData'], action.value);
+        break;
+      }
 
       case 'SELECT_ACTION': {
         const { actionToSelect } = action;

--- a/packages/strapi-plugin-users-permissions/admin/src/components/UsersPermissions/tests/reducer.test.js
+++ b/packages/strapi-plugin-users-permissions/admin/src/components/UsersPermissions/tests/reducer.test.js
@@ -125,6 +125,53 @@ describe('USERS PERMISSIONS | COMPONENTS | UsersPermissions | reducer', () => {
     });
   });
 
+  describe('ON_COPY_EXISTING_ROLE', () => {
+    it('should overwrite the modified data correctly with existing role permission', () => {
+      state.modifiedData = {
+        app: {
+          find: { enabled: true, policy: '' },
+          findOne: { enabled: false, policy: '' },
+          delete: { enabled: false, policy: '' },
+        },
+        app2: {
+          find: { enabled: false, policy: '' },
+          findOne: { enabled: false, policy: '' },
+        },
+      };
+
+      const action = {
+        type: 'ON_COPY_EXISTING_ROLE',
+        value: {
+          app: {
+            find: { enabled: false, policy: '' },
+            findOne: { enabled: false, policy: '' },
+            delete: { enabled: false, policy: '' },
+          },
+          app2: {
+            find: { enabled: true, policy: '' },
+            findOne: { enabled: true, policy: '' },
+          },
+        },
+      };
+
+      const expected = produce(state, draft => {
+        draft.modifiedData = {
+          app: {
+            find: { enabled: false, policy: '' },
+            findOne: { enabled: false, policy: '' },
+            delete: { enabled: false, policy: '' },
+          },
+          app2: {
+            find: { enabled: true, policy: '' },
+            findOne: { enabled: true, policy: '' },
+          },
+        };
+      });
+
+      expect(reducer(state, action)).toEqual(expected);
+    });
+  });
+
   describe('SELECT_ACTION', () => {
     it('should set the selectedAction correctly', () => {
       state.selectedAction = 'find';


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?
I added a dropdown button to permission section to copy permission from a existing role.

https://user-images.githubusercontent.com/4951716/112598536-12df0400-8e52-11eb-9012-3017cc960ffa.mp4

### Why is it needed?
Each time you create new role, you need to set permissions all over again and it's annoying.
you can copy permissions from a existing role with one click, It reduces amount of time to click checkboxes.

Describe the issue you are solving.

### How to test it?
1. Go to `.../admin/settings/users-permissions/roles/{id}` page
2. Scroll down to Permissions section
3. Click "Copy a existing role" button
4. Select a role you want to copy