### PR TITLE
fix: placeholder for email confirmation link input

### DIFF
--- a/packages/plugins/users-permissions/admin/src/translations/en.json
+++ b/packages/plugins/users-permissions/admin/src/translations/en.json
@@ -12,7 +12,7 @@
   "EditForm.inputToggle.label.email-confirmation-redirection": "Redirection url",
   "EditForm.inputToggle.label.email-reset-password": "Reset password page",
   "EditForm.inputToggle.label.sign-up": "Enable sign-ups",
-  "EditForm.inputToggle.placeholder.email-confirmation-redirection": "ex: https://yourfrontend.com/reset-password",
+  "EditForm.inputToggle.placeholder.email-confirmation-redirection": "ex: https://yourfrontend.com/confirmation-redirection",
   "EditForm.inputToggle.placeholder.email-reset-password": "ex: https://yourfrontend.com/reset-password",
   "EditPage.form.roles": "Role details",
   "Email.template.data.loaded": "Email templates has been loaded",


### PR DESCRIPTION


fix #12671 


### What does it do?

fix the placeholder of the input for the redirection of for email confirmation seems not correct.

### Why is it needed?

Describe the issue you are solving.

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
