### PR TITLE
[ML Folder] SelectTree box shadow

### DIFF
--- a/packages/core/helper-plugin/lib/src/components/ReactSelect/utils/getSelectStyles.js
+++ b/packages/core/helper-plugin/lib/src/components/ReactSelect/utils/getSelectStyles.js
@@ -8,12 +8,15 @@ const getSelectStyles = (theme, error) => {
     }),
     control: (base, state) => {
       let border = `1px solid ${theme.colors.neutral200} !important`;
+      let boxShadow = 0;
       let backgroundColor;
 
       if (state.isFocused) {
-        border = `1px solid ${theme.colors.primary200} !important`;
+        border = `1px solid ${theme.colors.primary600} !important`;
+        boxShadow = `${theme.colors.primary600} 0px 0px 0px 2px`;
       } else if (error) {
         border = `1px solid ${theme.colors.danger600} !important`;
+        boxShadow = `${theme.colors.danger600} 0px 0px 0px 2px`;
       }
 
       if (state.isDisabled) {
@@ -26,13 +29,13 @@ const getSelectStyles = (theme, error) => {
         height: 40,
         border,
         outline: 0,
-        boxShadow: 0,
         borderRadius: '2px !important',
         backgroundColor,
         borderTopLeftRadius: '4px !important',
         borderTopRightRadius: '4px !important',
         borderBottomLeftRadius: '4px !important',
         borderBottomRightRadius: '4px !important',
+        boxShadow,
       };
     },
     indicatorContainer: base => ({ ...base, padding: 0, paddingRight: theme.spaces[3] }),


### PR DESCRIPTION
## What

- Fixed wrong color token for focused state
- Added box-shadow to error and focused state (to match DS inputs style)


<img width="873" alt="Screenshot 2022-07-05 at 17 35 27" src="https://user-images.githubusercontent.com/71838159/177366848-ecadb5eb-d29a-4f05-85eb-1866c7e1a3dd.png">

<img width="886" alt="Screenshot 2022-07-05 at 17 35 13" src="https://user-images.githubusercontent.com/71838159/177366840-2f327ccd-386b-4584-9b31-1fa949f1f893.png">

