### PR TITLE
EditAssetDialog: Fix changing folder location

### DIFF
--- a/packages/core/upload/admin/src/components/EditAssetDialog/index.js
+++ b/packages/core/upload/admin/src/components/EditAssetDialog/index.js
@@ -42,6 +42,7 @@ const fileInfoSchema = yup.object({
   name: yup.string().required(),
   alternativeText: yup.string(),
   caption: yup.string(),
+  folder: yup.number(),
 });
 
 export const EditAssetDialog = ({
@@ -63,12 +64,12 @@ export const EditAssetDialog = ({
   });
 
   const handleSubmit = async values => {
-    if (asset.isLocal) {
-      const nextAsset = { ...asset, ...values };
+    const nextAsset = { ...asset, ...values, folder: values.parent.value };
 
+    if (asset.isLocal) {
       onClose(nextAsset);
     } else {
-      const editedAsset = await editAsset({ ...asset, ...values }, replacementFile);
+      const editedAsset = await editAsset(nextAsset, replacementFile);
       onClose(editedAsset);
     }
   };

--- a/packages/core/upload/admin/src/hooks/useEditAsset.js
+++ b/packages/core/upload/admin/src/hooks/useEditAsset.js
@@ -21,6 +21,7 @@ const editAssetRequest = (asset, file, cancelToken, onProgress) => {
     JSON.stringify({
       alternativeText: asset.alternativeText,
       caption: asset.caption,
+      folder: asset.folder,
       name: asset.name,
     })
   );


### PR DESCRIPTION
### What does it do?

When you change the location of an asset in the `EditAssetDialog` previously the file was not moved. This PR fixes the problem. I will add a test in another PR later to cover the issue.

### Why is it needed?

To be able to move files.
