### PR TITLE
Support adding custom locales for admin UI

### DIFF
--- a/packages/core/admin/admin/src/StrapiApp.js
+++ b/packages/core/admin/admin/src/StrapiApp.js
@@ -418,7 +418,10 @@ class StrapiApp {
 
   render() {
     const store = this.createStore();
-    const localeNames = pick(languageNativeNames, this.configurations.locales || []);
+    const localeNames = pick(
+      { ...languageNativeNames, ...this.customConfigurations.languageNativeNames },
+      this.configurations.locales || []
+    );
 
     const {
       components: { components },


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Allows developer to extend `packages/core/admin/admin/src/translations/languageNativeNames.js` using `languageNativeNames` key admin config (`src/admin/app.js`)

### Why is it needed?

Without this, extending translations for custom languages doesn't work.

### How to test it?

Modify `examples/getstarted/src/admin/app.js` and put the following:
```js
export default {
  config: {
    locales: ['fa'],
    languageNativeNames: {
      fa: 'فارسی',
    },
    translations: {
      fa: { 'Settings.profile.form.section.experience.interfaceLanguage': 'زبان رابط کاربری' },
    },
  },
  bootstrap() {},
};
```

Run the following command: `yarn workspace getstarted develop --watch-admin`

Open http://localhost:8000/admin/me in your browser, Set Interface Langauge to "فارسی", and Save.

The "Interface Language" title should change to "زبان رابط کاربری" which is defined in `examples/getstarted/src/admin/app.js`

