### PR TITLE
Load internal plugins

### DIFF
--- a/packages/core/admin/admin/src/pages/Admin/index.js
+++ b/packages/core/admin/admin/src/pages/Admin/index.js
@@ -23,13 +23,37 @@ import Logout from './Logout';
 import Wrapper from './Wrapper';
 import Content from './Content';
 
-const HomePage = lazy(() => import('../HomePage'));
-const InstalledPluginsPage = lazy(() => import('../InstalledPluginsPage'));
-const MarketplacePage = lazy(() => import('../MarketplacePage'));
+const HomePage = lazy(() => import(/* webpackChunkName: "Admin_homePage" */ '../HomePage'));
+const InstalledPluginsPage = lazy(() =>
+  import(/* webpackChunkName: "Admin_pluginsPage" */ '../InstalledPluginsPage')
+);
+const MarketplacePage = lazy(() =>
+  import(/* webpackChunkName: "Admin_marketplace" */ '../MarketplacePage')
+);
 const NotFoundPage = lazy(() => import('../NotFoundPage'));
-const PluginDispatcher = lazy(() => import('../PluginDispatcher'));
-const ProfilePage = lazy(() => import('../ProfilePage'));
-const SettingsPage = lazy(() => import('../SettingsPage'));
+const PluginDispatcher = lazy(() =>
+  import(/* webpackChunkName: "Admin_pluginDispatcher" */ '../PluginDispatcher')
+);
+const ProfilePage = lazy(() =>
+  import(/* webpackChunkName: "Admin_profilePage" */ '../ProfilePage')
+);
+const SettingsPage = lazy(() =>
+  import(/* webpackChunkName: "Admin_settingsPage" */ '../SettingsPage')
+);
+// These are internal plugins
+const CM = lazy(() =>
+  import(
+    /* webpackChunkName: "content-manager" */ '@strapi/plugin-content-manager/admin/src/pages/Main'
+  )
+);
+const CTB = lazy(() =>
+  import(
+    /* webpackChunkName: "content-type-builder" */ '@strapi/plugin-content-type-builder/admin/src/pages/App'
+  )
+);
+const Upload = lazy(() =>
+  import(/* webpackChunkName: "upload" */ '@strapi/plugin-upload/admin/src/pages/App')
+);
 
 // Simple hook easier for testing
 const useTrackUsage = () => {
@@ -68,6 +92,9 @@ const Admin = () => {
               <Switch>
                 <Route path="/" component={HomePage} exact />
                 <Route path="/me" component={ProfilePage} exact />
+                <Route path="/plugins/content-manager" component={CM} />
+                <Route path="/plugins/content-type-builder" component={CTB} />
+                <Route path="/plugins/upload" component={Upload} />
                 <Route path="/plugins/:pluginId" component={PluginDispatcher} />
                 <Route path="/settings/:settingId" component={SettingsPage} />
                 <Route path="/settings" component={SettingsPage} exact />

--- a/packages/core/admin/admin/src/pages/App/index.js
+++ b/packages/core/admin/admin/src/pages/App/index.js
@@ -21,7 +21,10 @@ import { Content, Wrapper } from './components';
 import routes from './utils/routes';
 import { makeUniqueRoutes, createRoute } from '../SettingsPage/utils';
 
-const AuthenticatedApp = lazy(() => import('../../components/AuthenticatedApp'));
+const AuthenticatedApp = lazy(() =>
+  import(/* webpackChunkName: "Admin-authenticatedApp" */ '../../components/AuthenticatedApp')
+);
+
 function App() {
   const toggleNotification = useNotification();
   const [{ isLoading, hasAdmin, uuid }, setState] = useState({ isLoading: true, hasAdmin: false });

--- a/packages/core/admin/webpack.config.js
+++ b/packages/core/admin/webpack.config.js
@@ -91,7 +91,8 @@ module.exports = ({
       rules: [
         {
           test: /\.m?js$/,
-          exclude: /node_modules/,
+          // TODO remove when plugins are built separately
+          exclude: /node_modules\/(?!(@strapi\/plugin-content-manager|@strapi\/plugin-content-type-builder|@strapi\/plugin-upload)\/).*/,
           use: {
             loader: require.resolve('babel-loader'),
             options: {
@@ -119,6 +120,7 @@ module.exports = ({
             },
           },
         },
+
         {
           test: /\.css$/i,
           use: ['style-loader', 'css-loader'],

--- a/packages/core/content-manager/admin/src/index.js
+++ b/packages/core/content-manager/admin/src/index.js
@@ -8,7 +8,6 @@
 import pluginPkg from '../../package.json';
 import pluginId from './pluginId';
 import pluginLogo from './assets/images/logo.svg';
-import App from './pages/Main';
 import reducers from './reducers';
 import trads from './translations';
 
@@ -30,7 +29,6 @@ export default {
       },
       isReady: true,
       isRequired: pluginPkg.strapi.required || false,
-      mainComponent: App,
       name,
       pluginLogo,
       trads,

--- a/packages/core/content-type-builder/admin/src/index.js
+++ b/packages/core/content-type-builder/admin/src/index.js
@@ -7,7 +7,6 @@
 
 import pluginPkg from '../../package.json';
 import pluginLogo from './assets/images/logo.svg';
-import App from './pages/App';
 import trads from './translations';
 import pluginPermissions from './permissions';
 import pluginId from './pluginId';
@@ -27,7 +26,6 @@ export default {
       id: pluginId,
       isRequired: pluginPkg.strapi.required || false,
       isReady: true,
-      mainComponent: App,
       name,
       pluginLogo,
       trads,

--- a/packages/core/upload/admin/src/index.js
+++ b/packages/core/upload/admin/src/index.js
@@ -12,7 +12,6 @@ import pluginPermissions from './permissions';
 import Initializer from './components/Initializer';
 import InputMedia from './components/InputMedia';
 import InputModalStepper from './components/InputModalStepper';
-import App from './pages/App';
 import SettingsPage from './pages/SettingsPage';
 import reducers from './reducers';
 import trads from './translations';
@@ -40,8 +39,6 @@ export default {
 
       isReady: false,
       isRequired: pluginPkg.strapi.required || false,
-
-      mainComponent: App,
       name,
       pluginLogo,
 


### PR DESCRIPTION
Signed-off-by: soupette <cyril.lpz@gmail.com>

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

It makes obvious for the admin package that the CTB, CM and upload plugins are required.
Until we built the plugins separately the admin panel can now require these plugin directly in the pages/Admin component.

### Why is it needed?

In order to remove some complex logic regarding these plugins and also to reduce the build size.

Now the main bundle size is about the following:

![Screenshot 2021-05-31 at 14 53 58](https://user-images.githubusercontent.com/13311463/120204668-5aef1e00-c229-11eb-87f0-7e9855ae11ca.png)


### How to test it?

It app should work as it used to.

### Related issue(s)/PR(s)


