### PR TITLE
Add hidden field feature in the Content Type Builder

### DIFF
--- a/packages/core/content-type-builder/admin/src/components/FormModal/attributes/advancedForm.js
+++ b/packages/core/content-type-builder/admin/src/components/FormModal/attributes/advancedForm.js
@@ -37,7 +37,6 @@ const advancedForm = {
                   metadatas: { intlLabel: { id: 'false', defaultMessage: 'false' } },
                 },
               ],
-              // validations: {},
             },
           ],
         },
@@ -46,7 +45,7 @@ const advancedForm = {
             id: getTrad('form.attribute.item.settings.name'),
             defaultMessage: 'Settings',
           },
-          items: [options.required, options.private],
+          items: [options.required, options.private, options.hidden],
         },
       ],
     };
@@ -64,7 +63,7 @@ const advancedForm = {
               id: getTrad('form.attribute.item.settings.name'),
               defaultMessage: 'Settings',
             },
-            items: [options.required, options.private, options.max, options.min],
+            items: [options.required, options.private, options.hidden, options.max, options.min],
           },
         ],
       };
@@ -77,7 +76,7 @@ const advancedForm = {
             id: getTrad('form.attribute.item.settings.name'),
             defaultMessage: 'Settings',
           },
-          items: [options.required, options.private],
+          items: [options.required, options.private, options.hidden],
         },
       ],
     };
@@ -103,7 +102,7 @@ const advancedForm = {
             id: getTrad('form.attribute.item.settings.name'),
             defaultMessage: 'Settings',
           },
-          items: [options.required, options.unique, options.private],
+          items: [options.required, options.unique, options.private, options.hidden],
         },
       ],
     };
@@ -145,6 +144,7 @@ const advancedForm = {
             options.maxLength,
             options.minLength,
             options.private,
+            options.hidden,
           ],
         },
       ],
@@ -209,7 +209,7 @@ const advancedForm = {
             id: getTrad('form.attribute.item.settings.name'),
             defaultMessage: 'Settings',
           },
-          items: [options.required, options.private],
+          items: [options.required, options.private, options.hidden],
         },
       ],
     };
@@ -222,7 +222,7 @@ const advancedForm = {
             id: getTrad('form.attribute.item.settings.name'),
             defaultMessage: 'Settings',
           },
-          items: [options.required, options.private],
+          items: [options.required, options.private, options.hidden],
         },
       ],
     };
@@ -282,7 +282,14 @@ const advancedForm = {
             id: getTrad('form.attribute.item.settings.name'),
             defaultMessage: 'Settings',
           },
-          items: [options.required, options.unique, options.max, options.min, options.private],
+          items: [
+            options.required,
+            options.unique,
+            options.max,
+            options.min,
+            options.private,
+            options.hidden,
+          ],
         },
       ],
     };
@@ -297,7 +304,13 @@ const advancedForm = {
             id: getTrad('form.attribute.item.settings.name'),
             defaultMessage: 'Settings',
           },
-          items: [options.required, options.maxLength, options.minLength, options.private],
+          items: [
+            options.required,
+            options.maxLength,
+            options.minLength,
+            options.private,
+            options.hidden,
+          ],
         },
       ],
     };
@@ -310,7 +323,7 @@ const advancedForm = {
             id: getTrad('form.attribute.item.settings.name'),
             defaultMessage: 'Settings',
           },
-          items: [options.private],
+          items: [options.private, options.hidden],
         },
       ],
     };
@@ -345,6 +358,7 @@ const advancedForm = {
             options.maxLength,
             options.minLength,
             options.private,
+            options.hidden,
           ],
         },
       ],
@@ -363,7 +377,13 @@ const advancedForm = {
             id: getTrad('form.attribute.item.settings.name'),
             defaultMessage: 'Settings',
           },
-          items: [options.required, options.maxLength, options.minLength, options.private],
+          items: [
+            options.required,
+            options.maxLength,
+            options.minLength,
+            options.private,
+            options.hidden,
+          ],
         },
       ],
     };

--- a/packages/core/content-type-builder/admin/src/components/FormModal/attributes/attributeOptions.js
+++ b/packages/core/content-type-builder/admin/src/components/FormModal/attributes/attributeOptions.js
@@ -9,6 +9,18 @@ const attributeOptions = {
       defaultMessage: 'Default value',
     },
   },
