### PR TITLE
QA/ InputJSON z-index

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/InputJSON/components.js
+++ b/packages/core/admin/admin/src/content-manager/components/InputJSON/components.js
@@ -24,6 +24,7 @@ const EditorWrapper = styled.div`
     /* Set height, width, borders, and global font properties here */
     font-size: ${14 / 16}rem;
     direction: ltr;
+    z-index: 0;
   }
 `;
 


### PR DESCRIPTION
## What 

Fixed inputJSON z-index 

## Demo

Go to CM / create edit an entry with inputJSON in it
Scroll until you find the input
inputJSON shouldn't go over/overflow the sticky header