### PR TITLE
Add incremental build by default in the generated tsconfig.json

### DIFF
--- a/packages/utils/typescript/lib/configs/server.json
+++ b/packages/utils/typescript/lib/configs/server.json
@@ -11,6 +11,7 @@
         "skipLibCheck": true,
         "forceConsistentCasingInFileNames": true,
 
+        "incremental": true,
         "esModuleInterop": true,
         "resolveJsonModule": true,
         "noEmitOnError": true


### PR DESCRIPTION

### What does it do?

Adds incremental builds by default for the generated tsconfig.json files.

### Why is it needed?

Increase builds time and decreases used resources
 
### How to test it?

1. Create a new TS project
2. Check that the incremental option is enabled in the generated tsconfig.json file
3. Make the first compilation, change a small line of code somewhere, and then rebuild. The second build should be faster than the first.
