### PR TITLE
Fix duplicate locale when creating an entry without specifying the locale

### DIFF
--- a/packages/strapi-plugin-i18n/config/policies/validateLocaleCreation.js
+++ b/packages/strapi-plugin-i18n/config/policies/validateLocaleCreation.js
@@ -51,7 +51,7 @@ const validateLocaleCreation = async (ctx, next) => {
 
   let relatedEntity;
   try {
-    relatedEntity = await getAndValidateRelatedEntity(relatedEntityId, model, locale);
+    relatedEntity = await getAndValidateRelatedEntity(relatedEntityId, model, entityLocale);
   } catch (e) {
     return ctx.badRequest(
       "The related entity doesn't exist or the entity already exists in this locale"


### PR DESCRIPTION
Replace #10256

**Description**
With the Content-Manager API It was possible to create a related entry in the default locale, even if the default locale was already existing. To do it, you just had to create a new locale without specifying the locale.