### PR TITLE
Fix #12865 displayErrors not working on singleType

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/SingleTypeFormWrapper/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/SingleTypeFormWrapper/index.js
@@ -143,10 +143,10 @@ const SingleTypeFormWrapper = ({ allLayoutData, children, slug }) => {
 
   const displayErrors = useCallback(
     err => {
-      const errorPayload = err.response.payload;
+      const errorPayload = err.response.data;
       console.error(errorPayload);
 
-      let errorMessage = get(errorPayload, ['message'], 'Bad Request');
+      let errorMessage = get(errorPayload, ['error', 'message'], 'Bad Request');
 
       // TODO handle errors correctly when back-end ready
       if (Array.isArray(errorMessage)) {


### PR DESCRIPTION
### What does it do?

Update the displayErrors function to obtain the errorPayload from `err.response.data` instead of `err.response.payload` as this property doesn't exists. It should have been part of [this change](195fa88), that's why it only works when using a `collection-type`.

### Why is it needed?

To be able to display custom error messages after save/submit a `single-type` form at strapi admin.

### How to test it?

1. Add this file at `src/extensions/content-manager/strapi-server.js` and start the server:
```
"use strict";
const { ForbiddenError } = require("@strapi/utils").errors;

module.exports = (plugin) => {
    const singleTypeController = plugin.controllers["single-types"];

    singleTypeController.createOrUpdate = function (ctx) {
        throw new ForbiddenError("Custom error");
    };

    return plugin;
};
```
2. If you don't have a single type created, go to **Content-Type Builder** and create a new single type.
3. Go to **Content Manager**
4. Click on any `Single Type` you have
5. Make any change and save it.
6. It should display this message:
<img width="443" alt="image" src="https://user-images.githubusercontent.com/17036072/158680418-fc07d8ee-49b9-489d-8447-5a28c0a32078.png">

### Related issue(s)/PR(s)

#12865