### PR TITLE
GH Workflow: Don't enforce issue labels on dependabot PRs

### DIFF
--- a/.github/actions/check-pr-status/__tests__/action.test.js
+++ b/.github/actions/check-pr-status/__tests__/action.test.js
@@ -44,6 +44,24 @@ test('Test missing source label', async () => {
   setFailed.mockRestore();
 });
 
+test('Test source label dependencies', async () => {
+  github.context = {
+    payload: {
+      pull_request: {
+        labels: [{ name: 'source: dependencies' }],
+      },
+    },
+  };
+
+  const setFailed = jest.spyOn(core, 'setFailed');
+
+  await action();
+
+  expect(setFailed).not.toHaveBeenCalled();
+
+  setFailed.mockRestore();
+});
+
 test('Test too many source label', async () => {
   github.context = {
     payload: {

--- a/.github/actions/check-pr-status/index.js
+++ b/.github/actions/check-pr-status/index.js
@@ -21,12 +21,15 @@ async function main() {
 
     const sourceLabelCount = labels.filter(label => label.name.startsWith('source: ')).length;
     const issueLabelCount = labels.filter(label => label.name.startsWith('issue-type: ')).length;
+    const hasSourceDependenciesLabel = !!labels.find(
+      label => label.name === 'source: dependencies'
+    );
 
     if (sourceLabelCount !== 1) {
       core.setFailed(`The PR must have one and only one 'source:' label.`);
     }
 
-    if (issueLabelCount !== 1) {
+    if (issueLabelCount !== 1 && !hasSourceDependenciesLabel) {
       core.setFailed(`The PR must have one and only one 'issue-type:' label.`);
     }
 


### PR DESCRIPTION
### What does it do?

Dependabot updates get a `source: dependencies` label. Currently all of the PRs fail on the first run, because it is being checked that any `issue-type: ` label is attached too, which, I believe, doesn't make much sense in that case. This PR adds a check, so that all dependabot PRs only need a `source: dependencies`.

### Why is it needed?

To see immediately if a dependency upgrade works or creates test failures.

### How to test it?

I've extended the existing tests.

### Related issue(s)/PR(s)

- https://github.com/strapi/strapi/pull/12439
