### PR TITLE
SelectTree: Fix collapsing/ expanding options with proper order

### DIFF
--- a/packages/core/upload/admin/src/components/SelectTree/utils/getOpenValues.js
+++ b/packages/core/upload/admin/src/components/SelectTree/utils/getOpenValues.js
@@ -1,4 +1,4 @@
-function getOpenValues(options, defaultValue) {
+function getOpenValues(options, defaultValue = {}) {
   let values = [];
   const { value } = defaultValue;
   const option = options.find(option => option.value === value);
@@ -11,7 +11,7 @@ function getOpenValues(options, defaultValue) {
 
   let { parent } = option;
 
-  while (parent) {
+  while (parent !== undefined) {
     // eslint-disable-next-line no-loop-func
     const option = options.find(({ value }) => value === parent);
 
@@ -19,7 +19,7 @@ function getOpenValues(options, defaultValue) {
     parent = option.parent;
   }
 
-  return values;
+  return values.reverse();
 }
 
 export default getOpenValues;

--- a/packages/core/upload/admin/src/components/SelectTree/utils/getValuesToClose.js
+++ b/packages/core/upload/admin/src/components/SelectTree/utils/getValuesToClose.js
@@ -1,0 +1,7 @@
+function getValuesToClose(options, value) {
+  const optionForValue = options.find(option => option.value === value);
+
+  return options.filter(option => option.depth >= optionForValue.depth).map(option => option.value);
+}
+
+export default getValuesToClose;

--- a/packages/core/upload/admin/src/components/SelectTree/utils/tests/getOpenvalues.test.js
+++ b/packages/core/upload/admin/src/components/SelectTree/utils/tests/getOpenvalues.test.js
@@ -3,26 +3,32 @@ import getOpenValues from '../getOpenValues';
 
 const FIXTURE = flattenTree([
   {
-    value: 'f-1',
-    label: 'Folder 1',
-  },
-
-  {
-    value: 'f-2',
-    label: 'Folder 2',
+    value: null,
+    label: 'Media Library',
     children: [
       {
-        value: 'f-2-1',
-        label: 'Folder 2-1',
+        value: 'f-1',
+        label: 'Folder 1',
       },
 
       {
-        value: 'f-2-2',
-        label: 'Folder 2-2',
+        value: 'f-2',
+        label: 'Folder 2',
         children: [
           {
-            value: 'f-2-2-1',
-            label: 'Folder 2-2-1',
+            value: 'f-2-1',
+            label: 'Folder 2-1',
+          },
+
+          {
+            value: 'f-2-2',
+            label: 'Folder 2-2',
+            children: [
+              {
+                value: 'f-2-2-1',
+                label: 'Folder 2-2-1',
+              },
+            ],
           },
         ],
       },
@@ -32,14 +38,27 @@ const FIXTURE = flattenTree([
 
 describe('getOpenValues', () => {
   test('returns 1 value for depth = 1', () => {
-    expect(getOpenValues(FIXTURE, { value: 'f-1' })).toStrictEqual(['f-1']);
+    expect(getOpenValues(FIXTURE, { value: null })).toStrictEqual([null]);
   });
 
-  test('returns 2 values for depth = 2', () => {
-    expect(getOpenValues(FIXTURE, { value: 'f-2-1' })).toStrictEqual(['f-2-1', 'f-2']);
+  test('returns 0 values for depth = 1 and no value', () => {
+    expect(getOpenValues(FIXTURE, undefined)).toStrictEqual([]);
   });
 
-  test('returns 3 values for depth = 3', () => {
-    expect(getOpenValues(FIXTURE, { value: 'f-2-2-1' })).toStrictEqual(['f-2-2-1', 'f-2-2', 'f-2']);
+  test('returns 1 value for depth = 2', () => {
+    expect(getOpenValues(FIXTURE, { value: 'f-1' })).toStrictEqual([null, 'f-1']);
+  });
+
+  test('returns 2 values for depth = 3', () => {
+    expect(getOpenValues(FIXTURE, { value: 'f-2-1' })).toStrictEqual([null, 'f-2', 'f-2-1']);
+  });
+
+  test('returns 3 values for depth = 4', () => {
+    expect(getOpenValues(FIXTURE, { value: 'f-2-2-1' })).toStrictEqual([
+      null,
+      'f-2',
+      'f-2-2',
+      'f-2-2-1',
+    ]);
   });
 });

--- a/packages/core/upload/admin/src/components/SelectTree/utils/tests/getValuesToClose.test.js
+++ b/packages/core/upload/admin/src/components/SelectTree/utils/tests/getValuesToClose.test.js
@@ -1,0 +1,64 @@
+import flattenTree from '../flattenTree';
+import getValuesToClose from '../getValuesToClose';
+
+const FIXTURE = flattenTree([
+  {
+    value: null,
+    label: 'Media Library',
+    children: [
+      {
+        value: 'f-1',
+        label: 'Folder 1',
+      },
+
+      {
+        value: 'f-2',
+        label: 'Folder 2',
+        children: [
+          {
+            value: 'f-2-1',
+            label: 'Folder 2-1',
+          },
+
+          {
+            value: 'f-2-2',
+            label: 'Folder 2-2',
+            children: [
+              {
+                value: 'f-2-2-1',
+                label: 'Folder 2-2-1',
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+]);
+
+describe('getValuesToClose', () => {
+  test('returns all value for depth = 1', () => {
+    expect(getValuesToClose(FIXTURE, null)).toStrictEqual([
+      null,
+      'f-1',
+      'f-2',
+      'f-2-1',
+      'f-2-2',
+      'f-2-2-1',
+    ]);
+  });
+
+  test('returns some values for depth = 2', () => {
+    expect(getValuesToClose(FIXTURE, 'f-1')).toStrictEqual([
+      'f-1',
+      'f-2',
+      'f-2-1',
+      'f-2-2',
+      'f-2-2-1',
+    ]);
+  });
+
+  test('returns some values for depth = 3', () => {
+    expect(getValuesToClose(FIXTURE, 'f-2-1')).toStrictEqual(['f-2-1', 'f-2-2', 'f-2-2-1']);
+  });
+});


### PR DESCRIPTION
### What does it do?

Fixes the way the `SelectTree` component handles expanding/ collapsing its options. The previous implementation had various problems:

- `null` (root) could not be expanded
- options appeared in the wrong nesting order
- only children at the lowest depth level were opened

This PR reworks the overall logic and fixes all of the above errors.

https://user-images.githubusercontent.com/2244375/174140837-566c7c64-f152-4a11-bbf2-d46d5967a5f4.mp4

### Why is it needed?

To properly support the tree select component.

