### PR TITLE
Wysiwyg: Update system font-family

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/Wysiwyg/EditorStylesContainer.js
+++ b/packages/core/admin/admin/src/content-manager/components/Wysiwyg/EditorStylesContainer.js
@@ -16,7 +16,7 @@ export const EditorStylesContainer = styled.div`
     height: ${({ isExpandMode }) => (isExpandMode ? '100%' : '290px')};
     color: ${({ theme }) => theme.colors.neutral800};
     direction: ltr;
-    font-family: --apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell,
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell,
       'Open Sans', 'Helvetica Neue', sans-serif;
   }
 

--- a/packages/core/admin/admin/src/content-manager/components/Wysiwyg/tests/index.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/Wysiwyg/tests/index.test.js
@@ -626,7 +626,7 @@ describe('Wysiwyg render and actions buttons', () => {
         height: 290px;
         color: #32324d;
         direction: ltr;
-        font-family: --apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen,Ubuntu,Cantarell, 'Open Sans','Helvetica Neue',sans-serif;
+        font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen,Ubuntu,Cantarell, 'Open Sans','Helvetica Neue',sans-serif;
       }
 
       .c34 .CodeMirror-lines {


### PR DESCRIPTION
> **Warning**
> To merge after [#13618](https://github.com/strapi/strapi/pull/13618).

### What does it do?

Corresponding PR for https://github.com/strapi/design-system/pull/630. At the moment we are using the wrong system font identifier on apple devices. This PR fixes that for the richtext editor component.

### Why is it needed?

To properly render the UI.

### Related issue(s)/PR(s)

- https://github.com/strapi/design-system/pull/630
- https://github.com/strapi/design-system/issues/629
- Refs #13618
