### PR TITLE
Fix users-permissions default permissions

### DIFF
--- a/packages/plugins/users-permissions/server/services/users-permissions.js
+++ b/packages/plugins/users-permissions/server/services/users-permissions.js
@@ -7,15 +7,14 @@ const urlJoin = require('url-join');
 const { getService } = require('../utils');
 
 const DEFAULT_PERMISSIONS = [
-  { action: 'plugin::users-permissions.auth.admincallback', roleType: 'public' },
-  { action: 'plugin::users-permissions.auth.adminregister', roleType: 'public' },
   { action: 'plugin::users-permissions.auth.callback', roleType: 'public' },
-  { action: 'plugin::users-permissions.auth.connect', roleType: null },
-  { action: 'plugin::users-permissions.auth.forgotpassword', roleType: 'public' },
-  { action: 'plugin::users-permissions.auth.resetpassword', roleType: 'public' },
+  { action: 'plugin::users-permissions.auth.connect', roleType: 'public' },
+  { action: 'plugin::users-permissions.auth.forgotPassword', roleType: 'public' },
+  { action: 'plugin::users-permissions.auth.resetPassword', roleType: 'public' },
   { action: 'plugin::users-permissions.auth.register', roleType: 'public' },
-  { action: 'plugin::users-permissions.auth.emailconfirmation', roleType: 'public' },
-  { action: 'plugin::users-permissions.user.me', roleType: null },
+  { action: 'plugin::users-permissions.auth.emailConfirmation', roleType: 'public' },
+  { action: 'plugin::users-permissions.auth.sendEmailConfirmation', roleType: 'public' },
+  { action: 'plugin::users-permissions.user.me', roleType: 'authenticated' },
 ];
 
 const transformRoutePrefixFor = pluginName => route => {


### PR DESCRIPTION
### What does it do?

Fixes invalid default users-permissions permissions.

### Why is it needed?

Default users-permissions permissions were invalid until now.

### How to test it?

Without this PR drop the db and restart. Check invalid permissions are checked. Then restart and check some permissions got unchecked

On this PR. Drop the db and restart. Check  all permissions are valid and persist on the second restart

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
