### PR TITLE
fix: ApolloServer middleware CORS issue

### DIFF
--- a/packages/plugins/graphql/server/bootstrap.js
+++ b/packages/plugins/graphql/server/bootstrap.js
@@ -114,7 +114,11 @@ module.exports = async ({ strapi }) => {
         },
 
         // Apollo Server
-        server.getMiddleware({ path }),
+        server.getMiddleware({
+          path,
+          cors: serverConfig.cors,
+          bodyParserConfig: serverConfig.bodyParserConfig,
+        }),
       ],
       config: {
         auth: false,


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

This PR passes down `cors` and `bodyParserConfig` params to the Apollo Server middleware.

### Why is it needed?

When enforcing `cors` with `/graphql` endpoint, if it is not passed down this middleware. `cors` will be set to `origin=*`.
```js
// apollo-server-koa/src/ApolloServer.ts - line 100
if (cors === true || cors === undefined) {
  // Unlike the express `cors` package, `fastify-cors`, or Hapi, Koa's cors
  // handling defaults to reflecting the incoming origin instead of '*'.
  // Let's make it match.
  middlewares.push(
    middlewareFromPath(path, corsMiddleware({ origin: '*' })),
  );
} else if (cors !== false) {
  middlewares.push(middlewareFromPath(path, corsMiddleware(cors)));
}
```

### How to test it?
Apollo Client (example: React) using `credentials=include` config which enforces cors
```js
const apolloLink = createHttpLink({
  uri: 'http://localhost:1337/graphql',
  credentials: 'include', // in order to send cookies and force cors
});

const apolloClient = new ApolloClient({
  link: apolloLink,
  cache: new InMemoryCache({
    addTypename: false,
  }),
});
```

Strapi Plugins Configuration
```js
// ./server/config/plugins.js
module.exports = {
  graphql: {
    config: {
      endpoint: '/graphql',
      apolloServer: {
        cors: {
          credentials: true,
          headers: ['Content-Type', 'Accept', 'Authorization'],
          origin: 'http://localhost:3000',
        },
      },
    },
  },
};
```