### PR TITLE
ML: Add useFolders() hook

### DIFF
--- a/packages/core/upload/admin/src/hooks/tests/useAssets.test.js
+++ b/packages/core/upload/admin/src/hooks/tests/useAssets.test.js
@@ -1,6 +1,3 @@
-/* eslint-disable import/order */
-/* eslint-disable import/first */
-
 import React from 'react';
 import { IntlProvider } from 'react-intl';
 import { QueryClientProvider, QueryClient } from 'react-query';
@@ -8,7 +5,9 @@ import { renderHook, act } from '@testing-library/react-hooks';
 import { BrowserRouter as Router, Route } from 'react-router-dom';
 
 import { NotificationsProvider, useNotification } from '@strapi/helper-plugin';
+import { useNotifyAT } from '@strapi/design-system/LiveRegions';
 
+import { axiosInstance } from '../../utils';
 import { useAssets } from '../useAssets';
 
 const notifyStatusMock = jest.fn();
@@ -20,8 +19,6 @@ jest.mock('@strapi/design-system/LiveRegions', () => ({
   }),
 }));
 
-import { useNotifyAT } from '@strapi/design-system/LiveRegions';
-
 jest.mock('../../utils', () => ({
   ...jest.requireActual('../../utils'),
   axiosInstance: {
@@ -32,8 +29,6 @@ jest.mock('../../utils', () => ({
     }),
   },
 }));
-
-import { axiosInstance } from '../../utils';
 
 const notificationStatusMock = jest.fn();
 

--- a/packages/core/upload/admin/src/hooks/tests/useAssets.test.js
+++ b/packages/core/upload/admin/src/hooks/tests/useAssets.test.js
@@ -1,0 +1,120 @@
+/* eslint-disable import/order */
+/* eslint-disable import/first */
+
+import React from 'react';
+import { IntlProvider } from 'react-intl';
+import { QueryClientProvider, QueryClient } from 'react-query';
+import { renderHook, act } from '@testing-library/react-hooks';
+import { BrowserRouter as Router, Route } from 'react-router-dom';
+
+import { NotificationsProvider, useNotification } from '@strapi/helper-plugin';
+
+import { useAssets } from '../useAssets';
+
+const notifyStatusMock = jest.fn();
+
+jest.mock('@strapi/design-system/LiveRegions', () => ({
+  ...jest.requireActual('@strapi/design-system/LiveRegions'),
+  useNotifyAT: () => ({
+    notifyStatus: notifyStatusMock,
+  }),
+}));
+
+import { useNotifyAT } from '@strapi/design-system/LiveRegions';
+
+jest.mock('../../utils', () => ({
+  ...jest.requireActual('../../utils'),
+  axiosInstance: {
+    get: jest.fn().mockResolvedValue({
+      data: {
+        id: 1,
+      },
+    }),
+  },
+}));
+
+import { axiosInstance } from '../../utils';
+
+const notificationStatusMock = jest.fn();
+
+jest.mock('@strapi/helper-plugin', () => ({
+  ...jest.requireActual('@strapi/helper-plugin'),
+  useNotification: () => notificationStatusMock,
+}));
+
+const client = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+    },
+  },
+});
+
+// eslint-disable-next-line react/prop-types
+function ComponentFixture({ children }) {
+  return (
+    <Router>
+      <Route>
+        <QueryClientProvider client={client}>
+          <NotificationsProvider toggleNotification={() => jest.fn()}>
+            <IntlProvider locale="en" messages={{}}>
+              {children}
+            </IntlProvider>
+          </NotificationsProvider>
+        </QueryClientProvider>
+      </Route>
+    </Router>
+  );
+}
+
+function setup(...args) {
+  return new Promise(resolve => {
+    act(() => {
+      resolve(renderHook(() => useAssets(...args), { wrapper: ComponentFixture }));
+    });
+  });
+}
+
+describe('useAssets', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('fetches data from the right URL', async () => {
+    const { result, waitFor } = await setup({});
+
+    await waitFor(() => result.current.isSuccess);
+
+    expect(axiosInstance.get).toBeCalledWith('/upload/files');
+  });
+
+  test('it does not fetch, if skipWhen is set', async () => {
+    const { result, waitFor } = await setup({ skipWhen: true });
+
+    await waitFor(() => result.current.isSuccess);
+
+    expect(axiosInstance.get).toBeCalledTimes(0);
+  });
+
+  test('calls notifyStatus in case of success', async () => {
+    const { notifyStatus } = useNotifyAT();
+    const toggleNotification = useNotification();
+    const { waitForNextUpdate } = await setup({});
+
+    await waitForNextUpdate();
+
+    expect(notifyStatus).toBeCalledWith('The assets have finished loading.');
+    expect(toggleNotification).toBeCalledTimes(0);
+  });
+
+  test('calls toggleNotification in case of error', async () => {
+    axiosInstance.get.mockRejectedValueOnce(new Error('Jest mock error'));
+
+    const { notifyStatus } = useNotifyAT();
+    const toggleNotification = useNotification();
+    const { waitFor } = await setup({});
+
+    await waitFor(() => expect(toggleNotification).toBeCalled());
+    await waitFor(() => expect(notifyStatus).not.toBeCalled());
+  });
+});

