### PR TITLE
Docs: Update PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,10 +3,10 @@ Hello 👋 Thank you for submitting a pull request.
 
 To help us merge your PR, make sure to follow the instructions below:
 
-- Create or update the documentation. (Should be made against the documentation branch)
-- Create or update the tests.
-- Refer to the issue you are closing in the PR description - fix #issue
-- Specify if the PR is in WIP (work in progress) state or ready to be merged
+- Create or update the tests
+- Create or update the documentation at https://github.com/strapi/documentation
+- Refer to the issue you are closing in the PR description: Fix #issue
+- Specify if the PR is work in progress (WIP) or ready to be merged
 
 Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
 -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,9 +6,9 @@ To help us merge your PR, make sure to follow the instructions below:
 - Create or update the tests
 - Create or update the documentation at https://github.com/strapi/documentation
 - Refer to the issue you are closing in the PR description: Fix #issue
-- Specify if the PR is work in progress (WIP) or ready to be merged
+- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)
 
-Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
+Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
 -->
 
 ### What does it do?


### PR DESCRIPTION
### What does it do?

Updates the wording of the PR template a little bit:

- swapped tests and documentation because usually you'd have to write tests first, before you contribute to the documentation
- mentioned the documentation repository instead of the documentation branch (which, I believe, doesn't exist anymore)

### Why is it needed?

The improve the setup/ contributing experience.
