### PR TITLE
Disable x-xss-protection by default

### DIFF
--- a/packages/strapi/lib/middlewares/xss/defaults.json
+++ b/packages/strapi/lib/middlewares/xss/defaults.json
@@ -1,6 +1,6 @@
 {
   "xss": {
     "enabled": false,
-    "mode": "block"
+    "mode": ""
   }
 }

--- a/packages/strapi/lib/middlewares/xss/index.js
+++ b/packages/strapi/lib/middlewares/xss/index.js
@@ -11,10 +11,7 @@ module.exports = strapi => {
       strapi.app.use(async (ctx, next) => {
         if (ctx.request.admin) {
           return await convert(
-            xssProtection({
-              enabled: true,
-              mode: defaults.xss.mode,
-            })
+            xssProtection(defaults.xss)
           )(ctx, next);
         }
 


### PR DESCRIPTION
### What does it do?

Disable `x-xss-protection` by default.

### Why is it needed?

As you know, Google Chrome Developers disabled XSS Auditor. Developers should be able to disable the auditor for older browsers and set it to 0.
The `x-xss-protection` header was found to have a multitude of issues, instead of helping the developers protect their application. (e.g. Bypass `x-xss-protection` header)

The following discussion describes the issue at hand with more references: 

https://github.com/OWASP/CheatSheetSeries/issues/376
https://github.com/OWASP/CheatSheetSeries/pull/378

Available for further discussions 😄 
