### PR TITLE
Disallow password fields to be selected as component main field

### DIFF
--- a/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/index.js
@@ -60,6 +60,7 @@ const EditSettingsView = ({ mainLayout, components, isContentTypeView, slug, upd
         'component',
         'boolean',
         'media',
+        'password',
         'richtext',
         'timestamp',
       ].includes(type) && !!type


### PR DESCRIPTION
### What does it do?

Removes `password` fields from the list of fields that can be selected as component main fields.

### Why is it needed?

To avoid a server error being thrown, since private fields can not be selected in the frontend.

### How to test it?

1. Create a new component
2. Assign a password field
3. Configure the component
4. You should not be able to see the password field in the select

### Related issue(s)/PR(s)

- Fixes https://github.com/strapi/strapi/issues/12973
