### PR TITLE
Fix CSP for safari

### DIFF
--- a/packages/core/strapi/lib/middlewares/security.js
+++ b/packages/core/strapi/lib/middlewares/security.js
@@ -14,6 +14,7 @@ const defaults = {
       'connect-src': ["'self'", 'https:'],
       'img-src': ["'self'", 'data:', 'blob:'],
       'media-src': ["'self'", 'data:', 'blob:'],
+      upgradeInsecureRequests: null,
     },
   },
   xssFilter: false,


### PR DESCRIPTION


### What does it do?

Fixes a CSP preventing safari from fetching https  (instead of HTTP) resources on localhost

### Why is it needed?

Allow people using Safari to run the project on localhost

### How to test it?

Run the project on safari, you should see the UI

### Other

Thanks @alexandrebodin for the help 🙏🏻 
