### PR TITLE
ML: Redirect to root, if a folder throws 404

### DIFF
--- a/packages/core/upload/admin/src/hooks/__mocks__/useFolder.js
+++ b/packages/core/upload/admin/src/hooks/__mocks__/useFolder.js
@@ -1,0 +1,32 @@
+export const useFolder = jest.fn().mockReturnValue({
+  data: {
+    id: 1,
+    name: 'Folder 1',
+    children: {
+      count: 1,
+    },
+    createdAt: '',
+    files: {
+      count: 1,
+    },
+    path: '/1',
+    pathId: '1',
+    updatedAt: '',
+    parent: {
+      id: 2,
+      name: 'Folder 2',
+      children: {
+        count: 1,
+      },
+      createdAt: '',
+      files: {
+        count: 1,
+      },
+      path: '/1',
+      pathId: '1',
+      updatedAt: '',
+    },
+  },
+  isLoading: false,
+  error: null,
+});

--- a/packages/core/upload/admin/src/hooks/tests/useFolder.test.js
+++ b/packages/core/upload/admin/src/hooks/tests/useFolder.test.js
@@ -1,0 +1,112 @@
+import React from 'react';
+import { IntlProvider } from 'react-intl';
+import { QueryClientProvider, QueryClient } from 'react-query';
+import { renderHook, act } from '@testing-library/react-hooks';
+import { BrowserRouter as Router, Route } from 'react-router-dom';
+
+import { NotificationsProvider, useNotification } from '@strapi/helper-plugin';
+import { useNotifyAT } from '@strapi/design-system/LiveRegions';
+
+import { axiosInstance } from '../../utils';
+import { useFolder } from '../useFolder';
+
+const notifyStatusMock = jest.fn();
+
+jest.mock('@strapi/design-system/LiveRegions', () => ({
+  ...jest.requireActual('@strapi/design-system/LiveRegions'),
+  useNotifyAT: () => ({
+    notifyStatus: notifyStatusMock,
+  }),
+}));
+
+jest.mock('../../utils', () => ({
+  ...jest.requireActual('../../utils'),
+  axiosInstance: {
+    get: jest.fn().mockResolvedValue({
+      data: {
+        id: 1,
+      },
+    }),
+  },
+}));
+
+const notificationStatusMock = jest.fn();
+
+jest.mock('@strapi/helper-plugin', () => ({
+  ...jest.requireActual('@strapi/helper-plugin'),
+  useNotification: () => notificationStatusMock,
+}));
+
+const client = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+    },
+  },
+});
+
+// eslint-disable-next-line react/prop-types
+function ComponentFixture({ children }) {
+  return (
+    <Router>
+      <Route>
+        <QueryClientProvider client={client}>
+          <NotificationsProvider toggleNotification={() => jest.fn()}>
+            <IntlProvider locale="en" messages={{}}>
+              {children}
+            </IntlProvider>
+          </NotificationsProvider>
+        </QueryClientProvider>
+      </Route>
+    </Router>
+  );
+}
+
+function setup(...args) {
+  return new Promise(resolve => {
+    act(() => {
+      resolve(renderHook(() => useFolder(...args), { wrapper: ComponentFixture }));
+    });
+  });
+}
+
+describe('useFolder', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('fetches data from the right URL if no query param was set', async () => {
+    const { result, waitFor, waitForNextUpdate } = await setup(1, {});
+
+    await waitFor(() => result.current.isSuccess);
+    await waitForNextUpdate();
+
+    expect(axiosInstance.get).toBeCalledWith(`/upload/folders/1?populate=parent`);
+  });
+
+  test('it does not fetch, if enabled is set to false', async () => {
+    const { result, waitFor } = await setup(1, { enabled: false });
+
+    await waitFor(() => result.current.isSuccess);
+
+    expect(axiosInstance.get).toBeCalledTimes(0);
+  });
+
+  test('calls toggleNotification in case of error', async () => {
+    const originalConsoleError = console.error;
+    console.error = jest.fn();
+
+    axiosInstance.get.mockRejectedValueOnce(new Error('Jest mock error'));
+
+    const { notifyStatus } = useNotifyAT();
+    const toggleNotification = useNotification();
+    const { result, waitFor } = await setup(1, {});
+
+    await waitFor(() => !result.current.isLoading);
+
+    expect(toggleNotification).toBeCalled();
+    expect(notifyStatus).not.toBeCalled();
+
+    console.error = originalConsoleError;
+  });
+});

