### PR TITLE
fix(polymorhic-relations-in-content-manager): allow to display collections with polymorphic relations

### DIFF
--- a/packages/strapi-plugin-content-manager/admin/src/hooks/useFetchContentTypeLayout/utils/formatLayouts.js
+++ b/packages/strapi-plugin-content-manager/admin/src/hooks/useFetchContentTypeLayout/utils/formatLayouts.js
@@ -14,6 +14,13 @@ const formatEditRelationsLayoutWithMetas = (contentTypeConfiguration, models) =>
       null
     );
     const targetModelSchema = getRelationModel(targetModelUID, models);
+
+    // for polymorphic relations, no `targetModelSchema` can be identified and therefore, we can stop processing the
+    // schema at this point.
+    if (!targetModelSchema) {
+      return acc;
+    }
+
     const targetModelPluginOptions = targetModelSchema.pluginOptions || {};
     const metadatas = get(contentTypeConfiguration, ['metadatas', current, 'edit'], {});
     const size = 6;


### PR DESCRIPTION
### What does it do?
As described in https://github.com/strapi/strapi/issues/10581, the content manager crashes when trying to open a collection's ListView where the collection contains a polymorphic relation.

This PR adds a more graceful error handling for this case in the resopnsible `formatEditRelationsLayoutWithMetas` utility function. So far, the assumption is that any relation in the relation model actually has a target model. For polymorphic relations, that's assumption is not true. This PR changes the behavior to simply skip over relations that have no target relation model that can be identified.

### Why is it needed?
As soon as you use a polymorphic relation, the content manager becomes unusable. Obviously, you still want to use the content manager even with polymorphic relations. It's clear that they are not officially supported in the content manager, but at least, normal behavior needs to be ensured.

### How to test it?
Create two entities that have a polymorphic relation, e.g.

`page.settings.js`:

```
{
    "attributes": {
      "related": {
            "collection": "*",
            "filter": "field",
            "configurable": false
          } 
    }
}
```

category.settings.js`:

```
{
    "attributes": {
        pages": {
            "collection": "page",
            "via": "related"
        }
}
```

Now start the admin UI: `yarn develop` and open [the page collection](http://localhost:1337/admin/plugins/content-manager/collectionType/application::page.page). Make sure the list view renders properly and when editing an entry, the edit view renders as well.

### Related issue(s)/PR(s)

fix #10581 
