### PR TITLE
Fix "Knex: Timeout acquiring a connection. The pool is probably full. Are you missing a .transacting(trx) call?" on Content Type updates for Postgres 

### DIFF
--- a/packages/core/database/lib/dialects/postgresql/schema-inspector.js
+++ b/packages/core/database/lib/dialects/postgresql/schema-inspector.js
@@ -39,11 +39,11 @@ const SQL_QUERIES = {
       AND t.relname = ?;
   `,
   FOREIGN_KEY_LIST: /* sql */ `
-    SELECT
+   SELECT
       tco."constraint_name" as constraint_name,
       kcu."column_name" as column_name,
-      rel_kcu."table_name" as foreign_table,
-      rel_kcu."column_name" as fk_column_name,
+      kcu."table_name" as foreign_table,
+      kcu."column_name" as fk_column_name,
       rco.update_rule as on_update,
       rco.delete_rule as on_delete
     FROM information_schema.table_constraints tco
@@ -53,10 +53,6 @@ const SQL_QUERIES = {
     JOIN information_schema.referential_constraints rco
       ON tco.constraint_schema = rco.constraint_schema
       AND tco.constraint_name = rco.constraint_name
-    JOIN information_schema.key_column_usage rel_kcu
-      ON rco.unique_constraint_schema = rel_kcu.constraint_schema
-      AND rco.unique_constraint_name = rel_kcu.constraint_name
-      AND kcu.ordinal_position = rel_kcu.ordinal_position
     WHERE
       tco.constraint_type = 'FOREIGN KEY'
       AND tco.constraint_schema = ?


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?


Removed the extra joins & order conditions  while getting foreign keys  and as these joins were taking time and we were getting time out issue .

### Why is it needed?

Using Strapi in a Postgres database with 250+ schemas and tables with foreign keys, the SQL query to get the foreign keys using inner joins is  very slow, which giving knex timeout errow while adding / deleting any field in content type.

### How to test it?

Create 250+ schemas and add / delete any field in content type and start the strapi server . 


### Related issue(s)/PR(s)

https://github.com/strapi/strapi/issues/11860

