### PR TITLE
MigrationQA / Action Layout overflow

### DIFF
--- a/packages/core/admin/admin/src/content-manager/pages/ListView/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/ListView/index.js
@@ -22,7 +22,6 @@ import { Main } from '@strapi/parts/Main';
 import { ActionLayout, ContentLayout, HeaderLayout } from '@strapi/parts/Layout';
 import { useNotifyAT } from '@strapi/parts/LiveRegions';
 import { Button } from '@strapi/parts/Button';
-import { Row } from '@strapi/parts/Row';
 import Add from '@strapi/icons/Add';
 import axios from 'axios';
 import { axiosInstance } from '../../../core/utils';
@@ -268,10 +267,10 @@ function ListView({
       {canRead && (isSearchable || isFilterable) && (
         <ActionLayout
           endActions={
-            <Row style={{ flexShrink: 0 }}>
+            <>
               <InjectionZone area="contentManager.listView.actions" />
               <FieldPicker layout={layout} />
-            </Row>
+            </>
           }
           startActions={
             <>


### PR DESCRIPTION
## What

Fixed action layout overflowing because of flex-skrink 0
=> Inputs now skrink inside end actions : will be fixed with a PR coming from parts

## Demo

<img width="1091" alt="Capture d’écran 2021-09-27 à 18 27 14" src="https://user-images.githubusercontent.com/71838159/134948265-024c75f4-8785-44c0-b658-1b7b88c19e3f.png">


