### PR TITLE
Fix SSO redirection

### DIFF
--- a/packages/core/admin/ee/admin/pages/App/utils/customRoutes.js
+++ b/packages/core/admin/ee/admin/pages/App/utils/customRoutes.js
@@ -2,7 +2,7 @@ import AuthResponse from '../../AuthResponse';
 
 const customRoutes = [
   {
-    Component: AuthResponse,
+    Component: () => ({ default: AuthResponse }),
     to: '/auth/login/:authResponse',
     exact: true,
   },

--- a/packages/core/admin/ee/server/controllers/authentication/utils.js
+++ b/packages/core/admin/ee/server/controllers/authentication/utils.js
@@ -12,7 +12,7 @@ const getAdminStore = async () => strapi.store({ type: 'core', name: 'admin' });
 
 const getPrefixedRedirectUrls = () => {
   const { url: adminUrl } = strapi.config.get('admin');
-  const prefixUrl = url => `${adminUrl || ''}${url}`;
+  const prefixUrl = url => `${adminUrl || '/admin'}${url}`;
 
   return mapValues(prefixUrl, PROVIDER_URLS_MAP);
 };


### PR DESCRIPTION
### What does it do?

Redirect URLs for SSO were missing a default "admin" value since the route has changed for the V4.

### Why is it needed?

Redirect for SSO is broken. See #12328 

### How to test it?

See #12328 

### Related issue(s)/PR(s)

fix #12328 