### PR TITLE
DynamicTable: Fix rendering of boolean fields

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/DynamicTable/CellContent/utils/hasContent.js
+++ b/packages/core/admin/admin/src/content-manager/components/DynamicTable/CellContent/utils/hasContent.js
@@ -56,5 +56,9 @@ export default function hasContent(type, content, metadatas, fieldSchema) {
     return isNumber(content);
   }
 
+  if (type === 'boolean') {
+    return content !== null;
+  }
+
   return !isEmpty(content);
 }

--- a/packages/core/admin/admin/src/content-manager/components/DynamicTable/CellContent/utils/tests/hasContent.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/DynamicTable/CellContent/utils/tests/hasContent.test.js
@@ -50,6 +50,23 @@ describe('hasContent', () => {
     });
   });
 
+  describe('boolean', () => {
+    it('returns true if enabled', () => {
+      const normalizedContent = hasContent('boolean', true);
+      expect(normalizedContent).toEqual(true);
+    });
+
+    it('returns false if disabled', () => {
+      const normalizedContent = hasContent('boolean', false);
+      expect(normalizedContent).toEqual(true);
+    });
+
+    it('returns false for null', () => {
+      const normalizedContent = hasContent('boolean', null);
+      expect(normalizedContent).toEqual(false);
+    });
+  });
+
   describe('ID', () => {
     it('returns true for id main fields', () => {
       const normalizedContent = hasContent('media', { id: 1 });


### PR DESCRIPTION
### What does it do?

Boolean fields aren't displayed properly after #12213. This PR restores the previous behavior:

<img width="823" alt="Screenshot 2022-04-07 at 10 22 01" src="https://user-images.githubusercontent.com/2244375/162154292-e3661109-960c-4585-a1e4-40b4191f21b9.png">

### Why is it needed?

To properly display the value of boolean fields in list views.

### How to test it?

Either create a content type, with a boolean field and test all 3 values (`null`, `false`, `true`) or trust the unit tests.

### Related issue(s)/PR(s)

- Fixes https://github.com/strapi/strapi/issues/13066
