### PR TITLE
Fix duplicate sort results

### DIFF
--- a/packages/core/database/lib/query/query-builder.js
+++ b/packages/core/database/lib/query/query-builder.js
@@ -275,6 +275,10 @@ const createQueryBuilder = (uid, db) => {
           qb.select(state.select.map(column => this.aliasColumn(column)));
 
           if (this.shouldUseDistinct()) {
+            if (state.joins.length > 1 && state.orderBy.length > 0) {
+              const [firstJoin] = state.joins;
+              qb.groupBy(firstJoin.referencedColumn);
+            }
             qb.distinct();
           }
 


### PR DESCRIPTION
### What does it do?

In query builder when we query for data and we have joins, we run `qb.distinct` which should remove duplicate data from the query but after some testing it doesn't seem to affect queries with multiple joins and duplicate data was queried when trying nested sorting. So I opted to use `qb.groupBy` instead when we have multiple joins and sorting

### Why is it needed?

When doing nested sorting, duplicate data is being returned

### How to test it?

run a strapi application and create content types with a relation, try to sort the parent content type based on a relation field there should be no duplicates, you can follow the same method in the issue I will reference below.

### Related issue(s)/PR(s)

fixes #11892 
