### PR TITLE
Add missing a plugin banner to marketplace

### DIFF
--- a/packages/core/admin/admin/src/pages/MarketplacePage/components/MissingPluginBanner/index.js
+++ b/packages/core/admin/admin/src/pages/MarketplacePage/components/MissingPluginBanner/index.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import { useIntl } from 'react-intl';
+import { ContentBox, useTracking } from '@strapi/helper-plugin';
+import GlassesSquare from '@strapi/icons/GlassesSquare';
+import ExternalLink from '@strapi/icons/ExternalLink';
+import { Icon } from '@strapi/design-system/Icon';
+
+const MissingPluginBanner = () => {
+  const { formatMessage } = useIntl();
+  const { trackUsage } = useTracking();
+
+  return (
+    <a
+      href="https://strapi.canny.io/plugin-requests"
+      target="_blank"
+      rel="noopener noreferrer nofollow"
+      style={{ textDecoration: 'none' }}
+      onClick={() => trackUsage('didMissMarketplacePlugin')}
+    >
+      <ContentBox
+        title={formatMessage({
+          id: 'admin.pages.MarketPlacePage.missingPlugin.title',
+          defaultMessage: 'Documentation',
+        })}
+        subtitle={formatMessage({
+          id: 'admin.pages.MarketPlacePage.missingPlugin.description',
+          defaultMessage:
+            "Tell us what plugin you are looking for and we'll let our community plugin developers know in case they are in search for inspiration!",
+        })}
+        icon={<GlassesSquare />}
+        iconBackground="alternative100"
+        endAction={
+          <Icon as={ExternalLink} color="neutral600" width={3} height={3} marginLeft={2} />
+        }
+      />
+    </a>
+  );
+};
+
+export default MissingPluginBanner;

--- a/packages/core/admin/admin/src/pages/MarketplacePage/index.js
+++ b/packages/core/admin/admin/src/pages/MarketplacePage/index.js
@@ -175,7 +175,6 @@ const MarketPlacePage = () => {
           }
         />
         <ContentLayout>
-          <MissingPluginBanner />
           <Box width="25%" paddingBottom={4}>
             <Searchbar
               name="searchbar"

--- a/packages/core/admin/admin/src/pages/MarketplacePage/index.js
+++ b/packages/core/admin/admin/src/pages/MarketplacePage/index.js
@@ -27,6 +27,7 @@ import { fetchAppInformation } from './utils/api';
 import useFetchInstalledPlugins from '../../hooks/useFetchInstalledPlugins';
 import useFetchMarketplacePlugins from '../../hooks/useFetchMarketplacePlugins';
 import adminPermissions from '../../permissions';
+import MissingPluginBanner from './components/MissingPluginBanner';
 
 const matchSearch = (plugins, search) => {
   return matchSorter(plugins, search, {
@@ -174,6 +175,7 @@ const MarketPlacePage = () => {
           }
         />
         <ContentLayout>
+          <MissingPluginBanner />
           <Box width="25%" paddingBottom={4}>
             <Searchbar
               name="searchbar"
@@ -219,6 +221,9 @@ const MarketPlacePage = () => {
               ))}
             </Grid>
           )}
+          <Box paddingTop={7}>
+            <MissingPluginBanner />
+          </Box>
         </ContentLayout>
       </Main>
     </Layout>

