### PR TITLE
remove unallowed fields from admin::user relations

### DIFF
--- a/packages/core/content-manager/server/tests/index.test.e2e.js
+++ b/packages/core/content-manager/server/tests/index.test.e2e.js
@@ -80,20 +80,20 @@ describe('Content Manager End to End', () => {
       data.tags.push(body);
 
       expect(body.id).toBeDefined();
-      // expect(Array.isArray(body.articles)).toBeTruthy();
+      expect(Array.isArray(body.articles)).toBeTruthy();
       expect(body.name).toBe('tag1');
-      // expect(body.createdBy).toMatchObject({
-      //   firstname: 'admin',
-      //   id: 1,
-      //   lastname: 'admin',
-      //   username: null,
-      // });
-      // expect(body.updatedBy).toMatchObject({
-      //   firstname: 'admin',
-      //   id: 1,
-      //   lastname: 'admin',
-      //   username: null,
-      // });
+      expect(body.createdBy).toMatchObject({
+        firstname: 'admin',
+        id: 1,
+        lastname: 'admin',
+        username: null,
+      });
+      expect(body.updatedBy).toMatchObject({
+        firstname: 'admin',
+        id: 1,
+        lastname: 'admin',
+        username: null,
+      });
       expect(body.publishedAt).toBeUndefined();
     });
 
@@ -109,20 +109,20 @@ describe('Content Manager End to End', () => {
       data.tags.push(body);
 
       expect(body.id).toBeDefined();
-      // expect(Array.isArray(body.articles)).toBeTruthy();
+      expect(Array.isArray(body.articles)).toBeTruthy();
       expect(body.name).toBe('tag2');
-      // expect(body.createdBy).toMatchObject({
-      //   firstname: 'admin',
-      //   id: 1,
-      //   lastname: 'admin',
-      //   username: null,
-      // });
-      // expect(body.updatedBy).toMatchObject({
-      //   firstname: 'admin',
-      //   id: 1,
-      //   lastname: 'admin',
-      //   username: null,
-      // });
+      expect(body.createdBy).toMatchObject({
+        firstname: 'admin',
+        id: 1,
+        lastname: 'admin',
+        username: null,
+      });
+      expect(body.updatedBy).toMatchObject({
+        firstname: 'admin',
+        id: 1,
+        lastname: 'admin',
+        username: null,
+      });
       expect(body.publishedAt).toBeUndefined();
     });
 
@@ -138,20 +138,20 @@ describe('Content Manager End to End', () => {
       data.tags.push(body);
 
       expect(body.id).toBeDefined();
-      // expect(Array.isArray(body.articles)).toBeTruthy();
+      expect(Array.isArray(body.articles)).toBeTruthy();
       expect(body.name).toBe('tag3');
-      // expect(body.createdBy).toMatchObject({
-      //   firstname: 'admin',
-      //   id: 1,
-      //   lastname: 'admin',
-      //   username: null,
-      // });
-      // expect(body.updatedBy).toMatchObject({
-      //   firstname: 'admin',
-      //   id: 1,
-      //   lastname: 'admin',
-      //   username: null,
-      // });
+      expect(body.createdBy).toMatchObject({
+        firstname: 'admin',
+        id: 1,
+        lastname: 'admin',
+        username: null,
+      });
+      expect(body.updatedBy).toMatchObject({
+        firstname: 'admin',
+        id: 1,
+        lastname: 'admin',
+        username: null,
+      });
       expect(body.publishedAt).toBeUndefined();
     });
 
@@ -173,20 +173,20 @@ describe('Content Manager End to End', () => {
       expect(body.id).toBeDefined();
       expect(body.title).toBe(entry.title);
       expect(body.content).toBe(entry.content);
-      // expect(Array.isArray(body.tags)).toBeTruthy();
-      // expect(body.tags.length).toBe(0);
-      // expect(body.createdBy).toMatchObject({
-      //   firstname: 'admin',
-      //   id: 1,
-      //   lastname: 'admin',
-      //   username: null,
-      // });
-      // expect(body.updatedBy).toMatchObject({
-      //   firstname: 'admin',
-      //   id: 1,
-      //   lastname: 'admin',
-      //   username: null,
-      // });
+      expect(Array.isArray(body.tags)).toBeTruthy();
+      expect(body.tags.length).toBe(0);
+      expect(body.createdBy).toMatchObject({
+        firstname: 'admin',
+        id: 1,
+        lastname: 'admin',
+        username: null,
+      });
+      expect(body.updatedBy).toMatchObject({
+        firstname: 'admin',
+        id: 1,
+        lastname: 'admin',
+        username: null,
+      });
       expect(body.publishedAt).toBeUndefined();
     });
 

