### PR TITLE
Fix typo in spanish translation

### DIFF
--- a/packages/strapi-admin/admin/src/translations/es.json
+++ b/packages/strapi-admin/admin/src/translations/es.json
@@ -64,7 +64,7 @@
   "Roles.ListPage.notification.delete-all-not-allowed": "Algunos roles no se pudieron eliminar porque están asociados a usuarios",
   "Roles.ListPage.notification.delete-not-allowed": "No se puede eliminar un rol si está asociado a usuarios",
   "Roles.RoleRow.user-count.plural": "{number} usuarios",
-  "Roles.RoleRow.user-count.singular": "{número} usuario",
+  "Roles.RoleRow.user-count.singular": "{number} usuario",
   "Roles.components.List.empty.withSearch": "No hay rol correspondiente a la búsqueda ({search})...",
   "Settings.PageTitle": "Configuración - {name}",
   "Settings.error": "Error",


### PR DESCRIPTION
### What does it do?
Fixed a small but annoying typo in the spanish translation

### Why is it needed?
The list in Settings > Roles page was showing literally the string `{número} usuario` instead of `1 usuario`.

### How to test it?
Check Settings > Roles page in spanish

### Related issue(s)/PR(s)
None (do you recommend to create an issue before the PR even for fixes small like this?)
