### PR TITLE
[ML Folder] AssetDialog header improvements

### DIFF
--- a/packages/core/upload/admin/src/components/AssetDialog/DialogHeader.js
+++ b/packages/core/upload/admin/src/components/AssetDialog/DialogHeader.js
@@ -12,6 +12,18 @@ import { useFolderStructure } from '../../hooks/useFolderStructure';
 
 const BackButton = styled.button`
   height: ${({ theme }) => theme.spaces[4]};
+  color: ${({ theme }) => theme.colors.neutral500};
+
+  &:hover,
+  &:focus {
+    color: ${({ theme }) => theme.colors.neutral600};
+  }
+`;
+
+const BackIcon = styled(Icon)`
+  path {
+    fill: currentColor;
+  }
 `;
 
 export const DialogHeader = ({ currentFolder, onChangeFolder }) => {
@@ -35,17 +47,7 @@ export const DialogHeader = ({ currentFolder, onChangeFolder }) => {
             type="button"
             onClick={() => onChangeFolder(folderMetadatas?.parentId)}
           >
-            <Icon
-              colors={theme =>
-                `&:hover {
-                  path {
-                    fill: ${theme.colors.neutral600};
-                  }
-                }`}
-              height="100%"
-              color="neutral500"
-              as={ArrowLeft}
-            />
+            <BackIcon height="100%" as={ArrowLeft} />
           </BackButton>
         )}
         <Breadcrumbs

--- a/packages/core/upload/admin/src/components/AssetDialog/DialogHeader.js
+++ b/packages/core/upload/admin/src/components/AssetDialog/DialogHeader.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 import { Breadcrumbs, Crumb } from '@strapi/design-system/Breadcrumbs';
@@ -8,6 +9,10 @@ import { Icon } from '@strapi/design-system/Icon';
 import ArrowLeft from '@strapi/icons/ArrowLeft';
 import { findRecursiveFolderMetadatas, getTrad } from '../../utils';
 import { useFolderStructure } from '../../hooks/useFolderStructure';
+
+const BackButton = styled.button`
+  height: ${({ theme }) => theme.spaces[4]};
+`;
 
 export const DialogHeader = ({ currentFolder, onChangeFolder }) => {
   const { formatMessage } = useIntl();
@@ -25,13 +30,23 @@ export const DialogHeader = ({ currentFolder, onChangeFolder }) => {
     <ModalHeader>
       <Stack horizontal spacing={4}>
         {currentFolder && (
-          <button
+          <BackButton
             aria-label={formatMessage({ id: 'modal.header.go-back', defaultMessage: 'Go back' })}
             type="button"
             onClick={() => onChangeFolder(folderMetadatas?.parentId)}
           >
-            <Icon color="neutral500" as={ArrowLeft} />
-          </button>
+            <Icon
+              colors={theme =>
+                `&:hover {
+                  path {
+                    fill: ${theme.colors.neutral600};
+                  }
+                }`}
+              height="100%"
+              color="neutral500"
+              as={ArrowLeft}
+            />
+          </BackButton>
         )}
         <Breadcrumbs
           label={`${formatMessage({


### PR DESCRIPTION
## What

- Fixed back button + folder title alignment
- Added hover state to back button to make it more clear that an action is available

⚠️ wait for design approval before merging