### PR TITLE
Automatically add new github issues to support project

### DIFF
--- a/.github/workflows/addToProject.yml
+++ b/.github/workflows/addToProject.yml
@@ -1,0 +1,17 @@
+name: Add bugs to bugs project
+
+on:
+  issues:
+    types:
+      - opened
+      - transferred
+
+jobs:
+  add-to-project:
+    name: Add issue to Support Team project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@main
+        with:
+          project-url: https://github.com/orgs/strapi/projects/15
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}

--- a/.github/workflows/addToProject.yml
+++ b/.github/workflows/addToProject.yml
@@ -14,4 +14,4 @@ jobs:
       - uses: actions/add-to-project@main
         with:
           project-url: https://github.com/orgs/strapi/projects/15
-          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          github-token: ${{ secrets.PROJECT_TRANSFER_TOKEN }}


### PR DESCRIPTION
Will need to have the ~~`ADD_TO_PROJECT_PAT`~~ `PROJECT_TRANSFER_TOKEN` secret added before merged.

Automatically adds new GitHub issues to the following project: https://github.com/orgs/strapi/projects/15/views/1