### PR TITLE
Converted the synchronous function to asynchronous

### DIFF
--- a/packages/core/strapi/lib/services/server/register-routes.js
+++ b/packages/core/strapi/lib/services/server/register-routes.js
@@ -20,7 +20,7 @@ const createRouteScopeGenerator = namespace => route => {
  * Register all routes
  * @param {import('../../').Strapi} strapi
  */
-module.exports = strapi => {
+module.exports = async strapi => {
   registerAdminRoutes(strapi);
   registerAPIRoutes(strapi);
   registerPluginRoutes(strapi);


### PR DESCRIPTION
This function is called as an asynchronous function in 
**"strapi/packages/core/strapi/lib/services/server/index.js"**
 file in `async initRouting()` function but it is a synchronous function so ` await ` has no effect . So I converted this **synchronous** function to **asynchronous** .