### PR TITLE
[TS] Add missing StrapiInterface 

### DIFF
--- a/packages/core/strapi/lib/index.d.ts
+++ b/packages/core/strapi/lib/index.d.ts
@@ -9,6 +9,8 @@ export type { Core };
 // Alias to resolve the Strapi global type easily
 export type Strapi = Core.Strapi;
 
+export interface StrapiInterface extends Core.Strapi {};
+
 declare global {
   interface AllTypes {}
 }


### PR DESCRIPTION
### What does it do?

Adds the missing StrapiInterface and exports it from `@strapi/strapi`.

