### PR TITLE
fix: Add dependency description for development environment.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,9 @@ schema.graphql
 front-workspace.code-workspace
 .yarn
 .yarnrc
+
+###########################
+# pyenv local version
+###########################
+
+.python-version

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,7 @@ The Strapi core team will review your pull request and either merge it, request 
 
 - You have [Node.js](https://nodejs.org/en/) at version >= v14 and <= v16 and [Yarn](https://yarnpkg.com/en/) at v1.2.0+ installed.
 - You are familiar with [Git](https://git-scm.com).
+- You Have [Python2](https://www.python.org/) at v2.7 installed.
 
 **Before submitting your pull request** make sure the following requirements are fulfilled:
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Add dependency descriptions for development environments.

### Why is it needed?

When I was building the build development environment (yarn setup) on my mac system, I found that it was executing with errors. After troubleshooting, I found that the reason is that my python version is python3, and the build environment dependency is python2. 
So I think I need to add a note about it in the documentation to avoid other contributors encountering similar problems.

### How to test it?

In a python3 environment, clone the project and execute yarn setup, and you will see the error. After changing the python version to python2, everything works fine.
