### PR TITLE
Fix headersearch when search with reserved characters

### DIFF
--- a/packages/strapi-helper-plugin/lib/src/hooks/useQueryParams/index.js
+++ b/packages/strapi-helper-plugin/lib/src/hooks/useQueryParams/index.js
@@ -28,11 +28,10 @@ const useQueryParams = initialParams => {
         nextQuery = {
           ...query,
           ...nextParams,
-          _q: encodeURI(encodeURIComponent(nextParams._q)),
         };
       }
 
-      push({ search: stringify(nextQuery, { encode: false }) });
+      push({ search: stringify(nextQuery, { encodeValuesOnly: true }) });
     },
     [push, query]
   );

--- a/packages/strapi-helper-plugin/lib/src/hooks/useQueryParams/index.js
+++ b/packages/strapi-helper-plugin/lib/src/hooks/useQueryParams/index.js
@@ -25,7 +25,11 @@ const useQueryParams = initialParams => {
           delete nextQuery[key];
         });
       } else {
-        nextQuery = { ...query, ...nextParams };
+        nextQuery = {
+          ...query,
+          ...nextParams,
+          _q: encodeURI(encodeURIComponent(nextParams._q)),
+        };
       }
 
       push({ search: stringify(nextQuery, { encode: false }) });

--- a/packages/strapi-helper-plugin/lib/src/hooks/useQueryParams/index.js
+++ b/packages/strapi-helper-plugin/lib/src/hooks/useQueryParams/index.js
@@ -28,10 +28,11 @@ const useQueryParams = initialParams => {
         nextQuery = {
           ...query,
           ...nextParams,
+          _q: encodeURIComponent(nextParams._q),
         };
       }
 
-      push({ search: stringify(nextQuery, { encodeValuesOnly: true }) });
+      push({ search: stringify(nextQuery, { encode: false }) });
     },
     [push, query]
   );

--- a/packages/strapi-plugin-content-manager/admin/src/containers/ListView/index.js
+++ b/packages/strapi-plugin-content-manager/admin/src/containers/ListView/index.js
@@ -110,7 +110,7 @@ function ListView({
   }, [query]);
 
   const _sort = query._sort;
-  const _q = query._q || '';
+  const _q = query._q ? decodeURIComponent(query._q) : '';
 
   const label = contentType.info.label;
 

--- a/packages/strapi-plugin-content-manager/admin/src/containers/ListView/index.js
+++ b/packages/strapi-plugin-content-manager/admin/src/containers/ListView/index.js
@@ -110,7 +110,7 @@ function ListView({
   }, [query]);
 
   const _sort = query._sort;
-  const _q = query._q ? decodeURIComponent(query._q) : '';
+  const _q = query._q || '';
 
   const label = contentType.info.label;
 

--- a/packages/strapi-plugin-content-manager/admin/src/containers/ListView/utils/buildQueryString.js
+++ b/packages/strapi-plugin-content-manager/admin/src/containers/ListView/utils/buildQueryString.js
@@ -16,11 +16,12 @@ const buildQueryString = (queryParams = {}) => {
    */
   const { plugins: _, ...otherQueryParams } = {
     ...queryParams,
+    ...(queryParams._q && { _q: encodeURIComponent(queryParams._q) }),
     _where,
     ...createPluginsFilter(queryParams.plugins),
   };
 
-  return `?${stringify(otherQueryParams, { encodeValuesOnly: true })}`;
+  return `?${stringify(otherQueryParams, { encode: false })}`;
 };
 
 export default buildQueryString;

--- a/packages/strapi-plugin-content-manager/admin/src/containers/ListView/utils/buildQueryString.js
+++ b/packages/strapi-plugin-content-manager/admin/src/containers/ListView/utils/buildQueryString.js
@@ -20,7 +20,7 @@ const buildQueryString = (queryParams = {}) => {
     ...createPluginsFilter(queryParams.plugins),
   };
 
-  return `?${stringify(otherQueryParams, { encode: false })}`;
+  return `?${stringify(otherQueryParams, { encodeValuesOnly: true })}`;
 };
 
 export default buildQueryString;


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Fix headersearch query when you search by reserved characters.
;,/?:@&=+$ -> Reserved Characters

### Why is it needed?

If you have content with reserved characters as a text, you can find it with the strapi content admin

### How to test it?

You can test it for example creating content with reserved characters in title like as "fish&chips" and use header search.
 
![image](https://user-images.githubusercontent.com/6350474/137806869-44ce3955-996f-4557-8fd8-0033da23ff5d.png)


### Related issue(s)/PR(s)

#10780
