### PR TITLE
Fixing Drag ordering bug with Nested Component.

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/RepeatableComponent/DraggedItem/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/RepeatableComponent/DraggedItem/index.js
@@ -121,6 +121,10 @@ const DraggedItem = ({
       if (dragIndex > hoverIndex && hoverClientY > hoverMiddleY) {
         return;
       }
+      // If They are not in the same level, should not move
+      if (dragPath.split('.').length !== hoverPath.split('.').length) {
+        return;
+      }
       // Time to actually perform the action in the data
       moveComponentField(pathToComponentArray, dragIndex, hoverIndex);
 


### PR DESCRIPTION
Fixes #12498 

### What does it do?

Guard with an IF condition to not replace/exhange position with an item of a different hierarchy level.

### Why is it needed?

When moving a ChildComponent it moved the ParentComponent instead the child.

### How to test it?

Create a Collection with a ComponentField (for example Menu), and add a ChildComponent (SubMenu) to the ParentComponent as a FieldComponent.

Try to order child components if you have multiple parent components.

### Related issue(s)/PR(s)

Issue: #12498 
