### PR TITLE
fix: added new eqi operator for case insensitive equal search

### DIFF
--- a/packages/core/database/lib/query/helpers/where.js
+++ b/packages/core/database/lib/query/helpers/where.js
@@ -13,7 +13,7 @@ const OPERATORS = [
   '$in',
   '$notIn',
   '$eq',
-  '$eqsi',
+  '$eqi',
   '$ne',
   '$gt',
   '$gte',
@@ -223,7 +223,7 @@ const applyOperator = (qb, column, operator, value) => {
       break;
     }
 
-    case '$eqsi': {
+    case '$eqi': {
       if (value === null) {
         qb.whereNull(column);
         break;

--- a/packages/core/database/lib/query/helpers/where.js
+++ b/packages/core/database/lib/query/helpers/where.js
@@ -13,6 +13,7 @@ const OPERATORS = [
   '$in',
   '$notIn',
   '$eq',
+  '$eqsi',
   '$ne',
   '$gt',
   '$gte',
@@ -219,6 +220,15 @@ const applyOperator = (qb, column, operator, value) => {
       }
 
       qb.where(column, value);
+      break;
+    }
+
+    case '$eqsi': {
+      if (value === null) {
+        qb.whereNull(column);
+        break;
+      }
+      qb.whereRaw(`${fieldLowerFn(qb)} LIKE LOWER(?)`, [column, `${value}`]);
       break;
     }
     case '$ne': {

--- a/packages/core/strapi/tests/filtering.test.e2e.js
+++ b/packages/core/strapi/tests/filtering.test.e2e.js
@@ -168,14 +168,14 @@ describe('Filtering API', () => {
       });
     });
     describe('Filter equals with case insensitive', () => {
-      test('Should be usable with eqsi suffix', async () => {
+      test('Should be usable with eqi suffix', async () => {
         const res = await rq({
           method: 'GET',
           url: '/products',
           qs: {
             filters: {
               name: {
-                $eqsi: 'PRODuct 1',
+                $eqi: 'PRODuct 1',
               },
             },
           },
@@ -192,7 +192,7 @@ describe('Filtering API', () => {
           qs: {
             filters: {
               name: {
-                $eqsi: 'Product non existant',
+                $eqi: 'Product non existant',
               },
             },
           },

--- a/packages/core/strapi/tests/filtering.test.e2e.js
+++ b/packages/core/strapi/tests/filtering.test.e2e.js
@@ -167,6 +167,40 @@ describe('Filtering API', () => {
         expect(res.body.data).toEqual([]);
       });
     });
+    describe('Filter equals with case insensitive', () => {
+      test('Should be usable with eqsi suffix', async () => {
+        const res = await rq({
+          method: 'GET',
+          url: '/products',
+          qs: {
+            filters: {
+              name: {
+                $eqsi: 'PRODuct 1',
+              },
+            },
+          },
+        });
+
+        expect(res.body.data.length).toBe(1);
+        expect(res.body.data[0]).toMatchObject(data.product[0]);
+      });
+
+      test('Should return an empty array when no match', async () => {
+        const res = await rq({
+          method: 'GET',
+          url: '/products',
+          qs: {
+            filters: {
+              name: {
+                $eqsi: 'Product non existant',
+              },
+            },
+          },
+        });
+
+        expect(res.body.data).toEqual([]);
+      });
+    });
 
     describe('Filter not equals', () => {
       test('Should return an array with matching entities', async () => {

--- a/packages/plugins/graphql/server/services/builders/filters/operators/eqi.js
+++ b/packages/plugins/graphql/server/services/builders/filters/operators/eqi.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const EQI_FIELD_NAME = 'eqi';
+
+module.exports = () => ({
+  fieldName: EQI_FIELD_NAME,
+
+  strapiOperator: '$eqi',
+
+  add(t, type) {
+    t.field(EQI_FIELD_NAME, { type });
+  },
+});

--- a/packages/plugins/graphql/server/services/builders/filters/operators/index.js
+++ b/packages/plugins/graphql/server/services/builders/filters/operators/index.js
@@ -8,6 +8,7 @@ const operators = {
   not: require('./not'),
 
   eq: require('./eq'),
+  eqi: require('./eqi'),
   ne: require('./ne'),
 
   startsWith: require('./starts-with'),

--- a/packages/plugins/graphql/server/services/constants.js
+++ b/packages/plugins/graphql/server/services/constants.js
@@ -85,6 +85,7 @@ const allOperators = [
   'not',
 
   'eq',
+  'eqi',
   'ne',
 
   'startsWith',

--- a/packages/plugins/graphql/tests/crud.test.e2e.js
+++ b/packages/plugins/graphql/tests/crud.test.e2e.js
@@ -294,6 +294,12 @@ describe('Test Graphql API End to End', () => {
       ],
       [
         {
+          category: { eqi: 'Blog' },
+        },
+        [postsPayload[0]],
+      ],
+      [
+        {
           name: { contains: 'post' },
         },
         postsPayload,


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?
This PR will add a new operator `$eqi` to perform an case insensitive equal comparison.

Describe the technical changes you did.

### Why is it needed?
Currently in strapi, we have equal(`$eq`) - case sensitive and $constainsi as contains(case insensitive) operator. However in some of the scenarios, we need the equal operator with case insensitive(Specially to compare the url names or parameters). 

Describe the issue you are solving.
To  filter using case insensitive equal operator.

### How to test it?
Add the `$eqi` to any filter query - similar to `$eq`

Provide information about the environment and the path to verify the behavior.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
