### PR TITLE
[MARKET] add copy command and track usage data

### DIFF
--- a/packages/core/admin/admin/src/pages/MarketplacePage/components/PluginCard/index.js
+++ b/packages/core/admin/admin/src/pages/MarketplacePage/components/PluginCard/index.js
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 import styled from 'styled-components';
@@ -29,7 +29,6 @@ const PluginCard = ({ plugin, installedPlugins, useYarn }) => {
   const { formatMessage } = useIntl();
   const toggleNotification = useNotification();
   const { trackUsage } = useTracking();
-  const trackUsageRef = useRef(trackUsage);
 
   const isInstalled = installedPlugins.includes(attributes.npmPackageName);
 
@@ -85,7 +84,7 @@ const PluginCard = ({ plugin, installedPlugins, useYarn }) => {
             { pluginName: attributes.name }
           )}
           variant="tertiary"
-          onClick={() => trackUsageRef.current('didLearnMore')}
+          onClick={() => trackUsage('didLearnMore')}
         >
           {formatMessage({
             id: 'admin.pages.MarketPlacePage.plugin.info.text',
@@ -105,7 +104,7 @@ const PluginCard = ({ plugin, installedPlugins, useYarn }) => {
         ) : (
           <CopyToClipboard
             onCopy={() => {
-              trackUsageRef.current('willInstallPlugin');
+              trackUsage('willInstallPlugin');
               toggleNotification({
                 type: 'success',
                 message: { id: 'admin.pages.MarketPlacePage.plugin.copy.success' },

--- a/packages/core/admin/admin/src/pages/MarketplacePage/components/PluginCard/index.js
+++ b/packages/core/admin/admin/src/pages/MarketplacePage/components/PluginCard/index.js
@@ -32,14 +32,10 @@ const PluginCard = ({ plugin, installedPlugins, useYarn }) => {
   const trackUsageRef = useRef(trackUsage);
 
   const isInstalled = installedPlugins.includes(attributes.npmPackageName);
-  // TODO: Remove this temp test boolean
-  const useYarn = true;
+
   const commandToCopy = useYarn
     ? `yarn add ${attributes.npmPackageName}`
     : `npm install ${attributes.npmPackageName}`;
-
-  // TODO: remove and use
-  console.log(useYarn);
 
   return (
     <Flex

--- a/packages/core/admin/admin/src/translations/en.json
+++ b/packages/core/admin/admin/src/translations/en.json
@@ -64,6 +64,7 @@
   "admin.pages.MarketPlacePage.plugin.info.text": "Learn more",
   "admin.pages.MarketPlacePage.plugin.info.label": "Learn more about {pluginName}",
   "admin.pages.MarketPlacePage.plugin.copy": "Copy install command",
+  "admin.pages.MarketPlacePage.plugin.copy.success": "install command copied",
   "admin.pages.MarketPlacePage.plugin.installed": "Installed",
   "admin.pages.MarketPlacePage.plugin.info": "Learn more",
   "admin.pages.MarketPlacePage.submit.plugin.link": "Submit your plugin",


### PR DESCRIPTION
### What does it do?

Adds the copy command on plugin cards
Adds tracking for learn more and copy command

### How to test it?

Click the copy command

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
