### PR TITLE
✏️ Edit the file watcher to only ignore admin folder occurrences from project folder onwards and not parent folder

### DIFF
--- a/packages/strapi/lib/commands/develop.js
+++ b/packages/strapi/lib/commands/develop.js
@@ -121,8 +121,8 @@ function watchFileChanges({ dir, strapiInstance, watchIgnoreFiles, polling }) {
     ignored: [
       /(^|[/\\])\../, // dot files
       /tmp/,
-      '**/admin',
-      '**/admin/**',
+      'admin',
+      'admin/**',
       'extensions/**/admin',
       'extensions/**/admin/**',
       '**/documentation',


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

This PR tells the file watcher to only ignore occurrences of the word admin from the root folder onwards

### Why is it needed?

It fixes this issue #11586. 

### How to test it?

Create a strapi project inside a parent folder called admin, and try to edit the project in all valid directories including extension and plugin admin directories, it works as expected. 

### Related issue(s)/PR(s)

#11586