--- a/packages/core/content-manager/server/tests/index.test.e2e.js
+++ b/packages/core/content-manager/server/tests/index.test.e2e.js
@@ -82,8 +82,18 @@ describe('Content Manager End to End', () => {
       expect(body.id).toBeDefined();
       // expect(Array.isArray(body.articles)).toBeTruthy();
       expect(body.name).toBe('tag1');
-      // expect(body.createdBy).toMatchObject({ email: 'admin@strapi.io' });
-      // expect(body.updatedBy).toMatchObject({ email: 'admin@strapi.io' });
+      // expect(body.createdBy).toMatchObject({
+      //   firstname: 'admin',
+      //   id: 1,
+      //   lastname: 'admin',
+      //   username: null,
+      // });
+      // expect(body.updatedBy).toMatchObject({
+      //   firstname: 'admin',
+      //   id: 1,
+      //   lastname: 'admin',
+      //   username: null,
+      // });
       expect(body.publishedAt).toBeUndefined();
     });
 
@@ -101,8 +111,18 @@ describe('Content Manager End to End', () => {
       expect(body.id).toBeDefined();
       // expect(Array.isArray(body.articles)).toBeTruthy();
       expect(body.name).toBe('tag2');
-      // expect(body.createdBy).toMatchObject({ email: 'admin@strapi.io' });
-      // expect(body.updatedBy).toMatchObject({ email: 'admin@strapi.io' });
+      // expect(body.createdBy).toMatchObject({
+      //   firstname: 'admin',
+      //   id: 1,
+      //   lastname: 'admin',
+      //   username: null,
+      // });
+      // expect(body.updatedBy).toMatchObject({
+      //   firstname: 'admin',
+      //   id: 1,
+      //   lastname: 'admin',
+      //   username: null,
+      // });
       expect(body.publishedAt).toBeUndefined();
     });
 
@@ -120,8 +140,18 @@ describe('Content Manager End to End', () => {
       expect(body.id).toBeDefined();
       // expect(Array.isArray(body.articles)).toBeTruthy();
       expect(body.name).toBe('tag3');
-      // expect(body.createdBy).toMatchObject({ email: 'admin@strapi.io' });
-      // expect(body.updatedBy).toMatchObject({ email: 'admin@strapi.io' });
+      // expect(body.createdBy).toMatchObject({
+      //   firstname: 'admin',
+      //   id: 1,
+      //   lastname: 'admin',
+      //   username: null,
+      // });
+      // expect(body.updatedBy).toMatchObject({
+      //   firstname: 'admin',
+      //   id: 1,
+      //   lastname: 'admin',
+      //   username: null,
+      // });
       expect(body.publishedAt).toBeUndefined();
     });
 
@@ -145,8 +175,18 @@ describe('Content Manager End to End', () => {
       expect(body.content).toBe(entry.content);
       // expect(Array.isArray(body.tags)).toBeTruthy();
       // expect(body.tags.length).toBe(0);
-      // expect(body.createdBy).toMatchObject({ email: 'admin@strapi.io' });
-      // expect(body.updatedBy).toMatchObject({ email: 'admin@strapi.io' });
+      // expect(body.createdBy).toMatchObject({
+      //   firstname: 'admin',
+      //   id: 1,
+      //   lastname: 'admin',
+      //   username: null,
+      // });
+      // expect(body.updatedBy).toMatchObject({
+      //   firstname: 'admin',
+      //   id: 1,
+      //   lastname: 'admin',
+      //   username: null,
+      // });
       expect(body.publishedAt).toBeUndefined();
     });
 
@@ -171,8 +211,18 @@ describe('Content Manager End to End', () => {
       expect(Array.isArray(body.tags)).toBeTruthy();
       expect(body.tags.length).toBe(1);
       expect(body.tags[0].id).toBe(data.tags[0].id);
-      expect(body.createdBy).toMatchObject({ email: 'admin@strapi.io' });
-      expect(body.updatedBy).toMatchObject({ email: 'admin@strapi.io' });
+      expect(body.createdBy).toMatchObject({
+        firstname: 'admin',
+        id: 1,
+        lastname: 'admin',
+        username: null,
+      });
+      expect(body.updatedBy).toMatchObject({
+        firstname: 'admin',
+        id: 1,
+        lastname: 'admin',
+        username: null,
+      });
       expect(body.publishedAt).toBeUndefined();
     });
 
