### PR TITLE
[v4] Rest api response format for relations

### DIFF
--- a/packages/core/strapi/lib/core-api/controller/__tests__/transform.test.js
+++ b/packages/core/strapi/lib/core-api/controller/__tests__/transform.test.js
@@ -35,4 +35,88 @@ describe('Transforms', () => {
       meta: someMeta,
     });
   });
+
+  test('Handles relations single value', () => {
+    const contentType = {
+      attributes: {
+        relation: {
+          type: 'relation',
+          target: 'xxx',
+        },
+      },
+    };
+
+    global.strapi = {
+      contentType() {
+        return undefined;
+      },
+    };
+
+    expect(
+      transforms.transformResponse(
+        { id: 1, title: 'Hello', relation: { id: 1, value: 'test' } },
+        undefined,
+        { contentType }
+      )
+    ).toStrictEqual({
+      data: {
+        id: 1,
+        attributes: {
+          title: 'Hello',
+          relation: {
+            data: {
+              id: 1,
+              attributes: {
+                value: 'test',
+              },
+            },
+          },
+        },
+      },
+      meta: {},
+    });
+  });
+
+  test('Handles relations array value', () => {
+    const contentType = {
+      attributes: {
+        relation: {
+          type: 'relation',
+          target: 'xxx',
+        },
+      },
+    };
+
+    global.strapi = {
+      contentType() {
+        return undefined;
+      },
+    };
+
+    expect(
+      transforms.transformResponse(
+        { id: 1, title: 'Hello', relation: [{ id: 1, value: 'test' }] },
+        undefined,
+        { contentType }
+      )
+    ).toStrictEqual({
+      data: {
+        id: 1,
+        attributes: {
+          title: 'Hello',
+          relation: {
+            data: [
+              {
+                id: 1,
+                attributes: {
+                  value: 'test',
+                },
+              },
+            ],
+          },
+        },
+      },
+      meta: {},
+    });
+  });
 });

--- a/packages/core/strapi/lib/core-api/controller/__tests__/transform.test.js
+++ b/packages/core/strapi/lib/core-api/controller/__tests__/transform.test.js
@@ -119,4 +119,108 @@ describe('Transforms', () => {
       meta: {},
     });
   });
+
+  test('Handles relations recursively', () => {
+    const contentType = {
+      attributes: {
+        relation: {
+          type: 'relation',
+          target: 'xxx',
+        },
+      },
+    };
+
+    global.strapi = {
+      contentType() {
+        return {
+          attributes: {
+            nestedRelation: {
+              type: 'relation',
+              target: 'xxxx',
+            },
+          },
+        };
+      },
+    };
+
+    expect(
+      transforms.transformResponse(
+        {
+          id: 1,
+          title: 'Hello',
+          relation: [{ id: 1, value: 'test', nestedRelation: { id: 2, foo: 'bar' } }],
+        },
+        undefined,
+        { contentType }
+      )
+    ).toStrictEqual({
+      data: {
+        id: 1,
+        attributes: {
+          title: 'Hello',
+          relation: {
+            data: [
+              {
+                id: 1,
+                attributes: {
+                  value: 'test',
+                  nestedRelation: {
+                    data: {
+                      id: 2,
+                      attributes: {
+                        foo: 'bar',
+                      },
+                    },
+                  },
+                },
+              },
+            ],
+          },
+        },
+      },
+      meta: {},
+    });
+  });
+
+  test('Handles media like relations', () => {
+    const contentType = {
+      attributes: {
+        media: {
+          type: 'media',
+        },
+      },
+    };
+
+    global.strapi = {
+      contentType() {
+        return undefined;
+      },
+    };
+
+    expect(
+      transforms.transformResponse(
+        { id: 1, title: 'Hello', media: [{ id: 1, value: 'test' }] },
+        undefined,
+        { contentType }
+      )
+    ).toStrictEqual({
+      data: {
+        id: 1,
+        attributes: {
+          title: 'Hello',
+          media: {
+            data: [
+              {
+                id: 1,
+                attributes: {
+                  value: 'test',
+                },
+              },
+            ],
+          },
+        },
+      },
+      meta: {},
+    });
+  });
 });

