### PR TITLE
Upgrade Sentry package version to latest

### DIFF
--- a/packages/strapi-plugin-sentry/package.json
+++ b/packages/strapi-plugin-sentry/package.json
@@ -8,7 +8,7 @@
     "description": "sentry.plugin.description"
   },
   "dependencies": {
-    "@sentry/node": "6.7.1"
+    "@sentry/node": "6.13.3"
   },
   "author": {
     "name": "Strapi team",


### PR DESCRIPTION
Minor upgrade of the Sentry plugin to use the latest npm release