### PR TITLE
ci(workflow): add cache to workflows using actions/setup-node

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/setup-node@v2-beta
         with:
           node-version: ${{ matrix.node }}
-          cache: npm
+          cache: yarn
       - uses: ./.github/actions/install-modules
       - name: Run lint
         run: yarn run -s lint
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/setup-node@v2-beta
         with:
           node-version: ${{ matrix.node }}
-          cache: npm
+          cache: yarn
       - uses: ./.github/actions/install-modules
         with:
           globalPackages: codecov
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/setup-node@v2-beta
         with:
           node-version: ${{ matrix.node }}
-          cache: npm
+          cache: yarn
       - uses: ./.github/actions/install-modules
         with:
           globalPackages: codecov
@@ -97,7 +97,7 @@ jobs:
       - uses: actions/setup-node@v2-beta
         with:
           node-version: ${{ matrix.node }}
-          cache: npm
+          cache: yarn
       - uses: ./.github/actions/install-modules
       - uses: ./.github/actions/run-e2e-tests
         with:
@@ -124,7 +124,7 @@ jobs:
       - uses: actions/setup-node@v2-beta
         with:
           node-version: ${{ matrix.node }}
-          cache: npm
+          cache: yarn
       - uses: ./.github/actions/install-modules
       - uses: ./.github/actions/run-e2e-tests
         with:
@@ -143,7 +143,7 @@ jobs:
       - uses: actions/setup-node@v2-beta
         with:
           node-version: ${{ matrix.node }}
-          cache: npm
+          cache: yarn
       - uses: ./.github/actions/install-modules
       - uses: ./.github/actions/run-e2e-tests
         with:
@@ -167,7 +167,7 @@ jobs:
       - uses: actions/setup-node@v2-beta
         with:
           node-version: ${{ matrix.node }}
-          cache: npm
+          cache: yarn
       - uses: ./.github/actions/install-modules
       - uses: ./.github/actions/run-e2e-tests
         with:
@@ -205,7 +205,7 @@ jobs:
       - uses: actions/setup-node@v2-beta
         with:
           node-version: ${{ matrix.node }}
-          cache: npm
+          cache: yarn
       - uses: ./.github/actions/install-modules
       - uses: ./.github/actions/run-e2e-tests
         with:
@@ -236,7 +236,7 @@ jobs:
       - uses: actions/setup-node@v2-beta
         with:
           node-version: ${{ matrix.node }}
-          cache: npm
+          cache: yarn
       - uses: ./.github/actions/install-modules
       - uses: ./.github/actions/run-e2e-tests
         with:
@@ -259,7 +259,7 @@ jobs:
       - uses: actions/setup-node@v2-beta
         with:
           node-version: ${{ matrix.node }}
-          cache: npm
+          cache: yarn
       - uses: ./.github/actions/install-modules
       - uses: ./.github/actions/run-e2e-tests
         with:
@@ -287,7 +287,7 @@ jobs:
       - uses: actions/setup-node@v2-beta
         with:
           node-version: ${{ matrix.node }}
-          cache: npm
+          cache: yarn
       - uses: ./.github/actions/install-modules
       - uses: ./.github/actions/run-e2e-tests
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: 'Tests'
+name: "Tests"
 
 on:
   push:
@@ -6,11 +6,11 @@ on:
       - master
   pull_request:
     paths-ignore:
-      - 'docs/**'
+      - "docs/**"
 
 jobs:
   lint:
-    name: 'lint (node: ${{ matrix.node }})'
+    name: "lint (node: ${{ matrix.node }})"
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -20,12 +20,13 @@ jobs:
       - uses: actions/setup-node@v2-beta
         with:
           node-version: ${{ matrix.node }}
+          cache: npm
       - uses: ./.github/actions/install-modules
       - name: Run lint
         run: yarn run -s lint
 
   unit_back:
-    name: 'unit_back (node: ${{ matrix.node }})'
+    name: "unit_back (node: ${{ matrix.node }})"
     needs: [lint]
     runs-on: ubuntu-latest
     env:
@@ -38,6 +39,7 @@ jobs:
       - uses: actions/setup-node@v2-beta
         with:
           node-version: ${{ matrix.node }}
+          cache: npm
       - uses: ./.github/actions/install-modules
         with:
           globalPackages: codecov
