### PR TITLE
Uniformize WYSIWYG preview/markdown button style

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/Wysiwyg/WysiwygNav.js
+++ b/packages/core/admin/admin/src/content-manager/components/Wysiwyg/WysiwygNav.js
@@ -84,7 +84,7 @@ const WysiwygNav = ({
             <MoreButton disabled ref={buttonMoreRef} id="more" label="More" icon={<More />} />
           </Flex>
 
-          <Button onClick={onTogglePreviewMode} variant="tertiary" size="L" id="preview">
+          <Button onClick={onTogglePreviewMode} variant="tertiary" id="preview">
             {formatMessage({
               id: 'components.Wysiwyg.ToggleMode.markdown-mode',
               defaultMessage: 'Markdown mode',


### PR DESCRIPTION
This change prevents layout shift when you switch between Preview & Markdown mode in the WYSIWYG editor.