### PR TITLE
FromComputerForm: Fix drag & drop events

### DIFF
--- a/packages/core/upload/admin/src/components/UploadAssetDialog/AddAssetStep/FromComputerForm.js
+++ b/packages/core/upload/admin/src/components/UploadAssetDialog/AddAssetStep/FromComputerForm.js
@@ -41,7 +41,15 @@ export const FromComputerForm = ({ onClose, onAddAssets, trackedLocation }) => {
   const inputRef = useRef(null);
   const { trackUsage } = useTracking();
 
-  const handleDragEnter = () => setDragOver(true);
+  const handleDragOver = event => {
+    event.preventDefault();
+  };
+
+  const handleDragEnter = event => {
+    event.preventDefault();
+    setDragOver(true);
+  };
+
   const handleDragLeave = () => setDragOver(false);
 
   const handleClick = e => {
@@ -68,6 +76,8 @@ export const FromComputerForm = ({ onClose, onAddAssets, trackedLocation }) => {
   };
 
   const handleDrop = e => {
+    e.preventDefault();
+
     if (e?.dataTransfer?.files) {
       const files = e.dataTransfer.files;
       const assets = [];
@@ -99,6 +109,7 @@ export const FromComputerForm = ({ onClose, onAddAssets, trackedLocation }) => {
             position="relative"
             onDragEnter={handleDragEnter}
             onDragLeave={handleDragLeave}
+            onDragOver={handleDragOver}
             onDrop={handleDrop}
           >
             <Flex justifyContent="center">


### PR DESCRIPTION
### What does it do?

Similar to https://github.com/strapi/strapi/pull/13696 this PR fixes dropping files into the media library "From Computer" field.

### Why is it needed?

To properly support dragging and dropping files.

### How to test it?

1. Use the "User" content type of the getstarted example
2. Drag & drop a file onto the picture field

### Related issue(s)/PR(s)

- Refs https://github.com/strapi/strapi/issues/13061
