### PR TITLE
Dealing with dependencies which don't export package.json

### DIFF
--- a/packages/core/strapi/lib/core/loaders/plugins/get-enabled-plugins.js
+++ b/packages/core/strapi/lib/core/loaders/plugins/get-enabled-plugins.js
@@ -60,7 +60,13 @@ const getEnabledPlugins = async strapi => {
   const installedPlugins = {};
   for (const dep in strapi.config.get('info.dependencies', {})) {
     const packagePath = join(dep, 'package.json');
-    const packageInfo = require(packagePath);
+    let packageInfo
+    try {
+      packageInfo = require(packagePath);
+    } catch {
+      // Some packages, including firebase-admin, do not export package.json.
+      continue
+    }
 
     if (isStrapiPlugin(packageInfo)) {
       validatePluginName(packageInfo.strapi.name);


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Fixes #11848 

### Why is it needed?

Strapi cannot start properly.

### How to test it?

I verified the strapi dev server can start with `firebase-admin`:

![image](https://user-images.githubusercontent.com/96157/145225396-bb26f910-284f-43a0-ab68-c70387d728c7.png)

### Related issue(s)/PR(s)

 #11848 