### PR TITLE
Add cache to node workflows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: 'Tests'
+name: "Tests"
 
 on:
   push:
@@ -6,11 +6,11 @@ on:
       - master
   pull_request:
     paths-ignore:
-      - 'docs/**'
+      - "docs/**"
 
 jobs:
   lint:
-    name: 'lint (node: ${{ matrix.node }})'
+    name: "lint (node: ${{ matrix.node }})"
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -20,12 +20,13 @@ jobs:
       - uses: actions/setup-node@v2-beta
         with:
           node-version: ${{ matrix.node }}
+          cache: npm
       - uses: ./.github/actions/install-modules
       - name: Run lint
         run: yarn run -s lint
 
   unit_back:
-    name: 'unit_back (node: ${{ matrix.node }})'
+    name: "unit_back (node: ${{ matrix.node }})"
     needs: [lint]
     runs-on: ubuntu-latest
     env:
@@ -38,6 +39,7 @@ jobs:
       - uses: actions/setup-node@v2-beta
         with:
           node-version: ${{ matrix.node }}
+          cache: npm
       - uses: ./.github/actions/install-modules
         with:
           globalPackages: codecov
@@ -45,7 +47,7 @@ jobs:
         run: yarn run -s test:unit --coverage && codecov -C -F unit
 
   unit_front:
-    name: 'unit_front (node: ${{ matrix.node }})'
+    name: "unit_front (node: ${{ matrix.node }})"
     needs: [lint]
     runs-on: ubuntu-latest
     env:
@@ -58,6 +60,7 @@ jobs:
       - uses: actions/setup-node@v2-beta
         with:
           node-version: ${{ matrix.node }}
+          cache: npm
       - uses: ./.github/actions/install-modules
         with:
           globalPackages: codecov
@@ -69,7 +72,7 @@ jobs:
   e2e_ce_pg:
     runs-on: ubuntu-latest
     needs: [lint, unit_back, unit_front]
-    name: '[CE] E2E (postgres, node: ${{ matrix.node }})'
+    name: "[CE] E2E (postgres, node: ${{ matrix.node }})"
     strategy:
       matrix:
         node: [12, 14, 16]
@@ -85,10 +88,7 @@ jobs:
           POSTGRES_DB: strapi_test
         # Set health checks to wait until postgres has started
         options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
+          --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
         ports:
           # Maps tcp port 5432 on service container to the host
           - 5432:5432
@@ -97,15 +97,16 @@ jobs:
       - uses: actions/setup-node@v2-beta
         with:
           node-version: ${{ matrix.node }}
+          cache: npm
       - uses: ./.github/actions/install-modules
       - uses: ./.github/actions/run-e2e-tests
         with:
-          dbOptions: '--dbclient=postgres --dbhost=localhost --dbport=5432 --dbname=strapi_test --dbusername=strapi --dbpassword=strapi'
+          dbOptions: "--dbclient=postgres --dbhost=localhost --dbport=5432 --dbname=strapi_test --dbusername=strapi --dbpassword=strapi"
 
   e2e_ce_mysql:
     runs-on: ubuntu-latest
     needs: [lint, unit_back, unit_front]
-    name: '[CE] E2E (mysql, node: ${{ matrix.node }})'
+    name: "[CE] E2E (mysql, node: ${{ matrix.node }})"
     strategy:
       matrix:
         node: [12, 14, 16]
@@ -114,16 +115,7 @@ jobs:
       mysql:
         image: mysql
         options: >-
-          --health-cmd="mysqladmin ping"
-          --health-interval=10s
-          --health-timeout=5s
-          --health-retries=3
-          -e MYSQL_ROOT_PASSWORD=strapi
-          -e MYSQL_ROOT_HOST="%"
-          -e MYSQL_USER=strapi
-          -e MYSQL_PASSWORD=strapi
-          -e MYSQL_DATABASE=strapi_test
-          --entrypoint sh mysql -c "exec docker-entrypoint.sh mysqld --default-authentication-plugin=mysql_native_password"
+          --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3 -e MYSQL_ROOT_PASSWORD=strapi -e MYSQL_ROOT_HOST="%" -e MYSQL_USER=strapi -e MYSQL_PASSWORD=strapi -e MYSQL_DATABASE=strapi_test --entrypoint sh mysql -c "exec docker-entrypoint.sh mysqld --default-authentication-plugin=mysql_native_password"
         ports:
           # Maps tcp port 5432 on service container to the host
           - 3306:3306
