### PR TITLE
Invalidate webpack cache in dev mode

### DIFF
--- a/examples/getstarted/api/address/models/Address.settings.json
+++ b/examples/getstarted/api/address/models/Address.settings.json
@@ -14,9 +14,19 @@
     ],
     "comment": ""
   },
+  "pluginOptions": {
+    "i18n": {
+      "localized": true
+    }
+  },
   "attributes": {
     "postal_coder": {
-      "type": "string"
+      "type": "string",
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
     },
     "categories": {
       "collection": "category",
@@ -33,7 +43,11 @@
       ],
       "plugin": "upload",
       "required": false,
-      "pluginOptions": {}
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
     },
     "images": {
       "collection": "file",
@@ -43,22 +57,70 @@
       ],
       "plugin": "upload",
       "required": false,
-      "pluginOptions": {}
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
     },
     "city": {
       "type": "string",
       "required": true,
-      "maxLength": 200
+      "maxLength": 200,
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
     },
     "likes": {
       "collection": "like",
       "via": "address"
     },
     "json": {
-      "type": "json"
+      "type": "json",
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
     },
     "slug": {
       "type": "uid"
+    },
+    "notrepeat_req": {
+      "type": "component",
+      "repeatable": false,
+      "pluginOptions": {
+        "i18n": {
+          "localized": false
+        }
+      },
+      "component": "blog.test-como",
+      "required": true
+    },
+    "repeat_req": {
+      "type": "component",
+      "repeatable": true,
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "component": "blog.test-como",
+      "required": true
+    },
+    "repeat_req_min": {
+      "type": "component",
+      "repeatable": true,
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "component": "blog.test-como",
+      "required": false,
+      "min": 2
     }
   }
 }

--- a/packages/core/admin/webpack.config.dev.js
+++ b/packages/core/admin/webpack.config.dev.js
@@ -43,6 +43,28 @@ module.exports = () => {
 
   return {
     ...config,
+    snapshot: {
+      managedPaths: [
+        path.resolve(__dirname, '../core/@strapi/plugin/content-manager'),
+        path.resolve(__dirname, '../core/@strapi/plugin/content-type-builder'),
+        path.resolve(__dirname, '../core/@strapi/plugin/upload'),
+        path.resolve(__dirname, '../core/@strapi/helper-plugin'),
+      ],
+      buildDependencies: {
+        hash: true,
+        timestamp: true,
+      },
+      module: {
+        timestamp: true,
+      },
+      resolve: {
+        timestamp: true,
+      },
+      resolveBuildDependencies: {
+        hash: true,
+        timestamp: true,
+      },
+    },
     devServer: {
       port: 4000,
       clientLogLevel: 'none',

--- a/packages/core/admin/webpack.config.dev.js
+++ b/packages/core/admin/webpack.config.dev.js
@@ -45,10 +45,10 @@ module.exports = () => {
     ...config,
     snapshot: {
       managedPaths: [
-        path.resolve(__dirname, '../core/@strapi/plugin/content-manager'),
-        path.resolve(__dirname, '../core/@strapi/plugin/content-type-builder'),
-        path.resolve(__dirname, '../core/@strapi/plugin/upload'),
-        path.resolve(__dirname, '../core/@strapi/helper-plugin'),
+        path.resolve(__dirname, '../content-manager'),
+        path.resolve(__dirname, '../content-type-builder'),
+        path.resolve(__dirname, '../upload'),
+        path.resolve(__dirname, '../helper-plugin'),
       ],
       buildDependencies: {
         hash: true,


### PR DESCRIPTION
Signed-off-by: soupette <cyril.lpz@gmail.com>

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

It invalidates the cache for the core plugins.

### Why is it needed?

Because of the new way of loading the internal plugins CM, CTB, upload webpack did not update the cache when making a modification in these packages.
This fixes the issue

