### PR TITLE
Fix empty locale picker on listview

### DIFF
--- a/packages/strapi-plugin-i18n/admin/src/components/LocalePicker/index.js
+++ b/packages/strapi-plugin-i18n/admin/src/components/LocalePicker/index.js
@@ -82,7 +82,9 @@ const LocalePicker = () => {
           onToggle();
         };
 
-        return (
+        const hasMultipleLocales = locales.length > 1;
+
+        return hasMultipleLocales ? (
           <Padded left right>
             <List>
               {locales.map(locale => {
@@ -102,7 +104,7 @@ const LocalePicker = () => {
               })}
             </List>
           </Padded>
-        );
+        ) : null;
       }}
     />
   );


### PR DESCRIPTION


### What does it do?

When there was only 1 locale available, we still displayed the locale picker (empty) list content on the screen when clicking on the locale picker of the listview.

This created a weird and empty white box. This PR aims to hide this box when there is only one locale