### PR TITLE
fix(editor): set proper line height

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/Wysiwyg/EditorStylesContainer.js
+++ b/packages/core/admin/admin/src/content-manager/components/Wysiwyg/EditorStylesContainer.js
@@ -224,7 +224,7 @@ export const EditorStylesContainer = styled.div`
     margin: 0;
     white-space: pre;
     word-wrap: normal;
-    line-height: inherit;
+    line-height: 1.5;
     color: inherit;
     /* z-index: 2; */
     position: relative;

--- a/packages/core/admin/admin/src/content-manager/components/Wysiwyg/tests/index.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/Wysiwyg/tests/index.test.js
@@ -818,7 +818,7 @@ describe('Wysiwyg render and actions buttons', () => {
         margin: 0;
         white-space: pre;
         word-wrap: normal;
-        line-height: inherit;
+        line-height: 1.5;
         color: inherit;
         position: relative;
         overflow: visible;


### PR DESCRIPTION
### What does it do?

Set `line-height` of the editor content to `1.5`.

### Why is it needed?

Currently, the `line-height` inherits from `body` where it is set to `1`. This lead to very tight leading, which makes the text inside of the editor hard to read.

### How to test it?

Open WYSIWYG editor and edit text.

#### Current state

<img width="880" alt="Screenshot 2022-01-16 at 13 50 04" src="https://user-images.githubusercontent.com/7645967/149660772-07c5fbd0-c808-4759-9962-111a45e507f5.png">

#### Updated 

<img width="939" alt="Screenshot 2022-01-16 at 13 49 11" src="https://user-images.githubusercontent.com/7645967/149660786-281224f2-4465-42ea-bb02-ac32376106f5.png">


