### PR TITLE
CTB: Fix alignment of curve icons in production mode

### DIFF
--- a/packages/core/content-type-builder/admin/src/components/ListRow/index.js
+++ b/packages/core/content-type-builder/admin/src/components/ListRow/index.js
@@ -6,10 +6,11 @@ import { IconButton } from '@strapi/design-system/IconButton';
 import { Flex } from '@strapi/design-system/Flex';
 import { Stack } from '@strapi/design-system/Stack';
 import { Typography } from '@strapi/design-system/Typography';
+import { Box } from '@strapi/design-system/Box';
+import Lock from '@strapi/icons/Lock';
 import Pencil from '@strapi/icons/Pencil';
 import Trash from '@strapi/icons/Trash';
-import { stopPropagation, onRowClick } from '@strapi/helper-plugin';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { stopPropagation, onRowClick, pxToRem } from '@strapi/helper-plugin';
 import useDataManager from '../../hooks/useDataManager';
 import getTrad from '../../utils/getTrad';
 import Curve from '../../icons/Curve';
@@ -132,7 +133,7 @@ function ListRow({
         )}
       </td>
       <td>
-        {isInDevelopmentMode && (
+        {isInDevelopmentMode ? (
           <Flex justifyContent="flex-end" {...stopPropagation}>
             {configurable ? (
               <Stack horizontal size={1}>
@@ -165,10 +166,16 @@ function ListRow({
                 />
               </Stack>
             ) : (
-              // ! TODO ASK DESIGN TO PUT LOCK ICON INSIDE DS
-              <FontAwesomeIcon icon="lock" />
+              <Lock />
             )}
           </Flex>
+        ) : (
+          /*
+            In production mode the edit icons aren't visible, therefore
+            we need to reserve the same space, otherwise the height of the
+            row might collapse, leading to bad positioned curve icons
+          */
+          <Box height={pxToRem(32)} />
         )}
       </td>
     </BoxWrapper>

--- a/packages/core/content-type-builder/admin/src/components/Tr/index.js
+++ b/packages/core/content-type-builder/admin/src/components/Tr/index.js
@@ -19,7 +19,7 @@ const Tr = styled.tr`
       &::before {
         content: '';
         width: ${pxToRem(4)};
-        height: calc(100% - 15px);
+        height: calc(100% - 40px);
         position: absolute;
         top: -7px;
         left: 1.625rem;

--- a/packages/core/content-type-builder/admin/src/pages/ListView/tests/__snapshots__/index.test.js.snap
+++ b/packages/core/content-type-builder/admin/src/pages/ListView/tests/__snapshots__/index.test.js.snap
@@ -942,7 +942,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
 .c39.dynamiczone-row > td:first-of-type::before {
   content: '';
   width: 0.25rem;
-  height: calc(100% - 15px);
+  height: calc(100% - 40px);
   position: absolute;
   top: -7px;
   left: 1.625rem;
@@ -975,7 +975,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
 .c50.dynamiczone-row > td:first-of-type::before {
   content: '';
   width: 0.25rem;
-  height: calc(100% - 15px);
+  height: calc(100% - 40px);
   position: absolute;
   top: -7px;
   left: 1.625rem;


### PR DESCRIPTION
### What does it do?

This fixes two visual glitches:

- in production mode the line on the left overflows the curve
- in production mode the curve isn't properly aligned to the vertical center of the word, because the rows were shorter, due to the missing action icons

| Before         | After     |
|--------------|-----------|
| <img width="1177" alt="Screenshot 2022-02-10 at 14 14 31" src="https://user-images.githubusercontent.com/2244375/153426641-5786299c-61de-4034-a6da-538e3d55dcce.png"> | ![Screenshot from 2022-02-10 15-15-52](https://user-images.githubusercontent.com/2244375/153426533-83f53d6e-a81b-4f14-8342-564a2f290139.png) |

### Why is it needed?

Fixes design issues.

### How to test it?

1. Go to the content type builder
2. Run the app in dev & production mode and see the curve icon of a content type in the right position

