### PR TITLE
Drop better-sqlite3 version to v7.4.6 for ARM64 Macs

### DIFF
--- a/packages/generators/app/lib/utils/db-client-dependencies.js
+++ b/packages/generators/app/lib/utils/db-client-dependencies.js
@@ -3,7 +3,7 @@
 const sqlClientModule = {
   mysql: { mysql: '2.18.1' },
   postgres: { pg: '8.6.0' },
-  sqlite: { 'better-sqlite3': '^7.5.0' },
+  sqlite: { 'better-sqlite3': '7.4.6' },
   'sqlite-legacy': { sqlite3: '^5.0.2' },
 };
 


### PR DESCRIPTION
Signed-off-by: Derrick Mehaffy <derrickmehaffy@gmail.com>

Some M1 mac users still are failing to install better-sqlite3 without build tools:

> prebuild-install WARN install No prebuilt binaries found (target=16.14.2 runtime=node arch=arm64 libc= platform=darwin)

> ENOENT: no such file or directory, symlink -snip-/node_modules/better-sqlite3/deps/sqlite3/sqlite3.c' -> '-snip-/node_modules/better-sqlite3/build/Release/obj/gen/sqlite3/sqlite3.c'  failedTask=build stackTrace=Error: ENOENT: no such file or directory...

Per this issue: https://github.com/JoshuaWise/better-sqlite3/issues/771#issuecomment-1054182344

> This problem has been introduced in the 7.5.0 release, downgrading to 7.4.6 the build process works correctly.