### PR TITLE
Shrink marketplace cards padding

### DIFF
--- a/packages/core/admin/admin/src/pages/MarketplacePage/components/PluginCard/index.js
+++ b/packages/core/admin/admin/src/pages/MarketplacePage/components/PluginCard/index.js
@@ -46,9 +46,9 @@ const PluginCard = ({ plugin, installedPluginNames, useYarn, isInDevelopmentMode
       direction="column"
       justifyContent="space-between"
       paddingTop={4}
-      paddingRight={6}
+      paddingRight={4}
       paddingBottom={4}
-      paddingLeft={6}
+      paddingLeft={4}
       hasRadius
       background="neutral0"
       shadow="tableShadow"

--- a/packages/core/admin/admin/src/pages/MarketplacePage/tests/index.test.js
+++ b/packages/core/admin/admin/src/pages/MarketplacePage/tests/index.test.js
@@ -252,9 +252,9 @@ describe('Marketplace page', () => {
       .c30 {
         background: #ffffff;
         padding-top: 16px;
-        padding-right: 24px;
+        padding-right: 16px;
         padding-bottom: 16px;
-        padding-left: 24px;
+        padding-left: 16px;
         border-radius: 4px;
         box-shadow: 0px 1px 4px rgba(33,33,52,0.1);
         height: 100%;


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Reduce horizontal padding on marketplace cards from 24px to 16px

### Why is it needed?

To prevent the buttons in marketplace cards from having to do a line break on most screen sizes
