### PR TITLE
Fix Email Provider Readme.

### DIFF
--- a/packages/strapi-plugin-email/README.md
+++ b/packages/strapi-plugin-email/README.md
@@ -1,1 +1,2 @@
 # Strapi plugin
+> :warning: The Shipper Email may also need to be changed in the `Email Templates` tab on the admin panel for emails to send properly

--- a/packages/strapi-provider-email-amazon-ses/README.md
+++ b/packages/strapi-provider-email-amazon-ses/README.md
@@ -34,6 +34,7 @@ npm install strapi-provider-email-amazon-ses --save
 | settings.defaultFrom    | string                  | Default sender mail address                                                                                                | no       | undefined |
 | settings.defaultReplyTo | string \| array<string> | Default address or addresses the receiver is asked to reply to                                                             | no       | undefined |
 
+> :warning: The Shipper Email (or defaultfrom) may also need to be changed in the `Email Templates` tab on the admin panel for emails to send properly
 ### Example
 
 **Path -** `config/plugins.js`

--- a/packages/strapi-provider-email-mailgun/README.md
+++ b/packages/strapi-provider-email-mailgun/README.md
@@ -34,6 +34,7 @@ npm install strapi-provider-email-mailgun --save
 | settings.defaultFrom    | string                  | Default sender mail address                                                                                                        | no       | undefined |
 | settings.defaultReplyTo | string \| array<string> | Default address or addresses the receiver is asked to reply to                                                                     | no       | undefined |
 
+> :warning: The Shipper Email (or defaultfrom) may also need to be changed in the `Email Templates` tab on the admin panel for emails to send properly
 ### Example
 
 **Path -** `config/plugins.js`
@@ -46,7 +47,7 @@ module.exports = ({ env }) => ({
     providerOptions: {
       apiKey: env('MAILGUN_API_KEY'),
       domain: env('MAILGUN_DOMAIN'), //Required if you have an account with multiple domains
-      host: env('MAILGUN_HOST', 'api.us.mailgun.net'), //Optional. If domain region is Europe use 'api.eu.mailgun.net'
+      host: env('MAILGUN_HOST', 'api.mailgun.net'), //Optional. If domain region is Europe use 'api.eu.mailgun.net'
     },
     settings: {
       defaultFrom: 'myemail@protonmail.com',

--- a/packages/strapi-provider-email-nodemailer/README.md
+++ b/packages/strapi-provider-email-nodemailer/README.md
@@ -105,6 +105,7 @@ module.exports = ({ env }) => ({
 ```
 
 ## Usage
+> :warning: The Shipper Email (or defaultfrom) may also need to be changed in the `Email Templates` tab on the admin panel for emails to send properly
 
 To send an email from anywhere inside Strapi:
 

--- a/packages/strapi-provider-email-sendgrid/README.md
+++ b/packages/strapi-provider-email-sendgrid/README.md
@@ -35,6 +35,7 @@ npm install strapi-provider-email-sendgrid --save
 | settings.defaultFrom    | string                  | Default sender mail address                                                                                             | no       | undefined |
 | settings.defaultReplyTo | string \| array<string> | Default address or addresses the receiver is asked to reply to                                                          | no       | undefined |
 
+> :warning: The Shipper Email (or defaultfrom) may also need to be changed in the `Email Templates` tab on the admin panel for emails to send properly
 ### Example
 
 **Path -** `config/plugins.js`

--- a/packages/strapi-provider-email-sendmail/README.md
+++ b/packages/strapi-provider-email-sendmail/README.md
@@ -34,6 +34,7 @@ npm install strapi-provider-email-sendmail --save
 | settings.defaultFrom    | string                  | Default sender mail address                                                                                              | no       | undefined |
 | settings.defaultReplyTo | string \| array<string> | Default address or addresses the receiver is asked to reply to                                                           | no       | undefined |
 
+> :warning: The Shipper Email (or defaultfrom) may also need to be changed in the `Email Templates` tab on the admin panel for emails to send properly
 ### Example
 
 **Path -** `config/plugins.js`


### PR DESCRIPTION
### What does it do?

Add a warning in the email provider & plugin readme to avoid errors when sending.

Changed the default mailgun api to the correct endpoint. see https://documentation.mailgun.com/en/latest/api-intro.html#introduction