### PR TITLE
Fix admin user registration

### DIFF
--- a/packages/core/admin/server/controllers/authentication.js
+++ b/packages/core/admin/server/controllers/authentication.js
@@ -124,10 +124,16 @@ module.exports = {
 
     strapi.telemetry.send('didCreateFirstAdmin');
 
+    const sanitizedUser = getService('user').sanitizeUser(user);
+
+    // Note: We need to assign manually the registrationToken to the
+    // final user payload so that it's not removed in the sanitation process.
+    Object.assign(sanitizedUser, { registrationToken: user.registrationToken });
+
     ctx.body = {
       data: {
         token: getService('token').createJwtToken(user),
-        user: getService('user').sanitizeUser(user),
+        user: sanitizedUser,
       },
     };
   },

--- a/packages/core/admin/server/controllers/authentication.js
+++ b/packages/core/admin/server/controllers/authentication.js
@@ -124,16 +124,10 @@ module.exports = {
 
     strapi.telemetry.send('didCreateFirstAdmin');
 
-    const sanitizedUser = getService('user').sanitizeUser(user);
-
-    // Note: We need to assign manually the registrationToken to the
-    // final user payload so that it's not removed in the sanitation process.
-    Object.assign(sanitizedUser, { registrationToken: user.registrationToken });
-
     ctx.body = {
       data: {
         token: getService('token').createJwtToken(user),
-        user: sanitizedUser,
+        user: getService('user').sanitizeUser(user),
       },
     };
   },

--- a/packages/core/admin/server/controllers/user.js
+++ b/packages/core/admin/server/controllers/user.js
@@ -36,6 +36,10 @@ module.exports = {
 
     const userInfo = getService('user').sanitizeUser(createdUser);
 
+    // Note: We need to assign manually the registrationToken to the
+    // final user payload so that it's not removed in the sanitation process.
+    Object.assign(userInfo, { registrationToken: createdUser.registrationToken });
+
     // Send 201 created
     ctx.created({ data: userInfo });
   },

--- a/packages/core/admin/server/tests/admin-user.test.e2e.js
+++ b/packages/core/admin/server/tests/admin-user.test.e2e.js
@@ -1,13 +1,14 @@
 'use strict';
 
-const _ = require('lodash');
+const { omit } = require('lodash/fp');
 const { createStrapiInstance } = require('../../../../../test/helpers/strapi');
 const { createAuthRequest } = require('../../../../../test/helpers/request');
 const { createUtils } = require('../../../../../test/helpers/utils');
 
 const edition = process.env.STRAPI_DISABLE_EE === 'true' ? 'CE' : 'EE';
 
-const omitTimestamps = obj => _.omit(obj, ['updatedAt', 'createdAt']);
+const omitTimestamps = omit(['updatedAt', 'createdAt']);
+const omitRegistrationToken = omit(['registrationToken']);
 
 /**
  * == Test Suite Overview ==
@@ -128,9 +129,10 @@ describe('Admin User CRUD (e2e)', () => {
 
     expect(res.statusCode).toBe(201);
     expect(res.body.data).not.toBeNull();
+    expect(res.body.data).toHaveProperty('registrationToken');
 
     // Using the created user as an example for the rest of the tests
-    testData.user = res.body.data;
+    testData.user = omitRegistrationToken(res.body.data);
   });
 
   test('3. Creates users with superAdmin role (success)', async () => {
@@ -153,7 +155,7 @@ describe('Admin User CRUD (e2e)', () => {
       expect(res.statusCode).toBe(201);
       expect(res.body.data).not.toBeNull();
 
-      testData.otherSuperAdminUsers.push(res.body.data);
+      testData.otherSuperAdminUsers.push(omitRegistrationToken(res.body.data));
     }
   });
 


### PR DESCRIPTION
### What does it do?

Bypass the default admin user sanitation to force the `registrationToken` property to be included in the response payload of the create user controller.

### Why is it needed?

Since v4.1.10, we're removing the `registrationToken` from the admin API responses. Even if it works for almost every scenario, we still need this property in the admin user creation flow.

### How to test it?

1. Create a new admin user
2. In the modal, the registration link should contains a valid registration token
3. Use this link to register the new admin

### Related issue(s)/PR(s)

fix #13300
