### PR TITLE
Remove npm warning from documentation plugin readme

### DIFF
--- a/packages/plugins/documentation/README.md
+++ b/packages/plugins/documentation/README.md
@@ -1,7 +1,6 @@
 # Plugin documentation
 
 This plugin automates your API documentation creation. It basically generates a swagger file. It follows the [Open API specification version 3.0.1](https://swagger.io/specification/).
-The documentation plugin is not release on npm yet, Here's how to install it.
 
 ## Usage
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Remove text about the docs plugin not being published on npm

### Why is it needed?

Because the docs plugin is published on npm
