### PR TITLE
[Starter CLI] fix has-yarn

### DIFF
--- a/packages/create-strapi-starter/utils/build-starter.js
+++ b/packages/create-strapi-starter/utils/build-starter.js
@@ -33,7 +33,7 @@ function readStarterJson(filePath, starterUrl) {
  * @param  {string} projectName Name of the project
  */
 async function initPackageJson(rootPath, projectName) {
-  const packageManager = hasYarn ? 'yarn --cwd' : 'npm run --prefix';
+  const packageManager = hasYarn() ? 'yarn --cwd' : 'npm run --prefix';
 
   try {
     await fse.writeJson(

--- a/packages/create-strapi-starter/utils/child-process.js
+++ b/packages/create-strapi-starter/utils/child-process.js
@@ -9,7 +9,7 @@ const logger = require('./logger');
  * @param  {string} path Path to directory (frontend, backend)
  */
 function runInstall(path) {
-  if (hasYarn) {
+  if (hasYarn()) {
     return execa('yarn', ['install'], {
       cwd: path,
       stdin: 'ignore',
@@ -20,7 +20,7 @@ function runInstall(path) {
 }
 
 function runApp(rootPath) {
-  if (hasYarn) {
+  if (hasYarn()) {
     return execa('yarn', ['develop'], {
       stdio: 'inherit',
       cwd: rootPath,

--- a/packages/create-strapi-starter/utils/has-yarn.js
+++ b/packages/create-strapi-starter/utils/has-yarn.js
@@ -4,8 +4,9 @@ const execa = require('execa');
 
 module.exports = function hasYarn() {
   try {
-    const { code } = execa.shellSync('yarnpkg --version');
-    if (code === 0) return true;
+    const { exitCode } = execa.sync('yarn --version', { shell: true });
+
+    if (exitCode === 0) return true;
     return false;
   } catch (err) {
     return false;


### PR DESCRIPTION
### What does it do?

Fixes https://github.com/strapi/strapi/issues/10516

### Why is it needed?

The function to check for yarn was not being invoked and always resolving to true

`execa.shellSync` has been removed
https://github.com/sindresorhus/execa/pull/219
