### PR TITLE
fix/i18n-superAdminRole

### DIFF
--- a/packages/strapi-plugin-i18n/services/permissions/actions.js
+++ b/packages/strapi-plugin-i18n/services/permissions/actions.js
@@ -77,6 +77,11 @@ const syncSuperAdminPermissionsWithLocales = async () => {
   const permissionService = strapi.admin.services.permission;
 
   const superAdminRole = await roleService.getSuperAdmin();
+
+  if (!superAdminRole) {
+    return;
+  }
+
   const superAdminPermissions = await permissionService.findUserPermissions({
     roles: [superAdminRole],
   });


### PR DESCRIPTION
### What does it do?

Returns early if a `superAdminRole` does not exist

### Why is it needed?

Throws an error in bootstrap function when creating a locale

### How to test it?

Create a locale in the bootstrap function

```
  await strapi.query("locale", "i18n").create({
    name: "French (fr)",
    code: "fr",
  });
```

