### PR TITLE
Fix sanitization of datetime type in query param

### DIFF
--- a/packages/core/utils/lib/convert-query-params.js
+++ b/packages/core/utils/lib/convert-query-params.js
@@ -4,7 +4,7 @@
  * Converts the standard Strapi REST query params to a more usable format for querying
  * You can read more here: https://docs.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/rest-api.html#filters
  */
-const { has, isEmpty, isObject, cloneDeep, get } = require('lodash/fp');
+const { has, isEmpty, isObject, isPlainObject, cloneDeep, get } = require('lodash/fp');
 const _ = require('lodash');
 const parseType = require('./parse-type');
 const contentTypesUtils = require('./content-types');
@@ -286,7 +286,7 @@ const convertFiltersQueryParams = (filters, schema) => {
 };
 
 const convertAndSanitizeFilters = (filters, schema) => {
-  if (!isObject(filters)) {
+  if (!isPlainObject(filters)) {
     return filters;
   }
 
@@ -339,11 +339,6 @@ const convertAndSanitizeFilters = (filters, schema) => {
       }
     }
 
-    // Handle dates
-    else if (value instanceof Date) {
-      return filters;
-    }
-
     // Handle operators
     else {
       if (['$null', '$notNull'].includes(key)) {
@@ -354,7 +349,7 @@ const convertAndSanitizeFilters = (filters, schema) => {
     }
 
     // Remove empty objects & arrays
-    if (isObject(filters[key]) && isEmpty(filters[key])) {
+    if (isPlainObject(filters[key]) && isEmpty(filters[key])) {
       removeOperator(key);
     }
   }

--- a/packages/core/utils/lib/convert-query-params.js
+++ b/packages/core/utils/lib/convert-query-params.js
@@ -339,6 +339,11 @@ const convertAndSanitizeFilters = (filters, schema) => {
       }
     }
 
+    // Handle dates
+    else if (value instanceof Date) {
+      return filters;
+    }
+
     // Handle operators
     else {
       if (['$null', '$notNull'].includes(key)) {

--- a/packages/plugins/graphql/tests/fields/date.test.e2e.js
+++ b/packages/plugins/graphql/tests/fields/date.test.e2e.js
@@ -113,5 +113,37 @@ describe('Test Graphql API End to End', () => {
         });
       }
     );
+
+    test.each(['2022-03-17', null])('Can filter query with date: %s', async value => {
+      const res = await graphqlQuery({
+        query: /* GraphQL */ `
+          query posts($data: PostInput!) {
+            posts(filters: { myDate: { gt: $data } }) {
+              data {
+                attributes {
+                  myDate
+                }
+              }
+            }
+          }
+        `,
+        variables: {
+          data: {
+            myDate: value,
+          },
+        },
+      });
+
+      const { body } = res;
+
+      expect(res.statusCode).toBe(200);
+      expect(body).toEqual({
+        data: {
+          posts: {
+            data: {},
+          },
+        },
+      });
+    });
   });
 });

--- a/packages/plugins/graphql/tests/fields/date.test.e2e.js
+++ b/packages/plugins/graphql/tests/fields/date.test.e2e.js
@@ -114,11 +114,11 @@ describe('Test Graphql API End to End', () => {
       }
     );
 