@@ -197,8 +247,18 @@ describe('Content Manager End to End', () => {
       expect(Array.isArray(body.tags)).toBeTruthy();
       expect(body.tags.length).toBe(1);
       expect(body.tags[0].id).toBe(data.tags[1].id);
-      expect(body.createdBy).toMatchObject({ email: 'admin@strapi.io' });
-      expect(body.updatedBy).toMatchObject({ email: 'admin@strapi.io' });
+      expect(body.createdBy).toMatchObject({
+        firstname: 'admin',
+        id: 1,
+        lastname: 'admin',
+        username: null,
+      });
+      expect(body.updatedBy).toMatchObject({
+        firstname: 'admin',
+        id: 1,
+        lastname: 'admin',
+        username: null,
+      });
       expect(body.publishedAt).toBeUndefined();
     });
 
@@ -224,8 +284,18 @@ describe('Content Manager End to End', () => {
       expect(body.content).toBe(entry.content);
       expect(Array.isArray(body.tags)).toBeTruthy();
       expect(body.tags.length).toBe(3);
-      expect(body.createdBy).toMatchObject({ email: 'admin@strapi.io' });
-      expect(body.updatedBy).toMatchObject({ email: 'admin@strapi.io' });
+      expect(body.createdBy).toMatchObject({
+        firstname: 'admin',
+        id: 1,
+        lastname: 'admin',
+        username: null,
+      });
+      expect(body.updatedBy).toMatchObject({
+        firstname: 'admin',
+        id: 1,
+        lastname: 'admin',
+        username: null,
+      });
       expect(body.publishedAt).toBeUndefined();
     });
 
@@ -248,8 +318,18 @@ describe('Content Manager End to End', () => {
       expect(body.content).toBe(entry.content);
       expect(Array.isArray(body.tags)).toBeTruthy();
       expect(body.tags.length).toBe(2);
-      expect(body.createdBy).toMatchObject({ email: 'admin@strapi.io' });
-      expect(body.updatedBy).toMatchObject({ email: 'admin@strapi.io' });
+      expect(body.createdBy).toMatchObject({
+        firstname: 'admin',
+        id: 1,
+        lastname: 'admin',
+        username: null,
+      });
+      expect(body.updatedBy).toMatchObject({
+        firstname: 'admin',
+        id: 1,
+        lastname: 'admin',
+        username: null,
+      });
       expect(body.publishedAt).toBeUndefined();
     });
 
@@ -273,8 +353,18 @@ describe('Content Manager End to End', () => {
       expect(body.content).toBe(entry.content);
       expect(Array.isArray(body.tags)).toBeTruthy();
       expect(body.tags.length).toBe(0);
-      expect(body.createdBy).toMatchObject({ email: 'admin@strapi.io' });
-      expect(body.updatedBy).toMatchObject({ email: 'admin@strapi.io' });
+      expect(body.createdBy).toMatchObject({
+        firstname: 'admin',
+        id: 1,
+        lastname: 'admin',
+        username: null,
+      });
+      expect(body.updatedBy).toMatchObject({
+        firstname: 'admin',
+        id: 1,
+        lastname: 'admin',
+        username: null,
+      });
       expect(body.publishedAt).toBeUndefined();
     });
 
@@ -384,8 +474,18 @@ describe('Content Manager End to End', () => {
       expect(Array.isArray(body.tags)).toBeTruthy();
       expect(body.tags.length).toBe(1);
       expect(body.tags[0].id).toBe(data.tags[0].id);
-      expect(body.createdBy).toMatchObject({ email: 'admin@strapi.io' });
-      expect(body.updatedBy).toMatchObject({ email: 'admin@strapi.io' });
+      expect(body.createdBy).toMatchObject({
+        firstname: 'admin',
+        id: 1,
+        lastname: 'admin',
+        username: null,
+      });
+      expect(body.updatedBy).toMatchObject({
+        firstname: 'admin',
+        id: 1,
+        lastname: 'admin',
+        username: null,
+      });
     });
   });
 
