### PR TITLE
add aws s3 bucket acl setting from config

### DIFF
--- a/packages/providers/upload-aws-s3/lib/index.js
+++ b/packages/providers/upload-aws-s3/lib/index.js
@@ -24,7 +24,7 @@ module.exports = {
           {
             Key: `${path}${file.hash}${file.ext}`,
             Body: file.stream || Buffer.from(file.buffer, 'binary'),
-            ACL: 'public-read',
+            ACL: config.params.ACL || 'public-read',
             ContentType: file.mime,
             ...customParams,
           },


### PR DESCRIPTION
### What does it do?

Added S3 Bucket ACL setting.

### Why is it needed?

In the following cases, we want to change the S3 Bucket ACL setting.

- 1. Upload images to S3 Bucket.(Private Bucket. Just need GetObject Policy from CloudFront.)
- 2. Get the image from CloudFront


### Detail

> 1. Upload images to S3 Bucket.(Private Bucket. Just need GetObject Policy from CloudFront.)

This pull request chages are needed.
And the configuration below.

.env
```
AWS_S3_ACL=private
```

plugins.js
```js
'use strict';

module.exports = ({ env }) => ({
  upload: {
    config: {
      provider: 'aws-s3',
      providerOptions: {
        ...,
        ...,
        params: {
          Bucket: env('AWS_BUCKET'),
          ACL: env('AWS_S3_ACL'),
        },
      },
    },
  },
});
```


> 2. Get the image from CloudFront

I needed to change BASE_URL.
The pull request below is need to merge.

https://github.com/strapi/strapi/pull/11886

### Impact
Default setting is `public-read`.
And env setting is optional.
If you do not explicitly change the setting in config file(plugins.js, .env), the default behavior does not change.

### How to test it?

1. Upload images from Media Library Page.
2. S3 Bucket has the images.
3. There are the images in Media Library Page. (Get the images from CloudFront)

### Related issue(s)/PR(s)
- Related to S3 Bucket ACL(`public-read `)
https://github.com/strapi/strapi/issues/5868

- Related to Get Image Path BASE_URL
https://github.com/strapi/strapi/pull/11886

