### PR TITLE
fix(create-strapi-app): disable the quickstart question because != 'undefined'

### DIFF
--- a/packages/cli/create-strapi-app/utils/prompt-user.js
+++ b/packages/cli/create-strapi-app/utils/prompt-user.js
@@ -30,7 +30,7 @@ async function getPromptQuestions(projectName, program) {
       type: 'list',
       name: 'quick',
       message: 'Choose your installation type',
-      when: !program.quickstart,
+      when: typeof program.quickstart === 'undefined',
       choices: [
         {
           name: 'Quickstart (recommended)',


### PR DESCRIPTION
### What does it do?

Skip quickstart question when DB configs is defined.

Eg: `npx create-strapi-app@latest --dbclient=sqlite --dbfile=./test.db .`

### Why is it needed?

Support create strapi app just by shell/bat cmd (necessary for docker)

### How to test it?

Nothing for test

### Related issue(s)/PR(s)

There is no issue/pull request is related to