### PR TITLE
QA/ Search query fix

### DIFF
--- a/packages/core/helper-plugin/lib/src/components/Search/index.js
+++ b/packages/core/helper-plugin/lib/src/components/Search/index.js
@@ -58,6 +58,12 @@ const Search = ({ label, trackedEvent }) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [value]);
 
+  useEffect(() => {
+    if (value && !isOpen) {
+      setIsOpen(true);
+    }
+  }, [value, isOpen]);
+
   if (isOpen) {
     return (
       <div ref={wrapperRef}>


### PR DESCRIPTION
## What

Attempt to fix the search by query in CM

## Demo

Go to CM listview of a collection type
Search for something in the search bar
The page should reload but the search bar stays open with the value of the search in it