### PR TITLE
Fix deployment on GCP by not having empty directory for migrations

### DIFF
--- a/packages/core/database/lib/migrations/index.js
+++ b/packages/core/database/lib/migrations/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const path = require('path');
+const fs = require('fs');
 const fse = require('fs-extra');
 const Umzug = require('umzug');
 
@@ -26,6 +27,7 @@ const createUmzugProvider = db => {
   const migrationDir = path.join(strapi.dirs.root, 'database/migrations');
 
   fse.ensureDirSync(migrationDir);
+  if (fs.readdirSync(migrationDir).length === 0) fse.writeFileSync(migrationDir + '/.gitkeep', '');
 
   const wrapFn = fn => db => db.getConnection().transaction(trx => Promise.resolve(fn(trx)));
   const storage = createStorage({ db, tableName: 'strapi_migrations' });

--- a/packages/core/database/lib/migrations/index.js
+++ b/packages/core/database/lib/migrations/index.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const path = require('path');
-const fs = require('fs');
 const fse = require('fs-extra');
 const Umzug = require('umzug');
 
@@ -27,7 +26,7 @@ const createUmzugProvider = db => {
   const migrationDir = path.join(strapi.dirs.root, 'database/migrations');
 
   fse.ensureDirSync(migrationDir);
-  if (fs.readdirSync(migrationDir).length === 0) fse.ensureFile(migrationDir + '/.gitkeep');
+  if (fse.readdirSync(migrationDir).length === 0) fse.ensureFile(migrationDir + '/.gitkeep');
 
   const wrapFn = fn => db => db.getConnection().transaction(trx => Promise.resolve(fn(trx)));
   const storage = createStorage({ db, tableName: 'strapi_migrations' });

--- a/packages/core/database/lib/migrations/index.js
+++ b/packages/core/database/lib/migrations/index.js
@@ -27,7 +27,7 @@ const createUmzugProvider = db => {
   const migrationDir = path.join(strapi.dirs.root, 'database/migrations');
 
   fse.ensureDirSync(migrationDir);
-  if (fs.readdirSync(migrationDir).length === 0) fse.writeFileSync(migrationDir + '/.gitkeep', '');
+  if (fs.readdirSync(migrationDir).length === 0) fse.ensureFile(migrationDir + '/.gitkeep');
 
   const wrapFn = fn => db => db.getConnection().transaction(trx => Promise.resolve(fn(trx)));
   const storage = createStorage({ db, tableName: 'strapi_migrations' });


### PR DESCRIPTION
### What does it do?

Creates a `.gitkeep` file in `database/migrations` if the folder is empty

### Why is it needed?

fixes #11762 certain hosting providers don't allow empty directories when deploying which breaks GCP

### How to test it?

Start a new project, ensure it creates a new, empty, `.gitkeep` folder, add a new file and delete the `.gitkeep` and see that it's not auto-generated

### Related issue(s)/PR(s)

#11762
