### PR TITLE
Add a missing new keyword when trying to format the graphql errors

### DIFF
--- a/packages/plugins/graphql/server/format-graphql-error.js
+++ b/packages/plugins/graphql/server/format-graphql-error.js
@@ -44,7 +44,7 @@ const formatGraphqlError = error => {
 
   // Internal server error
   strapi.log.error(originalError);
-  return ApolloError('Internal Server Error', 'INTERNAL_SERVER_ERROR');
+  return new ApolloError('Internal Server Error', 'INTERNAL_SERVER_ERROR');
 };
 
 module.exports = formatGraphqlError;


### PR DESCRIPTION
### What does it do?

Add a missing `new` keyword before ApolloError instanciation.

### Why is it needed?

It breaks otherwise.

### How to test it?

Throw an error so that it won't be caught by the first 5 ifs in `packages/plugins/graphql/server/format-graphql-error.js` (`formatGraphqlError`)

### Related issue(s)/PR(s)

fix #12622