### PR TITLE
Add timestamps to the Admin User model by default

### DIFF
--- a/packages/strapi-admin/models/User.settings.json
+++ b/packages/strapi-admin/models/User.settings.json
@@ -4,6 +4,9 @@
     "name": "User",
     "description": ""
   },
+  "options": {
+    "timestamps": true
+  },
   "pluginOptions": {
     "content-manager": {
       "visible": false


### PR DESCRIPTION
### What does it do?

Adds the default `created_at` and `updated_at` to the admin user model.

### Why is it needed?

Honestly I have no idea why we never had it to begin with, makes it much easier to do automated tasks on admin users via cronjobs like setting registration codes to expire on a cronjob. See: https://forum.strapi.io/t/how-to-make-the-registration-link-expire/11260/3

### How to test it?

Spin up a project and check that the fields exist with data when you register a user

### Related issue(s)/PR(s)

https://forum.strapi.io/t/how-to-make-the-registration-link-expire/11260
