### PR TITLE
Enable Node 16 and NPM 7/8 support on generation

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -43,9 +43,9 @@ If applicable, add code samples to help explain your problem.
 
 ### System
 
-- Node.js version: <!-- Please ensure you are using the Node LTS version (v12 / v14) -->
+- Node.js version: <!-- Please ensure you are using the Node LTS version (v12, v14, v16) -->
 - NPM version:
-- Strapi version: <!-- Beta and Alpha versions are no longer supported -->
+- Strapi version: <!-- v3 is not supported unless it is a critical/high security issue -->
 - Database:
 - Operating system:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ The core team will review your pull request and will either merge it, request ch
 
 ## Contribution Prerequisites
 
-- You have [Node](https://nodejs.org/en/) at >= v10 and <= v14 and [Yarn](https://yarnpkg.com/en/) at v1.2.0+.
+- You have [Node](https://nodejs.org/en/) at >= v12 and <= v16 and [Yarn](https://yarnpkg.com/en/) at v1.2.0+.
 - You are familiar with Git.
 
 ## Development Workflow

--- a/packages/generators/app/lib/resources/json/package.json.js
+++ b/packages/generators/app/lib/resources/json/package.json.js
@@ -44,8 +44,8 @@ module.exports = opts => {
       ...packageJsonStrapi,
     },
     engines: {
-      node: '>=12.x.x <=14.x.x',
-      npm: '^6.0.0',
+      node: '>=12.x.x <=16.x.x',
+      npm: '>=6.0.0',
     },
     license: 'MIT',
   };


### PR DESCRIPTION
### What does it do?

Modifies the new project generator to properly set the engines object to support Node 16

### Why is it needed?

Prepare for stable release

### How to test it?

- Generate a fresh project and confirm the root project package.json has the proper engine keys to match all other core packages
- Try to install node modules using both npm and yarn
- Try to start Strapi using Node 16

### Related issue(s)/PR(s)

fixes #11135 
