### PR TITLE
[v4] Add token only when available

### DIFF
--- a/packages/core/admin/admin/src/core/utils/axiosInstance.js
+++ b/packages/core/admin/admin/src/core/utils/axiosInstance.js
@@ -13,7 +13,7 @@ instance.interceptors.request.use(
     };
 
     if (auth.getToken() !== null) {
-      config.headers['Authorization'] = `Bearer ${auth.getToken()}`;
+      config.headers.Authorization = `Bearer ${auth.getToken()}`;
     }
 
     return config;

--- a/packages/core/admin/admin/src/core/utils/axiosInstance.js
+++ b/packages/core/admin/admin/src/core/utils/axiosInstance.js
@@ -8,10 +8,13 @@ const instance = axios.create({
 instance.interceptors.request.use(
   async config => {
     config.headers = {
-      Authorization: `Bearer ${auth.getToken()}`,
       Accept: 'application/json',
       'Content-Type': 'application/json',
     };
+
+    if (auth.getToken() !== null) {
+      config.headers['Authorization'] = `Bearer ${auth.getToken()}`;
+    }
 
     return config;
   },

--- a/packages/core/admin/admin/src/core/utils/axiosInstance.js
+++ b/packages/core/admin/admin/src/core/utils/axiosInstance.js
@@ -8,13 +8,10 @@ const instance = axios.create({
 instance.interceptors.request.use(
   async config => {
     config.headers = {
+      ...(auth.getToken() && { Authorization: `Bearer ${auth.getToken()}` }),
       Accept: 'application/json',
       'Content-Type': 'application/json',
     };
-
-    if (auth.getToken() !== null) {
-      config.headers.Authorization = `Bearer ${auth.getToken()}`;
-    }
 
     return config;
   },


### PR DESCRIPTION
### What does it do?
It prevents from sending a nulled Bearer Authentication header at login.

### Why is it needed?
When using basic authentication, to secure the general access of the admin UI, this ends up breaking the authentication because of a nulled `Bearer` at the moment.

### How to test it?
1. Logout of Strapi CMS
2. Open Web Inspector
3. Enable the Network tab
4. Login
5. Watch out for the `/admin/project-type` request
6. The request header should not include a nulled Authorization with this PR

### Related issue(s)/PR(s)
None