### PR TITLE
UID should be localized in i18n

### DIFF
--- a/packages/strapi-plugin-i18n/services/__tests__/content-types.test.js
+++ b/packages/strapi-plugin-i18n/services/__tests__/content-types.test.js
@@ -114,6 +114,21 @@ describe('content-types service', () => {
         })
       ).toEqual(['stars', 'price']);
     });
+
+    test('Consider uid to always be localized', () => {
+      expect(
+        getNonLocalizedAttributes({
+          attributes: {
+            price: {
+              type: 'integer',
+            },
+            slug: {
+              type: 'uid',
+            },
+          },
+        })
+      ).toEqual(['price']);
+    });
   });
 
   describe('getValidLocale', () => {

--- a/packages/strapi-plugin-i18n/services/content-types.js
+++ b/packages/strapi-plugin-i18n/services/content-types.js
@@ -6,6 +6,7 @@ const {
   isRelationalAttribute,
   getVisibleAttributes,
   isMediaAttribute,
+  isTypedAttribute,
 } = require('strapi-utils').contentTypes;
 const { getService } = require('../utils');
 
@@ -82,7 +83,9 @@ const isLocalizedAttribute = (model, attributeName) => {
   const attribute = model.attributes[attributeName];
 
   return (
-    isLocalized(attribute) || (isRelationalAttribute(attribute) && !isMediaAttribute(attribute))
+    isLocalized(attribute) ||
+    (isRelationalAttribute(attribute) && !isMediaAttribute(attribute)) ||
+    isTypedAttribute(attribute, 'uid')
   );
 };
 

--- a/packages/strapi-utils/lib/__tests__/content-types.test.js
+++ b/packages/strapi-utils/lib/__tests__/content-types.test.js
@@ -2,6 +2,7 @@
 
 const {
   isPrivateAttribute,
+  isTypedAttribute,
   getPrivateAttributes,
   getVisibleAttributes,
   getNonWritableAttributes,
@@ -256,5 +257,19 @@ describe('Content types utils', () => {
         expect(result).toBe(expectedResult);
       }
     );
+  });
+
+  describe('isTypedAttribute', () => {
+    test('Returns false if attribute does not have a type', () => {
+      expect(isTypedAttribute({})).toBe(false);
+    });
+
+    test('Returns true if attribute type matches passed type', () => {
+      expect(isTypedAttribute({ type: 'test' }, 'test')).toBe(true);
+    });
+
+    test('Returns false if type do not match', () => {
+      expect(isTypedAttribute({ type: 'test' }, 'other-type')).toBe(false);
+    });
   });
 });

--- a/packages/strapi-utils/lib/content-types.js
+++ b/packages/strapi-utils/lib/content-types.js
@@ -192,6 +192,15 @@ const isRelationalAttribute = attribute =>
   _.has(attribute, 'model') || _.has(attribute, 'collection');
 
 /**
+ * Checks if an attribute is of type `type`
+ * @param {*} attribute
+ * @param {*} type
+ */
+const isTypedAttribute = (attribute, type) => {
+  return _.has(attribute, 'type') && attribute.type === type;
+};
+
+/**
  *  Returns a route prefix for a contentType
  * @param {object} contentType
  * @returns {string}
@@ -206,6 +215,7 @@ module.exports = {
   isScalarAttribute,
   isMediaAttribute,
   isRelationalAttribute,
+  isTypedAttribute,
   getPrivateAttributes,
   getTimestampsAttributes,
   isPrivateAttribute,

--- a/packages/strapi-utils/lib/content-types.js
+++ b/packages/strapi-utils/lib/content-types.js
@@ -193,8 +193,8 @@ const isRelationalAttribute = attribute =>
 
 /**
  * Checks if an attribute is of type `type`
- * @param {*} attribute
- * @param {*} type
+ * @param {object} attribute
+ * @param {string} type
  */
 const isTypedAttribute = (attribute, type) => {
   return _.has(attribute, 'type') && attribute.type === type;


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

makes uid always localized in i18n

### Why is it needed?

This avoids removing the unique constraint from DB in v3
