### PR TITLE
Typescript Fix cli commands when outDir is changed

### DIFF
--- a/packages/core/strapi/lib/commands/admin-create.js
+++ b/packages/core/strapi/lib/commands/admin-create.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const path = require('path');
 const { yup } = require('@strapi/utils');
 const _ = require('lodash');
 const inquirer = require('inquirer');
@@ -95,6 +94,7 @@ async function createAdmin({ email, password, firstname, lastname }) {
   const appDir = process.cwd();
 
   const isTSProject = await tsUtils.isUsingTypeScript(appDir);
+  const compiledDirectoryPath = isTSProject ? tsUtils.resolveConfigOptions(`${appDir}/tsconfig.json`).options?.outDir : null
 
   if (isTSProject)
     await tsUtils.compile(appDir, {
@@ -102,7 +102,7 @@ async function createAdmin({ email, password, firstname, lastname }) {
       configOptions: { options: { incremental: true } },
     });
 
-  const distDir = isTSProject ? path.join(appDir, 'dist') : appDir;
+  const distDir = isTSProject ? compiledDirectoryPath : appDir;
 
   const app = await strapi({ appDir, distDir }).load();
 

--- a/packages/core/strapi/lib/commands/admin-create.js
+++ b/packages/core/strapi/lib/commands/admin-create.js
@@ -94,7 +94,9 @@ async function createAdmin({ email, password, firstname, lastname }) {
   const appDir = process.cwd();
 
   const isTSProject = await tsUtils.isUsingTypeScript(appDir);
-  const compiledDirectoryPath = isTSProject ? tsUtils.resolveConfigOptions(`${appDir}/tsconfig.json`).options?.outDir : null
+  const compiledDirectoryPath = isTSProject
+    ? tsUtils.resolveConfigOptions(`${appDir}/tsconfig.json`).options.outDir
+    : null;
 
   if (isTSProject)
     await tsUtils.compile(appDir, {

--- a/packages/core/strapi/lib/commands/admin-create.js
+++ b/packages/core/strapi/lib/commands/admin-create.js
@@ -94,9 +94,7 @@ async function createAdmin({ email, password, firstname, lastname }) {
   const appDir = process.cwd();
 
   const isTSProject = await tsUtils.isUsingTypeScript(appDir);
-  const compiledDirectoryPath = isTSProject
-    ? tsUtils.resolveConfigOptions(`${appDir}/tsconfig.json`).options.outDir
-    : null;
+  const outDir = await tsUtils.resolveOutDir(appDir);
 
   if (isTSProject)
     await tsUtils.compile(appDir, {
@@ -104,7 +102,7 @@ async function createAdmin({ email, password, firstname, lastname }) {
       configOptions: { options: { incremental: true } },
     });
 
-  const distDir = isTSProject ? compiledDirectoryPath : appDir;
+  const distDir = isTSProject ? outDir : appDir;
 
   const app = await strapi({ appDir, distDir }).load();
 

--- a/packages/core/strapi/lib/commands/admin-reset.js
+++ b/packages/core/strapi/lib/commands/admin-reset.js
@@ -46,7 +46,9 @@ async function changePassword({ email, password }) {
   const appDir = process.cwd();
 
   const isTSProject = await tsUtils.isUsingTypeScript(appDir);
-  const compiledDirectoryPath = isTSProject ? tsUtils.resolveConfigOptions(`${appDir}/tsconfig.json`).options?.outDir : null
+  const compiledDirectoryPath = isTSProject
+    ? tsUtils.resolveConfigOptions(`${appDir}/tsconfig.json`).options.outDir
+    : null;
 
   if (isTSProject)
     await tsUtils.compile(appDir, {

--- a/packages/core/strapi/lib/commands/admin-reset.js
+++ b/packages/core/strapi/lib/commands/admin-reset.js
@@ -46,9 +46,7 @@ async function changePassword({ email, password }) {
   const appDir = process.cwd();
 
   const isTSProject = await tsUtils.isUsingTypeScript(appDir);
-  const compiledDirectoryPath = isTSProject
-    ? tsUtils.resolveConfigOptions(`${appDir}/tsconfig.json`).options.outDir
-    : null;
+  const outDir = await tsUtils.resolveOutDir(appDir);
 
   if (isTSProject)
     await tsUtils.compile(appDir, {
@@ -56,7 +54,7 @@ async function changePassword({ email, password }) {
       configOptions: { options: { incremental: true } },
     });
 
-  const distDir = isTSProject ? compiledDirectoryPath : appDir;
+  const distDir = isTSProject ? outDir : appDir;
 
   const app = await strapi({ appDir, distDir }).load();
 

--- a/packages/core/strapi/lib/commands/admin-reset.js
+++ b/packages/core/strapi/lib/commands/admin-reset.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const path = require('path');
 const _ = require('lodash');
 const inquirer = require('inquirer');
 const tsUtils = require('@strapi/typescript-utils');
@@ -47,6 +46,7 @@ async function changePassword({ email, password }) {
   const appDir = process.cwd();
 
   const isTSProject = await tsUtils.isUsingTypeScript(appDir);
+  const compiledDirectoryPath = isTSProject ? tsUtils.resolveConfigOptions(`${appDir}/tsconfig.json`).options?.outDir : null
 
   if (isTSProject)
     await tsUtils.compile(appDir, {
@@ -54,7 +54,7 @@ async function changePassword({ email, password }) {
       configOptions: { options: { incremental: true } },
     });
 
-  const distDir = isTSProject ? path.join(appDir, 'dist') : appDir;
+  const distDir = isTSProject ? compiledDirectoryPath : appDir;
 
   const app = await strapi({ appDir, distDir }).load();
 

--- a/packages/core/strapi/lib/commands/build.js
+++ b/packages/core/strapi/lib/commands/build.js
@@ -1,5 +1,4 @@
 'use strict';
-const path = require('path');
 
 const tsUtils = require('@strapi/typescript-utils');
 const { buildAdmin, buildTypeScript } = require('./builders');
@@ -12,13 +11,14 @@ module.exports = async ({ optimization, forceBuild = true }) => {
   const srcDir = process.cwd();
 
   const useTypeScriptServer = await tsUtils.isUsingTypeScript(srcDir);
+  const compiledDirectoryPath = useTypeScriptServer ? tsUtils.resolveConfigOptions(`${srcDir}/tsconfig.json`).options?.outDir : null
 
   // Typescript
   if (useTypeScriptServer) {
     await buildTypeScript({ srcDir, watch: false });
 
     // Update the dir path for the next steps
-    buildDestDir = path.join(srcDir, 'dist');
+    buildDestDir = compiledDirectoryPath;
   }
 
   await buildAdmin({

--- a/packages/core/strapi/lib/commands/build.js
+++ b/packages/core/strapi/lib/commands/build.js
@@ -11,16 +11,14 @@ module.exports = async ({ optimization, forceBuild = true }) => {
   const srcDir = process.cwd();
 
   const useTypeScriptServer = await tsUtils.isUsingTypeScript(srcDir);
-  const compiledDirectoryPath = useTypeScriptServer
-    ? tsUtils.resolveConfigOptions(`${srcDir}/tsconfig.json`).options.outDir
-    : null;
+  const outDir = await tsUtils.resolveOutDir(srcDir);
 
   // Typescript
   if (useTypeScriptServer) {
     await buildTypeScript({ srcDir, watch: false });
 
     // Update the dir path for the next steps
-    buildDestDir = compiledDirectoryPath;
+    buildDestDir = outDir;
   }
 
   await buildAdmin({

--- a/packages/core/strapi/lib/commands/build.js
+++ b/packages/core/strapi/lib/commands/build.js
@@ -11,7 +11,9 @@ module.exports = async ({ optimization, forceBuild = true }) => {
   const srcDir = process.cwd();
 
   const useTypeScriptServer = await tsUtils.isUsingTypeScript(srcDir);
-  const compiledDirectoryPath = useTypeScriptServer ? tsUtils.resolveConfigOptions(`${srcDir}/tsconfig.json`).options?.outDir : null
+  const compiledDirectoryPath = useTypeScriptServer
+    ? tsUtils.resolveConfigOptions(`${srcDir}/tsconfig.json`).options.outDir
+    : null;
 
   // Typescript
   if (useTypeScriptServer) {

--- a/packages/core/strapi/lib/commands/configurationDump.js
+++ b/packages/core/strapi/lib/commands/configurationDump.js
@@ -16,8 +16,10 @@ module.exports = async function({ file: filePath, pretty }) {
   const appDir = process.cwd();
 
   const isTSProject = await tsUtils.isUsingTypeScript(appDir);
-  const compiledDirectoryPath = isTSProject ? tsUtils.resolveConfigOptions(`${appDir}/tsconfig.json`).options?.outDir : null
-  if (isTSProject) 
+  const compiledDirectoryPath = isTSProject
+    ? tsUtils.resolveConfigOptions(`${appDir}/tsconfig.json`).options.outDir
+    : null;
+  if (isTSProject)
     await tsUtils.compile(appDir, {
       watch: false,
       configOptions: { options: { incremental: true } },

--- a/packages/core/strapi/lib/commands/configurationDump.js
+++ b/packages/core/strapi/lib/commands/configurationDump.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const fs = require('fs');
-const path = require('path');
 const tsUtils = require('@strapi/typescript-utils');
 const strapi = require('../index');
 
@@ -17,14 +16,14 @@ module.exports = async function({ file: filePath, pretty }) {
   const appDir = process.cwd();
 
   const isTSProject = await tsUtils.isUsingTypeScript(appDir);
-
-  if (isTSProject)
+  const compiledDirectoryPath = isTSProject ? tsUtils.resolveConfigOptions(`${appDir}/tsconfig.json`).options?.outDir : null
+  if (isTSProject) 
     await tsUtils.compile(appDir, {
       watch: false,
       configOptions: { options: { incremental: true } },
     });
 
-  const distDir = isTSProject ? path.join(appDir, 'dist') : appDir;
+  const distDir = isTSProject ? compiledDirectoryPath : appDir;
 
   const app = await strapi({ appDir, distDir }).load();
 

--- a/packages/core/strapi/lib/commands/configurationDump.js
+++ b/packages/core/strapi/lib/commands/configurationDump.js
@@ -16,16 +16,14 @@ module.exports = async function({ file: filePath, pretty }) {
   const appDir = process.cwd();
 
   const isTSProject = await tsUtils.isUsingTypeScript(appDir);
-  const compiledDirectoryPath = isTSProject
-    ? tsUtils.resolveConfigOptions(`${appDir}/tsconfig.json`).options.outDir
-    : null;
+  const outDir = await tsUtils.resolveOutDir(appDir);
   if (isTSProject)
     await tsUtils.compile(appDir, {
       watch: false,
       configOptions: { options: { incremental: true } },
     });
 
-  const distDir = isTSProject ? compiledDirectoryPath : appDir;
+  const distDir = isTSProject ? outDir : appDir;
 
   const app = await strapi({ appDir, distDir }).load();
 

--- a/packages/core/strapi/lib/commands/configurationRestore.js
+++ b/packages/core/strapi/lib/commands/configurationRestore.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const fs = require('fs');
-const path = require('path');
 const _ = require('lodash');
 const tsUtils = require('@strapi/typescript-utils');
 
@@ -18,6 +17,7 @@ module.exports = async function({ file: filePath, strategy = 'replace' }) {
   const appDir = process.cwd();
 
   const isTSProject = await tsUtils.isUsingTypeScript(appDir);
+  const compiledDirectoryPath = isTSProject ? tsUtils.resolveConfigOptions(`${appDir}/tsconfig.json`).options?.outDir : null
 
   if (isTSProject)
     await tsUtils.compile(appDir, {
@@ -25,7 +25,7 @@ module.exports = async function({ file: filePath, strategy = 'replace' }) {
       configOptions: { options: { incremental: true } },
     });
 
-  const distDir = isTSProject ? path.join(appDir, 'dist') : appDir;
+  const distDir = isTSProject ? compiledDirectoryPath : appDir;
 
   const app = await strapi({ appDir, distDir }).load();
 

--- a/packages/core/strapi/lib/commands/configurationRestore.js
+++ b/packages/core/strapi/lib/commands/configurationRestore.js
@@ -17,7 +17,9 @@ module.exports = async function({ file: filePath, strategy = 'replace' }) {
   const appDir = process.cwd();
 
   const isTSProject = await tsUtils.isUsingTypeScript(appDir);
-  const compiledDirectoryPath = isTSProject ? tsUtils.resolveConfigOptions(`${appDir}/tsconfig.json`).options?.outDir : null
+  const compiledDirectoryPath = isTSProject
+    ? tsUtils.resolveConfigOptions(`${appDir}/tsconfig.json`).options.outDir
+    : null;
 
   if (isTSProject)
     await tsUtils.compile(appDir, {

--- a/packages/core/strapi/lib/commands/configurationRestore.js
+++ b/packages/core/strapi/lib/commands/configurationRestore.js
@@ -17,9 +17,7 @@ module.exports = async function({ file: filePath, strategy = 'replace' }) {
   const appDir = process.cwd();
 
   const isTSProject = await tsUtils.isUsingTypeScript(appDir);
-  const compiledDirectoryPath = isTSProject
-    ? tsUtils.resolveConfigOptions(`${appDir}/tsconfig.json`).options.outDir
-    : null;
+  const outDir = await tsUtils.resolveOutDir(appDir);
 
   if (isTSProject)
     await tsUtils.compile(appDir, {
@@ -27,7 +25,7 @@ module.exports = async function({ file: filePath, strategy = 'replace' }) {
       configOptions: { options: { incremental: true } },
     });
 
-  const distDir = isTSProject ? compiledDirectoryPath : appDir;
+  const distDir = isTSProject ? outDir : appDir;
 
   const app = await strapi({ appDir, distDir }).load();
 

--- a/packages/core/strapi/lib/commands/console.js
+++ b/packages/core/strapi/lib/commands/console.js
@@ -12,9 +12,7 @@ module.exports = async () => {
   // Now load up the Strapi framework for real.
   const appDir = process.cwd();
   const isTSProject = await tsUtils.isUsingTypeScript(appDir);
-  const compiledDirectoryPath = isTSProject
-    ? tsUtils.resolveConfigOptions(`${appDir}/tsconfig.json`).options.outDir
-    : undefined;
+  const outDir = await tsUtils.resolveOutDir(appDir);
 
   if (isTSProject)
     await tsUtils.compile(appDir, {
@@ -22,7 +20,7 @@ module.exports = async () => {
       configOptions: { options: { incremental: true } },
     });
 
-  const distDir = isTSProject ? compiledDirectoryPath : appDir;
+  const distDir = isTSProject ? outDir : appDir;
 
   const app = await strapi({ appDir, distDir }).load();
 

--- a/packages/core/strapi/lib/commands/console.js
+++ b/packages/core/strapi/lib/commands/console.js
@@ -12,9 +12,11 @@ module.exports = async () => {
   // Now load up the Strapi framework for real.
   const appDir = process.cwd();
   const isTSProject = await tsUtils.isUsingTypeScript(appDir);
-  const compiledDirectoryPath = isTSProject ? tsUtils.resolveConfigOptions(`${appDir}/tsconfig.json`).options?.outDir : undefined
+  const compiledDirectoryPath = isTSProject
+    ? tsUtils.resolveConfigOptions(`${appDir}/tsconfig.json`).options.outDir
+    : undefined;
 
-  if (isTSProject) 
+  if (isTSProject)
     await tsUtils.compile(appDir, {
       watch: false,
       configOptions: { options: { incremental: true } },

--- a/packages/core/strapi/lib/commands/console.js
+++ b/packages/core/strapi/lib/commands/console.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const REPL = require('repl');
-const path = require('path');
 const tsUtils = require('@strapi/typescript-utils');
 
 const strapi = require('../index');
@@ -12,16 +11,16 @@ const strapi = require('../index');
 module.exports = async () => {
   // Now load up the Strapi framework for real.
   const appDir = process.cwd();
-
   const isTSProject = await tsUtils.isUsingTypeScript(appDir);
+  const compiledDirectoryPath = isTSProject ? tsUtils.resolveConfigOptions(`${appDir}/tsconfig.json`).options?.outDir : undefined
 
-  if (isTSProject)
+  if (isTSProject) 
     await tsUtils.compile(appDir, {
       watch: false,
       configOptions: { options: { incremental: true } },
     });
 
-  const distDir = isTSProject ? path.join(appDir, 'dist') : appDir;
+  const distDir = isTSProject ? compiledDirectoryPath : appDir;
 
   const app = await strapi({ appDir, distDir }).load();
 

--- a/packages/core/strapi/lib/commands/develop.js
+++ b/packages/core/strapi/lib/commands/develop.js
@@ -22,7 +22,8 @@ module.exports = async function({ build, watchAdmin, polling, browser }) {
   const appDir = process.cwd();
 
   const isTSProject = await tsUtils.isUsingTypeScript(appDir);
-  const distDir = isTSProject ? path.join(appDir, 'dist') : appDir;
+  const compiledDirectoryPath = isTSProject ? tsUtils.resolveConfigOptions(`${appDir}/tsconfig.json`).options?.outDir : null
+  const distDir = isTSProject ? compiledDirectoryPath : appDir;
 
   try {
     if (cluster.isMaster || cluster.isPrimary) {

--- a/packages/core/strapi/lib/commands/develop.js
+++ b/packages/core/strapi/lib/commands/develop.js
@@ -22,10 +22,8 @@ module.exports = async function({ build, watchAdmin, polling, browser }) {
   const appDir = process.cwd();
 
   const isTSProject = await tsUtils.isUsingTypeScript(appDir);
-  const compiledDirectoryPath = isTSProject
-    ? tsUtils.resolveConfigOptions(`${appDir}/tsconfig.json`).options.outDir
-    : null;
-  const distDir = isTSProject ? compiledDirectoryPath : appDir;
+  const outDir = await tsUtils.resolveOutDir(appDir);
+  const distDir = isTSProject ? outDir : appDir;
 
   try {
     if (cluster.isMaster || cluster.isPrimary) {

--- a/packages/core/strapi/lib/commands/develop.js
+++ b/packages/core/strapi/lib/commands/develop.js
@@ -22,7 +22,9 @@ module.exports = async function({ build, watchAdmin, polling, browser }) {
   const appDir = process.cwd();
 
   const isTSProject = await tsUtils.isUsingTypeScript(appDir);
-  const compiledDirectoryPath = isTSProject ? tsUtils.resolveConfigOptions(`${appDir}/tsconfig.json`).options?.outDir : null
+  const compiledDirectoryPath = isTSProject
+    ? tsUtils.resolveConfigOptions(`${appDir}/tsconfig.json`).options.outDir
+    : null;
   const distDir = isTSProject ? compiledDirectoryPath : appDir;
 
   try {

--- a/packages/core/strapi/lib/commands/routes/list.js
+++ b/packages/core/strapi/lib/commands/routes/list.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const path = require('path');
 const CLITable = require('cli-table3');
 const chalk = require('chalk');
 const { toUpper } = require('lodash/fp');
@@ -12,7 +11,15 @@ module.exports = async function() {
   const appDir = process.cwd();
 
   const isTSProject = await tsUtils.isUsingTypeScript(appDir);
-  const distDir = isTSProject ? path.join(appDir, 'dist') : appDir;
+  const compiledDirectoryPath = isTSProject ? tsUtils.resolveConfigOptions(`${appDir}/tsconfig.json`).options?.outDir : null
+
+  if (isTSProject)
+    await tsUtils.compile(appDir, {
+      watch: false,
+      configOptions: { options: { incremental: true } },
+    });
+
+  const distDir = isTSProject ? compiledDirectoryPath : appDir;
 
   const app = await strapi({ appDir, distDir }).load();
 

--- a/packages/core/strapi/lib/commands/routes/list.js
+++ b/packages/core/strapi/lib/commands/routes/list.js
@@ -11,7 +11,9 @@ module.exports = async function() {
   const appDir = process.cwd();
 
   const isTSProject = await tsUtils.isUsingTypeScript(appDir);
-  const compiledDirectoryPath = isTSProject ? tsUtils.resolveConfigOptions(`${appDir}/tsconfig.json`).options?.outDir : null
+  const compiledDirectoryPath = isTSProject
+    ? tsUtils.resolveConfigOptions(`${appDir}/tsconfig.json`).options.outDir
+    : null;
 
   if (isTSProject)
     await tsUtils.compile(appDir, {

--- a/packages/core/strapi/lib/commands/routes/list.js
+++ b/packages/core/strapi/lib/commands/routes/list.js
@@ -11,9 +11,7 @@ module.exports = async function() {
   const appDir = process.cwd();
 
   const isTSProject = await tsUtils.isUsingTypeScript(appDir);
-  const compiledDirectoryPath = isTSProject
-    ? tsUtils.resolveConfigOptions(`${appDir}/tsconfig.json`).options.outDir
-    : null;
+  const outDir = await tsUtils.resolveOutDir(appDir);
 
   if (isTSProject)
     await tsUtils.compile(appDir, {
@@ -21,7 +19,7 @@ module.exports = async function() {
       configOptions: { options: { incremental: true } },
     });
 
-  const distDir = isTSProject ? compiledDirectoryPath : appDir;
+  const distDir = isTSProject ? outDir : appDir;
 
   const app = await strapi({ appDir, distDir }).load();
 

--- a/packages/core/strapi/lib/commands/start.js
+++ b/packages/core/strapi/lib/commands/start.js
@@ -1,4 +1,5 @@
 'use strict';
+const fs = require('fs');
 const tsUtils = require('@strapi/typescript-utils');
 const strapi = require('../index');
 
@@ -9,11 +10,8 @@ module.exports = async specifiedDir => {
   const appDir = process.cwd();
   const isTSProject = await tsUtils.isUsingTypeScript(appDir);
   const outDir = await tsUtils.resolveOutDir(appDir);
-  if (isTSProject)
-    await tsUtils.compile(appDir, {
-      watch: false,
-      configOptions: { options: { incremental: true } },
-    });
+  const buildDirExists = fs.existsSync(outDir);
+  if (isTSProject && !buildDirExists) throw new Error('Please build first to run this command');
   const distDir = isTSProject && !specifiedDir ? outDir : specifiedDir;
 
   strapi({ distDir }).start();

--- a/packages/core/strapi/lib/commands/start.js
+++ b/packages/core/strapi/lib/commands/start.js
@@ -8,7 +8,8 @@ const strapi = require('../index');
 module.exports = async specifiedDir => {
     const appDir = process.cwd();
     const isTSProject = await tsUtils.isUsingTypeScript(appDir)
-    const distDir = isTSProject && !specifiedDir ? 'dist' : specifiedDir;
+    const compiledDirectoryPath = isTSProject ? tsUtils.resolveConfigOptions(`${appDir}/tsconfig.json`).options?.outDir : null
+    const distDir = isTSProject && !specifiedDir ? compiledDirectoryPath : specifiedDir;
 
     strapi({ distDir }).start()
 };

--- a/packages/core/strapi/lib/commands/start.js
+++ b/packages/core/strapi/lib/commands/start.js
@@ -8,10 +8,13 @@ const strapi = require('../index');
 module.exports = async specifiedDir => {
   const appDir = process.cwd();
   const isTSProject = await tsUtils.isUsingTypeScript(appDir);
-  const compiledDirectoryPath = isTSProject
-    ? tsUtils.resolveConfigOptions(`${appDir}/tsconfig.json`).options.outDir
-    : null;
-  const distDir = isTSProject && !specifiedDir ? compiledDirectoryPath : specifiedDir;
+  const outDir = await tsUtils.resolveOutDir(appDir);
+  if (isTSProject)
+    await tsUtils.compile(appDir, {
+      watch: false,
+      configOptions: { options: { incremental: true } },
+    });
+  const distDir = isTSProject && !specifiedDir ? outDir : specifiedDir;
 
   strapi({ distDir }).start();
 };

--- a/packages/core/strapi/lib/commands/start.js
+++ b/packages/core/strapi/lib/commands/start.js
@@ -11,7 +11,7 @@ module.exports = async specifiedDir => {
   const isTSProject = await tsUtils.isUsingTypeScript(appDir);
   const outDir = await tsUtils.resolveOutDir(appDir);
   const buildDirExists = fs.existsSync(outDir);
-  if (isTSProject && !buildDirExists) throw new Error('Please build first to run this command');
+  if (isTSProject && !buildDirExists) throw new Error(`${outDir} directory not found. Please run the build command before starting your application`);
   const distDir = isTSProject && !specifiedDir ? outDir : specifiedDir;
 
   strapi({ distDir }).start();

--- a/packages/core/strapi/lib/commands/start.js
+++ b/packages/core/strapi/lib/commands/start.js
@@ -1,15 +1,17 @@
 'use strict';
-const tsUtils = require('@strapi/typescript-utils')
+const tsUtils = require('@strapi/typescript-utils');
 const strapi = require('../index');
 
 /**
  * `$ strapi start`
  */
 module.exports = async specifiedDir => {
-    const appDir = process.cwd();
-    const isTSProject = await tsUtils.isUsingTypeScript(appDir)
-    const compiledDirectoryPath = isTSProject ? tsUtils.resolveConfigOptions(`${appDir}/tsconfig.json`).options?.outDir : null
-    const distDir = isTSProject && !specifiedDir ? compiledDirectoryPath : specifiedDir;
+  const appDir = process.cwd();
+  const isTSProject = await tsUtils.isUsingTypeScript(appDir);
+  const compiledDirectoryPath = isTSProject
+    ? tsUtils.resolveConfigOptions(`${appDir}/tsconfig.json`).options.outDir
+    : null;
+  const distDir = isTSProject && !specifiedDir ? compiledDirectoryPath : specifiedDir;
 
-    strapi({ distDir }).start()
+  strapi({ distDir }).start();
 };

--- a/packages/core/strapi/lib/commands/watchAdmin.js
+++ b/packages/core/strapi/lib/commands/watchAdmin.js
@@ -12,10 +12,8 @@ module.exports = async function({ browser }) {
   const currentDirectory = process.cwd();
 
   const isTSProject = await tsUtils.isUsingTypeScript(currentDirectory);
-  const compiledDirectoryPath = isTSProject
-    ? tsUtils.resolveConfigOptions(`${currentDirectory}/tsconfig.json`).options.outDir
-    : null;
-  const buildDestDir = isTSProject ? compiledDirectoryPath : currentDirectory;
+  const outDir = await tsUtils.resolveOutDir(currentDirectory);
+  const buildDestDir = isTSProject ? outDir : currentDirectory;
 
   const strapiInstance = strapi({
     distDir: buildDestDir,

--- a/packages/core/strapi/lib/commands/watchAdmin.js
+++ b/packages/core/strapi/lib/commands/watchAdmin.js
@@ -13,7 +13,8 @@ module.exports = async function({ browser }) {
   const currentDirectory = process.cwd();
 
   const isTSProject = await tsUtils.isUsingTypeScript(currentDirectory);
-  const buildDestDir = isTSProject ? path.join(currentDirectory, 'dist') : currentDirectory;
+  const compiledDirectoryPath = isTSProject ? tsUtils.resolveConfigOptions(`${currentDirectory}/tsconfig.json`).options?.outDir : null
+  const buildDestDir = isTSProject ? compiledDirectoryPath : currentDirectory;
 
   const strapiInstance = strapi({
     distDir: buildDestDir,

--- a/packages/core/strapi/lib/commands/watchAdmin.js
+++ b/packages/core/strapi/lib/commands/watchAdmin.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const path = require('path');
 const strapiAdmin = require('@strapi/admin');
 const tsUtils = require('@strapi/typescript-utils');
 const { getConfigUrls, getAbsoluteServerUrl } = require('@strapi/utils');
@@ -13,7 +12,9 @@ module.exports = async function({ browser }) {
   const currentDirectory = process.cwd();
 
   const isTSProject = await tsUtils.isUsingTypeScript(currentDirectory);
-  const compiledDirectoryPath = isTSProject ? tsUtils.resolveConfigOptions(`${currentDirectory}/tsconfig.json`).options?.outDir : null
+  const compiledDirectoryPath = isTSProject
+    ? tsUtils.resolveConfigOptions(`${currentDirectory}/tsconfig.json`).options.outDir
+    : null;
   const buildDestDir = isTSProject ? compiledDirectoryPath : currentDirectory;
 
   const strapiInstance = strapi({

--- a/packages/utils/typescript/lib/utils/index.js
+++ b/packages/utils/typescript/lib/utils/index.js
@@ -6,6 +6,7 @@ const getConfigPath = require('./get-config-path');
 const reportDiagnostics = require('./report-diagnostics');
 const resolveConfigOptions = require('./resolve-config-options');
 const formatHost = require('./format-host');
+const resolveOutDir = require('./resolve-outdir');
 
 module.exports = {
   isUsingTypeScript,
@@ -14,4 +15,5 @@ module.exports = {
   reportDiagnostics,
   resolveConfigOptions,
   formatHost,
+  resolveOutDir,
 };

--- a/packages/utils/typescript/lib/utils/resolve-outdir.js
+++ b/packages/utils/typescript/lib/utils/resolve-outdir.js
@@ -1,16 +1,17 @@
 'use strict';
+const path = require('path');
 const resolveConfigOptions = require('./resolve-config-options');
 const isUsingTypescript = require('./is-using-typescript');
 
 const DEFAULT_TS_CONFIG_FILENAME = 'tsconfig.json';
 /**
- * Checks if `dir` is a using TypeScript (whether there is a tsconfig file or not)
+ * Gets the outDir value from config file (tsconfig)
  * @param {string} dir
  * @param {string | undefined} configFilename
  * @returns {string | undefined}
  */
 module.exports = async (dir, configFilename = DEFAULT_TS_CONFIG_FILENAME) => {
   return (await isUsingTypescript(dir))
-    ? resolveConfigOptions(`${dir}/${configFilename}`).options.outDir
+    ? resolveConfigOptions(path.join(dir, configFilename)).options.outDir
     : undefined;
 };

--- a/packages/utils/typescript/lib/utils/resolve-outdir.js
+++ b/packages/utils/typescript/lib/utils/resolve-outdir.js
@@ -1,0 +1,16 @@
+'use strict';
+const resolveConfigOptions = require('./resolve-config-options');
+const isUsingTypescript = require('./is-using-typescript');
+
+const DEFAULT_TS_CONFIG_FILENAME = 'tsconfig.json';
+/**
+ * Checks if `dir` is a using TypeScript (whether there is a tsconfig file or not)
+ * @param {string} dir
+ * @param {string | undefined} configFilename
+ * @returns {string | undefined}
+ */
+module.exports = async (dir, configFilename = DEFAULT_TS_CONFIG_FILENAME) => {
+  return (await isUsingTypescript(dir))
+    ? resolveConfigOptions(`${dir}/${configFilename}`).options.outDir
+    : undefined;
+};


### PR DESCRIPTION
### What does it do?

Get the outDir path for compiled code from tsconfig instead of using 'dist' statically

### Why is it needed?

if the user changes the outDir value all cli commands fail to excute since they will be looking for a dist folder

### How to test it?

Start a typescript project, and change outDir value in tsconfig, then test the cli commands, the compiled and build code should be in a directory with the name specified in outDir.

