### PR TITLE
Codecov: ignore md and mdx files

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -5,3 +5,7 @@ comment:
 
 github_checks:
   annotations: false
+
+ignore:
+  - '**/*.md'
+  - '**/*.mdx'


### PR DESCRIPTION
### What does it do?

In https://github.com/strapi/strapi/pull/12356 in realized codecov currently takes `.md` and `.mdx` files into account. Since we don't have any tests for these files, I think it makes sense to exclude them.

- https://docs.codecov.com/docs/ignoring-paths

### Why is it needed?

Adding for example some docs to a PR would show the checks as failed since the code coverage decreased.

### How to test it?

Rely on the automated checks.
