### PR TITLE
fix typo didGotToMarketplace => didGoToMarketPlace

### DIFF
--- a/packages/strapi-admin/admin/src/containers/MarketplacePage/index.js
+++ b/packages/strapi-admin/admin/src/containers/MarketplacePage/index.js
@@ -15,7 +15,7 @@ const MarketPlacePage = () => {
   const emitEventRef = useRef(emitEvent);
 
   useEffect(() => {
-    emitEventRef.current('didGotToMarketplace');
+    emitEventRef.current('didGoToMarketplace');
   }, []);
 
   if (isLoading || error) {


### PR DESCRIPTION
### What does it do?

Fixes a typo 

