### PR TITLE
RepeatableComponent: Fix error messages when component is nested

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/FieldComponent/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/FieldComponent/index.js
@@ -106,7 +106,6 @@ const FieldComponent = ({
             componentValue={componentValue}
             componentValueLength={componentValueLength}
             componentUid={componentUid}
-            isNested={isNested}
             isReadOnly={isReadOnly}
             max={max}
             min={min}

--- a/packages/core/admin/admin/src/content-manager/components/RepeatableComponent/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/RepeatableComponent/index.js
@@ -5,7 +5,6 @@ import { useIntl } from 'react-intl';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import get from 'lodash/get';
-import take from 'lodash/take';
 import { useNotification } from '@strapi/helper-plugin';
 import { Box } from '@strapi/design-system/Box';
 import { Flex } from '@strapi/design-system/Flex';
@@ -17,6 +16,7 @@ import ItemTypes from '../../utils/ItemTypes';
 import ComponentInitializer from '../ComponentInitializer';
 import connect from './utils/connect';
 import select from './utils/select';
+import getComponentErrorKeys from './utils/getComponentErrorKeys';
 import DraggedItem from './DraggedItem';
 import AccordionGroupCustom from './AccordionGroupCustom';
 
@@ -50,25 +50,16 @@ const RepeatableComponent = ({
   const [isDraggingSibling, setIsDraggingSibling] = useState(false);
   const [, drop] = useDrop({ accept: ItemTypes.COMPONENT });
   const { getComponentLayout } = useContentTypeLayout();
-  const componentLayoutData = useMemo(() => getComponentLayout(componentUid), [
-    componentUid,
-    getComponentLayout,
-  ]);
+  const componentLayoutData = useMemo(
+    () => getComponentLayout(componentUid),
+    [componentUid, getComponentLayout]
+  );
 
   const nextTempKey = useMemo(() => {
     return getMaxTempKey(componentValue || []) + 1;
   }, [componentValue]);
 
-  const componentErrorKeys = Object.keys(formErrors)
-    .filter(errorKey => {
-      return take(errorKey.split('.'), isNested ? 3 : 1).join('.') === name;
-    })
-    .map(errorKey => {
-      return errorKey
-        .split('.')
-        .slice(0, name.split('.').length + 1)
-        .join('.');
-    });
+  const componentErrorKeys = getComponentErrorKeys(name, formErrors, isNested);
 
   const toggleCollapses = () => {
     setCollapseToOpen('');
@@ -123,7 +114,7 @@ const RepeatableComponent = ({
   }
 
   const doesRepComponentHasChildError = componentErrorKeys.some(
-    error => error.split('.').length > 1
+    (error) => error.split('.').length > 1
   );
 
   if (doesRepComponentHasChildError && !hasMinError) {

--- a/packages/core/admin/admin/src/content-manager/components/RepeatableComponent/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/RepeatableComponent/index.js
@@ -38,7 +38,6 @@ const RepeatableComponent = ({
   componentUid,
   componentValue,
   componentValueLength,
-  isNested,
   isReadOnly,
   max,
   min,
@@ -50,16 +49,16 @@ const RepeatableComponent = ({
   const [isDraggingSibling, setIsDraggingSibling] = useState(false);
   const [, drop] = useDrop({ accept: ItemTypes.COMPONENT });
   const { getComponentLayout } = useContentTypeLayout();
-  const componentLayoutData = useMemo(
-    () => getComponentLayout(componentUid),
-    [componentUid, getComponentLayout]
-  );
+  const componentLayoutData = useMemo(() => getComponentLayout(componentUid), [
+    componentUid,
+    getComponentLayout,
+  ]);
 
   const nextTempKey = useMemo(() => {
     return getMaxTempKey(componentValue || []) + 1;
   }, [componentValue]);
 
-  const componentErrorKeys = getComponentErrorKeys(name, formErrors, isNested);
+  const componentErrorKeys = getComponentErrorKeys(name, formErrors);
 
   const toggleCollapses = () => {
     setCollapseToOpen('');
@@ -114,7 +113,7 @@ const RepeatableComponent = ({
   }
 
   const doesRepComponentHasChildError = componentErrorKeys.some(
-    (error) => error.split('.').length > 1
+    error => error.split('.').length > 1
   );
 
   if (doesRepComponentHasChildError && !hasMinError) {
@@ -178,7 +177,6 @@ RepeatableComponent.defaultProps = {
   componentValue: null,
   componentValueLength: 0,
   formErrors: {},
-  isNested: false,
   max: Infinity,
   min: 0,
 };
@@ -189,7 +187,6 @@ RepeatableComponent.propTypes = {
   componentValue: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
   componentValueLength: PropTypes.number,
   formErrors: PropTypes.object,
-  isNested: PropTypes.bool,
   isReadOnly: PropTypes.bool.isRequired,
   max: PropTypes.number,
   min: PropTypes.number,

--- a/packages/core/admin/admin/src/content-manager/components/RepeatableComponent/utils/getComponentErrorKeys.js
+++ b/packages/core/admin/admin/src/content-manager/components/RepeatableComponent/utils/getComponentErrorKeys.js
@@ -1,0 +1,14 @@
+import take from 'lodash/take';
+
+export default function getComponentErrorKeys(name, formErrors, isNested = false) {
+  return Object.keys(formErrors)
+    .filter((errorKey) => {
+      return take(errorKey.split('.'), isNested ? 2 : 1).join('.') === name;
+    })
+    .map((errorKey) => {
+      return errorKey
+        .split('.')
+        .slice(0, name.split('.').length + 1)
+        .join('.');
+    });
+}

--- a/packages/core/admin/admin/src/content-manager/components/RepeatableComponent/utils/getComponentErrorKeys.js
+++ b/packages/core/admin/admin/src/content-manager/components/RepeatableComponent/utils/getComponentErrorKeys.js
@@ -1,14 +1,10 @@
-import take from 'lodash/take';
-
-export default function getComponentErrorKeys(name, formErrors, isNested = false) {
+export default function getComponentErrorKeys(name, formErrors) {
   return Object.keys(formErrors)
-    .filter((errorKey) => {
-      return take(errorKey.split('.'), isNested ? 2 : 1).join('.') === name;
-    })
-    .map((errorKey) => {
-      return errorKey
+    .filter(errorKey => errorKey.startsWith(name))
+    .map(errorKey =>
+      errorKey
         .split('.')
         .slice(0, name.split('.').length + 1)
-        .join('.');
-    });
+        .join('.')
+    );
 }

--- a/packages/core/admin/admin/src/content-manager/components/RepeatableComponent/utils/tests/getComponentErrorKeys.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/RepeatableComponent/utils/tests/getComponentErrorKeys.test.js
@@ -19,7 +19,7 @@ describe('getComponentErrorKeys', () => {
       'parent.child.1.field': 'validation-error',
     };
 
-    expect(getComponentErrorKeys('parent.child', FIXTURE, true)).toStrictEqual([
+    expect(getComponentErrorKeys('parent.child', FIXTURE)).toStrictEqual([
       'parent.child.0',
       'parent.child.1',
     ]);

--- a/packages/core/admin/admin/src/content-manager/components/RepeatableComponent/utils/tests/getComponentErrorKeys.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/RepeatableComponent/utils/tests/getComponentErrorKeys.test.js
@@ -1,0 +1,27 @@
+import getComponentErrorKeys from '../getComponentErrorKeys';
+
+describe('getComponentErrorKeys', () => {
+  test('retrieves error keys for non nested components', () => {
+    const FIXTURE = {
+      'component.0.name': 'unique-error',
+      'component.1.field': 'validation-error',
+    };
+
+    expect(getComponentErrorKeys('component', FIXTURE)).toStrictEqual([
+      'component.0',
+      'component.1',
+    ]);
+  });
+
+  test('retrieves error keys for nested components', () => {
+    const FIXTURE = {
+      'parent.child.0.name': 'unique-error',
+      'parent.child.1.field': 'validation-error',
+    };
+
+    expect(getComponentErrorKeys('parent.child', FIXTURE, true)).toStrictEqual([
+      'parent.child.0',
+      'parent.child.1',
+    ]);
+  });
+});


### PR DESCRIPTION
### What does it do?

This PR fixes a case, where an error within a nested repeatable component is not properly displayed on the accordion.

| Before  | After  |
|---|---|
| <img width="834" alt="Screenshot 2022-03-29 at 13 47 54" src="https://user-images.githubusercontent.com/2244375/160604731-850c2a23-e529-4160-ad0c-c1a45892ea25.png">  | <img width="834" alt="Screenshot 2022-03-29 at 13 47 25" src="https://user-images.githubusercontent.com/2244375/160604725-b63b20e1-52bf-4d3b-99ff-975b82a7c53d.png">  |

### Why is it needed?

So content editors can see where an error occurred. 

### How to test it?

1. Use the Restaurant content type
2. Make one field of the "Dish" component required
3. Try to publish the content-type with the required field being empty