### PR TITLE
Chore/opt in telemetry

### DIFF
--- a/packages/core/strapi/bin/strapi.js
+++ b/packages/core/strapi/bin/strapi.js
@@ -230,7 +230,13 @@ program
 //    `$ strapi opt-out-telemetry`
 program
   .command('telemetry:disable')
-  .description('Stop Strapi from sending anonymous telemetry and metadata')
+  .description('Disable anonymous telemetry and metadata sending to Strapi analytics')
   .action(getLocalScript('opt-out-telemetry'));
+
+//    `$ strapi opt-in-telemetry`
+program
+  .command('telemetry:enable')
+  .description('Enable anonymous telemetry and metadata sending to Strapi analytics')
+  .action(getLocalScript('opt-in-telemetry'));
 
 program.parseAsync(process.argv);

--- a/packages/core/strapi/lib/commands/opt-in-telemetry.js
+++ b/packages/core/strapi/lib/commands/opt-in-telemetry.js
@@ -79,13 +79,11 @@ module.exports = async function optInTelemetry() {
 
   const packageObj = await readPackageJSON(packageJSONPath);
 
-  if (
-    packageObj.strapi &&
-    packageObj.strapi.uuid &&
-    packageObj.strapi.telemetryDisabled === false
-  ) {
-    console.log(`${chalk.yellow('Warning:')} telemetry is already enabled`);
-    process.exit(0);
+  if (packageObj.strapi && packageObj.strapi.uuid) {
+    if (packageObj.strapi.telemetryDisabled === false) {
+      console.log(`${chalk.yellow('Warning:')} telemetry is already enabled`);
+      process.exit(0);
+    }
   }
 
   const updatedPackageJSON = generateNewPackageJSON(packageObj);

--- a/packages/core/strapi/lib/commands/opt-in-telemetry.js
+++ b/packages/core/strapi/lib/commands/opt-in-telemetry.js
@@ -97,6 +97,6 @@ module.exports = async function optInTelemetry() {
   }
 
   await sendEvent(updatedPackageJSON.strapi.uuid);
-  console.log(`${chalk.green('Successfully opted in to Strapi telemetry')}`);
+  console.log(`${chalk.green('Successfully opted into and enabled Strapi telemetry')}`);
   process.exit(0);
 };

--- a/packages/core/strapi/lib/commands/opt-in-telemetry.js
+++ b/packages/core/strapi/lib/commands/opt-in-telemetry.js
@@ -22,6 +22,11 @@ const writePackageJSON = async (path, file, spacing) => {
     return true;
   } catch (err) {
     console.error(`${chalk.red('Error')}: ${err.message}`);
+    console.log(
+      `${chalk.yellow(
+        'Warning'
+      )}: There has been an error, please set "telemetryDisabled": false in the "strapi" object of your package.json manually.`
+    );
     return false;
   }
 };
@@ -88,11 +93,6 @@ module.exports = async function optInTelemetry() {
   const write = await writePackageJSON(packageJSONPath, updatedPackageJSON, 2);
 
   if (!write) {
-    console.log(
-      `${chalk.yellow(
-        'Warning'
-      )}: There has been an error, please set "telemetryDisabled": false in the "strapi" object of your package.json manually.`
-    );
     process.exit(0);
   }
 

--- a/packages/core/strapi/lib/commands/opt-in-telemetry.js
+++ b/packages/core/strapi/lib/commands/opt-in-telemetry.js
@@ -1,0 +1,102 @@
+'use strict';
+
+const { resolve } = require('path');
+const fse = require('fs-extra');
+const chalk = require('chalk');
+const fetch = require('node-fetch');
+const { v4: uuidv4 } = require('uuid');
+const machineID = require('../utils/machine-id');
+
+const readPackageJSON = async path => {
+  try {
+    const packageObj = await fse.readJson(path);
+    return packageObj;
+  } catch (err) {
+    console.error(`${chalk.red('Error')}: ${err.message}`);
+  }
+};
+
+const writePackageJSON = async (path, file, spacing) => {
+  try {
+    await fse.writeJson(path, file, { spaces: spacing });
+    return true;
+  } catch (err) {
+    console.error(`${chalk.red('Error')}: ${err.message}`);
+    return false;
+  }
+};
+
+const generateNewPackageJSON = packageObj => {
+  if (!packageObj.strapi) {
+    return {
+      ...packageObj,
+      strapi: {
+        uuid: uuidv4(),
+        telemetryDisabled: false,
+      },
+    };
+  } else {
+    return {
+      ...packageObj,
+      strapi: {
+        ...packageObj.strapi,
+        uuid: packageObj.strapi.uuid ? packageObj.strapi.uuid : uuidv4(),
+        telemetryDisabled: false,
+      },
+    };
+  }
+};
+
+const sendEvent = async uuid => {
+  try {
+    await fetch('https://analytics.strapi.io/track', {
+      method: 'POST',
+      body: JSON.stringify({
+        event: 'didOptInTelemetry',
+        uuid,
+        deviceId: machineID(),
+      }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (e) {
+    //...
+  }
+};
+
+module.exports = async function optInTelemetry() {
+  const packageJSONPath = resolve(process.cwd(), 'package.json');
+  const exists = await fse.pathExists(packageJSONPath);
+
+  if (!exists) {
+    console.log(`${chalk.yellow('Warning')}: could not find package.json`);
+    process.exit(0);
+  }
+
+  const packageObj = await readPackageJSON(packageJSONPath);
+
+  if (
+    packageObj.strapi &&
+    packageObj.strapi.uuid &&
+    packageObj.strapi.telemetryDisabled === false
+  ) {
+    console.log(`${chalk.yellow('Warning:')} telemetry is already enabled`);
+    process.exit(0);
+  }
+
+  const updatedPackageJSON = generateNewPackageJSON(packageObj);
+
+  const write = await writePackageJSON(packageJSONPath, updatedPackageJSON, 2);
+
+  if (!write) {
+    console.log(
+      `${chalk.yellow(
+        'Warning'
+      )}: There has been an error, please set "telemetryDisabled": false in the "strapi" object of your package.json manually.`
+    );
+    process.exit(0);
+  }
+
+  await sendEvent(updatedPackageJSON.strapi.uuid);
+  console.log(`${chalk.green('Successfully opted in to Strapi telemetry')}`);
+  process.exit(0);
+};


### PR DESCRIPTION
### What does it do?

This PR re-enables Strapi telemetry in case it was disabled. This PR introduces a CLI command that acts opposite to the `telemetry:disable` command that has been added recently.

### Why is it needed?

Gives an ability to re-enable telemetry easily should the user decide to do so.This is another step towards transparency of how our telemetry system works.

### How to test it?

Clone the repo, run `yarn strapi telemetry:enable` from the `getstarted` project. This will alter the `package.json` file.
