### PR TITLE
Fixed hot reload in admin

### DIFF
--- a/packages/core/admin/index.js
+++ b/packages/core/admin/index.js
@@ -262,7 +262,7 @@ async function watchAdmin({ plugins, dir, host, port, browser, options }) {
 
   const compiler = webpack(webpackConfig);
 
-  const server = new WebpackDevServer(compiler.options.devServer, compiler);
+  const server = new WebpackDevServer(args.devServer, compiler);
 
   const runServer = async () => {
     console.log(chalk.green('Starting the development server...'));


### PR DESCRIPTION
### What does it do?

The webpack argument was undefined, so it has been fixed.

### Why is it needed?

Hot reloads in admin did not work, fixed

### How to test it?

I changed the value of node_modules directly, and the server started on port 8000!

### Related issue(s)/PR(s)

#12343

Sorry if this has already been resolved.
