### PR TITLE
[Custom Fields] Convert custom field type

### DIFF
--- a/packages/core/content-type-builder/server/utils/__tests__/attributes.test.js
+++ b/packages/core/content-type-builder/server/utils/__tests__/attributes.test.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const { formatAttribute } = require('../attributes');
+
+describe('format attributes', () => {
+  it('replaces type customField with the underlying data type', () => {
+    const mockAttribute = {
+      type: 'customField',
+      customField: 'plugin::mycustomfields.color',
+    };
+
+    global.strapi = {
+      container: {
+        // mock container.get('custom-fields')
+        get: jest.fn(() => ({
+          // mock container.get('custom-fields').get(uid)
+          get: jest.fn(() => ({
+            name: 'color',
+            plugin: 'mycustomfields',
+            type: 'text',
+          })),
+        })),
+      },
+    };
+
+    const formattedAttribute = formatAttribute('key', mockAttribute);
+
+    const expected = {
+      type: 'text',
+      customField: 'plugin::mycustomfields.color',
+    };
+    expect(formattedAttribute).toEqual(expected);
+  });
+});

--- a/packages/core/content-type-builder/server/utils/attributes.js
+++ b/packages/core/content-type-builder/server/utils/attributes.js
@@ -67,6 +67,19 @@ const formatAttribute = (key, attribute) => {
     };
   }
 
+  if (attribute.type === 'customField') {
+    const customField = strapi.container.get('custom-fields').get(attribute.customField);
+
+    if (!customField) {
+      throw new Error(`Could not find Custom Field: ${attribute.customField}`);
+    }
+
+    return {
+      ...attribute,
+      type: customField.type,
+    };
+  }
+
   return attribute;
 };
 

--- a/packages/core/strapi/lib/core/registries/custom-fields.js
+++ b/packages/core/strapi/lib/core/registries/custom-fields.js
@@ -10,6 +10,9 @@ const customFieldsRegistry = strapi => {
     getAll() {
       return customFields;
     },
+    get(customField) {
+      return customFields[customField];
+    },
     add(customField) {
       const customFieldList = Array.isArray(customField) ? customField : [customField];
 

--- a/packages/plugins/documentation/server/services/helpers/utils/clean-schema-attributes.js
+++ b/packages/plugins/documentation/server/services/helpers/utils/clean-schema-attributes.js
@@ -19,6 +19,11 @@ const cleanSchemaAttributes = (attributes, { typeMap = new Map(), isRequest = fa
       delete attributesCopy[prop].default;
     }
 
+    if (attribute.type === 'customField') {
+      const customField = strapi.container.get('custom-fields').get(attribute.customField);
+      attribute.type = customField.type;
+    }
+
     switch (attribute.type) {
       case 'password': {
         if (!isRequest) {


### PR DESCRIPTION
⚠️ This PR depends on https://github.com/strapi/strapi/pull/13708, I will change the base branch to `features/custom-fields` when that PR is merged ⚠️ 
### What does it do?

- Converts a custom field attribute type to the underlying type found on a custom field
- Adds a `get` method on the customFields registry to get a single customField
- Fixes the documentation plugin to handle type customField

### Why is it needed?

So the Content-type builder knows what to do with a custom field

### How to test it?

In examples/getstarted add the following as an attribute to any content-type
```
 "color": {
    "type": "customField",
    "customField": "plugin::mycustomfields.color"
  }
```

- Go to the content-type builder and select the content-type with your custom field, it should display as a `text` attribute
- Inspect the network response for content-types, it should have `type: 'text'` instead of `type: 'customField'` for the custom field attribute on the content-type

