### PR TITLE
Add GET endpoint to list API tokens

### DIFF
--- a/packages/core/admin/server/content-types/api-token.js
+++ b/packages/core/admin/server/content-types/api-token.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const constants = require('../services/constants');
+
 module.exports = {
   collectionName: 'strapi_api_tokens',
   info: {
@@ -34,10 +36,10 @@ module.exports = {
     },
     type: {
       type: 'enumeration',
-      enum: ['read-only', 'full-access'],
+      enum: Object.values(constants.API_TOKEN_TYPE),
       configurable: false,
       required: false,
-      default: 'read-only',
+      default: constants.API_TOKEN_TYPE.READ_ONLY,
     },
     accessKey: {
       type: 'string',

--- a/packages/core/admin/server/controllers/__tests__/api-token.test.js
+++ b/packages/core/admin/server/controllers/__tests__/api-token.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const createContext = require('../../../../../../test/helpers/create-context');
+const constants = require('../../services/constants');
 const apiTokenController = require('../api-token');
 
 describe('API Token Controller', () => {
@@ -8,7 +9,7 @@ describe('API Token Controller', () => {
     const body = {
       name: 'api-token_tests-name',
       description: 'api-token_tests-description',
-      type: 'read-only',
+      type: constants.API_TOKEN_TYPE.READ_ONLY,
     };
 
     test('Fails if API Token already exists', async () => {
@@ -65,13 +66,13 @@ describe('API Token Controller', () => {
         id: 1,
         name: 'api-token_tests-name',
         description: 'api-token_tests-description',
-        type: 'read-only',
+        type: constants.API_TOKEN_TYPE.READ_ONLY,
       },
       {
         id: 2,
         name: 'api-token_tests-name-2',
         description: 'api-token_tests-description-2',
-        type: 'read-only',
+        type: constants.API_TOKEN_TYPE.READ_ONLY,
       },
     ];
 

--- a/packages/core/admin/server/controllers/__tests__/api-token.test.js
+++ b/packages/core/admin/server/controllers/__tests__/api-token.test.js
@@ -58,4 +58,42 @@ describe('API Token Controller', () => {
       expect(created).toHaveBeenCalled();
     });
   });
+
+  describe('List API tokens', () => {
+    const tokens = [
+      {
+        id: 1,
+        name: 'api-token_tests-name',
+        description: 'api-token_tests-description',
+        type: 'read-only',
+      },
+      {
+        id: 2,
+        name: 'api-token_tests-name-2',
+        description: 'api-token_tests-description-2',
+        type: 'read-only',
+      },
+    ];
+
+    test('List API tokens successfully', async () => {
+      const list = jest.fn().mockResolvedValue(tokens);
+      const send = jest.fn();
+      const ctx = createContext({}, { send });
+
+      global.strapi = {
+        admin: {
+          services: {
+            'api-token': {
+              list,
+            },
+          },
+        },
+      };
+
+      await apiTokenController.list(ctx);
+
+      expect(list).toHaveBeenCalled();
+      expect(send).toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/core/admin/server/controllers/__tests__/api-token.test.js
+++ b/packages/core/admin/server/controllers/__tests__/api-token.test.js
@@ -93,7 +93,7 @@ describe('API Token Controller', () => {
       await apiTokenController.list(ctx);
 
       expect(list).toHaveBeenCalled();
-      expect(send).toHaveBeenCalled();
+      expect(send).toHaveBeenCalledWith({ data: tokens });
     });
   });
 });

--- a/packages/core/admin/server/controllers/__tests__/api-token.test.js
+++ b/packages/core/admin/server/controllers/__tests__/api-token.test.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const createContext = require('../../../../../../test/helpers/create-context');
-const constants = require('../../services/constants');
 const apiTokenController = require('../api-token');
 
 describe('API Token Controller', () => {
@@ -9,7 +8,7 @@ describe('API Token Controller', () => {
     const body = {
       name: 'api-token_tests-name',
       description: 'api-token_tests-description',
-      type: constants.API_TOKEN_TYPE.READ_ONLY,
+      type: 'read-only',
     };
 
     test('Fails if API Token already exists', async () => {
@@ -66,13 +65,13 @@ describe('API Token Controller', () => {
         id: 1,
         name: 'api-token_tests-name',
         description: 'api-token_tests-description',
-        type: constants.API_TOKEN_TYPE.READ_ONLY,
+        type: 'read-only',
       },
       {
         id: 2,
         name: 'api-token_tests-name-2',
         description: 'api-token_tests-description-2',
-        type: constants.API_TOKEN_TYPE.READ_ONLY,
+        type: 'full-access',
       },
     ];
 

--- a/packages/core/admin/server/controllers/api-token.js
+++ b/packages/core/admin/server/controllers/api-token.js
@@ -34,4 +34,11 @@ module.exports = {
     const apiToken = await apiTokenService.create(attributes);
     ctx.created({ data: apiToken });
   },
+
+  async list(ctx) {
+    const apiTokenService = getService('api-token');
+    const apiTokens = await apiTokenService.list();
+
+    ctx.send({ data: apiTokens });
+  },
 };

--- a/packages/core/admin/server/routes.js
+++ b/packages/core/admin/server/routes.js
@@ -333,4 +333,15 @@ module.exports = [
       ],
     },
   },
+  {
+    method: 'GET',
+    path: '/api-tokens',
+    handler: 'api-token.list',
+    config: {
+      policies: [
+        'admin::isAuthenticatedAdmin',
+        { name: 'admin::hasPermissions', options: { actions: ['admin::api-tokens.read'] } },
+      ],
+    },
+  },
 ];

--- a/packages/core/admin/server/services/__tests__/api-token.test.js
+++ b/packages/core/admin/server/services/__tests__/api-token.test.js
@@ -118,4 +118,39 @@ describe('API Token', () => {
       }
     });
   });
+
+  describe('list', () => {
+    const tokens = [
+      {
+        id: 1,
+        name: 'api-token_tests-name',
+        description: 'api-token_tests-description',
+        type: 'read-only',
+      },
+      {
+        id: 2,
+        name: 'api-token_tests-name-2',
+        description: 'api-token_tests-description-2',
+        type: 'read-only',
+      },
+    ];
+
+    test('It lists all the tokens', async () => {
+      const findMany = jest.fn().mockResolvedValue(tokens);
+
+      global.strapi = {
+        query() {
+          return { findMany };
+        },
+      };
+
+      const res = await apiTokenService.list();
+
+      expect(findMany).toHaveBeenCalledWith({
+        select: ['id', 'name', 'description', 'type'],
+        orderBy: { name: 'ASC' },
+      });
+      expect(res).toEqual(tokens);
+    });
+  });
 });

--- a/packages/core/admin/server/services/__tests__/api-token.test.js
+++ b/packages/core/admin/server/services/__tests__/api-token.test.js
@@ -2,6 +2,7 @@
 
 const crypto = require('crypto');
 const apiTokenService = require('../api-token');
+const constants = require('../constants');
 
 describe('API Token', () => {
   const mockedApiToken = {
@@ -35,7 +36,7 @@ describe('API Token', () => {
       const attributes = {
         name: 'api-token_tests-name',
         description: 'api-token_tests-description',
-        type: 'read-only',
+        type: constants.API_TOKEN_TYPE.READ_ONLY,
       };
 
       const res = await apiTokenService.create(attributes);
@@ -125,13 +126,13 @@ describe('API Token', () => {
         id: 1,
         name: 'api-token_tests-name',
         description: 'api-token_tests-description',
-        type: 'read-only',
+        type: constants.API_TOKEN_TYPE.READ_ONLY,
       },
       {
         id: 2,
         name: 'api-token_tests-name-2',
         description: 'api-token_tests-description-2',
-        type: 'read-only',
+        type: constants.API_TOKEN_TYPE.READ_ONLY,
       },
     ];
 

--- a/packages/core/admin/server/services/__tests__/api-token.test.js
+++ b/packages/core/admin/server/services/__tests__/api-token.test.js
@@ -2,7 +2,6 @@
 
 const crypto = require('crypto');
 const apiTokenService = require('../api-token');
-const constants = require('../constants');
 
 describe('API Token', () => {
   const mockedApiToken = {
@@ -36,7 +35,7 @@ describe('API Token', () => {
       const attributes = {
         name: 'api-token_tests-name',
         description: 'api-token_tests-description',
-        type: constants.API_TOKEN_TYPE.READ_ONLY,
+        type: 'read-only',
       };
 
       const res = await apiTokenService.create(attributes);
@@ -126,13 +125,13 @@ describe('API Token', () => {
         id: 1,
         name: 'api-token_tests-name',
         description: 'api-token_tests-description',
-        type: constants.API_TOKEN_TYPE.READ_ONLY,
+        type: 'read-only',
       },
       {
         id: 2,
         name: 'api-token_tests-name-2',
         description: 'api-token_tests-description-2',
-        type: constants.API_TOKEN_TYPE.READ_ONLY,
+        type: 'full-access',
       },
     ];
 

--- a/packages/core/admin/server/services/api-token.js
+++ b/packages/core/admin/server/services/api-token.js
@@ -81,9 +81,17 @@ const createSaltIfNotDefined = () => {
   strapi.config.set('server.admin.api-token.salt', salt);
 };
 
+/**
+ * @returns {Promise<ApiToken[]>}
+ */
+const list = async () => {
+  return strapi.query('strapi::api-token').findMany({ orderBy: { name: 'ASC' } });
+};
+
 module.exports = {
   create,
   exists,
   createSaltIfNotDefined,
   hash,
+  list,
 };

--- a/packages/core/admin/server/services/api-token.js
+++ b/packages/core/admin/server/services/api-token.js
@@ -3,13 +3,17 @@
 const crypto = require('crypto');
 
 /**
+ * @typedef {'read-only'|'full-access'} TokenType
+ */
+
+/**
  * @typedef ApiToken
  *
- * @property {number} id
+ * @property {number|string} id
  * @property {string} name
  * @property {string} [description]
  * @property {string} accessKey
- * @property {'read-only'|'full-access'} type
+ * @property {TokenType} type
  */
 
 /**
@@ -39,7 +43,7 @@ const hash = accessKey => {
 
 /**
  * @param {Object} attributes
- * @param {'read-only'|'full-access'} attributes.type
+ * @param {TokenType} attributes.type
  * @param {string} attributes.name
  * @param {string} [attributes.description]
  *
@@ -82,11 +86,11 @@ const createSaltIfNotDefined = () => {
 };
 
 /**
- * @returns {Promise<ApiToken[]>}
+ * @returns {Promise<{id: number|string, name: string, description: string, type: TokenType}>}
  */
 const list = async () => {
-  return strapi.query('strapi::api-token').findMany({
-    select: ['id', 'name', 'description', 'type', 'accessKey'],
+  return strapi.query('admin::api-token').findMany({
+    select: ['id', 'name', 'description', 'type'],
     orderBy: { name: 'ASC' },
   });
 };

--- a/packages/core/admin/server/services/api-token.js
+++ b/packages/core/admin/server/services/api-token.js
@@ -85,7 +85,10 @@ const createSaltIfNotDefined = () => {
  * @returns {Promise<ApiToken[]>}
  */
 const list = async () => {
-  return strapi.query('strapi::api-token').findMany({ orderBy: { name: 'ASC' } });
+  return strapi.query('strapi::api-token').findMany({
+    select: ['id', 'name', 'description', 'type', 'accessKey'],
+    orderBy: { name: 'ASC' },
+  });
 };
 
 module.exports = {

--- a/packages/core/admin/server/services/constants.js
+++ b/packages/core/admin/server/services/constants.js
@@ -10,4 +10,8 @@ module.exports = {
   UPDATE_ACTION: 'plugin::content-manager.explorer.update',
   DELETE_ACTION: 'plugin::content-manager.explorer.delete',
   PUBLISH_ACTION: 'plugin::content-manager.explorer.publish',
+  API_TOKEN_TYPE: {
+    READ_ONLY: 'read-only',
+    FULL_ACCESS: 'full-access',
+  },
 };

--- a/packages/core/admin/server/tests/admin-api-token.test.e2e.js
+++ b/packages/core/admin/server/tests/admin-api-token.test.e2e.js
@@ -13,6 +13,7 @@ const { createAuthRequest } = require('../../../../../test/helpers/request');
  * 3. Creates an api token (successfully)
  * 4. Creates an api token without a description (successfully)
  * 5. Creates an api token with trimmed description and name (successfully)
+ * 6. List all tokens (successfully)
  */
 
 describe('Admin API Token CRUD (e2e)', () => {
@@ -143,5 +144,32 @@ describe('Admin API Token CRUD (e2e)', () => {
       type: body.type,
       id: expect.any(Number),
     });
+  });
+
+  test('6. List all tokens (successfully)', async () => {
+    const res = await rq({
+      url: '/admin/api-tokens',
+      method: 'GET',
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.data).not.toBeNull();
+    expect(res.body.data.length).toBe(2);
+    expect(res.body.data).toStrictEqual([
+      {
+        id: expect.any(Number),
+        name: 'api-token_tests-name',
+        description: 'api-token_tests-description',
+        type: 'read-only',
+        accessKey: expect.any(String),
+      },
+      {
+        id: expect.any(Number),
+        name: 'api-token_tests-name',
+        description: '',
+        type: 'read-only',
+        accessKey: expect.any(String),
+      },
+    ]);
   });
 });

--- a/packages/core/admin/server/tests/admin-api-token.test.e2e.js
+++ b/packages/core/admin/server/tests/admin-api-token.test.e2e.js
@@ -153,22 +153,25 @@ describe('Admin API Token CRUD (e2e)', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.body.data).not.toBeNull();
-    expect(res.body.data.length).toBe(2);
+    expect(res.body.data.length).toBe(3);
     expect(res.body.data).toStrictEqual([
       {
         id: expect.any(Number),
         name: 'api-token_tests-name',
         description: 'api-token_tests-description',
         type: 'read-only',
-        accessKey: expect.any(String),
       },
       {
         id: expect.any(Number),
-        name: 'api-token_tests-name',
+        name: 'api-token_tests-name-with-spaces-at-the-end',
+        description: 'api-token_tests-description-with-spaces-at-the-end',
+        type: 'read-only',
+      },
+      {
+        id: expect.any(Number),
+        name: 'api-token_tests-name-without-description',
         description: '',
         type: 'read-only',
-        accessKey: expect.any(String),
       },
     ]);
   });

--- a/packages/core/admin/server/tests/admin-api-token.test.e2e.js
+++ b/packages/core/admin/server/tests/admin-api-token.test.e2e.js
@@ -2,7 +2,6 @@
 
 const { createStrapiInstance } = require('../../../../../test/helpers/strapi');
 const { createAuthRequest } = require('../../../../../test/helpers/request');
-const constants = require('../services/constants');
 
 /**
  * == Test Suite Overview ==
@@ -74,11 +73,7 @@ describe('Admin API Token CRUD (e2e)', () => {
       error: 'Bad Request',
       message: 'ValidationError',
       data: {
-        type: [
-          `type must be one of the following values: ${Object.values(constants.API_TOKEN_TYPE).join(
-            ', '
-          )}`,
-        ],
+        type: ['type must be one of the following values: read-only, full-access'],
       },
     });
   });
@@ -87,7 +82,7 @@ describe('Admin API Token CRUD (e2e)', () => {
     const body = {
       name: 'api-token_tests-name',
       description: 'api-token_tests-description',
-      type: constants.API_TOKEN_TYPE.READ_ONLY,
+      type: 'read-only',
     };
 
     const res = await rq({
@@ -109,7 +104,7 @@ describe('Admin API Token CRUD (e2e)', () => {
   test('4. Creates an api token without a description (successfully)', async () => {
     const body = {
       name: 'api-token_tests-name-without-description',
-      type: constants.API_TOKEN_TYPE.READ_ONLY,
+      type: 'full-access',
     };
 
     const res = await rq({
@@ -132,7 +127,7 @@ describe('Admin API Token CRUD (e2e)', () => {
     const body = {
       name: 'api-token_tests-name-with-spaces-at-the-end   ',
       description: 'api-token_tests-description-with-spaces-at-the-end   ',
-      type: constants.API_TOKEN_TYPE.READ_ONLY,
+      type: 'read-only',
     };
 
     const res = await rq({
@@ -164,19 +159,19 @@ describe('Admin API Token CRUD (e2e)', () => {
         id: expect.any(Number),
         name: 'api-token_tests-name',
         description: 'api-token_tests-description',
-        type: constants.API_TOKEN_TYPE.READ_ONLY,
+        type: 'read-only',
       },
       {
         id: expect.any(Number),
         name: 'api-token_tests-name-with-spaces-at-the-end',
         description: 'api-token_tests-description-with-spaces-at-the-end',
-        type: constants.API_TOKEN_TYPE.READ_ONLY,
+        type: 'read-only',
       },
       {
         id: expect.any(Number),
         name: 'api-token_tests-name-without-description',
         description: '',
-        type: constants.API_TOKEN_TYPE.READ_ONLY,
+        type: 'full-access',
       },
     ]);
   });

--- a/packages/core/admin/server/tests/admin-api-token.test.e2e.js
+++ b/packages/core/admin/server/tests/admin-api-token.test.e2e.js
@@ -2,6 +2,7 @@
 
 const { createStrapiInstance } = require('../../../../../test/helpers/strapi');
 const { createAuthRequest } = require('../../../../../test/helpers/request');
+const constants = require('../services/constants');
 
 /**
  * == Test Suite Overview ==
@@ -73,7 +74,11 @@ describe('Admin API Token CRUD (e2e)', () => {
       error: 'Bad Request',
       message: 'ValidationError',
       data: {
-        type: ['type must be one of the following values: read-only, full-access'],
+        type: [
+          `type must be one of the following values: ${Object.values(constants.API_TOKEN_TYPE).join(
+            ', '
+          )}`,
+        ],
       },
     });
   });
@@ -82,7 +87,7 @@ describe('Admin API Token CRUD (e2e)', () => {
     const body = {
       name: 'api-token_tests-name',
       description: 'api-token_tests-description',
-      type: 'read-only',
+      type: constants.API_TOKEN_TYPE.READ_ONLY,
     };
 
     const res = await rq({
@@ -104,7 +109,7 @@ describe('Admin API Token CRUD (e2e)', () => {
   test('4. Creates an api token without a description (successfully)', async () => {
     const body = {
       name: 'api-token_tests-name-without-description',
-      type: 'read-only',
+      type: constants.API_TOKEN_TYPE.READ_ONLY,
     };
 
     const res = await rq({
@@ -127,7 +132,7 @@ describe('Admin API Token CRUD (e2e)', () => {
     const body = {
       name: 'api-token_tests-name-with-spaces-at-the-end   ',
       description: 'api-token_tests-description-with-spaces-at-the-end   ',
-      type: 'read-only',
+      type: constants.API_TOKEN_TYPE.READ_ONLY,
     };
 
     const res = await rq({
@@ -159,19 +164,19 @@ describe('Admin API Token CRUD (e2e)', () => {
         id: expect.any(Number),
         name: 'api-token_tests-name',
         description: 'api-token_tests-description',
-        type: 'read-only',
+        type: constants.API_TOKEN_TYPE.READ_ONLY,
       },
       {
         id: expect.any(Number),
         name: 'api-token_tests-name-with-spaces-at-the-end',
         description: 'api-token_tests-description-with-spaces-at-the-end',
-        type: 'read-only',
+        type: constants.API_TOKEN_TYPE.READ_ONLY,
       },
       {
         id: expect.any(Number),
         name: 'api-token_tests-name-without-description',
         description: '',
-        type: 'read-only',
+        type: constants.API_TOKEN_TYPE.READ_ONLY,
       },
     ]);
   });

--- a/packages/core/admin/server/validation/api-tokens.js
+++ b/packages/core/admin/server/validation/api-tokens.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { yup, formatYupErrors } = require('@strapi/utils');
+const constants = require('../services/constants');
 
 const handleReject = error => Promise.reject(formatYupErrors(error));
 
@@ -14,7 +15,7 @@ const apiTokenCreationSchema = yup
     description: yup.string().optional(),
     type: yup
       .string()
-      .oneOf(['read-only', 'full-access'])
+      .oneOf(Object.values(constants.API_TOKEN_TYPE))
       .required(),
   })
   .noUnknown();


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

It adds a GET endpoints that returns all the API tokens sorted alphabetically by `ApiToken.name`.

### Why is it needed?

This will allow us to retrieve all the tokens in the admin UI.

### How to test it?

The logic is supported by both unit and e2e tests.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