--- a/packages/core/upload/admin/src/hooks/useFolder.js
+++ b/packages/core/upload/admin/src/hooks/useFolder.js
@@ -1,0 +1,34 @@
+import { useQuery } from 'react-query';
+import { useNotification } from '@strapi/helper-plugin';
+
+import pluginId from '../pluginId';
+import { axiosInstance, getRequestUrl } from '../utils';
+
+export const useFolder = (id, { enabled = true }) => {
+  const toggleNotification = useNotification();
+  const dataRequestURL = getRequestUrl('folders');
+
+  const fetchFolder = async () => {
+    try {
+      const { data } = await axiosInstance.get(`${dataRequestURL}/${id}?populate=parent`);
+
+      return data.data;
+    } catch (err) {
+      toggleNotification({
+        type: 'warning',
+        message: { id: 'notification.error' },
+      });
+
+      throw err;
+    }
+  };
+
+  const { data, error, isLoading } = useQuery([pluginId, 'folder', id], fetchFolder, {
+    retry: false,
+    enabled,
+    staleTime: 0,
+    cacheTime: 0,
+  });
+
+  return { data, error, isLoading };
+};

--- a/packages/core/upload/admin/src/pages/App/components/Header.js
+++ b/packages/core/upload/admin/src/pages/App/components/Header.js
@@ -10,57 +10,44 @@ import { Stack } from '@strapi/design-system/Stack';
 import { Link } from '@strapi/design-system/Link';
 import ArrowLeft from '@strapi/icons/ArrowLeft';
 import Plus from '@strapi/icons/Plus';
