### PR TITLE
[CLI] filter out templates and starters not verified

### DIFF
--- a/packages/create-strapi-app/utils/prompt-user.js
+++ b/packages/create-strapi-app/utils/prompt-user.js
@@ -39,13 +39,15 @@ async function getTemplateQuestion() {
     };
   }
 
-  const choices = content.map(option => {
-    const name = option.title.replace('Template', '');
-    return {
-      name,
-      value: `https://github.com/${option.repo}`,
-    };
-  });
+  const choices = content
+    .filter(template => template.verified)
+    .map(template => {
+      const name = template.title.replace('Template', '');
+      return {
+        name,
+        value: `https://github.com/${template.repo}`,
+      };
+    });
 
   return {
     name: 'template',
@@ -102,6 +104,7 @@ async function getTemplateData() {
   const response = await fetch(
     `https://api.github.com/repos/strapi/community-content/contents/templates/templates.yml`
   );
+
   if (!response.ok) {
     return null;
   }

--- a/packages/create-strapi-starter/utils/prompt-user.js
+++ b/packages/create-strapi-starter/utils/prompt-user.js
@@ -64,14 +64,15 @@ async function getStarterQuestion() {
     };
   }
 
-  const choices = content.map(option => {
-    const name = option.title.replace('Starter', '');
-
-    return {
-      name,
-      value: `https://github.com/${option.repo}`,
-    };
-  });
+  const choices = content
+    .filter(starter => starter.verified)
+    .map(starter => {
+      const name = starter.title.replace('Starter', '');
+      return {
+        name,
+        value: `https://github.com/${starter.repo}`,
+      };
+    });
 
   return {
     type: 'list',


### PR DESCRIPTION
### What does it do?

Filters out templates and starter that are not in the strapi organzation

### Why is it needed?

We want community members to submit starters/templates but we also want to control what shows up in the CLI

### How to test it?
change one of the repo keys returned from `getTemplateData` or `getStarterData` to something that doesn't start with `strapi/`

run `./node_modules/.bin/create-strapi-starter` or `./node_modules/.bin/create-strapi-app`