### PR TITLE
fix documentation plugin paths builder when multiple contentTypes

### DIFF
--- a/packages/plugins/documentation/server/utils/builders/build-api-endpoint-path.js
+++ b/packages/plugins/documentation/server/utils/builders/build-api-endpoint-path.js
@@ -149,6 +149,7 @@ module.exports = api => {
   }
 
   // An api could have multiple contentTypes
+  let paths = {};
   for (const contentTypeName of api.ctNames) {
     // Get the attributes found on the api's contentType
     const uid = `${api.getter}::${api.name}.${contentTypeName}`;
@@ -169,6 +170,11 @@ module.exports = api => {
       tag,
     };
 
-    return getPaths(apiInfo);
+    paths = {
+      ...paths,
+      ...getPaths(apiInfo).paths
+    }
   }
+
+  return { paths };
 };


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

The documentation plugin was not generating the paths when having multiple content types in the same group. 

### Why is it needed?

This happened because of the `return` statement inside the `for` loop. The paths were not merged.

### How to test it?

See issue below. After the obvious fix, the swagger page renders nested content types correctly:

<img width="1522" alt="image" src="https://user-images.githubusercontent.com/6179477/155875055-c144fc0e-e4df-46ca-8eb2-1b568324d19d.png">


### Related issue(s)/PR(s)

Fixes #12674 
