### PR TITLE
Dark mode/fix links

### DIFF
--- a/packages/core/admin/admin/src/pages/ProfilePage/index.js
+++ b/packages/core/admin/admin/src/pages/ProfilePage/index.js
@@ -36,6 +36,10 @@ import { fetchUser, putUser } from './utils/api';
 import schema from './utils/schema';
 import { getFullName } from '../../utils';
 
+const DocumentationLink = styled.a`
+  color: ${({ theme }) => theme.colors.primary600};
+`;
+
 const PasswordInput = styled(TextInput)`
   ::-ms-reveal {
     display: none;
@@ -444,7 +448,7 @@ const ProfilePage = () => {
                               },
                               {
                                 documentation: (
-                                  <a
+                                  <DocumentationLink
                                     target="_blank"
                                     rel="noopener noreferrer"
                                     href="https://docs.strapi.io/developer-docs/latest/development/admin-customization.html#locales"
@@ -453,7 +457,7 @@ const ProfilePage = () => {
                                       id: 'Settings.profile.form.section.experience.documentation',
                                       defaultMessage: 'documentation',
                                     })}
-                                  </a>
+                                  </DocumentationLink>
                                 ),
                               }
                             )}

--- a/packages/core/admin/admin/src/pages/ProfilePage/tests/index.test.js
+++ b/packages/core/admin/admin/src/pages/ProfilePage/tests/index.test.js
@@ -233,7 +233,7 @@ describe('ADMIN | Pages | Profile page', () => {
         align-items: center;
       }
 
-      .c40 {
+      .c41 {
         position: absolute;
         left: 0;
         right: 0;
@@ -244,22 +244,22 @@ describe('ADMIN | Pages | Profile page', () => {
         border: none;
       }
 
-      .c40:focus {
+      .c41:focus {
         outline: none;
       }
 
-      .c40[aria-disabled='true'] {
+      .c41[aria-disabled='true'] {
         cursor: not-allowed;
       }
 
-      .c37 {
+      .c38 {
         font-weight: 600;
         color: #32324d;
         font-size: 0.75rem;
         line-height: 1.33;
       }
 
-      .c44 {
+      .c45 {
         color: #32324d;
         display: block;
         white-space: nowrap;
@@ -269,22 +269,22 @@ describe('ADMIN | Pages | Profile page', () => {
         line-height: 1.43;
       }
 
-      .c48 {
+      .c49 {
         color: #666687;
         font-size: 0.75rem;
         line-height: 1.33;
       }
 
-      .c43 {
+      .c44 {
         padding-right: 16px;
         padding-left: 16px;
       }
 
-      .c46 {
+      .c47 {
         padding-left: 12px;
       }
 
-      .c38 {
+      .c39 {
         display: -webkit-box;
         display: -webkit-flex;
         display: -ms-flexbox;
@@ -298,7 +298,7 @@ describe('ADMIN | Pages | Profile page', () => {
         align-items: center;
       }
 
-      .c41 {
+      .c42 {
         display: -webkit-box;
         display: -webkit-flex;
         display: -ms-flexbox;
@@ -316,7 +316,7 @@ describe('ADMIN | Pages | Profile page', () => {
         align-items: center;
       }
 
-      .c36 {
+      .c37 {
         display: -webkit-box;
         display: -webkit-flex;
         display: -ms-flexbox;
@@ -326,16 +326,16 @@ describe('ADMIN | Pages | Profile page', () => {
         flex-direction: column;
       }
 
-      .c36 > * {
+      .c37 > * {
         margin-top: 0;
         margin-bottom: 0;
       }
 
-      .c36 > * + * {
+      .c37 > * + * {
         margin-top: 4px;
       }
 
-      .c39 {
+      .c40 {
         position: relative;
         border: 1px solid #dcdce4;
         padding-right: 12px;
@@ -351,28 +351,28 @@ describe('ADMIN | Pages | Profile page', () => {
         transition-duration: 0.2s;
       }
 
-      .c39:focus-within {
+      .c40:focus-within {
         border: 1px solid #4945ff;
         box-shadow: #4945ff 0px 0px 0px 2px;
       }
 
-      .c45 {
+      .c46 {
         background: transparent;
         border: none;
         position: relative;
         z-index: 1;
       }
 
-      .c45 svg {
+      .c46 svg {
         height: 0.6875rem;
         width: 0.6875rem;
       }
 
-      .c45 svg path {
+      .c46 svg path {
         fill: #666687;
       }
 
-      .c47 {
+      .c48 {
         display: -webkit-box;
         display: -webkit-flex;
         display: -ms-flexbox;
@@ -381,11 +381,11 @@ describe('ADMIN | Pages | Profile page', () => {
         border: none;
       }
 
-      .c47 svg {
+      .c48 svg {
         width: 0.375rem;
       }
 
-      .c42 {
+      .c43 {
         width: 100%;
       }
 
@@ -705,6 +705,10 @@ describe('ADMIN | Pages | Profile page', () => {
       .c20 {
         grid-column: span 6;
         max-width: 100%;
+      }
+
+      .c36 {
+        color: #4945ff;
       }
 
       .c30::-ms-reveal {
@@ -1217,6 +1221,7 @@ describe('ADMIN | Pages | Profile page', () => {
                       >
                         Selection will change the interface language only for you. Please refer to this 
                         <a
+                          class="c36"
                           href="https://docs.strapi.io/developer-docs/latest/development/admin-customization.html#locales"
                           rel="noopener noreferrer"
                           target="_blank"
@@ -1237,17 +1242,17 @@ describe('ADMIN | Pages | Profile page', () => {
                         >
                           <div>
                             <div
-                              class="c36"
+                              class="c37"
                             >
                               <span
-                                class="c37"
+                                class="c38"
                                 for="select-1"
                                 id="select-1-label"
                               >
                                 Interface language
                               </span>
                               <div
-                                class="c38 c39"
+                                class="c39 c40"
                               >
                                 <button
                                   aria-describedby="select-1-hint"
@@ -1255,21 +1260,21 @@ describe('ADMIN | Pages | Profile page', () => {
                                   aria-expanded="false"
                                   aria-haspopup="listbox"
                                   aria-labelledby="select-1-label select-1-content"
-                                  class="c40"
+                                  class="c41"
                                   id="select-1"
                                   type="button"
                                 />
                                 <div
-                                  class="c41 c42"
+                                  class="c42 c43"
                                 >
                                   <div
-                                    class="c38"
+                                    class="c39"
                                   >
                                     <div
-                                      class="c43"
+                                      class="c44"
                                     >
                                       <span
-                                        class="c44"
+                                        class="c45"
                                         id="select-1-content"
                                       >
                                         Select
@@ -1277,12 +1282,12 @@ describe('ADMIN | Pages | Profile page', () => {
                                     </div>
                                   </div>
                                   <div
-                                    class="c38"
+                                    class="c39"
                                   >
                                     <button
                                       aria-disabled="false"
                                       aria-label="Clear the interface language selected"
-                                      class="c45"
+                                      class="c46"
                                     >
                                       <svg
                                         fill="none"
@@ -1299,7 +1304,7 @@ describe('ADMIN | Pages | Profile page', () => {
                                     </button>
                                     <button
                                       aria-hidden="true"
-                                      class="c46 c45 c47"
+                                      class="c47 c46 c48"
                                       tabindex="-1"
                                       type="button"
                                     >
@@ -1322,7 +1327,7 @@ describe('ADMIN | Pages | Profile page', () => {
                                 </div>
                               </div>
                               <p
-                                class="c48"
+                                class="c49"
                                 id="select-1-hint"
                               >
                                 This will only display your own interface in the chosen language.
@@ -1339,17 +1344,17 @@ describe('ADMIN | Pages | Profile page', () => {
                         >
                           <div>
                             <div
-                              class="c36"
+                              class="c37"
                             >
                               <span
-                                class="c37"
+                                class="c38"
                                 for="select-2"
                                 id="select-2-label"
                               >
                                 Interface mode
                               </span>
                               <div
-                                class="c38 c39"
+                                class="c39 c40"
                               >
                                 <button
                                   aria-describedby="select-2-hint"
@@ -1357,21 +1362,21 @@ describe('ADMIN | Pages | Profile page', () => {
                                   aria-expanded="false"
                                   aria-haspopup="listbox"
                                   aria-labelledby="select-2-label select-2-content"
-                                  class="c40"
+                                  class="c41"
                                   id="select-2"
                                   type="button"
                                 />
                                 <div
-                                  class="c41 c42"
+                                  class="c42 c43"
                                 >
                                   <div
-                                    class="c38"
+                                    class="c39"
                                   >
                                     <div
-                                      class="c43"
+                                      class="c44"
                                     >
                                       <span
-                                        class="c44"
+                                        class="c45"
                                         id="select-2-content"
                                       >
                                         Light mode
@@ -1379,11 +1384,11 @@ describe('ADMIN | Pages | Profile page', () => {
                                     </div>
                                   </div>
                                   <div
-                                    class="c38"
+                                    class="c39"
                                   >
                                     <button
                                       aria-hidden="true"
-                                      class="c46 c45 c47"
+                                      class="c47 c46 c48"
                                       tabindex="-1"
                                       type="button"
                                     >
@@ -1406,7 +1411,7 @@ describe('ADMIN | Pages | Profile page', () => {
                                 </div>
                               </div>
                               <p
-                                class="c48"
+                                class="c49"
                                 id="select-2-hint"
                               >
                                 Displays your interface in the chosen mode.

--- a/packages/core/email/admin/src/pages/Settings/components/Configuration.js
+++ b/packages/core/email/admin/src/pages/Settings/components/Configuration.js
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import styled from 'styled-components';
 import { useIntl } from 'react-intl';
 import { Stack } from '@strapi/design-system/Stack';
 import { Grid, GridItem } from '@strapi/design-system/Grid';
@@ -9,6 +10,10 @@ import { Typography } from '@strapi/design-system/Typography';
 import { TextInput } from '@strapi/design-system/TextInput';
 import { Select, Option } from '@strapi/design-system/Select';
 import getTrad from '../../../utils/getTrad';
+
+const DocumentationLink = styled.a`
+  color: ${({ theme }) => theme.colors.primary600};
+`;
 
 const Configuration = ({ config }) => {
   const { formatMessage } = useIntl();
@@ -32,13 +37,13 @@ const Configuration = ({ config }) => {
             {
               file: './config/plugins.js',
               link: (
-                <a
+                <DocumentationLink
                   href="https://docs.strapi.io/developer-docs/latest/plugins/email.html"
                   target="_blank"
                   rel="noopener noreferrer"
                 >
                   link
-                </a>
+                </DocumentationLink>
               ),
             }
           )}

--- a/packages/core/email/admin/src/pages/Settings/tests/index.test.js
+++ b/packages/core/email/admin/src/pages/Settings/tests/index.test.js
@@ -56,18 +56,18 @@ describe('Email | Pages | Settings', () => {
         box-shadow: 0px 1px 4px rgba(33,33,52,0.1);
       }
 
-      .c42 {
+      .c43 {
         font-weight: 600;
         color: #32324d;
         font-size: 0.75rem;
         line-height: 1.33;
       }
 
-      .c39 {
+      .c40 {
         padding-right: 8px;
       }
 
-      .c36 {
+      .c37 {
         display: -webkit-box;
         display: -webkit-flex;
         display: -ms-flexbox;
@@ -81,21 +81,21 @@ describe('Email | Pages | Settings', () => {
         outline: none;
       }
 
-      .c36 svg {
+      .c37 svg {
         height: 12px;
         width: 12px;
       }
 
-      .c36 svg > g,
-      .c36 svg path {
+      .c37 svg > g,
+      .c37 svg path {
         fill: #ffffff;
       }
 
-      .c36[aria-disabled='true'] {
+      .c37[aria-disabled='true'] {
         pointer-events: none;
       }
 
-      .c36:after {
+      .c37:after {
         -webkit-transition-property: all;
         transition-property: all;
         -webkit-transition-duration: 0.2s;
@@ -110,11 +110,11 @@ describe('Email | Pages | Settings', () => {
         border: 2px solid transparent;
       }
 
-      .c36:focus-visible {
+      .c37:focus-visible {
         outline: none;
       }
 
-      .c36:focus-visible:after {
+      .c37:focus-visible:after {
         border-radius: 8px;
         content: '';
         position: absolute;
@@ -125,11 +125,11 @@ describe('Email | Pages | Settings', () => {
         border: 2px solid #4945ff;
       }
 
-      .c40 {
+      .c41 {
         height: 100%;
       }
 
-      .c37 {
+      .c38 {
         -webkit-align-items: center;
         -webkit-box-align: center;
         -ms-flex-align: center;
@@ -141,7 +141,7 @@ describe('Email | Pages | Settings', () => {
         background: #4945ff;
       }
 
-      .c37 .c38 {
+      .c38 .c39 {
         display: -webkit-box;
         display: -webkit-flex;
         display: -ms-flexbox;
@@ -152,49 +152,49 @@ describe('Email | Pages | Settings', () => {
         align-items: center;
       }
 
-      .c37 .c41 {
+      .c38 .c42 {
         color: #ffffff;
       }
 
-      .c37[aria-disabled='true'] {
+      .c38[aria-disabled='true'] {
         border: 1px solid #dcdce4;
         background: #eaeaef;
       }
 
-      .c37[aria-disabled='true'] .c41 {
+      .c38[aria-disabled='true'] .c42 {
         color: #666687;
       }
 
-      .c37[aria-disabled='true'] svg > g,
-      .c37[aria-disabled='true'] svg path {
+      .c38[aria-disabled='true'] svg > g,
+      .c38[aria-disabled='true'] svg path {
         fill: #666687;
       }
 
-      .c37[aria-disabled='true']:active {
+      .c38[aria-disabled='true']:active {
         border: 1px solid #dcdce4;
         background: #eaeaef;
       }
 
-      .c37[aria-disabled='true']:active .c41 {
+      .c38[aria-disabled='true']:active .c42 {
         color: #666687;
       }
 
-      .c37[aria-disabled='true']:active svg > g,
-      .c37[aria-disabled='true']:active svg path {
+      .c38[aria-disabled='true']:active svg > g,
+      .c38[aria-disabled='true']:active svg path {
         fill: #666687;
       }
 
-      .c37:hover {
+      .c38:hover {
         border: 1px solid #7b79ff;
         background: #7b79ff;
       }
 
-      .c37:active {
+      .c38:active {
         border: 1px solid #4945ff;
         background: #4945ff;
       }
 
-      .c25 {
+      .c26 {
         position: absolute;
         left: 0;
         right: 0;
@@ -205,22 +205,22 @@ describe('Email | Pages | Settings', () => {
         border: none;
       }
 
-      .c25:focus {
+      .c26:focus {
         outline: none;
       }
 
-      .c25[aria-disabled='true'] {
+      .c26[aria-disabled='true'] {
         cursor: not-allowed;
       }
 
-      .c22 {
+      .c23 {
         font-weight: 600;
         color: #32324d;
         font-size: 0.75rem;
         line-height: 1.33;
       }
 
-      .c29 {
+      .c30 {
         color: #666687;
         display: block;
         white-space: nowrap;
@@ -230,16 +230,16 @@ describe('Email | Pages | Settings', () => {
         line-height: 1.43;
       }
 
-      .c28 {
+      .c29 {
         padding-right: 16px;
         padding-left: 16px;
       }
 
-      .c30 {
+      .c31 {
         padding-left: 12px;
       }
 
-      .c23 {
+      .c24 {
         display: -webkit-box;
         display: -webkit-flex;
         display: -ms-flexbox;
@@ -253,7 +253,7 @@ describe('Email | Pages | Settings', () => {
         align-items: center;
       }
 
-      .c26 {
+      .c27 {
         display: -webkit-box;
         display: -webkit-flex;
         display: -ms-flexbox;
@@ -271,7 +271,7 @@ describe('Email | Pages | Settings', () => {
         align-items: center;
       }
 
-      .c21 {
+      .c22 {
         display: -webkit-box;
         display: -webkit-flex;
         display: -ms-flexbox;
@@ -281,16 +281,16 @@ describe('Email | Pages | Settings', () => {
         flex-direction: column;
       }
 
-      .c21 > * {
+      .c22 > * {
         margin-top: 0;
         margin-bottom: 0;
       }
 
-      .c21 > * + * {
+      .c22 > * + * {
         margin-top: 4px;
       }
 
-      .c24 {
+      .c25 {
         position: relative;
         border: 1px solid #dcdce4;
         padding-right: 12px;
@@ -308,28 +308,28 @@ describe('Email | Pages | Settings', () => {
         transition-duration: 0.2s;
       }
 
-      .c24:focus-within {
+      .c25:focus-within {
         border: 1px solid #4945ff;
         box-shadow: #4945ff 0px 0px 0px 2px;
       }
 
-      .c31 {
+      .c32 {
         background: transparent;
         border: none;
         position: relative;
         z-index: 1;
       }
 
-      .c31 svg {
+      .c32 svg {
         height: 0.6875rem;
         width: 0.6875rem;
       }
 
-      .c31 svg path {
+      .c32 svg path {
         fill: #666687;
       }
 
-      .c32 {
+      .c33 {
         display: -webkit-box;
         display: -webkit-flex;
         display: -ms-flexbox;
@@ -339,11 +339,11 @@ describe('Email | Pages | Settings', () => {
         cursor: not-allowed;
       }
 
-      .c32 svg {
+      .c33 svg {
         width: 0.375rem;
       }
 
-      .c27 {
+      .c28 {
         width: 100%;
       }
 
@@ -404,14 +404,14 @@ describe('Email | Pages | Settings', () => {
         margin-top: 4px;
       }
 
-      .c17 {
+      .c18 {
         font-weight: 600;
         color: #32324d;
         font-size: 0.75rem;
         line-height: 1.33;
       }
 
-      .c16 {
+      .c17 {
         display: -webkit-box;
         display: -webkit-flex;
         display: -ms-flexbox;
@@ -425,7 +425,7 @@ describe('Email | Pages | Settings', () => {
         align-items: center;
       }
 
-      .c18 {
+      .c19 {
         display: -webkit-box;
         display: -webkit-flex;
         display: -ms-flexbox;
@@ -443,7 +443,7 @@ describe('Email | Pages | Settings', () => {
         align-items: center;
       }
 
-      .c20 {
+      .c21 {
         border: none;
         border-radius: 4px;
         padding-left: 16px;
@@ -456,37 +456,37 @@ describe('Email | Pages | Settings', () => {
         width: 100%;
       }
 
-      .c20::-webkit-input-placeholder {
+      .c21::-webkit-input-placeholder {
         color: #8e8ea9;
         opacity: 1;
       }
 
-      .c20::-moz-placeholder {
+      .c21::-moz-placeholder {
         color: #8e8ea9;
         opacity: 1;
       }
 
-      .c20:-ms-input-placeholder {
+      .c21:-ms-input-placeholder {
         color: #8e8ea9;
         opacity: 1;
       }
 
-      .c20::placeholder {
+      .c21::placeholder {
         color: #8e8ea9;
         opacity: 1;
       }
 
-      .c20[aria-disabled='true'] {
+      .c21[aria-disabled='true'] {
         background: inherit;
         color: inherit;
       }
 
-      .c20:focus {
+      .c21:focus {
         outline: none;
         box-shadow: none;
       }
 
-      .c34 {
+      .c35 {
         border: none;
         border-radius: 4px;
         padding-left: 16px;
@@ -498,37 +498,37 @@ describe('Email | Pages | Settings', () => {
         width: 100%;
       }
 
-      .c34::-webkit-input-placeholder {
+      .c35::-webkit-input-placeholder {
         color: #8e8ea9;
         opacity: 1;
       }
 
-      .c34::-moz-placeholder {
+      .c35::-moz-placeholder {
         color: #8e8ea9;
         opacity: 1;
       }
 
-      .c34:-ms-input-placeholder {
+      .c35:-ms-input-placeholder {
         color: #8e8ea9;
         opacity: 1;
       }
 
-      .c34::placeholder {
+      .c35::placeholder {
         color: #8e8ea9;
         opacity: 1;
       }
 
-      .c34[aria-disabled='true'] {
+      .c35[aria-disabled='true'] {
         background: inherit;
         color: inherit;
       }
 
-      .c34:focus {
+      .c35:focus {
         outline: none;
         box-shadow: none;
       }
 
-      .c19 {
+      .c20 {
         border: 1px solid #dcdce4;
         border-radius: 4px;
         background: #ffffff;
@@ -543,12 +543,12 @@ describe('Email | Pages | Settings', () => {
         background: #eaeaef;
       }
 
-      .c19:focus-within {
+      .c20:focus-within {
         border: 1px solid #4945ff;
         box-shadow: #4945ff 0px 0px 0px 2px;
       }
 
-      .c33 {
+      .c34 {
         border: 1px solid #dcdce4;
         border-radius: 4px;
         background: #ffffff;
@@ -561,12 +561,12 @@ describe('Email | Pages | Settings', () => {
         transition-duration: 0.2s;
       }
 
-      .c33:focus-within {
+      .c34:focus-within {
         border: 1px solid #4945ff;
         box-shadow: #4945ff 0px 0px 0px 2px;
       }
 
-      .c15 {
+      .c16 {
         display: -webkit-box;
         display: -webkit-flex;
         display: -ms-flexbox;
@@ -576,12 +576,12 @@ describe('Email | Pages | Settings', () => {
         flex-direction: column;
       }
 
-      .c15 > * {
+      .c16 > * {
         margin-top: 0;
         margin-bottom: 0;
       }
 
-      .c15 > * + * {
+      .c16 > * + * {
         margin-top: 4px;
       }
 
@@ -660,42 +660,46 @@ describe('Email | Pages | Settings', () => {
         line-height: 1.5;
       }
 
-      .c13 {
+      .c14 {
         display: grid;
         grid-template-columns: repeat(12,1fr);
         gap: 20px;
       }
 
-      .c14 {
+      .c15 {
         grid-column: span 6;
         max-width: 100%;
       }
 
-      .c35 {
+      .c36 {
         grid-column: span 7;
         max-width: 100%;
       }
 
+      .c13 {
+        color: #4945ff;
+      }
+
       @media (max-width:68.75rem) {
-        .c14 {
+        .c15 {
           grid-column: span 12;
         }
       }
 
       @media (max-width:34.375rem) {
-        .c14 {
+        .c15 {
           grid-column: span;
         }
       }
 
       @media (max-width:68.75rem) {
-        .c35 {
+        .c36 {
           grid-column: span 12;
         }
       }
 
       @media (max-width:34.375rem) {
-        .c35 {
+        .c36 {
           grid-column: span;
         }
       }
@@ -761,6 +765,7 @@ describe('Email | Pages | Settings', () => {
                     >
                       The plugin is configured through the ./config/plugins.js file, checkout this 
                       <a
+                        class="c13"
                         href="https://docs.strapi.io/developer-docs/latest/plugins/email.html"
                         rel="noopener noreferrer"
                         target="_blank"
@@ -771,10 +776,10 @@ describe('Email | Pages | Settings', () => {
                     </span>
                   </div>
                   <div
-                    class="c13"
+                    class="c14"
                   >
                     <div
-                      class="c14"
+                      class="c15"
                     >
                       <div
                         class=""
@@ -782,26 +787,26 @@ describe('Email | Pages | Settings', () => {
                         <div>
                           <div>
                             <div
-                              class="c15"
+                              class="c16"
                             >
                               <div
-                                class="c16"
+                                class="c17"
                               >
                                 <label
-                                  class="c17"
+                                  class="c18"
                                   for="textinput-3"
                                 >
                                   Default sender email
                                 </label>
                               </div>
                               <div
-                                class="c18 c19"
+                                class="c19 c20"
                                 disabled=""
                               >
                                 <input
                                   aria-disabled="true"
                                   aria-invalid="false"
-                                  class="c20"
+                                  class="c21"
                                   id="textinput-3"
                                   name="shipper-email"
                                   placeholder="ex: Strapi No-Reply <no-reply@strapi.io>"
@@ -814,7 +819,7 @@ describe('Email | Pages | Settings', () => {
                       </div>
                     </div>
                     <div
-                      class="c14"
+                      class="c15"
                     >
                       <div
                         class=""
@@ -822,26 +827,26 @@ describe('Email | Pages | Settings', () => {
                         <div>
                           <div>
                             <div
-                              class="c15"
+                              class="c16"
                             >
                               <div
-                                class="c16"
+                                class="c17"
                               >
                                 <label
-                                  class="c17"
+                                  class="c18"
                                   for="textinput-4"
                                 >
                                   Default response email
                                 </label>
                               </div>
                               <div
-                                class="c18 c19"
+                                class="c19 c20"
                                 disabled=""
                               >
                                 <input
                                   aria-disabled="true"
                                   aria-invalid="false"
-                                  class="c20"
+                                  class="c21"
                                   id="textinput-4"
                                   name="response-email"
                                   placeholder="ex: Strapi <example@strapi.io>"
@@ -854,24 +859,24 @@ describe('Email | Pages | Settings', () => {
                       </div>
                     </div>
                     <div
-                      class="c14"
+                      class="c15"
                     >
                       <div
                         class=""
                       >
                         <div>
                           <div
-                            class="c21"
+                            class="c22"
                           >
                             <span
-                              class="c22"
+                              class="c23"
                               for="select-2"
                               id="select-2-label"
                             >
                               Email provider
                             </span>
                             <div
-                              class="c23 c24"
+                              class="c24 c25"
                               disabled=""
                             >
                               <button
@@ -879,22 +884,22 @@ describe('Email | Pages | Settings', () => {
                                 aria-expanded="false"
                                 aria-haspopup="listbox"
                                 aria-labelledby="select-2-label select-2-content"
-                                class="c25"
+                                class="c26"
                                 id="select-2"
                                 name="email-provider"
                                 type="button"
                               />
                               <div
-                                class="c26 c27"
+                                class="c27 c28"
                               >
                                 <div
-                                  class="c23"
+                                  class="c24"
                                 >
                                   <div
-                                    class="c28"
+                                    class="c29"
                                   >
                                     <span
-                                      class="c29"
+                                      class="c30"
                                       id="select-2-content"
                                     >
                                       Select...
@@ -902,12 +907,12 @@ describe('Email | Pages | Settings', () => {
                                   </div>
                                 </div>
                                 <div
-                                  class="c23"
+                                  class="c24"
                                 >
                                   
                                   <button
                                     aria-hidden="true"
-                                    class="c30 c31 c32"
+                                    class="c31 c32 c33"
                                     disabled=""
                                     tabindex="-1"
                                     type="button"
@@ -949,10 +954,10 @@ describe('Email | Pages | Settings', () => {
                     Test email delivery
                   </h2>
                   <div
-                    class="c13"
+                    class="c14"
                   >
                     <div
-                      class="c14"
+                      class="c15"
                     >
                       <div
                         class=""
@@ -960,25 +965,25 @@ describe('Email | Pages | Settings', () => {
                         <div>
                           <div>
                             <div
-                              class="c15"
+                              class="c16"
                             >
                               <div
-                                class="c16"
+                                class="c17"
                               >
                                 <label
-                                  class="c17"
+                                  class="c18"
                                   for="test-address-input"
                                 >
                                   Recipient email
                                 </label>
                               </div>
                               <div
-                                class="c18 c33"
+                                class="c19 c34"
                               >
                                 <input
                                   aria-disabled="false"
                                   aria-invalid="false"
-                                  class="c34"
+                                  class="c35"
                                   id="test-address-input"
                                   name="test-address"
                                   placeholder="ex: developer@example.com"
@@ -991,20 +996,20 @@ describe('Email | Pages | Settings', () => {
                       </div>
                     </div>
                     <div
-                      class="c35"
+                      class="c36"
                     >
                       <div
                         class=""
                       >
                         <button
                           aria-disabled="true"
-                          class="c36 c37"
+                          class="c37 c38"
                           disabled=""
                           type="submit"
                         >
                           <div
                             aria-hidden="true"
-                            class="c38 c39 c40"
+                            class="c39 c40 c41"
                           >
                             <svg
                               fill="none"
@@ -1028,7 +1033,7 @@ describe('Email | Pages | Settings', () => {
                             </svg>
                           </div>
                           <span
-                            class="c41 c42"
+                            class="c42 c43"
                           >
                             Send test email
                           </span>


### PR DESCRIPTION
### What does it do?

Some links that are not design system `<links />` were using default browser style, which caused them to be unreadable with dark theme enabled.

We are now using `primary600` as color

![image](https://user-images.githubusercontent.com/89356961/155973887-04480929-2a8d-4d03-9985-c217420cf930.png)
