### PR TITLE
PreviewBox: Fix image cropping

### DIFF
--- a/packages/core/upload/admin/src/components/EditAssetDialog/PreviewBox/index.js
+++ b/packages/core/upload/admin/src/components/EditAssetDialog/PreviewBox/index.js
@@ -80,6 +80,13 @@ export const PreviewBox = ({
     }
   }, [replacementFile, asset]);
 
+  useEffect(() => {
+    if (!hasCropIntent) {
+      stopCropping();
+      onCropCancel();
+    }
+  }, [hasCropIntent, stopCropping, onCropCancel, onCropFinish]);
+
   const handleCropping = async () => {
     const nextAsset = { ...asset, width, height };
     const file = await produceFile(nextAsset.name, nextAsset.mime, nextAsset.updatedAt);
@@ -104,10 +111,9 @@ export const PreviewBox = ({
       trackUsage('didCropFile', { duplicatedFile: false, location: trackedLocation });
     }
 
-    stopCropping();
-    onCropCancel();
     setAssetUrl(optimizedCachingImage);
     setThumbnailUrl(optimizedCachingThumbnailImage);
+    setHasCropIntent(false);
   };
 
   const isInCroppingMode = isCropping && !isLoading;
@@ -120,15 +126,13 @@ export const PreviewBox = ({
 
     trackUsage('didCropFile', { duplicatedFile: true, location: trackedLocation });
 
-    stopCropping();
+    setHasCropIntent(false);
     onCropFinish();
   };
 
   const handleCropCancel = () => {
     setHasCropIntent(false);
     setIsCropImageReady(false);
-    stopCropping();
-    onCropCancel();
   };
 
   const handleCropStart = () => {

--- a/packages/core/upload/admin/src/components/EditAssetDialog/PreviewBox/index.js
+++ b/packages/core/upload/admin/src/components/EditAssetDialog/PreviewBox/index.js
@@ -116,7 +116,7 @@ export const PreviewBox = ({
     setHasCropIntent(false);
   };
 
-  const isInCroppingMode = isCropping && !isLoading;
+  const isInCroppingMode = asset.isLocal ? true : isCropping && !isLoading;
 
   const handleDuplication = async () => {
     const nextAsset = { ...asset, width, height };
@@ -218,7 +218,7 @@ export const PreviewBox = ({
             name={asset.name}
             url={hasCropIntent ? assetUrl : thumbnailUrl}
             onLoad={() => {
-              if (hasCropIntent) {
+              if (asset.isLocal ? true : hasCropIntent) {
                 setIsCropImageReady(true);
               }
             }}


### PR DESCRIPTION
### What does it do?

Fixes two bugs related to image cropping:

- the crop-box is not disabled after a crop was confirmed
- local files can not be cropped: https://github.com/strapi/strapi/issues/13417

### Why is it needed?

To properly support cropping images before and after uploading.

### How to test it?

#### First case

1. Select an asset and start cropping it
2. Select "Crop original asset"
3. Confirm the cropping box is closed afterwards

#### Second case

1. Select a new image to upload
2. Crop image
3. Confirm the image can properly be cropped

### Related issue(s)/PR(s)

- Fixes https://github.com/strapi/strapi/issues/13417
