### PR TITLE
ML: Swap width and height when displaying image dimensions

### DIFF
--- a/packages/core/upload/admin/src/components/AssetCard/ImageAssetCard.js
+++ b/packages/core/upload/admin/src/components/AssetCard/ImageAssetCard.js
@@ -79,7 +79,7 @@ export const ImageAssetCard = ({
           </Box>
           <CardSubtitle>
             <Extension>{extension}</Extension>
-            {height && width && ` - ${height}✕${width}`}
+            {height && width && ` - ${width}✕${height}`}
           </CardSubtitle>
         </CardContent>
         <CardBadge>

--- a/packages/core/upload/admin/src/components/AssetList/tests/AssetList.test.js
+++ b/packages/core/upload/admin/src/components/AssetList/tests/AssetList.test.js
@@ -529,7 +529,7 @@ describe('MediaLibrary / AssetList', () => {
                       >
                         png
                       </span>
-                       - 551✕1066
+                       - 1066✕551
                     </div>
                   </div>
                   <div

--- a/packages/core/upload/admin/src/components/EditAssetDialog/index.js
+++ b/packages/core/upload/admin/src/components/EditAssetDialog/index.js
@@ -141,7 +141,7 @@ export const EditAssetDialog = ({
                     <AssetMeta
                       size={formatBytes(asset.size)}
                       dimension={
-                        asset.height && asset.width ? `${asset.height}✕${asset.width}` : ''
+                        asset.height && asset.width ? `${asset.width}✕${asset.height}` : ''
                       }
                       date={formatDate(new Date(asset.createdAt))}
                       extension={getFileExtension(asset.ext)}

--- a/packages/core/upload/admin/src/components/EditAssetDialog/tests/__snapshots__/EditAssetDialog.test.js.snap
+++ b/packages/core/upload/admin/src/components/EditAssetDialog/tests/__snapshots__/EditAssetDialog.test.js.snap
@@ -1211,7 +1211,7 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
                                 <span
                                   class="c29"
                                 >
-                                  780✕1476
+                                  1476✕780
                                 </span>
                               </div>
                             </div>

--- a/packages/core/upload/admin/src/components/EditAssetDialog/tests/__snapshots__/index.test.js.snap
+++ b/packages/core/upload/admin/src/components/EditAssetDialog/tests/__snapshots__/index.test.js.snap
@@ -1211,7 +1211,7 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
                                 <span
                                   class="c29"
                                 >
-                                  780✕1476
+                                  1476✕780
                                 </span>
                               </div>
                             </div>


### PR DESCRIPTION
### What does it do?

Swaps the width and height attribute for an `ImageAssetCard`.

### Why is it needed?

It follows a convention to name the width first.

### How to test it?

1. Navigate to the ML
2. Upload an image asset
3. Check that width and height are displayed as `width x height`
4. Edit the asset
5. Check the "Dimensions" displays the same format as in 3.

### Related issue(s)/PR(s)

Fixes: https://github.com/strapi/strapi/issues/12594
