### PR TITLE
[@strapi/database]: Add missing WhereParams attributes to the type definition 

### DIFF
--- a/packages/core/database/lib/index.d.ts
+++ b/packages/core/database/lib/index.d.ts
@@ -2,16 +2,37 @@ import { LifecycleProvider } from './lifecycles';
 import { MigrationProvider } from './migrations';
 import { SchemaProvideer } from './schema';
 
-type BooleanWhere<T> = {
+type LogicOperators<T> = {
   $and?: WhereParams<T>[];
   $or?: WhereParams<T>[];
   $not?: WhereParams<T>;
-};
+}
 
-type WhereParams<T> = {
-  [K in keyof T]?: T[K];
+type AttributeOperators<T, K extends keyof T> = {
+  $eq?: T[K];
+  $ne?: T[K];
+  $in?: T[K][];
+  $notIn?: T[K][];
+  $lt?: T[K];
+  $lte?: T[K];
+  $gt?: T[K];
+  $gte?: T[K];
+  $between?: [T[K], T[K]];
+  $contains?: T[K];
+  $notContains?: T[K];
+  $containsi?: T[K];
+  $notContainsi?: T[K];
+  $startsWith?: T[K];
+  $endsWith?: T[K];
+  $null?: boolean;
+  $notNull?: boolean;
+  $not?: WhereParams<T> | AttributeOperators<T, K>;
+}
+
+export type WhereParams<T> = {
+  [K in keyof T]?: T[K] | T[K][] | AttributeOperators<T, K>;
 } &
-  BooleanWhere<T>;
+  LogicOperators<T>;
 
 type Sortables<T> = {
   // check sortable


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

Fixes #13287 

As described in the mentioned issue. Most of the parameters listed in the [docs](https://docs.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/query-engine/filtering.html#logical-operators) are missing. Only the and, or and not was added so far. 

This PR adds all missing attributes so that the typing for the WhereParams is correct.

### What does it do?

It adds the filter parameters `$eq`, `$ne`, `$in`, and all others while supporting the nested structure.

### Why is it needed?

As of now the typescript complirer throws an error on the where clause. Example:
```ts
const data = await strapi.query('api::bber-post.bber-post').findMany({
            where: {
                $and: [
                    { date: { $gte: '2019-01-01' } },
                    { date: { $lt: '2020-01-01' } }
                ]
            }
        });
```
this was not possible, because `$gte` and `$lt` where both within the missing attributes.

### How to test it?
Use the code example from above and try out valid queries. Now the types will be correct.

### Related issue(s)/PR(s)

#13287 
