### PR TITLE
Fix CORS response headers.

### DIFF
--- a/packages/core/strapi/lib/middlewares/cors.js
+++ b/packages/core/strapi/lib/middlewares/cors.js
@@ -40,7 +40,7 @@ module.exports = config => {
 
       const requestOrigin = ctx.accept.headers.origin;
       if (whitelist.includes('*')) {
-        return '*';
+        return credentials ? requestOrigin : '*';
       }
 
       if (!whitelist.includes(requestOrigin)) {


### PR DESCRIPTION
### What does it do?

It fixes invalid CORS headers returned by default by strapi middleware.

### Why is it needed?

Because the combination of `Access-Control-Allow-Credentials: true` and
`Access-Control-Allow-Origin: *` is illegal and requests can be blocked by browsers.

### Related issue(s)/PR(s)

https://stackoverflow.com/questions/70639958/strapi-v4-throwing-cors-exception

