### PR TITLE
Fix unable to input date in GraphQL

### DIFF
--- a/packages/core/database/lib/fields.js
+++ b/packages/core/database/lib/fields.js
@@ -120,8 +120,18 @@ const parseTime = value => {
 };
 
 const parseDate = value => {
-  const found = _.isString(value) ? value.match(partialDateRegex) || [] : [];
-  const extractedValue = found[0];
+  let found;
+  if (_.isString(value)) {
+    found = value.match(partialDateRegex) || [];
+  } else if (_.isDate(value)) {
+    found =
+      value
+        .toISOString()
+        .slice(0, 10)
+        .match(partialDateRegex) || [];
+  }
+
+  const [extractedValue] = found;
 
   if (extractedValue && !dateRegex.test(value)) {
     // TODO V5: throw an error when format yyyy-MM-dd is not respected


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

I added new logic that handles javascript `Date` object when it parses date. Because `parseDate` function only treats `string` type, when `Date` object comes throws an `Invalid Date` error.

### Why is it needed?

In order to create/update entry with date input.

### How to test it?

You can test with `strapi/examples/getstarted` example.

1. Go to http://localhost:1337/graphql
2. Execute mutation
```gql
mutation CreateCategory($data: CategoryInput!) {
  createCategory(data: $data) {
    data {
      attributes {
        date
        datetime
      }
    }
  }
}

{
  "data": {
    "date": "2022-01-01"
  }
}
```

### Related issue(s)/PR(s)

Closes #12630 