### PR TITLE
Fix missing lodash upgrade in i18n plugin

### DIFF
--- a/packages/strapi-plugin-i18n/package.json
+++ b/packages/strapi-plugin-i18n/package.json
@@ -9,7 +9,7 @@
     "required": false
   },
   "dependencies": {
-    "lodash": "4.17.20",
+    "lodash": "4.17.21",
     "p-map": "4.0.0",
     "pluralize": "8.0.0",
     "strapi-utils": "3.6.5"


### PR DESCRIPTION
Signed-off-by: Derrick Mehaffy <derrickmehaffy@gmail.com>

### What does it do?

Fixed missing lodash upgrade in the i18n plugin

### Why is it needed?

Prototype pollution fix when we upgraded the lodash version: https://github.com/strapi/strapi/pull/9990

### How to test it?

Run a `yarn audit` and notice missing vuln reports

### Related issue(s)/PR(s)

N/A
