### PR TITLE
Add customDomain option when uploading files to S3

### DIFF
--- a/packages/providers/upload-aws-s3/lib/index.js
+++ b/packages/providers/upload-aws-s3/lib/index.js
@@ -10,7 +10,7 @@ const _ = require('lodash');
 const AWS = require('aws-sdk');
 
 module.exports = {
-  init(config) {
+  init({ customDomain, ...config }) {
     const S3 = new AWS.S3({
       apiVersion: '2006-03-01',
       ...config,
@@ -20,9 +20,11 @@ module.exports = {
       new Promise((resolve, reject) => {
         // upload file on S3 bucket
         const path = file.path ? `${file.path}/` : '';
+        const fileKey = `${path}${file.hash}${file.ext}`
+        
         S3.upload(
           {
-            Key: `${path}${file.hash}${file.ext}`,
+            Key: fileKey,
             Body: file.stream || Buffer.from(file.buffer, 'binary'),
             ACL: 'public-read',
             ContentType: file.mime,
@@ -34,7 +36,7 @@ module.exports = {
             }
 
             // set the bucket file url
-            file.url = data.Location;
+            file.url = customDomain ? `${customDomain}/${fileKey}` : data.Location;
 
             resolve();
           }


### PR DESCRIPTION
Adding the `customDomain` config field to the `upload-aws-s3` provider. 

It allows you to specify a custom domain while saving the files' url. This is especially helpful when the media files are served through a CDN and you need the urls to point to that domain instead of the default bucket's one.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Describe the technical changes you did.

### Why is it needed?

Describe the issue you are solving.

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
