### PR TITLE
Make filter attribute of polimorphic to work for collections

### DIFF
--- a/packages/strapi-connector-bookshelf/lib/mount-models.js
+++ b/packages/strapi-connector-bookshelf/lib/mount-models.js
@@ -364,7 +364,7 @@ module.exports = async ({ models, target }, ctx, { selfFinalize = false } = {}) 
             : strapi.models[details.collection];
 
           const globalId = `${collection.collectionName}_morph`;
-          const filter = _.get(model, ['attributes', details.via, 'filter'], 'field');
+          const filter = _.get(collection, ['attributes', details.via, 'filter'], 'field');
 
           loadedModel[name] = function() {
             return this.morphMany(


### PR DESCRIPTION
### What does it do?

Use the polymorphic attribute info (`filter`) to relate to the filter column correctly for collections in https://github.com/strapi/strapi/blob/5202c4ed5c96d5e39823e8e6e936bb75c2c59a33/packages/strapi-connector-bookshelf/lib/mount-models.js

Whereas for oneMorph attributes (`"model": "*"`) the name of the filter column is derived correctly ...
https://github.com/strapi/strapi/blob/5202c4ed5c96d5e39823e8e6e936bb75c2c59a33/packages/strapi-connector-bookshelf/lib/mount-models.js#L342-L348

... simple copy-paste seems to have created this error in the case of manyMorph attributes (`"collection": "*"`) where `model` is not defined:
https://github.com/strapi/strapi/blob/5202c4ed5c96d5e39823e8e6e936bb75c2c59a33/packages/strapi-connector-bookshelf/lib/mount-models.js#L361-L367

Currently, It always uses the default column `field`, because `model` relates to the model name as es string in the outer context:
https://github.com/strapi/strapi/blob/5202c4ed5c96d5e39823e8e6e936bb75c2c59a33/packages/strapi-connector-bookshelf/lib/mount-models.js#L64

### Why is it needed?

Make custom filter columns work for manyMorph attributes as they do for oneMorph attributes.

### How to test it?

I am sure, that this is wrong, but can't figure out how to test it right now. I would be glad on any hints on how to test this tiny bit.

### Related issue(s)/PR(s)

I couldn't find any related issues, but found it during diving into the code in order to understand polymorphic relations better.
