### PR TITLE
Fix some users-permissions plugin HeaderNav translation ids

### DIFF
--- a/packages/strapi-plugin-users-permissions/admin/src/index.js
+++ b/packages/strapi-plugin-users-permissions/admin/src/index.js
@@ -74,7 +74,7 @@ export default strapi => {
           },
           {
             title: {
-              id: getTrad('HeaderNav.link.email-templates'),
+              id: getTrad('HeaderNav.link.emailTemplates'),
               defaultMessage: 'Email templates',
             },
             name: 'email-templates',
@@ -88,7 +88,7 @@ export default strapi => {
           },
           {
             title: {
-              id: getTrad('HeaderNav.link.advanced-settings'),
+              id: getTrad('HeaderNav.link.advancedSettings'),
               defaultMessage: 'Advanced Settings',
             },
             name: 'advanced-settings',


### PR DESCRIPTION
### What does it do?

It fixes some ids to activate translations on strapi-plugin-users-permissions HeaderNav

### Why is it needed?

To prevent mixed language content while using admin interface in another language rather than English (default).

### How to test it?

1. Change UI language through the user profile.
2. Access admin settings
3. You shall see at users-permissions links that "Email Templates" and "Advanced Settings" are not translated

This commit fix the issue.