### PR TITLE
[I18N] Fix padding in dropdown locale (settings)

### DIFF
--- a/packages/strapi-helper-plugin/lib/src/components/Select/styles.js
+++ b/packages/strapi-helper-plugin/lib/src/components/Select/styles.js
@@ -99,7 +99,7 @@ const getStyles = theme => {
     }),
     valueContainer: base => ({
       ...base,
-      padding: '2px 4px 4px 4px', // These value don't exist in the theme
+      padding: '2px 10px 4px 10px', // These value don't exist in the theme
       fontSize: sizes.fonts.md,
     }),
     indicatorsContainer: base => ({


### PR DESCRIPTION


### What does it do?

Fixes the padding for the locale dropdown in the settings when adding a new locale