### PR TITLE
Translation key correction of wording

### DIFF
--- a/packages/core/email/admin/src/pages/Settings/index.js
+++ b/packages/core/email/admin/src/pages/Settings/index.js
@@ -205,7 +205,7 @@ const SettingsPage = () => {
                         })
                       }
                       placeholder={formatMessage({
-                        id: 'Settings.email.plugin.placeholder.testAddress',
+                        id: getTrad('Settings.email.plugin.placeholder.testAddress'),
                         defaultMessage: 'ex: developer@example.com',
                       })}
                     />
@@ -217,7 +217,10 @@ const SettingsPage = () => {
                       type="submit"
                       startIcon={<Envelop />}
                     >
-                      Send test email
+                      {formatMessage({
+                        id: getTrad('Settings.email.plugin.button.test-email'),
+                        defaultMessage: 'Send test email',
+                      })}
                     </Button>
                   </GridItem>
                 </Grid>


### PR DESCRIPTION
### What does it do?

Fixed the translation key for the mail plugin.

### Why is it needed?

I was working on a plugin that translates into Japanese, and I noticed that it didn't translate correctly.

### How to test it?

Run examples/getstarted to enable the Japanese language setting.
This is because the default English and French languages do not have a translation key.

When I open the page in question, the buttons and text fields that should have translation keys are still in English.

Settings > Configuration
![fix_before](https://user-images.githubusercontent.com/44352732/152287610-2a09261a-7f8c-4c34-8a93-45b6b0067706.png)
![fix_after](https://user-images.githubusercontent.com/44352732/152287620-aa708ea2-8d02-44be-93df-848c2f09eb43.png)