--- a/packages/core/upload/admin/src/hooks/tests/useFolders.test.js
+++ b/packages/core/upload/admin/src/hooks/tests/useFolders.test.js
@@ -1,14 +1,13 @@
-/* eslint-disable import/no-duplicates */
-/* eslint-disable import/order */
-/* eslint-disable import/first */
-
 import React from 'react';
 import { IntlProvider } from 'react-intl';
 import { QueryClientProvider, QueryClient } from 'react-query';
 import { renderHook, act } from '@testing-library/react-hooks';
 import { BrowserRouter as Router, Route } from 'react-router-dom';
-import { NotificationsProvider } from '@strapi/helper-plugin';
 
+import { NotificationsProvider, useNotification } from '@strapi/helper-plugin';
+import { useNotifyAT } from '@strapi/design-system/LiveRegions';
+
+import { axiosInstance } from '../../utils';
 import { useFolders } from '../useFolders';
 
 const notifyStatusMock = jest.fn();
@@ -19,8 +18,6 @@ jest.mock('@strapi/design-system/LiveRegions', () => ({
     notifyStatus: notifyStatusMock,
   }),
 }));
-
-import { useNotifyAT } from '@strapi/design-system/LiveRegions';
 
 jest.mock('../../utils', () => ({
   ...jest.requireActual('../../utils'),
@@ -33,16 +30,12 @@ jest.mock('../../utils', () => ({
   },
 }));
 
-import { axiosInstance } from '../../utils';
-
 const notificationStatusMock = jest.fn();
 
 jest.mock('@strapi/helper-plugin', () => ({
   ...jest.requireActual('@strapi/helper-plugin'),
   useNotification: () => notificationStatusMock,
 }));
-
-import { useNotification } from '@strapi/helper-plugin';
 
 const client = new QueryClient({
   defaultOptions: {

--- a/packages/core/upload/admin/src/hooks/tests/useFolders.test.js
+++ b/packages/core/upload/admin/src/hooks/tests/useFolders.test.js
@@ -1,0 +1,122 @@
+/* eslint-disable import/no-duplicates */
+/* eslint-disable import/order */
+/* eslint-disable import/first */
+
+import React from 'react';
+import { IntlProvider } from 'react-intl';
+import { QueryClientProvider, QueryClient } from 'react-query';
+import { renderHook, act } from '@testing-library/react-hooks';
+import { BrowserRouter as Router, Route } from 'react-router-dom';
+import { NotificationsProvider } from '@strapi/helper-plugin';
+
+import { useFolders } from '../useFolders';
+
+const notifyStatusMock = jest.fn();
+
+jest.mock('@strapi/design-system/LiveRegions', () => ({
+  ...jest.requireActual('@strapi/design-system/LiveRegions'),
+  useNotifyAT: () => ({
+    notifyStatus: notifyStatusMock,
+  }),
+}));
+
+import { useNotifyAT } from '@strapi/design-system/LiveRegions';
+
+jest.mock('../../utils', () => ({
+  ...jest.requireActual('../../utils'),
+  axiosInstance: {
+    get: jest.fn().mockResolvedValue({
+      data: {
+        id: 1,
+      },
+    }),
+  },
+}));
+
+import { axiosInstance } from '../../utils';
+
+const notificationStatusMock = jest.fn();
+
+jest.mock('@strapi/helper-plugin', () => ({
+  ...jest.requireActual('@strapi/helper-plugin'),
+  useNotification: () => notificationStatusMock,
+}));
+
+import { useNotification } from '@strapi/helper-plugin';
+
+const client = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+    },
+  },
+});
+
+// eslint-disable-next-line react/prop-types
+function ComponentFixture({ children }) {
+  return (
+    <Router>
+      <Route>
+        <QueryClientProvider client={client}>
+          <NotificationsProvider toggleNotification={() => jest.fn()}>
+            <IntlProvider locale="en" messages={{}}>
+              {children}
+            </IntlProvider>
+          </NotificationsProvider>
+        </QueryClientProvider>
+      </Route>
+    </Router>
+  );
+}
+
+function setup(...args) {
+  return new Promise(resolve => {
+    act(() => {
+      resolve(renderHook(() => useFolders(...args), { wrapper: ComponentFixture }));
+    });
+  });
+}
+
+describe('useFolders', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('fetches data from the right URL', async () => {
+    const { result, waitFor } = await setup({});
+
+    await waitFor(() => result.current.isSuccess);
+
+    expect(axiosInstance.get).toBeCalledWith('/upload/folders');
+  });
+
+  test('it does not fetch, if enabled is set to false', async () => {
+    const { result, waitFor } = await setup({ enabled: false });
+
+    await waitFor(() => result.current.isSuccess);
+
+    expect(axiosInstance.get).toBeCalledTimes(0);
+  });
+
+  test('calls notifyStatus in case of success', async () => {
+    const { notifyStatus } = useNotifyAT();
+    const toggleNotification = useNotification();
+    const { waitForNextUpdate } = await setup({});
+
+    await waitForNextUpdate();
+
+    expect(notifyStatus).toBeCalledWith('The folders have finished loading.');
+    expect(toggleNotification).toBeCalledTimes(0);
+  });
+
+  test('calls toggleNotification in case of error', async () => {
+    axiosInstance.get.mockRejectedValueOnce(new Error('Jest mock error'));
+
+    const { notifyStatus } = useNotifyAT();
+    const toggleNotification = useNotification();
+    const { waitFor } = await setup({});
+
+    await waitFor(() => expect(toggleNotification).toBeCalled());
+    await waitFor(() => expect(notifyStatus).not.toBeCalled());
+  });
+});

