### PR TITLE
Bump tar version and nested depend for tar

### DIFF
--- a/packages/strapi-generate-new/lib/utils/db-client-dependencies.js
+++ b/packages/strapi-generate-new/lib/utils/db-client-dependencies.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const sqlClientModule = {
-  sqlite: { sqlite3: '5.0.0' },
+  sqlite: { sqlite3: '5.0.2' },
   postgres: { pg: '8.5.1' },
   mysql: { mysql: '2.18.1' },
 };

--- a/packages/strapi-generate-new/package.json
+++ b/packages/strapi-generate-new/package.json
@@ -23,7 +23,7 @@
     "node-fetch": "^2.6.1",
     "node-machine-id": "^1.1.10",
     "ora": "^5.4.0",
-    "tar": "6.1.9",
+    "tar": "6.1.11",
     "uuid": "^3.3.2"
   },
   "scripts": {


### PR DESCRIPTION
Signed-off-by: Derrick Mehaffy <derrickmehaffy@gmail.com>

### What does it do?

- Minor version bump to `tar` package in `strapi-generate-new` just in case
- Bump `sqlite3` due to nested depends to tar (sqlite3 => node-gyp => tar // and sqlite3 => node-pre-gyp => node-gyp => tar)

### Why is it needed?

https://github.blog/2021-09-08-github-security-update-vulnerabilities-tar-npmcli-arborist/

### How to test it?

Start new project and run `yarn audit`

### Related issue(s)/PR(s)

N/A
