### PR TITLE
[v4] Add timestamps to the Admin User model by default

### DIFF
--- a/packages/core/admin/server/content-types/User.js
+++ b/packages/core/admin/server/content-types/User.js
@@ -13,6 +13,9 @@ module.exports = {
     pluralName: 'users',
     displayName: 'User',
   },
+  options: {
+    timestamps: true,
+  },
   pluginOptions: {
     'content-manager': {
       visible: false,


### PR DESCRIPTION
### What does it do?

Same thing as linked PR but for v4

### Why is it needed?

Same thing as linked PR

### How to test it?

Same thing as linked PR

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/pull/10937
