### PR TITLE
bump sharp to 0.29.0

### DIFF
--- a/packages/strapi-plugin-upload/package.json
+++ b/packages/strapi-plugin-upload/package.json
@@ -35,7 +35,7 @@
     "react-router": "^5.2.0",
     "react-router-dom": "^5.0.0",
     "reactstrap": "8.4.1",
-    "sharp": "0.28.1",
+    "sharp": "0.29.0",
     "strapi-helper-plugin": "3.6.8",
     "strapi-provider-upload-local": "3.6.8",
     "strapi-utils": "3.6.8",


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Upgrades sharp dependency in strapi-plugin-upload to latest stable version (0.29.0).

### Why is it needed?

In some cases, width and height could not be determined for PNG images as sharp threw an error (`Input buffer has corrupt header: pngload_buffer: invalid chunk position`). This also prevented strapi-plugin-upload from generating different image sizes/formats.

The latest sharp version no longer has this issue.

### How to test it?

--

### Related issue(s)/PR(s)

--