### PR TITLE
fix: typo

### DIFF
--- a/packages/core/database/lib/query/helpers/where.js
+++ b/packages/core/database/lib/query/helpers/where.js
@@ -133,7 +133,7 @@ const processWhere = (where, ctx) => {
     }
 
     if (isOperator(key)) {
-      throw new Error(`Only $and, $or and $not can by used as root level operators. Found ${key}.`);
+      throw new Error(`Only $and, $or and $not can only be used as root level operators. Found ${key}.`);
     }
 
     const attribute = meta.attributes[key];


### PR DESCRIPTION
### What does it do?

Correct the error message
 `Only $and, $or and $not can by used as root level operators. Found ${key}.` to 
`Only $and, $or and $not can only be used as root level operators. Found ${key}.`


### Why is it needed?

It's syntactically incorrect and not clear enough

