### PR TITLE
Update Auth.js

### DIFF
--- a/packages/strapi-plugin-users-permissions/controllers/Auth.js
+++ b/packages/strapi-plugin-users-permissions/controllers/Auth.js
@@ -512,7 +512,8 @@ module.exports = {
         user: sanitizedUser,
       });
     } catch (err) {
-      const adminError = _.includes(err.message, 'username')
+
+      const adminError = _.includes(err.message, 'username') || _.includes(err.message, 'Duplicate')
         ? {
             id: 'Auth.form.error.username.taken',
             message: 'Username already taken',


### PR DESCRIPTION
When i'm trying to register via api, i'm get error 'Auth.form.error.email.taken', but it's not.


.includes(err.message, 'username') don't contains any username errors, because 
await strapi.query('user', 'users-permissions').create(params) throw warning
`warn Duplicate entry MongoError: E11000 duplicate key error collection: domosedka-b.users-permissions_user index: username_1 dup key: { username: "test" }`

https://github.com/strapi/strapi/blob/7a80bdaa8e4e4b194853b338a30495c8a1050f1e/packages/strapi-plugin-users-permissions/controllers/Auth.js#L515

### System

- Node.js version: 12.13.0
- NPM version: 6.12.0
- Strapi version: 3.6.6
- Database: Mongo
- Operating system: Win10