### PR TITLE
[ML folder] Search nested elements

### DIFF
--- a/packages/core/upload/admin/src/components/AssetDialog/BrowseStep/index.js
+++ b/packages/core/upload/admin/src/components/AssetDialog/BrowseStep/index.js
@@ -80,6 +80,13 @@ export const BrowseStep = ({
   const assetCount = assets.length;
   const folderCount = folders.length;
 
+  const handleClickFolderCard = id => {
+    // Search query will always fetch the same results
+    // we remove it here to allow navigating in a folder and see the result of this navigation
+    onChangeSearch('');
+    onChangeFolder(id);
+  };
+
   return (
     <Stack spacing={4}>
       {onSelectAllAsset && (
@@ -181,7 +188,7 @@ export const BrowseStep = ({
                 <FolderCard
                   ariaLabel={folder.name}
                   id={`folder-${folder.id}`}
-                  onClick={() => onChangeFolder(folder.id)}
+                  onClick={() => handleClickFolderCard(folder.id)}
                   cardActions={
                     onEditFolder && (
                       <IconButton
@@ -196,7 +203,7 @@ export const BrowseStep = ({
                   }
                 >
                   <FolderCardBody>
-                    <FolderCardBodyAction onClick={() => onChangeFolder(folder.id)}>
+                    <FolderCardBodyAction onClick={() => handleClickFolderCard(folder.id)}>
                       <Flex as="h2" direction="column" alignItems="start" maxWidth="100%">
                         <TypographyMaxWidth fontWeight="semiBold" ellipsis>
                           {folder.name}

--- a/packages/core/upload/admin/src/components/AssetDialog/BrowseStep/index.js
+++ b/packages/core/upload/admin/src/components/AssetDialog/BrowseStep/index.js
@@ -80,11 +80,11 @@ export const BrowseStep = ({
   const assetCount = assets.length;
   const folderCount = folders.length;
 
-  const handleClickFolderCard = id => {
+  const handleClickFolderCard = (...args) => {
     // Search query will always fetch the same results
     // we remove it here to allow navigating in a folder and see the result of this navigation
     onChangeSearch('');
-    onChangeFolder(id);
+    onChangeFolder(...args);
   };
 
   return (

--- a/packages/core/upload/admin/src/hooks/tests/useAssets.test.js
+++ b/packages/core/upload/admin/src/hooks/tests/useAssets.test.js
@@ -152,6 +152,30 @@ describe('useAssets', () => {
     );
   });
 
+  test('does not use folder filter in params if _q', async () => {
+    const { result, waitFor, waitForNextUpdate } = await setup({
+      query: { folder: 5, _q: 'something', filters: { $and: [{ something: 'true' }] } },
+    });
+
+    await waitFor(() => result.current.isSuccess);
+    await waitForNextUpdate();
+
+    const expected = {
+      filters: {
+        $and: [
+          {
+            something: true,
+          },
+        ],
+      },
+      _q: 'something',
+    };
+
+    expect(axiosInstance.get).toBeCalledWith(
+      `/upload/files?${stringify(expected, { encode: false })}`
+    );
+  });
+
   test('it does not fetch, if skipWhen is set', async () => {
     const { result, waitFor } = await setup({ skipWhen: true });
 

--- a/packages/core/upload/admin/src/hooks/tests/useFolders.test.js
+++ b/packages/core/upload/admin/src/hooks/tests/useFolders.test.js
@@ -104,6 +104,33 @@ describe('useFolders', () => {
     );
   });
 
+  test('does not use parent filter in params if _q', async () => {
+    const { result, waitFor, waitForNextUpdate } = await setup({
+      query: { folder: 5, _q: 'something', filters: { $and: [{ something: 'true' }] } },
+    });
+
+    await waitFor(() => result.current.isSuccess);
+    await waitForNextUpdate();
+
+    const expected = {
+      filters: {
+        $and: [
+          {
+            something: 'true',
+          },
+        ],
+      },
+      pagination: {
+        pageSize: -1,
+      },
+      _q: 'something',
+    };
+
+    expect(axiosInstance.get).toBeCalledWith(
+      `/upload/folders?${stringify(expected, { encode: false })}`
+    );
+  });
+
   test('fetches data from the right URL if a query param was set', async () => {
     const { result, waitFor, waitForNextUpdate } = await setup({ query: { folder: 1 } });
 

--- a/packages/core/upload/admin/src/hooks/useAssets.js
+++ b/packages/core/upload/admin/src/hooks/useAssets.js
@@ -13,10 +13,17 @@ export const useAssets = ({ skipWhen = false, query = {} } = {}) => {
   const { notifyStatus } = useNotifyAT();
   const dataRequestURL = getRequestUrl('files');
   const { folder, _q, ...paramsExceptFolderAndQ } = query;
-  const params = {
-    ...paramsExceptFolderAndQ,
-    ...(_q && { _q }),
-    ...(!_q && {
+
+  let params;
+
+  if (_q) {
+    params = {
+      ...paramsExceptFolderAndQ,
+      _q,
+    };
+  } else {
+    params = {
+      ...paramsExceptFolderAndQ,
       filters: {
         $and: [
           ...(query?.filters?.$and ?? []),
@@ -29,8 +36,8 @@ export const useAssets = ({ skipWhen = false, query = {} } = {}) => {
           },
         ],
       },
-    }),
-  };
+    };
+  }
 
   const getAssets = async () => {
     try {

--- a/packages/core/upload/admin/src/hooks/useAssets.js
+++ b/packages/core/upload/admin/src/hooks/useAssets.js
@@ -12,21 +12,24 @@ export const useAssets = ({ skipWhen = false, query = {} } = {}) => {
   const toggleNotification = useNotification();
   const { notifyStatus } = useNotifyAT();
   const dataRequestURL = getRequestUrl('files');
-  const { folder, ...paramsExceptFolder } = query;
+  const { folder, _q, ...paramsExceptFolderAndQ } = query;
   const params = {
-    ...paramsExceptFolder,
-    filters: {
-      $and: [
-        ...(query?.filters?.$and ?? []),
-        {
-          folder: {
-            id: query?.folder ?? {
-              $null: true,
+    ...paramsExceptFolderAndQ,
+    ...(_q && { _q }),
+    ...(!_q && {
+      filters: {
+        $and: [
+          ...(query?.filters?.$and ?? []),
+          {
+            folder: {
+              id: query?.folder ?? {
+                $null: true,
+              },
             },
           },
-        },
-      ],
-    },
+        ],
+      },
+    }),
   };
 
   const getAssets = async () => {

--- a/packages/core/upload/admin/src/hooks/useAssets.js
+++ b/packages/core/upload/admin/src/hooks/useAssets.js
@@ -26,10 +26,10 @@ export const useAssets = ({ skipWhen = false, query = {} } = {}) => {
       ...paramsExceptFolderAndQ,
       filters: {
         $and: [
-          ...(query?.filters?.$and ?? []),
+          ...(paramsExceptFolderAndQ?.filters?.$and ?? []),
           {
             folder: {
-              id: query?.folder ?? {
+              id: folder ?? {
                 $null: true,
               },
             },

--- a/packages/core/upload/admin/src/hooks/useFolders.js
+++ b/packages/core/upload/admin/src/hooks/useFolders.js
@@ -12,24 +12,28 @@ export const useFolders = ({ enabled = true, query = {} }) => {
   const toggleNotification = useNotification();
   const { notifyStatus } = useNotifyAT();
   const dataRequestURL = getRequestUrl('folders');
-  const { folder, ...paramsExceptFolder } = query;
+  const { folder, _q, ...paramsExceptFolderAndQ } = query;
+
   const params = {
-    ...paramsExceptFolder,
+    ...paramsExceptFolderAndQ,
     pagination: {
       pageSize: -1,
     },
-    filters: {
-      $and: [
-        ...(query?.filters?.$and ?? []),
-        {
-          parent: {
-            id: query?.folder ?? {
-              $null: true,
+    ...(_q && { _q }),
+    ...(!_q && {
+      filters: {
+        $and: [
+          ...(query?.filters?.$and ?? []),
+          {
+            parent: {
+              id: query?.folder ?? {
+                $null: true,
+              },
             },
           },
-        },
-      ],
-    },
+        ],
+      },
+    }),
   };
 
   const fetchFolders = async () => {

--- a/packages/core/upload/admin/src/hooks/useFolders.js
+++ b/packages/core/upload/admin/src/hooks/useFolders.js
@@ -19,17 +19,23 @@ export const useFolders = ({ enabled = true, query = {} }) => {
   if (_q) {
     params = {
       ...paramsExceptFolderAndQ,
+      pagination: {
+        pageSize: -1,
+      },
       _q,
     };
   } else {
     params = {
       ...paramsExceptFolderAndQ,
+      pagination: {
+        pageSize: -1,
+      },
       filters: {
         $and: [
-          ...(query?.filters?.$and ?? []),
+          ...(paramsExceptFolderAndQ?.filters?.$and ?? []),
           {
             parent: {
-              id: query?.folder ?? {
+              id: folder ?? {
                 $null: true,
               },
             },

--- a/packages/core/upload/admin/src/hooks/useFolders.js
+++ b/packages/core/upload/admin/src/hooks/useFolders.js
@@ -14,13 +14,16 @@ export const useFolders = ({ enabled = true, query = {} }) => {
   const dataRequestURL = getRequestUrl('folders');
   const { folder, _q, ...paramsExceptFolderAndQ } = query;
 
-  const params = {
-    ...paramsExceptFolderAndQ,
-    pagination: {
-      pageSize: -1,
-    },
-    ...(_q && { _q }),
-    ...(!_q && {
+  let params;
+
+  if (_q) {
+    params = {
+      ...paramsExceptFolderAndQ,
+      _q,
+    };
+  } else {
+    params = {
+      ...paramsExceptFolderAndQ,
       filters: {
         $and: [
           ...(query?.filters?.$and ?? []),
@@ -33,8 +36,8 @@ export const useFolders = ({ enabled = true, query = {} }) => {
           },
         ],
       },
-    }),
-  };
+    };
+  }
 
   const fetchFolders = async () => {
     try {

--- a/packages/core/upload/admin/src/pages/App/MediaLibrary.js
+++ b/packages/core/upload/admin/src/pages/App/MediaLibrary.js
@@ -244,8 +244,9 @@ export const MediaLibrary = () => {
                     const isSelected = !!selectedFolders.find(
                       currentFolder => currentFolder.id === folder.id
                     );
+                    const { _q, ...queryParamsWithoutQ } = query;
                     const url = `${pathname}?${stringify({
-                      ...query,
+                      ...queryParamsWithoutQ,
                       folder: folder.id,
                     })}`;
 

--- a/packages/core/upload/admin/src/pages/App/MediaLibrary.js
+++ b/packages/core/upload/admin/src/pages/App/MediaLibrary.js
@@ -244,6 +244,9 @@ export const MediaLibrary = () => {
                     const isSelected = !!selectedFolders.find(
                       currentFolder => currentFolder.id === folder.id
                     );
+
+                    // Search query will always fetch the same results
+                    // we remove it here to allow navigating in a folder and see the result of this navigation
                     const { _q, ...queryParamsWithoutQ } = query;
                     const url = `${pathname}?${stringify({
                       ...queryParamsWithoutQ,


### PR DESCRIPTION
## What

- Removed folder filter when searching to allow nested search
- Removed search param when clicking on a FolderCard to allow navigating in a folder after a search - if not the search query will always send the same result even after entering a new folder

## Test

Create nested folders with assets
Go to ML root and search for an asset in a nested folder
Without manually removing the search, navigate to a folder
See the folder result 

## Snapshot

<img width="860" alt="image" src="https://user-images.githubusercontent.com/71838159/174606444-40378897-e9a7-49e9-a5d2-8065e3d1e6f6.png">
