### PR TITLE
Add support for prefixed plugins

### DIFF
--- a/packages/strapi-admin/index.js
+++ b/packages/strapi-admin/index.js
@@ -181,7 +181,7 @@ async function createCacheDir(dir) {
 
   const pluginsToCopy = Object.keys(pkgJSON.dependencies).filter(
     dep =>
-      dep.startsWith('strapi-plugin') &&
+      dep.includes('strapi-plugin') &&
       fs.existsSync(path.resolve(getPkgPath(dep), 'admin', 'src', 'index.js'))
   );
 

--- a/packages/strapi/lib/load/package-path.js
+++ b/packages/strapi/lib/load/package-path.js
@@ -6,4 +6,17 @@ const path = require('path');
  * Returns the path to a node modules root directory (not the main file path)
  * @param {string} moduleName - name of a node module
  */
-module.exports = moduleName => path.dirname(require.resolve(`${moduleName}/package.json`));
+module.exports = moduleName => {
+  let packagePath = null;
+
+  try {
+    packagePath = require.resolve(`${moduleName}/package.json`);
+  } catch (err) {
+    const projectPackageJson = require(path.join(strapi.dir, 'package.json'));
+    const dependencies = Object.keys(projectPackageJson.dependencies);
+    const scopedModule = dependencies.find(d => d.includes(moduleName));
+    packagePath = require.resolve(`${scopedModule}/package.json`);
+  }
+
+  return path.dirname(packagePath);
+};

--- a/packages/strapi/lib/utils/get-prefixed-dependencies.js
+++ b/packages/strapi/lib/utils/get-prefixed-dependencies.js
@@ -1,7 +1,23 @@
 'use strict';
 
+function prefixTest(prefix, dependency) {
+  const re = new RegExp(`^(?:@[a-zA-Z0-9-]+/)?${prefix}`, '');
+  const r = re.exec(dependency);
+  if (!r) {
+    return false;
+  }
+  return r[0];
+}
+
 module.exports = (prefix, pkgJSON) => {
-  return Object.keys(pkgJSON.dependencies)
-    .filter(d => d.startsWith(prefix) && d.length > prefix.length)
-    .map(pkgName => pkgName.substring(prefix.length + 1));
+  const dependencies = pkgJSON.dependencies;
+  return Object.keys(dependencies)
+    .map(d => {
+      const prefixString = prefixTest(prefix, d);
+      if (!prefixString) {
+        return null;
+      }
+      return d.substring(prefixString.length + 1);
+    })
+    .filter(d => Boolean(d));
 };


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.

Did not see tests related to plugin validation

- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

WIP

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Allows for the use of scoped packages as plugins

Example

```
@scoped/strapi-plugin-woof
```

### Why is it needed?

The dependency on naming conventions prohibited scoped packages before this update

### How to test it?

Create a dependency called something like

```
@scoped/strapi-plugin-woof
```

See that is is automatically installed.
### Related issue(s)/PR(s)

None known.