### PR TITLE
fix: issue #13132 crashes when uploading faulty image

### DIFF
--- a/packages/core/upload/server/services/image-manipulation.js
+++ b/packages/core/upload/server/services/image-manipulation.js
@@ -81,8 +81,13 @@ const optimize = async file => {
 
   const newFile = { ...file };
 
-  const { width, height, size, format } = await getMetadata(newFile);
+  try {
+    const { width, height, size, format } = await getMetadata(newFile);
+  } catch(e) {
+    console.error("Image upload failed with error: ", e);
+  }
 
+  
   if (sizeOptimization || autoOrientation) {
     const transformer = sharp();
     transformer[format]({ quality: sizeOptimization ? 80 : 100 });


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

It catches the error instead of crashing the application when a faulty image is uploaded to strapi.

### Why is it needed?

It is better to catch errors and show meaningful messages than to crash the application. This PR takes care of it and allows the user to keep using the application as normal.

### How to test it?

Node v12.22.0 
Tested using Google Chrome version 101.0.4951.54
Uploaded an image added on issue #13132, it does not crash the application anymore

### Related issue(s)/PR(s)

fixes #13132 
