### PR TITLE
Add two new kurdish languages

### DIFF
--- a/packages/plugins/i18n/server/constants/iso-locales.json
+++ b/packages/plugins/i18n/server/constants/iso-locales.json
@@ -284,6 +284,14 @@
     "name":"Central Kurdish (ckb)"
   },
   {
+    "code":"kmr",
+    "name":"Northern Kurdish (kmr)"
+  },
+  {
+    "code":"sdh",
+    "name":"Southern Kurdish (sdh)"
+  },
+  {
     "code":"tzm",
     "name":"Central Morocco Tamazight (tzm)"
   },

--- a/packages/plugins/i18n/server/services/__tests__/__snapshots__/iso-locales.test.js.snap
+++ b/packages/plugins/i18n/server/services/__tests__/__snapshots__/iso-locales.test.js.snap
@@ -287,6 +287,14 @@ Array [
     "name": "Central Kurdish (ckb)",
   },
   Object {
+    "code": "kmr",
+    "name": "Northern Kurdish (kmr)",
+  },
+  Object {
+    "code": "sdh",
+    "name": "Southern Kurdish (sdh)",
+  },
+  Object {
     "code": "tzm",
     "name": "Central Morocco Tamazight (tzm)",
   },


### PR DESCRIPTION
I've just added two new Individual Kurdish Languages

We need this two new languages since there were only Central Kurdish (CKB) available

The current test already cover the file I've changed so no other steps are needed