### PR TITLE
Fix typo in query error message

### DIFF
--- a/packages/strapi-utils/lib/build-query.js
+++ b/packages/strapi-utils/lib/build-query.js
@@ -35,7 +35,7 @@ const getAssociationFromFieldKey = ({ model, field }) => {
 
     if (!assoc && (!isAttribute(tmpModel, part) || i !== fieldParts.length - 1)) {
       const err = new Error(
-        `Your filters contain a field '${field}' that doesn't appear on your model definition nor it's relations`
+        `Your filters contain a field '${field}' that doesn't appear on your model definition nor its relations`
       );
 
       err.status = 400;


### PR DESCRIPTION
The possessive `its` doesn't have an apostrophe.

https://www.dictionary.com/e/its-vs-its/