### PR TITLE
Add an env var to set the init locale code on startup

### DIFF
--- a/packages/strapi-plugin-i18n/constants/__tests__/index.test.js
+++ b/packages/strapi-plugin-i18n/constants/__tests__/index.test.js
@@ -5,7 +5,7 @@ const { getInitLocale } = require('../');
 describe('I18N default locale', () => {
   describe('getInitLocale', () => {
     test('The init locale is english by default', () => {
-      expect(getInitLocale()).toEqual({
+      expect(getInitLocale()).toStrictEqual({
         code: 'en',
         name: 'English (en)',
       });
@@ -13,8 +13,9 @@ describe('I18N default locale', () => {
 
     test('The init locale can be configured by an env var', () => {
       process.env.STRAPI_PLUGIN_I18N_INIT_LOCALE_CODE = 'fr';
-      expect(getInitLocale()).toMatchObject({
+      expect(getInitLocale()).toStrictEqual({
         code: 'fr',
+        name: 'French (fr)',
       });
     });
 

--- a/packages/strapi-plugin-i18n/constants/__tests__/index.test.js
+++ b/packages/strapi-plugin-i18n/constants/__tests__/index.test.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const { getInitLocale } = require('../');
+
+describe('I18N default locale', () => {
+  describe('getInitLocale', () => {
+    test('The init locale is english by default', () => {
+      expect(getInitLocale()).toEqual({
+        code: 'en',
+        name: 'English (en)',
+      });
+    });
+
+    test('The init locale can be configured by an env var', () => {
+      process.env.STRAPI_PLUGIN_I18N_INIT_LOCALE_CODE = 'fr';
+      expect(getInitLocale()).toMatchObject({
+        code: 'fr',
+      });
+    });
+
+    test('Throws if env var code is unknown in iso list', () => {
+      process.env.STRAPI_PLUGIN_I18N_INIT_LOCALE_CODE = 'zzzzz';
+      expect(() => getInitLocale()).toThrow();
+    });
+  });
+});

--- a/packages/strapi-plugin-i18n/constants/index.js
+++ b/packages/strapi-plugin-i18n/constants/index.js
@@ -2,12 +2,35 @@
 
 const isoLocales = require('./iso-locales');
 
-const DEFAULT_LOCALE = {
-  name: 'English',
-  code: 'en',
+/**
+ * Returns the default locale based either on env var or english
+ * @returns {string}
+ */
+const getInitLocale = () => {
+  const envLocaleCode = process.env.STRAPI_PLUGIN_I18N_INIT_LOCALE_CODE;
+
+  if (envLocaleCode) {
+    const matchingLocale = isoLocales.find(({ code }) => code === envLocaleCode);
+
+    if (!matchingLocale) {
+      throw new Error(
+        'Unknown locale code provided in the envrionment variable STRAPI_PLUGIN_I18N_INIT_LOCALE_CODE'
+      );
+    }
+
+    return { ...matchingLocale };
+  }
+
+  return {
+    code: 'en',
+    name: 'English (en)',
+  };
 };
+
+const DEFAULT_LOCALE = getInitLocale();
 
 module.exports = {
   isoLocales,
   DEFAULT_LOCALE,
+  getInitLocale,
 };

--- a/packages/strapi-plugin-i18n/constants/index.js
+++ b/packages/strapi-plugin-i18n/constants/index.js
@@ -14,7 +14,7 @@ const getInitLocale = () => {
 
     if (!matchingLocale) {
       throw new Error(
-        'Unknown locale code provided in the envrionment variable STRAPI_PLUGIN_I18N_INIT_LOCALE_CODE'
+        'Unknown locale code provided in the environment variable STRAPI_PLUGIN_I18N_INIT_LOCALE_CODE'
       );
     }
 

--- a/packages/strapi-plugin-i18n/services/__tests__/locales.test.js
+++ b/packages/strapi-plugin-i18n/services/__tests__/locales.test.js
@@ -172,7 +172,7 @@ describe('Locales', () => {
       await localesService.initDefaultLocale();
       expect(count).toHaveBeenCalledWith();
       expect(create).toHaveBeenCalledWith({
-        name: 'English',
+        name: 'English (en)',
         code: 'en',
       });
       expect(set).toHaveBeenCalledWith({ key: 'default_locale', value: 'en' });


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?
Add an env var to set the init locale code on startup
