### PR TITLE
Add configuration options to generate graphql schema + types

### DIFF
--- a/packages/plugins/graphql/server/services/content-api/index.js
+++ b/packages/plugins/graphql/server/services/content-api/index.js
@@ -68,6 +68,8 @@ module.exports = ({ strapi }) => {
       typegen: config('artifacts.typegen', false),
     };
 
+    const currentEnv = strapi.config.get('environment');
+
     const nexusSchema = makeSchema({
       // Build the schema from the merged GraphQL schema.
       // Since we're passing the schema to the mergeSchema property, it'll transform our SDL type definitions
@@ -79,7 +81,7 @@ module.exports = ({ strapi }) => {
 
       // Whether to generate artifacts (GraphQL schema, TS types definitions) or not.
       // By default, we generate artifacts only on development environment
-      shouldGenerateArtifacts: config('generateArtifacts', process.env.NODE_ENV === 'development'),
+      shouldGenerateArtifacts: config('generateArtifacts', currentEnv === 'development'),
 
       // Artifacts generation configuration
       outputs,

--- a/packages/plugins/graphql/server/services/content-api/index.js
+++ b/packages/plugins/graphql/server/services/content-api/index.js
@@ -3,7 +3,7 @@
 const { mergeSchemas, addResolversToSchema } = require('@graphql-tools/schema');
 const { pruneSchema } = require('@graphql-tools/utils');
 const { makeSchema } = require('nexus');
-const { prop, startsWith, negate, eq } = require('lodash/fp');
+const { prop, startsWith } = require('lodash/fp');
 
 const { wrapResolvers } = require('./wrap-resolvers');
 const {
@@ -77,8 +77,9 @@ module.exports = ({ strapi }) => {
       // Apply user-defined plugins
       plugins: extension.plugins,
 
-      // Generate artifacts only if one of the configuration has been set
-      shouldGenerateArtifacts: Object.values(outputs).some(negate(eq(false))),
+      // Whether to generate artifacts (GraphQL schema, TS types definitions) or not.
+      // By default, we generate artifacts only on development environment
+      shouldGenerateArtifacts: config('generateArtifacts', process.env.NODE_ENV === 'development'),
 
       // Artifacts generation configuration
       outputs,


### PR DESCRIPTION
### What does it do?

Adds a `artifacts` attribute in the GraphQL plugin configuration that allows generating artifacts (GraphQL schema & types definitions) for ou application.
Also, add a `generateArtifacts` config option to allow or not the generation of such artifacts. The default value is `true` in dev ENV and `false` otherwise.

A documentation PR will follow soon.

### Why is it needed?

In V3 it was possible to extract our GraphQL schema.

### How to test it?

`src/config/plugins.js`
```javascript
'use strict';

const { join } = require('path');

module.exports = () => ({
  // ...
  graphql: {
    enabled: true,
    config: {
      generateArtifacts: true,
      artifacts: {
        schema: join(__dirname, '..', 'schema.graphql'),
        typegen: join(__dirname, '..', 'types.d.ts'),
      },
    }
  }
})
```

### Related issue(s)/PR(s)

Fix https://github.com/strapi/strapi/issues/12420