### PR TITLE
GenericInput: prevent controlled/ uncontrolled warnings

### DIFF
--- a/packages/core/helper-plugin/lib/src/components/GenericInput/index.js
+++ b/packages/core/helper-plugin/lib/src/components/GenericInput/index.js
@@ -51,6 +51,15 @@ const GenericInput = ({
   // therefore we cast this case to undefined
   const value = defaultValue ?? undefined;
 
+  /*
+   TODO: ideally we should pass in `defaultValue` and `value` for
+   inputs, in order to make them controlled components. This variable
+   acts as a fallback for now, to prevent React errors in devopment mode
+
+   See: https://github.com/strapi/strapi/pull/12861
+  */
+  const valueWithEmptyStringFallback = value ?? '';
+
   if (CustomInput) {
     return (
       <CustomInput
@@ -128,7 +137,7 @@ const GenericInput = ({
             id: 'app.components.ToggleCheckbox.on-label',
             defaultMessage: 'True',
           })}
-          onChange={e => {
+          onChange={(e) => {
             onChange({ target: { name, value: e.target.checked } });
           }}
           required={required}
@@ -144,7 +153,7 @@ const GenericInput = ({
           hint={hint}
           id={name}
           name={name}
-          onValueChange={value => {
+          onValueChange={(value) => {
             onChange({ target: { name, value } });
           }}
           required={required}
@@ -165,7 +174,7 @@ const GenericInput = ({
           id={name}
           hint={hint}
           name={name}
-          onChange={date => {
+          onChange={(date) => {
             const formattedDate = date.toISOString();
 
             onChange({ target: { name, value: formattedDate, type } });
@@ -175,7 +184,7 @@ const GenericInput = ({
           placeholder={formattedPlaceholder}
           required={required}
           value={value && new Date(value)}
-          selectedDateLabel={formattedDate => `Date picker, current is ${formattedDate}`}
+          selectedDateLabel={(formattedDate) => `Date picker, current is ${formattedDate}`}
         />
       );
     }
@@ -196,7 +205,7 @@ const GenericInput = ({
           id={name}
           hint={hint}
           name={name}
-          onChange={date => {
+          onChange={(date) => {
             onChange({
               target: { name, value: formatISO(date, { representation: 'date' }), type },
             });
@@ -205,7 +214,7 @@ const GenericInput = ({
           placeholder={formattedPlaceholder}
           required={required}
           selectedDate={selectedDate}
-          selectedDateLabel={formattedDate => `Date picker, current is ${formattedDate}`}
+          selectedDateLabel={(formattedDate) => `Date picker, current is ${formattedDate}`}
         />
       );
     }
@@ -219,7 +228,7 @@ const GenericInput = ({
           id={name}
           hint={hint}
           name={name}
-          onValueChange={value => {
+          onValueChange={(value) => {
             onChange({ target: { name, value: value ?? null, type } });
           }}
           placeholder={formattedPlaceholder}
@@ -244,7 +253,7 @@ const GenericInput = ({
           placeholder={formattedPlaceholder}
           required={required}
           type="email"
-          value={value}
+          value={valueWithEmptyStringFallback}
         />
       );
     }
@@ -265,7 +274,7 @@ const GenericInput = ({
           placeholder={formattedPlaceholder}
           required={required}
           type="text"
-          value={value}
+          value={valueWithEmptyStringFallback}
         />
       );
     }
@@ -282,7 +291,7 @@ const GenericInput = ({
                 defaultMessage: 'Show password',
               })}
               onClick={() => {
-                setShowPassword(prev => !prev);
+                setShowPassword((prev) => !prev);
               }}
               style={{
                 border: 'none',
@@ -307,7 +316,7 @@ const GenericInput = ({
           placeholder={formattedPlaceholder}
           required={required}
           type={showPassword ? 'text' : 'password'}
-          value={value}
+          value={valueWithEmptyStringFallback}
         />
       );
     }
@@ -321,7 +330,7 @@ const GenericInput = ({
           id={name}
           hint={hint}
           name={name}
-          onChange={value => {
+          onChange={(value) => {
             onChange({ target: { name, value: value === '' ? null : value, type: 'select' } });
           }}
           placeholder={formattedPlaceholder}
@@ -352,7 +361,7 @@ const GenericInput = ({
           required={required}
           placeholder={formattedPlaceholder}
           type={type}
-          value={value}
+          value={valueWithEmptyStringFallback}
         >
           {value}
         </Textarea>
@@ -379,7 +388,7 @@ const GenericInput = ({
           id={name}
           hint={hint}
           name={name}
-          onChange={time => {
+          onChange={(time) => {
             onChange({ target: { name, value: `${time}`, type } });
           }}
           onClear={() => {


### PR DESCRIPTION
### What does it do?

https://github.com/strapi/strapi/pull/12861 made it visible that we currently do not handle controlled components for input fields properly (it should pass down `defaultValue` and `value` instead).

This PR partly reverts to the previous behavior to prevent React warnings in development mode. I did not revert to the old behavior to have a central place to add a TODO and to make the file easier to understand.

### Why is it needed?

To prevent React warnings in development mode.

> Warning: A component is changing an uncontrolled input of type text to be controlled. Input elements should not switch from uncontrolled to controlled (or vice versa). Decide between using a controlled or uncontrolled input element for the lifetime of the component.*

### How to test it?

Change the value of an empty text input field from nothing to something and you should not see the warning mentioned above in your browser console.

### Related issue(s)/PR(s)

- https://github.com/strapi/strapi/pull/12861
- https://github.com/strapi/strapi/pull/12632
