### PR TITLE
identify and auto rename columns at forceMigration after upgrade from v3

### DIFF
--- a/packages/core/database/lib/schema/builder.js
+++ b/packages/core/database/lib/schema/builder.js
@@ -225,6 +225,16 @@ const createHelpers = db => {
   };
 
   /**
+   * Renames a column in a table
+   * @param {Knex.TableBuilder} tableBuilder 
+   * @param {String} columnFrom
+   * @param {String} columnTo
+   */
+  const renameColumn = (tableBuilder, columnFrom, columnTo) => {
+    return tableBuilder.renameColumn(columnFrom, columnTo)
+  }
+
+  /**
    * Drops a column from a table
    * @param {Knex.TableBuilder} tableBuilder
    * @param {Column} column
@@ -285,6 +295,11 @@ const createHelpers = db => {
       for (const removedColumn of table.columns.removed) {
         debug(`Dropping column ${removedColumn.name}`);
         dropColumn(tableBuilder, removedColumn);
+      }
+
+      //rename columns
+      for (const renamedColumn of table.columns.renamed) {
+        renameColumn(tableBuilder, renamedColumn.name, renamedColumn.renameTo)
       }
 
       // Update existing columns / foreign keys / indexes


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Identifies columns that require renaming after migrating (using latest codemods pr I have up) from v3 to v4

### Why is it needed?

v4 enforces several rules on names during the codemods migration of an application, one of which is lowercase. At first boot, when strapi tries to forceMigration, the column names are forced to snakeCase in `/database/lib/metadata/index.js   line 24` which forces a column named "Name" to become "name" (_.snakeCase forces lowercase) and "MyField" to become "my_field". This creates an issue where the server crashes because "name" is supposed to be added to the database (instead of being a rename action) and sqlite will throw saying that column already exists. In the best case scenario, you will have data loss as the column containing the data is removed, and an empty column is added. The solution is to capture this "rename" condition and simply use knex.renameColumn to fix the column name before the alter/update is run. 

### How to test it?
migrate a project from v3 to v4 using codemods migrate application script (preferably using the latest PR) and run the application for the first time to allow the auto migration to take place

Before
![image](https://user-images.githubusercontent.com/14822908/166833757-0756ac0d-5065-4f01-b760-84cc9e566ae9.png)

After
![image](https://user-images.githubusercontent.com/14822908/166833666-4c488591-c2f6-47a1-b892-33280d0b48be.png)

Data preserved
![image](https://user-images.githubusercontent.com/14822908/166833821-af419354-bf98-4a6a-8442-9978b76fdc22.png)
