### PR TITLE
Fixes issue-11955 for same field name in dynamic zone

### DIFF
--- a/packages/core/utils/lib/convert-query-params.js
+++ b/packages/core/utils/lib/convert-query-params.js
@@ -164,6 +164,10 @@ const convertPopulateObject = (populate, schema) => {
     const attribute = attributes[key];
 
     if (!attribute) {
+      // this will fix the problem of field not displayed after save with same field name 
+      if (populate[key])
+        acc[key]=populate[key];
+      
       return acc;
     }
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests 
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Fixes #11955 and i have modified the convertPopulateObject function to take left behind field populate query to show results in admin panel and api side .

### Why is it needed?

Fixes #11955 issue and during fetching the data in admin panel and we are forming full populate query but in generatedynamiczone fakeschema its taking only first field and therefore the data not getting displayed in admin panel and api side .

### How to test it?

Replicate steps of #11955 

### Related issue(s)/PR(s)

#11955 
