### PR TITLE
[V4] Fix a bug preventing the filters to be passed in the populate params

### DIFF
--- a/packages/core/database/lib/query/helpers/populate.js
+++ b/packages/core/database/lib/query/helpers/populate.js
@@ -103,6 +103,7 @@ const pickPopulateParams = _.pick([
   'orderBy',
   'limit',
   'offset',
+  'filters',
 ]);
 
 // TODO: cleanup code
@@ -123,8 +124,8 @@ const applyPopulate = async (results, populate, ctx) => {
     const targetMeta = db.metadata.get(attribute.target);
 
     const populateValue = {
-      ...pickPopulateParams(populate[key]),
       filters: qb.state.filters,
+      ...pickPopulateParams(populate[key]),
     };
 
     const isCount = populateValue.count === true;


### PR DESCRIPTION
**Where?** Query builder's popualte helper

**What?**
- Prevent `filters` to be omitted from the populate params.
- Use the custom filters if they are defined in the populate params.