### PR TITLE
[v4] Update all documentation links to new docs url

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,7 +71,7 @@ _For users running on Apple Silicon M1, you may encounter errors thrown by `shar
 
 To facilitate the contribution, we have drastically reduced the amount of commands necessary to install the entire development environment.
 
-First of all, you need to check if you're using the [required versions of Node.js and npm](https://strapi.io/documentation/developer-docs/latest/setup-deployment-guides/deployment.html#recommended-requirements).
+First of all, you need to check if you're using the [required versions of Node.js and npm](https://docs.strapi.io/developer-docs/latest/setup-deployment-guides/deployment.html).
 
 Then, please follow the instructions below:
 

--- a/README.md
+++ b/README.md
@@ -33,13 +33,13 @@
 Strapi is a free and open-source headless CMS delivering your content anywhere you need.
 
 - **Keep control over your data**. With Strapi, you know where your data is stored, and you keep full control at all times.
-- **Self-hosted**. You can host and scale Strapi projects the way you want. You can choose any hosting platform you want: AWS, Render, Heroku, a VPS, or a dedicated server. You can scale as you grow, 100% independent.
-- **Database agnostic**. You can choose the database you prefer. Strapi works with SQL databases: PostgreSQL, MySQL, MariaDB, and SQLite.
+- **Self-hosted**. You can host and scale Strapi projects the way you want. You can choose any hosting platform you want: AWS, Render, Netlify, Heroku, a VPS, or a dedicated server. You can scale as you grow, 100% independent.
+- **Database agnostic**. Strapi works with SQL databases. You can choose the database you prefer: PostgreSQL, MySQL, MariaDB, and SQLite.
 - **Customizable**. You can quickly build your logic by fully customizing APIs, routes, or plugins to fit your needs perfectly.
 
 ## Getting Started
 
-<a href="https://strapi.io/documentation/developer-docs/latest/getting-started/quick-start.html" target="_blank">Read the Getting Started tutorial</a> or follow the steps below:
+<a href="https://docs.strapi.io/developer-docs/latest/getting-started/quick-start.html" target="_blank">Read the Getting Started tutorial</a> or follow the steps below:
 
 ### ⏳ Installation
 
@@ -65,7 +65,7 @@ Enjoy 🎉
 
 ### 🖐 Requirements
 
-Complete installation requirements can be found in the documentation under <a href="https://strapi.io/documentation/developer-docs/latest/setup-deployment-guides/deployment.html#recommended-requirements">Installation Requirements</a>.
+Complete installation requirements can be found in the documentation under <a href="https://docs.strapi.io/developer-docs/latest/setup-deployment-guides/deployment.html">Installation Requirements</a>.
 
 **Supported operating systems**:
 
@@ -109,7 +109,7 @@ Please read our [Contributing Guide](./CONTRIBUTING.md) before submitting a Pull
 
 ## Community support
 
-For general help using Strapi, please refer to [the official Strapi documentation](https://strapi.io/documentation/). For additional help, you can use one of these channels to ask a question:
+For general help using Strapi, please refer to [the official Strapi documentation](https://docs.strapi.io). For additional help, you can use one of these channels to ask a question:
 
 - [Discord](https://discord.strapi.io) (For live discussion with the Community and Strapi team)
 - [GitHub](https://github.com/strapi/strapi) (Bug reports, Contributions)
@@ -122,7 +122,7 @@ For general help using Strapi, please refer to [the official Strapi documentatio
 
 ## Migration
 
-Follow our [migration guides](https://strapi.io/documentation/developer-docs/latest/update-migration-guides/migration-guides.html) on the documentation to keep your projects up-to-date.
+Follow our [migration guides](https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides.html) on the documentation to keep your projects up-to-date.
 
 ## Roadmap
 
@@ -132,8 +132,8 @@ Check out our [roadmap](https://portal.productboard.com/strapi) to get informed 
 
 See our dedicated [repository](https://github.com/strapi/documentation) for the Strapi documentation, or view our documentation live:
 
-- [Developer docs](https://strapi.io/documentation/developer-docs/latest/getting-started/introduction.html)
-- [User docs](https://strapi.io/documentation/user-docs/latest/getting-started/introduction.html)
+- [Developer docs](https://docs.strapi.io/developer-docs/latest/getting-started/introduction.html)
+- [User guide](https://docs.strapi.io/user-docs/latest/getting-started/introduction.html)
 
 ## Try live demo
 

--- a/packages/core/admin/admin/src/components/AutoReloadOverlayBlockerProvider/Blocker.js
+++ b/packages/core/admin/admin/src/components/AutoReloadOverlayBlockerProvider/Blocker.js
@@ -73,7 +73,7 @@ const Blocker = ({ displayedIcon, description, title, isOpen }) => {
           <Flex justifyContent="center">
             <Box paddingTop={2}>
               <Link
-                href="https://strapi.io/documentation"
+                href="https://docs.strapi.io"
                 target="_blank"
                 rel="noopener noreferrer nofollow"
               >

--- a/packages/core/admin/admin/src/pages/Admin/Onboarding/index.js
+++ b/packages/core/admin/admin/src/pages/Admin/Onboarding/index.js
@@ -78,7 +78,7 @@ const Onboarding = () => {
         id: 'app.components.LeftMenuFooter.documentation',
         defaultMessage: 'Documentation',
       }),
-      destination: 'https://strapi.io/documentation',
+      destination: 'https://docs.strapi.io',
     },
     {
       icon: 'file',

--- a/packages/core/content-manager/oas.yml
+++ b/packages/core/content-manager/oas.yml
@@ -6,7 +6,7 @@ servers:
   - url: http://localhost:1337
     description: Local server
 externalDocs:
-  url: https://strapi.io/documentation
+  url: https://docs.strapi.io
   description: Strapi documentation
 paths:
   /content-manager/content-types:

--- a/packages/core/email/admin/src/pages/Settings/components/Configuration.js
+++ b/packages/core/email/admin/src/pages/Settings/components/Configuration.js
@@ -33,7 +33,7 @@ const Configuration = ({ config }) => {
               file: './config/plugins.js',
               link: (
                 <a
-                  href="https://strapi.io/documentation/developer-docs/latest/development/plugins/email.html#configure-the-plugin"
+                  href="https://docs.strapi.io/developer-docs/latest/plugins/email.html"
                   target="_blank"
                   rel="noopener noreferrer"
                 >

--- a/packages/core/email/server/controllers/email.js
+++ b/packages/core/email/server/controllers/email.js
@@ -41,7 +41,7 @@ module.exports = {
       subject: `Strapi test mail to: ${to}`,
       text: `Great! You have correctly configured the Strapi email plugin with the ${strapi.config.get(
         'plugin.email.provider'
-      )} provider. \r\nFor documentation on how to use the email plugin checkout: https://strapi.io/documentation/developer-docs/latest/development/plugins/email.html`,
+      )} provider. \r\nFor documentation on how to use the email plugin checkout: https://docs.strapi.io/developer-docs/latest/plugins/email.html`,
     };
 
     try {

--- a/packages/core/helper-plugin/lib/src/old/components/OverlayBlocker/index.js
+++ b/packages/core/helper-plugin/lib/src/old/components/OverlayBlocker/index.js
@@ -1,0 +1,142 @@
+/*
+ *
+ * OverlayBlocker
+ *
+ */
+
+import React from 'react';
+import ReactDOM from 'react-dom';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import cn from 'classnames';
+import Container from './Container';
+import Overlay from './Overlay';
+
+const DELAY = 1000;
+
+class OverlayBlocker extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = { elapsed: 0, start: 0 };
+    this.overlayContainer = document.createElement('div');
+
+    document.body.appendChild(this.overlayContainer);
+  }
+
+  componentDidUpdate(prevProps) {
+    const { isOpen } = this.props;
+
+    if (prevProps.isOpen !== this.props.isOpen && isOpen) {
+      this.startTimer();
+    }
+
+    if (prevProps.isOpen !== isOpen && !isOpen) {
+      this.stopTimer();
+    }
+  }
+
+  componentWillUnmount() {
+    document.body.removeChild(this.overlayContainer);
+  }
+
+  tick = () => {
+    const { elapsed } = this.state;
+
+    if (elapsed > 15) {
+      clearInterval(this.timer);
+
+      return;
+    }
+
+    this.setState(prevState => ({
+      elapsed: Math.round(Date.now() - prevState.start) / 1000,
+    }));
+  };
+
+  startTimer = () => {
+    this.setState({ start: Date.now() });
+    this.timer = setInterval(this.tick, DELAY);
+  };
+
+  stopTimer = () => {
+    this.setState({ elapsed: 0 });
+    clearInterval(this.timer);
+  };
+
+  render() {
+    let { title, description, icon } = this.props;
+    const { elapsed } = this.state;
+
+    let button = (
+      <div className="buttonContainer">
+        <a
+          className={cn('primary', 'btn')}
+          href="https://strapi.io/documentation"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Read the documentation
+        </a>
+      </div>
+    );
+
+    if (elapsed > 15) {
+      button = null;
+      icon = ['far', 'clock'];
+      description = 'components.OverlayBlocker.description.serverError';
+      title = 'components.OverlayBlocker.title.serverError';
+    }
+
+    const content = this.props.children ? (
+      this.props.children
+    ) : (
+      <Container>
+        <div className={cn('icoContainer', elapsed < 15 && 'spinner')}>
+          <FontAwesomeIcon icon={icon} />
+        </div>
+        <div>
+          <h4>
+            <FormattedMessage id={title} />
+          </h4>
+          <p>
+            <FormattedMessage id={description} />
+          </p>
+          {button}
+        </div>
+      </Container>
+    );
+
+    if (this.props.isOpen) {
+      return ReactDOM.createPortal(
+        <Overlay noGradient={this.props.noGradient}>
+          <div>{content}</div>
+        </Overlay>,
+        this.overlayContainer
+      );
+    }
+
+    return '';
+  }
+}
+
+OverlayBlocker.defaultProps = {
+  children: null,
+  description: 'components.OverlayBlocker.description',
+  icon: 'sync-alt',
+  isOpen: false,
+  noGradient: false,
+  title: 'components.OverlayBlocker.title',
+};
+
+OverlayBlocker.propTypes = {
+  children: PropTypes.node,
+  description: PropTypes.string,
+  icon: PropTypes.string,
+  isOpen: PropTypes.bool,
+  noGradient: PropTypes.bool,
+  title: PropTypes.string,
+};
+
+export default OverlayBlocker;

