### PR TITLE
Update dependabot label config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,6 @@ updates:
     ignore:
       - dependency-name: '*'
         update-types: ['version-update:semver-major']
+    labels:
+      - 'source: dependencies'
+      - 'pr: chore'


### PR DESCRIPTION

### What does it do?

Updates the dependabot config to use the right labels automatically

### Why is it needed?

To include dependency upgrade in changelogs and to CI pass checks

