### PR TITLE
Fix plugin crashing when content type gets deleted

### DIFF
--- a/packages/plugins/documentation/server/services/documentation.js
+++ b/packages/plugins/documentation/server/services/documentation.js
@@ -115,11 +115,15 @@ module.exports = ({ strapi }) => {
         const apiDirPath = path.join(this.getApiDocumentationPath(api), version);
 
         const apiDocPath = path.join(apiDirPath, `${apiName}.json`);
-
-        await fs.ensureFile(apiDocPath);
         const apiPathsObject = builApiEndpointPath(api);
 
+        if (!apiPathsObject) {
+          continue;
+        }
+
+        await fs.ensureFile(apiDocPath);
         await fs.writeJson(apiDocPath, apiPathsObject, { spaces: 2 });
+
         paths = { ...paths, ...apiPathsObject.paths };
       }
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Fix plugin crashing when content type gets deleted

### Why is it needed?

When deleting a content type the doc plugin still tries to write undefined data to disk and crashes