### PR TITLE
[plugin:documentation] fix required attributes on post requests

### DIFF
--- a/packages/plugins/documentation/__tests__/build-component-schema.test.js
+++ b/packages/plugins/documentation/__tests__/build-component-schema.test.js
@@ -147,8 +147,10 @@ describe('Build Component Schema', () => {
 
     const expectedShape = {
       type: 'object',
+      required: ['data'],
       properties: {
         data: {
+          required: [],
           type: 'object',
           properties: { test: { type: 'string' } },
         },
@@ -237,6 +239,7 @@ describe('Build Component Schema', () => {
 
     const expectedShape = {
       type: 'object',
+      required: ['locale'],
       properties: { test: { type: 'string' } },
     };
 

--- a/packages/plugins/documentation/server/services/helpers/build-component-schema.js
+++ b/packages/plugins/documentation/server/services/helpers/build-component-schema.js
@@ -36,23 +36,24 @@ const getAllSchemasForContentType = ({ routeInfo, attributes, uniqueName }) => {
     ];
     const attributesForRequest = _.omit(attributes, attributesToOmit);
 
-    const requiredAttributes = Object.entries(attributesForRequest)
-      .filter(([, attribute]) => attribute.required)
-      .map(([attributeName, attribute]) => {
-        return { [attributeName]: attribute };
-      });
+    // Get a list of required attribute names
+    const requiredAttributes = Object.entries(attributesForRequest).reduce((acc, attribute) => {
+      const [attributeKey, attributeValue] = attribute;
 
-    const requestAttributes =
-      routeMethods.includes('POST') && requiredAttributes.length
-        ? Object.assign({}, ...requiredAttributes)
-        : attributesForRequest;
+      if (attributeValue.required) {
+        acc.push(attributeKey);
+      }
+
+      return acc;
+    }, []);
 
     if (hasLocalizationPath) {
       schemas = {
         ...schemas,
         [`${pascalCase(uniqueName)}LocalizationRequest`]: {
+          required: requiredAttributes,
           type: 'object',
-          properties: cleanSchemaAttributes(requestAttributes, { isRequest: true }),
+          properties: cleanSchemaAttributes(attributesForRequest, { isRequest: true }),
         },
       };
     }
@@ -62,10 +63,12 @@ const getAllSchemasForContentType = ({ routeInfo, attributes, uniqueName }) => {
       ...schemas,
       [`${pascalCase(uniqueName)}Request`]: {
         type: 'object',
+        required: ['data'],
         properties: {
           data: {
+            required: requiredAttributes,
             type: 'object',
-            properties: cleanSchemaAttributes(requestAttributes, { isRequest: true }),
+            properties: cleanSchemaAttributes(attributesForRequest, { isRequest: true }),
           },
         },
       },

--- a/packages/plugins/documentation/server/services/helpers/build-component-schema.js
+++ b/packages/plugins/documentation/server/services/helpers/build-component-schema.js
@@ -51,7 +51,7 @@ const getAllSchemasForContentType = ({ routeInfo, attributes, uniqueName }) => {
       schemas = {
         ...schemas,
         [`${pascalCase(uniqueName)}LocalizationRequest`]: {
-          required: requiredAttributes,
+          required: [...requiredAttributes, 'locale'],
           type: 'object',
           properties: cleanSchemaAttributes(attributesForRequest, { isRequest: true }),
         },


### PR DESCRIPTION
### What does it do?

Returns all attributes for post requests distinguishing required attributes from non-required attributes.

https://swagger.io/docs/specification/2-0/describing-request-body/

### Why is it needed?

fixes: #12887

### How to test it?

Create a content type with required and non-required attributes. Open the documentation and look at the post request schema. The required should be marked required with a red `*`. The data object should always be marked required. Localization requests should also have `locale` marked as required.

