### PR TITLE
useEditAsset: Re-fetch folders after edit

### DIFF
--- a/packages/core/upload/admin/src/hooks/useEditAsset.js
+++ b/packages/core/upload/admin/src/hooks/useEditAsset.js
@@ -50,6 +50,7 @@ export const useEditAsset = () => {
       onSuccess: () => {
         queryClient.refetchQueries([pluginId, 'assets'], { active: true });
         queryClient.refetchQueries([pluginId, 'asset-count'], { active: true });
+        queryClient.refetchQueries([pluginId, 'folders'], { active: true });
       },
       onError: reason => {
         if (reason.response.status === 403) {


### PR DESCRIPTION
### What does it do?

Re-fetches folders, after an asset was edited. If an asset gets moved, the asset count on one or more folder cards might change.

### Why is it needed?

This PR ensures the counts are always in sync with the database.

### How to test it?

1. Move an asset into a sub-folder of your current folder.
2. Confirm the asset count of that sub-folder was updated.