@@ -132,10 +124,11 @@ jobs:
       - uses: actions/setup-node@v2-beta
         with:
           node-version: ${{ matrix.node }}
+          cache: npm
       - uses: ./.github/actions/install-modules
       - uses: ./.github/actions/run-e2e-tests
         with:
-          dbOptions: '--dbclient=mysql --dbhost=localhost --dbport=3306 --dbname=strapi_test --dbusername=strapi --dbpassword=strapi'
+          dbOptions: "--dbclient=mysql --dbhost=localhost --dbport=3306 --dbname=strapi_test --dbusername=strapi --dbpassword=strapi"
 
   e2e_ce_mysql_5:
     runs-on: ubuntu-latest
@@ -167,15 +160,24 @@ jobs:
       - uses: actions/setup-node@v2-beta
         with:
           node-version: ${{ matrix.node }}
+          cache: npm
       - uses: ./.github/actions/install-modules
       - uses: ./.github/actions/run-e2e-tests
         with:
+<<<<<<< HEAD
           dbOptions: '--dbclient=mysql --dbhost=localhost --dbport=3306 --dbname=strapi_test --dbusername=strapi --dbpassword=strapi'
+=======
+          dbOptions: "--dbclient=sqlite --dbfile=./tmp/data.db"
+>>>>>>> 498f4a595 (ci(workflow): add 'npm' cache for actions/setup-node in .github/workflows)
 
   e2e_ce_sqlite:
     runs-on: ubuntu-latest
     needs: [lint, unit_back, unit_front]
+<<<<<<< HEAD
     name: '[CE] E2E (sqlite, node: ${{ matrix.node }})'
+=======
+    name: "[CE] E2E (mongo, node: ${{ matrix.node }})"
+>>>>>>> 498f4a595 (ci(workflow): add 'npm' cache for actions/setup-node in .github/workflows)
     strategy:
       matrix:
         node: [12, 14, 16]
@@ -185,16 +187,21 @@ jobs:
       - uses: actions/setup-node@v2-beta
         with:
           node-version: ${{ matrix.node }}
+          cache: npm
       - uses: ./.github/actions/install-modules
       - uses: ./.github/actions/run-e2e-tests
         with:
+<<<<<<< HEAD
           dbOptions: '--dbclient=sqlite --dbfile=./tmp/data.db'
+=======
+          dbOptions: "--dbclient=mongo --dbhost=localhost --dbport=27017 --dbname=strapi_test"
+>>>>>>> 498f4a595 (ci(workflow): add 'npm' cache for actions/setup-node in .github/workflows)
 
   # EE
   e2e_ee_pg:
     runs-on: ubuntu-latest
     needs: [lint, unit_back, unit_front]
-    name: '[EE] E2E (postgres, node: ${{ matrix.node }})'
+    name: "[EE] E2E (postgres, node: ${{ matrix.node }})"
     if: github.event.pull_request.head.repo.full_name == github.repository && !(github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]')
     env:
       STRAPI_LICENSE: ${{ secrets.strapiLicense }}
@@ -213,10 +220,7 @@ jobs:
           POSTGRES_DB: strapi_test
         # Set health checks to wait until postgres has started
         options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
+          --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
         ports:
           # Maps tcp port 5432 on service container to the host
           - 5432:5432
@@ -225,16 +229,17 @@ jobs:
       - uses: actions/setup-node@v2-beta
         with:
           node-version: ${{ matrix.node }}
+          cache: npm
       - uses: ./.github/actions/install-modules
       - uses: ./.github/actions/run-e2e-tests
         with:
-          dbOptions: '--dbclient=postgres --dbhost=localhost --dbport=5432 --dbname=strapi_test --dbusername=strapi --dbpassword=strapi'
+          dbOptions: "--dbclient=postgres --dbhost=localhost --dbport=5432 --dbname=strapi_test --dbusername=strapi --dbpassword=strapi"
           runEE: true
 
   e2e_ee_mysql:
     runs-on: ubuntu-latest
     needs: [lint, unit_back, unit_front]
