### PR TITLE
Github: Fix coverage reports for front-end tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Build
         run: yarn build
       - name: Run test
-        run: yarn run -s test:front && codecov -C -F front
+        run: yarn run -s test:front --coverage && codecov -C -F front
 
   e2e_ce_pg:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### What does it do?

I had a gut feeling for a long time already that our front-end tests are not properly reported in the coverage reports, which leads sometimes to failed codecov runs, even though tests were added.

This PR fixes the jest coverage report.

### Why is it needed?

To properly display codecov reports.

### How to test it?

Github/ Jest / Codecov will test it for us.
