### PR TITLE
Fixes #10044

### DIFF
--- a/packages/strapi-plugin-upload/admin/src/components/EditForm/index.js
+++ b/packages/strapi-plugin-upload/admin/src/components/EditForm/index.js
@@ -9,7 +9,6 @@ import React, {
   useImperativeHandle,
 } from 'react';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
-import axios from 'axios';
 import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import { Row } from 'reactstrap';
@@ -200,21 +199,7 @@ const EditForm = forwardRef(
     };
 
     const handleClickDownload = () => {
-      axios
-        .get(prefixedFileURL, {
-          responseType: 'blob',
-        })
-        .then(({ data }) => {
-          const blobUrl = URL.createObjectURL(data);
-
-          aRef.current.download = downloadFileName;
-          aRef.current.href = blobUrl;
-
-          aRef.current.click();
-        })
-        .catch(err => {
-          console.error(err);
-        });
+      aRef.current.click();
     };
 
     const handleSubmit = e => {
@@ -256,9 +241,13 @@ const EditForm = forwardRef(
                                   />
                                 )}
                                 <a
+                                  dowload={downloadFileName}
                                   title={fileToEdit.fileInfo.name}
                                   style={{ display: 'none' }}
                                   ref={aRef}
+                                  href={prefixedFileURL}
+                                  target="_blank"
+                                  rel="noreferrer"
                                 >
                                   hidden
                                 </a>


### PR DESCRIPTION
Signed-off-by: soupette <cyril.lpz@gmail.com>

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

It changes the download file logic, now when clicking on the download button in the media library it will open a new tab with the attached file. To download a file the user will need to use the navigator default downloading system (right click + save)

Fixes #10044 