### PR TITLE
Enable .jsx extensions

### DIFF
--- a/packages/core/admin/webpack.config.js
+++ b/packages/core/admin/webpack.config.js
@@ -80,7 +80,7 @@ module.exports = ({
     module: {
       rules: [
         {
-          test: /\.m?js$/,
+          test: /\.m?jsx?$/,
           include: cacheDir,
           oneOf: [
             // Use babel-loader for files that distinct the ee and ce code
@@ -143,7 +143,7 @@ module.exports = ({
           ],
         },
         {
-          test: /\.m?js$/,
+          test: /\.m?jsx?$/,
           include: pluginsPath,
           use: {
             loader: require.resolve('esbuild-loader'),


### PR DESCRIPTION
Fixes #13124

Signed-off-by: soupette <cyril@strapi.io>

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

It enables `.jsx` extensions in the webpack config.


### Why is it needed?

To enable jsx

### How to test it?

Extend the getstarted application by creating a component with the .jsx file extension. Build the app.

### Related issue(s)/PR(s)

Fixes #13124 
