### PR TITLE
Add environment property to admin telemetry calls

### DIFF
--- a/packages/core/admin/admin/src/pages/App/index.js
+++ b/packages/core/admin/admin/src/pages/App/index.js
@@ -84,6 +84,9 @@ function App() {
                 event: 'didInitializeAdministration',
                 uuid,
                 deviceId,
+                properties: {
+                  environment: process.env.NODE_ENV
+                }
               }),
               headers: {
                 'Content-Type': 'application/json',

--- a/packages/core/helper-plugin/lib/src/hooks/useTracking/index.js
+++ b/packages/core/helper-plugin/lib/src/hooks/useTracking/index.js
@@ -11,7 +11,7 @@ const useTracking = () => {
       try {
         axios.post('https://analytics.strapi.io/track', {
           event,
-          properties: { ...properties, projectType: strapi.projectType },
+          properties: { ...properties, projectType: strapi.projectType, environment: process.env.NODE_ENV },
           uuid,
         });
       } catch (err) {


### PR DESCRIPTION
### What does it do?

Adds `environment` property to admin telemetry calls so that we can establish in what environment admin telemetry calls happen

### Why is it needed?

At the moment we only send environment with server telemetry calls, but not the admin. Hence, there are a lot of events that we see that don't have an environment associated with them. Having an environment on all calls will allow us to filter them better.
