### PR TITLE
Fix unable to reset password in GraphQL mutation

### DIFF
--- a/packages/plugins/users-permissions/server/graphql/mutations/auth/reset-password.js
+++ b/packages/plugins/users-permissions/server/graphql/mutations/auth/reset-password.js
@@ -26,7 +26,7 @@ module.exports = ({ nexus, strapi }) => {
       await strapi
         .plugin('users-permissions')
         .controller('auth')
-        .forgotPassword(koaContext);
+        .resetPassword(koaContext);
 
       const output = koaContext.body;
 


### PR DESCRIPTION
Signed-off-by: harimkims <harimkims@gmail.com>

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

- Replace `forgotPassword` with `resetPassword` in reset password GraphQL Mutation

### Why is it needed?

- Enabling reset-password by GraphQL Mutation

### How to test it?

1. Execute Mutation
```gql
mutation ForgotPassword($email: String!) {
  forgotPassword(email: $email) {
    ok
  }
}

# variables
{
  "email": "test@gmail.com"
}
```
2. Get reset-password token
3. Execute Mutation
```gql
mutation ResetPassword(
  $password: String!
  $passwordConfirmation: String!
  $code: String!
) {
  resetPassword(
    password: $password
    passwordConfirmation: $passwordConfirmation
    code: $code
  ) {
    jwt
    user {
      id
      email
    }
  }
}

# variables
{
  "password": "somepassword",
  "passwordConfirmation": "somepassword",
  "code": "sometoken"
}
```
4. Check out you get proper response with  `jwt`, `user` field

### Related issue(s)/PR(s)

Closes #11934 