### PR TITLE
Fix Rbac icon alignement

### DIFF
--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/ContentTypeCollapse/Collapse/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/ContentTypeCollapse/Collapse/index.js
@@ -26,7 +26,7 @@ const activeRowStyle = (theme, isActive) => `
     border-radius: ${isActive ? '2px 2px 0 0' : '2px'};
   }
   ${Chevron} {
-    display: block;
+    display: flex;
   }
   ${ConditionsButton} {
     display: block;


### PR DESCRIPTION
The caret was not aligned with the center of the row

Now =>

<img width="1920" alt="Screenshot 2021-09-27 at 16 16 55 (2)" src="https://user-images.githubusercontent.com/3874873/134926880-079bdabd-26de-42c0-a43c-68f1ae3c5ab8.png">

