### PR TITLE
Fix: Update firstname/lastname validation to trim whitespace on User Profile

### DIFF
--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Users/utils/validations/users/profile.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Users/utils/validations/users/profile.js
@@ -2,8 +2,11 @@ import * as yup from 'yup';
 import { translatedErrors } from '@strapi/helper-plugin';
 
 export const commonUserSchema = {
-  firstname: yup.mixed().required(translatedErrors.required),
-  lastname: yup.mixed(),
+  firstname: yup
+    .string()
+    .trim()
+    .required(translatedErrors.required),
+  lastname: yup.string().trim(),
   email: yup
     .string()
     .email(translatedErrors.email)


### PR DESCRIPTION
### What does it do?

It trims whitespace from the `firstname` and `lastname` fields in the user profile and prevents successful profile form submission when user enters only spaces in the required `firstname` field.

### How to test it?

1. Go to 'http://localhost:1337/admin/me'
2. Click on 'First Name' field
3. Press Space Bar 2-3 times
4. Try to Save, validation fails.

### Related issue(s)/PR(s)

[User Profile Name field not validated #13648](https://github.com/strapi/strapi/issues/13648)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202738709316451