### PR TITLE
Fix RBAC upload permissions

### DIFF
--- a/packages/strapi-plugin-upload/controllers/upload/admin.js
+++ b/packages/strapi-plugin-upload/controllers/upload/admin.js
@@ -90,6 +90,8 @@ module.exports = {
       id
     );
 
+    console.log(pm, file);
+
     await strapi.plugins['upload'].services.upload.remove(file);
 
     ctx.body = pm.sanitize(file, { action: ACTIONS.read, withPrivate: false });
@@ -199,9 +201,8 @@ const findEntityAndCheckPermissions = async (ability, action, model, id) => {
 
   const pm = strapi.admin.services.permission.createPermissionsManager({ ability, action, model });
 
-  const roles = _.has(file, 'created_by.id')
-    ? await strapi.query('role', 'admin').find({ 'users.id': file[CREATED_BY_ATTRIBUTE].id }, [])
-    : [];
+  const roles = await strapi.admin.services.role.find({ 'users.id': file[CREATED_BY_ATTRIBUTE] });
+
   const fileWithRoles = _.set(_.cloneDeep(file), 'created_by.roles', roles);
 
   if (pm.ability.cannot(pm.action, pm.toSubject(fileWithRoles))) {

--- a/packages/strapi-plugin-upload/controllers/upload/admin.js
+++ b/packages/strapi-plugin-upload/controllers/upload/admin.js
@@ -201,7 +201,7 @@ const findEntityAndCheckPermissions = async (ability, action, model, id) => {
 
   const roles = await strapi.admin.services.role.find({ 'users.id': file[CREATED_BY_ATTRIBUTE] });
 
-  const fileWithRoles = _.set(_.cloneDeep(file), 'created_by.roles', roles);
+  const fileWithRoles = _.set(_.cloneDeep(file), 'created_by.roles', roles || []);
 
   if (pm.ability.cannot(pm.action, pm.toSubject(fileWithRoles))) {
     throw strapi.errors.forbidden();

--- a/packages/strapi-plugin-upload/controllers/upload/admin.js
+++ b/packages/strapi-plugin-upload/controllers/upload/admin.js
@@ -199,7 +199,9 @@ const findEntityAndCheckPermissions = async (ability, action, model, id) => {
 
   const pm = strapi.admin.services.permission.createPermissionsManager({ ability, action, model });
 
-  const author = await strapi.admin.services.user.findOne({ id: file[CREATED_BY_ATTRIBUTE] });
+  const author = await strapi.admin.services.user.findOne({ id: file[CREATED_BY_ATTRIBUTE] }, [
+    'roles',
+  ]);
 
   const fileWithRoles = _.set(_.cloneDeep(file), 'created_by', author);
 

--- a/packages/strapi-plugin-upload/controllers/upload/admin.js
+++ b/packages/strapi-plugin-upload/controllers/upload/admin.js
@@ -90,8 +90,6 @@ module.exports = {
       id
     );
 
-    console.log(pm, file);
-
     await strapi.plugins['upload'].services.upload.remove(file);
 
     ctx.body = pm.sanitize(file, { action: ACTIONS.read, withPrivate: false });

--- a/packages/strapi-plugin-upload/controllers/upload/admin.js
+++ b/packages/strapi-plugin-upload/controllers/upload/admin.js
@@ -199,9 +199,9 @@ const findEntityAndCheckPermissions = async (ability, action, model, id) => {
 
   const pm = strapi.admin.services.permission.createPermissionsManager({ ability, action, model });
 
-  const roles = await strapi.admin.services.role.find({ 'users.id': file[CREATED_BY_ATTRIBUTE] });
+  const author = await strapi.admin.services.user.findOne({ id: file[CREATED_BY_ATTRIBUTE] });
 
-  const fileWithRoles = _.set(_.cloneDeep(file), 'created_by.roles', roles || []);
+  const fileWithRoles = _.set(_.cloneDeep(file), 'created_by', author);
 
   if (pm.ability.cannot(pm.action, pm.toSubject(fileWithRoles))) {
     throw strapi.errors.forbidden();


### PR DESCRIPTION
### What does it do?

Fix an issue where setting permissions with conditions on the assets for the upload plugin can break the permissions checks.
In a [previous PR](https://github.com/strapi/strapi/pull/10370/files#diff-ce5847e2721e68f1c2682b5812248461031c101c4bf74ed7abcbd6a8cd5b47d1R194), the auto-populate for the fetch has been removed, which caused the `created_by` attribute to be raw instead of populated, hence causing an issue when fetching the associated role.

As a fix, we simply use the raw identifier (from the `created_by` field) instead of trying to access the `id` property inside.

Another idea would've been to fetch directly the whole user based on the `created_by` id, but it would mean fetching also unwanted properties for the user, such as password & co. 

### Why is it needed?

Upload plugin's assets permissions are not working as they should.

### How to test it?

See: https://github.com/strapi/strapi/issues/10452 ("_Steps to reproduce this issue_")

### Related issue(s)/PR(s)

introduced by #10370 
fix #10452 


