### PR TITLE
Fix the populate filtering

### DIFF
--- a/packages/core/content-manager/server/tests/api/populate/filtering/index.test.e2e.js
+++ b/packages/core/content-manager/server/tests/api/populate/filtering/index.test.e2e.js
@@ -1,0 +1,287 @@
+'use strict';
+
+const { propEq, omit } = require('lodash/fp');
+
+const { createTestBuilder } = require('../../../../../../../../test/helpers/builder');
+const { createStrapiInstance } = require('../../../../../../../../test/helpers/strapi');
+const { createContentAPIRequest } = require('../../../../../../../../test/helpers/request');
+
+const builder = createTestBuilder();
+
+let strapi;
+let data;
+let rq;
+
+const schemas = {
+  components: {
+    foo: {
+      displayName: 'foo',
+      attributes: {
+        number: { type: 'integer' },
+        field: { type: 'string' },
+      },
+    },
+    bar: {
+      displayName: 'bar',
+      attributes: {
+        title: { type: 'string' },
+        field: { type: 'password' },
+      },
+    },
+  },
+  contentTypes: {
+    a: {
+      kind: 'collectionType',
+      displayName: 'a',
+      singularName: 'a',
+      pluralName: 'as',
+      attributes: {
+        name: { type: 'string' },
+        pass: { type: 'password' },
+        fooRef: { type: 'component', component: 'default.foo', repeatable: false },
+        barRefs: { type: 'component', component: 'default.bar', repeatable: true },
+      },
+    },
+    b: {
+      kind: 'collectionType',
+      displayName: 'b',
+      singularName: 'b',
+      pluralName: 'bs',
+      attributes: {
+        title: { type: 'string' },
+        dz: { type: 'dynamiczone', components: ['default.foo', 'default.bar'] },
+      },
+    },
+    c: {
+      kind: 'collectionType',
+      displayName: 'c',
+      singularName: 'c',
+      pluralName: 'cs',
+      attributes: {
+        first: { type: 'string' },
+        second: { type: 'component', component: 'default.foo', repeatable: false },
+        third: { type: 'relation', target: 'api::a.a', relation: 'oneToMany' },
+      },
+    },
+  },
+};
+
+const fixtures = {
+  a: [
+    {
+      name: 'first',
+      pass: 'strong_password',
+      fooRef: {
+        number: 4,
+        field: 'text',
+      },
+      barRefs: [{ title: 'john doe', field: '1234' }, { title: 'jane doe', field: '5678' }],
+    },
+    {
+      name: 'second',
+      pass: 'another_strong_password',
+      fooRef: {
+        number: 12,
+        field: 'text field',
+      },
+      barRefs: [
+        { title: 'foo', field: '1997' },
+        { title: 'bar', field: '2005' },
+        { title: 'foobar', field: '2022' },
+      ],
+    },
+  ],
+  b: [
+    {
+      title: 'something',
+      dz: [
+        {
+          __component: 'default.foo',
+          number: 1,
+          field: 'short text',
+        },
+        {
+          __component: 'default.foo',
+          number: 2,
+          field: 'short string',
+        },
+        {
+          __component: 'default.bar',
+          title: 'this is a title',
+          field: 'password',
+        },
+      ],
+    },
+    {
+      title: 'something else',
+      dz: [
+        {
+          __component: 'default.bar',
+          title: 'this is a another title',
+          field: 'password text',
+        },
+      ],
+    },
+  ],
+  c: fixtures => [
+    {
+      first: 'hello',
+      second: {
+        number: 16,
+        field: 'a simple string',
+      },
+      third: fixtures.a.map(entity => entity.id).slice(0, 1),
+    },
+    {
+      first: 'world',
+      second: {
+        number: 14,
+        field: 'a simple string',
+      },
+      third: fixtures.a.map(entity => entity.id).slice(0, 2),
+    },
+  ],
+};
+
+describe('Populate filters', () => {
+  beforeAll(async () => {
+    await builder
+      .addComponent(schemas.components.foo)
+      .addComponent(schemas.components.bar)
+      .addContentTypes(Object.values(schemas.contentTypes))
+      .addFixtures(schemas.contentTypes.a.singularName, fixtures.a)
+      .addFixtures(schemas.contentTypes.b.singularName, fixtures.b)
+      .addFixtures(schemas.contentTypes.c.singularName, fixtures.c)
+      .build();
+
+    strapi = await createStrapiInstance();
+    rq = createContentAPIRequest({ strapi });
+    data = await builder.sanitizedFixtures(strapi);
+  });
+
+  afterAll(async () => {
+    await strapi.destroy();
+    await builder.cleanup();
+  });
+
+  describe('Populate simple relation', () => {
+    test('No filters & no populate', async () => {
+      const { status, body } = await rq.get(`/${schemas.contentTypes.a.pluralName}`);
+
+      expect(status).toBe(200);
+      expect(body.data).toHaveLength(fixtures.a.length);
+
+      body.data.forEach(entity => {
+        expect(entity).not.toHaveProperty('fooRef');
+        expect(entity).not.toHaveProperty('barRefs');
+      });
+    });
+
+    test('No filters & specific populate', async () => {
+      const qs = {
+        populate: 'fooRef',
+      };
+
+      const { status, body } = await rq.get(`/${schemas.contentTypes.a.pluralName}`, { qs });
+
+      expect(status).toBe(200);
+      expect(body.data).toHaveLength(fixtures.a.length);
+
+      body.data.forEach(entity => {
+        expect(entity.attributes).toHaveProperty('fooRef');
+        expect(entity.attributes).not.toHaveProperty('barRefs');
+      });
+    });
+
+    test('No filters & populate all', async () => {
+      const qs = {
+        populate: '*',
+      };
+
+      const { status, body } = await rq.get(`/${schemas.contentTypes.a.pluralName}`, { qs });
+
+      expect(status).toBe(200);
+      expect(body.data).toHaveLength(fixtures.a.length);
+
+      body.data.forEach(entity => {
+        expect(entity.attributes).toHaveProperty('fooRef');
+        expect(entity.attributes).toHaveProperty('barRefs');
+      });
+    });
+
+    test('No filters & deep populate', async () => {
+      const qs = {
+        populate: ['second', 'third.fooRef'],
+      };
+      const { status, body } = await rq.get(`/${schemas.contentTypes.c.pluralName}`, { qs });
+
+      expect(status).toBe(200);
+      expect(body.data).toHaveLength(2);
+
+      body.data.forEach(entity => {
+        expect(entity.attributes).toHaveProperty('second');
+        expect(entity.attributes).toHaveProperty('third');
+
+        expect(Array.isArray(entity.attributes.third.data)).toBe(true);
+
+        entity.attributes.third.data.forEach(thirdItem => {
+          const expected = data.a.find(propEq('id', thirdItem.id));
+
+          expect(thirdItem.attributes).toMatchObject(omit('id', expected));
+        });
+      });
+    });
+
+    test('Simple filters & populate', async () => {
+      const qs = {
+        populate: {
+          second: {
+            filters: {
+              number: {
+                $lt: 15,
+              },
+            },
+          },
+        },
+      };
+      const { status, body } = await rq.get(`/${schemas.contentTypes.c.pluralName}`, { qs });
+
+      expect(status).toBe(200);
+      expect(body.data).toHaveLength(2);
+
+      const [firstItem, secondItem] = body.data;
+
+      expect(firstItem.attributes.second).toBeNull();
+      expect(secondItem.attributes.second).not.toBeNull();
+
+      expect(secondItem.attributes.second).toMatchObject({
+        number: 14,
+        field: 'a simple string',
+      });
+    });
+
+    test('Simple filters & deep populate', async () => {
+      const qs = {
+        populate: {
+          third: {
+            populate: {
+              fooRef: {
+                filters: { field: { $eq: 'text' } },
+              },
+            },
+          },
+        },
+      };
+      const { status, body } = await rq.get(`/${schemas.contentTypes.c.pluralName}`, { qs });
+
+      expect(status).toBe(200);
+      expect(body.data).toHaveLength(2);
+
+      const [firstItem, secondItem] = body.data;
+
+      expect(firstItem.attributes.third.data[0].attributes.fooRef).not.toBeNull();
+      expect(secondItem.attributes.third.data[0].attributes.fooRef).not.toBeNull();
+      expect(secondItem.attributes.third.data[1].attributes.fooRef).toBeNull();
+    });
+  });
+});

