### PR TITLE
Fix documentation plugin in TypeScript app

### DIFF
--- a/examples/kitchensink-ts/.gitignore
+++ b/examples/kitchensink-ts/.gitignore
@@ -112,3 +112,4 @@ exports
 *.cache
 build
 .strapi-updater.json
+documentation

--- a/examples/kitchensink-ts/package.json
+++ b/examples/kitchensink-ts/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@strapi/admin": "4.1.4",
+    "@strapi/plugin-documentation": "4.1.4",
     "@strapi/provider-email-mailgun": "4.1.4",
     "@strapi/provider-upload-aws-s3": "4.1.4",
     "@strapi/provider-upload-cloudinary": "4.1.4",

--- a/packages/plugins/documentation/server/controllers/documentation.js
+++ b/packages/plugins/documentation/server/controllers/documentation.js
@@ -49,7 +49,7 @@ module.exports = {
               .getDocumentationVersion();
 
       const openAPISpecsPath = path.join(
-        strapi.dirs.dist.extensions,
+        strapi.dirs.app.extensions,
         'documentation',
         'documentation',
         version,
@@ -82,7 +82,7 @@ module.exports = {
 
           try {
             const staticFolder = path.resolve(
-              strapi.dirs.dist.extensions,
+              strapi.dirs.app.extensions,
               'documentation',
               'public'
             );
@@ -120,7 +120,7 @@ module.exports = {
 
       try {
         const layoutPath = path.resolve(
-          strapi.dirs.dist.extensions,
+          strapi.dirs.app.extensions,
           'documentation',
           'public',
           'login.html'
@@ -131,7 +131,7 @@ module.exports = {
         ctx.url = path.basename(`${ctx.url}/login.html`);
 
         try {
-          const staticFolder = path.resolve(strapi.dirs.dist.extensions, 'documentation', 'public');
+          const staticFolder = path.resolve(strapi.dirs.app.extensions, 'documentation', 'public');
           return koaStatic(staticFolder)(ctx, next);
         } catch (e) {
           strapi.log.error(e);


### PR DESCRIPTION
Signed-off-by: soupette <cyril@strapi.io>

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

It allows to use the doc plugin inside a TS app.

### Why is it needed?

To use the plugin

### How to test it?

Install the plugin, create some content types and access the documentation

### Related issue(s)/PR(s)

Fixes #12923
