### PR TITLE
Allow snake case in content type generator 

### DIFF
--- a/packages/generators/generators/lib/plops/prompts/get-attributes-prompts.js
+++ b/packages/generators/generators/lib/plops/prompts/get-attributes-prompts.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const validateInputForAttribute = require('../utils/validate-input');
+const validateAttributeInput = require('../utils/validate-attribute-input');
 
 const DEFAULT_TYPES = [
   // advanced types
@@ -50,7 +50,7 @@ module.exports = async inquirer => {
         type: 'input',
         name: 'attributeName',
         message: 'Name of attribute',
-        validate: input => validateInputForAttribute(input),
+        validate: input => validateAttributeInput(input),
       },
       {
         type: 'list',

--- a/packages/generators/generators/lib/plops/prompts/get-attributes-prompts.js
+++ b/packages/generators/generators/lib/plops/prompts/get-attributes-prompts.js
@@ -50,7 +50,7 @@ module.exports = async inquirer => {
         type: 'input',
         name: 'attributeName',
         message: 'Name of attribute',
-        validate: input => validateInput(input),
+        validate: input => validateInput(input, true),
       },
       {
         type: 'list',

--- a/packages/generators/generators/lib/plops/prompts/get-attributes-prompts.js
+++ b/packages/generators/generators/lib/plops/prompts/get-attributes-prompts.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const validateInput = require('../utils/validate-input');
+const validateInputForAttribute = require('../utils/validate-input');
 
 const DEFAULT_TYPES = [
   // advanced types
@@ -50,7 +50,7 @@ module.exports = async inquirer => {
         type: 'input',
         name: 'attributeName',
         message: 'Name of attribute',
-        validate: input => validateInput(input, true),
+        validate: input => validateInputForAttribute(input),
       },
       {
         type: 'list',

--- a/packages/generators/generators/lib/plops/utils/validate-attribute-input.js
+++ b/packages/generators/generators/lib/plops/utils/validate-attribute-input.js
@@ -1,0 +1,11 @@
+'use strict';
+
+module.exports = (input) => {
+  const regex =  /^[A-Za-z-|_]+$/g
+
+  if (!input) {
+    return "You must provide an input";
+  }
+
+  return regex.test(input) || "Please use only letters, '-', '_',  and no spaces";
+};

--- a/packages/generators/generators/lib/plops/utils/validate-input.js
+++ b/packages/generators/generators/lib/plops/utils/validate-input.js
@@ -1,7 +1,7 @@
 'use strict';
 
-module.exports = (input, allowSnakeCase = false) => {
-  const regex = allowSnakeCase ? /^[A-Za-z-|_]+$/g : /^[A-Za-z-]+$/g;
+module.exports = (input) => {
+  const regex = /^[A-Za-z-]+$/g;
 
   if (!input) {
     return "You must provide an input";

--- a/packages/generators/generators/lib/plops/utils/validate-input.js
+++ b/packages/generators/generators/lib/plops/utils/validate-input.js
@@ -1,10 +1,10 @@
 'use strict';
 
-module.exports = input => {
-  const regex = /^[A-Za-z-]+$/g;
+module.exports = (input, allowSnakeCase = false) => {
+  const regex = allowSnakeCase ? /^[A-Za-z-|_]+$/g : /^[A-Za-z-]+$/g;
 
   if (!input) {
-    return 'You must provide an input';
+    return "You must provide an input";
   }
 
   return regex.test(input) || "Please use only letters, '-' and no spaces";


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Allow snake case in content type attribute names when generating them via the generator.

### Why is it needed?

Strapi content types can have underscores, its common practice, so this should be reflected in the generator.
Strapi 3 has this too, so its a missing feature in strapi 4.

### How to test it?

`npx strapi generate content-type`

__

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request

**https://github.com/strapi/strapi/issues/12670**
