### PR TITLE
Update Admin auth settings to separate sign options from verify options

### DIFF
--- a/examples/getstarted/config/admin.js
+++ b/examples/getstarted/config/admin.js
@@ -1,6 +1,7 @@
 module.exports = ({ env }) => ({
-  // autoOpen: false,
   auth: {
     secret: env('ADMIN_JWT_SECRET', 'example-token'),
+    signOptions: {},
+    verifyOptions: {},
   },
 });

--- a/packages/core/admin/server/services/token.js
+++ b/packages/core/admin/server/services/token.js
@@ -4,14 +4,16 @@ const crypto = require('crypto');
 const _ = require('lodash');
 const jwt = require('jsonwebtoken');
 
-const defaultJwtOptions = { expiresIn: '30d' };
+const defaultSignOptions = { expiresIn: '30d' };
+const defaultVerifyOptions = {};
 
 const getTokenOptions = () => {
-  const { options, secret } = strapi.config.get('admin.auth', {});
+  const { secret, signOptions, verifyOptions } = strapi.config.get('admin.auth', {});
 
   return {
     secret,
-    options: _.merge(defaultJwtOptions, options),
+    signOptions: _.merge(_.cloneDeep(defaultSignOptions), signOptions),
+    verifyOptions: _.merge(_.cloneDeep(defaultVerifyOptions), verifyOptions),
   };
 };
 
@@ -28,9 +30,9 @@ const createToken = () => {
  * @param {object} user - admin user
  */
 const createJwtToken = user => {
-  const { options, secret } = getTokenOptions();
+  const { signOptions, secret } = getTokenOptions();
 
-  return jwt.sign({ id: user.id }, secret, options);
+  return jwt.sign({ id: user.id }, secret, signOptions);
 };
 
 /**
@@ -39,10 +41,10 @@ const createJwtToken = user => {
  * @return {Object} decodeInfo - the decoded info
  */
 const decodeJwtToken = token => {
-  const { secret } = getTokenOptions();
+  const { secret, verifyOptions } = getTokenOptions();
 
   try {
-    const payload = jwt.verify(token, secret);
+    const payload = jwt.verify(token, secret, verifyOptions);
     return { payload, isValid: true };
   } catch (err) {
     return { payload: null, isValid: false };


### PR DESCRIPTION
### What does it do?

- Separates the auth sign config options from the auth verify config options

Describe the technical changes you did.

- Update the `admin.options` config to be separated into two separate config options, `signOptions` and `verifyOptions` that allows the developer to independently pass in values to each of those configs.

Describe the issue you are solving.

- We ran into an issue where we are using an RSA private key generated by Strapi by passing in `RS256` in the `options` config, but we were getting authentication issues because the `decodeJwtToken` was attempting to decode the JWT as if it were a `HS256` key because that is the default value that `jsonwebtoken` provides the `jwt.verify` function when no option is passed in. I noticed that there was only `auth.options` used in the `createJwtToken` but there were no configs passed into `decodeJwtToken` and since their inputs are different we figured it would be best to keep them separate.

Documentation PR: https://github.com/strapi/documentation/pull/612