### PR TITLE
Add support for string columns longer than the default 255 chars

### DIFF
--- a/packages/strapi-connector-bookshelf/lib/build-database-schema.js
+++ b/packages/strapi-connector-bookshelf/lib/build-database-schema.js
@@ -177,7 +177,7 @@ const buildColType = ({ name, attribute, table, tableExists = false, definition,
     case 'string':
     case 'password':
     case 'email':
-      return table.string(name);
+      return table.string(name, Math.max(attribute.maxLength || 0, 255));
     case 'integer':
       return table.integer(name);
     case 'biginteger':


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Updates bookshelf connector to pass through the maxLength field as the string column size.
In order to be a non-breaking change, it still passes through a minimum of 255 (the Knex default).

### Why is it needed?

The length of a string field is ignored, so if you were to create a field of size 300 and attempt to insert 300 chars into this field, it will fail. 

### How to test it?

1. Create new string field
2. Inspect created column to see that it has been created with a matching size or 255 (whichever is greater)

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/issues/11253