--- a/packages/core/admin/admin/src/pages/MarketplacePage/tests/index.test.js
+++ b/packages/core/admin/admin/src/pages/MarketplacePage/tests/index.test.js
@@ -58,47 +58,51 @@ describe('Marketplace page', () => {
     await waitFor(() => expect(getByRole('heading', { name: /marketplace/i })).toBeInTheDocument());
 
     expect(container.firstChild).toMatchInlineSnapshot(`
-      .c16 {
+      .c26 {
         padding-bottom: 16px;
         width: 25%;
       }
 
-      .c32 {
+      .c42 {
         border-radius: 4px;
         width: 64px;
         height: 64px;
       }
 
-      .c33 {
+      .c43 {
         padding-top: 16px;
       }
 
-      .c36 {
+      .c45 {
         padding-top: 8px;
       }
 
-      .c52 {
+      .c60 {
         margin-left: 4px;
         width: 24px;
         height: auto;
       }
 
-      .c53 {
+      .c61 {
         padding-left: 16px;
       }
 
-      .c49 {
+      .c64 {
+        padding-top: 32px;
+      }
+
+      .c57 {
         font-weight: 600;
         color: #32324d;
         font-size: 0.75rem;
         line-height: 1.33;
       }
 
-      .c46 {
+      .c54 {
         padding-right: 8px;
       }
 
-      .c43 {
+      .c51 {
         display: -webkit-box;
         display: -webkit-flex;
         display: -ms-flexbox;
@@ -112,21 +116,21 @@ describe('Marketplace page', () => {
         outline: none;
       }
 
-      .c43 svg {
+      .c51 svg {
         height: 12px;
         width: 12px;
       }
 
-      .c43 svg > g,
-      .c43 svg path {
+      .c51 svg > g,
+      .c51 svg path {
         fill: #ffffff;
       }
 
-      .c43[aria-disabled='true'] {
+      .c51[aria-disabled='true'] {
         pointer-events: none;
       }
 
-      .c43:after {
+      .c51:after {
         -webkit-transition-property: all;
         transition-property: all;
         -webkit-transition-duration: 0.2s;
@@ -141,11 +145,11 @@ describe('Marketplace page', () => {
         border: 2px solid transparent;
       }
 
-      .c43:focus-visible {
+      .c51:focus-visible {
         outline: none;
       }
 
-      .c43:focus-visible:after {
+      .c51:focus-visible:after {
         border-radius: 8px;
         content: '';
         position: absolute;
@@ -156,11 +160,11 @@ describe('Marketplace page', () => {
         border: 2px solid #4945ff;
       }
 
-      .c47 {
+      .c55 {
         height: 100%;
       }
 
-      .c44 {
+      .c52 {
         -webkit-align-items: center;
         -webkit-box-align: center;
         -ms-flex-align: center;
@@ -172,7 +176,7 @@ describe('Marketplace page', () => {
         background: #f0f0ff;
       }
 
-      .c44 .c45 {
+      .c52 .c53 {
         display: -webkit-box;
         display: -webkit-flex;
         display: -ms-flexbox;
@@ -183,66 +187,79 @@ describe('Marketplace page', () => {
         align-items: center;
       }
 
-      .c44 .c48 {
+      .c52 .c56 {
         color: #ffffff;
       }
 
-      .c44[aria-disabled='true'] {
+      .c52[aria-disabled='true'] {
         border: 1px solid #dcdce4;
         background: #eaeaef;
       }
 
-      .c44[aria-disabled='true'] .c48 {
+      .c52[aria-disabled='true'] .c56 {
         color: #666687;
       }
 
-      .c44[aria-disabled='true'] svg > g,
-      .c44[aria-disabled='true'] svg path {
+      .c52[aria-disabled='true'] svg > g,
+      .c52[aria-disabled='true'] svg path {
         fill: #666687;
       }
 
-      .c44[aria-disabled='true']:active {
+      .c52[aria-disabled='true']:active {
         border: 1px solid #dcdce4;
         background: #eaeaef;
       }
 
-      .c44[aria-disabled='true']:active .c48 {
+      .c52[aria-disabled='true']:active .c56 {
         color: #666687;
       }
 
-      .c44[aria-disabled='true']:active svg > g,
-      .c44[aria-disabled='true']:active svg path {
+      .c52[aria-disabled='true']:active svg > g,
+      .c52[aria-disabled='true']:active svg path {
         fill: #666687;
       }
 
-      .c44:hover {
+      .c52:hover {
         background-color: #ffffff;
       }
 
-      .c44:active {
+      .c52:active {
         background-color: #ffffff;
         border: 1px solid #4945ff;
       }
 
-      .c44:active .c48 {
+      .c52:active .c56 {
         color: #4945ff;
       }
 
-      .c44:active svg > g,
-      .c44:active svg path {
+      .c52:active svg > g,
+      .c52:active svg path {
         fill: #4945ff;
       }
 
-      .c44 .c48 {
+      .c52 .c56 {
         color: #271fe0;
       }
 
-      .c44 svg > g,
-      .c44 svg path {
+      .c52 svg > g,
+      .c52 svg path {
         fill: #271fe0;
       }
 
-      .c30 {
+      .c16 {
+        background: #ffffff;
+        padding: 24px;
+        border-radius: 4px;
+        box-shadow: 0px 1px 4px rgba(33,33,52,0.1);
+      }
+
+      .c18 {
+        background: #f6ecfc;
+        padding: 12px;
+        border-radius: 4px;
+      }
+
+      .c40 {
         background: #ffffff;
         padding-top: 16px;
         padding-right: 24px;
@@ -253,7 +270,21 @@ describe('Marketplace page', () => {
         height: 100%;
       }
 
-      .c31 {
+      .c17 {
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+        -webkit-flex-direction: row;
+        -ms-flex-direction: row;
+        flex-direction: row;
+        -webkit-align-items: center;
+        -webkit-box-align: center;
+        -ms-flex-align: center;
+        align-items: center;
+      }
+
+      .c41 {
         display: -webkit-box;
         display: -webkit-flex;
         display: -ms-flexbox;
@@ -271,42 +302,39 @@ describe('Marketplace page', () => {
         align-items: normal;
       }
 
-      .c35 {
-        display: -webkit-box;
-        display: -webkit-flex;
-        display: -ms-flexbox;
-        display: flex;
-        -webkit-flex-direction: row;
-        -ms-flex-direction: row;
-        flex-direction: row;
-        -webkit-align-items: center;
-        -webkit-box-align: center;
-        -ms-flex-align: center;
-        align-items: center;
+      .c23 {
+        color: #666687;
+        margin-left: 8px;
+        width: 12px;
+        height: 12px;
       }
 
-      .c50 {
+      .c58 {
         color: #328048;
         margin-left: 8px;
       }
 
-      .c54 {
+      .c62 {
         color: #328048;
         margin-right: 8px;
         width: 12;
         height: 12;
       }
 
-      .c51 path {
+      .c24 path {
+        fill: #666687;
+      }
+
+      .c59 path {
         fill: #328048;
       }
 
-      .c24 {
+      .c34 {
         padding-right: 8px;
         padding-left: 12px;
       }
 
-      .c20 {
+      .c30 {
         display: -webkit-box;
         display: -webkit-flex;
         display: -ms-flexbox;
@@ -320,7 +348,7 @@ describe('Marketplace page', () => {
         align-items: center;
       }
 
-      .c22 {
+      .c32 {
         display: -webkit-box;
         display: -webkit-flex;
         display: -ms-flexbox;
@@ -338,14 +366,14 @@ describe('Marketplace page', () => {
         align-items: center;
       }
 
-      .c19 {
+      .c29 {
         font-weight: 600;
         color: #32324d;
         font-size: 0.75rem;
         line-height: 1.33;
       }
 
-      .c27 {
+      .c37 {
         border: none;
         border-radius: 4px;
         padding-left: 0;
@@ -358,36 +386,36 @@ describe('Marketplace page', () => {
         background: inherit;
       }
 
-      .c27::-webkit-input-placeholder {
+      .c37::-webkit-input-placeholder {
         color: #8e8ea9;
         opacity: 1;
       }
 
-      .c27::-moz-placeholder {
+      .c37::-moz-placeholder {
         color: #8e8ea9;
         opacity: 1;
       }
 
-      .c27:-ms-input-placeholder {
+      .c37:-ms-input-placeholder {
         color: #8e8ea9;
         opacity: 1;
       }
 
-      .c27::placeholder {
+      .c37::placeholder {
         color: #8e8ea9;
         opacity: 1;
       }
 
-      .c27[aria-disabled='true'] {
+      .c37[aria-disabled='true'] {
         color: inherit;
       }
 
-      .c27:focus {
+      .c37:focus {
         outline: none;
         box-shadow: none;
       }
 
-      .c23 {
+      .c33 {
         border: 1px solid #dcdce4;
         border-radius: 4px;
         background: #ffffff;
@@ -400,12 +428,12 @@ describe('Marketplace page', () => {
         transition-duration: 0.2s;
       }
 
-      .c23:focus-within {
+      .c33:focus-within {
         border: 1px solid #4945ff;
         box-shadow: #4945ff 0px 0px 0px 2px;
       }
 
-      .c18 {
+      .c28 {
         border: 0;
         -webkit-clip: rect(0 0 0 0);
         clip: rect(0 0 0 0);
@@ -417,15 +445,15 @@ describe('Marketplace page', () => {
         width: 1px;
       }
 
-      .c26 {
+      .c36 {
         font-size: 0.8rem;
       }
 
-      .c26 svg path {
+      .c36 svg path {
         fill: #32324d;
       }
 
-      .c17 {
+      .c27 {
         border-radius: 4px;
         box-shadow: 0px 1px 4px rgba(33,33,52,0.1);
         outline: none;
@@ -436,24 +464,24 @@ describe('Marketplace page', () => {
         transition-duration: 0.2s;
       }
 
-      .c17:focus-within .c25 svg path {
+      .c27:focus-within .c35 svg path {
         fill: #4945ff;
       }
 
-      .c17 .c21 {
+      .c27 .c31 {
         border: 1px solid transparent;
       }
 
-      .c17 .c21:focus-within {
+      .c27 .c31:focus-within {
         border: 1px solid #4945ff;
         box-shadow: #4945ff 0px 0px 0px 2px;
       }
 
-      .c39 {
+      .c47 {
         padding-top: 24px;
       }
 
-      .c40 {
+      .c48 {
         display: -webkit-box;
         display: -webkit-flex;
         display: -ms-flexbox;
@@ -467,42 +495,77 @@ describe('Marketplace page', () => {
         align-items: center;
       }
 
-      .c41 > * {
+      .c20 {
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+        -webkit-flex-direction: column;
+        -ms-flex-direction: column;
+        flex-direction: column;
+      }
+
+      .c20 > * {
+        margin-top: 0;
+        margin-bottom: 0;
+      }
+
+      .c49 > * {
         margin-left: 0;
         margin-right: 0;
       }
 
-      .c41 > * + * {
+      .c49 > * + * {
         margin-left: 8px;
       }
 
-      .c34 {
+      .c21 {
+        font-weight: 500;
+        color: #32324d;
+        font-size: 0.75rem;
+        line-height: 1.33;
+      }
+
+      .c25 {
+        color: #666687;
+        font-size: 0.875rem;
+        line-height: 1.43;
+      }
+
+      .c44 {
         color: #32324d;
         font-weight: 500;
         font-size: 1rem;
         line-height: 1.25;
       }
 
-      .c37 {
-        color: #666687;
-        font-size: 0.875rem;
-        line-height: 1.43;
-      }
-
-      .c55 {
+      .c63 {
         font-weight: 600;
         color: #328048;
         font-size: 0.875rem;
         line-height: 1.43;
       }
 
-      .c28 {
+      .c19 {
+        margin-right: 24px;
+      }
+
+      .c19 svg {
+        width: 2rem;
+        height: 2rem;
+      }
+
+      .c22 {
+        word-break: break-all;
+      }
+
+      .c38 {
         display: grid;
         grid-template-columns: repeat(12,1fr);
         gap: 16px;
       }
 
-      .c29 {
+      .c39 {
         grid-column: span 4;
         max-width: 100%;
       }
@@ -593,7 +656,7 @@ describe('Marketplace page', () => {
         padding-right: 8px;
       }
 
-      .c42 {
+      .c50 {
         padding-left: 8px;
       }
 
@@ -730,7 +793,7 @@ describe('Marketplace page', () => {
         fill: #32324d;
       }
 
-      .c38 {
+      .c46 {
         display: -webkit-box;
         -webkit-box-orient: vertical;
         -webkit-line-clamp: 2;
@@ -738,13 +801,13 @@ describe('Marketplace page', () => {
       }
 
       @media (max-width:68.75rem) {
-        .c29 {
+        .c39 {
           grid-column: span 6;
         }
       }
 
       @media (max-width:34.375rem) {
-        .c29 {
+        .c39 {
           grid-column: span 12;
         }
       }
@@ -823,36 +886,100 @@ describe('Marketplace page', () => {
             <div
               class="c15"
             >
+              <a
+                href="https://strapi.canny.io/plugin-requests"
+                rel="noopener noreferrer nofollow"
+                style="text-decoration: none;"
+                target="_blank"
+              >
+                <div
+                  class="c16 c17"
+                >
+                  <div
+                    class="c18 c17 c19"
+                  >
+                    <svg
+                      fill="none"
+                      height="1em"
+                      viewBox="0 0 32 32"
+                      width="1em"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M0 4a4 4 0 014-4h24a4 4 0 014 4v24a4 4 0 01-4 4H4a4 4 0 01-4-4V4z"
+                        fill="#AC73E6"
+                      />
+                      <path
+                        clip-rule="evenodd"
+                        d="M15.027 13.839c-3.19-.836-6.305-1.064-10.18-.608-1.215.152-1.063 1.975.076 2.203.304.836.456 2.355.912 3.267.987 2.279 5.622 1.975 7.369.835 1.14-.683 1.443-2.279 1.9-3.494.227-.684 1.595-.684 1.822 0 .38 1.215.76 2.81 1.9 3.494 1.747 1.14 6.381 1.444 7.369-.835.456-.912.607-2.431.911-3.267 1.14-.228 1.216-2.051.076-2.203-3.874-.456-6.989-.228-10.18.608-.455.075-1.519.075-1.975 0z"
+                        fill="#fff"
+                        fill-rule="evenodd"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    class="c20"
+                  >
+                    <div
+                      class="c17"
+                    >
+                      <span
+                        class="c21 c22"
+                      >
+                        Documentation
+                      </span>
+                      <svg
+                        class="c23 c24"
+                        fill="none"
+                        height="3"
+                        viewBox="0 0 24 24"
+                        width="3"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M16.235 2.824a1.412 1.412 0 010-2.824h6.353C23.368 0 24 .633 24 1.412v6.353a1.412 1.412 0 01-2.823 0V4.82l-8.179 8.178a1.412 1.412 0 01-1.996-1.996l8.178-8.178h-2.945zm4.942 10.588a1.412 1.412 0 012.823 0v9.176c0 .78-.632 1.412-1.412 1.412H1.412C.632 24 0 23.368 0 22.588V1.412C0 .632.632 0 1.412 0h9.176a1.412 1.412 0 010 2.824H2.824v18.353h18.353v-7.765z"
+                          fill="#32324D"
+                        />
+                      </svg>
+                    </div>
+                    <span
+                      class="c25"
+                    >
+                      Tell us what plugin you are looking for and we'll let our community plugin developers know in case they are in search for inspiration!
+                    </span>
+                  </div>
+                </div>
+              </a>
               <div
-                class="c16"
+                class="c26"
                 width="25%"
               >
                 <div
-                  class="c17"
+                  class="c27"
                 >
                   <div>
                     <div
-                      class="c18"
+                      class="c28"
                     >
                       <label
-                        class="c19"
+                        class="c29"
                         for="field-1"
                       >
                         <div
-                          class="c20"
+                          class="c30"
                         >
                           Search for a plugin
                         </div>
                       </label>
                     </div>
                     <div
-                      class="c21 c22 c23"
+                      class="c31 c32 c33"
                     >
                       <div
-                        class="c24"
+                        class="c34"
                       >
                         <div
-                          class="c25 c20 c26"
+                          class="c35 c30 c36"
                         >
                           <svg
                             aria-hidden="true"
@@ -874,7 +1001,7 @@ describe('Marketplace page', () => {
                       <input
                         aria-disabled="false"
                         aria-invalid="false"
-                        class="c27"
+                        class="c37"
                         id="field-1"
                         name="searchbar"
                         placeholder="Search for a plugin"
@@ -885,17 +1012,17 @@ describe('Marketplace page', () => {
                 </div>
               </div>
               <div
-                class="c28"
+                class="c38"
               >
                 <div
-                  class="c29"
+                  class="c39"
                 >
                   <div
                     class=""
                     style="height: 100%;"
                   >
                     <div
-                      class="c30 c31"
+                      class="c40 c41"
                       height="100%"
                     >
                       <div
@@ -903,36 +1030,36 @@ describe('Marketplace page', () => {
                       >
                         <img
                           alt="Comments logo"
-                          class="c32"
+                          class="c42"
                           height="11"
                           src="https://dl.airtable.com/.attachments/eb4cd59876565af77c9c3e5966b59f10/2111bfc8/vl_strapi-comments.png"
                           width="11"
                         />
                         <div
-                          class="c33"
+                          class="c43"
                         >
                           <h3
-                            class="c34"
+                            class="c44"
                           >
                             <div
-                              class="c35"
+                              class="c17"
                             >
                               Comments
                             </div>
                           </h3>
                         </div>
                         <div
-                          class="c36"
+                          class="c45"
                         >
                           <p
-                            class="c37 c38"
+                            class="c25 c46"
                           >
                             Powerful Strapi based comments moderation tool for you and your users
                           </p>
                         </div>
                       </div>
                       <div
-                        class="c39 c40 c41"
+                        class="c47 c48 c49"
                         spacing="2"
                         style="align-self: flex-end;"
                       >
@@ -951,7 +1078,7 @@ describe('Marketplace page', () => {
                           </span>
                           <div
                             aria-hidden="true"
-                            class="c10 c42"
+                            class="c10 c50"
                           >
                             <svg
                               fill="none"
@@ -969,12 +1096,12 @@ describe('Marketplace page', () => {
                         </a>
                         <button
                           aria-disabled="false"
-                          class="c43 c44"
+                          class="c51 c52"
                           type="button"
                         >
                           <div
                             aria-hidden="true"
-                            class="c45 c46 c47"
+                            class="c53 c54 c55"
                           >
                             <svg
                               fill="none"
@@ -994,7 +1121,7 @@ describe('Marketplace page', () => {
                             </svg>
                           </div>
                           <span
-                            class="c48 c49"
+                            class="c56 c57"
                           >
                             Copy install command
                           </span>
@@ -1004,14 +1131,14 @@ describe('Marketplace page', () => {
                   </div>
                 </div>
                 <div
-                  class="c29"
+                  class="c39"
                 >
                   <div
                     class=""
                     style="height: 100%;"
                   >
                     <div
-                      class="c30 c31"
+                      class="c40 c41"
                       height="100%"
                     >
                       <div
@@ -1019,29 +1146,29 @@ describe('Marketplace page', () => {
                       >
                         <img
                           alt="Config Sync logo"
-                          class="c32"
+                          class="c42"
                           height="11"
                           src="https://dl.airtable.com/.attachments/e23a7231d12cce89cb4b05cbfe759d45/96f5f496/Screenshot2021-12-09at22.15.37.png"
                           width="11"
                         />
                         <div
-                          class="c33"
+                          class="c43"
                         >
                           <h3
-                            class="c34"
+                            class="c44"
                           >
                             <div
-                              class="c35"
+                              class="c17"
                             >
                               Config Sync
                               <span>
                                 <div
                                   aria-describedby="tooltip-1"
-                                  class="c35"
+                                  class="c17"
                                   tabindex="0"
                                 >
                                   <svg
-                                    class="c50 c51"
+                                    class="c58 c59"
                                     fill="none"
                                     height="1em"
                                     viewBox="0 0 24 24"
@@ -1061,17 +1188,17 @@ describe('Marketplace page', () => {
                           </h3>
                         </div>
                         <div
-                          class="c36"
+                          class="c45"
                         >
                           <p
-                            class="c37 c38"
+                            class="c25 c46"
                           >
                             Migrate your config data across environments using the CLI or Strapi admin panel.
                           </p>
                         </div>
                       </div>
                       <div
-                        class="c39 c40 c41"
+                        class="c47 c48 c49"
                         spacing="2"
                         style="align-self: flex-end;"
                       >
@@ -1090,7 +1217,7 @@ describe('Marketplace page', () => {
                           </span>
                           <div
                             aria-hidden="true"
-                            class="c10 c42"
+                            class="c10 c50"
                           >
                             <svg
                               fill="none"
@@ -1108,12 +1235,12 @@ describe('Marketplace page', () => {
                         </a>
                         <button
                           aria-disabled="false"
-                          class="c43 c44"
+                          class="c51 c52"
                           type="button"
                         >
                           <div
                             aria-hidden="true"
-                            class="c45 c46 c47"
+                            class="c53 c54 c55"
                           >
                             <svg
                               fill="none"
@@ -1133,7 +1260,7 @@ describe('Marketplace page', () => {
                             </svg>
                           </div>
                           <span
-                            class="c48 c49"
+                            class="c56 c57"
                           >
                             Copy install command
                           </span>
@@ -1143,14 +1270,14 @@ describe('Marketplace page', () => {
                   </div>
                 </div>
                 <div
-                  class="c29"
+                  class="c39"
                 >
                   <div
                     class=""
                     style="height: 100%;"
                   >
                     <div
-                      class="c30 c31"
+                      class="c40 c41"
                       height="100%"
                     >
                       <div
@@ -1158,36 +1285,36 @@ describe('Marketplace page', () => {
                       >
                         <img
                           alt="Content Versioning logo"
-                          class="c32"
+                          class="c42"
                           height="11"
                           src="https://dl.airtable.com/.attachments/0b86f18e2606ed7f53bd54d536a1bea5/13a87f30/Artboard7copy.png"
                           width="11"
                         />
                         <div
-                          class="c33"
+                          class="c43"
                         >
                           <h3
-                            class="c34"
+                            class="c44"
                           >
                             <div
-                              class="c35"
+                              class="c17"
                             >
                               Content Versioning
                             </div>
                           </h3>
                         </div>
                         <div
-                          class="c36"
+                          class="c45"
                         >
                           <p
-                            class="c37 c38"
+                            class="c25 c46"
                           >
                             This plugin enables you to versioning Content Types. It allows multiple draft versions✅ Keeps history of all changes (with time travel) ✅ 
                           </p>
                         </div>
                       </div>
                       <div
-                        class="c39 c40 c41"
+                        class="c47 c48 c49"
                         spacing="2"
                         style="align-self: flex-end;"
                       >
@@ -1206,7 +1333,7 @@ describe('Marketplace page', () => {
                           </span>
                           <div
                             aria-hidden="true"
-                            class="c10 c42"
+                            class="c10 c50"
                           >
                             <svg
                               fill="none"
@@ -1224,12 +1351,12 @@ describe('Marketplace page', () => {
                         </a>
                         <button
                           aria-disabled="false"
-                          class="c43 c44"
+                          class="c51 c52"
                           type="button"
                         >
                           <div
                             aria-hidden="true"
-                            class="c45 c46 c47"
+                            class="c53 c54 c55"
                           >
                             <svg
                               fill="none"
@@ -1249,7 +1376,7 @@ describe('Marketplace page', () => {
                             </svg>
                           </div>
                           <span
-                            class="c48 c49"
+                            class="c56 c57"
                           >
                             Copy install command
                           </span>
@@ -1259,14 +1386,14 @@ describe('Marketplace page', () => {
                   </div>
                 </div>
                 <div
-                  class="c29"
+                  class="c39"
                 >
                   <div
                     class=""
                     style="height: 100%;"
                   >
                     <div
-                      class="c30 c31"
+                      class="c40 c41"
                       height="100%"
                     >
                       <div
@@ -1274,30 +1401,30 @@ describe('Marketplace page', () => {
                       >
                         <img
                           alt="Documentation logo"
-                          class="c32"
+                          class="c42"
                           height="11"
                           src="https://dl.airtable.com/.attachments/b6998ac52e8b0460b8a14ced8074b788/2a4d4a90/swagger.png"
                           width="11"
                         />
                         <div
-                          class="c33"
+                          class="c43"
                         >
                           <h3
-                            class="c34"
+                            class="c44"
                           >
                             <div
-                              class="c35"
+                              class="c17"
                             >
                               Documentation
                               <span>
                                 <div
                                   aria-describedby="tooltip-3"
-                                  class="c35"
+                                  class="c17"
                                   tabindex="0"
                                 >
                                   <img
                                     alt="Made by Strapi"
-                                    class="c52"
+                                    class="c60"
                                     height="auto"
                                     src="IMAGE_MOCK"
                                     width="6"
@@ -1308,17 +1435,17 @@ describe('Marketplace page', () => {
                           </h3>
                         </div>
                         <div
-                          class="c36"
+                          class="c45"
                         >
                           <p
-                            class="c37 c38"
+                            class="c25 c46"
                           >
                             Create an OpenAPI Document and visualize your API with SWAGGER UI
                           </p>
                         </div>
                       </div>
                       <div
-                        class="c39 c40 c41"
+                        class="c47 c48 c49"
                         spacing="2"
                         style="align-self: flex-end;"
                       >
@@ -1337,7 +1464,7 @@ describe('Marketplace page', () => {
                           </span>
                           <div
                             aria-hidden="true"
-                            class="c10 c42"
+                            class="c10 c50"
                           >
                             <svg
                               fill="none"
@@ -1354,10 +1481,10 @@ describe('Marketplace page', () => {
                           </div>
                         </a>
                         <div
-                          class="c53"
+                          class="c61"
                         >
                           <svg
-                            class="c54 c51"
+                            class="c62 c59"
                             fill="none"
                             height="12"
                             viewBox="0 0 24 24"
@@ -1370,7 +1497,7 @@ describe('Marketplace page', () => {
                             />
                           </svg>
                           <span
-                            class="c55"
+                            class="c63"
                           >
                             Installed
                           </span>
@@ -1380,14 +1507,14 @@ describe('Marketplace page', () => {
                   </div>
                 </div>
                 <div
-                  class="c29"
+                  class="c39"
                 >
                   <div
                     class=""
                     style="height: 100%;"
                   >
                     <div
-                      class="c30 c31"
+                      class="c40 c41"
                       height="100%"
                     >
                       <div
@@ -1395,36 +1522,36 @@ describe('Marketplace page', () => {
                       >
                         <img
                           alt="Transformer logo"
-                          class="c32"
+                          class="c42"
                           height="11"
                           src="https://dl.airtable.com/.attachments/5ffd1782a2fabf423ccd6f56c562f31a/b8f8598f/transformer-logo.png"
                           width="11"
                         />
                         <div
-                          class="c33"
+                          class="c43"
                         >
                           <h3
-                            class="c34"
+                            class="c44"
                           >
                             <div
-                              class="c35"
+                              class="c17"
                             >
                               Transformer
                             </div>
                           </h3>
                         </div>
                         <div
-                          class="c36"
+                          class="c45"
                         >
                           <p
-                            class="c37 c38"
+                            class="c25 c46"
                           >
                             A plugin for Strapi Headless CMS that provides the ability to transform the API response. 
                           </p>
                         </div>
                       </div>
                       <div
-                        class="c39 c40 c41"
+                        class="c47 c48 c49"
                         spacing="2"
                         style="align-self: flex-end;"
                       >
@@ -1443,7 +1570,7 @@ describe('Marketplace page', () => {
                           </span>
                           <div
                             aria-hidden="true"
-                            class="c10 c42"
+                            class="c10 c50"
                           >
                             <svg
                               fill="none"
@@ -1461,12 +1588,12 @@ describe('Marketplace page', () => {
                         </a>
                         <button
                           aria-disabled="false"
-                          class="c43 c44"
+                          class="c51 c52"
                           type="button"
                         >
                           <div
                             aria-hidden="true"
-                            class="c45 c46 c47"
+                            class="c53 c54 c55"
                           >
                             <svg
                               fill="none"
@@ -1486,7 +1613,7 @@ describe('Marketplace page', () => {
                             </svg>
                           </div>
                           <span
-                            class="c48 c49"
+                            class="c56 c57"
                           >
                             Copy install command
                           </span>
@@ -1495,6 +1622,74 @@ describe('Marketplace page', () => {
                     </div>
                   </div>
                 </div>
+              </div>
+              <div
+                class="c64"
+              >
+                <a
+                  href="https://strapi.canny.io/plugin-requests"
+                  rel="noopener noreferrer nofollow"
+                  style="text-decoration: none;"
+                  target="_blank"
+                >
+                  <div
+                    class="c16 c17"
+                  >
+                    <div
+                      class="c18 c17 c19"
+                    >
+                      <svg
+                        fill="none"
+                        height="1em"
+                        viewBox="0 0 32 32"
+                        width="1em"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M0 4a4 4 0 014-4h24a4 4 0 014 4v24a4 4 0 01-4 4H4a4 4 0 01-4-4V4z"
+                          fill="#AC73E6"
+                        />
+                        <path
+                          clip-rule="evenodd"
+                          d="M15.027 13.839c-3.19-.836-6.305-1.064-10.18-.608-1.215.152-1.063 1.975.076 2.203.304.836.456 2.355.912 3.267.987 2.279 5.622 1.975 7.369.835 1.14-.683 1.443-2.279 1.9-3.494.227-.684 1.595-.684 1.822 0 .38 1.215.76 2.81 1.9 3.494 1.747 1.14 6.381 1.444 7.369-.835.456-.912.607-2.431.911-3.267 1.14-.228 1.216-2.051.076-2.203-3.874-.456-6.989-.228-10.18.608-.455.075-1.519.075-1.975 0z"
+                          fill="#fff"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                    <div
+                      class="c20"
+                    >
+                      <div
+                        class="c17"
+                      >
+                        <span
+                          class="c21 c22"
+                        >
+                          Documentation
+                        </span>
+                        <svg
+                          class="c23 c24"
+                          fill="none"
+                          height="3"
+                          viewBox="0 0 24 24"
+                          width="3"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M16.235 2.824a1.412 1.412 0 010-2.824h6.353C23.368 0 24 .633 24 1.412v6.353a1.412 1.412 0 01-2.823 0V4.82l-8.179 8.178a1.412 1.412 0 01-1.996-1.996l8.178-8.178h-2.945zm4.942 10.588a1.412 1.412 0 012.823 0v9.176c0 .78-.632 1.412-1.412 1.412H1.412C.632 24 0 23.368 0 22.588V1.412C0 .632.632 0 1.412 0h9.176a1.412 1.412 0 010 2.824H2.824v18.353h18.353v-7.765z"
+                            fill="#32324D"
+                          />
+                        </svg>
+                      </div>
+                      <span
+                        class="c25"
+                      >
+                        Tell us what plugin you are looking for and we'll let our community plugin developers know in case they are in search for inspiration!
+                      </span>
+                    </div>
+                  </div>
+                </a>
               </div>
             </div>
           </main>
@@ -1515,8 +1710,8 @@ describe('Marketplace page', () => {
   it('should return search results matching the query', async () => {
     const { container } = render(App);
     const input = await getByPlaceholderText(container, 'Search for a plugin');
-    fireEvent.change(input, { target: { value: 'documentation' } });
-    const match = screen.getByText('Documentation');
+    fireEvent.change(input, { target: { value: 'comment' } });
+    const match = screen.getByText('Comments');
     const notMatch = screen.queryByText('Sentry');
 
     expect(match).toBeVisible();

--- a/packages/core/admin/admin/src/pages/MarketplacePage/tests/index.test.js
+++ b/packages/core/admin/admin/src/pages/MarketplacePage/tests/index.test.js
@@ -58,51 +58,51 @@ describe('Marketplace page', () => {
     await waitFor(() => expect(getByRole('heading', { name: /marketplace/i })).toBeInTheDocument());
 
     expect(container.firstChild).toMatchInlineSnapshot(`
-      .c26 {
+      .c16 {
         padding-bottom: 16px;
         width: 25%;
       }
 
-      .c42 {
+      .c32 {
         border-radius: 4px;
         width: 64px;
         height: 64px;
       }
 
-      .c43 {
+      .c33 {
         padding-top: 16px;
       }
 
-      .c45 {
+      .c36 {
         padding-top: 8px;
       }
 
-      .c60 {
+      .c52 {
         margin-left: 4px;
         width: 24px;
         height: auto;
       }
 
-      .c61 {
+      .c53 {
         padding-left: 16px;
       }
 
-      .c64 {
+      .c56 {
         padding-top: 32px;
       }
 
-      .c57 {
+      .c49 {
         font-weight: 600;
         color: #32324d;
         font-size: 0.75rem;
         line-height: 1.33;
       }
 
-      .c54 {
+      .c46 {
         padding-right: 8px;
       }
 
-      .c51 {
+      .c43 {
         display: -webkit-box;
         display: -webkit-flex;
         display: -ms-flexbox;
@@ -116,21 +116,21 @@ describe('Marketplace page', () => {
         outline: none;
       }
 
-      .c51 svg {
+      .c43 svg {
         height: 12px;
         width: 12px;
       }
 
-      .c51 svg > g,
-      .c51 svg path {
+      .c43 svg > g,
+      .c43 svg path {
         fill: #ffffff;
       }
 
-      .c51[aria-disabled='true'] {
+      .c43[aria-disabled='true'] {
         pointer-events: none;
       }
 
-      .c51:after {
+      .c43:after {
         -webkit-transition-property: all;
         transition-property: all;
         -webkit-transition-duration: 0.2s;
@@ -145,11 +145,11 @@ describe('Marketplace page', () => {
         border: 2px solid transparent;
       }
 
-      .c51:focus-visible {
+      .c43:focus-visible {
         outline: none;
       }
 
-      .c51:focus-visible:after {
+      .c43:focus-visible:after {
         border-radius: 8px;
         content: '';
         position: absolute;
@@ -160,11 +160,11 @@ describe('Marketplace page', () => {
         border: 2px solid #4945ff;
       }
 
-      .c55 {
+      .c47 {
         height: 100%;
       }
 
-      .c52 {
+      .c44 {
         -webkit-align-items: center;
         -webkit-box-align: center;
         -ms-flex-align: center;
@@ -176,7 +176,7 @@ describe('Marketplace page', () => {
         background: #f0f0ff;
       }
 
-      .c52 .c53 {
+      .c44 .c45 {
         display: -webkit-box;
         display: -webkit-flex;
         display: -ms-flexbox;
@@ -187,79 +187,66 @@ describe('Marketplace page', () => {
         align-items: center;
       }
 
-      .c52 .c56 {
+      .c44 .c48 {
         color: #ffffff;
       }
 
-      .c52[aria-disabled='true'] {
+      .c44[aria-disabled='true'] {
         border: 1px solid #dcdce4;
         background: #eaeaef;
       }
 
-      .c52[aria-disabled='true'] .c56 {
+      .c44[aria-disabled='true'] .c48 {
         color: #666687;
       }
 
-      .c52[aria-disabled='true'] svg > g,
-      .c52[aria-disabled='true'] svg path {
+      .c44[aria-disabled='true'] svg > g,
+      .c44[aria-disabled='true'] svg path {
         fill: #666687;
       }
 
-      .c52[aria-disabled='true']:active {
+      .c44[aria-disabled='true']:active {
         border: 1px solid #dcdce4;
         background: #eaeaef;
       }
 
-      .c52[aria-disabled='true']:active .c56 {
+      .c44[aria-disabled='true']:active .c48 {
         color: #666687;
       }
 
-      .c52[aria-disabled='true']:active svg > g,
-      .c52[aria-disabled='true']:active svg path {
+      .c44[aria-disabled='true']:active svg > g,
+      .c44[aria-disabled='true']:active svg path {
         fill: #666687;
       }
 
-      .c52:hover {
+      .c44:hover {
         background-color: #ffffff;
       }
 
-      .c52:active {
+      .c44:active {
         background-color: #ffffff;
         border: 1px solid #4945ff;
       }
 
-      .c52:active .c56 {
+      .c44:active .c48 {
         color: #4945ff;
       }
 
-      .c52:active svg > g,
-      .c52:active svg path {
+      .c44:active svg > g,
+      .c44:active svg path {
         fill: #4945ff;
       }
 
-      .c52 .c56 {
+      .c44 .c48 {
         color: #271fe0;
       }
 
-      .c52 svg > g,
-      .c52 svg path {
+      .c44 svg > g,
+      .c44 svg path {
         fill: #271fe0;
       }
 
-      .c16 {
-        background: #ffffff;
-        padding: 24px;
-        border-radius: 4px;
-        box-shadow: 0px 1px 4px rgba(33,33,52,0.1);
-      }
-
-      .c18 {
-        background: #f6ecfc;
-        padding: 12px;
-        border-radius: 4px;
-      }
-
-      .c40 {
+      .c30 {
         background: #ffffff;
         padding-top: 16px;
         padding-right: 24px;
@@ -270,21 +257,20 @@ describe('Marketplace page', () => {
         height: 100%;
       }
 
-      .c17 {
-        display: -webkit-box;
-        display: -webkit-flex;
-        display: -ms-flexbox;
-        display: flex;
-        -webkit-flex-direction: row;
-        -ms-flex-direction: row;
-        flex-direction: row;
-        -webkit-align-items: center;
-        -webkit-box-align: center;
-        -ms-flex-align: center;
-        align-items: center;
+      .c57 {
+        background: #ffffff;
+        padding: 24px;
+        border-radius: 4px;
+        box-shadow: 0px 1px 4px rgba(33,33,52,0.1);
       }
 
-      .c41 {
+      .c58 {
+        background: #f6ecfc;
+        padding: 12px;
+        border-radius: 4px;
+      }
+
+      .c31 {
         display: -webkit-box;
         display: -webkit-flex;
         display: -ms-flexbox;
@@ -302,39 +288,7 @@ describe('Marketplace page', () => {
         align-items: normal;
       }
 
-      .c23 {
-        color: #666687;
-        margin-left: 8px;
-        width: 12px;
-        height: 12px;
-      }
-
-      .c58 {
-        color: #328048;
-        margin-left: 8px;
-      }
-
-      .c62 {
-        color: #328048;
-        margin-right: 8px;
-        width: 12;
-        height: 12;
-      }
-
-      .c24 path {
-        fill: #666687;
-      }
-
-      .c59 path {
-        fill: #328048;
-      }
-
-      .c34 {
-        padding-right: 8px;
-        padding-left: 12px;
-      }
-
-      .c30 {
+      .c35 {
         display: -webkit-box;
         display: -webkit-flex;
         display: -ms-flexbox;
@@ -348,7 +302,53 @@ describe('Marketplace page', () => {
         align-items: center;
       }
 
-      .c32 {
+      .c50 {
+        color: #328048;
+        margin-left: 8px;
+      }
+
+      .c54 {
+        color: #328048;
+        margin-right: 8px;
+        width: 12;
+        height: 12;
+      }
+
+      .c63 {
+        color: #666687;
+        margin-left: 8px;
+        width: 12px;
+        height: 12px;
+      }
+
+      .c51 path {
+        fill: #328048;
+      }
+
+      .c64 path {
+        fill: #666687;
+      }
+
+      .c24 {
+        padding-right: 8px;
+        padding-left: 12px;
+      }
+
+      .c20 {
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+        -webkit-flex-direction: row;
+        -ms-flex-direction: row;
+        flex-direction: row;
+        -webkit-align-items: center;
+        -webkit-box-align: center;
+        -ms-flex-align: center;
+        align-items: center;
+      }
+
+      .c22 {
         display: -webkit-box;
         display: -webkit-flex;
         display: -ms-flexbox;
@@ -366,14 +366,14 @@ describe('Marketplace page', () => {
         align-items: center;
       }
 
-      .c29 {
+      .c19 {
         font-weight: 600;
         color: #32324d;
         font-size: 0.75rem;
         line-height: 1.33;
       }
 
-      .c37 {
+      .c27 {
         border: none;
         border-radius: 4px;
         padding-left: 0;
@@ -386,36 +386,36 @@ describe('Marketplace page', () => {
         background: inherit;
       }
 
-      .c37::-webkit-input-placeholder {
+      .c27::-webkit-input-placeholder {
         color: #8e8ea9;
         opacity: 1;
       }
 
-      .c37::-moz-placeholder {
+      .c27::-moz-placeholder {
         color: #8e8ea9;
         opacity: 1;
       }
 
-      .c37:-ms-input-placeholder {
+      .c27:-ms-input-placeholder {
         color: #8e8ea9;
         opacity: 1;
       }
 
-      .c37::placeholder {
+      .c27::placeholder {
         color: #8e8ea9;
         opacity: 1;
       }
 
-      .c37[aria-disabled='true'] {
+      .c27[aria-disabled='true'] {
         color: inherit;
       }
 
-      .c37:focus {
+      .c27:focus {
         outline: none;
         box-shadow: none;
       }
 
-      .c33 {
+      .c23 {
         border: 1px solid #dcdce4;
         border-radius: 4px;
         background: #ffffff;
@@ -428,12 +428,12 @@ describe('Marketplace page', () => {
         transition-duration: 0.2s;
       }
 
-      .c33:focus-within {
+      .c23:focus-within {
         border: 1px solid #4945ff;
         box-shadow: #4945ff 0px 0px 0px 2px;
       }
 
-      .c28 {
+      .c18 {
         border: 0;
         -webkit-clip: rect(0 0 0 0);
         clip: rect(0 0 0 0);
@@ -445,15 +445,15 @@ describe('Marketplace page', () => {
         width: 1px;
       }
 
-      .c36 {
+      .c26 {
         font-size: 0.8rem;
       }
 
-      .c36 svg path {
+      .c26 svg path {
         fill: #32324d;
       }
 
-      .c27 {
+      .c17 {
         border-radius: 4px;
         box-shadow: 0px 1px 4px rgba(33,33,52,0.1);
         outline: none;
@@ -464,24 +464,24 @@ describe('Marketplace page', () => {
         transition-duration: 0.2s;
       }
 
-      .c27:focus-within .c35 svg path {
+      .c17:focus-within .c25 svg path {
         fill: #4945ff;
       }
 
-      .c27 .c31 {
+      .c17 .c21 {
         border: 1px solid transparent;
       }
 
-      .c27 .c31:focus-within {
+      .c17 .c21:focus-within {
         border: 1px solid #4945ff;
         box-shadow: #4945ff 0px 0px 0px 2px;
       }
 
-      .c47 {
+      .c39 {
         padding-top: 24px;
       }
 
-      .c48 {
+      .c40 {
         display: -webkit-box;
         display: -webkit-flex;
         display: -ms-flexbox;
@@ -495,7 +495,7 @@ describe('Marketplace page', () => {
         align-items: center;
       }
 
-      .c20 {
+      .c60 {
         display: -webkit-box;
         display: -webkit-flex;
         display: -ms-flexbox;
@@ -505,67 +505,67 @@ describe('Marketplace page', () => {
         flex-direction: column;
       }
 
-      .c20 > * {
+      .c60 > * {
         margin-top: 0;
         margin-bottom: 0;
       }
 
-      .c49 > * {
+      .c41 > * {
         margin-left: 0;
         margin-right: 0;
       }
 
-      .c49 > * + * {
+      .c41 > * + * {
         margin-left: 8px;
       }
 
-      .c21 {
-        font-weight: 500;
-        color: #32324d;
-        font-size: 0.75rem;
-        line-height: 1.33;
-      }
-
-      .c25 {
-        color: #666687;
-        font-size: 0.875rem;
-        line-height: 1.43;
-      }
-
-      .c44 {
+      .c34 {
         color: #32324d;
         font-weight: 500;
         font-size: 1rem;
         line-height: 1.25;
       }
 
-      .c63 {
+      .c37 {
+        color: #666687;
+        font-size: 0.875rem;
+        line-height: 1.43;
+      }
+
+      .c55 {
         font-weight: 600;
         color: #328048;
         font-size: 0.875rem;
         line-height: 1.43;
       }
 
-      .c19 {
+      .c61 {
+        font-weight: 500;
+        color: #32324d;
+        font-size: 0.75rem;
+        line-height: 1.33;
+      }
+
+      .c59 {
         margin-right: 24px;
       }
 
-      .c19 svg {
+      .c59 svg {
         width: 2rem;
         height: 2rem;
       }
 
-      .c22 {
+      .c62 {
         word-break: break-all;
       }
 
-      .c38 {
+      .c28 {
         display: grid;
         grid-template-columns: repeat(12,1fr);
         gap: 16px;
       }
 
-      .c39 {
+      .c29 {
         grid-column: span 4;
         max-width: 100%;
       }
@@ -656,7 +656,7 @@ describe('Marketplace page', () => {
         padding-right: 8px;
       }
 
-      .c50 {
+      .c42 {
         padding-left: 8px;
       }
 
@@ -793,7 +793,7 @@ describe('Marketplace page', () => {
         fill: #32324d;
       }
 
-      .c46 {
+      .c38 {
         display: -webkit-box;
         -webkit-box-orient: vertical;
         -webkit-line-clamp: 2;
@@ -801,13 +801,13 @@ describe('Marketplace page', () => {
       }
 
       @media (max-width:68.75rem) {
-        .c39 {
+        .c29 {
           grid-column: span 6;
         }
       }
 
       @media (max-width:34.375rem) {
-        .c39 {
+        .c29 {
           grid-column: span 12;
         }
       }
@@ -886,100 +886,36 @@ describe('Marketplace page', () => {
             <div
               class="c15"
             >
-              <a
-                href="https://strapi.canny.io/plugin-requests"
-                rel="noopener noreferrer nofollow"
-                style="text-decoration: none;"
-                target="_blank"
-              >
-                <div
-                  class="c16 c17"
-                >
-                  <div
-                    class="c18 c17 c19"
-                  >
-                    <svg
-                      fill="none"
-                      height="1em"
-                      viewBox="0 0 32 32"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M0 4a4 4 0 014-4h24a4 4 0 014 4v24a4 4 0 01-4 4H4a4 4 0 01-4-4V4z"
-                        fill="#AC73E6"
-                      />
-                      <path
-                        clip-rule="evenodd"
-                        d="M15.027 13.839c-3.19-.836-6.305-1.064-10.18-.608-1.215.152-1.063 1.975.076 2.203.304.836.456 2.355.912 3.267.987 2.279 5.622 1.975 7.369.835 1.14-.683 1.443-2.279 1.9-3.494.227-.684 1.595-.684 1.822 0 .38 1.215.76 2.81 1.9 3.494 1.747 1.14 6.381 1.444 7.369-.835.456-.912.607-2.431.911-3.267 1.14-.228 1.216-2.051.076-2.203-3.874-.456-6.989-.228-10.18.608-.455.075-1.519.075-1.975 0z"
-                        fill="#fff"
-                        fill-rule="evenodd"
-                      />
-                    </svg>
-                  </div>
-                  <div
-                    class="c20"
-                  >
-                    <div
-                      class="c17"
-                    >
-                      <span
-                        class="c21 c22"
-                      >
-                        Documentation
-                      </span>
-                      <svg
-                        class="c23 c24"
-                        fill="none"
-                        height="3"
-                        viewBox="0 0 24 24"
-                        width="3"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M16.235 2.824a1.412 1.412 0 010-2.824h6.353C23.368 0 24 .633 24 1.412v6.353a1.412 1.412 0 01-2.823 0V4.82l-8.179 8.178a1.412 1.412 0 01-1.996-1.996l8.178-8.178h-2.945zm4.942 10.588a1.412 1.412 0 012.823 0v9.176c0 .78-.632 1.412-1.412 1.412H1.412C.632 24 0 23.368 0 22.588V1.412C0 .632.632 0 1.412 0h9.176a1.412 1.412 0 010 2.824H2.824v18.353h18.353v-7.765z"
-                          fill="#32324D"
-                        />
-                      </svg>
-                    </div>
-                    <span
-                      class="c25"
-                    >
-                      Tell us what plugin you are looking for and we'll let our community plugin developers know in case they are in search for inspiration!
-                    </span>
-                  </div>
-                </div>
-              </a>
               <div
-                class="c26"
+                class="c16"
                 width="25%"
               >
                 <div
-                  class="c27"
+                  class="c17"
                 >
                   <div>
                     <div
-                      class="c28"
+                      class="c18"
                     >
                       <label
-                        class="c29"
+                        class="c19"
                         for="field-1"
                       >
                         <div
-                          class="c30"
+                          class="c20"
                         >
                           Search for a plugin
                         </div>
                       </label>
                     </div>
                     <div
-                      class="c31 c32 c33"
+                      class="c21 c22 c23"
                     >
                       <div
-                        class="c34"
+                        class="c24"
                       >
                         <div
-                          class="c35 c30 c36"
+                          class="c25 c20 c26"
                         >
                           <svg
                             aria-hidden="true"
@@ -1001,7 +937,7 @@ describe('Marketplace page', () => {
                       <input
                         aria-disabled="false"
                         aria-invalid="false"
-                        class="c37"
+                        class="c27"
                         id="field-1"
                         name="searchbar"
                         placeholder="Search for a plugin"
@@ -1012,17 +948,17 @@ describe('Marketplace page', () => {
                 </div>
               </div>
               <div
-                class="c38"
+                class="c28"
               >
                 <div
-                  class="c39"
+                  class="c29"
                 >
                   <div
                     class=""
                     style="height: 100%;"
                   >
                     <div
-                      class="c40 c41"
+                      class="c30 c31"
                       height="100%"
                     >
                       <div
@@ -1030,36 +966,36 @@ describe('Marketplace page', () => {
                       >
                         <img
                           alt="Comments logo"
-                          class="c42"
+                          class="c32"
                           height="11"
                           src="https://dl.airtable.com/.attachments/eb4cd59876565af77c9c3e5966b59f10/2111bfc8/vl_strapi-comments.png"
                           width="11"
                         />
                         <div
-                          class="c43"
+                          class="c33"
                         >
                           <h3
-                            class="c44"
+                            class="c34"
                           >
                             <div
-                              class="c17"
+                              class="c35"
                             >
                               Comments
                             </div>
                           </h3>
                         </div>
                         <div
-                          class="c45"
+                          class="c36"
                         >
                           <p
-                            class="c25 c46"
+                            class="c37 c38"
                           >
                             Powerful Strapi based comments moderation tool for you and your users
                           </p>
                         </div>
                       </div>
                       <div
-                        class="c47 c48 c49"
+                        class="c39 c40 c41"
                         spacing="2"
                         style="align-self: flex-end;"
                       >
@@ -1078,7 +1014,7 @@ describe('Marketplace page', () => {
                           </span>
                           <div
                             aria-hidden="true"
-                            class="c10 c50"
+                            class="c10 c42"
                           >
                             <svg
                               fill="none"
@@ -1096,12 +1032,12 @@ describe('Marketplace page', () => {
                         </a>
                         <button
                           aria-disabled="false"
-                          class="c51 c52"
+                          class="c43 c44"
                           type="button"
                         >
                           <div
                             aria-hidden="true"
-                            class="c53 c54 c55"
+                            class="c45 c46 c47"
                           >
                             <svg
                               fill="none"
@@ -1121,7 +1057,7 @@ describe('Marketplace page', () => {
                             </svg>
                           </div>
                           <span
-                            class="c56 c57"
+                            class="c48 c49"
                           >
                             Copy install command
                           </span>
@@ -1131,14 +1067,14 @@ describe('Marketplace page', () => {
                   </div>
                 </div>
                 <div
-                  class="c39"
+                  class="c29"
                 >
                   <div
                     class=""
                     style="height: 100%;"
                   >
                     <div
-                      class="c40 c41"
+                      class="c30 c31"
                       height="100%"
                     >
                       <div
@@ -1146,29 +1082,29 @@ describe('Marketplace page', () => {
                       >
                         <img
                           alt="Config Sync logo"
-                          class="c42"
+                          class="c32"
                           height="11"
                           src="https://dl.airtable.com/.attachments/e23a7231d12cce89cb4b05cbfe759d45/96f5f496/Screenshot2021-12-09at22.15.37.png"
                           width="11"
                         />
                         <div
-                          class="c43"
+                          class="c33"
                         >
                           <h3
-                            class="c44"
+                            class="c34"
                           >
                             <div
-                              class="c17"
+                              class="c35"
                             >
                               Config Sync
                               <span>
                                 <div
                                   aria-describedby="tooltip-1"
-                                  class="c17"
+                                  class="c35"
                                   tabindex="0"
                                 >
                                   <svg
-                                    class="c58 c59"
+                                    class="c50 c51"
                                     fill="none"
                                     height="1em"
                                     viewBox="0 0 24 24"
@@ -1188,17 +1124,17 @@ describe('Marketplace page', () => {
                           </h3>
                         </div>
                         <div
-                          class="c45"
+                          class="c36"
                         >
                           <p
-                            class="c25 c46"
+                            class="c37 c38"
                           >
                             Migrate your config data across environments using the CLI or Strapi admin panel.
                           </p>
                         </div>
                       </div>
                       <div
-                        class="c47 c48 c49"
+                        class="c39 c40 c41"
                         spacing="2"
                         style="align-self: flex-end;"
                       >
@@ -1217,7 +1153,7 @@ describe('Marketplace page', () => {
                           </span>
                           <div
                             aria-hidden="true"
-                            class="c10 c50"
+                            class="c10 c42"
                           >
                             <svg
                               fill="none"
@@ -1235,12 +1171,12 @@ describe('Marketplace page', () => {
                         </a>
                         <button
                           aria-disabled="false"
-                          class="c51 c52"
+                          class="c43 c44"
                           type="button"
                         >
                           <div
                             aria-hidden="true"
-                            class="c53 c54 c55"
+                            class="c45 c46 c47"
                           >
                             <svg
                               fill="none"
@@ -1260,7 +1196,7 @@ describe('Marketplace page', () => {
                             </svg>
                           </div>
                           <span
-                            class="c56 c57"
+                            class="c48 c49"
                           >
                             Copy install command
                           </span>
@@ -1270,14 +1206,14 @@ describe('Marketplace page', () => {
                   </div>
                 </div>
                 <div
-                  class="c39"
+                  class="c29"
                 >
                   <div
                     class=""
                     style="height: 100%;"
                   >
                     <div
-                      class="c40 c41"
+                      class="c30 c31"
                       height="100%"
                     >
                       <div
@@ -1285,36 +1221,36 @@ describe('Marketplace page', () => {
                       >
                         <img
                           alt="Content Versioning logo"
-                          class="c42"
+                          class="c32"
                           height="11"
                           src="https://dl.airtable.com/.attachments/0b86f18e2606ed7f53bd54d536a1bea5/13a87f30/Artboard7copy.png"
                           width="11"
                         />
                         <div
-                          class="c43"
+                          class="c33"
                         >
                           <h3
-                            class="c44"
+                            class="c34"
                           >
                             <div
-                              class="c17"
+                              class="c35"
                             >
                               Content Versioning
                             </div>
                           </h3>
                         </div>
                         <div
-                          class="c45"
+                          class="c36"
                         >
                           <p
-                            class="c25 c46"
+                            class="c37 c38"
                           >
                             This plugin enables you to versioning Content Types. It allows multiple draft versions✅ Keeps history of all changes (with time travel) ✅ 
                           </p>
                         </div>
                       </div>
                       <div
-                        class="c47 c48 c49"
+                        class="c39 c40 c41"
                         spacing="2"
                         style="align-self: flex-end;"
                       >
@@ -1333,7 +1269,7 @@ describe('Marketplace page', () => {
                           </span>
                           <div
                             aria-hidden="true"
-                            class="c10 c50"
+                            class="c10 c42"
                           >
                             <svg
                               fill="none"
@@ -1351,12 +1287,12 @@ describe('Marketplace page', () => {
                         </a>
                         <button
                           aria-disabled="false"
-                          class="c51 c52"
+                          class="c43 c44"
                           type="button"
                         >
                           <div
                             aria-hidden="true"
-                            class="c53 c54 c55"
+                            class="c45 c46 c47"
                           >
                             <svg
                               fill="none"
@@ -1376,7 +1312,7 @@ describe('Marketplace page', () => {
                             </svg>
                           </div>
                           <span
-                            class="c56 c57"
+                            class="c48 c49"
                           >
                             Copy install command
                           </span>
@@ -1386,14 +1322,14 @@ describe('Marketplace page', () => {
                   </div>
                 </div>
                 <div
-                  class="c39"
+                  class="c29"
                 >
                   <div
                     class=""
                     style="height: 100%;"
                   >
                     <div
-                      class="c40 c41"
+                      class="c30 c31"
                       height="100%"
                     >
                       <div
@@ -1401,30 +1337,30 @@ describe('Marketplace page', () => {
                       >
                         <img
                           alt="Documentation logo"
-                          class="c42"
+                          class="c32"
                           height="11"
                           src="https://dl.airtable.com/.attachments/b6998ac52e8b0460b8a14ced8074b788/2a4d4a90/swagger.png"
                           width="11"
                         />
                         <div
-                          class="c43"
+                          class="c33"
                         >
                           <h3
-                            class="c44"
+                            class="c34"
                           >
                             <div
-                              class="c17"
+                              class="c35"
                             >
                               Documentation
                               <span>
                                 <div
                                   aria-describedby="tooltip-3"
-                                  class="c17"
+                                  class="c35"
                                   tabindex="0"
                                 >
                                   <img
                                     alt="Made by Strapi"
-                                    class="c60"
+                                    class="c52"
                                     height="auto"
                                     src="IMAGE_MOCK"
                                     width="6"
@@ -1435,17 +1371,17 @@ describe('Marketplace page', () => {
                           </h3>
                         </div>
                         <div
-                          class="c45"
+                          class="c36"
                         >
                           <p
-                            class="c25 c46"
+                            class="c37 c38"
                           >
                             Create an OpenAPI Document and visualize your API with SWAGGER UI
                           </p>
                         </div>
                       </div>
                       <div
-                        class="c47 c48 c49"
+                        class="c39 c40 c41"
                         spacing="2"
                         style="align-self: flex-end;"
                       >
@@ -1464,7 +1400,7 @@ describe('Marketplace page', () => {
                           </span>
                           <div
                             aria-hidden="true"
-                            class="c10 c50"
+                            class="c10 c42"
                           >
                             <svg
                               fill="none"
@@ -1481,10 +1417,10 @@ describe('Marketplace page', () => {
                           </div>
                         </a>
                         <div
-                          class="c61"
+                          class="c53"
                         >
                           <svg
-                            class="c62 c59"
+                            class="c54 c51"
                             fill="none"
                             height="12"
                             viewBox="0 0 24 24"
@@ -1497,7 +1433,7 @@ describe('Marketplace page', () => {
                             />
                           </svg>
                           <span
-                            class="c63"
+                            class="c55"
                           >
                             Installed
                           </span>
@@ -1507,14 +1443,14 @@ describe('Marketplace page', () => {
                   </div>
                 </div>
                 <div
-                  class="c39"
+                  class="c29"
                 >
                   <div
                     class=""
                     style="height: 100%;"
                   >
                     <div
-                      class="c40 c41"
+                      class="c30 c31"
                       height="100%"
                     >
                       <div
@@ -1522,36 +1458,36 @@ describe('Marketplace page', () => {
                       >
                         <img
                           alt="Transformer logo"
-                          class="c42"
+                          class="c32"
                           height="11"
                           src="https://dl.airtable.com/.attachments/5ffd1782a2fabf423ccd6f56c562f31a/b8f8598f/transformer-logo.png"
                           width="11"
                         />
                         <div
-                          class="c43"
+                          class="c33"
                         >
                           <h3
-                            class="c44"
+                            class="c34"
                           >
                             <div
-                              class="c17"
+                              class="c35"
                             >
                               Transformer
                             </div>
                           </h3>
                         </div>
                         <div
-                          class="c45"
+                          class="c36"
                         >
                           <p
-                            class="c25 c46"
+                            class="c37 c38"
                           >
                             A plugin for Strapi Headless CMS that provides the ability to transform the API response. 
                           </p>
                         </div>
                       </div>
                       <div
-                        class="c47 c48 c49"
+                        class="c39 c40 c41"
                         spacing="2"
                         style="align-self: flex-end;"
                       >
@@ -1570,7 +1506,7 @@ describe('Marketplace page', () => {
                           </span>
                           <div
                             aria-hidden="true"
-                            class="c10 c50"
+                            class="c10 c42"
                           >
                             <svg
                               fill="none"
@@ -1588,12 +1524,12 @@ describe('Marketplace page', () => {
                         </a>
                         <button
                           aria-disabled="false"
-                          class="c51 c52"
+                          class="c43 c44"
                           type="button"
                         >
                           <div
                             aria-hidden="true"
-                            class="c53 c54 c55"
+                            class="c45 c46 c47"
                           >
                             <svg
                               fill="none"
@@ -1613,7 +1549,7 @@ describe('Marketplace page', () => {
                             </svg>
                           </div>
                           <span
-                            class="c56 c57"
+                            class="c48 c49"
                           >
                             Copy install command
                           </span>
@@ -1624,7 +1560,7 @@ describe('Marketplace page', () => {
                 </div>
               </div>
               <div
-                class="c64"
+                class="c56"
               >
                 <a
                   href="https://strapi.canny.io/plugin-requests"
@@ -1633,10 +1569,10 @@ describe('Marketplace page', () => {
                   target="_blank"
                 >
                   <div
-                    class="c16 c17"
+                    class="c57 c35"
                   >
                     <div
-                      class="c18 c17 c19"
+                      class="c58 c35 c59"
                     >
                       <svg
                         fill="none"
@@ -1658,18 +1594,18 @@ describe('Marketplace page', () => {
                       </svg>
                     </div>
                     <div
-                      class="c20"
+                      class="c60"
                     >
                       <div
-                        class="c17"
+                        class="c35"
                       >
                         <span
-                          class="c21 c22"
+                          class="c61 c62"
                         >
                           Documentation
                         </span>
                         <svg
-                          class="c23 c24"
+                          class="c63 c64"
                           fill="none"
                           height="3"
                           viewBox="0 0 24 24"
@@ -1683,7 +1619,7 @@ describe('Marketplace page', () => {
                         </svg>
                       </div>
                       <span
-                        class="c25"
+                        class="c37"
                       >
                         Tell us what plugin you are looking for and we'll let our community plugin developers know in case they are in search for inspiration!
                       </span>

--- a/packages/core/admin/admin/src/translations/en.json
+++ b/packages/core/admin/admin/src/translations/en.json
@@ -218,6 +218,8 @@
   "admin.pages.MarketPlacePage.search.placeholder": "Search for a plugin",
   "admin.pages.MarketPlacePage.submit.plugin.link": "Submit your plugin",
   "admin.pages.MarketPlacePage.subtitle": "Get more out of Strapi",
+  "admin.pages.MarketPlacePage.missingPlugin.title": "Missing a plugin?",
+  "admin.pages.MarketPlacePage.missingPlugin.description": "Tell us what plugin you are looking for and we'll let our community plugin developers know in case they are in search for inspiration!",
   "anErrorOccurred": "Woops! Something went wrong. Please, try again.",
   "app.component.CopyToClipboard.label": "Copy to clipboard",
   "app.component.search.label": "Search for {target}",


### PR DESCRIPTION
### What does it do?

- Adds a banner to tell users about about our portal for plugin requests
![Screenshot 2022-03-30 at 16 51 23](https://user-images.githubusercontent.com/8087692/160864073-2540dd6c-fa51-4bcc-83d7-fdb3d6c5953e.png)
- Update the snapshots.
- Update the plugin search test to use the comments plugin instead of the docs one. That's because the previous check now also matched the "documentation" plugin link in the main navigation, which caused a Jest error. Not sure why that didn't happen before though

### Why is it needed?

To promote our Canny portal, and to know what plugins are missing from the marketplace

### How to test it?

Open the `/admin/marketplace` page and scroll to the bottom, click on the banner

