### PR TITLE
[v4] Always use `Array.isArray`

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/utils/cleanData.js
+++ b/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/utils/cleanData.js
@@ -1,5 +1,4 @@
 import get from 'lodash/get';
-import isArray from 'lodash/isArray';
 import isObject from 'lodash/isObject';
 
 /* eslint-disable indent */
@@ -88,7 +87,7 @@ const cleanData = (retrievedData, currentSchema, componentsSchema) => {
 };
 
 export const helperCleanData = (value, key) => {
-  if (isArray(value)) {
+  if (Array.isArray(value)) {
     return value.map(obj => (obj[key] ? obj[key] : obj));
   }
   if (isObject(value)) {

--- a/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/utils/schema.js
+++ b/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/utils/schema.js
@@ -1,14 +1,4 @@
-import {
-  get,
-  isBoolean,
-  isNumber,
-  isNull,
-  isObject,
-  isArray,
-  isEmpty,
-  isNaN,
-  toNumber,
-} from 'lodash';
+import { get, isBoolean, isNumber, isNull, isObject, isEmpty, isNaN, toNumber } from 'lodash';
 
 import * as yup from 'yup';
 import { translatedErrors as errorsTrads } from '@strapi/helper-plugin';
@@ -224,7 +214,7 @@ const createYupSchemaAttribute = (type, validations, options) => {
           return true;
         }
 
-        if (isNumber(value) || isNull(value) || isObject(value) || isArray(value)) {
+        if (isNumber(value) || isNull(value) || isObject(value) || Array.isArray(value)) {
           return true;
         }
 

--- a/packages/core/admin/admin/src/content-manager/components/SelectWrapper/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/SelectWrapper/index.js
@@ -10,7 +10,6 @@ import { Stack } from '@strapi/parts/Stack';
 import { useTheme } from 'styled-components';
 import findIndex from 'lodash/findIndex';
 import get from 'lodash/get';
-import isArray from 'lodash/isArray';
 import isEmpty from 'lodash/isEmpty';
 import set from 'lodash/set';
 import { NotAllowedInput, useCMEditViewDataManager, useQueryParams } from '@strapi/helper-plugin';
@@ -253,7 +252,7 @@ function SelectWrapper({
   }
 
   const Component = isSingle ? SelectOne : SelectMany;
-  const associationsLength = isArray(value) ? value.length : 0;
+  const associationsLength = Array.isArray(value) ? value.length : 0;
 
   const isDisabled = useMemo(() => {
     if (isMorph) {

--- a/packages/core/admin/server/domain/action/index.js
+++ b/packages/core/admin/server/domain/action/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { curry, pipe, merge, set, pick, omit, includes, isArray, prop } = require('lodash/fp');
+const { curry, pipe, merge, set, pick, omit, includes, prop } = require('lodash/fp');
 
 /**
  * Domain representation of an Action (RBAC)
@@ -98,7 +98,10 @@ const assignOrOmitSubCategory = action => {
  * @return {boolean} Return true if the property can be applied for the given action
  */
 const appliesToProperty = curry((property, action) => {
-  return pipe(prop('options.applyToProperties'), includes(property))(action);
+  return pipe(
+    prop('options.applyToProperties'),
+    includes(property)
+  )(action);
 });
 
 /**
@@ -108,7 +111,7 @@ const appliesToProperty = curry((property, action) => {
  * @return {boolean}
  */
 const appliesToSubject = curry((subject, action) => {
-  return isArray(action.subjects) && includes(subject, action.subjects);
+  return Array.isArray(action.subjects) && includes(subject, action.subjects);
 });
 
 /**

--- a/packages/core/admin/server/domain/permission/index.js
+++ b/packages/core/admin/server/domain/permission/index.js
@@ -1,19 +1,6 @@
 'use strict';
 
-const {
-  pipe,
-  set,
-  pick,
-  eq,
-  omit,
-  remove,
-  get,
-  uniq,
-  isArray,
-  map,
-  curry,
-  merge,
-} = require('lodash/fp');
+const { pipe, set, pick, eq, omit, remove, get, uniq, map, curry, merge } = require('lodash/fp');
 
 /**
  * Domain representation of a Permission (RBAC)
@@ -99,7 +86,10 @@ const deleteProperty = (property, permission) => omit(`properties.${property}`, 
  * @return {Permission}
  */
 const create = attributes => {
-  return pipe(pick(permissionFields), merge(getDefaultPermission()))(attributes);
+  return pipe(
+    pick(permissionFields),
+    merge(getDefaultPermission())
+  )(attributes);
 };
 
 /**
@@ -109,7 +99,7 @@ const create = attributes => {
  * @return {Permission}
  */
 const sanitizeConditions = curry((provider, permission) => {
-  if (!isArray(permission.conditions)) {
+  if (!Array.isArray(permission.conditions)) {
     return permission;
   }
 
@@ -123,7 +113,7 @@ const sanitizeConditions = curry((provider, permission) => {
  * @param {object | object[]} payload - Can either be a single object of attributes or an array of those objects.
  * @return {Permission | Permission[]}
  */
-const toPermission = payload => (isArray(payload) ? map(create, payload) : create(payload));
+const toPermission = payload => (Array.isArray(payload) ? map(create, payload) : create(payload));
 
 module.exports = {
   addCondition,

--- a/packages/core/admin/server/policies/hasPermissions.js
+++ b/packages/core/admin/server/policies/hasPermissions.js
@@ -12,7 +12,7 @@ const inputModifiers = [
     transform: action => ({ action }),
   },
   {
-    check: _.isArray,
+    check: Array.isArray,
     transform: arr => ({ action: arr[0], subject: arr[1] }),
   },
   {

--- a/packages/core/admin/server/services/permission/engine.js
+++ b/packages/core/admin/server/services/permission/engine.js
@@ -7,7 +7,6 @@ const {
   propEq,
   isFunction,
   isBoolean,
-  isArray,
   isNil,
   isEmpty,
   isObject,
@@ -119,7 +118,7 @@ module.exports = conditionProvider => {
       // If the `fields` property is an empty array, then ignore the permission
       const { fields } = properties;
 
-      if (isArray(fields) && isEmpty(fields)) {
+      if (Array.isArray(fields) && isEmpty(fields)) {
         return null;
       }
 

--- a/packages/core/admin/server/services/permission/permissions-manager/index.js
+++ b/packages/core/admin/server/services/permission/permissions-manager/index.js
@@ -54,7 +54,7 @@ module.exports = ({ ability, action, model }) => ({
       isOutput = true,
     } = options;
 
-    if (_.isArray(data)) {
+    if (Array.isArray(data)) {
       return data.map(entity => this.sanitize(entity, { action, withPrivate, isOutput }));
     }
 

--- a/packages/core/admin/server/services/permission/permissions-manager/query-builers.js
+++ b/packages/core/admin/server/services/permission/permissions-manager/query-builers.js
@@ -35,10 +35,10 @@ const buildStrapiQuery = caslQuery => {
 };
 
 const unwrapDeep = obj => {
-  if (!_.isPlainObject(obj) && !_.isArray(obj)) {
+  if (!_.isPlainObject(obj) && !Array.isArray(obj)) {
     return obj;
   }
-  if (_.isArray(obj)) {
+  if (Array.isArray(obj)) {
     return obj.map(v => unwrapDeep(v));
   }
 
@@ -52,7 +52,7 @@ const unwrapDeep = obj => {
           v = v.$elemMatch; // removing this key
         }
         _.setWith(acc, key, unwrapDeep(v));
-      } else if (_.isArray(v)) {
+      } else if (Array.isArray(v)) {
         // prettier-ignore
         _.setWith(acc, key, v.map(v => unwrapDeep(v)));
       } else {

--- a/packages/core/admin/server/services/permission/queries.js
+++ b/packages/core/admin/server/services/permission/queries.js
@@ -4,7 +4,6 @@ const {
   flatMap,
   reject,
   isNil,
-  isArray,
   prop,
   xor,
   eq,
@@ -120,8 +119,9 @@ const filterPermissionsToRemove = async permissions => {
     );
 
     const isRegisteredAction = actionProvider.has(permission.action);
-    const hasInvalidProperties = isArray(applyToProperties) && invalidProperties.every(eq(true));
-    const isInvalidSubject = isArray(subjects) && !subjects.includes(permission.subject);
+    const hasInvalidProperties =
+      Array.isArray(applyToProperties) && invalidProperties.every(eq(true));
+    const isInvalidSubject = Array.isArray(subjects) && !subjects.includes(permission.subject);
 
     // If the permission has an invalid action, an invalid subject or invalid properties, then add it to the toBeRemoved collection
     if (!isRegisteredAction || isInvalidSubject || hasInvalidProperties) {

--- a/packages/core/admin/server/services/role.js
+++ b/packages/core/admin/server/services/role.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
-const { set, omit, pick, prop, isArray, differenceWith, differenceBy } = require('lodash/fp');
+const { set, omit, pick, prop, differenceWith, differenceBy } = require('lodash/fp');
 const deepEqual = require('fast-deep-equal');
 const {
   generateTimestampCode,
@@ -400,7 +400,7 @@ const resetSuperAdminPermissions = async () => {
   const otherPermissions = otherActions.reduce((acc, action) => {
     const { actionId, subjects } = action;
 
-    if (isArray(subjects)) {
+    if (Array.isArray(subjects)) {
       acc.push(...subjects.map(subject => permissionDomain.create({ action: actionId, subject })));
     } else {
       acc.push(permissionDomain.create({ action: actionId }));

--- a/packages/core/admin/server/validation/common-validators.js
+++ b/packages/core/admin/server/validation/common-validators.js
@@ -2,7 +2,7 @@
 
 const { yup } = require('@strapi/utils');
 const _ = require('lodash');
-const { isEmpty, has, isNil, isArray } = require('lodash/fp');
+const { isEmpty, has, isNil } = require('lodash/fp');
 const { getService } = require('../utils');
 const actionDomain = require('../domain/action');
 const {
@@ -129,7 +129,7 @@ const updatePermissions = yup
                   return isNil(subject);
                 }
 
-                if (isArray(action.subjects)) {
+                if (Array.isArray(action.subjects)) {
                   return action.subjects.includes(subject);
                 }
 
@@ -153,7 +153,7 @@ const updatePermissions = yup
 
                 const { applyToProperties } = action.options;
 
-                if (!isArray(applyToProperties)) {
+                if (!Array.isArray(applyToProperties)) {
                   return false;
                 }
 

--- a/packages/core/admin/server/validation/policies/hasPermissions.js
+++ b/packages/core/admin/server/validation/policies/hasPermissions.js
@@ -6,7 +6,7 @@ const { yup, formatYupErrors } = require('@strapi/utils');
 const hasPermissionsSchema = yup.object({
   actions: yup.array().of(
     yup.lazy(val => {
-      if (_.isArray(val)) {
+      if (Array.isArray(val)) {
         return yup
           .array()
           .of(yup.string())

--- a/packages/core/admin/strapi-server.js
+++ b/packages/core/admin/strapi-server.js
@@ -5,7 +5,7 @@ const _ = require('lodash');
 const admin = require('./server');
 
 const mergeRoutes = (a, b, key) => {
-  return _.isArray(a) && _.isArray(b) && key === 'routes' ? a.concat(b) : undefined;
+  return Array.isArray(a) && Array.isArray(b) && key === 'routes' ? a.concat(b) : undefined;
 };
 
 if (process.env.STRAPI_DISABLE_EE !== 'true' && strapi.EE) {

--- a/packages/core/content-type-builder/server/controllers/validation/common.js
+++ b/packages/core/content-type-builder/server/controllers/validation/common.js
@@ -89,7 +89,7 @@ const isValidDefaultJSON = {
       return true;
     }
 
-    if (_.isNumber(val) || _.isNull(val) || _.isObject(val) || _.isArray(val)) {
+    if (_.isNumber(val) || _.isNull(val) || _.isObject(val) || Array.isArray(val)) {
       return true;
     }
 

--- a/packages/core/database/lib/entity-manager.js
+++ b/packages/core/database/lib/entity-manager.js
@@ -192,7 +192,7 @@ const createEntityManager = db => {
       const metadata = db.metadata.get(uid);
       const { data } = params;
 
-      if (!_.isArray(data)) {
+      if (!Array.isArray(data)) {
         throw new Error('CreateMany expects data to be an array');
       }
 

--- a/packages/core/database/lib/lifecycles/subscribers/timestamps.js
+++ b/packages/core/database/lib/lifecycles/subscribers/timestamps.js
@@ -32,7 +32,7 @@ const timestampsLifecyclesSubscriber = {
     const { data } = event.params;
 
     const now = new Date();
-    if (_.isArray(data)) {
+    if (Array.isArray(data)) {
       data.forEach(data => _.defaults(data, { createdAt: now, updatedAt: now }));
     }
   },
@@ -56,7 +56,7 @@ const timestampsLifecyclesSubscriber = {
     const { data } = event.params;
 
     const now = new Date();
-    if (_.isArray(data)) {
+    if (Array.isArray(data)) {
       data.forEach(data => _.assign(data, { updatedAt: now }));
     }
   },

--- a/packages/core/database/lib/query/helpers/transform.js
+++ b/packages/core/database/lib/query/helpers/transform.js
@@ -47,7 +47,7 @@ const toRow = (meta, data = {}) => {
     return data;
   }
 
-  if (_.isArray(data)) {
+  if (Array.isArray(data)) {
     return data.map(datum => toRow(meta, datum));
   }
 

--- a/packages/core/database/lib/query/helpers/where.js
+++ b/packages/core/database/lib/query/helpers/where.js
@@ -40,11 +40,11 @@ const isOperator = key => OPERATORS.includes(key);
  * @returns {Object}
  */
 const processWhere = (where, ctx, depth = 0) => {
-  if (!_.isArray(where) && !_.isPlainObject(where)) {
+  if (!Array.isArray(where) && !_.isPlainObject(where)) {
     throw new Error('Where must be an array or an object');
   }
 
-  if (_.isArray(where)) {
+  if (Array.isArray(where)) {
     return where.map(sub => processWhere(sub, ctx));
   }
 
@@ -276,11 +276,11 @@ const applyWhereToColumn = (qb, column, columnWhere) => {
 };
 
 const applyWhere = (qb, where) => {
-  if (!_.isArray(where) && !_.isPlainObject(where)) {
+  if (!Array.isArray(where) && !_.isPlainObject(where)) {
     throw new Error('Where must be an array or an object');
   }
 
-  if (_.isArray(where)) {
+  if (Array.isArray(where)) {
     return qb.where(subQB => where.forEach(subWhere => applyWhere(subQB, subWhere)));
   }
 

--- a/packages/core/helper-plugin/lib/src/old/components/PluginHeaderActions/index.js
+++ b/packages/core/helper-plugin/lib/src/old/components/PluginHeaderActions/index.js
@@ -6,7 +6,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { isArray, isFunction } from 'lodash';
+import { isFunction } from 'lodash';
 
 import Button from '../Button';
 
@@ -15,7 +15,7 @@ import StyledPluginHeaderActions from './StyledPluginHeaderActions';
 function PluginHeaderActions({ actions, overrideRendering }) {
   let content = '';
 
-  if (isArray(actions)) {
+  if (Array.isArray(actions)) {
     content = actions.map(action => <Button {...action} key={action.label} />);
   }
 

--- a/packages/core/helper-plugin/lib/src/old/utils/cleanData.js
+++ b/packages/core/helper-plugin/lib/src/old/utils/cleanData.js
@@ -1,7 +1,7 @@
-import { isArray, isObject } from 'lodash';
+import { isObject } from 'lodash';
 
 const cleanData = (value, key, secondKey) => {
-  if (isArray(value)) {
+  if (Array.isArray(value)) {
     return value.map(obj => (obj[key] ? obj[key] : obj));
   }
   if (isObject(value)) {

--- a/packages/core/helper-plugin/lib/src/old/utils/templateObject.js
+++ b/packages/core/helper-plugin/lib/src/old/utils/templateObject.js
@@ -1,4 +1,4 @@
-import { isPlainObject, isString, isArray } from 'lodash';
+import { isPlainObject, isString } from 'lodash';
 
 const templateObject = function(obj, variables) {
   // Allow values which looks like such as
@@ -11,7 +11,7 @@ const templateObject = function(obj, variables) {
   };
 
   return Object.keys(obj).reduce((acc, key) => {
-    if (isPlainObject(obj[key]) || isArray(obj[key])) {
+    if (isPlainObject(obj[key]) || Array.isArray(obj[key])) {
       acc[key] = templateObject(obj[key], variables[key]);
     } else if (isString(obj[key]) && regex.test(obj[key])) {
       acc[key] = obj[key].replace(regex, replacer);

--- a/packages/core/strapi/lib/services/metrics/stringify-deep.js
+++ b/packages/core/strapi/lib/services/metrics/stringify-deep.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { map, mapValues, isObject, isArray, toString } = require('lodash/fp');
+const { map, mapValues, isObject, toString } = require('lodash/fp');
 
 /**
  * Stringify all non object valutes before send them
@@ -8,7 +8,7 @@ const { map, mapValues, isObject, isArray, toString } = require('lodash/fp');
  * @returns {object}
  */
 const stringifyDeep = value => {
-  if (isArray(value)) {
+  if (Array.isArray(value)) {
     return map(stringifyDeep, value);
   }
 

--- a/packages/core/strapi/lib/services/server/middleware.js
+++ b/packages/core/strapi/lib/services/server/middleware.js
@@ -1,14 +1,14 @@
 'use strict';
 
 const path = require('path');
-const { propOr, isArray, isNil } = require('lodash/fp');
+const { propOr, isNil } = require('lodash/fp');
 
 const getMiddlewareConfig = propOr([], 'config.middlewares');
 
 const resolveRouteMiddlewares = (route, strapi) => {
   const middlewaresConfig = getMiddlewareConfig(route);
 
-  if (!isArray(middlewaresConfig)) {
+  if (!Array.isArray(middlewaresConfig)) {
     throw new Error('Route middlewares config must be an array');
   }
 

--- a/packages/core/utils/lib/sanitize-entity.js
+++ b/packages/core/utils/lib/sanitize-entity.js
@@ -24,7 +24,7 @@ const sanitizeEntity = (dataSource, options) => {
     return data;
   }
 
-  if (_.isArray(data)) {
+  if (Array.isArray(data)) {
     return data.map(entity => sanitizeEntity(entity, options));
   }
 

--- a/packages/plugins/documentation/server/services/documentation.js
+++ b/packages/plugins/documentation/server/services/documentation.js
@@ -22,7 +22,7 @@ const defaultSettingsKeys = Object.keys(defaultSettings);
 const customIsEqual = (obj1, obj2) => _.isEqualWith(obj1, obj2, customComparator);
 
 const customComparator = (value1, value2) => {
-  if (_.isArray(value1) && _.isArray(value2)) {
+  if (Array.isArray(value1) && Array.isArray(value2)) {
     if (value1.length !== value2.length) {
       return false;
     }
@@ -39,7 +39,7 @@ module.exports = ({ strapi }) => ({
   cleanObject: obj => JSON.parse(JSON.stringify(obj)),
 
   arrayCustomizer(objValue, srcValue) {
-    if (_.isArray(objValue)) return objValue.concat(srcValue);
+    if (Array.isArray(objValue)) return objValue.concat(srcValue);
   },
 
   checkIfAPIDocNeedsUpdate(apiName) {

--- a/packages/plugins/graphql/server/bootstrap.js
+++ b/packages/plugins/graphql/server/bootstrap.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { isEmpty, mergeWith, isArray } = require('lodash/fp');
+const { isEmpty, mergeWith } = require('lodash/fp');
 const { ApolloServer } = require('apollo-server-koa');
 const {
   ApolloServerPluginLandingPageDisabled,
@@ -10,7 +10,7 @@ const depthLimit = require('graphql-depth-limit');
 const { graphqlUploadKoa } = require('graphql-upload');
 
 const merge = mergeWith((a, b) => {
-  if (isArray(a) && isArray(b)) {
+  if (Array.isArray(a) && Array.isArray(b)) {
     return a.concat(b);
   }
 });

--- a/packages/plugins/graphql/server/services/builders/type.js
+++ b/packages/plugins/graphql/server/services/builders/type.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { isArray, isString, isUndefined, constant } = require('lodash/fp');
+const { isString, isUndefined, constant } = require('lodash/fp');
 const { objectType } = require('nexus');
 
 const { contentTypes } = require('@strapi/utils');
@@ -190,7 +190,7 @@ module.exports = context => {
     }
 
     // If the target is an array of string, resolve the associated morph type and use it
-    else if (isArray(target) && target.every(isString)) {
+    else if (Array.isArray(target) && target.every(isString)) {
       const type = naming.getMorphRelationTypeName(contentType, attributeName);
 
       builder.field(attributeName, { type, resolve });
@@ -267,7 +267,7 @@ module.exports = context => {
       const { attributes, modelType, options = {} } = contentType;
 
       const attributesKey = Object.keys(attributes);
-      const hasTimestamps = isArray(options.timestamps);
+      const hasTimestamps = Array.isArray(options.timestamps);
 
       const name = (modelType === 'component' ? getComponentName : getTypeName).call(
         null,

--- a/packages/plugins/i18n/server/services/content-types.js
+++ b/packages/plugins/i18n/server/services/content-types.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
-const { pick, pipe, has, prop, isNil, cloneDeep, isArray } = require('lodash/fp');
+const { pick, pipe, has, prop, isNil, cloneDeep } = require('lodash/fp');
 const {
   isRelationalAttribute,
   getVisibleAttributes,
@@ -129,7 +129,7 @@ const removeIdsMut = (model, entry) => {
 
   _.forEach(model.attributes, (attr, attrName) => {
     const value = entry[attrName];
-    if (attr.type === 'dynamiczone' && isArray(value)) {
+    if (attr.type === 'dynamiczone' && Array.isArray(value)) {
       value.forEach(compo => {
         if (has('__component', compo)) {
           const model = strapi.components[compo.__component];
@@ -138,7 +138,7 @@ const removeIdsMut = (model, entry) => {
       });
     } else if (attr.type === 'component') {
       const model = strapi.components[attr.component];
-      if (isArray(value)) {
+      if (Array.isArray(value)) {
         value.forEach(compo => removeIdsMut(model, compo));
       } else {
         removeIdsMut(model, value);
@@ -158,7 +158,10 @@ const removeIdsMut = (model, entry) => {
 const copyNonLocalizedAttributes = (model, entry) => {
   const nonLocalizedAttributes = getNonLocalizedAttributes(model);
 
-  return pipe(pick(nonLocalizedAttributes), removeIds(model))(entry);
+  return pipe(
+    pick(nonLocalizedAttributes),
+    removeIds(model)
+  )(entry);
 };
 
 /**

--- a/packages/plugins/i18n/server/services/entity-service-decorator.js
+++ b/packages/plugins/i18n/server/services/entity-service-decorator.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { has, omit, isArray } = require('lodash/fp');
+const { has, omit } = require('lodash/fp');
 const { getService } = require('../utils');
 
 const LOCALE_QUERY_FILTER = 'locale';
@@ -10,7 +10,7 @@ const BULK_ACTIONS = ['delete'];
 const paramsContain = (key, params) => {
   return (
     has(key, params.filters) ||
-    (isArray(params.filters) && params.filters.some(clause => has(key, clause)))
+    (Array.isArray(params.filters) && params.filters.some(clause => has(key, clause)))
   );
 };
 

--- a/packages/plugins/i18n/server/services/permissions/actions.js
+++ b/packages/plugins/i18n/server/services/permissions/actions.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { capitalize, isArray, getOr, prop } = require('lodash/fp');
+const { capitalize, getOr, prop } = require('lodash/fp');
 const { getService } = require('../../utils');
 
 const actions = ['create', 'read', 'update', 'delete'].map(uid => ({
@@ -24,12 +24,12 @@ const addLocalesPropertyIfNeeded = ({ value: action }) => {
   }
 
   // If the 'locales' property is already declared within the applyToProperties array, then ignore the next steps
-  if (isArray(applyToProperties) && applyToProperties.includes('locales')) {
+  if (Array.isArray(applyToProperties) && applyToProperties.includes('locales')) {
     return;
   }
 
   // Add the 'locales' property to the applyToProperties array (create it if necessary)
-  action.options.applyToProperties = isArray(applyToProperties)
+  action.options.applyToProperties = Array.isArray(applyToProperties)
     ? applyToProperties.concat('locales')
     : ['locales'];
 };


### PR DESCRIPTION
### What does it do?

Replaces all imports of `isArray` from `lodash` with the native `Array.isArray`.

### Why is it needed?

`isArray` that `lodash` exports is just an alias for the `Array.isArray` method, no need to depend on `lodash` for this one. This PR also makes the use `Array.isArray` consistent across the whole codebase.

### How to test it?

Verify the changes in the PR.

### Related issue(s)/PR(s)


