### PR TITLE
Media Library: improve microcopy

### DIFF
--- a/packages/core/upload/admin/src/components/AssetDialog/SelectedStep/index.js
+++ b/packages/core/upload/admin/src/components/AssetDialog/SelectedStep/index.js
@@ -17,7 +17,7 @@ export const SelectedStep = ({ selectedAssets, onSelectAsset, onReorderAsset }) 
             {
               id: getTrad('list.assets.selected'),
               defaultMessage:
-                '{number, plural, =0 {No asset} one {1 asset} other {# assets}} selected',
+                '{number, plural, =0 {No asset} one {1 asset} other {# assets}} ready to upload',
             },
             { number: selectedAssets.length }
           )}
@@ -25,7 +25,7 @@ export const SelectedStep = ({ selectedAssets, onSelectAsset, onReorderAsset }) 
         <Typography variant="pi" textColor="neutral600">
           {formatMessage({
             id: getTrad('modal.upload-list.sub-header-subtitle'),
-            defaultMessage: 'Manage the assets before uploading them to the Media Library',
+            defaultMessage: 'Manage the assets before adding them to the Media Library',
           })}
         </Typography>
       </Stack>

--- a/packages/core/upload/admin/src/components/UploadAssetDialog/PendingAssetStep/PendingAssetStep.js
+++ b/packages/core/upload/admin/src/components/UploadAssetDialog/PendingAssetStep/PendingAssetStep.js
@@ -78,7 +78,7 @@ export const PendingAssetStep = ({
                   {
                     id: getTrad('list.assets.selected'),
                     defaultMessage:
-                      '{number, plural, =0 {No asset} one {1 asset} other {# assets}} selected',
+                      '{number, plural, =0 {No asset} one {1 asset} other {# assets}} ready to upload',
                   },
                   { number: assets.length }
                 )}
@@ -86,7 +86,7 @@ export const PendingAssetStep = ({
               <Typography variant="pi" textColor="neutral600">
                 {formatMessage({
                   id: getTrad('modal.upload-list.sub-header-subtitle'),
-                  defaultMessage: 'Manage the assets before uploading them to the Media Library',
+                  defaultMessage: 'Manage the assets before adding them to the Media Library',
                 })}
               </Typography>
             </Stack>

--- a/packages/core/upload/admin/src/components/UploadAssetDialog/PendingAssetStep/tests/__snapshots__/PendingAssetStep.test.js.snap
+++ b/packages/core/upload/admin/src/components/UploadAssetDialog/PendingAssetStep/tests/__snapshots__/PendingAssetStep.test.js.snap
@@ -765,7 +765,7 @@ exports[`PendingAssetStep snapshots the component with valid cards 1`] = `
             <span
               class="c12"
             >
-              Manage the assets before uploading them to the Media Library
+              Manage the assets before adding them to the Media Library
             </span>
           </div>
           <button

--- a/packages/core/upload/admin/src/components/UploadAssetDialog/tests/UploadAssetDialog.test.js
+++ b/packages/core/upload/admin/src/components/UploadAssetDialog/tests/UploadAssetDialog.test.js
@@ -101,7 +101,7 @@ describe('UploadAssetDialog', () => {
           )
         ).toBeInTheDocument();
         expect(
-          screen.getByText('Manage the assets before uploading them to the Media Library')
+          screen.getByText('Manage the assets before adding them to the Media Library')
         ).toBeInTheDocument();
         expect(screen.getAllByText(`test.${ext}`).length).toBe(number);
         expect(screen.getByText(ext)).toBeInTheDocument();
@@ -199,7 +199,7 @@ describe('UploadAssetDialog', () => {
       );
       expect(screen.getAllByText(`Add new assets`).length).toBe(2);
       expect(
-        screen.getByText('Manage the assets before uploading them to the Media Library')
+        screen.getByText('Manage the assets before adding them to the Media Library')
       ).toBeInTheDocument();
 
       assets.forEach(asset => {

--- a/packages/core/upload/admin/src/translations/en.json
+++ b/packages/core/upload/admin/src/translations/en.json
@@ -68,7 +68,7 @@
   "modal.remove.success-label": "The asset has been successfully removed.",
   "modal.selected-list.sub-header-subtitle": "Drag & drop to reorder the assets in the field",
   "modal.upload-list.footer.button": "Upload {number, plural, one {# asset} other {# assets}} to the library",
-  "modal.upload-list.sub-header-subtitle": "Manage the assets before uploading them to the Media Library",
+  "modal.upload-list.sub-header-subtitle": "Manage the assets before adding them to the Media Library",
   "modal.upload-list.sub-header.button": "Add more assets",
   "modal.upload.cancelled": "Upload manually aborted.",
   "page.title": "Settings - Media Library",


### PR DESCRIPTION
### What does it do?

Updates the microscopy in the Media Library to reflect the fact, that assets are added to the Media Library.

### Why is it needed?

To improve the content editors' understanding of what is actually happening in this step.

### How to test it?

Provide information about the environment and the path to verify the behavior.

### Related issue(s)/PR(s)

- Fixes https://github.com/strapi/strapi/issues/11570
