### PR TITLE
feat(menu-logo): added a permission for project level settings

### DIFF
--- a/packages/core/admin/server/config/admin-actions.js
+++ b/packages/core/admin/server/config/admin-actions.js
@@ -146,5 +146,12 @@ module.exports = {
       section: 'settings',
       category: 'api tokens',
     },
+    {
+      uid: 'project-settings.update',
+      displayName: 'Update the project level settings',
+      pluginName: 'admin',
+      section: 'settings',
+      category: 'project',
+    },
   ],
 };

--- a/packages/core/admin/server/tests/admin-permission.test.e2e.js
+++ b/packages/core/admin/server/tests/admin-permission.test.e2e.js
@@ -336,6 +336,12 @@ describe('Role CRUD End to End', () => {
                 "subCategory": "marketplace",
               },
               Object {
+                "action": "admin::project-settings.update",
+                "category": "project",
+                "displayName": "Update the project level settings",
+                "subCategory": "general",
+              },
+              Object {
                 "action": "admin::roles.create",
                 "category": "users and roles",
                 "displayName": "Create",
@@ -1233,6 +1239,12 @@ describe('Role CRUD End to End', () => {
                   "category": "plugins and marketplace",
                   "displayName": "Access the marketplace",
                   "subCategory": "marketplace",
+                },
+                Object {
+                  "action": "admin::project-settings.update",
+                  "category": "project",
+                  "displayName": "Update the project level settings",
+                  "subCategory": "general",
                 },
                 Object {
                   "action": "admin::roles.create",

--- a/packages/core/admin/server/tests/admin-permission.test.e2e.js
+++ b/packages/core/admin/server/tests/admin-permission.test.e2e.js
@@ -815,6 +815,12 @@ describe('Role CRUD End to End', () => {
                   "subCategory": "marketplace",
                 },
                 Object {
+                  "action": "admin::project-settings.update",
+                  "category": "project",
+                  "displayName": "Update the project level settings",
+                  "subCategory": "general",
+                },
+                Object {
                   "action": "admin::provider-login.read",
                   "category": "single sign on",
                   "displayName": "Read",


### PR DESCRIPTION
### What does it do?

Adds a permission in the core package for updating project settings.

### Why is it needed?

Needed for **logo customization** and next customization features / project level settings.
