### PR TITLE
[v4] Adjust api prefix location

### DIFF
--- a/packages/core/strapi/lib/services/server/content-api.js
+++ b/packages/core/strapi/lib/services/server/content-api.js
@@ -4,7 +4,7 @@ const { createAPI } = require('./api');
 
 const createContentAPI = strapi => {
   const opts = {
-    prefix: strapi.config.get('api.prefix', '/api'),
+    prefix: strapi.config.get('api.rest.prefix', '/api'),
     type: 'content-api',
   };
 


### PR DESCRIPTION
### What does it do?

Moves the API prefix into the REST object in `api.js`

### Why is it needed?

Only affects REST

### How to test it?

N/A

### Related issue(s)/PR(s)

N/A
