### PR TITLE
Add `magiclink` Provider under Users & Permissions

### DIFF
--- a/packages/strapi-plugin-users-permissions/config/functions/bootstrap.js
+++ b/packages/strapi-plugin-users-permissions/config/functions/bootstrap.js
@@ -56,6 +56,13 @@ module.exports = async () => {
       callback: `${strapi.config.server.url}/auth/github/callback`,
       scope: ['user', 'user:email'],
     },
+    magiclink: {
+      enabled: false,
+      icon: 'envelope',
+      key: '',
+      callback: `${strapi.config.server.url}/auth/magiclink/callback`,
+      scope: ['email'],
+    },
     microsoft: {
       enabled: false,
       icon: 'windows',

--- a/packages/strapi-plugin-users-permissions/services/Providers.js
+++ b/packages/strapi-plugin-users-permissions/services/Providers.js
@@ -266,6 +266,25 @@ const getProfile = async (provider, query, callback) => {
         });
       break;
     }
+    case 'magiclink': {
+      const magicLinkKey = grant["magiclink"]["key"];
+      if (access_token != magicLinkKey) {
+        callback(new Error('invalid key'));
+        return;
+      }
+
+      const email = query.email;
+      if (!email) {
+        callback(new Error('email is missing'));
+        return;
+      }
+
+      callback(null, {
+        username: email.split('@')[0],
+        email: email,
+      });
+      break;
+    }
     case 'microsoft': {
       const microsoft = purest({
         provider: 'microsoft',


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

This change adds a `magiclink` provider under the Users & Permissions plugin.

### Why is it needed?

This allows Strapi to support authenticating a user coming in via a "Magic Link". The need for this change came about when I was using NextAuth and their `email` provider (See [NextAuth/email](https://next-auth.js.org/providers/email)) which sends the user a magic link.

I initially stumbled upon NextAuth through this tutorial (See [Strapi Blog: User Authentication in NextJS with Strapi](https://strapi.io/blog/user-authentication-in-next-js-with-strapi)). It covers authenticating with social providers but not with the stock "magic-link" method, which necessitated this change.

### How to test it?

To test this change, start Strapi as usual, and under `Settings > Users & Permissions > Providers`, click on `Magiclink`, enable it and specify a `Client ID` which is equivalent to a `key`.

Then to authenticate (and possibly register) a user, make a call to `/api/auth/magiclink/callback?email=<email>&access_token=<key>`.

### Related issue(s)/PR(s)

N/A
