### PR TITLE
[V4] Fix DynamicZone queries for GraphQL

### DIFF
--- a/packages/core/strapi/lib/services/entity-service/index.js
+++ b/packages/core/strapi/lib/services/entity-service/index.js
@@ -264,7 +264,7 @@ const createDefaultImplementation = ({ strapi, db, eventHub, entityValidator }) 
     return db.query(uid).deleteMany(query);
   },
 
-  load(uid, entity, field, params) {
+  load(uid, entity, field, params = {}) {
     const { attributes } = strapi.getModel(uid);
 
     const attribute = attributes[field];


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

 Adds a default value to the params attribute of the entity-service's load method

### Why is it needed?

When loading a dynamic zone without any additional params, the entity service passes down params = undefined which cause the next layer to throw.

### How to test it?

See #11544

### Related issue(s)/PR(s)

Fix #11544
