### PR TITLE
feature:  parse "now()" -> new Date()

### DIFF
--- a/packages/core/database/package.json
+++ b/packages/core/database/package.json
@@ -36,6 +36,7 @@
     "fs-extra": "10.0.0",
     "knex": "0.95.6",
     "lodash": "4.17.21",
+    "@strapi/utils": "4.0.2",
     "umzug": "2.3.0"
   },
   "engines": {

--- a/packages/core/utils/lib/__tests__/parse-type.test.js
+++ b/packages/core/utils/lib/__tests__/parse-type.test.js
@@ -3,6 +3,15 @@
 const format = require('date-fns/format');
 const parseType = require('../parse-type');
 
+beforeAll(() => {
+  jest.useFakeTimers('modern');
+  jest.setSystemTime(new Date('2022-01-19T11:07:59.125Z'));
+});
+
+afterAll(() => {
+  jest.useRealTimers();
+});
+
 describe('parseType', () => {
   describe('boolean', () => {
     it('Handles string booleans', () => {
@@ -34,6 +43,10 @@ describe('parseType', () => {
       expect(parseType({ type: 'time', value: '12:31:11.319' })).toBe('12:31:11.319');
     });
 
+    it("Input 'now()' returns current time the same time format", () => {
+      expect(parseType({ type: 'time', value: 'now()' })).toBe('12:07:59.125');
+    });
+
     it('Throws on  invalid time format', () => {
       expect(() => parseType({ type: 'time', value: '25:12:09' })).toThrow();
       expect(() => parseType({ type: 'time', value: '23:78:09' })).toThrow();
@@ -59,6 +72,10 @@ describe('parseType', () => {
       expect(parseType({ type: 'date', value: isoDateFormat })).toBe(expectedDateFormat);
     });
 
+    it("Input 'now()' returns current date the same date format", () => {
+      expect(parseType({ type: 'date', value: 'now()' })).toBe('2022-01-19');
+    });
+
     it('Throws on invalid formator dates', () => {
       expect(() => parseType({ type: 'date', value: '-1029-11-02' })).toThrow();
       expect(() => parseType({ type: 'date', value: '2019-13-02' })).toThrow();
@@ -74,6 +91,12 @@ describe('parseType', () => {
         const r = parseType({ type: 'datetime', value });
         expect(r instanceof Date).toBe(true);
       }
+    );
+  });
+
+  it("Input 'now()' returns current datetime the same datetime format", () => {
+    expect(parseType({ type: 'datetime', value: 'now()' })).toStrictEqual(
+      new Date('2022-01-19T11:07:59.125Z')
     );
   });
 });

--- a/packages/core/utils/lib/parse-type.js
+++ b/packages/core/utils/lib/parse-type.js
@@ -7,6 +7,7 @@ const timeRegex = new RegExp('^(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(.[0-
 
 const parseTime = value => {
   if (dates.isDate(value)) return dates.format(value, 'HH:mm:ss.SSS');
+  if (value === 'now()') return dates.format(new Date(), 'HH:mm:ss.SSS');
 
   if (typeof value !== 'string') {
     throw new Error(`Expected a string, got a ${typeof value}`);
@@ -25,6 +26,8 @@ const parseTime = value => {
 
 const parseDate = value => {
   if (dates.isDate(value)) return dates.format(value, 'yyyy-MM-dd');
+  if (value === 'now()') return dates.format(new Date(), 'yyyy-MM-dd');
+
   try {
     let date = dates.parseISO(value);
 
@@ -38,6 +41,8 @@ const parseDate = value => {
 
 const parseDateTimeOrTimestamp = value => {
   if (dates.isDate(value)) return value;
+  if (value === 'now()') return new Date();
+
   try {
     const date = dates.parseISO(value);
     if (dates.isValid(date)) return date;

--- a/packages/plugins/graphql/server/services/internals/scalars/date.js
+++ b/packages/plugins/graphql/server/services/internals/scalars/date.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const { GraphQLDate } = require('graphql-iso-date/dist');
+
+const { parseLiteral: originalParseLiteral, parseValue } = GraphQLDate;
+
+GraphQLDate.parseLiteral = ast =>
+  ast.value === 'now()'
+    ? parseValue(new Date().toISOString().substring(0, 10))
+    : originalParseLiteral(ast.value);
+
+module.exports = GraphQLDate;

--- a/packages/plugins/graphql/server/services/internals/scalars/datetime.js
+++ b/packages/plugins/graphql/server/services/internals/scalars/datetime.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const { GraphQLDateTime } = require('graphql-iso-date/dist');
+
+const { parseLiteral: originalParseLiteral, parseValue } = GraphQLDateTime;
+
+GraphQLDateTime.parseLiteral = ast =>
+  ast.value === 'now()' ? parseValue(new Date().toISOString()) : originalParseLiteral(ast.value);
+
+module.exports = GraphQLDateTime;

--- a/packages/plugins/graphql/server/services/internals/scalars/index.js
+++ b/packages/plugins/graphql/server/services/internals/scalars/index.js
@@ -2,17 +2,18 @@
 
 const GraphQLJSON = require('graphql-type-json');
 const GraphQLLong = require('graphql-type-long');
-const { GraphQLDateTime, GraphQLDate } = require('graphql-iso-date/dist');
 const { GraphQLUpload } = require('graphql-upload');
 const { asNexusMethod } = require('nexus');
 
+const DateScalar = require('./date');
+const DateTimeScalar = require('./datetime');
 const TimeScalar = require('./time');
 
 module.exports = () => ({
   JSON: asNexusMethod(GraphQLJSON, 'json'),
-  DateTime: asNexusMethod(GraphQLDateTime, 'dateTime'),
+  DateTime: asNexusMethod(DateTimeScalar, 'dateTime'),
   Time: asNexusMethod(TimeScalar, 'time'),
-  Date: asNexusMethod(GraphQLDate, 'date'),
+  Date: asNexusMethod(DateScalar, 'date'),
   Long: asNexusMethod(GraphQLLong, 'long'),
   Upload: asNexusMethod(GraphQLUpload, 'upload'),
 });

--- a/test/e2e.js
+++ b/test/e2e.js
@@ -43,6 +43,7 @@ const runAllTests = async args => {
     cwd: path.resolve(__dirname, '..'),
     env: {
       FORCE_COLOR: 1,
+      TZ: 'UTC',
     },
   });
 };


### PR DESCRIPTION
## Parse 'now()' as current time (parse-type.js)

Parse value *'now()'* for types *time*, *date* and *datetime* to current time (formatted `new Date()`).
Same as calling the function with `value: new Date()`, but can this can be used in api calls.

### What does it do?

```
> parseType({type: 'time', value: 'now()'})
'22:15:56.361'

> parseType({type: 'date', value: 'now()'})
'2021-12-28'

> parseType({type: 'datetime', value: 'now()'})
2021-12-28T21:16:04.128Z
```


### Why is it needed?

This adds a feature. Allows queries to reference current server time.
E.g. query tasks that are passed due; without relying on the client.
(Inspired by posgres `NOW()`)

```
query {
  tasks(
      where: {
        deadline_lte: "now()"
      }
    ) {
      deadline
      priority
      title
    }
  }
}
```


### How to test it?

- aded three tests to **parse-type.test.js** with assertions: 
  - `expect(parseType({ type: 'time', value: 'now()' })).toBe('12:07:59.125')`
  - `expect(parseType({ type: 'date', value: 'now()' })).toBe('2022-01-19')`
  - `expect(parseType({ type: 'datetime', value: 'now()' })).toStrictEqual(new Date('2022-01-19T11:07:59.125Z'))`

### Related issue(s)/PR(s)

-
