### PR TITLE
Format Sentry plugin name in kebab-case

### DIFF
--- a/packages/plugins/sentry/package.json
+++ b/packages/plugins/sentry/package.json
@@ -4,6 +4,7 @@
   "description": "Send Strapi error events to Sentry",
   "strapi": {
     "name": "sentry",
+    "displayName": "Sentry",
     "icon": "plug",
     "description": "sentry.plugin.description",
     "kind": "plugin"

--- a/packages/plugins/sentry/package.json
+++ b/packages/plugins/sentry/package.json
@@ -3,7 +3,7 @@
   "version": "3.6.8",
   "description": "Send Strapi error events to Sentry",
   "strapi": {
-    "name": "Sentry",
+    "name": "sentry",
     "icon": "plug",
     "description": "sentry.plugin.description",
     "kind": "plugin"


### PR DESCRIPTION
### What does it do?

Reformat @strapi/plugin-sentry name

### Why is it needed?

To avoid this error in the v4:

>Plugin name "Sentry" is not in kebab (an-example-of-kebab-case)

