### PR TITLE
Add missing babel polyfill dependency

### DIFF
--- a/packages/core/admin/package.json
+++ b/packages/core/admin/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "@babel/core": "7.16.7",
     "@babel/plugin-transform-runtime": "7.16.7",
+    "@babel/polyfill": "7.12.1",
     "@babel/preset-env": "7.16.7",
     "@babel/preset-react": "7.16.7",
     "@babel/runtime": "7.16.7",


### PR DESCRIPTION
Signed-off-by: soupette <cyril@strapi.io>

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

It adds a missing dependency to the admin panel.

Babel polyfill is now needed in the webpack config so we need to add it to the package's dependencies.

### Why is it needed?

Describe the issue you are solving.

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
