### PR TITLE
[V4] GraphQL - Remove Manually Added Timestamps

### DIFF
--- a/packages/plugins/graphql/server/services/builders/type.js
+++ b/packages/plugins/graphql/server/services/builders/type.js
@@ -275,10 +275,9 @@ module.exports = context => {
         isRelation,
       } = utils.attributes;
 
-      const { attributes, modelType, options = {} } = contentType;
+      const { attributes, modelType } = contentType;
 
       const attributesKey = Object.keys(attributes);
-      const hasTimestamps = isArray(options.timestamps);
 
       const name = (modelType === 'component' ? getComponentName : getTypeName).call(
         null,
@@ -293,17 +292,7 @@ module.exports = context => {
             t.nonNull.id('id');
           }
 
-          // 1. Timestamps
-          // If the content type has timestamps enabled
-          // then we should add the corresponding attributes in the definition
-          if (hasTimestamps) {
-            const [createdAtKey, updatedAtKey] = contentType.options.timestamps;
-
-            t.nonNull.dateTime(createdAtKey);
-            t.nonNull.dateTime(updatedAtKey);
-          }
-
-          /** 2. Attributes
+          /** Attributes
            *
            * Attributes can be of 7 different kind:
            * - Scalar


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Remove code dedicated to timestamps in type definition

### Why is it needed?

Since timestamps are now handled as regular attributes, we don't need to add them manually in the type definition

