### PR TITLE
refactor: disable graphql playground in staging environment as well

### DIFF
--- a/packages/strapi-plugin-graphql/hooks/graphql/index.js
+++ b/packages/strapi-plugin-graphql/hooks/graphql/index.js
@@ -125,8 +125,8 @@ module.exports = strapi => {
         ...apolloServerConfig,
       };
 
-      // Disable GraphQL Playground in production environment.
-      if (strapi.config.environment !== 'production' || config.playgroundAlways) {
+      // Disable GraphQL Playground in production and staging environment.
+      if (strapi.config.environment !== ('production' || 'staging') || config.playgroundAlways) {
         serverParams.playground = {
           endpoint: `${strapi.config.server.url}${config.endpoint}`,
           shareEnabled: config.shareEnabled,


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Disable GraphQL playground in `staging` environment as well (other than production environment).

### Why is it needed?

Some projects might only have/run on : 
1) Development, Staging, Production environments
2) Development and Staging environments only

### How to test it?

In environment variable (`.env` file), set `NODE_ENV` value to `staging` or `production` to see the GraphQL playground disabled.

Any suggestion is appreciated!