### PR TITLE
Display locale code instead of name when name is not defined

### DIFF
--- a/packages/strapi-plugin-i18n/admin/src/components/LocalePicker/index.js
+++ b/packages/strapi-plugin-i18n/admin/src/components/LocalePicker/index.js
@@ -93,7 +93,9 @@ const LocalePicker = () => {
                 return (
                   <ListItem key={locale.id}>
                     <button onClick={() => handleClick(locale)} type="button">
-                      <EllipsisParagraph width="200px">{locale.name}</EllipsisParagraph>
+                      <EllipsisParagraph width="200px">
+                        {locale.name || locale.code}
+                      </EllipsisParagraph>
                     </button>
                   </ListItem>
                 );


### PR DESCRIPTION

### What does it do?

When a locale has been added without a display name, let's show the code instead in the locale picker of the ListView