### PR TITLE
BulkDelete for non-default locale collection

### DIFF
--- a/packages/core/admin/admin/src/content-manager/pages/ListView/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/ListView/index.js
@@ -155,6 +155,7 @@ function ListView({
       try {
         await axiosInstance.post(getRequestUrl(`collection-types/${slug}/actions/bulkDelete`), {
           ids,
+          params,
         });
 
         const requestUrl = getRequestUrl(`collection-types/${slug}${params}`);

--- a/packages/core/content-manager/server/controllers/collection-types.js
+++ b/packages/core/content-manager/server/controllers/collection-types.js
@@ -216,6 +216,7 @@ module.exports = {
     const { model } = ctx.params;
     const { query, body } = ctx.request;
     const { ids } = body;
+    const { params } = body;
 
     await validateBulkDeleteInput(body);
 
@@ -225,20 +226,20 @@ module.exports = {
     if (permissionChecker.cannot.delete()) {
       return ctx.forbidden();
     }
-
     // TODO: fix
     const permissionQuery = permissionChecker.buildDeleteQuery(query);
-
     const idsWhereClause = { id: { $in: ids } };
-    const params = {
+    const params_local = {
       ...permissionQuery,
       filters: {
         $and: [idsWhereClause].concat(permissionQuery.filters || []),
       },
     };
 
-    const { count } = await entityManager.deleteMany(params, model);
-
+    if (params && params.includes('locale')) {
+      params_local['locale'] = params.slice(params.indexOf('locale=') + 7);
+    }
+    const { count } = await entityManager.deleteMany(params_local, model);
     ctx.body = { count };
   },
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->
### What does it do?
Fix bulk delete Bug for non-default locale collection type entries.

### Why is it needed?
Bulk delete is not performed for non-default locale collection type entries, it is necessary to obtain the parameters where the selected "locale" is specified in the list of collection types.

### How to test it?
1. Go to a localizable collection type list
2. Select a locale that is not the default locale
3. Select multiple entries
4. Click on the delete button to delete selected entries

**The following video shows the PR solution.**

https://user-images.githubusercontent.com/70716664/149595296-e003acab-ca41-41ab-a768-ff07acc367be.mov



### Related issue(s)/PR(s)
**#12092** 