### PR TITLE
[v4] fix plugin name variable when generating controller

### DIFF
--- a/packages/generators/generators/lib/files/plugin/server/controllers/my-controller.js.hbs
+++ b/packages/generators/generators/lib/files/plugin/server/controllers/my-controller.js.hbs
@@ -3,7 +3,7 @@
 module.exports = {
   index(ctx) {
     ctx.body = strapi
-      .plugin('{{ id }}')
+      .plugin('{{ pluginName }}')
       .service('myService')
       .getWelcomeMessage();
   },


### PR DESCRIPTION
### What does it do?

Replaces 'id' with 'pluginName' in the handlebars template since that is what is passed in the plop generator

### Why is it needed?

The generated controller returns an empty string for the plugin
```
'use strict';

module.exports = {
  index(ctx) {
    ctx.body = strapi
      .plugin('') // should return the name of the plugin
      .service('myService')
      .getWelcomeMessage();
  },
};
```

### How to test it?

Run `yarn strapi generate` and generate a plugin

