### PR TITLE
Fix stream object in upload file response

### DIFF
--- a/packages/core/upload/server/services/upload.js
+++ b/packages/core/upload/server/services/upload.js
@@ -255,7 +255,7 @@ module.exports = ({ strapi }) => ({
         }
       }
 
-      getService('provider').upload(fileData);
+      await getService('provider').upload(fileData);
 
       // clear old formats
       _.set(fileData, 'formats', {});
@@ -265,7 +265,7 @@ module.exports = ({ strapi }) => ({
       if (await isSupportedImage(fileData)) {
         const thumbnailFile = await generateThumbnail(fileData);
         if (thumbnailFile) {
-          getService('provider').upload(thumbnailFile);
+          await getService('provider').upload(thumbnailFile);
           _.set(fileData, 'formats.thumbnail', thumbnailFile);
         }
 
@@ -276,7 +276,7 @@ module.exports = ({ strapi }) => ({
 
             const { key, file } = format;
 
-            getService('provider').upload(file);
+            await getService('provider').upload(file);
 
             _.set(fileData, ['formats', key], file);
           }


### PR DESCRIPTION
### What does it do?

Change all the upload calls to support `async` function so it will "wait" for the completion before continuing. 
The completion will remove the `stream` and `buffer` from `file` (check file `provider.js` in the same folder).

### Why is it needed?

The problem is described in this [PR - The upload files response from API contains stream object](https://github.com/strapi/strapi/issues/13202)

### How to test it?

1. Upload file in media and crop it.
2. Check the API response from `/api/upload/files`
3. See the stream object in the `formats` property is now gone.

### Related issue(s)/PR(s)

[PR - The upload files response from API contains stream object](https://github.com/strapi/strapi/issues/13202)
