### PR TITLE
Typo fix for English translations in user-permissions

### DIFF
--- a/packages/strapi-plugin-users-permissions/admin/src/translations/en.json
+++ b/packages/strapi-plugin-users-permissions/admin/src/translations/en.json
@@ -4,7 +4,7 @@
   "EditForm.inputSelect.description.role": "It will attach the new authenticated user to the selected role.",
   "EditForm.inputSelect.label.role": "Default role for authenticated users",
   "EditForm.inputToggle.description.email": "Disallow the user to create multiple accounts using the same email address with different authentication providers.",
-  "EditForm.inputToggle.description.email-confirmation": "When enabled (ON), new registred users receive a confirmation email.",
+  "EditForm.inputToggle.description.email-confirmation": "When enabled (ON), new registered users receive a confirmation email.",
   "EditForm.inputToggle.description.email-confirmation-redirection": "After you confirmed your email, choose where you will be redirected.",
   "EditForm.inputToggle.description.email-reset-password": "URL of your application's reset password page",
   "EditForm.inputToggle.description.sign-up": "When disabled (OFF), the registration process is forbidden. No one can subscribe anymore no matter the used provider.",


### PR DESCRIPTION
Minor typo fix:
registred to registered

Let me know if any further detail is required for the PR.
