### PR TITLE
[V4] Graphql - Fix nested component resolvers

### DIFF
--- a/packages/plugins/graphql/server/services/builders/resolvers/component.js
+++ b/packages/plugins/graphql/server/services/builders/resolvers/component.js
@@ -5,7 +5,7 @@ module.exports = ({ strapi }) => ({
     const { transformArgs } = strapi.plugin('graphql').service('builders').utils;
 
     return async (parent, args = {}) => {
-      const contentType = strapi.contentTypes[contentTypeUID];
+      const contentType = strapi.getModel(contentTypeUID);
 
       const { component: componentName } = contentType.attributes[attributeName];
       const component = strapi.getModel(componentName);


### PR DESCRIPTION
### What does it do?

Use `strapi.getModel` instead of `strapi.contentTypes[]` to fetch the model containing a given component, which allow to handle both content types & components parents.

### Why is it needed?

Currently, the resolvers are broken for components that are inside other components

### Related issue(s)/PR(s)

fix #11605
