### PR TITLE
Update bug report template with LTS version information

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -43,7 +43,7 @@ If applicable, add code samples to help explain your problem.
 
 ### System
 
-- Node.js version: <!-- Please ensure you are using the Node LTS version (v12) -->
+- Node.js version: <!-- Please ensure you are using the Node LTS version (v12 / v14) -->
 - NPM version:
 - Strapi version: <!-- Beta and Alpha versions are no longer supported -->
 - Database:


### PR DESCRIPTION
### What does it do?

Update the bug report template to state the new LTS version of Node

### Why is it needed?

v12 is no longer the LTS version

### How to test it?

N/A

### Related issue(s)/PR(s)

N/A
