### PR TITLE
feat: Add components definition from plugin 🎇 

### DIFF
--- a/examples/getstarted/src/api/kitchensink/content-types/kitchensink/schema.json
+++ b/examples/getstarted/src/api/kitchensink/content-types/kitchensink/schema.json
@@ -86,7 +86,7 @@
     },
     "dynamiczone": {
       "type": "dynamiczone",
-      "components": ["basic.simple"]
+      "components": ["basic.simple", "plg-cookbook.recipe"]
     },
     "one_way_tag": {
       "type": "relation",

--- a/examples/getstarted/src/plugins/myplugin/package.json
+++ b/examples/getstarted/src/plugins/myplugin/package.json
@@ -6,6 +6,7 @@
   "strapi": {
     "name": "my-plugin",
     "description": "Description of my plugin.",
-    "kind": "plugin"
+    "kind": "plugin",
+    "componentsPrefix": "plg"
   }
 }

--- a/examples/getstarted/src/plugins/myplugin/server/components/plg-cookbook/ingredient.json
+++ b/examples/getstarted/src/plugins/myplugin/server/components/plg-cookbook/ingredient.json
@@ -1,0 +1,20 @@
+{
+  "collectionName": "components_myplugin_ingredient",
+  "info": {
+    "displayName": "Ingredient",
+    "icon": "vial"
+  },
+  "options": {},
+  "attributes": {
+    "name": {
+      "type": "string"
+    },
+    "amount": {
+      "type": "integer"
+    },
+    "unit": {
+      "type": "enumeration",
+      "enum": ["g", "ml", "kg", "unit", "cups"]
+    }
+  }
+}

--- a/examples/getstarted/src/plugins/myplugin/server/components/plg-cookbook/note.json
+++ b/examples/getstarted/src/plugins/myplugin/server/components/plg-cookbook/note.json
@@ -1,0 +1,16 @@
+{
+  "collectionName": "components_myplugin_note",
+  "info": {
+    "displayName": "Note",
+    "icon": "pencil-alt"
+  },
+  "options": {},
+  "attributes": {
+    "title": {
+      "type": "string"
+    },
+    "note": {
+      "type": "richtext"
+    }
+  }
+}

--- a/examples/getstarted/src/plugins/myplugin/server/components/plg-cookbook/recipe.json
+++ b/examples/getstarted/src/plugins/myplugin/server/components/plg-cookbook/recipe.json
@@ -1,0 +1,19 @@
+{
+  "collectionName": "components_myplugin_recipe",
+  "info": {
+    "displayName": "Recipe",
+    "icon": "cheese"
+  },
+  "options": {},
+  "attributes": {
+    "title": {
+      "type": "string"
+    },
+    "ingredients": {
+      "displayName": "Fields",
+      "type": "component",
+      "repeatable": true,
+      "component": "plg-cookbook.ingredient"
+    }
+  }
+}

--- a/examples/getstarted/src/plugins/myplugin/server/content-types/cookbook/index.js
+++ b/examples/getstarted/src/plugins/myplugin/server/content-types/cookbook/index.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const schema = require('./schema');
+
+module.exports = {
+  schema,
+};

--- a/examples/getstarted/src/plugins/myplugin/server/content-types/cookbook/schema.json
+++ b/examples/getstarted/src/plugins/myplugin/server/content-types/cookbook/schema.json
@@ -1,0 +1,26 @@
+{
+  "info": {
+    "displayName": "Cookbook Notebook",
+    "singularName": "cookbook",
+    "pluralName": "cookbooks",
+    "description": ""
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "attributes": {
+    "name": {
+      "type": "string",
+      "required": true,
+      "unique": true,
+      "configurable": true
+    },
+    "customComponent": {
+      "type": "dynamiczone",
+      "components": [
+        "plg-cookbook.recipe",
+        "plg-cookbook.note"
+      ]
+    }
+  }
+}

--- a/examples/getstarted/src/plugins/myplugin/server/content-types/index.js
+++ b/examples/getstarted/src/plugins/myplugin/server/content-types/index.js
@@ -2,4 +2,5 @@
 
 module.exports = {
   test: require('./test'),
+  cookbook: require('./cookbook'),
 };


### PR DESCRIPTION
### What does it do?

I have added loading of components definitions from plugins. It loads from  `plugin/server/components` folder.
It allows components to be overwritten by local components. It supports editing from content-type manager.
It will prefix with either plugin name, or `componentsPrefix` defined in plugin *package.json*.

### Why is it needed?

It allows creating and using components from inside plugins. Extending the scenarios the plugins can be applied to.

### How to test it?

I have modified the *examples/getstarted* to make use of the components defined in plugin as well as added a content-type that makes full use of newly defined components.

### Related issue(s)/PR(s)

[FR] Create Components inside of reusable plugin - https://github.com/strapi/strapi/issues/7640
[PR] Previous attempt of someone else https://github.com/strapi/strapi/pull/9104