### PR TITLE
FolderCard: Increase icon size

### DIFF
--- a/packages/core/upload/admin/src/components/AssetDialog/BrowseStep/tests/__snapshots__/index.test.js.snap
+++ b/packages/core/upload/admin/src/components/AssetDialog/BrowseStep/tests/__snapshots__/index.test.js.snap
@@ -1193,9 +1193,9 @@ exports[`BrowseStep renders and match snapshot 1`] = `
                   <svg
                     class="c35"
                     fill="none"
-                    height="1.125rem"
+                    height="1.5rem"
                     viewBox="0 0 24 24"
-                    width="1.25rem"
+                    width="1.5rem"
                     xmlns="http://www.w3.org/2000/svg"
                   >
                     <path

--- a/packages/core/upload/admin/src/components/FolderCard/FolderCard/FolderCard.js
+++ b/packages/core/upload/admin/src/components/FolderCard/FolderCard/FolderCard.js
@@ -85,7 +85,7 @@ export const FolderCard = forwardRef(
               paddingRight={3}
               paddingTop={2}
             >
-              <StyledFolder width={pxToRem(20)} height={pxToRem(18)} />
+              <StyledFolder width={pxToRem(24)} height={pxToRem(24)} />
             </Box>
 
             {children}

--- a/packages/core/upload/admin/src/components/FolderCard/tests/__snapshots__/FolderCard.test.js.snap
+++ b/packages/core/upload/admin/src/components/FolderCard/tests/__snapshots__/FolderCard.test.js.snap
@@ -260,9 +260,9 @@ exports[`FolderCard has all required ids set when rendering a start action 1`] =
         <svg
           class="c8"
           fill="none"
-          height="1.125rem"
+          height="1.5rem"
           viewBox="0 0 24 24"
-          width="1.25rem"
+          width="1.5rem"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path
@@ -504,9 +504,9 @@ exports[`FolderCard renders and matches the snapshot 1`] = `
         <svg
           class="c6"
           fill="none"
-          height="1.125rem"
+          height="1.5rem"
           viewBox="0 0 24 24"
-          width="1.25rem"
+          width="1.5rem"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path


### PR DESCRIPTION
### What does it do?

This PR increases / fixes the size of the folder icon.

Signed off by @maevalienard.

### Why is it needed?

To look 💅🏼 .
