### PR TITLE
[DS] Typography Admin Roles

### DIFF
--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/ConditionsModal/ActionRow/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/ConditionsModal/ActionRow/index.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import IS_DISABLED from 'ee_else_ce/pages/SettingsPage/pages/Roles/EditPage/components/ConditionsModal/ActionRow/utils/constants';
 import { Box } from '@strapi/design-system/Box';
 import { Flex } from '@strapi/design-system/Flex';
-import { TableLabel } from '@strapi/design-system/Text';
+import { Typography } from '@strapi/design-system/Typography';
 import { MultiSelectNested } from '@strapi/design-system/Select';
 import upperFirst from 'lodash/upperFirst';
 import { useIntl } from 'react-intl';
@@ -59,35 +59,26 @@ const ActionRow = ({
   return (
     <FlexWrapper as="li" background={isGrey ? 'neutral100' : 'neutral0'}>
       <Flex paddingLeft={6} style={{ width: 180 }}>
-        <TableLabel textColor="neutral600">
+        <Typography variant="sigma" textColor="neutral600">
           {formatMessage({
             id: 'Settings.permissions.conditions.can',
             defaultMessage: 'Can',
           })}
           &nbsp;
-        </TableLabel>
-        <TableLabel
-          title={label}
-          textColor="primary600"
-          // ! REMOVE THIS WHEN DS IS UPDATED WITH ELLIPSIS PROP
-          style={{
-            overflow: 'hidden',
-            whiteSpace: 'nowrap',
-            textOverflow: 'ellipsis',
-          }}
-        >
+        </Typography>
+        <Typography variant="sigma" title={label} textColor="primary600" ellipsis>
           {formatMessage({
             id: `Settings.roles.form.permissions.${label.toLowerCase()}`,
             defaultMessage: label,
           })}
-        </TableLabel>
-        <TableLabel textColor="neutral600">
+        </Typography>
+        <Typography variant="sigma" textColor="neutral600">
           &nbsp;
           {formatMessage({
             id: 'Settings.permissions.conditions.when',
             defaultMessage: 'When',
           })}
-        </TableLabel>
+        </Typography>
       </Flex>
       <Box style={{ maxWidth: 430, width: '100%' }}>
         <MultiSelectNested

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/ConditionsModal/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/ConditionsModal/index.js
@@ -6,7 +6,7 @@ import { Divider } from '@strapi/design-system/Divider';
 import { Stack } from '@strapi/design-system/Stack';
 import { ModalFooter, ModalHeader, ModalLayout } from '@strapi/design-system/ModalLayout';
 import { Breadcrumbs, Crumb } from '@strapi/design-system/Breadcrumbs';
-import { H2, Text } from '@strapi/design-system/Text';
+import { Typography } from '@strapi/design-system/Typography';
 import produce from 'immer';
 import get from 'lodash/get';
 import groupBy from 'lodash/groupBy';
@@ -90,24 +90,24 @@ const ConditionsModal = ({ actions, headerBreadCrumbs, isFormDisabled, onClosed,
       </ModalHeader>
       <Box padding={8}>
         <Stack size={6}>
-          <H2>
+          <Typography variant="beta">
             {formatMessage({
               id: 'Settings.permissions.conditions.define-conditions',
               defaultMessage: 'Define conditions',
             })}
-          </H2>
+          </Typography>
           <Box>
             <Divider />
           </Box>
           <Box>
             {actionsToDisplay.length === 0 && (
-              <Text>
+              <Typography>
                 {formatMessage({
                   id: 'Settings.permissions.conditions.no-actions',
                   defaultMessage:
                     'You first need to select actions (create, read, update, ...) before defining conditions on them.',
                 })}
-              </Text>
+              </Typography>
             )}
             <ul>
               {actionsToDisplay.map(({ actionId, label, pathToConditionsObject }, index) => {

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/ContentTypeCollapse/CollapsePropertyMatrix/CarretIcon/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/ContentTypeCollapse/CollapsePropertyMatrix/CarretIcon/index.js
@@ -6,9 +6,9 @@ const CarretIcon = styled(CarretDown)`
   width: ${10 / 16}rem;
   transform: rotate(${({ $isActive }) => ($isActive ? '180' : '0')}deg);
   margin-left: ${({ theme }) => theme.spaces[2]};
-  * {
+  /* * {
     fill: ${({ theme }) => theme.colors.primary600};
-  }
+  } */
 `;
 
 export default CarretIcon;

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/ContentTypeCollapse/CollapsePropertyMatrix/Header/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/ContentTypeCollapse/CollapsePropertyMatrix/Header/index.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 import styled from 'styled-components';
 import { Flex } from '@strapi/design-system/Flex';
-import { TableLabel } from '@strapi/design-system/Text';
+import { Typography } from '@strapi/design-system/Typography';
 import { cellWidth, firstRowWidth, rowHeight } from '../../../Permissions/utils/constants';
 
 const HeaderLabel = styled(Flex)`
@@ -29,7 +29,9 @@ const Header = ({ headers, label }) => {
   return (
     <Flex>
       <PropertyLabelWrapper alignItems="center" paddingLeft={6}>
-        <TableLabel textColor="neutral500">{translatedLabel}</TableLabel>
+        <Typography variant="sigma" textColor="neutral500">
+          {translatedLabel}
+        </Typography>
       </PropertyLabelWrapper>
       {headers.map(header => {
         if (!header.isActionRelatedToCurrentProperty) {
@@ -38,12 +40,12 @@ const Header = ({ headers, label }) => {
 
         return (
           <HeaderLabel justifyContent="center" key={header.label}>
-            <TableLabel textColor="neutral500">
+            <Typography variant="sigma" textColor="neutral500">
               {formatMessage({
                 id: `Settings.roles.form.permissions.${header.label.toLowerCase()}`,
                 defaultMessage: header.label,
               })}
-            </TableLabel>
+            </Typography>
           </HeaderLabel>
         );
       })}

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/ContentTypeCollapse/CollapsePropertyMatrix/SubActionRow/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/ContentTypeCollapse/CollapsePropertyMatrix/SubActionRow/index.js
@@ -7,7 +7,7 @@ import styled from 'styled-components';
 import { BaseCheckbox } from '@strapi/design-system/BaseCheckbox';
 import { Box } from '@strapi/design-system/Box';
 import { Flex } from '@strapi/design-system/Flex';
-import { Text } from '@strapi/design-system/Text';
+import { Typography } from '@strapi/design-system/Typography';
 import IS_DISABLED from 'ee_else_ce/pages/SettingsPage/pages/Roles/EditPage/components/ContentTypeCollapse/CollapsePropertyMatrix/SubActionRow/utils/constants';
 import { usePermissionsDataManager } from '../../../../../../../../../hooks';
 import CollapseLabel from '../../../CollapseLabel';
@@ -126,7 +126,7 @@ const SubActionRow = ({
                     })}
                     title={label}
                   >
-                    <Text ellipsis>{upperFirst(label)}</Text>
+                    <Typography ellipsis>{upperFirst(label)}</Typography>
                     {required && <RequiredSign />}
                     <CarretIcon $isActive={isActive} />
                   </CollapseLabel>

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/ContentTypeCollapse/utils/activeStyle.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/ContentTypeCollapse/utils/activeStyle.js
@@ -4,7 +4,7 @@ import CarretIcon from '../CollapsePropertyMatrix/CarretIcon';
 const activeStyle = theme => `
   ${Typography} {
     color: ${theme.colors.primary600};
-    font-weight: bold;
+    font-weight: ${theme.fontWeights.bold}
   }
   ${CarretIcon} {
     display: block;

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/ContentTypeCollapse/utils/activeStyle.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/ContentTypeCollapse/utils/activeStyle.js
@@ -1,14 +1,16 @@
-import { Text } from '@strapi/design-system/Text';
+import { Typography } from '@strapi/design-system/Typography';
 import CarretIcon from '../CollapsePropertyMatrix/CarretIcon';
 
 const activeStyle = theme => `
-  ${Text} {
+  ${Typography} {
     color: ${theme.colors.primary600};
     font-weight: bold;
   }
   ${CarretIcon} {
     display: block;
-    color: ${theme.colors.primary600};
+    path {
+      fill: ${theme.colors.primary600}
+    };
   }
 `;
 

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/GlobalActions/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/GlobalActions/index.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { BaseCheckbox } from '@strapi/design-system/BaseCheckbox';
 import { Box } from '@strapi/design-system/Box';
 import { Stack } from '@strapi/design-system/Stack';
-import { TableLabel } from '@strapi/design-system/Text';
+import { Typography } from '@strapi/design-system/Typography';
 import styled from 'styled-components';
 import get from 'lodash/get';
 import IS_DISABLED from 'ee_else_ce/pages/SettingsPage/pages/Roles/EditPage/components/GlobalActions/utils/constants';
@@ -37,12 +37,12 @@ const GlobalActions = ({ actions, isFormDisabled, kind }) => {
         {displayedActions.map(({ label, actionId }) => {
           return (
             <CenteredStack key={actionId} size={3}>
-              <TableLabel textColor="neutral500">
+              <Typography variant="sigma" textColor="neutral500">
                 {formatMessage({
                   id: `Settings.roles.form.permissions.${label.toLowerCase()}`,
                   defaultMessage: label,
                 })}
-              </TableLabel>
+              </Typography>
               <BaseCheckbox
                 disabled={isFormDisabled || IS_DISABLED}
                 onValueChange={value => {

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/PluginsAndSettings/Row/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/PluginsAndSettings/Row/index.js
@@ -17,7 +17,6 @@ const PermissionRow = ({
   pathToData,
 }) => {
   const { formatMessage } = useIntl();
-
   const handleClick = () => {
     onOpenCategory(name);
   };
@@ -29,18 +28,22 @@ const PermissionRow = ({
   }, [name]);
 
   return (
-    <Accordion expanded={isOpen} toggle={handleClick} id={`accordion-${name}`}>
+    <Accordion
+      expanded={isOpen}
+      toggle={handleClick}
+      id={`accordion-${name}`}
+      variant={isWhite ? 'primary' : 'secondary'}
+    >
       <AccordionToggle
         title={upperFirst(categoryName)}
         description={`${formatMessage(
           { id: 'Settings.permissions.category' },
           { category: categoryName }
         )} ${kind === 'plugins' ? 'plugin' : kind}`}
-        variant={isWhite ? 'primary' : 'secondary'}
       />
 
       <AccordionContent>
-        <Box padding={6} background="neutral0">
+        <Box padding={6}>
           {childrenForm.map(({ actions, subCategoryName, subCategoryId }) => (
             <SubCategory
               key={subCategoryName}

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/PluginsAndSettings/SubCategory/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/PluginsAndSettings/SubCategory/index.js
@@ -5,7 +5,7 @@ import { Grid, GridItem } from '@strapi/design-system/Grid';
 import { Box } from '@strapi/design-system/Box';
 import { Checkbox } from '@strapi/design-system/Checkbox';
 import { Flex } from '@strapi/design-system/Flex';
-import { TableLabel } from '@strapi/design-system/Text';
+import { Typography } from '@strapi/design-system/Typography';
 import { useIntl } from 'react-intl';
 import get from 'lodash/get';
 import IS_DISABLED from 'ee_else_ce/pages/SettingsPage/pages/Roles/EditPage/components/PluginsAndSettings/SubCategory/utils/constants';
@@ -76,7 +76,9 @@ const SubCategory = ({ categoryName, isFormDisabled, subCategoryName, actions, p
       <Box>
         <Flex justifyContent="space-between" alignItems="center">
           <Box paddingRight={4}>
-            <TableLabel textColor="neutral600">{subCategoryName}</TableLabel>
+            <Typography variant="sigma" textColor="neutral600">
+              {subCategoryName}
+            </Typography>
           </Box>
           <Border />
           <Box paddingLeft={4}>

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/RoleForm/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/RoleForm/index.js
@@ -3,7 +3,7 @@ import { Box } from '@strapi/design-system/Box';
 import { Grid, GridItem } from '@strapi/design-system/Grid';
 import { Flex } from '@strapi/design-system/Flex';
 import { Stack } from '@strapi/design-system/Stack';
-import { Text } from '@strapi/design-system/Text';
+import { Typography } from '@strapi/design-system/Typography';
 import { Textarea } from '@strapi/design-system/Textarea';
 import { TextInput } from '@strapi/design-system/TextInput';
 import { Button } from '@strapi/design-system/Button';
@@ -20,24 +20,24 @@ const RoleForm = ({ disabled, role, values, errors, onChange, onBlur }) => {
           <Flex justifyContent="space-between">
             <Box>
               <Box>
-                <Text bold>
+                <Typography fontWeight="bold">
                   {role
                     ? role.name
                     : formatMessage({
                         id: 'Settings.roles.form.title',
                         defaultMessage: 'Details',
                       })}
-                </Text>
+                </Typography>
               </Box>
               <Box>
-                <Text textColor="neutral500" small>
+                <Typography textColor="neutral500" variant="pi">
                   {role
                     ? role.description
                     : formatMessage({
                         id: 'Settings.roles.form.description',
                         defaultMessage: 'Name and description of the role',
                       })}
-                </Text>
+                </Typography>
               </Box>
             </Box>
             <Button disabled variant="secondary">

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/RowLabelWithCheckbox/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/RowLabelWithCheckbox/index.js
@@ -60,7 +60,13 @@ const RowLabelWithCheckbox = ({
           role: 'button',
         })}
       >
-        <Typography ellipsis>{upperFirst(label)}</Typography>
+        <Typography
+          fontWeight={isActive ? 'bold' : ''}
+          textColor={isActive ? 'primary600' : 'neutral800'}
+          ellipsis
+        >
+          {upperFirst(label)}
+        </Typography>
         {children}
       </CollapseLabel>
     </Flex>

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/RowLabelWithCheckbox/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/RowLabelWithCheckbox/index.js
@@ -60,13 +60,7 @@ const RowLabelWithCheckbox = ({
           role: 'button',
         })}
       >
-        <Typography
-          fontWeight={isActive ? 'bold' : ''}
-          textColor={isActive ? 'primary600' : 'neutral800'}
-          ellipsis
-        >
-          {upperFirst(label)}
-        </Typography>
+        <Typography ellipsis>{upperFirst(label)}</Typography>
         {children}
       </CollapseLabel>
     </Flex>

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/RowLabelWithCheckbox/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/RowLabelWithCheckbox/index.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { BaseCheckbox } from '@strapi/design-system/BaseCheckbox';
 import { Box } from '@strapi/design-system/Box';
 import { Flex } from '@strapi/design-system/Flex';
-import { Text } from '@strapi/design-system/Text';
+import { Typography } from '@strapi/design-system/Typography';
 import upperFirst from 'lodash/upperFirst';
 import { useIntl } from 'react-intl';
 import CollapseLabel from '../CollapseLabel';
@@ -60,7 +60,7 @@ const RowLabelWithCheckbox = ({
           role: 'button',
         })}
       >
-        <Text ellipsis>{upperFirst(label)}</Text>
+        <Typography ellipsis>{upperFirst(label)}</Typography>
         {children}
       </CollapseLabel>
     </Flex>

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/tests/__snapshots__/index.test.js.snap
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/tests/__snapshots__/index.test.js.snap
@@ -353,20 +353,6 @@ exports[`<EditPage /> renders and matches the snapshot 1`] = `
   margin-left: 8px;
 }
 
-.c22 {
-  font-weight: 500;
-  font-size: 0.875rem;
-  line-height: 1.43;
-  color: #32324d;
-}
-
-.c23 {
-  font-weight: 400;
-  font-size: 0.75rem;
-  line-height: 1.33;
-  color: #8e8ea9;
-}
-
 .c30 {
   font-weight: 600;
   color: #32324d;
@@ -758,6 +744,19 @@ exports[`<EditPage /> renders and matches the snapshot 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+}
+
+.c22 {
+  font-weight: 600;
+  color: #32324d;
+  font-size: 0.875rem;
+  line-height: 1.43;
+}
+
+.c23 {
+  color: #8e8ea9;
+  font-size: 0.75rem;
+  line-height: 1.33;
 }
 
 .c26 {

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/ListPage/components/RoleRow/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/ListPage/components/RoleRow/index.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import styled from 'styled-components';
 import { Box } from '@strapi/design-system/Box';
 import { Flex } from '@strapi/design-system/Flex';
 import { Td, Tr } from '@strapi/design-system/Table';
@@ -8,10 +7,6 @@ import { Typography } from '@strapi/design-system/Typography';
 import { IconButton } from '@strapi/design-system/IconButton';
 import { stopPropagation, onRowClick, pxToRem } from '@strapi/helper-plugin';
 import { useIntl } from 'react-intl';
-
-const CustomTypographyEllipsis = styled(Typography)`
-  display: block;
-`;
 
 const RoleRow = ({ id, name, description, usersCount, icons }) => {
   const { formatMessage } = useIntl();
@@ -32,14 +27,14 @@ const RoleRow = ({ id, name, description, usersCount, icons }) => {
       })}
     >
       <Td maxWidth={pxToRem(130)}>
-        <CustomTypographyEllipsis ellipsis textColor="neutral800">
+        <Typography ellipsis textColor="neutral800">
           {name}
-        </CustomTypographyEllipsis>
+        </Typography>
       </Td>
       <Td maxWidth={pxToRem(250)}>
-        <CustomTypographyEllipsis ellipsis textColor="neutral800">
+        <Typography ellipsis textColor="neutral800">
           {description}
-        </CustomTypographyEllipsis>
+        </Typography>
       </Td>
       <Td>
         <Typography textColor="neutral800">{usersCountText}</Typography>

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/ListPage/components/RoleRow/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/ListPage/components/RoleRow/index.js
@@ -1,12 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import styled from 'styled-components';
 import { Box } from '@strapi/design-system/Box';
 import { Flex } from '@strapi/design-system/Flex';
 import { Td, Tr } from '@strapi/design-system/Table';
-import { Text, EllipsisText } from '@strapi/design-system/Text';
+import { Typography } from '@strapi/design-system/Typography';
 import { IconButton } from '@strapi/design-system/IconButton';
 import { stopPropagation, onRowClick, pxToRem } from '@strapi/helper-plugin';
 import { useIntl } from 'react-intl';
+
+const CustomTypographyEllipsis = styled(Typography)`
+  display: block;
+`;
 
 const RoleRow = ({ id, name, description, usersCount, icons }) => {
   const { formatMessage } = useIntl();
@@ -27,13 +32,17 @@ const RoleRow = ({ id, name, description, usersCount, icons }) => {
       })}
     >
       <Td maxWidth={pxToRem(130)}>
-        <EllipsisText textColor="neutral800">{name}</EllipsisText>
+        <CustomTypographyEllipsis ellipsis textColor="neutral800">
+          {name}
+        </CustomTypographyEllipsis>
       </Td>
       <Td maxWidth={pxToRem(250)}>
-        <EllipsisText textColor="neutral800">{description}</EllipsisText>
+        <CustomTypographyEllipsis ellipsis textColor="neutral800">
+          {description}
+        </CustomTypographyEllipsis>
       </Td>
       <Td>
-        <Text textColor="neutral800">{usersCountText}</Text>
+        <Typography textColor="neutral800">{usersCountText}</Typography>
       </Td>
       <Td>
         <Flex justifyContent="flex-end" {...stopPropagation}>

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/ListPage/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/ListPage/index.js
@@ -13,7 +13,7 @@ import Duplicate from '@strapi/icons/Duplicate';
 import { Button } from '@strapi/design-system/Button';
 import { ContentLayout, HeaderLayout } from '@strapi/design-system/Layout';
 import { Table, Tbody, Th, Thead, Tr, TFooter } from '@strapi/design-system/Table';
-import { TableLabel } from '@strapi/design-system/Text';
+import { Typography } from '@strapi/design-system/Typography';
 import { Main } from '@strapi/design-system/Main';
 import { VisuallyHidden } from '@strapi/design-system/VisuallyHidden';
 import { useIntl } from 'react-intl';
@@ -138,28 +138,28 @@ const RoleListPage = () => {
           <Thead>
             <Tr>
               <Th>
-                <TableLabel textColor="neutral600">
+                <Typography variant="sigma" textColor="neutral600">
                   {formatMessage({
                     id: 'Settings.roles.list.header.name',
                     defaultMessage: 'Name',
                   })}
-                </TableLabel>
+                </Typography>
               </Th>
               <Th>
-                <TableLabel textColor="neutral600">
+                <Typography variant="sigma" textColor="neutral600">
                   {formatMessage({
                     id: 'Settings.roles.list.header.description',
                     defaultMessage: 'Description',
                   })}
-                </TableLabel>
+                </Typography>
               </Th>
               <Th>
-                <TableLabel textColor="neutral600">
+                <Typography variant="sigma" textColor="neutral600">
                   {formatMessage({
                     id: 'Settings.roles.list.header.users',
                     defaultMessage: 'Users',
                   })}
-                </TableLabel>
+                </Typography>
               </Th>
               <Th>
                 <VisuallyHidden>

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/ListPage/tests/index.test.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/ListPage/tests/index.test.js
@@ -204,20 +204,20 @@ describe('<ListPage />', () => {
         padding-left: 24px;
       }
 
-      .c29 {
+      .c28 {
         background: #eaeaef;
       }
 
-      .c31 {
+      .c30 {
         background: #f0f0ff;
         padding: 20px;
       }
 
-      .c33 {
+      .c32 {
         background: #d9d8ff;
       }
 
-      .c35 {
+      .c34 {
         padding-left: 12px;
       }
 
@@ -259,7 +259,7 @@ describe('<ListPage />', () => {
         overflow-x: auto;
       }
 
-      .c28 tr:last-of-type {
+      .c27 tr:last-of-type {
         border-bottom: none;
       }
 
@@ -312,24 +312,24 @@ describe('<ListPage />', () => {
         vertical-align: sub;
       }
 
-      .c26 svg {
+      .c25 svg {
         height: 0.25rem;
       }
 
-      .c30 {
+      .c29 {
         height: 1px;
         border: none;
         margin: 0;
       }
 
-      .c36 {
+      .c35 {
         font-weight: 600;
         color: #4945ff;
         font-size: 0.75rem;
         line-height: 1.33;
       }
 
-      .c34 {
+      .c33 {
         height: 1.5rem;
         width: 1.5rem;
         border-radius: 50%;
@@ -347,36 +347,23 @@ describe('<ListPage />', () => {
         align-items: center;
       }
 
-      .c34 svg {
+      .c33 svg {
         height: 0.625rem;
         width: 0.625rem;
       }
 
-      .c34 svg path {
+      .c33 svg path {
         fill: #4945ff;
       }
 
-      .c32 {
+      .c31 {
         border-radius: 0 0 4px 4px;
         display: block;
         width: 100%;
         border: none;
       }
 
-      .c24 {
-        color: #666687;
-        font-size: 0.875rem;
-        line-height: 1.43;
-      }
-
-      .c25 {
-        font-weight: 600;
-        font-size: 0.6875rem;
-        line-height: 1.45;
-        text-transform: uppercase;
-      }
-
-      .c27 {
+      .c26 {
         border: 0;
         -webkit-clip: rect(0 0 0 0);
         clip: rect(0 0 0 0);
@@ -444,6 +431,14 @@ describe('<ListPage />', () => {
         color: #666687;
         font-size: 1rem;
         line-height: 1.5;
+      }
+
+      .c24 {
+        color: #666687;
+        font-weight: 600;
+        font-size: 0.6875rem;
+        line-height: 1.45;
+        text-transform: uppercase;
       }
 
       .c0 {
@@ -544,12 +539,12 @@ describe('<ListPage />', () => {
                           class="c23"
                         >
                           <span
-                            class="c24 c25"
+                            class="c24"
                           >
                             Name
                           </span>
                           <span
-                            class="c26"
+                            class="c25"
                           />
                         </div>
                       </th>
@@ -562,12 +557,12 @@ describe('<ListPage />', () => {
                           class="c23"
                         >
                           <span
-                            class="c24 c25"
+                            class="c24"
                           >
                             Description
                           </span>
                           <span
-                            class="c26"
+                            class="c25"
                           />
                         </div>
                       </th>
@@ -580,12 +575,12 @@ describe('<ListPage />', () => {
                           class="c23"
                         >
                           <span
-                            class="c24 c25"
+                            class="c24"
                           >
                             Users
                           </span>
                           <span
-                            class="c26"
+                            class="c25"
                           />
                         </div>
                       </th>
@@ -598,36 +593,36 @@ describe('<ListPage />', () => {
                           class="c23"
                         >
                           <div
-                            class="c27"
+                            class="c26"
                           >
                             Actions
                           </div>
                           <span
-                            class="c26"
+                            class="c25"
                           />
                         </div>
                       </th>
                     </tr>
                   </thead>
                   <tbody
-                    class="c28"
+                    class="c27"
                   />
                 </table>
               </div>
             </div>
             <div>
               <hr
-                class="c29 c30"
+                class="c28 c29"
               />
               <button
-                class="c31 c32"
+                class="c30 c31"
               >
                 <div
                   class="c23"
                 >
                   <div
                     aria-hidden="true"
-                    class="c33 c34"
+                    class="c32 c33"
                   >
                     <svg
                       fill="none"
@@ -643,10 +638,10 @@ describe('<ListPage />', () => {
                     </svg>
                   </div>
                   <div
-                    class="c35"
+                    class="c34"
                   >
                     <span
-                      class="c36"
+                      class="c35"
                     >
                       Add new role
                     </span>


### PR DESCRIPTION
## What

Replaced Text components with Typography component in admin role
Since ${Text} was used for label active style, fixed active style of main row labels and subrow labels