### PR TITLE
Sharp output options per format

### DIFF
--- a/packages/strapi-plugin-upload/services/image-manipulation.js
+++ b/packages/strapi-plugin-upload/services/image-manipulation.js
@@ -24,16 +24,16 @@ const THUMBNAIL_RESIZE_OPTIONS = {
 
 const DEFAULT_FORMAT_OPTIONS = {
   jpeg: {
-    quality: 85,
+    quality: 80,
   },
   png: {
     quality: 100,
   },
   tiff: {
-    quality: 85,
+    quality: 80,
   },
   webp: {
-    quality: 85,
+    quality: 80,
   },
 };
 

--- a/packages/strapi-plugin-upload/services/image-manipulation.js
+++ b/packages/strapi-plugin-upload/services/image-manipulation.js
@@ -24,33 +24,36 @@ const THUMBNAIL_RESIZE_OPTIONS = {
 
 const DEFAULT_FORMAT_OPTIONS = {
   jpeg: {
-    quality: 85
+    quality: 85,
   },
   png: {
-    quality: 100
+    quality: 100,
   },
   tiff: {
-    quality: 85
+    quality: 85,
   },
   webp: {
-    quality: 85
-  }
+    quality: 85,
+  },
 };
 
-const getFormatOptions = () => strapi.config.get('plugins.upload.formatOptions', DEFAULT_FORMAT_OPTIONS);
+const getFormatOptions = () =>
+  strapi.config.get('plugins.upload.formatOptions', DEFAULT_FORMAT_OPTIONS);
 
 const resizeTo = (buffer, options) => {
-  const sharpInstance = sharp(buffer).withMetadata().resize(options);
+  const sharpInstance = sharp(buffer)
+    .withMetadata()
+    .resize(options);
   const { format } = options;
 
   if (formatsToProccess.includes(format)) {
     const formatOptions = getFormatOptions();
 
-    sharpInstance[format](formatOptions[format])
+    sharpInstance[format](formatOptions[format]);
   }
-    
-  return sharpInstance.toBuffer().catch(() => null);;
-}
+
+  return sharpInstance.toBuffer().catch(() => null);
+};
 
 const generateThumbnail = async file => {
   if (!(await canBeProccessed(file.buffer))) {
@@ -149,7 +152,7 @@ const generateBreakpoint = async (key, { file, breakpoint }) => {
     width: breakpoint,
     height: breakpoint,
     fit: 'inside',
-    format: file.mime.split('/')[1]
+    format: file.mime.split('/')[1],
   });
 
   if (newBuff) {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

This PR allows the user to configure the [output options](https://sharp.pixelplumbing.com/api-output#jpeg) for the [image formats](https://github.com/strapi/strapi/blob/d91569c3b6061e51116db367fc25fc6a2881ee04/packages/strapi-plugin-upload/services/image-manipulation.js#L155) Strapi processes with Sharp. I followed a similar approach to the [breakpoints config](https://strapi.io/documentation/developer-docs/latest/development/plugins/upload.html#responsive-images).

#### A sample `config/plugins.js`

```
module.exports = {
  upload: {
    formatOptions: {
      jpeg: {
        chromaSubsampling: '4:4:4',
        progressive: true,
        quality: 90
      },
      png: {
        compressionLevel: 7,
        quality: 100
      },
      tiff: {
        compression: 'jpeg',
        quality: 90
      },
      webp: {
        quality: 90,
        smartSubsample: true
      }
    }
  }
};
```

### Why is it needed?

I was just unhappy with the default quality option Sharp uses for JPGs. I believe it's 80. This PR allows users to define which settings to use, otherwise it uses defaults.

### How to test it?

Follow the sample config above and upload some images.
