### PR TITLE
Add New Zealand - Māori locale

### DIFF
--- a/packages/strapi-plugin-i18n/constants/iso-locales.json
+++ b/packages/strapi-plugin-i18n/constants/iso-locales.json
@@ -1232,6 +1232,10 @@
     "name":"Manx (United Kingdom) (gv-GB)"
   },
   {
+    "code": "mi-nz",
+    "name:" "Māori (New Zealand) (mi-nz)"
+  },
+  {
     "code":"mr",
     "name":"Marathi (mr)"
   },


### PR DESCRIPTION
The Māori is an official language of New Zealand -  https://en.wikipedia.org/wiki/Official_language#New_Zealand

Citations for proof of mi-NZ

https://teara.govt.nz/en/matauranga-hangarau-information-technology/page-3
https://www.localeplanet.com/dotnet/mi-NZ/index.html


### What does it do?

Adds Māori to the iso-locales.json