### PR TITLE
AssetDialog: Allow folders to be edited

### DIFF
--- a/packages/core/upload/admin/src/components/AssetDialog/BrowseStep/index.js
+++ b/packages/core/upload/admin/src/components/AssetDialog/BrowseStep/index.js
@@ -11,6 +11,8 @@ import { BaseCheckbox } from '@strapi/design-system/BaseCheckbox';
 import { GridItem } from '@strapi/design-system/Grid';
 import { Typography } from '@strapi/design-system/Typography';
 import { VisuallyHidden } from '@strapi/design-system/VisuallyHidden';
+import { IconButton } from '@strapi/design-system/IconButton';
+import PencilIcon from '@strapi/icons/Pencil';
 import PlusIcon from '@strapi/icons/Plus';
 
 import { FolderDefinition, AssetDefinition } from '../../../constants';
@@ -56,6 +58,7 @@ export const BrowseStep = ({
   onChangeSort,
   onChangeFolder,
   onEditAsset,
+  onEditFolder,
   onSelectAllAsset,
   onSelectAsset,
   pagination,
@@ -179,6 +182,18 @@ export const BrowseStep = ({
                   ariaLabel={folder.name}
                   id={`folder-${folder.uid}`}
                   onClick={() => onChangeFolder(folder.id)}
+                  cardActions={
+                    onEditFolder && (
+                      <IconButton
+                        icon={<PencilIcon />}
+                        aria-label={formatMessage({
+                          id: getTrad('list.folder.edit'),
+                          defaultMessage: 'Edit folder',
+                        })}
+                        onClick={() => onEditFolder(folder)}
+                      />
+                    )
+                  }
                 >
                   <FolderCardBody>
                     <FolderCardBodyAction onClick={() => onChangeFolder(folder.id)}>
@@ -257,6 +272,7 @@ BrowseStep.defaultProps = {
   multiple: false,
   onSelectAllAsset: undefined,
   onEditAsset: undefined,
+  onEditFolder: undefined,
 };
 
 BrowseStep.propTypes = {
@@ -273,6 +289,7 @@ BrowseStep.propTypes = {
   onChangeSort: PropTypes.func.isRequired,
   onChangeSearch: PropTypes.func.isRequired,
   onEditAsset: PropTypes.func,
+  onEditFolder: PropTypes.func,
   onSelectAsset: PropTypes.func.isRequired,
   onSelectAllAsset: PropTypes.func,
   queryObject: PropTypes.shape({

--- a/packages/core/upload/admin/src/components/AssetDialog/index.js
+++ b/packages/core/upload/admin/src/components/AssetDialog/index.js
@@ -25,6 +25,7 @@ import { DialogHeader } from './DialogHeader';
 import { DialogFooter } from './DialogFooter';
 import { EditAssetDialog } from '../EditAssetDialog';
 import { moveElement } from '../../utils/moveElement';
+import { EditFolderDialog } from '../EditFolderDialog';
 
 const LoadingBody = styled(Flex)`
   /* 80px are coming from the Tabs component that is not included in the ModalBody */
@@ -44,6 +45,7 @@ export const AssetDialog = ({
   trackedLocation,
 }) => {
   const [assetToEdit, setAssetToEdit] = useState(undefined);
+  const [folderToEdit, setFolderToEdit] = useState(undefined);
   const { formatMessage } = useIntl();
   const {
     canRead,
@@ -152,6 +154,10 @@ export const AssetDialog = ({
     );
   }
 
+  if (folderToEdit) {
+    return <EditFolderDialog folder={folderToEdit} onClose={() => setFolderToEdit(undefined)} />;
+  }
+
   const handleMoveItem = (hoverIndex, destIndex) => {
     const offset = destIndex - hoverIndex;
     const orderedAssetsClone = selectedAssets.slice();
@@ -228,6 +234,7 @@ export const AssetDialog = ({
                 multiple={multiple}
                 onSelectAllAsset={handleSelectAllAssets}
                 onEditAsset={canUpdate ? setAssetToEdit : undefined}
+                onEditFolder={canUpdate ? setFolderToEdit : undefined}
                 pagination={pagination}
                 queryObject={queryObject}
                 onAddAsset={onAddAsset}


### PR DESCRIPTION
### What does it do?

This PR allows users to edit folders directly from the `AssetDialog`.

### Why is it needed?

To be consistent with assets.
