### PR TITLE
Use vanityName for username with LinkedIn Auth

### DIFF
--- a/packages/strapi-plugin-users-permissions/services/Providers.js
+++ b/packages/strapi-plugin-users-permissions/services/Providers.js
@@ -452,12 +452,12 @@ const getProfile = async (provider, query, callback) => {
           });
         };
 
-        const { localizedFirstName } = await getDetailsRequest();
+        const { vanityName } = await getDetailsRequest();
         const { elements } = await getEmailRequest();
         const email = elements[0]['handle~'];
 
         callback(null, {
-          username: localizedFirstName,
+          username: vanityName,
           email: email.emailAddress,
         });
       } catch (err) {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

The vanity name of the member. Vanity name is represented as a string is used for the public profile URL: `www.linkedin.com/in/{vanityName}`.

Changes the username from `localizedFirstName` to `vanityName`

### Why is it needed?

Getting an error for users with the same first name.


### How to test it?

Register via LinkedIn auth.

### Related issue(s)/PR(s)

None

References:
https://docs.microsoft.com/en-us/linkedin/shared/integrations/people/profile-api
https://docs.microsoft.com/en-us/linkedin/shared/references/v2/profile/basic-profile
