### PR TITLE
Fix issue with non-unique usernames in identity providers

### DIFF
--- a/packages/strapi-plugin-users-permissions/services/Providers.js
+++ b/packages/strapi-plugin-users-permissions/services/Providers.js
@@ -99,7 +99,7 @@ const connect = (provider, query) => {
         // Add a new #randomsuffix to the username till we find one that is not taken
         var newUsername;
         while (!_.isEmpty(usernames)) {
-          newUsername = `${profile.username} #${randomSuffix()}`;
+          newUsername = `${profile.username}~${randomSuffix()}`;
           usernames = await strapi.query('user', 'users-permissions').find({
             username: newUsername,
           });

--- a/packages/strapi-plugin-users-permissions/services/Providers.js
+++ b/packages/strapi-plugin-users-permissions/services/Providers.js
@@ -5,6 +5,7 @@
  */
 
 // Public node modules.
+const crypto = require('crypto');
 const _ = require('lodash');
 const request = require('request');
 
@@ -13,6 +14,9 @@ const purest = require('purest')({ request });
 const purestConfig = require('@purest/providers');
 const { getAbsoluteServerUrl } = require('strapi-utils');
 const jwt = require('jsonwebtoken');
+
+// Same random suffix as used in upload, except shorter
+const randomSuffix = () => crypto.randomBytes(3).toString('hex');
 
 /**
  * Connect thanks to a third-party provider.
@@ -89,19 +93,20 @@ const connect = (provider, query) => {
 
         // Check if a user with the username exists
         var usernames = await strapi.query('user', 'users-permissions').find({
-            username: profile.username,
+          username: profile.username,
+        });
+
+        // Add a new #randomsuffix to the username till we find one that is not taken
+        var newUsername;
+        while (!_.isEmpty(usernames)) {
+          newUsername = `${profile.username} #${randomSuffix()}`;
+          usernames = await strapi.query('user', 'users-permissions').find({
+            username: newUsername,
           });
-        
-          // Add ~(number) to the username till we find one that is not taken
-        var i=0;
-        while(!_.isEmpty(usernames)) {
-            usernames = await strapi.query('user', 'users-permissions').find({
-                username: `${profile.username}~${i}`,
-              });
         }
 
-        // Set the update username
-        profile.username = `${profile.username}~${i}`;
+        // Set the updated username
+        profile.username = newUsername;
 
         // Create the new user.
         const params = _.assign(profile, {

--- a/packages/strapi-plugin-users-permissions/services/Providers.js
+++ b/packages/strapi-plugin-users-permissions/services/Providers.js
@@ -87,6 +87,22 @@ const connect = (provider, query) => {
           .query('role', 'users-permissions')
           .findOne({ type: advanced.default_role }, []);
 
+        // Check if a user with the username exists
+        var usernames = await strapi.query('user', 'users-permissions').find({
+            username: profile.username,
+          });
+        
+          // Add ~(number) to the username till we find one that is not taken
+        var i=0;
+        while(!_.isEmpty(usernames)) {
+            usernames = await strapi.query('user', 'users-permissions').find({
+                username: `${profile.username}~${i}`,
+              });
+        }
+
+        // Set the update username
+        profile.username = `${profile.username}~${i}`;
+
         // Create the new user.
         const params = _.assign(profile, {
           provider: provider,


### PR DESCRIPTION
### What does it do?

Searching for an exisiting username before adding a user with that username. If an existing username is found we add tilde (~) and a random suffix.

The change is non-breaking for exisiting installations and the added part (after ~) can easily be filtered out by the front-end, if need be.

#### Considerations

Exactly what should be added after the username is up for consideration. 

For separator I opted for tilde (~) as it is in the standard character set and does not cause problems with front-end tools. In general the username should not be used for display purposes, one should use a "display name" instead, but for front-ends that wants to use it, everything after ~can be stripped leaving a "clean" username for display purposes.

I tried using a space and hash(#). This looks better on prociders that use "names", like Facebook. But Facebook should really use the username (the one in the address bar on a profile page) instead of a name.

For unique id, I opted for a semi-short hex-string, the same as in upload, only shorter. A short UUID would be better, but then we would introduce new pacakges, so I just used the same as in upload. 3 bytes (6 hex) allows for 16M combinations, so collisions is not really a problem, but I added the check to generate a new if it is already taken, now that we are fixing it.

### Why is it needed?

Adding users from external identity providers causes the initial login to fail, see  for example #6014 . This is  worse when you enable multiple login providers, as the same username is not unique across all providers.

### How to test it?

Simplest way to test it is to use two emails with the same part before @, e.g. **jonathan@gmail.com** and **jonathan@vulkaza.com**, and use auth0 with the examples/login-react. Signing up with the second user will fail, with no way for the front-end to remedy the error.

### Related issue(s)/PR(s)

fix: #6014
And related discussion: https://forum.strapi.io/t/global-authenticate-issue-facebook-google-local-provider-4998/1453/2
