### PR TITLE
Move emailRegex to utils

### DIFF
--- a/packages/core/utils/lib/__tests__/regex.test.js
+++ b/packages/core/utils/lib/__tests__/regex.test.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const { emailRegExp } = require('../regex');
+
+describe('Regex definition validation', () => {
+  describe('Email Regex validation against common test emails', () => {
+    const validEmails = [
+      'email@example.com',
+      'firstname.lastname@example.com',
+      'email@subdomain.example.com',
+      'firstname+lastname@example.com',
+      'email@[123.123.123.123]',
+      '"email"@example.com',
+      '1234567890@example.com',
+      'email@example-one.com',
+      '_______@example.com',
+      'email@example.name',
+      'email@example.museum',
+      'email@example.co.jp',
+      'firstname-lastname@example.com',
+    ];
+
+    test.each(validEmails)('<<%s>> should be a valid email against email regex', email =>
+      expect(emailRegExp.test(email)).toBeTruthy()
+    );
+
+    const invalidEmails = [
+      'plainaddress',
+      '#@%^%#$@#$@#.com',
+      '@example.com',
+      'Joe Smith <email@example.com>',
+      'email.example.com',
+      'email@example@example.com',
+      '.email@example.com',
+      'email.@example.com',
+      'email..email@example.com',
+      'email@example.com (Joe Smith)',
+      'email@example',
+      'email@111.222.333.44444',
+      'email@example..com',
+      'Abc..123@example.com',
+    ];
+
+    test.each(invalidEmails)('<<%s>> should be an invalid email against email regex', email =>
+      expect(emailRegExp.test(email)).toBeFalsy()
+    );
+  });
+});

--- a/packages/core/utils/lib/index.js
+++ b/packages/core/utils/lib/index.js
@@ -38,6 +38,7 @@ const pagination = require('./pagination');
 const sanitize = require('./sanitize');
 const traverseEntity = require('./traverse-entity');
 const pipeAsync = require('./pipe-async');
+const regex = require('./regex');
 
 module.exports = {
   yup,
@@ -79,4 +80,5 @@ module.exports = {
   errors,
   validateYupSchema,
   validateYupSchemaSync,
+  regex,
 };

--- a/packages/core/utils/lib/regex.js
+++ b/packages/core/utils/lib/regex.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/* eslint-disable no-useless-escape */
+const emailRegExp = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+
+module.exports = {
+  emailRegExp,
+};

--- a/packages/plugins/users-permissions/server/controllers/auth.js
+++ b/packages/plugins/users-permissions/server/controllers/auth.js
@@ -20,7 +20,7 @@ const {
 const { getAbsoluteAdminUrl, getAbsoluteServerUrl, sanitize } = utils;
 const { ApplicationError, ValidationError } = utils.errors;
 
-const emailRegExp = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+const { emailRegExp } = utils.regex;
 
 const sanitizeUser = (user, ctx) => {
   const { auth } = ctx.state;


### PR DESCRIPTION
### What does it do?

It will move some reusable parts of the code to utils in order to make the codebase more reusable.

### Why is it needed?

I want to use the same email regex for my plugin but I didn't have a direct solution. the only way was to copy and paste the defined regex in the users-permissions plugin to my plugin.

### How to test it?

I wrote some tests against the defined regex. I used samples from this [gist](https://gist.github.com/cjaoude/fd9910626629b53c4d25) but I think some of the emails have some problems against the defined regex.
