### PR TITLE
Add indicator for required fields in content-manager

### DIFF
--- a/packages/strapi-plugin-content-manager/admin/src/components/Inputs/index.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/Inputs/index.js
@@ -27,6 +27,7 @@ function Inputs({
   formErrors,
   isCreatingEntry,
   keys,
+  label,
   labelIcon,
   metadatas,
   onBlur,
@@ -184,13 +185,7 @@ function Inputs({
   }
 
   if (!shouldDisplayNotAllowedInput) {
-    return (
-      <NotAllowedInput
-        label={metadatas.label}
-        labelIcon={labelIconformatted}
-        error={errorMessage}
-      />
-    );
+    return <NotAllowedInput label={label} labelIcon={labelIconformatted} error={errorMessage} />;
   }
 
   if (type === 'relation') {
@@ -199,6 +194,7 @@ function Inputs({
         <SelectWrapper
           {...metadatas}
           {...fieldSchema}
+          label={label}
           labelIcon={labelIcon}
           isUserAllowedToEditField={isUserAllowedToEditField}
           isUserAllowedToReadField={isUserAllowedToReadField}
@@ -218,6 +214,7 @@ function Inputs({
       disabled={shouldDisableField}
       error={errorMessage}
       inputDescription={description}
+      label={label}
       labelIcon={labelIconformatted}
       description={description}
       contentTypeUID={currentContentTypeLayout.uid}
@@ -258,6 +255,7 @@ Inputs.propTypes = {
   formErrors: PropTypes.object,
   keys: PropTypes.string.isRequired,
   isCreatingEntry: PropTypes.bool.isRequired,
+  label: PropTypes.string.isRequired,
   labelIcon: PropTypes.shape({
     icon: PropTypes.node.isRequired,
     title: PropTypes.shape({

--- a/packages/strapi-plugin-content-manager/admin/src/containers/EditView/index.js
+++ b/packages/strapi-plugin-content-manager/admin/src/containers/EditView/index.js
@@ -154,6 +154,9 @@ const EditView = ({
                               {fieldsBlock.map(
                                 ({ name, size, fieldSchema, labelIcon, metadatas }, fieldIndex) => {
                                   const isComponent = fieldSchema.type === 'component';
+                                  const label = fieldSchema.required
+                                    ? `* ${metadatas.label}`
+                                    : metadatas.label;
 
                                   if (isComponent) {
                                     const { component, max, min, repeatable = false } = fieldSchema;
@@ -165,7 +168,7 @@ const EditView = ({
                                         componentUid={component}
                                         labelIcon={labelIcon}
                                         isRepeatable={repeatable}
-                                        label={metadatas.label}
+                                        label={label}
                                         max={max}
                                         min={min}
                                         name={name}
@@ -183,6 +186,7 @@ const EditView = ({
                                         }
                                         fieldSchema={fieldSchema}
                                         keys={name}
+                                        label={label}
                                         labelIcon={labelIcon}
                                         metadatas={metadatas}
                                       />


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Add indicator for each required field in the `strapi-plugin-content-manager`.

### Why is it needed?

To help content managers to know which fields are required before the validation. 

### How to test it?

You can start the default project by running the commands from the `CONTRIBUTING.md` and create a ned Address entity. There you can see that there is a `*` next to the label of the `City` field, which means that the field is required.

<img width="1212" alt="Screenshot 2021-08-27 at 12 14 30" src="https://user-images.githubusercontent.com/10163193/131112198-dec3515a-a073-4dfe-befa-83b5bc6b01e9.png">

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/issues/10030