--- a/packages/core/strapi/lib/core-api/controller/collection-type.js
+++ b/packages/core/strapi/lib/core-api/controller/collection-type.js
@@ -41,15 +41,11 @@ const createCollectionTypeController = ({ service, sanitize, parseMultipartData 
      * @return {Object}
      */
     async create(ctx) {
-      const { body, query } = ctx.request;
+      const { query } = ctx.request;
 
-      let entity;
-      if (ctx.is('multipart')) {
-        const { data, files } = parseMultipartData(ctx);
-        entity = await service.create({ params: query, data, files });
-      } else {
-        entity = await service.create({ params: query, data: body });
-      }
+      const { data, files } = parseMultipartData(ctx);
+
+      const entity = await service.create({ params: query, data, files });
 
       return transformResponse(sanitize(entity));
     },
@@ -61,15 +57,11 @@ const createCollectionTypeController = ({ service, sanitize, parseMultipartData 
      */
     async update(ctx) {
       const { id } = ctx.params;
-      const { body, query } = ctx.request;
+      const { query } = ctx.request;
 
-      let entity;
-      if (ctx.is('multipart')) {
-        const { data, files } = parseMultipartData(ctx);
-        entity = await service.update(id, { params: query, data, files });
-      } else {
-        entity = await service.update(id, { params: query, data: body });
-      }
+      const { data, files } = parseMultipartData(ctx);
+
+      const entity = await service.update(id, { params: query, data, files });
 
       return transformResponse(sanitize(entity));
     },

--- a/packages/core/strapi/lib/core-api/controller/collection-type.js
+++ b/packages/core/strapi/lib/core-api/controller/collection-type.js
@@ -1,12 +1,12 @@
 'use strict';
 
-const { transformResponse } = require('./transform');
+const { parseMultipartData } = require('@strapi/utils');
 
 /**
  *
  * Returns a collection type controller to handle default core-api actions
  */
-const createCollectionTypeController = ({ service, sanitize, parseMultipartData }) => {
+const createCollectionTypeController = ({ service, sanitize, transformResponse }) => {
   return {
     /**
      * Retrieve records.

--- a/packages/core/strapi/lib/core-api/controller/index.js
+++ b/packages/core/strapi/lib/core-api/controller/index.js
@@ -1,7 +1,8 @@
 'use strict';
 
-const { parseMultipartData, sanitizeEntity } = require('@strapi/utils');
+const { sanitizeEntity } = require('@strapi/utils');
 
+const { transformResponse } = require('./transform');
 const createSingleTypeController = require('./single-type');
 const createCollectionTypeController = require('./collection-type');
 
@@ -9,7 +10,9 @@ module.exports = ({ service, model }) => {
   const ctx = {
     model,
     service,
-    parseMultipartData,
+    transformResponse(data, meta) {
+      return transformResponse(data, meta, { contentType: model });
+    },
     sanitize(data) {
       return sanitizeEntity(data, { model: strapi.getModel(model.uid) });
     },

--- a/packages/core/strapi/lib/core-api/controller/single-type.js
+++ b/packages/core/strapi/lib/core-api/controller/single-type.js
@@ -1,11 +1,11 @@
 'use strict';
 
-const { transformResponse } = require('./transform');
+const { parseMultipartData } = require('@strapi/utils');
 
 /**
  * Returns a single type controller to handle default core-api actions
  */
-const createSingleTypeController = ({ service, parseMultipartData, sanitize }) => {
+const createSingleTypeController = ({ service, sanitize, transformResponse }) => {
   return {
     /**
      * Retrieve single type content

--- a/packages/core/strapi/lib/core-api/controller/single-type.js
+++ b/packages/core/strapi/lib/core-api/controller/single-type.js
@@ -24,15 +24,10 @@ const createSingleTypeController = ({ service, parseMultipartData, sanitize }) =
      * @return {Object}
      */
     async update(ctx) {
-      const { body, query } = ctx.request;
+      const { query } = ctx.request;
+      const { data, files } = parseMultipartData(ctx);
 
-      let entity;
-      if (ctx.is('multipart')) {
-        const { data, files } = parseMultipartData(ctx);
-        entity = await service.createOrUpdate({ params: query, data, files });
-      } else {
-        entity = await service.createOrUpdate({ params: query, data: body });
-      }
+      const entity = await service.createOrUpdate({ params: query, data, files });
 
       return transformResponse(sanitize(entity));
     },

--- a/packages/core/strapi/lib/core-api/controller/transform.js
+++ b/packages/core/strapi/lib/core-api/controller/transform.js
@@ -38,6 +38,10 @@ const transformEntry = (entry, contentType) => {
       const data = transformEntry(property, strapi.contentType(attribute.target));
 
       attributeValues[key] = { data };
+    } else if (attribute && attribute.type === 'media') {
+      const data = transformEntry(property, strapi.contentType('plugin::upload.file'));
+
+      attributeValues[key] = { data };
     } else {
       attributeValues[key] = property;
     }

--- a/packages/core/strapi/tests/endpoint.test.e2e.js
+++ b/packages/core/strapi/tests/endpoint.test.e2e.js
@@ -130,9 +130,9 @@ describe('Create Strapi API End to End', () => {
       expect(body.data.id).toBeDefined();
       expect(body.data.attributes.title).toBe(entry.title);
       expect(body.data.attributes.content).toBe(entry.content);
-      expect(Array.isArray(body.data.attributes.tags)).toBeTruthy();
-      expect(body.data.attributes.tags.length).toBe(1);
-      expect(body.data.attributes.tags[0].id).toBe(data.tags[0].id);
+      expect(Array.isArray(body.data.attributes.tags.data)).toBeTruthy();
+      expect(body.data.attributes.tags.data.length).toBe(1);
+      expect(body.data.attributes.tags.data[0].id).toBe(data.tags[0].id);
     });
 
     test('Update article1 add tag2', async () => {
@@ -157,9 +157,9 @@ describe('Create Strapi API End to End', () => {
       expect(body.data.id).toBeDefined();
       expect(body.data.attributes.title).toBe(entry.title);
       expect(body.data.attributes.content).toBe(entry.content);
-      expect(Array.isArray(body.data.attributes.tags)).toBeTruthy();
-      expect(body.data.attributes.tags.length).toBe(1);
-      expect(body.data.attributes.tags[0].id).toBe(data.tags[1].id);
+      expect(Array.isArray(body.data.attributes.tags.data)).toBeTruthy();
+      expect(body.data.attributes.tags.data.length).toBe(1);
+      expect(body.data.attributes.tags.data[0].id).toBe(data.tags[1].id);
     });
 
     test('Update article1 add tag1 and tag3', async () => {
@@ -183,15 +183,15 @@ describe('Create Strapi API End to End', () => {
       expect(body.data.id).toBeDefined();
       expect(body.data.attributes.title).toBe(entry.title);
       expect(body.data.attributes.content).toBe(entry.content);
-      expect(Array.isArray(body.data.attributes.tags)).toBeTruthy();
-      expect(body.data.attributes.tags.length).toBe(3);
+      expect(Array.isArray(body.data.attributes.tags.data)).toBeTruthy();
+      expect(body.data.attributes.tags.data.length).toBe(3);
     });
 
     test('Update article1 remove one tag', async () => {
       const { id, attributes } = data.articles[0];
 
       const entry = Object.assign({}, attributes);
-      entry.tags = entry.tags.slice(1).map(t => t.id);
+      entry.tags = entry.tags.data.slice(1).map(t => t.id);
 
       cleanDate(entry);
 
@@ -209,8 +209,8 @@ describe('Create Strapi API End to End', () => {
       expect(body.data.id).toBeDefined();
       expect(body.data.attributes.title).toBe(entry.title);
       expect(body.data.attributes.content).toBe(entry.content);
-      expect(Array.isArray(body.data.attributes.tags)).toBeTruthy();
-      expect(body.data.attributes.tags.length).toBe(2);
+      expect(Array.isArray(body.data.attributes.tags.data)).toBeTruthy();
+      expect(body.data.attributes.tags.data.length).toBe(2);
     });
 
     test('Update article1 remove all tag', async () => {
@@ -235,8 +235,8 @@ describe('Create Strapi API End to End', () => {
       expect(body.data.id).toBeDefined();
       expect(body.data.attributes.title).toBe(entry.title);
       expect(body.data.attributes.content).toBe(entry.content);
-      expect(Array.isArray(body.data.attributes.tags)).toBeTruthy();
-      expect(body.data.attributes.tags.length).toBe(0);
+      expect(Array.isArray(body.data.attributes.tags.data)).toBeTruthy();
+      expect(body.data.attributes.tags.data.length).toBe(0);
     });
   });
 
@@ -309,7 +309,9 @@ describe('Create Strapi API End to End', () => {
       expect(body.data.id).toBeDefined();
       expect(body.data.attributes.title).toBe(entry.title);
       expect(body.data.attributes.content).toBe(entry.content);
-      expect(body.data.attributes.category.name).toBe(data.categories[0].attributes.name);
+      expect(body.data.attributes.category.data.attributes.name).toBe(
+        data.categories[0].attributes.name
+      );
     });
 
     test('Update article1 with cat2', async () => {
@@ -334,7 +336,9 @@ describe('Create Strapi API End to End', () => {
       expect(body.data.id).toBeDefined();
       expect(body.data.attributes.title).toBe(entry.title);
       expect(body.data.attributes.content).toBe(entry.content);
-      expect(body.data.attributes.category.name).toBe(data.categories[1].attributes.name);
+      expect(body.data.attributes.category.data.attributes.name).toBe(
+        data.categories[1].attributes.name
+      );
     });
 
     test('Create article2', async () => {
@@ -379,14 +383,16 @@ describe('Create Strapi API End to End', () => {
       expect(body.data.id).toBeDefined();
       expect(body.data.attributes.title).toBe(entry.title);
       expect(body.data.attributes.content).toBe(entry.content);
-      expect(body.data.attributes.category.name).toBe(data.categories[1].attributes.name);
+      expect(body.data.attributes.category.data.attributes.name).toBe(
+        data.categories[1].attributes.name
+      );
     });
 
     test('Update cat1 with article1', async () => {
       const { id, attributes } = data.categories[0];
 
       const entry = Object.assign({}, attributes);
-      entry.articles = data.categories[0].attributes.articles
+      entry.articles = data.categories[0].attributes.articles.data
         .map(a => a.id)
         .concat(data.articles[0].id);
 
@@ -404,8 +410,8 @@ describe('Create Strapi API End to End', () => {
       data.categories[0] = body.data;
 
       expect(body.data.id).toBeDefined();
-      expect(Array.isArray(body.data.attributes.articles)).toBeTruthy();
-      expect(body.data.attributes.articles.length).toBe(1);
+      expect(Array.isArray(body.data.attributes.articles.data)).toBeTruthy();
+      expect(body.data.attributes.articles.data.length).toBe(1);
       expect(body.data.attributes.name).toBe(entry.name);
     });
 
@@ -427,8 +433,8 @@ describe('Create Strapi API End to End', () => {
       data.categories.push(body.data);
 
       expect(body.data.id).toBeDefined();
-      expect(Array.isArray(body.data.attributes.articles)).toBeTruthy();
-      expect(body.data.attributes.articles.length).toBe(1);
+      expect(Array.isArray(body.data.attributes.articles.data)).toBeTruthy();
+      expect(body.data.attributes.articles.data.length).toBe(1);
       expect(body.data.attributes.name).toBe(entry.name);
     });
 
@@ -442,7 +448,7 @@ describe('Create Strapi API End to End', () => {
       });
 
       expect(body.data.id).toBeDefined();
-      expect(body.data.attributes.category.id).toBe(data.categories[2].id);
+      expect(body.data.attributes.category.data.id).toBe(data.categories[2].id);
     });
 
     test('Get article2 with cat2', async () => {
@@ -455,7 +461,7 @@ describe('Create Strapi API End to End', () => {
       });
 
       expect(body.data.id).toBeDefined();
-      expect(body.data.attributes.category.id).toBe(data.categories[1].id);
+      expect(body.data.attributes.category.data.id).toBe(data.categories[1].id);
     });
 
     test('Get cat1 without relations', async () => {
@@ -468,7 +474,7 @@ describe('Create Strapi API End to End', () => {
       });
 
       expect(body.data.id).toBeDefined();
-      expect(body.data.attributes.articles.length).toBe(0);
+      expect(body.data.attributes.articles.data.length).toBe(0);
     });
 
     test('Get cat2 with article2', async () => {
@@ -481,8 +487,8 @@ describe('Create Strapi API End to End', () => {
       });
 
       expect(body.data.id).toBeDefined();
-      expect(body.data.attributes.articles.length).toBe(1);
-      expect(body.data.attributes.articles[0].id).toBe(data.articles[1].id);
+      expect(body.data.attributes.articles.data.length).toBe(1);
+      expect(body.data.attributes.articles.data[0].id).toBe(data.articles[1].id);
     });
 
     test('Get cat3 with article1', async () => {
@@ -495,8 +501,8 @@ describe('Create Strapi API End to End', () => {
       });
 
       expect(body.data.id).toBeDefined();
-      expect(body.data.attributes.articles.length).toBe(1);
-      expect(body.data.attributes.articles[0].id).toBe(data.articles[0].id);
+      expect(body.data.attributes.articles.data.length).toBe(1);
+      expect(body.data.attributes.articles.data[0].id).toBe(data.articles[0].id);
     });
   });
 
@@ -568,7 +574,7 @@ describe('Create Strapi API End to End', () => {
       expect(body.data.id).toBeDefined();
       expect(body.data.attributes.title).toBe(entry.title);
       expect(body.data.attributes.content).toBe(entry.content);
-      expect(body.data.attributes.reference.id).toBe(entry.reference);
+      expect(body.data.attributes.reference.data.id).toBe(entry.reference);
     });
 
     test('Create article2 with ref1', async () => {
@@ -592,7 +598,7 @@ describe('Create Strapi API End to End', () => {
       expect(body.data.id).toBeDefined();
       expect(body.data.attributes.title).toBe(entry.title);
       expect(body.data.attributes.content).toBe(entry.content);
-      expect(body.data.attributes.reference.id).toBe(entry.reference);
+      expect(body.data.attributes.reference.data.id).toBe(entry.reference);
     });
   });
 
@@ -636,7 +642,7 @@ describe('Create Strapi API End to End', () => {
       });
 
       data.references.push(createdReference);
-      expect(createdReference.attributes.tag.id).toBe(createdTag.id);
+      expect(createdReference.attributes.tag.data.id).toBe(createdTag.id);
     });
 
     test('Detach Tag from a Reference', async () => {
@@ -668,7 +674,7 @@ describe('Create Strapi API End to End', () => {
 
       data.references.push(createdReference);
 
-      expect(createdReference.attributes.tag.id).toBe(createdTag.id);
+      expect(createdReference.attributes.tag.data.id).toBe(createdTag.id);
 
       const {
         body: { data: updatedReference },
@@ -683,7 +689,7 @@ describe('Create Strapi API End to End', () => {
         },
       });
 
-      expect(updatedReference.attributes.tag).toBe(null);
+      expect(updatedReference.attributes.tag.data).toBe(null);
     });
 
     test('Delete Tag so the relation in the Reference side should be removed', async () => {
@@ -730,7 +736,7 @@ describe('Create Strapi API End to End', () => {
         },
       });
 
-      expect(foundReference.attributes.tag).toBe(null);
+      expect(foundReference.attributes.tag.data).toBe(null);
     });
   });
 });

--- a/packages/core/utils/lib/parse-multipart.js
+++ b/packages/core/utils/lib/parse-multipart.js
@@ -3,6 +3,10 @@
 const _ = require('lodash');
 
 module.exports = ctx => {
+  if (!ctx.is('multipart')) {
+    return { data: ctx.request.body, files: {} };
+  }
+
   const { body = {}, files = {} } = ctx.request;
 
   if (!body.data) {

--- a/packages/plugins/i18n/server/services/core-api.js
+++ b/packages/plugins/i18n/server/services/core-api.js
@@ -9,19 +9,6 @@ const { getService } = require('../utils');
 const { getContentTypeRoutePrefix, isSingleType, getWritableAttributes } = contentTypes;
 
 /**
- * Returns a parsed request body. It handles whether the body is multipart or not
- * @param {object} ctx - Koa request context
- * @returns {{ data: { [key: string]: any }, files: { [key: string]: any } }}
- */
-const parseRequest = ctx => {
-  if (ctx.is('multipart')) {
-    return parseMultipartData(ctx);
-  } else {
-    return { data: ctx.request.body, files: {} };
-  }
-};
-
-/**
  * Returns all locales for an entry
  * @param {object} entry
  * @returns {string[]}
@@ -105,7 +92,7 @@ const createLocalizationHandler = contentType => {
    * Create localized entry from another one
    */
   const createFromBaseEntry = async (ctx, entry) => {
-    const { data, files } = parseRequest(ctx);
+    const { data, files } = parseMultipartData(ctx);
 
     const { findByCode } = getService('locales');
 


### PR DESCRIPTION

Done in this PR:

- Cleanup parse multipart to be simpler
- Transform response relations to use data & meta format
- Apply relation format to media fields
