### PR TITLE
Remove region from S3 Upload Provider Middleware Docs

### DIFF
--- a/packages/providers/upload-aws-s3/README.md
+++ b/packages/providers/upload-aws-s3/README.md
@@ -67,8 +67,8 @@ module.exports = [
         useDefaults: true,
         directives: {
           'connect-src': ["'self'", 'https:'],
-          'img-src': ["'self'", 'data:', 'blob:', 'yourBucketName.s3.yourRegion.amazonaws.com'],
-          'media-src': ["'self'", 'data:', 'blob:', 'yourBucketName.s3.yourRegion.amazonaws.com'],
+          'img-src': ["'self'", 'data:', 'blob:', 'yourBucketName.s3.amazonaws.com'],
+          'media-src': ["'self'", 'data:', 'blob:', 'yourBucketName.s3.amazonaws.com'],
           upgradeInsecureRequests: null,
         },
       },


### PR DESCRIPTION
### What does it do?

Updates S3 upload provider documentation to remove region from the Security Middleware Configuration.

### Why is it needed?

When including the region in the configuration, I was unable to see the thumbnails as expected. I was able to correct this issue by removing the region information from the `img-src` and `media-src` directives. S3 is somewhat region-less, so including the region is likely unneeded and that may explain why the issue was present.

### How to test it?

Using the S3 upload provider, set the `img-src` and `media-src` directives to include a region as originally documented, with a string like `yourBucketName.s3.yourRegion.amazonaws.com`. Notice if the thumbnails for uploaded images are shown as expected. Remove the region from the string and observe the new state of the thumbnails.

### Related issue(s)/PR(s)

No issues related to this issue found in a quick check.
