### PR TITLE
Fix undefined error debug on AWS-SES email provider

### DIFF
--- a/packages/strapi-provider-email-amazon-ses/lib/index.js
+++ b/packages/strapi-provider-email-amazon-ses/lib/index.js
@@ -26,7 +26,7 @@ module.exports = {
           client.sendEmail(removeUndefined(msg), function(err) {
             if (err) {
               if (err.Message) {
-                reject(`${err.Message} ${err.Detail ? err.Detail : ''}`);
+                reject({message: `${err.Message} ${err.Detail ? err.Detail : ''}`});
               }
               reject(err);
             } else {


### PR DESCRIPTION
### What does it do?

Added the object with the message property so the error is can be properly debugged.

### Why is it needed?

When executing without a body property such as `text` or `message` the error returns:
```
error Error: Couldn't send email: undefined.
```

### How to test it?

Perform `POST` request on email endpoint with the following properties:
```json
{
    "subject": "Test mail",
    "to": "test@mail.com"
}
```