### PR TITLE
Fix loading time when opening an entity with many related entities

### DIFF
--- a/packages/core/content-manager/server/services/entity-manager.js
+++ b/packages/core/content-manager/server/services/entity-manager.js
@@ -55,9 +55,7 @@ const getDeepPopulate = (uid, populate, depth = 0) => {
     const attribute = attributes[attributeName];
 
     if (attribute.type === 'relation') {
-      populateAcc[attributeName] = attribute.target
-        ? { populate: getDeepPopulate(attribute.target, null, depth + 1) }
-        : true;
+      populateAcc[attributeName] = true; // Only populate first level of relations
     }
 
     if (attribute.type === 'component') {


### PR DESCRIPTION
Fix #12004

### how to test
In the project `getStarted`:
1. create a relation many-to-many between country and category.
2. in the file `src/index.js`, replace the bootstrap function by this one.
```js
  async bootstrap({ strapi }) {
    const countries = await strapi.entityService.findMany('api::country.country', {});
    if (countries.length > 50) {
      return;
    }

    const category = await strapi.entityService.create('api::category.category', {
      data: {
        name: 'Nice category',
      },
    });

    for (let i = 0; i < 1000; i +=1) {
      console.log('create country', i);
      await strapi.entityService.create('api::country.country', {
        data: {
          name: `France-${i}`,
          categories: [category.id],
        },
      });
    }
  },
```
3. start the project
4. in the CM, in `categories`, open the category `Nice category`
5. see that the loading time is reasonable and that the relations are correctly displayed.

For QA: to check that no other features in the app is broken, the ones that may use populated entities

NB: The loading time can still be improved but it's for another time :)