### PR TITLE
Fix CTB not adding all field extensions

### DIFF
--- a/packages/core/content-type-builder/admin/src/utils/formAPI.js
+++ b/packages/core/content-type-builder/admin/src/utils/formAPI.js
@@ -67,11 +67,10 @@ const formsAPI = {
             ],
           },
         };
-
-        formType[field].validators.push(validator);
-        formType[field].form.advanced.push(advanced);
-        formType[field].form.base.push(base);
       }
+      formType[field].validators.push(validator);
+      formType[field].form.advanced.push(advanced);
+      formType[field].form.base.push(base);
     });
   },
   getAdvancedForm(target, props = null) {


### PR DESCRIPTION
add validators and forms after the if clause

fixes #13322

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Basically as described in #13322 

The registration of validators and forms is done after the if clause where it is checked for if a validator for the specific field is in the defined attributes

### Why is it needed?

When the field is in the defined attributes, it could not be extended anymore

### How to test it?

See #13322 

### Related issue(s)/PR(s)

See #13322 
