### PR TITLE
Fix duplicate & crop an image on the media library file edit form

### DIFF
--- a/packages/core/upload/admin/src/components/EditAssetDialog/PreviewBox/AssetPreview.js
+++ b/packages/core/upload/admin/src/components/EditAssetDialog/PreviewBox/AssetPreview.js
@@ -11,12 +11,15 @@ const CardAsset = styled(Flex)`
   border-radius: ${({ theme }) => theme.borderRadius} ${({ theme }) => theme.borderRadius} 0 0;
   background: linear-gradient(180deg, #ffffff 0%, #f6f6f9 121.48%);
 `;
+const Img = styled.img``;
 
 export const AssetPreview = forwardRef(({ mime, url, name }, ref) => {
   const [lang] = usePersistentState('strapi-admin-language', 'en');
 
   if (mime.includes(AssetType.Image)) {
-    return <img ref={ref} src={url} alt={name} />;
+    console.log(mime);
+
+    return <Img ref={ref} src={url} alt={name} />;
   }
 
   if (mime.includes(AssetType.Video)) {

--- a/packages/core/upload/admin/src/components/EditAssetDialog/PreviewBox/AssetPreview.js
+++ b/packages/core/upload/admin/src/components/EditAssetDialog/PreviewBox/AssetPreview.js
@@ -11,15 +11,12 @@ const CardAsset = styled(Flex)`
   border-radius: ${({ theme }) => theme.borderRadius} ${({ theme }) => theme.borderRadius} 0 0;
   background: linear-gradient(180deg, #ffffff 0%, #f6f6f9 121.48%);
 `;
-const Img = styled.img``;
 
 export const AssetPreview = forwardRef(({ mime, url, name }, ref) => {
   const [lang] = usePersistentState('strapi-admin-language', 'en');
 
   if (mime.includes(AssetType.Image)) {
-    console.log(mime);
-
-    return <Img ref={ref} src={url} alt={name} />;
+    return <img ref={ref} src={url} alt={name} />;
   }
 
   if (mime.includes(AssetType.Video)) {

--- a/packages/core/upload/admin/src/components/EditAssetDialog/PreviewBox/index.js
+++ b/packages/core/upload/admin/src/components/EditAssetDialog/PreviewBox/index.js
@@ -114,7 +114,7 @@ export const PreviewBox = ({
     const nextAsset = { ...asset, width, height };
     const file = await produceFile(nextAsset.name, nextAsset.mime, nextAsset.updatedAt);
 
-    await upload(file);
+    await upload({ name: file.name, rawFile: file });
 
     trackUsage('didCropFile', { duplicatedFile: true, location: trackedLocation });
 


### PR DESCRIPTION
### Why is it needed?

The duplicate & crop feature does not work anymore

### How to test it?

- Go to the media library
- Upload an image
- Click the pencil icon button on the image to open the edit modal 
- Click the crop icon button 
- Try to Save (Duplicate & crop)

![Screenshot 2022-01-24 at 09 58 28](https://user-images.githubusercontent.com/7756284/150754967-90f11d64-fdba-4d8a-81eb-5c5a1579bb24.png)
