### PR TITLE
Fix date field being parsed with a timezone

### DIFF
--- a/packages/strapi-connector-bookshelf/lib/formatter.js
+++ b/packages/strapi-connector-bookshelf/lib/formatter.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { isValid, format, formatISO } = require('date-fns');
+const { isValid, format, formatISO, parseISO } = require('date-fns');
 const { has } = require('lodash');
 
 const createFormatter = client => ({ type }, value) => {
@@ -38,7 +38,7 @@ const defaultFormatter = {
     }
   },
   date: value => {
-    const cast = new Date(value);
+    const cast = parseISO(value);
     return isValid(cast) ? formatISO(cast, { representation: 'date' }) : null;
   },
   datetime: value => {

--- a/packages/strapi-connector-bookshelf/lib/formatter.js
+++ b/packages/strapi-connector-bookshelf/lib/formatter.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { isValid, format, formatISO, parseISO } = require('date-fns');
+const { isValid, format, formatISO } = require('date-fns');
 const { has } = require('lodash');
 
 const createFormatter = client => ({ type }, value) => {
@@ -38,7 +38,7 @@ const defaultFormatter = {
     }
   },
   date: value => {
-    const cast = parseISO(value);
+    const cast = new Date(value);
     return isValid(cast) ? formatISO(cast, { representation: 'date' }) : null;
   },
   datetime: value => {

--- a/packages/strapi-plugin-content-manager/admin/src/containers/EditViewDataManagerProvider/utils/cleanData.js
+++ b/packages/strapi-plugin-content-manager/admin/src/containers/EditViewDataManagerProvider/utils/cleanData.js
@@ -24,6 +24,9 @@ const cleanData = (retrievedData, currentSchema, componentsSchema) => {
 
           break;
         case 'date':
+          cleanedData =
+            value && value._isAMomentObject === true ? value.format('YYYY-MM-DD') : value;
+          break;
         case 'datetime':
           cleanedData = value && value._isAMomentObject === true ? value.toISOString() : value;
           break;


### PR DESCRIPTION
Signed-off-by: Derrick Mehaffy <derrickmehaffy@gmail.com>

### What does it do?

Stops using the built in Javascript date which reads the systems timezone by replacing `new Date()` with the date-fns function `parseISO` [see it's docs here](https://date-fns.org/v2.20.3/docs/parseISO)

### Why is it needed?

if the string value passed from upstream in Strapi is `2021-04-14`:

date-fns function
```js
const cast = parseISO(value);
// returns: 2021-04-14T07:00:00.000Z
```

javascript native function
```js
const cast = new Date(value);
const castString = cast.toString();
// returns: Tue Apr 13 2021 17:00:00 GMT-0700 (Mountain Standard Time)
```

The problem is that the built in Javascript `Date()` will use the local systems timezone, and instead the date-fns has the ability to just parse the raw date string and not pass in the system timezone.

### How to test it?

Your system must be set to a timezone that is +/- GMT by at least 1 hour

1. Create a project
2. Create a model with a date field
3. Add a new date via any means
4. See date doesn't move backwards or forwards

### Related issue(s)/PR(s)

fixes #9576

# [Edit]
I (@petersg83 ) took over this PR. It appears the problem is quite complex and larger than this specific issue. We need to refactor all the way we handle dates (disable timezone in pg for instance) and it would be more of a breaking change than a bug fix. So we won't fix everything now but it will be fixed in V4 (should come in beta ~summer and released before the end of the year).

However, I wrote a small change in the admin. It may fix #9576, not sure.
