### PR TITLE
Dark Mode: Update custom theme handling

### DIFF
--- a/packages/core/admin/admin/src/StrapiApp.js
+++ b/packages/core/admin/admin/src/StrapiApp.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { BrowserRouter } from 'react-router-dom';
 import { lightTheme } from '@strapi/design-system/themes';
-import cloneDeep from 'lodash/cloneDeep';
 import merge from 'lodash/merge';
 import pick from 'lodash/pick';
 import isFunction from 'lodash/isFunction';
@@ -35,7 +34,7 @@ class StrapiApp {
       locales: ['en'],
       menuLogo: MenuLogo,
       notifications: { releases: true },
-      themes: { light: lightTheme, dark: darkTheme, custom: null },
+      themes: { light: lightTheme, dark: darkTheme },
       translations: {},
       tutorials: true,
     };
@@ -227,10 +226,7 @@ class StrapiApp {
     }
 
     if (this.customConfigurations?.theme) {
-      this.configurations.themes.custom = merge(
-        cloneDeep(this.configurations.themes.light),
-        this.customConfigurations.theme
-      );
+      merge(this.configurations.themes.light, this.customConfigurations.theme);
     }
 
     if (this.customConfigurations?.notifications?.releases !== undefined) {

--- a/packages/core/admin/admin/src/tests/StrapiApp.test.js
+++ b/packages/core/admin/admin/src/tests/StrapiApp.test.js
@@ -293,13 +293,13 @@ describe('ADMIN | StrapiApp', () => {
 
     it('should override the theme', () => {
       const adminConfig = {
-        config: { theme: { main: { colors: { red: 'black' } } } },
+        config: { theme: { colors: { red: 'black' } } },
       };
       const app = StrapiApp({ middlewares, reducers, library, adminConfig });
 
       app.createCustomConfigurations();
 
-      expect(app.configurations.themes.custom.main.colors.red).toBe('black');
+      expect(app.configurations.themes.light.colors.red).toBe('black');
     });
 
     it('should override the tutorials', () => {


### PR DESCRIPTION
### What does it do?

Merges the custom theme (if provided) into the default light theme and doesn't show "Custom mode" in the theme mode select on the profile page.