### PR TITLE
Remove defaults key from stored grant config

### DIFF
--- a/packages/plugins/users-permissions/server/bootstrap/index.js
+++ b/packages/plugins/users-permissions/server/bootstrap/index.js
@@ -41,9 +41,6 @@ const initGrant = async pluginStore => {
   const baseURL = `${strapi.config.server.url}/${apiPrefix}/auth`;
 
   const grantConfig = {
-    defaults: {
-      prefix: `${apiPrefix}/connect`,
-    },
     email: {
       enabled: true,
       icon: 'envelope',

--- a/packages/plugins/users-permissions/server/controllers/auth.js
+++ b/packages/plugins/users-permissions/server/controllers/auth.js
@@ -162,9 +162,17 @@ module.exports = {
   async connect(ctx, next) {
     const grant = require('grant-koa');
 
-    const grantConfig = await strapi
+    const providers = await strapi
       .store({ type: 'plugin', name: 'users-permissions', key: 'grant' })
       .get();
+
+    const apiPrefix = strapi.config.get('api.rest.prefix');
+    const grantConfig = {
+      defaults: {
+        prefix: `${apiPrefix}/connect`,
+      },
+      ...providers,
+    };
 
     const [requestPath] = ctx.request.url.split('?');
     const provider = requestPath.split('/connect/')[1].split('/')[0];

--- a/packages/plugins/users-permissions/server/services/providers.js
+++ b/packages/plugins/users-permissions/server/services/providers.js
@@ -28,7 +28,7 @@ module.exports = ({ strapi }) => {
   const getProfile = async (provider, query, callback) => {
     const access_token = query.access_token || query.code || query.oauth_token;
 
-    const grant = await strapi
+    const providers = await strapi
       .store({ type: 'plugin', name: 'users-permissions', key: 'grant' })
       .get();
 
@@ -168,7 +168,7 @@ module.exports = ({ strapi }) => {
                 return callback(null, {
                   username: userbody.login,
                   email: Array.isArray(emailsbody)
-                    ? emailsbody.find((email) => email.primary === true).email
+                    ? emailsbody.find(email => email.primary === true).email
                     : null,
                 });
               });
@@ -201,8 +201,8 @@ module.exports = ({ strapi }) => {
         const twitter = purest({
           provider: 'twitter',
           config: purestConfig,
-          key: grant.twitter.key,
-          secret: grant.twitter.secret,
+          key: providers.twitter.key,
+          secret: providers.twitter.secret,
         });
 
         twitter
@@ -225,8 +225,8 @@ module.exports = ({ strapi }) => {
       case 'instagram': {
         const instagram = purest({
           provider: 'instagram',
-          key: grant.instagram.key,
-          secret: grant.instagram.secret,
+          key: providers.instagram.key,
+          secret: providers.instagram.secret,
           config: purestConfig,
         });
 
@@ -298,7 +298,7 @@ module.exports = ({ strapi }) => {
 
         twitch
           .get('users')
-          .auth(access_token, grant.twitch.key)
+          .auth(access_token, providers.twitch.key)
           .request((err, res, body) => {
             if (err) {
               callback(err);
@@ -403,7 +403,7 @@ module.exports = ({ strapi }) => {
       }
       case 'auth0': {
         const purestAuth0Conf = {};
-        purestAuth0Conf[`https://${grant.auth0.subdomain}.auth0.com`] = {
+        purestAuth0Conf[`https://${providers.auth0.subdomain}.auth0.com`] = {
           __domain: {
             auth: {
               auth: { bearer: '[0]' },
@@ -442,7 +442,7 @@ module.exports = ({ strapi }) => {
         break;
       }
       case 'cas': {
-        const provider_url = 'https://' + _.get(grant['cas'], 'subdomain');
+        const provider_url = 'https://' + _.get(providers.cas, 'subdomain');
         const cas = purest({
           provider: 'cas',
           config: {
@@ -551,7 +551,7 @@ module.exports = ({ strapi }) => {
           }
 
           if (
-            !_.isEmpty(_.find(users, (user) => user.provider !== provider)) &&
+            !_.isEmpty(_.find(users, user => user.provider !== provider)) &&
             advanced.unique_email
           ) {
             return resolve([


### PR DESCRIPTION
**Problem:**
The `defaults` key in grant config (stored in the database) is used as a provider by the strapi code, making the provider `defaults` shown in the admin.

**Fix:**
Remove the key from the database and only add it before passing the config to grant.
