### PR TITLE
Fix bullet position in delete content for a locale modal

### DIFF
--- a/packages/strapi-helper-plugin/lib/src/components/InjectionZone/InjectionZoneList.js
+++ b/packages/strapi-helper-plugin/lib/src/components/InjectionZone/InjectionZoneList.js
@@ -3,11 +3,22 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import useInjectionZone from './useInjectionZone';
 
+const List = styled.ul`
+  list-style-type: none;
+`;
+
 const ListItem = styled.li`
   font-size: ${p => p.theme.main.sizes.fonts.md};
 
-  &::marker {
-    color: ${p => p.theme.main.colors.grey};
+  &:before {
+    background: ${p => p.theme.main.colors.grey};
+    width: 4px;
+    height: 4px;
+    content: '';
+    position: absolute;
+    border-radius: 50%;
+    margin-left: -${p => p.theme.main.sizes.margins.sm};
+    margin-top: 8px;
   }
 `;
 
@@ -19,13 +30,13 @@ const InjectionZoneList = ({ area, ...props }) => {
   }
 
   return (
-    <ul>
+    <List>
       {compos.map(compo => (
         <ListItem key={compo.name}>
           <compo.Component {...props} />
         </ListItem>
       ))}
-    </ul>
+    </List>
   );
 };
 


### PR DESCRIPTION

### What does it do?

There's a difference on the way FF and Chrome manage list-style-type on UL elements. I had to move to use a `:before` pseudo-class in order to have the same behavior and to see that bullet point in the delete locale content modal