### PR TITLE
fix: hook getter spread make handlers invalid

### DIFF
--- a/packages/core/utils/lib/__tests__/hooks.test.js
+++ b/packages/core/utils/lib/__tests__/hooks.test.js
@@ -8,7 +8,7 @@ describe('Hooks Module', () => {
       test(`It's possible to create a hook that has all the needed methods`, () => {
         const hook = hooks.internals.createHook();
 
-        expect(hook).toHaveProperty('handlers', expect.any(Array));
+        expect(hook).toHaveProperty('getHandlers', expect.any(Function));
         expect(hook).toHaveProperty('register', expect.any(Function));
         expect(hook).toHaveProperty('delete', expect.any(Function));
         expect(hook).toHaveProperty('call', expect.any(Function));

--- a/packages/core/utils/lib/hooks.js
+++ b/packages/core/utils/lib/hooks.js
@@ -20,17 +20,19 @@ const createHook = () => {
   };
 
   return {
-    get handlers() {
+    getHandlers() {
       return state.handlers;
     },
 
     register(handler) {
       state.handlers.push(handler);
+
       return this;
     },
 
     delete(handler) {
       state.handlers = remove(eq(handler), state.handlers);
+
       return this;
     },
 
@@ -49,7 +51,7 @@ const createAsyncSeriesHook = () => ({
   ...createHook(),
 
   async call(context) {
-    for (const handler of this.handlers) {
+    for (const handler of this.getHandlers()) {
       await handler(context);
     }
   },
@@ -66,7 +68,7 @@ const createAsyncSeriesWaterfallHook = () => ({
   async call(param) {
     let res = param;
 
-    for (const handler of this.handlers) {
+    for (const handler of this.getHandlers()) {
       res = await handler(res);
     }
 
@@ -83,7 +85,7 @@ const createAsyncParallelHook = () => ({
   ...createHook(),
 
   async call(context) {
-    const promises = this.handlers.map(handler => handler(cloneDeep(context)));
+    const promises = this.getHandlers().map(handler => handler(cloneDeep(context)));
 
     return Promise.all(promises);
   },


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Fixes hooks getter being spread thus not allowing changes to handlers (delete is not working correctly).

### Why is it needed?

To allow unregistering a hook for customization purposes.

### How to test it?

try to delete a hook (e.g https://gist.github.com/alexandrebodin/62e5b0b446b9494c81ce672feaf0def3) to replace it with another function.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
