### PR TITLE
Add bottom margin to the user preferences page

### DIFF
--- a/packages/strapi-admin/admin/src/containers/ProfilePage/index.js
+++ b/packages/strapi-admin/admin/src/containers/ProfilePage/index.js
@@ -191,6 +191,8 @@ const ProfilePage = () => {
           </Padded>
         </Bloc>
       </Padded>
+
+      <BaselineAlignment top size="80px" />
     </form>
   );
 };


### PR DESCRIPTION


### What does it do?
 
Add bottom margin to the user preferences page so that we can see the locale dropdown entierly