### PR TITLE
[i18n] hide loader when trying to add a locale that already exists

### DIFF
--- a/packages/strapi-plugin-i18n/admin/src/hooks/useAddLocale/index.js
+++ b/packages/strapi-plugin-i18n/admin/src/hooks/useAddLocale/index.js
@@ -6,39 +6,21 @@ import { getTrad } from '../../utils';
 import { ADD_LOCALE } from '../constants';
 
 const addLocale = async ({ code, name, isDefault }) => {
-  try {
-    const data = await request(`/i18n/locales`, {
-      method: 'POST',
-      body: {
-        name,
-        code,
-        isDefault,
-      },
-    });
+  const data = await request(`/i18n/locales`, {
+    method: 'POST',
+    body: {
+      name,
+      code,
+      isDefault,
+    },
+  });
 
-    strapi.notification.toggle({
-      type: 'success',
-      message: { id: getTrad('Settings.locales.modal.create.success') },
-    });
+  strapi.notification.toggle({
+    type: 'success',
+    message: { id: getTrad('Settings.locales.modal.create.success') },
+  });
 
-    return data;
-  } catch (e) {
-    const message = get(e, 'response.payload.message', null);
-
-    if (message && message.includes('already exists')) {
-      strapi.notification.toggle({
-        type: 'warning',
-        message: { id: getTrad('Settings.locales.modal.create.alreadyExist') },
-      });
-    } else {
-      strapi.notification.toggle({
-        type: 'warning',
-        message: { id: 'notification.error' },
-      });
-    }
-
-    throw e;
-  }
+  return data;
 };
 
 const useAddLocale = () => {
@@ -48,10 +30,28 @@ const useAddLocale = () => {
   const persistLocale = async locale => {
     setLoading(true);
 
-    const newLocale = await addLocale(locale);
+    try {
+      const newLocale = await addLocale(locale);
+      dispatch({ type: ADD_LOCALE, newLocale });
+    } catch (e) {
+      const message = get(e, 'response.payload.message', null);
 
-    dispatch({ type: ADD_LOCALE, newLocale });
-    setLoading(false);
+      if (message && message.includes('already exists')) {
+        strapi.notification.toggle({
+          type: 'warning',
+          message: { id: getTrad('Settings.locales.modal.create.alreadyExist') },
+        });
+      } else {
+        strapi.notification.toggle({
+          type: 'warning',
+          message: { id: 'notification.error' },
+        });
+      }
+
+      throw e;
+    } finally {
+      setLoading(false);
+    }
   };
 
   return { isAdding: isLoading, addLocale: persistLocale };


### PR DESCRIPTION
### What does it do?

When trying to add a locale that already exists, we use to show a message informing the user. However, the loading information set on the submit button was never reset.

This PR makes sure that the loading information on the submit button is well reset on success AND on error.

![2021-03-30 10 44 15](https://user-images.githubusercontent.com/3874873/112960704-f6d6ad80-9144-11eb-9294-27193a6d1d92.gif)
