### PR TITLE
fix(dark-mode): fixed medialib empty card grid

### DIFF
--- a/packages/core/upload/admin/src/components/EmptyAssets/EmptyAssetGrid.js
+++ b/packages/core/upload/admin/src/components/EmptyAssets/EmptyAssetGrid.js
@@ -4,7 +4,11 @@ import styled from 'styled-components';
 import { Box } from '@strapi/design-system/Box';
 
 const EmptyAssetCard = styled(Box)`
-  background: linear-gradient(180deg, rgba(234, 234, 239, 0) 0%, #eaeaef 100%);
+  background: linear-gradient(
+    180deg,
+    rgba(234, 234, 239, 0) 0%,
+    ${({ theme }) => theme.colors.neutral200} 100%
+  );
   opacity: 0.33;
 `;
 


### PR DESCRIPTION
### What does it do?

Changes the background gradient color for the media library empty view.
Using a theme color `neutral200` instead of a hardcoded value `#eaeaef`

/!\ The fix makes the light theme cards a little darker as there is no theme color matching the previous hardcoded color.

**Before**
![image](https://user-images.githubusercontent.com/89356961/155966789-0634be74-62ee-42f7-899b-dbf123385fd1.png)

**After**
![image](https://user-images.githubusercontent.com/89356961/155966833-79cb94b4-cd4b-4748-a4aa-4a16233a8147.png)
