### PR TITLE
Fix yup strapiID not working

### DIFF
--- a/packages/core/utils/lib/__tests__/validators.test.js
+++ b/packages/core/utils/lib/__tests__/validators.test.js
@@ -1,0 +1,97 @@
+'use strict';
+
+const { yup } = require('../validators');
+
+describe('validators', () => {
+  describe('strapiID', () => {
+    test.each([
+      [0, true],
+      ['0', true],
+      [1, true],
+      ['1', true],
+      [undefined, true], // because it's not required
+      [{}, false],
+      [[], false],
+      [null, false],
+    ])('yup.strapiID(): %s => %s', async (value, expectedResult) => {
+      let result = true;
+      try {
+        await yup.strapiID().validate(value);
+      } catch (e) {
+        result = false;
+      }
+
+      expect(result).toBe(expectedResult);
+    });
+
+    test.each([
+      [0, true],
+      ['0', true],
+      [1, true],
+      ['1', true],
+      [undefined, false],
+      [{}, false],
+      [[], false],
+      [null, false],
+    ])('yup.strapiID().required(): %s => %s', async (value, expectedResult) => {
+      let result = true;
+      try {
+        await yup
+          .strapiID()
+          .required()
+          .validate(value);
+      } catch (e) {
+        result = false;
+      }
+
+      expect(result).toBe(expectedResult);
+    });
+
+    test.each([
+      [0, true],
+      ['0', true],
+      [1, true],
+      ['1', true],
+      [undefined, true],
+      [{}, false],
+      [[], false],
+      [null, true],
+    ])('yup.strapiID().nullable(): %s => %s', async (value, expectedResult) => {
+      let result = true;
+      try {
+        await yup
+          .strapiID()
+          .nullable()
+          .validate(value);
+      } catch (e) {
+        result = false;
+      }
+
+      expect(result).toBe(expectedResult);
+    });
+
+    test.each([
+      [0, true],
+      ['0', true],
+      [1, true],
+      ['1', true],
+      [undefined, false],
+      [{}, false],
+      [[], false],
+      [null, true],
+    ])('yup.strapiID().nullable().defined(): %s => %s', async (value, expectedResult) => {
+      let result = true;
+      try {
+        await yup
+          .strapiID()
+          .nullable()
+          .defined()
+          .validate(value);
+      } catch (e) {
+        result = false;
+      }
+
+      expect(result).toBe(expectedResult);
+    });
+  });
+});

--- a/packages/core/utils/lib/validators.js
+++ b/packages/core/utils/lib/validators.js
@@ -7,7 +7,7 @@ const utils = require('./string-formatting');
 const { YupValidationError } = require('./errors');
 const printValue = require('./print-value');
 
-const MixedSchemaType = yup.mixed;
+const MixedSchemaType = yup.MixedSchema;
 
 const isNotNilTest = value => !_.isNil(value);
 


### PR DESCRIPTION
`strapiID` got broken when upgrading yup from `0.28.1` to `0.32.9` : the mixed class is exported in a different key.

`strapiID` was not checking anything.