### PR TITLE
Fix actionOptions not taking into account by the upload provider

### DIFF
--- a/packages/core/upload/server/__tests__/bootstrap.test.js
+++ b/packages/core/upload/server/__tests__/bootstrap.test.js
@@ -4,7 +4,15 @@ const { join } = require('path');
 
 const bootstrap = require('../bootstrap');
 
-jest.mock('@strapi/provider-upload-local', () => ({ init() {} }));
+jest.mock('@strapi/provider-upload-local', () => ({
+  init() {
+    return {
+      uploadStream: jest.fn(),
+      upload: jest.fn(),
+      delete: jest.fn(),
+    };
+  },
+}));
 
 describe('Upload plugin bootstrap function', () => {
   test('Sets default config if it does not exist', async () => {

--- a/packages/core/upload/server/bootstrap.js
+++ b/packages/core/upload/server/bootstrap.js
@@ -49,33 +49,34 @@ const createProvider = config => {
 
   const providerInstance = provider.init(providerOptions);
 
-  return Object.assign(Object.create(baseProvider), {
-    ...providerInstance,
-    original: providerInstance,
-    uploadStream(file, options = actionOptions.upload) {
-      return providerInstance.uploadStream(file, options);
-    },
-    upload(file, options = actionOptions.upload) {
-      return providerInstance.upload(file, options);
-    },
-    delete(file, options = actionOptions.delete) {
-      return providerInstance.delete(file, options);
-    },
+  if (!providerInstance.delete) {
+    throw new Error(`The upload provider "${providerName}" didn't implement the delete method.`);
+  }
+
+  if (!providerInstance.upload && !providerInstance.uploadStream) {
+    throw new Error(
+      `The upload provider "${providerName}" didn't implement the uploadStream nor the upload method.`
+    );
+  }
+
+  if (!providerInstance.uploadStream) {
+    process.emitWarning(
+      `The upload provider "${providerName}" didn't implement the uploadStream function. Strapi will fallback on the upload method. Some performance issues may occur.`
+    );
+  }
+
+  const wrappedProvider = _.mapValues(providerInstance, (method, methodName) => {
+    return async function(file, options = actionOptions[methodName]) {
+      return providerInstance[methodName](file, options);
+    };
   });
+
+  return Object.assign(Object.create(baseProvider), wrappedProvider);
 };
 
 const baseProvider = {
   extend(obj) {
     Object.assign(this, obj);
-  },
-  uploadStream() {
-    throw new Error('Provider uploadStream method is not implemented');
-  },
-  upload() {
-    throw new Error('Provider upload method is not implemented');
-  },
-  delete() {
-    throw new Error('Provider delete method is not implemented');
   },
 };
 

--- a/packages/core/upload/server/bootstrap.js
+++ b/packages/core/upload/server/bootstrap.js
@@ -51,6 +51,10 @@ const createProvider = config => {
 
   return Object.assign(Object.create(baseProvider), {
     ...providerInstance,
+    original: providerInstance,
+    uploadStream(file, options = actionOptions.upload) {
+      return providerInstance.uploadStream(file, options);
+    },
     upload(file, options = actionOptions.upload) {
       return providerInstance.upload(file, options);
     },
@@ -63,6 +67,9 @@ const createProvider = config => {
 const baseProvider = {
   extend(obj) {
     Object.assign(this, obj);
+  },
+  uploadStream() {
+    throw new Error('Provider uploadStream method is not implemented');
   },
   upload() {
     throw new Error('Provider upload method is not implemented');

--- a/packages/core/upload/server/bootstrap.js
+++ b/packages/core/upload/server/bootstrap.js
@@ -50,18 +50,18 @@ const createProvider = config => {
   const providerInstance = provider.init(providerOptions);
 
   if (!providerInstance.delete) {
-    throw new Error(`The upload provider "${providerName}" didn't implement the delete method.`);
+    throw new Error(`The upload provider "${providerName}" doesn't implement the delete method.`);
   }
 
   if (!providerInstance.upload && !providerInstance.uploadStream) {
     throw new Error(
-      `The upload provider "${providerName}" didn't implement the uploadStream nor the upload method.`
+      `The upload provider "${providerName}" doesn't implement the uploadStream nor the upload method.`
     );
   }
 
   if (!providerInstance.uploadStream) {
     process.emitWarning(
-      `The upload provider "${providerName}" didn't implement the uploadStream function. Strapi will fallback on the upload method. Some performance issues may occur.`
+      `The upload provider "${providerName}" doesn't implement the uploadStream function. Strapi will fallback on the upload method. Some performance issues may occur.`
     );
   }
 

--- a/packages/core/upload/server/services/provider.js
+++ b/packages/core/upload/server/services/provider.js
@@ -5,7 +5,7 @@ const { streamToBuffer } = require('../utils/file');
 
 module.exports = ({ strapi }) => ({
   async upload(file) {
-    if (isFunction(strapi.plugin('upload').provider.uploadStream)) {
+    if (isFunction(strapi.plugin('upload').provider.original.uploadStream)) {
       file.stream = file.getStream();
       await strapi.plugin('upload').provider.uploadStream(file);
       delete file.stream;

--- a/packages/core/upload/server/services/provider.js
+++ b/packages/core/upload/server/services/provider.js
@@ -5,7 +5,7 @@ const { streamToBuffer } = require('../utils/file');
 
 module.exports = ({ strapi }) => ({
   async upload(file) {
-    if (isFunction(strapi.plugin('upload').provider.original.uploadStream)) {
+    if (isFunction(strapi.plugin('upload').provider.uploadStream)) {
       file.stream = file.getStream();
       await strapi.plugin('upload').provider.uploadStream(file);
       delete file.stream;


### PR DESCRIPTION
It implements `uploadStream` wrapping for `actionOptions`.

Thank you @neilpoulin for catching the issue and spotting the cause!

- Re-opens: https://github.com/strapi/strapi/pull/12838
- Fixes https://github.com/strapi/strapi/issues/12809
- Docs: https://github.com/strapi/strapi/pull/12959