### PR TITLE
useBulkMove: Always re-fetch folders after a move action

### DIFF
--- a/packages/core/upload/admin/src/hooks/tests/useBulkMove.test.js
+++ b/packages/core/upload/admin/src/hooks/tests/useBulkMove.test.js
@@ -177,23 +177,22 @@ describe('useBulkMove', () => {
     const toggleNotification = useNotification();
     const queryClient = useQueryClient();
 
-    const {
-      result: { current },
-      waitFor,
-    } = await setup();
-    const { move } = current;
+    const { result, waitFor } = await setup();
+    const { move } = result.current;
 
     await act(async () => {
       await move(FIXTURE_DESTINATION_FOLDER_ID, FIXTURE_ASSETS);
     });
 
-    await waitFor(() =>
-      expect(queryClient.refetchQueries).toHaveBeenCalledWith(['upload', 'assets'], {
-        active: true,
-      })
-    );
+    await waitFor(() => !result.current.isLoading);
 
-    await waitFor(() => expect(toggleNotification).toHaveBeenCalled());
+    expect(queryClient.refetchQueries).toHaveBeenCalledWith(['upload', 'assets'], {
+      active: true,
+    });
+    expect(queryClient.refetchQueries).toHaveBeenCalledWith(['upload', 'folders'], {
+      active: true,
+    });
+    expect(toggleNotification).toHaveBeenCalled();
   });
 
   test('does re-fetch folders, if folders were deleted', async () => {

--- a/packages/core/upload/admin/src/hooks/useBulkMove.js
+++ b/packages/core/upload/admin/src/hooks/useBulkMove.js
@@ -37,9 +37,9 @@ export const useBulkMove = () => {
         queryClient.refetchQueries([pluginId, 'asset-count'], { active: true });
       }
 
-      if (data?.folders?.length > 0) {
-        queryClient.refetchQueries([pluginId, 'folders'], { active: true });
-      }
+      // folders need to be re-fetched in any case, because assets might have been
+      // moved into a sub-folder and therefore the count needs to be updated
+      queryClient.refetchQueries([pluginId, 'folders'], { active: true });
 
       toggleNotification({
         type: 'success',


### PR DESCRIPTION
### What does it do?

After a bulk-move action folder always need to be re-fetched, to keep the file counts up-to-date.

### Why is it needed?

Fixes a bug similar but not equal to https://github.com/strapi/strapi/pull/13537.

### How to test it?

You can rely on the automated tests.
