### PR TITLE
Remove one-click deploy buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,24 +9,6 @@
 <br />
 
 <p align="center">
-  <a href="https://console.platform.sh/projects/create-project?template=https://raw.githubusercontent.com/platformsh/template-builder/master/templates/strapi/.platform.template.yaml&utm_content=strapi&utm_source=github&utm_medium=button&utm_campaign=deploy_on_platform">
-    <img src="https://assets.strapi.io/uploads/deploy_button_platform_sh_d032f646a7.png"  />
-  </a>
-
-  <a href="https://marketplace.digitalocean.com/apps/strapi">
-    <img src="https://assets.strapi.io/uploads/deploy_button_Digital_Ocean_fe2c286222.png" />
-  </a>
-
-  <a href="https://www.heroku.com/deploy/?template=https://github.com/strapi/strapi-heroku-template">
-    <img src="https://assets.strapi.io/uploads/Deploy_button_heroku_b1043fc67d.png" />
-  </a>
-
-  <a href="https://render.com/docs/deploy-strapi">
-    <img src="https://assets.strapi.io/uploads/deploy_render_e076b6f23a.png" height="44" />
-  </a>
-</p>
-
-<p align="center">
   <a href="https://www.npmjs.org/package/strapi">
     <img src="https://img.shields.io/npm/v/strapi/latest.svg" alt="NPM Version" />
   </a>

--- a/packages/strapi/README.md
+++ b/packages/strapi/README.md
@@ -9,24 +9,6 @@
 <br />
 
 <p align="center">
-  <a href="https://console.platform.sh/projects/create-project?template=https://raw.githubusercontent.com/platformsh/template-builder/master/templates/strapi/.platform.template.yaml&utm_content=strapi&utm_source=github&utm_medium=button&utm_campaign=deploy_on_platform">
-    <img src="https://assets.strapi.io/uploads/deploy_button_platform_sh_d032f646a7.png"  />
-  </a>
-
-  <a href="https://marketplace.digitalocean.com/apps/strapi">
-    <img src="https://assets.strapi.io/uploads/deploy_button_Digital_Ocean_fe2c286222.png" />
-  </a>
-
-  <a href="https://www.heroku.com/deploy/?template=https://github.com/strapi/strapi-heroku-template">
-    <img src="https://assets.strapi.io/uploads/Deploy_button_heroku_b1043fc67d.png" />
-  </a>
-
-  <a href="https://render.com/docs/deploy-strapi">
-    <img src="https://assets.strapi.io/uploads/deploy_render_e076b6f23a.png" height="44" />
-  </a>
-</p>
-
-<p align="center">
   <a href="https://www.npmjs.org/package/strapi">
     <img src="https://img.shields.io/npm/v/strapi/latest.svg" alt="NPM Version" />
   </a>


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Remove the one-click buttons as it is now the installation workflow we recommend.

### Why is it needed?

Strapi has been designed to be installed in a local environment, versioned through git, and deployed to production. The one-click deploy buttons create some confusion.

### How to test it?

Preview the markdown.md file.

### Related issue(s)/PR(s)

None.
