### PR TITLE
Fix margin cog again

### DIFF
--- a/packages/strapi-plugin-content-manager/admin/src/containers/ListView/FieldPicker/index.js
+++ b/packages/strapi-plugin-content-manager/admin/src/containers/ListView/FieldPicker/index.js
@@ -16,9 +16,9 @@ const FieldPicker = ({ displayedHeaders, items, onChange, onClickReset, slug }) 
         renderButtonContent={isOpen => (
           <Flex>
             <div>
-              <FontAwesomeIcon icon="cog" />
+              <FontAwesomeIcon icon="cog" style={{ marginRight: 5 }} />
             </div>
-            <Padded left size="sm">
+            <Padded>
               <Carret fill={isOpen ? '#007eff' : '#292b2c'} isUp={isOpen} />
             </Padded>
           </Flex>


### PR DESCRIPTION
### What does it do?

Fix the margin between the cog SVG and the Carret SVG. I failed on the previous one and the space was 15px instead of 10px (because of the extra margin on the carret svg)