### PR TITLE
feat: :lipstick: changed default "entries per page" from 10 to 20

### DIFF
--- a/packages/strapi-plugin-content-manager/admin/src/containers/ListView/Footer.js
+++ b/packages/strapi-plugin-content-manager/admin/src/containers/ListView/Footer.js
@@ -7,7 +7,7 @@ import { FooterWrapper, SelectWrapper, Label } from './components';
 
 function Footer({ count, onChange, params }) {
   const { emitEvent } = useGlobalContext();
-  const _limit = parseInt(params.pageSize, 10);
+  const _limit = parseInt(params.pageSize, 20);
   const _page = parseInt(params.page, 10);
 
   const handleChangePage = ({ target: { value } }) => {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

I changed the default pageSize from 10 to 20
```js
const _limit = parseInt(params.pageSize, 10); 
const _limit = parseInt(params.pageSize, 20);
```

### Why is it needed?

It is annoying to have to manually switch the default entries to more than 10. I changed it to 20 for now, maybe higher is a better option.

### How to test it?

I ran 
```js
yarn test:unit
yarn test:front
yarn lint

```
### Related issue(s)/PR(s)

I have not found any relating issues
