### PR TITLE
Use only one value for the enum type of a component (dynamic zone)

### DIFF
--- a/packages/strapi-plugin-documentation/services/Documentation.js
+++ b/packages/strapi-plugin-documentation/services/Documentation.js
@@ -623,7 +623,7 @@ module.exports = {
                 properties: {
                   __component: {
                     type: 'string',
-                    enum: components,
+                    enum: [component],
                   },
                 },
               },


### PR DESCRIPTION
### What does it do?

Use only the current component name in the enum instead of all component names. Enum with one value describe a constant parameter (see https://swagger.io/docs/specification/describing-parameters/)
>  You can define a constant parameter as a required parameter with only one possible value

Blocks config example: 

<img width="924" alt="image" src="https://user-images.githubusercontent.com/1102595/125166617-c5866880-e19c-11eb-9806-cf8102d7d6a5.png">

Example of generated code in the documentation, before/after:

```diff
{
  "cmsBlocks": {
    "type": "array",
    "items": {
      "oneOf": [
        {
          "properties": {
            "__component": {
              "type": "string",
              "enum": [
                "pages.hero-block"
-               "pages.title-block",
-               "pages.social-block"
              ]
            },
            "id": {
              "type": "string"
            },
            "title": {
              "type": "string"
            }
          },
          "required": [
            "id"
          ]
        },
        {
          "properties": {
            "__component": {
              "type": "string",
              "enum": [
-               "pages.hero-block",
                "pages.title-block",
-               "pages.social-block"
              ]
            },
            "id": {
              "type": "string"
            },
            "title": {
              "type": "string"
            }
          },
          "required": [
            "id"
          ]
        },
        {
          "properties": {
            "__component": {
              "type": "string",
              "enum": [
-              "pages.hero-block",
-              "pages.title-block",
                "pages.social-block"
              ]
            },
            "id": {
              "type": "string"
            },
            "facebookLink": {
              "type": "string"
            },
            "twitterLink": {
              "type": "string"
            }
          },
          "required": [
            "id"
          ]
        }
      ]
    }
  }
}
```
### Why is it needed?

 That allows us to get the right TypeScript types when using librairies like [swagger-typescript-api](https://github.com/acacode/swagger-typescript-api):

```tsx
const BlockRenderer = ({ page }: Props) => {
  return (
    <>
      {page.cmsBlocks.map((block, index) => {
        if (block.__component === 'pages.hero-block') {
          return (
            <HeroBlock
              key={index}
              title={block.title}             
            />
          )
        }
        if (block.__component === 'pages.social-block') {
          return (
            <SocialBlock
              key={index}
              facebookLink={block.facebookLink}
              twitterLink={block.twitterLink}           
            />
          )
        }
    </>
  )
}
```

Generated types before / after: 

```ts
 cmsBlocks?: (
    | { __component?: "pages.hero-block" | "pages.title-block" | "pages.social-block"; id: string; title?: string }
    | { __component?: "pages.hero-block" | "pages.title-block" | "pages.social-block"; id: string; title?: string }
    | {
        __component?: "pages.hero-block" | "pages.title-block" | "pages.social-block";
        id: string;
        facebookLink?: string;
        twitterLink?: string;
      }
  )[];
```

```ts
 cmsBlocks?: (
    | { __component?: "pages.hero-block"; id: string; title?: string }
    | { __component?: "pages.title-block"; id: string; title?: string }
    | { __component?: "pages.social-block"; id: string; facebookLink?: string; twitterLink?: string }
  )[];
```
