### PR TITLE
QA/ Wysiwyg link button size

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/Wysiwyg/WysiwygNav.js
+++ b/packages/core/admin/admin/src/content-manager/components/Wysiwyg/WysiwygNav.js
@@ -81,7 +81,7 @@ const WysiwygNav = ({
               />
             </MainButtons>
 
-            <MoreButton disabled ref={buttonMoreRef} id="more" label="more" icon={<More />} />
+            <MoreButton disabled ref={buttonMoreRef} id="more" label="More" icon={<More />} />
           </Flex>
 
           <Button onClick={onTogglePreviewMode} variant="tertiary" size="L" id="preview">
@@ -141,7 +141,7 @@ const WysiwygNav = ({
             ref={buttonMoreRef}
             onClick={onTogglePopover}
             id="more"
-            label="more"
+            label="More"
             icon={<More />}
           />
           {visiblePopover && (

--- a/packages/core/admin/admin/src/content-manager/components/Wysiwyg/WysiwygNav.js
+++ b/packages/core/admin/admin/src/content-manager/components/Wysiwyg/WysiwygNav.js
@@ -18,7 +18,13 @@ import Image from '@strapi/icons/Picture';
 import Link from '@strapi/icons/Link';
 import Quote from '@strapi/icons/Quote';
 import More from '@strapi/icons/More';
-import { MainButtons, CustomIconButton, MoreButton, IconButtonGroupMargin } from './WysiwygStyles';
+import {
+  MainButtons,
+  CustomIconButton,
+  MoreButton,
+  IconButtonGroupMargin,
+  CustomLinkIconButton,
+} from './WysiwygStyles';
 
 const WysiwygNav = ({
   editorRef,
@@ -179,7 +185,7 @@ const WysiwygNav = ({
                     name="Image"
                     icon={<Image />}
                   />
-                  <CustomIconButton
+                  <CustomLinkIconButton
                     onClick={() => onActionClick('Link', editorRef, onTogglePopover)}
                     id="Link"
                     label="Link"

--- a/packages/core/admin/admin/src/content-manager/components/Wysiwyg/WysiwygStyles.js
+++ b/packages/core/admin/admin/src/content-manager/components/Wysiwyg/WysiwygStyles.js
@@ -21,6 +21,13 @@ export const CustomIconButton = styled(IconButton)`
   }
 `;
 
+export const CustomLinkIconButton = styled(CustomIconButton)`
+  svg {
+    width: ${8 / 16}rem;
+    height: ${8 / 16}rem;
+  }
+`;
+
 export const MainButtons = styled(IconButtonGroup)`
   margin-left: ${({ theme }) => theme.spaces[4]};
 `;


### PR DESCRIPTION
## What

Fixed Wysiwyg link svg size (caused by @strapi/icons changes)

## Snapshot

before
<img width="630" alt="Capture d’écran 2021-10-29 à 23 20 49" src="https://user-images.githubusercontent.com/71838159/139877216-5339c842-1a0a-47fe-90e0-702550502863.png">

after

<img width="775" alt="Capture d’écran 2021-11-02 à 16 24 33" src="https://user-images.githubusercontent.com/71838159/139877255-6b046b5a-1536-4e54-82a1-34b310ce1687.png">


