### PR TITLE
strapi-plugin-users-permissions: allow passing jwtOptions to verify

### DIFF
--- a/packages/strapi-plugin-users-permissions/services/Jwt.js
+++ b/packages/strapi-plugin-users-permissions/services/Jwt.js
@@ -47,12 +47,12 @@ module.exports = {
     );
   },
 
-  verify(token) {
+  verify(token, jwtOptions = {}) {
     return new Promise(function(resolve, reject) {
       jwt.verify(
         token,
         _.get(strapi.plugins, ['users-permissions', 'config', 'jwtSecret']),
-        {},
+        jwtOptions,
         function(err, tokenPayload = {}) {
           if (err) {
             return reject(new Error('Invalid token.'));


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Added `jwtOptions` parameter on jwt verify service.

### Why is it needed?

To reuse the service code on verify from my own extensions override, I need to pass `ignoreExpiration` for my use case to refresh an already expired token

See https://github.com/strapi/strapi/issues/1676#issuecomment-859000233


### How to test it?

Not needed; the default behavior is not changed, as the parameter is an empty object options.

### Related issue(s)/PR(s)

See https://github.com/strapi/strapi/issues/1676