### PR TITLE
Add controller and policy plop generators

### DIFF
--- a/packages/generators/generate-plop/plopfile.js
+++ b/packages/generators/generate-plop/plopfile.js
@@ -50,4 +50,42 @@ module.exports = function(plop) {
       },
     ],
   });
+
+  // Controller generator
+  plop.setGenerator('controller', {
+    description: 'Generate a controller for an API',
+    prompts: [
+      {
+        type: 'input',
+        name: 'id',
+        message: 'Controller name',
+      },
+    ],
+    actions: [
+      {
+        type: 'add',
+        path: join(process.cwd(), 'api/{{id}}/controllers/{{id}}.js'),
+        templateFile: 'templates/controller.js.hbs',
+      },
+    ],
+  });
+
+  // Policy generator
+  plop.setGenerator('policy', {
+    description: 'Generate a policy',
+    prompts: [
+      {
+        type: 'input',
+        name: 'id',
+        message: 'Policy name',
+      },
+    ],
+    actions: [
+      {
+        type: 'add',
+        path: join(process.cwd(), 'config/policies/{{id}}.js'),
+        templateFile: 'templates/policy.js.hbs',
+      },
+    ],
+  });
 };

--- a/packages/generators/generate-plop/templates/controller.js.hbs
+++ b/packages/generators/generate-plop/templates/controller.js.hbs
@@ -1,0 +1,15 @@
+'use strict';
+
+/**
+ * A set of functions called "actions" for `{{id}}`
+ */
+
+module.exports = {
+  // exampleAction: async (ctx, next) => {
+  //   try {
+  //     ctx.body = 'ok';
+  //   } catch (err) {
+  //     ctx.body = err;
+  //   }
+  // }
+};

--- a/packages/generators/generate-plop/templates/policy.js.hbs
+++ b/packages/generators/generate-plop/templates/policy.js.hbs
@@ -1,0 +1,12 @@
+'use strict';
+
+/**
+ * `{{id}}` policy.
+ */
+
+module.exports = async (ctx, next) => {
+  // Add your own logic here.
+  console.log('In {{id}} policy.');
+
+  await next();
+};


### PR DESCRIPTION
### What does it do?

Add controller and policy generators to the generate-plop package, as part of the POC.

I thought I would add the API generator later, since that one will also rely on the model generator that I don't already have.