### PR TITLE
ignore test-files during file-loading

### DIFF
--- a/packages/strapi/lib/load/load-config-files.js
+++ b/packages/strapi/lib/load/load-config-files.js
@@ -15,7 +15,7 @@ const loadConfigFiles = (dir, pattern = 'config/**/*.+(js|json)') =>
     globArgs: {
       // used to load .init.json at first startup
       dot: true,
-      ignore: ['config/**/*.test.js'],
+      ignore: ['**/*.test.js'],
     },
   });
 

--- a/packages/strapi/lib/load/load-files.js
+++ b/packages/strapi/lib/load/load-files.js
@@ -19,7 +19,7 @@ const filePathToPath = require('./filepath-to-prop-path');
 const loadFiles = async (
   dir,
   pattern,
-  { requireFn = require, shouldUseFileNameAsKey = () => true, globArgs = {} } = {}
+  { requireFn = require, shouldUseFileNameAsKey = () => true, globArgs = { ignore: ['**/*.test.js'] } } = {}
 ) => {
   const root = {};
   const files = await glob(pattern, { cwd: dir, ...globArgs });


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Ignores `*.test.js` files during the file-loading of the application.

### Why is it needed?

If not applied, starting the application will lead to errors if one has test-files inside e.g. the `api` or `config` directory.
This happens because strapi will try to load these files, thus leading to errors (e.g. `describe is not defined`).

### How to test it?

Just add test-files to the `api` or `config` directory and try to run the application. If it works, everything is ok :)

### Related issue(s)/PR(s)

There seems to be no related issue yet.
