### PR TITLE
Allow all URI schemes for setting reset password page

### DIFF
--- a/packages/plugins/users-permissions/admin/src/pages/AdvancedSettings/tests/schema.test.js
+++ b/packages/plugins/users-permissions/admin/src/pages/AdvancedSettings/tests/schema.test.js
@@ -1,0 +1,47 @@
+import schema from '../utils/schema';
+
+describe('schema', () => {
+  it('should failed to validate', () => {
+    expect(() =>
+      schema.validateSync({
+        email_confirmation: true,
+        email_confirmation_redirection: '',
+        email_reset_password: null,
+      })
+    ).toThrow();
+  });
+
+  it('should success to validate', () => {
+    expect(() =>
+      schema.validateSync({
+        email_confirmation: true,
+        email_confirmation_redirection: 'http://example.com/redirection',
+        email_reset_password: null,
+      })
+    ).not.toThrow();
+
+    expect(() =>
+      schema.validateSync({
+        email_confirmation: true,
+        email_confirmation_redirection: 'https://example.com/redirection',
+        email_reset_password: null,
+      })
+    ).not.toThrow();
+
+    expect(() =>
+      schema.validateSync({
+        email_confirmation: true,
+        email_confirmation_redirection: 'some://link',
+        email_reset_password: null,
+      })
+    ).not.toThrow();
+
+    expect(() =>
+      schema.validateSync({
+        email_confirmation: true,
+        email_confirmation_redirection: 'market://details?id=com.example.com',
+        email_reset_password: null,
+      })
+    ).not.toThrow();
+  });
+});

--- a/packages/plugins/users-permissions/admin/src/pages/AdvancedSettings/utils/schema.js
+++ b/packages/plugins/users-permissions/admin/src/pages/AdvancedSettings/utils/schema.js
@@ -1,7 +1,7 @@
 import * as yup from 'yup';
 import { translatedErrors } from '@strapi/helper-plugin';
 
-const URL_REGEX = new RegExp('(^$)|((https?://.*)(d*)/?(.*))');
+const URL_REGEX = new RegExp('(^$)|((.+:\\/\\/.*)(d*)\\/?(.*))');
 
 const schema = yup.object().shape({
   email_confirmation_redirection: yup.mixed().when('email_confirmation', {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Allow all URI schemes other than http(s) for validating reset password page field.

### Why is it needed?

In order to cover cases such as deep link.

### How to test it?

1. Go to http://localhost:1337/admin/settings/users-permissions/advanced-settings
2. Enter `abcd://test` in Reset password page
3. Save without regex validation error.

### Related issue(s)/PR(s)

Closes #12629
