### PR TITLE
EditAssetDialog: Use original image as source for cropping

### DIFF
--- a/packages/core/upload/admin/src/components/EditAssetDialog/PreviewBox/AssetPreview.js
+++ b/packages/core/upload/admin/src/components/EditAssetDialog/PreviewBox/AssetPreview.js
@@ -13,16 +13,16 @@ const CardAsset = styled(Flex)`
   background: linear-gradient(180deg, #ffffff 0%, #f6f6f9 121.48%);
 `;
 
-export const AssetPreview = forwardRef(({ mime, url, name }, ref) => {
+export const AssetPreview = forwardRef(({ mime, url, name, ...props }, ref) => {
   const [lang] = usePersistentState('strapi-admin-language', 'en');
 
   if (mime.includes(AssetType.Image)) {
-    return <img ref={ref} src={url} alt={name} />;
+    return <img ref={ref} src={url} alt={name} {...props} />;
   }
 
   if (mime.includes(AssetType.Video)) {
     return (
-      <video controls src={url} ref={ref}>
+      <video controls src={url} ref={ref} {...props}>
         <track label={name} default kind="captions" srcLang={lang} src="" />
       </video>
     );
@@ -30,7 +30,7 @@ export const AssetPreview = forwardRef(({ mime, url, name }, ref) => {
 
   if (mime.includes(AssetType.Audio)) {
     return (
-      <audio controls src={url} ref={ref}>
+      <audio controls src={url} ref={ref} {...props}>
         {name}
       </audio>
     );
@@ -38,14 +38,14 @@ export const AssetPreview = forwardRef(({ mime, url, name }, ref) => {
 
   if (mime.includes('pdf')) {
     return (
-      <CardAsset justifyContent="center">
+      <CardAsset justifyContent="center" {...props}>
         <FilePdfIcon aria-label={name} />
       </CardAsset>
     );
   }
 
   return (
-    <CardAsset justifyContent="center">
+    <CardAsset justifyContent="center" {...props}>
       <FileIcon aria-label={name} />
     </CardAsset>
   );

--- a/packages/core/upload/admin/src/components/EditAssetDialog/PreviewBox/index.js
+++ b/packages/core/upload/admin/src/components/EditAssetDialog/PreviewBox/index.js
@@ -41,6 +41,8 @@ export const PreviewBox = ({
 }) => {
   const { trackUsage } = useTracking();
   const previewRef = useRef(null);
+  const [cropImageReady, setCropImageReady] = useState(false);
+  const [cropIntent, setCropIntent] = useState(false);
   const [assetUrl, setAssetUrl] = useState(createAssetUrl(asset, false));
   const [thumbnailUrl, setThumbnailUrl] = useState(createAssetUrl(asset, true));
   const { formatMessage } = useIntl();
@@ -123,14 +125,22 @@ export const PreviewBox = ({
   };
 
   const handleCropCancel = () => {
+    setCropIntent(false);
+    setCropImageReady(false);
     stopCropping();
     onCropCancel();
   };
 
   const handleCropStart = () => {
-    crop(previewRef.current);
-    onCropStart();
+    setCropIntent(true);
   };
+
+  useEffect(() => {
+    if (cropIntent && cropImageReady) {
+      crop(previewRef.current);
+      onCropStart();
+    }
+  }, [cropImageReady, cropIntent, onCropStart, crop]);
 
   return (
     <>
@@ -198,7 +208,17 @@ export const PreviewBox = ({
             </UploadProgressWrapper>
           )}
 
-          <AssetPreview ref={previewRef} mime={asset.mime} name={asset.name} url={thumbnailUrl} />
+          <AssetPreview
+            ref={previewRef}
+            mime={asset.mime}
+            name={asset.name}
+            url={cropIntent ? assetUrl : thumbnailUrl}
+            onLoad={() => {
+              if (cropIntent) {
+                setCropImageReady(true);
+              }
+            }}
+          />
         </Wrapper>
 
         <ActionRow

--- a/packages/core/upload/admin/src/components/EditAssetDialog/PreviewBox/index.js
+++ b/packages/core/upload/admin/src/components/EditAssetDialog/PreviewBox/index.js
@@ -41,8 +41,8 @@ export const PreviewBox = ({
 }) => {
   const { trackUsage } = useTracking();
   const previewRef = useRef(null);
-  const [cropImageReady, setCropImageReady] = useState(false);
-  const [cropIntent, setCropIntent] = useState(false);
+  const [isCropImageReady, setIsCropImageReady] = useState(false);
+  const [hasCropIntent, setHasCropIntent] = useState(false);
   const [assetUrl, setAssetUrl] = useState(createAssetUrl(asset, false));
   const [thumbnailUrl, setThumbnailUrl] = useState(createAssetUrl(asset, true));
   const { formatMessage } = useIntl();
@@ -125,22 +125,22 @@ export const PreviewBox = ({
   };
 
   const handleCropCancel = () => {
-    setCropIntent(false);
-    setCropImageReady(false);
+    setHasCropIntent(false);
+    setIsCropImageReady(false);
     stopCropping();
     onCropCancel();
   };
 
   const handleCropStart = () => {
-    setCropIntent(true);
+    setHasCropIntent(true);
   };
 
   useEffect(() => {
-    if (cropIntent && cropImageReady) {
+    if (hasCropIntent && isCropImageReady) {
       crop(previewRef.current);
       onCropStart();
     }
-  }, [cropImageReady, cropIntent, onCropStart, crop]);
+  }, [isCropImageReady, hasCropIntent, onCropStart, crop]);
 
   return (
     <>
@@ -212,10 +212,10 @@ export const PreviewBox = ({
             ref={previewRef}
             mime={asset.mime}
             name={asset.name}
-            url={cropIntent ? assetUrl : thumbnailUrl}
+            url={hasCropIntent ? assetUrl : thumbnailUrl}
             onLoad={() => {
-              if (cropIntent) {
-                setCropImageReady(true);
+              if (hasCropIntent) {
+                setIsCropImageReady(true);
               }
             }}
           />


### PR DESCRIPTION
### What does it do?

Since v4 only thumbnail images are loaded in the media library. However, this broke cropping images, because the crop would operate on the thumbnail image, instead of the original one, which leads to tiny images.

With this PR, we start cropping the original image again.

### Why is it needed?

To make the crop function work.

### How to test it?

1. Go to the media library
2. Upload an image
3. Edit the image and crop it (make the crop cover the full area or the original image)
4. Check the file-size of the generated image; it should be similar to the original one

### Related issue(s)/PR(s)

- Fixes https://github.com/strapi/strapi/issues/12568
- Refs https://github.com/strapi/strapi/issues/12599
