### PR TITLE
Adding support for TypeScript and better logging in development

### DIFF
--- a/packages/strapi/lib/commands/develop.js
+++ b/packages/strapi/lib/commands/develop.js
@@ -29,6 +29,7 @@ module.exports = async function({ build, watchAdmin, polling, browser }) {
         stdio: 'inherit',
       });
     } catch (err) {
+      console.log('Error running "build" command. It is likely missing from your package.json')
       process.exit(1);
     }
   }

--- a/packages/strapi/lib/core/app-configuration/config-loader.js
+++ b/packages/strapi/lib/core/app-configuration/config-loader.js
@@ -25,6 +25,8 @@ const loadFile = file => {
   switch (ext) {
     case '.js':
       return loadJsFile(file);
+    case '.ts':
+      return loadJsFile(file);
     case '.json':
       return loadJSONFile(file);
     default:


### PR DESCRIPTION
### What does it do?

1. Adds an importer to the config loader for `.ts` files. This allows for the use of `ts-node` to compile a typescript project. This has no impact for people not using typescript in their projects.

2. Logging output is added in the develop startup script to inform developers of a missing build script in package.json

### Why is it needed?

1. Since config files are loaded by filename before being imported as a module, using `ts-node` fails to start Strapi properly if config files are written in typescript. This is because Strapi only looks for javascript files.

2. If the build script is removed from package.json, Strapi develop commands fail silently.

### How to test it?

All existing tests can be used as is, with config files appended with `.ts` extensions instead of `.js`

`ts-node` must be used to run the `strapi ...` command

### Related issue(s)/PR(s)

This relates to a number of issues/discussions around adding typescript support to Strapi.
