### PR TITLE
Fix typo

### DIFF
--- a/packages/core/database/lib/dialects/index.js
+++ b/packages/core/database/lib/dialects/index.js
@@ -9,7 +9,7 @@ const getDialectClass = client => {
     case 'sqlite':
       return require('./sqlite');
     default:
-      throw new Error(`Unknow dialect ${client}`);
+      throw new Error(`Unknown dialect ${client}`);
   }
 };
 

--- a/packages/core/database/lib/metadata/relations.js
+++ b/packages/core/database/lib/metadata/relations.js
@@ -390,7 +390,7 @@ const createJoinTable = (metadata, { attributeName, attribute, meta }) => {
   const targetMeta = metadata.get(attribute.target);
 
   if (!targetMeta) {
-    throw new Error(`Unknow target ${attribute.target}`);
+    throw new Error(`Unknown target ${attribute.target}`);
   }
 
   const joinTableName = _.snakeCase(`${meta.tableName}_${attributeName}_links`);

--- a/packages/core/database/lib/schema/schema.js
+++ b/packages/core/database/lib/schema/schema.js
@@ -177,7 +177,7 @@ const getColumnType = attribute => {
       return { type: 'boolean' };
     }
     default: {
-      throw new Error(`Unknow type ${attribute.type}`);
+      throw new Error(`Unknown type ${attribute.type}`);
     }
   }
 };

--- a/packages/generators/app/lib/utils/merge-template.js
+++ b/packages/generators/app/lib/utils/merge-template.js
@@ -143,7 +143,7 @@ async function checkTemplateContentsStructure(templateContentsPath) {
         await checkPathContents(itemPath, nextParents);
       } else {
         throw Error(
-          `Illegal template structure, unknow file ${chalk.green(nextParents.join('/'))}`
+          `Illegal template structure, unknown file ${chalk.green(nextParents.join('/'))}`
         );
       }
     }


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Changed error message `unknow` to `unknown` at `~\packages\core\database\lib\dialects\index.js`, `~\packages\core\database\lib\schema\schema.js`, `~\packages\core\database\lib\metadata\relations.js`, and `~\packages\generators\app\lib\utils\merge-template.js`.

### Why is it needed?

There was a typo in four files. I think the typo shouldn't exist there.

### How to test it?

When you trigger a dialect error, you'll be able to see it.

### Related issue(s)/PR(s)
