### PR TITLE
fix #12395

### DIFF
--- a/packages/core/strapi/lib/services/entity-service/components.js
+++ b/packages/core/strapi/lib/services/entity-service/components.js
@@ -47,7 +47,7 @@ const createComponents = async (uid, data) => {
         );
 
         // TODO: add order
-        componentBody[attributeName] = components.map(({ id }, idx) => {
+        componentBody[attributeName] = components.filter(e => e).map(({ id }, idx) => {
           return {
             id,
             __pivot: {


### PR DESCRIPTION
### What does it do?
I filtered out `NaN`, `null`, `undefined` from the `components` list.

### Why is it needed?
if `components` somehow contained invalid value(s), they would cause an error.

### Related issue(s)/PR(s)
fixes #12395 