-    name: '[EE] E2E (mysql, node: ${{ matrix.node }})'
+    name: "[EE] E2E (mysql, node: ${{ matrix.node }})"
     if: github.event.pull_request.head.repo.full_name == github.repository && !(github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]')
     env:
       STRAPI_LICENSE: ${{ secrets.strapiLicense }}
@@ -246,16 +251,7 @@ jobs:
       mysql:
         image: mysql
         options: >-
-          --health-cmd="mysqladmin ping"
-          --health-interval=10s
-          --health-timeout=5s
-          --health-retries=3
-          -e MYSQL_ROOT_PASSWORD=strapi
-          -e MYSQL_ROOT_HOST="%"
-          -e MYSQL_USER=strapi
-          -e MYSQL_PASSWORD=strapi
-          -e MYSQL_DATABASE=strapi_test
-          --entrypoint sh mysql -c "exec docker-entrypoint.sh mysqld --default-authentication-plugin=mysql_native_password"
+          --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3 -e MYSQL_ROOT_PASSWORD=strapi -e MYSQL_ROOT_HOST="%" -e MYSQL_USER=strapi -e MYSQL_PASSWORD=strapi -e MYSQL_DATABASE=strapi_test --entrypoint sh mysql -c "exec docker-entrypoint.sh mysqld --default-authentication-plugin=mysql_native_password"
         ports:
           # Maps tcp port 5432 on service container to the host
           - 3306:3306
@@ -264,16 +260,17 @@ jobs:
       - uses: actions/setup-node@v2-beta
         with:
           node-version: ${{ matrix.node }}
+          cache: npm
       - uses: ./.github/actions/install-modules
       - uses: ./.github/actions/run-e2e-tests
         with:
-          dbOptions: '--dbclient=mysql --dbhost=localhost --dbport=3306 --dbname=strapi_test --dbusername=strapi --dbpassword=strapi'
+          dbOptions: "--dbclient=mysql --dbhost=localhost --dbport=3306 --dbname=strapi_test --dbusername=strapi --dbpassword=strapi"
           runEE: true
 
   e2e_ee_sqlite:
     runs-on: ubuntu-latest
     needs: [lint, unit_back, unit_front]
-    name: '[EE] E2E (sqlite, node: ${{ matrix.node }})'
+    name: "[EE] E2E (sqlite, node: ${{ matrix.node }})"
     if: github.event.pull_request.head.repo.full_name == github.repository && !(github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]')
     env:
       STRAPI_LICENSE: ${{ secrets.strapiLicense }}
@@ -286,8 +283,40 @@ jobs:
       - uses: actions/setup-node@v2-beta
         with:
           node-version: ${{ matrix.node }}
+          cache: npm
       - uses: ./.github/actions/install-modules
       - uses: ./.github/actions/run-e2e-tests
         with:
-          dbOptions: '--dbclient=sqlite --dbfile=./tmp/data.db'
+          dbOptions: "--dbclient=sqlite --dbfile=./tmp/data.db"
           runEE: true
+<<<<<<< HEAD
+=======
+
+  e2e_ee_mongo:
+    runs-on: ubuntu-latest
+    needs: [lint, unit_back, unit_front]
+    name: "[EE] E2E (mongo, node: ${{ matrix.node }})"
+    if: github.event.pull_request.head.repo.full_name == github.repository && !(github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]')
+    env:
+      STRAPI_LICENSE: ${{ secrets.strapiLicense }}
+    strategy:
+      matrix:
+        node: [12, 14]
+      max-parallel: 2
+    services:
+      mongo:
+        image: mongo
+        ports:
+          - 27017:27017
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2-beta
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+      - uses: ./.github/actions/install-modules
+      - uses: ./.github/actions/run-e2e-tests
+        with:
+          dbOptions: "--dbclient=mongo --dbhost=localhost --dbport=27017 --dbname=strapi_test"
+          runEE: true
+>>>>>>> 498f4a595 (ci(workflow): add 'npm' cache for actions/setup-node in .github/workflows)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/setup-node@v2-beta
         with:
           node-version: ${{ matrix.node }}
