### PR TITLE
Add SERVER_URL variable to user e-mail templates

### DIFF
--- a/packages/plugins/users-permissions/server/controllers/auth.js
+++ b/packages/plugins/users-permissions/server/controllers/auth.js
@@ -240,6 +240,7 @@ module.exports = {
 
     settings.message = await getService('users-permissions').template(settings.message, {
       URL: advanced.email_reset_password,
+      SERVER_URL: getAbsoluteServerUrl(strapi.config),
       USER: userInfo,
       TOKEN: resetPasswordToken,
     });

--- a/packages/plugins/users-permissions/server/controllers/auth.js
+++ b/packages/plugins/users-permissions/server/controllers/auth.js
@@ -17,7 +17,7 @@ const {
   validateSendEmailConfirmationBody,
 } = require('./validation/auth');
 
-const { getAbsoluteServerUrl, sanitize } = utils;
+const { getAbsoluteAdminUrl, getAbsoluteServerUrl, sanitize } = utils;
 const { ApplicationError, ValidationError } = utils.errors;
 
 const emailRegExp = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
@@ -137,7 +137,10 @@ module.exports = {
         throw new ValidationError('Incorrect code provided');
       }
 
-      await getService('user').edit(user.id, { resetPasswordToken: null, password: params.password });
+      await getService('user').edit(user.id, {
+        resetPasswordToken: null,
+        password: params.password,
+      });
       // Update the user.
       ctx.send({
         jwt: getService('jwt').issue({ id: user.id }),
@@ -241,6 +244,7 @@ module.exports = {
     settings.message = await getService('users-permissions').template(settings.message, {
       URL: advanced.email_reset_password,
       SERVER_URL: getAbsoluteServerUrl(strapi.config),
+      ADMIN_URL: getAbsoluteAdminUrl(strapi.config),
       USER: userInfo,
       TOKEN: resetPasswordToken,
     });
@@ -339,7 +343,7 @@ module.exports = {
         params.confirmed = true;
       }
 
-    const user = await getService('user').add(params);
+      const user = await getService('user').add(params);
 
       const sanitizedUser = await sanitizeUser(user, ctx);
 

--- a/packages/plugins/users-permissions/server/controllers/auth.js
+++ b/packages/plugins/users-permissions/server/controllers/auth.js
@@ -17,7 +17,7 @@ const {
   validateSendEmailConfirmationBody,
 } = require('./validation/auth');
 
-const { sanitize } = utils;
+const { getAbsoluteServerUrl, sanitize } = utils;
 const { ApplicationError, ValidationError } = utils.errors;
 
 const emailRegExp = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;

--- a/packages/plugins/users-permissions/server/controllers/validation/email-template.js
+++ b/packages/plugins/users-permissions/server/controllers/validation/email-template.js
@@ -3,7 +3,15 @@
 const _ = require('lodash');
 
 const invalidPatternsRegexes = [/<%[^=]([^<>%]*)%>/m, /\${([^{}]*)}/m];
-const authorizedKeys = ['URL', 'CODE', 'USER', 'USER.email', 'USER.username', 'TOKEN'];
+const authorizedKeys = [
+  'URL',
+  'SERVER_URL',
+  'CODE',
+  'USER',
+  'USER.email',
+  'USER.username',
+  'TOKEN',
+];
 
 const matchAll = (pattern, src) => {
   const matches = [];

--- a/packages/plugins/users-permissions/server/controllers/validation/email-template.js
+++ b/packages/plugins/users-permissions/server/controllers/validation/email-template.js
@@ -5,6 +5,7 @@ const _ = require('lodash');
 const invalidPatternsRegexes = [/<%[^=]([^<>%]*)%>/m, /\${([^{}]*)}/m];
 const authorizedKeys = [
   'URL',
+  'ADMIN_URL',
   'SERVER_URL',
   'CODE',
   'USER',

--- a/packages/plugins/users-permissions/server/services/user.js
+++ b/packages/plugins/users-permissions/server/services/user.js
@@ -10,7 +10,7 @@ const crypto = require('crypto');
 const bcrypt = require('bcryptjs');
 const urlJoin = require('url-join');
 
-const { getAbsoluteServerUrl, sanitize } = require('@strapi/utils');
+const { getAbsoluteAdminUrl, getAbsoluteServerUrl, sanitize } = require('@strapi/utils');
 const { getService } = require('../utils');
 
 module.exports = ({ strapi }) => ({
@@ -119,6 +119,7 @@ module.exports = ({ strapi }) => ({
     settings.message = await userPermissionService.template(settings.message, {
       URL: urlJoin(getAbsoluteServerUrl(strapi.config), apiPrefix, '/auth/email-confirmation'),
       SERVER_URL: getAbsoluteServerUrl(strapi.config),
+      ADMIN_URL: getAbsoluteAdminUrl(strapi.config),
       USER: sanitizedUserInfo,
       CODE: confirmationToken,
     });

--- a/packages/plugins/users-permissions/server/services/user.js
+++ b/packages/plugins/users-permissions/server/services/user.js
@@ -118,6 +118,7 @@ module.exports = ({ strapi }) => ({
     const apiPrefix = strapi.config.get('api.rest.prefix');
     settings.message = await userPermissionService.template(settings.message, {
       URL: urlJoin(getAbsoluteServerUrl(strapi.config), apiPrefix, '/auth/email-confirmation'),
+      SERVER_URL: getAbsoluteServerUrl(strapi.config),
       USER: sanitizedUserInfo,
       CODE: confirmationToken,
     });


### PR DESCRIPTION
### What does it do?

It adds an additional variable to e-mail templates ("Reset password" and "Email address confirmation") called `SERVER_URL` that holds the current absolute server URL provided by `getAbsoluteServerUrl(strapi.config)`.

### Why is it needed?

When the same application is deployed in several environments (i.e. staging, production), the domain and thereby the URL's might change. The server URL is configurable in the strapi configuration (which might be done using environment variables). However, the content of e-mail templates is configured via the admin panel (or the config-sync plugin). This makes referencing the server URL a hassle. By having the server URL as a variable in e-mail templates, adding deeplink to your templates becomes much easier.

### How to test it?

Add `<%= SERVER_URL %>` to the templates "Reset password" and "Email address confirmation" and verify that the correct value is rendered in these e-mails.

### Related issues

There are no related issues.