+  hidden: {
+    name: 'adminOptions.hidden',
+    type: 'checkbox',
+    intlLabel: {
+      id: getTrad('form.attribute.item.admin-hidden-field'),
+      defaultMessage: 'Hidden field',
+    },
+    description: {
+      id: getTrad('form.attribute.item.privateField.description'),
+      defaultMessage: 'This field will not show up in the API response',
+    },
+  },
   max: {
     name: 'max',
     type: 'checkbox-with-number-field',

--- a/packages/core/content-type-builder/admin/src/components/FormModal/attributes/attributeOptions.js
+++ b/packages/core/content-type-builder/admin/src/components/FormModal/attributes/attributeOptions.js
@@ -79,7 +79,7 @@ const attributeOptions = {
   },
   required: {
     name: 'required',
-    type: 'checkbox',
+    type: 'required-checkbox',
     intlLabel: {
       id: getTrad('form.attribute.item.requiredField'),
       defaultMessage: 'Required field',

--- a/packages/core/content-type-builder/admin/src/components/FormModal/attributes/validation/common.js
+++ b/packages/core/content-type-builder/admin/src/components/FormModal/attributes/validation/common.js
@@ -91,7 +91,18 @@ const validators = {
       .matches(NAME_REGEX, errorsTrads.regex)
       .required(errorsTrads.required);
   },
-  required: () => yup.boolean(),
+  required: () =>
+    yup.boolean().test({
+      name: 'requiredOption',
+      message: getTrad('error.validation.required'),
+      test(value) {
+        if (this.parent.adminOptions?.hidden) {
+          return !value;
+        }
+
+        return true;
+      },
+    }),
   type: () => yup.string().required(errorsTrads.required),
   unique: () => yup.boolean().nullable(),
 };

--- a/packages/core/content-type-builder/admin/src/components/FormModal/index.js
+++ b/packages/core/content-type-builder/admin/src/components/FormModal/index.js
@@ -134,6 +134,7 @@ const FormModal = () => {
     isCreatingComponentWhileAddingAField,
     modifiedData,
   } = reducerState;
+  console.log({ modifiedData });
 
   const pathToSchema =
     forTarget === 'contentType' || forTarget === 'component' ? [forTarget] : [forTarget, targetUid];

--- a/packages/core/content-type-builder/admin/src/components/FormModal/index.js
+++ b/packages/core/content-type-builder/admin/src/components/FormModal/index.js
@@ -30,7 +30,6 @@ import AttributeOptions from '../AttributeOptions';
 import DraftAndPublishToggle from '../DraftAndPublishToggle';
 import FormModalHeader from '../FormModalHeader';
 import FormModalEndActions from '../FormModalEndActions';
-
 import BooleanDefaultValueSelect from '../BooleanDefaultValueSelect';
 import BooleanRadioGroup from '../BooleanRadioGroup';
 import CheckboxWithNumberField from '../CheckboxWithNumberField';
@@ -38,6 +37,7 @@ import CustomRadioGroup from '../CustomRadioGroup';
 import ContentTypeRadioGroup from '../ContentTypeRadioGroup';
 import ComponentIconPicker from '../ComponentIconPicker';
 import Relation from '../Relation';
+import RequiredCheckbox from '../RequiredCheckbox';
 import PluralName from '../PluralName';
 import SelectCategory from '../SelectCategory';
 import SelectComponent from '../SelectComponent';
@@ -134,7 +134,6 @@ const FormModal = () => {
     isCreatingComponentWhileAddingAField,
     modifiedData,
   } = reducerState;
-  console.log({ modifiedData });
 
   const pathToSchema =
     forTarget === 'contentType' || forTarget === 'component' ? [forTarget] : [forTarget, targetUid];
@@ -837,6 +836,7 @@ const FormModal = () => {
       'content-type-radio-group': ContentTypeRadioGroup,
       'radio-group': CustomRadioGroup,
       relation: Relation,
+      'required-checkbox': RequiredCheckbox,
       'select-category': SelectCategory,
       'select-component': SelectComponent,
       'select-components': SelectComponents,

--- a/packages/core/content-type-builder/admin/src/components/FormModal/reducer.js
+++ b/packages/core/content-type-builder/admin/src/components/FormModal/reducer.js
@@ -30,9 +30,13 @@ const reducer = (state = initialState, action) =>
           const previousType = obj.type;
 
           if (previousType && ['date', 'datetime', 'time'].includes(previousType)) {
-            // return obj.updateIn(keys, () => value).remove('default');
             delete draftState.modifiedData.default;
           }
+        }
+
+        // Remove the required option when enabling the hidden field feature
+        if (keys.join('.') === 'adminOptions.hidden') {
+          delete draftState.modifiedData.required;
         }
 
         set(draftState, ['modifiedData', ...keys], value);

--- a/packages/core/content-type-builder/admin/src/components/FormModal/tests/reducer.test.js
+++ b/packages/core/content-type-builder/admin/src/components/FormModal/tests/reducer.test.js
@@ -79,6 +79,33 @@ describe('CTB | components | FormModal | reducer | actions', () => {
 
       expect(reducer(state, action)).toEqual(expected);
     });
+
+    it('should remove the required value when enabling adminOptions.hidden', () => {
+      const state = {
+        ...initialState,
+        modifiedData: {
+          name: 'field',
+          type: 'text',
+          required: true,
+        },
+      };
+      const action = {
+        type: actions.ON_CHANGE,
+        keys: ['adminOptions', 'hidden'],
+        value: true,
+      };
+
+      const expected = {
+        ...initialState,
+        modifiedData: {
+          name: 'field',
+          type: 'text',
+          adminOptions: { hidden: true },
+        },
+      };
+
+      expect(reducer(state, action)).toEqual(expected);
+    });
   });
 
   describe('ON_CHANGE_RELATION_TARGET', () => {

--- a/packages/core/content-type-builder/admin/src/components/RequiredCheckbox/index.js
+++ b/packages/core/content-type-builder/admin/src/components/RequiredCheckbox/index.js
@@ -1,0 +1,79 @@
+/**
+ *
+ * RequiredCheckbox
+ *
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useIntl } from 'react-intl';
+import { Checkbox } from '@strapi/design-system/Checkbox';
+
+const RequiredCheckbox = ({
+  description,
+  error,
+  intlLabel,
+  modifiedData,
+  name,
+  onChange,
+  value,
+}) => {
+  const { formatMessage } = useIntl();
+  const label = intlLabel.id
+    ? formatMessage(
+        { id: intlLabel.id, defaultMessage: intlLabel.defaultMessage },
+        { ...intlLabel.values }
+      )
+    : name;
+
+  const disabled = modifiedData.adminOptions?.hidden;
+  const hint = description
+    ? formatMessage(
+        { id: description.id, defaultMessage: description.defaultMessage },
+        { ...description.values }
+      )
+    : undefined;
+  const errorMessage = error ? formatMessage({ id: error, defaultMessage: error }) : '';
+
+  return (
+    <Checkbox
+      disabled={disabled}
+      error={errorMessage}
+      hint={hint}
+      id={name}
+      name={name}
+      onValueChange={value => {
+        onChange({ target: { name, value } });
+      }}
+      value={Boolean(value)}
+    >
+      {label}
+    </Checkbox>
+  );
+};
+
+RequiredCheckbox.defaultProps = {
+  description: undefined,
+  error: null,
+  value: null,
+};
+
+RequiredCheckbox.propTypes = {
+  description: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    defaultMessage: PropTypes.string.isRequired,
+    values: PropTypes.object,
+  }),
+  error: PropTypes.string,
+  intlLabel: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    defaultMessage: PropTypes.string.isRequired,
+    values: PropTypes.object,
+  }).isRequired,
+  modifiedData: PropTypes.object.isRequired,
+  name: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
+};
+
+export default RequiredCheckbox;

--- a/packages/core/content-type-builder/admin/src/components/RequiredCheckbox/tests/index.test.js
+++ b/packages/core/content-type-builder/admin/src/components/RequiredCheckbox/tests/index.test.js
@@ -11,21 +11,370 @@ import { IntlProvider } from 'react-intl';
 import RequiredCheckbox from '../index';
 
 const messages = {
-  'content-type-builder.component.name': 'Required Checkbox',
+  'form.attribute.item.admin-hidden-field': 'Hidden field',
+  'form.attribute.item.admin-hidden-field.description':
+    'This field will not show up in the Admin API',
 };
 
 describe('<RequiredCheckbox />', () => {
   it('renders and matches the snapshot', () => {
+    const props = {
+      modifiedData: {
+        adminOptions: { hidden: false },
+        required: true,
+      },
+      name: 'required',
+      onChange: jest.fn(),
+      intlLabel: {
+        id: 'form.attribute.item.requiredField',
+        defaultMessage: 'Required field',
+      },
+      description: {
+        id: 'form.attribute.item.requiredField.description',
+        defaultMessage: "You won't be able to create an entry if this field is empty",
+      },
+      value: true,
+    };
+
     const {
       container: { firstChild },
     } = render(
       <ThemeProvider theme={lightTheme}>
         <IntlProvider locale="en" messages={messages} defaultLocale="en">
-          <RequiredCheckbox />
+          <RequiredCheckbox {...props} />
         </IntlProvider>
       </ThemeProvider>
     );
 
-    expect(firstChild).toMatchInlineSnapshot();
+    expect(firstChild).toMatchInlineSnapshot(`
+      .c3 {
+        margin: 0;
+        height: 18px;
+        min-width: 18px;
+        border-radius: 4px;
+        border: 1px solid #c0c0cf;
+        -webkit-appearance: none;
+        background-color: #ffffff;
+        cursor: pointer;
+      }
+
+      .c3:checked {
+        background-color: #4945ff;
+        border: 1px solid #4945ff;
+      }
+
+      .c3:checked:after {
+        content: '';
+        display: block;
+        position: relative;
+        background: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTAiIGhlaWdodD0iOCIgdmlld0JveD0iMCAwIDEwIDgiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgPHBhdGgKICAgIGQ9Ik04LjU1MzIzIDAuMzk2OTczQzguNjMxMzUgMC4zMTYzNTUgOC43NjA1MSAwLjMxNTgxMSA4LjgzOTMxIDAuMzk1NzY4TDkuODYyNTYgMS40MzQwN0M5LjkzODkzIDEuNTExNTcgOS45MzkzNSAxLjYzNTkgOS44NjM0OSAxLjcxMzlMNC4wNjQwMSA3LjY3NzI0QzMuOTg1OSA3Ljc1NzU1IDMuODU3MDcgNy43NTgwNSAzLjc3ODM0IDcuNjc4MzRMMC4xMzg2NiAzLjk5MzMzQzAuMDYxNzc5OCAzLjkxNTQ5IDAuMDYxNzEwMiAzLjc5MDMyIDAuMTM4NTA0IDMuNzEyNEwxLjE2MjEzIDIuNjczNzJDMS4yNDAzOCAyLjU5NDMyIDEuMzY4NDMgMi41OTQyMiAxLjQ0NjggMi42NzM0OEwzLjkyMTc0IDUuMTc2NDdMOC41NTMyMyAwLjM5Njk3M1oiCiAgICBmaWxsPSJ3aGl0ZSIKICAvPgo8L3N2Zz4=) no-repeat no-repeat center center;
+        width: 10px;
+        height: 10px;
+        left: 50%;
+        top: 50%;
+        -webkit-transform: translateX(-50%) translateY(-50%);
+        -ms-transform: translateX(-50%) translateY(-50%);
+        transform: translateX(-50%) translateY(-50%);
+      }
+
+      .c3:checked:disabled:after {
+        background: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTAiIGhlaWdodD0iOCIgdmlld0JveD0iMCAwIDEwIDgiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgPHBhdGgKICAgIGQ9Ik04LjU1MzIzIDAuMzk2OTczQzguNjMxMzUgMC4zMTYzNTUgOC43NjA1MSAwLjMxNTgxMSA4LjgzOTMxIDAuMzk1NzY4TDkuODYyNTYgMS40MzQwN0M5LjkzODkzIDEuNTExNTcgOS45MzkzNSAxLjYzNTkgOS44NjM0OSAxLjcxMzlMNC4wNjQwMSA3LjY3NzI0QzMuOTg1OSA3Ljc1NzU1IDMuODU3MDcgNy43NTgwNSAzLjc3ODM0IDcuNjc4MzRMMC4xMzg2NiAzLjk5MzMzQzAuMDYxNzc5OCAzLjkxNTQ5IDAuMDYxNzEwMiAzLjc5MDMyIDAuMTM4NTA0IDMuNzEyNEwxLjE2MjEzIDIuNjczNzJDMS4yNDAzOCAyLjU5NDMyIDEuMzY4NDMgMi41OTQyMiAxLjQ0NjggMi42NzM0OEwzLjkyMTc0IDUuMTc2NDdMOC41NTMyMyAwLjM5Njk3M1oiCiAgICBmaWxsPSIjOEU4RUE5IgogIC8+Cjwvc3ZnPg==) no-repeat no-repeat center center;
+      }
+
+      .c3:disabled {
+        background-color: #dcdce4;
+        border: 1px solid #c0c0cf;
+      }
+
+      .c3:indeterminate {
+        background-color: #4945ff;
+        border: 1px solid #4945ff;
+      }
+
+      .c3:indeterminate:after {
+        content: '';
+        display: block;
+        position: relative;
+        color: white;
+        height: 2px;
+        width: 10px;
+        background-color: #ffffff;
+        left: 50%;
+        top: 50%;
+        -webkit-transform: translateX(-50%) translateY(-50%);
+        -ms-transform: translateX(-50%) translateY(-50%);
+        transform: translateX(-50%) translateY(-50%);
+      }
+
+      .c3:indeterminate:disabled {
+        background-color: #dcdce4;
+        border: 1px solid #c0c0cf;
+      }
+
+      .c3:indeterminate:disabled:after {
+        background-color: #8e8ea9;
+      }
+
+      .c4 {
+        padding-left: 8px;
+      }
+
+      .c0 {
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+        -webkit-flex-direction: column;
+        -ms-flex-direction: column;
+        flex-direction: column;
+      }
+
+      .c0 > * {
+        margin-top: 0;
+        margin-bottom: 0;
+      }
+
+      .c0 > * + * {
+        margin-top: 4px;
+      }
+
+      .c1 {
+        color: #32324d;
+        font-size: 0.875rem;
+        line-height: 1.43;
+      }
+
+      .c5 {
+        color: #666687;
+        font-size: 0.75rem;
+        line-height: 1.33;
+      }
+
+      .c2 {
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+        -webkit-align-items: flex-start;
+        -webkit-box-align: flex-start;
+        -ms-flex-align: flex-start;
+        align-items: flex-start;
+      }
+
+      .c2 * {
+        cursor: pointer;
+      }
+
+      <div>
+        <div
+          class="c0"
+        >
+          <label
+            class="c1 c2"
+          >
+            <input
+              aria-describedby="required-hint"
+              checked=""
+              class="c3"
+              id="required"
+              name="required"
+              type="checkbox"
+            />
+            <div
+              class="c4"
+            >
+              Required field
+            </div>
+          </label>
+          <p
+            class="c5"
+            id="required-hint"
+          >
+            You won't be able to create an entry if this field is empty
+          </p>
+        </div>
+      </div>
+    `);
+  });
+
+  it('shows a disabled state when adminOptions.hidden is enabled', () => {
+    const props = {
+      modifiedData: {
+        adminOptions: { hidden: true },
+        required: false,
+      },
+      name: 'required',
+      onChange: jest.fn(),
+      intlLabel: {
+        id: 'form.attribute.item.requiredField',
+        defaultMessage: 'Required field',
+      },
+      description: {
+        id: 'form.attribute.item.requiredField.description',
+        defaultMessage: "You won't be able to create an entry if this field is empty",
+      },
+      value: false,
+    };
+
+    const {
+      container: { firstChild },
+    } = render(
+      <ThemeProvider theme={lightTheme}>
+        <IntlProvider locale="en" messages={messages} defaultLocale="en">
+          <RequiredCheckbox {...props} />
+        </IntlProvider>
+      </ThemeProvider>
+    );
+
+    expect(firstChild).toMatchInlineSnapshot(`
+      .c3 {
+        margin: 0;
+        height: 18px;
+        min-width: 18px;
+        border-radius: 4px;
+        border: 1px solid #c0c0cf;
+        -webkit-appearance: none;
+        background-color: #ffffff;
+        cursor: pointer;
+      }
+
+      .c3:checked {
+        background-color: #4945ff;
+        border: 1px solid #4945ff;
+      }
+
+      .c3:checked:after {
+        content: '';
+        display: block;
+        position: relative;
+        background: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTAiIGhlaWdodD0iOCIgdmlld0JveD0iMCAwIDEwIDgiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgPHBhdGgKICAgIGQ9Ik04LjU1MzIzIDAuMzk2OTczQzguNjMxMzUgMC4zMTYzNTUgOC43NjA1MSAwLjMxNTgxMSA4LjgzOTMxIDAuMzk1NzY4TDkuODYyNTYgMS40MzQwN0M5LjkzODkzIDEuNTExNTcgOS45MzkzNSAxLjYzNTkgOS44NjM0OSAxLjcxMzlMNC4wNjQwMSA3LjY3NzI0QzMuOTg1OSA3Ljc1NzU1IDMuODU3MDcgNy43NTgwNSAzLjc3ODM0IDcuNjc4MzRMMC4xMzg2NiAzLjk5MzMzQzAuMDYxNzc5OCAzLjkxNTQ5IDAuMDYxNzEwMiAzLjc5MDMyIDAuMTM4NTA0IDMuNzEyNEwxLjE2MjEzIDIuNjczNzJDMS4yNDAzOCAyLjU5NDMyIDEuMzY4NDMgMi41OTQyMiAxLjQ0NjggMi42NzM0OEwzLjkyMTc0IDUuMTc2NDdMOC41NTMyMyAwLjM5Njk3M1oiCiAgICBmaWxsPSJ3aGl0ZSIKICAvPgo8L3N2Zz4=) no-repeat no-repeat center center;
+        width: 10px;
+        height: 10px;
+        left: 50%;
+        top: 50%;
+        -webkit-transform: translateX(-50%) translateY(-50%);
+        -ms-transform: translateX(-50%) translateY(-50%);
+        transform: translateX(-50%) translateY(-50%);
+      }
+
+      .c3:checked:disabled:after {
+        background: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTAiIGhlaWdodD0iOCIgdmlld0JveD0iMCAwIDEwIDgiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgPHBhdGgKICAgIGQ9Ik04LjU1MzIzIDAuMzk2OTczQzguNjMxMzUgMC4zMTYzNTUgOC43NjA1MSAwLjMxNTgxMSA4LjgzOTMxIDAuMzk1NzY4TDkuODYyNTYgMS40MzQwN0M5LjkzODkzIDEuNTExNTcgOS45MzkzNSAxLjYzNTkgOS44NjM0OSAxLjcxMzlMNC4wNjQwMSA3LjY3NzI0QzMuOTg1OSA3Ljc1NzU1IDMuODU3MDcgNy43NTgwNSAzLjc3ODM0IDcuNjc4MzRMMC4xMzg2NiAzLjk5MzMzQzAuMDYxNzc5OCAzLjkxNTQ5IDAuMDYxNzEwMiAzLjc5MDMyIDAuMTM4NTA0IDMuNzEyNEwxLjE2MjEzIDIuNjczNzJDMS4yNDAzOCAyLjU5NDMyIDEuMzY4NDMgMi41OTQyMiAxLjQ0NjggMi42NzM0OEwzLjkyMTc0IDUuMTc2NDdMOC41NTMyMyAwLjM5Njk3M1oiCiAgICBmaWxsPSIjOEU4RUE5IgogIC8+Cjwvc3ZnPg==) no-repeat no-repeat center center;
+      }
+
+      .c3:disabled {
+        background-color: #dcdce4;
+        border: 1px solid #c0c0cf;
+      }
+
+      .c3:indeterminate {
+        background-color: #4945ff;
+        border: 1px solid #4945ff;
+      }
+
+      .c3:indeterminate:after {
+        content: '';
+        display: block;
+        position: relative;
+        color: white;
+        height: 2px;
+        width: 10px;
+        background-color: #ffffff;
+        left: 50%;
+        top: 50%;
+        -webkit-transform: translateX(-50%) translateY(-50%);
+        -ms-transform: translateX(-50%) translateY(-50%);
+        transform: translateX(-50%) translateY(-50%);
+      }
+
+      .c3:indeterminate:disabled {
+        background-color: #dcdce4;
+        border: 1px solid #c0c0cf;
+      }
+
+      .c3:indeterminate:disabled:after {
+        background-color: #8e8ea9;
+      }
+
+      .c4 {
+        padding-left: 8px;
+      }
+
+      .c0 {
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+        -webkit-flex-direction: column;
+        -ms-flex-direction: column;
+        flex-direction: column;
+      }
+
+      .c0 > * {
+        margin-top: 0;
+        margin-bottom: 0;
+      }
+
+      .c0 > * + * {
+        margin-top: 4px;
+      }
+
+      .c1 {
+        color: #32324d;
+        font-size: 0.875rem;
+        line-height: 1.43;
+      }
+
+      .c5 {
+        color: #666687;
+        font-size: 0.75rem;
+        line-height: 1.33;
+      }
+
+      .c2 {
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+        -webkit-align-items: flex-start;
+        -webkit-box-align: flex-start;
+        -ms-flex-align: flex-start;
+        align-items: flex-start;
+      }
+
+      .c2 * {
+        cursor: not-allowed;
+      }
+
+      <div>
+        <div
+          class="c0"
+        >
+          <label
+            class="c1 c2"
+            disabled=""
+          >
+            <input
+              aria-describedby="required-hint"
+              class="c3"
+              disabled=""
+              id="required"
+              name="required"
+              type="checkbox"
+            />
+            <div
+              class="c4"
+            >
+              Required field
+            </div>
+          </label>
+          <p
+            class="c5"
+            id="required-hint"
+          >
+            You won't be able to create an entry if this field is empty
+          </p>
+        </div>
+      </div>
+    `);
   });
 });

--- a/packages/core/content-type-builder/admin/src/components/RequiredCheckbox/tests/index.test.js
+++ b/packages/core/content-type-builder/admin/src/components/RequiredCheckbox/tests/index.test.js
@@ -1,0 +1,31 @@
+/**
+ *
+ * Tests for RequiredCheckbox
+ *
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { ThemeProvider, lightTheme } from '@strapi/design-system';
+import { IntlProvider } from 'react-intl';
+import RequiredCheckbox from '../index';
+
+const messages = {
+  'content-type-builder.component.name': 'Required Checkbox',
+};
+
+describe('<RequiredCheckbox />', () => {
+  it('renders and matches the snapshot', () => {
+    const {
+      container: { firstChild },
+    } = render(
+      <ThemeProvider theme={lightTheme}>
+        <IntlProvider locale="en" messages={messages} defaultLocale="en">
+          <RequiredCheckbox />
+        </IntlProvider>
+      </ThemeProvider>
+    );
+
+    expect(firstChild).toMatchInlineSnapshot();
+  });
+});

--- a/packages/core/content-type-builder/admin/src/translations/en.json
+++ b/packages/core/content-type-builder/admin/src/translations/en.json
@@ -83,6 +83,8 @@
   "form.attribute.item.enumeration.graphql.description": "Allows you to override the default generated name for GraphQL",
   "form.attribute.item.enumeration.placeholder": "Ex:\nmorning\nnoon\nevening",
   "form.attribute.item.enumeration.rules": "Values (one line per value)",
+  "form.attribute.item.admin-hidden-field": "Hidden field",
+  "form.attribute.item.admin-hidden-field.description": "This field will not show up in the Admin API",
   "form.attribute.item.maximum": "Maximum value",
   "form.attribute.item.maximumLength": "Maximum length",
   "form.attribute.item.minimum": "Minimum value",

--- a/packages/core/content-type-builder/admin/src/translations/en.json
+++ b/packages/core/content-type-builder/admin/src/translations/en.json
@@ -63,6 +63,7 @@
   "error.validation.minSupMax": "Can't be superior",
   "error.validation.positive": "Must be a positive number",
   "error.validation.regex": "Regex pattern is invalid",
+  "error.validation.required": "The required option cannot be enabled when the hidden one is enabled",
   "error.validation.relation.targetAttribute-taken": "This name exists in the target",
   "form.attribute.component.option.add": "Add a component",
   "form.attribute.component.option.create": "Create a new component",


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

It allows to set a field as hidden in the content type builder.

### Why is it needed?

To have the same feature as the private fields for the Admin API.

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
