### PR TITLE
fix grammar

### DIFF
--- a/packages/strapi-admin/admin/src/translations/en.json
+++ b/packages/strapi-admin/admin/src/translations/en.json
@@ -55,7 +55,7 @@
   "HomePage.helmet.title": "Homepage",
   "HomePage.roadmap": "See our roadmap",
   "HomePage.welcome.congrats": "Congrats!",
-  "HomePage.welcome.congrats.content": "You are logged as the first administrator. To discover the powerful features provided by Strapi,",
+  "HomePage.welcome.congrats.content": "You are logged in as the first administrator. To discover the powerful features provided by Strapi,",
   "HomePage.welcome.congrats.content.bold": "we recommend you to create your first Collection-Type.",
   "Media Library": "Media Library",
   "New entry": "New entry",


### PR DESCRIPTION
"You are logged as the first administrator." -> "You are logged in as the first administrator."


### What does it do?

Fix a small grammar issue in the English translations for strapi-admin.

### Why is it needed?

I don't know.

### How to test it?

N/A

### Related issue(s)/PR(s)

N/A
