### PR TITLE
Always set the provider property in uploaded file database entries

### DIFF
--- a/packages/core/upload/server/services/upload.js
+++ b/packages/core/upload/server/services/upload.js
@@ -189,11 +189,11 @@ module.exports = ({ strapi }) => ({
       const { width, height } = await getDimensions(fileData);
 
       _.assign(fileData, {
-        provider: config.provider,
         width,
         height,
       });
     }
+    _.set(fileData, 'provider', config.provider);
 
     return this.add(fileData, { user });
   },
@@ -285,11 +285,11 @@ module.exports = ({ strapi }) => ({
         const { width, height } = await getDimensions(fileData);
 
         _.assign(fileData, {
-          provider: config.provider,
           width,
           height,
         });
       }
+      _.set(fileData, 'provider', config.provider);
     } finally {
       // delete temporary folder
       await fse.remove(tmpWorkingDirectory);

--- a/packages/core/upload/tests/upload.test.e2e.js
+++ b/packages/core/upload/tests/upload.test.e2e.js
@@ -196,6 +196,9 @@ describe('Upload plugin end to end tests', () => {
             profilePicture: {
               data: {
                 id: expect.anything(),
+                attributes: {
+                  provider: 'local',
+                },
               },
             },
           },
@@ -221,6 +224,9 @@ describe('Upload plugin end to end tests', () => {
             profilePicture: {
               data: {
                 id: expect.anything(),
+                attributes: {
+                  provider: 'local',
+                },
               },
             },
           },


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Assigns the `provider` property is unconditionally to uploaded file metadata before saving.

### Why is it needed?

Previously the uploaded file data was assigned a `provider` in the conditional block that calculated dimensions on supported images. This caused the provider to get stored as `null` in the database for some upload types such as PDFs and SVGs.


### How to test it?

* Run e2e tests at `packages/core/upload/tests/upload.test.e2e.js`
* Upload an SVG or PDF file via the Admin UI. Ensure the `provider` column in the `files` table contains a non-null value such as `"local"`

### Related issue(s)/PR(s)

Fix #12885 
