### PR TITLE
SelectTree: truncate long folder names

### DIFF
--- a/packages/core/upload/admin/src/components/SelectTree/Option.js
+++ b/packages/core/upload/admin/src/components/SelectTree/Option.js
@@ -24,7 +24,7 @@ const Option = ({ children, data, selectProps, ...props }) => {
     <>
       <components.Option {...props}>
         <Flex alignItems="start">
-          <Typography textColor="neutral800">
+          <Typography textColor="neutral800" ellipsis>
             <span style={{ paddingLeft: `${Math.min(depth, maxDisplayDepth) * 10}px` }}>
               {children}
             </span>


### PR DESCRIPTION
### What does it do?

Prevent overflows, if folder names are very long.

| Before  | After  |
|---|---|
| <img width="946" alt="Screenshot 2022-06-08 at 13 28 57" src="https://user-images.githubusercontent.com/2244375/172616477-31561356-3e01-463c-8472-ae44ff52695d.png">  |  <img width="946" alt="Screenshot 2022-06-08 at 13 28 37" src="https://user-images.githubusercontent.com/2244375/172616465-8e4177b5-f933-42eb-8759-1196fd660b7d.png"> | 

### Why is it needed?

To support long folder names.
