### PR TITLE
Fix #10125 - Accept falsy values returned by controllers in GraphQL queries and mutations

### DIFF
--- a/packages/strapi-plugin-graphql/services/__tests__/resolvers-builder.test.js
+++ b/packages/strapi-plugin-graphql/services/__tests__/resolvers-builder.test.js
@@ -1,0 +1,122 @@
+'use strict';
+
+const { buildMutation, buildQuery } = require('../resolvers-builder');
+
+global.strapi = {
+  plugins: {
+    graphql: {
+      config: {},
+    },
+  },
+  api: {
+    'my-api': {
+      controllers: {
+        'my-controller': {},
+      },
+    },
+  },
+};
+
+const graphqlContext = {
+  context: {
+    req: {},
+    res: {},
+    app: {
+      createContext(request, response) {
+        return { request, response };
+      },
+    },
+  },
+};
+
+describe('Resolvers builder', () => {
+  describe('buildMutation', () => {
+    it("Returns ctx.body if it's not falsy and the resolver is a string", async () => {
+      expect.assertions(1);
+
+      strapi.api['my-api'].controllers['my-controller'].myAction = async ctx => {
+        ctx.body = 1;
+      };
+
+      const resolver = buildMutation('mutation', {
+        resolver: 'application::my-api.my-controller.myAction',
+      });
+
+      const result = await resolver(null, {}, graphqlContext);
+      expect(result).toBe(1);
+    });
+
+    it("Returns ctx.body if it's not undefined and the resolver is a string", async () => {
+      expect.assertions(1);
+
+      strapi.api['my-api'].controllers['my-controller'].myAction = async ctx => {
+        ctx.body = 0;
+      };
+
+      const resolver = buildMutation('mutation', {
+        resolver: 'application::my-api.my-controller.myAction',
+      });
+
+      const result = await resolver(null, {}, graphqlContext);
+      expect(result).toBe(0);
+    });
+
+    it('Returns the action result if ctx.body is undefined and the resolver is a string', async () => {
+      expect.assertions(1);
+
+      strapi.api['my-api'].controllers['my-controller'].myAction = async () => 'result';
+
+      const resolver = buildMutation('mutation', {
+        resolver: 'application::my-api.my-controller.myAction',
+      });
+
+      const result = await resolver(null, {}, graphqlContext);
+      expect(result).toBe('result');
+    });
+  });
+
+  describe('buildQuery', () => {
+    it("Returns ctx.body if it's not falsy and the resolver is a string", async () => {
+      expect.assertions(1);
+
+      strapi.api['my-api'].controllers['my-controller'].myAction = async ctx => {
+        ctx.body = 1;
+      };
+
+      const resolver = buildQuery('mutation', {
+        resolver: 'application::my-api.my-controller.myAction',
+      });
+
+      const result = await resolver(null, {}, graphqlContext);
+      expect(result).toBe(1);
+    });
+
+    it("Returns ctx.body if it's not undefined and the resolver is a string", async () => {
+      expect.assertions(1);
+
+      strapi.api['my-api'].controllers['my-controller'].myAction = async ctx => {
+        ctx.body = 0;
+      };
+
+      const resolver = buildQuery('mutation', {
+        resolver: 'application::my-api.my-controller.myAction',
+      });
+
+      const result = await resolver(null, {}, graphqlContext);
+      expect(result).toBe(0);
+    });
+
+    it('Returns the action result if ctx.body is undefined and the resolver is a string', async () => {
+      expect.assertions(1);
+
+      strapi.api['my-api'].controllers['my-controller'].myAction = async () => 'result';
+
+      const resolver = buildQuery('mutation', {
+        resolver: 'application::my-api.my-controller.myAction',
+      });
+
+      const result = await resolver(null, {}, graphqlContext);
+      expect(result).toBe('result');
+    });
+  });
+});

--- a/packages/strapi-plugin-graphql/services/__tests__/resolvers-builder.test.js
+++ b/packages/strapi-plugin-graphql/services/__tests__/resolvers-builder.test.js
@@ -31,7 +31,7 @@ const graphqlContext = {
 
 describe('Resolvers builder', () => {
   describe('buildMutation', () => {
-    it("Returns ctx.body if it's not falsy and the resolver is a string", async () => {
+    test("Returns ctx.body if it's not falsy and the resolver is a string", async () => {
       expect.assertions(1);
 
       strapi.api['my-api'].controllers['my-controller'].myAction = async ctx => {
@@ -46,7 +46,7 @@ describe('Resolvers builder', () => {
       expect(result).toBe(1);
     });
 
-    it("Returns ctx.body if it's not undefined and the resolver is a string", async () => {
+    test("Returns ctx.body if it's not undefined and the resolver is a string", async () => {
       expect.assertions(1);
 
       strapi.api['my-api'].controllers['my-controller'].myAction = async ctx => {
@@ -61,7 +61,7 @@ describe('Resolvers builder', () => {
       expect(result).toBe(0);
     });
 
-    it('Returns the action result if ctx.body is undefined and the resolver is a string', async () => {
+    test('Returns the action result if ctx.body is undefined and the resolver is a string', async () => {
       expect.assertions(1);
 
       strapi.api['my-api'].controllers['my-controller'].myAction = async () => 'result';
@@ -76,7 +76,7 @@ describe('Resolvers builder', () => {
   });
 
   describe('buildQuery', () => {
-    it("Returns ctx.body if it's not falsy and the resolver is a string", async () => {
+    test("Returns ctx.body if it's not falsy and the resolver is a string", async () => {
       expect.assertions(1);
 
       strapi.api['my-api'].controllers['my-controller'].myAction = async ctx => {
@@ -91,7 +91,7 @@ describe('Resolvers builder', () => {
       expect(result).toBe(1);
     });
 
-    it("Returns ctx.body if it's not undefined and the resolver is a string", async () => {
+    test("Returns ctx.body if it's not undefined and the resolver is a string", async () => {
       expect.assertions(1);
 
       strapi.api['my-api'].controllers['my-controller'].myAction = async ctx => {
@@ -106,7 +106,7 @@ describe('Resolvers builder', () => {
       expect(result).toBe(0);
     });
 
-    it('Returns the action result if ctx.body is undefined and the resolver is a string', async () => {
+    test('Returns the action result if ctx.body is undefined and the resolver is a string', async () => {
       expect.assertions(1);
 
       strapi.api['my-api'].controllers['my-controller'].myAction = async () => 'result';

--- a/packages/strapi-plugin-graphql/services/resolvers-builder.js
+++ b/packages/strapi-plugin-graphql/services/resolvers-builder.js
@@ -48,7 +48,7 @@ const buildMutation = (mutationName, config) => {
     await policiesMiddleware(ctx);
 
     const values = await action(ctx);
-    const result = ctx.body || values;
+    const result = ctx.body !== undefined ? ctx.body : values;
 
     if (_.isError(result)) {
       throw result;
@@ -110,7 +110,7 @@ const buildQuery = (queryName, config) => {
     await policiesMiddleware(ctx);
 
     const values = await action(ctx);
-    const result = ctx.body || values;
+    const result = ctx.body !== undefined ? ctx.body : values;
 
     if (_.isError(result)) {
       throw result;


### PR DESCRIPTION
### What does it do?

Fix #10125 