### PR TITLE
added audio preview in content builder

### DIFF
--- a/examples/getstarted/src/api/address/content-types/address/schema.json
+++ b/examples/getstarted/src/api/address/content-types/address/schema.json
@@ -32,7 +32,8 @@
       "allowedTypes": [
         "files",
         "images",
-        "videos"
+        "videos",
+        "audios"
       ],
       "pluginOptions": {}
     },

--- a/packages/core/content-type-builder/admin/src/components/AllowedTypesSelect/index.js
+++ b/packages/core/content-type-builder/admin/src/components/AllowedTypesSelect/index.js
@@ -11,7 +11,8 @@ const options = [
     children: [
       { label: 'images (JPEG, PNG, GIF, SVG, TIFF, ICO, DVU)', value: 'images' },
       { label: 'videos (MPEG, MP4, Quicktime, WMV, AVI, FLV)', value: 'videos' },
-      { label: 'files (CSV, ZIP, MP3, PDF, Excel, JSON, ...)', value: 'files' },
+      { label: 'audios (MP3, WAV, OGG)', value: 'audios' },
+      { label: 'files (CSV, ZIP, PDF, Excel, JSON, ...)', value: 'files' },
     ],
   },
 ];

--- a/packages/core/content-type-builder/admin/src/components/FormModal/attributes/types.js
+++ b/packages/core/content-type-builder/admin/src/components/FormModal/attributes/types.js
@@ -215,7 +215,7 @@ const types = {
       required: validators.required(),
       allowedTypes: yup
         .array()
-        .of(yup.string().oneOf(['images', 'videos', 'files']))
+        .of(yup.string().oneOf(['images', 'videos', 'files', 'audios']))
         .min(1)
         .nullable(),
     };

