### PR TITLE
Remove Academy Link in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,6 @@ For general help using Strapi, please refer to [the official Strapi documentatio
 - [Discord](https://discord.strapi.io) (For live discussion with the Community and Strapi team)
 - [GitHub](https://github.com/strapi/strapi) (Bug reports, Contributions)
 - [Community Forum](https://forum.strapi.io) (Questions and Discussions)
-- [Academy](https://academy.strapi.io) (Learn the fundamentals of Strapi)
 - [ProductBoard](https://portal.productboard.com/strapi/tabs/2-under-consideration) (Roadmap, Feature requests)
 - [Twitter](https://twitter.com/strapijs) (Get the news fast)
 - [Facebook](https://www.facebook.com/Strapi-616063331867161)


### PR DESCRIPTION
### What does it do?

Removes Invalid Link to the Academy
