### PR TITLE
Use array checks in api-token aut strategy

### DIFF
--- a/packages/core/admin/server/strategies/__tests__/api-token.test.js
+++ b/packages/core/admin/server/strategies/__tests__/api-token.test.js
@@ -112,7 +112,7 @@ describe('API Token Auth Strategy', () => {
       expect(
         apiTokenStrategy.verify(
           { credentials: readOnlyApiToken },
-          { scope: 'api::model.model.find' }
+          { scope: ['api::model.model.find'] }
         )
       ).toBeUndefined();
     });
@@ -125,7 +125,7 @@ describe('API Token Auth Strategy', () => {
       expect(
         apiTokenStrategy.verify(
           { credentials: fullAccessApiToken },
-          { scope: 'api::model.model.create' }
+          { scope: ['api::model.model.create'] }
         )
       ).toBeUndefined();
     });
@@ -140,7 +140,7 @@ describe('API Token Auth Strategy', () => {
       try {
         apiTokenStrategy.verify(
           { credentials: { readOnlyApiToken } },
-          { scope: 'api::model.model.create' }
+          { scope: ['api::model.model.create'] }
         );
       } catch (err) {
         expect(err).toBeInstanceOf(Error);
@@ -155,7 +155,7 @@ describe('API Token Auth Strategy', () => {
       expect.assertions(1);
 
       try {
-        apiTokenStrategy.verify({}, { scope: 'api::model.model.create' });
+        apiTokenStrategy.verify({}, { scope: ['api::model.model.create'] });
       } catch (err) {
         expect(err).toBeInstanceOf(Error);
       }

--- a/packages/core/admin/server/strategies/api-token.js
+++ b/packages/core/admin/server/strategies/api-token.js
@@ -3,6 +3,8 @@
 const constants = require('../services/constants');
 const { getService } = require('../utils');
 
+const isReadScope = scope => scope.endsWith('find') || scope.endsWith('findOne');
+
 /** @type {import('.').AuthenticateFunction} */
 const authenticate = async ctx => {
   const apiTokenService = getService('api-token');
@@ -47,7 +49,8 @@ const verify = (auth, config) => {
    * If you don't have `full-access` you can only access `find` and `findOne`
    * scopes. If the route has no scope, then you can't get access to it.
    */
-  if (config.scope && (config.scope.endsWith('find') || config.scope.endsWith('findOne'))) {
+
+  if (config.scope && config.scope.every(isReadScope)) {
     return;
   }
 

--- a/packages/core/strapi/lib/services/server/register-routes.js
+++ b/packages/core/strapi/lib/services/server/register-routes.js
@@ -11,7 +11,7 @@ const createRouteScopeGenerator = namespace => route => {
     _.defaultsDeep(route, {
       config: {
         auth: {
-          scope: `${prefix}${controller}.${action}`,
+          scope: [`${prefix}${controller}.${action}`],
         },
       },
     });

--- a/packages/core/strapi/lib/services/server/routing.js
+++ b/packages/core/strapi/lib/services/server/routing.js
@@ -44,6 +44,18 @@ const routeSchema = yup.object({
   }),
   config: yup
     .object({
+      auth: yup.lazy(value => {
+        if (value === false) {
+          return yup.boolean().required();
+        }
+
+        return yup.object({
+          scope: yup
+            .array()
+            .of(yup.string())
+            .required(),
+        });
+      }),
       policies: yup
         .array()
         .of(policyOrMiddlewareSchema)


### PR DESCRIPTION

### What does it do?

Handle config.scope as array in api-token