### PR TITLE
Fix 9149 Mysql error on draft relationship

### DIFF
--- a/packages/strapi-plugin-graphql/services/shadow-crud.js
+++ b/packages/strapi-plugin-graphql/services/shadow-crud.js
@@ -257,7 +257,11 @@ const buildAssocResolvers = model => {
             };
 
             if (['oneToOne', 'oneWay', 'manyToOne'].includes(nature)) {
-              if (!_.has(obj, alias) || _.isNil(foreignId)) {
+              if (
+                !_.has(obj, alias) ||
+                _.isNil(foreignId) ||
+                (_.isObject(obj[alias]) && !_.has(obj[alias], targetPK))
+              ) {
                 return null;
               }
 


### PR DESCRIPTION
### What does it do?

Added an additional check to the graphql relationship resolver to correctly allow empty objects which are the result of draft relationships.

### Why is it needed?

Without it, querying a parent resource with a draft relationship causes the query to fail.

### How to test it?

See #9149 

### Related issue(s)/PR(s)

See #9149 
