### PR TITLE
[v4] Add possibility to set a status on a thrown Error

### DIFF
--- a/packages/core/strapi/lib/middlewares/errors.js
+++ b/packages/core/strapi/lib/middlewares/errors.js
@@ -32,7 +32,7 @@ module.exports = (/* _, { strapi } */) => {
 
       strapi.log.error(error);
 
-      const { status, body } = formatInternalError();
+      const { status, body } = formatInternalError(error);
       ctx.status = status;
       ctx.body = body;
     }

--- a/packages/core/strapi/lib/services/errors.js
+++ b/packages/core/strapi/lib/services/errors.js
@@ -60,9 +60,14 @@ const formatHttpError = error => {
   };
 };
 
-const formatInternalError = () => {
-  const error = createError(500);
-  return formatHttpError(error);
+const formatInternalError = error => {
+  const httpError = createError(error);
+
+  if (httpError.expose) {
+    return formatHttpError(httpError);
+  }
+
+  return formatHttpError(createError(httpError.status || 500));
 };
 
 module.exports = {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Add possibility to set a status on a thrown Error.

### Why is it needed?

The goal is to stay consistent with what koa offer with ctx.throw()

### How to test it?

you can create a custom controller and trow a new Error with a status code

