### PR TITLE
Ask the user about creating strapi app in a non-empty directory

### DIFF
--- a/packages/strapi-generate-new/lib/generate-new.js
+++ b/packages/strapi-generate-new/lib/generate-new.js
@@ -32,11 +32,12 @@ module.exports = async scope => {
 
     const files = await fse.readdir(scope.rootPath);
     if (files.length > 1) {
-      stopProcess(
-        `⛔️ You can only create a Strapi app in an empty directory.\nMake sure ${chalk.green(
-          scope.rootPath
-        )} is empty.`
+      const shouldInstallInNonEmptyDirectory = await askShouldInstallInNonEmptyDirectory(
+        scope.rootPath
       );
+      if (!shouldInstallInNonEmptyDirectory) {
+        stopProcess(`⛔️ Aborted because ${chalk.green(scope.rootPath)} is not empty.`);
+      }
     }
   }
 
@@ -82,4 +83,19 @@ async function askShouldUseQuickstart() {
   ]);
 
   return answer.type === 'quick';
+}
+
+async function askShouldInstallInNonEmptyDirectory(rootPath) {
+  const answer = await inquirer.prompt([
+    {
+      type: 'confirm',
+      name: 'installInNonEmptyDirectory',
+      message:
+        `The target directory (${rootPath}) is not empty. This may cause problems.\n` +
+        `Do you want to install anyway?`,
+      default: false,
+    },
+  ]);
+
+  return answer.installInNonEmptyDirectory;
 }


### PR DESCRIPTION
### What does it do?

This PR changes the behaviour of `strapi new` in case that the target directory is not empty. Instead of immediately exiting with an error message, the user is warned that installing in a non-empty directory can cause problems, and is asked if they want to install anyway (by default: no). If the user chooses not to install, the process aborts with a status message (that is similar to the one that is shown immediately in the current strapi version).

### Why is it needed?

I'm creating a code generator (https://github.com/mnieber/moonleap) that creates an entire stack based on a spec file. This stack can include a strapi server, but in this case the strapi target directory will already have some files (that the generator produced), such as a Makefile and Dockerfile. It's safe to install strapi in this directory, but strapi won't allow it.

### How to test it?

Create a directory with some dummy files and run `strapi new .` inside that directory.

![Selection_156](https://user-images.githubusercontent.com/818892/118275066-39223700-b4c6-11eb-8cc1-676279750eb4.png)


### Related issue(s)/PR(s)

It's not related to any issue/pull request

Note that this PR might introduce a problem where an automated process expects `strapi new` to either fail or pass (and not hang waiting for an answer). In other words, it might need an extra "--non-interactive" command line flag that prevents this situation.