### PR TITLE
Update sharp in upload plugin

### DIFF
--- a/packages/core/upload/package.json
+++ b/packages/core/upload/package.json
@@ -39,7 +39,7 @@
     "react-redux": "7.2.3",
     "react-router": "^5.2.0",
     "react-router-dom": "5.2.0",
-    "sharp": "0.29.3"
+    "sharp": "0.30.1"
   },
   "engines": {
     "node": ">=12.22.0 <=16.x.x",


### PR DESCRIPTION
### What does it do?

Update to the latest version of sharp in upload plugin.

### Why is it needed?

As of v0.30.0, sharp supports arm64 instances on AWS. I'd like to deploy my Strapi app on AWS, using these more efficient instance types. You find more about the support here: [https://github.com/lovell/sharp/issues/2938#issuecomment-1027322170](https://github.com/lovell/sharp/issues/2938#issuecomment-1027322170)

### How to test it?

-

### Related issue(s)/PR(s)

-
