### PR TITLE
Make config on router and handler config optional

### DIFF
--- a/packages/core/strapi/lib/factories.d.ts
+++ b/packages/core/strapi/lib/factories.d.ts
@@ -8,23 +8,23 @@ type ControllerConfig = Controller;
 type ServiceConfig = Service;
 
 type HandlerConfig = {
-  auth: false | { scope: string[] };
-  policies: Array<string | Policy>;
-  middlewares: Array<string | Middleware>;
+  auth?: false | { scope: string[] };
+  policies?: Array<string | Policy>;
+  middlewares?: Array<string | Middleware>;
 };
 
 type SingleTypeRouterConfig = {
-  find: HandlerConfig;
-  update: HandlerConfig;
-  delete: HandlerConfig;
+  find?: HandlerConfig;
+  update?: HandlerConfig;
+  delete?: HandlerConfig;
 };
 
 type CollectionTypeRouterConfig = {
-  find: HandlerConfig;
-  findOne: HandlerConfig;
-  create: HandlerConfig;
-  update: HandlerConfig;
-  delete: HandlerConfig;
+  find?: HandlerConfig;
+  findOne?: HandlerConfig;
+  create?: HandlerConfig;
+  update?: HandlerConfig;
+  delete?: HandlerConfig;
 };
 
 type RouterConfig = {


### PR DESCRIPTION
Per the documentation since you have the ability to configure only certain methods to be loaded
https://docs.strapi.io/developer-docs/latest/development/backend-customization/routes.html#configuring-core-routers
> only | Core routes that will only be loaded Anything not in this array is ignored.  

making it required to have every crud operation still need a HandlerConfig does not make sense.

Code example:

> {
      only: ['find'],
      find: {//handlerconfig here},
      create: {//handlerconfig here},
      findOne: {//handlerconfig here}
      delete: {//handlerconfig here}
  }

With the current types all of those useless operations are required when they should not be.

Secondly all of the properties on the HandlerConfig should also be optional since they're not required in the JS version. It should be the same in the typescript version.  More specifically for the handler config it does not make sense to have to pass a value for the auth property since leaving it null is the best way to handle the default behavior.  Somewhat related: https://github.com/strapi/strapi/issues/11644

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?
This makes the methods on the SingleTypeRouterConfig and the CollectionTypeRouterConfig optional.  The PR also makes the properties on the HandlerConfig optional.  

Since you can pass certain methods in the only array it doesn't make sense to then have to pass in a config with every single handler config on methods that will not be used.  If I have a router that was setup to be only: ['find'] I shouldn't need to create a HandlerConfig for the other crud operations.  As well as on the handlerconfig on javascript version of Strapi none of those properties are required, especially the auth property where the default is enabled when you **DO NOT** pass a value, meaning we certainly should not have to always pass a value for it when using typescript.

### Why is it needed?

Current types add useless code and breaks the default auth setting on router configurations.

### How to test it?

Try to set a router config without all the crud operations.  
Try to set a router crud operation config (single or collectiontype) with the default auth operation (no value).

### Related issue(s)/PR(s)
Very thinly related: https://github.com/strapi/strapi/issues/11644
