### PR TITLE
#11138 Adjust the description of the yarn strapi --help command for w…

### DIFF
--- a/packages/core/strapi/bin/strapi.js
+++ b/packages/core/strapi/bin/strapi.js
@@ -155,7 +155,7 @@ program
 program
   .command('watch-admin')
   .option('--browser <name>', 'Open the browser', true)
-  .description('Starts the admin dev server')
+  .description('Starts the admin front-end dev server')
   .action(getLocalScript('watchAdmin'));
 
 program


### PR DESCRIPTION
…atch-admin


### What does it do?

It adds more info on the cli --help command for watch-mode. Notably that it starts only the front-end dev server.

### Why is it needed?

There is a open issue https://github.com/strapi/strapi/issues/11138

### How to test it?

`yarn strapi --help`

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/issues/11138
