### PR TITLE
Fix generation of OpenAPI documentation with top level type attribute

### DIFF
--- a/packages/plugins/documentation/__tests__/build-component-schema.test.js
+++ b/packages/plugins/documentation/__tests__/build-component-schema.test.js
@@ -33,6 +33,7 @@ describe('Build Component Schema', () => {
     const [pluginResponseValue, apiResponseValue] = Object.values(schemas);
 
     const expectedShape = {
+      type: 'object',
       properties: {
         data: {
           type: 'object',
@@ -82,6 +83,7 @@ describe('Build Component Schema', () => {
     const apiListResponseValue = schemas['RestaurantListResponse'];
 
     const expectedShape = {
+      type: 'object',
       properties: {
         data: {
           type: 'array',

--- a/packages/plugins/documentation/server/services/helpers/build-component-schema.js
+++ b/packages/plugins/documentation/server/services/helpers/build-component-schema.js
@@ -95,6 +95,7 @@ const getAllSchemasForContentType = ({ routeInfo, attributes, uniqueName }) => {
     schemas = {
       ...schemas,
       [`${pascalCase(uniqueName)}ListResponse`]: {
+        type: 'object',
         properties: {
           data: {
             type: 'array',
@@ -128,6 +129,7 @@ const getAllSchemasForContentType = ({ routeInfo, attributes, uniqueName }) => {
   schemas = {
     ...schemas,
     [`${pascalCase(uniqueName)}Response`]: {
+      type: 'object',
       properties: {
         data: {
           type: 'object',


### PR DESCRIPTION
### What does it do?

Adds the type attribute to ListResponse and Response component schemas in the Documentation plugin.

### Why is it needed?

This is required to make TypeScript type generation work from the OpenAPI specification

### How to test it?

1. Generate a new strapi app
2. Install Documentation plugin
3. Start strapi app
4. Open ./src/extensions/documentation/documentation/1.0.0/full_documentation.json
5. Search for UsersPermissionsUserListResponse or UsersPermissionsUserResponse

These component definition lacked the type attribute at the top level before this PR.

### Related issue(s)/PR(s)

fixes #13373
