### PR TITLE
Fix 13774: Add support for mysql2 driver

### DIFF
--- a/packages/core/database/lib/connection.js
+++ b/packages/core/database/lib/connection.js
@@ -6,7 +6,7 @@ const knex = require('knex');
 
 const SqliteClient = require('knex/lib/dialects/sqlite3/index');
 
-const trySqlitePackage = packageName => {
+const tryPackage = packageName => {
   try {
     require.resolve(packageName);
     return packageName;
@@ -37,11 +37,12 @@ const getSqlitePackageName = () => {
 
   // NOTE: this tries to find the best sqlite module possible to use
   // while keeping retro compatibility
-  return (
-    trySqlitePackage('better-sqlite3') ||
-    trySqlitePackage('@vscode/sqlite3') ||
-    trySqlitePackage('sqlite3')
-  );
+  return tryPackage('better-sqlite3') || tryPackage('@vscode/sqlite3') || tryPackage('sqlite3');
+};
+
+const getMysqlPackageName = () => {
+  // Try the best mysql package
+  return tryPackage('mysql2') || tryPackage('mysql');
 };
 
 const createConnection = config => {
@@ -50,6 +51,10 @@ const createConnection = config => {
     const sqlitePackageName = getSqlitePackageName();
 
     knexConfig.client = clientMap[sqlitePackageName];
+  }
+
+  if (knexConfig.client === 'mysql') {
+    knexConfig.client = getMysqlPackageName();
   }
 
   const knexInstance = knex(knexConfig);


### PR DESCRIPTION
### What does it do?

When `mysql` client is specified in database settings, Strapi will test for multiple possible packages that could be used as the driver for this type of the client (in order of priority: `mysql2`, `mysql`).

### Why is it needed?

This fixes the issue https://github.com/strapi/strapi/issues/13774
When a developer wants to use `mysql2` driver it is currently impossible as knex is configured to look for `mysql` only.

### How to test it?

1. Create a strapi project and configure database client as "mysql".
2. Install `mysql2` driver (`npm install mysql2`). Make sure you don't install the mysqljs (`mysql`).
3. Run strapi and check that it starts normally without failing to find a package.

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/issues/13774
