### PR TITLE
Update contrib guide to swap slack for discord

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -164,7 +164,7 @@ Before submitting an issue you need to make sure:
 - You have already searched for related [issues](https://github.com/strapi/strapi/issues), and found none open (if you found a related _closed_ issue, please link to it from your post).
 - You are not asking a question about how to use Strapi or about whether or not Strapi has a certain feature. For general help using Strapi, you may:
   - Refer to [the official Strapi documentation](https://strapi.io).
-  - Ask a member of the community in the [Strapi Slack Community](https://slack.strapi.io/).
+  - Ask a member of the community in the [Strapi Discord Community](https://discord.strapi.io/).
   - Ask a question on [our community forum](https://forum.strapi.io).
 - Your issue title is concise, on-topic and polite.
 - You can and do provide steps to reproduce your issue.


### PR DESCRIPTION
### What does it do?

Changes the Slack to Discord in the contrib guide

### Why is it needed?

Deprov of Slack

### How to test it?

click the link

### Related issue(s)/PR(s)

N/A
