### PR TITLE
Integrate react-refresh to increase productivity

### DIFF
--- a/packages/core/admin/package.json
+++ b/packages/core/admin/package.json
@@ -49,6 +49,7 @@
     "@fortawesome/free-brands-svg-icons": "^5.15.3",
     "@fortawesome/free-solid-svg-icons": "^5.15.3",
     "@fortawesome/react-fontawesome": "^0.1.14",
+    "@pmmmwh/react-refresh-webpack-plugin": "0.5.4",
     "@strapi/babel-plugin-switch-ee-ce": "4.2.0",
     "@strapi/design-system": "1.1.1",
     "@strapi/helper-plugin": "4.2.0",
@@ -113,6 +114,7 @@
     "react-intl": "5.20.2",
     "react-query": "3.24.3",
     "react-redux": "7.2.3",
+    "react-refresh": "0.11.0",
     "react-router": "5.2.0",
     "react-router-dom": "5.2.0",
     "react-select": "^4.0.2",
@@ -133,9 +135,7 @@
     "yup": "^0.32.9"
   },
   "devDependencies": {
-    "@pmmmwh/react-refresh-webpack-plugin": "0.5.4",
     "duplicate-dependencies-webpack-plugin": "0.2.0",
-    "react-refresh": "0.11.0",
     "webpack-bundle-analyzer": "4.4.1"
   },
   "engines": {

--- a/packages/core/admin/package.json
+++ b/packages/core/admin/package.json
@@ -133,7 +133,9 @@
     "yup": "^0.32.9"
   },
   "devDependencies": {
+    "@pmmmwh/react-refresh-webpack-plugin": "0.5.4",
     "duplicate-dependencies-webpack-plugin": "0.2.0",
+    "react-refresh": "0.11.0",
     "webpack-bundle-analyzer": "4.4.1"
   },
   "engines": {

--- a/packages/core/admin/webpack.config.js
+++ b/packages/core/admin/webpack.config.js
@@ -8,6 +8,8 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const { ESBuildMinifyPlugin } = require('esbuild-loader');
 const WebpackBar = require('webpackbar');
 const NodePolyfillPlugin = require('node-polyfill-webpack-plugin');
+const ReactRefreshWebpackPlugin = require('@pmmmwh/react-refresh-webpack-plugin');
+
 const alias = require('./webpack.alias');
 const getClientEnvironment = require('./env');
 
@@ -204,7 +206,8 @@ module.exports = ({
       new webpack.DefinePlugin(envVariables),
 
       new NodePolyfillPlugin(),
+      !isProduction && process.env.REACT_REFRESH !== 'false' && new ReactRefreshWebpackPlugin(),
       ...webpackPlugins,
-    ],
+    ].filter(Boolean),
   };
 };


### PR DESCRIPTION
### What does it do?

- Integrate `react-refresh` to `core/admin`. We do not need a full reload after updating the source code.
- It applies both for contributors (`cd packages/core/admin && yarn develop --watch-admin`) and plugins developers (build their own plugin)

### Why is it needed?

- In saves us time after we hit the `Save` button.
=> Increase productivity of the developers => Make developers happy
- A table of comparison tested on my machine (Macbook 2019) after hitting Save in VSCode and when I see the change on Chrome:

|                        | Time to see updated UI | Preserve state |
| ---------------------- | ---------------------- | -------------- |
| Full Refresh (Current) | 4.01s                  | No             |
| Fast Refresh (This PR) | 1.02s                  | Yes            |

### How to test it?

1.  Start the admin

```bash
cd packages/core/admin && yarn develop --watch-admin
```

2. Navigate to http://localhost:4000
3. Make changes to any file
4. The changes reflect on http://localhost:4000 in about 1 second (compare to ~4 seconds)

### Demo

![React Refresh is very fast](https://user-images.githubusercontent.com/8603085/158021065-289fa5b6-ac09-4aeb-b8af-8697e4d56c24.gif)

### Notes

- Developers can opt-out of this feature by `FAST_REFRESH=false yarn develop --watch-admin`.
