### PR TITLE
Fix port miss-spelling for --watch-admin command from 8000 to 8080.

### DIFF
--- a/packages/core/strapi/lib/commands/watchAdmin.js
+++ b/packages/core/strapi/lib/commands/watchAdmin.js
@@ -21,7 +21,7 @@ module.exports = async function({ browser }) {
 
   const { adminPath } = getConfigUrls(strapiInstance.config, true);
 
-  const adminPort = strapiInstance.config.get('admin.port', 8000);
+  const adminPort = strapiInstance.config.get('admin.port', 8080);
   const adminHost = strapiInstance.config.get('admin.host', 'localhost');
   const adminWatchIgnoreFiles = strapiInstance.config.get('admin.watchIgnoreFiles', []);
 


### PR DESCRIPTION
### What does it do?

Changed console logging of the wrong port to correct one.

### Why is it needed?

It caused me to miss understand how to open the admin panel while using "--watch-admin".

### How to test it?

Just run "yarn develop --watch-admin" command on a project.

### Related issue(s)/PR(s)

This commit fixes #12496 
