### PR TITLE
Draft: [v4] Add support for graphql filters based on Nested Components

### DIFF
--- a/packages/plugins/graphql/server/services/builders/type.js
+++ b/packages/plugins/graphql/server/services/builders/type.js
@@ -243,10 +243,7 @@ module.exports = context => {
   };
 
   const isNotDisabled = contentType => attributeName => {
-    return extension
-      .shadowCRUD(contentType.uid)
-      .field(attributeName)
-      .hasOutputEnabled();
+    return extension.shadowCRUD(contentType.uid).field(attributeName).hasOutputEnabled();
   };
 
   return {

--- a/packages/plugins/graphql/server/services/utils/attributes.js
+++ b/packages/plugins/graphql/server/services/utils/attributes.js
@@ -9,10 +9,7 @@ module.exports = ({ strapi }) => {
    * @return {boolean}
    */
   const isStrapiScalar = attribute => {
-    return strapi
-      .plugin('graphql')
-      .service('constants')
-      .STRAPI_SCALARS.includes(attribute.type);
+    return strapi.plugin('graphql').service('constants').STRAPI_SCALARS.includes(attribute.type);
   };
 
   /**
@@ -21,10 +18,7 @@ module.exports = ({ strapi }) => {
    * @return {boolean}
    */
   const isGraphQLScalar = attribute => {
-    return strapi
-      .plugin('graphql')
-      .service('constants')
-      .GRAPHQL_SCALARS.includes(attribute.type);
+    return strapi.plugin('graphql').service('constants').GRAPHQL_SCALARS.includes(attribute.type);
   };
 
   /**


### PR DESCRIPTION
### What does it do?

It adds support to filter based on nested values aka. nested components

### Describe the technical changes you did.

Yolo'd around till I could query using nested filters. 

### Why is it needed?

This is a future I assumed was there heavily investing in using Strapi and rather than giving up and rage-quitting when realizing this feature was lacking, like I'd like anyone relying on OSS to do, tried to fix the issue myself.   

### How to test it?

I need to write tests, but since I wrote this patch on my M1 computer, I could not get Strapi mono-repo to run on my device.

### Related issue(s)/PR(s)

fixes https://github.com/strapi/strapi/issues/13248
https://github.com/strapi/strapi/issues/13150
https://github.com/strapi/strapi/issues/13169
https://github.com/strapi/strapi/issues/13150


#### Todos: 

- [ ] Create or update the tests
- [ ] Create or update the documentation at https://github.com/strapi/documentation