### PR TITLE
fix: consider custom devServer config

### DIFF
--- a/packages/strapi-admin/index.js
+++ b/packages/strapi-admin/index.js
@@ -250,6 +250,7 @@ async function watchAdmin({ dir, host, port, browser, options }) {
     options,
   };
 
+  const webpackConfig = getCustomWebpackConfig(dir, args);
   const opts = {
     clientLogLevel: 'silent',
     quiet: true,
@@ -259,9 +260,9 @@ async function watchAdmin({ dir, host, port, browser, options }) {
       index: options.publicPath,
       disableDotRule: true,
     },
+    ...webpack(webpackConfig).options.devServer
   };
 
-  const webpackConfig = getCustomWebpackConfig(dir, args);
   const server = new WebpackDevServer(webpack(webpackConfig), opts);
 
   server.listen(port, host, function(err) {


### PR DESCRIPTION
I´m using a custom Docker setup and had trouble to get the watch-admin running. After some testing i found a few things. 

I had to first add the url to the config and second add the devServer config.

webpack: (config, webpack) => {
      config.devServer = {
            host: '0.0.0.0',
            useLocalIp: false
    };
    return config;
},

After that strapi develop --watch-admin was accessible over the docker ip. But because the config gets not forwarded in the opts, the hot reload doesn't work. 
That's because this doesn't get the args that i setup.

function createDomain(options, server) {
  const protocol = options.https ? 'https' : 'http';
  const hostname = options.useLocalIp
    ? ip.v4.sync() || 'localhost'
    : options.host || 'localhost';

If there is a another way I would like to know. Otherwise I would appreciate this small hotfix.  

Here my original problem -> https://stackoverflow.com/questions/8925820/javascript-object-push-function

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Describe the technical changes you did.

### Why is it needed?

Describe the issue you are solving.

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
