### PR TITLE
Upload middleware route & typo fix

### DIFF
--- a/packages/core/strapi/lib/middlewares/public/index.js
+++ b/packages/core/strapi/lib/middlewares/public/index.js
@@ -77,9 +77,10 @@ module.exports = (config, { strapi }) => {
         }),
         config: { auth: false },
       },
+      // All other public GET-routes except /uploads/(.*) which is handled in upload middleware
       {
         method: 'GET',
-        path: '/(.*)',
+        path: '/((?!uploads/).+)',
         handler: koaStatic(strapi.dirs.static.public, {
           maxage: maxAge,
           defer: true,


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Fixes two different bugs I encountered while adding support for my plugin [strapi-middleware-upload-plugin-cache](https://github.com/alexkainzinger/strapi-middleware-upload-plugin-cache)

1. Fixes a typo, changing ``localeServer`` to ``localServer`` as described in [the docs](https://docs.strapi.io/developer-docs/latest/plugins/upload.html#local-server)
2. Uses a negative lookahead regex for the public middleware to handle all fallback GET-routes except the "/uploads/(.*)". With the current implementation, the route defined in ``packages/core/upload/server/middlewares/upload.js`` never is called (I literally was able to just remove it without any errors)

If the negative lookahead regex should not make it into the codebase, the typo fix also does not matter because the route won't be called anyway. If that should be the case, this PR can be closed

### Why is it needed?

1. To be able to configure the upload middleware as described in [the docs](https://docs.strapi.io/developer-docs/latest/plugins/upload.html#local-server)
2. To actually be able to use it

### How to test it?

Just check the uploaded files on the ``/uploads/(.*)`` route

### Related issue(s)/PR(s)

Noticed something strange here: https://github.com/strapi/strapi/issues/12657 & found the other issue while debugging
