### PR TITLE
Remove build command from install

### DIFF
--- a/packages/core/strapi/lib/commands/install.js
+++ b/packages/core/strapi/lib/commands/install.js
@@ -4,7 +4,6 @@ const { join } = require('path');
 const { existsSync } = require('fs-extra');
 const ora = require('ora');
 const execa = require('execa');
-const findPackagePath = require('../load/package-path');
 
 module.exports = async plugins => {
   const loader = ora();
@@ -25,21 +24,6 @@ module.exports = async plugins => {
     }
 
     loader.succeed();
-
-    // check if rebuild is necessary
-    let shouldRebuild = false;
-    for (let name of plugins) {
-      let pkgPath = findPackagePath(`@strapi/plugin-${name}`);
-      if (existsSync(join(pkgPath, 'admin', 'src', 'index.js'))) {
-        shouldRebuild = true;
-      }
-    }
-
-    if (shouldRebuild) {
-      loader.start(`Rebuilding admin UI`);
-      await execa('npm', ['run', 'build']);
-      loader.succeed();
-    }
   } catch (err) {
     loader.clear();
     console.error(err.message);


### PR DESCRIPTION
Signed-off-by: soupette <cyril@strapi.io>

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

It removes the build command from the install script.

### Why is it needed?

In order to serve the prebuilt admin directly when creating a new app.

