### PR TITLE
Use `ctx._matchedRoute` instead of `ctx.request.url` for Sentry transaction name

### DIFF
--- a/packages/plugins/sentry/server/middlewares/sentry.js
+++ b/packages/plugins/sentry/server/middlewares/sentry.js
@@ -28,7 +28,7 @@ module.exports = ({ strapi }) => {
         });
 
         // Manually add transaction name
-        scope.setTag('transaction', `${ctx.method} ${ctx.request.url}`);
+        scope.setTag('transaction', `${ctx.method} ${ctx._matchedRoute}`);
         // Manually add Strapi version
         scope.setTag('strapi_version', strapi.config.info.strapi);
         scope.setTag('method', ctx.method);


### PR DESCRIPTION
Since in Sentry the transaction name is used for grouping similar events, using `request.url` will create a new event for every unique path, so `/users/1` and `/users/2` will be different transactions.

This change will use the [matched route path](https://github.com/koajs/router/blob/1aead99e0e0fdb8666e9c6fa2f52b0463c622025/API.md?plain=1#L83), which could look sth like `/users/:id` making the transactions grouped together properly (i.e. per route).