### PR TITLE
Update slack to discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Please read our [Contributing Guide](./CONTRIBUTING.md) before submitting a Pull
 
 For general help using Strapi, please refer to [the official Strapi documentation](https://strapi.io/documentation/). For additional help, you can use one of these channels to ask a question:
 
-- [Slack](https://slack.strapi.io) (For live discussion with the Community and Strapi team)
+- [Discord](https://discord.strapi.io) (For live discussion with the Community and Strapi team)
 - [GitHub](https://github.com/strapi/strapi) (Bug reports, Contributions)
 - [Community Forum](https://forum.strapi.io) (Questions and Discussions)
 - [Academy](https://academy.strapi.io) (Learn the fundamentals of Strapi)


### PR DESCRIPTION
### What does it do?

Changes the slack link to a discord one

### Why is it needed?

Getting rid of slack

### How to test it?

click the link

### Related issue(s)/PR(s)

n/a