-import { getTrad, findRecursiveFolderMetadatas } from '../../../utils';
-import { useFolderStructure } from '../../../hooks/useFolderStructure';
+import { getTrad } from '../../../utils';
+import { FolderDefinition } from '../../../constants';
 
 export const Header = ({
-  assetCount,
-  folderCount,
   canCreate,
   onToggleEditFolderDialog,
   onToggleUploadAssetDialog,
+  folder,
 }) => {
   const { formatMessage } = useIntl();
   const { pathname } = useLocation();
-  const [
-    {
-      query: { folder, ...queryParamsWithoutFolder },
-    },
-  ] = useQueryParams();
-
-  const { data, isLoading } = useFolderStructure();
-  const isNestedFolder = !!folder;
-  const folderMetadatas = !isLoading && findRecursiveFolderMetadatas(data[0], folder);
-  const backQuery = stringify(
-    folderMetadatas?.parentId
-      ? { ...queryParamsWithoutFolder, folder: folderMetadatas.parentId }
-      : { ...queryParamsWithoutFolder },
-    { encode: false }
-  );
-
-  const folderLabel =
-    folderMetadatas?.currentFolderLabel &&
-    (folderMetadatas.currentFolderLabel.length > 30
-      ? `${folderMetadatas.currentFolderLabel.slice(0, 30)}...`
-      : folderMetadatas.currentFolderLabel);
+  const [{ query }] = useQueryParams();
+  const backQuery = {
+    ...query,
+    folder: folder?.parent?.id ?? undefined,
+  };
+  const name = folder?.name?.length > 30 ? `${folder.name.slice(0, 30)}...` : folder?.name;
 
   return (
     <HeaderLayout
       title={`${formatMessage({
         id: getTrad('plugin.name'),
         defaultMessage: `Media Library`,
-      })}${folderLabel ? ` - ${folderLabel}` : ''}`}
+      })}${name ? ` - ${name}` : ''}`}
       subtitle={formatMessage(
         {
           id: getTrad('header.content.assets'),
           defaultMessage:
             '{numberFolders, plural, one {1 folder} other {# folders}} - {numberAssets, plural, one {1 asset} other {# assets}}',
         },
-        { numberAssets: assetCount, numberFolders: folderCount }
+        { numberAssets: folder?.files?.count ?? 0, numberFolders: folder?.children?.count ?? 0 }
       )}
       navigationAction={
-        isNestedFolder && (
-          <Link startIcon={<ArrowLeft />} to={`${pathname}?${backQuery}`}>
+        folder?.parent && (
+          <Link
+            startIcon={<ArrowLeft />}
+            to={`${pathname}?${stringify(backQuery, { encode: false })}`}
+          >
             {formatMessage({
               id: getTrad('header.actions.folder-level-up'),
               defaultMessage: 'Back',
@@ -91,9 +78,12 @@ export const Header = ({
   );
 };
 
+Header.defaultProps = {
+  folder: null,
+};
+
 Header.propTypes = {
-  assetCount: PropTypes.number.isRequired,
-  folderCount: PropTypes.number.isRequired,
+  folder: PropTypes.shape(FolderDefinition),
   canCreate: PropTypes.bool.isRequired,
   onToggleEditFolderDialog: PropTypes.func.isRequired,
   onToggleUploadAssetDialog: PropTypes.func.isRequired,

--- a/packages/core/upload/admin/src/pages/App/tests/Header.test.js
+++ b/packages/core/upload/admin/src/pages/App/tests/Header.test.js
@@ -7,14 +7,40 @@ import { MemoryRouter } from 'react-router-dom';
 import { IntlProvider } from 'react-intl';
 
 import { Header } from '../components/Header';
-import { useFolderStructure } from '../../../hooks/useFolderStructure';
-
-jest.mock('../../../hooks/useFolderStructure');
 
 jest.mock('@strapi/helper-plugin', () => ({
   ...jest.requireActual('@strapi/helper-plugin'),
   useQueryParams: jest.fn().mockReturnValue([{ query: {}, rawQuery: '' }, jest.fn()]),
 }));
+
+const FIXTURE_FOLDER = {
+  id: 1,
+  name: 'Folder 1',
+  children: {
+    count: 1,
+  },
+  createdAt: '',
+  files: {
+    count: 1,
+  },
+  path: '/1',
+  pathId: '1',
+  updatedAt: '',
+  parent: {
+    id: 2,
+    name: 'Folder 2',
+    children: {
+      count: 1,
+    },
+    createdAt: '',
+    files: {
+      count: 1,
+    },
+    path: '/1',
+    pathId: '1',
+    updatedAt: '',
+  },
+};
 
 const setup = props => {
   const withDefaults = {
@@ -54,50 +80,29 @@ describe('Header', () => {
   });
 
   test('renders', () => {
-    const { container } = setup();
+    const { container } = setup({ folder: FIXTURE_FOLDER });
 
     expect(container).toMatchSnapshot();
   });
 
   test('truncates long folder lavels', () => {
     useQueryParams.mockReturnValueOnce([{ rawQuery: '', query: { folder: 2 } }, jest.fn()]);
-    useFolderStructure.mockReturnValueOnce({
-      isLoading: false,
-      error: null,
-      data: [
-        {
-          value: null,
-          label: 'Media Library',
-          children: [
-            {
-              value: 1,
-              label: 'Cats',
-              children: [
-                {
-                  value: 2,
-                  label: 'The length of this label exceeds the maximum',
-                  children: [],
-                },
-              ],
-            },
-          ],
-        },
-      ],
-    });
 
-    const { queryByText } = setup();
+    const { queryByText } = setup({
+      folder: { ...FIXTURE_FOLDER, name: 'The length of this label exceeds the maximum length' },
+    });
     expect(queryByText('Media Library - The length of this label excee...')).toBeInTheDocument();
   });
 
   test('does not render a back button at the root level of the media library', () => {
-    const { queryByText } = setup();
+    const { queryByText } = setup({ folder: { ...FIXTURE_FOLDER, parent: null } });
 
     expect(queryByText('Back')).not.toBeInTheDocument();
   });
 
   test('does render a back button at a nested level of the media library', () => {
     useQueryParams.mockReturnValueOnce([{ rawQuery: '', query: { folder: 2 } }, jest.fn()]);
-    const { queryByText } = setup();
+    const { queryByText } = setup({ folder: FIXTURE_FOLDER });
 
     expect(queryByText('Back')).toBeInTheDocument();
   });

--- a/packages/core/upload/admin/src/pages/App/tests/MediaLibrary.test.js
+++ b/packages/core/upload/admin/src/pages/App/tests/MediaLibrary.test.js
@@ -54,7 +54,7 @@ const FIXTURE_ASSETS = [
 
 jest.mock('../../../hooks/useMediaLibraryPermissions');
 jest.mock('../../../hooks/useFolders');
-jest.mock('../../../hooks/useFolderStructure');
+jest.mock('../../../hooks/useFolder');
 jest.mock('../../../hooks/useAssets');
 
 jest.mock('@strapi/helper-plugin', () => ({

--- a/packages/core/upload/admin/src/pages/App/tests/__snapshots__/Header.test.js.snap
+++ b/packages/core/upload/admin/src/pages/App/tests/__snapshots__/Header.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Header renders 1`] = `
-.c15 {
+.c20 {
   border: 0;
   -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
@@ -13,18 +13,18 @@ exports[`Header renders 1`] = `
   width: 1px;
 }
 
