### PR TITLE
CM: Allow displaying single components in list-views

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/DynamicTable/CellContent/SingleComponent/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/DynamicTable/CellContent/SingleComponent/index.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Flex } from '@strapi/design-system/Flex';
+import { Tooltip } from '@strapi/design-system/Tooltip';
+import { Typography } from '@strapi/design-system/Typography';
+import { stopPropagation } from '@strapi/helper-plugin';
+
+import CellValue from '../CellValue';
+
+const SingleComponentCell = ({ value, metadatas, component }) => {
+  const { mainField } = metadatas;
+  const content = value?.[mainField];
+  const type = component?.attributes?.[mainField]?.type;
+
+  return (
+    <Flex {...stopPropagation}>
+      <Tooltip label={content}>
+        <Typography textColor="neutral800" ellipsis>
+          <CellValue type={type} value={content} />
+        </Typography>
+      </Tooltip>
+    </Flex>
+  );
+};
+
+SingleComponentCell.propTypes = {
+  metadatas: PropTypes.shape({
+    mainField: PropTypes.string.isRequired,
+  }).isRequired,
+  value: PropTypes.object.isRequired,
+  component: PropTypes.shape({
+    attributes: PropTypes.arrayOf(
+      PropTypes.shape({
+        type: PropTypes.string.isRequired,
+      })
+    ).isRequired,
+  }).isRequired,
+};
+
+export default SingleComponentCell;

--- a/packages/core/admin/admin/src/content-manager/components/DynamicTable/CellContent/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/DynamicTable/CellContent/index.js
@@ -6,6 +6,7 @@ import Media from './Media';
 import MultipleMedias from './MultipleMedias';
 import Relation from './Relation';
 import RepeatableComponent from './RepeatableComponent';
+import SingleComponent from './SingleComponent';
 import CellValue from './CellValue';
 import hasContent from './utils/hasContent';
 
@@ -41,8 +42,18 @@ const CellContent = ({ content, fieldSchema, metadatas, name, queryInfos, rowId,
       );
 
     case 'component':
+      if (fieldSchema.repeatable === true) {
+        return (
+          <RepeatableComponent
+            value={content}
+            metadatas={metadatas}
+            component={layout?.components?.[fieldSchema.component]}
+          />
+        );
+      }
+
       return (
-        <RepeatableComponent
+        <SingleComponent
           value={content}
           metadatas={metadatas}
           component={layout?.components?.[fieldSchema.component]}

--- a/packages/core/admin/admin/src/content-manager/utils/checkIfAttributeIsDisplayable.js
+++ b/packages/core/admin/admin/src/content-manager/utils/checkIfAttributeIsDisplayable.js
@@ -3,10 +3,6 @@ import { toLower } from 'lodash';
 const checkIfAttributeIsDisplayable = attribute => {
   const type = attribute.type;
 
-  if (type === 'component') {
-    return attribute.repeatable;
-  }
-
   if (type === 'relation') {
     return !toLower(attribute.relationType).includes('morph');
   }


### PR DESCRIPTION
### What does it do?

Similar to #12213 it allows to display single components in the list view of the content manager.

TODO:

- [x] Normalize content across all cells
- [x] Configure view is broken
- [x] Render components fields based in their type
- [x] Move back shared logic into #12213

### How to test it?

- Create a new collection type
- Add a non-repeatable component to this collection type and save
- Create a new entry and fill several values for the non-repeatable component
- Go back to the collection type list view
- Enable the non-repeatable component field to show it in the list columns

### Related issue(s)/PR(s)

Refs: #12213
Refs: #12155
Issue: https://strapi-inc.atlassian.net/browse/CONTENT-48
