### PR TITLE
Dark mode/fix relation select fg color

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/SelectWrapper/utils/getSelectStyles.js
+++ b/packages/core/admin/admin/src/content-manager/components/SelectWrapper/utils/getSelectStyles.js
@@ -78,7 +78,7 @@ const getSelectStyles = theme => {
       return { ...base, lineHeight: theme.spaces[5], backgroundColor, borderRadius: 4 };
     },
     placeholder: base => ({ ...base, marginLeft: 0 }),
-    singleValue: base => ({ ...base, marginLeft: 0 }),
+    singleValue: base => ({ ...base, marginLeft: 0, color: theme.colors.neutral800 }),
     valueContainer: base => ({
       ...base,
       padding: 0,

--- a/packages/core/admin/admin/src/content-manager/components/SelectWrapper/utils/getSelectStyles.js
+++ b/packages/core/admin/admin/src/content-manager/components/SelectWrapper/utils/getSelectStyles.js
@@ -50,6 +50,7 @@ const getSelectStyles = theme => {
         width: '100%',
         marginTop: theme.spaces[1],
         backgroundColor: theme.colors.neutral0,
+        color: theme.colors.neutral800,
         borderRadius: '4px !important',
         borderTopLeftRadius: '4px !important',
         borderTopRightRadius: '4px !important',


### PR DESCRIPTION
### What does it do?

Fixes the relation select in CM

Before
![image](https://user-images.githubusercontent.com/89356961/158357655-c8df7f24-0ce6-47d0-be42-fd52fe06b863.png)
After
![image](https://user-images.githubusercontent.com/89356961/158360163-5de6ccb4-be75-4a54-acb9-4d66891862f2.png)

