### PR TITLE
Fix state not being shared with "beforeXXX" and "afterXXX" events

### DIFF
--- a/packages/core/database/lib/__tests__/lifecycles.test.js
+++ b/packages/core/database/lib/__tests__/lifecycles.test.js
@@ -34,12 +34,12 @@ describe('LifecycleProvider', () => {
     });
 
     it('use shared state', async () => {
-      const expectedState = new Date().toISOString();
+      const expectedState = { value: new Date().toISOString() };
       let receivedState;
 
       provider.subscribe({
         async beforeEvent(event) {
-          event.state = expectedState;
+          event.state.value = expectedState.value;
         },
         async afterEvent(event) {
           receivedState = event.state;

--- a/packages/core/database/lib/__tests__/lifecycles.test.js
+++ b/packages/core/database/lib/__tests__/lifecycles.test.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const { createLifecyclesProvider } = require('../lifecycles');
+
+describe('LifecycleProvider', () => {
+  describe('run', () => {
+    /** @type {import("../lifecycles").LifecycleProvider} */
+    let provider;
+    let dbMetadataGetStub = jest.fn(uid => ({ uid, name: 'TestModel' }));
+
+    beforeEach(() => {
+      const db = {
+        metadata: {
+          get: dbMetadataGetStub,
+        },
+      };
+      provider = createLifecyclesProvider(db);
+      provider.clear();
+    });
+
+    it('store state', async () => {
+      const expectedState = new Date().toISOString();
+
+      const subscriber = {
+        async beforeEvent(event) {
+          event.state = expectedState;
+        },
+      };
+      provider.subscribe(subscriber);
+
+      const stateBefore = await provider.run('beforeEvent', 'test-model', { id: 'instance-id' });
+
+      expect(stateBefore.get(subscriber)).toEqual(expectedState);
+    });
+
+    it('use shared state', async () => {
+      const expectedState = new Date().toISOString();
+      let receivedState;
+
+      provider.subscribe({
+        async beforeEvent(event) {
+          event.state = expectedState;
+        },
+        async afterEvent(event) {
+          receivedState = event.state;
+        },
+      });
+
+      const stateBefore = await provider.run('beforeEvent', 'test-model', { id: 'instance-id' });
+      await provider.run('afterEvent', 'test-model', { id: 'instance-id' }, stateBefore);
+
+      expect(receivedState).toEqual(expectedState);
+    });
+  });
+});

--- a/packages/core/database/lib/entity-manager.js
+++ b/packages/core/database/lib/entity-manager.js
@@ -113,33 +113,36 @@ const createEntityManager = db => {
 
   return {
     async findOne(uid, params) {
-      await db.lifecycles.run('beforeFindOne', uid, { params });
+      const event = { params };
+      await db.lifecycles.run('beforeFindOne', uid, event);
 
       const result = await this.createQueryBuilder(uid)
         .init(params)
         .first()
         .execute();
 
-      await db.lifecycles.run('afterFindOne', uid, { params, result });
+      await db.lifecycles.run('afterFindOne', uid, { ...event, result });
 
       return result;
     },
 
     // should we name it findOne because people are used to it ?
     async findMany(uid, params) {
-      await db.lifecycles.run('beforeFindMany', uid, { params });
+      const event = { params };
+      await db.lifecycles.run('beforeFindMany', uid, event);
 
       const result = await this.createQueryBuilder(uid)
         .init(params)
         .execute();
 
-      await db.lifecycles.run('afterFindMany', uid, { params, result });
+      await db.lifecycles.run('afterFindMany', uid, { ...event, result });
 
       return result;
     },
 
     async count(uid, params = {}) {
-      await db.lifecycles.run('beforeCount', uid, { params });
+      const event = { params };
+      await db.lifecycles.run('beforeCount', uid, event);
 
       const res = await this.createQueryBuilder(uid)
         .init(_.pick(['_q', 'where', 'filters'], params))
@@ -149,13 +152,14 @@ const createEntityManager = db => {
 
       const result = Number(res.count);
 
-      await db.lifecycles.run('afterCount', uid, { params, result });
+      await db.lifecycles.run('afterCount', uid, { ...event, result });
 
       return result;
     },
 
     async create(uid, params = {}) {
-      await db.lifecycles.run('beforeCreate', uid, { params });
+      const event = { params };
+      await db.lifecycles.run('beforeCreate', uid, event);
 
       const metadata = db.metadata.get(uid);
       const { data } = params;
@@ -182,14 +186,15 @@ const createEntityManager = db => {
         populate: params.populate,
       });
 
-      await db.lifecycles.run('afterCreate', uid, { params, result });
+      await db.lifecycles.run('afterCreate', uid, { ...event, result });
 
       return result;
     },
 
     // TODO: where do we handle relation processing for many queries ?
     async createMany(uid, params = {}) {
-      await db.lifecycles.run('beforeCreateMany', uid, { params });
+      const event = { params };
+      await db.lifecycles.run('beforeCreateMany', uid, event);
 
       const metadata = db.metadata.get(uid);
       const { data } = params;
@@ -210,13 +215,14 @@ const createEntityManager = db => {
 
       const result = { count: data.length };
 
-      await db.lifecycles.run('afterCreateMany', uid, { params, result });
+      await db.lifecycles.run('afterCreateMany', uid, { ...event, result });
 
       return result;
     },
 
     async update(uid, params = {}) {
-      await db.lifecycles.run('beforeUpdate', uid, { params });
+      const event = { params };
+      await db.lifecycles.run('beforeUpdate', uid, event);
 
       const metadata = db.metadata.get(uid);
       const { where, data } = params;
@@ -259,14 +265,15 @@ const createEntityManager = db => {
         populate: params.populate,
       });
 
-      await db.lifecycles.run('afterUpdate', uid, { params, result });
+      await db.lifecycles.run('afterUpdate', uid, { ...event, result });
 
       return result;
     },
 
     // TODO: where do we handle relation processing for many queries ?
     async updateMany(uid, params = {}) {
-      await db.lifecycles.run('beforeUpdateMany', uid, { params });
+      const event = { params };
+      await db.lifecycles.run('beforeUpdateMany', uid, event);
 
       const metadata = db.metadata.get(uid);
       const { where, data } = params;
@@ -284,13 +291,14 @@ const createEntityManager = db => {
 
       const result = { count: updatedRows };
 
-      await db.lifecycles.run('afterUpdateMany', uid, { params, result });
+      await db.lifecycles.run('afterUpdateMany', uid, { ...event, result });
 
       return result;
     },
 
     async delete(uid, params = {}) {
-      await db.lifecycles.run('beforeDelete', uid, { params });
+      const event = { params };
+      await db.lifecycles.run('beforeDelete', uid, event);
 
       const { where, select, populate } = params;
 
@@ -318,14 +326,15 @@ const createEntityManager = db => {
 
       await this.deleteRelations(uid, id);
 
-      await db.lifecycles.run('afterDelete', uid, { params, result: entity });
+      await db.lifecycles.run('afterDelete', uid, { ...event, result: entity });
 
       return entity;
     },
 
     // TODO: where do we handle relation processing for many queries ?
     async deleteMany(uid, params = {}) {
-      await db.lifecycles.run('beforeDeleteMany', uid, { params });
+      const event = { params };
+      await db.lifecycles.run('beforeDeleteMany', uid, event);
 
       const { where } = params;
 
@@ -336,7 +345,7 @@ const createEntityManager = db => {
 
       const result = { count: deletedRows };
 
-      await db.lifecycles.run('afterDelete', uid, { params, result });
+      await db.lifecycles.run('afterDelete', uid, { ...event, result });
 
       return result;
     },

--- a/packages/core/database/lib/entity-manager.js
+++ b/packages/core/database/lib/entity-manager.js
@@ -113,8 +113,7 @@ const createEntityManager = db => {
 
   return {
     async findOne(uid, params) {
-      const states = {};
-      await db.lifecycles.run('beforeFindOne', uid, { params }, states);
+      const states = await db.lifecycles.run('beforeFindOne', uid, { params });
 
       const result = await this.createQueryBuilder(uid)
         .init(params)
@@ -128,8 +127,7 @@ const createEntityManager = db => {
 
     // should we name it findOne because people are used to it ?
     async findMany(uid, params) {
-      const states = {};
-      await db.lifecycles.run('beforeFindMany', uid, { params }, states);
+      const states = await db.lifecycles.run('beforeFindMany', uid, { params });
 
       const result = await this.createQueryBuilder(uid)
         .init(params)
@@ -141,8 +139,7 @@ const createEntityManager = db => {
     },
 
     async count(uid, params) {
-      const states = {};
-      await db.lifecycles.run('beforeCount', uid, { params }, states);
+      const states = await db.lifecycles.run('beforeCount', uid, { params });
 
       const res = await this.createQueryBuilder(uid)
         .init(_.pick(['_q', 'where', 'filters'], params))
@@ -158,8 +155,7 @@ const createEntityManager = db => {
     },
 
     async create(uid, params) {
-      const states = {};
-      await db.lifecycles.run('beforeCreate', uid, { params }, states);
+      const states = await db.lifecycles.run('beforeCreate', uid, { params });
 
       const metadata = db.metadata.get(uid);
       const { data } = params;
@@ -193,8 +189,7 @@ const createEntityManager = db => {
 
     // TODO: where do we handle relation processing for many queries ?
     async createMany(uid, params) {
-      const states = {};
-      await db.lifecycles.run('beforeCreateMany', uid, { params }, states);
+      const states = await db.lifecycles.run('beforeCreateMany', uid, { params });
 
       const metadata = db.metadata.get(uid);
       const { data } = params;
@@ -221,8 +216,7 @@ const createEntityManager = db => {
     },
 
     async update(uid, params) {
-      const states = {};
-      await db.lifecycles.run('beforeUpdate', uid, { params }, states);
+      const states = await db.lifecycles.run('beforeUpdate', uid, { params });
 
       const metadata = db.metadata.get(uid);
       const { where, data } = params;
@@ -272,8 +266,7 @@ const createEntityManager = db => {
 
     // TODO: where do we handle relation processing for many queries ?
     async updateMany(uid, params) {
-      const states = {};
-      await db.lifecycles.run('beforeUpdateMany', uid, { params }, states);
+      const states = await db.lifecycles.run('beforeUpdateMany', uid, { params });
 
       const metadata = db.metadata.get(uid);
       const { where, data } = params;
@@ -297,8 +290,7 @@ const createEntityManager = db => {
     },
 
     async delete(uid, params) {
-      const states = {};
-      await db.lifecycles.run('beforeDelete', uid, { params }, states);
+      const states = await db.lifecycles.run('beforeDelete', uid, { params });
 
       const { where, select, populate } = params;
 
@@ -333,8 +325,7 @@ const createEntityManager = db => {
 
     // TODO: where do we handle relation processing for many queries ?
     async deleteMany(uid, params) {
-      const states = {};
-      await db.lifecycles.run('beforeDeleteMany', uid, { params }, states);
+      const states = await db.lifecycles.run('beforeDeleteMany', uid, { params });
 
       const { where } = params;
 

--- a/packages/core/database/lib/entity-manager.js
+++ b/packages/core/database/lib/entity-manager.js
@@ -336,7 +336,7 @@ const createEntityManager = db => {
 
       const result = { count: deletedRows };
 
-      await db.lifecycles.run('afterDelete', uid, { params, result }, states);
+      await db.lifecycles.run('afterDeleteMany', uid, { params, result }, states);
 
       return result;
     },

--- a/packages/core/database/lib/entity-manager.js
+++ b/packages/core/database/lib/entity-manager.js
@@ -113,36 +113,36 @@ const createEntityManager = db => {
 
   return {
     async findOne(uid, params) {
-      const event = { params };
-      await db.lifecycles.run('beforeFindOne', uid, event);
+      const states = {};
+      await db.lifecycles.run('beforeFindOne', uid, { params }, states);
 
       const result = await this.createQueryBuilder(uid)
         .init(params)
         .first()
         .execute();
 
-      await db.lifecycles.run('afterFindOne', uid, { ...event, result });
+      await db.lifecycles.run('afterFindOne', uid, { params, result }, states);
 
       return result;
     },
 
     // should we name it findOne because people are used to it ?
     async findMany(uid, params) {
-      const event = { params };
-      await db.lifecycles.run('beforeFindMany', uid, event);
+      const states = {};
+      await db.lifecycles.run('beforeFindMany', uid, { params }, states);
 
       const result = await this.createQueryBuilder(uid)
         .init(params)
         .execute();
 
-      await db.lifecycles.run('afterFindMany', uid, { ...event, result });
+      await db.lifecycles.run('afterFindMany', uid, { params, result }, states);
 
       return result;
     },
 
-    async count(uid, params = {}) {
-      const event = { params };
-      await db.lifecycles.run('beforeCount', uid, event);
+    async count(uid, params) {
+      const states = {};
+      await db.lifecycles.run('beforeCount', uid, { params }, states);
 
       const res = await this.createQueryBuilder(uid)
         .init(_.pick(['_q', 'where', 'filters'], params))
@@ -152,14 +152,14 @@ const createEntityManager = db => {
 
       const result = Number(res.count);
 
-      await db.lifecycles.run('afterCount', uid, { ...event, result });
+      await db.lifecycles.run('afterCount', uid, { params, result }, states);
 
       return result;
     },
 
-    async create(uid, params = {}) {
-      const event = { params };
-      await db.lifecycles.run('beforeCreate', uid, event);
+    async create(uid, params) {
+      const states = {};
+      await db.lifecycles.run('beforeCreate', uid, { params }, states);
 
       const metadata = db.metadata.get(uid);
       const { data } = params;
@@ -186,15 +186,15 @@ const createEntityManager = db => {
         populate: params.populate,
       });
 
-      await db.lifecycles.run('afterCreate', uid, { ...event, result });
+      await db.lifecycles.run('afterCreate', uid, { params, result }, states);
 
       return result;
     },
 
     // TODO: where do we handle relation processing for many queries ?
-    async createMany(uid, params = {}) {
-      const event = { params };
-      await db.lifecycles.run('beforeCreateMany', uid, event);
+    async createMany(uid, params) {
+      const states = {};
+      await db.lifecycles.run('beforeCreateMany', uid, { params }, states);
 
       const metadata = db.metadata.get(uid);
       const { data } = params;
@@ -215,14 +215,14 @@ const createEntityManager = db => {
 
       const result = { count: data.length };
 
-      await db.lifecycles.run('afterCreateMany', uid, { ...event, result });
+      await db.lifecycles.run('afterCreateMany', uid, { params, result }, states);
 
       return result;
     },
 
-    async update(uid, params = {}) {
-      const event = { params };
-      await db.lifecycles.run('beforeUpdate', uid, event);
+    async update(uid, params) {
+      const states = {};
+      await db.lifecycles.run('beforeUpdate', uid, { params }, states);
 
       const metadata = db.metadata.get(uid);
       const { where, data } = params;
@@ -265,15 +265,15 @@ const createEntityManager = db => {
         populate: params.populate,
       });
 
-      await db.lifecycles.run('afterUpdate', uid, { ...event, result });
+      await db.lifecycles.run('afterUpdate', uid, { params, result }, states);
 
       return result;
     },
 
     // TODO: where do we handle relation processing for many queries ?
-    async updateMany(uid, params = {}) {
-      const event = { params };
-      await db.lifecycles.run('beforeUpdateMany', uid, event);
+    async updateMany(uid, params) {
+      const states = {};
+      await db.lifecycles.run('beforeUpdateMany', uid, { params }, states);
 
       const metadata = db.metadata.get(uid);
       const { where, data } = params;
@@ -291,14 +291,14 @@ const createEntityManager = db => {
 
       const result = { count: updatedRows };
 
-      await db.lifecycles.run('afterUpdateMany', uid, { ...event, result });
+      await db.lifecycles.run('afterUpdateMany', uid, { params, result }, states);
 
       return result;
     },
 
-    async delete(uid, params = {}) {
-      const event = { params };
-      await db.lifecycles.run('beforeDelete', uid, event);
+    async delete(uid, params) {
+      const states = {};
+      await db.lifecycles.run('beforeDelete', uid, { params }, states);
 
       const { where, select, populate } = params;
 
@@ -326,15 +326,15 @@ const createEntityManager = db => {
 
       await this.deleteRelations(uid, id);
 
-      await db.lifecycles.run('afterDelete', uid, { ...event, result: entity });
+      await db.lifecycles.run('afterDelete', uid, { params, result: entity }, states);
 
       return entity;
     },
 
     // TODO: where do we handle relation processing for many queries ?
-    async deleteMany(uid, params = {}) {
-      const event = { params };
-      await db.lifecycles.run('beforeDeleteMany', uid, event);
+    async deleteMany(uid, params) {
+      const states = {};
+      await db.lifecycles.run('beforeDeleteMany', uid, { params }, states);
 
       const { where } = params;
 
@@ -345,7 +345,7 @@ const createEntityManager = db => {
 
       const result = { count: deletedRows };
 
-      await db.lifecycles.run('afterDelete', uid, { ...event, result });
+      await db.lifecycles.run('afterDelete', uid, { params, result }, states);
 
       return result;
     },

--- a/packages/core/database/lib/entity-manager.js
+++ b/packages/core/database/lib/entity-manager.js
@@ -154,7 +154,7 @@ const createEntityManager = db => {
       return result;
     },
 
-    async create(uid, params) {
+    async create(uid, params = {}) {
       const states = await db.lifecycles.run('beforeCreate', uid, { params });
 
       const metadata = db.metadata.get(uid);
@@ -188,7 +188,7 @@ const createEntityManager = db => {
     },
 
     // TODO: where do we handle relation processing for many queries ?
-    async createMany(uid, params) {
+    async createMany(uid, params = {}) {
       const states = await db.lifecycles.run('beforeCreateMany', uid, { params });
 
       const metadata = db.metadata.get(uid);
@@ -215,7 +215,7 @@ const createEntityManager = db => {
       return result;
     },
 
-    async update(uid, params) {
+    async update(uid, params = {}) {
       const states = await db.lifecycles.run('beforeUpdate', uid, { params });
 
       const metadata = db.metadata.get(uid);
@@ -265,7 +265,7 @@ const createEntityManager = db => {
     },
 
     // TODO: where do we handle relation processing for many queries ?
-    async updateMany(uid, params) {
+    async updateMany(uid, params = {}) {
       const states = await db.lifecycles.run('beforeUpdateMany', uid, { params });
 
       const metadata = db.metadata.get(uid);
@@ -289,7 +289,7 @@ const createEntityManager = db => {
       return result;
     },
 
-    async delete(uid, params) {
+    async delete(uid, params = {}) {
       const states = await db.lifecycles.run('beforeDelete', uid, { params });
 
       const { where, select, populate } = params;
@@ -324,7 +324,7 @@ const createEntityManager = db => {
     },
 
     // TODO: where do we handle relation processing for many queries ?
-    async deleteMany(uid, params) {
+    async deleteMany(uid, params = {}) {
       const states = await db.lifecycles.run('beforeDeleteMany', uid, { params });
 
       const { where } = params;

--- a/packages/core/database/lib/lifecycles/index.d.ts
+++ b/packages/core/database/lib/lifecycles/index.d.ts
@@ -43,7 +43,8 @@ export interface Event {
 export interface LifecycleProvider {
   subscribe(subscriber: Subscriber): () => void;
   clear(): void;
-  run(action: Action, uid: string, properties: any): Promise<void>;
+  run(action: Action, uid: string, properties: any): Promise<Map<any, any>>;
+  run(action: Action, uid: string, properties: any, states: Map<any, any>): Promise<Map<any, any>>;
   createEvent(action: Action, uid: string, properties: any): Event;
 }
 

--- a/packages/core/database/lib/lifecycles/index.js
+++ b/packages/core/database/lib/lifecycles/index.js
@@ -33,7 +33,7 @@ const createLifecyclesProvider = db => {
     /**
      * @param {string} action
      * @param {string} uid
-     * @param {{ param?: any, result?: any }} properties
+     * @param {{ params?: any, result?: any }} properties
      * @param {Map<any, any>} state
      */
     createEvent(action, uid, properties, state) {
@@ -50,7 +50,7 @@ const createLifecyclesProvider = db => {
     /**
      * @param {string} action
      * @param {string} uid
-     * @param {{ param?: any, result?: any }} properties
+     * @param {{ params?: any, result?: any }} properties
      * @param {Map<any, any>} states
      */
     async run(action, uid, properties, states = new Map()) {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Fix state not being shared between "beforeXXX" and "afterXXX" events, as described in the documentation here:
https://docs.strapi.io/developer-docs/latest/development/backend-customization/models.html#hook-event-object

### Why is it needed?

The feature is described in the documentation.
Sharing state can be useful to update external resources for instance.

### How to test it?

* Create a content-type `<type>` from the UI
* Create `lifecycles.js` file in `src/api/<type>/content-types/<type>`
* Minimal test case code
```js

module.exports = {
    async beforeUpdate(event) {
        event.state = 'hello world';
        return event;
    },

    async afterUpdate(event) {
        // event.state is undefined before this fix, but it should be set to 'hello world'
        console.log(event.state);
    },
};
```

### Related issue(s)/PR(s)

None
