### PR TITLE
Switch Enum from native type to string or text

### DIFF
--- a/packages/core/database/lib/dialects/mysql/schema-inspector.js
+++ b/packages/core/database/lib/dialects/mysql/schema-inspector.js
@@ -63,7 +63,7 @@ const toStrapiType = column => {
       return { type: 'bigInteger' };
     }
     case 'enum': {
-      return { type: 'enum' };
+      return { type: 'string' };
     }
     case 'tinyint': {
       return { type: 'boolean' };

--- a/packages/core/database/lib/dialects/sqlite/index.js
+++ b/packages/core/database/lib/dialects/sqlite/index.js
@@ -34,7 +34,6 @@ class SqliteDialect extends Dialect {
 
   getSqlType(type) {
     switch (type) {
-      // FIXME: enum must be dealt separately
       case 'enum': {
         return 'text';
       }

--- a/packages/core/database/lib/schema/diff.js
+++ b/packages/core/database/lib/schema/diff.js
@@ -137,9 +137,7 @@ module.exports = db => {
   const diffColumns = (oldColumn, column) => {
     const changes = [];
 
-    const isIgnoredType = ['increments', 'enum'].includes(column.type);
-
-    // NOTE: enum aren't updated, they need to be dropped & recreated. Knex doesn't handle it
+    const isIgnoredType = ['increments'].includes(column.type);
     const oldType = oldColumn.type;
     const type = db.dialect.getSqlType(column.type);
 

--- a/packages/core/database/lib/schema/schema.js
+++ b/packages/core/database/lib/schema/schema.js
@@ -113,7 +113,8 @@ const getColumnType = attribute => {
     // We might want to convert email/password to string types before going into the orm with specific validators & transformers
     case 'password':
     case 'email':
-    case 'string': {
+    case 'string':
+    case 'enumeration': {
       return { type: 'string' };
     }
     case 'uid': {
@@ -131,15 +132,6 @@ const getColumnType = attribute => {
     }
     case 'json': {
       return { type: 'jsonb' };
-    }
-    case 'enumeration': {
-      return {
-        type: 'enum',
-        args: [
-          attribute.enum,
-          /*,{ useNative: true, existingType: true, enumName: 'foo_type', schemaName: 'public' }*/
-        ],
-      };
     }
     case 'integer': {
       return { type: 'integer' };


### PR DESCRIPTION
Signed-off-by: Derrick Mehaffy <derrickmehaffy@gmail.com>

Fixes #11739

Native enum types aren't handled well in Knex and there really is no point to use them as you get almost zero benefit and a lot of drawbacks when you need to update them. A simple string is fine.