### PR TITLE
Show installed providers as already installed on marketplace

### DIFF
--- a/packages/core/admin/admin/src/hooks/useFetchEnabledPlugins/index.js
+++ b/packages/core/admin/admin/src/hooks/useFetchEnabledPlugins/index.js
@@ -1,11 +1,11 @@
 import { useQuery } from 'react-query';
 import { useNotification } from '@strapi/helper-plugin';
-import { fetchInstalledPlugins } from './utils/api';
+import { fetchEnabledPlugins } from './utils/api';
 
-const useFetchInstalledPlugins = notifyLoad => {
+const useFetchEnabledPlugins = notifyLoad => {
   const toggleNotification = useNotification();
 
-  return useQuery('list-installed-plugins', () => fetchInstalledPlugins(), {
+  return useQuery('list-enabled-plugins', () => fetchEnabledPlugins(), {
     onSuccess: () => {
       if (notifyLoad) {
         notifyLoad();
@@ -20,4 +20,4 @@ const useFetchInstalledPlugins = notifyLoad => {
   });
 };
 
-export default useFetchInstalledPlugins;
+export default useFetchEnabledPlugins;

--- a/packages/core/admin/admin/src/hooks/useFetchEnabledPlugins/utils/api.js
+++ b/packages/core/admin/admin/src/hooks/useFetchEnabledPlugins/utils/api.js
@@ -1,9 +1,9 @@
 import { axiosInstance } from '../../../core/utils';
 
-const fetchInstalledPlugins = async () => {
+const fetchEnabledPlugins = async () => {
   const { data } = await axiosInstance.get('/admin/plugins');
 
   return data;
 };
 
-export { fetchInstalledPlugins };
+export { fetchEnabledPlugins };

--- a/packages/core/admin/admin/src/pages/InstalledPluginsPage/Plugins.js
+++ b/packages/core/admin/admin/src/pages/InstalledPluginsPage/Plugins.js
@@ -6,7 +6,7 @@ import { Layout, HeaderLayout, ContentLayout } from '@strapi/design-system/Layou
 import { Main } from '@strapi/design-system/Main';
 import { Typography } from '@strapi/design-system/Typography';
 import { Table, Thead, Tbody, Tr, Td, Th } from '@strapi/design-system/Table';
-import useFetchInstalledPlugins from '../../hooks/useFetchInstalledPlugins';
+import useFetchEnabledPlugins from '../../hooks/useFetchEnabledPlugins';
 
 const Plugins = () => {
   const { formatMessage } = useIntl();
@@ -30,7 +30,7 @@ const Plugins = () => {
     );
   };
 
-  const { status, data } = useFetchInstalledPlugins(notifyPluginPageLoad);
+  const { status, data } = useFetchEnabledPlugins(notifyPluginPageLoad);
 
   const isLoading = status !== 'success' && status !== 'error';
 

--- a/packages/core/admin/admin/src/pages/MarketplacePage/components/NpmPackageCard/index.js
+++ b/packages/core/admin/admin/src/pages/MarketplacePage/components/NpmPackageCard/index.js
@@ -27,7 +27,7 @@ const EllipsisText = styled(Typography)`
 
 const NpmPackageCard = ({
   npmPackage,
-  installedPackageNames,
+  isInstalled,
   useYarn,
   isInDevelopmentMode,
   npmPackageType,
@@ -35,8 +35,6 @@ const NpmPackageCard = ({
   const { attributes } = npmPackage;
   const { formatMessage } = useIntl();
   const { trackUsage } = useTracking();
-
-  const isInstalled = installedPackageNames.includes(attributes.npmPackageName);
 
   const commandToCopy = useYarn
     ? `yarn add ${attributes.npmPackageName}`
@@ -167,7 +165,7 @@ NpmPackageCard.propTypes = {
       strapiCompatibility: PropTypes.oneOf(['v3', 'v4']),
     }).isRequired,
   }).isRequired,
-  installedPackageNames: PropTypes.arrayOf(PropTypes.string).isRequired,
+  isInstalled: PropTypes.bool.isRequired,
   useYarn: PropTypes.bool.isRequired,
   isInDevelopmentMode: PropTypes.bool,
   npmPackageType: PropTypes.string.isRequired,

--- a/packages/core/admin/admin/src/pages/MarketplacePage/components/NpmPackagesGrid/index.js
+++ b/packages/core/admin/admin/src/pages/MarketplacePage/components/NpmPackagesGrid/index.js
@@ -12,7 +12,7 @@ const NpmPackagesGrid = ({
 }) => {
   return (
     <Grid gap={4}>
-      {npmPackages.map((npmPackage) => (
+      {npmPackages.map(npmPackage => (
         <GridItem col={4} s={6} xs={12} style={{ height: '100%' }} key={npmPackage.id}>
           <NpmPackageCard
             npmPackage={npmPackage}

--- a/packages/core/admin/admin/src/pages/MarketplacePage/components/NpmPackagesGrid/index.js
+++ b/packages/core/admin/admin/src/pages/MarketplacePage/components/NpmPackagesGrid/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { Grid, GridItem } from '@strapi/design-system/Grid';
 import NpmPackageCard from '../NpmPackageCard';
@@ -10,13 +10,19 @@ const NpmPackagesGrid = ({
   isInDevelopmentMode,
   npmPackageType,
 }) => {
+  // Check if an individual package is in the dependencies
+  const checkAlreadyInstalled = useCallback(
+    npmPackageName => installedPackageNames.includes(npmPackageName),
+    [installedPackageNames]
+  );
+
   return (
     <Grid gap={4}>
       {npmPackages.map(npmPackage => (
         <GridItem col={4} s={6} xs={12} style={{ height: '100%' }} key={npmPackage.id}>
           <NpmPackageCard
             npmPackage={npmPackage}
-            installedPackageNames={installedPackageNames}
+            isInstalled={checkAlreadyInstalled(npmPackage.attributes.npmPackageName)}
             useYarn={useYarn}
             isInDevelopmentMode={isInDevelopmentMode}
             npmPackageType={npmPackageType}

--- a/packages/core/admin/admin/src/pages/MarketplacePage/index.js
+++ b/packages/core/admin/admin/src/pages/MarketplacePage/index.js
@@ -262,6 +262,7 @@ const MarketPlacePage = () => {
                 ) : (
                   <NpmPackagesGrid
                     npmPackages={providerSearchResults}
+                    installedPackageNames={installedPackageNames}
                     useYarn={useYarn}
                     isInDevelopmentMode={isInDevelopmentMode}
                     npmPackageType="provider"

--- a/packages/core/admin/admin/src/pages/MarketplacePage/tests/index.test.js
+++ b/packages/core/admin/admin/src/pages/MarketplacePage/tests/index.test.js
@@ -29,7 +29,11 @@ jest.mock('@strapi/helper-plugin', () => ({
   pxToRem: jest.fn(),
   CheckPagePermissions: ({ children }) => children,
   useTracking: jest.fn(() => ({ trackUsage: jest.fn() })),
-  useAppInfos: jest.fn(() => ({ autoReload: true })),
+  useAppInfos: jest.fn(() => ({
+    autoReload: true,
+    dependencies: { '@strapi/plugin-documentation': '4.2.0' },
+    useYarn: true,
+  })),
 }));
 
 const client = new QueryClient({
@@ -1813,7 +1817,7 @@ describe('Marketplace page', () => {
 
   it('handles production environment', () => {
     // Simulate production environment
-    useAppInfos.mockImplementation(() => ({ autoReload: false }));
+    useAppInfos.mockImplementation(() => ({ autoReload: false, dependencies: {}, useYarn: true }));
     const { queryByText } = render(App);
 
     // Should display notification

--- a/packages/core/admin/admin/src/pages/MarketplacePage/tests/server.js
+++ b/packages/core/admin/admin/src/pages/MarketplacePage/tests/server.js
@@ -22,23 +22,27 @@ const handlers = [
                 id: 'attzLRKpax5MIrMtq',
                 width: 160,
                 height: 160,
-                url: 'https://dl.airtable.com/.attachments/3e586bbcdd7dc2effc3770fd49506aa6/ddbb2540/cf-logo-v-rgb.jpg',
+                url:
+                  'https://dl.airtable.com/.attachments/3e586bbcdd7dc2effc3770fd49506aa6/ddbb2540/cf-logo-v-rgb.jpg',
                 filename: 'cf-logo-v-rgb.jpg',
                 size: 25615,
                 type: 'image/jpeg',
                 thumbnails: {
                   small: {
-                    url: 'https://dl.airtable.com/.attachmentThumbnails/aa98b52525fdeb5767cf554563a9df14/7a03d156',
+                    url:
+                      'https://dl.airtable.com/.attachmentThumbnails/aa98b52525fdeb5767cf554563a9df14/7a03d156',
                     width: 36,
                     height: 36,
                   },
                   large: {
-                    url: 'https://dl.airtable.com/.attachmentThumbnails/a0e91d3564a0f41d89799e352b06c8ee/3d45329e',
+                    url:
+                      'https://dl.airtable.com/.attachmentThumbnails/a0e91d3564a0f41d89799e352b06c8ee/3d45329e',
                     width: 160,
                     height: 160,
                   },
                   full: {
-                    url: 'https://dl.airtable.com/.attachmentThumbnails/20b4afecf2bf8bc081c54eae92a7f599/d1e10f39',
+                    url:
+                      'https://dl.airtable.com/.attachmentThumbnails/20b4afecf2bf8bc081c54eae92a7f599/d1e10f39',
                     width: 3000,
                     height: 3000,
                   },
@@ -63,23 +67,27 @@ const handlers = [
                 id: 'att1xGwmQzDOC2UwY',
                 width: 1080,
                 height: 1080,
-                url: 'https://dl.airtable.com/.attachments/eb4cd59876565af77c9c3e5966b59f10/2111bfc8/vl_strapi-comments.png',
+                url:
+                  'https://dl.airtable.com/.attachments/eb4cd59876565af77c9c3e5966b59f10/2111bfc8/vl_strapi-comments.png',
                 filename: 'vl_strapi-comments.png',
                 size: 344804,
                 type: 'image/png',
                 thumbnails: {
                   small: {
-                    url: 'https://dl.airtable.com/.attachmentThumbnails/92ec34110ff65c0993eac95a4f9ee906/76443a36',
+                    url:
+                      'https://dl.airtable.com/.attachmentThumbnails/92ec34110ff65c0993eac95a4f9ee906/76443a36',
                     width: 36,
                     height: 36,
                   },
                   large: {
-                    url: 'https://dl.airtable.com/.attachmentThumbnails/5136e180187206b2a90bfa9a5ca65149/64187ef0',
+                    url:
+                      'https://dl.airtable.com/.attachmentThumbnails/5136e180187206b2a90bfa9a5ca65149/64187ef0',
                     width: 512,
                     height: 512,
                   },
                   full: {
-                    url: 'https://dl.airtable.com/.attachmentThumbnails/4c3fdf040d05779adf251a737adcae55/590ff600',
+                    url:
+                      'https://dl.airtable.com/.attachmentThumbnails/4c3fdf040d05779adf251a737adcae55/590ff600',
                     width: 3000,
                     height: 3000,
                   },
@@ -90,23 +98,27 @@ const handlers = [
                   id: 'att4y0AbotGdAOdEJ',
                   width: 1920,
                   height: 1080,
-                  url: 'https://dl.airtable.com/.attachments/f6316615095b33ce67700a3810c1869c/a13c0ef1/screens.png',
+                  url:
+                    'https://dl.airtable.com/.attachments/f6316615095b33ce67700a3810c1869c/a13c0ef1/screens.png',
                   filename: 'screens.png',
                   size: 625578,
                   type: 'image/png',
                   thumbnails: {
                     small: {
-                      url: 'https://dl.airtable.com/.attachmentThumbnails/2ff8cdfc0f4c215ae63e96f21281b93d/d817fa87',
+                      url:
+                        'https://dl.airtable.com/.attachmentThumbnails/2ff8cdfc0f4c215ae63e96f21281b93d/d817fa87',
                       width: 64,
                       height: 36,
                     },
                     large: {
-                      url: 'https://dl.airtable.com/.attachmentThumbnails/4ecf8b86b1af9061bcdf90f42253531b/1a88263e',
+                      url:
+                        'https://dl.airtable.com/.attachmentThumbnails/4ecf8b86b1af9061bcdf90f42253531b/1a88263e',
                       width: 910,
                       height: 512,
                     },
                     full: {
-                      url: 'https://dl.airtable.com/.attachmentThumbnails/1f51a4dca550912863c9d43a8052ab77/e4fa5ec5',
+                      url:
+                        'https://dl.airtable.com/.attachmentThumbnails/1f51a4dca550912863c9d43a8052ab77/e4fa5ec5',
                       width: 3000,
                       height: 3000,
                     },
@@ -116,23 +128,27 @@ const handlers = [
                   id: 'att3k9vSnVo0KFSEA',
                   width: 2880,
                   height: 1578,
-                  url: 'https://dl.airtable.com/.attachments/a3c3451815e017baa04f4b92f26c29ef/243d8656/Screenshot2022-01-27at07.48.19.png',
+                  url:
+                    'https://dl.airtable.com/.attachments/a3c3451815e017baa04f4b92f26c29ef/243d8656/Screenshot2022-01-27at07.48.19.png',
                   filename: 'Screenshot 2022-01-27 at 07.48.19.png',
                   size: 1545826,
                   type: 'image/png',
                   thumbnails: {
                     small: {
-                      url: 'https://dl.airtable.com/.attachmentThumbnails/51d91e1e39eacf40f05fa193d367a306/1dbd8409',
+                      url:
+                        'https://dl.airtable.com/.attachmentThumbnails/51d91e1e39eacf40f05fa193d367a306/1dbd8409',
                       width: 66,
                       height: 36,
                     },
                     large: {
-                      url: 'https://dl.airtable.com/.attachmentThumbnails/392a6d72b82000b0b84d58c40319d3a0/2ccc6e5b',
+                      url:
+                        'https://dl.airtable.com/.attachmentThumbnails/392a6d72b82000b0b84d58c40319d3a0/2ccc6e5b',
                       width: 934,
                       height: 512,
                     },
                     full: {
-                      url: 'https://dl.airtable.com/.attachmentThumbnails/45fc5b9d4bc83d2ef5e0aa36d2918b8d/a05010ef',
+                      url:
+                        'https://dl.airtable.com/.attachmentThumbnails/45fc5b9d4bc83d2ef5e0aa36d2918b8d/a05010ef',
                       width: 3000,
                       height: 3000,
                     },
@@ -142,23 +158,27 @@ const handlers = [
                   id: 'attKuQmvrbDnp1tm1',
                   width: 2880,
                   height: 1582,
-                  url: 'https://dl.airtable.com/.attachments/d75abd544b3710060288547049d7bf22/1412b396/Screenshot2022-01-27at07.48.37.png',
+                  url:
+                    'https://dl.airtable.com/.attachments/d75abd544b3710060288547049d7bf22/1412b396/Screenshot2022-01-27at07.48.37.png',
                   filename: 'Screenshot 2022-01-27 at 07.48.37.png',
                   size: 1282068,
                   type: 'image/png',
                   thumbnails: {
                     small: {
-                      url: 'https://dl.airtable.com/.attachmentThumbnails/c41517eac949e0da38f0f19344fe875b/cec423d6',
+                      url:
+                        'https://dl.airtable.com/.attachmentThumbnails/c41517eac949e0da38f0f19344fe875b/cec423d6',
                       width: 66,
                       height: 36,
                     },
                     large: {
-                      url: 'https://dl.airtable.com/.attachmentThumbnails/e7881ee4b0b75fc0f2d40c53efa94b01/6513dcc2',
+                      url:
+                        'https://dl.airtable.com/.attachmentThumbnails/e7881ee4b0b75fc0f2d40c53efa94b01/6513dcc2',
                       width: 932,
                       height: 512,
                     },
                     full: {
-                      url: 'https://dl.airtable.com/.attachmentThumbnails/60d7b535cc8b579ee09a64ce23ec607e/954df7b1',
+                      url:
+                        'https://dl.airtable.com/.attachmentThumbnails/60d7b535cc8b579ee09a64ce23ec607e/954df7b1',
                       width: 3000,
                       height: 3000,
                     },
@@ -168,23 +188,27 @@ const handlers = [
                   id: 'att3iUd2fPh6xgsU4',
                   width: 2880,
                   height: 1580,
-                  url: 'https://dl.airtable.com/.attachments/87efb22ce60c67971a16bac929bb24aa/ef2da9b7/Screenshot2022-01-27at07.48.47.png',
+                  url:
+                    'https://dl.airtable.com/.attachments/87efb22ce60c67971a16bac929bb24aa/ef2da9b7/Screenshot2022-01-27at07.48.47.png',
                   filename: 'Screenshot 2022-01-27 at 07.48.47.png',
                   size: 1386662,
                   type: 'image/png',
                   thumbnails: {
                     small: {
-                      url: 'https://dl.airtable.com/.attachmentThumbnails/8e7ddb79f9ff320235a029df98872d74/85632ae0',
+                      url:
+                        'https://dl.airtable.com/.attachmentThumbnails/8e7ddb79f9ff320235a029df98872d74/85632ae0',
                       width: 66,
                       height: 36,
                     },
                     large: {
-                      url: 'https://dl.airtable.com/.attachmentThumbnails/6d6ad9667c04b08709dc3e6f2f68f064/da46238e',
+                      url:
+                        'https://dl.airtable.com/.attachmentThumbnails/6d6ad9667c04b08709dc3e6f2f68f064/da46238e',
                       width: 933,
                       height: 512,
                     },
                     full: {
-                      url: 'https://dl.airtable.com/.attachmentThumbnails/ebd28cadcab85bd217b066eeeb113723/6267c7e1',
+                      url:
+                        'https://dl.airtable.com/.attachmentThumbnails/ebd28cadcab85bd217b066eeeb113723/6267c7e1',
                       width: 3000,
                       height: 3000,
                     },
@@ -194,23 +218,27 @@ const handlers = [
                   id: 'attSRD1UvyPislYg4',
                   width: 2880,
                   height: 1580,
-                  url: 'https://dl.airtable.com/.attachments/3b104067762dedac336a938f57676f93/4deb3bae/Screenshot2022-01-27at07.48.07.png',
+                  url:
+                    'https://dl.airtable.com/.attachments/3b104067762dedac336a938f57676f93/4deb3bae/Screenshot2022-01-27at07.48.07.png',
                   filename: 'Screenshot 2022-01-27 at 07.48.07.png',
                   size: 1282540,
                   type: 'image/png',
                   thumbnails: {
                     small: {
-                      url: 'https://dl.airtable.com/.attachmentThumbnails/c215d62e79d7d13d2c40016f3118a979/37e7af8e',
+                      url:
+                        'https://dl.airtable.com/.attachmentThumbnails/c215d62e79d7d13d2c40016f3118a979/37e7af8e',
                       width: 66,
                       height: 36,
                     },
                     large: {
-                      url: 'https://dl.airtable.com/.attachmentThumbnails/4895150e0da9ba7edfa32cf2348d79cb/f5e8af82',
+                      url:
+                        'https://dl.airtable.com/.attachmentThumbnails/4895150e0da9ba7edfa32cf2348d79cb/f5e8af82',
                       width: 933,
                       height: 512,
                     },
                     full: {
-                      url: 'https://dl.airtable.com/.attachmentThumbnails/8e7a00bd492421447458cd2ee739aba2/bc5f3759',
+                      url:
+                        'https://dl.airtable.com/.attachmentThumbnails/8e7a00bd492421447458cd2ee739aba2/bc5f3759',
                       width: 3000,
                       height: 3000,
                     },
@@ -237,23 +265,27 @@ const handlers = [
                 id: 'att6OefK4471IpCZ5',
                 width: 320,
                 height: 320,
-                url: 'https://dl.airtable.com/.attachments/e23a7231d12cce89cb4b05cbfe759d45/96f5f496/Screenshot2021-12-09at22.15.37.png',
+                url:
+                  'https://dl.airtable.com/.attachments/e23a7231d12cce89cb4b05cbfe759d45/96f5f496/Screenshot2021-12-09at22.15.37.png',
                 filename: 'Screenshot 2021-12-09 at 22.15.37.png',
                 size: 11580,
                 type: 'image/png',
                 thumbnails: {
                   small: {
-                    url: 'https://dl.airtable.com/.attachmentThumbnails/2f69cd2d5a884ad733c2e18bbe3d2e39/9cf40c6f',
+                    url:
+                      'https://dl.airtable.com/.attachmentThumbnails/2f69cd2d5a884ad733c2e18bbe3d2e39/9cf40c6f',
                     width: 36,
                     height: 36,
                   },
                   large: {
-                    url: 'https://dl.airtable.com/.attachmentThumbnails/8301d585b4aaa2977fa1e007feb02a17/1d121e13',
+                    url:
+                      'https://dl.airtable.com/.attachmentThumbnails/8301d585b4aaa2977fa1e007feb02a17/1d121e13',
                     width: 320,
                     height: 320,
                   },
                   full: {
-                    url: 'https://dl.airtable.com/.attachmentThumbnails/15d442f81a47ff6ff002fd25ce6788d6/395c8aea',
+                    url:
+                      'https://dl.airtable.com/.attachmentThumbnails/15d442f81a47ff6ff002fd25ce6788d6/395c8aea',
                     width: 3000,
                     height: 3000,
                   },
@@ -264,23 +296,27 @@ const handlers = [
                   id: 'att0QiAtNRfoz3mwF',
                   width: 2206,
                   height: 1284,
-                  url: 'https://dl.airtable.com/.attachments/b6afdee7abfbf5c63ef3d2de243f99a4/a5f3f48c/config-diff.png',
+                  url:
+                    'https://dl.airtable.com/.attachments/b6afdee7abfbf5c63ef3d2de243f99a4/a5f3f48c/config-diff.png',
                   filename: 'config-diff.png',
                   size: 332901,
                   type: 'image/png',
                   thumbnails: {
                     small: {
-                      url: 'https://dl.airtable.com/.attachmentThumbnails/2135d552f535ead55971c9ae016bb178/5b71c76e',
+                      url:
+                        'https://dl.airtable.com/.attachmentThumbnails/2135d552f535ead55971c9ae016bb178/5b71c76e',
                       width: 62,
                       height: 36,
                     },
                     large: {
-                      url: 'https://dl.airtable.com/.attachmentThumbnails/4b972ba187e2bd589c10987871ef00df/35f22c62',
+                      url:
+                        'https://dl.airtable.com/.attachmentThumbnails/4b972ba187e2bd589c10987871ef00df/35f22c62',
                       width: 880,
                       height: 512,
                     },
                     full: {
-                      url: 'https://dl.airtable.com/.attachmentThumbnails/3b88bba22b7d9d9ec456bf849efeac53/423f1a93',
+                      url:
+                        'https://dl.airtable.com/.attachmentThumbnails/3b88bba22b7d9d9ec456bf849efeac53/423f1a93',
                       width: 3000,
                       height: 3000,
                     },
@@ -308,23 +344,27 @@ const handlers = [
                 id: 'attaMdJdER0feFBuX',
                 width: 1280,
                 height: 1280,
-                url: 'https://dl.airtable.com/.attachments/0b86f18e2606ed7f53bd54d536a1bea5/13a87f30/Artboard7copy.png',
+                url:
+                  'https://dl.airtable.com/.attachments/0b86f18e2606ed7f53bd54d536a1bea5/13a87f30/Artboard7copy.png',
                 filename: 'Artboard 7 copy.png',
                 size: 35705,
                 type: 'image/png',
                 thumbnails: {
                   small: {
-                    url: 'https://dl.airtable.com/.attachmentThumbnails/4c0179127f923c0ce01866c92e9664a8/347fbe74',
+                    url:
+                      'https://dl.airtable.com/.attachmentThumbnails/4c0179127f923c0ce01866c92e9664a8/347fbe74',
                     width: 36,
                     height: 36,
                   },
                   large: {
-                    url: 'https://dl.airtable.com/.attachmentThumbnails/0edca5708e30dc9fce6c962dcc28dbce/39b83021',
+                    url:
+                      'https://dl.airtable.com/.attachmentThumbnails/0edca5708e30dc9fce6c962dcc28dbce/39b83021',
                     width: 512,
                     height: 512,
                   },
                   full: {
-                    url: 'https://dl.airtable.com/.attachmentThumbnails/a44ea395865d5f6ba71dbcae814cfc83/31c3fffc',
+                    url:
+                      'https://dl.airtable.com/.attachmentThumbnails/a44ea395865d5f6ba71dbcae814cfc83/31c3fffc',
                     width: 3000,
                     height: 3000,
                   },
@@ -335,23 +375,27 @@ const handlers = [
                   id: 'attGD52ggRIgnsUKp',
                   width: 1920,
                   height: 1080,
-                  url: 'https://dl.airtable.com/.attachments/50126ddff8ef4ed7b7a693ecd156ae60/b6a9a4a6/Novprojekt15.png',
+                  url:
+                    'https://dl.airtable.com/.attachments/50126ddff8ef4ed7b7a693ecd156ae60/b6a9a4a6/Novprojekt15.png',
                   filename: 'Nový projekt (15).png',
                   size: 52163,
                   type: 'image/png',
                   thumbnails: {
                     small: {
-                      url: 'https://dl.airtable.com/.attachmentThumbnails/60382a6542a77f90594526b68fe5182c/f54e7675',
+                      url:
+                        'https://dl.airtable.com/.attachmentThumbnails/60382a6542a77f90594526b68fe5182c/f54e7675',
                       width: 64,
                       height: 36,
                     },
                     large: {
-                      url: 'https://dl.airtable.com/.attachmentThumbnails/05deee4e93b9b57e9cd4465e2c6622f1/1b377c4a',
+                      url:
+                        'https://dl.airtable.com/.attachmentThumbnails/05deee4e93b9b57e9cd4465e2c6622f1/1b377c4a',
                       width: 910,
                       height: 512,
                     },
                     full: {
-                      url: 'https://dl.airtable.com/.attachmentThumbnails/87ef842cda9b0647e7dd4d2f8a086379/303ecd98',
+                      url:
+                        'https://dl.airtable.com/.attachmentThumbnails/87ef842cda9b0647e7dd4d2f8a086379/303ecd98',
                       width: 3000,
                       height: 3000,
                     },
@@ -378,23 +422,27 @@ const handlers = [
                 id: 'att22dETRlzkfVWAl',
                 width: 225,
                 height: 225,
-                url: 'https://dl.airtable.com/.attachments/b6998ac52e8b0460b8a14ced8074b788/2a4d4a90/swagger.png',
+                url:
+                  'https://dl.airtable.com/.attachments/b6998ac52e8b0460b8a14ced8074b788/2a4d4a90/swagger.png',
                 filename: 'swagger.png',
                 size: 6052,
                 type: 'image/png',
                 thumbnails: {
                   small: {
-                    url: 'https://dl.airtable.com/.attachmentThumbnails/71a6b03e03a6b26647991a617478cdfa/8e1d8d2b',
+                    url:
+                      'https://dl.airtable.com/.attachmentThumbnails/71a6b03e03a6b26647991a617478cdfa/8e1d8d2b',
                     width: 36,
                     height: 36,
                   },
                   large: {
-                    url: 'https://dl.airtable.com/.attachmentThumbnails/c249c4953d5bb0e2f58ed7174afecc2f/796dca09',
+                    url:
+                      'https://dl.airtable.com/.attachmentThumbnails/c249c4953d5bb0e2f58ed7174afecc2f/796dca09',
                     width: 225,
                     height: 225,
                   },
                   full: {
-                    url: 'https://dl.airtable.com/.attachmentThumbnails/4b7bc3a765f3927b9fcd12809ddf82a8/d3a4b97b',
+                    url:
+                      'https://dl.airtable.com/.attachmentThumbnails/4b7bc3a765f3927b9fcd12809ddf82a8/d3a4b97b',
                     width: 3000,
                     height: 3000,
                   },
@@ -420,23 +468,27 @@ const handlers = [
                 id: 'att22dETRlzkfVWAl',
                 width: 225,
                 height: 225,
-                url: 'https://dl.airtable.com/.attachments/b6998ac52e8b0460b8a14ced8074b788/2a4d4a90/swagger.png',
+                url:
+                  'https://dl.airtable.com/.attachments/b6998ac52e8b0460b8a14ced8074b788/2a4d4a90/swagger.png',
                 filename: 'swagger.png',
                 size: 6052,
                 type: 'image/png',
                 thumbnails: {
                   small: {
-                    url: 'https://dl.airtable.com/.attachmentThumbnails/71a6b03e03a6b26647991a617478cdfa/8e1d8d2b',
+                    url:
+                      'https://dl.airtable.com/.attachmentThumbnails/71a6b03e03a6b26647991a617478cdfa/8e1d8d2b',
                     width: 36,
                     height: 36,
                   },
                   large: {
-                    url: 'https://dl.airtable.com/.attachmentThumbnails/c249c4953d5bb0e2f58ed7174afecc2f/796dca09',
+                    url:
+                      'https://dl.airtable.com/.attachmentThumbnails/c249c4953d5bb0e2f58ed7174afecc2f/796dca09',
                     width: 225,
                     height: 225,
                   },
                   full: {
-                    url: 'https://dl.airtable.com/.attachmentThumbnails/4b7bc3a765f3927b9fcd12809ddf82a8/d3a4b97b',
+                    url:
+                      'https://dl.airtable.com/.attachmentThumbnails/4b7bc3a765f3927b9fcd12809ddf82a8/d3a4b97b',
                     width: 3000,
                     height: 3000,
                   },
@@ -462,23 +514,27 @@ const handlers = [
                 id: 'attbggDs1BgpGByTz',
                 width: 158,
                 height: 158,
-                url: 'https://dl.airtable.com/.attachments/5ffd1782a2fabf423ccd6f56c562f31a/b8f8598f/transformer-logo.png',
+                url:
+                  'https://dl.airtable.com/.attachments/5ffd1782a2fabf423ccd6f56c562f31a/b8f8598f/transformer-logo.png',
                 filename: 'transformer-logo.png',
                 size: 5787,
                 type: 'image/png',
                 thumbnails: {
                   small: {
-                    url: 'https://dl.airtable.com/.attachmentThumbnails/53ee41b18d2f704257a483ea17de9020/07cabde5',
+                    url:
+                      'https://dl.airtable.com/.attachmentThumbnails/53ee41b18d2f704257a483ea17de9020/07cabde5',
                     width: 36,
                     height: 36,
                   },
                   large: {
-                    url: 'https://dl.airtable.com/.attachmentThumbnails/46185b0bddbd1684ac02d12d490a621b/37a04f6c',
+                    url:
+                      'https://dl.airtable.com/.attachmentThumbnails/46185b0bddbd1684ac02d12d490a621b/37a04f6c',
                     width: 158,
                     height: 158,
                   },
                   full: {
-                    url: 'https://dl.airtable.com/.attachmentThumbnails/1a6e9c656aacaca5536abbe2c2964d30/5e904c9c',
+                    url:
+                      'https://dl.airtable.com/.attachmentThumbnails/1a6e9c656aacaca5536abbe2c2964d30/5e904c9c',
                     width: 3000,
                     height: 3000,
                   },
@@ -495,75 +551,6 @@ const handlers = [
     );
   }),
 
-  rest.get('*/admin/plugins', (req, res, ctx) => {
-    return res(
-      ctx.delay(100),
-      ctx.status(200),
-      ctx.json({
-        plugins: [
-          {
-            name: 'content-manager',
-            displayName: 'Content Manager',
-            description: 'Quick way to see, edit and delete the data in your database.',
-          },
-          {
-            name: 'content-type-builder',
-            displayName: 'Content Type Builder',
-            description:
-              'Modelize the data structure of your API. Create new fields and relations in just a minute. The files are automatically created and updated in your project.',
-          },
-          {
-            name: 'email',
-            displayName: 'Email',
-            description: 'Configure your application to send emails.',
-          },
-          {
-            name: 'upload',
-            displayName: 'Media Library',
-            description: 'Media file management.',
-          },
-          {
-            name: 'graphql',
-            displayName: 'GraphQL',
-            description: 'Adds GraphQL endpoint with default API methods.',
-            packageName: '@strapi/plugin-graphql',
-          },
-          {
-            name: 'documentation',
-            displayName: 'Documentation',
-            description: 'Create an OpenAPI Document and visualize your API with SWAGGER UI.',
-            packageName: '@strapi/plugin-documentation',
-          },
-          {
-            name: 'my-plugin',
-            displayName: 'my-plugin',
-            description: 'Description of my plugin.',
-          },
-          {
-            name: 'i18n',
-            displayName: 'Internationalization',
-            description:
-              'This plugin enables to create, to read and to update content in different languages, both from the Admin Panel and from the API.',
-            packageName: '@strapi/plugin-i18n',
-          },
-          {
-            name: 'sentry',
-            displayName: 'Sentry',
-            description: 'Send Strapi error events to Sentry.',
-            packageName: '@strapi/plugin-sentry',
-          },
-          {
-            name: 'users-permissions',
-            displayName: 'Roles & Permissions',
-            description:
-              'Protect your API with a full authentication process based on JWT. This plugin comes also with an ACL strategy that allows you to manage the permissions between the groups of users.',
-            packageName: '@strapi/plugin-users-permissions',
-          },
-        ],
-      })
-    );
-  }),
-
   rest.get('*/admin/information', (req, res, ctx) => {
     return res(
       ctx.delay(100),
@@ -573,6 +560,9 @@ const handlers = [
           currentEnvironment: 'development',
           autoReload: true,
           strapiVersion: '4.1.0',
+          dependencies: {
+            '@strapi/plugin-documentation': '4.1.0',
+          },
           nodeVersion: 'v14.18.1',
           communityEdition: true,
           useYarn: false,
@@ -602,23 +592,27 @@ const handlers = [
                 id: 'attPkleJsAHaDv8vC',
                 width: 256,
                 height: 256,
-                url: 'https://dl.airtable.com/.attachments/04be9ade6077d029a9d4108cd2f47c8e/f5fe8d67/amazonSES.png?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=0561c26f91b25e21',
+                url:
+                  'https://dl.airtable.com/.attachments/04be9ade6077d029a9d4108cd2f47c8e/f5fe8d67/amazonSES.png?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=0561c26f91b25e21',
                 filename: 'amazonSES.png',
                 size: 17284,
                 type: 'image/png',
                 thumbnails: {
                   small: {
-                    url: 'https://dl.airtable.com/.attachmentThumbnails/c9643af6593cacd432a65755c6cc8369/bd74f743?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=15a41c58b4726d77',
+                    url:
+                      'https://dl.airtable.com/.attachmentThumbnails/c9643af6593cacd432a65755c6cc8369/bd74f743?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=15a41c58b4726d77',
                     width: 36,
                     height: 36,
                   },
                   large: {
-                    url: 'https://dl.airtable.com/.attachmentThumbnails/ae318dfd252d61d4c6302e055e883df0/aa87e132?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=9277ec20b0fbef11',
+                    url:
+                      'https://dl.airtable.com/.attachmentThumbnails/ae318dfd252d61d4c6302e055e883df0/aa87e132?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=9277ec20b0fbef11',
                     width: 256,
                     height: 256,
                   },
                   full: {
-                    url: 'https://dl.airtable.com/.attachmentThumbnails/4bf5b25a4f4be4fc3da2a145406b0aa1/095a0e80?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=74744934a5c587e5',
+                    url:
+                      'https://dl.airtable.com/.attachmentThumbnails/4bf5b25a4f4be4fc3da2a145406b0aa1/095a0e80?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=74744934a5c587e5',
                     width: 3000,
                     height: 3000,
                   },
@@ -644,23 +638,27 @@ const handlers = [
                 id: 'att0O0zMQjUcgO9An',
                 width: 428,
                 height: 512,
-                url: 'https://dl.airtable.com/.attachments/e24c0ef99b1e952cbf0c8cbeed8cc24f/da30ba27/Amazon-S3-Logo.png?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=953eaf833eba09a2',
+                url:
+                  'https://dl.airtable.com/.attachments/e24c0ef99b1e952cbf0c8cbeed8cc24f/da30ba27/Amazon-S3-Logo.png?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=953eaf833eba09a2',
                 filename: 'Amazon-S3-Logo.png',
                 size: 8747,
                 type: 'image/png',
                 thumbnails: {
                   small: {
-                    url: 'https://dl.airtable.com/.attachmentThumbnails/c321c1a3812cfe2fec89d50e59608dfc/f33dfcb7?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=aa69cd4276a975c5',
+                    url:
+                      'https://dl.airtable.com/.attachmentThumbnails/c321c1a3812cfe2fec89d50e59608dfc/f33dfcb7?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=aa69cd4276a975c5',
                     width: 30,
                     height: 36,
                   },
                   large: {
-                    url: 'https://dl.airtable.com/.attachmentThumbnails/9ea423169f9f584d764bf3dc4309f27c/acb36ad2?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=787909ce6eb1c12f',
+                    url:
+                      'https://dl.airtable.com/.attachmentThumbnails/9ea423169f9f584d764bf3dc4309f27c/acb36ad2?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=787909ce6eb1c12f',
                     width: 428,
                     height: 512,
                   },
                   full: {
-                    url: 'https://dl.airtable.com/.attachmentThumbnails/3cd1f6a2d6470f4fd6f241a4fd49863e/46d55428?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=e7a579bb13a12962',
+                    url:
+                      'https://dl.airtable.com/.attachmentThumbnails/3cd1f6a2d6470f4fd6f241a4fd49863e/46d55428?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=e7a579bb13a12962',
                     width: 3000,
                     height: 3000,
                   },
@@ -687,23 +685,27 @@ const handlers = [
                 id: 'attWcLyN8uXzKMkyp',
                 width: 1000,
                 height: 1000,
-                url: 'https://dl.airtable.com/.attachments/74df39c3715a78589be1cbff69009dc2/14734e59/cloudinary.png?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=d82f74e2c1563864',
+                url:
+                  'https://dl.airtable.com/.attachments/74df39c3715a78589be1cbff69009dc2/14734e59/cloudinary.png?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=d82f74e2c1563864',
                 filename: 'cloudinary.png',
                 size: 40035,
                 type: 'image/png',
                 thumbnails: {
                   small: {
-                    url: 'https://dl.airtable.com/.attachmentThumbnails/09e31f64effadbb0db337ce62ce6e82f/41c381e5?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=009f1b66ad3ce551',
+                    url:
+                      'https://dl.airtable.com/.attachmentThumbnails/09e31f64effadbb0db337ce62ce6e82f/41c381e5?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=009f1b66ad3ce551',
                     width: 36,
                     height: 36,
                   },
                   large: {
-                    url: 'https://dl.airtable.com/.attachmentThumbnails/73a94b8533235b8b16c35971555c4c7c/2ff7c5de?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=f8f69638a0122a41',
+                    url:
+                      'https://dl.airtable.com/.attachmentThumbnails/73a94b8533235b8b16c35971555c4c7c/2ff7c5de?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=f8f69638a0122a41',
                     width: 512,
                     height: 512,
                   },
                   full: {
-                    url: 'https://dl.airtable.com/.attachmentThumbnails/5f5f4c13f8dddeaffd790c91c01f2de1/3f9fe205?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=3ccfc4325d8c2950',
+                    url:
+                      'https://dl.airtable.com/.attachmentThumbnails/5f5f4c13f8dddeaffd790c91c01f2de1/3f9fe205?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=3ccfc4325d8c2950',
                     width: 3000,
                     height: 3000,
                   },
@@ -730,23 +732,27 @@ const handlers = [
                 id: 'att8OCweGsCtYGZeR',
                 width: 80,
                 height: 80,
-                url: 'https://dl.airtable.com/.attachments/6707fcab8f5530214160bacf6f4369ec/9ed22aaf/typeplaceholderversion1.png?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=35d9e0bb75e4528a',
+                url:
+                  'https://dl.airtable.com/.attachments/6707fcab8f5530214160bacf6f4369ec/9ed22aaf/typeplaceholderversion1.png?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=35d9e0bb75e4528a',
                 filename: 'type=placeholder, version=1.png',
                 size: 1460,
                 type: 'image/png',
                 thumbnails: {
                   small: {
-                    url: 'https://dl.airtable.com/.attachmentThumbnails/8d7f33de80df88b2a2c0bd0b655a8cb5/87df3cd7?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=84f984cef71ffa27',
+                    url:
+                      'https://dl.airtable.com/.attachmentThumbnails/8d7f33de80df88b2a2c0bd0b655a8cb5/87df3cd7?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=84f984cef71ffa27',
                     width: 36,
                     height: 36,
                   },
                   large: {
-                    url: 'https://dl.airtable.com/.attachmentThumbnails/5b047bcf648bcb742b604ca69e2f668d/90d7caa8?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=16607a5798ba4057',
+                    url:
+                      'https://dl.airtable.com/.attachmentThumbnails/5b047bcf648bcb742b604ca69e2f668d/90d7caa8?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=16607a5798ba4057',
                     width: 80,
                     height: 80,
                   },
                   full: {
-                    url: 'https://dl.airtable.com/.attachmentThumbnails/499515fba624161eff1042e9bb7c1e5e/ecae1616?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=eb01b0394a8c1c38',
+                    url:
+                      'https://dl.airtable.com/.attachmentThumbnails/499515fba624161eff1042e9bb7c1e5e/ecae1616?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=eb01b0394a8c1c38',
                     width: 3000,
                     height: 3000,
                   },
@@ -772,23 +778,27 @@ const handlers = [
                 id: 'attXAPE3yfQFOiZM0',
                 width: 299,
                 height: 300,
-                url: 'https://dl.airtable.com/.attachments/73118ab0aea4d9eae66edc18a1db4982/808842ba/mailgun-logo-5388F66106-seeklogo_com.png?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=2e2e9ecb19e752ca',
+                url:
+                  'https://dl.airtable.com/.attachments/73118ab0aea4d9eae66edc18a1db4982/808842ba/mailgun-logo-5388F66106-seeklogo_com.png?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=2e2e9ecb19e752ca',
                 filename: 'mailgun-logo-5388F66106-seeklogo_com.png',
                 size: 19931,
                 type: 'image/png',
                 thumbnails: {
                   small: {
-                    url: 'https://dl.airtable.com/.attachmentThumbnails/70bdc0cc08226c5f54606f1b112ecc89/d57aeb29?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=1796f030bacf7ccf',
+                    url:
+                      'https://dl.airtable.com/.attachmentThumbnails/70bdc0cc08226c5f54606f1b112ecc89/d57aeb29?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=1796f030bacf7ccf',
                     width: 36,
                     height: 36,
                   },
                   large: {
-                    url: 'https://dl.airtable.com/.attachmentThumbnails/bca142748177bbcea58303c80461f3db/dce79b36?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=8b26f9319deb2fe3',
+                    url:
+                      'https://dl.airtable.com/.attachmentThumbnails/bca142748177bbcea58303c80461f3db/dce79b36?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=8b26f9319deb2fe3',
                     width: 299,
                     height: 300,
                   },
                   full: {
-                    url: 'https://dl.airtable.com/.attachmentThumbnails/f1978a5f2fc19ab02d1cb5e987481661/6389d07c?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=c4d70a9a26baf3b1',
+                    url:
+                      'https://dl.airtable.com/.attachmentThumbnails/f1978a5f2fc19ab02d1cb5e987481661/6389d07c?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=c4d70a9a26baf3b1',
                     width: 3000,
                     height: 3000,
                   },
@@ -814,23 +824,27 @@ const handlers = [
                 id: 'attu6UsiH02uW4mwL',
                 width: 200,
                 height: 200,
-                url: 'https://dl.airtable.com/.attachments/73bea518f68fc312ec15a4a988da3bbc/4c024fea/Nodemailer.jpeg?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=a5dec98be44fa4e6',
+                url:
+                  'https://dl.airtable.com/.attachments/73bea518f68fc312ec15a4a988da3bbc/4c024fea/Nodemailer.jpeg?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=a5dec98be44fa4e6',
                 filename: 'Nodemailer.jpeg',
                 size: 5055,
                 type: 'image/jpeg',
                 thumbnails: {
                   small: {
-                    url: 'https://dl.airtable.com/.attachmentThumbnails/9cc0b414f2653afb4286238c8ec522fe/a914a2b0?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=e370f43cd0e9b772',
+                    url:
+                      'https://dl.airtable.com/.attachmentThumbnails/9cc0b414f2653afb4286238c8ec522fe/a914a2b0?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=e370f43cd0e9b772',
                     width: 36,
                     height: 36,
                   },
                   large: {
-                    url: 'https://dl.airtable.com/.attachmentThumbnails/ab632a86e17718e9d98b10ccb926be75/640eb57d?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=9479daaa35f0751c',
+                    url:
+                      'https://dl.airtable.com/.attachmentThumbnails/ab632a86e17718e9d98b10ccb926be75/640eb57d?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=9479daaa35f0751c',
                     width: 200,
                     height: 200,
                   },
                   full: {
-                    url: 'https://dl.airtable.com/.attachmentThumbnails/14c63b4b32d5d4efb846705ad6a67c34/0310e71e?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=d6ed6efdb841be01',
+                    url:
+                      'https://dl.airtable.com/.attachmentThumbnails/14c63b4b32d5d4efb846705ad6a67c34/0310e71e?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=d6ed6efdb841be01',
                     width: 3000,
                     height: 3000,
                   },
@@ -856,23 +870,27 @@ const handlers = [
                 id: 'attwjN4k8kRJqlP7q',
                 width: 1024,
                 height: 1024,
-                url: 'https://dl.airtable.com/.attachments/f1e20497044cc6035f43b94f46bd5381/c78cbd9f/rackspace-logo.png?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=641682ec9adc2d1c',
+                url:
+                  'https://dl.airtable.com/.attachments/f1e20497044cc6035f43b94f46bd5381/c78cbd9f/rackspace-logo.png?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=641682ec9adc2d1c',
                 filename: 'rackspace-logo.png',
                 size: 18186,
                 type: 'image/png',
                 thumbnails: {
                   small: {
-                    url: 'https://dl.airtable.com/.attachmentThumbnails/8f9bed56940dbbf48d9e0d137b7ef725/1ddefd5c?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=e8a6fa209cf90d7d',
+                    url:
+                      'https://dl.airtable.com/.attachmentThumbnails/8f9bed56940dbbf48d9e0d137b7ef725/1ddefd5c?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=e8a6fa209cf90d7d',
                     width: 36,
                     height: 36,
                   },
                   large: {
-                    url: 'https://dl.airtable.com/.attachmentThumbnails/fba1cb15c6f10602abbf43c8017cab0d/f1b221a8?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=84e391b031a95da3',
+                    url:
+                      'https://dl.airtable.com/.attachmentThumbnails/fba1cb15c6f10602abbf43c8017cab0d/f1b221a8?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=84e391b031a95da3',
                     width: 512,
                     height: 512,
                   },
                   full: {
-                    url: 'https://dl.airtable.com/.attachmentThumbnails/7eb59048226a755cdaf03f430c634293/b85dd69d?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=04b1f6ac2595a233',
+                    url:
+                      'https://dl.airtable.com/.attachmentThumbnails/7eb59048226a755cdaf03f430c634293/b85dd69d?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=04b1f6ac2595a233',
                     width: 3000,
                     height: 3000,
                   },
@@ -899,23 +917,27 @@ const handlers = [
                 id: 'att3OLz4K78pUVTjt',
                 width: 300,
                 height: 300,
-                url: 'https://dl.airtable.com/.attachments/c09bfc173321ee79a972a10735ed6cf7/4e0a5321/sendgrid-logo-7574E52082-seeklogo_com.png?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=1ff0a128488e143f',
+                url:
+                  'https://dl.airtable.com/.attachments/c09bfc173321ee79a972a10735ed6cf7/4e0a5321/sendgrid-logo-7574E52082-seeklogo_com.png?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=1ff0a128488e143f',
                 filename: 'sendgrid-logo-7574E52082-seeklogo_com.png',
                 size: 3124,
                 type: 'image/png',
                 thumbnails: {
                   small: {
-                    url: 'https://dl.airtable.com/.attachmentThumbnails/7f9a60bffd359b890d697f6a4c713854/d0f3170f?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=2be1006f6571a145',
+                    url:
+                      'https://dl.airtable.com/.attachmentThumbnails/7f9a60bffd359b890d697f6a4c713854/d0f3170f?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=2be1006f6571a145',
                     width: 36,
                     height: 36,
                   },
                   large: {
-                    url: 'https://dl.airtable.com/.attachmentThumbnails/36018ddc97bc30cfb2c38dae7dbd39d0/87a95a5e?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=7e86b0c57901541a',
+                    url:
+                      'https://dl.airtable.com/.attachmentThumbnails/36018ddc97bc30cfb2c38dae7dbd39d0/87a95a5e?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=7e86b0c57901541a',
                     width: 300,
                     height: 300,
                   },
                   full: {
-                    url: 'https://dl.airtable.com/.attachmentThumbnails/d6193a48fe30fa59e84ffc5a400c731f/199e4af5?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=4d7e9d25cfcd3eee',
+                    url:
+                      'https://dl.airtable.com/.attachmentThumbnails/d6193a48fe30fa59e84ffc5a400c731f/199e4af5?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=4d7e9d25cfcd3eee',
                     width: 3000,
                     height: 3000,
                   },
@@ -941,23 +963,27 @@ const handlers = [
                 id: 'att5AVRI4yF9iI5vr',
                 width: 2400,
                 height: 2400,
-                url: 'https://dl.airtable.com/.attachments/0f14c78742105dffd36d6e253612f992/2f0e8605/sendmail-logo-png-transparent.png?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=65d4bd3786c6b0a2',
+                url:
+                  'https://dl.airtable.com/.attachments/0f14c78742105dffd36d6e253612f992/2f0e8605/sendmail-logo-png-transparent.png?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=65d4bd3786c6b0a2',
                 filename: 'sendmail-logo-png-transparent.png',
                 size: 89691,
                 type: 'image/png',
                 thumbnails: {
                   small: {
-                    url: 'https://dl.airtable.com/.attachmentThumbnails/9fed2bb13d53fe0cd1d770c5af83ff07/dcd12795?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=853034a7a274633f',
+                    url:
+                      'https://dl.airtable.com/.attachmentThumbnails/9fed2bb13d53fe0cd1d770c5af83ff07/dcd12795?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=853034a7a274633f',
                     width: 36,
                     height: 36,
                   },
                   large: {
-                    url: 'https://dl.airtable.com/.attachmentThumbnails/264a135d3364255e5e97cd699632fbe9/83835476?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=e515faafd9024636',
+                    url:
+                      'https://dl.airtable.com/.attachmentThumbnails/264a135d3364255e5e97cd699632fbe9/83835476?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=e515faafd9024636',
                     width: 512,
                     height: 512,
                   },
                   full: {
-                    url: 'https://dl.airtable.com/.attachmentThumbnails/7d89484dad9a056c482f869b7b3db0d2/be86bd9c?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=8469840a78f8719d',
+                    url:
+                      'https://dl.airtable.com/.attachmentThumbnails/7d89484dad9a056c482f869b7b3db0d2/be86bd9c?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=8469840a78f8719d',
                     width: 3000,
                     height: 3000,
                   },
@@ -976,4 +1002,5 @@ const handlers = [
 
 const server = setupServer(...handlers);
 
+export { rest };
 export default server;

--- a/packages/core/admin/admin/src/pages/MarketplacePage/utils/api.js
+++ b/packages/core/admin/admin/src/pages/MarketplacePage/utils/api.js
@@ -1,9 +1,0 @@
-import { axiosInstance } from '../../../core/utils';
-
-const fetchAppInformation = async () => {
-  const { data } = await axiosInstance.get('/admin/information');
-
-  return data;
-};
-
-export { fetchAppInformation };

--- a/packages/core/admin/server/controllers/__tests__/admin.test.js
+++ b/packages/core/admin/server/controllers/__tests__/admin.test.js
@@ -66,6 +66,9 @@ describe('Admin Controller', () => {
               ({
                 autoReload: undefined,
                 'info.strapi': '1.0.0',
+                'info.dependencies': {
+                  dependency: '1.0.0',
+                },
                 environment: 'development',
               }[key] || value)
           ),
@@ -81,12 +84,16 @@ describe('Admin Controller', () => {
         ['environment'],
         ['autoReload', false],
         ['info.strapi', null],
+        ['info.dependencies', {}],
       ]);
       expect(result.data).toBeDefined();
       expect(result.data).toStrictEqual({
         currentEnvironment: 'development',
         autoReload: false,
         strapiVersion: '1.0.0',
+        dependencies: {
+          dependency: '1.0.0',
+        },
         nodeVersion: process.version,
         communityEdition: false,
         useYarn: true,

--- a/packages/core/admin/server/controllers/admin.js
+++ b/packages/core/admin/server/controllers/admin.js
@@ -85,6 +85,7 @@ module.exports = {
     const currentEnvironment = strapi.config.get('environment');
     const autoReload = strapi.config.get('autoReload', false);
     const strapiVersion = strapi.config.get('info.strapi', null);
+    const dependencies = strapi.config.get('info.dependencies', {});
     const nodeVersion = process.version;
     const communityEdition = !strapi.EE;
     const useYarn = await exists(path.join(process.cwd(), 'yarn.lock'));
@@ -94,6 +95,7 @@ module.exports = {
         currentEnvironment,
         autoReload,
         strapiVersion,
+        dependencies,
         nodeVersion,
         communityEdition,
         useYarn,


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Two visible changes on the marketplace:

- Show installed providers as already installed on marketplace
- Show disabled (but installed) plugins as already installed

Note that this PR does not handle packages installed by default by a plugin (local upload and sendmail). They will be removed from the database the day we ship this change.

I also took this opportunity to do a couple technical changes:

- Use the appInformation data from the context, to no longer call that endpoint twice
- Check if a package is installed outside of the card component, for a slight perf benefit (I think)

### Why is it needed?

To let users know they don't need to install a package they already have.

### How to test it?

- disable a plugin via `config/plugins.js` => it should still appear as installed on the marketplace page
- on the marketplace providers tab, some providers should appear as already installed, and they won't have the copy install command button

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
