### PR TITLE
Fix: apply user-defined nexus plugins when building merged schema

### DIFF
--- a/packages/plugins/graphql/server/services/content-api/index.js
+++ b/packages/plugins/graphql/server/services/content-api/index.js
@@ -99,11 +99,17 @@ module.exports = ({ strapi }) => {
 
   const buildMergedSchema = ({ registry }) => {
     // Here we extract types, plugins & typeDefs from a temporary generated
-    // extension since there won't be any addition allowed after schemas generation
-    const { types, typeDefs = [] } = extensionService.generate({ typeRegistry: registry });
+    // extension since there won't be any addition allowed after schemas generation.
+    const { types, typeDefs = [], plugins = [] } = extensionService.generate({
+      typeRegistry: registry,
+    });
 
     // Nexus schema built with user-defined & shadow CRUD auto generated Nexus types
-    const nexusSchema = makeSchema({ types: [registry.definitions, types] });
+    // Apply user-defined plugins to make them available in user-defined type extensions.
+    const nexusSchema = makeSchema({
+      types: [registry.definitions, types],
+      plugins,
+    });
 
     // Merge type definitions with the Nexus schema
     return mergeSchemas({

--- a/packages/plugins/graphql/server/services/content-api/index.js
+++ b/packages/plugins/graphql/server/services/content-api/index.js
@@ -105,10 +105,11 @@ module.exports = ({ strapi }) => {
     });
 
     // Nexus schema built with user-defined & shadow CRUD auto generated Nexus types
-    // Apply user-defined plugins to make them available in user-defined type extensions.
+    // WIP: apply "globally" flagged plugins in order to allow nexus plugins providing extensions
+    // to the Nexus builder function to be available in user-defined Strapi GraphQL extensions
     const nexusSchema = makeSchema({
       types: [registry.definitions, types],
-      plugins,
+      plugins: plugins.filter(plugin => plugin.__STRAPI_GLOBAL_NEXUS_PLUGIN__ === true),
     });
 
     // Merge type definitions with the Nexus schema


### PR DESCRIPTION
### What does it do?

Tries to fix #13632 
Nexus plugins extending the Nexus builder function (`t`) should be available when defining or extending new types in a user-defined Strapi GraphQL extension.

This bug makes the usage of `Nexus.connectionPlugin` impossible. It should affect similar plugins in the same way.
I understand why user-defined plugins are registered in the final `makeSchema` call (and not in the intermediate `buildMergedSchema`) : it makes sense when registering a nexus plugin that will leverage all the available nexus hooks in order for them to execute on the final schema - but some plugins may require to be registered during the wrapped `makeSchema` call inside `buildMergedSchema` to make them available in Strapi GraphQL type extensions.

**The only problem with the current PR is that plugins will be registered twice on each `makeSchema` call - it would probably be a better idea to split the plugins into two groups when registering them : one for each call (split the plugins into beforeMergeSchema & afterMergeSchema - ie: we could check for an `onInstall` property on the resulting plugin's config in order to determine if "dynamics fields" are being added to the definition block) ? What do you think ?**

### Why is it needed?

In the case of the `connectionPlugin`, the plugin will install a `t.connectionField` method made available on the object definition builder. This leads to this method being unavailable when extending or creating new types in a Strapi GraphQL extension.

> Also - I developed a small utility package to create a relay connection from any strapi graphql content-type and this bug makes it harder to use it out of the box. For now I simply override the `plugins/graphql/server/services/content-api/index.js` service and register the `connectionPlugin` directly in the `buildMergedSchema` call.

### How to test it?

> see issue 

### Related issue(s)/PR(s)

#13632 
