### PR TITLE
Disable Cache Bust for base64 encoded images

### DIFF
--- a/packages/strapi-plugin-upload/admin/src/components/CardPreview/index.js
+++ b/packages/strapi-plugin-upload/admin/src/components/CardPreview/index.js
@@ -36,8 +36,9 @@ const CardPreview = ({ extension, hasError, hasIcon, url, previewUrl, type, with
         <VideoPreview src={url} previewUrl={previewUrl} hasIcon={hasIcon} />
       ) : (
         // Adding performance.now forces the browser no to cache the img
+        // if we want to save base64 coded images the cachebust will break the base64 encoded data
         // https://stackoverflow.com/questions/126772/how-to-force-a-web-browser-not-to-cache-images
-        <Image src={`${url}${withFileCaching ? `?${cacheRef.current}` : ''}`} />
+        <Image src={`${url}${withFileCaching && url.slice(0, 10) !== 'data:image' ? `?${cacheRef.current}` : ''}`} />
       )}
     </Wrapper>
   );


### PR DESCRIPTION
Images in strapi are always available to everybody.
To keep images of a collection private they can be saved as base64 encoded data.
This will not work if a cache bust (query string) is appended to the
image url, so cache busting for base64 encoded images must be disabled.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Disabled the cache bust for base64 images

### Why is it needed?
Appending a query string to base64 images will break them


### How to test it?
Save a base64 image to a strap collection. Before the fix it won't be displayed


Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
