### PR TITLE
[V4] Fix sso existing user query

### DIFF
--- a/packages/core/admin/ee/server/controllers/authentication/middlewares.js
+++ b/packages/core/admin/ee/server/controllers/authentication/middlewares.js
@@ -27,7 +27,7 @@ const authenticate = async (ctx, next) => {
       return ctx.redirect(redirectUrls.error);
     }
 
-    const user = await getService('user').findOne({ email: profile.email });
+    const user = await getService('user').findOneByEmail(profile.email);
     const scenario = user ? existingUserScenario : nonExistingUserScenario;
 
     return scenario(ctx, next)(user || profile, provider);

--- a/packages/core/admin/server/services/user.js
+++ b/packages/core/admin/server/services/user.js
@@ -180,6 +180,19 @@ const findOne = async (id, populate = ['roles']) => {
   return strapi.entityService.findOne('admin::user', id, { populate });
 };
 
+/**
+ * Find one user by its email
+ * @param {string} id  email
+ * @param {string || string[] || object} populate
+ * @returns
+ */
+const findOneByEmail = async (email, populate = []) => {
+  return strapi.query('admin::user').findOne({
+    where: { email },
+    populate,
+  });
+};
+
 /** Find many users (paginated)
  * @param query
  * @returns {Promise<user>}
@@ -309,6 +322,7 @@ module.exports = {
   register,
   sanitizeUser,
   findOne,
+  findOneByEmail,
   findPage,
   deleteById,
   deleteByIds,


### PR DESCRIPTION
### What does it do?

It adds a findUserByEmail method in the admin user service & use it from the admin authentication middleware

### Why is it needed?

The admin authentication middleware was using the old findOne syntax to check for an existing user (by mail). This caused the app to crash when trying to log in using SSO.

### Related issue(s)/PR(s)

Should fix #11652
