### PR TITLE
Deep Filtering for JSON using contains

### DIFF
--- a/packages/strapi-utils/lib/build-query.js
+++ b/packages/strapi-utils/lib/build-query.js
@@ -21,7 +21,7 @@ const getAssociationFromFieldKey = ({ model, field }) => {
   let association;
   let attribute;
 
-  for (let i = 0; i < fieldParts.length; i++) {
+  for (let i = 1; i < fieldParts.length; i++) {
     const part = fieldParts[i];
     attribute = part;
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

![image](https://user-images.githubusercontent.com/38387413/134371852-172302c0-f717-485f-89ff-c9a275053a9b.png)

This for loop should executes only if the **fieldParts** having length greater than 1. We need to initialize the i = 1, so only
the field has **Association** which means **association is possible only if the fieldParts length greater than 1.**

### Why is it needed?

It will solve the issue for quering Json fields using contains other than relations

![image](https://user-images.githubusercontent.com/38387413/134373572-4c8ab98c-90a5-47fc-a3d7-307ed944711c.png)


### Related issue(s)/PR(s)

https://github.com/strapi/strapi/issues/4343

Let us know if this is related to any issue/pull request
