### PR TITLE
#12081 Fix empty string is accepted by API

### DIFF
--- a/packages/core/strapi/lib/services/entity-validator/__tests__/email-validators.test.js
+++ b/packages/core/strapi/lib/services/entity-validator/__tests__/email-validators.test.js
@@ -12,7 +12,7 @@ describe('Email validator', () => {
       const validator = strapiUtils.validateYupSchema(
         validators.email(
           {
-            attr: { type: 'string' },
+            attr: { type: 'email' },
           },
           { isDraft: false }
         )
@@ -29,7 +29,7 @@ describe('Email validator', () => {
       const validator = strapiUtils.validateYupSchema(
         validators.email(
           {
-            attr: { type: 'string' },
+            attr: { type: 'email' },
           },
           { isDraft: false }
         )
@@ -40,18 +40,14 @@ describe('Email validator', () => {
 
     test('it validates non-empty email required field', async () => {
       const validator = strapiUtils.validateYupSchema(
-        validators.email(
-          {
-            attr: { type: 'string', required: true, regex: '^\\w+$' },
-          },
-          { isDraft: false }
-        )
+        validators.email({ attr: { type: 'email' } }, { isDraft: false })
       );
 
       try {
         await validator('');
       } catch (err) {
         expect(err).toBeInstanceOf(YupValidationError);
+        expect(err.message).toBe('this cannot be empty');
       }
     });
   });

--- a/packages/core/strapi/lib/services/entity-validator/__tests__/email-validators.test.js
+++ b/packages/core/strapi/lib/services/entity-validator/__tests__/email-validators.test.js
@@ -37,5 +37,18 @@ describe('Email validator', () => {
 
       expect(await validator('valid@email.com')).toBe('valid@email.com');
     });
+
+    test('it validates non-empty email required field', async () => {
+      const validator = strapiUtils.validateYupSchema(
+        validators.email(
+          {
+            attr: { type: 'string', required: true },
+          },
+          { isDraft: false }
+        )
+      );
+
+      expect(await validator('valid@email.com')).not.toBe('');
+    });
   });
 });

--- a/packages/core/strapi/lib/services/entity-validator/__tests__/email-validators.test.js
+++ b/packages/core/strapi/lib/services/entity-validator/__tests__/email-validators.test.js
@@ -42,13 +42,17 @@ describe('Email validator', () => {
       const validator = strapiUtils.validateYupSchema(
         validators.email(
           {
-            attr: { type: 'string', required: true },
+            attr: { type: 'string', required: true, regex: '^\\w+$' },
           },
           { isDraft: false }
         )
       );
 
-      expect(await validator('valid@email.com')).not.toBe('');
+      try {
+        await validator('');
+      } catch (err) {
+        expect(err).toBeInstanceOf(YupValidationError);
+      }
     });
   });
 });

--- a/packages/core/strapi/lib/services/entity-validator/validators.js
+++ b/packages/core/strapi/lib/services/entity-validator/validators.js
@@ -3,7 +3,6 @@
 const _ = require('lodash');
 
 const { yup } = require('@strapi/utils');
-const { ValidationError } = require('@strapi/utils/lib/errors');
 
 /**
  * @type {import('yup').StringSchema} StringSchema
@@ -160,14 +159,7 @@ const addUniqueValidator = (validator, { attr, model, updatedAttribute, entity }
 /* Type validators */
 
 const stringValidator = composeValidators(
-  () =>
-    yup.string().transform((val, originalVal) => {
-      if (!_.isEmpty(originalVal) && !_.isNull(originalVal)) {
-        return originalVal;
-      } else {
-        throw new ValidationError(`Expected non-empty string`);
-      }
-    }),
+  () => yup.string().transform((val, originalVal) => originalVal),
   addMinLengthValidator,
   addMaxLengthValidator,
   addStringRegexValidator,

--- a/packages/core/strapi/lib/services/entity-validator/validators.js
+++ b/packages/core/strapi/lib/services/entity-validator/validators.js
@@ -3,6 +3,7 @@
 const _ = require('lodash');
 
 const { yup } = require('@strapi/utils');
+const { ValidationError } = require('@strapi/utils/lib/errors');
 
 /**
  * @type {import('yup').StringSchema} StringSchema
@@ -159,7 +160,14 @@ const addUniqueValidator = (validator, { attr, model, updatedAttribute, entity }
 /* Type validators */
 
 const stringValidator = composeValidators(
-  () => yup.string().transform((val, originalVal) => originalVal),
+  () =>
+    yup.string().transform((val, originalVal) => {
+      if (!_.isEmpty(originalVal) && !_.isNull(originalVal)) {
+        return originalVal;
+      } else {
+        throw new ValidationError(`Expected non-empty string`);
+      }
+    }),
   addMinLengthValidator,
   addMaxLengthValidator,
   addStringRegexValidator,

--- a/packages/core/strapi/lib/services/entity-validator/validators.js
+++ b/packages/core/strapi/lib/services/entity-validator/validators.js
@@ -166,7 +166,9 @@ const stringValidator = composeValidators(
   addUniqueValidator
 );
 
-const emailValidator = composeValidators(stringValidator, validator => validator.email());
+const emailValidator = composeValidators(stringValidator, validator =>
+  validator.email().required()
+);
 
 const uidValidator = composeValidators(stringValidator, validator =>
   validator.matches(new RegExp('^[A-Za-z0-9-_.~]*$'))

--- a/packages/core/strapi/lib/services/entity-validator/validators.js
+++ b/packages/core/strapi/lib/services/entity-validator/validators.js
@@ -166,9 +166,7 @@ const stringValidator = composeValidators(
   addUniqueValidator
 );
 
-const emailValidator = composeValidators(stringValidator, validator =>
-  validator.email().required()
-);
+const emailValidator = composeValidators(stringValidator, validator => validator.email().min(1));
 
 const uidValidator = composeValidators(stringValidator, validator =>
   validator.matches(new RegExp('^[A-Za-z0-9-_.~]*$'))

--- a/packages/core/strapi/lib/services/entity-validator/validators.js
+++ b/packages/core/strapi/lib/services/entity-validator/validators.js
@@ -166,7 +166,9 @@ const stringValidator = composeValidators(
   addUniqueValidator
 );
 
-const emailValidator = composeValidators(stringValidator, validator => validator.email().min(1));
+const emailValidator = composeValidators(stringValidator, validator =>
+  validator.email().min(1, '${path} cannot be empty')
+);
 
 const uidValidator = composeValidators(stringValidator, validator =>
   validator.matches(new RegExp('^[A-Za-z0-9-_.~]*$'))


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Check for not empty string or not null value accepted by API.

### Why is it needed?

 When I send a POST request to API with an email field type, for example: 
`{
  "data": {
    "email": ""
  }
}` 

It creates an empty object and get a 200 OK response.

### How to test it?

1. Create a collection type with a required email field
2. Send a post request with an empty string for the field
3. Now get a 400 Validation Error instead 200.

### Related issue(s)/PR(s)

Related Issue: [12081](https://github.com/strapi/strapi/issues/12081)
