### PR TITLE
Prevent `argv` check on "add-missing-keys-to-other-language"

### DIFF
--- a/scripts/front/add-missing-keys-to-other-language.js
+++ b/scripts/front/add-missing-keys-to-other-language.js
@@ -63,16 +63,16 @@ const addMissingKeys = async lang => {
   translationFiles.forEach(addMissingKeyForSingleFile);
 };
 
-if (process.argv.length < 3) {
-  console.warn(
-    chalk.yellow(
-      'Please provide a language. For example:\nnode scripts/front/add-missing-keys-to-other-language.js vi'
-    )
-  );
-  process.exit(1);
-}
-
 if (require.main === module) {
+  if (process.argv.length < 3) {
+    console.warn(
+      chalk.yellow(
+        'Please provide a language. For example:\nnode scripts/front/add-missing-keys-to-other-language.js vi'
+      )
+    );
+    process.exit(1);
+  }
+
   addMissingKeys(process.argv[2]).catch(err => console.error(err));
 }
 


### PR DESCRIPTION
### What does it do?
Fixes a bug that doesn't affect many users but causes unit tests to fail.


There is a `require.main === module` in the file, Next to the `argv` check file,

All I did was moving `argv` check within the `if` block to prevent the check when the module is being imported (like in the `scripts/front/__tests__/add-missing-keys-to-other-language.test.js`)



### Why is it needed?
The file is not imported anywhere, I'm not sure if anyone imports `updateMissingKeysToJSON` from this file (which is a script => `scripts/front/add-missing-keys-to-other-language.test.js`),

Maybe deleting the `module.exports` and the `require.main === module` check is a better refactoring solution,

I agree with you, "Why is it needed?"

### How to test it?
Run `yarn test:unit` in the "main" branch and compare the output of the same command within this PR's branch.


