### PR TITLE
[v4] Fix template install from npm

### DIFF
--- a/packages/generators/app/lib/utils/fetch-npm-template.js
+++ b/packages/generators/app/lib/utils/fetch-npm-template.js
@@ -51,10 +51,7 @@ async function downloadNpmTemplate({ name, version }, parentDir) {
   });
 
   // Return the path of the actual template
-  const exactTemplatePath = require.resolve(path.join('node_modules', name), {
-    paths: [parentDir],
-  });
-  // const exactTemplatePath = path.resolve(parentDir, 'node_modules', name);
+  const exactTemplatePath = path.resolve(parentDir, 'node_modules', name);
   return exactTemplatePath;
 }
 


### PR DESCRIPTION
### What does it do?

Fixes a bug that breaks the new v4 template system when using a template published on npm.

To confirm the bug, run this command and watch it fail:

```sh
npx create-strapi-app@beta corporate --quickstart --template corporate
```

### Why is it needed?

I failed to properly test #11093 after its latest changes.

The implementation of require.resolve was wrong, as it never actually resolved the node_modules folder.

But it turns out that require.resolve wasn't necessary IMO. We used it because we were afraid that the node_modules directory may be located in a parent directory [when creating an app in a monorepo](https://github.com/strapi/strapi/pull/11093#discussion_r736489044).

However, the `npm install` command is run inside a [temporary directory created by node](https://github.com/strapi/strapi/pull/11093/files#diff-b46ea4713f494cd0acca39f2c65720a01afdc3f5413281a0d9637ce31ef97556R46-R48). So it's unrelated to any monorepo setup.

So I restored the previous path.join solution. I tested the command in monorepo and non-monorepo setups, both worked fine.
