### PR TITLE
[V4] GraphQL - Fix components' filtering

### DIFF
--- a/packages/plugins/graphql/server/services/builders/resolvers/component.js
+++ b/packages/plugins/graphql/server/services/builders/resolvers/component.js
@@ -6,7 +6,11 @@ module.exports = ({ strapi }) => ({
 
     return async (parent, args = {}) => {
       const contentType = strapi.contentTypes[contentTypeUID];
-      const transformedArgs = transformArgs(args, { contentType, usePagination: true });
+
+      const { component: componentName } = contentType.attributes[attributeName];
+      const component = strapi.getModel(componentName);
+
+      const transformedArgs = transformArgs(args, { contentType: component, usePagination: true });
 
       return strapi.entityService.load(contentTypeUID, parent, attributeName, transformedArgs);
     };

--- a/packages/plugins/graphql/server/services/builders/type.js
+++ b/packages/plugins/graphql/server/services/builders/type.js
@@ -66,7 +66,7 @@ module.exports = context => {
       strapi,
     });
 
-    const args = getContentTypeArgs(targetComponent);
+    const args = getContentTypeArgs(targetComponent, { multiple: !!attribute.repeatable });
 
     builder.field(attributeName, { type, resolve, args });
   };

--- a/packages/plugins/graphql/server/services/builders/utils.js
+++ b/packages/plugins/graphql/server/services/builders/utils.js
@@ -25,6 +25,8 @@ module.exports = ({ strapi }) => {
 
       // Components
       if (modelType === 'component') {
+        if (!multiple) return {};
+
         return {
           filters: naming.getFiltersInputTypeName(contentType),
           pagination: args.PaginationArg,


### PR DESCRIPTION
### What does it do?

- Removes args (filters, sort, etc...) from non-repeatable components
- Fix filters transformation when loading components 

### Why is it needed?

Filters for non-repeatable components are basically useless & filters are currently broken

