### PR TITLE
Typescript/fix cli

### DIFF
--- a/packages/core/strapi/bin/strapi.js
+++ b/packages/core/strapi/bin/strapi.js
@@ -95,6 +95,7 @@ program
   .option('--dbssl <dbssl>', 'Database SSL')
   .option('--dbfile <dbfile>', 'Database file path for sqlite')
   .option('--dbforce', 'Allow overwriting existing database content')
+  .option('-ts, --typescript', 'Create a typescript project')
   .description('Create a new application')
   .action(require('../lib/commands/new'));
 

--- a/packages/core/strapi/lib/commands/admin-create.js
+++ b/packages/core/strapi/lib/commands/admin-create.js
@@ -3,6 +3,8 @@
 const { yup } = require('@strapi/utils');
 const _ = require('lodash');
 const inquirer = require('inquirer');
+const tsUtils = require('@strapi/typescript-utils')
+const path = require('path')
 const strapi = require('../index');
 
 const emailValidator = yup
@@ -60,7 +62,7 @@ const promptQuestions = [
  * @param {string} cmdOptions.firstname - new admin's first name
  * @param {string} [cmdOptions.lastname] - new admin's last name
  */
-module.exports = async function(cmdOptions = {}) {
+module.exports = async function (cmdOptions = {}) {
   let { email, password, firstname, lastname } = cmdOptions;
 
   if (
@@ -90,7 +92,12 @@ module.exports = async function(cmdOptions = {}) {
 };
 
 async function createAdmin({ email, password, firstname, lastname }) {
-  const app = await strapi().load();
+  const appDir = process.cwd();
+
+  const isTSProject = await tsUtils.isUsingTypeScript(appDir)
+  const distDir = isTSProject ? path.join(appDir, 'dist') : appDir;
+
+  const app = await strapi({ appDir, distDir }).load();
 
   const user = await app.admin.services.user.exists({ email });
 

--- a/packages/core/strapi/lib/commands/admin-create.js
+++ b/packages/core/strapi/lib/commands/admin-create.js
@@ -1,10 +1,10 @@
 'use strict';
 
+const path = require('path');
 const { yup } = require('@strapi/utils');
 const _ = require('lodash');
 const inquirer = require('inquirer');
-const tsUtils = require('@strapi/typescript-utils')
-const path = require('path')
+const tsUtils = require('@strapi/typescript-utils');
 const strapi = require('../index');
 
 const emailValidator = yup
@@ -62,7 +62,7 @@ const promptQuestions = [
  * @param {string} cmdOptions.firstname - new admin's first name
  * @param {string} [cmdOptions.lastname] - new admin's last name
  */
-module.exports = async function (cmdOptions = {}) {
+module.exports = async function(cmdOptions = {}) {
   let { email, password, firstname, lastname } = cmdOptions;
 
   if (
@@ -94,7 +94,7 @@ module.exports = async function (cmdOptions = {}) {
 async function createAdmin({ email, password, firstname, lastname }) {
   const appDir = process.cwd();
 
-  const isTSProject = await tsUtils.isUsingTypeScript(appDir)
+  const isTSProject = await tsUtils.isUsingTypeScript(appDir);
   const distDir = isTSProject ? path.join(appDir, 'dist') : appDir;
 
   const app = await strapi({ appDir, distDir }).load();

--- a/packages/core/strapi/lib/commands/admin-reset.js
+++ b/packages/core/strapi/lib/commands/admin-reset.js
@@ -1,9 +1,9 @@
 'use strict';
 
+const path = require('path');
 const _ = require('lodash');
 const inquirer = require('inquirer');
-const tsUtils = require('@strapi/typescript-utils')
-const path = require('path')
+const tsUtils = require('@strapi/typescript-utils');
 const strapi = require('../index');
 
 const promptQuestions = [
@@ -22,7 +22,7 @@ const promptQuestions = [
  * @param {string} cmdOptions.email - user's email
  * @param {string} cmdOptions.password - user's new password
  */
-module.exports = async function (cmdOptions = {}) {
+module.exports = async function(cmdOptions = {}) {
   const { email, password } = cmdOptions;
 
   if (_.isEmpty(email) && _.isEmpty(password) && process.stdin.isTTY) {
@@ -46,7 +46,7 @@ module.exports = async function (cmdOptions = {}) {
 async function changePassword({ email, password }) {
   const appDir = process.cwd();
 
-  const isTSProject = await tsUtils.isUsingTypeScript(appDir)
+  const isTSProject = await tsUtils.isUsingTypeScript(appDir);
   const distDir = isTSProject ? path.join(appDir, 'dist') : appDir;
 
   const app = await strapi({ appDir, distDir }).load();

--- a/packages/core/strapi/lib/commands/admin-reset.js
+++ b/packages/core/strapi/lib/commands/admin-reset.js
@@ -2,6 +2,8 @@
 
 const _ = require('lodash');
 const inquirer = require('inquirer');
+const tsUtils = require('@strapi/typescript-utils')
+const path = require('path')
 const strapi = require('../index');
 
 const promptQuestions = [
@@ -20,7 +22,7 @@ const promptQuestions = [
  * @param {string} cmdOptions.email - user's email
  * @param {string} cmdOptions.password - user's new password
  */
-module.exports = async function(cmdOptions = {}) {
+module.exports = async function (cmdOptions = {}) {
   const { email, password } = cmdOptions;
 
   if (_.isEmpty(email) && _.isEmpty(password) && process.stdin.isTTY) {
@@ -42,7 +44,12 @@ module.exports = async function(cmdOptions = {}) {
 };
 
 async function changePassword({ email, password }) {
-  const app = await strapi().load();
+  const appDir = process.cwd();
+
+  const isTSProject = await tsUtils.isUsingTypeScript(appDir)
+  const distDir = isTSProject ? path.join(appDir, 'dist') : appDir;
+
+  const app = await strapi({ appDir, distDir }).load();
 
   await app.admin.services.user.resetPasswordByEmail(email, password);
 

--- a/packages/core/strapi/lib/commands/configurationDump.js
+++ b/packages/core/strapi/lib/commands/configurationDump.js
@@ -1,18 +1,25 @@
 'use strict';
 
 const fs = require('fs');
-const strapi = require('../index');
+const tsUtils = require('@strapi/typescript-utils')
+const path = require('path')
 
+const strapi = require('../index');
 const CHUNK_SIZE = 100;
 
 /**
  * Will dump configurations to a file or stdout
  * @param {string} file filepath to use as output
  */
-module.exports = async function({ file: filePath, pretty }) {
+module.exports = async function ({ file: filePath, pretty }) {
   const output = filePath ? fs.createWriteStream(filePath) : process.stdout;
 
-  const app = await strapi().load();
+  const appDir = process.cwd();
+
+  const isTSProject = await tsUtils.isUsingTypeScript(appDir)
+  const distDir = isTSProject ? path.join(appDir, 'dist') : appDir;
+
+  const app = await strapi({ appDir, distDir }).load();
 
   const count = await app.query('strapi::core-store').count();
 

--- a/packages/core/strapi/lib/commands/configurationDump.js
+++ b/packages/core/strapi/lib/commands/configurationDump.js
@@ -1,22 +1,22 @@
 'use strict';
 
 const fs = require('fs');
-const tsUtils = require('@strapi/typescript-utils')
-const path = require('path')
-
+const path = require('path');
+const tsUtils = require('@strapi/typescript-utils');
 const strapi = require('../index');
+
 const CHUNK_SIZE = 100;
 
 /**
  * Will dump configurations to a file or stdout
  * @param {string} file filepath to use as output
  */
-module.exports = async function ({ file: filePath, pretty }) {
+module.exports = async function({ file: filePath, pretty }) {
   const output = filePath ? fs.createWriteStream(filePath) : process.stdout;
 
   const appDir = process.cwd();
 
-  const isTSProject = await tsUtils.isUsingTypeScript(appDir)
+  const isTSProject = await tsUtils.isUsingTypeScript(appDir);
   const distDir = isTSProject ? path.join(appDir, 'dist') : appDir;
 
   const app = await strapi({ appDir, distDir }).load();

--- a/packages/core/strapi/lib/commands/configurationRestore.js
+++ b/packages/core/strapi/lib/commands/configurationRestore.js
@@ -1,9 +1,9 @@
 'use strict';
 
 const fs = require('fs');
+const path = require('path');
 const _ = require('lodash');
-const tsUtils = require('@strapi/typescript-utils')
-const path = require('path')
+const tsUtils = require('@strapi/typescript-utils');
 
 const strapi = require('../index');
 
@@ -12,12 +12,12 @@ const strapi = require('../index');
  * @param {string} file filepath to use as input
  * @param {string} strategy import strategy. one of (replace, merge, keep, default: replace)
  */
-module.exports = async function ({ file: filePath, strategy = 'replace' }) {
+module.exports = async function({ file: filePath, strategy = 'replace' }) {
   const input = filePath ? fs.readFileSync(filePath) : await readStdin(process.stdin);
 
   const appDir = process.cwd();
 
-  const isTSProject = await tsUtils.isUsingTypeScript(appDir)
+  const isTSProject = await tsUtils.isUsingTypeScript(appDir);
   const distDir = isTSProject ? path.join(appDir, 'dist') : appDir;
 
   const app = await strapi({ appDir, distDir }).load();

--- a/packages/core/strapi/lib/commands/configurationRestore.js
+++ b/packages/core/strapi/lib/commands/configurationRestore.js
@@ -2,6 +2,9 @@
 
 const fs = require('fs');
 const _ = require('lodash');
+const tsUtils = require('@strapi/typescript-utils')
+const path = require('path')
+
 const strapi = require('../index');
 
 /**
@@ -9,10 +12,15 @@ const strapi = require('../index');
  * @param {string} file filepath to use as input
  * @param {string} strategy import strategy. one of (replace, merge, keep, default: replace)
  */
-module.exports = async function({ file: filePath, strategy = 'replace' }) {
+module.exports = async function ({ file: filePath, strategy = 'replace' }) {
   const input = filePath ? fs.readFileSync(filePath) : await readStdin(process.stdin);
 
-  const app = await strapi().load();
+  const appDir = process.cwd();
+
+  const isTSProject = await tsUtils.isUsingTypeScript(appDir)
+  const distDir = isTSProject ? path.join(appDir, 'dist') : appDir;
+
+  const app = await strapi({ appDir, distDir }).load();
 
   let dataToImport;
   try {

--- a/packages/core/strapi/lib/commands/console.js
+++ b/packages/core/strapi/lib/commands/console.js
@@ -1,19 +1,27 @@
 'use strict';
 
 const REPL = require('repl');
+const tsUtils = require('@strapi/typescript-utils')
+const path = require('path')
+
 const strapi = require('../index');
 
 /**
  * `$ strapi console`
  */
-module.exports = () => {
+module.exports = async () => {
   // Now load up the Strapi framework for real.
-  const app = strapi();
+  const appDir = process.cwd();
+
+  const isTSProject = await tsUtils.isUsingTypeScript(appDir)
+  const distDir = isTSProject ? path.join(appDir, 'dist') : appDir;
+
+  const app = await strapi({ appDir, distDir }).load();
 
   app.start().then(() => {
     const repl = REPL.start(app.config.info.name + ' > ' || 'strapi > '); // eslint-disable-line prefer-template
 
-    repl.on('exit', function(err) {
+    repl.on('exit', function (err) {
       if (err) {
         app.log.error(err);
         process.exit(1);

--- a/packages/core/strapi/lib/commands/console.js
+++ b/packages/core/strapi/lib/commands/console.js
@@ -1,8 +1,8 @@
 'use strict';
 
 const REPL = require('repl');
-const tsUtils = require('@strapi/typescript-utils')
-const path = require('path')
+const path = require('path');
+const tsUtils = require('@strapi/typescript-utils');
 
 const strapi = require('../index');
 
@@ -13,7 +13,7 @@ module.exports = async () => {
   // Now load up the Strapi framework for real.
   const appDir = process.cwd();
 
-  const isTSProject = await tsUtils.isUsingTypeScript(appDir)
+  const isTSProject = await tsUtils.isUsingTypeScript(appDir);
   const distDir = isTSProject ? path.join(appDir, 'dist') : appDir;
 
   const app = await strapi({ appDir, distDir }).load();
@@ -21,7 +21,7 @@ module.exports = async () => {
   app.start().then(() => {
     const repl = REPL.start(app.config.info.name + ' > ' || 'strapi > '); // eslint-disable-line prefer-template
 
-    repl.on('exit', function (err) {
+    repl.on('exit', function(err) {
       if (err) {
         app.log.error(err);
         process.exit(1);

--- a/packages/core/strapi/lib/commands/routes/list.js
+++ b/packages/core/strapi/lib/commands/routes/list.js
@@ -1,17 +1,17 @@
 'use strict';
 
+const path = require('path');
 const CLITable = require('cli-table3');
 const chalk = require('chalk');
 const { toUpper } = require('lodash/fp');
-const tsUtils = require('@strapi/typescript-utils')
-const path = require('path')
+const tsUtils = require('@strapi/typescript-utils');
 
 const strapi = require('../../index');
 
-module.exports = async function () {
+module.exports = async function() {
   const appDir = process.cwd();
 
-  const isTSProject = await tsUtils.isUsingTypeScript(appDir)
+  const isTSProject = await tsUtils.isUsingTypeScript(appDir);
   const distDir = isTSProject ? path.join(appDir, 'dist') : appDir;
 
   const app = await strapi({ appDir, distDir }).load();

--- a/packages/core/strapi/lib/commands/routes/list.js
+++ b/packages/core/strapi/lib/commands/routes/list.js
@@ -3,11 +3,18 @@
 const CLITable = require('cli-table3');
 const chalk = require('chalk');
 const { toUpper } = require('lodash/fp');
+const tsUtils = require('@strapi/typescript-utils')
+const path = require('path')
 
 const strapi = require('../../index');
 
-module.exports = async function() {
-  const app = await strapi().load();
+module.exports = async function () {
+  const appDir = process.cwd();
+
+  const isTSProject = await tsUtils.isUsingTypeScript(appDir)
+  const distDir = isTSProject ? path.join(appDir, 'dist') : appDir;
+
+  const app = await strapi({ appDir, distDir }).load();
 
   const list = app.server.listRoutes();
 

--- a/packages/core/strapi/lib/commands/start.js
+++ b/packages/core/strapi/lib/commands/start.js
@@ -1,8 +1,14 @@
 'use strict';
-
+const tsUtils = require('@strapi/typescript-utils')
 const strapi = require('../index');
 
 /**
  * `$ strapi start`
  */
-module.exports = distDir => strapi({ distDir }).start();
+module.exports = async specifiedDir => {
+    const appDir = process.cwd();
+    const isTSProject = await tsUtils.isUsingTypeScript(appDir)
+    const distDir = isTSProject && !specifiedDir ? 'dist' : specifiedDir;
+
+    strapi({ distDir }).start()
+};

--- a/packages/generators/app/lib/create-customized-project.js
+++ b/packages/generators/app/lib/create-customized-project.js
@@ -17,6 +17,14 @@ const createProject = require('./create-project');
 module.exports = async scope => {
   await trackUsage({ event: 'didChooseCustomDatabase', scope });
 
+  if (!scope.useTypescript) {
+    // check how to handle track usage here 
+    const isTypescript = await askAboutLanguages(scope).catch(error => {
+      console.log(error)
+    })
+    scope.useTypescript = isTypescript;
+  }
+
   const configuration = await askDbInfosAndTest(scope).catch(error => {
     return trackUsage({ event: 'didNotConnectDatabase', scope, error }).then(() => {
       throw error;
@@ -156,4 +164,18 @@ async function installDatabaseTestingDep({ scope, configuration }) {
   });
 
   await execa(packageManager, cmd.concat(deps));
+}
+
+async function askAboutLanguages() {
+  const { client } = await inquirer.prompt([
+    {
+      type: 'list',
+      name: 'client',
+      message: 'Choose your language',
+      choices: ['Typescript', 'Javascript'],
+      default: 'Javascript',
+    },
+  ]);
+
+  return client === 'Typescript';
 }

--- a/packages/generators/app/lib/create-customized-project.js
+++ b/packages/generators/app/lib/create-customized-project.js
@@ -15,13 +15,14 @@ const dbQuestions = require('./utils/db-questions');
 const createProject = require('./create-project');
 
 module.exports = async scope => {
-  await trackUsage({ event: 'didChooseCustomDatabase', scope });
 
   if (!scope.useTypescript) {
     // check how to handle track usage here 
     const language = await askAboutLanguages(scope);
     scope.useTypescript = language === "Typescript";
   }
+
+  await trackUsage({ event: 'didChooseCustomDatabase', scope });
 
   const configuration = await askDbInfosAndTest(scope).catch(error => {
     return trackUsage({ event: 'didNotConnectDatabase', scope, error }).then(() => {

--- a/packages/generators/app/lib/create-customized-project.js
+++ b/packages/generators/app/lib/create-customized-project.js
@@ -15,11 +15,9 @@ const dbQuestions = require('./utils/db-questions');
 const createProject = require('./create-project');
 
 module.exports = async scope => {
-
   if (!scope.useTypescript) {
-    // check how to handle track usage here 
     const language = await askAboutLanguages(scope);
-    scope.useTypescript = language === "Typescript";
+    scope.useTypescript = language === 'Typescript';
   }
 
   await trackUsage({ event: 'didChooseCustomDatabase', scope });

--- a/packages/generators/app/lib/create-customized-project.js
+++ b/packages/generators/app/lib/create-customized-project.js
@@ -19,10 +19,8 @@ module.exports = async scope => {
 
   if (!scope.useTypescript) {
     // check how to handle track usage here 
-    const isTypescript = await askAboutLanguages(scope).catch(error => {
-      console.log(error)
-    })
-    scope.useTypescript = isTypescript;
+    const language = await askAboutLanguages(scope);
+    scope.useTypescript = language === "Typescript";
   }
 
   const configuration = await askDbInfosAndTest(scope).catch(error => {
@@ -167,15 +165,15 @@ async function installDatabaseTestingDep({ scope, configuration }) {
 }
 
 async function askAboutLanguages() {
-  const { client } = await inquirer.prompt([
+  const { language } = await inquirer.prompt([
     {
       type: 'list',
-      name: 'client',
-      message: 'Choose your language',
-      choices: ['Typescript', 'Javascript'],
+      name: 'language',
+      message: 'Choose your preferred language',
+      choices: ['Javascript', 'Typescript'],
       default: 'Javascript',
     },
   ]);
 
-  return client === 'Typescript';
+  return language;
 }

--- a/packages/generators/generators/lib/plops/plugin.js
+++ b/packages/generators/generators/lib/plops/plugin.js
@@ -1,11 +1,12 @@
 'use strict';
 
 const chalk = require('chalk');
-const tsUtils = require('@strapi/typescript-utils');
 
 const logInstructions = (pluginName, { language }) => {
   const maxLength = `    resolve: './src/plugins/${pluginName}'`.length;
-  const separator = Array(maxLength).fill('─').join('');
+  const separator = Array(maxLength)
+    .fill('─')
+    .join('');
 
   const exportInstruction = language === 'js' ? 'module.exports =' : 'export default';
 
@@ -26,7 +27,7 @@ ${separator}
 `;
 };
 
-module.exports = (plop) => {
+module.exports = plop => {
   // Plugin generator
   plop.setGenerator('plugin', {
     description: 'Generate a basic plugin',
@@ -42,10 +43,10 @@ module.exports = (plop) => {
         message: 'Choose your preferred language',
         choices: ['Javascript', 'Typescript'],
         default: 'Javascript',
-      }
+      },
     ],
     actions(answers) {
-      const isTypescript = answers?.language === 'Typescript';
+      const isTypescript = answers.language === 'Typescript';
       const language = isTypescript ? 'ts' : 'js';
 
       // TODO: Adds tsconfig & build command for TS plugins?

--- a/packages/generators/generators/lib/plops/plugin.js
+++ b/packages/generators/generators/lib/plops/plugin.js
@@ -5,9 +5,7 @@ const tsUtils = require('@strapi/typescript-utils');
 
 const logInstructions = (pluginName, { language }) => {
   const maxLength = `    resolve: './src/plugins/${pluginName}'`.length;
-  const separator = Array(maxLength)
-    .fill('─')
-    .join('');
+  const separator = Array(maxLength).fill('─').join('');
 
   const exportInstruction = language === 'js' ? 'module.exports =' : 'export default';
 
@@ -28,7 +26,7 @@ ${separator}
 `;
 };
 
-module.exports = plop => {
+module.exports = (plop) => {
   // Plugin generator
   plop.setGenerator('plugin', {
     description: 'Generate a basic plugin',
@@ -38,10 +36,18 @@ module.exports = plop => {
         name: 'pluginName',
         message: 'Plugin name',
       },
+      {
+        type: 'list',
+        name: 'isTypescript',
+        message: 'Choose your preferred language',
+        choices: ['Javascript', 'Typescript'],
+        default: 'Javascript',
+      },
     ],
     actions(answers) {
       const currentDir = process.cwd();
-      const language = tsUtils.isUsingTypeScriptSync(currentDir) ? 'ts' : 'js';
+      const isTypescript = answers.isTypescript === 'Typescript';
+      const language = tsUtils.isUsingTypeScriptSync(currentDir) || isTypescript ? 'ts' : 'js';
 
       // TODO: Adds tsconfig & build command for TS plugins?
 

--- a/packages/generators/generators/lib/plops/plugin.js
+++ b/packages/generators/generators/lib/plops/plugin.js
@@ -27,14 +27,6 @@ ${separator}
 };
 
 module.exports = (plop) => {
-  const currentDir = process.cwd();
-  const typescriptPrompt = tsUtils.isUsingTypeScriptSync(currentDir) ? [] : [{
-    type: 'list',
-    name: 'isTypescript',
-    message: 'Choose your preferred language',
-    choices: ['Javascript', 'Typescript'],
-    default: 'Javascript',
-  }];
   // Plugin generator
   plop.setGenerator('plugin', {
     description: 'Generate a basic plugin',
@@ -44,11 +36,17 @@ module.exports = (plop) => {
         name: 'pluginName',
         message: 'Plugin name',
       },
-      ...typescriptPrompt
+      {
+        type: 'list',
+        name: 'language',
+        message: 'Choose your preferred language',
+        choices: ['Javascript', 'Typescript'],
+        default: 'Javascript',
+      }
     ],
     actions(answers) {
-      const isTypescript = answers?.isTypescript === 'Typescript';
-      const language = tsUtils.isUsingTypeScriptSync(currentDir) || isTypescript ? 'ts' : 'js';
+      const isTypescript = answers?.language === 'Typescript';
+      const language = isTypescript ? 'ts' : 'js';
 
       // TODO: Adds tsconfig & build command for TS plugins?
 

--- a/packages/generators/generators/lib/plops/plugin.js
+++ b/packages/generators/generators/lib/plops/plugin.js
@@ -27,6 +27,14 @@ ${separator}
 };
 
 module.exports = (plop) => {
+  const currentDir = process.cwd();
+  const typescriptPrompt = tsUtils.isUsingTypeScriptSync(currentDir) ? [] : [{
+    type: 'list',
+    name: 'isTypescript',
+    message: 'Choose your preferred language',
+    choices: ['Javascript', 'Typescript'],
+    default: 'Javascript',
+  }];
   // Plugin generator
   plop.setGenerator('plugin', {
     description: 'Generate a basic plugin',
@@ -36,17 +44,10 @@ module.exports = (plop) => {
         name: 'pluginName',
         message: 'Plugin name',
       },
-      {
-        type: 'list',
-        name: 'isTypescript',
-        message: 'Choose your preferred language',
-        choices: ['Javascript', 'Typescript'],
-        default: 'Javascript',
-      },
+      ...typescriptPrompt
     ],
     actions(answers) {
-      const currentDir = process.cwd();
-      const isTypescript = answers.isTypescript === 'Typescript';
+      const isTypescript = answers?.isTypescript === 'Typescript';
       const language = tsUtils.isUsingTypeScriptSync(currentDir) || isTypescript ? 'ts' : 'js';
 
       // TODO: Adds tsconfig & build command for TS plugins?


### PR DESCRIPTION
### What does it do?

- Fixes Strapi commands so they can work in a typescript project
- Make users able to create a Typescript strapi project while creating a custom Strapi project
- Make users able to create a Typescript plugin with the generate command 

### How to test it?

- Create a Typescript Strapi project:
Navigate to examples folder in the repo, run `node ../packages/cli/create-strapi-app/index` in your terminal and choose a custom typescript project

- Navigate to the project and test the Strapi commands
 you can find a list of strapi commands here https://docs.strapi.io/developer-docs/latest/developer-resources/cli/CLI.html#strapi-new


### Related issue(s)/PR(s)

#13095 
#13079 
