### PR TITLE
Prepare for deprecated cluster.isMaster in node > 16.0.0

### DIFF
--- a/packages/core/strapi/lib/commands/develop.js
+++ b/packages/core/strapi/lib/commands/develop.js
@@ -22,7 +22,7 @@ module.exports = async function({ build, watchAdmin, polling, browser }) {
   const logger = createLogger(config.logger, {});
 
   try {
-    if (cluster.isMaster) {
+    if (cluster.isMaster || cluster.isPrimary) {
       const serveAdminPanel = getOr(true, 'admin.serveAdminPanel')(config);
 
       const buildExists = fs.existsSync(path.join(dir, 'build'));


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

**Cluster.isMaster => Cluster.isPrimary** 
A minor fix that will embrace backward and forward compatibility with the Cluster module. 

### Why is it needed?

Cluster.isMaster was marked as deprecated by node since version 16.0.0
This fix will allow to continue using the deprecated name with prior node versions and prepare the codebase to work with the new name. [nodejs.org/api/cluster](https://nodejs.org/api/cluster.html#clusterismaster)
