### PR TITLE
Update bug report template to remove outdated message

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -43,11 +43,11 @@ If applicable, add code samples to help explain your problem.
 
 ### System
 
-- Node.js version: <!-- Please ensure you are using the Node LTS version (v12 / v14) -->
-- NPM version:
-- Strapi version: <!-- Beta and Alpha versions are no longer supported -->
-- Database:
-- Operating system:
+- Node.js version: 
+- NPM version: 
+- Strapi version: 
+- Database: 
+- Operating system: 
 
 ### Additional context
 


### PR DESCRIPTION
### What does it do?

Cleaned up bug report template to remove outdated messages

### Why is it needed?

Referenced we didn't support beta versions of Strapi, this was back from the v3.0.0-beta.x days and no longer applies

### How to test it?

N/A

### Related issue(s)/PR(s)

N/A
