### PR TITLE
Added test to validate the min constraint for big integer if no min is specified

### DIFF
--- a/packages/core/strapi/lib/services/entity-validator/__tests__/biginteger-validators.test.js
+++ b/packages/core/strapi/lib/services/entity-validator/__tests__/biginteger-validators.test.js
@@ -200,4 +200,19 @@ describe('BigInteger validator', () => {
       });
     });
   });
+
+  describe('min', () => {
+    test('it does not validate the min constraint if the attribute min is not a number', async () => {
+      const validator = strapiUtils.validateYupSchema(
+        validators.biginteger(
+          {
+            attr: { type: 'biginteger', minLength: '123' },
+          },
+          { isDraft: false }
+        )
+      );
+
+      expect(await validator(1)).toBe(1);
+    });
+  });
 });


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Test validates the min constraint if no min is specified.

### Why is it needed?

The file biginteger-validators.test.js did not have test for min while test files for integer-validators.test.js and float-validators.test.js had the min tests.

### How to test it?

Test can be run through IDE, such as WebStorm, or using yarn/npm command.

### Related issue(s)/PR(s)

No related issues.
