### PR TITLE
add missing await in upload plugin

### DIFF
--- a/packages/core/upload/server/services/upload.js
+++ b/packages/core/upload/server/services/upload.js
@@ -255,7 +255,7 @@ module.exports = ({ strapi }) => ({
         }
       }
 
-      getService('provider').upload(fileData);
+      await getService('provider').upload(fileData);
 
       // clear old formats
       _.set(fileData, 'formats', {});
@@ -265,7 +265,7 @@ module.exports = ({ strapi }) => ({
       if (await isSupportedImage(fileData)) {
         const thumbnailFile = await generateThumbnail(fileData);
         if (thumbnailFile) {
-          getService('provider').upload(thumbnailFile);
+          await getService('provider').upload(thumbnailFile);
           _.set(fileData, 'formats.thumbnail', thumbnailFile);
         }
 
@@ -276,7 +276,7 @@ module.exports = ({ strapi }) => ({
 
             const { key, file } = format;
 
-            getService('provider').upload(file);
+            await getService('provider').upload(file);
 
             _.set(fileData, ['formats', key], file);
           }


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

I added missing `await` in upload plugin

### Why is it needed?

The service's `replace` function is not awaiting for file uploads. This results in the database data to be corrupt as instead of including uploaded data, it includes a JSON stringified version of the temporary file stream

### How to test it?

Before change: "replace media" and check that in the database data, the thumbnail doesn't have a url, but has the node stream file properties
After change: it works

### Related issue(s)/PR(s)

N/A
