### PR TITLE
fix: serve admin static file with public cache

### DIFF
--- a/packages/core/admin/server/routes/serve-admin-panel.js
+++ b/packages/core/admin/server/routes/serve-admin-panel.js
@@ -32,7 +32,7 @@ const registerAdminPanelRoute = ({ strapi }) => {
       path: `${strapi.config.admin.path}/:path*`,
       handler: [
         serveAdminMiddleware,
-        serveStatic(buildDir, { maxage: 60000, defer: false, index: 'index.html' }),
+        serveStatic(buildDir, { maxage: 31536000, defer: false, index: 'index.html' }),
       ],
       config: { auth: false },
     },
@@ -46,6 +46,13 @@ const serveStatic = (filesDir, koaStaticOptions = {}) => {
   return async (ctx, next) => {
     const prev = ctx.path;
     const newPath = path.basename(ctx.path);
+    const ext = path.extname(ctx.path);
+
+    // publicly cache static files to avoid unnecessary network & disk access
+    if (ext === '.css' || ext === '.js') {
+      ctx.set('cache-control', 'public, max-age=31536000, immutable');
+    }
+
     ctx.path = newPath;
     await serve(ctx, async () => {
       ctx.path = prev;


### PR DESCRIPTION
### What does it do?

This add `cache-control: public, max-age=31536000, immutable` to `.js` and `.css` files served for the admin panel.

The `immutable` and long `max-age` can safely be used because [`[contenthash:8]` is used by webpack](https://github.com/strapi/strapi/blob/master/packages/core/admin/webpack.config.js#L63) to generate filenames

### Why is it needed?

As you saw on this screen, the total admin sources take `8.7 MB`, which without this patch are always downloaded on each visit.
With this enabled, transferred size go down to `72.4 kB` on each visit (**which represent a ~120% bandwidth saving**)

![image](https://user-images.githubusercontent.com/3911343/156889981-6d7ebe35-64fa-44f4-bae2-1fc92254a2e7.png)

Save bandwidth, save money, save the planet 👍 

### Related issue(s)/PR(s)

close #12763 
