### PR TITLE
MigrationQA/ Headers alignment

### DIFF
--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Webhooks/EditView/components/HeadersInput/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Webhooks/EditView/components/HeadersInput/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import styled from 'styled-components';
 import { RemoveRoundedButton } from '@strapi/helper-plugin';
 import AddIcon from '@strapi/icons/AddIcon';
 import { Box } from '@strapi/parts/Box';
@@ -10,6 +11,10 @@ import { TextInput } from '@strapi/parts/TextInput';
 import { TextButton } from '@strapi/parts/TextButton';
 import { Field, FieldArray, useFormikContext } from 'formik';
 import { useIntl } from 'react-intl';
+
+const RemoveButtonContainer = styled(Box)`
+  transform: translateY(50%);
+`;
 
 const HeadersInput = () => {
   const { formatMessage } = useIntl();
@@ -70,7 +75,7 @@ const HeadersInput = () => {
                           }
                         />
                       </Box>
-                      <Box paddingLeft={2}>
+                      <RemoveButtonContainer paddingLeft={2}>
                         <RemoveRoundedButton
                           onClick={() => values.headers.length !== 1 && remove(i)}
                           label={formatMessage(
@@ -81,7 +86,7 @@ const HeadersInput = () => {
                             { number: i + 1 }
                           )}
                         />
-                      </Box>
+                      </RemoveButtonContainer>
                     </Row>
                   </GridItem>
                 </React.Fragment>


### PR DESCRIPTION
## What

Fixed alignment between webhooks input headers and remove webhook button
Align-items center doesn't help since input height = input + label

## Screenshot

<img width="975" alt="Capture d’écran 2021-10-05 à 18 02 25" src="https://user-images.githubusercontent.com/71838159/136061293-b38f37b6-b769-4a89-899e-f6386f8e3be8.png">


