### PR TITLE
[Marketplace] add link to the providers detail page on strapi market

### DIFF
--- a/packages/core/admin/admin/src/pages/MarketplacePage/components/NpmPackageCard/index.js
+++ b/packages/core/admin/admin/src/pages/MarketplacePage/components/NpmPackageCard/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 import styled from 'styled-components';
+import pluralize from 'pluralize';
 import { Box } from '@strapi/design-system/Box';
 import { Stack } from '@strapi/design-system/Stack';
 import { Typography } from '@strapi/design-system/Typography';
@@ -47,10 +48,9 @@ const NpmPackageCard = ({
     defaultMessage: 'Made by Strapi',
   });
 
-  const npmPackageHref =
-    npmPackageType === 'provider'
-      ? attributes.npmPackageUrl
-      : `https://market.strapi.io/plugins/${attributes.slug}`;
+  const npmPackageHref = `https://market.strapi.io/${pluralize.plural(npmPackageType)}/${
+    attributes.slug
+  }`;
 
   return (
     <Flex


### PR DESCRIPTION
### What does it do?
Changes the link on the providers cards from the npm page to the strapi market page.

### Why is it needed?
Users should end up on Strapi market

### How to test it?

Go to the Marketplace 
Click the providers tab
Click "learn more" on a provider, it should take you to Strapi market.

⚠️ The page doesn't exist yet since we are still waiting for that PR to be merged on the website ⚠️ 
