### PR TITLE
feat: expose documentation json specs

### DIFF
--- a/packages/plugins/documentation/README.md
+++ b/packages/plugins/documentation/README.md
@@ -70,6 +70,17 @@ It has the following structure
   "components": {} // Default generated components and custom ones
 }
 ```
+### `swagger.json` and `openapi.json` files
+
+This plugin is able to serve up these files. The endpoints exposed are (assuming you use the default `/documentation` base
+URL):
+
+- `/documentation/swagger.json` or `/documentation/openapi.json`: the OpenAPI
+  spec for the latest version of your API. Both endpoints serve the same
+  document.
+- `/documentation/vN.N.N/swagger.json` or
+  `/documentation/vN.N.N/openapi.json`: request the spec for a specific
+  version of your API. For example: `/documentation/v1.0.0/openapi.json`
 
 ### Overriding the suggested documentation
 

--- a/packages/plugins/documentation/server/controllers/documentation.js
+++ b/packages/plugins/documentation/server/controllers/documentation.js
@@ -96,7 +96,34 @@ module.exports = {
       strapi.log.error(e);
     }
   },
+  async getApiSpecJson(ctx) {
+    const { major, minor, patch } = ctx.params;
+    const version =
+      major && minor && patch
+        ? `${major}.${minor}.${patch}`
+        : strapi
+            .plugin('documentation')
+            .service('documentation')
+            .getDocumentationVersion();
 
+    const openAPISpecsPath = path.join(
+      strapi.dirs.extensions,
+      'documentation',
+      'documentation',
+      version,
+      'full_documentation.json'
+    );
+    try {
+      const documentation = fs.readFileSync(openAPISpecsPath, 'utf8');
+      return JSON.parse(documentation);
+    } catch (err) {
+      if (err && err.code === 'ENOENT') {
+        ctx.response.status = 404;
+        return;
+      }
+      throw err;
+    }
+  },
   async loginView(ctx, next) {
     // lazy require cheerio
     const cheerio = require('cheerio');

--- a/packages/plugins/documentation/server/routes/index.js
+++ b/packages/plugins/documentation/server/routes/index.js
@@ -80,4 +80,40 @@ module.exports = [
       policies: [],
     },
   },
+  {
+    method: "GET",
+    path: "/v:major(\\d+).:minor(\\d+).:patch(\\d+)/swagger.json",
+    handler: "documentation.getApiSpecJson",
+    config: {
+      auth: false,
+      middlewares: [restrictAccess],
+    },
+  },
+  {
+    method: "GET",
+    path: "/v:major(\\d+).:minor(\\d+).:patch(\\d+)/openapi.json",
+    handler: "documentation.getApiSpecJson",
+    config: {
+      auth: false,
+      middlewares: [restrictAccess],
+    },
+  },
+  {
+    method: "GET",
+    path: "/swagger.json",
+    handler: "documentation.getApiSpecJson",
+    config: {
+      auth: false,
+      middlewares: [restrictAccess],
+    },
+  },
+  {
+    method: "GET",
+    path: "/openapi.json",
+    handler: "documentation.getApiSpecJson",
+    config: {
+      auth: false,
+      middlewares: [restrictAccess],
+    },
+  },
 ];


### PR DESCRIPTION
**This PR is an update of the code made in the PR #8486 for Strapi v4. Thank you @tomsaleeba 😉**

### What does it do?

Add controller and routes to expose the endpoints:
- /swagger.json (the latest spec)
- /openapi.json (the latest spec)
- /vN.N.N/swagger.json
- /vN.N.N/openapi.json

### Why is it needed?

Users of a Strapi API may want to use a code generator to create a client for their language of choice. To do this, they need the OpenAPI spec document. Currently the document is only served up inside the index.html for the swagger UI.

### How to test it?

Try to access to json data in all the previously given routes, for different versions of the documentation.

### Related issue(s)/PR(s)

PR #8486 
Issue #10734