-          cache: npm
+          cache: yarn
       - uses: ./.github/actions/install-modules
       - name: Run lint
         run: yarn run -s lint
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/setup-node@v2-beta
         with:
           node-version: ${{ matrix.node }}
-          cache: npm
+          cache: yarn
       - uses: ./.github/actions/install-modules
         with:
           globalPackages: codecov
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/setup-node@v2-beta
         with:
           node-version: ${{ matrix.node }}
-          cache: npm
+          cache: yarn
       - uses: ./.github/actions/install-modules
         with:
           globalPackages: codecov
@@ -97,7 +97,7 @@ jobs:
       - uses: actions/setup-node@v2-beta
         with:
           node-version: ${{ matrix.node }}
-          cache: npm
+          cache: yarn
       - uses: ./.github/actions/install-modules
       - uses: ./.github/actions/run-e2e-tests
         with:
@@ -124,7 +124,7 @@ jobs:
       - uses: actions/setup-node@v2-beta
         with:
           node-version: ${{ matrix.node }}
-          cache: npm
+          cache: yarn
       - uses: ./.github/actions/install-modules
       - uses: ./.github/actions/run-e2e-tests
         with:
@@ -160,7 +160,7 @@ jobs:
       - uses: actions/setup-node@v2-beta
         with:
           node-version: ${{ matrix.node }}
-          cache: npm
+          cache: yarn
       - uses: ./.github/actions/install-modules
       - uses: ./.github/actions/run-e2e-tests
         with:
@@ -187,7 +187,7 @@ jobs:
       - uses: actions/setup-node@v2-beta
         with:
           node-version: ${{ matrix.node }}
-          cache: npm
+          cache: yarn
       - uses: ./.github/actions/install-modules
       - uses: ./.github/actions/run-e2e-tests
         with:
@@ -229,7 +229,7 @@ jobs:
       - uses: actions/setup-node@v2-beta
         with:
           node-version: ${{ matrix.node }}
-          cache: npm
+          cache: yarn
       - uses: ./.github/actions/install-modules
       - uses: ./.github/actions/run-e2e-tests
         with:
@@ -260,7 +260,7 @@ jobs:
       - uses: actions/setup-node@v2-beta
         with:
           node-version: ${{ matrix.node }}
-          cache: npm
+          cache: yarn
       - uses: ./.github/actions/install-modules
       - uses: ./.github/actions/run-e2e-tests
         with:
@@ -283,7 +283,7 @@ jobs:
       - uses: actions/setup-node@v2-beta
         with:
           node-version: ${{ matrix.node }}
-          cache: npm
+          cache: yarn
       - uses: ./.github/actions/install-modules
       - uses: ./.github/actions/run-e2e-tests
         with:
@@ -313,7 +313,7 @@ jobs:
       - uses: actions/setup-node@v2-beta
         with:
           node-version: ${{ matrix.node }}
-          cache: npm
+          cache: yarn
       - uses: ./.github/actions/install-modules
       - uses: ./.github/actions/run-e2e-tests
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,16 +133,45 @@ The administration panel will be available at http://localhost:4000/admin
 
 ---
 
-## Running the tests
+## Running the e2e tests
+
+The end-to-end tests require a Strapi app to be able to run. You can generate a "test app" using `yarn test:generate-app <database>`:
+
+```bash
+$ yarn test:generate-app sqlite
+$ yarn test:generate-app mongo
+$ yarn test:generate-app postgres
+$ yarn test:generate-app mysql
+```
+
+You require a new app every time you run the tests. Otherwise, the test suite will fail. A script is available to make this process easier: `node test/e2e.js`. It'll delete the current test app, generate a new one, and run the test suite.
 
 **Changing the database:**
 
