### PR TITLE
Add PolicyError error class for use in policies

### DIFF
--- a/packages/core/strapi/lib/services/server/policy.js
+++ b/packages/core/strapi/lib/services/server/policy.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { propOr } = require('lodash/fp');
-const { ForbiddenError } = require('@strapi/utils').errors;
+const { PolicyError } = require('@strapi/utils').errors;
 const { policy: policyUtils } = require('@strapi/utils');
 
 const getPoliciesConfig = propOr([], 'config.policies');
@@ -17,7 +17,7 @@ const resolvePolicies = route => {
       const result = await handler(context, config, { strapi });
 
       if (![true, undefined].includes(result)) {
-        throw new ForbiddenError('Policies failed.');
+        throw new PolicyError();
       }
     }
 

--- a/packages/core/utils/lib/errors.js
+++ b/packages/core/utils/lib/errors.js
@@ -69,6 +69,15 @@ class UnauthorizedError extends ApplicationError {
   }
 }
 
+class PolicyError extends ApplicationError {
+  constructor(message, details) {
+    super(message, details);
+    this.name = 'PolicyError';
+    this.message = message || 'Policy Failed';
+    this.details = details || {};
+  }
+}
+
 module.exports = {
   HttpError,
   ApplicationError,
@@ -79,4 +88,5 @@ module.exports = {
   ForbiddenError,
   PayloadTooLargeError,
   UnauthorizedError,
+  PolicyError,
 };

--- a/packages/core/utils/lib/errors.js
+++ b/packages/core/utils/lib/errors.js
@@ -69,7 +69,7 @@ class UnauthorizedError extends ApplicationError {
   }
 }
 
-class PolicyError extends ApplicationError {
+class PolicyError extends ForbiddenError {
   constructor(message, details) {
     super(message, details);
     this.name = 'PolicyError';

--- a/packages/plugins/graphql/server/services/content-api/policy.js
+++ b/packages/plugins/graphql/server/services/content-api/policy.js
@@ -2,7 +2,7 @@
 
 const { propOr } = require('lodash/fp');
 const { policy: policyUtils } = require('@strapi/utils');
-const { ForbiddenError } = require('@strapi/utils').errors;
+const { PolicyError } = require('@strapi/utils').errors;
 
 const getPoliciesConfig = propOr([], 'policies');
 
@@ -19,7 +19,7 @@ const createPoliciesMiddleware = (resolverConfig, { strapi }) => {
       const result = await handler(context, config, { strapi });
 
       if (![true, undefined].includes(result)) {
-        throw new ForbiddenError('Policies failed.');
+        throw new PolicyError();
       }
     }
 


### PR DESCRIPTION
### What does it do?

Adds a new error type for policies that user can extend with their own custom classes if they want

### Why is it needed?

Better to have a specific error class for throwing custom errors in policies

### How to test it?

```js
// path: ./src/policies/test.js

const utils = require('@strapi/utils');
const { PolicyError } = utils.errors;

module.exports = (policyContext, config, { strapi }) => {
  let blah = false

  if (blah === false) {
    throw new PolicyError('Some message', { policy: 'test' })
  } else {
    return true
  }
}
```

### Related issue(s)/PR(s)

N/A
