### PR TITLE
[users-permissions]: Populate user object to include relations from an extended user model

### DIFF
--- a/packages/plugins/users-permissions/server/controllers/auth.js
+++ b/packages/plugins/users-permissions/server/controllers/auth.js
@@ -56,7 +56,7 @@ module.exports = {
       }
 
       // Check if the user exists.
-      const user = await strapi.query('plugin::users-permissions.user').findOne({ where: query });
+      const user = await strapi.query('plugin::users-permissions.user').findOne({ where: query, populate: true });
 
       if (!user) {
         throw new ValidationError('Invalid identifier or password');
@@ -124,7 +124,7 @@ module.exports = {
     ) {
       const user = await strapi
         .query('plugin::users-permissions.user')
-        .findOne({ where: { resetPasswordToken: `${params.code}` } });
+        .findOne({ where: { resetPasswordToken: `${params.code}` }, populate: true });
 
       if (!user) {
         throw new ValidationError('Incorrect code provided');
@@ -321,6 +321,7 @@ module.exports = {
 
     const user = await strapi.query('plugin::users-permissions.user').findOne({
       where: { email: params.email },
+      populate: true,
     });
 
     if (user && user.provider === params.provider) {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?
This PR fixes #13334, by adding the `populate: true` attribute to the queries. 
As described in the issue, if you extend a user model with relation fields, they will not be loaded and send over to the API. This limits the functionality compared to the MongoDB in v3. 

### Why is it needed?

As described in the corresponding issue, I have a project that extends the existing user model from the users-permissions plugin. It has a list of products a user should have access to and in v3 with the MongoDB this was not a problem at all, but with an SQL based DB, the populate attribute is needed. 
I assume that this could be helpful for more people than just me and would be nice if added to the codebase.

### How to test it?

Add a relation field to the existing user collection model, log in via the `auth/local` route and the relation will not show in the user object send in the response. Then use this PR with the added populate attribute and the relation will show up. 

### Related issue(s)/PR(s)

#13334
