### PR TITLE
[v4] add filterable attributes to content manager table

### DIFF
--- a/packages/core/content-manager/server/services/data-mapper.js
+++ b/packages/core/content-manager/server/services/data-mapper.js
@@ -57,10 +57,10 @@ const formatContentTypeLabel = contentType => {
 };
 
 const formatAttributes = contentType => {
-  const { getVisibleAttributes } = contentTypesUtils;
+  const { getFilterableAttributes } = contentTypesUtils;
 
   // only get attributes that can be seen in the auto generated Edit view or List view
-  return getVisibleAttributes(contentType).reduce((acc, key) => {
+  return getFilterableAttributes(contentType).reduce((acc, key) => {
     const attribute = contentType.attributes[key];
 
     // ignore morph until they are handled in the front

--- a/packages/core/utils/lib/__tests__/content-types.test.js
+++ b/packages/core/utils/lib/__tests__/content-types.test.js
@@ -6,6 +6,7 @@ const {
   getPrivateAttributes,
   getVisibleAttributes,
   getNonWritableAttributes,
+  getFilterableAttributes,
   constants,
 } = require('../content-types');
 
@@ -78,6 +79,12 @@ describe('Content types utils', () => {
           title: {
             type: 'string',
           },
+          createdAt: {
+            type: 'timestamp',
+          },
+          updatedAt: {
+            type: 'timestamp',
+          },
           invisible_field: {
             type: 'datetime',
             visible: false,
@@ -85,7 +92,7 @@ describe('Content types utils', () => {
         },
       });
 
-      expect(getVisibleAttributes(model)).toEqual(['title']);
+      expect(getFilterableAttributes(model)).toEqual(['title', 'createdAt', 'updatedAt']);
     });
 
     test('Excludes id', () => {

--- a/packages/core/utils/lib/content-types.js
+++ b/packages/core/utils/lib/content-types.js
@@ -67,6 +67,14 @@ const getVisibleAttributes = model => {
   return _.difference(_.keys(model.attributes), getNonVisibleAttributes(model));
 };
 
+const getFilterableAttributes = model => {
+  const timeStamps = getTimestamps();
+  const nonFilterableAttributes = getNonVisibleAttributes(model).filter(
+    attr => !timeStamps.includes(attr)
+  );
+  return _.difference(_.keys(model.attributes), nonFilterableAttributes);
+};
+
 const isVisibleAttribute = (model, attributeName) => {
   return getVisibleAttributes(model).includes(attributeName);
 };
@@ -137,6 +145,7 @@ module.exports = {
   isWritableAttribute,
   getNonVisibleAttributes,
   getVisibleAttributes,
+  getFilterableAttributes,
   isVisibleAttribute,
   hasDraftAndPublish,
   isDraft,


### PR DESCRIPTION
### What does it do?

It adds the attributes `createdAt` and `updatedAt` to the filter in Content Manager table. These attributes are not shown in the table in Content-Types Builder.

### Why is it needed?

Before it was not possible to filter the table based on the attributes `createdAt` and `updatedAt`.

### Related issue(s)/PR(s)

This PR is related to the issue #11151 
