### PR TITLE
CM: Make fields resizable

### DIFF
--- a/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/components/FormModal.js
+++ b/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/components/FormModal.js
@@ -26,7 +26,7 @@ const HeaderContainer = styled(Flex)`
   }
 `;
 
-const FormModal = ({ onToggle, onChange, onSubmit, type }) => {
+const FormModal = ({ onToggle, onMetaChange, onSizeChange, onSubmit, type }) => {
   const { selectedField } = useLayoutDnd();
   const { formatMessage } = useIntl();
 
@@ -61,7 +61,7 @@ const FormModal = ({ onToggle, onChange, onSubmit, type }) => {
         </ModalHeader>
         <ModalBody>
           <Grid gap={4}>
-            <ModalForm onChange={onChange} />
+            <ModalForm onMetaChange={onMetaChange} onSizeChange={onSizeChange} />
           </Grid>
         </ModalBody>
         <ModalFooter
@@ -84,7 +84,8 @@ const FormModal = ({ onToggle, onChange, onSubmit, type }) => {
 FormModal.propTypes = {
   onSubmit: PropTypes.func.isRequired,
   onToggle: PropTypes.func.isRequired,
-  onChange: PropTypes.func.isRequired,
+  onMetaChange: PropTypes.func.isRequired,
+  onSizeChange: PropTypes.func.isRequired,
   type: PropTypes.string.isRequired,
 };
 

--- a/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/components/ModalForm.js
+++ b/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/components/ModalForm.js
@@ -1,6 +1,7 @@
 import React, { useMemo, useCallback } from 'react';
 import get from 'lodash/get';
 import { GridItem } from '@strapi/design-system/Grid';
+import { Select, Option } from '@strapi/design-system/Select';
 import { useSelector, shallowEqual } from 'react-redux';
 import { useIntl } from 'react-intl';
 import { useLayoutDnd } from '../../../hooks';
@@ -9,7 +10,21 @@ import { makeSelectModelAndComponentSchemas } from '../../App/selectors';
 import getTrad from '../../../utils/getTrad';
 import GenericInput from './GenericInput';
 
-const ModalForm = ({ onChange }) => {
+const FIELD_SIZES = [
+  [4, '33%'],
+  [6, '50%'],
+  [8, '66%'],
+  [12, '100%']
+];
+
+const NON_RESIZABLE_FIELD_TYPES = [
+  'dynamiczone',
+  'component',
+  'json',
+  'richtext'
+];
+
+const ModalForm = ({ onMetaChange, onSizeChange }) => {
   const { formatMessage } = useIntl();
   const { modifiedData, selectedField, attributes, fieldForm } = useLayoutDnd();
   const schemasSelector = useMemo(makeSelectModelAndComponentSchemas, []);
@@ -44,7 +59,7 @@ const ModalForm = ({ onChange }) => {
     [selectedField, componentsAndModelsPossibleMainFields, modifiedData]
   );
 
-  return formToDisplay.map(meta => {
+  const metaFields = formToDisplay.map(meta => {
     const formType = get(attributes, [selectedField, 'type']);
 
     if (
@@ -77,13 +92,40 @@ const ModalForm = ({ onChange }) => {
             id: get(getInputProps(meta), 'label.id', 'app.utils.defaultMessage'),
           })}
           name={meta}
-          onChange={onChange}
-          value={get(fieldForm, meta, '')}
+          onChange={onMetaChange}
+          value={get(fieldForm, ['metadata', meta], '')}
           options={getSelectedItemSelectOptions(formType)}
         />
       </GridItem>
     );
   });
+
+  const canResize = !NON_RESIZABLE_FIELD_TYPES.includes(attributes[selectedField].type);
+
+  const sizeField = <GridItem col={6} key="size">
+    <Select
+      value={fieldForm?.size}
+      name="size"
+      onChange={(value) => {
+        onSizeChange({ name: selectedField, value });
+      }}
+      label={formatMessage({
+        id: getTrad('containers.SettingPage.editSettings.size.label'),
+        defaultMessage: "Size"
+      })}
+    >
+      {FIELD_SIZES.map(([value, label]) => (
+        <Option key={value} value={value}>
+          {label}
+        </Option>
+      ))}
+    </Select>
+                    </GridItem>;
+
+  return <>
+    {metaFields}
+    {canResize && sizeField}
+  </>
 };
 
 export default ModalForm;

--- a/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/components/ModalForm.js
+++ b/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/components/ModalForm.js
@@ -1,4 +1,5 @@
 import React, { useMemo, useCallback } from 'react';
+import PropTypes from 'prop-types';
 import get from 'lodash/get';
 import { GridItem } from '@strapi/design-system/Grid';
 import { Select, Option } from '@strapi/design-system/Select';
@@ -120,12 +121,17 @@ const ModalForm = ({ onMetaChange, onSizeChange }) => {
         </Option>
       ))}
     </Select>
-                    </GridItem>;
+  </GridItem>;
 
   return <>
     {metaFields}
     {canResize && sizeField}
   </>
+};
+
+ModalForm.propTypes = {
+  onMetaChange: PropTypes.func.isRequired,
+  onSizeChange: PropTypes.func.isRequired,
 };
 
 export default ModalForm;

--- a/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/components/ModalForm.js
+++ b/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/components/ModalForm.js
@@ -11,19 +11,9 @@ import { makeSelectModelAndComponentSchemas } from '../../App/selectors';
 import getTrad from '../../../utils/getTrad';
 import GenericInput from './GenericInput';
 
-const FIELD_SIZES = [
-  [4, '33%'],
-  [6, '50%'],
-  [8, '66%'],
-  [12, '100%']
-];
+const FIELD_SIZES = [[4, '33%'], [6, '50%'], [8, '66%'], [12, '100%']];
 
-const NON_RESIZABLE_FIELD_TYPES = [
-  'dynamiczone',
-  'component',
-  'json',
-  'richtext'
-];
+const NON_RESIZABLE_FIELD_TYPES = ['dynamiczone', 'component', 'json', 'richtext'];
 
 const ModalForm = ({ onMetaChange, onSizeChange }) => {
   const { formatMessage } = useIntl();
@@ -103,30 +93,34 @@ const ModalForm = ({ onMetaChange, onSizeChange }) => {
 
   const canResize = !NON_RESIZABLE_FIELD_TYPES.includes(attributes[selectedField].type);
 
-  const sizeField = <GridItem col={6} key="size">
-    <Select
-      value={fieldForm?.size}
-      name="size"
-      onChange={(value) => {
-        onSizeChange({ name: selectedField, value });
-      }}
-      label={formatMessage({
-        id: getTrad('containers.SettingPage.editSettings.size.label'),
-        defaultMessage: "Size"
-      })}
-    >
-      {FIELD_SIZES.map(([value, label]) => (
-        <Option key={value} value={value}>
-          {label}
-        </Option>
-      ))}
-    </Select>
-  </GridItem>;
+  const sizeField = (
+    <GridItem col={6} key="size">
+      <Select
+        value={fieldForm?.size}
+        name="size"
+        onChange={value => {
+          onSizeChange({ name: selectedField, value });
+        }}
+        label={formatMessage({
+          id: getTrad('containers.SettingPage.editSettings.size.label'),
+          defaultMessage: 'Size',
+        })}
+      >
+        {FIELD_SIZES.map(([value, label]) => (
+          <Option key={value} value={value}>
+            {label}
+          </Option>
+        ))}
+      </Select>
+    </GridItem>
+  );
 
-  return <>
-    {metaFields}
-    {canResize && sizeField}
-  </>
+  return (
+    <>
+      {metaFields}
+      {canResize && sizeField}
+    </>
+  );
 };
 
 ModalForm.propTypes = {

--- a/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/index.js
@@ -110,6 +110,14 @@ const EditSettingsView = ({ mainLayout, components, isContentTypeView, slug, upd
     });
   };
 
+  const handleSizeChange = ({ name, value }) => {
+    dispatch({
+      type: 'ON_CHANGE_SIZE',
+      name,
+      value,
+    });
+  };
+
   const handleMetaSubmit = e => {
     e.preventDefault();
     dispatch({
@@ -365,7 +373,8 @@ const EditSettingsView = ({ mainLayout, components, isContentTypeView, slug, upd
             onSubmit={handleMetaSubmit}
             onToggle={handleToggleModal}
             type={get(attributes, [metaToEdit, 'type'], '')}
-            onChange={handleMetaChange}
+            onMetaChange={handleMetaChange}
+            onSizeChange={handleSizeChange}
           />
         )}
       </Main>

--- a/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/reducer.js
+++ b/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/reducer.js
@@ -4,7 +4,7 @@ import get from 'lodash/get';
 import cloneDeep from 'lodash/cloneDeep';
 
 import { arrayMoveItem } from '../../utils';
-import { formatLayout, getInputSize } from './utils/layout';
+import { formatLayout, getDefaultInputSize, getFieldSize, setFieldSize } from './utils/layout';
 
 const initialState = {
   fieldForm: {},
@@ -45,7 +45,7 @@ const reducer = (state = initialState, action) =>
       }
       case 'ON_ADD_FIELD': {
         const newState = cloneDeep(state);
-        const size = getInputSize(
+        const size = getDefaultInputSize(
           get(newState, ['modifiedData', 'attributes', action.name, 'type'], '')
         );
         const listSize = get(newState, layoutPathEdit, []).length;
@@ -76,7 +76,11 @@ const reducer = (state = initialState, action) =>
         break;
       }
       case 'ON_CHANGE_META': {
-        set(draftState, ['metaForm', ...action.keys], action.value);
+        set(draftState, ['metaForm', 'metadata', ...action.keys], action.value);
+        break;
+      }
+      case 'ON_CHANGE_SIZE': {
+        set(draftState, ['metaForm', 'size'], action.value);
         break;
       }
       case 'ON_RESET': {
@@ -168,11 +172,28 @@ const reducer = (state = initialState, action) =>
       }
       case 'SET_FIELD_TO_EDIT': {
         draftState.metaToEdit = action.name;
-        draftState.metaForm = get(state, ['modifiedData', 'metadatas', action.name, 'edit'], {});
+        draftState.metaForm = {
+          metadata: get(state, ['modifiedData', 'metadatas', action.name, 'edit'], {}),
+          size:
+            getFieldSize(action.name, state.modifiedData?.layouts?.edit) ?? getDefaultInputSize(),
+        };
+
         break;
       }
       case 'SUBMIT_META_FORM': {
-        set(draftState, ['modifiedData', 'metadatas', state.metaToEdit, 'edit'], state.metaForm);
+        set(
+          draftState,
+          ['modifiedData', 'metadatas', state.metaToEdit, 'edit'],
+          state.metaForm.metadata
+        );
+
+        const layoutsCopy = cloneDeep(get(state, layoutPathEdit, []));
+        const nextLayoutValue = setFieldSize(state.metaToEdit, state.metaForm.size, layoutsCopy);
+
+        if (nextLayoutValue.length > 0) {
+          set(draftState, layoutPathEdit, nextLayoutValue);
+        }
+
         break;
       }
       case 'SUBMIT_SUCCEEDED': {

--- a/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/reducer.js
+++ b/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/reducer.js
@@ -191,7 +191,7 @@ const reducer = (state = initialState, action) =>
         const nextLayoutValue = setFieldSize(state.metaToEdit, state.metaForm.size, layoutsCopy);
 
         if (nextLayoutValue.length > 0) {
-          set(draftState, layoutPathEdit, nextLayoutValue);
+          set(draftState, layoutPathEdit, formatLayout(nextLayoutValue));
         }
 
         break;

--- a/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/tests/reducer.test.js
+++ b/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/tests/reducer.test.js
@@ -150,10 +150,7 @@ describe('CONTENT MANAGER | CONTAINERS | EditSettingsView | reducer', () => {
             edit: [
               {
                 rowId: 0,
-                rowContent: [
-                  { name: 'title', size: 6 },
-                  { name: '_TEMP_', size: 6 },
-                ],
+                rowContent: [{ name: 'title', size: 6 }, { name: '_TEMP_', size: 6 }],
               },
             ],
           },
@@ -173,10 +170,7 @@ describe('CONTENT MANAGER | CONTAINERS | EditSettingsView | reducer', () => {
         edit: [
           {
             rowId: 0,
-            rowContent: [
-              { name: 'title', size: 8 },
-              { name: '_TEMP_', size: 4 },
-            ],
+            rowContent: [{ name: 'title', size: 8 }, { name: '_TEMP_', size: 4 }],
           },
         ],
       };
@@ -192,10 +186,7 @@ describe('CONTENT MANAGER | CONTAINERS | EditSettingsView | reducer', () => {
             edit: [
               {
                 rowId: 0,
-                rowContent: [
-                  { name: 'title', size: 8 },
-                  { name: 'isActive', size: 4 },
-                ],
+                rowContent: [{ name: 'title', size: 8 }, { name: 'isActive', size: 4 }],
               },
             ],
           },
@@ -243,10 +234,7 @@ describe('CONTENT MANAGER | CONTAINERS | EditSettingsView | reducer', () => {
               },
               {
                 rowId: 1,
-                rowContent: [
-                  { name: 'title', size: 6 },
-                  { name: '_TEMP_', size: 6 },
-                ],
+                rowContent: [{ name: 'title', size: 6 }, { name: '_TEMP_', size: 6 }],
               },
             ],
           },
@@ -277,15 +265,36 @@ describe('CONTENT MANAGER | CONTAINERS | EditSettingsView | reducer', () => {
   });
 
   describe('ON_CHANGE_META', () => {
-    it('should set the data to change in the modifiedData object', () => {
-      state.metaForm.label = 'Postal_coder';
+    it('should set the data to change in the modifiedData.metadata object', () => {
+      state.metaForm.metadata = {
+        label: 'Postal_coder',
+      };
       const expected = {
         ...state,
         metaForm: {
-          label: 'postal_code',
+          metadata: {
+            label: 'postal_code',
+          },
         },
       };
       const action = { type: 'ON_CHANGE_META', keys: ['label'], value: 'postal_code' };
+
+      expect(reducer(state, action)).toEqual(expected);
+    });
+  });
+
+  describe('ON_CHANGE_SIZE', () => {
+    it('should set the data to change in the modifiedData.size object', () => {
+      state.metaForm.metadata = {};
+
+      const expected = {
+        ...state,
+        metaForm: {
+          metadata: {},
+          size: 6,
+        },
+      };
+      const action = { type: 'ON_CHANGE_SIZE', name: 'postal_code', value: 6 };
 
       expect(reducer(state, action)).toEqual(expected);
     });
@@ -349,10 +358,7 @@ describe('CONTENT MANAGER | CONTAINERS | EditSettingsView | reducer', () => {
             edit: [
               {
                 rowId: 0,
-                rowContent: [
-                  { name: 'isActive', size: 4 },
-                  { name: '_TEMP_', size: 8 },
-                ],
+                rowContent: [{ name: 'isActive', size: 4 }, { name: '_TEMP_', size: 8 }],
               },
             ],
           },
@@ -398,10 +404,7 @@ describe('CONTENT MANAGER | CONTAINERS | EditSettingsView | reducer', () => {
             },
             {
               rowId: 1,
-              rowContent: [
-                { name: 'slug', size: 6 },
-                { name: '_TEMP_', size: 6 },
-              ],
+              rowContent: [{ name: 'slug', size: 6 }, { name: '_TEMP_', size: 6 }],
             },
           ],
         },
@@ -421,10 +424,7 @@ describe('CONTENT MANAGER | CONTAINERS | EditSettingsView | reducer', () => {
               },
               {
                 rowId: 1,
-                rowContent: [
-                  { name: 'second', size: 4 },
-                  { name: '_TEMP_', size: 8 },
-                ],
+                rowContent: [{ name: 'second', size: 4 }, { name: '_TEMP_', size: 8 }],
               },
             ],
           },
@@ -455,10 +455,7 @@ describe('CONTENT MANAGER | CONTAINERS | EditSettingsView | reducer', () => {
             },
             {
               rowId: 1,
-              rowContent: [
-                { name: 'slug', size: 6 },
-                { name: '_TEMP_', size: 6 },
-              ],
+              rowContent: [{ name: 'slug', size: 6 }, { name: '_TEMP_', size: 6 }],
             },
           ],
         },
@@ -478,10 +475,7 @@ describe('CONTENT MANAGER | CONTAINERS | EditSettingsView | reducer', () => {
               },
               {
                 rowId: 1,
-                rowContent: [
-                  { name: 'slug', size: 6 },
-                  { name: '_TEMP_', size: 6 },
-                ],
+                rowContent: [{ name: 'slug', size: 6 }, { name: '_TEMP_', size: 6 }],
               },
             ],
           },
@@ -505,10 +499,7 @@ describe('CONTENT MANAGER | CONTAINERS | EditSettingsView | reducer', () => {
         edit: [
           {
             rowId: 0,
-            rowContent: [
-              { name: 'city', size: 6 },
-              { name: 'slug', size: 6 },
-            ],
+            rowContent: [{ name: 'city', size: 6 }, { name: 'slug', size: 6 }],
           },
           {
             rowId: 1,
@@ -527,10 +518,7 @@ describe('CONTENT MANAGER | CONTAINERS | EditSettingsView | reducer', () => {
             edit: [
               {
                 rowId: 0,
-                rowContent: [
-                  { name: 'city', size: 6 },
-                  { name: 'slug', size: 6 },
-                ],
+                rowContent: [{ name: 'city', size: 6 }, { name: 'slug', size: 6 }],
               },
               {
                 rowId: 1,
@@ -563,7 +551,10 @@ describe('CONTENT MANAGER | CONTAINERS | EditSettingsView | reducer', () => {
         ...state,
         metaToEdit: 'city',
         metaForm: {
-          label: 'City',
+          metadata: {
+            label: 'City',
+          },
+          size: 6,
         },
         modifiedData: {
           metadatas: {
@@ -585,7 +576,9 @@ describe('CONTENT MANAGER | CONTAINERS | EditSettingsView | reducer', () => {
     it('should submit the meta form', () => {
       state.metaToEdit = 'city';
       state.metaForm = {
-        label: 'New City label',
+        metadata: {
+          label: 'New City label',
+        },
       };
       state.modifiedData.metadatas = {
         city: {
@@ -598,7 +591,9 @@ describe('CONTENT MANAGER | CONTAINERS | EditSettingsView | reducer', () => {
         ...state,
         metaToEdit: 'city',
         metaForm: {
-          label: 'New City label',
+          metadata: {
+            label: 'New City label',
+          },
         },
         modifiedData: {
           metadatas: {
@@ -658,7 +653,7 @@ describe('CONTENT MANAGER | CONTAINERS | EditSettingsView | reducer', () => {
   describe('UNSET_FIELD_TO_EDIT', () => {
     it('should unset the metadatas to edit and the form data', () => {
       state.metaToEdit = 'city';
-      state.metaForm = {
+      state.metaForm.metadata = {
         label: 'New city label',
       };
       const expected = {

--- a/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/utils/layout.js
+++ b/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/utils/layout.js
@@ -28,13 +28,7 @@ const formatLayout = arr => {
 
         return acc2;
       }, []);
-      const rowId =
-        acc.length === 0
-          ? 0
-          : Math.max.apply(
-              Math,
-              acc.map(o => o.rowId)
-            ) + 1;
+      const rowId = acc.length === 0 ? 0 : Math.max.apply(Math, acc.map(o => o.rowId)) + 1;
 
       const currentRowSize = getRowSize(currentRow);
 
@@ -75,7 +69,7 @@ const unformatLayout = arr => {
   }, []);
 };
 
-const getInputSize = type => {
+const getDefaultInputSize = type => {
   switch (type) {
     case 'boolean':
     case 'date':
@@ -95,4 +89,41 @@ const getInputSize = type => {
   }
 };
 
-export { createLayout, formatLayout, getInputSize, getRowSize, unformatLayout };
+const getFieldSize = (name, layouts = []) => {
+  return layouts.reduce((acc, { rowContent }) => {
+    const size = rowContent.find(row => row.name === name)?.size ?? null;
+
+    if (size) {
+      acc = size;
+    }
+
+    return acc;
+  }, null);
+};
+
+const setFieldSize = (name, size, layouts = []) => {
+  return layouts.map(row => {
+    row.rowContent = row.rowContent.map(column => {
+      if (column.name === name) {
+        return {
+          ...column,
+          size,
+        };
+      }
+
+      return column;
+    });
+
+    return row;
+  });
+};
+
+export {
+  createLayout,
+  formatLayout,
+  getDefaultInputSize,
+  getFieldSize,
+  setFieldSize,
+  getRowSize,
+  unformatLayout,
+};

--- a/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/utils/tests/layout.test.js
+++ b/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/utils/tests/layout.test.js
@@ -1,34 +1,30 @@
-import { createLayout, formatLayout, getInputSize, getRowSize, unformatLayout } from '../layout';
+import {
+  createLayout,
+  formatLayout,
+  getDefaultInputSize,
+  getFieldSize,
+  setFieldSize,
+  getRowSize,
+  unformatLayout,
+} from '../layout';
 
 describe('Content Manager | containers | EditSettingsView | utils | layout', () => {
   describe('createLayout', () => {
     it('should return an array of object with keys rowId and rowContent', () => {
       const data = [
-        [
-          { name: 'test', size: 4 },
-          { name: 'test1', size: 4 },
-        ],
+        [{ name: 'test', size: 4 }, { name: 'test1', size: 4 }],
         [{ name: 'test2', size: 12 }],
-        [
-          { name: 'test3', size: 6 },
-          { name: 'test4', size: 1 },
-        ],
+        [{ name: 'test3', size: 6 }, { name: 'test4', size: 1 }],
       ];
       const expected = [
         {
           rowId: 0,
-          rowContent: [
-            { name: 'test', size: 4 },
-            { name: 'test1', size: 4 },
-          ],
+          rowContent: [{ name: 'test', size: 4 }, { name: 'test1', size: 4 }],
         },
         { rowId: 1, rowContent: [{ name: 'test2', size: 12 }] },
         {
           rowId: 2,
-          rowContent: [
-            { name: 'test3', size: 6 },
-            { name: 'test4', size: 1 },
-          ],
+          rowContent: [{ name: 'test3', size: 6 }, { name: 'test4', size: 1 }],
         },
       ];
 
@@ -41,18 +37,12 @@ describe('Content Manager | containers | EditSettingsView | utils | layout', () 
       const data = [
         {
           rowId: 0,
-          rowContent: [
-            { name: 'test', size: 4 },
-            { name: 'test1', size: 4 },
-          ],
+          rowContent: [{ name: 'test', size: 4 }, { name: 'test1', size: 4 }],
         },
         { rowId: 1, rowContent: [{ name: 'test2', size: 12 }] },
         {
           rowId: 2,
-          rowContent: [
-            { name: 'test3', size: 6 },
-            { name: 'test4', size: 1 },
-          ],
+          rowContent: [{ name: 'test3', size: 6 }, { name: 'test4', size: 1 }],
         },
       ];
       const expected = [
@@ -99,10 +89,7 @@ describe('Content Manager | containers | EditSettingsView | utils | layout', () 
         },
         {
           rowId: 3,
-          rowContent: [
-            { name: 'test5', size: 6 },
-            { name: 'test6', size: 6 },
-          ],
+          rowContent: [{ name: 'test5', size: 6 }, { name: 'test6', size: 6 }],
         },
       ];
 
@@ -110,21 +97,94 @@ describe('Content Manager | containers | EditSettingsView | utils | layout', () 
     });
   });
 
-  describe('getInputSize', () => {
+  describe('getDefaultInputSize', () => {
     it('Should return 6 if the type is unknown, undefined or text', () => {
-      expect(getInputSize(undefined)).toBe(6);
-      expect(getInputSize('unkown')).toBe(6);
-      expect(getInputSize('text')).toBe(6);
+      expect(getDefaultInputSize(undefined)).toBe(6);
+      expect(getDefaultInputSize('unkown')).toBe(6);
+      expect(getDefaultInputSize('text')).toBe(6);
     });
 
     it('Should return 12 if the type is either json, component or richtext', () => {
-      expect(getInputSize('json')).toBe(12);
-      expect(getInputSize('richtext')).toBe(12);
-      expect(getInputSize('component')).toBe(12);
+      expect(getDefaultInputSize('json')).toBe(12);
+      expect(getDefaultInputSize('richtext')).toBe(12);
+      expect(getDefaultInputSize('component')).toBe(12);
     });
 
     it('Should return 4 if the type is boolean', () => {
-      expect(getInputSize('boolean')).toBe(4);
+      expect(getDefaultInputSize('boolean')).toBe(4);
+    });
+  });
+
+  describe('getFieldSize', () => {
+    const fixture = [
+      {
+        rowContent: [
+          {
+            name: 'test_1',
+            size: 6,
+          },
+        ],
+      },
+
+      {
+        rowContent: [
+          {
+            name: 'test_2',
+            size: 12,
+          },
+        ],
+      },
+    ];
+
+    const expected = [
+      {
+        name: 'test_1',
+        value: 6,
+      },
+
+      {
+        name: 'test_2',
+        value: 12,
+      },
+
+      {
+        name: 'test_3',
+        value: null,
+      },
+    ];
+
+    expected.forEach(({ name, value }) => {
+      it(`Should return the proper field size for ${name}`, () => {
+        expect(getFieldSize(name, fixture)).toBe(value);
+      });
+    });
+  });
+
+  describe('setFieldSize', () => {
+    const fixture = [
+      {
+        rowContent: [
+          {
+            name: 'test_1',
+            size: 6,
+          },
+        ],
+      },
+    ];
+
+    const expected = [
+      {
+        name: 'test_1',
+        value: 12,
+      },
+    ];
+
+    expected.forEach(({ name, value }) => {
+      it(`Should set the proper field size for ${name}`, () => {
+        const newLayout = setFieldSize(name, value, [...fixture]);
+
+        expect(newLayout[0].rowContent[0].size).toBe(value);
+      });
     });
   });
 
@@ -178,10 +238,7 @@ describe('Content Manager | containers | EditSettingsView | utils | layout', () 
         },
       ];
       const expected = [
-        [
-          { name: 'name', size: 6 },
-          { name: 'test', size: 4 },
-        ],
+        [{ name: 'name', size: 6 }, { name: 'test', size: 4 }],
         [{ name: 'name1', size: 4 }],
       ];
 


### PR DESCRIPTION
### What does it do?

Allows fields to be resized in the content types builder. They can either be `4`, `6`, `8` or `12` columns wide. The field types `dynamiczone`, `component`, `json` and `richtext` are excluded for now and can only render at full-width.

![Screenshot from 2022-02-10 12-32-04](https://user-images.githubusercontent.com/2244375/153400819-9c24eb68-8c5a-45f1-b81c-0b2be628b264.png)

TODO:

- [x] Fix media fields with 33% width: https://github.com/strapi/design-system/pull/502
- [x] Update the design-system dependency 
- [x] Clarify media fields at 100%
- [x] 🐛 When saving the layout, sometimes the resized fields are stored at the end of the layout

### Why is it needed?

Content-editors need to tailor the edit interfaces to their needs.

### How to test it?

1. Go to the content-type builder
2. Add at least one field to the layout
3. Edit the field and select the desired size

### Related issue(s)/PR(s)

Closes: https://github.com/strapi/strapi/issues/8094
Issue: https://strapi-inc.atlassian.net/browse/CONTENT-10

