### PR TITLE
Set visibility on create component button when in production

### DIFF
--- a/packages/core/content-type-builder/admin/src/components/ContentTypeBuilderNav/useContentTypeBuilderMenu.js
+++ b/packages/core/content-type-builder/admin/src/components/ContentTypeBuilderNav/useContentTypeBuilderMenu.js
@@ -152,7 +152,7 @@ const useContentTypeBuilderMenu = () => {
         id: `${getTrad('menu.section.components.name.')}`,
         defaultMessage: 'Components',
       },
-      customLink: {
+      customLink: isInDevelopmentMode && {
         id: `${getTrad('button.component.create')}`,
         defaultMessage: 'Create a new component',
         onClick: handleClickOpenModalCreateComponent,


### PR DESCRIPTION
### What does it do?

Updated `useContentTypeBuilderMenu.js` to include `isInDevelopmentMode` on the data customLink

### Why is it needed?

Noticed a slight admin UI error, when running in production the create component button was still visible (although nonfunctional) and therefore should be removed from the render. 

### How to test it?

Run Strapi in production, do you see the create component button?

### Related issue(s)/PR(s)

["Create new component" toggle visible in production #11790](https://github.com/strapi/strapi/issues/11790)
