### PR TITLE
fix: Documentation settings load from json file

### DIFF
--- a/packages/plugins/documentation/server/services/documentation.js
+++ b/packages/plugins/documentation/server/services/documentation.js
@@ -149,10 +149,7 @@ module.exports = ({ strapi }) => {
         'full_documentation.json'
       );
 
-      const settings = {
-        ..._.cloneDeep(defaultConfig),
-        ...this.getDocumentationSettings()
-      };
+      const settings = _.merge(_.cloneDeep(defaultConfig), this.getDocumentationSettings());
 
       const serverUrl = getAbsoluteServerUrl(strapi.config);
       const apiPath = strapi.config.get('api.rest.prefix');

--- a/packages/plugins/documentation/server/services/documentation.js
+++ b/packages/plugins/documentation/server/services/documentation.js
@@ -149,22 +149,22 @@ module.exports = ({ strapi }) => {
         'full_documentation.json'
       );
 
-      const settings = _.merge(_.cloneDeep(defaultConfig), this.getDocumentationSettings());
+      const defaultSettings = _.cloneDeep(defaultConfig);
 
       const serverUrl = getAbsoluteServerUrl(strapi.config);
       const apiPath = strapi.config.get('api.rest.prefix');
 
-      if(_.isEmpty(settings.servers)) {
-        _.set(settings, 'servers', [
-          {
-            url: `${serverUrl}${apiPath}`,
-            description: 'Development server',
-          },
-        ]);
-      }
+      _.set(defaultSettings, 'servers', [
+        {
+          url: `${serverUrl}${apiPath}`,
+          description: 'Development server',
+        },
+      ]);
 
-      _.set(settings, ['info', 'x-generation-date'], new Date().toISOString());
-      _.set(settings, ['info', 'version'], version);
+      _.set(defaultSettings, ['info', 'x-generation-date'], new Date().toISOString());
+      _.set(defaultSettings, ['info', 'version'], version);
+
+      const settings = _.merge(defaultSettings, this.getDocumentationSettings());
 
       await fs.ensureFile(fullDocJsonPath);
       await fs.writeJson(fullDocJsonPath, { ...settings, paths }, { spaces: 2 });


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

The settings for the documentation that can be set as described [here](https://docs.strapi.io/developer-docs/latest/plugins/documentation.html#settings) weren't merged with the default config. This way the settings could not be set.

### Why is it needed?

The custom documentation setting weren't loaded.

### How to test it?

Follow the documentation [here](https://docs.strapi.io/developer-docs/latest/plugins/documentation.html#settings) and after regenerating your documentation, check if the documentation settings are updated. 

### Related issue(s)/PR(s)

Checked https://github.com/strapi/strapi/pull/12070, but added a check for the servers as otherwise it is overridden.
https://github.com/strapi/strapi/issues/12046
https://github.com/strapi/strapi/issues/11840
