### PR TITLE
[i18n] fix carret margin on the locale dropdown in i18n/settings/create

### DIFF
--- a/packages/strapi-helper-plugin/lib/src/components/Carret/index.js
+++ b/packages/strapi-helper-plugin/lib/src/components/Carret/index.js
@@ -3,7 +3,6 @@ import styled from 'styled-components';
 import { Carret as Base } from '@buffetjs/icons';
 
 const Carret = styled(({ isUp, ...rest }) => <Base {...rest} />)`
-  margin-left: 5px;
   ${({ isUp }) =>
     isUp &&
     `


### PR DESCRIPTION

### What does it do?

Removes the margin on I18N settings / creation modal

<img width="889" alt="Screenshot 2021-03-30 at 09 42 53" src="https://user-images.githubusercontent.com/3874873/112952083-66946a80-913c-11eb-9cd2-6ab4d239cd02.png">
