### PR TITLE
Fix compatibility issue for mongo < 4.2

### DIFF
--- a/packages/strapi-admin/config/migrations/permissions-fields-to-properties.js
+++ b/packages/strapi-admin/config/migrations/permissions-fields-to-properties.js
@@ -91,10 +91,13 @@ module.exports = {
       for (const permission of permissions) {
         const { fields, _id } = permission;
 
-        await model.updateOne({ _id }, [
-          { $set: { properties: { fields } } },
-          { $unset: ['fields'] },
-        ]);
+        await model.updateOne(
+          { _id },
+          {
+            $set: { properties: { fields } },
+            $unset: { fields: true },
+          }
+        );
       }
     }
   },


### PR DESCRIPTION
### What does it do?

Fix usage of model.updateOne in admin migration to ensure compatibility with mongo < 4.2.

### Why is it needed?

Aggregate (array) parameter is not available for model.updateOne until mongo 4.2.

### Related issue(s)/PR(s)

should fix #10096
