### PR TITLE
Fix graphql naming to use the same input naming convention as the graphql plugin

### DIFF
--- a/packages/strapi-plugin-i18n/services/core-api.js
+++ b/packages/strapi-plugin-i18n/services/core-api.js
@@ -271,8 +271,10 @@ const addGraphqlLocalizationAction = contentType => {
 
   // add new mutation to create a localization
   const typeName = globalId;
-  const mutationName = `create${typeName}Localization`;
-  const mutationDef = `${mutationName}(input: update${typeName}Input!): ${typeName}!`;
+
+  const capitalizedName = _.upperFirst(toSingular(modelName));
+  const mutationName = `create${capitalizedName}Localization`;
+  const mutationDef = `${mutationName}(input: update${capitalizedName}Input!): ${typeName}!`;
   const actionName = `${contentType.uid}.createLocalization`;
 
   addGraphqlSchema({

--- a/packages/strapi-plugin-i18n/tests/graphql.test.e2e.js
+++ b/packages/strapi-plugin-i18n/tests/graphql.test.e2e.js
@@ -1,0 +1,120 @@
+'use strict';
+
+// Helpers.
+const { createTestBuilder } = require('../../../test/helpers/builder');
+const { createStrapiInstance } = require('../../../test/helpers/strapi');
+const { createAuthRequest } = require('../../../test/helpers/request');
+
+const builder = createTestBuilder();
+let strapi;
+let rq;
+let graphqlQuery;
+let localeId;
+
+const recipesModel = {
+  attributes: {
+    name: {
+      type: 'string',
+    },
+  },
+  pluginOptions: {
+    i18n: {
+      localized: true,
+    },
+  },
+  connection: 'default',
+  name: 'recipes',
+  description: '',
+  collectionName: '',
+};
+
+describe('Test Graphql API create localization', () => {
+  beforeAll(async () => {
+    await builder.addContentType(recipesModel).build();
+
+    strapi = await createStrapiInstance();
+    rq = await createAuthRequest({ strapi });
+
+    graphqlQuery = body => {
+      return rq({
+        url: '/graphql',
+        method: 'POST',
+        body,
+      });
+    };
+
+    const locale = await strapi.query('locale', 'i18n').create({
+      code: 'fr',
+      name: 'French',
+    });
+
+    localeId = locale.id;
+  });
+
+  afterAll(async () => {
+    await strapi.query('locale', 'i18n').delete({ id: localeId });
+    await strapi.query('recipes').delete();
+    await strapi.destroy();
+    await builder.cleanup();
+  });
+
+  test('Create localization for a model with plural name', async () => {
+    const createResponse = await graphqlQuery({
+      query: /* GraphQL */ `
+        mutation createRecipe($input: createRecipeInput) {
+          createRecipe(input: $input) {
+            recipe {
+              id
+              name
+              locale
+            }
+          }
+        }
+      `,
+      variables: {
+        input: {
+          data: {
+            name: 'Recipe Name',
+          },
+        },
+      },
+    });
+
+    expect(createResponse.statusCode).toBe(200);
+    expect(createResponse.body.data.createRecipe.recipe).toMatchObject({
+      name: 'Recipe Name',
+      locale: 'en',
+    });
+
+    const recipeId = createResponse.body.data.createRecipe.recipe.id;
+
+    const createLocalizationResponse = await graphqlQuery({
+      query: /* GraphQL */ `
+        mutation createRecipeLocalization($input: updateRecipeInput!) {
+          createRecipeLocalization(input: $input) {
+            id
+            name
+            locale
+          }
+        }
+      `,
+      variables: {
+        input: {
+          where: {
+            id: recipeId,
+          },
+          data: {
+            name: 'Recipe Name fr',
+            locale: 'fr',
+          },
+        },
+      },
+    });
+
+    expect(createLocalizationResponse.statusCode).toBe(200);
+    expect(createLocalizationResponse.body.data.createRecipeLocalization).toMatchObject({
+      name: 'Recipe Name fr',
+      locale: 'fr',
+    });
+  });
+});


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Fix graphql naming to use the same input namine convention as the plugin