### PR TITLE
fix(content-type-builder/attribute-option): align text to the left

### DIFF
--- a/packages/core/content-type-builder/admin/src/components/AttributeOptions/AttributeOption/BoxWrapper.js
+++ b/packages/core/content-type-builder/admin/src/components/AttributeOptions/AttributeOption/BoxWrapper.js
@@ -5,6 +5,7 @@ const BoxWrapper = styled(Box)`
   width: 100%;
   height: 100%;
   border: 1px solid ${({ theme }) => theme.colors.neutral200};
+  text-align: left;
   &:hover {
     background: ${({ theme }) => theme.colors.primary100};
     border: 1px solid ${({ theme }) => theme.colors.primary200};


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Aligns the content within the AttributeOption component to the left.

### Why is it needed?

While working on polish translations for the Admin panel I noticed that there's a problem with alignment for longer descriptions inside the component box (AttributeOption).

<img width="823" alt="Zrzut ekranu 2022-05-26 o 18 34 00" src="https://user-images.githubusercontent.com/23500678/174050591-5f681d06-f3b5-4ae1-914e-12e578dc9203.png">


### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
