### PR TITLE
feat: add a custom url prefix to the local-upload plugin.

### DIFF
--- a/packages/providers/upload-local/README.md
+++ b/packages/providers/upload-local/README.md
@@ -23,7 +23,10 @@ npm install @strapi/provider-upload-local --save
 
 ## Configurations
 
-This provider has only one parameter: `sizeLimit`.
+This provider has two parameters:
+
+- `sizeLimit` that defines the max size of the file
+- `publicUrlPrefix` that allows for a custom base URL
 
 ### Provider Configuration
 
@@ -37,6 +40,7 @@ module.exports = ({ env }) => ({
       provider: 'local',
       providerOptions: {
         sizeLimit: 100000,
+        publicUrlPrefix: 'http://localhost:1337',
       },
     },
   },

--- a/packages/providers/upload-local/lib/index.js
+++ b/packages/providers/upload-local/lib/index.js
@@ -10,7 +10,7 @@ const path = require('path');
 const { PayloadTooLargeError } = require('@strapi/utils').errors;
 
 module.exports = {
-  init({ sizeLimit = 1000000 } = {}) {
+  init({ sizeLimit = 1000000, publicUrlPrefix = '' } = {}) {
     const verifySize = file => {
       if (file.size > sizeLimit) {
         throw new PayloadTooLargeError();
@@ -33,7 +33,7 @@ module.exports = {
                 return reject(err);
               }
 
-              file.url = `/uploads/${file.hash}${file.ext}`;
+              file.url = `${publicUrlPrefix}/uploads/${file.hash}${file.ext}`;
 
               resolve();
             }


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Add option `publicUrlPrefix` that enables a custom prefix URL for the upload-local plugin.

### Why is it needed?

To keep it coherent with other storage providers that return the absolute path.

### How to test it?

Add the `publicUrlPrefix` property to the plugin configuration, upload a file via Strapi and check if the URL matches the correct url and the file is delivered.

### Related issue(s)/PR(s)

N/A
