### PR TITLE
ML: Add audio type to asset filters

### DIFF
--- a/packages/core/upload/admin/src/utils/displayedFilters.js
+++ b/packages/core/upload/admin/src/utils/displayedFilters.js
@@ -18,9 +18,10 @@ const displayedFilters = [
     fieldSchema: {
       type: 'enumeration',
       options: [
+        { label: 'audio', value: 'audio' },
+        { label: 'file', value: 'file' },
         { label: 'image', value: 'image' },
         { label: 'video', value: 'video' },
-        { label: 'file', value: 'file' },
       ],
     },
     metadatas: { label: 'type' },

--- a/packages/core/upload/admin/src/utils/getAllowedFiles.js
+++ b/packages/core/upload/admin/src/utils/getAllowedFiles.js
@@ -12,7 +12,7 @@ const getAllowedFiles = (pluralTypes, files) => {
   const allowedFiles = files.filter(file => {
     const fileType = file.mime.split('/')[0];
 
-    if (singularTypes.includes('file') && !['video', 'image'].includes(fileType)) {
+    if (singularTypes.includes('file') && !['video', 'image', 'audio'].includes(fileType)) {
       return true;
     }
 

--- a/packages/core/upload/admin/src/utils/tests/getAllowedFiles.test.js
+++ b/packages/core/upload/admin/src/utils/tests/getAllowedFiles.test.js
@@ -25,6 +25,18 @@ const files = [
     id: 6,
     mime: 'image/test',
   },
+  {
+    id: 7,
+    mime: 'audio/mpeg',
+  },
+  {
+    id: 8,
+    mime: 'audio/x-wav',
+  },
+  {
+    id: 9,
+    mime: 'audio/ogg',
+  },
 ];
 
 describe('UPLOAD | components | MediaLibraryInput | utils | getAllowedFiles', () => {
@@ -60,6 +72,25 @@ describe('UPLOAD | components | MediaLibraryInput | utils | getAllowedFiles', ()
     ]);
   });
 
+  it('returns an array with elements that are only video when the allowedTypes is videos', () => {
+    const results = getAllowedFiles(['audios'], files);
+
+    expect(results).toEqual([
+      {
+        id: 7,
+        mime: 'audio/mpeg',
+      },
+      {
+        id: 8,
+        mime: 'audio/x-wav',
+      },
+      {
+        id: 9,
+        mime: 'audio/ogg',
+      },
+    ]);
+  });
+
   it('returns an array with elements that are only image when the allowedTypes is images', () => {
     const results = getAllowedFiles(['images'], files);
 
@@ -80,7 +111,7 @@ describe('UPLOAD | components | MediaLibraryInput | utils | getAllowedFiles', ()
   });
 
   it('returns an array with elements that are image and video when the allowedTypes are videos and images', () => {
-    const results = getAllowedFiles(['videos', 'images'], files);
+    const results = getAllowedFiles(['videos', 'images', 'audios'], files);
 
     expect(results).toEqual([
       {
@@ -99,11 +130,23 @@ describe('UPLOAD | components | MediaLibraryInput | utils | getAllowedFiles', ()
         id: 6,
         mime: 'image/test',
       },
+      {
+        id: 7,
+        mime: 'audio/mpeg',
+      },
+      {
+        id: 8,
+        mime: 'audio/x-wav',
+      },
+      {
+        id: 9,
+        mime: 'audio/ogg',
+      },
     ]);
   });
 
   it('returns an array with all the elements', () => {
-    const results = getAllowedFiles(['videos', 'images', 'files'], files);
+    const results = getAllowedFiles(['videos', 'images', 'files', 'audios'], files);
 
     expect(results).toEqual(files);
   });


### PR DESCRIPTION
### What does it do?

Since https://github.com/strapi/strapi/pull/12419 audio files can be uploaded & displayed in the media library. However, we never added a filter for it.

### Why is it needed?

To be consistent with other mime-types which have a preview.

### How to test it?

1. Upload an audio file to the ML
2. Select "type=audio" from the filter
3. Expect to see the audio file (only)
