### PR TITLE
Enable to create/trigger webhooks with no events

### DIFF
--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Webhooks/EditView/components/EventInput/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Webhooks/EditView/components/EventInput/index.js
@@ -63,7 +63,7 @@ const EventInput = ({ isDraftAndPublish }) => {
     : displayedData.events.default;
 
   const { formatMessage } = useIntl();
-  const { values, errors, handleChange: onChange } = useFormikContext();
+  const { values, handleChange: onChange } = useFormikContext();
 
   const inputName = 'events';
   const inputValue = values.events;
@@ -100,7 +100,7 @@ const EventInput = ({ isDraftAndPublish }) => {
 
   return (
     <Stack size={1}>
-      <FieldLabel required>
+      <FieldLabel>
         {formatMessage({
           id: 'Settings.webhooks.form.events',
           defaultMessage: 'Events',
@@ -154,14 +154,6 @@ const EventInput = ({ isDraftAndPublish }) => {
           })}
         </tbody>
       </StyledTable>
-      {errors.events && (
-        <Typography variant="pi" textColor="danger600" data-strapi-field-error>
-          {formatMessage({
-            id: 'components.Input.error.validation.required',
-            defaultMessage: 'This value is required',
-          })}
-        </Typography>
-      )}
     </Stack>
   );
 };

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Webhooks/EditView/components/utils/schema.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Webhooks/EditView/components/utils/schema.js
@@ -29,10 +29,7 @@ const schema = yup.object().shape({
       })
     );
   }),
-  events: yup
-    .array()
-    .min(1, translatedErrors.min)
-    .required(translatedErrors.required),
+  events: yup.array(),
 });
 
 export default schema;

--- a/packages/core/admin/server/controllers/webhooks.js
+++ b/packages/core/admin/server/controllers/webhooks.js
@@ -28,16 +28,12 @@ const webhookValidator = yup
         )
         .required();
     }),
-    events: yup
-      .array()
-      .of(
-        yup
-          .string()
-          .oneOf(_.values(webhookUtils.webhookEvents))
-          .required()
-      )
-      .min(1)
-      .required(),
+    events: yup.array().of(
+      yup
+        .string()
+        .oneOf(_.values(webhookUtils.webhookEvents))
+        .required()
+    ),
   })
   .noUnknown();
 


### PR DESCRIPTION
### What does it do?

Remove required validation for the events attributes of webhooks

### Why is it needed?

In a previous minor version of the v3 of Strapi, the events attribute (checkboxes) was not required to trigger a webhook (some developers used it to check their app was functioning).
Therefore this PR takes advantage of the V4' refactor to remove this dependency and allow to trigger a webhook from that very button without checking any box of the events

### How to test it?

https://www.loom.com/share/d13b510de1ed454ea733218e9291325a
