### PR TITLE
BrowseStep: Always display filter toolbar (regardless of asset/ folder count)

### DIFF
--- a/packages/core/upload/admin/src/components/AssetDialog/BrowseStep/index.js
+++ b/packages/core/upload/admin/src/components/AssetDialog/BrowseStep/index.js
@@ -83,7 +83,7 @@ export const BrowseStep = ({
         <Box>
           <Box paddingBottom={4}>
             <Flex justifyContent="space-between" alignItems="flex-start">
-              {(assetCount > 0 || folderCount > 0) && (
+              {(assetCount > 0 || folderCount > 0 || isFiltering) && (
                 <StartBlockActions wrap="wrap">
                   {multiple && (
                     <Flex

--- a/packages/core/upload/admin/src/components/AssetDialog/BrowseStep/tests/index.test.js
+++ b/packages/core/upload/admin/src/components/AssetDialog/BrowseStep/tests/index.test.js
@@ -137,6 +137,16 @@ describe('BrowseStep', () => {
     expect(screen.getByText('There are no assets with the applied filters')).toBeInTheDocument();
   });
 
+  it('does display filters, even if no assets or folders were found', () => {
+    setup({
+      folders: [],
+      assets: [],
+      queryObject: { page: 1, pageSize: 10, filters: { $and: [{ mime: 'audio' }] }, _q: '' },
+    });
+
+    expect(screen.getByText('Filters')).toBeInTheDocument();
+  });
+
   it('does not display assets title if searching and no folders', () => {
     setup({
       folders: [],


### PR DESCRIPTION
### What does it do?

Forces the filter in the `AssetModal` to be open, regardless of the asset or folder count, if the user is filtering.

### Why is it needed?

To properly support filtering.

### How to test it?

1. Open the media library modal
2. Select a filter, by which neither assets nor folders are returned
3. Confirm the filter toolbar is still visible 
