### PR TITLE
Fixed ListView rendering for RBAC

### DIFF
--- a/packages/strapi-plugin-content-manager/services/entity-manager.js
+++ b/packages/strapi-plugin-content-manager/services/entity-manager.js
@@ -52,8 +52,15 @@ module.exports = {
     return strapi.entityService.findPage({ params, populate }, { model });
   },
 
-  findWithRelationCounts(params, model, populate) {
-    return strapi.entityService.findWithRelationCounts({ params, populate }, { model });
+  async findWithRelationCounts(params, model, populate) {
+    const data = await strapi.entityService.findWithRelationCounts({ params, populate }, { model });
+    const ctx = this;
+    const results = await Promise.all(
+      prop('results', data).map(async entity =>
+        entity ? await this.assocCreatorRoles.call(ctx, entity) : entity
+      )
+    );
+    return assoc('results', results, data);
   },
 
   search(params, model, populate) {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Associates roles with all the entities retrieved by using `findWithRelationCounts`. More specifically fixes #10010

### Why is it needed?

Should allow for ListView to render all content correctly when trying to read as another user with the same role. More details in related PR.

### How to test it?

1. Create a brand new project with `yarn create strapi-app my-project --quickstart`
2. Add the EE license in to `.env` or `license.txt` (I used a trial license)
3. Rebuild the admin panel with `yarn build --clean`
4. Start the project with `yarn develop`
5. Create a sample model (called `article` perhaps) with a couple of fields (for eg: `title`, `content`, `isActive`)
**title**: string
**body**: richtext
**isActive**: Boolean
6. Create a new role `test`
7. Assign all field permissions but apply custom conditions
        **Can Create**: Anytime
        **Can Read**: Is creator and Has same role as creator
        **Can Update**: Is creator
        **Can Delete**: Is creator
8. Create 2 test users (User One and User two)
9. Create an article on one
10. Attempt to read on the other. Should be able to view all the data.

### Related issue(s)/PR(s)

fixes #10010
