### PR TITLE
remove count route from the upload plugin

### DIFF
--- a/packages/core/upload/server/controllers/admin-api.js
+++ b/packages/core/upload/server/controllers/admin-api.js
@@ -60,23 +60,6 @@ module.exports = {
     ctx.body = pm.sanitize(file, { withPrivate: false });
   },
 
-  async count(ctx) {
-    const pm = strapi.admin.services.permission.createPermissionsManager({
-      ability: ctx.state.userAbility,
-      action: ACTIONS.read,
-      model: fileModel,
-    });
-
-    if (!pm.isAllowed) {
-      return ctx.forbidden();
-    }
-
-    const query = pm.addPermissionsQueryTo(ctx.query);
-    const count = await getService('upload').count(query);
-
-    ctx.body = { count };
-  },
-
   async destroy(ctx) {
     const { id } = ctx.params;
     const { userAbility } = ctx.state;

--- a/packages/core/upload/server/routes/admin.js
+++ b/packages/core/upload/server/routes/admin.js
@@ -45,22 +45,6 @@ module.exports = {
     },
     {
       method: 'GET',
-      path: '/files/count',
-      handler: 'admin-api.count',
-      config: {
-        policies: [
-          'admin::isAuthenticatedAdmin',
-          {
-            name: 'admin::hasPermissions',
-            config: {
-              actions: ['plugin::upload.read'],
-            },
-          },
-        ],
-      },
-    },
-    {
-      method: 'GET',
       path: '/files',
       handler: 'admin-api.find',
       config: {

--- a/packages/core/upload/server/services/upload.js
+++ b/packages/core/upload/server/services/upload.js
@@ -310,10 +310,6 @@ module.exports = ({ strapi }) => ({
     return strapi.entityService.findPage('plugin::upload.file', query);
   },
 
-  count(query) {
-    return strapi.entityService.count('plugin::upload.file', query);
-  },
-
   async remove(file) {
     const config = strapi.config.get('plugin.upload');
 

--- a/packages/core/upload/tests/upload.test.e2e.js
+++ b/packages/core/upload/tests/upload.test.e2e.js
@@ -162,7 +162,6 @@ describe('Upload plugin end to end tests', () => {
     });
   });
 
-  test.todo('GET /upload/files/count => Count available files');
   test.todo('GET /upload/files/:id => Find one file');
   test.todo('GET /upload/search/:id => Search files');
   test.todo('DELETE /upload/files/:id => Delete a file');


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Removes the count route from the admin api for the upload plugin.

### Why is it needed?

The route isn't used by the front-end anymore.
