### PR TITLE
better support for federation, especially when not using ShadowCRUD

### DIFF
--- a/packages/strapi-plugin-graphql/services/schema-generator.js
+++ b/packages/strapi-plugin-graphql/services/schema-generator.js
@@ -40,7 +40,7 @@ const generateSchema = () => {
   const { definition, query, mutation, resolver = {} } = _schema;
 
   // Polymorphic.
-  const polymorphicSchema = Types.addPolymorphicUnionType(definition + shadowCRUD.definition);
+  const polymorphicSchema = Types.addPolymorphicUnionType(definition + shadowCRUD.definition, isFederated);
 
   const builtResolvers = _.merge({}, shadowCRUD.resolvers, polymorphicSchema.resolvers);
 
@@ -98,7 +98,7 @@ const generateSchema = () => {
     `;
 
   // Build schema.
-  const schema = makeExecutableSchema({
+  const schema = isFederated ? buildFederatedSchema({ typeDefs: gql(typeDefs), resolvers }) : makeExecutableSchema({
     typeDefs,
     resolvers,
   });
@@ -109,7 +109,7 @@ const generateSchema = () => {
     writeGenerateSchema(generatedSchema);
   }
 
-  return isFederated ? getFederatedSchema(generatedSchema, resolvers) : generatedSchema;
+  return generatedSchema
 };
 
 const getFederatedSchema = (schema, resolvers) =>

--- a/packages/strapi-plugin-graphql/services/type-builder.js
+++ b/packages/strapi-plugin-graphql/services/type-builder.js
@@ -183,7 +183,26 @@ module.exports = {
    * @return string
    */
 
-  addPolymorphicUnionType(definition) {
+  addPolymorphicUnionType(definition, isFederated) {
+
+    // if the declarations contain federated decorators, we need these to keep `graphql.parse(...)` happy
+    if( isFederated ){
+      definition = `
+        scalar _FieldSet
+        directive @extends on OBJECT | INTERFACE
+
+        directive @external on FIELD_DEFINITION
+
+        directive @key(fields: _FieldSet!) repeatable on OBJECT | INTERFACE
+
+        directive @provides(fields: _FieldSet!) on FIELD_DEFINITION
+
+        directive @requires(fields: _FieldSet!) on FIELD_DEFINITION
+
+        ${definition}
+      `
+    }
+
     const types = graphql
       .parse(definition)
       .definitions.filter(def => def.kind === 'ObjectTypeDefinition' && def.name.value !== 'Query')


### PR DESCRIPTION
### What does it do?

Changed how GQL Schemas are generated with Federation, and created a mechanism to filter the schemas composed by the autoloading mechanism.

### Why is it needed?

See https://github.com/strapi/strapi/issues/10862  but essentially it's pretty hard to get a decent federated Strapi instance out of the box. 

### How to test it?


1. Create a new project: npx create-strapi-app my-project --quickstart
2. Add GraphQL: npx strapi install graphql
3. Enable GQL Federation and disable Shadow CRUD in config/plugins.js


### Related issue(s)/PR(s)

* See https://github.com/strapi/strapi/issues/10862  
