### PR TITLE
Always remove the build and cache folder when running the build command

### DIFF
--- a/packages/core/strapi/bin/strapi.js
+++ b/packages/core/strapi/bin/strapi.js
@@ -133,7 +133,6 @@ program
 
 program
   .command('build')
-  .option('--clean', 'Remove the build and .cache folders', false)
   .option('--no-optimization', 'Build the Administration without assets optimization')
   .description('Builds the strapi admin app')
   .action(getLocalScript('build'));

--- a/packages/core/strapi/lib/commands/build.js
+++ b/packages/core/strapi/lib/commands/build.js
@@ -12,7 +12,7 @@ const getEnabledPlugins = require('../core/loaders/plugins/get-enabled-plugins')
 /**
  * `$ strapi build`
  */
-module.exports = async ({ clean, optimization, forceBuild = true }) => {
+module.exports = async ({ optimization, forceBuild = true }) => {
   const dir = process.cwd();
 
   const strapiInstance = strapi({
@@ -28,9 +28,8 @@ module.exports = async ({ clean, optimization, forceBuild = true }) => {
 
   console.log(`Building your admin UI with ${green(env)} configuration ...`);
 
-  if (clean) {
-    await strapiAdmin.clean({ dir });
-  }
+  // Always remove the .cache and build folders
+  await strapiAdmin.clean({ dir });
 
   ee({ dir });
 

--- a/packages/core/strapi/lib/commands/develop.js
+++ b/packages/core/strapi/lib/commands/develop.js
@@ -29,7 +29,7 @@ module.exports = async function({ build, watchAdmin, polling, browser }) {
       // Don't run the build process if the admin is in watch mode
       if (build && !watchAdmin && serveAdminPanel && !buildExists) {
         try {
-          await buildAdmin({ clean: false, optimization: false, forceBuild: false });
+          await buildAdmin({ optimization: false, forceBuild: false });
         } catch (err) {
           process.exit(1);
         }


### PR DESCRIPTION
Signed-off-by: soupette <cyril@strapi.io>

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

It forces the deletion of the .cache and build folder when running the build command.

### Why is it needed?

I am seeing a lot of issues being opened because the build is wrong. This is often dure because the `.cache` folder is not clear when running the build command without `--clean` flag.

After some thoughts I think that the `--clean` flag should be removed and that we should always trigger a build with a clean .cache folder in order to avoid issues when upgrading a Strapi app.

⚠️ We need to update the documentation and remove this [line](https://github.com/strapi/documentation/blob/717d9c31ee02b4f0f62ba8c7ade4b3643657985c/docs/developer-docs/latest/developer-resources/cli/CLI.md?plain=1#L94) 
