### PR TITLE
[GraphQL] Enable filtering on nested components

### DIFF
--- a/packages/plugins/graphql/server/services/builders/filters/content-type.js
+++ b/packages/plugins/graphql/server/services/builders/filters/content-type.js
@@ -50,7 +50,10 @@ module.exports = ({ strapi }) => {
           // Handle relations
           else if (isRelation(attribute)) {
             addRelationalAttribute(t, attributeName, attribute);
-          } else if (isComponent(attribute)) {
+          }
+
+          // Handle components
+          else if (isComponent(attribute)) {
             addComponentAttribute(t, attributeName, attribute);
           }
         }

--- a/packages/plugins/graphql/server/services/utils/mappers/graphql-filters-to-strapi-query.js
+++ b/packages/plugins/graphql/server/services/utils/mappers/graphql-filters-to-strapi-query.js
@@ -42,7 +42,7 @@ module.exports = ({ strapi }) => {
      * @return {object | object[]}
      */
     graphQLFiltersToStrapiQuery(filters, contentType = {}) {
-      const { isStrapiScalar, isMedia, isRelation } = getService('utils').attributes;
+      const { isStrapiScalar, isMedia, isRelation, isComponent } = getService('utils').attributes;
       const { operators } = getService('builders').filters;
 
       const ROOT_LEVEL_OPERATORS = [operators.and, operators.or, operators.not];
@@ -85,6 +85,16 @@ module.exports = ({ strapi }) => {
             // Recursively apply the mapping to the value using the fetched model,
             // and update the value within `resultMap`
             resultMap[key] = this.graphQLFiltersToStrapiQuery(value, relModel);
+          }
+
+          // If it's a deep filter on a component
+          else if (isComponent(attribute)) {
+            // Fetch the model from the component attribute
+            const componentModel = strapi.getModel(attribute.component);
+
+            // Recursively apply the mapping to the value using the fetched model,
+            // and update the value within `resultMap`
+            resultMap[key] = this.graphQLFiltersToStrapiQuery(value, componentModel);
           }
         }
 


### PR DESCRIPTION
_Based on an original idea from @reimertz in #13267_

## What does it do?
Adds support for filters on nested components in the GraphQL content API

## How to test it

### Content-Type
![image](https://user-images.githubusercontent.com/25851739/174029862-e0ec2ffb-a1dd-460f-bae1-dc9e5f9497af.png)

### Schema
Entity

```json
{
  "kind": "collectionType",
  "collectionName": "entities",
  "info": {
    "singularName": "entity",
    "pluralName": "entities",
    "displayName": "Entity"
  },
  "options": {
    "draftAndPublish": false
  },
  "pluginOptions": {},
  "attributes": {
    "comp1": {
      "type": "component",
      "repeatable": false,
      "component": "basic.comp1"
    }
  }
}
```

Comp1
```json
{
  "collectionName": "components_basic_comp1s",
  "info": {
    "displayName": "Comp1",
    "icon": "align-center"
  },
  "options": {},
  "attributes": {
    "comp2": {
      "displayName": "Comp2",
      "type": "component",
      "repeatable": true,
      "component": "basic.comp2"
    }
  }
}

```

Comp2
```json
{
  "collectionName": "components_basic_comp2s",
  "info": {
    "displayName": "Comp2",
    "icon": "arrow-circle-left"
  },
  "options": {},
  "attributes": {
    "field": {
      "type": "string"
    }
  }
}

```
### Query

```gql
query {
  entities(filters: { comp1: { comp2: { field: { contains: "My" } } } }) {
    data {
      attributes {
        comp1 {
          comp2 {
            field
          }
        }
      }
    }
  }
}
```

This query should return only the `entities` where at least one of the `comp2`'s `field` values in their `comp1` attribute contains the string `My` 
