### PR TITLE
feat: add option to run Strapi from CLI without the admin panel

### DIFF
--- a/packages/core/strapi/bin/strapi.js
+++ b/packages/core/strapi/bin/strapi.js
@@ -110,6 +110,7 @@ program
   .alias('dev')
   .option('--no-build', 'Disable build')
   .option('--watch-admin', 'Enable watch', false)
+  .option('--no-admin-panel', 'Disable admin panel', true)
   .option('--polling', 'Watch for file changes in network directories', false)
   .option('--browser <name>', 'Open the browser', true)
   .description('Start your Strapi application in development mode')

--- a/packages/core/strapi/lib/commands/develop.js
+++ b/packages/core/strapi/lib/commands/develop.js
@@ -16,14 +16,14 @@ const buildAdmin = require('./build');
  * `$ strapi develop`
  *
  */
-module.exports = async function({ build, watchAdmin, polling, browser }) {
+module.exports = async function({ build, watchAdmin, adminPanel, polling, browser }) {
   const dir = process.cwd();
   const config = loadConfiguration(dir);
   const logger = createLogger(config.logger, {});
 
   try {
     if (cluster.isMaster || cluster.isPrimary) {
-      const serveAdminPanel = getOr(true, 'admin.serveAdminPanel')(config);
+      const serveAdminPanel = !adminPanel ? false : getOr(true, 'admin.serveAdminPanel')(config);
 
       const buildExists = fs.existsSync(path.join(dir, 'build'));
       // Don't run the build process if the admin is in watch mode
@@ -68,7 +68,7 @@ module.exports = async function({ build, watchAdmin, polling, browser }) {
       const strapiInstance = strapi({
         dir,
         autoReload: true,
-        serveAdminPanel: watchAdmin ? false : true,
+        serveAdminPanel: !adminPanel ? false : (watchAdmin ? false : true),
       });
 
       const adminWatchIgnoreFiles = getOr([], 'admin.watchIgnoreFiles')(config);


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Add a way to run Strapi server without the admin panel through the CLI.

This PR add a `--no-admin-panel` option to strapi CLI `develop` command.

### Why is it needed?

The only way I found in the documentation to run only the Strapi server is by settings `serveAdminPanel: false` option in `config/admin.js`.
I hope we could add an option to the Strapi CLI to easily disable admin panel, without the need to modify a configuration file.
See related feature request for further details.

### How to test it?

Run `yarn strapi develop --no-admin-panel` and verify that only Strapi server is launched.
Also, verify that `yarn strapi develop` and `yarn strapi develop --watch-admin` continue to work as expected.

### Related issue(s)/PR(s)

Related to feature request #12696 