-.c12 {
+.c17 {
   font-weight: 600;
   color: #32324d;
   font-size: 0.75rem;
   line-height: 1.33;
 }
 
-.c9 {
+.c14 {
   padding-right: 8px;
 }
 
-.c6 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -38,21 +38,21 @@ exports[`Header renders 1`] = `
   outline: none;
 }
 
-.c6 svg {
+.c11 svg {
   height: 12px;
   width: 12px;
 }
 
-.c6 svg > g,
-.c6 svg path {
+.c11 svg > g,
+.c11 svg path {
   fill: #ffffff;
 }
 
-.c6[aria-disabled='true'] {
+.c11[aria-disabled='true'] {
   pointer-events: none;
 }
 
-.c6:after {
+.c11:after {
   -webkit-transition-property: all;
   transition-property: all;
   -webkit-transition-duration: 0.2s;
@@ -67,11 +67,11 @@ exports[`Header renders 1`] = `
   border: 2px solid transparent;
 }
 
-.c6:focus-visible {
+.c11:focus-visible {
   outline: none;
 }
 
-.c6:focus-visible:after {
+.c11:focus-visible:after {
   border-radius: 8px;
   content: '';
   position: absolute;
@@ -82,11 +82,11 @@ exports[`Header renders 1`] = `
   border: 2px solid #4945ff;
 }
 
-.c10 {
+.c15 {
   height: 100%;
 }
 
-.c7 {
+.c12 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -98,7 +98,7 @@ exports[`Header renders 1`] = `
   background: #f0f0ff;
 }
 
-.c7 .c8 {
+.c12 .c13 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -109,66 +109,66 @@ exports[`Header renders 1`] = `
   align-items: center;
 }
 
-.c7 .c11 {
+.c12 .c16 {
   color: #ffffff;
 }
 
-.c7[aria-disabled='true'] {
+.c12[aria-disabled='true'] {
   border: 1px solid #dcdce4;
   background: #eaeaef;
 }
 
-.c7[aria-disabled='true'] .c11 {
+.c12[aria-disabled='true'] .c16 {
   color: #666687;
 }
 
-.c7[aria-disabled='true'] svg > g,
-.c7[aria-disabled='true'] svg path {
+.c12[aria-disabled='true'] svg > g,
+.c12[aria-disabled='true'] svg path {
   fill: #666687;
 }
 
-.c7[aria-disabled='true']:active {
+.c12[aria-disabled='true']:active {
   border: 1px solid #dcdce4;
   background: #eaeaef;
 }
 
-.c7[aria-disabled='true']:active .c11 {
+.c12[aria-disabled='true']:active .c16 {
   color: #666687;
 }
 
-.c7[aria-disabled='true']:active svg > g,
-.c7[aria-disabled='true']:active svg path {
+.c12[aria-disabled='true']:active svg > g,
+.c12[aria-disabled='true']:active svg path {
   fill: #666687;
 }
 
-.c7:hover {
+.c12:hover {
   background-color: #ffffff;
 }
 
-.c7:active {
+.c12:active {
   background-color: #ffffff;
   border: 1px solid #4945ff;
 }
 
-.c7:active .c11 {
+.c12:active .c16 {
   color: #4945ff;
 }
 
-.c7:active svg > g,
-.c7:active svg path {
+.c12:active svg > g,
+.c12:active svg path {
   fill: #4945ff;
 }
 
-.c7 .c11 {
+.c12 .c16 {
   color: #271fe0;
 }
 
-.c7 svg > g,
-.c7 svg path {
+.c12 svg > g,
+.c12 svg path {
   fill: #271fe0;
 }
 
-.c13 {
+.c18 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -178,7 +178,7 @@ exports[`Header renders 1`] = `
   border: 1px solid #4945ff;
 }
 
-.c13 .c8 {
+.c18 .c13 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -189,54 +189,54 @@ exports[`Header renders 1`] = `
   align-items: center;
 }
 
-.c13 .c11 {
+.c18 .c16 {
   color: #ffffff;
 }
 
-.c13[aria-disabled='true'] {
+.c18[aria-disabled='true'] {
   border: 1px solid #dcdce4;
   background: #eaeaef;
 }
 
-.c13[aria-disabled='true'] .c11 {
+.c18[aria-disabled='true'] .c16 {
   color: #666687;
 }
 
-.c13[aria-disabled='true'] svg > g,
-.c13[aria-disabled='true'] svg path {
+.c18[aria-disabled='true'] svg > g,
+.c18[aria-disabled='true'] svg path {
   fill: #666687;
 }
 
-.c13[aria-disabled='true']:active {
+.c18[aria-disabled='true']:active {
   border: 1px solid #dcdce4;
   background: #eaeaef;
 }
 
-.c13[aria-disabled='true']:active .c11 {
+.c18[aria-disabled='true']:active .c16 {
   color: #666687;
 }
 
-.c13[aria-disabled='true']:active svg > g,
-.c13[aria-disabled='true']:active svg path {
+.c18[aria-disabled='true']:active svg > g,
+.c18[aria-disabled='true']:active svg path {
   fill: #666687;
 }
 
-.c13:hover {
+.c18:hover {
   border: 1px solid #7b79ff;
   background: #7b79ff;
 }
 
-.c13:active {
+.c18:active {
   border: 1px solid #4945ff;
   background: #4945ff;
 }
 
-.c13 svg > g,
-.c13 svg path {
+.c18 svg > g,
+.c18 svg path {
   fill: #ffffff;
 }
 
-.c4 {
+.c9 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -250,24 +250,28 @@ exports[`Header renders 1`] = `
   flex-direction: row;
 }
 
-.c5 > * {
+.c10 > * {
   margin-left: 0;
   margin-right: 0;
 }
 
-.c5 > * + * {
+.c10 > * + * {
   margin-left: 8px;
 }
 
 .c0 {
   background: #f6f6f9;
-  padding-top: 40px;
+  padding-top: 24px;
   padding-right: 56px;
   padding-bottom: 40px;
   padding-left: 56px;
 }
 
 .c1 {
+  padding-bottom: 8px;
+}
+
+.c6 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -285,7 +289,7 @@ exports[`Header renders 1`] = `
   justify-content: space-between;
 }
 
-.c2 {
+.c7 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -299,17 +303,87 @@ exports[`Header renders 1`] = `
   flex-direction: row;
 }
 
-.c3 {
+.c8 {
   color: #32324d;
   font-weight: 600;
   font-size: 2rem;
   line-height: 1.25;
 }
 
-.c14 {
+.c19 {
   color: #666687;
   font-size: 1rem;
   line-height: 1.5;
+}
+
+.c5 {
+  color: #4945ff;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
+.c3 {
+  padding-right: 8px;
+}
+
+.c2 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  position: relative;
+  outline: none;
+}
+
+.c2 svg path {
+  fill: #4945ff;
+}
+
+.c2 svg {
+  font-size: 0.625rem;
+}
+
+.c2:after {
+  -webkit-transition-property: all;
+  transition-property: all;
+  -webkit-transition-duration: 0.2s;
+  transition-duration: 0.2s;
+  border-radius: 8px;
+  content: '';
+  position: absolute;
+  top: -4px;
+  bottom: -4px;
+  left: -4px;
+  right: -4px;
+  border: 2px solid transparent;
+}
+
+.c2:focus-visible {
+  outline: none;
+}
+
+.c2:focus-visible:after {
+  border-radius: 8px;
+  content: '';
+  position: absolute;
+  top: -5px;
+  bottom: -5px;
+  left: -5px;
+  right: -5px;
+  border: 2px solid #4945ff;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
 }
 
 <div>
@@ -323,27 +397,59 @@ exports[`Header renders 1`] = `
       <div
         class="c1"
       >
+        <a
+          aria-current="page"
+          class="c2 active"
+          href="/?folder=2"
+        >
+          <span
+            aria-hidden="true"
+            class="c3 c4"
+          >
+            <svg
+              fill="none"
+              height="1em"
+              viewBox="0 0 24 24"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M24 13.3a.2.2 0 01-.2.2H5.74l8.239 8.239a.2.2 0 010 .282L12.14 23.86a.2.2 0 01-.282 0L.14 12.14a.2.2 0 010-.282L11.86.14a.2.2 0 01.282 0L13.98 1.98a.2.2 0 010 .282L5.74 10.5H23.8c.11 0 .2.09.2.2v2.6z"
+                fill="#212134"
+              />
+            </svg>
+          </span>
+          <span
+            class="c5"
+          >
+            Back
+          </span>
+        </a>
+      </div>
+      <div
+        class="c6"
+      >
         <div
-          class="c2"
+          class="c7"
         >
           <h1
-            class="c3"
+            class="c8"
           >
-            Media Library
+            Media Library - Folder 1
           </h1>
         </div>
         <div
-          class="c4 c5"
+          class="c9 c10"
           spacing="2"
         >
           <button
             aria-disabled="false"
-            class="c6 c7"
+            class="c11 c12"
             type="button"
           >
             <div
               aria-hidden="true"
-              class="c8 c9 c10"
+              class="c13 c14 c15"
             >
               <svg
                 fill="none"
@@ -359,19 +465,19 @@ exports[`Header renders 1`] = `
               </svg>
             </div>
             <span
-              class="c11 c12"
+              class="c16 c17"
             >
               Add new folder
             </span>
           </button>
           <button
             aria-disabled="false"
-            class="c6 c13"
+            class="c11 c18"
             type="button"
           >
             <div
               aria-hidden="true"
-              class="c8 c9 c10"
+              class="c13 c14 c15"
             >
               <svg
                 fill="none"
@@ -387,7 +493,7 @@ exports[`Header renders 1`] = `
               </svg>
             </div>
             <span
-              class="c11 c12"
+              class="c16 c17"
             >
               Add new assets
             </span>
@@ -395,14 +501,14 @@ exports[`Header renders 1`] = `
         </div>
       </div>
       <p
-        class="c14"
+        class="c19"
       >
-        2 folders - 2 assets
+        1 folder - 1 asset
       </p>
     </div>
   </div>
   <div
-    class="c15"
+    class="c20"
   >
     <p
       aria-live="polite"


### PR DESCRIPTION
### What does it do?

This PR introduces a new hook `useFolder()` which fetches a single folder by id, since `useFolders()` will never throw a 404 HTTP status code.

It also refactors the media library header a bit, to make it easier to understand and to remove the need to fetch the whole folder structure each time.

### Why is it needed?

To have a proper 404 state.

### How to test it?

Navigate to a folder id that does not exist.
