### PR TITLE
[FIX] respect custom ENV_PATH

### DIFF
--- a/packages/core/admin/server/services/api-token.js
+++ b/packages/core/admin/server/services/api-token.js
@@ -86,7 +86,7 @@ const createSaltIfNotDefined = () => {
   }
 
   const salt = crypto.randomBytes(16).toString('hex');
-  strapi.fs.appendFile('.env', `API_TOKEN_SALT=${salt}\n`);
+  strapi.fs.appendFile(process.env.ENV_PATH || '.env', `API_TOKEN_SALT=${salt}\n`);
   strapi.config.set('admin.apiToken.salt', salt);
 };
 

--- a/packages/plugins/users-permissions/server/bootstrap/index.js
+++ b/packages/plugins/users-permissions/server/bootstrap/index.js
@@ -31,7 +31,7 @@ module.exports = async ({ strapi }) => {
     strapi.config.set('plugin.users-permissions.jwtSecret', jwtSecret);
 
     if (!process.env.JWT_SECRET) {
-      strapi.fs.appendFile('.env', `JWT_SECRET=${jwtSecret}\n`);
+      strapi.fs.appendFile(process.env.ENV_PATH || '.env', `JWT_SECRET=${jwtSecret}\n`);
     }
   }
 };


### PR DESCRIPTION
### What does it do?

When setting a custom ENV_PATH the variables API_TOKEN_SALT and JWT_SECRET are now written in the file that is set via the variable.

### Why is it needed?

The ENV_PATH was not respected

### How to test it?

Create a folder `test` and run `ENV_PATH=./test/.env strapi start`
The .env file is created in the the folder `test` now.
