### PR TITLE
ML: Do not load folders, if an asset-only filter is applied

### DIFF
--- a/packages/core/upload/admin/src/components/AssetDialog/BrowseStep/index.js
+++ b/packages/core/upload/admin/src/components/AssetDialog/BrowseStep/index.js
@@ -253,6 +253,7 @@ export const BrowseStep = ({
 
 BrowseStep.defaultProps = {
   allowedTypes: [],
+  folders: [],
   multiple: false,
   onSelectAllAsset: undefined,
   onEditAsset: undefined,
@@ -262,7 +263,7 @@ BrowseStep.propTypes = {
   allowedTypes: PropTypes.arrayOf(PropTypes.string),
   assets: PropTypes.arrayOf(AssetDefinition).isRequired,
   canCreate: PropTypes.bool.isRequired,
-  folders: PropTypes.arrayOf(FolderDefinition).isRequired,
+  folders: PropTypes.arrayOf(FolderDefinition),
   multiple: PropTypes.bool,
   onAddAsset: PropTypes.func.isRequired,
   onChangeFilters: PropTypes.func.isRequired,

--- a/packages/core/upload/admin/src/components/AssetDialog/index.js
+++ b/packages/core/upload/admin/src/components/AssetDialog/index.js
@@ -12,7 +12,7 @@ import { Loader } from '@strapi/design-system/Loader';
 import { Stack } from '@strapi/design-system/Stack';
 import { NoPermissions, AnErrorOccurred, useSelectionState, pxToRem } from '@strapi/helper-plugin';
 
-import getTrad from '../../utils/getTrad';
+import { getTrad, containsAssetFilter } from '../../utils';
 import { SelectedStep } from './SelectedStep';
 import { BrowseStep } from './BrowseStep';
 import { useMediaLibraryPermissions } from '../../hooks/useMediaLibraryPermissions';
@@ -70,6 +70,7 @@ export const AssetDialog = ({
     error: errorAssets,
   } = useAssets({ skipWhen: !canRead, query: queryObject });
   const { data: folders, isLoading: isLoadingFolders, error: errorFolders } = useFolders({
+    enabled: canRead && !containsAssetFilter(queryObject) && pagination?.page === 1,
     query: queryObject,
   });
 

--- a/packages/core/upload/admin/src/pages/App/MediaLibrary.js
+++ b/packages/core/upload/admin/src/pages/App/MediaLibrary.js
@@ -33,7 +33,7 @@ import { FolderList } from '../../components/FolderList';
 import SortPicker from '../../components/SortPicker';
 import { useAssets } from '../../hooks/useAssets';
 import { useFolders } from '../../hooks/useFolders';
-import { getTrad, isAssetOnlyFilter } from '../../utils';
+import { getTrad, containsAssetFilter } from '../../utils';
 import { PaginationFooter } from '../../components/PaginationFooter';
 import { useMediaLibraryPermissions } from '../../hooks/useMediaLibraryPermissions';
 import { EmptyAssets } from '../../components/EmptyAssets';
@@ -78,7 +78,7 @@ export const MediaLibrary = () => {
   });
 
   const { data: folders, isLoading: foldersLoading, errors: foldersError } = useFolders({
-    enabled: canRead && assetsData?.pagination?.page === 1 && !isAssetOnlyFilter(query),
+    enabled: canRead && assetsData?.pagination?.page === 1 && !containsAssetFilter(query),
     query,
   });
 

--- a/packages/core/upload/admin/src/pages/App/MediaLibrary.js
+++ b/packages/core/upload/admin/src/pages/App/MediaLibrary.js
@@ -33,7 +33,7 @@ import { FolderList } from '../../components/FolderList';
 import SortPicker from '../../components/SortPicker';
 import { useAssets } from '../../hooks/useAssets';
 import { useFolders } from '../../hooks/useFolders';
-import { getTrad } from '../../utils';
+import { getTrad, isAssetOnlyFilter } from '../../utils';
 import { PaginationFooter } from '../../components/PaginationFooter';
 import { useMediaLibraryPermissions } from '../../hooks/useMediaLibraryPermissions';
 import { EmptyAssets } from '../../components/EmptyAssets';
@@ -78,7 +78,7 @@ export const MediaLibrary = () => {
   });
 
   const { data: folders, isLoading: foldersLoading, errors: foldersError } = useFolders({
-    enabled: assetsData?.pagination?.page === 1,
+    enabled: canRead && assetsData?.pagination?.page === 1 && !isAssetOnlyFilter(query),
     query,
   });
 

--- a/packages/core/upload/admin/src/utils/containsAssetFilter.js
+++ b/packages/core/upload/admin/src/utils/containsAssetFilter.js
@@ -12,8 +12,8 @@ const containsMimeTypeFilter = query => {
   return !!result;
 };
 
-const isAssetOnlyFilter = query => {
+const containsAssetFilter = query => {
   return containsMimeTypeFilter(query);
 };
 
-export default isAssetOnlyFilter;
+export default containsAssetFilter;

--- a/packages/core/upload/admin/src/utils/index.js
+++ b/packages/core/upload/admin/src/utils/index.js
@@ -4,4 +4,5 @@ export { default as getRequestUrl } from './getRequestUrl';
 export { default as getTrad } from './getTrad';
 export { default as findRecursiveFolderByValue } from './findRecursiveFolderByValue';
 export { default as findRecursiveFolderMetadatas } from './findRecursiveFolderMetadatas';
+export { default as isAssetOnlyFilter } from './isAssetOnlyFilter';
 export * from './formatDuration';

--- a/packages/core/upload/admin/src/utils/index.js
+++ b/packages/core/upload/admin/src/utils/index.js
@@ -4,5 +4,5 @@ export { default as getRequestUrl } from './getRequestUrl';
 export { default as getTrad } from './getTrad';
 export { default as findRecursiveFolderByValue } from './findRecursiveFolderByValue';
 export { default as findRecursiveFolderMetadatas } from './findRecursiveFolderMetadatas';
-export { default as isAssetOnlyFilter } from './isAssetOnlyFilter';
+export { default as containsAssetFilter } from './containsAssetFilter';
 export * from './formatDuration';

--- a/packages/core/upload/admin/src/utils/isAssetOnlyFilter.js
+++ b/packages/core/upload/admin/src/utils/isAssetOnlyFilter.js
@@ -1,0 +1,19 @@
+const containsMimeTypeFilter = query => {
+  const filters = query?.filters?.$and;
+
+  if (!filters) {
+    return false;
+  }
+
+  const result = filters.find(filter => {
+    return Object.keys(filter).includes('mime');
+  });
+
+  return !!result;
+};
+
+const isAssetOnlyFilter = query => {
+  return containsMimeTypeFilter(query);
+};
+
+export default isAssetOnlyFilter;

--- a/packages/core/upload/admin/src/utils/tests/containsAssetOnlyFilter.test.js
+++ b/packages/core/upload/admin/src/utils/tests/containsAssetOnlyFilter.test.js
@@ -1,0 +1,39 @@
+import { containsAssetFilter } from '..';
+
+describe('containsAssetFilter', () => {
+  test('does not fail on empty query objects', () => {
+    expect(containsAssetFilter(null)).toBeFalsy();
+    expect(containsAssetFilter({})).toBeFalsy();
+    expect(containsAssetFilter({ filters: {} })).toBeFalsy();
+    expect(containsAssetFilter({ filters: { $and: [] } })).toBeFalsy();
+  });
+
+  test('recognizes the mime-type filter', () => {
+    expect(
+      containsAssetFilter({
+        filters: {
+          $and: [
+            {
+              mime: 'image',
+            },
+          ],
+        },
+      })
+    ).toBeTruthy();
+
+    expect(
+      containsAssetFilter({
+        filters: {
+          $and: [
+            {
+              some: 'filter',
+            },
+            {
+              mime: 'image',
+            },
+          ],
+        },
+      })
+    ).toBeTruthy();
+  });
+});


### PR DESCRIPTION
### What does it do?

Previously when a user wanted to filter for `mime-type=image|audio|video` the request to fetch folders would fail, because an invalid filter was applied. With this PR folders are not displayed anymore, if an asset-only filter (such as mime-type) is applied.

### Why is it needed?

To support all filtering functions.

### How to test it?

a) I've added automated tests
b) Go to the media library, select a filter "type" of something and confirm the folders are not displayed, but assets are

I'll add some more integration tests in an upcoming PR.