### PR TITLE
Allow date fields to be selected as component main fields

### DIFF
--- a/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/index.js
@@ -59,7 +59,6 @@ const EditSettingsView = ({ mainLayout, components, isContentTypeView, slug, upd
         'relation',
         'component',
         'boolean',
-        'date',
         'media',
         'richtext',
         'timestamp',


### PR DESCRIPTION
### What does it do?

Allows fields of type `date` to be selected as a components main field.

### Why is it needed?

Because all other date flavours (time, dateTime) are already selectable.

### How to test it?

1. Create a component that contains a field of type date
2. Configure the view of the component to use the date field as entry title

### Related issue(s)/PR(s)

- Fixes https://github.com/strapi/strapi/issues/12974
