### PR TITLE
Update rateLimit.js

### DIFF
--- a/packages/strapi-plugin-users-permissions/config/policies/rateLimit.js
+++ b/packages/strapi-plugin-users-permissions/config/policies/rateLimit.js
@@ -21,13 +21,13 @@ module.exports = async (ctx, next) => {
   return lazyRateLimit.RateLimit.middleware(
     Object.assign(
       {},
+      strapi.plugins['users-permissions'].config.ratelimit,
       {
         interval: 1 * 60 * 1000,
         max: 5,
         prefixKey: `${ctx.request.path}:${ctx.request.ip}`,
         message,
-      },
-      strapi.plugins['users-permissions'].config.ratelimit
+      }
     )
   )(ctx, next);
 };


### PR DESCRIPTION
Simple change for making effective an update of the ratelimit. Otherwise the changes were overwritten by the 'strapi.plugins['users-permissions'].config.ratelimit' that was placed as last parameter