### PR TITLE
SingleTypeFormWrapper: Display custom error messages

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/SingleTypeFormWrapper/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/SingleTypeFormWrapper/index.js
@@ -143,8 +143,8 @@ const SingleTypeFormWrapper = ({ allLayoutData, children, slug }) => {
 
   const displayErrors = useCallback(
     err => {
-      const errorPayload = err.response.payload;
-      let errorMessage = get(errorPayload, ['message'], 'Bad Request');
+      const errorPayload = err.response.data;
+      let errorMessage = get(errorPayload, ['error', 'message'], 'Bad Request');
 
       // TODO handle errors correctly when back-end ready
       if (Array.isArray(errorMessage)) {


### PR DESCRIPTION
### What does it do?

This brings single content types in line with collection types, when errors from e.g. lifecycle events need to be displayed. Collection types display the error message defined in the backend, where as single types only displayed "Bad Request".

### Why is it needed?

Solves an issue by a user. Error messages should be as helpful as possible.

### How to test it?

1. Create a new content-type (single)
2. Create a file called `lifecycles.js` in `./src/api/[content-type]/content-types/` with the following content:

```js
const { ForbiddenError } = require("@strapi/utils").errors

module.exports = {
    async beforeCreate(event) {
        console.log('wwatt')

        throw new ForbiddenError("Custom error")
    }
}
```

3. Try to save the content type
4. Validate the error message displayed contains the text "Custom error"

### Related issue(s)/PR(s)

- Fixes https://github.com/strapi/strapi/issues/13250
