### PR TITLE
Include required description in 200 response

### DIFF
--- a/packages/plugins/documentation/server/utils/builders/build-api-responses.js
+++ b/packages/plugins/documentation/server/utils/builders/build-api-responses.js
@@ -57,6 +57,7 @@ module.exports = (attributes, route, isListOfEntities = false) => {
   return {
     responses: {
       '200': {
+        description: 'OK',
         content: {
           'application/json': {
             schema,


### PR DESCRIPTION
fix #12487

### What does it do?

This solves #12487. The problem was just a missing `description` property in the response object of the 200 response.

### How to test it?

Start the example getstarted project and look at the generated file **examples/getstarted/src/extensions/documentation/documentation/2.0.0/full_documentation.json**. It should now contain a `description` property for 200 response like it does for all other responses.

### Related issue(s)/PR(s)

#12487