### PR TITLE
Added logo for GitHub dark mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
-[![Strapi](https://strapi.io/assets/strapi-logo-dark.svg)](https://strapi.io/#gh-light-mode-only)
-[![Strapi](https://strapi.io/assets/strapi-logo-light.svg)](https://strapi.io/#gh-dark-mode-only)
+<p align="center">
+  <a href="https://strapi.io/#gh-light-mode-only">
+    <img src="https://strapi.io/assets/strapi-logo-dark.svg" width="318px" alt="Strapi logo" />
+  </a>
+  <a href="https://strapi.io/#gh-dark-mode-only">
+    <img src="https://strapi.io/assets/strapi-logo-light.svg" width="318px" alt="Strapi logo" />
+  </a>
+</p>
 
 <h3 align="center">API creation made simple, secure and fast.</h3>
 <p align="center">The most advanced open-source headless CMS to build powerful APIs with no effort.</p>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Strapi](https://strapi.io/assets/strapi-logo-dark.svg#gh-light-mode-only)](https://strapi.io)
-[![Strapi](https://strapi.io/assets/strapi-logo-light.svg#gh-dark-mode-only)](https://strapi.io)
+[![Strapi](https://strapi.io/assets/strapi-logo-dark.svg)](https://strapi.io/#gh-light-mode-only)
+[![Strapi](https://strapi.io/assets/strapi-logo-light.svg)](https://strapi.io/#gh-dark-mode-only)
 
 <h3 align="center">API creation made simple, secure and fast.</h3>
 <p align="center">The most advanced open-source headless CMS to build powerful APIs with no effort.</p>

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
-<p align="center">
-  <a href="https://strapi.io">
-    <img src="https://strapi.io/assets/strapi-logo-dark.svg" width="318px" alt="Strapi logo" />
-  </a>
-</p>
+[![Strapi](https://strapi.io/assets/strapi-logo-dark.svg#gh-light-mode-only)](https://strapi.io)
+[![Strapi](https://strapi.io/assets/strapi-logo-light.svg#gh-dark-mode-only)](https://strapi.io)
+
 <h3 align="center">API creation made simple, secure and fast.</h3>
 <p align="center">The most advanced open-source headless CMS to build powerful APIs with no effort.</p>
 <p align="center"><a href="https://strapi.io/demo">Try live demo</a></p>


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Added a logo for project README in dark mode as per [this syntax](https://docs.github.com/en/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#specifying-the-theme-an-image-is-shown-to).

Previously logo was set to 318px width and centered with HTML, which is not possible with markdown, while conditional images for light/dark themes is only supported in markdown.

With this change, the image is now the default 100% width for SVG images in markdown.

### Why is it needed?

The logo is hard to read in a dark theme.

### How to test it?

View project README in dark & light GitHub theme.

### Related issue(s)/PR(s)

Fixes #10917
