### PR TITLE
QA/ Truncate name-description Role LV

### DIFF
--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/ListPage/components/RoleRow/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/ListPage/components/RoleRow/index.js
@@ -5,7 +5,7 @@ import { Flex } from '@strapi/design-system/Flex';
 import { Td, Tr } from '@strapi/design-system/Table';
 import { Text, EllipsisText } from '@strapi/design-system/Text';
 import { IconButton } from '@strapi/design-system/IconButton';
-import { stopPropagation, onRowClick } from '@strapi/helper-plugin';
+import { stopPropagation, onRowClick, pxToRem } from '@strapi/helper-plugin';
 import { useIntl } from 'react-intl';
 
 const RoleRow = ({ id, name, description, usersCount, icons }) => {
@@ -26,10 +26,10 @@ const RoleRow = ({ id, name, description, usersCount, icons }) => {
         fn: icons[1].onClick,
       })}
     >
-      <Td maxWidth={`${130 / 16}rem`}>
+      <Td maxWidth={pxToRem(130)}>
         <EllipsisText textColor="neutral800">{name}</EllipsisText>
       </Td>
-      <Td maxWidth={`${250 / 16}rem`}>
+      <Td maxWidth={pxToRem(250)}>
         <EllipsisText textColor="neutral800">{description}</EllipsisText>
       </Td>
       <Td>

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/ListPage/components/RoleRow/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/ListPage/components/RoleRow/index.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Box } from '@strapi/design-system/Box';
 import { Flex } from '@strapi/design-system/Flex';
 import { Td, Tr } from '@strapi/design-system/Table';
-import { Text } from '@strapi/design-system/Text';
+import { Text, EllipsisText } from '@strapi/design-system/Text';
 import { IconButton } from '@strapi/design-system/IconButton';
 import { stopPropagation, onRowClick } from '@strapi/helper-plugin';
 import { useIntl } from 'react-intl';
@@ -26,11 +26,11 @@ const RoleRow = ({ id, name, description, usersCount, icons }) => {
         fn: icons[1].onClick,
       })}
     >
-      <Td>
-        <Text textColor="neutral800">{name}</Text>
+      <Td maxWidth={`${130 / 16}rem`}>
+        <EllipsisText textColor="neutral800">{name}</EllipsisText>
       </Td>
-      <Td>
-        <Text textColor="neutral800">{description}</Text>
+      <Td maxWidth={`${250 / 16}rem`}>
+        <EllipsisText textColor="neutral800">{description}</EllipsisText>
       </Td>
       <Td>
         <Text textColor="neutral800">{usersCountText}</Text>


### PR DESCRIPTION
## What

Added truncate text on name and description columns in Settings/Roles/LV
Added fix width to allow ellipsis to work

## Snapshot

<img width="1111" alt="Capture d’écran 2021-11-02 à 18 57 25" src="https://user-images.githubusercontent.com/71838159/139920731-2de21aae-29bf-481b-8883-ac31755feeaf.png">


