### PR TITLE
add DELETE route to revoke API tokens

### DIFF
--- a/packages/core/admin/server/controllers/__tests__/api-token.test.js
+++ b/packages/core/admin/server/controllers/__tests__/api-token.test.js
@@ -123,7 +123,7 @@ describe('API Token Controller', () => {
       await apiTokenController.revoke(ctx);
 
       expect(revoke).toHaveBeenCalledWith(token.id);
-      expect(deleted).toHaveBeenCalledWith();
+      expect(deleted).toHaveBeenCalledWith({ data: token });
     });
 
     test('Does not return an error if the ressource does not exists', async () => {
@@ -144,7 +144,7 @@ describe('API Token Controller', () => {
       await apiTokenController.revoke(ctx);
 
       expect(revoke).toHaveBeenCalledWith(token.id);
-      expect(deleted).toHaveBeenCalledWith();
+      expect(deleted).toHaveBeenCalledWith({ data: null });
     });
   });
 });

--- a/packages/core/admin/server/controllers/__tests__/api-token.test.js
+++ b/packages/core/admin/server/controllers/__tests__/api-token.test.js
@@ -96,4 +96,55 @@ describe('API Token Controller', () => {
       expect(send).toHaveBeenCalledWith({ data: tokens });
     });
   });
+
+  describe('Delete an API token', () => {
+    const token = {
+      id: 1,
+      name: 'api-token_tests-name',
+      description: 'api-token_tests-description',
+      type: 'read-only',
+    };
+
+    test('Deletes an API token successfully', async () => {
+      const revoke = jest.fn().mockResolvedValue(token);
+      const deleted = jest.fn();
+      const ctx = createContext({ params: { id: token.id } }, { deleted });
+
+      global.strapi = {
+        admin: {
+          services: {
+            'api-token': {
+              revoke,
+            },
+          },
+        },
+      };
+
+      await apiTokenController.revoke(ctx);
+
+      expect(revoke).toHaveBeenCalledWith(token.id);
+      expect(deleted).toHaveBeenCalledWith();
+    });
+
+    test('Does not return an error if the ressource does not exists', async () => {
+      const revoke = jest.fn().mockResolvedValue(null);
+      const deleted = jest.fn();
+      const ctx = createContext({ params: { id: token.id } }, { deleted });
+
+      global.strapi = {
+        admin: {
+          services: {
+            'api-token': {
+              revoke,
+            },
+          },
+        },
+      };
+
+      await apiTokenController.revoke(ctx);
+
+      expect(revoke).toHaveBeenCalledWith(token.id);
+      expect(deleted).toHaveBeenCalledWith();
+    });
+  });
 });

--- a/packages/core/admin/server/controllers/api-token.js
+++ b/packages/core/admin/server/controllers/api-token.js
@@ -41,4 +41,13 @@ module.exports = {
 
     ctx.send({ data: apiTokens });
   },
+
+  async revoke(ctx) {
+    const { id } = ctx.params;
+    const apiTokenService = getService('api-token');
+
+    await apiTokenService.revoke(id);
+
+    ctx.deleted();
+  },
 };

--- a/packages/core/admin/server/controllers/api-token.js
+++ b/packages/core/admin/server/controllers/api-token.js
@@ -45,9 +45,8 @@ module.exports = {
   async revoke(ctx) {
     const { id } = ctx.params;
     const apiTokenService = getService('api-token');
+    const apiToken = await apiTokenService.revoke(id);
 
-    await apiTokenService.revoke(id);
-
-    ctx.deleted();
+    ctx.deleted({ data: apiToken });
   },
 };

--- a/packages/core/admin/server/routes.js
+++ b/packages/core/admin/server/routes.js
@@ -344,4 +344,15 @@ module.exports = [
       ],
     },
   },
+  {
+    method: 'DELETE',
+    path: '/api-tokens/:id',
+    handler: 'api-token.revoke',
+    config: {
+      policies: [
+        'admin::isAuthenticatedAdmin',
+        { name: 'admin::hasPermissions', options: { actions: ['admin::api-tokens.delete'] } },
+      ],
+    },
+  },
 ];

--- a/packages/core/admin/server/services/__tests__/api-token.test.js
+++ b/packages/core/admin/server/services/__tests__/api-token.test.js
@@ -173,7 +173,10 @@ describe('API Token', () => {
 
       const res = await apiTokenService.revoke(token.id);
 
-      expect(mockedDelete).toHaveBeenCalledWith({ where: { id: token.id } });
+      expect(mockedDelete).toHaveBeenCalledWith({
+        select: ['id', 'name', 'description', 'type'],
+        where: { id: token.id },
+      });
       expect(res).toEqual(token);
     });
 
