### PR TITLE
Fix blocked users being able to sign in using forgot password

### DIFF
--- a/packages/strapi-plugin-users-permissions/controllers/Auth.js
+++ b/packages/strapi-plugin-users-permissions/controllers/Auth.js
@@ -310,6 +310,11 @@ module.exports = {
       );
     }
 
+    // User blocked
+    if (user.blocked) {
+      return ctx.badRequest('blocked.user');
+    }
+
     // Generate random token.
     const resetPasswordToken = crypto.randomBytes(64).toString('hex');
 

--- a/packages/strapi-plugin-users-permissions/controllers/Auth.js
+++ b/packages/strapi-plugin-users-permissions/controllers/Auth.js
@@ -283,7 +283,7 @@ module.exports = {
         null,
         formatError({
           id: 'Auth.form.error.email.format',
-          message: 'Please provide valid email address.',
+          message: 'Please provide a valid email address.',
         })
       );
     }
@@ -312,7 +312,13 @@ module.exports = {
 
     // User blocked
     if (user.blocked) {
-      return ctx.badRequest('blocked.user');
+      return ctx.badRequest(
+        null,
+        formatError({
+          id: 'Auth.form.error.user.blocked',
+          message: 'This user is disabled.',
+        })
+      );
     }
 
     // Generate random token.


### PR DESCRIPTION
Signed-off-by: Derrick Mehaffy <derrickmehaffy@gmail.com>

### What does it do?

Adds a check in the forgot password controller to see if a user is blocked and return the valid error message if they are

### Why is it needed?

Blocked users should not be able to perform any request at all

### How to test it?

Create a user, set them as blocked, and attempt to send a password reset request

### Related issue(s)/PR(s)

fixes #10776
