### PR TITLE
Typescript / CJS / MJS Just in time compilation support

### DIFF
--- a/packages/core/strapi/lib/core/loaders/apis.js
+++ b/packages/core/strapi/lib/core/loaders/apis.js
@@ -5,6 +5,7 @@ const { existsSync } = require('fs-extra');
 const _ = require('lodash');
 const fse = require('fs-extra');
 const { isKebabCase } = require('@strapi/utils');
+const jiti = require('jiti')(__dirname);
 
 // to handle names with numbers in it we first check if it is already in kebabCase
 const normalizeName = name => (isKebabCase(name) ? name : _.kebabCase(name));
@@ -99,6 +100,12 @@ const loadAPI = async dir => {
 const loadIndex = async dir => {
   if (await fse.pathExists(join(dir, 'index.js'))) {
     return loadFile(join(dir, 'index.js'));
+  } else if (await fse.pathExists(join(dir, 'index.cjs'))) {
+    return loadFile(join(dir, 'index.cjs'));
+  } else if (await fse.pathExists(join(dir, 'index.mjs'))) {
+    return loadFile(join(dir, 'index.mjs'));
+  } else if (await fse.pathExists(join(dir, 'index.ts'))) {
+    return loadFile(join(dir, 'index.ts'));
   }
 };
 
@@ -150,7 +157,21 @@ const loadFile = file => {
 
   switch (ext) {
     case '.js':
+    case '.cjs':
       return require(file);
+    case '.ts':
+    case '.mjs':
+      try {
+        const esModule = jiti(file);
+
+        if (!esModule || !esModule.default) {
+          throw new Error(`The file has no default export`);
+        }
+
+        return esModule.default;
+      } catch (error) {
+        throw new Error(`Could not load es/ts module config file ${file}: ${error.message}`);
+      }
     case '.json':
       return fse.readJSON(file);
     default:

--- a/packages/core/strapi/lib/core/loaders/apis.js
+++ b/packages/core/strapi/lib/core/loaders/apis.js
@@ -98,14 +98,10 @@ const loadAPI = async dir => {
 };
 
 const loadIndex = async dir => {
-  if (await fse.pathExists(join(dir, 'index.js'))) {
-    return loadFile(join(dir, 'index.js'));
-  } else if (await fse.pathExists(join(dir, 'index.cjs'))) {
-    return loadFile(join(dir, 'index.cjs'));
-  } else if (await fse.pathExists(join(dir, 'index.mjs'))) {
-    return loadFile(join(dir, 'index.mjs'));
-  } else if (await fse.pathExists(join(dir, 'index.ts'))) {
-    return loadFile(join(dir, 'index.ts'));
+  for (const file of ['index.js', 'index.ts', 'index.mjs', 'index.cjs']) {
+    if (await fse.pathExists(join(dir, file))) {
+      return loadFile(join(dir, file));
+    }
   }
 };
 

--- a/packages/core/strapi/lib/core/loaders/components.js
+++ b/packages/core/strapi/lib/core/loaders/components.js
@@ -10,7 +10,7 @@ module.exports = async strapi => {
     return {};
   }
 
-  const map = await loadFiles(strapi.dirs.components, '*/*.*(js|json)');
+  const map = await loadFiles(strapi.dirs.components, '*/*.*(js|ts|cjs|mjs|json)');
 
   return Object.keys(map).reduce((acc, category) => {
     Object.keys(map[category]).forEach(key => {

--- a/packages/core/strapi/lib/core/loaders/plugins/get-user-plugins-config.js
+++ b/packages/core/strapi/lib/core/loaders/plugins/get-user-plugins-config.js
@@ -12,23 +12,24 @@ const loadConfigFile = require('../../app-configuration/load-config-file');
  * @return {Promise<{}>}
  */
 const getUserPluginsConfig = async () => {
-  const globalUserConfigPath = join(strapi.dirs.config, 'plugins.js');
-  const currentEnvUserConfigPath = join(
-    strapi.dirs.config,
-    'env',
-    process.env.NODE_ENV,
-    'plugins.js'
-  );
   let config = {};
 
   // assign global user config if exists
-  if (await fse.pathExists(globalUserConfigPath)) {
-    config = loadConfigFile(globalUserConfigPath);
+  for (const file of ['plugins.js', 'plugins.ts', 'plugins.mjs', 'plugins.cjs']) {
+    const filepath = join(strapi.dirs.config, file);
+    if (await fse.pathExists(filepath)) {
+      config = loadConfigFile(filepath);
+      break;
+    }
   }
 
   // and merge user config by environment if exists
-  if (await fse.pathExists(currentEnvUserConfigPath)) {
-    config = merge(config, loadConfigFile(currentEnvUserConfigPath));
+  for (const file of ['plugins.js', 'plugins.ts', 'plugins.mjs', 'plugins.cjs']) {
+    let filepath = join(strapi.dirs.config, 'env', process.env.NODE_ENV, file);
+    if (await fse.pathExists(filepath)) {
+      config = merge(config, loadConfigFile(filepath));
+      break;
+    }
   }
 
   return config;

--- a/packages/core/strapi/lib/factories.d.ts
+++ b/packages/core/strapi/lib/factories.d.ts
@@ -43,6 +43,6 @@ interface Router {
   routes: Route[];
 }
 
-export function createCoreRouter(uid: string, cfg: RouterConfig): () => Router;
-export function createCoreController(uid: string, cfg: ControllerConfig): () => Controller;
-export function createCoreService(uid: string, cfg: ServiceConfig): () => Service;
+export function createCoreRouter(uid: string, cfg?: Partial<RouterConfig>): () => Router;
+export function createCoreController(uid: string, cfg?: Partial<ControllerConfig>): () => Controller;
+export function createCoreService(uid: string, cfg?: Partial<ServiceConfig>): () => Service;

--- a/packages/core/strapi/lib/load/filepath-to-prop-path.js
+++ b/packages/core/strapi/lib/load/filepath-to-prop-path.js
@@ -11,7 +11,7 @@ module.exports = (filePath, useFileNameAsKey = true) => {
   let cleanPath = filePath.startsWith('./') ? filePath.slice(2) : filePath;
 
   const prop = cleanPath
-    .replace(/(\.settings|\.json|\.js)/g, '')
+    .replace(/(\.settings|\.json|\.js|\.cjs|\.mjs|\.ts)/g, '')
     .toLowerCase()
     .split('/')
     .map(p => _.trimStart(p, '.'))

--- a/packages/core/strapi/package.json
+++ b/packages/core/strapi/package.json
@@ -103,6 +103,7 @@
     "dotenv": "10.0.0",
     "execa": "5.1.1",
     "fs-extra": "10.0.0",
+    "jiti": "1.12.15",
     "glob": "7.2.0",
     "http-errors": "1.8.0",
     "inquirer": "8.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14011,6 +14011,11 @@ jest@26.6.3:
     import-local "^3.0.2"
     jest-cli "^26.6.3"
 
+jiti@1.12.15:
+  version "1.12.15"
+  resolved "https://registry.yarnpkg.com/jiti/-/jiti-1.12.15.tgz#8f6a141c06524ab32e05d5e3c9b33eeda54ae775"
+  integrity sha512-/+K89y6KJA2nISbWrlc/773XdpDgSQq/LdQ+ZZyw2jRxUNyquPtbsDCCCMRzzNORUgroUGc4nAXxJEnQvpViCA==
+
 jmespath@0.15.0:
   version "0.15.0"
   resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.15.0.tgz#a3f222a9aae9f966f5d27c796510e28091764217"


### PR DESCRIPTION
### What does it do?

These changes allow loading `.cjs`, `.mjs` and `.ts` files for any part of strapi server without any extra configuration for the client:

- [x] apis (routes/controllers/services/contentTypes)
- [x] middlewares
- [x] policies
- [x] extensions
- [x] plugins
- [x] configurations files

I've used [`jiti`](https://github.com/unjs/jiti) which describe itself to be a "Runtime typescript and ESM support for Node.js (CommonJS)"

### Why is it needed?

This allows developers to use typescript in their application or plugins

### How to test it?

I have made a working template https://github.com/stafyniaksacha/strapi-typescript-sample

```bash
git clone git@github.com:stafyniaksacha/strapi-typescript-sample.git
cd strapi-typescript-sample
yarn
yarn develop # or yarn start
```

### What does it do not?

This PR does not aim to provide strapi core types, but only to add the ability to use strapi with typescript and ESM modules
