### PR TITLE
[I18N] improve simplified Japanese translation #10811

### DIFF
--- a/packages/strapi-plugin-email/admin/src/translations/ja.json
+++ b/packages/strapi-plugin-email/admin/src/translations/ja.json
@@ -1,4 +1,22 @@
 {
   "plugin.description.long": "メールを送る",
-  "plugin.description.short": "メールを送る"
+  "plugin.description.short": "メールを送る",
+  "SettingsNav.section-label": "メールプラグイン",
+  "SettingsNav.link.settings": "メールの設定",
+  "Settings.title": "メールの設定",
+  "Settings.subTitle": "メールの設定をテストする",
+  "Settings.button.test-email": "メールをテスト",
+  "Settings.notification.test.success": "メールの送信に成功しました, {to} メールボックスを確認してください",
+  "Settings.notification.test.error": "{to}へのメールの送信を失敗しました",
+  "Settings.notification.config.error": "メールのコンフィグの受信に失敗しました",
+  "Settings.form.title.config": "コンフィグレーション",
+  "Settings.form.title.test": "メールの送信をテストする",
+  "Settings.form.label.provider": "メールのプロバイダー",
+  "Settings.form.label.defaultFrom": "デフォルトの送信メールアドレス",
+  "Settings.form.label.defaultReplyTo": "デフォルトの受信メールアドレス",
+  "Settings.form.label.testAddress": "テスト送信で使用するメールアドレス",
+  "Settings.form.placeholder.defaultFrom": "例: Strapi No-Reply <no-reply@strapi.io>",
+  "Settings.form.placeholder.defaultReplyTo": "例: Strapi <example@strapi.io>",
+  "Settings.form.placeholder.testAddress": "例: developer@example.com"
 }
+


### PR DESCRIPTION
Improve simplified Chinese translation.

Includes translation for strapi-admin and the translations for the following plugins：

strapi/packages/strapi-plugin-email/admin/src/translations/ja.json
How to test it?

None