### PR TITLE
Update package.json to include the repository key 

### DIFF
--- a/packages/strapi-helper-plugin/package.json
+++ b/packages/strapi-helper-plugin/package.json
@@ -5,6 +5,11 @@
   "files": [
     "dist"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/strapi/strapi.git",
+    "directory": "packages/strapi-helper-plugin"
+  },
   "engines": {
     "node": ">=10.16.0 <=14.x.x",
     "npm": ">=6.0.0"

--- a/packages/strapi-plugin-documentation/package.json
+++ b/packages/strapi-plugin-documentation/package.json
@@ -38,6 +38,11 @@
     "strapi-helper-plugin": "3.6.6",
     "swagger-ui-dist": "3.47.1"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/strapi/strapi.git",
+    "directory": "packages/strapi-plugin-documentation"
+  },
   "author": {
     "name": "soupette",
     "email": "hi@strapi.io",

--- a/packages/strapi-plugin-graphql/package.json
+++ b/packages/strapi-plugin-graphql/package.json
@@ -29,6 +29,11 @@
     "pluralize": "^8.0.0",
     "strapi-utils": "3.6.6"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/strapi/strapi.git",
+    "directory": "packages/strapi-plugin-graphql"
+  },
   "devDependencies": {
     "cross-env": "^7.0.3",
     "koa": "^2.13.1",

--- a/packages/strapi-plugin-i18n/package.json
+++ b/packages/strapi-plugin-i18n/package.json
@@ -14,6 +14,11 @@
     "pluralize": "8.0.0",
     "strapi-utils": "3.6.6"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/strapi/strapi.git",
+    "directory": "packages/strapi-plugin-i18n"
+  },
   "author": {
     "name": "A Strapi developer",
     "email": "",

--- a/packages/strapi-plugin-sentry/package.json
+++ b/packages/strapi-plugin-sentry/package.json
@@ -15,6 +15,11 @@
     "email": "hi@strapi.io",
     "url": "https://strapi.io"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/strapi/strapi.git",
+    "directory": "packages/strapi-plugin-sentry"
+  },
   "maintainers": [
     {
       "name": "Strapi team",

--- a/packages/strapi-plugin-upload/package.json
+++ b/packages/strapi-plugin-upload/package.json
@@ -42,6 +42,11 @@
     "stream-to-array": "^2.3.0",
     "uuid": "^3.2.1"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/strapi/strapi.git",
+    "directory": "packages/strapi-plugin-upload"
+  },
   "author": {
     "name": "Strapi team",
     "email": "hi@strapi.io",

--- a/packages/strapi-provider-upload-rackspace/package.json
+++ b/packages/strapi-provider-upload-rackspace/package.json
@@ -13,6 +13,11 @@
     "pkgcloud": "^2.0.0",
     "streamifier": "^0.1.1"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/strapi/strapi.git",
+    "directory": "packages/strapi-provider-upload-rackspace"
+  },
   "engines": {
     "node": ">=10.16.0 <=14.x.x",
     "npm": ">=6.0.0"


### PR DESCRIPTION
With the rise in supply chain attacks and OSS dependencies being used as a attack vector, Microsoft is working with our ecosystem partners, such as the Linux Foundation's OpenSSF, to enable OSS consumers to track packages back to their public sources.
We've identified that the following packages published to NPM do not report where sources can be found, typically accomplished by including a link to your GitHub repository in your `package.json` REPOSITORY field. This PR was created to add this value, ensuring future releases will include this provenance information.
Published NPM packages with repository information:
* strapi-helper-plugin
* strapi-plugin-documentation
* strapi-plugin-graphql
* strapi-plugin-i18n
* strapi-plugin-sentry
* strapi-plugin-upload
* strapi-provider-upload-rackspace

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Describe the technical changes you did.

### Why is it needed?

Describe the issue you are solving.

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
