### PR TITLE
MediaLibraryInput: Fix drag & drop events

### DIFF
--- a/packages/core/upload/admin/src/components/MediaLibraryInput/Carousel/EmptyStateAsset.js
+++ b/packages/core/upload/admin/src/components/MediaLibraryInput/Carousel/EmptyStateAsset.js
@@ -18,14 +18,24 @@ export const EmptyStateAsset = ({ disabled, onClick, onDropAsset }) => {
   const { formatMessage } = useIntl();
   const [dragOver, setDragOver] = useState(false);
 
-  const handleDragEnter = () => setDragOver(true);
+  const handleDragEnter = e => {
+    e.preventDefault();
+    setDragOver(true);
+  };
+
   const handleDragLeave = e => {
     if (!e.currentTarget.contains(e.relatedTarget)) {
       setDragOver(false);
     }
   };
 
+  const handleDragOver = e => {
+    e.preventDefault();
+  };
+
   const handleDrop = e => {
+    e.preventDefault();
+
     if (e?.dataTransfer?.files) {
       const files = e.dataTransfer.files;
       const assets = [];
@@ -59,6 +69,7 @@ export const EmptyStateAsset = ({ disabled, onClick, onDropAsset }) => {
       onClick={onClick}
       onDragEnter={handleDragEnter}
       onDragLeave={handleDragLeave}
+      onDragOver={handleDragOver}
       onDrop={handleDrop}
       style={{ cursor: disabled ? 'not-allowed' : 'pointer' }}
     >


### PR DESCRIPTION
### What does it do?

Fixes dropping files into media library input fields.

### Why is it needed?

To properly support dragging and dropping files.

### How to test it?

1. Use the "User" content type of the getstarted example
2. Drag & drop a file onto the picture field

### Related issue(s)/PR(s)

- Fixes https://github.com/strapi/strapi/issues/13061
