### PR TITLE
fix: url too long

### DIFF
--- a/packages/core/upload/server/content-types/file/schema.js
+++ b/packages/core/upload/server/content-types/file/schema.js
@@ -28,11 +28,11 @@ module.exports = {
       required: true,
     },
     alternativeText: {
-      type: 'string',
+      type: 'text',
       configurable: false,
     },
     caption: {
-      type: 'string',
+      type: 'text',
       configurable: false,
     },
     width: {

--- a/packages/core/upload/server/content-types/file/schema.js
+++ b/packages/core/upload/server/content-types/file/schema.js
@@ -67,12 +67,12 @@ module.exports = {
       required: true,
     },
     url: {
-      type: 'string',
+      type: 'text',
       configurable: false,
       required: true,
     },
     previewUrl: {
-      type: 'string',
+      type: 'text',
       configurable: false,
     },
     provider: {


### PR DESCRIPTION
Most of browsers are supporting around 2000 long urls

fix #7762

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Changes the types of attributes of File model, url, previewUrl, alternativeText, and caption.
They all could be derived from the long file name or you can say long urls.

### Why is it needed?

There are cases where the mobile apps generate long file names 
In my case, it was cropped file with some uuids in the name of the file.
Which then be uploaded to a strapi service and possibly encounter this issue where relational database type VarChar(255) can not hold it. 

However, http spec and most of browsers are supporting almost 2000 long urls. 

### How to test it?

Once the strapi is up and running try to upload a file with a very long name (longer than 255 chars)

### Related issue(s)/PR(s)

fix #7762
