### PR TITLE
CM: Fix changed field sizes during the bootstrap process

### DIFF
--- a/packages/core/content-manager/server/services/utils/configuration/layouts.js
+++ b/packages/core/content-manager/server/services/utils/configuration/layouts.js
@@ -5,28 +5,38 @@ const { isListable, hasEditableAttribute, hasRelationAttribute } = require('./at
 
 const DEFAULT_LIST_LENGTH = 4;
 const MAX_ROW_SIZE = 12;
+const FIELD_TYPES_FULL_SIZE = ['dynamiczone', 'component', 'json', 'richtext'];
+const FIELD_TYPES_SMALL = [
+  'checkbox',
+  'boolean',
+  'date',
+  'time',
+  'biginteger',
+  'decimal',
+  'float',
+  'integer',
+  'number',
+];
 
-const typeToSize = type => {
-  switch (type) {
-    case 'checkbox':
-    case 'boolean':
-    case 'date':
-    case 'time':
-    case 'biginteger':
-    case 'decimal':
-    case 'float':
-    case 'integer':
-    case 'number':
-      return MAX_ROW_SIZE / 3;
-    case 'json':
-    case 'component':
-    case 'richtext':
-    case 'dynamiczone':
-      return MAX_ROW_SIZE;
-
-    default:
-      return MAX_ROW_SIZE / 2;
+const isAllowedFieldSize = (type, size) => {
+  if (FIELD_TYPES_FULL_SIZE.includes(type)) {
+    return size === MAX_ROW_SIZE;
   }
+
+  // validate, whether the field has 4, 6, 8 or 12 columns?
+  return size <= MAX_ROW_SIZE;
+};
+
+const getDefaultFieldSize = type => {
+  if (FIELD_TYPES_FULL_SIZE.includes(type)) {
+    return MAX_ROW_SIZE;
+  }
+
+  if (FIELD_TYPES_SMALL.includes(type)) {
+    return MAX_ROW_SIZE / 3;
+  }
+
+  return MAX_ROW_SIZE / 2;
 };
 
 async function createDefaultLayouts(schema) {
@@ -77,8 +87,10 @@ function syncLayouts(configuration, schema) {
     for (let el of row) {
       if (!hasEditableAttribute(schema, el.name)) continue;
 
-      // if size of the element has changed (type changes)
-      if (typeToSize(schema.attributes[el.name].type) !== el.size) {
+      /* if the type of a field was changed (ex: string -> json) or a new field was added in the schema
+         and the new type doesn't allow the size of the previous type, append the field at the end of layouts
+      */
+      if (!el.size || !isAllowedFieldSize(schema.attributes[el.name].type, el.size)) {
         elementsToReAppend.push(el.name);
         continue;
       }
@@ -141,7 +153,8 @@ const appendToEditLayout = (layout = [], keysToAppend, schema) => {
 
   for (let key of keysToAppend) {
     const attribute = schema.attributes[key];
-    const attributeSize = typeToSize(attribute.type);
+
+    const attributeSize = getDefaultFieldSize(attribute.type);
     let currenRowSize = rowSize(layout[currentRowIndex]);
 
     if (currenRowSize + attributeSize > MAX_ROW_SIZE) {

--- a/packages/core/content-manager/server/services/utils/configuration/layouts.js
+++ b/packages/core/content-manager/server/services/utils/configuration/layouts.js
@@ -90,7 +90,7 @@ function syncLayouts(configuration, schema) {
       /* if the type of a field was changed (ex: string -> json) or a new field was added in the schema
          and the new type doesn't allow the size of the previous type, append the field at the end of layouts
       */
-      if (!el.size || !isAllowedFieldSize(schema.attributes[el.name].type, el.size)) {
+      if (!isAllowedFieldSize(schema.attributes[el.name].type, el.size)) {
         elementsToReAppend.push(el.name);
         continue;
       }


### PR DESCRIPTION
### What does it do?

In https://github.com/strapi/strapi/pull/12398 I didn't notice that the layout is also validated & processed by the bootstrap process. This PR refactors the validation, so that it doesn't invalidate fields with a modified size.

### Why is it needed?

Before the field invalidation was triggered by two things:

- a new field was added
- the type of a field has changed

Now we have to validate, if the size of a field size is smaller than the allowed size of it. If so, everything is fine. If not, the field should be resized to it's maximum size. In case a field was added manually, a sensible default size should be applied.

### How to test it?

#### Resize

1. Resize a field in the content manager
2. Restart strapi
3. Validate the size of field hasn't changed and the field is still in the proper position of the layout

#### Type change

1. Change the type of field to your schema (ex. string -> json)
2. (Re)-start the server
3. Validate the field is set to a size of 100 and is appended to the list

#### New field

1. Add a new field to your schema (ex. type json) by adding it to the json file directly
2. Start the server
3. Validate the field is set to a size of 100 and is appended to the list

### Related issue(s)/PR(s)

- Fixes: https://github.com/strapi/strapi/issues/12574
