### PR TITLE
Fix CVE-2021-46708

### DIFF
--- a/packages/plugins/documentation/package.json
+++ b/packages/plugins/documentation/package.json
@@ -42,7 +42,7 @@
     "react-router-dom": "5.2.0",
     "redux": "^4.0.1",
     "reselect": "^4.0.0",
-    "swagger-ui-dist": "3.47.1"
+    "swagger-ui-dist": "4.11.1"
   },
   "peerDependencies": {
     "@strapi/strapi": "^4.0.0"


### PR DESCRIPTION
### What does it do?

Updates Swagger UI (I did look through their change log and the only breaking change I saw was moving from react 15 to 17 which we already use anyway)

### Why is it needed?

Fix these:

- https://github.com/advisories/GHSA-6c9x-mj3g-h47x
- https://github.com/advisories/GHSA-qrmm-w75w-3wpx

### How to test it?

Run a yarn audit and check the two advisories are gone

### Related issue(s)/PR(s)

N/A
