### PR TITLE
Fix email confirmation in graphql

### DIFF
--- a/packages/plugins/users-permissions/server/controllers/auth.js
+++ b/packages/plugins/users-permissions/server/controllers/auth.js
@@ -29,6 +29,16 @@ const sanitizeUser = (user, ctx) => {
   return sanitize.contentAPI.output(user, userSchema, { auth });
 };
 
+const getEmailConfirmationToken = (ctx) => {
+  if (ctx.request.method === "GET"){
+      // REST API Request
+      return ctx.query.confirmation;
+    }else{
+      // For GraphQL Request
+      return ctx.request.body.confirmation;
+    }
+}
+
 module.exports = {
   async callback(ctx) {
     const provider = ctx.params.provider || 'local';
@@ -376,7 +386,7 @@ module.exports = {
   },
 
   async emailConfirmation(ctx, next, returnUser) {
-    const { confirmation: confirmationToken } = ctx.query;
+    const confirmationToken = getEmailConfirmationToken(ctx);
 
     const userService = getService('user');
     const jwtService = getService('jwt');


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

This fixes email confirmations in users-permissions for graphql

### Why is it needed?

Email confirmation tokens are not passed to the controller correctly when the request is made from the graphql plugin.

### How to test it?

Run the `emailConfirmatinon` mutation in the latest version of Strapi v4 and notice the invalid token error even when it's correct. 

### Related issue(s)/PR(s)

#12772
