### PR TITLE
Throw error if users try to sign up with a username that is already taken

### DIFF
--- a/packages/plugins/users-permissions/server/controllers/auth.js
+++ b/packages/plugins/users-permissions/server/controllers/auth.js
@@ -339,6 +339,16 @@ module.exports = {
       throw new ApplicationError('Email is already taken');
     }
 
+    if (params.username) {
+      const userWithUsername = await strapi.query('plugin::users-permissions.user').findOne({
+        where: { username: params.username },
+      });
+
+      if (userWithUsername) {
+        throw new ApplicationError('Username is already taken');
+      }
+    }
+
     try {
       if (!settings.email_confirmation) {
         params.confirmed = true;


### PR DESCRIPTION
…aken

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Solves #12319.

### Why is it needed?

It prevents multiple users from signing up with the same username.

### How to test it?

Try creating two users with the same username through a POST request to `/api/auth/local/register`.

### Related issue(s)/PR(s)

#12319