### PR TITLE
Disable primary key requirement on session initialize

### DIFF
--- a/packages/core/database/lib/dialects/mysql/index.js
+++ b/packages/core/database/lib/dialects/mysql/index.js
@@ -32,6 +32,10 @@ class MysqlDialect extends Dialect {
     };
   }
 
+  async initialize() {
+    await this.db.connection.raw(`set session sql_require_primary_key = 0;`);
+  }
+
   async startSchemaUpdate() {
     await this.db.connection.raw(`set foreign_key_checks = 0;`);
   }

--- a/packages/core/database/lib/dialects/mysql/index.js
+++ b/packages/core/database/lib/dialects/mysql/index.js
@@ -36,7 +36,7 @@ class MysqlDialect extends Dialect {
     try {
       await this.db.connection.raw(`set session sql_require_primary_key = 0;`);
     } catch (err) {
-      console.error({ err });
+      // Ignore error due to lack of session permissions
     }
   }
 

--- a/packages/core/database/lib/dialects/mysql/index.js
+++ b/packages/core/database/lib/dialects/mysql/index.js
@@ -33,7 +33,11 @@ class MysqlDialect extends Dialect {
   }
 
   async initialize() {
-    await this.db.connection.raw(`set session sql_require_primary_key = 0;`);
+    try {
+      await this.db.connection.raw(`set session sql_require_primary_key = 0;`);
+    } catch (err) {
+      console.error({ err });
+    }
   }
 
   async startSchemaUpdate() {


### PR DESCRIPTION
fixes #11723

Based on: https://www.digitalocean.com/community/questions/how-to-disable-sql_require_primary_key-in-digital-ocean-manged-database-for-mysql

DigitalOcean forcefully requires primary keys on all tables, in Strapi we don't place primary keys on join tables for relations because they aren't needed. During the database initialization, we do some migration steps and it was during this the error occured. This PR disables this requirement for the session to allow the migration to function and shouldn't be needed later on.