### PR TITLE
[RBAC] Ignore only non visible attributes instead of non configurable ones

### DIFF
--- a/packages/strapi-admin/services/permission/sections-builder/handlers.js
+++ b/packages/strapi-admin/services/permission/sections-builder/handlers.js
@@ -94,7 +94,7 @@ const subjectsHandlerFor = kind => ({ action, section: contentTypesSection }) =>
   contentTypesSection.subjects.push(...newSubjects);
 };
 
-const buildNodeFor = model => ([attributeName, attribute]) => {
+const buildNode = (model, attributeName, attribute) => {
   if (!isVisibleAttribute(model, attributeName)) {
     return null;
   }
@@ -115,7 +115,7 @@ const buildNodeFor = model => ([attributeName, attribute]) => {
 
 const buildDeepAttributesCollection = model => {
   return Object.entries(model.attributes)
-    .map(buildNodeFor(model))
+    .map(([attributeName, attribute]) => buildNode(model, attributeName, attribute))
     .filter(node => node !== null);
 };
 

--- a/packages/strapi-admin/services/permission/sections-builder/handlers.js
+++ b/packages/strapi-admin/services/permission/sections-builder/handlers.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { isVisibleAttribute } = require('strapi-utils').contentTypes;
+
 const {
   toSubjectTemplate,
   getValidOptions,
@@ -92,8 +94,8 @@ const subjectsHandlerFor = kind => ({ action, section: contentTypesSection }) =>
   contentTypesSection.subjects.push(...newSubjects);
 };
 
-const buildNode = ([attributeName, attribute]) => {
-  if (attribute.configurable === false) {
+const buildNodeFor = model => ([attributeName, attribute]) => {
+  if (!isVisibleAttribute(model, attributeName)) {
     return null;
   }
 
@@ -105,15 +107,15 @@ const buildNode = ([attributeName, attribute]) => {
 
   if (attribute.type === 'component') {
     const component = strapi.components[attribute.component];
-    return { ...node, children: buildDeepAttributesCollection(component.attributes) };
+    return { ...node, children: buildDeepAttributesCollection(component) };
   }
 
   return node;
 };
 
-const buildDeepAttributesCollection = attributes => {
-  return Object.entries(attributes)
-    .map(buildNode)
+const buildDeepAttributesCollection = model => {
+  return Object.entries(model.attributes)
+    .map(buildNodeFor(model))
     .filter(node => node !== null);
 };
 
@@ -136,7 +138,7 @@ const fieldsProperty = ({ action, section }) => {
         return;
       }
 
-      const fields = buildDeepAttributesCollection(contentType.attributes);
+      const fields = buildDeepAttributesCollection(contentType);
       const fieldsProp = { label: 'Fields', value: 'fields', children: fields };
 
       subject.properties.push(fieldsProp);

--- a/packages/strapi-admin/tests/admin-permission.test.e2e.js
+++ b/packages/strapi-admin/tests/admin-permission.test.e2e.js
@@ -115,7 +115,46 @@ describe('Role CRUD End to End', () => {
                   "label": "user",
                   "properties": Array [
                     Object {
-                      "children": Array [],
+                      "children": Array [
+                        Object {
+                          "label": "username",
+                          "required": true,
+                          "value": "username",
+                        },
+                        Object {
+                          "label": "email",
+                          "required": true,
+                          "value": "email",
+                        },
+                        Object {
+                          "label": "provider",
+                          "value": "provider",
+                        },
+                        Object {
+                          "label": "password",
+                          "value": "password",
+                        },
+                        Object {
+                          "label": "resetPasswordToken",
+                          "value": "resetPasswordToken",
+                        },
+                        Object {
+                          "label": "confirmationToken",
+                          "value": "confirmationToken",
+                        },
+                        Object {
+                          "label": "confirmed",
+                          "value": "confirmed",
+                        },
+                        Object {
+                          "label": "blocked",
+                          "value": "blocked",
+                        },
+                        Object {
+                          "label": "role",
+                          "value": "role",
+                        },
+                      ],
                       "label": "Fields",
                       "value": "fields",
                     },
@@ -530,7 +569,46 @@ describe('Role CRUD End to End', () => {
                     "label": "user",
                     "properties": Array [
                       Object {
-                        "children": Array [],
+                        "children": Array [
+                          Object {
+                            "label": "username",
+                            "required": true,
+                            "value": "username",
+                          },
+                          Object {
+                            "label": "email",
+                            "required": true,
+                            "value": "email",
+                          },
+                          Object {
+                            "label": "provider",
+                            "value": "provider",
+                          },
+                          Object {
+                            "label": "password",
+                            "value": "password",
+                          },
+                          Object {
+                            "label": "resetPasswordToken",
+                            "value": "resetPasswordToken",
+                          },
+                          Object {
+                            "label": "confirmationToken",
+                            "value": "confirmationToken",
+                          },
+                          Object {
+                            "label": "confirmed",
+                            "value": "confirmed",
+                          },
+                          Object {
+                            "label": "blocked",
+                            "value": "blocked",
+                          },
+                          Object {
+                            "label": "role",
+                            "value": "role",
+                          },
+                        ],
                         "label": "Fields",
                         "value": "fields",
                       },


### PR DESCRIPTION
The permission builder is currently ignoring all non-configurable attributes. This leads to missing fields for some CTs (eg: user-permissions::user).
This PR update the attribute validation and ignore only the non-visible attributes.