### PR TITLE
fix role population for users-permission

### DIFF
--- a/packages/plugins/users-permissions/server/controllers/role.js
+++ b/packages/plugins/users-permissions/server/controllers/role.js
@@ -33,7 +33,7 @@ module.exports = {
     ctx.send({ role });
   },
 
-  async getRoles(ctx) {
+  async find(ctx) {
     const roles = await getService('role').getRoles();
 
     ctx.send({ roles });

--- a/packages/plugins/users-permissions/server/routes/admin/role.js
+++ b/packages/plugins/users-permissions/server/routes/admin/role.js
@@ -19,7 +19,7 @@ module.exports = [
   {
     method: 'GET',
     path: '/roles',
-    handler: 'role.getRoles',
+    handler: 'role.find',
     config: {
       policies: [
         {

--- a/packages/plugins/users-permissions/server/routes/content-api/role.js
+++ b/packages/plugins/users-permissions/server/routes/content-api/role.js
@@ -9,7 +9,7 @@ module.exports = [
   {
     method: 'GET',
     path: '/roles',
-    handler: 'role.getRoles',
+    handler: 'role.find',
   },
   {
     method: 'POST',


### PR DESCRIPTION
### What does it do?

@strapi/utils/lib/sanitize/visitors/remove-restricted-relations.js
there is const ACTIONS_TO_VERIFY = ['find'];
which will be use as the postfix for the verify strategy of user-permission plugin
however name of the route for getting "roles" is => getRoles
and activating getRoles handler for permission access in admin panel does not take affect since
'plugin::users-permissions.user.getRole' will be inserted in the up_permissions table
so simply changin the api route name for getRoles to => "find" would fix the problem

### Why is it needed?

it fix the the population of roles in user-permission plugin

### How to test it?

calling api route for get user(s) and use populate query "role"
find user and find role should be seleceted in the admin for the role of api caller

### Related issue(s)/PR(s)


