### PR TITLE
Fix roadmap links in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ For general help using Strapi, please refer to [the official Strapi documentatio
 - [Discord](https://discord.strapi.io) (For live discussion with the Community and Strapi team)
 - [GitHub](https://github.com/strapi/strapi) (Bug reports, Contributions)
 - [Community Forum](https://forum.strapi.io) (Questions and Discussions)
-- [ProductBoard](https://portal.productboard.com/strapi/tabs/2-under-consideration) (Roadmap, Feature requests)
+- [Feedback section](https://feedback.strapi.io) (Roadmap, Feature requests)
 - [Twitter](https://twitter.com/strapijs) (Get the news fast)
 - [Facebook](https://www.facebook.com/Strapi-616063331867161)
 - [YouTube Channel](https://www.youtube.com/strapi) (Learn from Video Tutorials)
@@ -129,7 +129,7 @@ Follow our [migration guides](https://docs.strapi.io/developer-docs/latest/updat
 
 ## Roadmap
 
-Check out our [roadmap](https://portal.productboard.com/strapi) to get informed of the latest features released and the upcoming ones. You may also give us insights and vote for a specific feature.
+Check out our [roadmap](https://feedback.strapi.io) to get informed of the latest features released and the upcoming ones. You may also give us insights and vote for a specific feature.
 
 ## Documentation
 


### PR DESCRIPTION
### What does it do?

Replace old roadmap links with the new one in the readme.
