### PR TITLE
Translations cleanup: duplicates finder script

### DIFF
--- a/scripts/front/find-duplicate-translation-values.js
+++ b/scripts/front/find-duplicate-translation-values.js
@@ -1,0 +1,93 @@
+'use strict';
+
+const chalk = require('chalk');
+const { merge } = require('lodash/fp');
+const { readAllTranslationFiles } = require('./utils/translation-files');
+
+const printResults = results => {
+  let valuesCount = 0;
+  let keysCount = 0;
+
+  results.forEach(values => {
+    Object.entries(values).forEach(([value, pkgs]) => {
+      Object.entries(pkgs).forEach(([packageName, keys]) => {
+        keys.forEach(key => {
+          console.log(`"${chalk.yellow(value)}" ${packageName} ${chalk.blue(key)}`);
+          keysCount++;
+        });
+      });
+      valuesCount++;
+      console.log();
+    });
+  });
+
+  console.log(`${valuesCount} duplicated values`);
+  console.log(`${keysCount} keys can be merged`);
+};
+
+const getDuplicatesObject = (prevDups = {}, { f1Key, f2Keys, f1PackageName, f2PackageName }) => {
+  const f1PackagePrevDups = prevDups[f1PackageName] || [];
+  const f2PackagePrevDups = prevDups[f2PackageName] || [];
+  const duplicates = {};
+
+  // Merge and spread duplicate keys array to sets to remove duplicates
+  duplicates[f1PackageName] = new Set([...f1PackagePrevDups, f1Key]);
+  duplicates[f2PackageName] = new Set([...f2PackagePrevDups, ...f2Keys]);
+
+  return duplicates;
+};
+
+const findDuplicates = (file1, file2, { sameFile } = { sameFile: false }) => {
+  const dupValues = {};
+
+  // Find in file2 duplicates of every file1 value
+  // Format a duplicate object and add it to the dupValues object with translation value as key
+  Object.entries(file1.fileContent).forEach(([f1Key, f1Value]) => {
+    // Match translations with the same value
+    // Skip translations with identical key in a same file (avoid matching itself)
+    // Get an array of keys
+    const f2Keys = Object.entries(file2.fileContent)
+      .filter(([, f2Value]) => f2Value === f1Value)
+      .filter(([f2Key]) => !sameFile || f1Key !== f2Key)
+      .map(([f2Key]) => f2Key);
+
+    // Add a duplicate value to dupValues if duplicates have been found
+    if (f2Keys.length > 0) {
+      dupValues[f1Value] = getDuplicatesObject(dupValues[f1Value], {
+        f1Key,
+        f2Keys,
+        f1PackageName: file1.packageName,
+        f2PackageName: file2.packageName,
+      });
+    }
+  });
+
+  return dupValues;
+};
+
+const findDuplicateTranslationValues = () => {
+  const files = readAllTranslationFiles();
+
+  // Separate core/admin file from plugin files
+  const [coreFile] = files.splice(files.findIndex(file => file.packageName === 'core/admin'), 1);
+  const pluginFiles = files;
+
+  // Find duplicates inside every file separately
+  const coreAdminDuplicates = findDuplicates(coreFile, coreFile, { sameFile: true });
+  const pluginsDuplicates = pluginFiles.map(pluginFile =>
+    findDuplicates(pluginFile, pluginFile, { sameFile: true })
+  );
+
+  // Find duplicates between core/admin and every plugin file
+  // Merge the results with core/admin duplicates to avoid showing the same key twice
+  // (in case core/admin contains duplicate values that also exists in a plugin)
+  let crossPackagesDuplicates = coreAdminDuplicates;
+  pluginFiles.forEach(file => {
+    crossPackagesDuplicates = merge(crossPackagesDuplicates, findDuplicates(coreFile, file));
+  });
+
+  return [crossPackagesDuplicates, ...pluginsDuplicates];
+};
+
+// Entrypoint
+printResults(findDuplicateTranslationValues());

--- a/scripts/front/utils/translation-files.js
+++ b/scripts/front/utils/translation-files.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const glob = require('glob');
+
+const PACKAGES_DIR_PATH = 'packages/';
+const TRANSLATION_FILE_PATH = '/admin/src/translations/en.json';
+
+const getPackageNameFromPath = filePath => {
+  return filePath.replace(PACKAGES_DIR_PATH, '').replace(TRANSLATION_FILE_PATH, '');
+};
+
+const readTranslationFile = filePath => ({
+  filePath,
+  packageName: getPackageNameFromPath(filePath),
+  fileContent: JSON.parse(fs.readFileSync(filePath).toString('utf-8')),
+});
+
+const readAllTranslationFiles = () => {
+  const translationFilesPaths = [
+    ...glob.sync(path.join(PACKAGES_DIR_PATH, 'core/*/', TRANSLATION_FILE_PATH)),
+    ...glob.sync(path.join(PACKAGES_DIR_PATH, 'plugins/*/', TRANSLATION_FILE_PATH)),
+  ];
+
+  return translationFilesPaths.map(readTranslationFile);
+};
+
+module.exports = {
+  readTranslationFile,
+  readAllTranslationFiles,
+};


### PR DESCRIPTION
### What does it do?

Adds a script to detect duplicate translations
- Search for duplicates within each file (separately)
- Search for duplicates between the main translation file (core/admin) and every other file

Output example:

![image](https://user-images.githubusercontent.com/89356961/149798205-181858ca-27d8-4b8d-a149-ca8d0ba563be.png)

### Why is it needed?

To cleanup and maintain the translation files

### How to test it?

```sh
node scripts/front/find-duplicate-translation-values.js
```
