### PR TITLE
Allow SDL type definitions to beneficiate from Nexus types context & processing

### DIFF
--- a/packages/plugins/graphql/package.json
+++ b/packages/plugins/graphql/package.json
@@ -43,7 +43,7 @@
     "graphql-upload": "^13.0.0",
     "koa-compose": "^4.1.0",
     "lodash": "4.17.21",
-    "nexus": "1.1.0",
+    "nexus": "1.2.0",
     "pluralize": "^8.0.0",
     "subscriptions-transport-ws": "0.9.19"
   },

--- a/packages/plugins/graphql/server/services/content-api/index.js
+++ b/packages/plugins/graphql/server/services/content-api/index.js
@@ -65,7 +65,7 @@ module.exports = ({ strapi }) => {
     const nexusSchema = makeSchema({
       // Build the schema from the merged GraphQL schema.
       // Since we're passing the schema to the mergeSchema property, it'll transform our SDL type definitions
-      // into Nexus type definition, thus allowing them to be handled bu Nexus plugins & other processing
+      // into Nexus type definition, thus allowing them to be handled by  Nexus plugins & other processing
       mergeSchema: { schema: schemaWithResolvers },
 
       // Apply user-defined plugins

--- a/packages/plugins/graphql/server/services/content-api/index.js
+++ b/packages/plugins/graphql/server/services/content-api/index.js
@@ -1,10 +1,6 @@
 'use strict';
 
-const {
-  mergeSchemas,
-  makeExecutableSchema,
-  addResolversToSchema,
-} = require('@graphql-tools/schema');
+const { mergeSchemas, addResolversToSchema } = require('@graphql-tools/schema');
 const { pruneSchema } = require('@graphql-tools/utils');
 const { makeSchema } = require('nexus');
 const { prop, startsWith } = require('lodash/fp');
@@ -54,11 +50,8 @@ module.exports = ({ strapi }) => {
       shadowCRUD();
     }
 
-    // Build a collection of schema based on the type registry (& temporary generated extension)
-    const schemas = buildSchemas({ registry });
-
-    // Merge every created schema into a single one
-    const mergedSchema = mergeSchemas({ schemas });
+    // Build a merged schema from both Nexus types & SDL type definitions
+    const schema = buildMergedSchema({ registry });
 
     // Generate the extension configuration for the content API.
     // This extension instance needs to be generated after the Nexus schema's
@@ -67,42 +60,43 @@ module.exports = ({ strapi }) => {
     const extension = extensionService.generate({ typeRegistry: registry });
 
     // Add the extension's resolvers to the final schema
-    const schema = addResolversToSchema(mergedSchema, extension.resolvers);
+    const schemaWithResolvers = addResolversToSchema(schema, extension.resolvers);
+
+    const nexusSchema = makeSchema({
+      // Build the schema from the merged GraphQL schema.
+      // Since we're passing the schema to the mergeSchema property, it'll transform our SDL type definitions
+      // into Nexus type definition, thus allowing them to be handled bu Nexus plugins & other processing
+      mergeSchema: { schema: schemaWithResolvers },
+
+      // Apply user-defined plugins
+      plugins: extension.plugins,
+    });
 
     // Wrap resolvers if needed (auth, middlewares, policies...) as configured in the extension
-    const wrappedSchema = wrapResolvers({ schema, strapi, extension });
+    const wrappedNexusSchema = wrapResolvers({ schema: nexusSchema, strapi, extension });
 
     // Prune schema, remove unused types
     // eg: removes registered subscriptions if they're disabled in the config)
-    const prunedSchema = pruneSchema(wrappedSchema);
+    const prunedNexusSchema = pruneSchema(wrappedNexusSchema);
 
-    return prunedSchema;
+    return prunedNexusSchema;
   };
 
-  const buildSchemas = ({ registry }) => {
+  const buildMergedSchema = ({ registry }) => {
     // Here we extract types, plugins & typeDefs from a temporary generated
     // extension since there won't be any addition allowed after schemas generation
-    const { types, plugins, typeDefs = [] } = extensionService.generate({ typeRegistry: registry });
+    const { types, typeDefs = [] } = extensionService.generate({ typeRegistry: registry });
 
-    // Create a new Nexus schema (shadow CRUD) & add it to the schemas collection
-    const nexusSchema = makeSchema({
-      types: [
-        // Add the auto-generated Nexus types (shadow CRUD)
-        registry.definitions,
-        // Add every Nexus type registered using the extension service
-        types,
-      ],
+    // Nexus schema built with user-defined & shadow CRUD auto generated Nexus types
+    const nexusSchema = makeSchema({ types: [registry.definitions, types] });
 
-      plugins: [
-        // Add every plugin registered using the extension service
-        ...plugins,
-      ],
+    // Merge type definitions with the Nexus schema
+    return mergeSchemas({
+      typeDefs,
+      // Give access to the shadowCRUD & nexus based types
+      // Note: This is necessary so that types defined in SDL can reference types defined with Nexus
+      schemas: [nexusSchema],
     });
-
-    // Build schemas based on SDL type definitions (defined in the extension)
-    const sdlSchemas = typeDefs.map(sdl => makeExecutableSchema({ typeDefs: sdl }));
-
-    return [nexusSchema, ...sdlSchemas];
   };
 
   const shadowCRUD = () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -16124,10 +16124,10 @@ netmask@^2.0.1:
   resolved "https://registry.yarnpkg.com/netmask/-/netmask-2.0.2.tgz#8b01a07644065d536383835823bc52004ebac5e7"
   integrity sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==
 
-nexus@1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/nexus/-/nexus-1.1.0.tgz#3d8fa05c29e7a61aa55f64ef5e0ba43dd76b3ed6"
-  integrity sha512-jUhbg22gKVY2YwZm726BrbfHaQ7Xzc0hNXklygDhuqaVxCuHCgFMhWa2svNWd1npe8kfeiu5nbwnz+UnhNXzCQ==
+nexus@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/nexus/-/nexus-1.2.0.tgz#12c4611702184fac170c98c1a2c778a76a9e9827"
+  integrity sha512-7+0240LrQNnKKLTgbxM6KLLdfMgm4wp1TPAULim0lGmHfX7QsJK39i2KmFdMr3WdsAKoybMmwyrJtaYOq0q62g==
   dependencies:
     iterall "^1.3.0"
     tslib "^2.0.3"


### PR DESCRIPTION
### What does it do?

Merge SDL type definition with Nexus' ones before binding the plugins

### Why is it needed?

Currently, it's not possible to either reference types defined from Nexus (shadow CRUD or user-defined) or to apply plugin to SDL type definitions

### How to test it?

`src/index.js`
```javascript
"use strict";

module.exports = {
  /**
   * An asynchronous register function that runs before
   * your application is initialized.
   *
   * This gives you an opportunity to extend code.
   */
  register({ strapi }) {
    const extensionService = strapi.plugin('graphql').service('extension');
    extensionService.use(({ nexus }) => ({
      typeDefs: /* GraphQL */`
          type Query {
              test: JSON
          }
      `,
      resolvers: {
        Query: {
          test: {
            async resolve() {
              return {'foo':'baz'}
            },
          },
        }
      },
      resolversConfig: {
        'Query.test': {
          auth: false,
        },
      },
    }));
  },

  /**
   * An asynchronous bootstrap function that runs before
   * your application gets started.
   *
   * This gives you an opportunity to set up your data model,
   * run jobs, or perform some special logic.
   */
  bootstrap(/*{ strapi }*/) { },
};
```

Since the `JSON` scalar is defined through the shadowCRUD feature, it should prove that you can reference Nexus' types from typedefs

### Related issue(s)/PR(s)

Close https://github.com/strapi/strapi/issues/12382