### PR TITLE
fix(permission): add default value to fields

### DIFF
--- a/packages/strapi-admin/services/content-type.js
+++ b/packages/strapi-admin/services/content-type.js
@@ -159,12 +159,9 @@ const cleanPermissionFields = (permissions, { nestingLevel } = {}) => {
   const { actionProvider } = getService('permission');
 
   return permissions.map(permission => {
-    const {
-      action: actionId,
-      subject,
-      properties: { fields },
-    } = permission;
+    const { action: actionId, subject, properties } = permission;
 
+    const { fields = [] } = properties || {};
     const action = actionProvider.get(actionId);
 
     // todo see if it's possible to check property on action + subject (async)

--- a/packages/strapi-admin/services/permission/queries.js
+++ b/packages/strapi-admin/services/permission/queries.js
@@ -156,7 +156,10 @@ const cleanPermissionsInDatabase = async () => {
     // Update only the ones that need to be updated
     const permissionsNeedingToBeUpdated = differenceWith(
       (a, b) => {
-        return a.id === b.id && xor(a.properties.fields, b.properties.fields).length === 0;
+        const aFields = (a.properties && a.properties.fields) || [];
+        const bFields = (b.properties && b.properties.fields) || [];
+
+        return a.id === b.id && xor(aFields, bFields).length === 0;
       },
       permissionsWithCleanFields,
       remainingPermissions

--- a/packages/strapi-admin/services/role.js
+++ b/packages/strapi-admin/services/role.js
@@ -48,6 +48,10 @@ const sortDeep = data => {
 };
 
 const sortPermissionProperties = permission => {
+  if (!permission.properties) {
+    return permission;
+  }
+
   return Object.entries(permission.properties).reduce(
     (acc, [name, value]) => permissionDomain.setProperty(name, sortDeep(value), acc),
     permission


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?
Adds default `[]` for fields in `properties`

### Why is it needed?
Due to change in [PR](https://github.com/strapi/strapi/pull/9535) and  [line](https://github.com/strapi/strapi/pull/9535/files#diff-1b56cc461eeba0732d09a82a527789be2af4e5e35013e490346294f44d41fc79R31) causes the following error on `yarn run develop`

`strapi_permission` table

<img width="1622" alt="Screenshot 2021-06-05 at 5 09 21 PM" src="https://user-images.githubusercontent.com/25791025/120890553-257b7380-c621-11eb-8f90-ae7f41834216.png">


On `yarn run dev`
<img width="1012" alt="Screenshot 2021-06-05 at 10 04 35 AM" src="https://user-images.githubusercontent.com/25791025/120890472-8191c800-c620-11eb-8746-df99be5c5f43.png">

### How to test it?
In `strapi_permission` table need a row where `properties` is `null`

### Related issue(s)/PR(s)
#9535

Let us know if this is related to any issue/pull request
