### PR TITLE
Fix CVE-2022-29256

### DIFF
--- a/packages/core/upload/package.json
+++ b/packages/core/upload/package.json
@@ -41,7 +41,7 @@
     "react-redux": "7.2.3",
     "react-router": "^5.2.0",
     "react-router-dom": "5.2.0",
-    "sharp": "0.30.4"
+    "sharp": "0.30.6"
   },
   "engines": {
     "node": ">=12.22.0 <=16.x.x",


### PR DESCRIPTION


### What does it do?

Updates Sharp to latest version

### Why is it needed?

CVE Details: https://github.com/advisories/GHSA-gp95-ppv5-3jc5

Low sev as it requires your build env to be vuln but it's a quick fix.

### How to test it?

Install and run `yarn audit` check to make sure there is no CVE alert

### Related issue(s)/PR(s)

N/A