@@ -45,7 +47,7 @@ jobs:
         run: yarn run -s test:unit --coverage && codecov -C -F unit
 
   unit_front:
-    name: 'unit_front (node: ${{ matrix.node }})'
+    name: "unit_front (node: ${{ matrix.node }})"
     needs: [lint]
     runs-on: ubuntu-latest
     env:
@@ -58,6 +60,7 @@ jobs:
       - uses: actions/setup-node@v2-beta
         with:
           node-version: ${{ matrix.node }}
+          cache: npm
       - uses: ./.github/actions/install-modules
         with:
           globalPackages: codecov
@@ -69,7 +72,7 @@ jobs:
   e2e_ce_pg:
     runs-on: ubuntu-latest
     needs: [lint, unit_back, unit_front]
-    name: '[CE] E2E (postgres, node: ${{ matrix.node }})'
+    name: "[CE] E2E (postgres, node: ${{ matrix.node }})"
     strategy:
       matrix:
         node: [12, 14]
@@ -85,10 +88,7 @@ jobs:
           POSTGRES_DB: strapi_test
         # Set health checks to wait until postgres has started
         options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
+          --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
         ports:
           # Maps tcp port 5432 on service container to the host
           - 5432:5432
@@ -97,15 +97,16 @@ jobs:
       - uses: actions/setup-node@v2-beta
         with:
           node-version: ${{ matrix.node }}
+          cache: npm
       - uses: ./.github/actions/install-modules
       - uses: ./.github/actions/run-e2e-tests
         with:
-          dbOptions: '--dbclient=postgres --dbhost=localhost --dbport=5432 --dbname=strapi_test --dbusername=strapi --dbpassword=strapi'
+          dbOptions: "--dbclient=postgres --dbhost=localhost --dbport=5432 --dbname=strapi_test --dbusername=strapi --dbpassword=strapi"
 
   e2e_ce_mysql:
     runs-on: ubuntu-latest
     needs: [lint, unit_back, unit_front]
-    name: '[CE] E2E (mysql, node: ${{ matrix.node }})'
+    name: "[CE] E2E (mysql, node: ${{ matrix.node }})"
     strategy:
       matrix:
         node: [12, 14]
@@ -114,16 +115,7 @@ jobs:
       mysql:
         image: mysql
         options: >-
-          --health-cmd="mysqladmin ping"
-          --health-interval=10s
-          --health-timeout=5s
-          --health-retries=3
-          -e MYSQL_ROOT_PASSWORD=strapi
-          -e MYSQL_ROOT_HOST="%"
-          -e MYSQL_USER=strapi
-          -e MYSQL_PASSWORD=strapi
-          -e MYSQL_DATABASE=strapi_test
-          --entrypoint sh mysql -c "exec docker-entrypoint.sh mysqld --default-authentication-plugin=mysql_native_password"
+          --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3 -e MYSQL_ROOT_PASSWORD=strapi -e MYSQL_ROOT_HOST="%" -e MYSQL_USER=strapi -e MYSQL_PASSWORD=strapi -e MYSQL_DATABASE=strapi_test --entrypoint sh mysql -c "exec docker-entrypoint.sh mysqld --default-authentication-plugin=mysql_native_password"
         ports:
           # Maps tcp port 5432 on service container to the host
           - 3306:3306
@@ -132,15 +124,16 @@ jobs:
       - uses: actions/setup-node@v2-beta
         with:
           node-version: ${{ matrix.node }}
+          cache: npm
       - uses: ./.github/actions/install-modules
       - uses: ./.github/actions/run-e2e-tests
         with:
-          dbOptions: '--dbclient=mysql --dbhost=localhost --dbport=3306 --dbname=strapi_test --dbusername=strapi --dbpassword=strapi'
+          dbOptions: "--dbclient=mysql --dbhost=localhost --dbport=3306 --dbname=strapi_test --dbusername=strapi --dbpassword=strapi"
 
   e2e_ce_sqlite:
     runs-on: ubuntu-latest
     needs: [lint, unit_back, unit_front]
-    name: '[CE] E2E (sqlite, node: ${{ matrix.node }})'
+    name: "[CE] E2E (sqlite, node: ${{ matrix.node }})"
     strategy:
       matrix:
         node: [12, 14]
