### PR TITLE
Share state object across lifecycles

### DIFF
--- a/packages/core/database/lib/entity-manager.js
+++ b/packages/core/database/lib/entity-manager.js
@@ -113,33 +113,39 @@ const createEntityManager = db => {
 
   return {
     async findOne(uid, params) {
-      await db.lifecycles.run('beforeFindOne', uid, { params });
+      const state = {};
+
+      await db.lifecycles.run('beforeFindOne', uid, { params }, state);
 
       const result = await this.createQueryBuilder(uid)
         .init(params)
         .first()
         .execute();
 
-      await db.lifecycles.run('afterFindOne', uid, { params, result });
+      await db.lifecycles.run('afterFindOne', uid, { params, result }, state);
 
       return result;
     },
 
     // should we name it findOne because people are used to it ?
     async findMany(uid, params) {
-      await db.lifecycles.run('beforeFindMany', uid, { params });
+      const state = {};
+
+      await db.lifecycles.run('beforeFindMany', uid, { params }, state);
 
       const result = await this.createQueryBuilder(uid)
         .init(params)
         .execute();
 
-      await db.lifecycles.run('afterFindMany', uid, { params, result });
+      await db.lifecycles.run('afterFindMany', uid, { params, result }, state);
 
       return result;
     },
 
     async count(uid, params = {}) {
-      await db.lifecycles.run('beforeCount', uid, { params });
+      const state = {};
+
+      await db.lifecycles.run('beforeCount', uid, { params }, state);
 
       const res = await this.createQueryBuilder(uid)
         .init(_.pick(['_q', 'where', 'filters'], params))
@@ -149,13 +155,15 @@ const createEntityManager = db => {
 
       const result = Number(res.count);
 
-      await db.lifecycles.run('afterCount', uid, { params, result });
+      await db.lifecycles.run('afterCount', uid, { params, result }, state);
 
       return result;
     },
 
     async create(uid, params = {}) {
-      await db.lifecycles.run('beforeCreate', uid, { params });
+      const state = {};
+
+      await db.lifecycles.run('beforeCreate', uid, { params }, state);
 
       const metadata = db.metadata.get(uid);
       const { data } = params;
@@ -180,14 +188,16 @@ const createEntityManager = db => {
         populate: params.populate,
       });
 
-      await db.lifecycles.run('afterCreate', uid, { params, result });
+      await db.lifecycles.run('afterCreate', uid, { params, result }, state);
 
       return result;
     },
 
     // TODO: where do we handle relation processing for many queries ?
     async createMany(uid, params = {}) {
-      await db.lifecycles.run('beforeCreateMany', uid, { params });
+      const state = {};
+
+      await db.lifecycles.run('beforeCreateMany', uid, { params }, state);
 
       const metadata = db.metadata.get(uid);
       const { data } = params;
@@ -208,13 +218,15 @@ const createEntityManager = db => {
 
       const result = { count: data.length };
 
-      await db.lifecycles.run('afterCreateMany', uid, { params, result });
+      await db.lifecycles.run('afterCreateMany', uid, { params, result }, state);
 
       return result;
     },
 
     async update(uid, params = {}) {
-      await db.lifecycles.run('beforeUpdate', uid, { params });
+      const state = {};
+
+      await db.lifecycles.run('beforeUpdate', uid, { params }, state);
 
       const metadata = db.metadata.get(uid);
       const { where, data } = params;
@@ -257,14 +269,16 @@ const createEntityManager = db => {
         populate: params.populate,
       });
 
-      await db.lifecycles.run('afterUpdate', uid, { params, result });
+      await db.lifecycles.run('afterUpdate', uid, { params, result }, state);
 
       return result;
     },
 
     // TODO: where do we handle relation processing for many queries ?
     async updateMany(uid, params = {}) {
-      await db.lifecycles.run('beforeUpdateMany', uid, { params });
+      const state = {};
+
+      await db.lifecycles.run('beforeUpdateMany', uid, { params }, state);
 
       const metadata = db.metadata.get(uid);
       const { where, data } = params;
@@ -282,13 +296,15 @@ const createEntityManager = db => {
 
       const result = { count: updatedRows };
 
-      await db.lifecycles.run('afterUpdateMany', uid, { params, result });
+      await db.lifecycles.run('afterUpdateMany', uid, { params, result }, state);
 
       return result;
     },
 
     async delete(uid, params = {}) {
-      await db.lifecycles.run('beforeDelete', uid, { params });
+      const state = {};
+
+      await db.lifecycles.run('beforeDelete', uid, { params }, state);
 
       const { where, select, populate } = params;
 
@@ -316,14 +332,16 @@ const createEntityManager = db => {
 
       await this.deleteRelations(uid, id);
 
-      await db.lifecycles.run('afterDelete', uid, { params, result: entity });
+      await db.lifecycles.run('afterDelete', uid, { params, result: entity }, state);
 
       return entity;
     },
 
     // TODO: where do we handle relation processing for many queries ?
     async deleteMany(uid, params = {}) {
-      await db.lifecycles.run('beforeDeleteMany', uid, { params });
+      const state = {};
+
+      await db.lifecycles.run('beforeDeleteMany', uid, { params }, state);
 
       const { where } = params;
 
@@ -334,7 +352,7 @@ const createEntityManager = db => {
 
       const result = { count: deletedRows };
 
-      await db.lifecycles.run('afterDelete', uid, { params, result });
+      await db.lifecycles.run('afterDelete', uid, { params, result }, state);
 
       return result;
     },

--- a/packages/core/database/lib/lifecycles/index.d.ts
+++ b/packages/core/database/lib/lifecycles/index.d.ts
@@ -43,8 +43,8 @@ export interface Event {
 export interface LifecycleProvider {
   subscribe(subscriber: Subscriber): () => void;
   clear(): void;
-  run(action: Action, uid: string, properties: any): Promise<void>;
-  createEvent(action: Action, uid: string, properties: any): Event;
+  run(action: Action, uid: string, properties: any, state: any): Promise<void>;
+  createEvent(action: Action, uid: string, properties: any, state: any): Event;
 }
 
 export function createLifecyclesProvider(db: Database): LifecycleProvider;

--- a/packages/core/database/lib/lifecycles/index.js
+++ b/packages/core/database/lib/lifecycles/index.js
@@ -30,20 +30,21 @@ const createLifecyclesProvider = db => {
       subscribers = [];
     },
 
-    createEvent(action, uid, properties) {
+    createEvent(action, uid, properties, state) {
       const model = db.metadata.get(uid);
 
       return {
         action,
         model,
+        state,
         ...properties,
       };
     },
 
-    async run(action, uid, properties) {
+    async run(action, uid, properties, state) {
       for (const subscriber of subscribers) {
         if (typeof subscriber === 'function') {
-          const event = this.createEvent(action, uid, properties);
+          const event = this.createEvent(action, uid, properties, state);
           await subscriber(event);
           continue;
         }
@@ -52,7 +53,7 @@ const createLifecyclesProvider = db => {
         const hasModel = !subscriber.models || subscriber.models.includes(uid);
 
         if (hasAction && hasModel) {
-          const event = this.createEvent(action, uid, properties);
+          const event = this.createEvent(action, uid, properties, state);
 
           await subscriber[action](event);
         }


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Shares a `state` object between `before` and `after` lifecycles.

### Why is it needed?

There is no way to share data across lifecycles of the same category.

### Related issue(s)/PR(s)

Implemented changes requested in #12203 by @alexandrebodin.