-    test.each(['2022-03-17', null])('Can filter query with date: %s', async value => {
+    test.each(['2022-03-17'])('Can filter query with date: %s', async value => {
       const res = await graphqlQuery({
         query: /* GraphQL */ `
-          query posts($data: PostInput!) {
-            posts(filters: { myDate: { gt: $data } }) {
+          query posts($myDate: Date!) {
+            posts(filters: { myDate: { gt: $myDate } }) {
               data {
                 attributes {
                   myDate
@@ -128,9 +128,7 @@ describe('Test Graphql API End to End', () => {
           }
         `,
         variables: {
-          data: {
-            myDate: value,
-          },
+          myDate: value,
         },
       });
 
@@ -140,7 +138,7 @@ describe('Test Graphql API End to End', () => {
       expect(body).toEqual({
         data: {
           posts: {
-            data: {},
+            data: [],
           },
         },
       });

--- a/packages/plugins/graphql/tests/fields/datetime.test.e2e.js
+++ b/packages/plugins/graphql/tests/fields/datetime.test.e2e.js
@@ -1,0 +1,152 @@
+'use strict';
+
+// Helpers.
+const { createTestBuilder } = require('../../../../../test/helpers/builder');
+const { createStrapiInstance } = require('../../../../../test/helpers/strapi');
+const { createAuthRequest } = require('../../../../../test/helpers/request');
+
+const builder = createTestBuilder();
+let strapi;
+let rq;
+let graphqlQuery;
+
+const postModel = {
+  attributes: {
+    myDatetime: {
+      type: 'datetime',
+    },
+  },
+  singularName: 'post',
+  pluralName: 'posts',
+  displayName: 'Post',
+  description: '',
+  collectionName: '',
+};
+
+describe('Test Graphql API End to End', () => {
+  beforeAll(async () => {
+    await builder.addContentType(postModel).build();
+
+    strapi = await createStrapiInstance();
+    rq = await createAuthRequest({ strapi });
+
+    graphqlQuery = body => {
+      return rq({
+        url: '/graphql',
+        method: 'POST',
+        body,
+      });
+    };
+  });
+
+  afterAll(async () => {
+    await strapi.destroy();
+    await builder.cleanup();
+  });
+
+  describe('GraphQL - Datetime field', () => {
+    test.each(['2022-03-17T15:06:57.878Z', null])(
+      'Can create an entity with date equals: %s',
+      async value => {
+        const res = await graphqlQuery({
+          query: /* GraphQL */ `
+            mutation createPost($data: PostInput!) {
+              createPost(data: $data) {
+                data {
+                  attributes {
+                    myDatetime
+                  }
+                }
+              }
+            }
+          `,
+          variables: {
+            data: {
+              myDatetime: value,
+            },
+          },
+        });
+
+        const { body } = res;
+
+        expect(res.statusCode).toBe(200);
+        expect(body).toEqual({
+          data: {
+            createPost: {
+              data: {
+                attributes: { myDatetime: value },
+              },
+            },
+          },
+        });
+      }
+    );
+
+    test.each(['2022-03-17', {}, [], 'something'])(
+      'Cannot create an entity with date equals: %s',
+      async value => {
+        const res = await graphqlQuery({
+          query: /* GraphQL */ `
+            mutation createPost($data: PostInput!) {
+              createPost(data: $data) {
+                data {
+                  attributes {
+                    myDatetime
+                  }
+                }
+              }
+            }
+          `,
+          variables: {
+            data: {
+              myDatetime: value,
+            },
+          },
+        });
+
+        const { body } = res;
+
+        expect(res.statusCode).toBe(400);
+        expect(body).toMatchObject({
+          errors: [
+            {
+              extensions: { code: 'BAD_USER_INPUT' },
+            },
+          ],
+        });
+      }
+    );
+
+    test.each(['2022-03-17T15:06:57.878Z', null])('Can filter query with date: %s', async value => {
+      const res = await graphqlQuery({
+        query: /* GraphQL */ `
+          query posts($data: PostInput!) {
+            posts(filters: { myDatetime: { gt: $data } }) {
+              data {
+                attributes {
+                  myDatetime
+                }
+              }
+            }
+          }
+        `,
+        variables: {
+          data: {
+            myDatetime: value,
+          },
+        },
+      });
+
+      const { body } = res;
+
+      expect(res.statusCode).toBe(200);
+      expect(body).toEqual({
+        data: {
+          posts: {
+            data: {},
+          },
+        },
+      });
+    });
+  });
+});

--- a/packages/plugins/graphql/tests/fields/datetime.test.e2e.js
+++ b/packages/plugins/graphql/tests/fields/datetime.test.e2e.js
@@ -45,8 +45,8 @@ describe('Test Graphql API End to End', () => {
   });
 
   describe('GraphQL - Datetime field', () => {
-    test.each(['2022-03-17T15:06:57.878Z', null])(
-      'Can create an entity with date equals: %s',
+    test.each(['2022-03-17T15:06:57.000Z', null])(
+      'Can create an entity with datetime equals: %s',
       async value => {
         const res = await graphqlQuery({
           query: /* GraphQL */ `
@@ -83,7 +83,7 @@ describe('Test Graphql API End to End', () => {
     );
 
     test.each(['2022-03-17', {}, [], 'something'])(
-      'Cannot create an entity with date equals: %s',
+      'Cannot create an entity with datetime equals: %s',
       async value => {
         const res = await graphqlQuery({
           query: /* GraphQL */ `
@@ -117,11 +117,11 @@ describe('Test Graphql API End to End', () => {
       }
     );
 
-    test.each(['2022-03-17T15:06:57.878Z', null])('Can filter query with date: %s', async value => {
+    test.each(['2022-03-17T15:06:57.878Z'])('Can filter query with datetime: %s', async value => {
       const res = await graphqlQuery({
         query: /* GraphQL */ `
-          query posts($data: PostInput!) {
-            posts(filters: { myDatetime: { gt: $data } }) {
+          query posts($myDatetime: DateTime!) {
+            posts(filters: { myDatetime: { gt: $myDatetime } }) {
               data {
                 attributes {
                   myDatetime
@@ -131,9 +131,7 @@ describe('Test Graphql API End to End', () => {
           }
         `,
         variables: {
-          data: {
-            myDatetime: value,
-          },
+          myDatetime: value,
         },
       });
 
@@ -143,7 +141,7 @@ describe('Test Graphql API End to End', () => {
       expect(body).toEqual({
         data: {
           posts: {
-            data: {},
+            data: [],
           },
         },
       });


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Adds a separated verification for date type in the filter. Currently filters with type `Date` are being incorrectly handled as objects when sanitizing.

Currently, the result it's parsing a date/datetime value as an operator, due to `isObject(date)` from lodash handling dates as Objects, but with this PR it should parse as a primitive value.

### Why is it needed?

Filters of date and datetime are broken in GraphQL API. The query returns the entities without applying the filter.

### How to test it?

See the issue mentioned below, the steps should be similar but for the `example/getstarted`.

### Related issue(s)/PR(s)

Fix #12706 

The bug resulted from password sanitization in PR https://github.com/strapi/strapi/pull/11917 when released [v4.0.8](https://github.com/strapi/strapi/releases/tag/v4.0.8)
