### PR TITLE
Fixed non-shell host crash on startup

### DIFF
--- a/packages/core/strapi/lib/services/metrics/sender.js
+++ b/packages/core/strapi/lib/services/metrics/sender.js
@@ -3,10 +3,10 @@
 const os = require('os');
 const _ = require('lodash');
 const isDocker = require('is-docker');
-const { machineIdSync } = require('node-machine-id');
 const fetch = require('node-fetch');
 const ciEnv = require('ci-info');
 const ee = require('../../utils/ee');
+const machineID = require('../../utils/machine-id');
 const stringifyDeep = require('./stringify-deep');
 
 const defaultQueryOpts = {
@@ -33,7 +33,7 @@ const addPackageJsonStrapiMetadata = (metadata, strapi) => {
  */
 module.exports = strapi => {
   const { uuid } = strapi.config;
-  const deviceId = machineIdSync();
+  const deviceId = machineID();
   const isEE = strapi.EE === true && ee.isEE === true;
 
   const anonymous_metadata = {

--- a/packages/core/strapi/lib/utils/machine-id.js
+++ b/packages/core/strapi/lib/utils/machine-id.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const { machineIdSync } = require('node-machine-id');
+const uuid = require('uuid');
+
+module.exports = () => {
+  try {
+    const deviceId = machineIdSync();
+    return deviceId;
+  } catch (error) {
+    const deviceId = uuid();
+    return deviceId;
+  }
+};

--- a/packages/core/strapi/lib/utils/success.js
+++ b/packages/core/strapi/lib/utils/success.js
@@ -5,7 +5,7 @@
  */
 
 const fetch = require('node-fetch');
-const { machineIdSync } = require('node-machine-id');
+const machineID = require('./machine-id');
 
 /*
  * No need to worry about this file, we only retrieve anonymous data here.
@@ -21,7 +21,7 @@ try {
       method: 'POST',
       body: JSON.stringify({
         event: 'didInstallStrapi',
-        deviceId: machineIdSync(),
+        deviceId: machineID(),
       }),
       headers: { 'Content-Type': 'application/json' },
     }).catch(() => {});

--- a/packages/core/strapi/package.json
+++ b/packages/core/strapi/package.json
@@ -126,7 +126,8 @@
     "qs": "6.10.1",
     "resolve-cwd": "3.0.0",
     "semver": "7.3.5",
-    "statuses": "2.0.1"
+    "statuses": "2.0.1",
+    "uuid": "^3.3.2"
   },
   "devDependencies": {
     "supertest": "^6.1.6"

--- a/packages/generators/app/lib/index.js
+++ b/packages/generators/app/lib/index.js
@@ -3,7 +3,6 @@
 const { join, resolve, basename } = require('path');
 const os = require('os');
 const crypto = require('crypto');
-const { machineIdSync } = require('node-machine-id');
 const uuid = require('uuid/v4');
 const sentry = require('@sentry/node');
 // FIXME
@@ -14,6 +13,7 @@ const { trackError, captureException } = require('./utils/usage');
 const parseDatabaseArguments = require('./utils/parse-db-arguments');
 const generateNew = require('./generate-new');
 const checkInstallPath = require('./utils/check-install-path');
+const machineID = require('./utils/machine-id');
 
 sentry.init({
   dsn: 'https://841d2b2c9b4d4b43a4cde92794cb705a@sentry.io/1762059',
@@ -44,7 +44,7 @@ const generateNewApp = (projectDirectory, cliArguments) => {
     },
     uuid: (process.env.STRAPI_UUID_PREFIX || '') + uuid(),
     docker: process.env.DOCKER === 'true',
-    deviceId: machineIdSync(),
+    deviceId: machineID(),
     tmpPath,
     // use yarn if available and --use-npm isn't true
     useYarn: !useNpm && hasYarn(),

--- a/packages/generators/app/lib/utils/machine-id.js
+++ b/packages/generators/app/lib/utils/machine-id.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const { machineIdSync } = require('node-machine-id');
+const uuid = require('uuid');
+
+module.exports = () => {
+  try {
+    const deviceId = machineIdSync();
+    return deviceId;
+  } catch (error) {
+    const deviceId = uuid();
+    return deviceId;
+  }
+};


### PR DESCRIPTION
### What does it do?

This PR adds try/catch logic to all places where deviceId is generated with machineIdSync(). As machineIdSync requires a shell to be available in order to work, it crashes the startup script on non-shell hosts, such as distroless containers. Instead, if no shell is available, deviceId will be generated by using uuid/v4. Although such id is not persistent, it will still help us to track analytics from a container session while the container is up and running; and allow our tracker to function without any changes. Currently, if there is no deviceId on the request to the tracker, such request will not go through.

### Why is it needed?

Fixes the issue where startup script would fail on non-shell hosts.

### How to test it?

Create a distroless container and run the application. It should start up as normal.

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/issues/8893
https://github.com/strapi/strapi/issues/9920