### PR TITLE
[V4] CLI add warning for ct without attributes

### DIFF
--- a/packages/generators/generators/lib/plops/prompts/get-attributes-prompts.js
+++ b/packages/generators/generators/lib/plops/prompts/get-attributes-prompts.js
@@ -92,6 +92,10 @@ module.exports = async inquirer => {
 
   if (addAttributes) {
     await createNewAttributes(inquirer);
+  } else {
+    console.warn(
+      `You won't be able to manage entries from the admin, you can still add attributes later from the content type builder.`
+    );
   }
 
   return attributes;


### PR DESCRIPTION
### What does it do?

Adds the following warning when creating a content type from the CLI without attributes.

> You won't be able to manage entries from the admin, you can still add attributes later from the content type builder.

### Why is it needed?

Offer more visibility on the impact of creating a ct without any attributes

