### PR TITLE
Ensure the session PK check is disabled during schema update for MySQL

### DIFF
--- a/packages/core/database/lib/dialects/mysql/index.js
+++ b/packages/core/database/lib/dialects/mysql/index.js
@@ -41,7 +41,12 @@ class MysqlDialect extends Dialect {
   }
 
   async startSchemaUpdate() {
-    await this.db.connection.raw(`set foreign_key_checks = 0;`);
+    try {
+      await this.db.connection.raw(`set foreign_key_checks = 0;`);
+      await this.db.connection.raw(`set session sql_require_primary_key = 0;`);
+    } catch (err) {
+      // Ignore error due to lack of session permissions
+    }
   }
 
   async endSchemaUpdate() {


### PR DESCRIPTION
fixes: #12553

For some reason the initialize option for this didn't work on all schema changes, this PR forcefully ensures the check is passed during the schemaUpdate function.

Tested this fix manually using v4.1.2 as a base on a DO droplet + a managed MySQL database on DO.