### PR TITLE
CM: Remove private fields from column view selection

### DIFF
--- a/packages/core/admin/admin/src/content-manager/utils/checkIfAttributeIsDisplayable.js
+++ b/packages/core/admin/admin/src/content-manager/utils/checkIfAttributeIsDisplayable.js
@@ -1,7 +1,11 @@
 import { toLower } from 'lodash';
 
 const checkIfAttributeIsDisplayable = attribute => {
-  const type = attribute.type;
+  const { type, private: isPrivate } = attribute;
+
+  if (isPrivate) {
+    return false;
+  }
 
   if (type === 'relation') {
     return !toLower(attribute.relationType).includes('morph');

--- a/packages/core/admin/admin/src/content-manager/utils/tests/checkIfAttributeIsDisplayable.test.js
+++ b/packages/core/admin/admin/src/content-manager/utils/tests/checkIfAttributeIsDisplayable.test.js
@@ -33,4 +33,12 @@ describe('CONTENT MANAGER | utils | checkIfAttributeIsDisplayable', () => {
 
     expect(checkIfAttributeIsDisplayable(attribute)).toBeTruthy();
   });
+
+  it('should return false if the field is private', () => {
+    const attribute = {
+      private: true,
+    };
+
+    expect(checkIfAttributeIsDisplayable(attribute)).toBeFalsy();
+  });
 });


### PR DESCRIPTION
### What does it do?

Hides private fields from the selection of the content manager list view configuration.

### Why is it needed?

To prevent a user error mentioned in the issue attached.

### How to test it?

1. Navigate to the users collection
2. Try to display a private field such as a password
3. The field should not show up in the selct

### Related issue(s)/PR(s)

- Fixes https://github.com/strapi/strapi/issues/12611
