### PR TITLE
Remove empty requestBody which violates OpenAPI spec

### DIFF
--- a/packages/plugins/documentation/server/utils/builders/build-api-endpoint-path.js
+++ b/packages/plugins/documentation/server/utils/builders/build-api-endpoint-path.js
@@ -97,7 +97,6 @@ const getPaths = ({ routeInfo, attributes, tag }) => {
       responses,
       tags: [_.upperFirst(tag)],
       parameters: [],
-      requestBody: {},
     };
 
     if (isListOfEntities) {


### PR DESCRIPTION
fix #12485

### What does it do?

This solves #12485. The problem was that the property `requestBody` was initialized with an empty object instead of leaving it undefined.

### How to test it?

Start the example getstarted project and look at the generated file **examples/getstarted/src/extensions/documentation/documentation/2.0.0/full_documentation.json**. It should no longer contain empty `requestBody` fields.

### Related issue(s)/PR(s)

#12485
