### PR TITLE
UP: Make password field required by default

### DIFF
--- a/examples/getstarted/src/extensions/users-permissions/content-types/user/schema.json
+++ b/examples/getstarted/src/extensions/users-permissions/content-types/user/schema.json
@@ -32,7 +32,8 @@
       "type": "password",
       "minLength": 6,
       "configurable": false,
-      "private": true
+      "private": true,
+      "required": true
     },
     "resetPasswordToken": {
       "type": "string",


### PR DESCRIPTION
### What does it do?

Users in the getstarted example require a password field to be set, which is not reflected in the schema. This PR marks the field as required, so error messages are shown properly.

| Before | After |
|---|---|
| ![Screenshot from 2022-02-10 11-26-38](https://user-images.githubusercontent.com/2244375/153388408-96ea34cf-26c0-49ff-bdbd-c75426d31e9b.png) | ![Screenshot from 2022-02-10 11-27-29](https://user-images.githubusercontent.com/2244375/153388443-54a06e0c-9be8-4238-b3cc-06fff18a39cf.png) |

### Why is it needed?

To reflect the default state of the application properly in the schema and CM form.

### How to test it?

1. Go to the content manager
2. Navigate the the users content type
3. Try to create a new user

http://localhost:1337/admin/content-manager/collectionType/plugin::users-permissions.user/create
