### PR TITLE
Allow upload to custom provider

### DIFF
--- a/packages/strapi-plugin-upload/config/functions/bootstrap.js
+++ b/packages/strapi-plugin-upload/config/functions/bootstrap.js
@@ -142,3 +142,5 @@ const registerPermissionActions = () => {
   const { actionProvider } = strapi.admin.services.permission;
   actionProvider.register(actions);
 };
+
+module.exports.createProvider = createProvider;


### PR DESCRIPTION
Add arguments property "provider"

### What does it do?

Add the `provider` property to the parameters of the` upload` method.

### Why is it needed?

Main upload provider on my website uses aws s3, used to store main data as .doc, .pdf documents. But not all files uploaded to my website are stored in aws s3. I want when a user uploads their avatar to use a `local` provider.

### How to use?
```js
const uploadedFiles = await strapi.plugins.upload.services.upload.upload({
        files: files.file,
        data: {
          fileInfo: {
            alternativeText: 'Avatar',
            caption: '',
            name: null,
          }
        }
      }, { user: ctx.state.user, provider: 'local' });
```

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
