### PR TITLE
CM: Fix displaying number fields in the DynamicTable

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/DynamicTable/CellContent/utils/hasContent.js
+++ b/packages/core/admin/admin/src/content-manager/components/DynamicTable/CellContent/utils/hasContent.js
@@ -1,11 +1,13 @@
 import isEmpty from 'lodash/isEmpty';
+import isNumber from 'lodash/isNumber';
 
 import isSingleRelation from './isSingleRelation';
+import isFieldTypeNumber from '../../../../utils/isFieldTypeNumber';
 
 export default function hasContent(type, content, metadatas, fieldSchema) {
   if (type === 'component') {
     const {
-      mainField: { name: mainFieldName },
+      mainField: { name: mainFieldName, type: mainFieldType },
     } = metadatas;
 
     // Repeatable fields show the ID as fallback, in case the mainField
@@ -14,7 +16,23 @@ export default function hasContent(type, content, metadatas, fieldSchema) {
       return content.length > 0;
     }
 
-    return !isEmpty(content[mainFieldName]);
+    const value = content[mainFieldName];
+
+    /* The ID field reports itself as type `integer`, which makes it
+       impossible to distinguish it from other number fields.
+
+       Biginteger fields need to be treated as strings, as `isNumber`
+       doesn't deal with them.
+    */
+    if (
+      isFieldTypeNumber(mainFieldType) &&
+      mainFieldType !== 'biginteger' &&
+      mainFieldName !== 'id'
+    ) {
+      return isNumber(value);
+    }
+
+    return !isEmpty(value);
   }
 
   if (type === 'relation') {
@@ -23,6 +41,14 @@ export default function hasContent(type, content, metadatas, fieldSchema) {
     }
 
     return content.count > 0;
+  }
+
+  /* 
+      Biginteger fields need to be treated as strings, as `isNumber`
+      doesn't deal with them.
+  */
+  if (isFieldTypeNumber(type) && type !== 'biginteger') {
+    return isNumber(content);
   }
 
   return !isEmpty(content);

--- a/packages/core/admin/admin/src/content-manager/components/DynamicTable/CellContent/utils/tests/hasContent.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/DynamicTable/CellContent/utils/tests/hasContent.test.js
@@ -1,125 +1,237 @@
 import hasContent from '../hasContent';
 
 describe('hasContent', () => {
-  it('returns true for text content', () => {
-    const normalizedContent = hasContent('text', 'content');
-    expect(normalizedContent).toEqual(true);
-  });
-
-  it('returns false for empty text content', () => {
-    const normalizedContent = hasContent('text', '');
-    expect(normalizedContent).toEqual(false);
-  });
-
-  it('returns false for undefined text content', () => {
-    const normalizedContent = hasContent('text', undefined);
-    expect(normalizedContent).toEqual(false);
-  });
-
-  it('extracts content from single components with content', () => {
-    const normalizedContent = hasContent(
-      'component',
-      { name: 'content', id: 1 },
-      { mainField: { name: 'name' } }
-    );
-    expect(normalizedContent).toEqual(true);
-  });
-
-  it('extracts content from single components without content', () => {
-    const normalizedContent = hasContent(
-      'component',
-      { name: '', id: 1 },
-      { mainField: { name: 'name' } }
-    );
-    expect(normalizedContent).toEqual(false);
-  });
-
-  it('extracts content from repeatable components with content', () => {
-    const normalizedContent = hasContent(
-      'component',
-      [{ name: 'content_2', value: 'truthy', id: 1 }],
-      { mainField: { name: 'content_2' } },
-      { repeatable: true }
-    );
-    expect(normalizedContent).toEqual(true);
-  });
-
-  it('extracts content from repeatable components without content', () => {
-    const normalizedContent = hasContent(
-      'component',
-      [{ name: 'content_2', value: '', id: 1 }],
-      { mainField: { name: 'content_2' } },
-      { repeatable: true }
-    );
-    expect(normalizedContent).toEqual(true);
-  });
-
-  it('extracts content from repeatable components without content', () => {
-    const normalizedContent = hasContent(
-      'component',
-      [{ id: 1 }, { id: 2 }],
-      { mainField: { name: 'content_2' } },
-      { repeatable: true }
-    );
-    expect(normalizedContent).toEqual(true);
-  });
-
-  it('extracts content from repeatable components without content', () => {
-    const normalizedContent = hasContent(
-      'component',
-      [],
-      { mainField: { name: 'content_2' } },
-      { repeatable: true }
-    );
-    expect(normalizedContent).toEqual(false);
-  });
-
-  it('extracts content from multiple relations with content', () => {
-    const normalizedContent = hasContent('relation', { count: 1 }, undefined, {
-      relation: 'manyToMany',
+  describe('number fields', () => {
+    it('returns true for integer', () => {
+      const normalizedContent = hasContent('integer', 1);
+      expect(normalizedContent).toEqual(true);
     });
-    expect(normalizedContent).toEqual(true);
+
+    it('returns false for string integer', () => {
+      const normalizedContent = hasContent('integer', '1');
+      expect(normalizedContent).toEqual(false);
+    });
+
+    it('returns false for undefined text', () => {
+      const normalizedContent = hasContent('integer', undefined);
+      expect(normalizedContent).toEqual(false);
+    });
+
+    it('returns true for float', () => {
+      const normalizedContent = hasContent('float', 1.111);
+      expect(normalizedContent).toEqual(true);
+    });
+
+    it('returns true for decimal', () => {
+      const normalizedContent = hasContent('decimal', 1.111);
+      expect(normalizedContent).toEqual(true);
+    });
+
+    it('returns true for biginteger', () => {
+      const normalizedContent = hasContent('biginteger', '12345678901234567890');
+      expect(normalizedContent).toEqual(true);
+    });
   });
 
-  it('extracts content from multiple relations without content', () => {
-    const normalizedContent = hasContent('relation', { count: 0 }, undefined, {
-      relation: 'manyToMany',
+  describe('text', () => {
+    it('returns true for text content', () => {
+      const normalizedContent = hasContent('text', 'content');
+      expect(normalizedContent).toEqual(true);
     });
-    expect(normalizedContent).toEqual(false);
+
+    it('returns false for empty text content', () => {
+      const normalizedContent = hasContent('text', '');
+      expect(normalizedContent).toEqual(false);
+    });
+
+    it('returns false for undefined text content', () => {
+      const normalizedContent = hasContent('text', undefined);
+      expect(normalizedContent).toEqual(false);
+    });
   });
 
-  it('extracts content from single relations with content', () => {
-    const normalizedContent = hasContent('relation', { id: 1 }, undefined, {
-      relation: 'oneToOne',
+  describe('single component', () => {
+    it('extracts content from single components with content', () => {
+      const normalizedContent = hasContent(
+        'component',
+        { name: 'content', id: 1 },
+        { mainField: { name: 'name' } }
+      );
+      expect(normalizedContent).toEqual(true);
     });
-    expect(normalizedContent).toEqual(true);
+
+    it('extracts content from single components without content', () => {
+      const normalizedContent = hasContent(
+        'component',
+        { name: '', id: 1 },
+        { mainField: { name: 'name' } }
+      );
+      expect(normalizedContent).toEqual(false);
+    });
+
+    it('extracts integers from single components with content', () => {
+      const normalizedContent = hasContent(
+        'component',
+        { number: 1, id: 1 },
+        { mainField: { name: 'number', type: 'integer' } }
+      );
+      expect(normalizedContent).toEqual(true);
+    });
+
+    it('extracts integers from single components without content', () => {
+      const normalizedContent = hasContent(
+        'component',
+        { number: null, id: 1 },
+        { mainField: { name: 'number', type: 'integer' } }
+      );
+      expect(normalizedContent).toEqual(false);
+    });
+
+    it('extracts float from single components with content', () => {
+      const normalizedContent = hasContent(
+        'component',
+        { number: 1.11, id: 1 },
+        { mainField: { name: 'number', type: 'float' } }
+      );
+      expect(normalizedContent).toEqual(true);
+    });
+
+    it('extracts float from single components without content', () => {
+      const normalizedContent = hasContent(
+        'component',
+        { number: null, id: 1 },
+        { mainField: { name: 'number', type: 'float' } }
+      );
+      expect(normalizedContent).toEqual(false);
+    });
+
+    it('extracts decimal from single components with content', () => {
+      const normalizedContent = hasContent(
+        'component',
+        { number: 1.11, id: 1 },
+        { mainField: { name: 'number', type: 'decimal' } }
+      );
+      expect(normalizedContent).toEqual(true);
+    });
+
+    it('extracts decimal from single components without content', () => {
+      const normalizedContent = hasContent(
+        'component',
+        { number: null, id: 1 },
+        { mainField: { name: 'number', type: 'decimal' } }
+      );
+      expect(normalizedContent).toEqual(false);
+    });
+
+    it('extracts biginteger from single components with content', () => {
+      const normalizedContent = hasContent(
+        'component',
+        { number: '12345678901234567890', id: 1 },
+        { mainField: { name: 'number', type: 'biginteger' } }
+      );
+      expect(normalizedContent).toEqual(true);
+    });
+
+    it('extracts biginteger from single components without content', () => {
+      const normalizedContent = hasContent(
+        'component',
+        { number: null, id: 1 },
+        { mainField: { name: 'number', type: 'biginteger' } }
+      );
+      expect(normalizedContent).toEqual(false);
+    });
   });
 
-  it('extracts content from single relations without content', () => {
-    const normalizedContent = hasContent('relation', null, undefined, {
-      relation: 'oneToOne',
+  describe('repeatable components', () => {
+    it('extracts content from repeatable components with content', () => {
+      const normalizedContent = hasContent(
+        'component',
+        [{ name: 'content_2', value: 'truthy', id: 1 }],
+        { mainField: { name: 'content_2' } },
+        { repeatable: true }
+      );
+      expect(normalizedContent).toEqual(true);
     });
-    expect(normalizedContent).toEqual(false);
+
+    it('extracts content from repeatable components without content', () => {
+      const normalizedContent = hasContent(
+        'component',
+        [{ name: 'content_2', value: '', id: 1 }],
+        { mainField: { name: 'content_2' } },
+        { repeatable: true }
+      );
+      expect(normalizedContent).toEqual(true);
+    });
+
+    it('extracts content from repeatable components without content', () => {
+      const normalizedContent = hasContent(
+        'component',
+        [{ id: 1 }, { id: 2 }],
+        { mainField: { name: 'content_2' } },
+        { repeatable: true }
+      );
+      expect(normalizedContent).toEqual(true);
+    });
+
+    it('extracts content from repeatable components without content', () => {
+      const normalizedContent = hasContent(
+        'component',
+        [],
+        { mainField: { name: 'content_2' } },
+        { repeatable: true }
+      );
+      expect(normalizedContent).toEqual(false);
+    });
   });
 
-  it('returns oneToManyMorph relations as false with content', () => {
-    const normalizedContent = hasContent('relation', { id: 1 }, undefined, {
-      relation: 'oneToManyMorph',
+  describe('relations', () => {
+    it('extracts content from multiple relations with content', () => {
+      const normalizedContent = hasContent('relation', { count: 1 }, undefined, {
+        relation: 'manyToMany',
+      });
+      expect(normalizedContent).toEqual(true);
     });
-    expect(normalizedContent).toEqual(false);
-  });
 
-  it('extracts content from oneToManyMorph relations with content', () => {
-    const normalizedContent = hasContent('relation', { id: 1 }, undefined, {
-      relation: 'oneToOneMorph',
+    it('extracts content from multiple relations without content', () => {
+      const normalizedContent = hasContent('relation', { count: 0 }, undefined, {
+        relation: 'manyToMany',
+      });
+      expect(normalizedContent).toEqual(false);
     });
-    expect(normalizedContent).toEqual(true);
-  });
 
-  it('extracts content from oneToManyMorph relations with content', () => {
-    const normalizedContent = hasContent('relation', null, undefined, {
-      relation: 'oneToOneMorph',
+    it('extracts content from single relations with content', () => {
+      const normalizedContent = hasContent('relation', { id: 1 }, undefined, {
+        relation: 'oneToOne',
+      });
+      expect(normalizedContent).toEqual(true);
     });
-    expect(normalizedContent).toEqual(false);
+
+    it('extracts content from single relations without content', () => {
+      const normalizedContent = hasContent('relation', null, undefined, {
+        relation: 'oneToOne',
+      });
+      expect(normalizedContent).toEqual(false);
+    });
+
+    it('returns oneToManyMorph relations as false with content', () => {
+      const normalizedContent = hasContent('relation', { id: 1 }, undefined, {
+        relation: 'oneToManyMorph',
+      });
+      expect(normalizedContent).toEqual(false);
+    });
+
+    it('extracts content from oneToManyMorph relations with content', () => {
+      const normalizedContent = hasContent('relation', { id: 1 }, undefined, {
+        relation: 'oneToOneMorph',
+      });
+      expect(normalizedContent).toEqual(true);
+    });
+
+    it('extracts content from oneToManyMorph relations with content', () => {
+      const normalizedContent = hasContent('relation', null, undefined, {
+        relation: 'oneToOneMorph',
+      });
+      expect(normalizedContent).toEqual(false);
+    });
   });
 });

--- a/packages/core/admin/admin/src/content-manager/utils/isFieldTypeNumber.js
+++ b/packages/core/admin/admin/src/content-manager/utils/isFieldTypeNumber.js
@@ -1,0 +1,3 @@
+export default function isFieldTypeNumber(type) {
+  return ['integer', 'biginteger', 'decimal', 'float', 'number'].includes(type);
+}

--- a/packages/core/admin/admin/src/content-manager/utils/tests/isFieldTypeNumber.test.js
+++ b/packages/core/admin/admin/src/content-manager/utils/tests/isFieldTypeNumber.test.js
@@ -1,0 +1,18 @@
+import isFieldTypeNumber from '../isFieldTypeNumber';
+
+const FIXTURE = [
+  ['integer', true],
+  ['float', true],
+  ['decimal', true],
+  ['biginteger', true],
+  ['number', true],
+  ['text', false],
+];
+
+describe('isFieldTypeNumber', () => {
+  FIXTURE.forEach(([type, expectation]) => {
+    test(`${type} is ${expectation}`, () => {
+      expect(isFieldTypeNumber(type)).toBe(expectation);
+    });
+  });
+});


### PR DESCRIPTION
### What does it do?

Fixes displaying number fields in list views, which broke with https://github.com/strapi/strapi/pull/12213

#### Before

<img width="1056" alt="Screenshot 2022-03-29 at 10 34 01" src="https://user-images.githubusercontent.com/2244375/160569397-f39fdc69-730b-451b-bb36-8456ca910d62.png">

#### After

<img width="1056" alt="Screenshot 2022-03-29 at 10 33 48" src="https://user-images.githubusercontent.com/2244375/160569385-6f8f2c4c-8f74-48d7-b2cb-45f37aaa1ff2.png">


### Why is it needed?

To properly display all field types in list views.

### How to test it?

You can either trust the automated tests or create a content type that contains all sorts of number fields and/ or components containing these.

### Related issue(s)/PR(s)

- https://github.com/strapi/strapi/pull/12213