@@ -415,8 +515,18 @@ describe('Content Manager End to End', () => {
       expect(body.id).toBeDefined();
       expect(Array.isArray(body.articles)).toBeTruthy();
       expect(body.name).toBe('cat1');
-      expect(body.createdBy).toMatchObject({ email: 'admin@strapi.io' });
-      expect(body.updatedBy).toMatchObject({ email: 'admin@strapi.io' });
+      expect(body.createdBy).toMatchObject({
+        firstname: 'admin',
+        id: 1,
+        lastname: 'admin',
+        username: null,
+      });
+      expect(body.updatedBy).toMatchObject({
+        firstname: 'admin',
+        id: 1,
+        lastname: 'admin',
+        username: null,
+      });
       expect(body.publishedAt).toBeUndefined();
     });
 
@@ -434,8 +544,18 @@ describe('Content Manager End to End', () => {
       expect(body.id).toBeDefined();
       expect(Array.isArray(body.articles)).toBeTruthy();
       expect(body.name).toBe('cat2');
-      expect(body.createdBy).toMatchObject({ email: 'admin@strapi.io' });
-      expect(body.updatedBy).toMatchObject({ email: 'admin@strapi.io' });
+      expect(body.createdBy).toMatchObject({
+        firstname: 'admin',
+        id: 1,
+        lastname: 'admin',
+        username: null,
+      });
+      expect(body.updatedBy).toMatchObject({
+        firstname: 'admin',
+        id: 1,
+        lastname: 'admin',
+        username: null,
+      });
       expect(body.publishedAt).toBeUndefined();
     });
 
