### PR TITLE
CTB: Improve UI validation for enum values

### DIFF
--- a/packages/core/content-type-builder/admin/src/components/FormModal/attributes/types.js
+++ b/packages/core/content-type-builder/admin/src/components/FormModal/attributes/types.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import uniq from 'lodash/uniq';
 import * as yup from 'yup';
 import { translatedErrors as errorsTrads } from '@strapi/helper-plugin';
 import getTrad from '../../../utils/getTrad';
@@ -153,12 +153,11 @@ const types = {
           name: 'areEnumValuesUnique',
           message: getTrad('error.validation.enum-duplicate'),
           test(values) {
-            const normalizedEnum = values.map(toRegressedEnumValue);
-            const duplicates = _(normalizedEnum)
-              .groupBy()
-              .pickBy(x => x.length > 1)
-              .keys()
-              .value();
+            const duplicates = uniq(
+              values
+                .map(toRegressedEnumValue)
+                .filter((value, index, values) => values.indexOf(value) !== index)
+            );
 
             return !duplicates.length;
           },

--- a/packages/core/content-type-builder/admin/src/components/FormModal/attributes/types.js
+++ b/packages/core/content-type-builder/admin/src/components/FormModal/attributes/types.js
@@ -4,7 +4,6 @@ import { translatedErrors as errorsTrads } from '@strapi/helper-plugin';
 import getTrad from '../../../utils/getTrad';
 import getRelationType from '../../../utils/getRelationType';
 import toRegressedEnumValue from '../../../utils/toRegressedEnumValue';
-import startsWithANumber from '../../../utils/startsWithANumber';
 import {
   alreadyUsedAttributeNames,
   createTextShape,
@@ -169,9 +168,9 @@ const types = {
           test: values => !values.some(val => val === ''),
         })
         .test({
-          name: 'doesNotStartWithANumber',
-          message: getTrad('error.validation.enum-number'),
-          test: values => !values.some(startsWithANumber),
+          name: 'doesMatchRegex',
+          message: getTrad('error.validation.enum-regex'),
+          test: values => values.map(toRegressedEnumValue).every(value => ENUM_REGEX.test(value)),
         }),
       enumName: yup.string().nullable(),
     };

