### PR TITLE
Increase network timeout connection for Yarn users

### DIFF
--- a/packages/generators/app/lib/create-project.js
+++ b/packages/generators/app/lib/create-project.js
@@ -181,6 +181,9 @@ module.exports = async function createProject(scope, { client, connection, depen
 const installArguments = ['install', '--production', '--no-optional'];
 function runInstall({ rootPath, useYarn }) {
   if (useYarn) {
+    // Increase timeout for slow internet connections.
+    installArguments.push('--network-timeout 1000000');
+
     return execa('yarnpkg', installArguments, {
       cwd: rootPath,
       stdin: 'ignore',


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

I added a new parameter in the yarn install command to avoid network timeout on `date-fns`

### Why is it needed?

5% of the users trying to install Strapi are facing network timeout issues.

### How to test it?

No idea as it's really hard to reproduce. However, I successfully install a new application with that command using the local binary of the updated node_modules.
