### PR TITLE
Fix sentry plugin calling sendError on wrong object

### DIFF
--- a/packages/plugins/sentry/server/middlewares/sentry.js
+++ b/packages/plugins/sentry/server/middlewares/sentry.js
@@ -18,7 +18,7 @@ module.exports = ({ strapi }) => {
     try {
       await next();
     } catch (error) {
-      sentry.sendError(error, (scope, sentryInstance) => {
+      sentryService.sendError(error, (scope, sentryInstance) => {
         scope.addEventProcessor(event => {
           // Parse Koa context to add error metadata
           return sentryInstance.Handlers.parseRequest(event, ctx.request, {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Fixes the sentry plugin middleware throwing an error when trying to send another error to sentry.

According to #12064 the plugin middleware was calling the `sendError()` function on the wrong object:
https://github.com/strapi/strapi/blob/6b2e0dc72db42f8aceb98da87865d9300c298375/packages/plugins/sentry/server/middlewares/sentry.js#L8-L22

The code loaded the sentry plugin service (line 8). Based on this service it loaded the Sentry SDK by using the `getInstance` (line 10) and stores the this instance in the `sentry` variable.

On this sentry variable, it calls the `sendError()` function (line 21)
This is wrong: this `sendError()` function is not part of the Sentry SDK so it does not exist here.
Instead this function is defined in the plugin service itself. So the correct code should be:


#### What I changed
I changed the variable on which the `sendError()` function is called.

### Why is it needed?

The sentry integration created the following error when trying to send another error to sentry.

```sh
error: sentry.sendError is not a function
TypeError: sentry.sendError is not a function
    at /Users/derweili/Code/rnk-vaccine-dashboard/rnk-vaccine-dashboard-server/node_modules/@strapi/plugin-sentry/server/middlewares/sentry.js:22:14
    at async /Users/derweili/Code/rnk-vaccine-dashboard/rnk-vaccine-dashboard-server/node_modules/@strapi/strapi/lib/middlewares/body.js:24:7
    at async /Users/derweili/Code/rnk-vaccine-dashboard/rnk-vaccine-dashboard-server/node_modules/@strapi/strapi/lib/middlewares/logger.js:22:5
    at async /Users/derweili/Code/rnk-vaccine-dashboard/rnk-vaccine-dashboard-server/node_modules/@strapi/strapi/lib/middlewares/powered-by.js:16:5
    at async cors (/Users/derweili/Code/rnk-vaccine-dashboard/rnk-vaccine-dashboard-server/node_modules/@koa/cors/index.js:56:32)
    at async /Users/derweili/Code/rnk-vaccine-dashboard/rnk-vaccine-dashboard-server/node_modules/@strapi/strapi/lib/middlewares/errors.js:13:7
    at async /Users/derweili/Code/rnk-vaccine-dashboard/rnk-vaccine-dashboard-server/node_modules/@strapi/strapi/lib/services/metrics/middleware.js:29:5
```

### How to test it?

1. Install the current sentry plugin 
2. Enforce an error e.g. by calling `throw new Error('Test Error');`
3. You will see the sentry plugin will throw the `error: sentry.sendError is not a function` from above.
4. Now try it with this pull request, you won't see the `error: sentry.sendError`. Instead you will only see the `Test Error` Exception

Note: When installing and configuration the sentry plugin, you must follow the instructions from this pr: #12066 because the current instructions in the plugin readme have errors, too. Otherwise you will receive other errors.


### Related issue(s)/PR(s)

fixes #12064 