### PR TITLE
Fix issue with incorrect cli termination when using flags quickstart and no-run

### DIFF
--- a/packages/create-strapi-app/create-strapi-app.js
+++ b/packages/create-strapi-app/create-strapi-app.js
@@ -40,4 +40,8 @@ if (projectName === undefined) {
   process.exit(1);
 }
 
-generateNewApp(projectName, program);
+generateNewApp(projectName, program).then(() => {
+  if (process.platform === 'win32') {
+    process.exit(0);
+  }
+});


### PR DESCRIPTION
Fixes #5759

### What does it do?

On Windows, an empty return from the `createQuickStartProject` function caused the process termination to hang.
Added explicit process termination for this platform

### Why is it needed?

Command `yarn create strapi-app backend --quickstart --no-run` did not work as expected from the documentation.

### How to test it?

Run command `yarn create strapi-app backend --quickstart --no-run`

### Related issue(s)/PR(s)
In PR #6721 problem fixed by change return statement to `process.exit` but @alexandrebodin said that this is an incorrect decision.
I decided to fix it in the package `create-strapi-app` by getting the result of the promise and terminate process if the platform is windows