--- a/packages/core/strapi/README.md
+++ b/packages/core/strapi/README.md
@@ -39,7 +39,7 @@ Strapi is a free and open-source headless CMS delivering your content anywhere y
 
 ## Getting Started
 
-<a href="https://strapi.io/documentation/developer-docs/latest/getting-started/quick-start.html" target="_blank">Read the Getting Started tutorial</a> or follow the steps below:
+<a href="https://docs.strapi.io/developer-docs/latest/getting-started/quick-start.html" target="_blank">Read the Getting Started tutorial</a> or follow the steps below:
 
 ### ⏳ Installation
 
@@ -65,7 +65,7 @@ Enjoy 🎉
 
 ### 🖐 Requirements
 
-Complete installation requirements can be found in the documentation under <a href="https://strapi.io/documentation/developer-docs/latest/setup-deployment-guides/deployment.html#recommended-requirements">Installation Requirements</a>.
+Complete installation requirements can be found in the documentation under <a href="https://docs.strapi.io/developer-docs/latest/setup-deployment-guides/deployment.html">Installation Requirements</a>.
 
 **Supported operating systems**:
 
@@ -79,7 +79,7 @@ Complete installation requirements can be found in the documentation under <a hr
 
 **Node:**
 
-- NodeJS >= 10.16 <=14
+- NodeJS >= 12 <= 16
 - NPM >= 6.x
 
 **Database:**
