### PR TITLE
Show correct strapi version

### DIFF
--- a/packages/core/admin/admin/src/components/AuthenticatedApp/utils/api.js
+++ b/packages/core/admin/admin/src/components/AuthenticatedApp/utils/api.js
@@ -7,10 +7,10 @@ const strapiVersion = packageJSON.version;
 const fetchStrapiLatestRelease = async () => {
   try {
     const {
-      data: { tag_name },
-    } = await axios.get('https://api.github.com/repos/strapi/strapi/releases/latest');
+      data: { strapiVersion },
+    } = await axios.get(`${strapi.backendURL}/admin/information`);
 
-    return tag_name;
+    return strapiVersion;
   } catch (err) {
     // Don't throw an error
     return strapiVersion;


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Changed API source where get current strapi version.

### Why is it needed?

v4 does not show the correct strapi version.

### How to test it?

After build application, open the Strapi Application Info Page.

### Related issue(s)/PR(s)

Related issue: v4 does not show the correct version #11150
