### PR TITLE
Adding line break and empty line in markdown preview.

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/PreviewWysiwyg/Wrapper.js
+++ b/packages/core/admin/admin/src/content-manager/components/PreviewWysiwyg/Wrapper.js
@@ -13,6 +13,7 @@ const Wrapper = styled.div`
   cursor: not-allowed;
   color: ${({ theme }) => theme.colors.neutral800};
   white-space: pre-wrap;
+
   h1,
   h2,
   h3,

--- a/packages/core/admin/admin/src/content-manager/components/PreviewWysiwyg/Wrapper.js
+++ b/packages/core/admin/admin/src/content-manager/components/PreviewWysiwyg/Wrapper.js
@@ -12,7 +12,7 @@ const Wrapper = styled.div`
   z-index: 2;
   cursor: not-allowed;
   color: ${({ theme }) => theme.colors.neutral800};
-
+  white-space: pre-wrap;
   h1,
   h2,
   h3,


### PR DESCRIPTION
### What does it do?
Enhances the markdown preview in the admin panel.
Added CSS property to achieve the required feature.
Before - 
![Wrapper js - strapi - Visual Studio Code 1_25_2022 3_21_12 PM](https://user-images.githubusercontent.com/27822551/150955430-e4feb080-3d3a-4119-a394-3c7f66ff4019.png)

After - 
![Content Manager — Mozilla Firefox 1_25_2022 3_20_45 PM](https://user-images.githubusercontent.com/27822551/150955454-77b468e3-a8cb-4667-949f-a66c9b1972fd.png)


### Why is it needed?
Enhancing the markdown preview thus provides a great experience to the writer.

### Related issue(s)/PR(s)
#12121 
