### PR TITLE
[V4] GraphQL - Only keep writable attributes in input types

### DIFF
--- a/packages/plugins/graphql/server/services/builders/input.js
+++ b/packages/plugins/graphql/server/services/builders/input.js
@@ -2,7 +2,7 @@
 
 const { inputObjectType, nonNull } = require('nexus');
 const {
-  contentTypes: { getWritableAttributes },
+  contentTypes: { isWritableAttribute },
 } = require('@strapi/utils');
 
 module.exports = context => {
@@ -41,9 +41,6 @@ module.exports = context => {
         name,
 
         definition(t) {
-          const writableAttributes = getWritableAttributes(contentType);
-
-          const isWritableAttribute = attributeName => writableAttributes.includes(attributeName);
           const isFieldEnabled = fieldName => {
             return extension
               .shadowCRUD(contentType.uid)
@@ -51,9 +48,9 @@ module.exports = context => {
               .hasInputEnabled();
           };
 
-          const validAttributes = Object.entries(attributes).filter(
-            ([attributeName]) => isWritableAttribute(attributeName) && isFieldEnabled(attributeName)
-          );
+          const validAttributes = Object.entries(attributes).filter(([attributeName]) => {
+            return isWritableAttribute(contentType, attributeName) && isFieldEnabled(attributeName);
+          });
 
           // Add the ID for the component to enable inplace updates
           if (modelType === 'component' && isFieldEnabled('id')) {

--- a/packages/plugins/graphql/server/services/builders/input.js
+++ b/packages/plugins/graphql/server/services/builders/input.js
@@ -1,6 +1,9 @@
 'use strict';
 
 const { inputObjectType, nonNull } = require('nexus');
+const {
+  contentTypes: { getWritableAttributes },
+} = require('@strapi/utils');
 
 module.exports = context => {
   const { strapi } = context;
@@ -38,6 +41,9 @@ module.exports = context => {
         name,
 
         definition(t) {
+          const writableAttributes = getWritableAttributes(contentType);
+
+          const isWritableAttribute = attributeName => writableAttributes.includes(attributeName);
           const isFieldEnabled = fieldName => {
             return extension
               .shadowCRUD(contentType.uid)
@@ -45,8 +51,8 @@ module.exports = context => {
               .hasInputEnabled();
           };
 
-          const validAttributes = Object.entries(attributes).filter(([attributeName]) =>
-            isFieldEnabled(attributeName)
+          const validAttributes = Object.entries(attributes).filter(
+            ([attributeName]) => isWritableAttribute(attributeName) && isFieldEnabled(attributeName)
           );
 
           // Add the ID for the component to enable inplace updates


### PR DESCRIPTION
### What does it do?

Removes non-writable attributes from GraphQL input types

### Why is it needed?

Currently, non-writable attributes are registered in input types (such as `createdAt` or `updatedAt`) but are sanitized later on. This PR removes this weird scenario by eliminating those fields from the input types.

