### PR TITLE
Menu logo/update project settings route

### DIFF
--- a/packages/core/admin/server/controllers/admin.js
+++ b/packages/core/admin/server/controllers/admin.js
@@ -61,7 +61,7 @@ module.exports = {
     const formatedFiles = await projectSettingsService.parseFilesData(files);
     await validateUpdateProjectSettingsImagesDimensions(formatedFiles);
 
-    return projectSettingsService.updateProjectSettings({ body, files: formatedFiles });
+    return projectSettingsService.updateProjectSettings({ ...body, ...formatedFiles });
   },
 
   async information() {

--- a/packages/core/admin/server/controllers/admin.js
+++ b/packages/core/admin/server/controllers/admin.js
@@ -61,12 +61,7 @@ module.exports = {
     const formatedFiles = await projectSettingsService.parseFilesData(files);
     await validateUpdateProjectSettingsImagesDimensions(formatedFiles);
 
-    const updatedProjectSettings = await projectSettingsService.updateProjectSettings(
-      body,
-      formatedFiles
-    );
-
-    console.log(updatedProjectSettings);
+    return projectSettingsService.updateProjectSettings(body, formatedFiles);
   },
 
   async information() {

--- a/packages/core/admin/server/controllers/admin.js
+++ b/packages/core/admin/server/controllers/admin.js
@@ -8,7 +8,10 @@ const { ValidationError } = require('@strapi/utils').errors;
 // eslint-disable-next-line node/no-extraneous-require
 const ee = require('@strapi/strapi/lib/utils/ee');
 
-const { validateUpdateProjectSettings } = require('../validation/project-settings');
+const {
+  validateUpdateProjectSettings,
+  validateUpdateProjectSettingsFiles,
+} = require('../validation/project-settings');
 const { getService } = require('../utils');
 
 const PLUGIN_NAME_REGEX = /^[A-Za-z][A-Za-z0-9-_]+$/;
@@ -46,14 +49,21 @@ module.exports = {
 
   async updateProjectSettings(ctx) {
     const {
-      request: { files },
+      request: { files, body },
     } = ctx;
 
-    await validateUpdateProjectSettings(files);
+    await validateUpdateProjectSettings(body);
+    await validateUpdateProjectSettingsFiles(files);
 
-    const uploadedFiles = await getService('project-settings').uploadProjectSettingsFiles(files);
+    const projectSettingsService = getService('project-settings');
 
-    console.log(uploadedFiles);
+    const uploadedFiles = await projectSettingsService.uploadFiles(files);
+    const updatedProjectSettings = await projectSettingsService.updateProjectSettings(
+      body,
+      uploadedFiles
+    );
+
+    console.log(updatedProjectSettings);
   },
 
   async information() {

--- a/packages/core/admin/server/controllers/admin.js
+++ b/packages/core/admin/server/controllers/admin.js
@@ -8,6 +8,7 @@ const { ValidationError } = require('@strapi/utils').errors;
 // eslint-disable-next-line node/no-extraneous-require
 const ee = require('@strapi/strapi/lib/utils/ee');
 
+const { validateUpdateProjectSettings } = require('../validation/project-settings');
 const { getService } = require('../utils');
 
 const PLUGIN_NAME_REGEX = /^[A-Za-z][A-Za-z0-9-_]+$/;
@@ -44,7 +45,13 @@ module.exports = {
   },
 
   async updateProjectSettings(ctx) {
-    console.log(ctx);
+    const {
+      request: { files },
+    } = ctx;
+
+    await validateUpdateProjectSettings(files);
+
+    console.log(files);
   },
 
   async information() {

--- a/packages/core/admin/server/controllers/admin.js
+++ b/packages/core/admin/server/controllers/admin.js
@@ -58,13 +58,12 @@ module.exports = {
     await validateUpdateProjectSettings(body);
     await validateUpdateProjectSettingsFiles(files);
 
-    const formatedFiles = await projectSettingsService.getFormatedFilesData(files);
+    const formatedFiles = await projectSettingsService.parseFilesData(files);
     await validateUpdateProjectSettingsImagesDimensions(formatedFiles);
 
-    const uploadedFiles = await projectSettingsService.uploadFiles(files);
     const updatedProjectSettings = await projectSettingsService.updateProjectSettings(
       body,
-      uploadedFiles
+      formatedFiles
     );
 
     console.log(updatedProjectSettings);

--- a/packages/core/admin/server/controllers/admin.js
+++ b/packages/core/admin/server/controllers/admin.js
@@ -61,7 +61,7 @@ module.exports = {
     const formatedFiles = await projectSettingsService.parseFilesData(files);
     await validateUpdateProjectSettingsImagesDimensions(formatedFiles);
 
-    return projectSettingsService.updateProjectSettings(body, formatedFiles);
+    return projectSettingsService.updateProjectSettings({ body, files: formatedFiles });
   },
 
   async information() {

--- a/packages/core/admin/server/controllers/admin.js
+++ b/packages/core/admin/server/controllers/admin.js
@@ -11,6 +11,7 @@ const ee = require('@strapi/strapi/lib/utils/ee');
 const {
   validateUpdateProjectSettings,
   validateUpdateProjectSettingsFiles,
+  validateUpdateProjectSettingsImagesDimensions,
 } = require('../validation/project-settings');
 const { getService } = require('../utils');
 
@@ -48,6 +49,8 @@ module.exports = {
   },
 
   async updateProjectSettings(ctx) {
+    const projectSettingsService = getService('project-settings');
+
     const {
       request: { files, body },
     } = ctx;
@@ -55,7 +58,8 @@ module.exports = {
     await validateUpdateProjectSettings(body);
     await validateUpdateProjectSettingsFiles(files);
 
-    const projectSettingsService = getService('project-settings');
+    const formatedFiles = await projectSettingsService.getFormatedFilesData(files);
+    await validateUpdateProjectSettingsImagesDimensions(formatedFiles);
 
     const uploadedFiles = await projectSettingsService.uploadFiles(files);
     const updatedProjectSettings = await projectSettingsService.updateProjectSettings(

--- a/packages/core/admin/server/controllers/admin.js
+++ b/packages/core/admin/server/controllers/admin.js
@@ -43,6 +43,10 @@ module.exports = {
     return { data: { uuid, hasAdmin } };
   },
 
+  async updateProjectSettings(ctx) {
+    console.log(ctx);
+  },
+
   async information() {
     const currentEnvironment = strapi.config.get('environment');
     const autoReload = strapi.config.get('autoReload', false);

--- a/packages/core/admin/server/controllers/admin.js
+++ b/packages/core/admin/server/controllers/admin.js
@@ -51,7 +51,9 @@ module.exports = {
 
     await validateUpdateProjectSettings(files);
 
-    console.log(files);
+    const uploadedFiles = await getService('project-settings').uploadProjectSettingsFiles(files);
+
+    console.log(uploadedFiles);
   },
 
   async information() {

--- a/packages/core/admin/server/routes/admin.js
+++ b/packages/core/admin/server/routes/admin.js
@@ -8,6 +8,20 @@ module.exports = [
     config: { auth: false },
   },
   {
+    method: 'POST',
+    path: '/project-settings',
+    handler: 'admin.updateProjectSettings',
+    config: {
+      policies: [
+        'admin::isAuthenticatedAdmin',
+        {
+          name: 'admin::hasPermissions',
+          config: { actions: ['admin::project-settings.update'] },
+        },
+      ],
+    },
+  },
+  {
     method: 'GET',
     path: '/project-type',
     handler: 'admin.getProjectType',

--- a/packages/core/admin/server/services/__tests__/project-settings.test.js
+++ b/packages/core/admin/server/services/__tests__/project-settings.test.js
@@ -32,7 +32,7 @@ global.strapi = {
             hash: 'filename_123',
             ext: '.png',
             mime: 'image/png',
-            size: 1024 * 1024,
+            size: 123,
           }),
         },
         'image-manipulation': {
@@ -49,6 +49,8 @@ global.strapi = {
         url: 'file/url',
         width: 100,
         height: 100,
+        ext: 'png',
+        size: 123,
       },
     }),
     set: storeSet,
@@ -62,7 +64,7 @@ describe('Project setting', () => {
     it('Should parse valid files object', async () => {
       const files = {
         menuLogo: {
-          size: 24085,
+          size: 123,
           path: '/tmp/filename_123',
           name: 'file.png',
           type: 'image/png',
@@ -77,7 +79,7 @@ describe('Project setting', () => {
           hash: 'filename_123',
           ext: '.png',
           mime: 'image/png',
-          size: 1024 * 1024,
+          size: 123,
           stream: null,
           width: 100,
           height: 100,
@@ -111,6 +113,8 @@ describe('Project setting', () => {
           url: 'file/url',
           width: 100,
           height: 100,
+          ext: 'png',
+          size: 123,
         },
       };
 
@@ -208,7 +212,7 @@ describe('Project setting', () => {
           hash: 'filename_123',
           ext: '.png',
           mime: 'image/png',
-          size: 1024 * 1024,
+          size: 123,
           stream: null,
           width: 100,
           height: 100,
@@ -225,6 +229,8 @@ describe('Project setting', () => {
           url: '/uploads/filename_123.png',
           width: 100,
           height: 100,
+          ext: 'png',
+          size: 123,
         },
       };
 
@@ -265,6 +271,8 @@ describe('Project setting', () => {
           url: 'file/url',
           width: 100,
           height: 100,
+          ext: 'png',
+          size: 123,
         },
       };
 

--- a/packages/core/admin/server/services/__tests__/project-settings.test.js
+++ b/packages/core/admin/server/services/__tests__/project-settings.test.js
@@ -8,6 +8,7 @@ const {
 } = require('../project-settings');
 
 jest.mock('fs', () => ({
+  ...jest.requireActual('fs'),
   createReadStream: () => null,
 }));
 
@@ -230,7 +231,7 @@ describe('Project setting', () => {
         menuLogo: {
           name: 'filename.png',
           hash: 'filename_123',
-          url: '/uploads/filename_123',
+          url: '/uploads/filename_123.png',
           width: 100,
           height: 100,
           ext: '.png',
@@ -238,7 +239,7 @@ describe('Project setting', () => {
         },
       };
 
-      await updateProjectSettings({ body, files });
+      await updateProjectSettings({ ...body, ...files });
 
       expect(storeSet).toBeCalledTimes(1);
       expect(storeSet).toBeCalledWith({
@@ -255,7 +256,7 @@ describe('Project setting', () => {
         menuLogo: null,
       };
 
-      await updateProjectSettings({ body, files });
+      await updateProjectSettings({ ...body, ...files });
 
       expect(storeSet).toBeCalledTimes(1);
       expect(storeSet).toBeCalledWith({
@@ -280,7 +281,7 @@ describe('Project setting', () => {
         },
       };
 
-      await updateProjectSettings({ body, files });
+      await updateProjectSettings({ ...body, ...files });
 
       expect(storeSet).toBeCalledTimes(1);
       expect(storeSet).toBeCalledWith({

--- a/packages/core/admin/server/services/__tests__/project-settings.test.js
+++ b/packages/core/admin/server/services/__tests__/project-settings.test.js
@@ -191,13 +191,14 @@ describe('Project setting', () => {
           type: 'image/png',
           provider: 'local',
           url: 'file/url',
+          hash: '123',
         },
       };
 
       const newSettings = {
         menuLogo: {
           ...previousSettings.menuLogo,
-          url: 'file/new',
+          hash: '456',
         },
       };
 

--- a/packages/core/admin/server/services/__tests__/project-settings.test.js
+++ b/packages/core/admin/server/services/__tests__/project-settings.test.js
@@ -133,7 +133,7 @@ describe('Project setting', () => {
         },
       };
 
-      await deleteOldFiles(previousSettings, newSettings);
+      await deleteOldFiles({ previousSettings, newSettings });
 
       expect(unlinkSync).not.toBeCalled();
     });
@@ -150,7 +150,7 @@ describe('Project setting', () => {
 
       const newSettings = previousSettings;
 
-      await deleteOldFiles(previousSettings, newSettings);
+      await deleteOldFiles({ previousSettings, newSettings });
 
       expect(unlinkSync).not.toBeCalled();
     });
@@ -167,7 +167,7 @@ describe('Project setting', () => {
 
       const newSettings = { menuLogo: null };
 
-      await deleteOldFiles(previousSettings, newSettings);
+      await deleteOldFiles({ previousSettings, newSettings });
 
       expect(unlinkSync).toBeCalledTimes(1);
       expect(unlinkSync).toBeCalledWith(previousSettings.menuLogo.path);
@@ -190,7 +190,7 @@ describe('Project setting', () => {
         },
       };
 
-      await deleteOldFiles(previousSettings, newSettings);
+      await deleteOldFiles({ previousSettings, newSettings });
 
       expect(unlinkSync).toBeCalledTimes(1);
       expect(unlinkSync).toBeCalledWith(previousSettings.menuLogo.path);
@@ -228,7 +228,7 @@ describe('Project setting', () => {
         },
       };
 
-      await updateProjectSettings(body, files);
+      await updateProjectSettings({ body, files });
 
       expect(storeSet).toBeCalledTimes(1);
       expect(storeSet).toBeCalledWith({
@@ -245,7 +245,7 @@ describe('Project setting', () => {
         menuLogo: null,
       };
 
-      await updateProjectSettings(body, files);
+      await updateProjectSettings({ body, files });
 
       expect(storeSet).toBeCalledTimes(1);
       expect(storeSet).toBeCalledWith({
@@ -268,7 +268,7 @@ describe('Project setting', () => {
         },
       };
 
-      await updateProjectSettings(body, files);
+      await updateProjectSettings({ body, files });
 
       expect(storeSet).toBeCalledTimes(1);
       expect(storeSet).toBeCalledWith({

--- a/packages/core/admin/server/services/__tests__/project-settings.test.js
+++ b/packages/core/admin/server/services/__tests__/project-settings.test.js
@@ -1,0 +1,280 @@
+'use strict';
+
+const { unlinkSync } = require('fs');
+const {
+  parseFilesData,
+  getProjectSettings,
+  deleteOldFiles,
+  updateProjectSettings,
+} = require('../project-settings');
+
+jest.mock('fs', () => ({
+  createReadStream: () => null,
+  unlinkSync: jest.fn(),
+}));
+
+const storeSet = jest.fn();
+global.strapi = {
+  dirs: {
+    public: 'publicDir',
+  },
+  plugins: {
+    upload: {
+      provider: {
+        uploadStream: jest.fn(),
+      },
+      services: {
+        upload: {
+          formatFileInfo: () => ({
+            name: 'filename.png',
+            alternativeText: null,
+            caption: null,
+            hash: 'filename_123',
+            ext: '.png',
+            mime: 'image/png',
+            size: 1024 * 1024,
+          }),
+        },
+        'image-manipulation': {
+          getDimensions: () => ({ width: 100, height: 100 }),
+        },
+      },
+    },
+  },
+  store: () => ({
+    get: () => ({
+      menuLogo: {
+        name: 'name',
+        path: 'path/to/file',
+        url: 'file/url',
+        width: 100,
+        height: 100,
+      },
+    }),
+    set: storeSet,
+  }),
+};
+
+describe('Project setting', () => {
+  beforeEach(jest.resetAllMocks);
+
+  describe('parseFilesData', () => {
+    it('Should parse valid files object', async () => {
+      const files = {
+        menuLogo: {
+          size: 24085,
+          path: '/tmp/filename_123',
+          name: 'file.png',
+          type: 'image/png',
+        },
+      };
+
+      const expectedOutput = {
+        menuLogo: {
+          name: 'filename.png',
+          alternativeText: null,
+          caption: null,
+          hash: 'filename_123',
+          ext: '.png',
+          mime: 'image/png',
+          size: 1024 * 1024,
+          stream: null,
+          width: 100,
+          height: 100,
+          path: 'publicDir/uploads/filename_123.png',
+          tmpPath: '/tmp/filename_123',
+          url: '/uploads/filename_123.png',
+        },
+      };
+
+      const parsedFiles = await parseFilesData(files);
+
+      expect(parsedFiles).toEqual(expectedOutput);
+    });
+
+    it('Should skip empty files object with no error', async () => {
+      const files = {};
+      const expectedOutput = {};
+
+      const parsedFiles = await parseFilesData(files);
+      expect(parsedFiles).toEqual(expectedOutput);
+    });
+  });
+
+  describe('getProjectSettings', () => {
+    it('Should return project settings from store (only the right subset of fields)', async () => {
+      const projectSettings = await getProjectSettings();
+
+      const expectedOutput = {
+        menuLogo: {
+          name: 'name',
+          url: 'file/url',
+          width: 100,
+          height: 100,
+        },
+      };
+
+      expect(projectSettings).toStrictEqual(expectedOutput);
+    });
+  });
+
+  describe('deleteOldFiles', () => {
+    it('Does not delete when there was no previous file', async () => {
+      const previousSettings = {
+        menuLogo: null,
+      };
+
+      const newSettings = {
+        menuLogo: {
+          size: 24085,
+          path: '/tmp/filename_123',
+          name: 'file.png',
+          type: 'image/png',
+        },
+      };
+
+      await deleteOldFiles(previousSettings, newSettings);
+
+      expect(unlinkSync).not.toBeCalled();
+    });
+
+    it('Does not delete when there is no new file uploaded', async () => {
+      const previousSettings = {
+        menuLogo: {
+          size: 24085,
+          path: '/tmp/filename_123',
+          name: 'file.png',
+          type: 'image/png',
+        },
+      };
+
+      const newSettings = previousSettings;
+
+      await deleteOldFiles(previousSettings, newSettings);
+
+      expect(unlinkSync).not.toBeCalled();
+    });
+
+    it('Deletes when inputs are explicitely set to null', async () => {
+      const previousSettings = {
+        menuLogo: {
+          size: 24085,
+          path: '/tmp/filename_123',
+          name: 'file.png',
+          type: 'image/png',
+        },
+      };
+
+      const newSettings = { menuLogo: null };
+
+      await deleteOldFiles(previousSettings, newSettings);
+
+      expect(unlinkSync).toBeCalledTimes(1);
+      expect(unlinkSync).toBeCalledWith(previousSettings.menuLogo.path);
+    });
+
+    it('Deletes when new files are uploaded', async () => {
+      const previousSettings = {
+        menuLogo: {
+          size: 24085,
+          path: '/tmp/filename_123',
+          name: 'file.png',
+          type: 'image/png',
+        },
+      };
+
+      const newSettings = {
+        menuLogo: {
+          ...previousSettings.menuLogo,
+          path: 'another/path',
+        },
+      };
+
+      await deleteOldFiles(previousSettings, newSettings);
+
+      expect(unlinkSync).toBeCalledTimes(1);
+      expect(unlinkSync).toBeCalledWith(previousSettings.menuLogo.path);
+    });
+  });
+
+  describe('updateProjectSettings', () => {
+    it('Updates the project settings', async () => {
+      const body = {};
+      const files = {
+        menuLogo: {
+          name: 'filename.png',
+          alternativeText: null,
+          caption: null,
+          hash: 'filename_123',
+          ext: '.png',
+          mime: 'image/png',
+          size: 1024 * 1024,
+          stream: null,
+          width: 100,
+          height: 100,
+          path: 'publicDir/uploads/filename_123.png',
+          tmpPath: '/tmp/filename_123',
+          url: '/uploads/filename_123.png',
+        },
+      };
+
+      const expectedOutput = {
+        menuLogo: {
+          name: 'filename.png',
+          path: 'publicDir/uploads/filename_123.png',
+          url: '/uploads/filename_123.png',
+          width: 100,
+          height: 100,
+        },
+      };
+
+      await updateProjectSettings(body, files);
+
+      expect(storeSet).toBeCalledTimes(1);
+      expect(storeSet).toBeCalledWith({
+        key: 'project-settings',
+        value: expectedOutput,
+      });
+    });
+
+    it('Updates the project settings (delete)', async () => {
+      const body = { menuLogo: '' };
+      const files = {};
+
+      const expectedOutput = {
+        menuLogo: null,
+      };
+
+      await updateProjectSettings(body, files);
+
+      expect(storeSet).toBeCalledTimes(1);
+      expect(storeSet).toBeCalledWith({
+        key: 'project-settings',
+        value: expectedOutput,
+      });
+    });
+
+    it('Keeps the previous project settings', async () => {
+      const body = {};
+      const files = {};
+
+      const expectedOutput = {
+        menuLogo: {
+          name: 'name',
+          path: 'path/to/file',
+          url: 'file/url',
+          width: 100,
+          height: 100,
+        },
+      };
+
+      await updateProjectSettings(body, files);
+
+      expect(storeSet).toBeCalledTimes(1);
+      expect(storeSet).toBeCalledWith({
+        key: 'project-settings',
+        value: expectedOutput,
+      });
+    });
+  });
+});

--- a/packages/core/admin/server/services/index.js
+++ b/packages/core/admin/server/services/index.js
@@ -13,4 +13,5 @@ module.exports = {
   auth: require('./auth'),
   action: require('./action'),
   'api-token': require('./api-token'),
+  'project-settings': require('./project-settings'),
 };

--- a/packages/core/admin/server/services/project-settings.js
+++ b/packages/core/admin/server/services/project-settings.js
@@ -51,7 +51,7 @@ const parseFilesData = async files => {
 };
 
 const getProjectSettings = async () => {
-  const store = await strapi.store({ type: 'core', name: 'admin' });
+  const store = strapi.store({ type: 'core', name: 'admin' });
   const projectSettings = await store.get({ key: 'project-settings' });
 
   // Filter file input fields
@@ -107,7 +107,7 @@ const deleteOldFiles = async ({ previousSettings, newSettings }) => {
 };
 
 const updateProjectSettings = async ({ body, files }) => {
-  const store = await strapi.store({ type: 'core', name: 'admin' });
+  const store = strapi.store({ type: 'core', name: 'admin' });
   const previousSettings = await store.get({ key: 'project-settings' });
 
   await uploadFiles(files);

--- a/packages/core/admin/server/services/project-settings.js
+++ b/packages/core/admin/server/services/project-settings.js
@@ -73,7 +73,7 @@ const uploadFiles = async files => {
   return Promise.all(Object.values(files).map(strapi.plugin('upload').provider.uploadStream));
 };
 
-const deleteOldFiles = async (previousSettings, newSettings) => {
+const deleteOldFiles = async ({ previousSettings, newSettings }) => {
   return Promise.all(
     PROJECT_SETTINGS_FILE_INPUTS.map(async inputName => {
       // Skip if there was no previous file
@@ -96,7 +96,7 @@ const deleteOldFiles = async (previousSettings, newSettings) => {
   );
 };
 
-const updateProjectSettings = async (body, files) => {
+const updateProjectSettings = async ({ body, files }) => {
   const store = await strapi.store({ type: 'core', name: 'admin' });
   const previousSettings = await store.get({ key: 'project-settings' });
 
@@ -126,9 +126,12 @@ const updateProjectSettings = async (body, files) => {
 
   // No await to proceed asynchronously
   uploadFiles(files);
-  deleteOldFiles(previousSettings, newSettings);
+  deleteOldFiles({ previousSettings, newSettings });
 
-  store.set({ key: 'project-settings', value: { ...previousSettings, ...newSettings } });
+  await store.set({
+    key: 'project-settings',
+    value: { ...previousSettings, ...newSettings },
+  });
 
   return getProjectSettings();
 };

--- a/packages/core/admin/server/services/project-settings.js
+++ b/packages/core/admin/server/services/project-settings.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const fs = require('fs');
+const path = require('path');
+const { pick } = require('lodash');
 
 const PROJECT_SETTINGS_FILE_INPUTS = ['menuLogo'];
 
@@ -9,30 +11,22 @@ const parseFilesData = async files => {
 
   await Promise.all(
     PROJECT_SETTINGS_FILE_INPUTS.map(async inputName => {
-      // Do not parse empty file inputs
+      // Skip empty file inputs
       if (!files[inputName]) {
         return;
       }
 
       const getStream = () => fs.createReadStream(files[inputName].path);
 
-      formatedFilesData[inputName] = {
-        path: files[inputName].path,
-        stream: getStream(),
-      };
-
       // Add formated data for the upload provider
-      Object.assign(
-        formatedFilesData[inputName],
-        strapi
-          .plugin('upload')
-          .service('upload')
-          .formatFileInfo({
-            filename: files[inputName].name,
-            type: files[inputName].type,
-            size: files[inputName].size,
-          })
-      );
+      formatedFilesData[inputName] = strapi
+        .plugin('upload')
+        .service('upload')
+        .formatFileInfo({
+          filename: files[inputName].name,
+          type: files[inputName].type,
+          size: files[inputName].size,
+        });
 
       // Add image dimensions
       Object.assign(
@@ -42,14 +36,64 @@ const parseFilesData = async files => {
           .service('image-manipulation')
           .getDimensions({ getStream })
       );
+
+      // Add file path, url and stream
+      const url = `/uploads/${formatedFilesData[inputName].hash}${formatedFilesData[inputName].ext}`;
+      Object.assign(formatedFilesData[inputName], {
+        path: path.join(strapi.dirs.public, url),
+        stream: getStream(),
+        tmpPath: files[inputName].path,
+        url,
+      });
     })
   );
 
   return formatedFilesData;
 };
 
+const getProjectSettings = async () => {
+  const store = await strapi.store({ type: 'core', name: 'admin' });
+  const projectSettings = await store.get({ key: 'project-settings' });
+
+  PROJECT_SETTINGS_FILE_INPUTS.forEach(inputName => {
+    if (projectSettings[inputName]) {
+      projectSettings[inputName] = pick(projectSettings[inputName], [
+        'name',
+        'url',
+        'width',
+        'height',
+      ]);
+    }
+  });
+
+  return projectSettings;
+};
+
 const uploadFiles = async files => {
   return Promise.all(Object.values(files).map(strapi.plugin('upload').provider.uploadStream));
+};
+
+const deleteOldFiles = async (previousSettings, newSettings) => {
+  return Promise.all(
+    PROJECT_SETTINGS_FILE_INPUTS.map(async inputName => {
+      // Skip if there was no previous file
+      if (!previousSettings[inputName]) {
+        return;
+      }
+
+      // Skip if the file was not changed
+      if (
+        newSettings[inputName] &&
+        previousSettings[inputName].path === newSettings[inputName].path
+      ) {
+        return;
+      }
+
+      // There was a previous file and an new file was uploaded
+      // Remove the previous file
+      fs.unlinkSync(previousSettings[inputName].path);
+    })
+  );
 };
 
 const updateProjectSettings = async (body, files) => {
@@ -72,7 +116,8 @@ const updateProjectSettings = async (body, files) => {
       // Update the file
       newSettings[inputName] = {
         name: newSettings[inputName].name,
-        url: 'test',
+        path: newSettings[inputName].path,
+        url: newSettings[inputName].url,
         width: newSettings[inputName].width,
         height: newSettings[inputName].height,
       };
@@ -81,12 +126,15 @@ const updateProjectSettings = async (body, files) => {
 
   // No await to proceed asynchronously
   uploadFiles(files);
+  deleteOldFiles(previousSettings, newSettings);
 
-  return store.set({ key: 'project-settings', value: { ...previousSettings, ...newSettings } });
+  store.set({ key: 'project-settings', value: { ...previousSettings, ...newSettings } });
+
+  return getProjectSettings();
 };
 
 module.exports = {
   parseFilesData,
-  uploadFiles,
+  getProjectSettings,
   updateProjectSettings,
 };

--- a/packages/core/admin/server/services/project-settings.js
+++ b/packages/core/admin/server/services/project-settings.js
@@ -55,6 +55,7 @@ const getProjectSettings = async () => {
   const store = await strapi.store({ type: 'core', name: 'admin' });
   const projectSettings = await store.get({ key: 'project-settings' });
 
+  // Filter file input fields
   PROJECT_SETTINGS_FILE_INPUTS.forEach(inputName => {
     if (projectSettings[inputName]) {
       projectSettings[inputName] = pick(projectSettings[inputName], [
@@ -62,6 +63,8 @@ const getProjectSettings = async () => {
         'url',
         'width',
         'height',
+        'ext',
+        'size',
       ]);
     }
   });
@@ -120,6 +123,8 @@ const updateProjectSettings = async ({ body, files }) => {
         url: newSettings[inputName].url,
         width: newSettings[inputName].width,
         height: newSettings[inputName].height,
+        ext: newSettings[inputName].ext.replace('.', ''),
+        size: newSettings[inputName].size,
       };
     }
   });

--- a/packages/core/admin/server/services/project-settings.js
+++ b/packages/core/admin/server/services/project-settings.js
@@ -134,6 +134,7 @@ const updateProjectSettings = async (body, files) => {
 };
 
 module.exports = {
+  deleteOldFiles,
   parseFilesData,
   getProjectSettings,
   updateProjectSettings,

--- a/packages/core/admin/server/services/project-settings.js
+++ b/packages/core/admin/server/services/project-settings.js
@@ -89,7 +89,7 @@ const deleteOldFiles = async ({ previousSettings, newSettings }) => {
       // Skip if the file was not changed
       if (
         newSettings[inputName] &&
-        previousSettings[inputName].url === newSettings[inputName].url
+        previousSettings[inputName].hash === newSettings[inputName].hash
       ) {
         return;
       }

--- a/packages/core/admin/server/services/project-settings.js
+++ b/packages/core/admin/server/services/project-settings.js
@@ -3,6 +3,8 @@
 const fs = require('fs');
 const { transform } = require('lodash');
 
+const PROJECT_SETTINGS_FILE_INPUTS = ['menuLogo'];
+
 const getFormatedFileData = data => ({
   path: data.path,
   ...strapi
@@ -15,7 +17,7 @@ const getFormatedFileData = data => ({
     }),
 });
 
-const uploadProjectSettingsFiles = async files => {
+const uploadFiles = async files => {
   const formatedFilesData = transform(files, (result, value, key) => {
     if (value) {
       result[key] = getFormatedFileData(value);
@@ -33,6 +35,40 @@ const uploadProjectSettingsFiles = async files => {
   return formatedFilesData;
 };
 
+const updateProjectSettings = async (body, uploadedFiles) => {
+  const store = await strapi.store({ type: 'core', name: 'admin' });
+
+  const previousSettings = await store.get({ key: 'project-settings' });
+
+  const newSettings = {
+    ...body,
+    ...uploadedFiles,
+  };
+
+  PROJECT_SETTINGS_FILE_INPUTS.forEach(inputName => {
+    if (newSettings[inputName] !== undefined && !(typeof newSettings[inputName] === 'object')) {
+      // If the user input exists but is not a formdata "file" remove the file
+      newSettings[inputName] = null;
+
+      // TODO unlink the file
+    } else if (!newSettings[inputName]) {
+      // If the user input is undefined reuse previous setting (do not update field)
+      newSettings[inputName] = previousSettings[inputName];
+    } else {
+      // Update the file
+      newSettings[inputName] = {
+        name: newSettings[inputName].name,
+        url: 'test',
+        width: 0,
+        height: 0,
+      };
+    }
+  });
+
+  return store.set({ key: 'project-settings', value: { ...previousSettings, ...newSettings } });
+};
+
 module.exports = {
-  uploadProjectSettingsFiles,
+  uploadFiles,
+  updateProjectSettings,
 };

--- a/packages/core/admin/server/services/project-settings.js
+++ b/packages/core/admin/server/services/project-settings.js
@@ -78,7 +78,7 @@ const uploadFiles = async (files = {}) => {
   return Promise.all(
     Object.values(files)
       .filter(file => file.stream instanceof fs.ReadStream)
-      .map(strapi.plugin('upload').provider.uploadStream)
+      .map(file => strapi.plugin('upload').provider.uploadStream(file))
   );
 };
 

--- a/packages/core/admin/server/services/project-settings.js
+++ b/packages/core/admin/server/services/project-settings.js
@@ -73,7 +73,7 @@ const getProjectSettings = async () => {
   return projectSettings;
 };
 
-const uploadFiles = async files => {
+const uploadFiles = async (files = {}) => {
   // Call the provider upload function for each file
   return Promise.all(Object.values(files).map(strapi.plugin('upload').provider.uploadStream));
 };

--- a/packages/core/admin/server/services/project-settings.js
+++ b/packages/core/admin/server/services/project-settings.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const fs = require('fs');
+const { transform } = require('lodash');
+
+const getFormatedFileData = data => ({
+  path: data.path,
+  ...strapi
+    .plugin('upload')
+    .service('upload')
+    .formatFileInfo({
+      filename: data.name,
+      type: data.type,
+      size: data.size,
+    }),
+});
+
+const uploadProjectSettingsFiles = async files => {
+  const formatedFilesData = transform(files, (result, value, key) => {
+    if (value) {
+      result[key] = getFormatedFileData(value);
+    }
+  });
+
+  Object.values(formatedFilesData).map(data =>
+    // Do not await to upload asynchronously
+    strapi.plugin('upload').provider.uploadStream({
+      ...data,
+      stream: fs.createReadStream(data.path),
+    })
+  );
+
+  return formatedFilesData;
+};
+
+module.exports = {
+  uploadProjectSettingsFiles,
+};

--- a/packages/core/admin/server/utils/index.d.ts
+++ b/packages/core/admin/server/utils/index.d.ts
@@ -6,6 +6,7 @@ import * as metrics from '../services/metrics';
 import * as token from '../services/token';
 import * as auth from '../services/auth';
 import * as apiToken from '../services/api-token';
+import * as projectSettings from '../services/project-settings';
 
 type S = {
   role: typeof role;
@@ -16,6 +17,7 @@ type S = {
   auth: typeof auth;
   metrics: typeof metrics;
   'api-token': typeof apiToken;
+  'project-settings': typeof projectSettings;
 };
 
 export function getService<T extends keyof S>(name: T): S[T];

--- a/packages/core/admin/server/validation/project-settings.js
+++ b/packages/core/admin/server/validation/project-settings.js
@@ -2,8 +2,10 @@
 
 const { yup, validateYupSchemaSync } = require('@strapi/utils');
 
-const MAX_LOGO_SIZE = 1024 * 1024; // 1Mo
-const ALLOWED_LOGO_FILE_TYPES = ['image/jpeg', 'image/png', 'image/svg+xml'];
+const MAX_IMAGE_WIDTH = 750;
+const MAX_IMAGE_HEIGHT = MAX_IMAGE_WIDTH;
+const MAX_IMAGE_FILE_SIZE = 1024 * 1024; // 1Mo
+const ALLOWED_IMAGE_FILE_TYPES = ['image/jpeg', 'image/png', 'image/svg+xml'];
 
 const updateProjectSettings = yup
   .object({
@@ -15,13 +17,24 @@ const updateProjectSettingsFiles = yup
   .object({
     menuLogo: yup.object({
       name: yup.string(),
-      type: yup.string().oneOf(ALLOWED_LOGO_FILE_TYPES),
-      size: yup.number().max(MAX_LOGO_SIZE),
+      type: yup.string().oneOf(ALLOWED_IMAGE_FILE_TYPES),
+      size: yup.number().max(MAX_IMAGE_FILE_SIZE),
     }),
   })
   .noUnknown();
 
+const updateProjectSettingsImagesDimensions = yup
+  .object({
+    menuLogo: yup.object({
+      width: yup.number().max(MAX_IMAGE_WIDTH),
+      height: yup.number().max(MAX_IMAGE_HEIGHT),
+    }),
+  })
+
 module.exports = {
   validateUpdateProjectSettings: validateYupSchemaSync(updateProjectSettings),
   validateUpdateProjectSettingsFiles: validateYupSchemaSync(updateProjectSettingsFiles),
+  validateUpdateProjectSettingsImagesDimensions: validateYupSchemaSync(
+    updateProjectSettingsImagesDimensions
+  ),
 };

--- a/packages/core/admin/server/validation/project-settings.js
+++ b/packages/core/admin/server/validation/project-settings.js
@@ -23,13 +23,12 @@ const updateProjectSettingsFiles = yup
   })
   .noUnknown();
 
-const updateProjectSettingsImagesDimensions = yup
-  .object({
-    menuLogo: yup.object({
-      width: yup.number().max(MAX_IMAGE_WIDTH),
-      height: yup.number().max(MAX_IMAGE_HEIGHT),
-    }),
-  })
+const updateProjectSettingsImagesDimensions = yup.object({
+  menuLogo: yup.object({
+    width: yup.number().max(MAX_IMAGE_WIDTH),
+    height: yup.number().max(MAX_IMAGE_HEIGHT),
+  }),
+});
 
 module.exports = {
   validateUpdateProjectSettings: validateYupSchemaSync(updateProjectSettings),

--- a/packages/core/admin/server/validation/project-settings.js
+++ b/packages/core/admin/server/validation/project-settings.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const { yup, validateYupSchemaSync } = require('@strapi/utils');
+
+const MAX_LOGO_SIZE = 1024 * 1024; // 1Mo
+const ALLOWED_LOGO_FILE_TYPES = ['image/jpeg', 'image/png', 'image/svg+xml'];
+
+const updateProjectSettings = yup
+  .object({
+    menuLogo: yup.object({
+      name: yup.string().max(255),
+      type: yup.string().oneOf(ALLOWED_LOGO_FILE_TYPES),
+      size: yup.number().max(MAX_LOGO_SIZE),
+    }),
+  })
+  .noUnknown();
+
+module.exports = {
+  validateUpdateProjectSettings: validateYupSchemaSync(updateProjectSettings),
+};

--- a/packages/core/admin/server/validation/project-settings.js
+++ b/packages/core/admin/server/validation/project-settings.js
@@ -8,7 +8,7 @@ const ALLOWED_LOGO_FILE_TYPES = ['image/jpeg', 'image/png', 'image/svg+xml'];
 const updateProjectSettings = yup
   .object({
     menuLogo: yup.object({
-      name: yup.string().max(255),
+      name: yup.string(),
       type: yup.string().oneOf(ALLOWED_LOGO_FILE_TYPES),
       size: yup.number().max(MAX_LOGO_SIZE),
     }),

--- a/packages/core/admin/server/validation/project-settings.js
+++ b/packages/core/admin/server/validation/project-settings.js
@@ -7,6 +7,12 @@ const ALLOWED_LOGO_FILE_TYPES = ['image/jpeg', 'image/png', 'image/svg+xml'];
 
 const updateProjectSettings = yup
   .object({
+    menuLogo: yup.string(),
+  })
+  .noUnknown();
+
+const updateProjectSettingsFiles = yup
+  .object({
     menuLogo: yup.object({
       name: yup.string(),
       type: yup.string().oneOf(ALLOWED_LOGO_FILE_TYPES),
@@ -17,4 +23,5 @@ const updateProjectSettings = yup
 
 module.exports = {
   validateUpdateProjectSettings: validateYupSchemaSync(updateProjectSettings),
+  validateUpdateProjectSettingsFiles: validateYupSchemaSync(updateProjectSettingsFiles),
 };


### PR DESCRIPTION
### What does it do?

- It adds `POST /project-settings` route in the admin API
- It takes `form-data` to allow file upload
- It allows to update/delete a custom menu logo
- It is restricted to users with `admin::project-settings.update` permission

Example requests:

**Logo upload | POST /project-settings**

Body:
```
menuLogo: file.png
```

Response:
```json
{
  "menuLogo": {
    "name": "file.png",
    "url": "/uploads/file_201796d45f.png",
    "width": 498,
    "height": 570,
    "ext": ".png",
    "size": 24.61
  }
}
```

**Logo delete | POST /project-settings**

Body:
```
menuLogo: (empty)
```
Response:
```json
{
  "menuLogo": null
}
```

### Why is it needed?

This is necessary for the menu logo customization feature + upcomming project wide settings for customization