### PR TITLE
ML: Fix bulk action "select all"

### DIFF
--- a/packages/core/upload/admin/src/pages/App/MediaLibrary.js
+++ b/packages/core/upload/admin/src/pages/App/MediaLibrary.js
@@ -142,7 +142,12 @@ export const MediaLibrary = () => {
                       (assetCount > 0 || folderCount > 0) &&
                       selected.length === assetCount + folderCount
                     }
-                    onChange={() => selectAll([assets, folders])}
+                    onChange={() => {
+                      selectAll([
+                        ...assets.map(asset => ({ ...asset, type: 'asset' })),
+                        ...folders.map(folder => ({ ...folder, type: 'folder' })),
+                      ]);
+                    }}
                   />
                 </BoxWithHeight>
               )}


### PR DESCRIPTION
### What does it do?

It Fixes the select all bulk action in the media library.

https://user-images.githubusercontent.com/2244375/171360190-86cabb75-7042-4a48-9822-2999c36e8c92.mp4

### Why is it needed?

To support all bulk actions properly.

### How to test it?

1. Navigate to the media library
2. Click the select/ unselect all checkbox
3. Verify all folders and assets are selected
