### PR TITLE
MediaLibraryDialog: Fix displayed location after changes

### DIFF
--- a/packages/core/upload/admin/src/components/MediaLibraryDialog/index.js
+++ b/packages/core/upload/admin/src/components/MediaLibraryDialog/index.js
@@ -20,7 +20,12 @@ export const MediaLibraryDialog = ({ onClose, onSelectAssets, allowedTypes }) =>
       return (
         <AssetDialog
           allowedTypes={allowedTypes}
-          onClose={onClose}
+          folderId={folderId}
+          onClose={() => {
+            setStep(undefined);
+            setFolderId(null);
+            onClose();
+          }}
           onValidate={onSelectAssets}
           onAddAsset={() => setStep(STEPS.AssetUpload)}
           onAddFolder={() => setStep(STEPS.FolderCreate)}


### PR DESCRIPTION
### What does it do?

This PR fixes a case, where the user wasn't redirected properly after creating a folder or uploading a file using the modal from a richtext field.

### Why is it needed?

To properly give location context for the user.

### How to test it?

1. Open an media library modal from a richtext field
2. navigate into a folder
3. create a folder or upload a file
4. you should still be in the proper location
