### PR TITLE
Increase test coverage for get-file-path util

### DIFF
--- a/packages/generators/generators/lib/plops/utils/__tests__/get-file-path.test.js
+++ b/packages/generators/generators/lib/plops/utils/__tests__/get-file-path.test.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const getFilePath = require('../get-file-path');
+
+describe('Get-File-Path util', () => {
+  test('with destination set as api', () => {
+    const filePath = getFilePath('api');
+    expect(filePath).toBe(`api/{{ api }}`);
+  })
+
+  test('with destination set as plugin', () => {
+    const filePath = getFilePath('plugin');
+    expect(filePath).toBe(`plugins/{{ plugin }}/server`);
+  })
+
+  test('with destination set as root', () => {
+    const filePath = getFilePath('root');
+    expect(filePath).toBe(`./`);
+  })
+
+  test('with empty destination string', () => {
+    const filePath = getFilePath('');
+    expect(filePath).toBe(`api/{{ id }}`);
+  })
+})


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Increased test coverage for generators/lib/utils/get-file-path

### Why is it needed?

Three different paths in get-file-path.js in the generators/lib/utils were not being tested. I have added test cases to make sure it returns the right route according to the given destination.

### How to test it?

Run unit tests with yarn/npm. You can also use WebStorm IDE to run tests directly in the added file

### Related issue(s)/PR(s)

Increased test coverage for generators/lib/utils/get-file-path. No related issues.