@@ -150,15 +143,16 @@ jobs:
       - uses: actions/setup-node@v2-beta
         with:
           node-version: ${{ matrix.node }}
+          cache: npm
       - uses: ./.github/actions/install-modules
       - uses: ./.github/actions/run-e2e-tests
         with:
-          dbOptions: '--dbclient=sqlite --dbfile=./tmp/data.db'
+          dbOptions: "--dbclient=sqlite --dbfile=./tmp/data.db"
 
   e2e_ce_mongo:
     runs-on: ubuntu-latest
     needs: [lint, unit_back, unit_front]
-    name: '[CE] E2E (mongo, node: ${{ matrix.node }})'
+    name: "[CE] E2E (mongo, node: ${{ matrix.node }})"
     strategy:
       matrix:
         node: [12, 14]
@@ -173,16 +167,17 @@ jobs:
       - uses: actions/setup-node@v2-beta
         with:
           node-version: ${{ matrix.node }}
+          cache: npm
       - uses: ./.github/actions/install-modules
       - uses: ./.github/actions/run-e2e-tests
         with:
-          dbOptions: '--dbclient=mongo --dbhost=localhost --dbport=27017 --dbname=strapi_test'
+          dbOptions: "--dbclient=mongo --dbhost=localhost --dbport=27017 --dbname=strapi_test"
 
   # EE
   e2e_ee_pg:
     runs-on: ubuntu-latest
     needs: [lint, unit_back, unit_front]
-    name: '[EE] E2E (postgres, node: ${{ matrix.node }})'
+    name: "[EE] E2E (postgres, node: ${{ matrix.node }})"
     if: github.event.pull_request.head.repo.full_name == github.repository && !(github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]')
     env:
       STRAPI_LICENSE: ${{ secrets.strapiLicense }}
@@ -201,10 +196,7 @@ jobs:
           POSTGRES_DB: strapi_test
         # Set health checks to wait until postgres has started
         options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
+          --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
         ports:
           # Maps tcp port 5432 on service container to the host
           - 5432:5432
@@ -213,16 +205,17 @@ jobs:
       - uses: actions/setup-node@v2-beta
         with:
           node-version: ${{ matrix.node }}
+          cache: npm
       - uses: ./.github/actions/install-modules
       - uses: ./.github/actions/run-e2e-tests
         with:
-          dbOptions: '--dbclient=postgres --dbhost=localhost --dbport=5432 --dbname=strapi_test --dbusername=strapi --dbpassword=strapi'
+          dbOptions: "--dbclient=postgres --dbhost=localhost --dbport=5432 --dbname=strapi_test --dbusername=strapi --dbpassword=strapi"
           runEE: true
 
   e2e_ee_mysql:
     runs-on: ubuntu-latest
     needs: [lint, unit_back, unit_front]
-    name: '[EE] E2E (mysql, node: ${{ matrix.node }})'
+    name: "[EE] E2E (mysql, node: ${{ matrix.node }})"
     if: github.event.pull_request.head.repo.full_name == github.repository && !(github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]')
     env:
       STRAPI_LICENSE: ${{ secrets.strapiLicense }}
@@ -234,16 +227,7 @@ jobs:
       mysql:
         image: mysql
         options: >-
-          --health-cmd="mysqladmin ping"
-          --health-interval=10s
-          --health-timeout=5s
-          --health-retries=3
-          -e MYSQL_ROOT_PASSWORD=strapi
-          -e MYSQL_ROOT_HOST="%"
-          -e MYSQL_USER=strapi
-          -e MYSQL_PASSWORD=strapi
-          -e MYSQL_DATABASE=strapi_test
-          --entrypoint sh mysql -c "exec docker-entrypoint.sh mysqld --default-authentication-plugin=mysql_native_password"
+          --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3 -e MYSQL_ROOT_PASSWORD=strapi -e MYSQL_ROOT_HOST="%" -e MYSQL_USER=strapi -e MYSQL_PASSWORD=strapi -e MYSQL_DATABASE=strapi_test --entrypoint sh mysql -c "exec docker-entrypoint.sh mysqld --default-authentication-plugin=mysql_native_password"
         ports:
           # Maps tcp port 5432 on service container to the host
           - 3306:3306
@@ -252,16 +236,17 @@ jobs:
       - uses: actions/setup-node@v2-beta
         with:
           node-version: ${{ matrix.node }}
