### PR TITLE
Remove to lowercase in update user-permission

### DIFF
--- a/packages/strapi-plugin-users-permissions/controllers/user/api.js
+++ b/packages/strapi-plugin-users-permissions/controllers/user/api.js
@@ -155,7 +155,6 @@ module.exports = {
           })
         );
       }
-      ctx.request.body.email = ctx.request.body.email.toLowerCase();
     }
 
     let updateData = {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Removed toLowercase when update user-permission

### Why is it needed?

This change is needed because whenever there is an update of the `user-permission` collection, the email is transformed to lowercase.
This causes that when we then try to request the resource (find / findOne), the user is not found, because its original email contains some characters uppercase.

### How to test it?

Just update the user, the email need to be exactly the same as in the payload

