### PR TITLE
Fix starter CLI creating Strapi apps without a template

### DIFF
--- a/packages/cli/create-strapi-starter/utils/build-starter.js
+++ b/packages/cli/create-strapi-starter/utils/build-starter.js
@@ -166,7 +166,7 @@ module.exports = async function buildStarter({ projectName, starter }, program) 
     starter: starterPackageInfo.name,
     run: false,
   };
-  if (starterPackageInfo.version) {
+  if (starterJson.template.version) {
     generateStrapiAppOptions.template = `${starterJson.template.name}@${starterJson.template.version}`;
   } else {
     generateStrapiAppOptions.template = starterJson.template.name;

--- a/packages/cli/create-strapi-starter/utils/build-starter.js
+++ b/packages/cli/create-strapi-starter/utils/build-starter.js
@@ -167,9 +167,9 @@ module.exports = async function buildStarter({ projectName, starter }, program) 
     run: false,
   };
   if (starterPackageInfo.version) {
-    starterPackageInfo.template = `${starterJson.template.name}@${starterJson.template.version}`;
+    generateStrapiAppOptions.template = `${starterJson.template.name}@${starterJson.template.version}`;
   } else {
-    starterPackageInfo.template = starterJson.template.name;
+    generateStrapiAppOptions.template = starterJson.template.name;
   }
 
   // Create strapi app using the template


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Fixes a bug in the create-strapi-starter CLI: when the starter monorepo's backend is created, it doesn't use the template specified by the starter.json file.

The bug was introduced when I wanted to apply [this feedback comment](https://github.com/strapi/strapi/pull/11635#discussion_r754892072)

### How to test it:

The command:

```sh
npx create-strapi-starter@beta blog-starter-test next-blog --quickstart
```

currently creates an empty Strapi app, so the starter frontend breaks