### PR TITLE
feat(provider-upload-aws-s3): add publicURL parameter in provider options

### DIFF
--- a/packages/providers/upload-aws-s3/lib/index.js
+++ b/packages/providers/upload-aws-s3/lib/index.js
@@ -34,7 +34,7 @@ module.exports = {
             }
 
             // set the bucket file url
-            file.url = data.Location;
+            file.url = config.publicURL ? new URL(data.Key, config.publicURL).toString() : data.Location;
 
             resolve();
           }


### PR DESCRIPTION
### What does it do?

This PR basically makes it possible to override the URL stored in Strapi by providing a different domain. This can also be useful for organizations that prefer to use a custom domain name for assets rather than the one of the S3 provider.

### Why is it needed?

I am using the @strapi/provider-upload-aws-s3 package to upload to my organization's S3 (hosted on OVH). However, the URL returned in the S3 API upload response does not match a valid one. This is a problem on behalf of OVH, but this situation could also happen with other S3 providers.

### How to test it?

Add the publicURL parameter to the provider options with your domain. Make sure that the URL ends with a trailing slash.

```js
upload: {
    config: {
      provider: 'aws-s3',
      providerOptions: {
        //...
        publicURL: "https://storage.gra.cloud.ovh.net/v1/AUTH_123xxxx678/strapi-assets/",
        //...
      },
    },
  },
```
