### PR TITLE
ML: Display proper error message thrown by the API

### DIFF
--- a/packages/core/upload/admin/src/components/AssetCard/UploadingAssetCard.js
+++ b/packages/core/upload/admin/src/components/AssetCard/UploadingAssetCard.js
@@ -100,7 +100,10 @@ export const UploadingAssetCard = ({ asset, onCancel, onStatusChange, addUploade
       </Card>
       {error ? (
         <Typography variant="pi" fontWeight="bold" textColor="danger600">
-          {error.message}
+          {formatMessage({
+            id: getTrad(`apiError.${error.response.data.error.message}`),
+            defaultMessage: error.response.data.error.message,
+          })}
         </Typography>
       ) : (
         undefined

--- a/packages/core/upload/admin/src/translations/en.json
+++ b/packages/core/upload/admin/src/translations/en.json
@@ -1,4 +1,5 @@
 {
+  "apiError.FileTooBig": "The uploaded file exceeds the maximum allowed asset size.",
   "bulk.select.label": "Select all assets",
   "button.next": "Next",
   "checkControl.crop-duplicate": "Duplicate & crop the asset",


### PR DESCRIPTION
### What does it do?

If a file upload fails we currently display a generic error message which is not helpful to the user and doesn't support custom error messages thrown by controllers in the API.

This PR displays the error message thrown in the API and makes it translateable.

### Why is it needed?

To properly give feedback to our users, on what went wrong and to allow developers to display custom error messages.

### How to test it?

1. Limit the filesize of uploads using https://docs.strapi.io/developer-docs/latest/plugins/upload.html#configuration
2. Upload a file with a larger size than configured
3. See the proper error message

### Related issue(s)/PR(s)

- Fixes https://github.com/strapi/strapi/issues/13767
