### PR TITLE
Remove extra forward slash from user-permissions base URL

### DIFF
--- a/packages/plugins/users-permissions/server/bootstrap/index.js
+++ b/packages/plugins/users-permissions/server/bootstrap/index.js
@@ -41,7 +41,7 @@ module.exports = async ({ strapi }) => {
 
 const initGrant = async pluginStore => {
   const apiPrefix = strapi.config.get('api.rest.prefix');
-  const baseURL = `${strapi.config.server.url}/${apiPrefix}/auth`;
+  const baseURL = `${strapi.config.server.url}${apiPrefix}/auth`;
 
   const grantConfig = {
     email: {


### PR DESCRIPTION
When the user-permissions plugin bootstraps, it is creating some URLs in the database with an extra slash.

`strapi.config.get('api.rest.prefix')` defaults to '/api' so it should already have a slash

See packages/core/strapi/lib/services/server/content-api.js where it is set.
```
prefix: strapi.config.get('api.rest.prefix', '/api'),
```

### What does it do?

Fixes bootstrap URI in user-permissions plugin that made URIs look like `http://localhost:1337//api/auth/facebook/callback` instead of `http://localhost:1337/api/auth/facebook/callback`

### Why is it needed?

Login process wasn't working with two slashes when using CAS provider. 

