### PR TITLE
Saml support sso

### DIFF
--- a/packages/core/admin/ee/middlewares/features-routes/routes.js
+++ b/packages/core/admin/ee/middlewares/features-routes/routes.js
@@ -3,6 +3,11 @@
 module.exports = {
   sso: [
     {
+      method: 'POST',
+      path: '/providers',
+      handler: 'authentication.getProviders',
+    },
+    {
       method: 'GET',
       path: '/providers',
       handler: 'authentication.getProviders',

--- a/packages/core/admin/ee/middlewares/features-routes/routes.js
+++ b/packages/core/admin/ee/middlewares/features-routes/routes.js
@@ -3,17 +3,17 @@
 module.exports = {
   sso: [
     {
+      method: 'GET',
+      path: '/providers',
+      handler: 'authentication.getProviders',
+    },
+    {
+      method: 'GET',
+      path: '/connect/:provider',
+      handler: 'authentication.providerLogin',
+    },
+    {
       method: 'POST',
-      path: '/providers',
-      handler: 'authentication.getProviders',
-    },
-    {
-      method: 'GET',
-      path: '/providers',
-      handler: 'authentication.getProviders',
-    },
-    {
-      method: 'GET',
       path: '/connect/:provider',
       handler: 'authentication.providerLogin',
     },


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

This PR creates a route that accepts a POST request for SAML login to work with Strapi. 

### Why is it needed?

## TL;DR

We need to add an additional route to [this file](https://github.com/strapi/strapi/blob/master/packages/strapi-admin/ee/middlewares/features-routes/routes.js) in the Strapi SSO code to allow SAML login. Instead of sending a `GET` request to the route:

```jsx
/connect/:provider
```

Services like OKTA and OneLogin, i.e SAML SSO login strategies send a `POST` request there. This results in a `405` error being thrown. `Method not allowed` . 

## Details

It turns out that the `passport-saml` auth strategy is sending a `POST` request to the route `/connect/:provider` instead of the expected `GET` request. This was causing all login attempts to fail, throwing a 405 error. The issue was tracked to this [routes.js](https://github.com/strapi/strapi/blob/master/packages/strapi-admin/ee/middlewares/features-routes/routes.js) file. After adding the code below to the array: 

```jsx
{
  method: 'POST',
  path: '/connect/:provider',
  handler: 'authentication.providerLogin',
}
```

the SSO feature worked again. 

### How to test it?

Attempt to perform login with a provider like OneLogin or Okta. This currently exists on Strapi v3.x.x and v4.x-next
