### PR TITLE
Add more injection zones

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/DynamicTable/TableRows/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/DynamicTable/TableRows/index.js
@@ -14,6 +14,7 @@ import { useIntl } from 'react-intl';
 import { usePluginsQueryParams } from '../../../hooks';
 import CellContent from '../CellContent';
 import { getFullName } from '../../../../utils';
+import { InjectionZone } from '../../../../shared/components';
 
 const TableRows = ({
   canCreate,
@@ -156,6 +157,7 @@ const TableRows = ({
                       />
                     </Box>
                   )}
+                  <InjectionZone area="contentManager.listView.action-icons" />
                 </Flex>
               </Td>
             )}

--- a/packages/core/admin/admin/src/content-manager/components/DynamicTable/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/DynamicTable/index.js
@@ -11,6 +11,7 @@ import State from '../State';
 import TableRows from './TableRows';
 import ConfirmDialogDeleteAll from './ConfirmDialogDeleteAll';
 import ConfirmDialogDelete from './ConfirmDialogDelete';
+import { InjectionZone } from '../../../shared/components';
 
 const DynamicTable = ({
   canCreate,
@@ -87,6 +88,15 @@ const DynamicTable = ({
       rows={rows}
       withBulkActions
       withMainAction={canDelete && isBulkable}
+      additionalBulkActions={[
+        entries => (
+          <InjectionZone
+            key="injection-zone"
+            entries={entries}
+            area="contentManager.listView.bulk-actions"
+          />
+        ),
+      ]}
     >
       <TableRows
         canCreate={canCreate}

--- a/packages/core/admin/admin/src/content-manager/pages/EditView/Header/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/EditView/Header/index.js
@@ -19,6 +19,7 @@ import ExclamationMarkCircle from '@strapi/icons/ExclamationMarkCircle';
 import Check from '@strapi/icons/Check';
 import { getTrad } from '../../../utils';
 import { connect, getDraftRelations, select } from './utils';
+import { InjectionZone } from '../../../../shared/components';
 
 const Header = ({
   allowedActions: { canUpdate, canCreate, canPublish },
@@ -83,6 +84,7 @@ const Header = ({
             defaultMessage: 'Save',
           })}
         </Button>
+        <InjectionZone area="contentManager.editView.header-actions" />
       </Stack>
     );
   }
@@ -110,7 +112,7 @@ const Header = ({
     /* eslint-enable indent */
 
     primaryAction = (
-      <Flex>
+      <Stack horizontal spacing={2}>
         {shouldShowPublishButton && (
           <Button
             disabled={didChangeData}
@@ -130,7 +132,8 @@ const Header = ({
             })}
           </Button>
         </Box>
-      </Flex>
+        <InjectionZone area="contentManager.editView.header-actions" />
+      </Stack>
     );
   }
 

--- a/packages/core/admin/admin/src/content-manager/pages/EditView/Header/tests/index.test.js
+++ b/packages/core/admin/admin/src/content-manager/pages/EditView/Header/tests/index.test.js
@@ -14,6 +14,7 @@ import ThemeToggleProvider from '../../../../../components/ThemeToggleProvider';
 import { Header } from '../index';
 import components from '../utils/tests/data/compos-schema.json';
 import ct from '../utils/tests/data/ct-schema.json';
+import { AdminContext } from '../../../../../contexts';
 
 const defaultProps = {
   allowedActions: { canUpdate: true, canCreate: true, canPublish: true },
@@ -32,13 +33,15 @@ const defaultProps = {
 const makeApp = (props = defaultProps) => {
   return (
     <MemoryRouter>
-      <IntlProvider locale="en" defaultLocale="en" messages={{}}>
-        <ThemeToggleProvider themes={{ light: lightTheme, dark: darkTheme }}>
-          <Theme>
-            <Header {...props} />
-          </Theme>
-        </ThemeToggleProvider>
-      </IntlProvider>
+      <AdminContext.Provider value={{ getAdminInjectedComponents: () => [] }}>
+        <IntlProvider locale="en" defaultLocale="en" messages={{}}>
+          <ThemeToggleProvider themes={{ light: lightTheme, dark: darkTheme }}>
+            <Theme>
+              <Header {...props} />
+            </Theme>
+          </ThemeToggleProvider>
+        </IntlProvider>
+      </AdminContext.Provider>
     </MemoryRouter>
   );
 };

--- a/packages/core/admin/admin/src/content-manager/pages/EditView/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/EditView/index.js
@@ -132,6 +132,7 @@ const EditView = ({
             <Main aria-busy={status !== 'resolved'}>
               <Header allowedActions={allowedActions} />
               <ContentLayout>
+                <InjectionZone area="contentManager.editView.before-form" />
                 <Grid gap={4}>
                   <GridItem col={9} s={12}>
                     <Stack spacing={6}>
@@ -354,6 +355,7 @@ const EditView = ({
                     </Stack>
                   </GridItem>
                 </Grid>
+                <InjectionZone area="contentManager.editView.after-form" />
               </ContentLayout>
             </Main>
           </EditViewDataManagerProvider>

--- a/packages/core/admin/admin/src/content-manager/pages/ListView/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/ListView/index.js
@@ -19,6 +19,7 @@ import {
   useTracking,
   Link,
 } from '@strapi/helper-plugin';
+import { Stack } from '@strapi/design-system/Stack';
 import { IconButton } from '@strapi/design-system/IconButton';
 import { Main } from '@strapi/design-system/Main';
 import { Box } from '@strapi/design-system/Box';
@@ -261,7 +262,12 @@ function ListView({
   return (
     <Main aria-busy={isLoading}>
       <HeaderLayout
-        primaryAction={getCreateAction()}
+        primaryAction={
+          <Stack spacing={2} horizontal>
+            {getCreateAction()}
+            <InjectionZone area="contentManager.listView.header-actions" />
+          </Stack>
+        }
         subtitle={subtitle}
         title={headerLayoutTitle}
         navigationAction={

--- a/packages/core/admin/admin/src/injectionZones.js
+++ b/packages/core/admin/admin/src/injectionZones.js
@@ -10,10 +10,23 @@ const injectionZones = {
     tutorials: {
       links: [],
     },
+    homepage: { 'content-top': [], 'content-bottom': [] },
   },
   contentManager: {
-    editView: { informations: [], 'right-links': [] },
-    listView: { actions: [], deleteModalAdditionalInfos: [] },
+    editView: {
+      informations: [],
+      'right-links': [],
+      'header-actions': [],
+      'before-form': [],
+      'after-form': [],
+    },
+    listView: {
+      actions: [],
+      deleteModalAdditionalInfos: [],
+      'header-actions': [],
+      'bulk-actions': [],
+      'action-icons': [],
+    },
   },
 };
 

--- a/packages/core/admin/admin/src/pages/HomePage/index.js
+++ b/packages/core/admin/admin/src/pages/HomePage/index.js
@@ -20,6 +20,7 @@ import GuidedTourHomepage from '../../components/GuidedTour/Homepage';
 import SocialLinks from './SocialLinks';
 import HomeHeader from './HomeHeader';
 import ContentBlocks from './ContentBlocks';
+import { InjectionZone } from '../../shared/components';
 
 const LogoContainer = styled(Box)`
   position: absolute;
@@ -75,6 +76,7 @@ const HomePage = () => {
               />
             </GridItem>
           </Grid>
+          <InjectionZone area="admin.homepage.content-top" />
           <Grid gap={6}>
             <GridItem col={8} s={12}>
               {showGuidedTour ? <GuidedTourHomepage /> : <ContentBlocks />}
@@ -83,6 +85,7 @@ const HomePage = () => {
               <SocialLinks />
             </GridItem>
           </Grid>
+          <InjectionZone area="admin.homepage.content-bottom" />
         </Box>
       </Main>
     </Layout>

--- a/packages/core/admin/admin/src/pages/HomePage/tests/index.test.js
+++ b/packages/core/admin/admin/src/pages/HomePage/tests/index.test.js
@@ -6,6 +6,7 @@ import { IntlProvider } from 'react-intl';
 import { ThemeProvider, lightTheme } from '@strapi/design-system';
 import HomePage from '../index';
 import { useModels } from '../../../hooks';
+import { AdminContext } from '../../../contexts';
 
 jest.mock('@strapi/helper-plugin', () => ({
   ...jest.requireActual('@strapi/helper-plugin'),
@@ -36,11 +37,13 @@ const history = createMemoryHistory();
 
 const App = (
   <ThemeProvider theme={lightTheme}>
-    <IntlProvider locale="en" messages={{}} textComponent="span">
-      <Router history={history}>
-        <HomePage />
-      </Router>
-    </IntlProvider>
+    <AdminContext.Provider value={{ getAdminInjectedComponents: () => [] }}>
+      <IntlProvider locale="en" messages={{}} textComponent="span">
+        <Router history={history}>
+          <HomePage />
+        </Router>
+      </IntlProvider>
+    </AdminContext.Provider>
   </ThemeProvider>
 );
 

--- a/packages/core/helper-plugin/lib/src/components/DynamicTable/index.js
+++ b/packages/core/helper-plugin/lib/src/components/DynamicTable/index.js
@@ -34,6 +34,7 @@ const Table = ({
   onConfirmDelete,
   onOpenDeleteAllModalTrackedEvent,
   rows,
+  additionalBulkActions,
   withBulkActions,
   withMainAction,
   ...rest
@@ -155,6 +156,8 @@ const Table = ({
                 >
                   {formatMessage({ id: 'global.delete', defaultMessage: 'Delete' })}
                 </Button>
+                {additionalBulkActions &&
+                  additionalBulkActions.map(action => action(entriesToDelete))}
               </BlockActions>
             </Flex>
           </Box>
@@ -221,6 +224,7 @@ Table.defaultProps = {
   onConfirmDelete: () => {},
   onOpenDeleteAllModalTrackedEvent: undefined,
   rows: [],
+  additionalBulkActions: null,
   withBulkActions: false,
   withMainAction: false,
 };
@@ -250,6 +254,7 @@ Table.propTypes = {
   onConfirmDelete: PropTypes.func,
   onOpenDeleteAllModalTrackedEvent: PropTypes.string,
   rows: PropTypes.array,
+  additionalBulkActions: PropTypes.arrayOf(PropTypes.func),
   withBulkActions: PropTypes.bool,
   withMainAction: PropTypes.bool,
 };


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

This PR aims at adding additional injection zones into Strapi, mainly for plugin development.
It related to both [this RFC](https://github.com/strapi/rfcs/pull/37) and [this other one](https://github.com/strapi/rfcs/pull/44).

The injection zones being added in this PR are the following:

**Homepage**
1) `before-content` lets developers add content before the content blocks and social links.
2) `after-content` lets developers add content after the content blocks and social links.

**List view**
1) `header-actions` lets developers add content next to the _Create new entry_ button.
2) `action-icons` lets developer add content next to the edit/duplicate/delete icons.
3) `bulk-actions` lets developers add content next to the _Delete_ button when multiple entries have been selected.

**Edit view**
1) `before-form` lets developers add content before the content form and information cards.
2) `after-form` lets developers add content after the content form and information cards.
3) `header-actions` lets developers add content next to the _Save_ and _Publish_ buttons.

### Why is it needed?

The list of existing injection zones was pretty scarce, and discussing with other plugin developers, I realized there was a need for more injection zones. This will hopefully allow devs to improve their plugin's UX and allow for a more customizable admin panel.

### How to test it?

You can embed [this snippet](https://gist.github.com/WalkingPizza/32dd633d2a01c628eb73e6d453a9bd57) in the `bootstrap` function of your plugin to add placeholders in the new injection zones and see their positioning on your own admin panel, or look at the attached screenshots.

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/34224657/171214063-ef1d282e-5fb5-4bd1-abe8-7db67b458333.png">
<img width="1728" alt="image" src="https://user-images.githubusercontent.com/34224657/171214165-79418dfa-1e54-4fec-922a-a71996fc9875.png">
<img width="1728" alt="image" src="https://user-images.githubusercontent.com/34224657/171214211-a22272f6-ba8d-4e26-8997-acf8e7409933.png">
<img width="1728" alt="image" src="https://user-images.githubusercontent.com/34224657/171214244-8cd53658-e53e-4a13-8daf-1b745008cb8a.png">

