### PR TITLE
Add some i18n e2e tests

### DIFF
--- a/packages/strapi-plugin-i18n/config/policies/validateLocaleCreation.js
+++ b/packages/strapi-plugin-i18n/config/policies/validateLocaleCreation.js
@@ -51,7 +51,7 @@ const validateLocaleCreation = async (ctx, next) => {
 
   let relatedEntity;
   try {
-    relatedEntity = await getAndValidateRelatedEntity(relatedEntityId, model, locale);
+    relatedEntity = await getAndValidateRelatedEntity(relatedEntityId, model, entityLocale);
   } catch (e) {
     return ctx.badRequest(
       "The related entity doesn't exist or the entity already exists in this locale"

--- a/packages/strapi-plugin-i18n/config/routes.json
+++ b/packages/strapi-plugin-i18n/config/routes.json
@@ -16,7 +16,7 @@
       "path": "/locales",
       "handler": "locales.listLocales",
       "config": {
-        "policies": ["admin::isAuthenticatedAdmin"]
+        "policies": []
       }
     },
     {

--- a/packages/strapi-plugin-i18n/tests/api/create-ct.test.e2e.js
+++ b/packages/strapi-plugin-i18n/tests/api/create-ct.test.e2e.js
@@ -1,0 +1,111 @@
+'use strict';
+
+const { createTestBuilder } = require('../../../../test/helpers/builder');
+const { createStrapiInstance } = require('../../../../test/helpers/strapi');
+const { createAuthRequest } = require('../../../../test/helpers/request');
+
+const builder = createTestBuilder();
+let strapi;
+let rq;
+let localeId;
+
+const recipesModel = {
+  attributes: {
+    name: {
+      type: 'string',
+    },
+  },
+  pluginOptions: {
+    i18n: {
+      localized: true,
+    },
+  },
+  connection: 'default',
+  name: 'recipes',
+  description: '',
+  collectionName: '',
+};
+
+describe('Create entries in different locales', () => {
+  beforeAll(async () => {
+    await builder.addContentType(recipesModel).build();
+
+    strapi = await createStrapiInstance();
+    rq = await createAuthRequest({ strapi });
+
+    const locale = await strapi.query('locale', 'i18n').create({
+      code: 'fr',
+      name: 'French',
+    });
+
+    localeId = locale.id;
+  });
+
+  afterAll(async () => {
+    await strapi.query('locale', 'i18n').delete({ id: localeId });
+    await strapi.query('recipes').delete();
+    await strapi.destroy();
+    await builder.cleanup();
+  });
+
+  describe('Collection-Type', () => {
+    test('Create an entry in default locale (locale specified)', async () => {
+      const res = await rq({
+        method: 'POST',
+        url: '/recipes',
+        body: { name: 'Onion soup', locale: 'en' },
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({ name: 'Onion soup', locale: 'en', localizations: [] });
+    });
+
+    test('Create an entry in default locale (locale not specified)', async () => {
+      const res = await rq({
+        method: 'POST',
+        url: '/recipes',
+        body: { name: 'Onion soup' },
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({ name: 'Onion soup', locale: 'en', localizations: [] });
+    });
+
+    test('Create an entry in "fr"', async () => {
+      const res = await rq({
+        method: 'POST',
+        url: '/recipes',
+        body: { name: 'Onion soup', locale: 'fr' },
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({ name: 'Onion soup', locale: 'fr', localizations: [] });
+    });
+
+    test('Cannot create an entry in an unknown locale', async () => {
+      const res = await rq({
+        method: 'POST',
+        url: '/recipes',
+        body: { name: 'Onion soup', locale: 'unknown-locale' },
+      });
+
+      expect(res.status).toBe(400);
+      expect(res.body).toMatchObject({
+        error: 'Bad Request',
+        message: "This locale doesn't exist",
+        statusCode: 400,
+      });
+    });
+
+    test.skip('Cannot create an entry with localizations', async () => {
+      const res = await rq({
+        method: 'POST',
+        url: '/recipes',
+        body: { name: 'Onion soup', locale: 'en', localizations: [localeId] }, // random id
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({ name: 'Onion soup', locale: 'en', localizations: [] });
+    });
+  });
+});

--- a/packages/strapi-plugin-i18n/tests/api/create-st.test.e2e.js
+++ b/packages/strapi-plugin-i18n/tests/api/create-st.test.e2e.js
@@ -1,0 +1,115 @@
+'use strict';
+
+const { createTestBuilder } = require('../../../../test/helpers/builder');
+const { createStrapiInstance } = require('../../../../test/helpers/strapi');
+const { createAuthRequest } = require('../../../../test/helpers/request');
+
+const builder = createTestBuilder();
+let strapi;
+let rq;
+let localeId;
+
+const recipeModel = {
+  kind: 'singleType',
+  attributes: {
+    name: {
+      type: 'string',
+    },
+  },
+  pluginOptions: {
+    i18n: {
+      localized: true,
+    },
+  },
+  connection: 'default',
+  name: 'recipe',
+  description: '',
+  collectionName: '',
+};
+
+describe('Create entries in different locales', () => {
+  beforeAll(async () => {
+    await builder.addContentType(recipeModel).build();
+
+    strapi = await createStrapiInstance();
+    rq = await createAuthRequest({ strapi });
+
+    const locale = await strapi.query('locale', 'i18n').create({
+      code: 'fr',
+      name: 'French',
+    });
+
+    localeId = locale.id;
+  });
+
+  afterAll(async () => {
+    await strapi.query('locale', 'i18n').delete({ id: localeId });
+    await strapi.query('recipe').delete();
+    await strapi.destroy();
+    await builder.cleanup();
+  });
+
+  describe('Single-Type', () => {
+    test('Create an entry in default locale (locale specified)', async () => {
+      const res = await rq({
+        method: 'PUT',
+        url: '/recipe',
+        body: { name: 'Onion soup', locale: 'en' },
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({ name: 'Onion soup', locale: 'en', localizations: [] });
+      await strapi.query('recipe').delete();
+    });
+
+    test('Create an entry in default locale (locale not specified)', async () => {
+      const res = await rq({
+        method: 'PUT',
+        url: '/recipe',
+        body: { name: 'Onion soup' },
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({ name: 'Onion soup', locale: 'en', localizations: [] });
+      await strapi.query('recipe').delete();
+    });
+
+    test('Create an entry in "fr"', async () => {
+      const res = await rq({
+        method: 'PUT',
+        url: '/recipe',
+        body: { name: 'Onion soup', locale: 'fr' },
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({ name: 'Onion soup', locale: 'fr', localizations: [] });
+    });
+
+    test('Cannot create an entry if one already exist', async () => {
+      const res = await rq({
+        method: 'PUT',
+        url: '/recipe',
+        body: { name: 'Onion soup', locale: 'en' },
+      });
+
+      expect(res.status).toBe(400);
+      expect(res.body).toMatchObject({
+        error: 'Bad Request',
+        message: 'singleType.alreadyExists',
+        statusCode: 400,
+      });
+    });
+
+    test('Cannot create an entry with localizations', async () => {
+      await strapi.query('recipe').delete();
+      const res = await rq({
+        method: 'PUT',
+        url: '/recipe',
+        body: { name: 'Onion soup', locale: 'en', localizations: [localeId] }, // random id
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({ name: 'Onion soup', locale: 'en', localizations: [] });
+    });
+  });
+});

--- a/packages/strapi-plugin-i18n/tests/api/delete-st.test.e2e.js
+++ b/packages/strapi-plugin-i18n/tests/api/delete-st.test.e2e.js
@@ -1,0 +1,109 @@
+'use strict';
+
+const { createTestBuilder } = require('../../../../test/helpers/builder');
+const { createStrapiInstance } = require('../../../../test/helpers/strapi');
+const { createAuthRequest } = require('../../../../test/helpers/request');
+
+const builder = createTestBuilder();
+let strapi;
+let rq;
+let localeId;
+
+const recipeModel = {
+  kind: 'singleType',
+  attributes: {
+    name: {
+      type: 'string',
+    },
+  },
+  pluginOptions: {
+    i18n: {
+      localized: true,
+    },
+  },
+  connection: 'default',
+  name: 'recipe',
+  description: '',
+  collectionName: '',
+};
+
+describe('Delete entries in different locales', () => {
+  beforeAll(async () => {
+    await builder.addContentType(recipeModel).build();
+
+    strapi = await createStrapiInstance();
+    rq = await createAuthRequest({ strapi });
+
+    const locale = await strapi.query('locale', 'i18n').create({
+      code: 'fr',
+      name: 'French',
+    });
+
+    localeId = locale.id;
+  });
+
+  afterAll(async () => {
+    await strapi.query('locale', 'i18n').delete({ id: localeId });
+    await strapi.query('recipe').delete();
+    await strapi.destroy();
+    await builder.cleanup();
+  });
+
+  describe('Single-Type', () => {
+    test('Delete an entry in default locale (locale specified)', async () => {
+      await strapi.entityService.create(
+        { data: { name: 'Onion soup', locale: 'en' } },
+        { model: 'recipe' }
+      );
+
+      const res = await rq({
+        method: 'DELETE',
+        url: '/recipe',
+        qs: { _locale: 'en' },
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({ name: 'Onion soup', locale: 'en', localizations: [] });
+    });
+
+    test('Delete an entry in default locale (locale not specified)', async () => {
+      await strapi.entityService.create(
+        { data: { name: 'Onion soup', locale: 'en' } },
+        { model: 'recipe' }
+      );
+
+      const res = await rq({
+        method: 'DELETE',
+        url: '/recipe',
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({ name: 'Onion soup', locale: 'en', localizations: [] });
+    });
+
+    test('Delete only entry in "fr"', async () => {
+      await strapi.entityService.create(
+        { data: { name: 'Onion soup', locale: 'fr' } },
+        { model: 'recipe' }
+      );
+      await rq({
+        method: 'POST',
+        url: '/recipe/localizations',
+        body: { name: 'Onion soup', locale: 'en' },
+      });
+
+      const res = await rq({
+        method: 'DELETE',
+        url: '/recipe',
+        qs: { _locale: 'fr' },
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({
+        name: 'Onion soup',
+        locale: 'fr',
+        localizations: [{ locale: 'en' }],
+      });
+    });
+  });
+});

--- a/packages/strapi-plugin-i18n/tests/api/localizations-ct.test.e2e.js
+++ b/packages/strapi-plugin-i18n/tests/api/localizations-ct.test.e2e.js
@@ -1,0 +1,146 @@
+'use strict';
+
+const { prop } = require('lodash/fp');
+const { createTestBuilder } = require('../../../../test/helpers/builder');
+const { createStrapiInstance } = require('../../../../test/helpers/strapi');
+const { createAuthRequest } = require('../../../../test/helpers/request');
+
+const builder = createTestBuilder();
+let strapi;
+let rq;
+const localeIds = [];
+const recipes = {};
+const model = 'recipe';
+
+const recipeModel = {
+  attributes: {
+    name: {
+      type: 'string',
+    },
+  },
+  pluginOptions: {
+    i18n: {
+      localized: true,
+    },
+  },
+  connection: 'default',
+  name: 'recipe',
+  description: '',
+  collectionName: '',
+};
+
+describe('Create related entries in different locales', () => {
+  beforeAll(async () => {
+    await builder.addContentType(recipeModel).build();
+
+    strapi = await createStrapiInstance();
+    rq = await createAuthRequest({ strapi });
+
+    for (const locale of [
+      { code: 'fr', name: 'French' },
+      { code: 'asa', name: 'Asu' },
+    ]) {
+      const createdLocale = await strapi.query('locale', 'i18n').create(locale);
+      localeIds.push(createdLocale.id);
+    }
+    const recipe = await strapi.entityService.create(
+      { data: { name: 'Onion soup', locale: 'asa' } },
+      { model }
+    );
+    recipes.asa = recipe;
+  });
+
+  afterAll(async () => {
+    await strapi.query('locale', 'i18n').delete({ id_in: localeIds });
+    await strapi.query('recipe').delete();
+    await strapi.destroy();
+    await builder.cleanup();
+  });
+
+  describe('Collection-Type', () => {
+    test('Can create a related entry (1 existing)', async () => {
+      const res = await rq({
+        method: 'POST',
+        url: `/recipes/${recipes.asa.id}/localizations`,
+        body: { name: 'Onion soup', locale: 'fr' },
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({
+        name: 'Onion soup',
+        locale: 'fr',
+        localizations: [{ locale: 'asa' }],
+      });
+      recipes.fr = res.body;
+    });
+
+    test('Can create a related entry (2 existing)', async () => {
+      const { status, body } = await rq({
+        method: 'POST',
+        url: `/recipes/${recipes.fr.id}/localizations`,
+        body: { name: 'Onion soup', locale: 'en' },
+      });
+
+      expect(status).toBe(200);
+      expect(body).toMatchObject({ name: 'Onion soup', locale: 'en' });
+      expect(body.localizations.map(prop('locale')).sort()).toEqual(['asa', 'fr']);
+      recipes.en = body;
+    });
+
+    test.each([
+      ['en', ['asa', 'fr']],
+      ['fr', ['asa', 'en']],
+      ['asa', ['en', 'fr']],
+    ])('Localizations is correctly set in locale "%s"', async (locale, relatedlocales) => {
+      const { body } = await rq({ method: 'GET', url: `/recipes/${recipes[locale].id}` });
+      expect(body.localizations.map(prop('locale')).sort()).toEqual(relatedlocales);
+    });
+
+    test('Cannot create an entry without locale being specified', async () => {
+      const res = await rq({
+        method: 'POST',
+        url: `/recipes/${recipes.asa.id}/localizations`,
+        body: { name: 'Onion soup' },
+      });
+
+      expect(res.status).toBe(400);
+      expect(res.body).toMatchObject({
+        error: 'Bad Request',
+        message: 'locale.missing',
+        statusCode: 400,
+      });
+    });
+
+    test.each([['en'], ['fr']])('Cannot create an entry already existing "%s"', async locale => {
+      const res = await rq({
+        method: 'POST',
+        url: `/recipes/${recipes.asa.id}/localizations`,
+        body: { name: 'Onion soup', locale },
+      });
+
+      expect(res.status).toBe(400);
+      expect(res.body).toMatchObject({
+        error: 'Bad Request',
+        message: 'locale.already.used',
+        statusCode: 400,
+      });
+    });
+
+    test("Cannot create an entry related to an entry that doesn't exist", async () => {
+      await strapi.query('recipe').delete();
+
+      const res = await rq({
+        method: 'POST',
+        url: `/recipes/${recipes.asa.id}/localizations`,
+        body: { name: 'Onion soup', locale: 'en' },
+      });
+
+      expect(res.status).toBe(404);
+      expect(res.body).toMatchObject({
+        error: 'Not Found',
+        message: 'baseEntryId.invalid',
+        statusCode: 404,
+      });
+    });
+  });
+});

--- a/packages/strapi-plugin-i18n/tests/api/localizations-st.test.e2e.js
+++ b/packages/strapi-plugin-i18n/tests/api/localizations-st.test.e2e.js
@@ -1,0 +1,123 @@
+'use strict';
+
+const { prop } = require('lodash/fp');
+const { createTestBuilder } = require('../../../../test/helpers/builder');
+const { createStrapiInstance } = require('../../../../test/helpers/strapi');
+const { createAuthRequest } = require('../../../../test/helpers/request');
+
+const builder = createTestBuilder();
+let strapi;
+let rq;
+const localeIds = [];
+const model = 'recipe';
+
+const recipeModel = {
+  kind: 'singleType',
+  attributes: {
+    name: {
+      type: 'string',
+    },
+  },
+  pluginOptions: {
+    i18n: {
+      localized: true,
+    },
+  },
+  connection: 'default',
+  name: 'recipe',
+  description: '',
+  collectionName: '',
+};
+
+describe('Create related entries in different locales', () => {
+  beforeAll(async () => {
+    await builder.addContentType(recipeModel).build();
+
+    strapi = await createStrapiInstance();
+    rq = await createAuthRequest({ strapi });
+
+    for (const locale of [
+      { code: 'fr', name: 'French' },
+      { code: 'asa', name: 'Asu' },
+    ]) {
+      const createdLocale = await strapi.query('locale', 'i18n').create(locale);
+      localeIds.push(createdLocale.id);
+    }
+    await strapi.entityService.create({ data: { name: 'Onion soup', locale: 'asa' } }, { model });
+  });
+
+  afterAll(async () => {
+    await strapi.query('locale', 'i18n').delete({ id_in: localeIds });
+    await strapi.query('recipe').delete();
+    await strapi.destroy();
+    await builder.cleanup();
+  });
+
+  describe('Single-Type', () => {
+    test('Can create a related entry (1 existing)', async () => {
+      const res = await rq({
+        method: 'POST',
+        url: '/recipe/localizations',
+        body: { name: 'Onion soup', locale: 'fr' },
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({
+        name: 'Onion soup',
+        locale: 'fr',
+        localizations: [{ locale: 'asa' }],
+      });
+    });
+
+    test('Can create a related entry (2 existing)', async () => {
+      const { body, status } = await rq({
+        method: 'POST',
+        url: '/recipe/localizations',
+        body: { name: 'Onion soup', locale: 'en' },
+      });
+
+      expect(status).toBe(200);
+      expect(body).toMatchObject({ name: 'Onion soup', locale: 'en' });
+      expect(body.localizations.map(prop('locale')).sort()).toEqual(['asa', 'fr']);
+    });
+
+    test.each([
+      ['en', ['asa', 'fr']],
+      ['fr', ['asa', 'en']],
+      ['asa', ['en', 'fr']],
+    ])('Localizations is correctly set in locale "%s"', async (locale, relatedlocales) => {
+      let { body } = await rq({ method: 'GET', url: '/recipe', qs: { _locale: locale } });
+      expect(body.localizations.map(prop('locale')).sort()).toEqual(relatedlocales);
+    });
+
+    test('Cannot create an entry without locale being specified', async () => {
+      const res = await rq({
+        method: 'POST',
+        url: '/recipe/localizations',
+        body: { name: 'Onion soup' },
+      });
+
+      expect(res.status).toBe(400);
+      expect(res.body).toMatchObject({
+        error: 'Bad Request',
+        message: 'locale.missing',
+        statusCode: 400,
+      });
+    });
+
+    test.each([['en'], ['fr']])('Cannot create an entry already existing "%s"', async locale => {
+      const res = await rq({
+        method: 'POST',
+        url: '/recipe/localizations',
+        body: { name: 'Onion soup', locale },
+      });
+
+      expect(res.status).toBe(400);
+      expect(res.body).toMatchObject({
+        error: 'Bad Request',
+        message: 'locale.already.used',
+        statusCode: 400,
+      });
+    });
+  });
+});

--- a/packages/strapi-plugin-i18n/tests/api/read-st.test.e2e.js
+++ b/packages/strapi-plugin-i18n/tests/api/read-st.test.e2e.js
@@ -1,0 +1,119 @@
+'use strict';
+
+const { createTestBuilder } = require('../../../../test/helpers/builder');
+const { createStrapiInstance } = require('../../../../test/helpers/strapi');
+const { createAuthRequest } = require('../../../../test/helpers/request');
+
+const builder = createTestBuilder();
+let strapi;
+let rq;
+let localeId;
+
+const recipeModel = {
+  kind: 'singleType',
+  attributes: {
+    name: {
+      type: 'string',
+    },
+  },
+  pluginOptions: {
+    i18n: {
+      localized: true,
+    },
+  },
+  connection: 'default',
+  name: 'recipe',
+  description: '',
+  collectionName: '',
+};
+
+describe('Read entries in different locales', () => {
+  beforeAll(async () => {
+    await builder.addContentType(recipeModel).build();
+
+    strapi = await createStrapiInstance();
+    rq = await createAuthRequest({ strapi });
+
+    const locale = await strapi.query('locale', 'i18n').create({
+      code: 'fr',
+      name: 'French',
+    });
+
+    localeId = locale.id;
+  });
+
+  afterAll(async () => {
+    await strapi.query('locale', 'i18n').delete({ id: localeId });
+    await strapi.query('recipe').delete();
+    await strapi.destroy();
+    await builder.cleanup();
+  });
+
+  describe('Single-Type', () => {
+    test("Cannot read an entry that doesn't exist (locale not specified)", async () => {
+      const res = await rq({
+        method: 'GET',
+        url: '/recipe',
+      });
+
+      expect(res.status).toBe(404);
+    });
+
+    test("Cannot read an entry that doesn't exist (locale specified)", async () => {
+      const res = await rq({
+        method: 'GET',
+        url: '/recipe',
+        qs: { _locale: 'en' },
+      });
+
+      expect(res.status).toBe(404);
+    });
+
+    test('Can read an entry in default locale (locale not specified)', async () => {
+      await strapi.entityService.create(
+        { data: { name: 'Onion soup', locale: 'en' } },
+        { model: 'recipe' }
+      );
+
+      const res = await rq({
+        method: 'GET',
+        url: '/recipe',
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({ name: 'Onion soup', locale: 'en', localizations: [] });
+    });
+
+    test('Can read an entry in default locale (locale specified)', async () => {
+      const res = await rq({
+        method: 'GET',
+        url: '/recipe',
+        qs: { _locale: 'en' },
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({ name: 'Onion soup', locale: 'en', localizations: [] });
+    });
+
+    test('Can read an entry in "fr"', async () => {
+      await rq({
+        method: 'POST',
+        url: '/recipe/localizations',
+        body: { name: 'Onion soup', locale: 'fr' },
+      });
+
+      const res = await rq({
+        method: 'GET',
+        url: '/recipe',
+        qs: { _locale: 'fr' },
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({
+        name: 'Onion soup',
+        locale: 'fr',
+        localizations: [{ locale: 'en' }],
+      });
+    });
+  });
+});

--- a/packages/strapi-plugin-i18n/tests/api/update-ct.test.e2e.js
+++ b/packages/strapi-plugin-i18n/tests/api/update-ct.test.e2e.js
@@ -1,0 +1,83 @@
+'use strict';
+
+const { createTestBuilder } = require('../../../../test/helpers/builder');
+const { createStrapiInstance } = require('../../../../test/helpers/strapi');
+const { createAuthRequest } = require('../../../../test/helpers/request');
+
+const builder = createTestBuilder();
+let strapi;
+let rq;
+let localeId;
+const model = 'recipe';
+let recipe;
+
+const recipeModel = {
+  attributes: {
+    name: {
+      type: 'string',
+    },
+  },
+  pluginOptions: {
+    i18n: {
+      localized: true,
+    },
+  },
+  connection: 'default',
+  name: 'recipe',
+  description: '',
+  collectionName: '',
+};
+
+describe('Update entries in different locales', () => {
+  beforeAll(async () => {
+    await builder.addContentType(recipeModel).build();
+
+    strapi = await createStrapiInstance();
+    rq = await createAuthRequest({ strapi });
+
+    const locale = await strapi.query('locale', 'i18n').create({
+      code: 'fr',
+      name: 'French',
+    });
+
+    recipe = await strapi.entityService.create(
+      { data: { name: 'Onion soup', locale: 'en' } },
+      { model }
+    );
+
+    localeId = locale.id;
+  });
+
+  afterAll(async () => {
+    await strapi.query('locale', 'i18n').delete({ id: localeId });
+    await strapi.query('recipe').delete();
+    await strapi.destroy();
+    await builder.cleanup();
+  });
+
+  describe('Collection-Type', () => {
+    test('Cannot update locale', async () => {
+      const res = await rq({
+        method: 'PUT',
+        url: `/recipes/${recipe.id}`,
+        qs: { _locale: 'en' },
+        body: { name: 'Best onion soup', locale: 'fr' },
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({ name: 'Best onion soup', locale: 'en', localizations: [] });
+    });
+
+    test('Cannot update localizations', async () => {
+      const res = await rq({
+        method: 'PUT',
+        url: `/recipes/${recipe.id}`,
+        qs: { _locale: 'en' },
+        body: { name: 'Best onion soup', localizations: [localeId] }, // random id
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({ name: 'Best onion soup', locale: 'en', localizations: [] });
+    });
+  });
+});

--- a/packages/strapi-plugin-i18n/tests/api/update-st.test.e2e.js
+++ b/packages/strapi-plugin-i18n/tests/api/update-st.test.e2e.js
@@ -1,0 +1,142 @@
+'use strict';
+
+const { createTestBuilder } = require('../../../../test/helpers/builder');
+const { createStrapiInstance } = require('../../../../test/helpers/strapi');
+const { createAuthRequest } = require('../../../../test/helpers/request');
+
+const builder = createTestBuilder();
+let strapi;
+let rq;
+let localeId;
+const model = 'recipe';
+
+const recipeModel = {
+  kind: 'singleType',
+  attributes: {
+    name: {
+      type: 'string',
+    },
+  },
+  pluginOptions: {
+    i18n: {
+      localized: true,
+    },
+  },
+  connection: 'default',
+  name: 'recipe',
+  description: '',
+  collectionName: '',
+};
+
+describe('Update entries in different locales', () => {
+  beforeAll(async () => {
+    await builder.addContentType(recipeModel).build();
+
+    strapi = await createStrapiInstance();
+    rq = await createAuthRequest({ strapi });
+
+    const locale = await strapi.query('locale', 'i18n').create({
+      code: 'fr',
+      name: 'French',
+    });
+
+    const enRecipe = await strapi.entityService.create(
+      { data: { name: 'Onion soup', locale: 'en' } },
+      { model }
+    );
+    await strapi.entityService.create(
+      { data: { name: 'Onion soup', locale: 'fr', localizations: [enRecipe.id] } },
+      { model }
+    );
+
+    localeId = locale.id;
+  });
+
+  afterAll(async () => {
+    await strapi.query('locale', 'i18n').delete({ id: localeId });
+    await strapi.query('recipe').delete();
+    await strapi.destroy();
+    await builder.cleanup();
+  });
+
+  describe('Single-Type', () => {
+    test('Can update an entry in default locale (locale not specified)', async () => {
+      const res = await rq({
+        method: 'PUT',
+        url: '/recipe',
+        body: { name: 'Best onion soup' },
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({
+        name: 'Best onion soup',
+        locale: 'en',
+        localizations: [{ locale: 'fr' }],
+      });
+    });
+
+    test('Can update an entry in default locale (locale specified)', async () => {
+      const res = await rq({
+        method: 'PUT',
+        url: '/recipe',
+        body: { name: 'Best onion soup' },
+        qs: { _locale: 'en' },
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({
+        name: 'Best onion soup',
+        locale: 'en',
+        localizations: [{ locale: 'fr' }],
+      });
+    });
+
+    test('Can update an entry in "FR"', async () => {
+      const res = await rq({
+        method: 'PUT',
+        url: '/recipe',
+        body: { name: 'Best onion soup' },
+        qs: { _locale: 'fr' },
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({
+        name: 'Best onion soup',
+        locale: 'fr',
+        localizations: [{ locale: 'en' }],
+      });
+    });
+
+    test('Cannot update locale', async () => {
+      const res = await rq({
+        method: 'PUT',
+        url: '/recipe',
+        qs: { _locale: 'en' },
+        body: { name: 'Best onion soup', locale: 'fr' },
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({
+        name: 'Best onion soup',
+        locale: 'en',
+        localizations: [{ locale: 'fr' }],
+      });
+    });
+
+    test('Cannot update localizations', async () => {
+      const res = await rq({
+        method: 'PUT',
+        url: '/recipe',
+        qs: { _locale: 'en' },
+        body: { name: 'Best onion soup', localizations: [localeId] }, // random id
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({
+        name: 'Best onion soup',
+        locale: 'en',
+        localizations: [{ locale: 'fr' }],
+      });
+    });
+  });
+});

--- a/packages/strapi-plugin-i18n/tests/content-manager/create-ct.test.e2e.js
+++ b/packages/strapi-plugin-i18n/tests/content-manager/create-ct.test.e2e.js
@@ -1,0 +1,127 @@
+'use strict';
+
+const { createTestBuilder } = require('../../../../test/helpers/builder');
+const { createStrapiInstance } = require('../../../../test/helpers/strapi');
+const { createAuthRequest } = require('../../../../test/helpers/request');
+
+const builder = createTestBuilder();
+let strapi;
+let rq;
+let localeId;
+
+const recipesModel = {
+  attributes: {
+    name: {
+      type: 'string',
+    },
+  },
+  pluginOptions: {
+    i18n: {
+      localized: true,
+    },
+  },
+  connection: 'default',
+  name: 'recipes',
+  description: '',
+  collectionName: '',
+};
+
+describe('Create entries in different locales', () => {
+  beforeAll(async () => {
+    await builder.addContentType(recipesModel).build();
+
+    strapi = await createStrapiInstance();
+    rq = await createAuthRequest({ strapi });
+
+    const locale = await strapi.query('locale', 'i18n').create({
+      code: 'fr',
+      name: 'French',
+    });
+
+    localeId = locale.id;
+  });
+
+  afterAll(async () => {
+    await strapi.query('locale', 'i18n').delete({ id: localeId });
+    await strapi.query('recipes').delete();
+    await strapi.destroy();
+    await builder.cleanup();
+  });
+
+  describe('Collection-Type', () => {
+    test('Create an entry in default locale (locale specified)', async () => {
+      const res = await rq({
+        method: 'POST',
+        url: '/content-manager/collection-types/application::recipes.recipes',
+        qs: { plugins: { i18n: { locale: 'en' } } },
+        body: { name: 'Onion soup' },
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({ name: 'Onion soup', locale: 'en', localizations: [] });
+    });
+
+    test('Create an entry in default locale (locale not specified)', async () => {
+      const res = await rq({
+        method: 'POST',
+        url: '/content-manager/collection-types/application::recipes.recipes',
+        body: { name: 'Onion soup' },
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({ name: 'Onion soup', locale: 'en', localizations: [] });
+    });
+
+    test('Create an entry in "fr"', async () => {
+      const res = await rq({
+        method: 'POST',
+        url: '/content-manager/collection-types/application::recipes.recipes',
+        qs: { plugins: { i18n: { locale: 'fr' } } },
+        body: { name: 'Onion soup' },
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({ name: 'Onion soup', locale: 'fr', localizations: [] });
+    });
+
+    test('Cannot create an entry in an unknown locale', async () => {
+      const res = await rq({
+        method: 'POST',
+        url: '/content-manager/collection-types/application::recipes.recipes',
+        qs: { plugins: { i18n: { locale: 'unknown-locale' } } },
+        body: { name: 'Onion soup' },
+      });
+
+      expect(res.status).toBe(400);
+      expect(res.body).toMatchObject({
+        error: 'Bad Request',
+        message: "This locale doesn't exist",
+        statusCode: 400,
+      });
+    });
+
+    test('Cannot create an entry with localizations', async () => {
+      const res = await rq({
+        method: 'POST',
+        url: '/content-manager/collection-types/application::recipes.recipes',
+        qs: { plugins: { i18n: { locale: 'en' } } },
+        body: { name: 'Onion soup', localizations: [1] },
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({ name: 'Onion soup', locale: 'en', localizations: [] });
+    });
+
+    test('Cannot create an entry with locale', async () => {
+      const res = await rq({
+        method: 'POST',
+        url: '/content-manager/collection-types/application::recipes.recipes',
+        qs: { plugins: { i18n: { locale: 'en' } } },
+        body: { name: 'Onion soup', locale: 'fr' },
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({ name: 'Onion soup', locale: 'en', localizations: [] });
+    });
+  });
+});

--- a/packages/strapi-plugin-i18n/tests/content-manager/create-st.test.e2e.js
+++ b/packages/strapi-plugin-i18n/tests/content-manager/create-st.test.e2e.js
@@ -1,0 +1,116 @@
+'use strict';
+
+const { createTestBuilder } = require('../../../../test/helpers/builder');
+const { createStrapiInstance } = require('../../../../test/helpers/strapi');
+const { createAuthRequest } = require('../../../../test/helpers/request');
+
+const builder = createTestBuilder();
+let strapi;
+let rq;
+let localeId;
+
+const recipeModel = {
+  kind: 'singleType',
+  attributes: {
+    name: {
+      type: 'string',
+    },
+  },
+  pluginOptions: {
+    i18n: {
+      localized: true,
+    },
+  },
+  connection: 'default',
+  name: 'recipe',
+  description: '',
+  collectionName: '',
+};
+
+describe('Create entries in different locales', () => {
+  beforeAll(async () => {
+    await builder.addContentType(recipeModel).build();
+
+    strapi = await createStrapiInstance();
+    rq = await createAuthRequest({ strapi });
+
+    const locale = await strapi.query('locale', 'i18n').create({
+      code: 'fr',
+      name: 'French',
+    });
+
+    localeId = locale.id;
+  });
+
+  afterAll(async () => {
+    await strapi.query('locale', 'i18n').delete({ id: localeId });
+    await strapi.query('recipe').delete();
+    await strapi.destroy();
+    await builder.cleanup();
+  });
+
+  describe('Single-Type', () => {
+    test('Create an entry in default locale (locale specified)', async () => {
+      const res = await rq({
+        method: 'PUT',
+        url: '/content-manager/single-types/application::recipe.recipe',
+        body: { name: 'Onion soup' },
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({ name: 'Onion soup', locale: 'en', localizations: [] });
+      await strapi.query('recipe').delete();
+    });
+
+    test('Create an entry in default locale (locale not specified)', async () => {
+      const res = await rq({
+        method: 'PUT',
+        url: '/content-manager/single-types/application::recipe.recipe',
+        qs: { plugins: { i18n: { locale: 'en' } } },
+        body: { name: 'Onion soup' },
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({ name: 'Onion soup', locale: 'en', localizations: [] });
+      await strapi.query('recipe').delete();
+    });
+
+    test('Create an entry in "fr"', async () => {
+      const res = await rq({
+        method: 'PUT',
+        url: '/content-manager/single-types/application::recipe.recipe',
+        qs: { plugins: { i18n: { locale: 'fr' } } },
+        body: { name: 'Onion soup' },
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({ name: 'Onion soup', locale: 'fr', localizations: [] });
+    });
+
+    test('Cannot create an entry with locale', async () => {
+      await strapi.query('recipe').delete();
+      const res = await rq({
+        method: 'PUT',
+        url: '/content-manager/single-types/application::recipe.recipe',
+        qs: { plugins: { i18n: { locale: 'en' } } },
+        body: { name: 'Onion soup', locale: 'fr' },
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({ name: 'Onion soup', locale: 'en', localizations: [] });
+    });
+
+    test('Cannot create an entry with localizations', async () => {
+      await strapi.query('recipe').delete();
+      const res = await rq({
+        method: 'PUT',
+        url: '/content-manager/single-types/application::recipe.recipe',
+        qs: { plugins: { i18n: { locale: 'en' } } },
+        body: { name: 'Onion soup', localizations: [1] },
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({ name: 'Onion soup', locale: 'en', localizations: [] });
+    });
+  });
+});

--- a/packages/strapi-plugin-i18n/tests/content-manager/delete-st.test.e2e.js
+++ b/packages/strapi-plugin-i18n/tests/content-manager/delete-st.test.e2e.js
@@ -1,0 +1,110 @@
+'use strict';
+
+const { createTestBuilder } = require('../../../../test/helpers/builder');
+const { createStrapiInstance } = require('../../../../test/helpers/strapi');
+const { createAuthRequest } = require('../../../../test/helpers/request');
+
+const builder = createTestBuilder();
+let strapi;
+let rq;
+let localeId;
+
+const recipeModel = {
+  kind: 'singleType',
+  attributes: {
+    name: {
+      type: 'string',
+    },
+  },
+  pluginOptions: {
+    i18n: {
+      localized: true,
+    },
+  },
+  connection: 'default',
+  name: 'recipe',
+  description: '',
+  collectionName: '',
+};
+
+describe('Delete entries in different locales', () => {
+  beforeAll(async () => {
+    await builder.addContentType(recipeModel).build();
+
+    strapi = await createStrapiInstance();
+    rq = await createAuthRequest({ strapi });
+
+    const locale = await strapi.query('locale', 'i18n').create({
+      code: 'fr',
+      name: 'French',
+    });
+
+    localeId = locale.id;
+  });
+
+  afterAll(async () => {
+    await strapi.query('locale', 'i18n').delete({ id: localeId });
+    await strapi.query('recipe').delete();
+    await strapi.destroy();
+    await builder.cleanup();
+  });
+
+  describe('Single-Type', () => {
+    test('Delete an entry in default locale (locale specified)', async () => {
+      await strapi.entityService.create(
+        { data: { name: 'Onion soup', locale: 'en' } },
+        { model: 'recipe' }
+      );
+
+      const res = await rq({
+        method: 'DELETE',
+        url: '/content-manager/single-types/application::recipe.recipe',
+        qs: { _locale: 'en' },
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({ name: 'Onion soup', locale: 'en', localizations: [] });
+    });
+
+    test('Delete an entry in default locale (locale not specified)', async () => {
+      await strapi.entityService.create(
+        { data: { name: 'Onion soup', locale: 'en' } },
+        { model: 'recipe' }
+      );
+
+      const res = await rq({
+        method: 'DELETE',
+        url: '/content-manager/single-types/application::recipe.recipe',
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({ name: 'Onion soup', locale: 'en', localizations: [] });
+    });
+
+    test('Delete only entry in "fr"', async () => {
+      await strapi.entityService.create(
+        { data: { name: 'Onion soup', locale: 'fr' } },
+        { model: 'recipe' }
+      );
+      await rq({
+        method: 'PUT',
+        url: '/content-manager/single-types/application::recipe.recipe',
+        qs: { plugins: { i18n: { locale: 'en' } } },
+        body: { name: 'Onion soup' },
+      });
+
+      const res = await rq({
+        method: 'DELETE',
+        url: '/content-manager/single-types/application::recipe.recipe',
+        qs: { _locale: 'fr' },
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({
+        name: 'Onion soup',
+        locale: 'fr',
+        localizations: [{ locale: 'en' }],
+      });
+    });
+  });
+});

--- a/packages/strapi-plugin-i18n/tests/content-manager/localizations-ct.test.e2e.js
+++ b/packages/strapi-plugin-i18n/tests/content-manager/localizations-ct.test.e2e.js
@@ -1,0 +1,152 @@
+'use strict';
+
+const { prop } = require('lodash/fp');
+const { createTestBuilder } = require('../../../../test/helpers/builder');
+const { createStrapiInstance } = require('../../../../test/helpers/strapi');
+const { createAuthRequest } = require('../../../../test/helpers/request');
+
+const builder = createTestBuilder();
+let strapi;
+let rq;
+const localeIds = [];
+const recipes = {};
+const model = 'recipe';
+
+const recipeModel = {
+  attributes: {
+    name: {
+      type: 'string',
+    },
+  },
+  pluginOptions: {
+    i18n: {
+      localized: true,
+    },
+  },
+  connection: 'default',
+  name: 'recipe',
+  description: '',
+  collectionName: '',
+};
+
+describe('Create related entries in different locales', () => {
+  beforeAll(async () => {
+    await builder.addContentType(recipeModel).build();
+
+    strapi = await createStrapiInstance();
+    rq = await createAuthRequest({ strapi });
+
+    for (const locale of [
+      { code: 'fr', name: 'French' },
+      { code: 'asa', name: 'Asu' },
+      // { code: 'ak', name: 'Akan' },
+    ]) {
+      const createdLocale = await strapi.query('locale', 'i18n').create(locale);
+      localeIds.push(createdLocale.id);
+    }
+    const recipe = await strapi.entityService.create(
+      { data: { name: 'Onion soup', locale: 'asa' } },
+      { model }
+    );
+    recipes.asa = recipe;
+  });
+
+  afterAll(async () => {
+    await strapi.query('locale', 'i18n').delete({ id_in: localeIds });
+    await strapi.query('recipe').delete();
+    await strapi.destroy();
+    await builder.cleanup();
+  });
+
+  describe('Collection-Type', () => {
+    test('Can create a related entry (1 existing)', async () => {
+      const { status, body } = await rq({
+        method: 'POST',
+        url: '/content-manager/collection-types/application::recipe.recipe',
+        qs: { plugins: { i18n: { locale: 'fr', relatedEntityId: recipes.asa.id } } },
+        body: { name: 'Onion soup' },
+      });
+
+      expect(status).toBe(200);
+      expect(body).toMatchObject({ name: 'Onion soup', locale: 'fr' });
+      expect(body.localizations.map(prop('locale')).sort()).toEqual(['asa']);
+      recipes.fr = body;
+    });
+
+    test('Can create a related entry (2 existing)', async () => {
+      const { status, body } = await rq({
+        method: 'POST',
+        url: '/content-manager/collection-types/application::recipe.recipe',
+        qs: { plugins: { i18n: { locale: 'en', relatedEntityId: recipes.fr.id } } },
+        body: { name: 'Onion soup' },
+      });
+
+      expect(status).toBe(200);
+      expect(body).toMatchObject({ name: 'Onion soup', locale: 'en' });
+      expect(body.localizations.map(prop('locale')).sort()).toEqual(['asa', 'fr']);
+      recipes.en = body;
+    });
+
+    test.each([
+      ['en', ['asa', 'fr']],
+      ['fr', ['asa', 'en']],
+      ['asa', ['en', 'fr']],
+    ])('Localizations is correctly set in locale "%s"', async (locale, relatedlocales) => {
+      const { body } = await rq({
+        method: 'GET',
+        url: `/content-manager/collection-types/application::recipe.recipe/${recipes[locale].id}`,
+      });
+      expect(body.localizations.map(prop('locale')).sort()).toEqual(relatedlocales);
+    });
+
+    test('Cannot create an entry without locale being specified', async () => {
+      const res = await rq({
+        method: 'POST',
+        url: '/content-manager/collection-types/application::recipe.recipe',
+        qs: { plugins: { i18n: { relatedEntityId: recipes.fr.id } } },
+        body: { name: 'Onion soup' },
+      });
+
+      expect(res.status).toBe(400);
+      expect(res.body).toMatchObject({
+        error: 'Bad Request',
+        message: "The related entity doesn't exist or the entity already exists in this locale",
+        statusCode: 400,
+      });
+    });
+
+    test.each([['en'], ['fr']])('Cannot create an entry already existing "%s"', async locale => {
+      const res = await rq({
+        method: 'POST',
+        url: '/content-manager/collection-types/application::recipe.recipe',
+        qs: { plugins: { i18n: { locale, relatedEntityId: recipes.asa.id } } },
+        body: { name: 'Onion soup' },
+      });
+
+      expect(res.status).toBe(400);
+      expect(res.body).toMatchObject({
+        error: 'Bad Request',
+        message: "The related entity doesn't exist or the entity already exists in this locale",
+        statusCode: 400,
+      });
+    });
+
+    test("Cannot create an entry related to an entry that doesn't exist", async () => {
+      await strapi.query('recipe').delete();
+
+      const res = await rq({
+        method: 'POST',
+        url: '/content-manager/collection-types/application::recipe.recipe',
+        qs: { plugins: { i18n: { locale: 'en', relatedEntityId: recipes.asa.id } } },
+        body: { name: 'Onion soup' },
+      });
+
+      expect(res.status).toBe(400);
+      expect(res.body).toMatchObject({
+        error: 'Bad Request',
+        message: "The related entity doesn't exist or the entity already exists in this locale",
+        statusCode: 400,
+      });
+    });
+  });
+});

--- a/packages/strapi-plugin-i18n/tests/content-manager/read-st.test.e2e.js
+++ b/packages/strapi-plugin-i18n/tests/content-manager/read-st.test.e2e.js
@@ -1,0 +1,120 @@
+'use strict';
+
+const { createTestBuilder } = require('../../../../test/helpers/builder');
+const { createStrapiInstance } = require('../../../../test/helpers/strapi');
+const { createAuthRequest } = require('../../../../test/helpers/request');
+
+const builder = createTestBuilder();
+let strapi;
+let rq;
+let localeId;
+
+const recipeModel = {
+  kind: 'singleType',
+  attributes: {
+    name: {
+      type: 'string',
+    },
+  },
+  pluginOptions: {
+    i18n: {
+      localized: true,
+    },
+  },
+  connection: 'default',
+  name: 'recipe',
+  description: '',
+  collectionName: '',
+};
+
+describe('Read entries in different locales', () => {
+  beforeAll(async () => {
+    await builder.addContentType(recipeModel).build();
+
+    strapi = await createStrapiInstance();
+    rq = await createAuthRequest({ strapi });
+
+    const locale = await strapi.query('locale', 'i18n').create({
+      code: 'fr',
+      name: 'French',
+    });
+
+    localeId = locale.id;
+  });
+
+  afterAll(async () => {
+    await strapi.query('locale', 'i18n').delete({ id: localeId });
+    await strapi.query('recipe').delete();
+    await strapi.destroy();
+    await builder.cleanup();
+  });
+
+  describe('Single-Type', () => {
+    test("Cannot read an entry that doesn't exist (locale not specified)", async () => {
+      const res = await rq({
+        method: 'GET',
+        url: '/content-manager/single-types/application::recipe.recipe',
+      });
+
+      expect(res.status).toBe(404);
+    });
+
+    test("Cannot read an entry that doesn't exist (locale specified)", async () => {
+      const res = await rq({
+        method: 'GET',
+        url: '/content-manager/single-types/application::recipe.recipe',
+        qs: { _locale: 'en' },
+      });
+
+      expect(res.status).toBe(404);
+    });
+
+    test('Can read an entry in default locale (locale not specified)', async () => {
+      await strapi.entityService.create(
+        { data: { name: 'Onion soup', locale: 'en' } },
+        { model: 'recipe' }
+      );
+
+      const res = await rq({
+        method: 'GET',
+        url: '/content-manager/single-types/application::recipe.recipe',
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({ name: 'Onion soup', locale: 'en', localizations: [] });
+    });
+
+    test('Can read an entry in default locale (locale specified)', async () => {
+      const res = await rq({
+        method: 'GET',
+        url: '/content-manager/single-types/application::recipe.recipe',
+        qs: { _locale: 'en' },
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({ name: 'Onion soup', locale: 'en', localizations: [] });
+    });
+
+    test('Can read an entry in "fr"', async () => {
+      await rq({
+        method: 'PUT',
+        url: '/content-manager/single-types/application::recipe.recipe',
+        qs: { plugins: { i18n: { locale: 'fr' } } },
+        body: { name: 'Onion soup' },
+      });
+
+      const res = await rq({
+        method: 'GET',
+        url: '/content-manager/single-types/application::recipe.recipe',
+        qs: { _locale: 'fr' },
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({
+        name: 'Onion soup',
+        locale: 'fr',
+        localizations: [{ locale: 'en' }],
+      });
+    });
+  });
+});

--- a/packages/strapi-plugin-i18n/tests/content-manager/update-ct.test.e2e.js
+++ b/packages/strapi-plugin-i18n/tests/content-manager/update-ct.test.e2e.js
@@ -1,0 +1,81 @@
+'use strict';
+
+const { createTestBuilder } = require('../../../../test/helpers/builder');
+const { createStrapiInstance } = require('../../../../test/helpers/strapi');
+const { createAuthRequest } = require('../../../../test/helpers/request');
+
+const builder = createTestBuilder();
+let strapi;
+let rq;
+let localeId;
+const model = 'recipe';
+let recipe;
+
+const recipeModel = {
+  attributes: {
+    name: {
+      type: 'string',
+    },
+  },
+  pluginOptions: {
+    i18n: {
+      localized: true,
+    },
+  },
+  connection: 'default',
+  name: 'recipe',
+  description: '',
+  collectionName: '',
+};
+
+describe('Update entries in different locales', () => {
+  beforeAll(async () => {
+    await builder.addContentType(recipeModel).build();
+
+    strapi = await createStrapiInstance();
+    rq = await createAuthRequest({ strapi });
+
+    const locale = await strapi.query('locale', 'i18n').create({
+      code: 'fr',
+      name: 'French',
+    });
+
+    recipe = await strapi.entityService.create(
+      { data: { name: 'Onion soup', locale: 'en' } },
+      { model }
+    );
+
+    localeId = locale.id;
+  });
+
+  afterAll(async () => {
+    await strapi.query('locale', 'i18n').delete({ id: localeId });
+    await strapi.query('recipe').delete();
+    await strapi.destroy();
+    await builder.cleanup();
+  });
+
+  describe('Collection-Type', () => {
+    test('Cannot update locale', async () => {
+      const res = await rq({
+        method: 'PUT',
+        url: `/content-manager/collection-types/application::recipe.recipe/${recipe.id}`,
+        body: { name: 'Best onion soup', locale: 'fr' },
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({ name: 'Best onion soup', locale: 'en', localizations: [] });
+    });
+
+    test('Cannot update localizations', async () => {
+      const res = await rq({
+        method: 'PUT',
+        url: `/content-manager/collection-types/application::recipe.recipe/${recipe.id}`,
+        body: { name: 'Best onion soup', localizations: [1] },
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({ name: 'Best onion soup', locale: 'en', localizations: [] });
+    });
+  });
+});

--- a/packages/strapi-plugin-i18n/tests/content-manager/update-st.test.e2e.js
+++ b/packages/strapi-plugin-i18n/tests/content-manager/update-st.test.e2e.js
@@ -1,0 +1,142 @@
+'use strict';
+
+const { createTestBuilder } = require('../../../../test/helpers/builder');
+const { createStrapiInstance } = require('../../../../test/helpers/strapi');
+const { createAuthRequest } = require('../../../../test/helpers/request');
+
+const builder = createTestBuilder();
+let strapi;
+let rq;
+let localeId;
+const model = 'recipe';
+
+const recipeModel = {
+  kind: 'singleType',
+  attributes: {
+    name: {
+      type: 'string',
+    },
+  },
+  pluginOptions: {
+    i18n: {
+      localized: true,
+    },
+  },
+  connection: 'default',
+  name: 'recipe',
+  description: '',
+  collectionName: '',
+};
+
+describe('Update entries in different locales', () => {
+  beforeAll(async () => {
+    await builder.addContentType(recipeModel).build();
+
+    strapi = await createStrapiInstance();
+    rq = await createAuthRequest({ strapi });
+
+    const locale = await strapi.query('locale', 'i18n').create({
+      code: 'fr',
+      name: 'French',
+    });
+
+    const enRecipe = await strapi.entityService.create(
+      { data: { name: 'Onion soup', locale: 'en' } },
+      { model }
+    );
+    await strapi.entityService.create(
+      { data: { name: 'Onion soup', locale: 'fr', localizations: [enRecipe.id] } },
+      { model }
+    );
+
+    localeId = locale.id;
+  });
+
+  afterAll(async () => {
+    await strapi.query('locale', 'i18n').delete({ id: localeId });
+    await strapi.query('recipe').delete();
+    await strapi.destroy();
+    await builder.cleanup();
+  });
+
+  describe('Single-Type', () => {
+    test('Can update an entry in default locale (locale not specified)', async () => {
+      const res = await rq({
+        method: 'PUT',
+        url: '/content-manager/single-types/application::recipe.recipe',
+        body: { name: 'Best onion soup' },
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({
+        name: 'Best onion soup',
+        locale: 'en',
+        localizations: [{ locale: 'fr' }],
+      });
+    });
+
+    test('Can update an entry in default locale (locale specified)', async () => {
+      const res = await rq({
+        method: 'PUT',
+        url: '/content-manager/single-types/application::recipe.recipe',
+        body: { name: 'Best onion soup' },
+        qs: { plugins: { i18n: { locale: 'en' } } },
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({
+        name: 'Best onion soup',
+        locale: 'en',
+        localizations: [{ locale: 'fr' }],
+      });
+    });
+
+    test('Can update an entry in "FR"', async () => {
+      const res = await rq({
+        method: 'PUT',
+        url: '/content-manager/single-types/application::recipe.recipe',
+        body: { name: 'Best onion soup' },
+        qs: { plugins: { i18n: { locale: 'fr' } } },
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({
+        name: 'Best onion soup',
+        locale: 'fr',
+        localizations: [{ locale: 'en' }],
+      });
+    });
+
+    test('Cannot update locale', async () => {
+      const res = await rq({
+        method: 'PUT',
+        url: '/content-manager/single-types/application::recipe.recipe',
+        qs: { plugins: { i18n: { locale: 'en' } } },
+        body: { name: 'Best onion soup update', locale: 'fr' },
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({
+        name: 'Best onion soup update',
+        locale: 'en',
+        localizations: [{ locale: 'fr' }],
+      });
+    });
+
+    test('Cannot update localizations', async () => {
+      const res = await rq({
+        method: 'PUT',
+        url: '/content-manager/single-types/application::recipe.recipe',
+        qs: { plugins: { i18n: { locale: 'en' } } },
+        body: { name: 'Best onion soup', localizations: [1] },
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({
+        name: 'Best onion soup',
+        locale: 'en',
+        localizations: [{ locale: 'fr' }],
+      });
+    });
+  });
+});


### PR DESCRIPTION
Merge https://github.com/strapi/strapi/pull/10255 before.

- Add many e2e tests
- Make a small fix. With the Content-Manager API It was possible to create a related entry in the default locale even if the default locale was already existing. To do it, it was need to not specify the locale in the query.