### PR TITLE
dots in bucket names

### DIFF
--- a/packages/providers/upload-aws-s3/README.md
+++ b/packages/providers/upload-aws-s3/README.md
@@ -89,6 +89,7 @@ module.exports = [
   // ...
 ];
 ```
+If you use dots in your bucket name, the url of the ressource is in directory style (`s3.yourRegion.amazonaws.com/your.bucket.name/image.jpg`) instead of `yourBucketName.s3.yourRegion.amazonaws.com/image.jpg`. Then only add `s3.yourRegion.amazonaws.com` to img-src and media-src directives.
 
 ## Required AWS Policy Actions
 


### PR DESCRIPTION

### What does it do?
Add information for security settings in middleware.js if dots in a bucket name are used.

### Why is it needed?

If a bucket name has dots in it, the url of the ressources in the buckets are different to buckets with names without dots. This has consequences what to add to the security settings in middleware.js.

### How to test it?

Uploading and deleting files to s3 buckets with and without dots in their names.

