### PR TITLE
Enhancement/user-id

### DIFF
--- a/packages/core/admin/package.json
+++ b/packages/core/admin/package.json
@@ -128,6 +128,7 @@
     "sift": "13.5.0",
     "style-loader": "3.3.1",
     "styled-components": "5.3.3",
+    "uuid": "8.3.2",
     "webpack": "5.65.0",
     "webpack-cli": "4.9.1",
     "webpack-dev-server": "4.7.3",

--- a/packages/core/admin/server/content-types/User.js
+++ b/packages/core/admin/server/content-types/User.js
@@ -73,6 +73,11 @@ module.exports = {
       configurable: false,
       private: true,
     },
+    uniqueAdminID: {
+      type: 'string',
+      configurable: false,
+      private: true,
+    },
     roles: {
       configurable: false,
       private: true,

--- a/packages/core/admin/server/controllers/authentication.js
+++ b/packages/core/admin/server/controllers/authentication.js
@@ -2,6 +2,7 @@
 
 const passport = require('koa-passport');
 const compose = require('koa-compose');
+const { v4: uuidv4 } = require('uuid');
 const { ApplicationError, ValidationError } = require('@strapi/utils').errors;
 const { getService } = require('../utils');
 const {
@@ -86,6 +87,8 @@ module.exports = {
 
     await validateRegistrationInput(input);
 
+    input.uniqueAdminID = uuidv4();
+
     const user = await getService('user').register(input);
 
     ctx.body = {
@@ -120,6 +123,7 @@ module.exports = {
       registrationToken: null,
       isActive: true,
       roles: superAdminRole ? [superAdminRole.id] : [],
+      uniqueAdminID: uuidv4(),
     });
 
     strapi.telemetry.send('didCreateFirstAdmin');

--- a/packages/core/admin/server/services/user.js
+++ b/packages/core/admin/server/services/user.js
@@ -157,7 +157,7 @@ const findRegistrationInfo = async registrationToken => {
  * @param {Object} params.registrationToken registration token
  * @param {Object} params.userInfo user info
  */
-const register = async ({ registrationToken, userInfo }) => {
+const register = async ({ registrationToken, userInfo, uniqueAdminID }) => {
   const matchingUser = await strapi.query('admin::user').findOne({ where: { registrationToken } });
 
   if (!matchingUser) {
@@ -170,6 +170,7 @@ const register = async ({ registrationToken, userInfo }) => {
     lastname: userInfo.lastname,
     registrationToken: null,
     isActive: true,
+    uniqueAdminID,
   });
 };
 

--- a/packages/core/strapi/lib/commands/admin-create.js
+++ b/packages/core/strapi/lib/commands/admin-create.js
@@ -3,6 +3,7 @@
 const { yup } = require('@strapi/utils');
 const _ = require('lodash');
 const inquirer = require('inquirer');
+const uuid = require('uuid');
 const strapi = require('../index');
 
 const emailValidator = yup
@@ -106,6 +107,7 @@ async function createAdmin({ email, password, firstname, lastname }) {
     firstname,
     lastname,
     isActive: true,
+    uniqueAdminID: uuid(),
     roles: [superAdminRole.id],
     ...(password && { password, registrationToken: null }),
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -18467,6 +18467,18 @@ path-exists@^2.0.0:
   dependencies:
     pinkie-promise "^2.0.0"
 
+path-dirname@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/path-dirname/-/path-dirname-1.0.2.tgz#cc33d24d525e099a5388c0336c6e32b9160609e0"
+  integrity sha512-ALzNPpyNq9AqXMBjeymIjFDAkAFH06mHJH/cSBHAgU0s4vfpBn6b2nf8tiRLvagKD8RbTpq2FKTBg7cl9l3c7Q==
+
+path-exists@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-2.1.0.tgz#0feb6c64f0fc518d9a754dd5efb62c7022761f4b"
+  integrity sha512-yTltuKuhtNeFJKa1PiRzfLAU5182q1y4Eb4XCJ3PBqyzEDkAZRzBrKKBct682ls9reBVHf9udYLN5Nd+K1B9BQ==
+  dependencies:
+    pinkie-promise "^2.0.0"
+
 path-exists@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
@@ -19320,6 +19332,13 @@ qs@6.9.7:
   version "6.9.7"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.7.tgz#4610846871485e1e048f44ae3b94033f0e675afe"
   integrity sha512-IhMFgUmuNpyRfxA90umL7ByLlgRXu6tIfKPpF5TmcfRLlLCckfP/g3IQmju6jjpu+Hh8rA+2p6A27ZSPOOHdKw==
+
+qs@^6.10.0:
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.11.0.tgz#fd0d963446f7a65e1367e01abd85429453f0c37a"
+  integrity sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==
+  dependencies:
+    side-channel "^1.0.4"
 
 qs@~6.5.2:
   version "6.5.3"
@@ -23269,11 +23288,6 @@ uuid@^3.3.2:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
-
-uuid@^8.0.0, uuid@^8.3.0, uuid@^8.3.2:
-  version "8.3.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
-  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
 v8-compile-cache@^2.0.3, v8-compile-cache@^2.3.0:
   version "2.3.0"


### PR DESCRIPTION
### What does it do?

This PR adds functionality to create a unique ID for admin registrations. For the first admin, unique admin id is added at the time of registration. For any other admin roles unique admin id is added only when the user follows the link to complete the registration. This is to avoid adding unnecessary identification to users that haven't completed registration. Any non-admin users are not affected. Unique admin ID is also added when new admin user is registered via the CLI command.

### Why is it needed?

The goal is to be able to use this unique admin id with Amplitude in order to better understand which admin roles use what functionality in Strapi. However, we will not use the actual unique admin id, only its hash. The goal is to be able to confidently distinguish unique users, their role and their actions in Strapi without being able identify the actual person. This will help us to understand what functionality in Strapi is redundant, what is needed and will help us to better plan for new features.

### How to test it?

Run `getstarted` application, register the admin, then you can check the sqlite db file to the the generated `unique_user_id` column and the corresponding data.

