### PR TITLE
LocalePicker: Always set page to 1 after updating a locale

### DIFF
--- a/packages/plugins/i18n/admin/src/components/LocalePicker/index.js
+++ b/packages/plugins/i18n/admin/src/components/LocalePicker/index.js
@@ -54,6 +54,7 @@ const LocalePicker = () => {
     setSelected(code);
 
     setQuery({
+      page: 1,
       plugins: { ...query.plugins, i18n: { locale: code } },
     });
   };


### PR DESCRIPTION
### What does it do?

After changing the locale in the content-manager listview we currently preserve the current page, which could lead to problems, if that page does not exist in the selected locale.

This PR aims to fix that bug, by resetting the current page to 1, when the locale was changed.

### Why is it needed?

Fixes the attached bug.

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

- Fixes https://github.com/strapi/strapi/issues/13673
