### PR TITLE
Make alternativeText and caption empty by default

### DIFF
--- a/packages/core/upload/admin/src/hooks/useUpload.js
+++ b/packages/core/upload/admin/src/hooks/useUpload.js
@@ -17,8 +17,8 @@ const uploadAsset = (asset, cancelToken, onProgress) => {
     'fileInfo',
     JSON.stringify({
       name,
-      caption: caption || name,
-      alternativeText: alternativeText || name,
+      caption: caption || '',
+      alternativeText: alternativeText || '',
     })
   );
 


### PR DESCRIPTION
Changed default value of alternative text and caption to an empty string, instead of name.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

It fixes the auto-filling of caption and alternative text with fileName on upload of media.

### Why is it needed?

To avoid auto-filling the caption and alternative text on upload and keeping the field empty.

### How to test it?

Setup a new Strapi project.
Go to Media Library.
Upload an Asset completely.
Click on the Edit Button of the Asset to view Asset details. The caption and alternative text should be empty.

Note:-
If Edit Button is clicked before uploading the Asset (before `/upload` endpoint is hit), the caption and alternative text are empty.


### Related issue(s)/PR(s)

#13295 