### PR TITLE
Change error type according to standard practice

### DIFF
--- a/packages/plugins/users-permissions/server/controllers/auth.js
+++ b/packages/plugins/users-permissions/server/controllers/auth.js
@@ -18,7 +18,7 @@ const {
 } = require('./validation/auth');
 
 const { getAbsoluteAdminUrl, getAbsoluteServerUrl, sanitize } = utils;
-const { ApplicationError, ValidationError } = utils.errors;
+const { ApplicationError, ValidationError, UnauthorizedError } = utils.errors;
 
 const emailRegExp = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
 
@@ -59,7 +59,7 @@ module.exports = {
       const user = await strapi.query('plugin::users-permissions.user').findOne({ where: query });
 
       if (!user) {
-        throw new ValidationError('Invalid identifier or password');
+        throw new UnauthorizedError('Invalid identifier or password');
       }
 
       if (
@@ -86,7 +86,7 @@ module.exports = {
       );
 
       if (!validPassword) {
-        throw new ValidationError('Invalid identifier or password');
+        throw new UnauthorizedError('Invalid identifier or password');
       } else {
         ctx.send({
           jwt: getService('jwt').issue({


### PR DESCRIPTION
Refused Authorization should return unauthorized error instead of validation error.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

The Error type returned when invalid credentials have been provided has been changed from validation error to unauthorized error.

### Why is it needed?

According to [RFC7235 Section 3.1](https://www.rfc-editor.org/rfc/rfc7235#section-3.1):

> The 401 (Unauthorized) status code indicates that the request has not been applied because it lacks valid authentication credentials for the target resource. The server generating a 401 response MUST send a WWW-Authenticate header field (Section 4.1) containing at least one challenge applicable to the target resource.
>If the request included authentication credentials, then the 401 response indicates that authorization has been refused for those credentials. The user agent MAY repeat the request with a new or replaced Authorization header field (Section 4.2).

### How to test it?

Attempting to call /api/auth/local with invalid credentials will return 400 error instead of 401.
The proposed change fixes this issue.

### Related issue(s)/PR(s)

Issues discussing this error were unable to be found.