### PR TITLE
Github: Add admin bundle-size PR reporter

### DIFF
--- a/.github/workflows/adminBundleSize.yml
+++ b/.github/workflows/adminBundleSize.yml
@@ -25,4 +25,4 @@ jobs:
       - uses: preactjs/compressed-size-action@v2
         with:
           pattern: '**/build/**/*.{js,css,html,svg}'
-          strip-hash: "\\.((\\w{8})\\.(chunk))|(\\.\\w{8})"
+          strip-hash: "\\.(?:(\\w{8})\\.chunk)|(?:\\.(\\w{8}))"

--- a/.github/workflows/adminBundleSize.yml
+++ b/.github/workflows/adminBundleSize.yml
@@ -1,0 +1,28 @@
+name: Admin bundle-size
+
+on:
+  pull_request:
+    branches:
+      - '**'
+    paths:
+      - '**/admin/src/**.js'
+      - '**/helper-plugin/lib/src/**.js'
+      - '**/translations/**.json'
+      - 'yarn.lock'
+
+jobs:
+  admin_size:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
+          cache: yarn
+
+      - uses: preactjs/compressed-size-action@v2
+        with:
+          pattern: '**/build/**/*.{js,css,html,svg}'
+          strip-hash: "\\.((\\w{8})\\.(chunk))|(\\.\\w{8})"

--- a/.github/workflows/adminBundleSize.yml
+++ b/.github/workflows/adminBundleSize.yml
@@ -2,8 +2,6 @@ name: Admin bundle-size
 
 on:
   pull_request:
-    branches:
-      - '**'
     paths:
       - '**/admin/src/**.js'
       - '**/helper-plugin/lib/src/**.js'


### PR DESCRIPTION
### What does it do?

This PR adds a new check/ report to PRs, which modified either:

- files on which the admin build depends
- dependencies

All PRs, which only modify backend code, won't see the report. It will report the final gzipped bundle size to the PR and is based on the [compressed-size-action](https://github.com/preactjs/compressed-size-action) maintained by the preact team. It doesn't require any data to store, because it runs twice: the PR branch and the master branch and compares both results. [Example output](https://github.com/preactjs/preact/pull/3603#issuecomment-1173062288).

This will help us to monitor the impact of e.g. dependency updates on the bundle size of the frontend. @alexandrebodin and I briefly discussed whether we should setup a new test-app for each run, but I don't think it is necessary, because the action is setup to collect all build directories in the repository. An improvement that could be made would be to run the check with `NODE_ENV=production` being set - currently it is impossible due to a `devDependencies` mixup, which will and should be adressed by https://github.com/strapi/strapi/pull/13769.

### Why is it needed?

To create visiblity for the bundle-size of the admin app and to understand the impact of dependency updates better.

### How to test it?

I've added examples. Without it being allowed by a repository admin, we won't see it in action.

