### PR TITLE
Fix better-sqlite3 version

### DIFF
--- a/examples/getstarted/package.json
+++ b/examples/getstarted/package.json
@@ -24,7 +24,7 @@
     "@strapi/strapi": "4.1.6",
     "@strapi/utils": "4.1.6",
     "@vscode/sqlite3": "5.0.8",
-    "better-sqlite3": "7.5.0",
+    "better-sqlite3": "7.4.6",
     "lodash": "4.17.21",
     "mysql": "2.18.1",
     "passport-google-oauth2": "0.2.0",

--- a/packages/generators/app/lib/utils/db-client-dependencies.js
+++ b/packages/generators/app/lib/utils/db-client-dependencies.js
@@ -3,7 +3,7 @@
 const sqlClientModule = {
   mysql: { mysql: '2.18.1' },
   postgres: { pg: '8.6.0' },
-  sqlite: { 'better-sqlite3': '^7.5.0' },
+  sqlite: { 'better-sqlite3': '7.4.6' },
   'sqlite-legacy': { sqlite3: '^5.0.2' },
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7373,13 +7373,14 @@ better-opn@^2.1.1:
   dependencies:
     open "^7.0.3"
 
-better-sqlite3@7.5.0:
-  version "7.5.0"
-  resolved "https://registry.yarnpkg.com/better-sqlite3/-/better-sqlite3-7.5.0.tgz#2a91cb616453f002096743b0e5b66a7021cd1c63"
-  integrity sha512-6FdG9DoytYGDhLW7VWW1vxjEz7xHkqK6LnaUQYA8d6GHNgZhu9PFX2xwKEEnSBRoT1J4PjTUPeg217ShxNmuPg==
+better-sqlite3@7.4.6:
+  version "7.4.6"
+  resolved "https://registry.yarnpkg.com/better-sqlite3/-/better-sqlite3-7.4.6.tgz#c5dc35c71bb9c9ef5d9e16019686371ff6a5f25e"
+  integrity sha512-LB/UxnMhcJY12bRCDXl2jTk0lsbXHCHOLn3cPjGhy3GCcVPGq45sCGJPUdfBZnfXGN14tYTJyq0ztUI3lGng8A==
   dependencies:
     bindings "^1.5.0"
     prebuild-install "^7.0.0"
+    tar "^6.1.11"
 
 big-integer@^1.6.16:
   version "1.6.51"
@@ -21179,7 +21180,7 @@ tar-stream@^2.1.4:
     inherits "^2.0.3"
     readable-stream "^3.1.1"
 
-tar@6.1.11, tar@^6.0.2, tar@^6.1.0:
+tar@6.1.11, tar@^6.0.2, tar@^6.1.0, tar@^6.1.11:
   version "6.1.11"
   resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.11.tgz#6760a38f003afa1b2ffd0ffe9e9abbd0eab3d621"
   integrity sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==


### PR DESCRIPTION
Some M1 mac users still are failing to install better-sqlite3 without build tools:

> prebuild-install WARN install No prebuilt binaries found (target=16.14.2 runtime=node arch=arm64 libc= platform=darwin)

> ENOENT: no such file or directory, symlink -snip-/node_modules/better-sqlite3/deps/sqlite3/sqlite3.c' -> '-snip-/node_modules/better-sqlite3/build/Release/obj/gen/sqlite3/sqlite3.c'  failedTask=build stackTrace=Error: ENOENT: no such file or directory...

Per this issue: https://github.com/JoshuaWise/better-sqlite3/issues/771#issuecomment-1054182344

> This problem has been introduced in the 7.5.0 release, downgrading to 7.4.6 the build process works correctly.