### PR TITLE
[TS] Updated tsconfigs design for generated app

### DIFF
--- a/packages/core/admin/index.js
+++ b/packages/core/admin/index.js
@@ -41,7 +41,7 @@ async function build({
     ceRoot: path.resolve(cacheDir, 'admin', 'src'),
   };
 
-  const pluginsPath = Object.keys(plugins).map(pluginName => plugins[pluginName].appPathToPlugin);
+  const pluginsPath = Object.keys(plugins).map(pluginName => plugins[pluginName].pathToPlugin);
 
   const config = getCustomWebpackConfig(appDir, {
     appDir,
@@ -118,7 +118,7 @@ async function watchAdmin({
     ceRoot: path.resolve(cacheDir, 'admin', 'src'),
   };
 
-  const pluginsPath = Object.keys(plugins).map(pluginName => plugins[pluginName].appPathToPlugin);
+  const pluginsPath = Object.keys(plugins).map(pluginName => plugins[pluginName].pathToPlugin);
 
   const args = {
     appDir,

--- a/packages/core/admin/utils/create-cache-dir.js
+++ b/packages/core/admin/utils/create-cache-dir.js
@@ -8,7 +8,7 @@ const getCustomAppConfigFile = require('./get-custom-app-config-file');
 const getPkgPath = name => path.dirname(require.resolve(`${name}/package.json`));
 
 async function createPluginsJs(plugins, dest) {
-  const pluginsArray = plugins.map(({ appPathToPlugin, name }) => {
+  const pluginsArray = plugins.map(({ pathToPlugin, name }) => {
     const shortName = _.camelCase(name);
 
     /**
@@ -20,7 +20,7 @@ async function createPluginsJs(plugins, dest) {
      * Backslash looks to work only for absolute paths with webpack => https://webpack.js.org/concepts/module-resolution/#absolute-paths
      */
     const realPath = path
-      .join(path.relative(path.resolve(dest, 'admin', 'src'), appPathToPlugin), 'strapi-admin.js')
+      .join(path.relative(path.resolve(dest, 'admin', 'src'), pathToPlugin), 'strapi-admin.js')
       .replace(/\\/g, '/');
 
     return {

--- a/packages/core/admin/webpack.config.js
+++ b/packages/core/admin/webpack.config.js
@@ -54,7 +54,7 @@ module.exports = ({
     const tsChecker = new ForkTsCheckerPlugin({
       typescript: {
         // FIXME
-        configFile: path.join(appDir, 'tsconfig-admin.json'),
+        configFile: path.join(appDir, 'src', 'admin', 'tsconfig.json'),
       },
     });
 

--- a/packages/core/admin/webpack.config.js
+++ b/packages/core/admin/webpack.config.js
@@ -53,7 +53,6 @@ module.exports = ({
   if (useTypeScript) {
     const tsChecker = new ForkTsCheckerPlugin({
       typescript: {
-        // FIXME
         configFile: path.join(appDir, 'src', 'admin', 'tsconfig.json'),
       },
     });

--- a/packages/core/strapi/lib/commands/build.js
+++ b/packages/core/strapi/lib/commands/build.js
@@ -24,7 +24,6 @@ module.exports = async ({ optimization, forceBuild = true }) => {
   await buildAdmin({
     buildDestDir,
     forceBuild,
-    // TODO: Delegate the is-ts-project check to the admin
     isTSProject: useTypeScriptServer,
     optimization,
     srcDir,

--- a/packages/core/strapi/lib/commands/build.js
+++ b/packages/core/strapi/lib/commands/build.js
@@ -11,10 +11,10 @@ module.exports = async ({ optimization, forceBuild = true }) => {
   let buildDestDir = process.cwd();
   const srcDir = process.cwd();
 
-  const isTSProject = await tsUtils.isTypeScriptProject(srcDir);
+  const useTypeScriptServer = await tsUtils.isUsingTypeScript(srcDir);
 
   // Typescript
-  if (isTSProject) {
+  if (useTypeScriptServer) {
     await buildTypeScript({ srcDir, watch: false });
 
     // Update the dir path for the next steps
@@ -24,7 +24,8 @@ module.exports = async ({ optimization, forceBuild = true }) => {
   await buildAdmin({
     buildDestDir,
     forceBuild,
-    isTSProject,
+    // TODO: Delegate the is-ts-project check to the admin
+    isTSProject: useTypeScriptServer,
     optimization,
     srcDir,
   });

--- a/packages/core/strapi/lib/commands/builders/admin.js
+++ b/packages/core/strapi/lib/commands/builders/admin.js
@@ -12,8 +12,10 @@ const getEnabledPlugins = require('../../core/loaders/plugins/get-enabled-plugin
 
 module.exports = async ({ buildDestDir, forceBuild = true, isTSProject, optimization, srcDir }) => {
   const strapiInstance = strapi({
-    // TODO check if this is working @convly
+    // Directories
+    appDir: srcDir,
     distDir: buildDestDir,
+    // Options
     autoReload: true,
     serveAdminPanel: false,
   });

--- a/packages/core/strapi/lib/commands/builders/typescript.js
+++ b/packages/core/strapi/lib/commands/builders/typescript.js
@@ -5,8 +5,8 @@ const fs = require('fs-extra');
 const tsUtils = require('@strapi/typescript-utils');
 
 const cleanupDistDirectory = async distDir => {
-  if (!await fs.pathExists(distDir)){
-    return 
+  if (!(await fs.pathExists(distDir))) {
+    return;
   }
 
   const dirContent = await fs.readdir(distDir);
@@ -14,20 +14,17 @@ const cleanupDistDirectory = async distDir => {
     // Ignore the admin build folder
     .filter(filename => filename !== 'build');
 
-
   for (const filename of validFilenames) {
     await fs.remove(path.resolve(distDir, filename));
   }
 };
 
 module.exports = async ({ srcDir, distDir, watch = false }) => {
-  const isTSProject = await tsUtils.isTypeScriptProject(srcDir);
+  const isTSProject = await tsUtils.isUsingTypeScript(srcDir);
 
   if (!isTSProject) {
     throw new Error(`tsconfig file not found in ${srcDir}`);
   }
-
-  
 
   await cleanupDistDirectory(distDir);
 

--- a/packages/core/strapi/lib/commands/develop.js
+++ b/packages/core/strapi/lib/commands/develop.js
@@ -61,7 +61,6 @@ const primaryProcess = async ({ distDir, appDir, build, isTSProject, watchAdmin,
       await buildAdmin({
         buildDestDir: distDir,
         forceBuild: false,
-        // TODO: delegates the is-ts-project check to the admin
         isTSProject,
         optimization: false,
         srcDir: appDir,

--- a/packages/core/strapi/lib/commands/develop.js
+++ b/packages/core/strapi/lib/commands/develop.js
@@ -21,7 +21,7 @@ const { buildTypeScript, buildAdmin } = require('./builders');
 module.exports = async function({ build, watchAdmin, polling, browser }) {
   const appDir = process.cwd();
 
-  const isTSProject = await tsUtils.isTypeScriptProject(appDir);
+  const isTSProject = await tsUtils.isUsingTypeScript(appDir);
   const distDir = isTSProject ? path.join(appDir, 'dist') : appDir;
 
   try {
@@ -61,6 +61,7 @@ const primaryProcess = async ({ distDir, appDir, build, isTSProject, watchAdmin,
       await buildAdmin({
         buildDestDir: distDir,
         forceBuild: false,
+        // TODO: delegates the is-ts-project check to the admin
         isTSProject,
         optimization: false,
         srcDir: appDir,

--- a/packages/core/strapi/lib/commands/watchAdmin.js
+++ b/packages/core/strapi/lib/commands/watchAdmin.js
@@ -12,7 +12,7 @@ const strapi = require('../index');
 module.exports = async function({ browser }) {
   const currentDirectory = process.cwd();
 
-  const isTSProject = await tsUtils.isTypeScriptProject(currentDirectory);
+  const isTSProject = await tsUtils.isUsingTypeScript(currentDirectory);
   const buildDestDir = isTSProject ? path.join(currentDirectory, 'dist') : currentDirectory;
 
   const strapiInstance = strapi({

--- a/packages/core/strapi/lib/core/loaders/plugins/get-enabled-plugins.js
+++ b/packages/core/strapi/lib/core/loaders/plugins/get-enabled-plugins.js
@@ -29,15 +29,11 @@ const toDetailedDeclaration = declaration => {
   let detailedDeclaration = pick(['enabled'], declaration);
   if (has('resolve', declaration)) {
     let pathToPlugin = '';
-    let appPathToPlugin = '';
 
     try {
       pathToPlugin = dirname(require.resolve(declaration.resolve));
-      appPathToPlugin = pathToPlugin;
     } catch (e) {
-      // FIXME: It'll break for resolve paths that are located outside the project files
-      pathToPlugin = resolve(strapi.dirs.dist.root, declaration.resolve);
-      appPathToPlugin = resolve(strapi.dirs.app.root, declaration.resolve);
+      pathToPlugin = resolve(strapi.dirs.app.root, declaration.resolve);
 
       if (!existsSync(pathToPlugin) || !statSync(pathToPlugin).isDirectory()) {
         throw new Error(`${declaration.resolve} couldn't be resolved`);
@@ -45,7 +41,6 @@ const toDetailedDeclaration = declaration => {
     }
 
     detailedDeclaration.pathToPlugin = pathToPlugin;
-    detailedDeclaration.appPathToPlugin = appPathToPlugin;
   }
   return detailedDeclaration;
 };

--- a/packages/generators/app/lib/create-project.js
+++ b/packages/generators/app/lib/create-project.js
@@ -92,7 +92,7 @@ module.exports = async function createProject(scope, { client, connection, depen
 
         const json = require(srcPath)();
 
-        await fse.writeJSON(destPath, JSON.stringify(json, null, 2));
+        await fse.writeJSON(destPath, json, { spaces: 2 });
       }
     }
 

--- a/packages/generators/app/lib/create-project.js
+++ b/packages/generators/app/lib/create-project.js
@@ -81,16 +81,19 @@ module.exports = async function createProject(scope, { client, connection, depen
 
     if (useTypescript) {
       const tsJSONDir = join(__dirname, 'resources', 'json', 'ts');
-      const files = ['tsconfig-admin.json.js', 'tsconfig-server.json.js'];
+      const filesMap = {
+        'tsconfig-admin.json.js': 'src/admin',
+        'tsconfig-server.json.js': '.',
+      };
 
-      files.forEach(file => {
-        const srcPath = join(tsJSONDir, file);
-        const destPath = join(rootPath, `${file.slice(0, -3)}`);
+      for (const [fileName, path] of Object.entries(filesMap)) {
+        const srcPath = join(tsJSONDir, fileName);
+        const destPath = join(rootPath, path, 'tsconfig.json');
 
         const json = require(srcPath)();
 
-        fse.writeJSONSync(destPath, json);
-      });
+        await fse.writeJSON(destPath, JSON.stringify(json, null, 2));
+      }
     }
 
     // ensure node_modules is created

--- a/packages/generators/app/lib/resources/json/ts/tsconfig-admin.json.js
+++ b/packages/generators/app/lib/resources/json/ts/tsconfig-admin.json.js
@@ -1,20 +1,7 @@
 'use strict';
 
 module.exports = () => ({
-  compilerOptions: {
-    lib: ['es2019', 'es2020.promise', 'es2020.bigint', 'es2020.string', 'DOM'],
-    noImplicitAny: false,
-    module: 'es2020',
-    target: 'es5',
-    jsx: 'react',
-    allowJs: true,
-    moduleResolution: 'node',
-    skipLibCheck: true,
-    esModuleInterop: true,
-    allowSyntheticDefaultImports: true,
-    resolveJsonModule: true,
-    noEmit: false,
-    incremental: true,
-  },
-  exclude: ['node_modules', '**/*.test.js', '*.js'],
+  extends: '@strapi/typescript-utils/lib/configs/admin',
+
+  exclude: ['node_modules/', 'build/', 'dist/', '**/*.test.ts'],
 });

--- a/packages/generators/app/lib/resources/json/ts/tsconfig-server.json.js
+++ b/packages/generators/app/lib/resources/json/ts/tsconfig-server.json.js
@@ -3,6 +3,11 @@
 module.exports = () => ({
   extends: '@strapi/typescript-utils/lib/configs/server',
 
+  compilerOptions: {
+    outDir: 'dist',
+    rootDir: '.'
+  },
+
   include: [
     // Include the root directory
     './',

--- a/packages/generators/app/lib/resources/json/ts/tsconfig-server.json.js
+++ b/packages/generators/app/lib/resources/json/ts/tsconfig-server.json.js
@@ -5,7 +5,7 @@ module.exports = () => ({
 
   compilerOptions: {
     outDir: 'dist',
-    rootDir: '.'
+    rootDir: '.',
   },
 
   include: [

--- a/packages/generators/app/lib/resources/json/ts/tsconfig-server.json.js
+++ b/packages/generators/app/lib/resources/json/ts/tsconfig-server.json.js
@@ -1,23 +1,27 @@
 'use strict';
 
 module.exports = () => ({
-  compilerOptions: {
-    lib: ['es2019', 'es2020.promise', 'es2020.bigint', 'es2020.string', 'DOM'],
-    module: 'commonjs',
-    target: 'es2019',
-    strict: false,
-    jsx: 'react',
-    noImplicitAny: false,
-    esModuleInterop: true,
-    skipLibCheck: true,
-    forceConsistentCasingInFileNames: true,
-    allowJs: true,
-    outDir: 'dist',
-    rootDir: '.',
-    noEmitOnError: true,
-    resolveJsonModule: true,
-  },
+  extends: '@strapi/typescript-utils/lib/configs/server',
 
-  include: ['src/**/*.json', './'],
-  exclude: ['node_modules/', 'build/', 'dist/', 'src/admin', '.cache/', '.tmp/'],
+  include: [
+    // Include the root directory
+    './',
+    // Force the JSON files in the src folder to be included
+    'src/**/*.json',
+  ],
+
+  exclude: [
+    'node_modules/',
+    'build/',
+    'dist/',
+    '.cache/',
+    '.tmp/',
+
+    // Do not include admin files in the server compilation
+    'src/admin/',
+    // Do not include test files
+    '**/*.test.ts',
+    // Do not include plugins in the server compilation
+    'src/plugins/**',
+  ],
 });

--- a/packages/generators/generators/lib/files/ts/plugin/strapi-server.js
+++ b/packages/generators/generators/lib/files/ts/plugin/strapi-server.js
@@ -1,3 +1,3 @@
 'use strict';
 
-module.exports = require('./server');
+module.exports = require('./dist/server');

--- a/packages/generators/generators/lib/files/ts/plugin/tsconfig.json
+++ b/packages/generators/generators/lib/files/ts/plugin/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "extends": "@strapi/typescript-utils/lib/configs/server",
+
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "."
+  },
+
+  "include": [
+    // Include the root directory
+    "server",
+    // Force the JSON files in the src folder to be included
+    "server/**/*.json"
+  ],
+
+  "exclude": [
+    "node_modules/",
+    "dist/",
+
+    // Do not include admin files in the server compilation
+    "admin/",
+    // Do not include test files
+    "**/*.test.ts"
+  ]
+}

--- a/packages/generators/generators/lib/plops/api.js
+++ b/packages/generators/generators/lib/plops/api.js
@@ -49,7 +49,7 @@ module.exports = plop => {
     actions(answers) {
       const filePath = answers.isPluginApi && answers.plugin ? 'plugins/{{plugin}}' : 'api/{{id}}';
       const currentDir = process.cwd();
-      const language = tsUtils.isTypeScriptProjectSync(currentDir) ? 'ts' : 'js';
+      const language = tsUtils.isUsingTypeScriptSync(currentDir) ? 'ts' : 'js';
 
       const baseActions = [
         {

--- a/packages/generators/generators/lib/plops/content-type.js
+++ b/packages/generators/generators/lib/plops/content-type.js
@@ -83,7 +83,7 @@ module.exports = plop => {
 
       const filePath = getFilePath(answers.destination);
       const currentDir = process.cwd();
-      const language = tsUtils.isTypeScriptProjectSync(currentDir) ? 'ts' : 'js';
+      const language = tsUtils.isUsingTypeScriptSync(currentDir) ? 'ts' : 'js';
 
       const baseActions = [
         {

--- a/packages/generators/generators/lib/plops/controller.js
+++ b/packages/generators/generators/lib/plops/controller.js
@@ -22,7 +22,7 @@ module.exports = plop => {
     actions(answers) {
       const filePath = getFilePath(answers.destination);
       const currentDir = process.cwd();
-      const language = tsUtils.isTypeScriptProjectSync(currentDir) ? 'ts' : 'js';
+      const language = tsUtils.isUsingTypeScriptSync(currentDir) ? 'ts' : 'js';
 
       return [
         {

--- a/packages/generators/generators/lib/plops/middleware.js
+++ b/packages/generators/generators/lib/plops/middleware.js
@@ -20,7 +20,7 @@ module.exports = plop => {
     actions(answers) {
       const filePath = getFilePath(answers.destination);
       const currentDir = process.cwd();
-      const language = tsUtils.isTypeScriptProjectSync(currentDir) ? 'ts' : 'js';
+      const language = tsUtils.isUsingTypeScriptSync(currentDir) ? 'ts' : 'js';
 
       return [
         {

--- a/packages/generators/generators/lib/plops/plugin.js
+++ b/packages/generators/generators/lib/plops/plugin.js
@@ -39,7 +39,7 @@ module.exports = plop => {
     ],
     actions(answers) {
       const currentDir = process.cwd();
-      const language = tsUtils.isTypeScriptProjectSync(currentDir) ? 'ts' : 'js';
+      const language = tsUtils.isUsingTypeScriptSync(currentDir) ? 'ts' : 'js';
 
       // TODO: Adds tsconfig & build command for TS plugins?
 

--- a/packages/generators/generators/lib/plops/policy.js
+++ b/packages/generators/generators/lib/plops/policy.js
@@ -20,7 +20,7 @@ module.exports = plop => {
     actions(answers) {
       const filePath = getFilePath(answers.destination);
       const currentDir = process.cwd();
-      const language = tsUtils.isTypeScriptProjectSync(currentDir) ? 'ts' : 'js';
+      const language = tsUtils.isUsingTypeScriptSync(currentDir) ? 'ts' : 'js';
 
       return [
         {

--- a/packages/generators/generators/lib/plops/service.js
+++ b/packages/generators/generators/lib/plops/service.js
@@ -20,7 +20,7 @@ module.exports = plop => {
     actions(answers) {
       const filePath = getFilePath(answers.destination);
       const currentDir = process.cwd();
-      const language = tsUtils.isTypeScriptProjectSync(currentDir) ? 'ts' : 'js';
+      const language = tsUtils.isUsingTypeScriptSync(currentDir) ? 'ts' : 'js';
 
       return [
         {

--- a/packages/generators/generators/lib/templates/ts/plugin-package.json.hbs
+++ b/packages/generators/generators/lib/templates/ts/plugin-package.json.hbs
@@ -8,6 +8,10 @@
     "kind": "plugin"
   },
   "dependencies": {},
+  "devDependencies": {
+    "typescript": "4.6.3",
+    "@strapi/strapi": "4.1.7"
+  },
   "author": {
     "name": "A Strapi developer"
   },
@@ -19,6 +23,10 @@
   "engines": {
     "node": ">=12.x.x <=16.x.x",
     "npm": ">=6.0.0"
+  },
+  "scripts": {
+    "develop": "tsc -w",
+    "build": "tsc"
   },
   "license": "MIT"
 }

--- a/packages/utils/typescript/lib/configs/admin.json
+++ b/packages/utils/typescript/lib/configs/admin.json
@@ -1,0 +1,20 @@
+{
+    "$schema": "https://json.schemastore.org/tsconfig",
+    
+    "compilerOptions": {
+        "module": "ES2020",
+        "moduleResolution": "node",
+        "lib": ["ES2020", "DOM"],
+        "target": "ES5",
+
+        "jsx": "react",
+        "sourceMap": true,
+        "incremental": true,
+
+        "allowJs": true,
+        "allowSyntheticDefaultImports": true,
+        "resolveJsonModule": true,
+        "noEmit": true,
+        "skipLibCheck": true
+    }
+}

--- a/packages/utils/typescript/lib/configs/server.json
+++ b/packages/utils/typescript/lib/configs/server.json
@@ -1,0 +1,18 @@
+{
+    "$schema": "https://json.schemastore.org/tsconfig",
+    
+    "compilerOptions": {
+        "module": "CommonJS",
+        "moduleResolution": "Node",
+        "lib": ["ES2020"],
+        "target": "ES2019",
+
+        "strict": false,
+        "skipLibCheck": true,
+        "forceConsistentCasingInFileNames": true,
+
+        "esModuleInterop": true,
+        "resolveJsonModule": true,
+        "noEmitOnError": true
+    }
+}

--- a/packages/utils/typescript/lib/utils/get-config-path.js
+++ b/packages/utils/typescript/lib/utils/get-config-path.js
@@ -2,8 +2,8 @@
 
 const ts = require('typescript');
 
-const DEFAULT_FILE_NAME = 'tsconfig-server.json';
+const DEFAULT_TS_CONFIG_FILENAME = 'tsconfig.json';
 
-module.exports = (dir, filename = DEFAULT_FILE_NAME) => {
+module.exports = (dir, filename = DEFAULT_TS_CONFIG_FILENAME) => {
   return ts.findConfigFile(dir, ts.sys.fileExists, filename);
 };

--- a/packages/utils/typescript/lib/utils/index.js
+++ b/packages/utils/typescript/lib/utils/index.js
@@ -1,15 +1,15 @@
 'use strict';
 
-const isTypeScriptProject = require('./is-typescript-project');
-const isTypeScriptProjectSync = require('./is-typescript-project-sync');
+const isUsingTypeScript = require('./is-using-typescript');
+const isUsingTypeScriptSync = require('./is-using-typescript-sync');
 const getConfigPath = require('./get-config-path');
 const reportDiagnostics = require('./report-diagnostics');
 const resolveConfigOptions = require('./resolve-config-options');
 const formatHost = require('./format-host');
 
 module.exports = {
-  isTypeScriptProject,
-  isTypeScriptProjectSync,
+  isUsingTypeScript,
+  isUsingTypeScriptSync,
   getConfigPath,
   reportDiagnostics,
   resolveConfigOptions,

--- a/packages/utils/typescript/lib/utils/is-using-typescript-sync.js
+++ b/packages/utils/typescript/lib/utils/is-using-typescript-sync.js
@@ -5,13 +5,13 @@ const fse = require('fs-extra');
 const getConfigPath = require('./get-config-path');
 
 /**
- * Checks if `dir` is a TypeScript directory (whether there is a tsconfig file or not)
+ * Checks if `dir` is a using TypeScript (whether there is a tsconfig file or not)
  * @param {string} dir
  * @param {string | undefined} filename
- * @returns {Promise<boolean>}
+ * @returns {boolean}
  */
 module.exports = (dir, filename = undefined) => {
   const filePath = getConfigPath(dir, filename);
 
-  return fse.pathExists(filePath);
+  return fse.pathExistsSync(filePath);
 };

--- a/packages/utils/typescript/lib/utils/is-using-typescript.js
+++ b/packages/utils/typescript/lib/utils/is-using-typescript.js
@@ -5,13 +5,13 @@ const fse = require('fs-extra');
 const getConfigPath = require('./get-config-path');
 
 /**
- * Checks if `dir` is a TypeScript directory (whether there is a tsconfig file or not)
+ * Checks if `dir` is a using TypeScript (whether there is a tsconfig file or not)
  * @param {string} dir
  * @param {string | undefined} filename
- * @returns {boolean}
+ * @returns {Promise<boolean>}
  */
 module.exports = (dir, filename = undefined) => {
   const filePath = getConfigPath(dir, filename);
 
-  return fse.pathExistsSync(filePath);
+  return fse.pathExists(filePath);
 };


### PR DESCRIPTION
### What does it do?

### In this PR
- [x] Replace the `tsconfig-admin.json` and `tsconfig-server.json` files by `./tsconfig.json` and `./src/admin/tsconfig.json`
- [x] Adds a dedicated `tsconfig.json` for each local plugins (./src/plugins/**/tsconfig.json) + scripts to handle develop, build & start.

### Why is it needed?

See #12927 

### How to test it?

- clone the monorepository
- create a new Strapi project using the cli (in the monorepo) with --ts
- the project should have been created with 2 tsconfig.json files (one at the root level & another one in src/admin)
- try to yarn develop inside this project
- everything should work correctly

### Related issue(s)/PR(s)

#12927 
