### PR TITLE
ReactSelect: Backport changes from #13291

### DIFF
--- a/packages/core/helper-plugin/lib/src/components/ReactSelect/utils/getSelectStyles.js
+++ b/packages/core/helper-plugin/lib/src/components/ReactSelect/utils/getSelectStyles.js
@@ -42,7 +42,7 @@ const getSelectStyles = theme => {
       };
     },
     indicatorContainer: base => ({ ...base, padding: 0, paddingRight: theme.spaces[3] }),
-    input: base => ({ ...base, margin: 0, padding: 0 }),
+    input: base => ({ ...base, margin: 0, padding: 0, color: theme.colors.neutral800 }),
     menu: base => {
       return {
         ...base,

--- a/packages/core/upload/admin/src/components/EditFolderDialog/tests/__snapshots__/EditFolderDialog.test.js.snap
+++ b/packages/core/upload/admin/src/components/EditFolderDialog/tests/__snapshots__/EditFolderDialog.test.js.snap
@@ -809,7 +809,7 @@ exports[`EditFolderDialog renders and matches the snapshot 1`] = `
                               Media Library
                             </div>
                             <div
-                              class="css-reu10z-Input"
+                              class="css-fph3ax-Input"
                             >
                               <div
                                 class=""

--- a/packages/core/upload/admin/src/components/SelectTree/tests/__snapshots__/SelectTree.test.js.snap
+++ b/packages/core/upload/admin/src/components/SelectTree/tests/__snapshots__/SelectTree.test.js.snap
@@ -63,7 +63,7 @@ Object {
               class=" css-p5rves-singleValue"
             />
             <div
-              class="css-reu10z-Input"
+              class="css-fph3ax-Input"
             >
               <div
                 class=""
@@ -150,7 +150,7 @@ Object {
             class=" css-p5rves-singleValue"
           />
           <div
-            class="css-reu10z-Input"
+            class="css-fph3ax-Input"
           >
             <div
               class=""


### PR DESCRIPTION
### What does it do?

Backports the change from https://github.com/strapi/strapi/pull/13291 into the new component structure, which will be part of the media library folders.

### Why is it needed?

To not re-introduce a bug, once the feature is merged.

### Related issue(s)/PR(s)

- https://github.com/strapi/strapi/pull/13291
