### PR TITLE
Upload: Fix typo in upload middleware

### DIFF
--- a/packages/core/upload/server/middlewares/upload.js
+++ b/packages/core/upload/server/middlewares/upload.js
@@ -19,7 +19,7 @@ module.exports = ({ strapi }) => {
     strapi.server.app.onerror(err);
   });
 
-  const localServerConfig = strapi.config.get('plugin.upload.providerOptions.localeServer', {});
+  const localServerConfig = strapi.config.get('plugin.upload.providerOptions.localServer', {});
 
   strapi.server.routes([
     {


### PR DESCRIPTION
### What does it do?

https://github.com/strapi/strapi/issues/13737 mentioned a typo in the upload middleware, which is fixed by this PR.

### Why is it needed?

To properly support the `localeServer` option: https://docs.strapi.io/developer-docs/latest/plugins/upload.html#configuration

### How to test it?

🤷🏼 

### Related issue(s)/PR(s)

- Refs https://github.com/strapi/strapi/issues/13737
