### PR TITLE
Check `role` to not be null in user-permissions

### DIFF
--- a/packages/strapi-plugin-users-permissions/services/UsersPermissions.js
+++ b/packages/strapi-plugin-users-permissions/services/UsersPermissions.js
@@ -259,7 +259,7 @@ module.exports = {
     const dbPermissions = await strapi
       .query('permission', 'users-permissions')
       .find({ _limit: -1 });
-    let permissionsFoundInDB = dbPermissions.map(
+    let permissionsFoundInDB = dbPermissions.filter(p => !!p.role).map(
       p => `${p.type}.${p.controller}.${p.action}.${p.role[primaryKey]}`
     );
     permissionsFoundInDB = _.uniq(permissionsFoundInDB);


### PR DESCRIPTION
### What does it do?

Check user-permissions `role` to not be null before accessing primaryKey `id`

### Why is it needed?

![image](https://user-images.githubusercontent.com/1384475/139204442-0104152f-475e-4c59-9956-bbf4aa925614.png)

### How to test it?

Run `yarn develop` or `yarn strapi develop`

### Related issue(s)/PR(s)

No
