### PR TITLE
fix(plugin template): missing patch `x` symbol for v12

### DIFF
--- a/packages/generators/generators/lib/templates/plugin-package.json.hbs
+++ b/packages/generators/generators/lib/templates/plugin-package.json.hbs
@@ -17,7 +17,7 @@
     }
   ],
   "engines": {
-    "node": ">=12.x. <=16.x.x",
+    "node": ">=12.x.x <=16.x.x",
     "npm": ">=6.0.0"
   },
   "license": "MIT"


### PR DESCRIPTION
### What does it do?

Adds the missing patch `x` for the node endine compatibility section in the plugins `package.json` template

### Why is it needed?

Without it the compatibility version specification is invalid. This causes issue with programs like eslint where the `node/no-unsupported-features/es-syntax` is triggering on supported features as it sees node compatibility set to '>=8.0.0' (the default) instead of >=12.x.x

### How to test it?

- generate a plugin via this PRs codebase.
- view the `engines.node` value in the generated package.json file.

### Related issue(s)/PR(s)

N/A
