### PR TITLE
 Make file upload async blocking for upload images replace

### DIFF
--- a/packages/core/upload/server/services/upload.js
+++ b/packages/core/upload/server/services/upload.js
@@ -255,7 +255,7 @@ module.exports = ({ strapi }) => ({
         }
       }
 
-      getService('provider').upload(fileData);
+      await getService('provider').upload(fileData);
 
       // clear old formats
       _.set(fileData, 'formats', {});
@@ -265,7 +265,7 @@ module.exports = ({ strapi }) => ({
       if (await isSupportedImage(fileData)) {
         const thumbnailFile = await generateThumbnail(fileData);
         if (thumbnailFile) {
-          getService('provider').upload(thumbnailFile);
+          await getService('provider').upload(thumbnailFile);
           _.set(fileData, 'formats.thumbnail', thumbnailFile);
         }
 
@@ -276,7 +276,7 @@ module.exports = ({ strapi }) => ({
 
             const { key, file } = format;
 
-            getService('provider').upload(file);
+            await getService('provider').upload(file);
 
             _.set(fileData, ['formats', key], file);
           }


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Add async blocking in images replacement for upload providers, because in some cases like aws-s3, datas in database are saved before obtaining the upload result from the provider.

### Why is it needed?

The fix is inspired from `uploadFileAndPersist` from file `packages/core/upload/server/services/upload.js` from the create media function `upload`

### How to test it?

The best way to test it, is to have a remote provider like aws-s3 and throttle your connection.
Without the fix, you will have in the table `files` an empty `url` attribute and in `formats` attribute all the formats without `url` json attribute and with a `stream` json attribute from the provider.
