### PR TITLE
Set operationId

### DIFF
--- a/packages/plugins/documentation/server/utils/builders/build-api-endpoint-path.js
+++ b/packages/plugins/documentation/server/utils/builders/build-api-endpoint-path.js
@@ -97,7 +97,7 @@ const getPaths = ({ routeInfo, attributes, tag }) => {
       responses,
       tags: [_.upperFirst(tag)],
       parameters: [],
-      requestBody: {},
+      operationId: `${methodVerb}${_.upperFirst(routePath)}`,
     };
 
     if (isListOfEntities) {

--- a/packages/plugins/documentation/server/utils/builders/build-api-endpoint-path.js
+++ b/packages/plugins/documentation/server/utils/builders/build-api-endpoint-path.js
@@ -97,7 +97,7 @@ const getPaths = ({ routeInfo, attributes, tag }) => {
       responses,
       tags: [_.upperFirst(tag)],
       parameters: [],
-      operationId: `${methodVerb}${_.upperFirst(routePath)}`,
+      operationId: `${methodVerb}${routePath}`,
     };
 
     if (isListOfEntities) {


### PR DESCRIPTION
fix #12489

### What does it do?

This solves #12489 by generating operationIds consisting of the HTTP verb and the route.

### How to test it?

Start the example getstarted project and look at the generated file **examples/getstarted/src/extensions/documentation/documentation/2.0.0/full_documentation.json**. All operations should now contain a `operationId` field.

### Related issue(s)/PR(s)

#12489
Should be merged after #12488 to avoid confusion or merge conflicts.