@@ -188,7 +191,10 @@ describe('API Token', () => {
 
       const res = await apiTokenService.revoke(42);
 
-      expect(mockedDelete).toHaveBeenCalledWith({ where: { id: 42 } });
+      expect(mockedDelete).toHaveBeenCalledWith({
+        select: ['id', 'name', 'description', 'type'],
+        where: { id: 42 },
+      });
       expect(res).toEqual(null);
     });
   });

--- a/packages/core/admin/server/services/__tests__/api-token.test.js
+++ b/packages/core/admin/server/services/__tests__/api-token.test.js
@@ -153,4 +153,43 @@ describe('API Token', () => {
       expect(res).toEqual(tokens);
     });
   });
+
+  describe('revoke', () => {
+    const token = {
+      id: 1,
+      name: 'api-token_tests-name',
+      description: 'api-token_tests-description',
+      type: 'read-only',
+    };
+
+    test('It deletes the token', async () => {
+      const mockedDelete = jest.fn().mockResolvedValue(token);
+
+      global.strapi = {
+        query() {
+          return { delete: mockedDelete };
+        },
+      };
+
+      const res = await apiTokenService.revoke(token.id);
+
+      expect(mockedDelete).toHaveBeenCalledWith({ where: { id: token.id } });
+      expect(res).toEqual(token);
+    });
+
+    test('It returns `null` if the resource does not exists', async () => {
+      const mockedDelete = jest.fn().mockResolvedValue(null);
+
+      global.strapi = {
+        query() {
+          return { delete: mockedDelete };
+        },
+      };
+
+      const res = await apiTokenService.revoke(42);
+
+      expect(mockedDelete).toHaveBeenCalledWith({ where: { id: 42 } });
+      expect(res).toEqual(null);
+    });
+  });
 });

--- a/packages/core/admin/server/services/__tests__/api-token.test.js
+++ b/packages/core/admin/server/services/__tests__/api-token.test.js
@@ -180,7 +180,7 @@ describe('API Token', () => {
       expect(res).toEqual(token);
     });
 