--- a/packages/core/strapi/lib/services/entity-service/params.js
+++ b/packages/core/strapi/lib/services/entity-service/params.js
@@ -17,7 +17,7 @@ const pickSelectionParams = pick(['fields', 'populate']);
 
 const transformParamsToQuery = (uid, params) => {
   // NOTE: can be a CT, a Compo or nothing in the case of polymorphism (DZ & morph relations)
-  const type = strapi.getModel(uid);
+  const schema = strapi.getModel(uid);
 
   const query = {};
 
@@ -32,7 +32,7 @@ const transformParamsToQuery = (uid, params) => {
   }
 
   if (!isNil(filters)) {
-    query.where = convertFiltersQueryParams(filters, type);
+    query.where = convertFiltersQueryParams(filters, schema);
   }
 
   if (!isNil(fields)) {
@@ -40,7 +40,7 @@ const transformParamsToQuery = (uid, params) => {
   }
 
   if (!isNil(populate)) {
-    query.populate = convertPopulateQueryParams(populate);
+    query.populate = convertPopulateQueryParams(populate, schema);
   }
 
   const isPagePagination = !isNil(page) || !isNil(pageSize);
@@ -84,7 +84,7 @@ const transformParamsToQuery = (uid, params) => {
     query.limit = convertLimitQueryParams(limit);
   }
 
-  convertPublicationStateParams(type, params, query);
+  convertPublicationStateParams(schema, params, query);
 
   return query;
 };

--- a/packages/core/utils/lib/convert-query-params.js
+++ b/packages/core/utils/lib/convert-query-params.js
@@ -304,7 +304,7 @@ const convertAndSanitizeFilters = (filters, schema) => {
 
   // Here, `key` can either be an operator or an attribute name
   for (const [key, value] of Object.entries(filters)) {
-    const attribute = get('key', schema.attributes);
+    const attribute = get(key, schema.attributes);
 
     // Handle attributes
     if (attribute) {

--- a/packages/core/utils/lib/convert-query-params.js
+++ b/packages/core/utils/lib/convert-query-params.js
@@ -150,14 +150,43 @@ const convertPopulateQueryParams = (populate, schema, depth = 0) => {
 
   if (_.isPlainObject(populate)) {
     const transformedPopulate = {};
+
     for (const key in populate) {
-      const targetSchema = strapi.getModel(attributes[key].target);
+      const attribute = attributes[key];
+      const subPopulate = populate[key];
+
+      if (!attribute) {
+        continue;
+      }
+
+      // Retrieve the target schema UID.
+      // This flows only handle basic relations and component since it's
+      // not possible to populate with params for a dynamic zone or polymorphic relations.
+
+      let targetSchemaUID;
+
+      // Relations
+      if (attribute.type === 'relation') {
+        targetSchemaUID = attribute.target;
+      }
+
+      // Components
+      else if (attribute.type === 'component') {
+        targetSchemaUID = attribute.component;
+      }
+
+      // Fallback
+      else {
+        continue;
+      }
+
+      const targetSchema = strapi.getModel(targetSchemaUID);
 
       if (!targetSchema) {
         continue;
       }
 
-      transformedPopulate[key] = convertNestedPopulate(populate[key], targetSchema);
+      transformedPopulate[key] = convertNestedPopulate(subPopulate, targetSchema);
     }
 
     return transformedPopulate;

--- a/packages/core/utils/lib/convert-query-params.js
+++ b/packages/core/utils/lib/convert-query-params.js
@@ -184,17 +184,8 @@ const convertPopulateObject = (populate, schema) => {
       };
     }
 
-    if (attribute.type === 'media') {
-      const fileSchema = strapi.getModel('plugin::upoad.file');
-
-      return {
-        ...acc,
-        [key]: convertNestedPopulate(subPopulate, fileSchema),
-      };
-    }
-
     // NOTE: Retrieve the target schema UID.
-    // Only handles basic relations and component since it's not possible
+    // Only handles basic relations, medias and component since it's not possible
     // to populate with options for a dynamic zone or a polymorphic relation
     let targetSchemaUID;
 
@@ -202,6 +193,8 @@ const convertPopulateObject = (populate, schema) => {
       targetSchemaUID = attribute.target;
     } else if (attribute.type === 'component') {
       targetSchemaUID = attribute.component;
+    } else if (attribute.type === 'media') {
+      targetSchemaUID = 'plugin::upload.file';
     } else {
       return acc;
     }

--- a/packages/core/utils/lib/convert-query-params.js
+++ b/packages/core/utils/lib/convert-query-params.js
@@ -167,14 +167,14 @@ const convertPopulateObject = (populate, schema) => {
       return acc;
     }
 
-    // TODO: This is a temporary solution for dynamic zones that should be
-    // fixed when we'll implement a more accurate way to query dynamic zones
+    // FIXME: This is a temporary solution for dynamic zones that should be
+    // fixed when we'll implement a more accurate way to query them
     if (attribute.type === 'dynamiczone') {
       const generatedFakeDynamicZoneSchema = {
         uid: `${schema.uid}.${key}`,
         attributes: attribute.components
-          .map(uid => strapi.getModel(uid))
-          .map(component => component.attributes)
+          .sort()
+          .map(uid => strapi.getModel(uid).attributes)
           .reduce((acc, componentAttributes) => ({ ...acc, ...componentAttributes }), {}),
       };
 

--- a/packages/core/utils/lib/convert-query-params.js
+++ b/packages/core/utils/lib/convert-query-params.js
@@ -334,7 +334,7 @@ const convertAndSanitizeFilters = (filters, schema) => {
         if (attribute.type === 'password') {
           removeOperator(key);
         } else {
-          filters[key] = convertAndSanitizeFilters(value);
+          filters[key] = convertAndSanitizeFilters(value, schema);
         }
       }
     }


### PR DESCRIPTION
### What does it do?

4.0.8 introduced a bug that breaks the populate filtering. This PR aims to resolve the issue by correctly passing down the entry schema in the `convertPopulateQueryParams` function.

### Why is it needed?

Populate filtering is broken right now

### How to test it?

1. Create a new app
2. Try to make a request with a populate + some filtering on it (eg: ?populate[relationField][filters][id][$eq]=2
3. It should work and return the expected data without throwing a 500 error.

### Related issue(s)/PR(s)

Fix https://github.com/strapi/strapi/issues/12578
