### PR TITLE
Uid fields are localised in CM

### DIFF
--- a/packages/strapi-plugin-i18n/admin/src/middlewares/extendCMEditViewLayoutMiddleware.js
+++ b/packages/strapi-plugin-i18n/admin/src/middlewares/extendCMEditViewLayoutMiddleware.js
@@ -28,10 +28,11 @@ const enhanceRelationLayout = (layout, locale) =>
 const enhanceEditLayout = layout =>
   layout.map(row => {
     const enhancedRow = row.reduce((acc, field) => {
+      const type = get(field, ['fieldSchema', 'type'], null);
       const hasI18nEnabled = get(
         field,
         ['fieldSchema', 'pluginOptions', 'i18n', 'localized'],
-        false
+        type === 'uid'
       );
 
       const labelIcon = {

--- a/packages/strapi-plugin-i18n/admin/src/middlewares/tests/extendCMEditViewLayoutMiddleware.test.js
+++ b/packages/strapi-plugin-i18n/admin/src/middlewares/tests/extendCMEditViewLayoutMiddleware.test.js
@@ -368,6 +368,13 @@ describe('i18n | Middlewares | extendCMEditViewLayoutMiddleware', () => {
               type: 'string',
             },
           },
+          {
+            name: 'slug',
+            size: 6,
+            fieldSchema: {
+              type: 'uid',
+            },
+          },
         ],
       ];
       const expected = [
@@ -392,6 +399,17 @@ describe('i18n | Middlewares | extendCMEditViewLayoutMiddleware', () => {
             fieldSchema: {
               pluginOptions: { i18n: { localized: true } },
               type: 'string',
+            },
+            labelIcon: {
+              title: { id: localizedTrad, defaultMessage: localizedTradDefaultMessage },
+              icon: <Globe />,
+            },
+          },
+          {
+            name: 'slug',
+            size: 6,
+            fieldSchema: {
+              type: 'uid',
             },
             labelIcon: {
               title: { id: localizedTrad, defaultMessage: localizedTradDefaultMessage },


### PR DESCRIPTION
Signed-off-by: soupette <cyril.lpz@gmail.com>

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

it shows that uid fields are localised in the content manager / edit view