### PR TITLE
repeatable relations - show title, not blank title

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/RepeatableComponent/DraggedItem/utils/select.js
+++ b/packages/core/admin/admin/src/content-manager/components/RepeatableComponent/DraggedItem/utils/select.js
@@ -12,9 +12,13 @@ function useSelect({ schema, componentFieldName }) {
   } = useCMEditViewDataManager();
 
   const mainField = useMemo(() => get(schema, ['settings', 'mainField'], 'id'), [schema]);
-  const displayedValue = toString(
-    get(modifiedData, [...componentFieldName.split('.'), mainField], '')
-  );
+  const nestedObjectTitle = schema.layouts.edit?.[0]?.[0]?.metadatas?.mainField?.name;
+  const nestedObjectField = schema.layouts.edit?.[0]?.[0]?.name;
+  const displayValuePath =
+    mainField === 'id' && !!nestedObjectTitle
+      ? [...componentFieldName.split('.'), nestedObjectField, nestedObjectTitle]
+      : [...componentFieldName.split('.'), mainField];
+  const displayedValue = toString(get(modifiedData, displayValuePath, ''));
 
   return {
     displayedValue,


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Makes a repeatable show the title of a nested relation when a default title is not available

### Why is it needed?

No title is currently shown when a relation is the only property in a repeatable. I found this discussion and seems to be desired in v4 - https://forum.strapi.io/t/using-a-relationships-entry-title-as-a-repeatable-components-entry-title/6186

Before - see blank title on repeatable:
<img width="839" alt="before" src="https://user-images.githubusercontent.com/31095524/155505579-6833d850-8192-49d8-a5c1-f61e225dbac3.png">

With change, it will now use the title of the relation
<img width="880" alt="after" src="https://user-images.githubusercontent.com/31095524/155505674-5463bc6a-a1b5-4012-83a6-067bba46ca15.png">

This allows an array to be created with relations to be ordered, while now showing them in a user friendly manner

### How to test it?

1. Create a component with only 1 attribute - a `oneToOne` relation to a collection
2. Add a repeatable to a content type with the component
3. In content manager, add and remove relations to the content type and see the title now showing

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