@@ -109,7 +109,7 @@ Please read our [Contributing Guide](./CONTRIBUTING.md) before submitting a Pull
 
 ## Community support
 
-For general help using Strapi, please refer to [the official Strapi documentation](https://strapi.io/documentation/). For additional help, you can use one of these channels to ask a question:
+For general help using Strapi, please refer to [the official Strapi documentation](https://docs.strapi.io). For additional help, you can use one of these channels to ask a question:
 
 - [Discord](https://discord.strapi.io) (For live discussion with the Community and Strapi team)
 - [GitHub](https://github.com/strapi/strapi) (Bug reports, Contributions)
@@ -122,7 +122,7 @@ For general help using Strapi, please refer to [the official Strapi documentatio
 
 ## Migration
 
-Follow our [migration guides](https://strapi.io/documentation/developer-docs/latest/update-migration-guides/migration-guides.html) on the documentation to keep your projects up-to-date.
+Follow our [migration guides](https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides.html) on the documentation to keep your projects up-to-date.
 
 ## Roadmap
 
@@ -132,8 +132,8 @@ Check out our [roadmap](https://portal.productboard.com/strapi) to get informed 
 
 See our dedicated [repository](https://github.com/strapi/documentation) for the Strapi documentation, or view our documentation live:
 
-- [Developer docs](https://strapi.io/documentation/developer-docs/latest/getting-started/introduction.html)
-- [User docs](https://strapi.io/documentation/user-docs/latest/getting-started/introduction.html)
+- [Developer docs](https://docs.strapi.io/developer-docs/latest/getting-started/introduction.html)
+- [User guide](https://docs.strapi.io/user-docs/latest/getting-started/introduction.html)
 
 ## Try live demo
 

--- a/packages/core/strapi/lib/services/metrics/index.js
+++ b/packages/core/strapi/lib/services/metrics/index.js
@@ -1,7 +1,7 @@
 'use strict';
 /**
  * Strapi telemetry package.
- * You can learn more at https://strapi.io/documentation/developer-docs/latest/getting-started/usage-information.html
+ * You can learn more at https://docs.strapi.io/developer-docs/latest/getting-started/usage-information.html
  */
 
 const crypto = require('crypto');

--- a/packages/core/utils/lib/convert-query-params.js
+++ b/packages/core/utils/lib/convert-query-params.js
@@ -2,7 +2,7 @@
 
 /**
  * Converts the standard Strapi REST query params to a more usable format for querying
- * You can read more here: https://strapi.io/documentation/developer-docs/latest/developer-resources/content-api/content-api.html#filters
+ * You can read more here: https://docs.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/rest-api.html#filters
  */
 const { has } = require('lodash/fp');
 const _ = require('lodash');

--- a/packages/plugins/documentation/server/config/default-config.js
+++ b/packages/plugins/documentation/server/config/default-config.js
@@ -26,7 +26,7 @@ module.exports = {
   servers: [],
   externalDocs: {
     description: 'Find out more',
-    url: 'https://strapi.io/documentation/developer-docs/latest/getting-started/introduction.html',
+    url: 'https://docs.strapi.io/developer-docs/latest/getting-started/introduction.html',
   },
   security: [
     {

--- a/packages/plugins/graphql/README.md
+++ b/packages/plugins/graphql/README.md
@@ -3,4 +3,4 @@
 This plugin will add GraphQL functionality to your app.
 By default it will provide you with most of the CRUD methods exposed in the Strapi REST API.
 
-To learn more about GraphQL in Strapi [visit documentation](https://strapi.io/documentation/developer-docs/latest/development/plugins/graphql.html)
+To learn more about GraphQL in Strapi [visit documentation](https://docs.strapi.io/developer-docs/latest/plugins/graphql.html)

--- a/packages/plugins/i18n/oas.yml
+++ b/packages/plugins/i18n/oas.yml
@@ -6,7 +6,7 @@ servers:
   - url: http://localhost:1337
     description: Local server
 externalDocs:
-  url: https://strapi.io/documentation
+  url: https://docs.strapi.io
   description: Strapi documentation
 paths:
   /i18n/iso-locales:

--- a/packages/plugins/users-permissions/documentation/1.0.0/overrides/users-permissions-User.json
+++ b/packages/plugins/users-permissions/documentation/1.0.0/overrides/users-permissions-User.json
@@ -6,7 +6,7 @@
         "security": [],
         "externalDocs": {
           "description": "Find out more in the strapi's documentation",
-          "url": "https://strapi.io/documentation/developer-docs/latest/development/plugins/users-permissions.html#registration"
+          "url": "https://docs.strapi.io/developer-docs/latest/plugins/users-permissions.html#registration"
         },
         "responses": {
           "200": {
@@ -58,7 +58,7 @@
         "security": [],
         "externalDocs": {
           "description": "Find out more in the strapi's documentation",
-          "url": "https://strapi.io/documentation/developer-docs/latest/development/plugins/users-permissions.html#email-validation"
+          "url": "https://docs.strapi.io/developer-docs/latest/plugins/users-permissions.html#email-validation"
         },
         "responses": {
           "200": {
@@ -130,7 +130,7 @@
         ],
         "externalDocs": {
           "description": "Find out more about the authentication flow in the strapi documentation",
-          "url": "https://strapi.io/documentation/developer-docs/latest/development/plugins/users-permissions.html#setting-up-the-provider-examples"
+          "url": "https://docs.strapi.io/developer-docs/latest/plugins/users-permissions.html#providers"
         },
         "responses": {
           "200": {
@@ -143,7 +143,7 @@
       "post": {
         "externalDocs": {
           "description": "Find out more in the strapi's documentation",
-          "url": "https://strapi.io/documentation/developer-docs/latest/development/plugins/users-permissions.html#login"
+          "url": "https://docs.strapi.io/developer-docs/latest/plugins/users-permissions.html#login"
         },
         "tags": ["Authentication"],
         "security": [],
@@ -188,7 +188,7 @@
         "tags": ["Authentication"],
         "externalDocs": {
           "description": "Find out more in the strapi's documentation",
-          "url": "https://strapi.io/documentation/developer-docs/latest/development/plugins/users-permissions.html#setting-up-the-provider-examples"
+          "url": "https://docs.strapi.io/developer-docs/latest/plugins/users-permissions.html#providers"
         },
         "parameters": [
           {
@@ -223,7 +223,7 @@
         "summary": "Send an email to reset your password",
         "externalDocs": {
           "description": "Find out more in the strapi's documentation",
-          "url": "https://strapi.io/documentation/developer-docs/latest/development/plugins/users-permissions.html#forgotten-reset-password"
+          "url": "https://docs.strapi.io/developer-docs/latest/plugins/users-permissions.html#forgotten-reset-password"
         },
         "requestBody": {
           "description": "",
@@ -315,7 +315,7 @@
       "description": "All the routes related to the authentication",
       "externalDocs": {
         "description": "Find out more in strapi's documentation",
-        "url": "https://strapi.io/documentation/developer-docs/latest/development/plugins/users-permissions.html"
+        "url": "https://docs.strapi.io/developer-docs/latest/plugins/users-permissions.html"
       }
     },
     {

--- a/packages/plugins/users-permissions/server/controllers/auth.js
+++ b/packages/plugins/users-permissions/server/controllers/auth.js
@@ -175,7 +175,7 @@ module.exports = {
 
     if (!strapi.config.server.url.startsWith('http')) {
       strapi.log.warn(
-        'You are using a third party provider for login. Make sure to set an absolute url in config/server.js. More info here: https://strapi.io/documentation/developer-docs/latest/development/plugins/users-permissions.html#setting-up-the-server-url'
+        'You are using a third party provider for login. Make sure to set an absolute url in config/server.js. More info here: https://docs.strapi.io/developer-docs/latest/plugins/users-permissions.html#setting-up-the-server-url'
       );
     }
 

--- a/packages/providers/upload-aws-s3/README.md
+++ b/packages/providers/upload-aws-s3/README.md
@@ -4,7 +4,7 @@
 
 Your configuration is passed down to the provider. (e.g: `new AWS.S3(config)`). You can see the complete list of options [here](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#constructor-property)
 
-See the [using a provider](https://strapi.io/documentation/developer-docs/latest/development/plugins/upload.html#using-a-provider) documentation for information on installing and using a provider. And see the [environment variables](https://strapi.io/documentation/developer-docs/latest/setup-deployment-guides/configurations.html#environment-variables) for setting and using environment variables in your configs.
+See the [using a provider](https://docs.strapi.io/developer-docs/latest/plugins/upload.html#using-a-provider) documentation for information on installing and using a provider. And see the [environment variables](https://docs.strapi.io/developer-docs/latest/setup-deployment-guides/configurations/optional/environment.html#environment-variables) for setting and using environment variables in your configs.
 
 **Example**
 

--- a/packages/providers/upload-cloudinary/README.md
+++ b/packages/providers/upload-cloudinary/README.md
@@ -6,7 +6,7 @@ Your configuration is passed down to the cloudinary configuration. (e.g: `cloudi
 
 `actionOptions` are passed directly to the upload and delete functions respectively allowing for custom options such as folder, type, etc. You can see the complete list of upload options [here](https://cloudinary.com/documentation/image_upload_api_reference#upload_optional_parameters) and delete options [here](https://cloudinary.com/documentation/image_upload_api_reference#destroy_optional_parameters)
 
-See the [using a provider](https://strapi.io/documentation/developer-docs/latest/development/plugins/upload.html#using-a-provider) documentation for information on installing and using a provider. And see the [environment variables](https://strapi.io/documentation/developer-docs/latest/setup-deployment-guides/configurations.html#environment-variables) for setting and using environment variables in your configs.
+See the [using a provider](https://docs.strapi.io/developer-docs/latest/plugins/upload.html#using-a-provider) documentation for information on installing and using a provider. And see the [environment variables](https://docs.strapi.io/developer-docs/latest/setup-deployment-guides/configurations/optional/environment.html#environment-variables) for setting and using environment variables in your configs.
 
 **Example**
 

--- a/packages/providers/upload-local/README.md
+++ b/packages/providers/upload-local/README.md
@@ -17,7 +17,7 @@ This provider has only one parameter: `sizeLimit`.
 }
 ```
 
-The `sizeLimit` parameter must be a number. Be aware that the unit is in bytes, and the default is 1000000. When setting this value high, you should make sure to also configure the body parser middleware `maxFileSize` so the file can be sent and processed. Read more [here](https://strapi.io/documentation/developer-docs/latest/development/plugins/upload.html#configuration)
+The `sizeLimit` parameter must be a number. Be aware that the unit is in bytes, and the default is 1000000. When setting this value high, you should make sure to also configure the body parser middleware `maxFileSize` so the file can be sent and processed. Read more [here](https://docs.strapi.io/developer-docs/latest/plugins/upload.html#configuration)
 
 ## Resources
 

--- a/packages/providers/upload-rackspace/README.md
+++ b/packages/providers/upload-rackspace/README.md
@@ -4,7 +4,7 @@
 
 Your configuration is passed down to the client initialization. (e.g: `createClient(config)`). The implementation is based on the package `pkgcloud`. You can read the docs [here](https://github.com/pkgcloud/pkgcloud#storage).
 
-See the [using a provider](https://strapi.io/documentation/developer-docs/latest/development/plugins/upload.html#using-a-provider) documentation for information on installing and using a provider. And see the [environment variables](https://strapi.io/documentation/developer-docs/latest/setup-deployment-guides/configurations.html#environment-variables) for setting and using environment variables in your configs.
+See the [using a provider](https://docs.strapi.io/developer-docs/latest/plugins/upload.html#using-a-provider) documentation for information on installing and using a provider. And see the [environment variables](https://docs.strapi.io/developer-docs/latest/setup-deployment-guides/configurations/optional/environment.html#environment-variables) for setting and using environment variables in your configs.
 
 **Example**
 


### PR DESCRIPTION
# DO NOT MERGE until v4 release day (or right before)

### What does it do?

Updates all references of `strapi.io/documentation` to their new `docs.strapi.io` links

### Why is it needed?

Moving documentation to a subdomain

### How to test it?

N/A

### Related issue(s)/PR(s)

N/A
