### PR TITLE
fix: skip git config file that looks like dir

### DIFF
--- a/packages/core/strapi/lib/core/loaders/apis.js
+++ b/packages/core/strapi/lib/core/loaders/apis.js
@@ -126,7 +126,7 @@ const loadContentTypes = async dir => {
 };
 
 const loadDir = async dir => {
-  if (!(await fse.pathExists(dir))) {
+  if (!(await fse.pathExists(dir)) || fse.stat(dir).isFile()) {
     return;
   }
 

--- a/packages/core/strapi/lib/core/loaders/apis.js
+++ b/packages/core/strapi/lib/core/loaders/apis.js
@@ -6,31 +6,35 @@ const _ = require('lodash');
 const fse = require('fs-extra');
 const { isKebabCase } = require('@strapi/utils');
 
-// to handle names with numbers in it we first check if it is already in kebabCase
-const normalizeName = name => (isKebabCase(name) ? name : _.kebabCase(name));
-
 const DEFAULT_CONTENT_TYPE = {
   schema: {},
   actions: {},
   lifecycles: {},
 };
 
+// to handle names with numbers in it we first check if it is already in kebabCase
+const normalizeName = name => (isKebabCase(name) ? name : _.kebabCase(name));
+
+const isDirectory = fd => fd.isDirectory();
+const isDotFile = fd => fd.name.startsWith('.');
+
 module.exports = async strapi => {
   if (!existsSync(strapi.dirs.api)) {
     throw new Error('Missing api folder. Please create one at `./src/api`');
   }
 
-  const apisFDs = await fse.readdir(strapi.dirs.api, { withFileTypes: true });
+  const apisFDs = await (await fse.readdir(strapi.dirs.api, { withFileTypes: true }))
+    .filter(isDirectory)
+    .filter(_.negate(isDotFile));
+
   const apis = {};
 
   // only load folders
   for (const apiFD of apisFDs) {
-    if (apiFD.isDirectory()) {
-      const apiName = normalizeName(apiFD.name);
-      const api = await loadAPI(join(strapi.dirs.api, apiFD.name));
+    const apiName = normalizeName(apiFD.name);
+    const api = await loadAPI(join(strapi.dirs.api, apiFD.name));
 
-      apis[apiName] = api;
-    }
+    apis[apiName] = api;
   }
 
   validateContentTypesUnicity(apis);
@@ -126,7 +130,7 @@ const loadContentTypes = async dir => {
 };
 
 const loadDir = async dir => {
-  if (!(await fse.pathExists(dir)) || fse.stat(dir).isFile()) {
+  if (!(await fse.pathExists(dir))) {
     return;
   }
 


### PR DESCRIPTION
### What does it do?

I want to track the folders in /src/api in their own git repo, as I can imagine reusing some of that on different projects. I ended up with /src/api/.git/config, which I think made the loader try to add .git as a content type. :)

The error message when I ran strapi develop was:

```
error: ENOTDIR: not a directory, scandir '/api/src/api/.git/config'
api         | Error: ENOTDIR: not a directory, scandir '/api/src/api/.git/config'
```

loadDir was checking that the path to "config" existed, but not that config was folder, so fse was getting confused at readdir. This adds an additional check that config is a directory rather than a path.