### PR TITLE
[Fix] Guided tour skipped local storage

### DIFF
--- a/packages/core/helper-plugin/lib/src/utils/auth/index.js
+++ b/packages/core/helper-plugin/lib/src/utils/auth/index.js
@@ -6,6 +6,7 @@ const TOKEN_KEY = 'jwtToken';
 const USER_INFO = 'userInfo';
 const CURRENT_STEP = 'GUIDED_TOUR_CURRENT_STEP';
 const COMPLETED_STEPS = 'GUIDED_TOUR_COMPLETED_STEPS';
+const SKIPPED = 'GUIDED_TOUR_SKIPPED';
 const THEME_KEY = 'STRAPI_THEME'; // Also used in packages/core/admin/admin/src/components/ThemeToggleProvider/index.js
 
 const parse = JSON.parse;
@@ -32,6 +33,7 @@ const auth = {
       const localeLang = localStorage.getItem('strapi-admin-language');
       const guidedTourCurrentStep = auth.get(CURRENT_STEP);
       const guidedTourState = auth.get(COMPLETED_STEPS);
+      const guidedTourSkipped = parse(localStorage.getItem(SKIPPED));
       const applicationTheme = localStorage.getItem(THEME_KEY);
 
       localStorage.clear();
@@ -42,6 +44,7 @@ const auth = {
       localStorage.setItem('strapi-admin-language', localeLang);
       localStorage.setItem(CURRENT_STEP, stringify(guidedTourCurrentStep));
       localStorage.setItem(COMPLETED_STEPS, stringify(guidedTourState));
+      localStorage.setItem(SKIPPED, stringify(guidedTourSkipped));
       localStorage.setItem(THEME_KEY, applicationTheme);
     }
 


### PR DESCRIPTION
## Issue

GUIDED_TOUR_SKIPPED variable in local storage wasn't memorized when logging out

## Solution

Memorize GUIDED_TOUR_SKIPPED before clearing local storage
setItem after clearing local storage