-You can run the test suites using different databases:
+By default the script `test/e2e,js` creates an app that uses `sqlite`. But you can run the test suites using different databases:
 
 ```bash
 $ node test/e2e.js --db=sqlite
 $ node test/e2e.js --db=postgres
 $ node test/e2e.js --db=mysql
+```
+
+**Running the tests for the CE**
+
+The test suites will run the tests for the EE version of Strapi. Should you want to test the CE version you will need to use the ENV variable `STRAPI_DISABLE_EE`:
+
+```bash
+$ STRAPI_DISABLE_EE=true node test/e2e.js
+$ STRAPI_DISABLE_EE=true yarn test:e2e
+```
+
+**Specifying a license to use for the EE e2e tests**
+
+The EE tests need a valid license to run correctly. To specify which license to use you can use `STRAPI_LICENSE`. You can specify it in an env file or as a prefix to the cli command:
+
+```bash
+$ STRAPI_LICENSE=<license> node test/e2e.js
+$ STRAPI_LICENSE=<license> yarn test:e2e
 ```
 
 ---

--- a/packages/plugins/documentation/package.json
+++ b/packages/plugins/documentation/package.json
@@ -33,6 +33,11 @@
     "reselect": "^4.0.0",
     "swagger-ui-dist": "3.47.1"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/strapi/strapi.git",
+    "directory": "packages/strapi-plugin-documentation"
+  },
   "author": {
     "name": "soupette",
     "email": "hi@strapi.io",

--- a/packages/plugins/graphql/package.json
+++ b/packages/plugins/graphql/package.json
@@ -31,6 +31,11 @@
     "nexus": "1.1.0",
     "pluralize": "^8.0.0"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/strapi/strapi.git",
+    "directory": "packages/strapi-plugin-graphql"
+  },
   "devDependencies": {
     "cross-env": "^7.0.3",
     "koa": "^2.13.1"

--- a/packages/plugins/i18n/package.json
+++ b/packages/plugins/i18n/package.json
@@ -13,6 +13,11 @@
     "@strapi/utils": "3.6.8",
     "lodash": "4.17.21"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/strapi/strapi.git",
+    "directory": "packages/strapi-plugin-i18n"
+  },
   "author": {
     "name": "A Strapi developer",
     "email": "",

--- a/packages/plugins/sentry/package.json
+++ b/packages/plugins/sentry/package.json
@@ -16,6 +16,11 @@
     "email": "hi@strapi.io",
     "url": "https://strapi.io"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/strapi/strapi.git",
+    "directory": "packages/strapi-plugin-sentry"
+  },
   "maintainers": [
     {
       "name": "Strapi team",

--- a/packages/providers/upload-rackspace/package.json
+++ b/packages/providers/upload-rackspace/package.json
@@ -13,6 +13,11 @@
     "pkgcloud": "2.2.0",
     "streamifier": "0.1.1"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/strapi/strapi.git",
+    "directory": "packages/strapi-provider-upload-rackspace"
+  },
   "engines": {
     "node": ">=12.x.x <=16.x.x",
     "npm": ">=6.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -22805,6 +22805,18 @@ tar@6.1.11, tar@^6.0.2, tar@^6.1.0:
     mkdirp "^1.0.3"
     yallist "^4.0.0"
 
+tar@6.1.9:
+  version "6.1.9"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.9.tgz#5646ef51342ac55456b2466e44da810439978db1"
+  integrity sha512-XjLaMNl76o07zqZC/aW4lwegdY07baOH1T8w3AEfrHAdyg/oYO4ctjzEBq9Gy9fEP9oHqLIgvx6zuGDGe+bc8Q==
+  dependencies:
+    chownr "^2.0.0"
+    fs-minipass "^2.0.0"
+    minipass "^3.0.0"
+    minizlib "^2.1.1"
+    mkdirp "^1.0.3"
+    yallist "^4.0.0"
+
 tar@^2.0.0:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/tar/-/tar-2.2.2.tgz#0ca8848562c7299b8b446ff6a4d60cdbb23edc40"


### PR DESCRIPTION
## Description

Add `cache` to workflows using `actions/setup-node`

## Context

`setup-node` GitHub Action just released a new option to add cache to steps using it.

You can find the details here: https://github.blog/changelog/2021-07-02-github-actions-setup-node-now-supports-dependency-caching/

---

🤖 This PR has been generated automatically by [this octoherd script](https://github.com/oscard0m/octoherd-script-add-cache-to-node-github-action), feel free to run it in your GitHub user/org repositories! 💪🏾
