### PR TITLE
add api and plugin prompt arguments

### DIFF
--- a/packages/generators/generate/templates/model.settings.json.hbs
+++ b/packages/generators/generate/templates/model.settings.json.hbs
@@ -1,6 +1,6 @@
 
 {
-  "kind": "collectionType",
+  "kind": "{{kind}}",
   "collectionName": "{{id}}",
   "info": {
     "name": "{{id}}"


### PR DESCRIPTION
### What does it do?

Adds missing arguments to the plop generators

For adding attributes to models I think we might be able to use something like this: https://github.com/nathanloisel/inquirer-recursive and plop.setPrompt()



