### PR TITLE
CellContent: Fix date-format across timezones for date fields in CM list-views

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/DynamicTable/CellContent/CellValue.js
+++ b/packages/core/admin/admin/src/content-manager/components/DynamicTable/CellContent/CellValue.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 import toString from 'lodash/toString';
+import parseISO from 'date-fns/parseISO';
 import { getNumberOfDecimals } from './utils/getNumberOfDecimals';
 
 const CellValue = ({ type, value }) => {
@@ -8,7 +9,7 @@ const CellValue = ({ type, value }) => {
   let formattedValue = value;
 
   if (type === 'date') {
-    formattedValue = formatDate(value, { dateStyle: 'full' });
+    formattedValue = formatDate(parseISO(value), { dateStyle: 'full' });
   }
 
   if (type === 'datetime') {

--- a/packages/core/helper-plugin/lib/src/components/DateTimePicker/tests/__snapshots__/index.test.js.snap
+++ b/packages/core/helper-plugin/lib/src/components/DateTimePicker/tests/__snapshots__/index.test.js.snap
@@ -387,7 +387,7 @@ exports[`DateTimePicker snapshots the component 1`] = `
                 >
                   <button
                     aria-disabled="false"
-                    aria-label="Date picker, current is 10/13/2021"
+                    aria-label="Date picker, current is 13/10/2021"
                     class="c10"
                     type="button"
                   >
@@ -417,8 +417,8 @@ exports[`DateTimePicker snapshots the component 1`] = `
                   data-testid="datetimepicker-date"
                   id="datepicker-1"
                   name="datetimepicker"
-                  placeholder="1/1/1970"
-                  value="10/13/2021"
+                  placeholder="01/01/1970"
+                  value="13/10/2021"
                 />
               </div>
             </div>


### PR DESCRIPTION
### What does it do?

Similar to https://github.com/strapi/strapi/pull/12267 it utilizes `parseISO` to properly show dates in list-views of the content manager.

### Why is it needed?

To properly display dates in list-views of the content-manager.

### How to test it?

1. Create e.g. a new category in the content-manager
2. Change your timezone to e.g. Tokyo (in chrome-based browser this can be achieved by setting Devtools > Sensors > Location)
3. Validate the right date is displayed

### Related issue(s)/PR(s)

Refs: https://github.com/strapi/strapi/issues/11509
