### PR TITLE
Added config info about S3 compatible services

### DIFF
--- a/packages/providers/upload-aws-s3/README.md
+++ b/packages/providers/upload-aws-s3/README.md
@@ -50,6 +50,29 @@ module.exports = ({ env }) => ({
   // ...
 });
 ```
+#### Configuration for S3 compatible services
+This plugin may work with S3 compatible services by using the `endpoint` option instead of `region`. Scaleway example:
+`./config/plugins.js`
+
+```js
+module.exports = ({ env }) => ({
+  // ...
+  upload: {
+    config: {
+      provider: 'aws-s3',
+      providerOptions: {
+        accessKeyId: env('SCALEWAY_ACCESS_KEY_ID'),
+        secretAccessKey: env('SCALEWAY_ACCESS_SECRET'),
+        endpoint: env('SCALEWAY_ENDPOINT'), // e.g. "s3.fr-par.scw.cloud"
+        params: {
+          Bucket: env('SCALEWAY_BUCKET'),
+        },
+      },
+    },
+  },
+  // ...
+});
+```
 
 ### Security Middleware Configuration
 


### PR DESCRIPTION
Added information, that this upload provider works also with S3 compatible services. I tested it with scaleway.com

### What does it do?

Adds information, that this upload provider works also with S3 compatible services. I tested it with scaleway.com

### Why is it needed?

Make clear, that this provider is also working with S3 compatible services, not only AWS S3

### How to test it?

Uploaded images to, and deleted from scaleway.com S3 service
