### PR TITLE
fix emailConfirmation graphql mutation

### DIFF
--- a/packages/plugins/users-permissions/server/graphql/mutations/auth/email-confirmation.js
+++ b/packages/plugins/users-permissions/server/graphql/mutations/auth/email-confirmation.js
@@ -19,7 +19,7 @@ module.exports = ({ nexus, strapi }) => {
     async resolve(parent, args, context) {
       const { koaContext } = context;
 
-      koaContext.request.body = toPlainObject(args);
+      koaContext.query = toPlainObject(args);
 
       await strapi
         .plugin('users-permissions')


### PR DESCRIPTION
### What does it do?

Fix emailConfirmation graphql mutaion to correctly call auth.emailConfirmation by passing args as query instead of request.body

### Why is it needed?

To let graphql mutation confirm email using confirmation code

### How to test it?

Register a user and get confirmation code from email to test with graphql request below
```
{"query":"\n  mutation ($confirmation:String!){\n    emailConfirmation(confirmation: $confirmation) {\n      jwt\n    }\n  }\n  ","variables":{"confirmation":"code-from-email"}}
```

### Related issue(s)/PR(s)

Related issue #12772 