-    test('It returns `null` if the resource does not exists', async () => {
+    test('It returns `null` if the resource does not exist', async () => {
       const mockedDelete = jest.fn().mockResolvedValue(null);
 
       global.strapi = {

--- a/packages/core/admin/server/services/api-token.js
+++ b/packages/core/admin/server/services/api-token.js
@@ -16,6 +16,9 @@ const crypto = require('crypto');
  * @property {TokenType} type
  */
 
+/** @constant {Array<string>} */
+const SELECT_FIELDS = ['id', 'name', 'description', 'type'];
+
 /**
  * @param {Object} whereParams
  * @param {string} whereParams.name
@@ -53,7 +56,7 @@ const create = async attributes => {
   const accessKey = crypto.randomBytes(128).toString('hex');
 
   const apiToken = await strapi.query('admin::api-token').create({
-    select: ['id', 'name', 'description', 'type'],
+    select: SELECT_FIELDS,
     data: {
       ...attributes,
       accessKey: hash(accessKey),
@@ -86,11 +89,11 @@ const createSaltIfNotDefined = () => {
 };
 
 /**
- * @returns {Promise<{id: number|string, name: string, description: string, type: TokenType}>}
+ * @returns {Promise<Omit<ApiToken, 'accessKey'>>}
  */
 const list = async () => {
   return strapi.query('admin::api-token').findMany({
-    select: ['id', 'name', 'description', 'type'],
+    select: SELECT_FIELDS,
     orderBy: { name: 'ASC' },
   });
 };
@@ -98,10 +101,10 @@ const list = async () => {
 /**
  * @param {string|number} id
  *
- * @returns {Promise<void>}
+ * @returns {Promise<Omit<ApiToken, 'accessKey'>>}
  */
 const revoke = async id => {
-  return strapi.query('admin::api-token').delete({ where: { id } });
+  return strapi.query('admin::api-token').delete({ select: SELECT_FIELDS, where: { id } });
 };
 
 module.exports = {

--- a/packages/core/admin/server/services/api-token.js
+++ b/packages/core/admin/server/services/api-token.js
@@ -95,10 +95,20 @@ const list = async () => {
   });
 };
 
+/**
+ * @param {string|number} id
+ *
+ * @returns {Promise<void>}
+ */
+const revoke = async id => {
+  return strapi.query('admin::api-token').delete({ where: { id } });
+};
+
 module.exports = {
   create,
   exists,
   createSaltIfNotDefined,
   hash,
   list,
+  revoke,
 };

--- a/packages/core/admin/server/tests/admin-api-token.test.e2e.js
+++ b/packages/core/admin/server/tests/admin-api-token.test.e2e.js
@@ -92,7 +92,7 @@ describe('Admin API Token CRUD (e2e)', () => {
     });
 
     expect(res.statusCode).toBe(201);
-    expect(res.body.data).toMatchObject({
+    expect(res.body.data).toStrictEqual({
       accessKey: expect.any(String),
       name: body.name,
       description: body.description,
@@ -114,7 +114,7 @@ describe('Admin API Token CRUD (e2e)', () => {
     });
 
     expect(res.statusCode).toBe(201);
-    expect(res.body.data).toMatchObject({
+    expect(res.body.data).toStrictEqual({
       accessKey: expect.any(String),
       name: body.name,
       description: '',
@@ -137,7 +137,7 @@ describe('Admin API Token CRUD (e2e)', () => {
     });
 
     expect(res.statusCode).toBe(201);
-    expect(res.body.data).toMatchObject({
+    expect(res.body.data).toStrictEqual({
       accessKey: expect.any(String),
       name: 'api-token_tests-name-with-spaces-at-the-end',
       description: 'api-token_tests-description-with-spaces-at-the-end',
@@ -182,8 +182,13 @@ describe('Admin API Token CRUD (e2e)', () => {
       method: 'DELETE',
     });
 
-    expect(res.statusCode).toBe(204);
-    expect(res.body.data).toBeUndefined();
+    expect(res.statusCode).toBe(200);
+    expect(res.body.data).toStrictEqual({
+      name: 'api-token_tests-name-with-spaces-at-the-end',
+      description: 'api-token_tests-description-with-spaces-at-the-end',
+      type: 'read-only',
+      id: 3,
+    });
   });
 
   test('8. Does not return an error if the ressource does not exists', async () => {
@@ -192,7 +197,7 @@ describe('Admin API Token CRUD (e2e)', () => {
       method: 'DELETE',
     });
 
-    expect(res.statusCode).toBe(204);
-    expect(res.body.data).toBeUndefined();
+    expect(res.statusCode).toBe(200);
+    expect(res.body.data).toBeNull();
   });
 });

--- a/packages/core/admin/server/tests/admin-api-token.test.e2e.js
+++ b/packages/core/admin/server/tests/admin-api-token.test.e2e.js
@@ -175,4 +175,24 @@ describe('Admin API Token CRUD (e2e)', () => {
       },
     ]);
   });
+
+  test('7. Deletes a token (successfully)', async () => {
+    const res = await rq({
+      url: '/admin/api-tokens/3',
+      method: 'DELETE',
+    });
+
+    expect(res.statusCode).toBe(204);
+    expect(res.body.data).toBeUndefined();
+  });
+
+  test('8. Does not return an error if the ressource does not exists', async () => {
+    const res = await rq({
+      url: '/admin/api-tokens/42',
+      method: 'DELETE',
+    });
+
+    expect(res.statusCode).toBe(204);
+    expect(res.body.data).toBeUndefined();
+  });
 });

--- a/packages/core/admin/server/tests/admin-api-token.test.e2e.js
+++ b/packages/core/admin/server/tests/admin-api-token.test.e2e.js
@@ -14,6 +14,8 @@ const { createAuthRequest } = require('../../../../../test/helpers/request');
  * 4. Creates an api token without a description (successfully)
  * 5. Creates an api token with trimmed description and name (successfully)
  * 6. List all tokens (successfully)
+ * 7. Deletes a token (successfully)
+ * 8. Does not return an error if the ressource does not exist
  */
 
 describe('Admin API Token CRUD (e2e)', () => {
@@ -191,7 +193,7 @@ describe('Admin API Token CRUD (e2e)', () => {
     });
   });
 
-  test('8. Does not return an error if the ressource does not exists', async () => {
+  test('8. Does not return an error if the ressource does not exist', async () => {
     const res = await rq({
       url: '/admin/api-tokens/42',
       method: 'DELETE',


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

It adds an endpoint to revoke (delete) an api token.

### Why is it needed?

This will allow users to revoke tokens that shouldn't be used anymore (ie. for security reason).

### How to test it?

The endpoint is supported by unit and e2e tests.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
