### PR TITLE
added regex verification for CTB enum type

### DIFF
--- a/packages/core/content-type-builder/admin/src/components/FormModal/attributes/types.js
+++ b/packages/core/content-type-builder/admin/src/components/FormModal/attributes/types.js
@@ -5,6 +5,7 @@ import getTrad from '../../../utils/getTrad';
 import getRelationType from '../../../utils/getRelationType';
 import toRegressedEnumValue from '../../../utils/toRegressedEnumValue';
 import startsWithANumber from '../../../utils/startsWithANumber';
+import matchRegex from '../../../utils/matchRegex';
 import {
   alreadyUsedAttributeNames,
   createTextShape,
@@ -172,7 +173,13 @@ const types = {
           name: 'doesNotStartWithANumber',
           message: getTrad('error.validation.enum-number'),
           test: values => !values.some(startsWithANumber),
+        })
+        .test({
+          name: 'matchesRegex',
+          message: getTrad('error.validation.match-regex'),
+          test: values => values.every(matchRegex),
         }),
+
       enumName: yup.string().nullable(),
     };
 

--- a/packages/core/content-type-builder/admin/src/components/FormModal/attributes/types.js
+++ b/packages/core/content-type-builder/admin/src/components/FormModal/attributes/types.js
@@ -5,7 +5,6 @@ import getTrad from '../../../utils/getTrad';
 import getRelationType from '../../../utils/getRelationType';
 import toRegressedEnumValue from '../../../utils/toRegressedEnumValue';
 import startsWithANumber from '../../../utils/startsWithANumber';
-import matchRegex from '../../../utils/matchRegex';
 import {
   alreadyUsedAttributeNames,
   createTextShape,
@@ -177,7 +176,7 @@ const types = {
         .test({
           name: 'matchesRegex',
           message: getTrad('error.validation.match-regex'),
-          test: values => values.every(matchRegex),
+          test: values => values.every(ENUM_REGEX.test),
         }),
 
       enumName: yup.string().nullable(),

--- a/packages/core/content-type-builder/admin/src/translations/en.json
+++ b/packages/core/content-type-builder/admin/src/translations/en.json
@@ -60,6 +60,7 @@
   "error.contentTypeName.reserved-name": "This name cannot be used in your project as it might break other functionalities",
   "error.validation.enum-duplicate": "Duplicate values are not allowed",
   "error.validation.enum-empty-string": "Empty strings are not allowed",
+  "error.validation.match-regex": "The value does not match the regex.",
   "error.validation.enum-number": "Values cannot start with a number",
   "error.validation.minSupMax": "Can't be superior",
   "error.validation.positive": "Must be a positive number",

--- a/packages/core/content-type-builder/admin/src/utils/matchRegex.js
+++ b/packages/core/content-type-builder/admin/src/utils/matchRegex.js
@@ -1,0 +1,3 @@
+const matchRegex = value => /^[_A-Za-z][_0-9A-Za-z]*$/.test(value);
+
+export default matchRegex;

--- a/packages/core/content-type-builder/admin/src/utils/matchRegex.js
+++ b/packages/core/content-type-builder/admin/src/utils/matchRegex.js
@@ -1,3 +1,0 @@
-const matchRegex = value => /^[_A-Za-z][_0-9A-Za-z]*$/.test(value);
-
-export default matchRegex;


### PR DESCRIPTION
Enumeration type in CTB was not tested if it starts with a special character

Fix #13428
Ready to be merged

I added a regex check that does not allow to create enum type if it starts with a special character different than '_'

Before see Issue #13428
Also it was seeing different strings as duplicates as in the printscreen below:

<img width="920" alt="Screenshot 2022-06-07 at 16 29 44" src="https://user-images.githubusercontent.com/103041489/172599941-a4061ea9-761a-441f-973e-9fd3584a1c85.png">

After 
<img width="920" alt="Screenshot 2022-06-08 at 13 47 05" src="https://user-images.githubusercontent.com/103041489/172599387-30b6a764-f507-44ac-934a-784808900f43.png">

### Tests run
![Screenshot 2022-06-08 at 13 51 36](https://user-images.githubusercontent.com/103041489/172599247-2cd2ac1d-7663-41dd-a69b-af8f522fc6be.png)

![Screenshot 2022-06-08 at 13 47 59](https://user-images.githubusercontent.com/103041489/172599293-6112948e-c6c6-4180-9cf3-812d14478de7.png)
