### PR TITLE
#9512 Fix API access return 403 instead 401

### DIFF
--- a/packages/strapi-plugin-users-permissions/config/policies/permissions.js
+++ b/packages/strapi-plugin-users-permissions/config/policies/permissions.js
@@ -10,7 +10,7 @@ module.exports = async (ctx, next) => {
     return next();
   }
 
-  if (ctx.request && ctx.request.header && ctx.request.header.authorization) {
+  if (ctx.request && ctx.request.header && isAuthorized(ctx)) {
     try {
       const { id } = await strapi.plugins['users-permissions'].services.jwt.getToken(ctx);
 
@@ -86,6 +86,14 @@ module.exports = async (ctx, next) => {
 
   // Execute the action.
   await next();
+};
+
+const isAuthorized = ctx => {
+  if (!ctx.request.header.authorization) {
+    return handleErrors(ctx, undefined, 'unauthorized');
+  }
+
+  return ctx.request.header.authorization;
 };
 
 const handleErrors = (ctx, err = undefined, type) => {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Capture error 401 instead of 403 if API access is unauthorized.

### Why is it needed?

API access while unauthorized should return 401, but instead returns 403. 

### How to test it?

making an API call to a private route without providing a correct header authorization.

### Related issue(s)/PR(s)

Related issue: API access while unauthorized should return 401, but instead returns 403. #9512
