### PR TITLE
Add strapi as peerDependency to Strapi Market plugins

### DIFF
--- a/packages/plugins/documentation/package.json
+++ b/packages/plugins/documentation/package.json
@@ -44,6 +44,9 @@
     "reselect": "^4.0.0",
     "swagger-ui-dist": "3.47.1"
   },
+  "peerDependencies": {
+    "@strapi/strapi": "^4.0.0"
+  },
   "engines": {
     "node": ">=12.22.0 <=16.x.x",
     "npm": ">=6.0.0"

--- a/packages/plugins/graphql/package.json
+++ b/packages/plugins/graphql/package.json
@@ -51,6 +51,9 @@
     "cross-env": "^7.0.3",
     "koa": "^2.13.1"
   },
+  "peerDependencies": {
+    "@strapi/strapi": "^4.0.0"
+  },
   "engines": {
     "node": ">=12.22.0 <=16.x.x",
     "npm": ">=6.0.0"

--- a/packages/plugins/sentry/package.json
+++ b/packages/plugins/sentry/package.json
@@ -26,6 +26,9 @@
   "dependencies": {
     "@sentry/node": "6.7.1"
   },
+  "peerDependencies": {
+    "@strapi/strapi": "^4.0.0"
+  },
   "engines": {
     "node": ">=12.22.0 <=16.x.x",
     "npm": ">=6.0.0"


### PR DESCRIPTION
### What does it do?

Adds Strapi as a peerDependency to the sentry, graphql and docs plugins

### Why is it needed?

Sentry, GraphQL & Documentation plugins are listed on the marketplace. It is a [requirement](https://market.strapi.io/guidelines#guidelines) of Strapi Market to specify `@strapi/strapi` compatibility as a peerDependency. This lets the marketplace know if a plugin is compatible with a user's version of Strapi. Also, it generates an npm warning when you install an incompatible Strapi plugin.

### Related issue(s)/PR(s)

I'll create a similar PR for v3 too
