### PR TITLE
add missing items property causing infinite load on error schema

### DIFF
--- a/packages/plugins/documentation/server/config/default-plugin-config.js
+++ b/packages/plugins/documentation/server/config/default-plugin-config.js
@@ -48,7 +48,7 @@ module.exports = {
         properties: {
           data: {
             nullable: true,
-            oneOf: [{ type: 'object' }, { type: 'array' }],
+            oneOf: [{ type: 'object' }, { type: 'array', items: [] }],
           },
           error: {
             type: 'object',


### PR DESCRIPTION
### What does it do?

Adds the `items` property to the Error schema 

### Why is it needed?

 it is required for `type: array`
https://swagger.io/docs/specification/data-models/data-types/#array

Otherwise it causes an infinite loader

### How to test it?

Open the documentation, go to the Error schema, click on data, click on the array. 

You should see an empty object inside instead of an infinite load