@@ -459,8 +579,18 @@ describe('Content Manager End to End', () => {
       expect(body.content).toBe(entry.content);
       expect(body.category.name).toBe(data.categories[0].name);
       expect(Array.isArray(body.tags)).toBeTruthy();
-      expect(body.createdBy).toMatchObject({ email: 'admin@strapi.io' });
-      expect(body.updatedBy).toMatchObject({ email: 'admin@strapi.io' });
+      expect(body.createdBy).toMatchObject({
+        firstname: 'admin',
+        id: 1,
+        lastname: 'admin',
+        username: null,
+      });
+      expect(body.updatedBy).toMatchObject({
+        firstname: 'admin',
+        id: 1,
+        lastname: 'admin',
+        username: null,
+      });
     });
 
     test('Update article1 with cat2', async () => {
@@ -483,8 +613,18 @@ describe('Content Manager End to End', () => {
       expect(body.content).toBe(entry.content);
       expect(body.category.name).toBe(data.categories[1].name);
       expect(Array.isArray(body.tags)).toBeTruthy();
-      expect(body.createdBy).toMatchObject({ email: 'admin@strapi.io' });
-      expect(body.updatedBy).toMatchObject({ email: 'admin@strapi.io' });
+      expect(body.createdBy).toMatchObject({
+        firstname: 'admin',
+        id: 1,
+        lastname: 'admin',
+        username: null,
+      });
+      expect(body.updatedBy).toMatchObject({
+        firstname: 'admin',
+        id: 1,
+        lastname: 'admin',
+        username: null,
+      });
     });
 
     test('Create article2', async () => {
@@ -505,8 +645,18 @@ describe('Content Manager End to End', () => {
       expect(body.title).toBe(entry.title);
       expect(body.content).toBe(entry.content);
       expect(Array.isArray(body.tags)).toBeTruthy();
-      expect(body.createdBy).toMatchObject({ email: 'admin@strapi.io' });
-      expect(body.updatedBy).toMatchObject({ email: 'admin@strapi.io' });
+      expect(body.createdBy).toMatchObject({
+        firstname: 'admin',
+        id: 1,
+        lastname: 'admin',
+        username: null,
+      });
+      expect(body.updatedBy).toMatchObject({
+        firstname: 'admin',
+        id: 1,
+        lastname: 'admin',
+        username: null,
+      });
     });
 
     test('Update article2 with cat2', async () => {
@@ -529,8 +679,18 @@ describe('Content Manager End to End', () => {
       expect(body.content).toBe(entry.content);
       expect(body.category.name).toBe(data.categories[1].name);
       expect(Array.isArray(body.tags)).toBeTruthy();
-      expect(body.createdBy).toMatchObject({ email: 'admin@strapi.io' });
-      expect(body.updatedBy).toMatchObject({ email: 'admin@strapi.io' });
+      expect(body.createdBy).toMatchObject({
+        firstname: 'admin',
+        id: 1,
+        lastname: 'admin',
+        username: null,
+      });
+      expect(body.updatedBy).toMatchObject({
+        firstname: 'admin',
+        id: 1,
+        lastname: 'admin',
+        username: null,
+      });
     });
 
     test('Update cat1 with article1', async () => {
@@ -552,8 +712,18 @@ describe('Content Manager End to End', () => {
       expect(Array.isArray(body.articles)).toBeTruthy();
       expect(body.articles.length).toBe(1);
       expect(body.name).toBe(entry.name);
-      expect(body.createdBy).toMatchObject({ email: 'admin@strapi.io' });
-      expect(body.updatedBy).toMatchObject({ email: 'admin@strapi.io' });
+      expect(body.createdBy).toMatchObject({
+        firstname: 'admin',
+        id: 1,
+        lastname: 'admin',
+        username: null,
+      });
+      expect(body.updatedBy).toMatchObject({
+        firstname: 'admin',
+        id: 1,
+        lastname: 'admin',
+        username: null,
+      });
     });
 
     test('Create cat3 with article1', async () => {
@@ -574,8 +744,18 @@ describe('Content Manager End to End', () => {
       expect(Array.isArray(body.articles)).toBeTruthy();
       expect(body.articles.length).toBe(1);
       expect(body.name).toBe(entry.name);
-      expect(body.createdBy).toMatchObject({ email: 'admin@strapi.io' });
-      expect(body.updatedBy).toMatchObject({ email: 'admin@strapi.io' });
+      expect(body.createdBy).toMatchObject({
+        firstname: 'admin',
+        id: 1,
+        lastname: 'admin',
+        username: null,
+      });
+      expect(body.updatedBy).toMatchObject({
+        firstname: 'admin',
+        id: 1,
+        lastname: 'admin',
+        username: null,
+      });
     });
 
     test('Get article1 with cat3', async () => {
@@ -586,8 +766,18 @@ describe('Content Manager End to End', () => {
 
       expect(body.id).toBeDefined();
       expect(body.category.id).toBe(data.categories[2].id);
-      expect(body.createdBy).toMatchObject({ email: 'admin@strapi.io' });
-      expect(body.updatedBy).toMatchObject({ email: 'admin@strapi.io' });
+      expect(body.createdBy).toMatchObject({
+        firstname: 'admin',
+        id: 1,
+        lastname: 'admin',
+        username: null,
+      });
+      expect(body.updatedBy).toMatchObject({
+        firstname: 'admin',
+        id: 1,
+        lastname: 'admin',
+        username: null,
+      });
     });
 
     test('Get article2 with cat2', async () => {
@@ -598,8 +788,18 @@ describe('Content Manager End to End', () => {
 
       expect(body.id).toBeDefined();
       expect(body.category.id).toBe(data.categories[1].id);
-      expect(body.createdBy).toMatchObject({ email: 'admin@strapi.io' });
-      expect(body.updatedBy).toMatchObject({ email: 'admin@strapi.io' });
+      expect(body.createdBy).toMatchObject({
+        firstname: 'admin',
+        id: 1,
+        lastname: 'admin',
+        username: null,
+      });
+      expect(body.updatedBy).toMatchObject({
+        firstname: 'admin',
+        id: 1,
+        lastname: 'admin',
+        username: null,
+      });
     });
 
     test('Get cat1 without relations', async () => {
@@ -610,8 +810,18 @@ describe('Content Manager End to End', () => {
 
       expect(body.id).toBeDefined();
       expect(body.articles.length).toBe(0);
-      expect(body.createdBy).toMatchObject({ email: 'admin@strapi.io' });
-      expect(body.updatedBy).toMatchObject({ email: 'admin@strapi.io' });
+      expect(body.createdBy).toMatchObject({
+        firstname: 'admin',
+        id: 1,
+        lastname: 'admin',
+        username: null,
+      });
+      expect(body.updatedBy).toMatchObject({
+        firstname: 'admin',
+        id: 1,
+        lastname: 'admin',
+        username: null,
+      });
     });
 
     test('Get cat2 with article2', async () => {
@@ -623,8 +833,18 @@ describe('Content Manager End to End', () => {
       expect(body.id).toBeDefined();
       expect(body.articles.length).toBe(1);
       expect(body.articles[0].id).toBe(data.articles[1].id);
-      expect(body.createdBy).toMatchObject({ email: 'admin@strapi.io' });
-      expect(body.updatedBy).toMatchObject({ email: 'admin@strapi.io' });
+      expect(body.createdBy).toMatchObject({
+        firstname: 'admin',
+        id: 1,
+        lastname: 'admin',
+        username: null,
+      });
+      expect(body.updatedBy).toMatchObject({
+        firstname: 'admin',
+        id: 1,
+        lastname: 'admin',
+        username: null,
+      });
     });
 
     test('Get cat3 with article1', async () => {
@@ -636,8 +856,18 @@ describe('Content Manager End to End', () => {
       expect(body.id).toBeDefined();
       expect(body.articles.length).toBe(1);
       expect(body.articles[0].id).toBe(data.articles[0].id);
-      expect(body.createdBy).toMatchObject({ email: 'admin@strapi.io' });
-      expect(body.updatedBy).toMatchObject({ email: 'admin@strapi.io' });
+      expect(body.createdBy).toMatchObject({
+        firstname: 'admin',
+        id: 1,
+        lastname: 'admin',
+        username: null,
+      });
+      expect(body.updatedBy).toMatchObject({
+        firstname: 'admin',
+        id: 1,
+        lastname: 'admin',
+        username: null,
+      });
     });
   });
 
@@ -666,8 +896,18 @@ describe('Content Manager End to End', () => {
 
       expect(body.id).toBeDefined();
       expect(body.name).toBe('ref1');
-      expect(body.createdBy).toMatchObject({ email: 'admin@strapi.io' });
-      expect(body.updatedBy).toMatchObject({ email: 'admin@strapi.io' });
+      expect(body.createdBy).toMatchObject({
+        firstname: 'admin',
+        id: 1,
+        lastname: 'admin',
+        username: null,
+      });
+      expect(body.updatedBy).toMatchObject({
+        firstname: 'admin',
+        id: 1,
+        lastname: 'admin',
+        username: null,
+      });
     });
 
     test('Create article1', async () => {
@@ -687,8 +927,18 @@ describe('Content Manager End to End', () => {
       expect(body.id).toBeDefined();
       expect(body.title).toBe(entry.title);
       expect(body.content).toBe(entry.content);
-      expect(body.createdBy).toMatchObject({ email: 'admin@strapi.io' });
-      expect(body.updatedBy).toMatchObject({ email: 'admin@strapi.io' });
+      expect(body.createdBy).toMatchObject({
+        firstname: 'admin',
+        id: 1,
+        lastname: 'admin',
+        username: null,
+      });
+      expect(body.updatedBy).toMatchObject({
+        firstname: 'admin',
+        id: 1,
+        lastname: 'admin',
+        username: null,
+      });
       expect(body.publishedAt).toBeUndefined();
     });
 
@@ -711,8 +961,18 @@ describe('Content Manager End to End', () => {
       expect(body.title).toBe(entry.title);
       expect(body.content).toBe(entry.content);
       expect(body.reference.id).toBe(entry.reference);
-      expect(body.createdBy).toMatchObject({ email: 'admin@strapi.io' });
-      expect(body.updatedBy).toMatchObject({ email: 'admin@strapi.io' });
+      expect(body.createdBy).toMatchObject({
+        firstname: 'admin',
+        id: 1,
+        lastname: 'admin',
+        username: null,
+      });
+      expect(body.updatedBy).toMatchObject({
+        firstname: 'admin',
+        id: 1,
+        lastname: 'admin',
+        username: null,
+      });
     });
 
     test('Create article2 with ref1', async () => {
@@ -734,8 +994,18 @@ describe('Content Manager End to End', () => {
       expect(body.title).toBe(entry.title);
       expect(body.content).toBe(entry.content);
       expect(body.reference.id).toBe(entry.reference);
-      expect(body.createdBy).toMatchObject({ email: 'admin@strapi.io' });
-      expect(body.updatedBy).toMatchObject({ email: 'admin@strapi.io' });
+      expect(body.createdBy).toMatchObject({
+        firstname: 'admin',
+        id: 1,
+        lastname: 'admin',
+        username: null,
+      });
+      expect(body.updatedBy).toMatchObject({
+        firstname: 'admin',
+        id: 1,
+        lastname: 'admin',
+        username: null,
+      });
     });
   });
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

It sanitize the admin::user relations to only keeps relevant fields and avoid disclosing sensible information to the front-end.

### Why is it needed?

It prevent the disclosure of sensible information that can be used to take over someone else's account.

### How to test it?

Check the network tab when in the CM. When it queries the content-types the query results contains the `createdBy` and `updatedBy` information.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
