### PR TITLE
Fix core-store set default value

### DIFF
--- a/packages/strapi/lib/services/core-store.js
+++ b/packages/strapi/lib/services/core-store.js
@@ -78,7 +78,7 @@ const createCoreStore = ({ environment: defaultEnv, db }) => {
     }
 
     async function set(params = {}) {
-      const { key, value, environment = defaultEnv, type, name, tag = '' } = Object.assign(
+      const { key, value, environment = defaultEnv, type = 'core', name = '', tag = '' } = Object.assign(
         {},
         source,
         params


### PR DESCRIPTION
Fixed an issue, where core-store's set function had no default values. Further explanation can be found in the issue.

https://github.com/strapi/strapi/issues/11159