--- a/packages/core/upload/admin/src/hooks/useAssets.js
+++ b/packages/core/upload/admin/src/hooks/useAssets.js
@@ -1,4 +1,3 @@
-import { useEffect } from 'react';
 import { useQuery } from 'react-query';
 import { useNotifyAT } from '@strapi/design-system/LiveRegions';
 import { useNotification, useQueryParams } from '@strapi/helper-plugin';
@@ -13,9 +12,25 @@ export const useAssets = ({ skipWhen }) => {
   const dataRequestURL = getRequestUrl('files');
 
   const getAssets = async () => {
-    const { data } = await axiosInstance.get(`${dataRequestURL}${rawQuery}`);
+    try {
+      const { data } = await axiosInstance.get(`${dataRequestURL}${rawQuery}`);
 
-    return data;
+      notifyStatus(
+        formatMessage({
+          id: 'list.asset.at.finished',
+          defaultMessage: 'The assets have finished loading.',
+        })
+      );
+
+      return data;
+    } catch (err) {
+      toggleNotification({
+        type: 'warning',
+        message: { id: 'notification.error' },
+      });
+
+      throw err;
+    }
   };
 
   const { data, error, isLoading } = useQuery([`assets`, rawQuery], getAssets, {
@@ -23,26 +38,6 @@ export const useAssets = ({ skipWhen }) => {
     staleTime: 0,
     cacheTime: 0,
   });
-
-  useEffect(() => {
-    if (data) {
-      notifyStatus(
-        formatMessage({
-          id: 'list.asset.at.finished',
-          defaultMessage: 'The assets have finished loading.',
-        })
-      );
-    }
-  }, [data, notifyStatus, formatMessage]);
-
-  useEffect(() => {
-    if (error) {
-      toggleNotification({
-        type: 'warning',
-        message: { id: 'notification.error' },
-      });
-    }
-  }, [error, toggleNotification]);
 
   return { data, error, isLoading };
 };

--- a/packages/core/upload/admin/src/hooks/useFolders.js
+++ b/packages/core/upload/admin/src/hooks/useFolders.js
@@ -1,4 +1,3 @@
-import { useEffect } from 'react';
 import { useQuery } from 'react-query';
 import { useNotifyAT } from '@strapi/design-system/LiveRegions';
 import { useNotification, useQueryParams } from '@strapi/helper-plugin';
@@ -13,9 +12,25 @@ export const useFolders = ({ enabled = true }) => {
   const dataRequestURL = getRequestUrl('folders');
 
   const fetchFolders = async () => {
-    const { data } = await axiosInstance.get(`${dataRequestURL}${rawQuery}`);
+    try {
+      const { data } = await axiosInstance.get(`${dataRequestURL}${rawQuery}`);
 
-    return data;
+      notifyStatus(
+        formatMessage({
+          id: 'list.asset.at.finished',
+          defaultMessage: 'The folders have finished loading.',
+        })
+      );
+
+      return data;
+    } catch (err) {
+      toggleNotification({
+        type: 'warning',
+        message: { id: 'notification.error' },
+      });
+
+      throw err;
+    }
   };
 
   const { data, error, isLoading } = useQuery([`folders`, rawQuery], fetchFolders, {
@@ -23,26 +38,6 @@ export const useFolders = ({ enabled = true }) => {
     staleTime: 0,
     cacheTime: 0,
   });
-
-  useEffect(() => {
-    if (data) {
-      notifyStatus(
-        formatMessage({
-          id: 'list.asset.at.finished',
-          defaultMessage: 'The folders have finished loading.',
-        })
-      );
-    }
-  }, [data, notifyStatus, formatMessage]);
-
-  useEffect(() => {
-    if (error) {
-      toggleNotification({
-        type: 'warning',
-        message: { id: 'notification.error' },
-      });
-    }
-  }, [error, toggleNotification]);
 
   return { data, error, isLoading };
 };

--- a/packages/core/upload/admin/src/hooks/useFolders.js
+++ b/packages/core/upload/admin/src/hooks/useFolders.js
@@ -1,0 +1,48 @@
+import { useEffect } from 'react';
+import { useQuery } from 'react-query';
+import { useNotifyAT } from '@strapi/design-system/LiveRegions';
+import { useNotification, useQueryParams } from '@strapi/helper-plugin';
+import { useIntl } from 'react-intl';
+import { axiosInstance, getRequestUrl } from '../utils';
+
+export const useFolders = ({ enabled = true }) => {
+  const { formatMessage } = useIntl();
+  const toggleNotification = useNotification();
+  const { notifyStatus } = useNotifyAT();
+  const [{ rawQuery }] = useQueryParams();
+  const dataRequestURL = getRequestUrl('folders');
+
+  const fetchFolders = async () => {
+    const { data } = await axiosInstance.get(`${dataRequestURL}${rawQuery}`);
+
+    return data;
+  };
+
+  const { data, error, isLoading } = useQuery([`folders`, rawQuery], fetchFolders, {
+    enabled,
+    staleTime: 0,
+    cacheTime: 0,
+  });
+
+  useEffect(() => {
+    if (data) {
+      notifyStatus(
+        formatMessage({
+          id: 'list.asset.at.finished',
+          defaultMessage: 'The folders have finished loading.',
+        })
+      );
+    }
+  }, [data, notifyStatus, formatMessage]);
+
+  useEffect(() => {
+    if (error) {
+      toggleNotification({
+        type: 'warning',
+        message: { id: 'notification.error' },
+      });
+    }
+  }, [error, toggleNotification]);
+
+  return { data, error, isLoading };
+};


### PR DESCRIPTION
### What does it do?

Similar to use `useAssets()` this PR adds a hook called `useFolders()`, which will be used to fetch folders from the API in the media library.

This PR adds tests to both of them.

### Why is it needed?

To be able to fetch folders.

### How to test it?

Not yet. It's preparation work.
