### PR TITLE
Update webhook doc link

### DIFF
--- a/packages/strapi-admin/admin/src/containers/Webhooks/ListView/index.js
+++ b/packages/strapi-admin/admin/src/containers/Webhooks/ListView/index.js
@@ -300,7 +300,7 @@ function ListView() {
             <EmptyState
               title={formatMessage({ id: 'Settings.webhooks.list.empty.title' })}
               description={formatMessage({ id: 'Settings.webhooks.list.empty.description' })}
-              link="https://strapi.io/documentation/developer-docs/latest/concepts/webhooks.html"
+              link="https://strapi.io/documentation/developer-docs/latest/development/backend-customization.html#webhooks"
               linkText={formatMessage({ id: 'Settings.webhooks.list.empty.link' })}
             />
           )}


### PR DESCRIPTION
### What does it do?

Replaced link in webhooks page with proper documentation link

### Why is it needed?

Doc link for webhooks returned a 404

### How to test it?

Run Strapi application, go to settings => webhook and click on the documentation link

### Related issue(s)/PR(s)

fixes #10294
