### PR TITLE
Delete relations when disabling dp on a content type

### DIFF
--- a/packages/strapi-connector-mongoose/lib/migrations/draft-publish.js
+++ b/packages/strapi-connector-mongoose/lib/migrations/draft-publish.js
@@ -1,9 +1,43 @@
 'use strict';
 
 const _ = require('lodash');
+const pmap = require('p-map');
 const { contentTypes: contentTypesUtils } = require('strapi-utils');
 
 const { PUBLISHED_AT_ATTRIBUTE } = contentTypesUtils.constants;
+
+const BATCH_SIZE = 1000;
+
+const deleteDrafts = async ({ model }) => {
+  let lastId;
+  const findParams = { [PUBLISHED_AT_ATTRIBUTE]: null };
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    if (lastId) {
+      findParams._id = { $gt: lastId };
+    }
+
+    const batch = await model
+      .find(findParams, ['id'])
+      .sort({ _id: 1 })
+      .limit(BATCH_SIZE);
+
+    if (batch.length > 0) {
+      lastId = batch[batch.length - 1]._id;
+    }
+
+    await pmap(batch, entry => model.deleteRelations(entry), {
+      concurrency: 100,
+      stopOnError: true,
+    });
+
+    if (batch.length < BATCH_SIZE) {
+      break;
+    }
+  }
+  await model.deleteMany({ [PUBLISHED_AT_ATTRIBUTE]: null });
+};
 
 const getDraftAndPublishMigrationWay = async ({ definition, previousDefinition }) => {
   const previousDraftAndPublish = contentTypesUtils.hasDraftAndPublish(previousDefinition);
@@ -38,7 +72,7 @@ const migrateDraftAndPublish = async ({ definition, previousDefinition, model })
       ])
       .exec();
   } else if (way === 'disable') {
-    await model.deleteMany({ [PUBLISHED_AT_ATTRIBUTE]: null });
+    await deleteDrafts({ model });
     await model.updateMany({}, { $unset: { [PUBLISHED_AT_ATTRIBUTE]: '' } }, { strict: false });
   }
 };

--- a/packages/strapi-connector-mongoose/package.json
+++ b/packages/strapi-connector-mongoose/package.json
@@ -19,6 +19,7 @@
     "mongoose": "5.10.8",
     "mongoose-float": "^1.0.4",
     "mongoose-long": "^0.3.2",
+    "p-map": "4.0.0",
     "pluralize": "^8.0.0",
     "semver": "^7.3.4",
     "strapi-utils": "3.5.4"


### PR DESCRIPTION
I think we can create a function `deleteRelationsWhere` to avoid copy-pasting the same logic. However, as it will all change soon, it may not be worth spending time on it. What do you think ?

Also this PR is based on `features/i18n`, it could be on `master`. What do you prefer?

EDIT: base branch changed to `releases/v3.6.9`