### PR TITLE
Fix/sso redirect uri

### DIFF
--- a/packages/plugins/users-permissions/server/bootstrap/index.js
+++ b/packages/plugins/users-permissions/server/bootstrap/index.js
@@ -163,6 +163,16 @@ const initGrant = async pluginStore => {
       scope: ['openid email'], // scopes should be space delimited
       subdomain: 'my.subdomain.com/cas',
     },
+    crossid: {
+      enabled: false,
+      icon: '',
+      key: '',
+      secret: '',
+      state: true,
+      callback: `${baseURL}/auth/crossid/callback`,
+      subdomain: 'my-tenant',
+      scope: ['openid', 'email', 'profile'],
+    },
   };
 
   const prevGrantConfig = (await pluginStore.get({ key: 'grant' })) || {};

--- a/packages/plugins/users-permissions/server/services/providers.js
+++ b/packages/plugins/users-permissions/server/services/providers.js
@@ -489,6 +489,45 @@ module.exports = ({ strapi }) => {
           });
         break;
       }
+      case 'crossid': {
+        const purestCrossidConf = {};
+        purestCrossidConf[`https://${grant.crossid.subdomain}.crossid.io`] = {
+          __domain: {
+            auth: {
+              auth: { bearer: '[0]' },
+            },
+          },
+          '{endpoint}': {
+            __path: {
+              alias: '__default',
+            },
+          },
+        };
+        const crossid = purest({
+          provider: 'crossid',
+          config: {
+            crossid: purestCrossidConf,
+          },
+        });
+
+        crossid
+          .get('oauth2/userinfo')
+          .auth(access_token)
+          .request((err, res, body) => {
+            if (err) {
+              callback(err);
+            } else {
+              const username =
+                body.preferred_username || body.username || body.email.split('@')[0] || body.sub;
+              const email = body.email || `${username.replace(/\s+/g, '.')}@strapi.io`;
+              callback(null, {
+                username,
+                email,
+              });
+            }
+          });
+        break;
+      }
       default:
         callback(new Error('Unknown provider.'));
         break;

--- a/packages/plugins/users-permissions/server/services/providers.js
+++ b/packages/plugins/users-permissions/server/services/providers.js
@@ -588,7 +588,7 @@ module.exports = ({ strapi }) => {
 
   const buildRedirectUri = (provider = '') => {
     const apiPrefix = strapi.config.get('api.rest.prefix');
-    return `${getAbsoluteServerUrl(strapi.config)}/${apiPrefix}/connect/${provider}/callback`;
+    return `${getAbsoluteServerUrl(strapi.config)}${apiPrefix}/connect/${provider}/callback`;
   };
 
   return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12263,9 +12263,9 @@ grant-koa@5.4.8:
     grant "^5.4.8"
 
 grant@^5.4.8:
-  version "5.4.17"
-  resolved "https://registry.yarnpkg.com/grant/-/grant-5.4.17.tgz#59aad7f04c1843612cb0e6816e038a07f65c9859"
-  integrity sha512-bLpJYxkmi3kg/gV5v9Iv7xqgzAgWP7MhXaMwZVKnzhwiFPKZGzntUgq61aQ8QuLdmpm7tPxRv9Rw6xY4vqaAsA==
+  version "5.4.18"
+  resolved "https://registry.yarnpkg.com/grant/-/grant-5.4.18.tgz#4d95ef7be1db6169feb638a26762a9525faea675"
+  integrity sha512-5rw0RkbpmzgM1Q4n8FSasnlqud2NcyxFaEMjA++JQ77MGbRL8VnUZ3JeBoF0HTyfI+xzJbHn68LhtLdYnBz3rA==
   dependencies:
     qs "^6.10.1"
     request-compose "^2.1.4"


### PR DESCRIPTION
- Authenticate via crossid.io provider.
- Fixes an issue where redirect URI is built with a double slash.

What does it do?
Adds crossid.io as an auth provider.

Related issue(s)/PR(s)
Related to issue #11305
Related to PR #11306