### PR TITLE
Fix label overflow on cm edit settings view

### DIFF
--- a/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/components/DisplayedFieldButton.js
+++ b/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/components/DisplayedFieldButton.js
@@ -230,7 +230,7 @@ const DisplayedFieldButton = ({
 
       return {
         index,
-        labelField: name,
+        labelField: children,
         rowIndex,
         name,
         size,

--- a/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/components/FieldButtonContent.js
+++ b/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/components/FieldButtonContent.js
@@ -5,7 +5,7 @@ import { useIntl } from 'react-intl';
 import { Box } from '@strapi/design-system/Box';
 import { Flex } from '@strapi/design-system/Flex';
 import { IconButton } from '@strapi/design-system/IconButton';
-import { Text } from '@strapi/design-system/Text';
+import { Typography } from '@strapi/design-system/Typography';
 import Pencil from '@strapi/icons/Pencil';
 import Trash from '@strapi/icons/Trash';
 import { getTrad } from '../../../utils';
@@ -25,11 +25,9 @@ const FieldButtonContent = ({ attribute, onEditField, onDeleteField, children })
   return (
     <Box overflow="hidden" width="100%">
       <Flex paddingLeft={3} alignItems="baseline" justifyContent="space-between">
-        <Box>
-          <Text textColor="neutral800" bold>
-            {children}
-          </Text>
-        </Box>
+        <Typography fontWeight="semiBold" textColor="neutral800" ellipsis>
+          {children}
+        </Typography>
         <Flex>
           <CustomIconButton
             label={formatMessage(

--- a/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/tests/__snapshots__/index.test.js.snap
+++ b/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/tests/__snapshots__/index.test.js.snap
@@ -653,6 +653,17 @@ exports[`EditSettingsView renders and matches the snapshot 1`] = `
   line-height: 1.33;
 }
 
+.c65 {
+  font-weight: 500;
+  color: #32324d;
+  display: block;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: 0.875rem;
+  line-height: 1.43;
+}
+
 .c0 {
   outline: none;
 }
@@ -828,13 +839,6 @@ exports[`EditSettingsView renders and matches the snapshot 1`] = `
   height: 1px;
   border: none;
   margin: 0;
-}
-
-.c65 {
-  font-weight: 500;
-  font-size: 0.875rem;
-  line-height: 1.43;
-  color: #32324d;
 }
 
 .c68 {
@@ -1449,15 +1453,11 @@ exports[`EditSettingsView renders and matches the snapshot 1`] = `
                                   <div
                                     class="c63 c64"
                                   >
-                                    <div
-                                      class=""
+                                    <span
+                                      class="c65"
                                     >
-                                      <span
-                                        class="c65"
-                                      >
-                                        postal_code
-                                      </span>
-                                    </div>
+                                      postal_code
+                                    </span>
                                     <div
                                       class="c54"
                                     >
@@ -1580,15 +1580,11 @@ exports[`EditSettingsView renders and matches the snapshot 1`] = `
                                   <div
                                     class="c63 c64"
                                   >
-                                    <div
-                                      class=""
+                                    <span
+                                      class="c65"
                                     >
-                                      <span
-                                        class="c65"
-                                      >
-                                        city
-                                      </span>
-                                    </div>
+                                      city
+                                    </span>
                                     <div
                                       class="c54"
                                     >
@@ -1779,15 +1775,11 @@ exports[`EditSettingsView renders and matches the snapshot 1`] = `
                           <div
                             class="c63 c64"
                           >
-                            <div
-                              class=""
+                            <span
+                              class="c65"
                             >
-                              <span
-                                class="c65"
-                              >
-                                categories
-                              </span>
-                            </div>
+                              categories
+                            </span>
                             <div
                               class="c54"
                             >
@@ -2545,6 +2537,17 @@ exports[`EditSettingsView should add field 1`] = `
   line-height: 1.33;
 }
 
+.c65 {
+  font-weight: 500;
+  color: #32324d;
+  display: block;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: 0.875rem;
+  line-height: 1.43;
+}
+
 .c0 {
   outline: none;
 }
@@ -2720,13 +2723,6 @@ exports[`EditSettingsView should add field 1`] = `
   height: 1px;
   border: none;
   margin: 0;
-}
-
-.c65 {
-  font-weight: 500;
-  font-size: 0.875rem;
-  line-height: 1.43;
-  color: #32324d;
 }
 
 .c68 {
@@ -3341,15 +3337,11 @@ exports[`EditSettingsView should add field 1`] = `
                                     <div
                                       class="c63 c64"
                                     >
-                                      <div
-                                        class=""
+                                      <span
+                                        class="c65"
                                       >
-                                        <span
-                                          class="c65"
-                                        >
-                                          postal_code
-                                        </span>
-                                      </div>
+                                        postal_code
+                                      </span>
                                       <div
                                         class="c54"
                                       >
@@ -3472,15 +3464,11 @@ exports[`EditSettingsView should add field 1`] = `
                                     <div
                                       class="c63 c64"
                                     >
-                                      <div
-                                        class=""
+                                      <span
+                                        class="c65"
                                       >
-                                        <span
-                                          class="c65"
-                                        >
-                                          city
-                                        </span>
-                                      </div>
+                                        city
+                                      </span>
                                       <div
                                         class="c54"
                                       >
@@ -3671,15 +3659,11 @@ exports[`EditSettingsView should add field 1`] = `
                             <div
                               class="c63 c64"
                             >
-                              <div
-                                class=""
+                              <span
+                                class="c65"
                               >
-                                <span
-                                  class="c65"
-                                >
-                                  categories
-                                </span>
-                              </div>
+                                categories
+                              </span>
                               <div
                                 class="c54"
                               >
@@ -4930,6 +4914,17 @@ exports[`EditSettingsView should add relation 1`] = `
   line-height: 1.33;
 }
 
+.c65 {
+  font-weight: 500;
+  color: #32324d;
+  display: block;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: 0.875rem;
+  line-height: 1.43;
+}
+
 .c0 {
   outline: none;
 }
@@ -5105,13 +5100,6 @@ exports[`EditSettingsView should add relation 1`] = `
   height: 1px;
   border: none;
   margin: 0;
-}
-
-.c65 {
-  font-weight: 500;
-  font-size: 0.875rem;
-  line-height: 1.43;
-  color: #32324d;
 }
 
 .c68 {
@@ -5727,15 +5715,11 @@ exports[`EditSettingsView should add relation 1`] = `
                                     <div
                                       class="c63 c64"
                                     >
-                                      <div
-                                        class=""
+                                      <span
+                                        class="c65"
                                       >
-                                        <span
-                                          class="c65"
-                                        >
-                                          postal_code
-                                        </span>
-                                      </div>
+                                        postal_code
+                                      </span>
                                       <div
                                         class="c54"
                                       >
@@ -5858,15 +5842,11 @@ exports[`EditSettingsView should add relation 1`] = `
                                     <div
                                       class="c63 c64"
                                     >
-                                      <div
-                                        class=""
+                                      <span
+                                        class="c65"
                                       >
-                                        <span
-                                          class="c65"
-                                        >
-                                          city
-                                        </span>
-                                      </div>
+                                        city
+                                      </span>
                                       <div
                                         class="c54"
                                       >
@@ -6057,15 +6037,11 @@ exports[`EditSettingsView should add relation 1`] = `
                             <div
                               class="c63 c64"
                             >
-                              <div
-                                class=""
+                              <span
+                                class="c65"
                               >
-                                <span
-                                  class="c65"
-                                >
-                                  categories
-                                </span>
-                              </div>
+                                categories
+                              </span>
                               <div
                                 class="c54"
                               >


### PR DESCRIPTION
Signed-off-by: HichamELBSI <elabbassih@gmail.com>

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Fix the label overflow on CM edit settings view

### Why is it needed?

Describe the issue you are solving.

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
