### PR TITLE
Remove the build directory from the watched files list

### DIFF
--- a/packages/core/strapi/lib/commands/develop.js
+++ b/packages/core/strapi/lib/commands/develop.js
@@ -126,6 +126,8 @@ function watchFileChanges({ dir, strapiInstance, watchIgnoreFiles, polling }) {
       '**/node_modules',
       '**/node_modules/**',
       '**/plugins.json',
+      '**/build',
+      '**/build/**',
       '**/index.html',
       '**/public',
       '**/public/**',


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Ignore the build folder (and its files) when watching for changes.
Went from 466 to 208 files watched on the getstarted example.

### Why is it needed?

Trying to remove as many useless watches as possible so we don't reach the default limit on different OS

