### PR TITLE
FilterPopoverURLQuery: Remove all time-releated information from date

### DIFF
--- a/packages/core/helper-plugin/lib/src/components/FilterPopoverURLQuery/Inputs.js
+++ b/packages/core/helper-plugin/lib/src/components/FilterPopoverURLQuery/Inputs.js
@@ -1,5 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import parseISO from 'date-fns/parseISO';
+import formatISO from 'date-fns/formatISO';
 import { DatePicker } from '@strapi/design-system/DatePicker';
 import { Field, FieldInput } from '@strapi/design-system/Field';
 import { NumberInput } from '@strapi/design-system/NumberInput';
@@ -31,9 +33,9 @@ const Inputs = ({ label, onChange, options, type, value }) => {
         clearLabel={formatMessage({ id: 'clearLabel', defaultMessage: 'Clear' })}
         ariaLabel={label}
         name="datepicker"
-        onChange={date => onChange(date.toISOString())}
+        onChange={date => onChange(formatISO(date, { representation: 'date' }))}
         onClear={() => onChange(null)}
-        selectedDate={value ? new Date(value) : null}
+        selectedDate={value ? parseISO(value) : null}
         selectedDateLabel={formattedDate => `Date picker, current is ${formattedDate}`}
       />
     );


### PR DESCRIPTION
### What does it do?

It removes all time-related information from the date filter of the content manager list-view, to avoid deprecation warnings and to fix the filter.

### Why is it needed?

Fixes a bug mentioned & related to https://github.com/strapi/strapi/issues/11509.

### How to test it?

1. Navigate to the content manger
2. Create a piece of content with a date field (ex. Category)
3. Filter for the date in the content manager list view.

### Related issue(s)/PR(s)

Refs: https://github.com/strapi/strapi/pull/12586
Refs: https://github.com/strapi/strapi/issues/11509
