### PR TITLE
Fix json string parsing error

### DIFF
--- a/packages/core/database/lib/fields.js
+++ b/packages/core/database/lib/fields.js
@@ -34,7 +34,14 @@ class JSONField extends Field {
   }
 
   fromDB(value) {
-    if (typeof value === 'string') return JSON.parse(value);
+    if (typeof value === 'string') {
+      try {
+        return JSON.parse(value);
+      } catch (e) {
+        // A string is still valid JSON even if it can't be parsed to an object
+        return value
+      }
+    }
     return value;
   }
 }


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #13032 
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Allows simple string values to to be added to JSON fields.

### Why is it needed?

A simple string is valid JSON [[See RFC](https://datatracker.ietf.org/doc/html/rfc8259#section-13)]. The JSON field type correctly allows a string value and stores it to the database, but throws an error when retrieving the value because `JSON.parse(...)` fails.

### How to test it?
1. Create a fresh install of a Strapi application.
2. Create a new content type with a JSON field.
3. Create a new record of that content type in the content manager with a string value in the JSON field, e.g. "test"
4. Save the record and see no error message.  Prior to this change, an error message would appear even though the data was persisted.

> Note: I couldn't find any unit tests for the classes in `fields.js` — if they exist, please point me to them and I'll write tests for this change.

Provide information about the environment and the path to verify the behaviour.
### Related issue(s)/PR(s)

Fixes #13032 (though in testing, numbers seem to work fine at present)