### PR TITLE
Use upload_chunked_stream in Cloudinary provider package

### DIFF
--- a/packages/providers/upload-cloudinary/lib/index.js
+++ b/packages/providers/upload-cloudinary/lib/index.js
@@ -25,7 +25,7 @@ module.exports = {
             config.filename = `${file.hash}${file.ext}`;
           }
 
-          const upload_stream = cloudinary.uploader.upload_stream(
+          const upload_stream = cloudinary.uploader.upload_chunked_stream(
             { ...config, ...customConfig },
             (err, image) => {
               if (err) {


### PR DESCRIPTION
### What does it do?

This PR replaces usage of `upload_stream` method with `upload_chunked_stream` in the cloudinary provider package.

### Why is it needed?

Because larger files especially videos over 100mb cannot be uploaded using `upload_stream` even if the account is upgraded

### How to test it?

1. Hook up the provider to your Strapi application with the config and environment variables set
2. Upload a video over 100mb to see if it works