### PR TITLE
Add cropping asset to ML v4

### DIFF
--- a/packages/core/upload/admin/src/components/AssetCard/ImageAssetCard.js
+++ b/packages/core/upload/admin/src/components/AssetCard/ImageAssetCard.js
@@ -35,6 +35,11 @@ export const ImageAssetCard = ({
 }) => {
   const { formatMessage } = useIntl();
 
+  // Prevents the browser from caching the URL for all sizes and allow react-query to make a smooth update
+  // instead of a full refresh
+  const optimizedCachingThumbnail =
+    width && height ? `${thumbnail}?width=${width}&height=${height}` : thumbnail;
+
   return (
     <Card>
       <CardHeader>
@@ -48,7 +53,7 @@ export const ImageAssetCard = ({
             />
           </CardAction>
         )}
-        <CardAsset src={thumbnail} size={size} />
+        <CardAsset src={optimizedCachingThumbnail} size={size} />
       </CardHeader>
       <CardBody>
         <CardContent>

--- a/packages/core/upload/admin/src/components/AssetCard/UploadingAssetCard.js
+++ b/packages/core/upload/admin/src/components/AssetCard/UploadingAssetCard.js
@@ -10,47 +10,21 @@ import {
   CardSubtitle,
   CardBadge,
 } from '@strapi/parts/Card';
-import CloseAlertIcon from '@strapi/icons/CloseAlertIcon';
 import { Text } from '@strapi/parts/Text';
-import { Box } from '@strapi/parts/Box';
-import { Row } from '@strapi/parts/Row';
 import { Stack } from '@strapi/parts/Stack';
-import { ProgressBar } from '@strapi/parts/ProgressBar';
 import { useIntl } from 'react-intl';
 import { getTrad } from '../../utils';
 import { AssetType } from '../../constants';
 import { useUpload } from '../../hooks/useUpload';
+import { UploadProgress } from '../UploadProgress';
+
+const UploadProgressWrapper = styled.div`
+  height: ${88 / 16}rem;
+  width: 100%;
+`;
 
 const Extension = styled.span`
   text-transform: uppercase;
-`;
-
-const BoxWrapper = styled(Row)`
-  height: 88px;
-  width: 100%;
-  flex-direction: column;
-
-  svg {
-    path {
-      fill: ${({ theme, error }) => (error ? theme.colors.danger600 : undefined)};
-    }
-  }
-`;
-
-const CancelButton = styled.button`
-  border: none;
-  background: none;
-  display: flex;
-  align-items: center;
-
-  svg {
-    path {
-      fill: ${({ theme }) => theme.colors.neutral200};
-    }
-
-    height: 10px;
-    width: 10px;
-  }
 `;
 
 export const UploadingAssetCard = ({
@@ -101,36 +75,9 @@ export const UploadingAssetCard = ({
     <Stack size={1}>
       <Card borderColor={error ? 'danger600' : undefined}>
         <CardHeader>
-          <BoxWrapper
-            background={error ? 'danger100' : 'neutral700'}
-            justifyContent="center"
-            error={error}
-            hasRadius
-          >
-            {error ? (
-              <CloseAlertIcon aria-hidden />
-            ) : (
-              <>
-                <Box paddingBottom={2}>
-                  <ProgressBar value={progress} size="S">
-                    {`${progress}/100%`}
-                  </ProgressBar>
-                </Box>
-
-                <CancelButton type="button" onClick={handleCancel}>
-                  <Text small as="span" textColor="neutral200">
-                    {formatMessage({
-                      id: 'app.components.Button.cancel',
-                      defaultMessage: 'Cancel',
-                    })}
-                  </Text>
-                  <Box as="span" paddingLeft={2} aria-hidden>
-                    <CloseAlertIcon />
-                  </Box>
-                </CancelButton>
-              </>
-            )}
-          </BoxWrapper>
+          <UploadProgressWrapper>
+            <UploadProgress error={error} onCancel={handleCancel} progress={progress} />
+          </UploadProgressWrapper>
         </CardHeader>
         <CardBody>
           <CardContent>

--- a/packages/core/upload/admin/src/components/AssetCard/tests/ImageAssetCard.test.js
+++ b/packages/core/upload/admin/src/components/AssetCard/tests/ImageAssetCard.test.js
@@ -406,7 +406,7 @@ describe('ImageAssetCard', () => {
               <img
                 aria-hidden="true"
                 class="c9"
-                src="http://somewhere.com/hello.png"
+                src="http://somewhere.com/hello.png?width=40&height=40"
               />
             </div>
           </div>

--- a/packages/core/upload/admin/src/components/EditAssetDialog/PreviewBox/CopyLinkButton.js
+++ b/packages/core/upload/admin/src/components/EditAssetDialog/PreviewBox/CopyLinkButton.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useIntl } from 'react-intl';
+import { IconButton } from '@strapi/parts/IconButton';
+import { CopyToClipboard } from 'react-copy-to-clipboard';
+import { useNotification } from '@strapi/helper-plugin';
+import LinkIcon from '@strapi/icons/LinkIcon';
+import getTrad from '../../../utils/getTrad';
+
+export const CopyLinkButton = ({ url }) => {
+  const toggleNotification = useNotification();
+  const { formatMessage } = useIntl();
+
+  return (
+    <CopyToClipboard
+      text={url}
+      onCopy={() => {
+        toggleNotification({
+          type: 'success',
+          message: {
+            id: 'notification.link-copied',
+            defaultMessage: 'Link copied into the clipboard',
+          },
+        });
+      }}
+    >
+      <IconButton
+        label={formatMessage({
+          id: getTrad('control-card.copy-link'),
+          defaultMessage: 'Copy link',
+        })}
+        icon={<LinkIcon />}
+      />
+    </CopyToClipboard>
+  );
+};
+
+CopyLinkButton.propTypes = {
+  url: PropTypes.string.isRequired,
+};

--- a/packages/core/upload/admin/src/components/EditAssetDialog/PreviewBox/CroppingActions.js
+++ b/packages/core/upload/admin/src/components/EditAssetDialog/PreviewBox/CroppingActions.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { IconButton } from '@strapi/parts/IconButton';
+import { FocusTrap } from '@strapi/parts/FocusTrap';
+import CloseAlertIcon from '@strapi/icons/CloseAlertIcon';
+import CheckIcon from '@strapi/icons/CheckIcon';
+import { Stack } from '@strapi/parts/Stack';
+import { useIntl } from 'react-intl';
+import getTrad from '../../../utils/getTrad';
+import { CroppingActionRow } from './components';
+
+export const CroppingActions = ({ onCancel, onValidate }) => {
+  const { formatMessage } = useIntl();
+
+  return (
+    <FocusTrap onEscape={onCancel}>
+      <CroppingActionRow justifyContent="flex-end" paddingLeft={3} paddingRight={3}>
+        <Stack size={1} horizontal>
+          <IconButton
+            label={formatMessage({
+              id: getTrad('control-card.stop-crop'),
+              defaultMessage: 'Stop cropping',
+            })}
+            icon={<CloseAlertIcon />}
+            onClick={onCancel}
+          />
+
+          <IconButton
+            label={formatMessage({
+              id: getTrad('control-card.crop'),
+              defaultMessage: 'Crop',
+            })}
+            icon={<CheckIcon />}
+            onClick={onValidate}
+          />
+        </Stack>
+      </CroppingActionRow>
+    </FocusTrap>
+  );
+};
+
+CroppingActions.propTypes = {
+  onCancel: PropTypes.func.isRequired,
+  onValidate: PropTypes.func.isRequired,
+};

--- a/packages/core/upload/admin/src/components/EditAssetDialog/PreviewBox/components.js
+++ b/packages/core/upload/admin/src/components/EditAssetDialog/PreviewBox/components.js
@@ -1,0 +1,47 @@
+import styled from 'styled-components';
+import { Box } from '@strapi/parts/Box';
+import { Row } from '@strapi/parts/Row';
+import { Badge } from '@strapi/parts/Badge';
+
+export const RelativeBox = styled(Box)`
+  position: relative;
+`;
+
+export const Wrapper = styled.div`
+  position: relative;
+
+  img {
+    margin: 0;
+    padding: 0;
+    max-height: 100%;
+    max-width: 100%;
+  }
+`;
+
+export const ActionRow = styled(Row)`
+  height: ${52 / 16}rem;
+  background-color: ${({ blurry }) => (blurry ? `rgba(33, 33, 52, 0.4)` : undefined)};
+`;
+
+export const CroppingActionRow = styled(Row)`
+  z-index: 1;
+  height: ${52 / 16}rem;
+  position: absolute;
+  background-color: rgba(33, 33, 52, 0.4);
+  width: 100%;
+`;
+
+// TODO: fix in parts, this shouldn't happen
+export const BadgeOverride = styled(Badge)`
+  span {
+    color: inherit;
+    font-weight: ${({ theme }) => theme.fontWeights.regular};
+  }
+`;
+
+export const UploadProgressWrapper = styled.div`
+  position: absolute;
+  z-index: 2;
+  height: 100%;
+  width: 100%;
+`;

--- a/packages/core/upload/admin/src/components/EditAssetDialog/PreviewBox/index.js
+++ b/packages/core/upload/admin/src/components/EditAssetDialog/PreviewBox/index.js
@@ -1,0 +1,146 @@
+import React, { useState, useRef } from 'react';
+import PropTypes from 'prop-types';
+import { useIntl } from 'react-intl';
+import { Stack } from '@strapi/parts/Stack';
+import { IconButton } from '@strapi/parts/IconButton';
+import DeleteIcon from '@strapi/icons/DeleteIcon';
+import DownloadIcon from '@strapi/icons/DownloadIcon';
+import Resize from '@strapi/icons/Resize';
+import { prefixFileUrlWithBackendUrl } from '@strapi/helper-plugin';
+import getTrad from '../../../utils/getTrad';
+import { downloadFile } from '../../../utils/downloadFile';
+import { RemoveAssetDialog } from '../RemoveAssetDialog';
+import { useCropImg } from '../../../hooks/useCropImg';
+import { useEditAsset } from '../../../hooks/useEditAsset';
+import {
+  RelativeBox,
+  ActionRow,
+  Wrapper,
+  BadgeOverride,
+  UploadProgressWrapper,
+} from './components';
+import { CroppingActions } from './CroppingActions';
+import { CopyLinkButton } from './CopyLinkButton';
+import { UploadProgress } from '../../UploadProgress';
+
+export const PreviewBox = ({ asset, onDelete }) => {
+  const previewRef = useRef(null);
+  const [assetUrl, setAssetUrl] = useState(prefixFileUrlWithBackendUrl(asset.url));
+  const { formatMessage } = useIntl();
+  const [showConfirmDialog, setShowConfirmDialog] = useState(false);
+  const {
+    crop,
+    produceFile,
+    stopCropping,
+    isCropping,
+    isCropperReady,
+    width,
+    height,
+  } = useCropImg();
+  const { editAsset, error, isLoading, progress, cancel } = useEditAsset();
+
+  const handleCropping = async () => {
+    const nextAsset = { ...asset, width, height };
+    const file = await produceFile(nextAsset.name, nextAsset.mime, nextAsset.updatedAt);
+
+    await editAsset(nextAsset, file);
+
+    // Making sure that when persistent the new asset, the URL changes with width and height
+    // So that the browser makes a request and handle the image caching correctly at the good size
+    const optimizedCachingImage = `${asset.url}?width=${width}&height=${height}`;
+    setAssetUrl(prefixFileUrlWithBackendUrl(optimizedCachingImage));
+
+    stopCropping();
+  };
+
+  const isInCroppingMode = isCropping && !isLoading;
+
+  return (
+    <>
+      <RelativeBox hasRadius background="neutral150" borderColor="neutral200">
+        {isCropperReady && isInCroppingMode && (
+          <CroppingActions onValidate={handleCropping} onCancel={stopCropping} />
+        )}
+
+        <ActionRow paddingLeft={3} paddingRight={3} justifyContent="flex-end">
+          <Stack size={1} horizontal>
+            <IconButton
+              label={formatMessage({
+                id: getTrad('app.utils.delete'),
+                defaultMessage: 'Delete',
+              })}
+              icon={<DeleteIcon />}
+              onClick={() => setShowConfirmDialog(true)}
+            />
+
+            <IconButton
+              label={formatMessage({
+                id: getTrad('control-card.download'),
+                defaultMessage: 'Download',
+              })}
+              icon={<DownloadIcon />}
+              onClick={() => downloadFile(assetUrl, asset.name)}
+            />
+
+            <CopyLinkButton url={assetUrl} />
+
+            <IconButton
+              label={formatMessage({ id: getTrad('control-card.crop'), defaultMessage: 'Crop' })}
+              icon={<Resize />}
+              onClick={() => crop(previewRef.current)}
+            />
+          </Stack>
+        </ActionRow>
+
+        <Wrapper>
+          {isLoading && (
+            <UploadProgressWrapper>
+              <UploadProgress error={error} onCancel={cancel} progress={progress} />
+            </UploadProgressWrapper>
+          )}
+
+          <img aria-hidden={isLoading} ref={previewRef} src={assetUrl} alt={asset.name} />
+        </Wrapper>
+
+        <ActionRow
+          paddingLeft={2}
+          paddingRight={2}
+          justifyContent="flex-end"
+          blurry={isInCroppingMode}
+        >
+          {isInCroppingMode && width && height && (
+            <BadgeOverride background="neutral900" color="neutral0">
+              {`${height}✕${width}`}
+            </BadgeOverride>
+          )}
+        </ActionRow>
+      </RelativeBox>
+
+      {showConfirmDialog && (
+        <RemoveAssetDialog
+          onClose={() => {
+            setShowConfirmDialog(false);
+            onDelete();
+          }}
+          asset={asset}
+        />
+      )}
+    </>
+  );
+};
+
+PreviewBox.propTypes = {
+  asset: PropTypes.shape({
+    id: PropTypes.number,
+    height: PropTypes.number,
+    width: PropTypes.number,
+    size: PropTypes.number,
+    createdAt: PropTypes.string,
+    ext: PropTypes.string,
+    name: PropTypes.string,
+    url: PropTypes.string,
+    mime: PropTypes.string,
+    updatedAt: PropTypes.string,
+  }).isRequired,
+  onDelete: PropTypes.func.isRequired,
+};

--- a/packages/core/upload/admin/src/components/EditAssetDialog/index.js
+++ b/packages/core/upload/admin/src/components/EditAssetDialog/index.js
@@ -13,7 +13,7 @@ import { Stack } from '@strapi/parts/Stack';
 import { Grid, GridItem } from '@strapi/parts/Grid';
 import { Button } from '@strapi/parts/Button';
 import { TextInput } from '@strapi/parts/TextInput';
-import { getFileExtension, prefixFileUrlWithBackendUrl } from '@strapi/helper-plugin';
+import { getFileExtension } from '@strapi/helper-plugin';
 import { PreviewBox } from './PreviewBox';
 import { AssetMeta } from './AssetMeta';
 import { getTrad } from '../../utils';
@@ -36,9 +36,7 @@ export const EditAssetDialog = ({ onClose, asset }) => {
         <ModalBody>
           <Grid gap={4}>
             <GridItem xs={12} col={6}>
-              <PreviewBox asset={asset} onDelete={onClose}>
-                <img src={prefixFileUrlWithBackendUrl(asset.url)} alt={asset.name} />
-              </PreviewBox>
+              <PreviewBox asset={asset} onDelete={onClose} />
             </GridItem>
             <GridItem xs={12} col={6}>
               <Stack size={3}>

--- a/packages/core/upload/admin/src/components/EditAssetDialog/tests/index.test.js
+++ b/packages/core/upload/admin/src/components/EditAssetDialog/tests/index.test.js
@@ -1221,12 +1221,7 @@ describe('<EditAssetDialog />', () => {
                           </div>
                           <div
                             class="c23"
-                          >
-                            <img
-                              alt="Screenshot 2.png"
-                              src="http://localhost:1337/uploads/Screenshot_2_5d4a574d61.png"
-                            />
-                          </div>
+                          />
                           <div
                             class="c16 c24 c18"
                           />

--- a/packages/core/upload/admin/src/components/UploadProgress/index.js
+++ b/packages/core/upload/admin/src/components/UploadProgress/index.js
@@ -1,0 +1,85 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import CloseAlertIcon from '@strapi/icons/CloseAlertIcon';
+import { Text } from '@strapi/parts/Text';
+import { Box } from '@strapi/parts/Box';
+import { Row } from '@strapi/parts/Row';
+import { ProgressBar } from '@strapi/parts/ProgressBar';
+import { useIntl } from 'react-intl';
+
+const BoxWrapper = styled(Row)`
+  width: 100%;
+  height: 100%;
+  flex-direction: column;
+
+  svg {
+    path {
+      fill: ${({ theme, error }) => (error ? theme.colors.danger600 : undefined)};
+    }
+  }
+`;
+
+const CancelButton = styled.button`
+  border: none;
+  background: none;
+  display: flex;
+  align-items: center;
+
+  svg {
+    path {
+      fill: ${({ theme }) => theme.colors.neutral200};
+    }
+
+    height: 10px;
+    width: 10px;
+  }
+`;
+
+export const UploadProgress = ({ onCancel, progress, error }) => {
+  const { formatMessage } = useIntl();
+
+  return (
+    <BoxWrapper
+      background={error ? 'danger100' : 'neutral700'}
+      justifyContent="center"
+      error={error}
+      hasRadius
+    >
+      {error ? (
+        <CloseAlertIcon aria-label={error?.message} />
+      ) : (
+        <>
+          <Box paddingBottom={2}>
+            <ProgressBar value={progress} size="S">
+              {`${progress}/100%`}
+            </ProgressBar>
+          </Box>
+
+          <CancelButton type="button" onClick={onCancel}>
+            <Text small as="span" textColor="neutral200">
+              {formatMessage({
+                id: 'app.components.Button.cancel',
+                defaultMessage: 'Cancel',
+              })}
+            </Text>
+            <Box as="span" paddingLeft={2} aria-hidden>
+              <CloseAlertIcon />
+            </Box>
+          </CancelButton>
+        </>
+      )}
+    </BoxWrapper>
+  );
+};
+
+UploadProgress.defaultProps = {
+  error: undefined,
+  progress: 0,
+};
+
+UploadProgress.propTypes = {
+  error: PropTypes.instanceOf(Error),
+  onCancel: PropTypes.func.isRequired,
+  progress: PropTypes.number,
+};

--- a/packages/core/upload/admin/src/components/UploadProgress/tests/index.test.js
+++ b/packages/core/upload/admin/src/components/UploadProgress/tests/index.test.js
@@ -1,0 +1,251 @@
+/**
+ *
+ * Tests for EditAssetDialog
+ *
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ThemeProvider, lightTheme } from '@strapi/parts';
+import { IntlProvider } from 'react-intl';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { UploadProgress } from '..';
+import en from '../../../translations/en.json';
+
+const messageForPlugin = Object.keys(en).reduce((acc, curr) => {
+  acc[curr] = `upload.${en[curr]}`;
+
+  return acc;
+}, {});
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+    },
+  },
+});
+
+const renderCompo = props =>
+  render(
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider theme={lightTheme}>
+        <IntlProvider locale="en" messages={messageForPlugin} defaultLocale="en">
+          <UploadProgress onCancel={jest.fn()} error={undefined} {...props} />
+        </IntlProvider>
+      </ThemeProvider>
+    </QueryClientProvider>,
+    { container: document.body }
+  );
+
+describe('<UploadProgress />', () => {
+  it('renders with no error', () => {
+    const {
+      container: { firstChild },
+    } = renderCompo();
+
+    expect(firstChild).toMatchInlineSnapshot(`
+      .c6 {
+        font-weight: 400;
+        font-size: 0.75rem;
+        line-height: 1.33;
+        color: #dcdce4;
+      }
+
+      .c3 {
+        padding-bottom: 8px;
+      }
+
+      .c7 {
+        padding-left: 8px;
+      }
+
+      .c0 {
+        background: #4a4a6a;
+        border-radius: 4px;
+      }
+
+      .c1 {
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+        -webkit-flex-direction: row;
+        -ms-flex-direction: row;
+        flex-direction: row;
+        -webkit-box-pack: center;
+        -webkit-justify-content: center;
+        -ms-flex-pack: center;
+        justify-content: center;
+        -webkit-align-items: center;
+        -webkit-box-align: center;
+        -ms-flex-align: center;
+        align-items: center;
+      }
+
+      .c4 {
+        background: #666687;
+        border-radius: 4px;
+        position: relative;
+        width: 78px;
+        height: 4px;
+      }
+
+      .c4:before {
+        content: '';
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        border-radius: 4px;
+        width: 0%;
+        background: #eaeaef;
+      }
+
+      .c2 {
+        width: 100%;
+        height: 100%;
+        -webkit-flex-direction: column;
+        -ms-flex-direction: column;
+        flex-direction: column;
+      }
+
+      .c5 {
+        border: none;
+        background: none;
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+        -webkit-align-items: center;
+        -webkit-box-align: center;
+        -ms-flex-align: center;
+        align-items: center;
+      }
+
+      .c5 svg {
+        height: 10px;
+        width: 10px;
+      }
+
+      .c5 svg path {
+        fill: #dcdce4;
+      }
+
+      <div
+        class="c0 c1 c2"
+      >
+        <div
+          class="c3"
+        >
+          <div
+            aria-label="0/100%"
+            aria-valuemax="100"
+            aria-valuemin="0"
+            aria-valuenow="0"
+            class="c4"
+            role="progressbar"
+            value="0"
+          />
+        </div>
+        <button
+          class="c5"
+          type="button"
+        >
+          <span
+            class="c6"
+          >
+            Cancel
+          </span>
+          <span
+            aria-hidden="true"
+            class="c7"
+          >
+            <svg
+              fill="none"
+              height="1em"
+              viewBox="0 0 24 24"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M24 2.417L21.583 0 12 9.583 2.417 0 0 2.417 9.583 12 0 21.583 2.417 24 12 14.417 21.583 24 24 21.583 14.417 12 24 2.417z"
+                fill="#212134"
+              />
+            </svg>
+          </span>
+        </button>
+      </div>
+    `);
+  });
+
+  it('renders with an error', () => {
+    const {
+      container: { firstChild },
+    } = renderCompo({ error: new Error('Something went wrong') });
+
+    expect(firstChild).toMatchInlineSnapshot(`
+      .c0 {
+        background: #fcecea;
+        border-radius: 4px;
+      }
+
+      .c1 {
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+        -webkit-flex-direction: row;
+        -ms-flex-direction: row;
+        flex-direction: row;
+        -webkit-box-pack: center;
+        -webkit-justify-content: center;
+        -ms-flex-pack: center;
+        justify-content: center;
+        -webkit-align-items: center;
+        -webkit-box-align: center;
+        -ms-flex-align: center;
+        align-items: center;
+      }
+
+      .c2 {
+        width: 100%;
+        height: 100%;
+        -webkit-flex-direction: column;
+        -ms-flex-direction: column;
+        flex-direction: column;
+      }
+
+      .c2 svg path {
+        fill: #d02b20;
+      }
+
+      <div
+        class="c0 c1 c2"
+      >
+        <svg
+          aria-label="Something went wrong"
+          fill="none"
+          height="1em"
+          viewBox="0 0 24 24"
+          width="1em"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M24 2.417L21.583 0 12 9.583 2.417 0 0 2.417 9.583 12 0 21.583 2.417 24 12 14.417 21.583 24 24 21.583 14.417 12 24 2.417z"
+            fill="#212134"
+          />
+        </svg>
+      </div>
+    `);
+  });
+
+  it('cancel the upload when pressing cancel', () => {
+    const onCancelSpy = jest.fn();
+
+    renderCompo({ onCancel: onCancelSpy });
+
+    fireEvent.click(screen.getByText('Cancel'));
+
+    expect(onCancelSpy).toHaveBeenCalled();
+  });
+});

--- a/packages/core/upload/admin/src/hooks/useCropImg.js
+++ b/packages/core/upload/admin/src/hooks/useCropImg.js
@@ -1,0 +1,84 @@
+import Cropper from 'cropperjs';
+import { useRef, useEffect, useState } from 'react';
+
+const QUALITY = 1;
+
+export const useCropImg = () => {
+  const cropperRef = useRef();
+  const [isCropping, setIsCropping] = useState(false);
+  const [size, setSize] = useState({ width: undefined, height: undefined });
+
+  useEffect(() => {
+    return () => {
+      if (cropperRef.current) {
+        cropperRef.current.destroy();
+      }
+    };
+  }, []);
+
+  const handleResize = ({ detail: { height, width } }) => {
+    const roundedDataWidth = Math.round(width);
+    const roundedDataHeight = Math.round(height);
+
+    setSize({ width: roundedDataWidth, height: roundedDataHeight });
+  };
+
+  const crop = image => {
+    if (!cropperRef.current) {
+      cropperRef.current = new Cropper(image, {
+        modal: true,
+        initialAspectRatio: 16 / 9,
+        movable: true,
+        zoomable: false,
+        cropBoxResizable: true,
+        background: false,
+        crop: handleResize,
+      });
+
+      setIsCropping(true);
+    }
+  };
+
+  const stopCropping = () => {
+    if (cropperRef.current) {
+      cropperRef.current.destroy();
+      cropperRef.current = undefined;
+      setIsCropping(false);
+    }
+  };
+
+  const produceFile = (name, mimeType, lastModifiedDate) =>
+    new Promise((resolve, reject) => {
+      if (!cropperRef.current) {
+        return reject(
+          new Error(
+            'The cropper has not been instanciated: make sure to call the crop() function before calling produceFile().'
+          )
+        );
+      }
+
+      const canvas = cropperRef.current.getCroppedCanvas();
+
+      return canvas.toBlob(
+        blob => {
+          resolve(
+            new File([blob], name, {
+              type: mimeType,
+              lastModifiedDate,
+            })
+          );
+        },
+        mimeType,
+        QUALITY
+      );
+    });
+
+  return {
+    crop,
+    produceFile,
+    stopCropping,
+    isCropping,
+    isCropperReady: Boolean(cropperRef.current),
+    ...size,
+  };
+};

--- a/packages/core/upload/admin/src/hooks/useEditAsset.js
+++ b/packages/core/upload/admin/src/hooks/useEditAsset.js
@@ -1,0 +1,67 @@
+import axios from 'axios';
+import { useRef, useState } from 'react';
+import { useMutation, useQueryClient } from 'react-query';
+import { useIntl } from 'react-intl';
+import { useNotification } from '@strapi/helper-plugin';
+import { axiosInstance, getTrad } from '../utils';
+import pluginId from '../pluginId';
+
+const editAssetRequest = (asset, file, cancelToken, onProgress) => {
+  const endpoint = `/${pluginId}?id=${asset.id}`;
+
+  const formData = new FormData();
+
+  if (file) {
+    formData.append('files', file);
+  }
+
+  formData.append(
+    'fileInfo',
+    JSON.stringify({
+      alternativeText: asset.alternativeText,
+      caption: asset.caption,
+      name: asset.name,
+    })
+  );
+
+  return axiosInstance({
+    method: 'post',
+    url: endpoint,
+    data: formData,
+    cancelToken: cancelToken.token,
+    onUploadProgress({ total, loaded }) {
+      onProgress((loaded / total) * 100);
+    },
+  }).then(res => res.data);
+};
+
+export const useEditAsset = () => {
+  const [progress, setProgress] = useState(0);
+  const { formatMessage } = useIntl();
+  const toggleNotification = useNotification();
+  const queryClient = useQueryClient();
+  const tokenRef = useRef(axios.CancelToken.source());
+
+  const mutation = useMutation(
+    ({ asset, file }) => editAssetRequest(asset, file, tokenRef.current, setProgress),
+    {
+      onSuccess: assetUpdated => {
+        queryClient.setQueryData('assets', cachedAssets =>
+          cachedAssets.map(asset => (asset.id === assetUpdated.id ? { ...assetUpdated } : asset))
+        );
+      },
+      onError: error => {
+        toggleNotification({ type: 'warning', message: error.message });
+      },
+    }
+  );
+
+  const editAsset = (asset, file) => mutation.mutateAsync({ asset, file });
+
+  const cancel = () =>
+    tokenRef.current.cancel(
+      formatMessage({ id: getTrad('modal.upload.cancelled'), defaultMessage: '' })
+    );
+
+  return { ...mutation, cancel, editAsset, progress, status: mutation.status };
+};

--- a/packages/core/upload/admin/src/pages/App/components/tests/ListView.test.js
+++ b/packages/core/upload/admin/src/pages/App/components/tests/ListView.test.js
@@ -770,7 +770,7 @@ describe('MediaLibrary / ListView', () => {
                   <img
                     aria-hidden="true"
                     class="c8"
-                    src="http://localhost:1337/uploads/thumbnail_strapi_cover_1fabc982ce_5b43615ed5.png"
+                    src="http://localhost:1337/uploads/thumbnail_strapi_cover_1fabc982ce_5b43615ed5.png?width=1066&height=551"
                   />
                 </div>
               </div>

--- a/packages/core/upload/admin/src/translations/en.json
+++ b/packages/core/upload/admin/src/translations/en.json
@@ -7,6 +7,7 @@
   "control-card.cancel": "Cancel",
   "control-card.copy-link": "Copy link",
   "control-card.crop": "Crop",
+  "control-card.stop-crop": "Stop cropping",
   "control-card.delete": "Delete",
   "control-card.download": "Download",
   "control-card.edit": "Edit",


### PR DESCRIPTION
### What does it do?

- Adds cropping to the ML V4

### Why is it needed?

🙄 

### How to test it?

- Go to the ML
- Upload an asset somehow
- Edit the asset
- Crop the image
- Validate the cropping
- [ ] The image should be resized, the popup should still be opened for editing purpose.
- [ ] When closing the modal, the image should be resized in the listview
- [ ] Refreshing the page should show the image resized

