### PR TITLE
[TS] Allow to extend the StrapiInterface type

### DIFF
--- a/examples/kitchensink-ts/index.d.ts
+++ b/examples/kitchensink-ts/index.d.ts
@@ -1,0 +1,7 @@
+import '@strapi/strapi';
+
+declare module '@strapi/strapi' {
+  interface StrapiInterface {
+    customAddMethod(n1: number, n2: number): number;
+  }
+}

--- a/examples/kitchensink-ts/src/index.ts
+++ b/examples/kitchensink-ts/src/index.ts
@@ -1,0 +1,15 @@
+export default {
+  register({ strapi }: { strapi: Strapi }) {
+    // No error when trying the access & set the
+    strapi.customAddMethod = (n1, n2) => {
+      return n1 + n2;
+    };
+  },
+
+  bootstrap({ strapi }: { strapi: Strapi }) {
+    const result = strapi.customAddMethod(12, 32);
+
+    // This should print "42"
+    console.log(result);
+  },
+};

--- a/examples/kitchensink-ts/src/index.ts
+++ b/examples/kitchensink-ts/src/index.ts
@@ -1,3 +1,5 @@
+import type { Strapi } from '@strapi/strapi';
+
 export default {
   register({ strapi }: { strapi: Strapi }) {
     // No error when trying the access & set the
@@ -7,7 +9,7 @@ export default {
   },
 
   bootstrap({ strapi }: { strapi: Strapi }) {
-    const result = strapi.customAddMethod(12, 32);
+    const result = strapi.customAddMethod(11, 31);
 
     // This should print "42"
     console.log(result);

--- a/packages/core/strapi/lib/index.d.ts
+++ b/packages/core/strapi/lib/index.d.ts
@@ -3,7 +3,7 @@ import { EntityService } from './services/entity-service';
 import { Strapi as StrapiClass } from './Strapi';
 
 export * as factories from './factories';
-interface StrapiInterface extends StrapiClass {
+export interface StrapiInterface extends StrapiClass {
   query: Database['query'];
   entityService: EntityService;
 }


### PR DESCRIPTION
### What does it do?

Simply export the StrapiInterface type so that it can be extended by the user in its custom definition files.
This allows users to benefit from future Strapi typings updates and add their definitions.

Note: The `AllTypes` interface is still exposed globally, but it shouldn't be used now as it's considered unstable. The next iteration on `Strapi` <> `TypeScript` will replace this interface with another one. Thus, it's strongly advised not to use it.

### Why is it needed?

Currently, the `StrapiInterface` isn't exported, which means that the `Strapi` type based on it cannot be extended to fit specific users' needs.

### How to test it?

Create a test project & add an `index.d.ts` file containing the following snippet:

```typescript
import '@strapi/strapi'

declare module '@strapi/strapi' {
    interface StrapiInterface {
        customAddMethod(n1: number, n2: number): number;
    }
}
```

Then in your code (`src/index.ts` file), you can test it correctly resolves the extended type like so:
```ts
export default {
  register({ strapi }: { strapi: Strapi }) {
    // No type error when trying the access & set the `customAddMethod` method
    strapi.customAddMethod = (n1, n2) => {
      return n1 + n2;
    };
  },

  bootstrap({ strapi }: { strapi: Strapi }) {
    const result = strapi.customAddMethod(11, 31);

    // This should print "42"
    console.log(result);
  },
};

```
 

### Related issue(s)/PR(s)

fix #12898
