### PR TITLE
Enable to drop image to upload dialog in edit view

### DIFF
--- a/packages/core/upload/admin/src/components/UploadAssetDialog/AddAssetStep/FromComputerForm.js
+++ b/packages/core/upload/admin/src/components/UploadAssetDialog/AddAssetStep/FromComputerForm.js
@@ -67,6 +67,24 @@ export const FromComputerForm = ({ onClose, onAddAssets, trackedLocation }) => {
     onAddAssets(assets);
   };
 
+  const handleDrop = e => {
+    if (e?.dataTransfer?.files) {
+      const files = e.dataTransfer.files;
+      const assets = [];
+
+      for (let i = 0; i < files.length; i++) {
+        const file = files.item(i);
+        const asset = rawFileToAsset(file, AssetSource.Computer);
+
+        assets.push(asset);
+      }
+
+      onAddAssets(assets);
+    }
+
+    setDragOver(false);
+  };
+
   return (
     <form>
       <Box paddingLeft={8} paddingRight={8} paddingTop={6} paddingBottom={6}>
@@ -81,6 +99,7 @@ export const FromComputerForm = ({ onClose, onAddAssets, trackedLocation }) => {
             position="relative"
             onDragEnter={handleDragEnter}
             onDragLeave={handleDragLeave}
+            onDrop={handleDrop}
           >
             <Flex justifyContent="center">
               <Wrapper>


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Enable to drop image to upload dialog in edit view

### Why is it needed?

Because drag & drop image uploading doesn't work

### How to test it?

1. Create Content-type with media field
2. Drop & Drop image to asset box

### Related issue(s)/PR(s)

Close #12230 