### PR TITLE
Fix relations are not populated when API key is read-only

### DIFF
--- a/packages/core/admin/server/strategies/api-token.js
+++ b/packages/core/admin/server/strategies/api-token.js
@@ -60,7 +60,8 @@ const verify = (auth, config) => {
    * scopes. If the route has no scope, then you can't get access to it.
    */
 
-  if (config.scope && config.scope.every(isReadScope)) {
+  const scopes = Array.isArray(config.scope) ? config.scope : [config.scope];
+  if (config.scope && scopes.every(isReadScope)) {
     return;
   }
 


### PR DESCRIPTION
Signed-off-by: harimkims <harimkims@gmail.com>

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

- Fix bug throwing an error when API-token verify scope

When sanitizing result, `strapi.auth.verify` **send a string scope** as a second parameter.
```js
// packages/core/utils/lib/sanitize/visitors/remove-restricted-relations.js

const hasAccessToSomeScopes = async (scopes, auth) => {
  for (const scope of scopes) {
    try {
      await strapi.auth.verify(auth, { scope });
      return true;
    } catch {
      continue;
    }
  }

  return false;
};
```

And it throws an error in below code - `config.scope.every is not a function` - since scope is string, not an array..

```js
// packages/core/admin/server/strategies/api-token.js

if (config.scope && config.scope.every(isReadScope)) {
```

So I store them in an array if it's not an array.
```js
const scopes = Array.isArray(config.scope) ? config.scope : [config.scope];
if (config.scope && scopes.every(isReadScope)) {
```

### Why is it needed?

- To fix a bug in population

### How to test it?

1. Create a collection type includes relation attribute.
2. Send a GET request with Read-only API Token.
3. See relation is included in result.

### Related issue(s)/PR(s)

Closes #11920 