### PR TITLE
FIx upload error: Error: VipsJpeg: Invalid SOS parameters for sequential JPEG

### DIFF
--- a/packages/core/upload/package.json
+++ b/packages/core/upload/package.json
@@ -40,7 +40,7 @@
     "react-redux": "7.2.3",
     "react-router": "^5.2.0",
     "react-router-dom": "5.2.0",
-    "sharp": "0.30.1"
+    "sharp": "0.30.4"
   },
   "engines": {
     "node": ">=12.22.0 <=16.x.x",


### PR DESCRIPTION
### What does it do?

Update sharp package version from 0.30.1 to 0.30.4 

### Why is it needed?

Strapi server crashed with  error when upload big image (15Mb). 
Image was photographed on Samsung device.

Error: `Error: VipsJpeg: Invalid SOS parameters for sequential JPEG`

I found sharp issue - https://github.com/lovell/sharp/issues/2780

They recommend add sharp option `failOnError: false` on sharp transformer creation.

But `failOnError` option deprecated in [v0.30.4](https://github.com/lovell/sharp/blob/main/docs/changelog.md#v0304---tbd) in favor `failOn` option.

`failOn`has `warning` value by default and  should not crash strapi server on uploading invalid images.

[sharp docs](https://github.com/lovell/sharp/blob/926572b41ea363ede57189128441a42fb77f66f4/docs/api-constructor.md#parameters):

> options.failOn [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) level of sensitivity to invalid images, one of (in order of sensitivity): 'none' (least), 'truncated', 'error' or 'warning' (most), highers level imply lower levels. (optional, default 'warning')

### How to test it?

- Upload big [image](https://drive.google.com/file/d/1Z_45piSElMhIZICrnc1xwxoTW5hRTdNk/view?usp=sharing)
- Server should not crashed

### Related issue(s)/PR(s)

- https://github.com/lovell/sharp/issues/2780
