### PR TITLE
remove extra '/' in baseURL

### DIFF
--- a/packages/plugins/users-permissions/server/bootstrap/index.js
+++ b/packages/plugins/users-permissions/server/bootstrap/index.js
@@ -8,6 +8,7 @@
  * run jobs, or perform some special logic.
  */
 const _ = require('lodash');
+const urljoin = require('url-join');
 const uuid = require('uuid/v4');
 const { getService } = require('../utils');
 
@@ -41,7 +42,7 @@ module.exports = async ({ strapi }) => {
 
 const initGrant = async pluginStore => {
   const apiPrefix = strapi.config.get('api.rest.prefix');
-  const baseURL = `${strapi.config.server.url}${apiPrefix}/auth`;
+  const baseURL = urljoin(`${strapi.config.server.url}/`, apiPrefix, '/auth');
 
   const grantConfig = {
     email: {

--- a/packages/plugins/users-permissions/server/bootstrap/index.js
+++ b/packages/plugins/users-permissions/server/bootstrap/index.js
@@ -42,7 +42,7 @@ module.exports = async ({ strapi }) => {
 
 const initGrant = async pluginStore => {
   const apiPrefix = strapi.config.get('api.rest.prefix');
-  const baseURL = urljoin(`${strapi.config.server.url}/`, apiPrefix, '/auth');
+  const baseURL = urljoin(strapi.config.server.url, apiPrefix, 'auth');
 
   const grantConfig = {
     email: {

--- a/packages/plugins/users-permissions/server/bootstrap/index.js
+++ b/packages/plugins/users-permissions/server/bootstrap/index.js
@@ -41,7 +41,7 @@ module.exports = async ({ strapi }) => {
 
 const initGrant = async pluginStore => {
   const apiPrefix = strapi.config.get('api.rest.prefix');
-  const baseURL = `${strapi.config.server.url}/${apiPrefix}/auth`;
+  const baseURL = `${strapi.config.server.url}${apiPrefix}/auth`;
 
   const grantConfig = {
     email: {


### PR DESCRIPTION
Default redirect url setting in User-Permission's provider has a extra slash, because of apiPrefix has already contain a '/'.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Remove extra '/' in baseURL

### Why is it needed?

Default redirect url setting in User-Permission's provider has a extra slash, because of apiPrefix has already contain a '/'.

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/issues/12403