--- a/packages/core/content-type-builder/admin/src/components/FormModal/attributes/types.js
+++ b/packages/core/content-type-builder/admin/src/components/FormModal/attributes/types.js
@@ -131,7 +131,18 @@ const types = {
     return yup.object(shape);
   },
   enumeration: (usedAttributeNames, reservedNames) => {
-    // See GraphQL Spec https://spec.graphql.org/June2018/#sec-Names
+    /**
+     * For enumerations the least common denomiator is GraphQL, where
+     * values needs to match the secure name regex:
+     * GraphQL Spec https://spec.graphql.org/June2018/#sec-Names
+     *
+     * Therefore we need to make sure our users only use values, which
+     * can be returned by GraphQL, by checking the regressed values
+     * agains the GraphQL regex.
+     *
+     * TODO V5: check if we can avoid this coupling by moving this logic
+     * into the GraphQL plugin.
+     */
     const GRAPHQL_ENUM_REGEX = new RegExp('^[_A-Za-z][_0-9A-Za-z]*$');
 
     const shape = {

--- a/packages/core/content-type-builder/admin/src/components/FormModal/attributes/types.js
+++ b/packages/core/content-type-builder/admin/src/components/FormModal/attributes/types.js
@@ -165,7 +165,7 @@ const types = {
         .test({
           name: 'doesNotHaveEmptyValues',
           message: getTrad('error.validation.enum-empty-string'),
-          test: values => !values.some(val => val === ''),
+          test: values => !values.map(toRegressedEnumValue).some(val => val === ''),
         })
         .test({
           name: 'doesMatchRegex',

--- a/packages/core/content-type-builder/admin/src/components/FormModal/attributes/types.js
+++ b/packages/core/content-type-builder/admin/src/components/FormModal/attributes/types.js
@@ -131,14 +131,15 @@ const types = {
     return yup.object(shape);
   },
   enumeration: (usedAttributeNames, reservedNames) => {
-    const ENUM_REGEX = new RegExp('^[_A-Za-z][_0-9A-Za-z]*$');
+    // See GraphQL Spec https://spec.graphql.org/June2018/#sec-Names
+    const GRAPHQL_ENUM_REGEX = new RegExp('^[_A-Za-z][_0-9A-Za-z]*$');
 
     const shape = {
       name: yup
         .string()
         .test(alreadyUsedAttributeNames(usedAttributeNames))
         .test(isNameAllowed(reservedNames))
-        .matches(ENUM_REGEX, errorsTrads.regex)
+        .matches(GRAPHQL_ENUM_REGEX, errorsTrads.regex)
         .required(errorsTrads.required),
       type: validators.type(),
       default: validators.default(),
@@ -170,7 +171,8 @@ const types = {
         .test({
           name: 'doesMatchRegex',
           message: getTrad('error.validation.enum-regex'),
-          test: values => values.map(toRegressedEnumValue).every(value => ENUM_REGEX.test(value)),
+          test: values =>
+            values.map(toRegressedEnumValue).every(value => GRAPHQL_ENUM_REGEX.test(value)),
         }),
       enumName: yup.string().nullable(),
     };

--- a/packages/core/content-type-builder/admin/src/translations/en.json
+++ b/packages/core/content-type-builder/admin/src/translations/en.json
@@ -60,7 +60,7 @@
   "error.contentTypeName.reserved-name": "This name cannot be used in your project as it might break other functionalities",
   "error.validation.enum-duplicate": "Duplicate values are not allowed",
   "error.validation.enum-empty-string": "Empty strings are not allowed",
-  "error.validation.enum-regex": "At least one value contains invalid characters. Values should always have an alphabetical character preceding any number.",
+  "error.validation.enum-regex": "At least one value contains invalid characters. Values should start with an alphabetical character preceeding the first occurence of a number.",
   "error.validation.minSupMax": "Can't be superior",
   "error.validation.positive": "Must be a positive number",
   "error.validation.regex": "Regex pattern is invalid",

--- a/packages/core/content-type-builder/admin/src/translations/en.json
+++ b/packages/core/content-type-builder/admin/src/translations/en.json
@@ -60,7 +60,7 @@
   "error.contentTypeName.reserved-name": "This name cannot be used in your project as it might break other functionalities",
   "error.validation.enum-duplicate": "Duplicate values are not allowed",
   "error.validation.enum-empty-string": "Empty strings are not allowed",
-  "error.validation.enum-number": "Values cannot start with a number",
+  "error.validation.enum-regex": "At least one value contains invalid characters. Non alphanumerical characters should not be followed by numbers at the beginning of a value.",
   "error.validation.minSupMax": "Can't be superior",
   "error.validation.positive": "Must be a positive number",
   "error.validation.regex": "Regex pattern is invalid",

--- a/packages/core/content-type-builder/admin/src/translations/en.json
+++ b/packages/core/content-type-builder/admin/src/translations/en.json
@@ -60,7 +60,7 @@
   "error.contentTypeName.reserved-name": "This name cannot be used in your project as it might break other functionalities",
   "error.validation.enum-duplicate": "Duplicate values are not allowed",
   "error.validation.enum-empty-string": "Empty strings are not allowed",
-  "error.validation.enum-regex": "At least one value contains invalid characters. Non alphanumerical characters should not be followed by numbers at the beginning of a value.",
+  "error.validation.enum-regex": "At least one value contains invalid characters. Values should always have an alphabetical character preceding any number.",
   "error.validation.minSupMax": "Can't be superior",
   "error.validation.positive": "Must be a positive number",
   "error.validation.regex": "Regex pattern is invalid",

--- a/packages/core/content-type-builder/admin/src/translations/en.json
+++ b/packages/core/content-type-builder/admin/src/translations/en.json
@@ -60,7 +60,7 @@
   "error.contentTypeName.reserved-name": "This name cannot be used in your project as it might break other functionalities",
   "error.validation.enum-duplicate": "Duplicate values are not allowed",
   "error.validation.enum-empty-string": "Empty strings are not allowed",
-  "error.validation.enum-regex": "At least one value contains invalid characters. Values should start with an alphabetical character preceeding the first occurence of a number.",
+  "error.validation.enum-regex": "At least one value is invalid. Values should have at least one alphabetical character preceeding the first occurence of a number.",
   "error.validation.minSupMax": "Can't be superior",
   "error.validation.positive": "Must be a positive number",
   "error.validation.regex": "Regex pattern is invalid",

--- a/packages/core/content-type-builder/admin/src/translations/en.json
+++ b/packages/core/content-type-builder/admin/src/translations/en.json
@@ -58,7 +58,7 @@
   "error.contentType.pluralName-used": "This value cannot be the same as the singular one",
   "error.contentType.singularName-used": "This value cannot be the same as the plural one",
   "error.contentTypeName.reserved-name": "This name cannot be used in your project as it might break other functionalities",
-  "error.validation.enum-duplicate": "Duplicate values are not allowed",
+  "error.validation.enum-duplicate": "Duplicate values are not allowed (only alphanumeric characters are taken into account).",
   "error.validation.enum-empty-string": "Empty strings are not allowed",
   "error.validation.enum-regex": "At least one value is invalid. Values should have at least one alphabetical character preceeding the first occurence of a number.",
   "error.validation.minSupMax": "Can't be superior",

--- a/packages/core/strapi/lib/core/domain/content-type/validator.js
+++ b/packages/core/strapi/lib/core/domain/content-type/validator.js
@@ -24,7 +24,18 @@ const LIFECYCLES = [
   'afterDeleteMany',
 ];
 
-// See GraphQL Spec https://spec.graphql.org/June2018/#sec-Names
+/**
+ * For enumerations the least common denomiator is GraphQL, where
+ * values needs to match the secure name regex:
+ * GraphQL Spec https://spec.graphql.org/June2018/#sec-Names
+ *
+ * Therefore we need to make sure our users only use values, which
+ * can be returned by GraphQL, by checking the regressed values
+ * agains the GraphQL regex.
+ *
+ * TODO V5: check if we can avoid this coupling by moving this logic
+ * into the GraphQL plugin.
+ */
 const GRAPHQL_ENUM_REGEX = new RegExp('^[_A-Za-z][_0-9A-Za-z]*$');
 
 const lifecyclesShape = _.mapValues(_.keyBy(LIFECYCLES), () =>

--- a/packages/core/strapi/lib/core/domain/content-type/validator.js
+++ b/packages/core/strapi/lib/core/domain/content-type/validator.js
@@ -61,7 +61,7 @@ const contentTypeSchemaValidator = yup.object().shape({
 
             // should match the GraphQL regex
             if (!regressedValues.every(value => GRAPHQL_ENUM_REGEX.test(value))) {
-              const message = `Invalid enumervarion value. Values should always have an alphabetical character preceding any number. Update your enumeration '${attrName}'.`;
+              const message = `Invalid enumeration value. Values should start with an alphabetical character preceeding the first occurence of a number. Update your enumeration '${attrName}'.`;
 
               return this.createError({ message });
             }
@@ -79,7 +79,7 @@ const contentTypeSchemaValidator = yup.object().shape({
             );
 
             if (duplicates.length) {
-              const message = `Some enum values of the field '${attrName}' collide when normalized: ${duplicates.join(
+              const message = `Some enumeration values of the field '${attrName}' collide when normalized: ${duplicates.join(
                 ', '
               )}. Please modify your enumeration.`;
 

--- a/packages/core/strapi/lib/core/domain/content-type/validator.js
+++ b/packages/core/strapi/lib/core/domain/content-type/validator.js
@@ -72,7 +72,7 @@ const contentTypeSchemaValidator = yup.object().shape({
 
             // should match the GraphQL regex
             if (!regressedValues.every(value => GRAPHQL_ENUM_REGEX.test(value))) {
-              const message = `Invalid enumeration value. Values should start with an alphabetical character preceeding the first occurence of a number. Update your enumeration '${attrName}'.`;
+              const message = `Invalid enumeration value. Values should have at least one alphabetical character preceeding the first occurence of a number. Update your enumeration '${attrName}'.`;
 
               return this.createError({ message });
             }
@@ -80,7 +80,7 @@ const contentTypeSchemaValidator = yup.object().shape({
             // should not contain empty values
             if (regressedValues.some(value => value === '')) {
               return this.createError({
-                message: `At least one value of the enumeration '${attrName}' appears to be empty.`,
+                message: `At least one value of the enumeration '${attrName}' appears to be empty. Only alphanumerical characters are taken into account.`,
               });
             }
 


### PR DESCRIPTION
### What does it do?

Builds on top of https://github.com/strapi/strapi/pull/13503, to improve the enum values validation in the admin UI. Instead of testing each value directly this PR tests the `regressed` value. This will allow more values and only fail on the ones that GraphQL can not deal with.

### Why is it needed?

It helps to prevent crashing Strapi at the bootstrap phase, after a new invalid value has been added to an enum field in the admin UI.

### How to test it?

1. Navigate to CTB
2. Add a new enum field to a content-type
3. Add invalid values (such as `--1`)
4. Validate a frontend validation error is shown

### Related issue(s)/PR(s)

- Refs https://github.com/strapi/strapi/pull/13503
- Fixes https://github.com/strapi/strapi/issues/13428
