### PR TITLE
fix reset layouts bug

### DIFF
--- a/packages/core/content-manager/server/services/utils/configuration/layouts.js
+++ b/packages/core/content-manager/server/services/utils/configuration/layouts.js
@@ -69,20 +69,12 @@ function syncLayouts(configuration, schema) {
 
   let cleanEditRelations = editRelations.filter(attr => hasRelationAttribute(schema, attr));
 
-  let elementsToReAppend = [];
   let cleanEdit = [];
   for (let row of edit) {
     let newRow = [];
 
     for (let el of row) {
       if (!hasEditableAttribute(schema, el.name)) continue;
-
-      // if size of the element has changed (type changes)
-      if (typeToSize(schema.attributes[el.name].type) !== el.size) {
-        elementsToReAppend.push(el.name);
-        continue;
-      }
-
       newRow.push(el);
     }
 
@@ -90,8 +82,6 @@ function syncLayouts(configuration, schema) {
       cleanEdit.push(newRow);
     }
   }
-
-  cleanEdit = appendToEditLayout(cleanEdit, elementsToReAppend, schema);
 
   const newAttributes = _.difference(
     Object.keys(schema.attributes),


### PR DESCRIPTION
### What does it do?

Fixed the bug that all layouts settings are cleared when restart.

### Why is it needed?

Because the layout settings disappeared when I restarted

### How to test it?

Run examples/getstarted to set layouts.
Restart examples/getstarted, make sure the layouts remains.

<img width="1386" alt="スクリーンショット 2022-02-22 0 52 28" src="https://user-images.githubusercontent.com/22957487/154989083-e63dd377-560a-4abc-9f84-76ab78152e05.png">

### Related issue(s)/PR(s)