### PR TITLE
Fix provider config examples for v4

### DIFF
--- a/packages/providers/email-amazon-ses/README.md
+++ b/packages/providers/email-amazon-ses/README.md
@@ -44,15 +44,17 @@ npm install strapi-provider-email-amazon-ses --save
 module.exports = ({ env }) => ({
   // ...
   email: {
-    provider: 'amazon-ses',
-    providerOptions: {
-      key: env('AWS_SES_KEY'),
-      secret: env('AWS_SES_SECRET'),
-      amazon: 'https://email.us-east-1.amazonaws.com',
-    },
-    settings: {
-      defaultFrom: 'myemail@protonmail.com',
-      defaultReplyTo: 'myemail@protonmail.com',
+    config: {
+      provider: 'amazon-ses',
+      providerOptions: {
+        key: env('AWS_SES_KEY'),
+        secret: env('AWS_SES_SECRET'),
+        amazon: 'https://email.us-east-1.amazonaws.com',
+      },
+      settings: {
+        defaultFrom: 'myemail@protonmail.com',
+        defaultReplyTo: 'myemail@protonmail.com',
+      },
     },
   },
   // ...

--- a/packages/providers/email-mailgun/README.md
+++ b/packages/providers/email-mailgun/README.md
@@ -44,15 +44,17 @@ npm install strapi-provider-email-mailgun --save
 module.exports = ({ env }) => ({
   // ...
   email: {
-    provider: 'mailgun',
-    providerOptions: {
-      apiKey: env('MAILGUN_API_KEY'),
-      domain: env('MAILGUN_DOMAIN'), //Required if you have an account with multiple domains
-      host: env('MAILGUN_HOST', 'api.mailgun.net'), //Optional. If domain region is Europe use 'api.eu.mailgun.net'
-    },
-    settings: {
-      defaultFrom: 'myemail@protonmail.com',
-      defaultReplyTo: 'myemail@protonmail.com',
+    config: {
+      provider: 'mailgun',
+      providerOptions: {
+        apiKey: env('MAILGUN_API_KEY'),
+        domain: env('MAILGUN_DOMAIN'), //Required if you have an account with multiple domains
+        host: env('MAILGUN_HOST', 'api.mailgun.net'), //Optional. If domain region is Europe use 'api.eu.mailgun.net'
+      },
+      settings: {
+        defaultFrom: 'myemail@protonmail.com',
+        defaultReplyTo: 'myemail@protonmail.com',
+      },
     },
   },
   // ...

--- a/packages/providers/email-nodemailer/README.md
+++ b/packages/providers/email-nodemailer/README.md
@@ -30,22 +30,26 @@ npm install strapi-provider-email-nodemailer --save
 
 ```js
 module.exports = ({ env }) => ({
+  // ...
   email: {
-    provider: 'nodemailer',
-    providerOptions: {
-      host: env('SMTP_HOST', 'smtp.example.com'),
-      port: env('SMTP_PORT', 587),
-      auth: {
-        user: env('SMTP_USERNAME'),
-        pass: env('SMTP_PASSWORD'),
+    config: {
+      provider: 'nodemailer',
+      providerOptions: {
+        host: env('SMTP_HOST', 'smtp.example.com'),
+        port: env('SMTP_PORT', 587),
+        auth: {
+          user: env('SMTP_USERNAME'),
+          pass: env('SMTP_PASSWORD'),
+        },
+        // ... any custom nodemailer options
       },
-      // ... any custom nodemailer options
-    },
-    settings: {
-      defaultFrom: 'hello@example.com',
-      defaultReplyTo: 'hello@example.com',
+      settings: {
+        defaultFrom: 'hello@example.com',
+        defaultReplyTo: 'hello@example.com',
+      },
     },
   },
+  // ...
 });
 ```
 

--- a/packages/providers/email-sendgrid/README.md
+++ b/packages/providers/email-sendgrid/README.md
@@ -45,13 +45,15 @@ npm install strapi-provider-email-sendgrid --save
 module.exports = ({ env }) => ({
   // ...
   email: {
-    provider: 'sendgrid',
-    providerOptions: {
-      apiKey: env('SENDGRID_API_KEY'),
-    },
-    settings: {
-      defaultFrom: 'myemail@protonmail.com',
-      defaultReplyTo: 'myemail@protonmail.com',
+    config: {
+      provider: 'sendgrid',
+      providerOptions: {
+        apiKey: env('SENDGRID_API_KEY'),
+      },
+      settings: {
+        defaultFrom: 'myemail@protonmail.com',
+        defaultReplyTo: 'myemail@protonmail.com',
+      },
     },
   },
   // ...

--- a/packages/providers/email-sendmail/README.md
+++ b/packages/providers/email-sendmail/README.md
@@ -45,10 +45,12 @@ npm install strapi-provider-email-sendmail --save
 module.exports = ({ env }) => ({
   // ...
   email: {
-    provider: 'sendmail',
-    settings: {
-      defaultFrom: 'myemail@protonmail.com',
-      defaultReplyTo: 'myemail@protonmail.com',
+    config: {
+      provider: 'sendmail',
+      settings: {
+        defaultFrom: 'myemail@protonmail.com',
+        defaultReplyTo: 'myemail@protonmail.com',
+      },
     },
   },
   // ...

--- a/packages/providers/upload-aws-s3/README.md
+++ b/packages/providers/upload-aws-s3/README.md
@@ -14,13 +14,15 @@ See the [using a provider](https://docs.strapi.io/developer-docs/latest/plugins/
 module.exports = ({ env }) => ({
   // ...
   upload: {
-    provider: 'aws-s3',
-    providerOptions: {
-      accessKeyId: env('AWS_ACCESS_KEY_ID'),
-      secretAccessKey: env('AWS_ACCESS_SECRET'),
-      region: env('AWS_REGION'),
-      params: {
-        Bucket: env('AWS_BUCKET'),
+    config: {
+      provider: 'aws-s3',
+      providerOptions: {
+        accessKeyId: env('AWS_ACCESS_KEY_ID'),
+        secretAccessKey: env('AWS_ACCESS_SECRET'),
+        region: env('AWS_REGION'),
+        params: {
+          Bucket: env('AWS_BUCKET'),
+        },
       },
     },
   },

--- a/packages/providers/upload-cloudinary/README.md
+++ b/packages/providers/upload-cloudinary/README.md
@@ -16,15 +16,17 @@ See the [using a provider](https://docs.strapi.io/developer-docs/latest/plugins/
 module.exports = ({ env }) => ({
   // ...
   upload: {
-    provider: 'cloudinary',
-    providerOptions: {
-      cloud_name: env('CLOUDINARY_NAME'),
-      api_key: env('CLOUDINARY_KEY'),
-      api_secret: env('CLOUDINARY_SECRET'),
-    },
-    actionOptions: {
-      upload: {},
-      delete: {},
+    config: {
+      provider: 'cloudinary',
+      providerOptions: {
+        cloud_name: env('CLOUDINARY_NAME'),
+        api_key: env('CLOUDINARY_KEY'),
+        api_secret: env('CLOUDINARY_SECRET'),
+      },
+      actionOptions: {
+        upload: {},
+        delete: {},
+      },
     },
   },
   // ...

--- a/packages/providers/upload-local/README.md
+++ b/packages/providers/upload-local/README.md
@@ -6,15 +6,21 @@ This provider has only one parameter: `sizeLimit`.
 
 **Example**
 
-`./extensions/upload/config/settings.json`
+`./config/plugins.js`
 
-```json
-{
-  "provider": "local",
-  "providerOptions": {
-    "sizeLimit": 100000
-  }
-}
+```js
+module.exports = ({ env }) => ({
+  // ...
+  upload: {
+    config: {
+      provider: 'local',
+      providerOptions: {
+        sizeLimit: 100000,
+      },
+    },
+  },
+  // ...
+});
 ```
 
 The `sizeLimit` parameter must be a number. Be aware that the unit is in bytes, and the default is 1000000. When setting this value high, you should make sure to also configure the body parser middleware `maxFileSize` so the file can be sent and processed. Read more [here](https://docs.strapi.io/developer-docs/latest/plugins/upload.html#configuration)

--- a/packages/providers/upload-rackspace/README.md
+++ b/packages/providers/upload-rackspace/README.md
@@ -14,12 +14,14 @@ See the [using a provider](https://docs.strapi.io/developer-docs/latest/plugins/
 module.exports = ({ env }) => ({
   // ...
   upload: {
-    provider: 'rackspace',
-    providerOptions: {
-      username: env('RACKSPACE_USERNAME'),
-      apiKey: env('RACKSPACE_KEY'),
-      region: env('RACKSPACE_REGION'),
-      container: env('RACKSPACE_CONTAINER'),
+    config: {
+      provider: 'rackspace',
+      providerOptions: {
+        username: env('RACKSPACE_USERNAME'),
+        apiKey: env('RACKSPACE_KEY'),
+        region: env('RACKSPACE_REGION'),
+        container: env('RACKSPACE_CONTAINER'),
+      },
     },
   },
   // ...


### PR DESCRIPTION
Signed-off-by: Derrick Mehaffy <derrickmehaffy@gmail.com>

Fixed all the example configs as they were not wrapped in a `config: {}` object