### PR TITLE
[ML]: Duplicate when cropping in v4

### DIFF
--- a/packages/core/upload/admin/src/components/EditAssetDialog/PreviewBox/CroppingActions.js
+++ b/packages/core/upload/admin/src/components/EditAssetDialog/PreviewBox/CroppingActions.js
@@ -10,7 +10,7 @@ import { useIntl } from 'react-intl';
 import getTrad from '../../../utils/getTrad';
 import { CroppingActionRow } from './components';
 
-export const CroppingActions = ({ onCancel, onValidate }) => {
+export const CroppingActions = ({ onCancel, onValidate, onDuplicate }) => {
   const { formatMessage } = useIntl();
 
   return (
@@ -34,8 +34,18 @@ export const CroppingActions = ({ onCancel, onValidate }) => {
             as={IconButton}
             icon={<CheckIcon />}
           >
-            <MenuItem onClick={onValidate}>Crop the original asset</MenuItem>
-            <MenuItem>Somewhere internal</MenuItem>
+            <MenuItem onClick={onValidate}>
+              {formatMessage({
+                id: getTrad('checkControl.crop-original'),
+                defaultMessage: 'Crop the original asset',
+              })}
+            </MenuItem>
+            <MenuItem onClick={onDuplicate}>
+              {formatMessage({
+                id: getTrad('checkControl.crop-duplicate'),
+                defaultMessage: 'Duplicate & crop the asset',
+              })}
+            </MenuItem>
           </SimpleMenu>
         </Stack>
       </CroppingActionRow>
@@ -45,5 +55,6 @@ export const CroppingActions = ({ onCancel, onValidate }) => {
 
 CroppingActions.propTypes = {
   onCancel: PropTypes.func.isRequired,
+  onDuplicate: PropTypes.func.isRequired,
   onValidate: PropTypes.func.isRequired,
 };

--- a/packages/core/upload/admin/src/components/EditAssetDialog/index.js
+++ b/packages/core/upload/admin/src/components/EditAssetDialog/index.js
@@ -52,7 +52,12 @@ export const EditAssetDialog = ({ onClose, asset }) => {
         <ModalBody>
           <Grid gap={4}>
             <GridItem xs={12} col={6}>
-              <PreviewBox asset={asset} onDelete={onClose} replacementFile={replacementFile} />
+              <PreviewBox
+                asset={asset}
+                onDelete={onClose}
+                onCropFinish={onClose}
+                replacementFile={replacementFile}
+              />
             </GridItem>
             <GridItem xs={12} col={6}>
               <Formik

--- a/packages/core/upload/admin/src/hooks/useUpload.js
+++ b/packages/core/upload/admin/src/hooks/useUpload.js
@@ -37,7 +37,7 @@ export const useUpload = () => {
     },
   });
 
-  const upload = asset => mutation.mutate(asset);
+  const upload = asset => mutation.mutateAsync(asset);
   const cancel = () =>
     tokenRef.current.cancel(
       formatMessage({ id: getTrad('modal.upload.cancelled'), defaultMessage: '' })


### PR DESCRIPTION
### What does it do?

Allows to crop & duplicate an asset in v4

### Why is it needed?

🙄 

### How to test it?

- Create an asset in the media library
- Edit the asset
- Crop the asset in the preview
- Validate and select the duplicate option
- [ ] The popup should close
- [ ] The list should refresh with the new duplicated & cropped asset
