### PR TITLE
Update .gitignore to allow use of word "coverage"

### DIFF
--- a/examples/getstarted/.gitignore
+++ b/examples/getstarted/.gitignore
@@ -101,6 +101,8 @@ node_modules
 
 testApp
 coverage
+!src/api/coverage
+!src/api/content-types/coverage
 
 ############################
 # Strapi

--- a/examples/getstarted/.gitignore
+++ b/examples/getstarted/.gitignore
@@ -100,9 +100,7 @@ node_modules
 ############################
 
 testApp
-coverage
-!src/api/coverage
-!src/api/content-types/coverage
+/coverage/
 
 ############################
 # Strapi


### PR DESCRIPTION
API endpoints and content-types created with name "coverage" will be omitted unless exempted

### What does it do?

We can all now use the word `coverage` as a collection-type or single-type without fear.

We know we used a reserved word usually meaning "test coverage" which `.gitignore` prevents from going out to our friends and colleagues using our `Strapi` implementation.

### Why is it needed?

Because `coverage` is a normal word to use in day-to-day life, as it pertains to `geographical` coverage, etc. We really, in a way, just saved "the world" here. Believe it or not.

### How to test it?

Create a new `Strapi` implementation using `--quickstart` and relax, seeing that when we `commit` updates to endpoints and schema, all our team members and out future selves, will have `coverage` in the repository, even though it is a reserved word.