### PR TITLE
Fix admin.port not used in the webpack dev server configuration

### DIFF
--- a/packages/core/admin/index.js
+++ b/packages/core/admin/index.js
@@ -29,6 +29,11 @@ function getCustomWebpackConfig(dir, config) {
     const webpackAdminConfig = require(path.resolve(adminConfigPath));
 
     if (_.isFunction(webpackAdminConfig)) {
+      // Expose the devServer configuration
+      if (config.devServer) {
+        webpackConfig.devServer = config.devServer;
+      }
+
       webpackConfig = webpackAdminConfig(webpackConfig, webpack);
 
       if (!webpackConfig) {
@@ -232,41 +237,42 @@ async function watchAdmin({ plugins, dir, host, port, browser, options }) {
     port,
     options,
     roots,
+    devServer: {
+      port,
+      client: {
+        logging: 'none',
+        overlay: {
+          errors: true,
+          warnings: false,
+        },
+      },
+
+      open: browser === 'true' ? true : browser,
+      devMiddleware: {
+        publicPath: options.adminPath,
+      },
+      historyApiFallback: {
+        index: options.adminPath,
+        disableDotRule: true,
+      },
+    },
   };
 
   const webpackConfig = getCustomWebpackConfig(dir, args);
-  const opts = {
-    client: {
-      logging: 'none',
-      overlay: {
-        errors: true,
-        warnings: false,
-      },
-    },
 
-    open: browser === 'true' ? true : browser,
-    devMiddleware: {
-      publicPath: options.adminPath,
-    },
-    historyApiFallback: {
-      index: options.adminPath,
-      disableDotRule: true,
-    },
+  const compiler = webpack(webpackConfig);
 
-    ...webpack(webpackConfig).options.devServer,
-  };
+  const server = new WebpackDevServer(compiler.options.devServer, compiler);
 
-  const server = new WebpackDevServer(opts, webpack(webpackConfig));
-
-  server.start(port, host, function(err) {
-    if (err) {
-      console.log(err);
-    }
-
+  const runServer = async () => {
     console.log(chalk.green('Starting the development server...'));
     console.log();
     console.log(chalk.green(`Admin development at http://${host}:${port}${options.adminPath}`));
-  });
+
+    await server.start();
+  };
+
+  runServer();
 
   watchFiles(dir);
 }


### PR DESCRIPTION
Signed-off-by: soupette <cyril@strapi.io>

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

It exposes the webpack devServer configuration when extending the configuration.

It fixes #11936 

### Why is it needed?

To be able to change the port when developing the in the admin panel.

### How to test it?

1. Change the `/config/admin.js` configuration:

```js
module.exports = ({ env }) => ({
  // autoOpen: false,
  auth: {
    secret: env('ADMIN_JWT_SECRET', 'example-token'),
  },
  port: 3000
});
```
2. Run `yarn develop --watch-admin`


It should open the dev server on the 3000 port.


### Related issue(s)/PR(s)
It fixes #11936 

