### PR TITLE
[ML Folder] Fix count info in EditFolderDialog

### DIFF
--- a/packages/core/upload/admin/src/components/EditFolderDialog/EditFolderDialog.js
+++ b/packages/core/upload/admin/src/components/EditFolderDialog/EditFolderDialog.js
@@ -152,11 +152,11 @@ export const EditFolderDialog = ({ onClose, folder, parentFolderId }) => {
                             value: formatMessage(
                               {
                                 id: getTrad('modal.folder.elements.count'),
-                                defaultMessage: '{assetCount} assets, {folderCount} folders',
+                                defaultMessage: '{folderCount} folders, {assetCount} assets',
                               },
                               {
                                 assetCount: folder?.files?.count ?? 0,
-                                folderCount: folder?.children?.length ?? 0,
+                                folderCount: folder?.children?.count ?? 0,
                               }
                             ),
                           },

--- a/packages/core/upload/admin/src/translations/en.json
+++ b/packages/core/upload/admin/src/translations/en.json
@@ -59,6 +59,7 @@
   "modal.file-details.dimensions": "Dimensions",
   "modal.file-details.extension": "Extension",
   "modal.file-details.size": "Size",
+  "modal.folder.elements.count": "{folderCount} folders, {assetCount} assets",
   "modal.header.browse": "Upload assets",
   "modal.header.file-detail": "Details",
   "modal.header.pending-assets": "Pending assets",


### PR DESCRIPTION
## What

Fixed folder count not showing in EditFolderDialog
Fixed count information format

## Snapshot

<img width="875" alt="image" src="https://user-images.githubusercontent.com/71838159/173624875-a53303d1-98b1-4ff2-8991-d4502dee9f92.png">
