### PR TITLE
Updated database validation to include `.` in the names of all databases except mongo db

### DIFF
--- a/packages/strapi-generate-new/lib/utils/db-questions.js
+++ b/packages/strapi-generate-new/lib/utils/db-questions.js
@@ -1,15 +1,16 @@
 'use strict';
 
-const database = ({ scope }) => ({
+const database = ({ scope, client }) => ({
   type: 'input',
   name: 'database',
   message: 'Database name:',
   default: scope.name,
   validate: value => {
-    if (value.includes('.')) {
+    if (client === 'mongo') {
+      if (value.includes('.')) {
       return `The database name can't contain a "."`;
+      }
     }
-
     return true;
   },
 });


### PR DESCRIPTION
What does it do?
The check which prevented the database name from containing a '.' is needed only for mongo db. But it used to check for all databases, now it only checks in the case of mongo db. This PR fixes #5267

Why is it needed?
It prevents databases from having names that contain '.' even if it is permissible.

How to test it?
This behaviour can be tested while creating a stapi app using the npx create-strapi-app app-name command and choosing the custom option, then selecting a database other than mongo db.

The changes have been made in:
strapi/packages/strapi-generate-new/lib/utils/db-questions.js

Running yarn lint showed some errors.

Related issue(s)/PR(s)
Issue #5267