### PR TITLE
fix: merge devServer custom configuration with default #12667

### DIFF
--- a/packages/core/admin/index.js
+++ b/packages/core/admin/index.js
@@ -262,7 +262,12 @@ async function watchAdmin({ plugins, dir, host, port, browser, options }) {
 
   const compiler = webpack(webpackConfig);
 
-  const server = new WebpackDevServer(args.devServer, compiler);
+  const devServerArgs = {
+    ...args.devServer,
+    ...webpackConfig.devServer
+  }
+
+  const server = new WebpackDevServer(devServerArgs, compiler);
 
   const runServer = async () => {
     console.log(chalk.green('Starting the development server...'));


### PR DESCRIPTION

### What does it do?

This PR merge the custom configuration for webpack-dev-server specified in `src/admin/webpack.config.js` with the application default.

### Why is it needed?

The bug is described in #12667 

### How to test it?

Specify a custom devServer configuration in `src/admin/webpack.config.js`:
```
'use strict';

/* eslint-disable no-unused-vars */
module.exports = (config, webpack) => {
  // Note: we provide webpack above so you should not `require` it
  // Perform customizations to webpack config
  // Important: return the modified config

  config.devServer = {
    ...config.devServer,
    port: 9000,
    allowedHosts: 'all',
  };

  return config;
};
```
Then run `yarn strapi develop --watch-admin` and verify that port `9000` is used for the front-end development server.

### Related issue(s)/PR(s)

Fixes #12667
