### PR TITLE
Fix email confirmation

### DIFF
--- a/packages/plugins/users-permissions/server/controllers/auth.js
+++ b/packages/plugins/users-permissions/server/controllers/auth.js
@@ -378,7 +378,7 @@ module.exports = {
       throw new ValidationError('token.invalid');
     }
 
-    const user = await userService.fetch({ confirmationToken }, []);
+    const [user] = await userService.fetchAll({ filters: { confirmationToken }});
 
     if (!user) {
       throw new ValidationError('token.invalid');


### PR DESCRIPTION
### What does it do?
Fix `emailConfirmation` inside the `auth` controller
### Why is it needed?

`emailConfirmation` method is failed because `userService.fetch` applies only `id` after [User population](https://github.com/strapi/strapi/pull/11960) was merged.

### How to test it?

strapi@4.1.10
An error when I try to use email confirmation:
```
   Undefined attribute level operator confirmationToken

      at processAttributeWhere (node_modules/@strapi/database/lib/query/helpers/where.js:82:13)
      at processWhere (node_modules/@strapi/database/lib/query/helpers/where.js:176:36)
      at node_modules/@strapi/database/lib/query/helpers/where.js:104:29
          at Array.map (<anonymous>)
      at Object.processWhere (node_modules/@strapi/database/lib/query/helpers/where.js:104:18)
      at Object.processState (node_modules/@strapi/database/lib/query/query-builder.js:234:29)
      at Object.getKnexQuery (node_modules/@strapi/database/lib/query/query-builder.js:271:12)
      at Object.execute (node_modules/@strapi/database/lib/query/query-builder.js:352:25)
      at Object.findOne (node_modules/@strapi/database/lib/entity-manager.js:121:10)
      at Object.findOne (node_modules/@strapi/strapi/lib/services/entity-service/index.js:67:20)
      at Object.emailConfirmation (node_modules/@strapi/plugin-users-permissions/server/controllers/auth.js:381:18)
```

### Related issue(s)/PR(s)

Closes #13297 