### PR TITLE
Fix/validate username

### DIFF
--- a/packages/strapi-plugin-users-permissions/controllers/user/admin.js
+++ b/packages/strapi-plugin-users-permissions/controllers/user/admin.js
@@ -76,6 +76,18 @@ module.exports = {
     if (!username) return ctx.badRequest('missing.username');
     if (!password) return ctx.badRequest('missing.password');
 
+    const validUsername = await strapi.plugins['users-permissions']
+      .services.user.validateUsername(username);
+    if (!validUsername) {
+      return ctx.badRequest(
+        null,
+        formatError({
+          id: 'invalid.username',
+          message: 'Username only include letters, numbers, and underscores',
+          field: ['username']
+        }))
+    };
+
     const userWithSameUsername = await strapi
       .query('user', 'users-permissions')
       .findOne({ username });

--- a/packages/strapi-plugin-users-permissions/controllers/user/api.js
+++ b/packages/strapi-plugin-users-permissions/controllers/user/api.js
@@ -33,6 +33,18 @@ module.exports = {
     if (!username) return ctx.badRequest('missing.username');
     if (!password) return ctx.badRequest('missing.password');
 
+    const validUsername = await strapi.plugins['users-permissions']
+    .services.user.validateUsername(username);
+    if (!validUsername) {
+      return ctx.badRequest(
+        null,
+        formatError({
+          id: 'invalid.username',
+          message: 'Username only include letters, numbers, and underscores',
+          field: ['username']
+        }))
+    };
+
     const userWithSameUsername = await strapi
       .query('user', 'users-permissions')
       .findOne({ username });

--- a/packages/strapi-plugin-users-permissions/controllers/user/api.js
+++ b/packages/strapi-plugin-users-permissions/controllers/user/api.js
@@ -33,17 +33,19 @@ module.exports = {
     if (!username) return ctx.badRequest('missing.username');
     if (!password) return ctx.badRequest('missing.password');
 
-    const validUsername = await strapi.plugins['users-permissions']
-    .services.user.validateUsername(username);
+    const validUsername = await strapi.plugins['users-permissions'].services.user.validateUsername(
+      username
+    );
     if (!validUsername) {
       return ctx.badRequest(
         null,
         formatError({
           id: 'invalid.username',
           message: 'Username only include letters, numbers, and underscores',
-          field: ['username']
-        }))
-    };
+          field: ['username'],
+        })
+      );
+    }
 
     const userWithSameUsername = await strapi
       .query('user', 'users-permissions')

--- a/packages/strapi-plugin-users-permissions/services/User.js
+++ b/packages/strapi-plugin-users-permissions/services/User.js
@@ -164,4 +164,13 @@ module.exports = {
       html: settings.message,
     });
   },
+
+  /**
+   * Allow username include letters, numbers, and underscores
+   * @param username
+   * @returns {Boolean}
+   */
+  validateUsername (username) {
+    return username.match(/^[a-zA-Z0-9_]+$/);
+  },
 };


### PR DESCRIPTION
### What does it do?

Validating the username which only include letters, numbers and underscores, when client create new account

### Why is it needed?

Adding service named validateUsername into file packages/strapi-plugin-users-permissions/services/User.js
Adding validator and response error on username is wrong, into controller create in files packages/strapi-plugin-users-permissions/controllers/user/api.js, packages/strapi-plugin-users-permissions/controllers/user/admin.js
