### PR TITLE
add consumer_key and consumer_secret

### DIFF
--- a/packages/plugins/users-permissions/server/services/providers-list.js
+++ b/packages/plugins/users-permissions/server/services/providers-list.js
@@ -113,6 +113,12 @@ module.exports = async ({ provider, access_token, query, providers }) => {
     case 'twitter': {
       const twitter = purest({
         provider: 'twitter',
+        defaults: {
+          oauth: {
+            consumer_key: providers.twitter.key,
+            consumer_secret: providers.twitter.secret
+          }
+        }
       });
 
       return twitter


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

add `consumer_key` and `consumer_secret` to purest constructor

### Why is it needed?

Since Twitter API still uses Oauth1.0, key and secret is needed for it.

### How to test it?

Enable Twitter provider and go http://localhost:1337/api/connect/twitter

### Related issue

Fix #13217