### PR TITLE
feat: Order plugin loader by plugin weight

### DIFF
--- a/packages/core/strapi/lib/core/loaders/plugins/get-enabled-plugins.js
+++ b/packages/core/strapi/lib/core/loaders/plugins/get-enabled-plugins.js
@@ -106,13 +106,17 @@ const getEnabledPlugins = async strapi => {
     installedPlugins
   );
 
-  const enabledPlugins = pipe(
+  let enabledPlugins = pipe(
     defaultsDeep(declaredPlugins),
     defaultsDeep(installedPluginsNotAlreadyUsed),
     pickBy(p => p.enabled)
   )(internalPlugins);
 
-  return enabledPlugins;
+  const orderedPlugins = {};
+  enabledPlugins = _.orderBy(Object.values(enabledPlugins), item => item.info.weight, ['desc']);
+  enabledPlugins.map((plugin) => orderedPlugins[plugin.info.name] = plugin);
+
+  return orderedPlugins;
 };
 
 module.exports = getEnabledPlugins;


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?
It allows you to manipulate the order in which plugins are loaded in your project.

### Why is it needed?
I was checking out the `strapi.contentTypes` object in the `strapi-server.js` file of my custom plugin.
There I found that not all content types were (yet) available.

With this PR you can set a `weight` property in the `package.json` of your plugin to manipulate the order in which your plugin get's loaded in Strapi.

### How to test it?

Issue:
- Setup a Strapi 4 project.
- Create a custom content type (from the content-types builder)
- Create a custom plugin with a `strapi-server.js` file.
- Console log the content types in the `strapi-server.js` file: `console.log(Object.keys(strapi.contentTypes));`.
- See that your custom type does not get printed

Fix:
- Apply the PR change to Strapi.
- In the `package.json` of your plugin set the `strapi.weight` property to `10`.
- Your plugin will now be loaded as the last plugin.
- Reload and see the `console.log` printing your custom content type.

### Additional context

Eventhough I'm now seeing my custom types I still can't see some others.
Including `plugin::users-permissions.role`.
