### PR TITLE
CM: Add e2e tests for layout updates

### DIFF
--- a/packages/core/content-manager/server/tests/content-manager/content-types.test.e2e.js
+++ b/packages/core/content-manager/server/tests/content-manager/content-types.test.e2e.js
@@ -1,0 +1,155 @@
+'use strict';
+
+// Helpers.
+const { createTestBuilder } = require('../../../../../../test/helpers/builder');
+const { createStrapiInstance } = require('../../../../../../test/helpers/strapi');
+const form = require('../../../../../../test/helpers/generators');
+const { createAuthRequest } = require('../../../../../../test/helpers/request');
+
+const builder = createTestBuilder();
+let strapi;
+let rq;
+
+const restart = async () => {
+  await strapi.destroy();
+  strapi = await createStrapiInstance();
+  rq = await createAuthRequest({ strapi });
+};
+
+const FIXTURE_DEFAULT_LAYOUT = [
+  [
+    {
+      name: 'title',
+      size: 6,
+    },
+    {
+      name: 'date',
+      size: 4,
+    },
+  ],
+  [
+    {
+      name: 'jsonField',
+      size: 12,
+    },
+  ],
+  [
+    {
+      name: 'content',
+      size: 12,
+    },
+  ],
+];
+
+describe('Content Manager - Update Layout', () => {
+  beforeAll(async () => {
+    await builder.addContentTypes([form.article]).build();
+
+    strapi = await createStrapiInstance();
+    rq = await createAuthRequest({ strapi });
+  });
+
+  afterAll(async () => {
+    await strapi.destroy();
+    await builder.cleanup();
+  });
+
+  test('Fetch default layout', async () => {
+    const { body } = await rq({
+      url: '/content-manager/content-types/api::article.article/configuration',
+      method: 'GET',
+    });
+
+    expect(body.data.contentType.layouts.edit).toStrictEqual(FIXTURE_DEFAULT_LAYOUT);
+  });
+
+  test('Update field size', async () => {
+    const payload = [...FIXTURE_DEFAULT_LAYOUT];
+    payload[0][0].size = 12;
+
+    await rq({
+      url: '/content-manager/content-types/api::article.article/configuration',
+      method: 'PUT',
+      body: {
+        layouts: {
+          edit: payload,
+          editRelations: [],
+          list: [],
+        },
+      },
+    });
+
+    const { body } = await rq({
+      url: '/content-manager/content-types/api::article.article/configuration',
+      method: 'GET',
+    });
+
+    expect(body.data.contentType.layouts.edit[0][0].size).toBe(12);
+  });
+
+  test('Update field size with server restart and invalid JSON size', async () => {
+    const payload = [...FIXTURE_DEFAULT_LAYOUT];
+    payload[0][0].size = 8; // title
+    payload[0][1].size = 4; // date
+    payload[1][0].size = 6; // jsonField
+
+    await rq({
+      url: '/content-manager/content-types/api::article.article/configuration',
+      method: 'PUT',
+      body: {
+        layouts: {
+          edit: payload,
+          editRelations: [],
+          list: [],
+        },
+      },
+    });
+
+    await restart();
+
+    const { body } = await rq({
+      url: '/content-manager/content-types/api::article.article/configuration',
+      method: 'GET',
+    });
+
+    expect(body.data.contentType.layouts.edit[0][0].name).toBe('title');
+    expect(body.data.contentType.layouts.edit[0][0].size).toBe(8);
+
+    expect(body.data.contentType.layouts.edit[0][1].name).toBe('date');
+    expect(body.data.contentType.layouts.edit[0][1].size).toBe(4);
+
+    expect(body.data.contentType.layouts.edit[2][0].name).toBe('jsonField');
+    expect(body.data.contentType.layouts.edit[2][0].size).toBe(12);
+  });
+
+  test('Update field size with server restart and invalid date size', async () => {
+    const payload = [...FIXTURE_DEFAULT_LAYOUT];
+    payload[0][0].size = 12; // title
+    payload[0][1].size = 14; // date
+
+    await rq({
+      url: '/content-manager/content-types/api::article.article/configuration',
+      method: 'PUT',
+      body: {
+        layouts: {
+          edit: payload,
+          editRelations: [],
+          list: [],
+        },
+      },
+    });
+
+    await restart();
+
+    const { body } = await rq({
+      url: '/content-manager/content-types/api::article.article/configuration',
+      method: 'GET',
+    });
+
+    expect(body.data.contentType.layouts.edit[0][0].name).toBe('title');
+    expect(body.data.contentType.layouts.edit[0][0].size).toBe(12);
+
+    expect(body.data.contentType.layouts.edit[2][0].name).toBe('date');
+    expect(body.data.contentType.layouts.edit[2][0].size).toBe(4);
+  });
+});

--- a/packages/core/content-manager/server/tests/content-manager/content-types.test.e2e.js
+++ b/packages/core/content-manager/server/tests/content-manager/content-types.test.e2e.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const cloneDeep = require('lodash/cloneDeep');
 const merge = require('lodash/merge');
 
 // Helpers.
@@ -17,14 +16,6 @@ const restart = async () => {
   await strapi.destroy();
   strapi = await createStrapiInstance();
   rq = await createAuthRequest({ strapi });
-};
-
-const transformLayout = (layout, partialNewLayout) => {
-  return partialNewLayout.reduce((acc, row, rowIndex) => {
-    acc[rowIndex] = row.map((column, columnIndex) => merge(acc[rowIndex][columnIndex], column));
-
-    return acc;
-  }, layout);
 };
 
 const FIXTURE_DEFAULT_LAYOUT = [
@@ -88,7 +79,7 @@ describe('Content Manager - Update Layout', () => {
         },
       ],
     ];
-    const payload = transformLayout(cloneDeep(FIXTURE_DEFAULT_LAYOUT), transformation);
+    const payload = merge([], FIXTURE_DEFAULT_LAYOUT, transformation);
 
     await rq({
       url: '/content-manager/content-types/api::article.article/configuration',
@@ -107,7 +98,7 @@ describe('Content Manager - Update Layout', () => {
       method: 'GET',
     });
 
-    const expectation = transformLayout(cloneDeep(FIXTURE_DEFAULT_LAYOUT), transformation);
+    const expectation = merge([], FIXTURE_DEFAULT_LAYOUT, transformation);
 
     expect(body.data.contentType.layouts.edit).toStrictEqual(expectation);
   });
@@ -133,7 +124,7 @@ describe('Content Manager - Update Layout', () => {
         },
       ],
     ];
-    const payload = transformLayout(cloneDeep(FIXTURE_DEFAULT_LAYOUT), transformation);
+    const payload = merge([], FIXTURE_DEFAULT_LAYOUT, transformation);
 
     await rq({
       url: '/content-manager/content-types/api::article.article/configuration',
@@ -199,7 +190,7 @@ describe('Content Manager - Update Layout', () => {
         },
       ],
     ];
-    const payload = transformLayout(cloneDeep(FIXTURE_DEFAULT_LAYOUT), transformation);
+    const payload = merge([], FIXTURE_DEFAULT_LAYOUT, transformation);
 
     await rq({
       url: '/content-manager/content-types/api::article.article/configuration',


### PR DESCRIPTION
### What does it do?

Adds end-to-end tests for https://github.com/strapi/strapi/pull/12577.

### Why is it needed?

Because the case it not obvious and it will help in the future to avoid this error.

### How to test it?

Trust the test.

### Related issue(s)/PR(s)

- https://github.com/strapi/strapi/pull/12577
