### PR TITLE
CellContent: Fix relations, if a user does not have read permissions

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/DynamicTable/CellContent/utils/hasContent.js
+++ b/packages/core/admin/admin/src/content-manager/components/DynamicTable/CellContent/utils/hasContent.js
@@ -45,7 +45,7 @@ export default function hasContent(type, content, metadatas, fieldSchema) {
       return !isEmpty(content);
     }
 
-    return content.count > 0;
+    return content?.count > 0;
   }
 
   /* 

--- a/packages/core/admin/admin/src/content-manager/components/DynamicTable/CellContent/utils/tests/hasContent.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/DynamicTable/CellContent/utils/tests/hasContent.test.js
@@ -227,15 +227,22 @@ describe('hasContent', () => {
   });
 
   describe('relations', () => {
-    it('extracts content from multiple relations with content', () => {
+    it('extracts content from multiple relations with count=1', () => {
       const normalizedContent = hasContent('relation', { count: 1 }, undefined, {
         relation: 'manyToMany',
       });
       expect(normalizedContent).toEqual(true);
     });
 
-    it('extracts content from multiple relations without content', () => {
+    it('extracts content from multiple relations with count=0', () => {
       const normalizedContent = hasContent('relation', { count: 0 }, undefined, {
+        relation: 'manyToMany',
+      });
+      expect(normalizedContent).toEqual(false);
+    });
+
+    it('extracts content from multiple relations without content', () => {
+      const normalizedContent = hasContent('relation', undefined, undefined, {
         relation: 'manyToMany',
       });
       expect(normalizedContent).toEqual(false);


### PR DESCRIPTION
### What does it do?

Fixes a bug, where relational cells without read permissions would crash the admin app, because an attribute that doesn't exist (`count`) was accessed without checking upfront.

### Why is it needed?

To not crash the admin interface.

### How to test it?

1. Start Strapi in EE mode
2. Create new role
3. Remove read permissions from `categories` field of the `Address` content-type for the custom role
4. Invite new user and assign them the new role
5. Login and navigate to the content-manager list-view
6. Before: The app would crash; After: the cell reports itself as empty

### Related issue(s)/PR(s)

- Fixes https://github.com/strapi/strapi/issues/13413
