### PR TITLE
Fix broken MongoDB information links

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Complete installation requirements can be found in the documentation under <a hr
 
 **Database:**
 
-- MongoDB >= 3.6 ([dropping MongoDB support](https://forum.strapi.io/t/dropping-mongodb-support/) in next major version)
+- MongoDB >= 3.6 ([dropping MongoDB support](https://forum.strapi.io/t/mongodb-compatibility-delayed-on-v4/4549) in next major version)
 - MySQL >= 5.6
 - MariaDB >= 10.1
 - PostgreSQL >= 10
@@ -118,7 +118,7 @@ Complete installation requirements can be found in the documentation under <a hr
 - **Blazing Fast:** Built on top of Node.js, Strapi delivers amazing performance.
 - **Front-end Agnostic:** Use any front-end framework (React, Vue, Angular, etc.), mobile apps or even IoT.
 - **Powerful CLI:** Scaffold projects and APIs on the fly.
-- **SQL & NoSQL databases:** Works with MongoDB ([dropping MongoDB support](https://forum.strapi.io/t/dropping-mongodb-support/) in next major version), PostgreSQL, MySQL, MariaDB, and SQLite.
+- **SQL & NoSQL databases:** Works with MongoDB ([dropping MongoDB support](https://forum.strapi.io/t/mongodb-compatibility-delayed-on-v4/4549) in next major version), PostgreSQL, MySQL, MariaDB, and SQLite.
 
 **[See more on our website](https://strapi.io/overview)**.
 


### PR DESCRIPTION
### What does it do?

Updated links to forum thread about MongoDB

### Why is it needed?

Links did not include the trailing thread ID so when the thread name changed the links became broken

### How to test it?

N/A

### Related issue(s)/PR(s)

N/A