--- a/packages/core/content-type-builder/admin/src/components/FormModal/reducer.js
+++ b/packages/core/content-type-builder/admin/src/components/FormModal/reducer.js
@@ -266,7 +266,7 @@ const reducer = (state = initialState, action) =>
           dataToSet = options;
         } else if (attributeType === 'media') {
           dataToSet = {
-            allowedTypes: ['images', 'files', 'videos'],
+            allowedTypes: ['images', 'files', 'videos', 'audios'],
             type: 'media',
             multiple: true,
             ...options,

--- a/packages/core/content-type-builder/admin/src/components/FormModal/tests/reducer.test.js
+++ b/packages/core/content-type-builder/admin/src/components/FormModal/tests/reducer.test.js
@@ -582,7 +582,7 @@ describe('CTB | components | FormModal | reducer | actions', () => {
         modifiedData: {
           type: 'media',
           multiple: true,
-          allowedTypes: ['images', 'files', 'videos'],
+          allowedTypes: ['images', 'files', 'videos', 'audios'],
         },
       };
 

--- a/packages/core/content-type-builder/admin/src/pages/ListView/tests/mockData.js
+++ b/packages/core/content-type-builder/admin/src/pages/ListView/tests/mockData.js
@@ -36,7 +36,7 @@ export default {
           type: 'media',
           multiple: false,
           required: false,
-          allowedTypes: ['files', 'images', 'videos'],
+          allowedTypes: ['files', 'images', 'videos', 'audios'],
           pluginOptions: {
             i18n: {
               localized: true,

--- a/packages/core/content-type-builder/server/controllers/validation/types.js
+++ b/packages/core/content-type-builder/server/controllers/validation/types.js
@@ -53,7 +53,7 @@ const getTypeShape = (attribute, { modelType, attributes } = {}) => {
         required: validators.required,
         allowedTypes: yup
           .array()
-          .of(yup.string().oneOf(['images', 'videos', 'files']))
+          .of(yup.string().oneOf(['images', 'videos', 'files', 'audios']))
           .min(1),
       };
     }

--- a/packages/core/upload/admin/src/components/AssetCard/AssetCard.js
+++ b/packages/core/upload/admin/src/components/AssetCard/AssetCard.js
@@ -20,9 +20,12 @@ export const AssetCard = ({
   local,
 }) => {
   const singularTypes = toSingularTypes(allowedTypes);
-
-  let handleSelect = onSelect ? () => onSelect(asset) : undefined;
   const fileType = asset.mime.split('/')[0];
+  const handleSelect = onSelect ? () => onSelect(asset) : undefined;
+  const canSelectAsset =
+    singularTypes.includes(fileType) ||
+    (singularTypes.includes('file') && !['video', 'image', 'audio'].includes(fileType));
+
   const commonAssetCardProps = {
     id: asset.id,
     extension: getFileExtension(asset.ext),
@@ -31,29 +34,17 @@ export const AssetCard = ({
     url: local ? asset.url : createAssetUrl(asset, true),
     mime: asset.mime,
     onEdit: onEdit ? () => onEdit(asset) : undefined,
-    onSelect: handleSelect,
+    onSelect: !canSelectAsset && !isSelected ? undefined : handleSelect,
     onRemove: onRemove ? () => onRemove(asset) : undefined,
     selected: isSelected,
     size,
   };
 
   if (asset.mime.includes(AssetType.Video)) {
-    const canSelectAsset = singularTypes.includes(fileType);
-
-    if (!canSelectAsset && !isSelected) {
-      handleSelect = undefined;
-    }
-
     return <VideoAssetCard {...commonAssetCardProps} />;
   }
 
   if (asset.mime.includes(AssetType.Image)) {
-    const canSelectAsset = singularTypes.includes(fileType);
-
-    if (!canSelectAsset && !isSelected) {
-      handleSelect = undefined;
-    }
-
     return (
       <ImageAssetCard
         {...commonAssetCardProps}
@@ -66,20 +57,7 @@ export const AssetCard = ({
   }
 
   if (asset.mime.includes(AssetType.Audio)) {
-    const canSelectAsset = singularTypes.includes(fileType);
-
-    if (!canSelectAsset && !isSelected) {
-      handleSelect = undefined;
-    }
-
     return <AudioAssetCard {...commonAssetCardProps} />;
-  }
-
-  const canSelectAsset =
-    singularTypes.includes('file') && !['video', 'image', 'audio'].includes(fileType);
-
-  if (!canSelectAsset && !isSelected) {
-    handleSelect = undefined;
   }
 
   return <DocAssetCard {...commonAssetCardProps} />;

--- a/packages/core/upload/admin/src/components/AssetCard/AssetCard.js
+++ b/packages/core/upload/admin/src/components/AssetCard/AssetCard.js
@@ -72,20 +72,7 @@ export const AssetCard = ({
       handleSelect = undefined;
     }
 
-    return (
-      <AudioAssetCard
-        id={asset.id}
-        key={asset.id}
-        name={asset.name}
-        extension={getFileExtension(asset.ext)}
-        url={local ? asset.url : createAssetUrl(asset, true)}
-        mime={asset.mime}
-        onEdit={onEdit ? () => onEdit(asset) : undefined}
-        onSelect={handleSelect}
-        selected={isSelected}
-        size={size}
-      />
-    );
+    return <AudioAssetCard {...commonAssetCardProps} />;
   }
 
   const canSelectAsset =

--- a/packages/core/upload/admin/src/components/AssetCard/AssetCard.js
+++ b/packages/core/upload/admin/src/components/AssetCard/AssetCard.js
@@ -4,6 +4,7 @@ import { prefixFileUrlWithBackendUrl, getFileExtension } from '@strapi/helper-pl
 import { ImageAssetCard } from './ImageAssetCard';
 import { VideoAssetCard } from './VideoAssetCard';
 import { DocAssetCard } from './DocAssetCard';
+import { AudioAssetCard } from './AudioAssetCard';
 import { AssetType, AssetDefinition } from '../../constants';
 import { createAssetUrl } from '../../utils/createAssetUrl';
 import toSingularTypes from '../../utils/toSingularTypes';
@@ -64,7 +65,31 @@ export const AssetCard = ({
     );
   }
 
-  const canSelectAsset = singularTypes.includes('file') && !['video', 'image'].includes(fileType);
+  if (asset.mime.includes(AssetType.Audio)) {
+    const canSelectAsset = singularTypes.includes(fileType);
+
+    if (!canSelectAsset && !isSelected) {
+      handleSelect = undefined;
+    }
+
+    return (
+      <AudioAssetCard
+        id={asset.id}
+        key={asset.id}
+        name={asset.name}
+        extension={getFileExtension(asset.ext)}
+        url={local ? asset.url : createAssetUrl(asset, true)}
+        mime={asset.mime}
+        onEdit={onEdit ? () => onEdit(asset) : undefined}
+        onSelect={handleSelect}
+        selected={isSelected}
+        size={size}
+      />
+    );
+  }
+
+  const canSelectAsset =
+    singularTypes.includes('file') && !['video', 'image', 'audio'].includes(fileType);
 
   if (!canSelectAsset && !isSelected) {
     handleSelect = undefined;
@@ -74,7 +99,7 @@ export const AssetCard = ({
 };
 
 AssetCard.defaultProps = {
-  allowedTypes: ['images', 'files', 'videos'],
+  allowedTypes: ['images', 'files', 'videos', 'audios'],
   isSelected: false,
   // Determine if the asset is loaded locally or from a remote resource
   local: false,

--- a/packages/core/upload/admin/src/components/AssetCard/AudioAssetCard.js
+++ b/packages/core/upload/admin/src/components/AssetCard/AudioAssetCard.js
@@ -15,6 +15,7 @@ import {
 } from '@strapi/design-system/Card';
 import { IconButton } from '@strapi/design-system/IconButton';
 import Pencil from '@strapi/icons/Pencil';
+import Trash from '@strapi/icons/Trash';
 import { useIntl } from 'react-intl';
 import { Box } from '@strapi/design-system/Box';
 import { AudioPreview } from './AudioPreview';
@@ -33,7 +34,16 @@ const AudioPreviewWrapper = styled(Box)`
   }
 `;
 
-export const AudioAssetCard = ({ name, extension, url, selected, onSelect, onEdit, size }) => {
+export const AudioAssetCard = ({
+  name,
+  extension,
+  url,
+  selected,
+  onSelect,
+  onEdit,
+  onRemove,
+  size,
+}) => {
   const { formatMessage } = useIntl();
 
   return (
@@ -45,13 +55,26 @@ export const AudioAssetCard = ({ name, extension, url, selected, onSelect, onEdi
           </AudioPreviewWrapper>
         </CardAsset>
         {onSelect && <CardCheckbox value={selected} onValueChange={onSelect} />}
-        {onEdit && (
+        {(onRemove || onEdit) && (
           <CardAction position="end">
-            <IconButton
-              label={formatMessage({ id: getTrad('control-card.edit'), defaultMessage: 'Edit' })}
-              icon={<Pencil />}
-              onClick={onEdit}
-            />
+            {onRemove && (
+              <IconButton
+                label={formatMessage({
+                  id: getTrad('control-card.remove-selection'),
+                  defaultMessage: 'Remove from selection',
+                })}
+                icon={<Trash />}
+                onClick={onRemove}
+              />
+            )}
+
+            {onEdit && (
+              <IconButton
+                label={formatMessage({ id: getTrad('control-card.edit'), defaultMessage: 'Edit' })}
+                icon={<Pencil />}
+                onClick={onEdit}
+              />
+            )}
           </CardAction>
         )}
       </CardHeader>
@@ -75,6 +98,7 @@ export const AudioAssetCard = ({ name, extension, url, selected, onSelect, onEdi
 AudioAssetCard.defaultProps = {
   onSelect: undefined,
   onEdit: undefined,
+  onRemove: undefined,
   selected: false,
   size: 'M',
 };
@@ -84,6 +108,7 @@ AudioAssetCard.propTypes = {
   name: PropTypes.string.isRequired,
   onSelect: PropTypes.func,
   onEdit: PropTypes.func,
+  onRemove: PropTypes.func,
   url: PropTypes.string.isRequired,
   selected: PropTypes.bool,
   size: PropTypes.oneOf(['S', 'M']),

--- a/packages/core/upload/admin/src/components/AssetCard/AudioAssetCard.js
+++ b/packages/core/upload/admin/src/components/AssetCard/AudioAssetCard.js
@@ -33,16 +33,7 @@ const AudioPreviewWrapper = styled(Box)`
   }
 `;
 
-export const AudioAssetCard = ({
-  name,
-  extension,
-  url,
-  mime,
-  selected,
-  onSelect,
-  onEdit,
-  size,
-}) => {
+export const AudioAssetCard = ({ name, extension, url, selected, onSelect, onEdit, size }) => {
   const { formatMessage } = useIntl();
 
   return (
@@ -50,7 +41,7 @@ export const AudioAssetCard = ({
       <CardHeader>
         <CardAsset size={size}>
           <AudioPreviewWrapper size={size}>
-            <AudioPreview url={url} mime={mime} alt={name} />
+            <AudioPreview url={url} alt={name} />
           </AudioPreviewWrapper>
         </CardAsset>
         {onSelect && <CardCheckbox value={selected} onValueChange={onSelect} />}
@@ -90,7 +81,6 @@ AudioAssetCard.defaultProps = {
 
 AudioAssetCard.propTypes = {
   extension: PropTypes.string.isRequired,
-  mime: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
   onSelect: PropTypes.func,
   onEdit: PropTypes.func,

--- a/packages/core/upload/admin/src/components/AssetCard/AudioAssetCard.js
+++ b/packages/core/upload/admin/src/components/AssetCard/AudioAssetCard.js
@@ -1,0 +1,100 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import {
+  Card,
+  CardAction,
+  CardAsset,
+  CardBadge,
+  CardBody,
+  CardCheckbox,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardSubtitle,
+} from '@strapi/design-system/Card';
+import { IconButton } from '@strapi/design-system/IconButton';
+import Pencil from '@strapi/icons/Pencil';
+import { useIntl } from 'react-intl';
+import { Box } from '@strapi/design-system/Box';
+import { AudioPreview } from './AudioPreview';
+import { getTrad } from '../../utils';
+
+const Extension = styled.span`
+  text-transform: uppercase;
+`;
+
+const AudioPreviewWrapper = styled(Box)`
+  canvas,
+  audio {
+    display: block;
+    max-width: 100%;
+    max-height: ${({ size }) => (size === 'M' ? 164 / 16 : 88 / 16)}rem;
+  }
+`;
+
+export const AudioAssetCard = ({
+  name,
+  extension,
+  url,
+  mime,
+  selected,
+  onSelect,
+  onEdit,
+  size,
+}) => {
+  const { formatMessage } = useIntl();
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardAsset size={size}>
+          <AudioPreviewWrapper size={size}>
+            <AudioPreview url={url} mime={mime} alt={name} />
+          </AudioPreviewWrapper>
+        </CardAsset>
+        {onSelect && <CardCheckbox value={selected} onValueChange={onSelect} />}
+        {onEdit && (
+          <CardAction position="end">
+            <IconButton
+              label={formatMessage({ id: getTrad('control-card.edit'), defaultMessage: 'Edit' })}
+              icon={<Pencil />}
+              onClick={onEdit}
+            />
+          </CardAction>
+        )}
+      </CardHeader>
+      <CardBody>
+        <CardContent>
+          <Box paddingTop={1}>
+            <CardTitle as="h2">{name}</CardTitle>
+          </Box>
+          <CardSubtitle>
+            <Extension>{extension}</Extension>
+          </CardSubtitle>
+        </CardContent>
+        <CardBadge>
+          {formatMessage({ id: getTrad('settings.section.audio.label'), defaultMessage: 'Audio' })}
+        </CardBadge>
+      </CardBody>
+    </Card>
+  );
+};
+
+AudioAssetCard.defaultProps = {
+  onSelect: undefined,
+  onEdit: undefined,
+  selected: false,
+  size: 'M',
+};
+
+AudioAssetCard.propTypes = {
+  extension: PropTypes.string.isRequired,
+  mime: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+  onSelect: PropTypes.func,
+  onEdit: PropTypes.func,
+  url: PropTypes.string.isRequired,
+  selected: PropTypes.bool,
+  size: PropTypes.oneOf(['S', 'M']),
+};

--- a/packages/core/upload/admin/src/components/AssetCard/AudioPreview.js
+++ b/packages/core/upload/admin/src/components/AssetCard/AudioPreview.js
@@ -1,0 +1,24 @@
+/* eslint-disable jsx-a11y/media-has-caption */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Box } from '@strapi/design-system/Box';
+import { VisuallyHidden } from '@strapi/design-system/VisuallyHidden';
+
+export const AudioPreview = ({ url, mime, alt }) => {
+  return (
+    <Box>
+      <audio controls>
+        <source src={url} type={mime} />
+      </audio>
+      <VisuallyHidden as="figcaption">{alt}</VisuallyHidden>
+    </Box>
+  );
+};
+
+AudioPreview.defaultProps = {};
+
+AudioPreview.propTypes = {
+  alt: PropTypes.string.isRequired,
+  url: PropTypes.string.isRequired,
+  mime: PropTypes.string.isRequired,
+};

--- a/packages/core/upload/admin/src/components/AssetCard/AudioPreview.js
+++ b/packages/core/upload/admin/src/components/AssetCard/AudioPreview.js
@@ -2,15 +2,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Box } from '@strapi/design-system/Box';
-import { VisuallyHidden } from '@strapi/design-system/VisuallyHidden';
 
-export const AudioPreview = ({ url, mime, alt }) => {
+export const AudioPreview = ({ url, alt }) => {
   return (
     <Box>
-      <audio controls>
-        <source src={url} type={mime} />
+      <audio controls src={url}>
+        {alt}
       </audio>
-      <VisuallyHidden as="figcaption">{alt}</VisuallyHidden>
     </Box>
   );
 };
@@ -20,5 +18,4 @@ AudioPreview.defaultProps = {};
 AudioPreview.propTypes = {
   alt: PropTypes.string.isRequired,
   url: PropTypes.string.isRequired,
-  mime: PropTypes.string.isRequired,
 };

--- a/packages/core/upload/admin/src/components/AssetCard/DocAssetCard.js
+++ b/packages/core/upload/admin/src/components/AssetCard/DocAssetCard.js
@@ -18,6 +18,7 @@ import { IconButton } from '@strapi/design-system/IconButton';
 import Pencil from '@strapi/icons/Pencil';
 import FileIcon from '@strapi/icons/File';
 import FilePdfIcon from '@strapi/icons/FilePdf';
+import Trash from '@strapi/icons/Trash';
 import { pxToRem } from '@strapi/helper-plugin';
 import { useIntl } from 'react-intl';
 import { getTrad } from '../../utils';
@@ -37,20 +38,33 @@ const CardAsset = styled(Flex)`
   background: linear-gradient(180deg, #ffffff 0%, #f6f6f9 121.48%);
 `;
 
-export const DocAssetCard = ({ name, extension, selected, onSelect, onEdit, size }) => {
+export const DocAssetCard = ({ name, extension, selected, onSelect, onEdit, onRemove, size }) => {
   const { formatMessage } = useIntl();
 
   return (
     <Card>
       <CardHeader>
         {onSelect && <CardCheckbox value={selected} onValueChange={onSelect} />}
-        {onEdit && (
+        {(onRemove || onEdit) && (
           <CardAction position="end">
-            <IconButton
-              label={formatMessage({ id: getTrad('control-card.edit'), defaultMessage: 'Edit' })}
-              icon={<Pencil />}
-              onClick={onEdit}
-            />
+            {onRemove && (
+              <IconButton
+                label={formatMessage({
+                  id: getTrad('control-card.remove-selection'),
+                  defaultMessage: 'Remove from selection',
+                })}
+                icon={<Trash />}
+                onClick={onRemove}
+              />
+            )}
+
+            {onEdit && (
+              <IconButton
+                label={formatMessage({ id: getTrad('control-card.edit'), defaultMessage: 'Edit' })}
+                icon={<Pencil />}
+                onClick={onEdit}
+              />
+            )}
           </CardAction>
         )}
         <CardAsset
@@ -88,6 +102,7 @@ DocAssetCard.defaultProps = {
   selected: false,
   onEdit: undefined,
   onSelect: undefined,
+  onRemove: undefined,
   size: 'M',
 };
 
@@ -95,6 +110,7 @@ DocAssetCard.propTypes = {
   extension: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
   onEdit: PropTypes.func,
+  onRemove: PropTypes.func,
   onSelect: PropTypes.func,
   selected: PropTypes.bool,
   size: PropTypes.oneOf(['S', 'M']),

--- a/packages/core/upload/admin/src/components/AssetCard/UploadingAssetCard.js
+++ b/packages/core/upload/admin/src/components/AssetCard/UploadingAssetCard.js
@@ -44,6 +44,11 @@ export const UploadingAssetCard = ({ asset, onCancel, onStatusChange, addUploade
       id: getTrad('settings.section.video.label'),
       defaultMessage: 'Video',
     });
+  } else if (asset.type === AssetType.Audio) {
+    badgeContent = formatMessage({
+      id: getTrad('settings.section.audio.label'),
+      defaultMessage: 'Audio',
+    });
   } else {
     badgeContent = formatMessage({
       id: getTrad('settings.section.doc.label'),

--- a/packages/core/upload/admin/src/components/AssetCard/VideoAssetCard.js
+++ b/packages/core/upload/admin/src/components/AssetCard/VideoAssetCard.js
@@ -16,6 +16,7 @@ import {
 } from '@strapi/design-system/Card';
 import { IconButton } from '@strapi/design-system/IconButton';
 import Pencil from '@strapi/icons/Pencil';
+import Trash from '@strapi/icons/Trash';
 import { useIntl } from 'react-intl';
 import { Box } from '@strapi/design-system/Box';
 import { VideoPreview } from './VideoPreview';
@@ -42,6 +43,7 @@ export const VideoAssetCard = ({
   selected,
   onSelect,
   onEdit,
+  onRemove,
   size,
 }) => {
   const { formatMessage } = useIntl();
@@ -52,13 +54,26 @@ export const VideoAssetCard = ({
     <Card>
       <CardHeader>
         {onSelect && <CardCheckbox value={selected} onValueChange={onSelect} />}
-        {onEdit && (
+        {(onRemove || onEdit) && (
           <CardAction position="end">
-            <IconButton
-              label={formatMessage({ id: getTrad('control-card.edit'), defaultMessage: 'Edit' })}
-              icon={<Pencil />}
-              onClick={onEdit}
-            />
+            {onRemove && (
+              <IconButton
+                label={formatMessage({
+                  id: getTrad('control-card.remove-selection'),
+                  defaultMessage: 'Remove from selection',
+                })}
+                icon={<Trash />}
+                onClick={onRemove}
+              />
+            )}
+
+            {onEdit && (
+              <IconButton
+                label={formatMessage({ id: getTrad('control-card.edit'), defaultMessage: 'Edit' })}
+                icon={<Pencil />}
+                onClick={onEdit}
+              />
+            )}
           </CardAction>
         )}
         <CardAsset size={size}>
@@ -88,6 +103,7 @@ export const VideoAssetCard = ({
 VideoAssetCard.defaultProps = {
   onSelect: undefined,
   onEdit: undefined,
+  onRemove: undefined,
   selected: false,
   size: 'M',
 };
@@ -98,6 +114,7 @@ VideoAssetCard.propTypes = {
   name: PropTypes.string.isRequired,
   onSelect: PropTypes.func,
   onEdit: PropTypes.func,
+  onRemove: PropTypes.func,
   url: PropTypes.string.isRequired,
   selected: PropTypes.bool,
   size: PropTypes.oneOf(['S', 'M']),

--- a/packages/core/upload/admin/src/components/AssetList/index.js
+++ b/packages/core/upload/admin/src/components/AssetList/index.js
@@ -75,7 +75,7 @@ export const AssetList = ({
 };
 
 AssetList.defaultProps = {
-  allowedTypes: ['images', 'files', 'videos'],
+  allowedTypes: ['images', 'files', 'videos', 'audios'],
   onEditAsset: undefined,
   size: 'M',
   onReorderAsset: undefined,

--- a/packages/core/upload/admin/src/components/EditAssetDialog/PreviewBox/AssetPreview.js
+++ b/packages/core/upload/admin/src/components/EditAssetDialog/PreviewBox/AssetPreview.js
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/media-has-caption */
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import FileIcon from '@strapi/icons/File';
@@ -30,7 +31,7 @@ export const AssetPreview = forwardRef(({ mime, url, name }, ref) => {
   if (mime.includes(AssetType.Audio)) {
     return (
       <audio controls src={url} ref={ref}>
-        <track label={name} default kind="captions" srcLang={lang} src="" />
+        {name}
       </audio>
     );
   }

--- a/packages/core/upload/admin/src/components/EditAssetDialog/PreviewBox/AssetPreview.js
+++ b/packages/core/upload/admin/src/components/EditAssetDialog/PreviewBox/AssetPreview.js
@@ -27,6 +27,14 @@ export const AssetPreview = forwardRef(({ mime, url, name }, ref) => {
     );
   }
 
+  if (mime.includes(AssetType.Audio)) {
+    return (
+      <audio controls src={url} ref={ref}>
+        <track label={name} default kind="captions" srcLang={lang} src="" />
+      </audio>
+    );
+  }
+
   if (mime.includes('pdf')) {
     return (
       <CardAsset justifyContent="center">

--- a/packages/core/upload/admin/src/components/MediaLibraryDialog/index.js
+++ b/packages/core/upload/admin/src/components/MediaLibraryDialog/index.js
@@ -27,7 +27,7 @@ export const MediaLibraryDialog = ({ onClose, onSelectAssets, allowedTypes }) =>
 };
 
 MediaLibraryDialog.defaultProps = {
-  allowedTypes: ['files', 'images', 'videos'],
+  allowedTypes: ['files', 'images', 'videos', 'audios'],
 };
 
 MediaLibraryDialog.propTypes = {

--- a/packages/core/upload/admin/src/components/MediaLibraryInput/Carousel/CarouselAsset.js
+++ b/packages/core/upload/admin/src/components/MediaLibraryInput/Carousel/CarouselAsset.js
@@ -21,6 +21,13 @@ const VideoPreviewWrapper = styled(Box)`
   }
 `;
 
+const AudioPreviewWrapper = styled(Box)`
+  canvas,
+  audio {
+    max-width: 100%;
+  }
+`;
+
 export const CarouselAsset = ({ asset }) => {
   if (asset.mime.includes(AssetType.Video)) {
     return (
@@ -36,11 +43,13 @@ export const CarouselAsset = ({ asset }) => {
 
   if (asset.mime.includes(AssetType.Audio)) {
     return (
-      <AudioPreview
-        url={createAssetUrl(asset, true)}
-        mime={asset.mime}
-        alt={asset.alternativeText || asset.name}
-      />
+      <AudioPreviewWrapper>
+        <AudioPreview
+          url={createAssetUrl(asset, true)}
+          mime={asset.mime}
+          alt={asset.alternativeText || asset.name}
+        />
+      </AudioPreviewWrapper>
     );
   }
 

--- a/packages/core/upload/admin/src/components/MediaLibraryInput/Carousel/CarouselAsset.js
+++ b/packages/core/upload/admin/src/components/MediaLibraryInput/Carousel/CarouselAsset.js
@@ -44,11 +44,7 @@ export const CarouselAsset = ({ asset }) => {
   if (asset.mime.includes(AssetType.Audio)) {
     return (
       <AudioPreviewWrapper>
-        <AudioPreview
-          url={createAssetUrl(asset, true)}
-          mime={asset.mime}
-          alt={asset.alternativeText || asset.name}
-        />
+        <AudioPreview url={createAssetUrl(asset, true)} alt={asset.alternativeText || asset.name} />
       </AudioPreviewWrapper>
     );
   }

--- a/packages/core/upload/admin/src/components/MediaLibraryInput/Carousel/CarouselAsset.js
+++ b/packages/core/upload/admin/src/components/MediaLibraryInput/Carousel/CarouselAsset.js
@@ -6,6 +6,7 @@ import { Box } from '@strapi/design-system/Box';
 import { Flex } from '@strapi/design-system/Flex';
 import { AssetType, AssetDefinition } from '../../../constants';
 import { VideoPreview } from '../../AssetCard/VideoPreview';
+import { AudioPreview } from '../../AssetCard/AudioPreview';
 import { createAssetUrl } from '../../../utils/createAssetUrl';
 
 const DocAsset = styled(Flex)`
@@ -30,6 +31,16 @@ export const CarouselAsset = ({ asset }) => {
           alt={asset.alternativeText || asset.name}
         />
       </VideoPreviewWrapper>
+    );
+  }
+
+  if (asset.mime.includes(AssetType.Audio)) {
+    return (
+      <AudioPreview
+        url={createAssetUrl(asset, true)}
+        mime={asset.mime}
+        alt={asset.alternativeText || asset.name}
+      />
     );
   }
 

--- a/packages/core/upload/admin/src/components/MediaLibraryInput/index.js
+++ b/packages/core/upload/admin/src/components/MediaLibraryInput/index.js
@@ -24,7 +24,7 @@ export const MediaLibraryInput = ({
   value,
   required,
 }) => {
-  const fieldAllowedTypes = allowedTypes || ['files', 'images', 'videos'];
+  const fieldAllowedTypes = allowedTypes || ['files', 'images', 'videos', 'audios'];
   const [uploadedFiles, setUploadedFiles] = useState([]);
   const [step, setStep] = useState(undefined);
   const [selectedIndex, setSelectedIndex] = useState(0);
@@ -180,7 +180,7 @@ export const MediaLibraryInput = ({
 };
 
 MediaLibraryInput.defaultProps = {
-  attribute: { allowedTypes: ['videos', 'files', 'images'] },
+  attribute: { allowedTypes: ['videos', 'files', 'images', 'audios'] },
   disabled: false,
   description: undefined,
   error: undefined,

--- a/packages/core/upload/admin/src/constants.js
+++ b/packages/core/upload/admin/src/constants.js
@@ -4,6 +4,7 @@ export const AssetType = {
   Video: 'video',
   Image: 'image',
   Document: 'doc',
+  Audio: 'audio',
 };
 
 export const AssetSource = {

--- a/packages/core/upload/admin/src/utils/typeFromMime.js
+++ b/packages/core/upload/admin/src/utils/typeFromMime.js
@@ -7,6 +7,9 @@ export const typeFromMime = mime => {
   if (mime.includes(AssetType.Video)) {
     return AssetType.Video;
   }
+  if (mime.includes(AssetType.Audio)) {
+    return AssetType.Audio;
+  }
 
   return AssetType.Document;
 };

--- a/packages/generators/generators/lib/plops/content-type.js
+++ b/packages/generators/generators/lib/plops/content-type.js
@@ -73,7 +73,7 @@ module.exports = plop => {
         }
 
         if (answer.attributeType === 'media') {
-          val.allowedTypes = ['images', 'files', 'videos'];
+          val.allowedTypes = ['images', 'files', 'videos', 'audios'];
           val.multiple = answer.multiple;
         }
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

- Added a new file type category: Audio for the supported types cfr w3c, https://www.w3schools.com/tags/tag_audio.asp
- Added specific preview for this type both in builder and content mode so audio can be played in the admin panels

Following things I'm not entirely sure about:
- I presume this could be a breaking change for items which currently have 'files' as allowed type if currently it would be a different file type. I'm not really sure what the best way to tackle this is.
- Not sure if translation additions/changes would be required
- AudioAssetCard has a different dom order than VideoAssetCard for the select/edit buttons because otherwise the z-index didn't play nicely and I couldn't figure out why it did work for video/image currently.

Some screenshots of what it looks like:
![Screenshot 2022-02-06 at 11 59 33](https://user-images.githubusercontent.com/1830018/152677736-0a15eace-51ca-4c4a-9867-32c2462c20a9.png)
![Screenshot 2022-02-06 at 11 59 40](https://user-images.githubusercontent.com/1830018/152677735-c5042587-11d5-4ceb-95f3-55224c2785f1.png)
![Screenshot 2022-02-06 at 11 59 52](https://user-images.githubusercontent.com/1830018/152677734-81976c1c-7d2d-445b-b0c5-81997261af7e.png)
![Screenshot 2022-02-06 at 12 00 04](https://user-images.githubusercontent.com/1830018/152677732-a42b0ff1-e4a6-4a13-8b4b-03c8a4712e50.png)

### Why is it needed?

Videos and images already have previews in the media library / while editing content but audio did not. This allows easily verifying the audio file linked to a content item - or item in the media library.

### How to test it?

Upload supported audio types (mp3, ogg, wav) in the media library or on a content type. Expected behaviour: ability to playback the audio file instead of the current 'doc' icon which only allows downloading.

### Related issue(s)/PR(s)

There is no linked issue/PR I'm aware of.
