### PR TITLE
[V3] Packages Deprecation

### DIFF
--- a/packages/strapi-admin/README.md
+++ b/packages/strapi-admin/README.md
@@ -1,5 +1,23 @@
 # Strapi built-in admin panel
 
+---
+
+## Deprecation Warning :warning:
+
+Hello! We have some news to share,
+
+We’ve decided it’ll soon be time to end the support for `strapi-admin`.
+
+After years of iterations, Strapi is going to V4 and we won’t maintain V3 packages when it’ll reach its end-of-support milestone (~early Q3 2022).
+
+If you’ve been using `strapi-admin` and have migrated to V4 (or if you want to), you can find the equivalent and updated version of this package at this [URL](https://github.com/strapi/strapi/tree/master/packages/core/admin) and with the following name on NPM: `@strapi/admin`.
+
+If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 version soon.
+
+The Strapi team
+
+---
+
 ## Description
 
 TODO

--- a/packages/strapi-admin/README.md
+++ b/packages/strapi-admin/README.md
@@ -8,7 +8,7 @@ Hello! We have some news to share,
 
 We’ve decided it’ll soon be time to end the support for `strapi-admin`.
 
-After years of iterations, Strapi is going to V4 and we won’t maintain V3 packages when it’ll reach its end-of-support milestone (~early Q3 2022).
+After years of iterations, Strapi is going to V4 and we won’t maintain V3 packages when it’ll reach its end-of-support milestone (~end of Q3 2022).
 
 If you’ve been using `strapi-admin` and have migrated to V4 (or if you want to), you can find the equivalent and updated version of this package at this [URL](https://github.com/strapi/strapi/tree/master/packages/core/admin) and with the following name on NPM: `@strapi/admin`.
 

--- a/packages/strapi-admin/README.md
+++ b/packages/strapi-admin/README.md
@@ -12,7 +12,7 @@ After years of iterations, Strapi is going to V4 and we won’t maintain V3 pack
 
 If you’ve been using `strapi-admin` and have migrated to V4 (or if you want to), you can find the equivalent and updated version of this package at this [URL](https://github.com/strapi/strapi/tree/master/packages/core/admin) and with the following name on NPM: `@strapi/admin`.
 
-If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 version soon.
+If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 soon.
 
 The Strapi team
 

--- a/packages/strapi-connector-bookshelf/README.md
+++ b/packages/strapi-connector-bookshelf/README.md
@@ -18,7 +18,7 @@ We released Strapi V4 in Q4 2021 and Strapi V3 will reach end-of-support around 
 
 Since this package won't be ported in V4, we took the decision to deprecate it.
 
-If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 version soon.
+If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 soon.
 
 The Strapi team
 

--- a/packages/strapi-connector-bookshelf/README.md
+++ b/packages/strapi-connector-bookshelf/README.md
@@ -8,6 +8,22 @@
 
 This built-in connector allows you to use the [Bookshelf ORM](http://bookshelfjs.org/) using the `strapi-connector-knex` connector.
 
+---
+
+## Deprecation Warning :warning:
+
+Hello, we've some news to share!
+
+We released Strapi V4 in Q4 2021 and Strapi V3 will reach end-of-support around Q3 2022.
+
+Since this package won't be ported in V4, we took the decision to deprecate it.
+
+If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 version soon.
+
+The Strapi team
+
+---
+
 [Bookshelf ORM](http://bookshelfjs.org/) is a JavaScript ORM for Node.js, built on the [Knex node module](http://knexjs.org/) SQL query builder. Featuring both promise based and traditional callback interfaces, providing transaction support, eager/nested-eager relation loading, polymorphic associations, and support for one-to-one, one-to-many, and many-to-many relations.
 
 It is designed to work well with SQLite3, PostgreSQL, MySQL, MariaDB, Microsoft SQL Server and Oracle.

--- a/packages/strapi-connector-bookshelf/README.md
+++ b/packages/strapi-connector-bookshelf/README.md
@@ -14,7 +14,7 @@ This built-in connector allows you to use the [Bookshelf ORM](http://bookshelfjs
 
 Hello, we've some news to share!
 
-We released Strapi V4 in Q4 2021 and Strapi V3 will reach end-of-support around Q3 2022.
+We released Strapi V4 in Q4 2021 and Strapi V3 will reach end-of-support around the end of Q3 2022.
 
 Since this package won't be ported in V4, we took the decision to deprecate it.
 

--- a/packages/strapi-connector-mongoose/README.md
+++ b/packages/strapi-connector-mongoose/README.md
@@ -18,7 +18,7 @@ We released Strapi V4 in Q4 2021 and Strapi V3 will reach end-of-support around 
 
 Since this package won't be ported in V4, we took the decision to deprecate it.
 
-If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 version soon.
+If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 soon.
 
 The Strapi team
 

--- a/packages/strapi-connector-mongoose/README.md
+++ b/packages/strapi-connector-mongoose/README.md
@@ -8,6 +8,22 @@
 
 This built-in connector allows you to use the [Mongoose ORM](http://mongoosejs.com/).
 
+---
+
+## Deprecation Warning :warning:
+
+Hello, we've some news to share!
+
+We released Strapi V4 in Q4 2021 and Strapi V3 will reach end-of-support around Q3 2022.
+
+Since this package won't be ported in V4, we took the decision to deprecate it.
+
+If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 version soon.
+
+The Strapi team
+
+---
+
 [Mongoose ORM](http://mongoosejs.com/) provides a straight-forward, schema-based solution to model your application data. It includes built-in type casting, validation, query building, business logic connectors and more, out of the box.
 
 ## Resources

--- a/packages/strapi-connector-mongoose/README.md
+++ b/packages/strapi-connector-mongoose/README.md
@@ -14,7 +14,7 @@ This built-in connector allows you to use the [Mongoose ORM](http://mongoosejs.c
 
 Hello, we've some news to share!
 
-We released Strapi V4 in Q4 2021 and Strapi V3 will reach end-of-support around Q3 2022.
+We released Strapi V4 in Q4 2021 and Strapi V3 will reach end-of-support around the end of Q3 2022.
 
 Since this package won't be ported in V4, we took the decision to deprecate it.
 

--- a/packages/strapi-database/README.md
+++ b/packages/strapi-database/README.md
@@ -18,7 +18,7 @@ After years of iterations, Strapi is going to V4 and we won’t maintain V3 pack
 
 If you’ve been using `strapi-database` and have migrated to V4 (or if you want to), you can find the equivalent and updated version of this package at this [URL](https://github.com/strapi/strapi/tree/master/packages/core/database) and with the following name on NPM: `@strapi/database`.
 
-If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 version soon.
+If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 soon.
 
 The Strapi team
 

--- a/packages/strapi-database/README.md
+++ b/packages/strapi-database/README.md
@@ -6,6 +6,24 @@
 [![Build status](https://travis-ci.org/strapi/strapi-database.svg?branch=master)](https://travis-ci.org/strapi/strapi-database)
 [![Slack status](https://slack.strapi.io/badge.svg)](https://slack.strapi.io)
 
+---
+
+## Deprecation Warning :warning:
+
+Hello! We have some news to share,
+
+We’ve decided it’ll soon be time to end the support for `strapi-database`.
+
+After years of iterations, Strapi is going to V4 and we won’t maintain V3 packages when it’ll reach its end-of-support milestone (~early Q3 2022).
+
+If you’ve been using `strapi-database` and have migrated to V4 (or if you want to), you can find the equivalent and updated version of this package at this [URL](https://github.com/strapi/strapi/tree/master/packages/core/database) and with the following name on NPM: `@strapi/database`.
+
+If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 version soon.
+
+The Strapi team
+
+---
+
 This package is strapi's database handling layer. It is responsible for orchestrating database connectors and implementing the logic of strapi's data structures.
 
 This package is not meant to be used as a standalone module.

--- a/packages/strapi-database/README.md
+++ b/packages/strapi-database/README.md
@@ -14,7 +14,7 @@ Hello! We have some news to share,
 
 We’ve decided it’ll soon be time to end the support for `strapi-database`.
 
-After years of iterations, Strapi is going to V4 and we won’t maintain V3 packages when it’ll reach its end-of-support milestone (~early Q3 2022).
+After years of iterations, Strapi is going to V4 and we won’t maintain V3 packages when it’ll reach its end-of-support milestone (~end of Q3 2022).
 
 If you’ve been using `strapi-database` and have migrated to V4 (or if you want to), you can find the equivalent and updated version of this package at this [URL](https://github.com/strapi/strapi/tree/master/packages/core/database) and with the following name on NPM: `@strapi/database`.
 

--- a/packages/strapi-helper-plugin/README.md
+++ b/packages/strapi-helper-plugin/README.md
@@ -12,7 +12,7 @@ After years of iterations, Strapi is going to V4 and we won’t maintain V3 pack
 
 If you’ve been using `strapi-helper-plugin` and have migrated to V4 (or if you want to), you can find the equivalent and updated version of this package at this [URL](https://github.com/strapi/strapi/tree/master/packages/core/helper-plugin) and with the following name on NPM: `@strapi/helper-plugin`.
 
-If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 version soon.
+If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 soon.
 
 The Strapi team
 

--- a/packages/strapi-helper-plugin/README.md
+++ b/packages/strapi-helper-plugin/README.md
@@ -1,5 +1,23 @@
 # Strapi Helper Plugin
 
+---
+
+## Deprecation Warning :warning:
+
+Hello! We have some news to share,
+
+We’ve decided it’ll soon be time to end the support for `strapi-helper-plugin`.
+
+After years of iterations, Strapi is going to V4 and we won’t maintain V3 packages when it’ll reach its end-of-support milestone (~early Q3 2022).
+
+If you’ve been using `strapi-helper-plugin` and have migrated to V4 (or if you want to), you can find the equivalent and updated version of this package at this [URL](https://github.com/strapi/strapi/tree/master/packages/core/helper-plugin) and with the following name on NPM: `@strapi/helper-plugin`.
+
+If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 version soon.
+
+The Strapi team
+
+---
+
 ## Description
 
 Helper to develop Strapi plugins.

--- a/packages/strapi-helper-plugin/README.md
+++ b/packages/strapi-helper-plugin/README.md
@@ -8,7 +8,7 @@ Hello! We have some news to share,
 
 We’ve decided it’ll soon be time to end the support for `strapi-helper-plugin`.
 
-After years of iterations, Strapi is going to V4 and we won’t maintain V3 packages when it’ll reach its end-of-support milestone (~early Q3 2022).
+After years of iterations, Strapi is going to V4 and we won’t maintain V3 packages when it’ll reach its end-of-support milestone (~end of Q3 2022).
 
 If you’ve been using `strapi-helper-plugin` and have migrated to V4 (or if you want to), you can find the equivalent and updated version of this package at this [URL](https://github.com/strapi/strapi/tree/master/packages/core/helper-plugin) and with the following name on NPM: `@strapi/helper-plugin`.
 

--- a/packages/strapi-hook-ejs/README.md
+++ b/packages/strapi-hook-ejs/README.md
@@ -18,7 +18,7 @@ We released Strapi V4 in Q4 2021 and Strapi V3 will reach end-of-support around 
 
 Since this package won't be ported in V4, we took the decision to deprecate it.
 
-If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 version soon.
+If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 soon.
 
 The Strapi team
 

--- a/packages/strapi-hook-ejs/README.md
+++ b/packages/strapi-hook-ejs/README.md
@@ -8,6 +8,22 @@
 
 This built-in hook allows you to use the EJS template engine with custom options.
 
+---
+
+## Deprecation Warning :warning:
+
+Hello, we've some news to share!
+
+We released Strapi V4 in Q4 2021 and Strapi V3 will reach end-of-support around Q3 2022.
+
+Since this package won't be ported in V4, we took the decision to deprecate it.
+
+If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 version soon.
+
+The Strapi team
+
+---
+
 ## Configuration
 
 To configure your hook with custom options, you need to edit your `./config/hook.json` file in your Strapi app.

--- a/packages/strapi-hook-ejs/README.md
+++ b/packages/strapi-hook-ejs/README.md
@@ -14,7 +14,7 @@ This built-in hook allows you to use the EJS template engine with custom options
 
 Hello, we've some news to share!
 
-We released Strapi V4 in Q4 2021 and Strapi V3 will reach end-of-support around Q3 2022.
+We released Strapi V4 in Q4 2021 and Strapi V3 will reach end-of-support around the end of Q3 2022.
 
 Since this package won't be ported in V4, we took the decision to deprecate it.
 

--- a/packages/strapi-hook-redis/README.md
+++ b/packages/strapi-hook-redis/README.md
@@ -14,7 +14,7 @@ This built-in hook allows you to use [Redis](https://redis.io/) as a databases c
 
 Hello, we've some news to share!
 
-We released Strapi V4 in Q4 2021 and Strapi V3 will reach end-of-support around Q3 2022.
+We released Strapi V4 in Q4 2021 and Strapi V3 will reach end-of-support around the end of Q3 2022.
 
 Since this package won't be ported in V4, we took the decision to deprecate it.
 

--- a/packages/strapi-hook-redis/README.md
+++ b/packages/strapi-hook-redis/README.md
@@ -18,7 +18,7 @@ We released Strapi V4 in Q4 2021 and Strapi V3 will reach end-of-support around 
 
 Since this package won't be ported in V4, we took the decision to deprecate it.
 
-If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 version soon.
+If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 soon.
 
 The Strapi team
 

--- a/packages/strapi-hook-redis/README.md
+++ b/packages/strapi-hook-redis/README.md
@@ -8,6 +8,22 @@
 
 This built-in hook allows you to use [Redis](https://redis.io/) as a databases connection. Redis is an open source (BSD licensed), in-memory data structure store, used as a database, cache and message broker.
 
+---
+
+## Deprecation Warning :warning:
+
+Hello, we've some news to share!
+
+We released Strapi V4 in Q4 2021 and Strapi V3 will reach end-of-support around Q3 2022.
+
+Since this package won't be ported in V4, we took the decision to deprecate it.
+
+If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 version soon.
+
+The Strapi team
+
+---
+
 ## Motivation
 
 We developed this hook to use Redis as cache database for our Strapi apps.

--- a/packages/strapi-middleware-views/README.md
+++ b/packages/strapi-middleware-views/README.md
@@ -8,6 +8,22 @@
 
 Views middleware to enable server-side rendering for the Strapi framework. It will let you use [koa-views](https://www.npmjs.com/package/koa-views) and [consolidate](https://github.com/tj/consolidate.js/).
 
+---
+
+## Deprecation Warning :warning:
+
+Hello, we've some news to share!
+
+We released Strapi V4 in Q4 2021 and Strapi V3 will reach end-of-support around Q3 2022.
+
+Since this package won't be ported in V4, we took the decision to deprecate it.
+
+If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 version soon.
+
+The Strapi team
+
+---
+
 ## Resources
 
 - [License](LICENSE)

--- a/packages/strapi-middleware-views/README.md
+++ b/packages/strapi-middleware-views/README.md
@@ -18,7 +18,7 @@ We released Strapi V4 in Q4 2021 and Strapi V3 will reach end-of-support around 
 
 Since this package won't be ported in V4, we took the decision to deprecate it.
 
-If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 version soon.
+If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 soon.
 
 The Strapi team
 

--- a/packages/strapi-middleware-views/README.md
+++ b/packages/strapi-middleware-views/README.md
@@ -14,7 +14,7 @@ Views middleware to enable server-side rendering for the Strapi framework. It wi
 
 Hello, we've some news to share!
 
-We released Strapi V4 in Q4 2021 and Strapi V3 will reach end-of-support around Q3 2022.
+We released Strapi V4 in Q4 2021 and Strapi V3 will reach end-of-support around the end of Q3 2022.
 
 Since this package won't be ported in V4, we took the decision to deprecate it.
 

--- a/packages/strapi-plugin-content-manager/README.md
+++ b/packages/strapi-plugin-content-manager/README.md
@@ -8,7 +8,7 @@ Hello! We have some news to share,
 
 We’ve decided it’ll soon be time to end the support for `strapi-plugin-content-manager`.
 
-After years of iterations, Strapi is going to V4 and we won’t maintain V3 packages when it’ll reach its end-of-support milestone (~early Q3 2022).
+After years of iterations, Strapi is going to V4 and we won’t maintain V3 packages when it’ll reach its end-of-support milestone (~end of Q3 2022).
 
 If you’ve been using `strapi-plugin-content-manager` and have migrated to V4 (or if you want to), you can find the equivalent and updated version of this package at this [URL](https://github.com/strapi/strapi/tree/master/packages/core/content-manager) and with the following name on NPM: `@strapi/plugin-content-manager`.
 

--- a/packages/strapi-plugin-content-manager/README.md
+++ b/packages/strapi-plugin-content-manager/README.md
@@ -12,7 +12,7 @@ After years of iterations, Strapi is going to V4 and we won’t maintain V3 pack
 
 If you’ve been using `strapi-plugin-content-manager` and have migrated to V4 (or if you want to), you can find the equivalent and updated version of this package at this [URL](https://github.com/strapi/strapi/tree/master/packages/core/content-manager) and with the following name on NPM: `@strapi/plugin-content-manager`.
 
-If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 version soon.
+If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 soon.
 
 The Strapi team
 

--- a/packages/strapi-plugin-content-manager/README.md
+++ b/packages/strapi-plugin-content-manager/README.md
@@ -1,5 +1,23 @@
 # Strapi Content Manager
 
+---
+
+## Deprecation Warning :warning:
+
+Hello! We have some news to share,
+
+We’ve decided it’ll soon be time to end the support for `strapi-plugin-content-manager`.
+
+After years of iterations, Strapi is going to V4 and we won’t maintain V3 packages when it’ll reach its end-of-support milestone (~early Q3 2022).
+
+If you’ve been using `strapi-plugin-content-manager` and have migrated to V4 (or if you want to), you can find the equivalent and updated version of this package at this [URL](https://github.com/strapi/strapi/tree/master/packages/core/content-manager) and with the following name on NPM: `@strapi/plugin-content-manager`.
+
+If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 version soon.
+
+The Strapi team
+
+---
+
 ## Description
 
 This plugin allows you to manage your data through a UI.

--- a/packages/strapi-plugin-content-type-builder/README.md
+++ b/packages/strapi-plugin-content-type-builder/README.md
@@ -12,7 +12,7 @@ After years of iterations, Strapi is going to V4 and we won’t maintain V3 pack
 
 If you’ve been using `strapi-plugin-content-type-builder` and have migrated to V4 (or if you want to), you can find the equivalent and updated version of this package at this [URL](https://github.com/strapi/strapi/tree/master/packages/core/content-type-builder) and with the following name on NPM: `@strapi/plugin-content-type-builder`.
 
-If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 version soon.
+If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 soon.
 
 The Strapi team
 

--- a/packages/strapi-plugin-content-type-builder/README.md
+++ b/packages/strapi-plugin-content-type-builder/README.md
@@ -1,1 +1,19 @@
 # Strapi plugin
+
+---
+
+## Deprecation Warning :warning:
+
+Hello! We have some news to share,
+
+We’ve decided it’ll soon be time to end the support for `strapi-plugin-content-type-builder`.
+
+After years of iterations, Strapi is going to V4 and we won’t maintain V3 packages when it’ll reach its end-of-support milestone (~early Q3 2022).
+
+If you’ve been using `strapi-plugin-content-type-builder` and have migrated to V4 (or if you want to), you can find the equivalent and updated version of this package at this [URL](https://github.com/strapi/strapi/tree/master/packages/core/content-type-builder) and with the following name on NPM: `@strapi/plugin-content-type-builder`.
+
+If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 version soon.
+
+The Strapi team
+
+---

--- a/packages/strapi-plugin-content-type-builder/README.md
+++ b/packages/strapi-plugin-content-type-builder/README.md
@@ -8,7 +8,7 @@ Hello! We have some news to share,
 
 We’ve decided it’ll soon be time to end the support for `strapi-plugin-content-type-builder`.
 
-After years of iterations, Strapi is going to V4 and we won’t maintain V3 packages when it’ll reach its end-of-support milestone (~early Q3 2022).
+After years of iterations, Strapi is going to V4 and we won’t maintain V3 packages when it’ll reach its end-of-support milestone (~end of Q3 2022).
 
 If you’ve been using `strapi-plugin-content-type-builder` and have migrated to V4 (or if you want to), you can find the equivalent and updated version of this package at this [URL](https://github.com/strapi/strapi/tree/master/packages/core/content-type-builder) and with the following name on NPM: `@strapi/plugin-content-type-builder`.
 

--- a/packages/strapi-plugin-documentation/README.md
+++ b/packages/strapi-plugin-documentation/README.md
@@ -1,5 +1,23 @@
 # Plugin documentation
 
+---
+
+## Deprecation Warning :warning:
+
+Hello! We have some news to share,
+
+We’ve decided it’ll soon be time to end the support for `strapi-plugin-documentation`.
+
+After years of iterations, Strapi is going to V4 and we won’t maintain V3 packages when it’ll reach its end-of-support milestone (~early Q3 2022).
+
+If you’ve been using `strapi-plugin-documentation` and have migrated to V4 (or if you want to), you can find the equivalent and updated version of this package at this [URL](https://github.com/strapi/strapi/tree/master/packages/plugins/documentation) and with the following name on NPM: `@strapi/plugin-documentation`.
+
+If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 version soon.
+
+The Strapi team
+
+---
+
 This plugin automates your API documentation creation. It basically generates a swagger file. It follows the [Open API specification version 3.0.1](https://swagger.io/specification/).
 The documentation plugin is not release on npm yet, Here's how to install it.
 

--- a/packages/strapi-plugin-documentation/README.md
+++ b/packages/strapi-plugin-documentation/README.md
@@ -12,7 +12,7 @@ After years of iterations, Strapi is going to V4 and we won’t maintain V3 pack
 
 If you’ve been using `strapi-plugin-documentation` and have migrated to V4 (or if you want to), you can find the equivalent and updated version of this package at this [URL](https://github.com/strapi/strapi/tree/master/packages/plugins/documentation) and with the following name on NPM: `@strapi/plugin-documentation`.
 
-If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 version soon.
+If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 soon.
 
 The Strapi team
 

--- a/packages/strapi-plugin-documentation/README.md
+++ b/packages/strapi-plugin-documentation/README.md
@@ -8,7 +8,7 @@ Hello! We have some news to share,
 
 We’ve decided it’ll soon be time to end the support for `strapi-plugin-documentation`.
 
-After years of iterations, Strapi is going to V4 and we won’t maintain V3 packages when it’ll reach its end-of-support milestone (~early Q3 2022).
+After years of iterations, Strapi is going to V4 and we won’t maintain V3 packages when it’ll reach its end-of-support milestone (~end of Q3 2022).
 
 If you’ve been using `strapi-plugin-documentation` and have migrated to V4 (or if you want to), you can find the equivalent and updated version of this package at this [URL](https://github.com/strapi/strapi/tree/master/packages/plugins/documentation) and with the following name on NPM: `@strapi/plugin-documentation`.
 

--- a/packages/strapi-plugin-email/README.md
+++ b/packages/strapi-plugin-email/README.md
@@ -1,2 +1,21 @@
 # Strapi plugin
+
+---
+
+## Deprecation Warning :warning:
+
+Hello! We have some news to share,
+
+We’ve decided it’ll soon be time to end the support for `strapi-plugin-email`.
+
+After years of iterations, Strapi is going to V4 and we won’t maintain V3 packages when it’ll reach its end-of-support milestone (~early Q3 2022).
+
+If you’ve been using `strapi-plugin-email` and have migrated to V4 (or if you want to), you can find the equivalent and updated version of this package at this [URL](https://github.com/strapi/strapi/tree/master/packages/core/email) and with the following name on NPM: `@strapi/plugin-email`.
+
+If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 version soon.
+
+The Strapi team
+
+---
+
 > :warning: The Shipper Email may also need to be changed in the `Email Templates` tab on the admin panel for emails to send properly

--- a/packages/strapi-plugin-email/README.md
+++ b/packages/strapi-plugin-email/README.md
@@ -8,7 +8,7 @@ Hello! We have some news to share,
 
 We’ve decided it’ll soon be time to end the support for `strapi-plugin-email`.
 
-After years of iterations, Strapi is going to V4 and we won’t maintain V3 packages when it’ll reach its end-of-support milestone (~early Q3 2022).
+After years of iterations, Strapi is going to V4 and we won’t maintain V3 packages when it’ll reach its end-of-support milestone (~end of Q3 2022).
 
 If you’ve been using `strapi-plugin-email` and have migrated to V4 (or if you want to), you can find the equivalent and updated version of this package at this [URL](https://github.com/strapi/strapi/tree/master/packages/core/email) and with the following name on NPM: `@strapi/plugin-email`.
 

--- a/packages/strapi-plugin-email/README.md
+++ b/packages/strapi-plugin-email/README.md
@@ -12,7 +12,7 @@ After years of iterations, Strapi is going to V4 and we won’t maintain V3 pack
 
 If you’ve been using `strapi-plugin-email` and have migrated to V4 (or if you want to), you can find the equivalent and updated version of this package at this [URL](https://github.com/strapi/strapi/tree/master/packages/core/email) and with the following name on NPM: `@strapi/plugin-email`.
 
-If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 version soon.
+If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 soon.
 
 The Strapi team
 

--- a/packages/strapi-plugin-graphql/README.md
+++ b/packages/strapi-plugin-graphql/README.md
@@ -8,7 +8,7 @@ Hello! We have some news to share,
 
 We’ve decided it’ll soon be time to end the support for `strapi-plugin-graphql`.
 
-After years of iterations, Strapi is going to V4 and we won’t maintain V3 packages when it’ll reach its end-of-support milestone (~early Q3 2022).
+After years of iterations, Strapi is going to V4 and we won’t maintain V3 packages when it’ll reach its end-of-support milestone (~end of Q3 2022).
 
 If you’ve been using `strapi-plugin-graphql` and have migrated to V4 (or if you want to), you can find the equivalent and updated version of this package at this [URL](https://github.com/strapi/strapi/tree/master/packages/plugins/graphql) and with the following name on NPM: `@strapi/plugin-graphql`.
 

--- a/packages/strapi-plugin-graphql/README.md
+++ b/packages/strapi-plugin-graphql/README.md
@@ -12,7 +12,7 @@ After years of iterations, Strapi is going to V4 and we won’t maintain V3 pack
 
 If you’ve been using `strapi-plugin-graphql` and have migrated to V4 (or if you want to), you can find the equivalent and updated version of this package at this [URL](https://github.com/strapi/strapi/tree/master/packages/plugins/graphql) and with the following name on NPM: `@strapi/plugin-graphql`.
 
-If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 version soon.
+If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 soon.
 
 The Strapi team
 

--- a/packages/strapi-plugin-graphql/README.md
+++ b/packages/strapi-plugin-graphql/README.md
@@ -1,5 +1,23 @@
 # Strapi GraphQL
 
+---
+
+## Deprecation Warning :warning:
+
+Hello! We have some news to share,
+
+We’ve decided it’ll soon be time to end the support for `strapi-plugin-graphql`.
+
+After years of iterations, Strapi is going to V4 and we won’t maintain V3 packages when it’ll reach its end-of-support milestone (~early Q3 2022).
+
+If you’ve been using `strapi-plugin-graphql` and have migrated to V4 (or if you want to), you can find the equivalent and updated version of this package at this [URL](https://github.com/strapi/strapi/tree/master/packages/plugins/graphql) and with the following name on NPM: `@strapi/plugin-graphql`.
+
+If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 version soon.
+
+The Strapi team
+
+---
+
 This plugin will add GraphQL functionality to your app.
 By default it will provide you with most of the CRUD methods exposed in the Strapi REST API.
 

--- a/packages/strapi-plugin-i18n/README.md
+++ b/packages/strapi-plugin-i18n/README.md
@@ -1,1 +1,19 @@
 # strapi-plugin-i18n
+
+---
+
+## Deprecation Warning :warning:
+
+Hello! We have some news to share,
+
+We’ve decided it’ll soon be time to end the support for `strapi-plugin-i18n`.
+
+After years of iterations, Strapi is going to V4 and we won’t maintain V3 packages when it’ll reach its end-of-support milestone (~early Q3 2022).
+
+If you’ve been using `strapi-plugin-i18n` and have migrated to V4 (or if you want to), you can find the equivalent and updated version of this package at this [URL](https://github.com/strapi/strapi/tree/master/packages/plugins/i18n) and with the following name on NPM: `@strapi/plugin-i18n`.
+
+If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 version soon.
+
+The Strapi team
+
+---

--- a/packages/strapi-plugin-i18n/README.md
+++ b/packages/strapi-plugin-i18n/README.md
@@ -12,7 +12,7 @@ After years of iterations, Strapi is going to V4 and we won’t maintain V3 pack
 
 If you’ve been using `strapi-plugin-i18n` and have migrated to V4 (or if you want to), you can find the equivalent and updated version of this package at this [URL](https://github.com/strapi/strapi/tree/master/packages/plugins/i18n) and with the following name on NPM: `@strapi/plugin-i18n`.
 
-If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 version soon.
+If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 soon.
 
 The Strapi team
 

--- a/packages/strapi-plugin-i18n/README.md
+++ b/packages/strapi-plugin-i18n/README.md
@@ -8,7 +8,7 @@ Hello! We have some news to share,
 
 We’ve decided it’ll soon be time to end the support for `strapi-plugin-i18n`.
 
-After years of iterations, Strapi is going to V4 and we won’t maintain V3 packages when it’ll reach its end-of-support milestone (~early Q3 2022).
+After years of iterations, Strapi is going to V4 and we won’t maintain V3 packages when it’ll reach its end-of-support milestone (~end of Q3 2022).
 
 If you’ve been using `strapi-plugin-i18n` and have migrated to V4 (or if you want to), you can find the equivalent and updated version of this package at this [URL](https://github.com/strapi/strapi/tree/master/packages/plugins/i18n) and with the following name on NPM: `@strapi/plugin-i18n`.
 

--- a/packages/strapi-plugin-sentry/README.md
+++ b/packages/strapi-plugin-sentry/README.md
@@ -14,7 +14,7 @@ After years of iterations, Strapi is going to V4 and we won’t maintain V3 pack
 
 If you’ve been using `strapi-plugin-sentry` and have migrated to V4 (or if you want to), you can find the equivalent and updated version of this package at this [URL](https://github.com/strapi/strapi/tree/master/packages/plugins/sentry) and with the following name on NPM: `@strapi/plugin-sentry`.
 
-If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 version soon.
+If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 soon.
 
 The Strapi team
 

--- a/packages/strapi-plugin-sentry/README.md
+++ b/packages/strapi-plugin-sentry/README.md
@@ -2,6 +2,24 @@
 
 The official plugin to track Strapi errors with Sentry.
 
+---
+
+## Deprecation Warning :warning:
+
+Hello! We have some news to share,
+
+We’ve decided it’ll soon be time to end the support for `strapi-plugin-sentry`.
+
+After years of iterations, Strapi is going to V4 and we won’t maintain V3 packages when it’ll reach its end-of-support milestone (~early Q3 2022).
+
+If you’ve been using `strapi-plugin-sentry` and have migrated to V4 (or if you want to), you can find the equivalent and updated version of this package at this [URL](https://github.com/strapi/strapi/tree/master/packages/plugins/sentry) and with the following name on NPM: `@strapi/plugin-sentry`.
+
+If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 version soon.
+
+The Strapi team
+
+---
+
 ## Features
 
 - Initialize a Sentry instance when your Strapi app starts

--- a/packages/strapi-plugin-sentry/README.md
+++ b/packages/strapi-plugin-sentry/README.md
@@ -10,7 +10,7 @@ Hello! We have some news to share,
 
 We’ve decided it’ll soon be time to end the support for `strapi-plugin-sentry`.
 
-After years of iterations, Strapi is going to V4 and we won’t maintain V3 packages when it’ll reach its end-of-support milestone (~early Q3 2022).
+After years of iterations, Strapi is going to V4 and we won’t maintain V3 packages when it’ll reach its end-of-support milestone (~end of Q3 2022).
 
 If you’ve been using `strapi-plugin-sentry` and have migrated to V4 (or if you want to), you can find the equivalent and updated version of this package at this [URL](https://github.com/strapi/strapi/tree/master/packages/plugins/sentry) and with the following name on NPM: `@strapi/plugin-sentry`.
 

--- a/packages/strapi-plugin-upload/README.md
+++ b/packages/strapi-plugin-upload/README.md
@@ -1,1 +1,19 @@
 # strapi-plugin-upload
+
+---
+
+## Deprecation Warning :warning:
+
+Hello! We have some news to share,
+
+We’ve decided it’ll soon be time to end the support for `strapi-plugin-upload`.
+
+After years of iterations, Strapi is going to V4 and we won’t maintain V3 packages when it’ll reach its end-of-support milestone (~early Q3 2022).
+
+If you’ve been using `strapi-plugin-upload` and have migrated to V4 (or if you want to), you can find the equivalent and updated version of this package at this [URL](https://github.com/strapi/strapi/tree/master/packages/core/upload) and with the following name on NPM: `@strapi/plugin-upload`.
+
+If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 version soon.
+
+The Strapi team
+
+---

--- a/packages/strapi-plugin-upload/README.md
+++ b/packages/strapi-plugin-upload/README.md
@@ -8,7 +8,7 @@ Hello! We have some news to share,
 
 We’ve decided it’ll soon be time to end the support for `strapi-plugin-upload`.
 
-After years of iterations, Strapi is going to V4 and we won’t maintain V3 packages when it’ll reach its end-of-support milestone (~early Q3 2022).
+After years of iterations, Strapi is going to V4 and we won’t maintain V3 packages when it’ll reach its end-of-support milestone (~end of Q3 2022).
 
 If you’ve been using `strapi-plugin-upload` and have migrated to V4 (or if you want to), you can find the equivalent and updated version of this package at this [URL](https://github.com/strapi/strapi/tree/master/packages/core/upload) and with the following name on NPM: `@strapi/plugin-upload`.
 

--- a/packages/strapi-plugin-upload/README.md
+++ b/packages/strapi-plugin-upload/README.md
@@ -12,7 +12,7 @@ After years of iterations, Strapi is going to V4 and we won’t maintain V3 pack
 
 If you’ve been using `strapi-plugin-upload` and have migrated to V4 (or if you want to), you can find the equivalent and updated version of this package at this [URL](https://github.com/strapi/strapi/tree/master/packages/core/upload) and with the following name on NPM: `@strapi/plugin-upload`.
 
-If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 version soon.
+If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 soon.
 
 The Strapi team
 

--- a/packages/strapi-plugin-users-permissions/README.md
+++ b/packages/strapi-plugin-users-permissions/README.md
@@ -1,1 +1,19 @@
 # Strapi plugin
+
+---
+
+## Deprecation Warning :warning:
+
+Hello! We have some news to share,
+
+We’ve decided it’ll soon be time to end the support for `strapi-plugin-users-permissions`.
+
+After years of iterations, Strapi is going to V4 and we won’t maintain V3 packages when it’ll reach its end-of-support milestone (~early Q3 2022).
+
+If you’ve been using `strapi-plugin-users-permissions` and have migrated to V4 (or if you want to), you can find the equivalent and updated version of this package at this [URL](https://github.com/strapi/strapi/tree/master/packages/plugins/users-permissions) and with the following name on NPM: `@strapi/plugin-users-permissions`.
+
+If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 version soon.
+
+The Strapi team
+
+---

--- a/packages/strapi-plugin-users-permissions/README.md
+++ b/packages/strapi-plugin-users-permissions/README.md
@@ -12,7 +12,7 @@ After years of iterations, Strapi is going to V4 and we won’t maintain V3 pack
 
 If you’ve been using `strapi-plugin-users-permissions` and have migrated to V4 (or if you want to), you can find the equivalent and updated version of this package at this [URL](https://github.com/strapi/strapi/tree/master/packages/plugins/users-permissions) and with the following name on NPM: `@strapi/plugin-users-permissions`.
 
-If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 version soon.
+If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 soon.
 
 The Strapi team
 

--- a/packages/strapi-plugin-users-permissions/README.md
+++ b/packages/strapi-plugin-users-permissions/README.md
@@ -8,7 +8,7 @@ Hello! We have some news to share,
 
 We’ve decided it’ll soon be time to end the support for `strapi-plugin-users-permissions`.
 
-After years of iterations, Strapi is going to V4 and we won’t maintain V3 packages when it’ll reach its end-of-support milestone (~early Q3 2022).
+After years of iterations, Strapi is going to V4 and we won’t maintain V3 packages when it’ll reach its end-of-support milestone (~end of Q3 2022).
 
 If you’ve been using `strapi-plugin-users-permissions` and have migrated to V4 (or if you want to), you can find the equivalent and updated version of this package at this [URL](https://github.com/strapi/strapi/tree/master/packages/plugins/users-permissions) and with the following name on NPM: `@strapi/plugin-users-permissions`.
 

--- a/packages/strapi-provider-email-amazon-ses/README.md
+++ b/packages/strapi-provider-email-amazon-ses/README.md
@@ -8,7 +8,7 @@ Hello! We have some news to share,
 
 We’ve decided it’ll soon be time to end the support for `strapi-provider-email-amazon-ses`.
 
-After years of iterations, Strapi is going to V4 and we won’t maintain V3 packages when it’ll reach its end-of-support milestone (~early Q3 2022).
+After years of iterations, Strapi is going to V4 and we won’t maintain V3 packages when it’ll reach its end-of-support milestone (~end of Q3 2022).
 
 If you’ve been using `strapi-provider-email-amazon-ses` and have migrated to V4 (or if you want to), you can find the equivalent and updated version of this package at this [URL](https://github.com/strapi/strapi/tree/master/packages/providers/email-amazon-ses) and with the following name on NPM: `@strapi/provider-email-amazon-ses`.
 

--- a/packages/strapi-provider-email-amazon-ses/README.md
+++ b/packages/strapi-provider-email-amazon-ses/README.md
@@ -12,7 +12,7 @@ After years of iterations, Strapi is going to V4 and we won’t maintain V3 pack
 
 If you’ve been using `strapi-provider-email-amazon-ses` and have migrated to V4 (or if you want to), you can find the equivalent and updated version of this package at this [URL](https://github.com/strapi/strapi/tree/master/packages/providers/email-amazon-ses) and with the following name on NPM: `@strapi/provider-email-amazon-ses`.
 
-If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 version soon.
+If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 soon.
 
 The Strapi team
 

--- a/packages/strapi-provider-email-amazon-ses/README.md
+++ b/packages/strapi-provider-email-amazon-ses/README.md
@@ -1,5 +1,23 @@
 # strapi-provider-email-amazon-ses
 
+---
+
+## Deprecation Warning :warning:
+
+Hello! We have some news to share,
+
+We’ve decided it’ll soon be time to end the support for `strapi-provider-email-amazon-ses`.
+
+After years of iterations, Strapi is going to V4 and we won’t maintain V3 packages when it’ll reach its end-of-support milestone (~early Q3 2022).
+
+If you’ve been using `strapi-provider-email-amazon-ses` and have migrated to V4 (or if you want to), you can find the equivalent and updated version of this package at this [URL](https://github.com/strapi/strapi/tree/master/packages/providers/email-amazon-ses) and with the following name on NPM: `@strapi/provider-email-amazon-ses`.
+
+If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 version soon.
+
+The Strapi team
+
+---
+
 ## Resources
 
 - [License](LICENSE)
@@ -35,6 +53,7 @@ npm install strapi-provider-email-amazon-ses --save
 | settings.defaultReplyTo | string \| array<string> | Default address or addresses the receiver is asked to reply to                                                             | no       | undefined |
 
 > :warning: The Shipper Email (or defaultfrom) may also need to be changed in the `Email Templates` tab on the admin panel for emails to send properly
+
 ### Example
 
 **Path -** `config/plugins.js`

--- a/packages/strapi-provider-email-mailgun/README.md
+++ b/packages/strapi-provider-email-mailgun/README.md
@@ -1,5 +1,23 @@
 # strapi-provider-email-mailgun
 
+---
+
+## Deprecation Warning :warning:
+
+Hello! We have some news to share,
+
+We’ve decided it’ll soon be time to end the support for `strapi-provider-email-mailgun`.
+
+After years of iterations, Strapi is going to V4 and we won’t maintain V3 packages when it’ll reach its end-of-support milestone (~early Q3 2022).
+
+If you’ve been using `strapi-provider-email-mailgun` and have migrated to V4 (or if you want to), you can find the equivalent and updated version of this package at this [URL](https://github.com/strapi/strapi/tree/master/packages/providers/email-mailgun) and with the following name on NPM: `@strapi/provider-email-mailgun`.
+
+If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 version soon.
+
+The Strapi team
+
+---
+
 ## Resources
 
 - [License](LICENSE)
@@ -35,6 +53,7 @@ npm install strapi-provider-email-mailgun --save
 | settings.defaultReplyTo | string \| array<string> | Default address or addresses the receiver is asked to reply to                                                                     | no       | undefined |
 
 > :warning: The Shipper Email (or defaultfrom) may also need to be changed in the `Email Templates` tab on the admin panel for emails to send properly
+
 ### Example
 
 **Path -** `config/plugins.js`

--- a/packages/strapi-provider-email-mailgun/README.md
+++ b/packages/strapi-provider-email-mailgun/README.md
@@ -12,7 +12,7 @@ After years of iterations, Strapi is going to V4 and we won’t maintain V3 pack
 
 If you’ve been using `strapi-provider-email-mailgun` and have migrated to V4 (or if you want to), you can find the equivalent and updated version of this package at this [URL](https://github.com/strapi/strapi/tree/master/packages/providers/email-mailgun) and with the following name on NPM: `@strapi/provider-email-mailgun`.
 
-If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 version soon.
+If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 soon.
 
 The Strapi team
 

--- a/packages/strapi-provider-email-mailgun/README.md
+++ b/packages/strapi-provider-email-mailgun/README.md
@@ -8,7 +8,7 @@ Hello! We have some news to share,
 
 We’ve decided it’ll soon be time to end the support for `strapi-provider-email-mailgun`.
 
-After years of iterations, Strapi is going to V4 and we won’t maintain V3 packages when it’ll reach its end-of-support milestone (~early Q3 2022).
+After years of iterations, Strapi is going to V4 and we won’t maintain V3 packages when it’ll reach its end-of-support milestone (~end of Q3 2022).
 
 If you’ve been using `strapi-provider-email-mailgun` and have migrated to V4 (or if you want to), you can find the equivalent and updated version of this package at this [URL](https://github.com/strapi/strapi/tree/master/packages/providers/email-mailgun) and with the following name on NPM: `@strapi/provider-email-mailgun`.
 

--- a/packages/strapi-provider-email-nodemailer/README.md
+++ b/packages/strapi-provider-email-nodemailer/README.md
@@ -8,7 +8,7 @@ Hello! We have some news to share,
 
 We’ve decided it’ll soon be time to end the support for `strapi-provider-email-nodemailer`.
 
-After years of iterations, Strapi is going to V4 and we won’t maintain V3 packages when it’ll reach its end-of-support milestone (~early Q3 2022).
+After years of iterations, Strapi is going to V4 and we won’t maintain V3 packages when it’ll reach its end-of-support milestone (~end of Q3 2022).
 
 If you’ve been using `strapi-provider-email-nodemailer` and have migrated to V4 (or if you want to), you can find the equivalent and updated version of this package at this [URL](https://github.com/strapi/strapi/tree/master/packages/providers/email-nodemailer) and with the following name on NPM: `@strapi/provider-email-nodemailer`.
 

--- a/packages/strapi-provider-email-nodemailer/README.md
+++ b/packages/strapi-provider-email-nodemailer/README.md
@@ -12,7 +12,7 @@ After years of iterations, Strapi is going to V4 and we won’t maintain V3 pack
 
 If you’ve been using `strapi-provider-email-nodemailer` and have migrated to V4 (or if you want to), you can find the equivalent and updated version of this package at this [URL](https://github.com/strapi/strapi/tree/master/packages/providers/email-nodemailer) and with the following name on NPM: `@strapi/provider-email-nodemailer`.
 
-If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 version soon.
+If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 soon.
 
 The Strapi team
 

--- a/packages/strapi-provider-email-nodemailer/README.md
+++ b/packages/strapi-provider-email-nodemailer/README.md
@@ -1,5 +1,23 @@
 # strapi-provider-email-nodemailer
 
+---
+
+## Deprecation Warning :warning:
+
+Hello! We have some news to share,
+
+We’ve decided it’ll soon be time to end the support for `strapi-provider-email-nodemailer`.
+
+After years of iterations, Strapi is going to V4 and we won’t maintain V3 packages when it’ll reach its end-of-support milestone (~early Q3 2022).
+
+If you’ve been using `strapi-provider-email-nodemailer` and have migrated to V4 (or if you want to), you can find the equivalent and updated version of this package at this [URL](https://github.com/strapi/strapi/tree/master/packages/providers/email-nodemailer) and with the following name on NPM: `@strapi/provider-email-nodemailer`.
+
+If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 version soon.
+
+The Strapi team
+
+---
+
 ## Resources
 
 - [License](LICENSE)
@@ -105,6 +123,7 @@ module.exports = ({ env }) => ({
 ```
 
 ## Usage
+
 > :warning: The Shipper Email (or defaultfrom) may also need to be changed in the `Email Templates` tab on the admin panel for emails to send properly
 
 To send an email from anywhere inside Strapi:

--- a/packages/strapi-provider-email-sendgrid/README.md
+++ b/packages/strapi-provider-email-sendgrid/README.md
@@ -1,5 +1,23 @@
 # strapi-provider-email-sendgrid
 
+---
+
+## Deprecation Warning :warning:
+
+Hello! We have some news to share,
+
+We’ve decided it’ll soon be time to end the support for `strapi-provider-email-sendgrid`.
+
+After years of iterations, Strapi is going to V4 and we won’t maintain V3 packages when it’ll reach its end-of-support milestone (~early Q3 2022).
+
+If you’ve been using `strapi-provider-email-sendgrid` and have migrated to V4 (or if you want to), you can find the equivalent and updated version of this package at this [URL](https://github.com/strapi/strapi/tree/master/packages/providers/email-sendgrid) and with the following name on NPM: `@strapi/provider-email-sendgrid`.
+
+If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 version soon.
+
+The Strapi team
+
+---
+
 ## Resources
 
 - [License](LICENSE)
@@ -36,6 +54,7 @@ npm install strapi-provider-email-sendgrid --save
 | settings.defaultReplyTo | string \| array<string> | Default address or addresses the receiver is asked to reply to                                                          | no       | undefined |
 
 > :warning: The Shipper Email (or defaultfrom) may also need to be changed in the `Email Templates` tab on the admin panel for emails to send properly
+
 ### Example
 
 **Path -** `config/plugins.js`

--- a/packages/strapi-provider-email-sendgrid/README.md
+++ b/packages/strapi-provider-email-sendgrid/README.md
@@ -8,7 +8,7 @@ Hello! We have some news to share,
 
 We’ve decided it’ll soon be time to end the support for `strapi-provider-email-sendgrid`.
 
-After years of iterations, Strapi is going to V4 and we won’t maintain V3 packages when it’ll reach its end-of-support milestone (~early Q3 2022).
+After years of iterations, Strapi is going to V4 and we won’t maintain V3 packages when it’ll reach its end-of-support milestone (~end of Q3 2022).
 
 If you’ve been using `strapi-provider-email-sendgrid` and have migrated to V4 (or if you want to), you can find the equivalent and updated version of this package at this [URL](https://github.com/strapi/strapi/tree/master/packages/providers/email-sendgrid) and with the following name on NPM: `@strapi/provider-email-sendgrid`.
 

--- a/packages/strapi-provider-email-sendgrid/README.md
+++ b/packages/strapi-provider-email-sendgrid/README.md
@@ -12,7 +12,7 @@ After years of iterations, Strapi is going to V4 and we won’t maintain V3 pack
 
 If you’ve been using `strapi-provider-email-sendgrid` and have migrated to V4 (or if you want to), you can find the equivalent and updated version of this package at this [URL](https://github.com/strapi/strapi/tree/master/packages/providers/email-sendgrid) and with the following name on NPM: `@strapi/provider-email-sendgrid`.
 
-If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 version soon.
+If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 soon.
 
 The Strapi team
 

--- a/packages/strapi-provider-email-sendmail/README.md
+++ b/packages/strapi-provider-email-sendmail/README.md
@@ -12,7 +12,7 @@ After years of iterations, Strapi is going to V4 and we won’t maintain V3 pack
 
 If you’ve been using `strapi-provider-email-sendmail` and have migrated to V4 (or if you want to), you can find the equivalent and updated version of this package at this [URL](https://github.com/strapi/strapi/tree/master/packages/providers/email-sendmail) and with the following name on NPM: `@strapi/provider-email-sendmail`.
 
-If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 version soon.
+If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 soon.
 
 The Strapi team
 

--- a/packages/strapi-provider-email-sendmail/README.md
+++ b/packages/strapi-provider-email-sendmail/README.md
@@ -1,5 +1,23 @@
 # strapi-provider-email-sendmail
 
+---
+
+## Deprecation Warning :warning:
+
+Hello! We have some news to share,
+
+We’ve decided it’ll soon be time to end the support for `strapi-provider-email-sendmail`.
+
+After years of iterations, Strapi is going to V4 and we won’t maintain V3 packages when it’ll reach its end-of-support milestone (~early Q3 2022).
+
+If you’ve been using `strapi-provider-email-sendmail` and have migrated to V4 (or if you want to), you can find the equivalent and updated version of this package at this [URL](https://github.com/strapi/strapi/tree/master/packages/providers/email-sendmail) and with the following name on NPM: `@strapi/provider-email-sendmail`.
+
+If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 version soon.
+
+The Strapi team
+
+---
+
 ## Resources
 
 - [License](LICENSE)
@@ -26,16 +44,17 @@ npm install strapi-provider-email-sendmail --save
 
 ## Configuration
 
-| Variable                | Type               | Description                                                  | Required | Default   |
-| ----------------------- | ------------------ | ------------------------------------------------------------ | -------- | --------- |
-| provider                | string             | The name of the provider you use                             | yes      |           |
-| providerOptions         | object             | Will be directly given to `require('sendmail')`. Please refer to [sendmail](https://www.npmjs.com/package/sendmail) doc. | no       | {}        |
-| settings                | object             | Settings                                                     | no       | {}        |
-| settings.defaultFrom    | string             | Default sender mail address                                  | no       | undefined |
-| settings.defaultReplyTo | string \| array    | Default address or addresses the receiver is asked to reply to | no       | undefined |
-| providerOptions.dkim    | object  \| boolean | DKIM parameters having two properties: { privateKey, keySelector } | no       | false     |
+| Variable                | Type              | Description                                                                                                              | Required | Default   |
+| ----------------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------ | -------- | --------- |
+| provider                | string            | The name of the provider you use                                                                                         | yes      |           |
+| providerOptions         | object            | Will be directly given to `require('sendmail')`. Please refer to [sendmail](https://www.npmjs.com/package/sendmail) doc. | no       | {}        |
+| settings                | object            | Settings                                                                                                                 | no       | {}        |
+| settings.defaultFrom    | string            | Default sender mail address                                                                                              | no       | undefined |
+| settings.defaultReplyTo | string \| array   | Default address or addresses the receiver is asked to reply to                                                           | no       | undefined |
+| providerOptions.dkim    | object \| boolean | DKIM parameters having two properties: { privateKey, keySelector }                                                       | no       | false     |
 
 > :warning: The Shipper Email (or defaultfrom) may also need to be changed in the `Email Templates` tab on the admin panel for emails to send properly
+
 ### Example
 
 **Path -** `config/plugins.js`
@@ -56,7 +75,7 @@ module.exports = ({ env }) => ({
 
 ### Example with DKIM
 
-Using **DKIM** (DomainKeys Identified Mail) can prevent  emails from being considered as spam. More details about this subject  can be found in the discussion on the Strapi forum:  [Unsolved problem: emails goes to spam!](https://forum.strapi.io/t/unsolved-problem-emails-goes-to-spam/512?u=soringfs)
+Using **DKIM** (DomainKeys Identified Mail) can prevent emails from being considered as spam. More details about this subject can be found in the discussion on the Strapi forum: [Unsolved problem: emails goes to spam!](https://forum.strapi.io/t/unsolved-problem-emails-goes-to-spam/512?u=soringfs)
 
 #### Generate the keys using OpenSSL
 
@@ -76,7 +95,7 @@ module.exports = ({ env }) => ({
       dkim: {
         privateKey: 'replace-with-dkim-private-key',
         keySelector: 'abcd', // the same as the one set in DNS txt record, use online dns lookup tools to be sure that is retreivable
-      }
+      },
     },
     settings: {
       defaultFrom: 'myemail@protonmail.com',

--- a/packages/strapi-provider-email-sendmail/README.md
+++ b/packages/strapi-provider-email-sendmail/README.md
@@ -8,7 +8,7 @@ Hello! We have some news to share,
 
 We’ve decided it’ll soon be time to end the support for `strapi-provider-email-sendmail`.
 
-After years of iterations, Strapi is going to V4 and we won’t maintain V3 packages when it’ll reach its end-of-support milestone (~early Q3 2022).
+After years of iterations, Strapi is going to V4 and we won’t maintain V3 packages when it’ll reach its end-of-support milestone (~end of Q3 2022).
 
 If you’ve been using `strapi-provider-email-sendmail` and have migrated to V4 (or if you want to), you can find the equivalent and updated version of this package at this [URL](https://github.com/strapi/strapi/tree/master/packages/providers/email-sendmail) and with the following name on NPM: `@strapi/provider-email-sendmail`.
 

--- a/packages/strapi-provider-upload-aws-s3/README.md
+++ b/packages/strapi-provider-upload-aws-s3/README.md
@@ -8,7 +8,7 @@ Hello! We have some news to share,
 
 We’ve decided it’ll soon be time to end the support for `strapi-provider-upload-aws-s3`.
 
-After years of iterations, Strapi is going to V4 and we won’t maintain V3 packages when it’ll reach its end-of-support milestone (~early Q3 2022).
+After years of iterations, Strapi is going to V4 and we won’t maintain V3 packages when it’ll reach its end-of-support milestone (~end of Q3 2022).
 
 If you’ve been using `strapi-provider-upload-aws-s3` and have migrated to V4 (or if you want to), you can find the equivalent and updated version of this package at this [URL](https://github.com/strapi/strapi/tree/master/packages/providers/upload-aws-s3) and with the following name on NPM: `@strapi/provider-upload-aws-s3`.
 

--- a/packages/strapi-provider-upload-aws-s3/README.md
+++ b/packages/strapi-provider-upload-aws-s3/README.md
@@ -1,5 +1,23 @@
 # strapi-provider-upload-aws-s3
 
+---
+
+## Deprecation Warning :warning:
+
+Hello! We have some news to share,
+
+We’ve decided it’ll soon be time to end the support for `strapi-provider-upload-aws-s3`.
+
+After years of iterations, Strapi is going to V4 and we won’t maintain V3 packages when it’ll reach its end-of-support milestone (~early Q3 2022).
+
+If you’ve been using `strapi-provider-upload-aws-s3` and have migrated to V4 (or if you want to), you can find the equivalent and updated version of this package at this [URL](https://github.com/strapi/strapi/tree/master/packages/providers/upload-aws-s3) and with the following name on NPM: `@strapi/provider-upload-aws-s3`.
+
+If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 version soon.
+
+The Strapi team
+
+---
+
 ## Configurations
 
 Your configuration is passed down to the provider. (e.g: `new AWS.S3(config)`). You can see the complete list of options [here](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#constructor-property)

--- a/packages/strapi-provider-upload-aws-s3/README.md
+++ b/packages/strapi-provider-upload-aws-s3/README.md
@@ -12,7 +12,7 @@ After years of iterations, Strapi is going to V4 and we won’t maintain V3 pack
 
 If you’ve been using `strapi-provider-upload-aws-s3` and have migrated to V4 (or if you want to), you can find the equivalent and updated version of this package at this [URL](https://github.com/strapi/strapi/tree/master/packages/providers/upload-aws-s3) and with the following name on NPM: `@strapi/provider-upload-aws-s3`.
 
-If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 version soon.
+If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 soon.
 
 The Strapi team
 

--- a/packages/strapi-provider-upload-cloudinary/README.md
+++ b/packages/strapi-provider-upload-cloudinary/README.md
@@ -12,7 +12,7 @@ After years of iterations, Strapi is going to V4 and we won’t maintain V3 pack
 
 If you’ve been using `strapi-provider-upload-cloudinary` and have migrated to V4 (or if you want to), you can find the equivalent and updated version of this package at this [URL](https://github.com/strapi/strapi/tree/master/packages/providers/upload-cloudinary) and with the following name on NPM: `@strapi/provider-upload-cloudinary`.
 
-If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 version soon.
+If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 soon.
 
 The Strapi team
 

--- a/packages/strapi-provider-upload-cloudinary/README.md
+++ b/packages/strapi-provider-upload-cloudinary/README.md
@@ -1,5 +1,23 @@
 # strapi-provider-upload-cloudinary
 
+---
+
+## Deprecation Warning :warning:
+
+Hello! We have some news to share,
+
+We’ve decided it’ll soon be time to end the support for `strapi-provider-upload-cloudinary`.
+
+After years of iterations, Strapi is going to V4 and we won’t maintain V3 packages when it’ll reach its end-of-support milestone (~early Q3 2022).
+
+If you’ve been using `strapi-provider-upload-cloudinary` and have migrated to V4 (or if you want to), you can find the equivalent and updated version of this package at this [URL](https://github.com/strapi/strapi/tree/master/packages/providers/upload-cloudinary) and with the following name on NPM: `@strapi/provider-upload-cloudinary`.
+
+If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 version soon.
+
+The Strapi team
+
+---
+
 ## Configurations
 
 Your configuration is passed down to the cloudinary configuration. (e.g: `cloudinary.config(config)`). You can see the complete list of options [here](https://cloudinary.com/documentation/cloudinary_sdks#configuration_parameters)

--- a/packages/strapi-provider-upload-cloudinary/README.md
+++ b/packages/strapi-provider-upload-cloudinary/README.md
@@ -8,7 +8,7 @@ Hello! We have some news to share,
 
 We’ve decided it’ll soon be time to end the support for `strapi-provider-upload-cloudinary`.
 
-After years of iterations, Strapi is going to V4 and we won’t maintain V3 packages when it’ll reach its end-of-support milestone (~early Q3 2022).
+After years of iterations, Strapi is going to V4 and we won’t maintain V3 packages when it’ll reach its end-of-support milestone (~end of Q3 2022).
 
 If you’ve been using `strapi-provider-upload-cloudinary` and have migrated to V4 (or if you want to), you can find the equivalent and updated version of this package at this [URL](https://github.com/strapi/strapi/tree/master/packages/providers/upload-cloudinary) and with the following name on NPM: `@strapi/provider-upload-cloudinary`.
 

--- a/packages/strapi-provider-upload-local/README.md
+++ b/packages/strapi-provider-upload-local/README.md
@@ -8,7 +8,7 @@ Hello! We have some news to share,
 
 We’ve decided it’ll soon be time to end the support for `strapi-provider-upload-local`.
 
-After years of iterations, Strapi is going to V4 and we won’t maintain V3 packages when it’ll reach its end-of-support milestone (~early Q3 2022).
+After years of iterations, Strapi is going to V4 and we won’t maintain V3 packages when it’ll reach its end-of-support milestone (~end of Q3 2022).
 
 If you’ve been using `strapi-provider-upload-local` and have migrated to V4 (or if you want to), you can find the equivalent and updated version of this package at this [URL](https://github.com/strapi/strapi/tree/master/packages/providers/upload-local) and with the following name on NPM: `@strapi/provider-upload-local`.
 

--- a/packages/strapi-provider-upload-local/README.md
+++ b/packages/strapi-provider-upload-local/README.md
@@ -12,7 +12,7 @@ After years of iterations, Strapi is going to V4 and we won’t maintain V3 pack
 
 If you’ve been using `strapi-provider-upload-local` and have migrated to V4 (or if you want to), you can find the equivalent and updated version of this package at this [URL](https://github.com/strapi/strapi/tree/master/packages/providers/upload-local) and with the following name on NPM: `@strapi/provider-upload-local`.
 
-If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 version soon.
+If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 soon.
 
 The Strapi team
 

--- a/packages/strapi-provider-upload-local/README.md
+++ b/packages/strapi-provider-upload-local/README.md
@@ -1,5 +1,23 @@
 # strapi-provider-upload-local
 
+---
+
+## Deprecation Warning :warning:
+
+Hello! We have some news to share,
+
+We’ve decided it’ll soon be time to end the support for `strapi-provider-upload-local`.
+
+After years of iterations, Strapi is going to V4 and we won’t maintain V3 packages when it’ll reach its end-of-support milestone (~early Q3 2022).
+
+If you’ve been using `strapi-provider-upload-local` and have migrated to V4 (or if you want to), you can find the equivalent and updated version of this package at this [URL](https://github.com/strapi/strapi/tree/master/packages/providers/upload-local) and with the following name on NPM: `@strapi/provider-upload-local`.
+
+If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 version soon.
+
+The Strapi team
+
+---
+
 ## Configurations
 
 This provider has only one parameter: `sizeLimit`.

--- a/packages/strapi-provider-upload-rackspace/README.md
+++ b/packages/strapi-provider-upload-rackspace/README.md
@@ -1,5 +1,23 @@
 # strapi-provider-upload-rackspace
 
+---
+
+## Deprecation Warning :warning:
+
+Hello! We have some news to share,
+
+We’ve decided it’ll soon be time to end the support for `strapi-provider-upload-rackspace`.
+
+After years of iterations, Strapi is going to V4 and we won’t maintain V3 packages when it’ll reach its end-of-support milestone (~early Q3 2022).
+
+If you’ve been using `strapi-provider-upload-rackspace` and have migrated to V4 (or if you want to), you can find the equivalent and updated version of this package at this [URL](https://github.com/strapi/strapi/tree/master/packages/providers/upload-rackspace) and with the following name on NPM: `@strapi/provider-upload-rackspace`.
+
+If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 version soon.
+
+The Strapi team
+
+---
+
 ## Configurations
 
 Your configuration is passed down to the client initialization. (e.g: `createClient(config)`). The implementation is based on the package `pkgcloud`. You can read the docs [here](https://github.com/pkgcloud/pkgcloud#storage).

--- a/packages/strapi-provider-upload-rackspace/README.md
+++ b/packages/strapi-provider-upload-rackspace/README.md
@@ -12,7 +12,7 @@ After years of iterations, Strapi is going to V4 and we won’t maintain V3 pack
 
 If you’ve been using `strapi-provider-upload-rackspace` and have migrated to V4 (or if you want to), you can find the equivalent and updated version of this package at this [URL](https://github.com/strapi/strapi/tree/master/packages/providers/upload-rackspace) and with the following name on NPM: `@strapi/provider-upload-rackspace`.
 
-If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 version soon.
+If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 soon.
 
 The Strapi team
 

--- a/packages/strapi-provider-upload-rackspace/README.md
+++ b/packages/strapi-provider-upload-rackspace/README.md
@@ -8,7 +8,7 @@ Hello! We have some news to share,
 
 We’ve decided it’ll soon be time to end the support for `strapi-provider-upload-rackspace`.
 
-After years of iterations, Strapi is going to V4 and we won’t maintain V3 packages when it’ll reach its end-of-support milestone (~early Q3 2022).
+After years of iterations, Strapi is going to V4 and we won’t maintain V3 packages when it’ll reach its end-of-support milestone (~end of Q3 2022).
 
 If you’ve been using `strapi-provider-upload-rackspace` and have migrated to V4 (or if you want to), you can find the equivalent and updated version of this package at this [URL](https://github.com/strapi/strapi/tree/master/packages/providers/upload-rackspace) and with the following name on NPM: `@strapi/provider-upload-rackspace`.
 

--- a/packages/strapi-utils/README.md
+++ b/packages/strapi-utils/README.md
@@ -8,7 +8,7 @@ Hello! We have some news to share,
 
 We’ve decided it’ll soon be time to end the support for `strapi-utils`.
 
-After years of iterations, Strapi is going to V4 and we won’t maintain V3 packages when it’ll reach its end-of-support milestone (~early Q3 2022).
+After years of iterations, Strapi is going to V4 and we won’t maintain V3 packages when it’ll reach its end-of-support milestone (~end of Q3 2022).
 
 If you’ve been using `strapi-utils` and have migrated to V4 (or if you want to), you can find the equivalent and updated version of this package at this [URL](https://github.com/strapi/strapi/tree/master/packages/core/utils) and with the following name on NPM: `@strapi/utils`.
 

--- a/packages/strapi-utils/README.md
+++ b/packages/strapi-utils/README.md
@@ -12,7 +12,7 @@ After years of iterations, Strapi is going to V4 and we won’t maintain V3 pack
 
 If you’ve been using `strapi-utils` and have migrated to V4 (or if you want to), you can find the equivalent and updated version of this package at this [URL](https://github.com/strapi/strapi/tree/master/packages/core/utils) and with the following name on NPM: `@strapi/utils`.
 
-If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 version soon.
+If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 soon.
 
 The Strapi team
 

--- a/packages/strapi-utils/README.md
+++ b/packages/strapi-utils/README.md
@@ -1,5 +1,23 @@
 # strapi-utils
 
+---
+
+## Deprecation Warning :warning:
+
+Hello! We have some news to share,
+
+We’ve decided it’ll soon be time to end the support for `strapi-utils`.
+
+After years of iterations, Strapi is going to V4 and we won’t maintain V3 packages when it’ll reach its end-of-support milestone (~early Q3 2022).
+
+If you’ve been using `strapi-utils` and have migrated to V4 (or if you want to), you can find the equivalent and updated version of this package at this [URL](https://github.com/strapi/strapi/tree/master/packages/core/utils) and with the following name on NPM: `@strapi/utils`.
+
+If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 version soon.
+
+The Strapi team
+
+---
+
 [![npm version](https://img.shields.io/npm/v/strapi-utils.svg)](https://www.npmjs.org/package/strapi-utils)
 [![npm downloads](https://img.shields.io/npm/dm/strapi-utils.svg)](https://www.npmjs.org/package/strapi-utils)
 [![npm dependencies](https://david-dm.org/strapi/strapi-utils.svg)](https://david-dm.org/strapi/strapi-utils)

--- a/packages/strapi/README.md
+++ b/packages/strapi/README.md
@@ -42,7 +42,7 @@ After years of iterations, Strapi is going to V4 and we won’t maintain V3 pack
 
 If you’ve been using `strapi` and have migrated to V4 (or if you want to), you can find the equivalent and updated version of this package at this [URL](https://github.com/strapi/strapi/tree/master/packages/core/strapi) and with the following name on NPM: `@strapi/strapi`.
 
-If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 version soon.
+If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 soon.
 
 The Strapi team
 

--- a/packages/strapi/README.md
+++ b/packages/strapi/README.md
@@ -30,6 +30,24 @@
 
 <br>
 
+---
+
+## Deprecation Warning :warning:
+
+Hello! We have some news to share,
+
+We’ve decided it’ll soon be time to end the support for `strapi`.
+
+After years of iterations, Strapi is going to V4 and we won’t maintain V3 packages when it’ll reach its end-of-support milestone (~early Q3 2022).
+
+If you’ve been using `strapi` and have migrated to V4 (or if you want to), you can find the equivalent and updated version of this package at this [URL](https://github.com/strapi/strapi/tree/master/packages/core/strapi) and with the following name on NPM: `@strapi/strapi`.
+
+If you’ve contributed to the development of this package, thank you again for that! We hope to see you on the V4 version soon.
+
+The Strapi team
+
+---
+
 Strapi is a free and open-source headless CMS delivering your content anywhere you need.
 
 - **Keep control over your data**. With Strapi, you know where your data is stored, and you keep full control at all times.

--- a/packages/strapi/README.md
+++ b/packages/strapi/README.md
@@ -38,7 +38,7 @@ Hello! We have some news to share,
 
 We’ve decided it’ll soon be time to end the support for `strapi`.
 
-After years of iterations, Strapi is going to V4 and we won’t maintain V3 packages when it’ll reach its end-of-support milestone (~early Q3 2022).
+After years of iterations, Strapi is going to V4 and we won’t maintain V3 packages when it’ll reach its end-of-support milestone (~end of Q3 2022).
 
 If you’ve been using `strapi` and have migrated to V4 (or if you want to), you can find the equivalent and updated version of this package at this [URL](https://github.com/strapi/strapi/tree/master/packages/core/strapi) and with the following name on NPM: `@strapi/strapi`.
 


### PR DESCRIPTION
### What does it do?

As we released Strapi V4 and are about to reach end-of-support for Strapi V3 (around Q3 2022).
We decided to add a deprecation notice to the concerned packages so that users can be warned in advance about what's going to happen.

Packages will either:
- Not going to change at all (no deprecation warning)
- Be moved to another package (deprecation warning + link to the V4 version of the package)
- Be deleted (deprecation warning + notice of no further support)

### Why is it needed?

We want to prepare the migration from V3 to V4 the best we can, and it includes warning the community as soon as possible about the changes that are about to come.

### How to test it?

Open some packages readme (`strapi`, `strapi-hook-ejs`, `strapi-plugin-graphql`) files and... read them :shrug:

