### PR TITLE
Fix Datetime field cannot be empty

### DIFF
--- a/packages/core/helper-plugin/lib/src/components/GenericInput/index.js
+++ b/packages/core/helper-plugin/lib/src/components/GenericInput/index.js
@@ -147,7 +147,7 @@ const GenericInput = ({
             onChange({ target: { name, value: formattedDate, type } });
           }}
           step={step}
-          onClear={() => onChange({ target: { name, value: '', type } })}
+          onClear={() => onChange({ target: { name, value: null, type } })}
           placeholder={formattedPlaceholder}
           required={required}
           value={value ? new Date(value) : null}


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Clear datetime field `null` instead of `''`

### Why is it needed?

In order to fix a bug that datetime field cannot be empty

### How to test it?

1. Add a datetime field named 'foo', set "Required field" off
2. Insert a new record with a valid date in 'foo' field
3. Edit the record
4. Reset the 'foo' field
5. Save

### Related issue(s)/PR(s)

Closes #12431