### PR TITLE
Make The User Name Required & Unique

### DIFF
--- a/packages/strapi-plugin-users-permissions/controllers/Auth.js
+++ b/packages/strapi-plugin-users-permissions/controllers/Auth.js
@@ -404,6 +404,17 @@ module.exports = {
       );
     }
 
+    // Username is required.
+    if (!params.username) {
+      return ctx.badRequest(
+        null,
+        formatError({
+          id: 'Auth.form.error.username.provide',
+          message: 'Please provide your username.',
+        })
+      );
+    }
+
     // Email is required.
     if (!params.email) {
       return ctx.badRequest(
@@ -474,6 +485,21 @@ module.exports = {
     }
 
     if (user && user.provider !== params.provider && settings.unique_email) {
+      return ctx.badRequest(
+        null,
+        formatError({
+          id: 'Auth.form.error.email.taken',
+          message: 'Email is already taken.',
+        })
+      );
+    }
+
+    // Make The Username Unique
+    const username = await strapi.query('user', 'users-permissions').findOne({
+      username: params.username,
+    });
+
+    if (username) {
       return ctx.badRequest(
         null,
         formatError({


### PR DESCRIPTION
### What does it do?

It prevents the registering from '/api/auth/local/register' without specifying username and that username should be unique

### Why is it needed?

In the User from users-permissions plugin there is a place for username and in content-types it's unique (so when you create user from administration panel you should pass unique username) but it's not unique when we register from the specified endpoint

### How to test it?

If we try to make request to '/api/auth/local/register' from any request maker (e.g. Postman) we will be able to make new user without a username param

### Related issue(s)/PR(s)

The related issue: #11810 
