### PR TITLE
Add footer to DynamicTable component

### DIFF
--- a/packages/core/helper-plugin/lib/src/components/DynamicTable/DynamicTable.stories.mdx
+++ b/packages/core/helper-plugin/lib/src/components/DynamicTable/DynamicTable.stories.mdx
@@ -8,7 +8,7 @@ import { Box } from '@strapi/design-system/Box';
 import { Flex } from '@strapi/design-system/Flex';
 import { BaseCheckbox } from '@strapi/design-system/BaseCheckbox';
 import { Dialog, DialogBody, DialogFooter } from '@strapi/design-system/Dialog';
-import { Tbody, Td, Tr } from '@strapi/design-system/Table';
+import { Tbody, Td, Tr, TFooter } from '@strapi/design-system/Table';
 import { Typography } from '@strapi/design-system/Typography';
 import { IconButton } from '@strapi/design-system/IconButton';
 import { Plus, Pencil, Trash } from '@strapi/icons';
@@ -86,6 +86,43 @@ import { DynamicTable } from '@strapi/helper-plugin';
         <Main>
           <Box paddingTop={6}>
             <DynamicTable headers={headers} contentType="users" />
+          </Box>
+        </Main>
+      );
+    }}
+  </Story>
+</Canvas>
+
+## Usage No content with footer
+
+<Canvas>
+  <Story name="no-content-with-footer">
+    {() => {
+      const headers = [
+        {
+          name: 'firstname',
+          metadatas: { label: 'Firstname', sortable: false },
+          key: '__firstname_key__',
+        },
+        {
+          name: 'lastname',
+          metadatas: { label: 'Email', sortable: false },
+          key: '__lastname_key__',
+        },
+        {
+          name: 'email',
+          metadatas: { label: 'Email', sortable: false },
+          key: '__email_key__',
+        },
+      ];
+      const [{ query }, setQuery] = useQueryParams();
+      useEffect(() => {
+        setQuery({ filters: { $and: [{ firstname: { $eq: 'soupette' } }] } });
+      }, []);
+      return (
+        <Main>
+          <Box paddingTop={6}>
+            <DynamicTable headers={headers} contentType="users" footer={<TFooter icon={<Plus />}>Add another user</TFooter>}/>
           </Box>
         </Main>
       );

--- a/packages/core/helper-plugin/lib/src/components/DynamicTable/index.js
+++ b/packages/core/helper-plugin/lib/src/components/DynamicTable/index.js
@@ -23,10 +23,11 @@ const BlockActions = styled(Flex)`
 `;
 
 const Table = ({
+  action,
   children,
   contentType,
   components,
-  action,
+  footer,
   headers,
   isLoading,
   onConfirmDeleteAll,
@@ -159,7 +160,7 @@ const Table = ({
           </Box>
         </Box>
       )}
-      <TableCompo colCount={COL_COUNT} rowCount={ROW_COUNT}>
+      <TableCompo colCount={COL_COUNT} rowCount={ROW_COUNT} footer={footer}>
         <TableHead
           areAllEntriesSelected={areAllEntriesSelected}
           entriesToDelete={entriesToDelete}
@@ -207,12 +208,13 @@ const Table = ({
 };
 
 Table.defaultProps = {
+  action: undefined,
   children: undefined,
   components: {
     ConfirmDialogDeleteAll: undefined,
     ConfirmDialogDelete: undefined,
   },
-  action: undefined,
+  footer: undefined,
   headers: [],
   isLoading: false,
   onConfirmDeleteAll: () => {},
@@ -224,13 +226,14 @@ Table.defaultProps = {
 };
 
 Table.propTypes = {
+  action: PropTypes.node,
   children: PropTypes.node,
   contentType: PropTypes.string.isRequired,
   components: PropTypes.shape({
     ConfirmDialogDelete: PropTypes.oneOfType([PropTypes.func, PropTypes.element]),
     ConfirmDialogDeleteAll: PropTypes.oneOfType([PropTypes.func, PropTypes.element]),
   }),
-  action: PropTypes.node,
+  footer: PropTypes.node,
   headers: PropTypes.arrayOf(
     PropTypes.shape({
       cellFormatter: PropTypes.func,


### PR DESCRIPTION
### What does it do?

Adds the option to add a `footer` (e.g. `TFooter`) to the `DynamicTable` helper component.

![image](https://user-images.githubusercontent.com/31662805/159100696-161947d3-a7b0-40c9-a9a0-73c403d7e094.png)

### Why is it needed?

So custom plugin development can use the `TFooter` from the Strap DS when using the `DynamicTable`.

### How to test it?

(Re)build the `helper-plugin` and run its storybook with:
 ```bash
 cd packages/core/helper-plugin
 yarn build
 yarn storybook
 ```
 
Check example at: http://localhost:6006/?path=/docs/components-dynamictable--delete-custom-components#usage-no-content-with-footer.