### PR TITLE
Added Sanskrit (sa) to i18n locales

### DIFF
--- a/packages/plugins/i18n/server/constants/iso-locales.json
+++ b/packages/plugins/i18n/server/constants/iso-locales.json
@@ -1520,6 +1520,10 @@
     "name":"Sangu (Tanzania) (sbp-TZ)"
   },
   {
+    "code":"sa",
+    "name":"Sanskrit (sa)"
+  },
+  {
     "code":"seh",
     "name":"Sena (seh)"
   },

--- a/packages/plugins/i18n/server/services/__tests__/__snapshots__/iso-locales.test.js.snap
+++ b/packages/plugins/i18n/server/services/__tests__/__snapshots__/iso-locales.test.js.snap
@@ -1523,6 +1523,10 @@ Array [
     "name": "Sangu (Tanzania) (sbp-TZ)",
   },
   Object {
+    "code": "sa",
+    "name": "Sanskrit (sa)",
+  },
+  Object {
     "code": "seh",
     "name": "Sena (seh)",
   },


### PR DESCRIPTION
Added Sanskrit (ISO 639-1 code `sa`) to `/packages/plugins/i18n/server/constants/iso-locales.json`
