### PR TITLE
Fix regex validation for empty string in non-required fields

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/utils/schema.js
+++ b/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/utils/schema.js
@@ -338,7 +338,10 @@ const createYupSchemaAttribute = (type, validations, options) => {
           break;
         }
         case 'regex':
-          schema = schema.matches(new RegExp(validationValue), errorsTrads.regex);
+          schema = schema.matches(new RegExp(validationValue), {
+            message: errorsTrads.regex,
+            excludeEmptyString: validations.required !== true,
+          });
           break;
         case 'lowercase':
           if (['text', 'textarea', 'email', 'string'].includes(type)) {

--- a/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/utils/schema.js
+++ b/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/utils/schema.js
@@ -340,7 +340,7 @@ const createYupSchemaAttribute = (type, validations, options) => {
         case 'regex':
           schema = schema.matches(new RegExp(validationValue), {
             message: errorsTrads.regex,
-            excludeEmptyString: validations.required !== true,
+            excludeEmptyString: !validations.required,
           });
           break;
         case 'lowercase':

--- a/packages/core/strapi/lib/services/entity-validator/__tests__/validators.test.js
+++ b/packages/core/strapi/lib/services/entity-validator/__tests__/validators.test.js
@@ -20,7 +20,7 @@ describe('Entity validator', () => {
     fakeFindOne.mockReset();
   });
 
-  describe('String RegExp validaor', () => {
+  describe('String RegExp validator', () => {
     const fakeModel = {
       kind: 'contentType',
       modelName: 'test-model',
@@ -28,12 +28,12 @@ describe('Entity validator', () => {
       privateAttributes: [],
       options: {},
       attributes: {
-        attrStringRequiredRegex: { type: 'string', required: false },
+        attrStringRequiredRegex: { type: 'string', required: true },
         attrStringNotRequiredRegex: { type: 'string', required: false },
       },
     };
 
-    test('Empty string in required field', () => {
+    test('It fails the validation of an empty string for a required field', () => {
       const validator = strapiUtils.validateYupSchema(
         entityValidator.string(
           {
@@ -52,7 +52,7 @@ describe('Entity validator', () => {
       return expect(validator('')).rejects.toBeInstanceOf(YupValidationError);
     });
 
-    test('Valid regex in required field', () => {
+    test('It validates successfully for a string that follows regex for a required field', () => {
       const value = '1234';
 
       const validator = strapiUtils.validateYupSchema(
@@ -73,7 +73,7 @@ describe('Entity validator', () => {
       return expect(validator(value)).resolves.toEqual(value);
     });
 
-    test('Empty string in not required field', async () => {
+    test('It validates empty string successfully for non-required field with regex constraint', () => {
       const value = '';
 
       const validator = strapiUtils.validateYupSchema(
@@ -94,7 +94,7 @@ describe('Entity validator', () => {
       return expect(validator(value)).resolves.toEqual(value);
     });
 
-    test('Valid regex in not required field', () => {
+    test('It validates successfully for string that follows regex for a non-required field', () => {
       const value = '1234';
 
       const validator = strapiUtils.validateYupSchema(

--- a/packages/core/strapi/lib/services/entity-validator/__tests__/validators.test.js
+++ b/packages/core/strapi/lib/services/entity-validator/__tests__/validators.test.js
@@ -20,6 +20,102 @@ describe('Entity validator', () => {
     fakeFindOne.mockReset();
   });
 
+  describe('String RegExp validaor', () => {
+    const fakeModel = {
+      kind: 'contentType',
+      modelName: 'test-model',
+      uid: 'test-uid',
+      privateAttributes: [],
+      options: {},
+      attributes: {
+        attrStringRequiredRegex: { type: 'string', required: false },
+        attrStringNotRequiredRegex: { type: 'string', required: false },
+      },
+    };
+
+    test('Empty string in required field', () => {
+      const validator = strapiUtils.validateYupSchema(
+        entityValidator.string(
+          {
+            attr: { type: 'string', required: true, regex: '^\\d+$' },
+            model: fakeModel,
+            updatedAttribute: {
+              name: 'attrStringRequiredRegex',
+              value: '',
+            },
+            entity: null,
+          },
+          { isDraft: false }
+        )
+      );
+
+      return expect(validator('')).rejects.toBeInstanceOf(YupValidationError);
+    });
+
+    test('Valid regex in required field', () => {
+      const value = '1234';
+
+      const validator = strapiUtils.validateYupSchema(
+        entityValidator.string(
+          {
+            attr: { type: 'string', required: true, regex: '^\\d+$' },
+            model: fakeModel,
+            updatedAttribute: {
+              name: 'attrStringRequiredRegex',
+              value,
+            },
+            entity: null,
+          },
+          { isDraft: false }
+        )
+      );
+
+      return expect(validator(value)).resolves.toEqual(value);
+    });
+
+    test('Empty string in not required field', async () => {
+      const value = '';
+
+      const validator = strapiUtils.validateYupSchema(
+        entityValidator.string(
+          {
+            attr: { type: 'string', required: false, regex: '^\\d+$' },
+            model: fakeModel,
+            updatedAttribute: {
+              name: 'attrStringNotRequiredRegex',
+              value,
+            },
+            entity: null,
+          },
+          { isDraft: false }
+        )
+      );
+
+      return expect(validator(value)).resolves.toEqual(value);
+    });
+
+    test('Valid regex in not required field', () => {
+      const value = '1234';
+
+      const validator = strapiUtils.validateYupSchema(
+        entityValidator.string(
+          {
+            attr: { type: 'string', required: false, regex: '^\\d+$' },
+            model: fakeModel,
+            updatedAttribute: {
+              name: 'attrStringNotRequiredRegex',
+              value,
+            },
+            entity: null,
+          },
+          { isDraft: false }
+        )
+      );
+
+      return expect(validator(value)).resolves.toEqual(value);
+    });
+  });
+
   describe('String unique validator', () => {
     const fakeModel = {
       kind: 'contentType',

--- a/packages/core/strapi/lib/services/entity-validator/validators.js
+++ b/packages/core/strapi/lib/services/entity-validator/validators.js
@@ -104,7 +104,9 @@ const addMaxFloatValidator = (validator, { attr }) =>
  * @returns {StringSchema}
  */
 const addStringRegexValidator = (validator, { attr }) =>
-  _.isUndefined(attr.regex) ? validator : validator.matches(new RegExp(attr.regex));
+  _.isUndefined(attr.regex)
+    ? validator
+    : validator.matches(new RegExp(attr.regex), { excludeEmptyString: attr.required !== true });
 
 /**
  *

--- a/packages/core/strapi/lib/services/entity-validator/validators.js
+++ b/packages/core/strapi/lib/services/entity-validator/validators.js
@@ -106,7 +106,7 @@ const addMaxFloatValidator = (validator, { attr }) =>
 const addStringRegexValidator = (validator, { attr }) =>
   _.isUndefined(attr.regex)
     ? validator
-    : validator.matches(new RegExp(attr.regex), { excludeEmptyString: attr.required !== true });
+    : validator.matches(new RegExp(attr.regex), { excludeEmptyString: !attr.required });
 
 /**
  *


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Fixes a validation bug that caused empty strings to not validate in non-required fields with a regex constraint. This PR contains fixes for both frontend (admin) and backend validation.

### Why is it needed?

It should be possible to leave out non-required fields even if they uses regex validation.

### How to test it?

1. Go to content-type builder and create a text field that is not required but has some form of RegExp validation (e.g., `^\d+$`)
2. Go to content-manager and create a new entry with that field correctly filled in (as a number)
3. Edit that same entry and remove that field's value (back to blank).
4. Update should be successful.
5. Update the content type and set the regex field to be required.
6. Update the entry created in step 2 and try to save it with the regex field empty (update should fail)
7. Fill in a valid value and select update, update should now be successfull.

### Related issue(s)/PR(s)

Related issue: #11781

### PR State
PR is ready to be merged.