### PR TITLE
EditAssetDialog: Disable location select field conditionally

### DIFF
--- a/packages/core/upload/admin/src/components/EditAssetDialog/index.js
+++ b/packages/core/upload/admin/src/components/EditAssetDialog/index.js
@@ -270,6 +270,7 @@ export const EditAssetDialog = ({
                         }}
                         menuPortalTarget={document.querySelector('body')}
                         inputId="asset-folder"
+                        disabled={formDisabled}
                         {...(errors.parent
                           ? {
                               'aria-errormessage': 'folder-parent-error',


### PR DESCRIPTION
### What does it do?

Properly set the `disabled` prop on the location field of the `EditAssetDialog`, if the user does not have permissions or is in cropping mode, same as all other fields.

### Why is it needed?

Consistent UI.