### PR TITLE
Fix unable to fetch all single type with locale all params

### DIFF
--- a/packages/core/strapi/lib/services/entity-service/index.js
+++ b/packages/core/strapi/lib/services/entity-service/index.js
@@ -109,7 +109,7 @@ const createDefaultImplementation = ({ strapi, db, eventHub, entityValidator }) 
 
     const query = transformParamsToQuery(uid, wrappedParams);
 
-    if (kind === 'singleType' && opts.locale !== 'all') {
+    if (kind === 'singleType' && (opts || {}).locale !== 'all') {
       return db.query(uid).findOne(query);
     }
 

--- a/packages/core/strapi/lib/services/entity-service/index.js
+++ b/packages/core/strapi/lib/services/entity-service/index.js
@@ -109,7 +109,7 @@ const createDefaultImplementation = ({ strapi, db, eventHub, entityValidator }) 
 
     const query = transformParamsToQuery(uid, wrappedParams);
 
-    if (kind === 'singleType') {
+    if (kind === 'singleType' && opts.locale !== 'all') {
       return db.query(uid).findOne(query);
     }
 

--- a/packages/plugins/i18n/tests/content-api/content-api.test.e2e.js
+++ b/packages/plugins/i18n/tests/content-api/content-api.test.e2e.js
@@ -197,7 +197,7 @@ describe('i18n - Content API', () => {
       const { statusCode, body } = res;
 
       expect(statusCode).toBe(200);
-      expect(body.data).toMatchObject(transformToRESTResource(data.homepages[0]));
+      expect(body.data).toMatchObject(transformToRESTResource(data.homepages));
     });
   });
 });


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Return `find` insteadOf `findOne` when `locale=all` is applied on single type filter.

### Why is it needed?

In order to fetch single types with all locales.

### How to test it?

1.
```
cd strapi/examples/getstarted
yarn develop
```
2. Create any language in international admin panel
3. Create single type data in `homepage` menu in `en`.
4. Create single type data in `homepage` menu in another language.
5. Send request `http://localhost:1337/api/homepage?locale=all` and see if it returns an array contains data per locale.

### Related issue(s)/PR(s)

#12638 
