### PR TITLE
Make updateContentTypeConfiguration endpoint return full data

### DIFF
--- a/packages/core/admin/admin/src/content-manager/hooks/useFetchContentTypeLayout/index.js
+++ b/packages/core/admin/admin/src/content-manager/hooks/useFetchContentTypeLayout/index.js
@@ -68,10 +68,10 @@ const useFetchContentTypeLayout = contentTypeUID => {
   }, [contentTypeUID, getData]);
 
   const updateLayout = useCallback(
-    newLayout => {
+    data => {
       dispatch({
         type: 'UPDATE_LAYOUT',
-        newLayout: formatLayouts({ contentType: newLayout, components: {} }, schemas),
+        newLayout: formatLayouts(data, schemas),
       });
     },
     [schemas]

--- a/packages/core/content-manager/server/controllers/content-types.js
+++ b/packages/core/content-manager/server/controllers/content-types.js
@@ -107,6 +107,18 @@ module.exports = {
 
     await metricsService.sendDidConfigureListView(contentType, newConfiguration);
 
-    ctx.body = { data: newConfiguration };
+    const confWithUpdatedMetadata = {
+      ...newConfiguration,
+      metadatas: mapValues(assocMainField, newConfiguration.metadatas),
+    };
+
+    const components = await contentTypeService.findComponentsConfigurations(contentType);
+
+    ctx.body = {
+      data: {
+        contentType: confWithUpdatedMetadata,
+        components,
+      },
+    };
   },
 };


### PR DESCRIPTION
This PR fixes the issue #13675 

The Content-type controller returns the same response object as the "findConfiguration" now.

### What does it do?

This PR changes the response of the `PUT /content-types/:uid/configuration` to be the same as `GET /content-types/:uid/configuration`.

*In general it is a good practice for the REST APIs to have the same response object for `GET` and `PUT` for the same route with the `PUT` returning modified resource.*

### Why is it needed?

As described in the linked issue, attempting to change view configuration for a single-type entry will fail if the entry contains components.
What happens is that the `PUT /content-types/:uid/configuration` responds with only half of the data that the "Admin" UI package needs for correct behaviour. And the `updateLayout` method simply hardcodes the missing piece with an empty object `components: {}`.
The problem happens when later in the execution flow tree there is an attempt to dereference a null pointer:
https://github.com/strapi/strapi/blob/8b719b12e917cba7ef2d50b458331c59bd7a94c9/packages/core/admin/admin/src/content-manager/hooks/useFetchContentTypeLayout/utils/formatLayouts.js#L167-L170

Here the `components` is an empty object, hence the `component` is undefined. Which means `component.settings` expression is doomed to fail.

### How to test it?

1. Create a fresh new project with Strapi.
2. Create a new component.
3. Create a single-type model
4. Go to Content Manager, and click the "Configure the view" button.
5. Shuffle the fields around and click save button
6. Confirm the action in the dialog

### Related issue(s)/PR(s)

fixes #13675

Note: No tests have been added for this code change. I don't have capacity to look into and update/add tests, sorry. 