### PR TITLE
[ML Folder] fixes EditFolderDialog

### DIFF
--- a/packages/core/upload/admin/src/components/EditFolderDialog/EditFolderDialog.js
+++ b/packages/core/upload/admin/src/components/EditFolderDialog/EditFolderDialog.js
@@ -52,7 +52,7 @@ export const EditFolderDialog = ({ onClose, folder, parentFolderId }) => {
   const isEditing = !!folder;
   const formDisabled = (folder && !canUpdate) || (!folder && !canCreate);
   const initialFormData = !folderStructureIsLoading && {
-    name: folder?.name ?? undefined,
+    name: folder?.name ?? '',
     parent: {
       /* ideally we would use folderStructure[0].value, but since it is null
          react complains about rendering null as field value */

--- a/packages/core/upload/admin/src/pages/App/MediaLibrary.js
+++ b/packages/core/upload/admin/src/pages/App/MediaLibrary.js
@@ -118,7 +118,10 @@ export const MediaLibrary = () => {
   const handleEditFolderClose = payload => {
     setFolderToEdit(null);
     toggleEditFolderDialog(payload);
-    currentFolderToEditRef.current.focus();
+
+    if (currentFolderToEditRef.current) {
+      currentFolderToEditRef.current.focus();
+    }
   };
 
   useFocusWhenNavigate();


### PR DESCRIPTION
## What

Fixed not checking if `currentFolderToEditRef` exists, which doesn't when on create mode
Fixed passing undefined value to `name` TextInput when on create mode