### PR TITLE
Build: Prevent output from swallowing webpack errors

### DIFF
--- a/packages/core/admin/scripts/build.js
+++ b/packages/core/admin/scripts/build.js
@@ -2,6 +2,7 @@
 
 const path = require('path');
 const webpack = require('webpack');
+const { isObject } = require('lodash');
 const webpackConfig = require('../webpack.config');
 const {
   getCorePluginsPath,
@@ -58,7 +59,20 @@ const buildAdmin = async () => {
         if (messages.errors.length > 1) {
           messages.errors.length = 1;
         }
-        return reject(new Error(messages.errors.join('\n\n')));
+
+        return reject(
+          new Error(
+            messages.errors.reduce((acc, error) => {
+              if (isObject(error)) {
+                acc += error.message;
+              } else {
+                acc += error.join('\n\n');
+              }
+
+              return acc;
+            }, '')
+          )
+        );
       }
 
       return resolve({


### PR DESCRIPTION
### What does it do?

It prevents the swallowing of errors thrown in e.g. webpack.

| Before | After |
|---|---|
| <img width="1533" alt="Screenshot 2022-03-25 at 10 02 00" src="https://user-images.githubusercontent.com/2244375/160090215-da7dbd89-0858-4bbd-8b3c-57cfa08d0ee1.png">  |  <img width="1533" alt="Screenshot 2022-03-25 at 09 45 10" src="https://user-images.githubusercontent.com/2244375/160090267-83ec1c27-b17e-4009-ae3f-1e3e085ff1af.png"> | 

### Why is it needed?

Better developer experience.

### How to test it?

1. E.g. mess up a path, which leads to a webpack error.
2. Run `yarn build`
