### PR TITLE
fix: content-types builder search button tooltip

### DIFF
--- a/packages/core/admin/admin/src/content-manager/pages/ListView/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/ListView/index.js
@@ -309,8 +309,8 @@ function ListView({
                     { target: headerLayoutTitle }
                   )}
                   placeholder={formatMessage({
-                    id: 'app.component.search.placeholder',
-                    defaultMessage: 'Search...',
+                    id: 'global.search',
+                    defaultMessage: 'Search',
                   })}
                   trackedEvent="didSearch"
                 />

--- a/packages/core/admin/admin/src/translations/en.json
+++ b/packages/core/admin/admin/src/translations/en.json
@@ -679,6 +679,7 @@
   "content-manager.apiError.This attribute must be unique": "{field} must be unique",
   "form.button.continue": "Continue",
   "form.button.done": "Done",
+  "global.search": "Search",
   "global.actions": "Actions",
   "global.back": "Back",
   "global.change-password": "Change password",

--- a/packages/core/admin/admin/src/translations/zh-Hans.json
+++ b/packages/core/admin/admin/src/translations/zh-Hans.json
@@ -604,7 +604,7 @@
   "content-type-builder.menu.section.single-types.name": "单一类型",
   "content-type-builder.plugin.name": "模型构建器",
   "form.button.done": "完成",
-  "global.Search": "搜索",
+  "global.search": "搜索",
   "global.back": "返回",
   "global.content-manager": "内容管理",
   "global.delete-target": "删除 {target}",

--- a/packages/core/content-type-builder/admin/src/components/ContentTypeBuilderNav/index.js
+++ b/packages/core/content-type-builder/admin/src/components/ContentTypeBuilderNav/index.js
@@ -36,7 +36,10 @@ const ContentTypeBuilderNav = () => {
           id: `${getTrad('plugin.name')}`,
           defaultMessage: 'Content-Types Builder',
         })}
-        searchLabel="Search..."
+        searchLabel={formatMessage({
+          id: 'content-manager.components.LeftMenu.Search.label',
+          defaultMessage: 'Search for a content type',
+        })}
       />
       <SubNavSections>
         {menu.map(section => {

--- a/packages/core/content-type-builder/admin/src/components/ContentTypeBuilderNav/index.js
+++ b/packages/core/content-type-builder/admin/src/components/ContentTypeBuilderNav/index.js
@@ -37,8 +37,8 @@ const ContentTypeBuilderNav = () => {
           defaultMessage: 'Content-Types Builder',
         })}
         searchLabel={formatMessage({
-          id: 'content-manager.components.LeftMenu.Search.label',
-          defaultMessage: 'Search for a content type',
+          id: 'global.search',
+          defaultMessage: 'Search',
         })}
       />
       <SubNavSections>

--- a/packages/core/helper-plugin/lib/src/components/SearchURLQuery/index.js
+++ b/packages/core/helper-plugin/lib/src/components/SearchURLQuery/index.js
@@ -71,7 +71,7 @@ const SearchURLQuery = ({ label, placeholder, trackedEvent }) => {
     <IconButton
       ref={iconButtonRef}
       icon={<Icon as={SearchIcon} color="neutral800" />}
-      label="Search"
+      label={formatMessage({ id: 'global.search', defaultMessage: 'Search' })}
       onClick={handleToggle}
     />
   );


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Adds tooltip functionality to the content-type builder's search button.

###  Why is it needed?

This is a missing feature, because in content-manager, the search button has tooltip. The code function is the same in both places, so it should be there in both, or neither.

###  How to test it?

You can see the tooltip on the button by passing the mouse over it.

