### PR TITLE
[V4] Add support to have multiple Strapi instances in same database using table prefix

### DIFF
--- a/examples/getstarted/config/database.js
+++ b/examples/getstarted/config/database.js
@@ -34,6 +34,19 @@ const db = {
   postgres,
 };
 
+/**
+ * You can have multiple Strapi installations in the same database
+ * if you give each installation a unique table prefix.
+ *
+ * Requirements:
+ * - Maximum 10 characters.
+ * - Letters, numbers and underscore.
+ *
+ * Table prefix will be transformed using Lodash snakeCase-function. (https://lodash.com/docs#snakeCase)
+ */
+const tablePrefix = '';
+
 module.exports = {
   connection: process.env.DB ? db[process.env.DB] || db.sqlite : db.sqlite,
+  tablePrefix,
 };

--- a/packages/core/database/lib/dialects/mysql/schema-inspector.js
+++ b/packages/core/database/lib/dialects/mysql/schema-inspector.js
@@ -1,14 +1,16 @@
 'use strict';
 
-const SQL_QUERIES = {
-  TABLE_LIST: /* sql */ `
+const buildSqlQueries = db => {
+  return {
+    TABLE_LIST: /* sql */ `
     SELECT
       t.table_name as table_name
     FROM information_schema.tables t
     WHERE table_type = 'BASE TABLE'
-    AND table_schema = schema();
+    AND table_schema = schema()
+    ${db.tablePrefix ? ` AND table_name LIKE '${db.tablePrefix}%'` : ''};
   `,
-  LIST_COLUMNS: /* sql */ `
+    LIST_COLUMNS: /* sql */ `
     SELECT
       c.data_type as data_type,
       c.column_name as column_name,
@@ -21,10 +23,10 @@ const SQL_QUERIES = {
     WHERE table_schema = database()
     AND table_name = ?;
   `,
-  INDEX_LIST: /* sql */ `
+    INDEX_LIST: /* sql */ `
     show index from ??;
   `,
-  FOREIGN_KEY_LIST: /* sql */ `
+    FOREIGN_KEY_LIST: /* sql */ `
     SELECT
       tc.constraint_name as constraint_name,
       kcu.column_name as column_name,
@@ -40,6 +42,7 @@ const SQL_QUERIES = {
     AND tc.table_name = ?;
 
   `,
+  };
 };
 
 const toStrapiType = column => {
@@ -98,6 +101,7 @@ const toStrapiType = column => {
 class MysqlSchemaInspector {
   constructor(db) {
     this.db = db;
+    this.queries = buildSqlQueries(db);
   }
 
   async getSchema() {
@@ -128,13 +132,13 @@ class MysqlSchemaInspector {
   }
 
   async getTables() {
-    const [rows] = await this.db.connection.raw(SQL_QUERIES.TABLE_LIST);
+    const [rows] = await this.db.connection.raw(this.queries.TABLE_LIST);
 
     return rows.map(row => row.table_name);
   }
 
   async getColumns(tableName) {
-    const [rows] = await this.db.connection.raw(SQL_QUERIES.LIST_COLUMNS, [tableName]);
+    const [rows] = await this.db.connection.raw(this.queries.LIST_COLUMNS, [tableName]);
 
     return rows.map(row => {
       const { type, args = [], ...rest } = toStrapiType(row);
@@ -152,7 +156,7 @@ class MysqlSchemaInspector {
   }
 
   async getIndexes(tableName) {
-    const [rows] = await this.db.connection.raw(SQL_QUERIES.INDEX_LIST, [tableName]);
+    const [rows] = await this.db.connection.raw(this.queries.INDEX_LIST, [tableName]);
 
     const ret = {};
 
@@ -176,7 +180,7 @@ class MysqlSchemaInspector {
   }
 
   async getForeignKeys(tableName) {
-    const [rows] = await this.db.connection.raw(SQL_QUERIES.FOREIGN_KEY_LIST, [tableName]);
+    const [rows] = await this.db.connection.raw(this.queries.FOREIGN_KEY_LIST, [tableName]);
 
     const ret = {};
 

--- a/packages/core/database/lib/dialects/postgresql/schema-inspector.js
+++ b/packages/core/database/lib/dialects/postgresql/schema-inspector.js
@@ -1,21 +1,23 @@
 'use strict';
 
-const SQL_QUERIES = {
-  TABLE_LIST: /* sql */ `
+const buildSqlQueries = db => {
+  return {
+    TABLE_LIST: /* sql */ `
     SELECT *
     FROM information_schema.tables
     WHERE
       table_schema = ?
       AND table_type = 'BASE TABLE'
       AND table_name != 'geometry_columns'
-      AND table_name != 'spatial_ref_sys';
-  `,
-  LIST_COLUMNS: /* sql */ `
+      AND table_name != 'spatial_ref_sys'
+      ${db.tablePrefix ? `AND table_name LIKE '${db.tablePrefix}%'` : ''};
+    `,
+    LIST_COLUMNS: /* sql */ `
     SELECT data_type, column_name, character_maximum_length, column_default, is_nullable
     FROM information_schema.columns
     WHERE table_schema = ? AND table_name = ?;
   `,
-  INDEX_LIST: /* sql */ `
+    INDEX_LIST: /* sql */ `
     SELECT
       ix.indexrelid,
       i.relname as index_name,
@@ -38,7 +40,7 @@ const SQL_QUERIES = {
       AND s.nspname = ?
       AND t.relname = ?;
   `,
-  FOREIGN_KEY_LIST: /* sql */ `
+    FOREIGN_KEY_LIST: /* sql */ `
     SELECT
       tco."constraint_name" as constraint_name,
       kcu."column_name" as column_name,
@@ -62,7 +64,8 @@ const SQL_QUERIES = {
       AND tco.constraint_schema = ?
       AND tco.table_name = ?
     ORDER BY kcu.table_schema, kcu.table_name, kcu.ordinal_position, kcu.constraint_name;
-  `,
+    `,
+  };
 };
 
 const toStrapiType = column => {
@@ -113,6 +116,7 @@ const toStrapiType = column => {
 class PostgresqlSchemaInspector {
   constructor(db) {
     this.db = db;
+    this.queries = buildSqlQueries(db);
   }
 
   async getSchema() {
@@ -143,7 +147,7 @@ class PostgresqlSchemaInspector {
   }
 
   async getTables() {
-    const { rows } = await this.db.connection.raw(SQL_QUERIES.TABLE_LIST, [
+    const { rows } = await this.db.connection.raw(this.queries.TABLE_LIST, [
       this.getDatabaseSchema(),
     ]);
 
@@ -151,7 +155,7 @@ class PostgresqlSchemaInspector {
   }
 
   async getColumns(tableName) {
-    const { rows } = await this.db.connection.raw(SQL_QUERIES.LIST_COLUMNS, [
+    const { rows } = await this.db.connection.raw(this.queries.LIST_COLUMNS, [
       this.getDatabaseSchema(),
       tableName,
     ]);
@@ -175,7 +179,7 @@ class PostgresqlSchemaInspector {
   }
 
   async getIndexes(tableName) {
-    const { rows } = await this.db.connection.raw(SQL_QUERIES.INDEX_LIST, [
+    const { rows } = await this.db.connection.raw(this.queries.INDEX_LIST, [
       this.getDatabaseSchema(),
       tableName,
     ]);
@@ -202,7 +206,7 @@ class PostgresqlSchemaInspector {
   }
 
   async getForeignKeys(tableName) {
-    const { rows } = await this.db.connection.raw(SQL_QUERIES.FOREIGN_KEY_LIST, [
+    const { rows } = await this.db.connection.raw(this.queries.FOREIGN_KEY_LIST, [
       this.getDatabaseSchema(),
       tableName,
     ]);

--- a/packages/core/database/lib/dialects/sqlite/schema-inspector.js
+++ b/packages/core/database/lib/dialects/sqlite/schema-inspector.js
@@ -1,11 +1,19 @@
 'use strict';
 
-const SQL_QUERIES = {
-  TABLE_LIST: `select name from sqlite_master where type = 'table' and name NOT LIKE 'sqlite%'`,
-  TABLE_INFO: `pragma table_info(??)`,
-  INDEX_LIST: 'pragma index_list(??)',
-  INDEX_INFO: 'pragma index_info(??)',
-  FOREIGN_KEY_LIST: 'pragma foreign_key_list(??)',
+const buildSqlQueries = db => {
+  const queries = {
+    TABLE_LIST: `select name from sqlite_master where type = 'table' and name NOT LIKE 'sqlite%'`,
+    TABLE_INFO: `pragma table_info(??)`,
+    INDEX_LIST: 'pragma index_list(??)',
+    INDEX_INFO: 'pragma index_info(??)',
+    FOREIGN_KEY_LIST: 'pragma foreign_key_list(??)',
+  };
+
+  if (db.tablePrefix) {
+    queries.TABLE_LIST += ` and name LIKE '${db.tablePrefix}%'`;
+  }
+
+  return queries;
 };
 
 const toStrapiType = column => {
@@ -59,6 +67,7 @@ const toStrapiType = column => {
 class SqliteSchemaInspector {
   constructor(db) {
     this.db = db;
+    this.queries = buildSqlQueries(db);
   }
 
   async getSchema() {
@@ -82,13 +91,13 @@ class SqliteSchemaInspector {
   }
 
   async getTables() {
-    const rows = await this.db.connection.raw(SQL_QUERIES.TABLE_LIST);
+    const rows = await this.db.connection.raw(this.queries.TABLE_LIST);
 
     return rows.map(row => row.name);
   }
 
   async getColumns(tableName) {
-    const rows = await this.db.connection.raw(SQL_QUERIES.TABLE_INFO, [tableName]);
+    const rows = await this.db.connection.raw(this.queries.TABLE_INFO, [tableName]);
 
     return rows.map(row => {
       const { type, args = [], ...rest } = toStrapiType(row);
@@ -106,12 +115,12 @@ class SqliteSchemaInspector {
   }
 
   async getIndexes(tableName) {
-    const indexes = await this.db.connection.raw(SQL_QUERIES.INDEX_LIST, [tableName]);
+    const indexes = await this.db.connection.raw(this.queries.INDEX_LIST, [tableName]);
 
     const ret = [];
 
     for (const index of indexes.filter(index => !index.name.startsWith('sqlite_'))) {
-      const res = await this.db.connection.raw(SQL_QUERIES.INDEX_INFO, [index.name]);
+      const res = await this.db.connection.raw(this.queries.INDEX_INFO, [index.name]);
 
       ret.push({
         columns: res.map(row => row.name),
@@ -124,7 +133,7 @@ class SqliteSchemaInspector {
   }
 
   async getForeignKeys(tableName) {
-    const fks = await this.db.connection.raw(SQL_QUERIES.FOREIGN_KEY_LIST, [tableName]);
+    const fks = await this.db.connection.raw(this.queries.FOREIGN_KEY_LIST, [tableName]);
 
     const ret = {};
 

--- a/packages/core/database/lib/index.js
+++ b/packages/core/database/lib/index.js
@@ -8,6 +8,7 @@ const createMetadata = require('./metadata');
 const { createEntityManager } = require('./entity-manager');
 const { createMigrationsProvider } = require('./migrations');
 const { createLifecyclesProvider } = require('./lifecycles');
+const { createTablePrefix } = require('./utils/table-prefix');
 const errors = require('./errors');
 
 // TODO: move back into strapi
@@ -15,7 +16,9 @@ const { transformContentTypes } = require('./utils/content-types');
 
 class Database {
   constructor(config) {
-    this.metadata = createMetadata(config.models);
+    this.tablePrefix = createTablePrefix(config.tablePrefix);
+
+    this.metadata = createMetadata(config.models, this.tablePrefix);
 
     this.config = config;
 

--- a/packages/core/database/lib/metadata/index.js
+++ b/packages/core/database/lib/metadata/index.js
@@ -17,7 +17,7 @@ class Metadata extends Map {
  * @param {object[]} models
  * @returns {Metadata}
  */
-const createMetadata = (models = []) => {
+const createMetadata = (models = [], tablePrefix = '') => {
   const metadata = new Metadata();
 
   // init pass
@@ -25,7 +25,7 @@ const createMetadata = (models = []) => {
     metadata.add({
       singularName: model.singularName,
       uid: model.uid,
-      tableName: model.tableName,
+      tableName: tablePrefix + model.tableName,
       attributes: {
         id: {
           type: 'increments',

--- a/packages/core/database/lib/migrations/index.js
+++ b/packages/core/database/lib/migrations/index.js
@@ -28,7 +28,7 @@ const createUmzugProvider = db => {
   fse.ensureDirSync(migrationDir);
 
   const wrapFn = fn => db => db.connection.transaction(trx => Promise.resolve(fn(trx)));
-  const storage = createStorage({ db, tableName: 'strapi_migrations' });
+  const storage = createStorage({ db, tableName: db.tablePrefix + 'strapi_migrations' });
 
   return new Umzug({
     storage,

--- a/packages/core/database/lib/migrations/storage.js
+++ b/packages/core/database/lib/migrations/storage.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const createStorage = (opts = {}) => {
-  const tableName = opts.tableName || 'strapi_migrations';
+  const tableName = opts.tableName || opts.db.tablePrefix + 'strapi_migrations';
   const knex = opts.db.connection;
 
   const hasMigrationTable = () => knex.schema.hasTable(tableName);

--- a/packages/core/database/lib/schema/diff.js
+++ b/packages/core/database/lib/schema/diff.js
@@ -13,6 +13,9 @@ const statuses = {
 // => this will make the creation a bit more complicated (ordering, Object.values(tables | columns)) -> not a big pbl
 
 const helpers = {
+  isReservedTableName(db, tableName) {
+    return RESERVED_TABLE_NAMES.includes(db.tablePrefix + tableName);
+  },
   hasTable(schema, tableName) {
     return schema.tables.findIndex(table => table.name === tableName) !== -1;
   },
@@ -349,7 +352,7 @@ module.exports = db => {
     for (const srcTable of srcSchema.tables) {
       if (
         !helpers.hasTable(destSchema, srcTable.name) &&
-        !RESERVED_TABLE_NAMES.includes(srcTable.name)
+        !helpers.isReservedTableName(db, srcTable.name)
       ) {
         removedTables.push(srcTable);
       }

--- a/packages/core/database/lib/schema/storage.js
+++ b/packages/core/database/lib/schema/storage.js
@@ -2,9 +2,10 @@
 
 const crypto = require('crypto');
 
-const TABLE_NAME = 'strapi_database_schema';
+const TABLE_BASE_NAME = 'strapi_database_schema';
 
 module.exports = db => {
+  const TABLE_NAME = db.tablePrefix + TABLE_BASE_NAME;
   const hasSchemaTable = () => db.connection.schema.hasTable(TABLE_NAME);
 
   const createSchemaTable = () => {

--- a/packages/core/database/lib/utils/table-prefix.js
+++ b/packages/core/database/lib/utils/table-prefix.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const _ = require('lodash/fp');
+const debug = require('debug')('strapi::database');
+
+const TABLE_PREFIX_MAX_LENGTH = 10;
+
+const createTablePrefix = prefix => {
+  const pattern = `^([a-zA-Z0-9]|_){1,${TABLE_PREFIX_MAX_LENGTH}}$`;
+  const re = new RegExp(pattern);
+
+  if (typeof prefix === 'string' && re.test(prefix)) {
+    prefix = _.snakeCase(prefix);
+    if (!prefix.endsWith('_')) {
+      prefix += '_';
+    }
+    debug(`Using table prefix: ${prefix}`);
+    return prefix;
+  }
+  return '';
+};
+
+module.exports = { createTablePrefix };


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Add support to have multiple Strapi instances use the same table by making use of table prefixes.

- `examples/getstarted/config/database.js`
Lets user specify table prefix to use for the particular instance.
- `packages/core/database/lib/dialects/[sqlite|mysql|postgres]/schema-inspector.js`
Update `LIST_TABLE` SQL-query to only return the tables associated with the particular Strapi instance (i.e. only return tables that have the prefix).
- `packages/core/database/lib/index.js`
Add field `tablePrefix` to database class and pass it to `createMetadata` to make all tables to be created gets the correct prefix.
- `packages/core/database/lib/metadata/index.js`
Prepend prefix to table name.
- `packages/core/database/lib/migrations/index.js` and `packages/core/database/lib/migrations/storage.js`
Add table prefix to migration table.
- `packages/core/database/lib/schema/diff.js`
Extend checks that are used to determine whether a table has a reserved name or not to handle table prefixes.
- `packages/core/database/lib/schema/storage.js`
Add prefix support for the `strapi_database_schema`-table.
- `packages/core/database/lib/utils/table-prefix.js`
Function to validate and create the table prefix. 

### Why is it needed?

This PR solves the problem of using the same database for multiple Strapi instances. Typically some hosting providers have database limits and by using prefixes the same database can be reused for multiple purposes (e.g. multiple Strapi instances).

### How to test it?

Configure two Strapi-instances to use different table prefixes but make them communicate to the same database. In the case of SQLite, you create a `data.db` file and then set the same path for both instances in `examples/getstarted/config/database.js`. The same applies for MySQL and Postgres.

### Related issue(s)/PR(s)

Related issue: #5080

### State of PR
This PR is ready to be merged.
