### PR TITLE
Add DKIM config example

### DIFF
--- a/packages/strapi-provider-email-sendmail/README.md
+++ b/packages/strapi-provider-email-sendmail/README.md
@@ -26,13 +26,14 @@ npm install strapi-provider-email-sendmail --save
 
 ## Configuration
 
-| Variable                | Type                    | Description                                                                                                              | Required | Default   |
-| ----------------------- | ----------------------- | ------------------------------------------------------------------------------------------------------------------------ | -------- | --------- |
-| provider                | string                  | The name of the provider you use                                                                                         | yes      |           |
-| providerOptions         | object                  | Will be directly given to `require('sendmail')`. Please refer to [sendmail](https://www.npmjs.com/package/sendmail) doc. | no       | {}        |
-| settings                | object                  | Settings                                                                                                                 | no       | {}        |
-| settings.defaultFrom    | string                  | Default sender mail address                                                                                              | no       | undefined |
-| settings.defaultReplyTo | string \| array<string> | Default address or addresses the receiver is asked to reply to                                                           | no       | undefined |
+| Variable                | Type               | Description                                                  | Required | Default   |
+| ----------------------- | ------------------ | ------------------------------------------------------------ | -------- | --------- |
+| provider                | string             | The name of the provider you use                             | yes      |           |
+| providerOptions         | object             | Will be directly given to `require('sendmail')`. Please refer to [sendmail](https://www.npmjs.com/package/sendmail) doc. | no       | {}        |
+| settings                | object             | Settings                                                     | no       | {}        |
+| settings.defaultFrom    | string             | Default sender mail address                                  | no       | undefined |
+| settings.defaultReplyTo | string \| array    | Default address or addresses the receiver is asked to reply to | no       | undefined |
+| providerOptions.dkim    | object  \| boolean | DKIM parameters having two properties: { privateKey, keySelector } | no       | false     |
 
 ### Example
 
@@ -43,6 +44,39 @@ module.exports = ({ env }) => ({
   // ...
   email: {
     provider: 'sendmail',
+    settings: {
+      defaultFrom: 'myemail@protonmail.com',
+      defaultReplyTo: 'myemail@protonmail.com',
+    },
+  },
+  // ...
+});
+```
+
+### Example with DKIM
+
+Using **DKIM** (DomainKeys Identified Mail) can prevent  emails from being considered as spam. More details about this subject  can be found in the discussion on the Strapi forum:  [Unsolved problem: emails goes to spam!](https://forum.strapi.io/t/unsolved-problem-emails-goes-to-spam/512?u=soringfs)
+
+#### Generate the keys using OpenSSL
+
+```perl
+openssl genrsa -out dkim-private.pem 1024
+openssl rsa -in dkim-private.pem -pubout -out dkim-public.pem
+```
+
+**Path -** `config/plugins.js`
+
+```js
+module.exports = ({ env }) => ({
+  // ...
+  email: {
+    provider: 'sendmail',
+    providerOptions: {
+      dkim: {
+        privateKey: 'replace-with-dkim-private-key',
+        keySelector: 'abcd', // the same as the one set in DNS txt record, use online dns lookup tools to be sure that is retreivable
+      }
+    },
     settings: {
       defaultFrom: 'myemail@protonmail.com',
       defaultReplyTo: 'myemail@protonmail.com',


### PR DESCRIPTION
### What does it do?

Updating the `readme` file by adding the DKIM configuration example for `strapi-provider-email-sendmail`.