### PR TITLE
Differenciate app and dist directories

### DIFF
--- a/packages/core/admin/server/routes/serve-admin-panel.js
+++ b/packages/core/admin/server/routes/serve-admin-panel.js
@@ -5,7 +5,7 @@ const fse = require('fs-extra');
 const koaStatic = require('koa-static');
 
 const registerAdminPanelRoute = ({ strapi }) => {
-  let buildDir = path.resolve(strapi.dirs.root, 'build');
+  let buildDir = path.resolve(strapi.dirs.dist.root, 'build');
 
   if (!fse.pathExistsSync(buildDir)) {
     buildDir = path.resolve(__dirname, '../../build');

--- a/packages/core/admin/utils/create-cache-dir.js
+++ b/packages/core/admin/utils/create-cache-dir.js
@@ -7,7 +7,7 @@ const fs = require('fs-extra');
 const getPkgPath = name => path.dirname(require.resolve(`${name}/package.json`));
 
 async function createPluginsJs(plugins, dest) {
-  const pluginsArray = plugins.map(({ pathToPlugin, name }) => {
+  const pluginsArray = plugins.map(({ appPathToPlugin, name }) => {
     const shortName = _.camelCase(name);
 
     /**
@@ -19,7 +19,7 @@ async function createPluginsJs(plugins, dest) {
      * Backslash looks to work only for absolute paths with webpack => https://webpack.js.org/concepts/module-resolution/#absolute-paths
      */
     const realPath = path
-      .join(path.relative(path.resolve(dest, 'admin', 'src'), pathToPlugin), 'strapi-admin.js')
+      .join(path.relative(path.resolve(dest, 'admin', 'src'), appPathToPlugin), 'strapi-admin.js')
       .replace(/\\/g, '/');
 
     return {

--- a/packages/core/content-type-builder/server/services/api-handler.js
+++ b/packages/core/content-type-builder/server/services/api-handler.js
@@ -10,7 +10,7 @@ const fse = require('fs-extra');
 async function clear(uid) {
   const { apiName, modelName } = strapi.contentTypes[uid];
 
-  const apiFolder = path.join(strapi.dirs.api, apiName);
+  const apiFolder = path.join(strapi.dirs.app.api, apiName);
 
   await recursiveRemoveFiles(apiFolder, createDeleteApiFunction(modelName));
   await deleteBackup(uid);
@@ -23,8 +23,8 @@ async function clear(uid) {
 async function backup(uid) {
   const { apiName } = strapi.contentTypes[uid];
 
-  const apiFolder = path.join(strapi.dirs.api, apiName);
-  const backupFolder = path.join(strapi.dirs.api, '.backup', apiName);
+  const apiFolder = path.join(strapi.dirs.app.api, apiName);
+  const backupFolder = path.join(strapi.dirs.app.api, '.backup', apiName);
 
   // backup the api folder
   await fse.copy(apiFolder, backupFolder);
@@ -37,8 +37,8 @@ async function backup(uid) {
 async function deleteBackup(uid) {
   const { apiName } = strapi.contentTypes[uid];
 
-  const backupFolder = path.join(strapi.dirs.api, '.backup');
-  const apiBackupFolder = path.join(strapi.dirs.api, '.backup', apiName);
+  const backupFolder = path.join(strapi.dirs.app.api, '.backup');
+  const apiBackupFolder = path.join(strapi.dirs.app.api, '.backup', apiName);
 
   await fse.remove(apiBackupFolder);
 
@@ -55,8 +55,8 @@ async function deleteBackup(uid) {
 async function rollback(uid) {
   const { apiName } = strapi.contentTypes[uid];
 
-  const apiFolder = path.join(strapi.dirs.api, apiName);
-  const backupFolder = path.join(strapi.dirs.api, '.backup', apiName);
+  const apiFolder = path.join(strapi.dirs.app.api, apiName);
+  const backupFolder = path.join(strapi.dirs.app.api, '.backup', apiName);
 
   const exists = await fse.exists(backupFolder);
 

--- a/packages/core/content-type-builder/server/services/component-categories.js
+++ b/packages/core/content-type-builder/server/services/component-categories.js
@@ -34,7 +34,7 @@ const editCategory = async (name, infos) => {
     // only edit the components in this specific category
     if (component.category !== name) return;
 
-    component.setUID(newUID).setDir(join(strapi.dirs.components, newName));
+    component.setUID(newUID).setDir(join(strapi.dirs.app.components, newName));
 
     builder.components.forEach(compo => {
       compo.updateComponent(oldUID, newUID);

--- a/packages/core/content-type-builder/server/services/content-types.js
+++ b/packages/core/content-type-builder/server/services/content-types.js
@@ -141,7 +141,7 @@ const generateAPI = ({ singularName, kind = 'collectionType', pluralName, displa
       bootstrapApi: true,
       attributes: [],
     },
-    { dir: strapi.dirs.root }
+    { dir: strapi.dirs.app.root }
   );
 };
 

--- a/packages/core/content-type-builder/server/services/schema-builder/component-builder.js
+++ b/packages/core/content-type-builder/server/services/schema-builder/component-builder.js
@@ -39,7 +39,7 @@ module.exports = function createComponentBuilder() {
       }
 
       const handler = createSchemaHandler({
-        dir: path.join(strapi.dirs.components, nameToSlug(infos.category)),
+        dir: path.join(strapi.dirs.app.components, nameToSlug(infos.category)),
         filename: `${nameToSlug(infos.displayName)}.json`,
       });
 
@@ -88,7 +88,7 @@ module.exports = function createComponentBuilder() {
         throw new ApplicationError('component.edit.alreadyExists');
       }
 
-      const newDir = path.join(strapi.dirs.components, newCategory);
+      const newDir = path.join(strapi.dirs.app.components, newCategory);
 
       const oldAttributes = component.schema.attributes;
 

--- a/packages/core/content-type-builder/server/services/schema-builder/content-type-builder.js
+++ b/packages/core/content-type-builder/server/services/schema-builder/content-type-builder.js
@@ -79,7 +79,12 @@ module.exports = function createComponentBuilder() {
 
       const contentType = createSchemaHandler({
         modelName: infos.singularName,
-        dir: path.join(strapi.dirs.api, infos.singularName, 'content-types', infos.singularName),
+        dir: path.join(
+          strapi.dirs.app.api,
+          infos.singularName,
+          'content-types',
+          infos.singularName
+        ),
         filename: `schema.json`,
       });
 

--- a/packages/core/content-type-builder/server/services/schema-builder/index.js
+++ b/packages/core/content-type-builder/server/services/schema-builder/index.js
@@ -23,7 +23,7 @@ module.exports = function createBuilder() {
       plugin: compo.modelName,
       uid: compo.uid,
       filename: compo.__filename__,
-      dir: join(strapi.dirs.components, compo.category),
+      dir: join(strapi.dirs.app.components, compo.category),
       schema: compo.__schema__,
     };
   });
@@ -33,12 +33,17 @@ module.exports = function createBuilder() {
 
     const dir = contentType.plugin
       ? join(
-          strapi.dirs.extensions,
+          strapi.dirs.app.extensions,
           contentType.plugin,
           'content-types',
           contentType.info.singularName
         )
-      : join(strapi.dirs.api, contentType.apiName, 'content-types', contentType.info.singularName);
+      : join(
+          strapi.dirs.app.api,
+          contentType.apiName,
+          'content-types',
+          contentType.info.singularName
+        );
 
     return {
       modelName: contentType.modelName,
@@ -182,9 +187,10 @@ function createSchemaBuilder({ components, contentTypes }) {
      */
     rollback() {
       return Promise.all(
-        [...Array.from(tmpComponents.values()), ...Array.from(tmpContentTypes.values())].map(
-          schema => schema.rollback()
-        )
+        [
+          ...Array.from(tmpComponents.values()),
+          ...Array.from(tmpContentTypes.values()),
+        ].map(schema => schema.rollback())
       );
     },
   };

--- a/packages/core/database/lib/migrations/index.js
+++ b/packages/core/database/lib/migrations/index.js
@@ -23,7 +23,7 @@ const migrationResolver = path => {
 };
 
 const createUmzugProvider = db => {
-  const migrationDir = path.join(strapi.dirs.root, 'database/migrations');
+  const migrationDir = path.join(strapi.dirs.app.root, 'database/migrations');
 
   fse.ensureDirSync(migrationDir);
 

--- a/packages/core/strapi/lib/Strapi.js
+++ b/packages/core/strapi/lib/Strapi.js
@@ -51,8 +51,11 @@ const LIFECYCLES = {
 class Strapi {
   constructor(opts = {}) {
     destroyOnSignal(this);
-    this.dirs = utils.getDirs(opts.dir ? path.resolve(process.cwd(), opts.dir) : process.cwd());
-    const appConfig = loadConfiguration(this.dirs.root, opts);
+    this.dirs = utils.getDirs({
+      appDir: process.cwd(),
+      distDir: opts.dir ? path.resolve(process.cwd(), opts.dir) : process.cwd(),
+    });
+    const appConfig = loadConfiguration(this.dirs.dist.root, opts);
     this.container = createContainer(this);
     this.container.register('config', createConfigProvider(appConfig));
     this.container.register('content-types', contentTypesRegistry(this));
@@ -85,7 +88,7 @@ class Strapi {
   }
 
   get EE() {
-    return ee({ dir: this.dirs.root, logger: this.log });
+    return ee({ dir: this.dirs.dist.root, logger: this.log });
   }
 
   get services() {

--- a/packages/core/strapi/lib/Strapi.js
+++ b/packages/core/strapi/lib/Strapi.js
@@ -48,15 +48,40 @@ const LIFECYCLES = {
   DESTROY: 'destroy',
 };
 
+/**
+ * Resolve the working directories based on the instance options.
+ *
+ * Behavior:
+ * - `appDir` is the directory where Strapi will write every file (schemas, generated APIs, controllers or services)
+ * - `distDir` is the directory where Strapi will read configurations, schemas and any compiled code
+ *
+ * Default values:
+ * - If `appDir` is `undefined`, it'll be set to `process.cwd()`
+ * - If `distDir` is `undefined`, it'll be set to `appDir`
+ */
+const resolveWorkingDirectories = opts => {
+  const cwd = process.cwd();
+
+  const appDir = opts.appDir ? path.resolve(cwd, opts.appDir) : cwd;
+  const distDir = opts.distDir ? path.resolve(cwd, opts.distDir) : appDir;
+
+  return { appDir, distDir };
+};
+
 class Strapi {
   constructor(opts = {}) {
     destroyOnSignal(this);
-    this.dirs = utils.getDirs({
-      appDir: process.cwd(),
-      distDir: opts.dir ? path.resolve(process.cwd(), opts.dir) : process.cwd(),
-    });
+
+    // Create a mapping of every useful directory (both for the app and dist directories)
+    this.dirs = utils.getDirs(resolveWorkingDirectories(opts));
+
+    // Load the app configuration from the dist directory
     const appConfig = loadConfiguration(this.dirs.dist.root, opts);
+
+    // Instanciate the Strapi container
     this.container = createContainer(this);
+
+    // Register every Strapi registry in the container
     this.container.register('config', createConfigProvider(appConfig));
     this.container.register('content-types', contentTypesRegistry(this));
     this.container.register('services', servicesRegistry(this));
@@ -69,10 +94,14 @@ class Strapi {
     this.container.register('apis', apisRegistry(this));
     this.container.register('auth', createAuth(this));
 
+    // Strapi state management variables
     this.isLoaded = false;
     this.reload = this.reload();
+
+    // Instanciate the Koa app & the HTTP server
     this.server = createServer(this);
 
+    // Strapi utils instanciation
     this.fs = createStrapiFs(this);
     this.eventHub = createEventHub();
     this.startupLogger = createStartupLogger(this);

--- a/packages/core/strapi/lib/commands/builders/admin.js
+++ b/packages/core/strapi/lib/commands/builders/admin.js
@@ -13,7 +13,7 @@ const getEnabledPlugins = require('../../core/loaders/plugins/get-enabled-plugin
 module.exports = async ({ buildDestDir, forceBuild = true, isTSProject, optimization, srcDir }) => {
   const strapiInstance = strapi({
     // TODO check if this is working @convly
-    dir: buildDestDir,
+    distDir: buildDestDir,
     autoReload: true,
     serveAdminPanel: false,
   });

--- a/packages/core/strapi/lib/commands/start.js
+++ b/packages/core/strapi/lib/commands/start.js
@@ -5,4 +5,4 @@ const strapi = require('../index');
 /**
  * `$ strapi start`
  */
-module.exports = dir => strapi({ dir }).start();
+module.exports = distDir => strapi({ distDir }).start();

--- a/packages/core/strapi/lib/commands/watchAdmin.js
+++ b/packages/core/strapi/lib/commands/watchAdmin.js
@@ -16,7 +16,7 @@ module.exports = async function({ browser }) {
   const buildDestDir = isTSProject ? path.join(currentDirectory, 'dist') : currentDirectory;
 
   const strapiInstance = strapi({
-    dir: buildDestDir,
+    distDir: buildDestDir,
     autoReload: true,
     serveAdminPanel: false,
   });

--- a/packages/core/strapi/lib/core/loaders/apis.js
+++ b/packages/core/strapi/lib/core/loaders/apis.js
@@ -18,18 +18,18 @@ const DEFAULT_CONTENT_TYPE = {
 };
 
 module.exports = async strapi => {
-  if (!existsSync(strapi.dirs.api)) {
+  if (!existsSync(strapi.dirs.dist.api)) {
     return;
   }
 
-  const apisFDs = await fse.readdir(strapi.dirs.api, { withFileTypes: true });
+  const apisFDs = await fse.readdir(strapi.dirs.dist.api, { withFileTypes: true });
   const apis = {};
 
   // only load folders
   for (const apiFD of apisFDs) {
     if (apiFD.isDirectory()) {
       const apiName = normalizeName(apiFD.name);
-      const api = await loadAPI(join(strapi.dirs.api, apiFD.name));
+      const api = await loadAPI(join(strapi.dirs.dist.api, apiFD.name));
 
       apis[apiName] = api;
     }

--- a/packages/core/strapi/lib/core/loaders/components.js
+++ b/packages/core/strapi/lib/core/loaders/components.js
@@ -6,19 +6,20 @@ const { pathExists } = require('fs-extra');
 const loadFiles = require('../../load/load-files');
 
 module.exports = async strapi => {
-  if (!(await pathExists(strapi.dirs.components))) {
+  if (!(await pathExists(strapi.dirs.dist.components))) {
     return {};
   }
 
-  const map = await loadFiles(strapi.dirs.components, '*/*.*(js|json)');
+  const map = await loadFiles(strapi.dirs.dist.components, '*/*.*(js|json)');
 
   return Object.keys(map).reduce((acc, category) => {
     Object.keys(map[category]).forEach(key => {
       const schema = map[category][key];
 
-      const filePath = join(strapi.dirs.components, category, schema.__filename__);
-
       if (!schema.collectionName) {
+        // NOTE: We're using the filepath from the app directory instead of the dist for information purpose
+        const filePath = join(strapi.dirs.app.components, category, schema.__filename__);
+
         return strapi.stopWithError(
           `Component ${key} is missing a "collectionName" property.\nVerify file ${filePath}.`
         );

--- a/packages/core/strapi/lib/core/loaders/middlewares.js
+++ b/packages/core/strapi/lib/core/loaders/middlewares.js
@@ -13,7 +13,7 @@ module.exports = async function loadMiddlewares(strapi) {
 };
 
 const loadLocalMiddlewares = async strapi => {
-  const dir = strapi.dirs.middlewares;
+  const dir = strapi.dirs.dist.middlewares;
 
   if (!(await fse.pathExists(dir))) {
     return {};

--- a/packages/core/strapi/lib/core/loaders/plugins/get-enabled-plugins.js
+++ b/packages/core/strapi/lib/core/loaders/plugins/get-enabled-plugins.js
@@ -29,10 +29,15 @@ const toDetailedDeclaration = declaration => {
   let detailedDeclaration = pick(['enabled'], declaration);
   if (has('resolve', declaration)) {
     let pathToPlugin = '';
+    let appPathToPlugin = '';
+
     try {
       pathToPlugin = dirname(require.resolve(declaration.resolve));
+      appPathToPlugin = pathToPlugin;
     } catch (e) {
-      pathToPlugin = resolve(strapi.dirs.root, declaration.resolve);
+      // FIXME: It'll break for resolve paths that are located outside the project files
+      pathToPlugin = resolve(strapi.dirs.dist.root, declaration.resolve);
+      appPathToPlugin = resolve(strapi.dirs.app.root, declaration.resolve);
 
       if (!existsSync(pathToPlugin) || !statSync(pathToPlugin).isDirectory()) {
         throw new Error(`${declaration.resolve} couldn't be resolved`);
@@ -40,6 +45,7 @@ const toDetailedDeclaration = declaration => {
     }
 
     detailedDeclaration.pathToPlugin = pathToPlugin;
+    detailedDeclaration.appPathToPlugin = appPathToPlugin;
   }
   return detailedDeclaration;
 };

--- a/packages/core/strapi/lib/core/loaders/plugins/get-user-plugins-config.js
+++ b/packages/core/strapi/lib/core/loaders/plugins/get-user-plugins-config.js
@@ -12,9 +12,9 @@ const loadConfigFile = require('../../app-configuration/load-config-file');
  * @return {Promise<{}>}
  */
 const getUserPluginsConfig = async () => {
-  const globalUserConfigPath = join(strapi.dirs.config, 'plugins.js');
+  const globalUserConfigPath = join(strapi.dirs.dist.config, 'plugins.js');
   const currentEnvUserConfigPath = join(
-    strapi.dirs.config,
+    strapi.dirs.dist.config,
     'env',
     process.env.NODE_ENV,
     'plugins.js'

--- a/packages/core/strapi/lib/core/loaders/plugins/index.js
+++ b/packages/core/strapi/lib/core/loaders/plugins/index.js
@@ -26,7 +26,7 @@ const defaultPlugin = {
 };
 
 const applyUserExtension = async plugins => {
-  const extensionsDir = strapi.dirs.extensions;
+  const extensionsDir = strapi.dirs.dist.extensions;
   if (!(await fse.pathExists(extensionsDir))) {
     return;
   }

--- a/packages/core/strapi/lib/core/loaders/policies.js
+++ b/packages/core/strapi/lib/core/loaders/policies.js
@@ -5,7 +5,7 @@ const fse = require('fs-extra');
 
 // TODO:: allow folders with index.js inside for bigger policies
 module.exports = async function loadPolicies(strapi) {
-  const dir = strapi.dirs.policies;
+  const dir = strapi.dirs.dist.policies;
 
   if (!(await fse.pathExists(dir))) {
     return;

--- a/packages/core/strapi/lib/core/loaders/src-index.js
+++ b/packages/core/strapi/lib/core/loaders/src-index.js
@@ -18,11 +18,11 @@ const validateSrcIndex = srcIndex => {
 };
 
 module.exports = strapi => {
-  if (!existsSync(strapi.dirs.src)) {
+  if (!existsSync(strapi.dirs.dist.src)) {
     return;
   }
 
-  const pathToSrcIndex = resolve(strapi.dirs.src, 'index.js');
+  const pathToSrcIndex = resolve(strapi.dirs.dist.src, 'index.js');
   if (!existsSync(pathToSrcIndex) || statSync(pathToSrcIndex).isDirectory()) {
     return {};
   }

--- a/packages/core/strapi/lib/middlewares/favicon.js
+++ b/packages/core/strapi/lib/middlewares/favicon.js
@@ -15,5 +15,5 @@ const defaults = {
 module.exports = (config, { strapi }) => {
   const { maxAge, path: faviconPath } = defaultsDeep(defaults, config);
 
-  return favicon(resolve(strapi.dirs.root, faviconPath), { maxAge });
+  return favicon(resolve(strapi.dirs.app.root, faviconPath), { maxAge });
 };

--- a/packages/core/strapi/lib/middlewares/public/index.js
+++ b/packages/core/strapi/lib/middlewares/public/index.js
@@ -71,6 +71,7 @@ module.exports = (config, { strapi }) => {
       {
         method: 'GET',
         path: '/assets/images/(.*)',
+        // Why do we use the __dirname and not strapi.dirs here? @alexandrebodin
         handler: serveStatic(path.resolve(__dirname, 'assets/images'), {
           maxage: maxAge,
           defer: true,
@@ -80,7 +81,7 @@ module.exports = (config, { strapi }) => {
       {
         method: 'GET',
         path: '/(.*)',
-        handler: koaStatic(strapi.dirs.public, {
+        handler: koaStatic(strapi.dirs.app.public, {
           maxage: maxAge,
           defer: true,
         }),

--- a/packages/core/strapi/lib/services/__tests__/fs.test.js
+++ b/packages/core/strapi/lib/services/__tests__/fs.test.js
@@ -11,7 +11,7 @@ const fs = require('../fs');
 
 describe('Strapi fs utils', () => {
   const strapi = {
-    dirs: { root: '/tmp' },
+    dirs: { dist: { root: '/tmp' }, app: { root: '/tmp' } },
   };
 
   test('Provides new functions', () => {

--- a/packages/core/strapi/lib/services/fs.js
+++ b/packages/core/strapi/lib/services/fs.js
@@ -12,7 +12,7 @@ module.exports = strapi => {
 
     const normalizedPath = path.normalize(filePath).replace(/^\/?(\.\/|\.\.\/)+/, '');
 
-    return path.resolve(strapi.dirs.root, normalizedPath);
+    return path.resolve(strapi.dirs.app.root, normalizedPath);
   }
 
   const strapiFS = {

--- a/packages/core/strapi/lib/services/metrics/index.js
+++ b/packages/core/strapi/lib/services/metrics/index.js
@@ -90,7 +90,7 @@ const hashProject = strapi =>
 
 const hashDep = strapi => {
   const depStr = JSON.stringify(strapi.config.info.dependencies);
-  const readmePath = path.join(strapi.dirs.root, 'README.md');
+  const readmePath = path.join(strapi.dirs.app.root, 'README.md');
 
   try {
     if (fs.existsSync(readmePath)) {

--- a/packages/core/strapi/lib/services/server/middleware.js
+++ b/packages/core/strapi/lib/services/server/middleware.js
@@ -112,7 +112,7 @@ const resolveCustomMiddleware = (resolve, strapi) => {
     modulePath = require.resolve(resolve);
   } catch (error) {
     if (error.code === 'MODULE_NOT_FOUND') {
-      modulePath = path.resolve(strapi.dirs.root, resolve);
+      modulePath = path.resolve(strapi.dirs.dist.root, resolve);
     } else {
       throw error;
     }

--- a/packages/core/strapi/lib/utils/get-dirs.js
+++ b/packages/core/strapi/lib/utils/get-dirs.js
@@ -2,16 +2,29 @@
 
 const { join } = require('path');
 
-const getDirs = root => ({
-  root,
-  src: join(root, 'src'),
-  api: join(root, 'src', 'api'),
-  components: join(root, 'src', 'components'),
-  extensions: join(root, 'src', 'extensions'),
-  policies: join(root, 'src', 'policies'),
-  middlewares: join(root, 'src', 'middlewares'),
-  config: join(root, 'config'),
-  public: join(root, 'public'),
+const getDirs = ({ appDir, distDir }) => ({
+  dist: {
+    root: distDir,
+    src: join(distDir, 'src'),
+    api: join(distDir, 'src', 'api'),
+    components: join(distDir, 'src', 'components'),
+    extensions: join(distDir, 'src', 'extensions'),
+    policies: join(distDir, 'src', 'policies'),
+    middlewares: join(distDir, 'src', 'middlewares'),
+    config: join(distDir, 'config'),
+    public: join(distDir, 'public'),
+  },
+  app: {
+    root: appDir,
+    src: join(appDir, 'src'),
+    api: join(appDir, 'src', 'api'),
+    components: join(appDir, 'src', 'components'),
+    extensions: join(appDir, 'src', 'extensions'),
+    policies: join(appDir, 'src', 'policies'),
+    middlewares: join(appDir, 'src', 'middlewares'),
+    config: join(appDir, 'config'),
+    public: join(appDir, 'public'),
+  },
 });
 
 module.exports = getDirs;

--- a/packages/core/strapi/lib/utils/update-notifier/index.js
+++ b/packages/core/strapi/lib/utils/update-notifier/index.js
@@ -38,7 +38,7 @@ const createUpdateNotifier = strapi => {
     config = new Configstore(
       pkg.name,
       {},
-      { configPath: path.join(strapi.dirs.root, '.strapi-updater.json') }
+      { configPath: path.join(strapi.dirs.app.root, '.strapi-updater.json') }
     );
   } catch {
     // we don't have write access to the file system

--- a/packages/core/upload/server/__tests__/bootstrap.test.js
+++ b/packages/core/upload/server/__tests__/bootstrap.test.js
@@ -8,7 +8,7 @@ describe('Upload plugin bootstrap function', () => {
     const registerMany = jest.fn(() => {});
 
     global.strapi = {
-      dirs: { root: process.cwd() },
+      dirs: { dist: { root: process.cwd() }, app: { root: process.cwd() } },
       admin: {
         services: { permission: { actionProvider: { registerMany } } },
       },

--- a/packages/core/upload/server/middlewares/upload.js
+++ b/packages/core/upload/server/middlewares/upload.js
@@ -25,7 +25,7 @@ module.exports = ({ strapi }) => {
     {
       method: 'GET',
       path: '/uploads/(.*)',
-      handler: [range, koaStatic(strapi.dirs.public, { defer: true, ...localServerConfig })],
+      handler: [range, koaStatic(strapi.dirs.app.public, { defer: true, ...localServerConfig })],
       config: { auth: false },
     },
   ]);

--- a/packages/plugins/documentation/server/controllers/documentation.js
+++ b/packages/plugins/documentation/server/controllers/documentation.js
@@ -49,7 +49,7 @@ module.exports = {
               .getDocumentationVersion();
 
       const openAPISpecsPath = path.join(
-        strapi.dirs.extensions,
+        strapi.dirs.dist.extensions,
         'documentation',
         'documentation',
         version,
@@ -69,7 +69,7 @@ module.exports = {
 
         try {
           const layoutPath = path.resolve(
-            strapi.dirs.extensions,
+            strapi.dirs.app.extensions,
             'documentation',
             'public',
             'index.html'
@@ -81,7 +81,11 @@ module.exports = {
           ctx.url = path.basename(`${ctx.url}/index.html`);
 
           try {
-            const staticFolder = path.resolve(strapi.dirs.extensions, 'documentation', 'public');
+            const staticFolder = path.resolve(
+              strapi.dirs.dist.extensions,
+              'documentation',
+              'public'
+            );
             return koaStatic(staticFolder)(ctx, next);
           } catch (e) {
             strapi.log.error(e);
@@ -116,7 +120,7 @@ module.exports = {
 
       try {
         const layoutPath = path.resolve(
-          strapi.dirs.extensions,
+          strapi.dirs.dist.extensions,
           'documentation',
           'public',
           'login.html'
@@ -127,7 +131,7 @@ module.exports = {
         ctx.url = path.basename(`${ctx.url}/login.html`);
 
         try {
-          const staticFolder = path.resolve(strapi.dirs.extensions, 'documentation', 'public');
+          const staticFolder = path.resolve(strapi.dirs.dist.extensions, 'documentation', 'public');
           return koaStatic(staticFolder)(ctx, next);
         } catch (e) {
           strapi.log.error(e);

--- a/packages/plugins/documentation/server/services/documentation.js
+++ b/packages/plugins/documentation/server/services/documentation.js
@@ -17,11 +17,12 @@ module.exports = ({ strapi }) => {
     },
 
     getFullDocumentationPath() {
-      return path.join(strapi.dirs.extensions, 'documentation', 'documentation');
+      return path.join(strapi.dirs.app.extensions, 'documentation', 'documentation');
     },
 
     getCustomDocumentationPath() {
-      return path.join(strapi.dirs.extensions, 'documentation', 'config', 'settings.json');
+      // ??
+      return path.join(strapi.dirs.app.extensions, 'documentation', 'config', 'settings.json');
     },
 
     getDocumentationVersions() {
@@ -71,10 +72,10 @@ module.exports = ({ strapi }) => {
      */
     getApiDocumentationPath(api) {
       if (api.getter === 'plugin') {
-        return path.join(strapi.dirs.extensions, api.name, 'documentation');
+        return path.join(strapi.dirs.app.extensions, api.name, 'documentation');
       }
 
-      return path.join(strapi.dirs.api, api.name, 'documentation');
+      return path.join(strapi.dirs.app.api, api.name, 'documentation');
     },
 
     async deleteDocumentation(version) {

--- a/packages/providers/upload-local/lib/index.js
+++ b/packages/providers/upload-local/lib/index.js
@@ -18,7 +18,7 @@ module.exports = {
       }
     };
 
-    const publicDir = strapi.dirs.public;
+    const publicDir = strapi.dirs.app.public;
 
     return {
       uploadStream(file) {

--- a/test/helpers/strapi.js
+++ b/test/helpers/strapi.js
@@ -24,7 +24,10 @@ const createStrapiInstance = async ({
 } = {}) => {
   // read .env file as it could have been updated
   dotenv.config({ path: process.env.ENV_PATH });
-  const options = { dir: TEST_APP_URL };
+  const options = {
+    appDir: TEST_APP_URL,
+    distDir: TEST_APP_URL,
+  };
   const instance = strapi(options);
 
   if (bypassAuth) {


### PR DESCRIPTION
### What does it do?

adds two namespaces for sub directories (API, components, etc...): `app` and `dist`

### Why is it needed?

We need a way to make a distinction between app files (where we want to write files) and dist files (where we want to output/read files)
