### PR TITLE
fix: winston default configuration

### DIFF
--- a/packages/utils/logger/lib/default-configuration.js
+++ b/packages/utils/logger/lib/default-configuration.js
@@ -1,15 +1,15 @@
 'use strict';
 
 const { transports } = require('winston');
-const { LEVEL, LEVEL_LABEL, LEVELS } = require('./constants');
+const { LEVEL_LABEL, LEVELS } = require('./constants');
 const { prettyPrint } = require('./formats');
 
 const createDefaultConfiguration = () => {
   return {
-    level: LEVEL,
+    level: LEVEL_LABEL,
     levels: LEVELS,
     format: prettyPrint(),
-    transports: [new transports.Console({ level: LEVEL_LABEL })],
+    transports: [new transports.Console()],
   };
 };
 


### PR DESCRIPTION
### What does it do?

This fix log level override of winston logger

### How to test it?

Create `config/logger.js`

```js
"use strict";

module.exports = ({ env }) => ({
  level: env("STRAPI_LOG_LEVEL", "error"),
});
```

Using `strapi.log.silly('foo')` should output nothing
