### PR TITLE
fixed active style of React Select option

### DIFF
--- a/packages/core/helper-plugin/lib/src/components/ReactSelect/utils/getSelectStyles.js
+++ b/packages/core/helper-plugin/lib/src/components/ReactSelect/utils/getSelectStyles.js
@@ -79,7 +79,15 @@ const getSelectStyles = (theme, error) => {
         backgroundColor = theme.colors.primary100;
       }
 
-      return { ...base, lineHeight: theme.spaces[5], backgroundColor, borderRadius: 4 };
+      return {
+        ...base,
+        lineHeight: theme.spaces[5],
+        backgroundColor,
+        borderRadius: 4,
+        '&:active': {
+          backgroundColor: theme.colors.primary100,
+        },
+      };
     },
     placeholder: base => ({ ...base, marginLeft: 0 }),
     singleValue: base => ({ ...base, marginLeft: 0, color: theme.colors.neutral800 }),


### PR DESCRIPTION
## What

Fixed active style on React Select option: removed blue background when clicking on an option

## Snapshots

_Before_
<img width="345" alt="Screenshot 2022-06-20 at 21 25 34" src="https://user-images.githubusercontent.com/71838159/174666866-126c008c-6bd0-4889-8ae7-1367d992072a.png">


_After_
<img width="394" alt="Screenshot 2022-06-20 at 21 23 48" src="https://user-images.githubusercontent.com/71838159/174666879-c60f48bf-7af8-467f-87d9-4c26db9f82d2.png">

