### PR TITLE
Remove limit on deep populate on components

### DIFF
--- a/packages/core/content-manager/server/services/entity-manager.js
+++ b/packages/core/content-manager/server/services/entity-manager.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { assoc, has, prop, omit } = require('lodash/fp');
+const { assoc, has, prop, omit, merge } = require('lodash/fp');
 const strapiUtils = require('@strapi/utils');
 const { ApplicationError } = require('@strapi/utils').errors;
 
@@ -40,13 +40,9 @@ const findCreatorRoles = entity => {
 };
 
 // TODO: define when we use this one vs basic populate
-const getDeepPopulate = (uid, populate, depth = 0) => {
+const getDeepPopulate = (uid, populate) => {
   if (populate) {
     return populate;
-  }
-
-  if (depth > 2) {
-    return {};
   }
 
   const { attributes } = strapi.getModel(uid);
@@ -60,7 +56,7 @@ const getDeepPopulate = (uid, populate, depth = 0) => {
 
     if (attribute.type === 'component') {
       populateAcc[attributeName] = {
-        populate: getDeepPopulate(attribute.component, null, depth + 1),
+        populate: getDeepPopulate(attribute.component, null),
       };
     }
 
@@ -71,7 +67,7 @@ const getDeepPopulate = (uid, populate, depth = 0) => {
     if (attribute.type === 'dynamiczone') {
       populateAcc[attributeName] = {
         populate: (attribute.components || []).reduce((acc, componentUID) => {
-          return Object.assign(acc, getDeepPopulate(componentUID, null, depth + 1));
+          return merge(acc, getDeepPopulate(componentUID, null));
         }, {}),
       };
     }


### PR DESCRIPTION
### What does it do?

Removes the hard limit on deep populate for an entity.
(It was not possible before but since we populate relations only once, it is possible to remove the limit)

### Why is it needed?

In order to populate the admin edit view when there are more than 2 levels of nested components.

### How to test it?

1. Create compo1 with a field "name"
2. Create compo2 with a field "compo1" and a field "name"
3. Create compo3 with a field "compo2" and a field "name"
4. Create a content-type "dog" with a field "compo3"
5. Create an entry for the content-type "dog" with all the components filled
6. Save and see that the data is correctly displayed

NB: component creation is possible only by editing the files directly, not through the content-type builder.

### Related issue(s)/PR(s)

- https://github.com/strapi/strapi/issues/11319
- https://feedback.strapi.io/customization/p/allow-nesting-of-components-more-than-2-levels-deep
