### PR TITLE
Replace outdated link to documentation

### DIFF
--- a/packages/strapi-generate-model/templates/model.template
+++ b/packages/strapi-generate-model/templates/model.template
@@ -1,7 +1,7 @@
 'use strict';
 
 /**
- * Read the documentation (https://strapi.io/documentation/developer-docs/latest/concepts/models.html#lifecycle-hooks)
+ * Read the documentation (https://strapi.io/documentation/developer-docs/latest/development/backend-customization.html#lifecycle-hooks)
  * to customize this model
  */
 


### PR DESCRIPTION
Hi,

while setting up a new project I noticed a dead link when creating a new model with the CLI

### What does it do?

Replaced link to documentation

### Why is it needed?

The original link is dead

### How to test it?

Visit links

### Related issue(s)/PR(s)

/