+          cache: npm
       - uses: ./.github/actions/install-modules
       - uses: ./.github/actions/run-e2e-tests
         with:
-          dbOptions: '--dbclient=mysql --dbhost=localhost --dbport=3306 --dbname=strapi_test --dbusername=strapi --dbpassword=strapi'
+          dbOptions: "--dbclient=mysql --dbhost=localhost --dbport=3306 --dbname=strapi_test --dbusername=strapi --dbpassword=strapi"
           runEE: true
 
   e2e_ee_sqlite:
     runs-on: ubuntu-latest
     needs: [lint, unit_back, unit_front]
-    name: '[EE] E2E (sqlite, node: ${{ matrix.node }})'
+    name: "[EE] E2E (sqlite, node: ${{ matrix.node }})"
     if: github.event.pull_request.head.repo.full_name == github.repository && !(github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]')
     env:
       STRAPI_LICENSE: ${{ secrets.strapiLicense }}
@@ -274,16 +259,17 @@ jobs:
       - uses: actions/setup-node@v2-beta
         with:
           node-version: ${{ matrix.node }}
+          cache: npm
       - uses: ./.github/actions/install-modules
       - uses: ./.github/actions/run-e2e-tests
         with:
-          dbOptions: '--dbclient=sqlite --dbfile=./tmp/data.db'
+          dbOptions: "--dbclient=sqlite --dbfile=./tmp/data.db"
           runEE: true
 
   e2e_ee_mongo:
     runs-on: ubuntu-latest
     needs: [lint, unit_back, unit_front]
-    name: '[EE] E2E (mongo, node: ${{ matrix.node }})'
+    name: "[EE] E2E (mongo, node: ${{ matrix.node }})"
     if: github.event.pull_request.head.repo.full_name == github.repository && !(github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]')
     env:
       STRAPI_LICENSE: ${{ secrets.strapiLicense }}
@@ -301,8 +287,9 @@ jobs:
       - uses: actions/setup-node@v2-beta
         with:
           node-version: ${{ matrix.node }}
+          cache: npm
       - uses: ./.github/actions/install-modules
       - uses: ./.github/actions/run-e2e-tests
         with:
-          dbOptions: '--dbclient=mongo --dbhost=localhost --dbport=27017 --dbname=strapi_test'
+          dbOptions: "--dbclient=mongo --dbhost=localhost --dbport=27017 --dbname=strapi_test"
           runEE: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
         node: [12, 14]
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2-beta
+      - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
           cache: yarn
@@ -36,7 +36,7 @@ jobs:
         node: [12, 14]
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2-beta
+      - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
           cache: yarn
@@ -57,7 +57,7 @@ jobs:
         node: [12, 14]
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2-beta
+      - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
           cache: yarn
@@ -94,7 +94,7 @@ jobs:
           - 5432:5432
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2-beta
+      - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
           cache: yarn
@@ -121,7 +121,7 @@ jobs:
           - 3306:3306
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2-beta
+      - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
           cache: yarn
@@ -140,7 +140,7 @@ jobs:
       max-parallel: 2
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2-beta
+      - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
           cache: yarn
@@ -164,7 +164,7 @@ jobs:
           - 27017:27017
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2-beta
+      - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
           cache: yarn
@@ -202,7 +202,7 @@ jobs:
           - 5432:5432
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2-beta
+      - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
           cache: yarn
@@ -233,7 +233,7 @@ jobs:
           - 3306:3306
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2-beta
+      - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
           cache: yarn
@@ -256,7 +256,7 @@ jobs:
       max-parallel: 2
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2-beta
+      - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
           cache: yarn
@@ -284,7 +284,7 @@ jobs:
           - 27017:27017
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2-beta
+      - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
           cache: yarn


### PR DESCRIPTION
## Description

Add `cache` to workflows using `actions/setup-node`

## Context

`setup-node` GitHub Action just released a new option to add cache to steps using it.

You can find the details here: https://github.blog/changelog/2021-07-02-github-actions-setup-node-now-supports-dependency-caching/

---

🤖 This PR has been generated automatically by [this octoherd script](https://github.com/oscard0m/octoherd-script-add-cache-to-node-github-action), feel free to run it in your GitHub user/org repositories! 💪🏾
