### PR TITLE
Attempt to fix plugin loading on v4

### DIFF
--- a/packages/core/admin/index.js
+++ b/packages/core/admin/index.js
@@ -95,10 +95,11 @@ async function createPluginsJs(plugins, dest) {
 
     /**
      * path.join, on windows, it uses backslashes to resolve path.
-     * The problem is that JavaScript does not resolve the path as windows.
-     * In JavaScript, we need to rely on "/" and not "\".
-     * This is the reason why '..\\..\\..\\node_modules\\@strapi\\plugin-content-type-builder/strapi-admin.js' was not working in javascript.
-     * The regexp at line 105 aims to replace the windows backslashes by standard slash so that javascript can deal with them.
+     * The problem is that Webpack does not windows paths
+     * With this tool, we need to rely on "/" and not "\".
+     * This is the reason why '..\\..\\..\\node_modules\\@strapi\\plugin-content-type-builder/strapi-admin.js' was not working.
+     * The regexp at line 105 aims to replace the windows backslashes by standard slash so that webpack can deal with them.
+     * Backslash looks to work only for absolute paths with webpack => https://webpack.js.org/concepts/module-resolution/#absolute-paths
      */
     const realPath = path
       .join(path.relative(path.resolve(dest, 'admin', 'src'), pathToPlugin), 'strapi-admin.js')

--- a/packages/core/admin/index.js
+++ b/packages/core/admin/index.js
@@ -101,7 +101,7 @@ async function createPluginsJs(plugins, dest) {
      * The regexp at line 105 aims to replace the windows backslashes by standard slash so that javascript can deal with them.
      */
     const realPath = path
-      .join(path.relative(path.resolve(dest, 'admin/src'), pathToPlugin), 'strapi-admin.js')
+      .join(path.relative(path.resolve(dest, 'admin', 'src'), pathToPlugin), 'strapi-admin.js')
       .replace(/\\/g, '/');
 
     return {


### PR DESCRIPTION
### What does it do?

- Allows to build the admin using the V4

### Why is it needed?

🙄 

### How to test it?

It's quite hard actually. One way is to checkout this PR and run `yarn build` inside the example folder. The other way is a bit complex but is the most realistic way:

- `npx create-strapi-app@beta beta --quickstart`
- Inside a code editor, go to the `node_modules\@strapi\admin\index.js` file and modify the line 99 with the following (it's the code suggested in this PR):

```javascript
const realPath = path
      .join(path.relative(path.resolve(dest, 'admin/src'), pathToPlugin), 'strapi-admin.js')
      .replace(/\\/g, '/');
```
and to modify the line 117 of the same file and put ` const req = `'${pathToPlugin}'`;` instead (removing `/strapi-admin.js`)

### Related issue(s)/PR(s)

There are multiples, or too many 😬 
