### PR TITLE
Replace placeholder 404 page

### DIFF
--- a/packages/core/admin/admin/src/pages/NotFoundPage/index.js
+++ b/packages/core/admin/admin/src/pages/NotFoundPage/index.js
@@ -1,10 +1,107 @@
+import { useIntl } from 'react-intl';
+import { Helmet } from 'react-helmet';
+import styled from 'styled-components';
+import { useHistory } from 'react-router';
+import React, { useCallback, useMemo } from 'react';
+
+import { Box } from '@strapi/design-system/Box';
+import { Button } from '@strapi/design-system/Button';
+import { Layout } from '@strapi/design-system/Layout';
+
+import Logo from '../../assets/images/homepage-logo.png';
+
+const LogoContainer = styled(Box)`
+  position: absolute;
+  top: 0;
+  right: 0;
+  img {
+    width: ${150 / 16}rem;
+  }
+`;
+
+const ContentContainer = styled(Box)`
+  flex-direction: column;
+  position: absolute;
+  max-width: 900px;
+  min-width: unset;
+  left: calc(50% - 450px);
+  top: 34%;
+`;
+
+const ErrorCode = styled(Box)`
+  font-size: 120px;
+  font-weight: 600;
+  color: rgba(0, 0, 0, 0.9);
+  padding-bottom: 16px;
+`;
+
+const Subtitle = styled(Box)`
+  font-size: 24px;
+  color: rgba(0, 0, 0, 0.8);
+  padding-bottom: 16px;
+`;
+
+const Description = styled(Box)`
+  font-size: 22px;
+  line-height: 32px;
+  color: rgba(0, 0, 0, 0.6);
+  padding-bottom: 16px;
+`;
+
 /**
  * NotFoundPage
  *
  * This is the page we show when the user visits a url that doesn't have a route
  *
  */
+const NotFoundPage = () => {
+  const history = useHistory();
+  const { formatMessage } = useIntl();
 
-const NotFoundPage = () => 'TODO NOT FOUND';
+  // page translations
+  const { title, subtitle, action, message } = useMemo(
+    () => ({
+      title: formatMessage({
+        id: 'app.components.NotFoundPage.description',
+        defaultMessage: 'Not Found',
+      }),
+      subtitle: formatMessage({
+        id: 'content-manager.pageNotFound',
+        defaultMessage: 'Not Found',
+      }),
+      action: formatMessage({
+        id: 'app.components.NotFoundPage.back',
+        defaultMessage: 'Back',
+      }),
+      message: formatMessage({
+        id: 'app.components.NotFoundPage.message',
+        defaultMessage: '',
+      }),
+    }),
+    [formatMessage]
+  );
+
+  // executed on primary action clicked
+  const navigateHome = useCallback(() => {
+    history.push('/');
+  }, [history]);
+
+  return (
+    <Layout>
+      <Helmet title={title} />
+      <Box>
+        <LogoContainer>
+          <img alt="" aria-hidden src={Logo} />
+        </LogoContainer>
+        <ContentContainer>
+          <Subtitle>{subtitle}</Subtitle>
+          <ErrorCode>404</ErrorCode>
+          <Description>{message}</Description>
+          <Button onClick={navigateHome}>{action}</Button>
+        </ContentContainer>
+      </Box>
+    </Layout>
+  );
+};
 
 export default NotFoundPage;

--- a/packages/core/admin/admin/src/translations/en.json
+++ b/packages/core/admin/admin/src/translations/en.json
@@ -308,6 +308,7 @@
   "app.components.MarketplaceBanner.image.alt": "a strapi rocket logo",
   "app.components.MarketplaceBanner.link": "Check it out now",
   "app.components.NotFoundPage.back": "Back to homepage",
+  "app.components.NotFoundPage.message": "We're not quite sure what you're searching for, but we are quite sure you won't find it here.",
   "app.components.NotFoundPage.description": "Not Found",
   "app.components.Official": "Official",
   "app.components.Onboarding.help.button": "Help button",


### PR DESCRIPTION
### What does it do?

Replace previously used "placeholder" 404 page.

![Screen Shot 2021-12-15 at 15 30 02](https://user-images.githubusercontent.com/36916632/146205151-53a40664-e7fd-49cb-b819-2e619c1aaa5c.png)

### Why is it needed?

Gives the user the option to navigate back to the homepage and makes a more professional impression than the previous placeholder content.

### How to test it?

Navigate to a non-existent page and / or take a look at the screenshot above.

### Related issue(s)/PR(s)

#11921 
