### PR TITLE
remove uploadStream from cloudinary provider. Update bootstrap.js to initialize uploadStream method properly.

### DIFF
--- a/packages/core/upload/server/bootstrap.js
+++ b/packages/core/upload/server/bootstrap.js
@@ -49,8 +49,16 @@ const createProvider = config => {
 
   const providerInstance = provider.init(providerOptions);
 
+  let optionalUploadStream;
+  if (providerInstance.uploadStream) {
+    optionalUploadStream = (file, options = actionOptions.upload) => {
+      return providerInstance.uploadStream(file, options);
+    };
+  }
+
   return Object.assign(Object.create(baseProvider), {
-    ...providerInstance,
+    ...providerInstance,    
+    uploadStream: optionalUploadStream,
     upload(file, options = actionOptions.upload) {
       return providerInstance.upload(file, options);
     },

--- a/packages/providers/upload-cloudinary/lib/index.js
+++ b/packages/providers/upload-cloudinary/lib/index.js
@@ -57,9 +57,10 @@ module.exports = {
       });
 
     return {
-      uploadStream(file, customConfig = {}) {
-        return upload(file, customConfig);
-      },
+      // Remove uploadStream so that `upload` is used instead with the correct arguments
+      // uploadStream(file, customConfig = {}) {
+      //   return upload(file, customConfig);
+      // },
       upload(file, customConfig = {}) {
         return upload(file, customConfig);
       },


### PR DESCRIPTION
Fixes #12809 by optionally initializing the uploadStream method for upload providers. 

Also removes the uploadStream method on the cloudinary provider to ensure the `upload` method is called. This could be added back in since the boostrap function now properly initialized the `uploadStream` method. 


### Why is it needed?

To get the upload-providers to accept the configuration options as expected. 

### How to test it?

Please see the bug report #12809 for more details. 
