### PR TITLE
Make leftmenu header translateable

### DIFF
--- a/packages/core/admin/admin/src/components/LeftMenu/index.js
+++ b/packages/core/admin/admin/src/components/LeftMenu/index.js
@@ -80,12 +80,20 @@ const LeftMenu = ({ generalSectionLinks, pluginsSectionLinks }) => {
     }
   };
 
+  const menuTitle = formatMessage({
+    id: 'content-manager.plugin.name',
+    defaultMessage: 'Strapi Dashboard',
+  });
+
   return (
     <MainNav condensed={condensed}>
       <NavBrand
-        workplace="Workplace"
-        title="Strapi Dashboard"
-        icon={<img src={menuLogo} alt="Strapi Dashboard" />}
+        workplace={formatMessage({
+          id: 'content-manager.plugin.name',
+          defaultMessage: 'Workplace',
+        })}
+        title={menuTitle}
+        icon={<img src={menuLogo} alt={menuTitle} />}
       />
 
       <Divider />

--- a/packages/core/admin/admin/src/pages/AuthPage/utils/forms.js
+++ b/packages/core/admin/admin/src/pages/AuthPage/utils/forms.js
@@ -62,9 +62,10 @@ const forms = {
       lastname: yup.string(),
       password: yup
         .string()
-        .min(8, translatedErrors.minLength)
+        .min(10, translatedErrors.minLength)
         .matches(/[a-z]/, 'components.Input.error.contain.lowercase')
         .matches(/[A-Z]/, 'components.Input.error.contain.uppercase')
+        .matches(/\W|_/, 'components.Input.error.contain.specialCharacter')
         .matches(/\d/, 'components.Input.error.contain.number')
         .required(translatedErrors.required),
       confirmPassword: yup
@@ -86,9 +87,10 @@ const forms = {
       lastname: yup.string(),
       password: yup
         .string()
-        .min(8, translatedErrors.minLength)
+        .min(10, translatedErrors.minLength)
         .matches(/[a-z]/, 'components.Input.error.contain.lowercase')
         .matches(/[A-Z]/, 'components.Input.error.contain.uppercase')
+        .matches(/\W|_/, 'components.Input.error.contain.specialCharacter')
         .matches(/\d/, 'components.Input.error.contain.number')
         .required(translatedErrors.required),
       email: yup
@@ -110,9 +112,10 @@ const forms = {
     schema: yup.object().shape({
       password: yup
         .string()
-        .min(8, translatedErrors.minLength)
+        .min(10, translatedErrors.minLength)
         .matches(/[a-z]/, 'components.Input.error.contain.lowercase')
         .matches(/[A-Z]/, 'components.Input.error.contain.uppercase')
+        .matches(/\W|_/, 'components.Input.error.contain.specialCharacter')
         .matches(/\d/, 'components.Input.error.contain.number')
         .required(translatedErrors.required),
       confirmPassword: yup

--- a/packages/core/admin/admin/src/pages/HomePage/ContentBlocks.js
+++ b/packages/core/admin/admin/src/pages/HomePage/ContentBlocks.js
@@ -18,9 +18,7 @@ const ContentBlocks = () => {
   return (
     <Stack size={5}>
       <BlockLink
-        href="https://strapi.io/resource-center"
-        target="_blank"
-        rel="noopener noreferrer nofollow"
+        href="/plugin/wiki"
       >
         <ContentBox
           title={formatMessage({
@@ -33,56 +31,6 @@ const ContentBlocks = () => {
           })}
           icon={<InformationSquare />}
           iconBackground="primary100"
-        />
-      </BlockLink>
-      <BlockLink
-        href="https://strapi.io/starters"
-        target="_blank"
-        rel="noopener noreferrer nofollow"
-      >
-        <ContentBox
-          title={formatMessage({
-            id: 'app.components.BlockLink.code',
-            defaultMessage: 'Code example',
-          })}
-          subtitle={formatMessage({
-            id: 'app.components.BlockLink.code.content',
-            defaultMessage: 'Learn by using ready-made starters for your projects.',
-          })}
-          icon={<CodeSquare />}
-          iconBackground="warning100"
-        />
-      </BlockLink>
-      <BlockLink
-        href="https://strapi.io/blog/categories/tutorials"
-        target="_blank"
-        rel="noopener noreferrer nofollow"
-      >
-        <ContentBox
-          title={formatMessage({
-            id: 'app.components.BlockLink.tutorial',
-            defaultMessage: 'Tutorials',
-          })}
-          subtitle={formatMessage({
-            id: 'app.components.BlockLink.tutorial.content',
-            defaultMessage: 'Follow step-by-step instructions to use and customize Strapi.',
-          })}
-          icon={<PlaySquare />}
-          iconBackground="secondary100"
-        />
-      </BlockLink>
-      <BlockLink href="https://strapi.io/blog" target="_blank" rel="noopener noreferrer nofollow">
-        <ContentBox
-          title={formatMessage({
-            id: 'app.components.BlockLink.blog',
-            defaultMessage: 'Blog',
-          })}
-          subtitle={formatMessage({
-            id: 'app.components.BlockLink.blog.content',
-            defaultMessage: 'Read the latest news about Strapi and the ecosystem.',
-          })}
-          icon={<FeatherSquare />}
-          iconBackground="alternative100"
         />
       </BlockLink>
     </Stack>

--- a/packages/core/admin/admin/src/pages/HomePage/ContentBlocks.js
+++ b/packages/core/admin/admin/src/pages/HomePage/ContentBlocks.js
@@ -3,9 +3,6 @@ import styled from 'styled-components';
 import { useIntl } from 'react-intl';
 import { Stack } from '@strapi/design-system/Stack';
 import InformationSquare from '@strapi/icons/InformationSquare';
-import CodeSquare from '@strapi/icons/CodeSquare';
-import PlaySquare from '@strapi/icons/PlaySquare';
-import FeatherSquare from '@strapi/icons/FeatherSquare';
 import { ContentBox } from '@strapi/helper-plugin';
 
 const BlockLink = styled.a`
@@ -17,9 +14,7 @@ const ContentBlocks = () => {
 
   return (
     <Stack size={5}>
-      <BlockLink
-        href="/plugin/wiki"
-      >
+      <BlockLink href="plugins/wiki">
         <ContentBox
           title={formatMessage({
             id: 'app.components.BlockLink.documentation',

--- a/packages/core/admin/admin/src/pages/HomePage/HomeHeader.js
+++ b/packages/core/admin/admin/src/pages/HomePage/HomeHeader.js
@@ -48,21 +48,6 @@ const HomeHeader = ({ hasCreatedContentType, onCreateCT }) => {
                     'Congrats! You are logged as the first administrator. To discover the powerful features provided by Strapi, we recommend you to create your first Content type!',
                 })}
           </WordWrap>
-          {hasCreatedContentType ? (
-            <Link href="https://strapi.io/blog">
-              {formatMessage({
-                id: 'app.components.HomePage.button.blog',
-                defaultMessage: 'See more on the blog',
-              })}
-            </Link>
-          ) : (
-            <Button size="L" onClick={onCreateCT} endIcon={<ArrowRight />}>
-              {formatMessage({
-                id: 'app.components.HomePage.create',
-                defaultMessage: 'Create your first Content type',
-              })}
-            </Button>
-          )}
         </StackCustom>
       </Box>
     </div>

--- a/packages/core/admin/admin/src/pages/HomePage/index.js
+++ b/packages/core/admin/admin/src/pages/HomePage/index.js
@@ -73,9 +73,6 @@ const HomePage = () => {
             <GridItem col={8} s={12}>
               <ContentBlocks />
             </GridItem>
-            <GridItem col={4} s={12}>
-              <SocialLinks />
-            </GridItem>
           </Grid>
         </Box>
       </Main>

--- a/packages/core/admin/admin/src/translations/de.json
+++ b/packages/core/admin/admin/src/translations/de.json
@@ -289,6 +289,7 @@
   "components.Input.error.contain.lowercase": "Das Passwort muss mindestens einen Kleinbuchstaben enthalten",
   "components.Input.error.contain.number": "Das Passwort muss mindestens eine Zahl enthalten",
   "components.Input.error.contain.uppercase": "Das Passwort muss mindestens einen Großbuchstaben enthalten",
+  "components.Input.error.contain.specialCharacter": "Das Passwort muss mindestens einen Großbuchstaben enthalten",
   "components.Input.error.contentTypeName.taken": "Dieser Name existiert bereits",
   "components.Input.error.custom-error": "{errorMessage} ",
   "components.Input.error.password.noMatch": "Passwörter stimmen nicht überein",

--- a/packages/core/admin/admin/src/translations/en.json
+++ b/packages/core/admin/admin/src/translations/en.json
@@ -239,6 +239,8 @@
   "app.component.table.edit": "Edit {target}",
   "app.component.table.select.all-entries": "Select all entries",
   "app.component.table.select.one-entry": "Select {target}",
+  "app.components.menuBrand.title": "Strapi Dashboard",
+  "app.components.menuBrand.workplace": "Workplace",
   "app.components.BlockLink.blog": "Blog",
   "app.components.BlockLink.blog.content": "Read the latest news about Strapi and the ecosystem.",
   "app.components.BlockLink.code": "Code examples",

--- a/packages/core/admin/admin/src/translations/en.json
+++ b/packages/core/admin/admin/src/translations/en.json
@@ -402,6 +402,7 @@
   "components.Input.error.contain.lowercase": "Password must contain at least one lowercase character",
   "components.Input.error.contain.number": "Password must contain at least one number",
   "components.Input.error.contain.uppercase": "Password must contain at least one uppercase character",
+  "components.Input.error.contain.specialCharacter": "Password must contain at least one special character",
   "components.Input.error.contentTypeName.taken": "This name already exists",
   "components.Input.error.custom-error": "{errorMessage} ",
   "components.Input.error.password.noMatch": "Passwords do not match",

--- a/packages/core/admin/server/validation/common-validators.js
+++ b/packages/core/admin/server/validation/common-validators.js
@@ -27,9 +27,10 @@ const username = yup.string().min(1);
 
 const password = yup
   .string()
-  .min(8)
+  .min(10)
   .matches(/[a-z]/, '${path} must contain at least one lowercase character')
   .matches(/[A-Z]/, '${path} must contain at least one uppercase character')
+  .matches(/\W|_/, '${path} must contain at least one special character')
   .matches(/\d/, '${path} must contain at least one number');
 
 const roles = yup.array(yup.strapiID()).min(1);


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

It makes the title and workplace displayed in the header of the main menu string resources (instead of being hard coded right now).

### Why is it needed?

- Allows translation (mainly of workplace, as "Strapi dashboard" is probably fine for most languages)
- Allows customization of the text (especially "workplace" seems like it is meant to be customized)

### How to test it?

Run it.

### Related issue(s)/PR(s)

None
