### PR TITLE
Allow `populate` in the paginated queries

### DIFF
--- a/packages/strapi-database/lib/queries/paginated-queries.js
+++ b/packages/strapi-database/lib/queries/paginated-queries.js
@@ -7,7 +7,7 @@ const createPaginatedQuery = ({ fetch, count }) => async (queryParams, ...args) 
   const pagination = await getPaginationInfos(queryParams, count, ...args);
 
   Object.assign(params, paginationToQueryParams(pagination));
-  const results = await fetch(params, undefined, ...args);
+  const results = await fetch(params, ...args);
 
   return { results, pagination };
 };


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Remove the `undefined` to allow `populate` in the paginated queries.

### Why is it needed?

To allow `populate` in the paginated queries.

For example for this: https://github.com/strapi/strapi/pull/9307
