### PR TITLE
[Fix] CTB Media advanced settings layout

### DIFF
--- a/packages/core/content-type-builder/admin/src/components/FormModal/attributes/advancedForm.js
+++ b/packages/core/content-type-builder/admin/src/components/FormModal/attributes/advancedForm.js
@@ -251,7 +251,7 @@ const advancedForm = {
             id: 'global.settings',
             defaultMessage: 'Settings',
           },
-          items: [options.private, options.required],
+          items: [options.required, options.private],
         },
       ],
     };


### PR DESCRIPTION
## What

Fixed required field checkbox to be on the left side to be consistent with other content-types

<img width="864" alt="image" src="https://user-images.githubusercontent.com/71838159/168325556-8e65fdb1-0097-4eea-bbcc-70e293c8aeb0.png">
