### PR TITLE
Make component category translatable

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/DynamicZone/components/ComponentPicker/Category/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/DynamicZone/components/ComponentPicker/Category/index.js
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types';
 import { Accordion, AccordionToggle, AccordionContent } from '@strapi/design-system/Accordion';
 import { Box } from '@strapi/design-system/Box';
 import styled from 'styled-components';
-import ComponentCard from './ComponentCard';
 import { useIntl } from 'react-intl';
+import ComponentCard from './ComponentCard';
 
 const Grid = styled.div`
   display: grid;

--- a/packages/core/admin/admin/src/content-manager/components/DynamicZone/components/ComponentPicker/Category/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/DynamicZone/components/ComponentPicker/Category/index.js
@@ -4,6 +4,7 @@ import { Accordion, AccordionToggle, AccordionContent } from '@strapi/design-sys
 import { Box } from '@strapi/design-system/Box';
 import styled from 'styled-components';
 import ComponentCard from './ComponentCard';
+import { useIntl } from 'react-intl';
 
 const Grid = styled.div`
   display: grid;
@@ -12,6 +13,8 @@ const Grid = styled.div`
 `;
 
 const Category = ({ category, components, isOdd, isOpen, onAddComponent, onToggle }) => {
+  const { formatMessage } = useIntl();
+
   const handleToggle = () => {
     onToggle(category);
   };
@@ -20,7 +23,7 @@ const Category = ({ category, components, isOdd, isOpen, onAddComponent, onToggl
     <Accordion expanded={isOpen} toggle={handleToggle} size="S">
       <AccordionToggle
         variant={isOdd ? 'primary' : 'secondary'}
-        title={category}
+        title={formatMessage({ id: category, defaultMessage: category })}
         togglePosition="left"
       />
       <AccordionContent>


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Tries to use translation for category label in the dynamic zone component picker.

### Why is it needed?

Internationalization of the admin panel.

### How to test it?

Setup environment, create a dynamic zone with some components. Override the translation of the category name in `src/admin/app.js` (`config.translations`).
