### PR TITLE
Add `S3.config.publicUrl` setting to handle public/CDN asset URLs

### DIFF
--- a/packages/providers/upload-aws-s3/lib/index.js
+++ b/packages/providers/upload-aws-s3/lib/index.js
@@ -34,7 +34,13 @@ module.exports = {
             }
 
             // set the bucket file url
-            file.url = data.Location;
+            if (config.publicUrl) {
+              // write the url using the public url instead of S3 location
+              file.url = `${config.publicUrl.replace(/\/+$/, '')}/${data.Key}`;
+            } else {
+              // use the S3 location if there's no public url given
+              file.url = data.Location;
+            }
 
             resolve();
           }


### PR DESCRIPTION
### What does it do?

It adds ability to use public URL for assets uploaded to S3.

### Why is it needed?

To use custom CDN/public URL for assets uploaded to S3.