### PR TITLE
[Custom Fields] Add tabs to attribute modal

### DIFF
--- a/packages/core/content-type-builder/admin/src/components/AttributeOptions/index.js
+++ b/packages/core/content-type-builder/admin/src/components/AttributeOptions/index.js
@@ -12,66 +12,71 @@ import { Divider } from '@strapi/design-system/Divider';
 import { Grid, GridItem } from '@strapi/design-system/Grid';
 import { KeyboardNavigable } from '@strapi/design-system/KeyboardNavigable';
 import { ModalBody } from '@strapi/design-system/ModalLayout';
-import { Flex } from '@strapi/design-system/Flex';
 import { Stack } from '@strapi/design-system/Stack';
-import { Typography } from '@strapi/design-system/Typography';
+import { Tabs, Tab, TabGroup, TabPanels, TabPanel } from '@strapi/design-system/Tabs';
 import { getTrad } from '../../utils';
 import AttributeOption from './AttributeOption';
 
-const AttributeOptions = ({ attributes, forTarget, kind }) => {
+const AttributeOptions = ({ attributes }) => {
   const { formatMessage } = useIntl();
 
-  const titleIdSuffix = forTarget.includes('component') ? 'component' : kind;
-  const titleId = getTrad(`modalForm.sub-header.chooseAttribute.${titleIdSuffix}`);
+  const defaultTabId = getTrad(`modalForm.tabs.default`);
+  const customTabId = getTrad(`modalForm.tabs.custom`);
 
   return (
-    <ModalBody>
-      <Flex paddingBottom={4}>
-        <Typography variant="beta" as="h2">
-          {formatMessage({ id: titleId, defaultMessage: 'Select a field' })}
-        </Typography>
-      </Flex>
-      <Divider />
-      <Box paddingTop={6} paddingBottom={4}>
-        <KeyboardNavigable tagName="button">
-          <Stack spacing={8}>
-            {attributes.map((attributeRow, index) => {
-              const key = index;
+    <ModalBody paddingTop={3} paddingLeft={6} paddingRight={6} paddingBottom={4}>
+      <TabGroup label="Attribute type tabs" id="attribute-type-tabs" variant="simple">
+        <Tabs>
+          <Tab>{formatMessage({ id: defaultTabId, defaultMessage: 'Default' })}</Tab>
+          <Tab>{formatMessage({ id: customTabId, defaultMessage: 'Custom' })}</Tab>
+        </Tabs>
+        <Box paddingBottom={6}>
+          <Divider />
+        </Box>
+        <TabPanels>
+          <TabPanel>
+            <KeyboardNavigable tagName="button">
+              <Stack spacing={8}>
+                {attributes.map((attributeRow, index) => {
+                  const key = index;
 
-              return (
-                <Grid key={key} gap={0}>
-                  {attributeRow.map((attribute, index) => {
-                    const isOdd = index % 2 === 1;
-                    const paddingLeft = isOdd ? 2 : 0;
-                    const paddingRight = isOdd ? 0 : 2;
+                  return (
+                    <Grid key={key} gap={0}>
+                      {attributeRow.map((attribute, index) => {
+                        const isOdd = index % 2 === 1;
+                        const paddingLeft = isOdd ? 2 : 0;
+                        const paddingRight = isOdd ? 0 : 2;
 
-                    return (
-                      <GridItem key={attribute} col={6} style={{ height: '100%' }}>
-                        <Box
-                          paddingLeft={paddingLeft}
-                          paddingRight={paddingRight}
-                          paddingBottom={1}
-                          style={{ height: '100%' }}
-                        >
-                          <AttributeOption type={attribute} />
-                        </Box>
-                      </GridItem>
-                    );
-                  })}
-                </Grid>
-              );
-            })}
-          </Stack>
-        </KeyboardNavigable>
-      </Box>
+                        return (
+                          <GridItem key={attribute} col={6} style={{ height: '100%' }}>
+                            <Box
+                              paddingLeft={paddingLeft}
+                              paddingRight={paddingRight}
+                              paddingBottom={2}
+                              style={{ height: '100%' }}
+                            >
+                              <AttributeOption type={attribute} />
+                            </Box>
+                          </GridItem>
+                        );
+                      })}
+                    </Grid>
+                  );
+                })}
+              </Stack>
+            </KeyboardNavigable>
+          </TabPanel>
+          <TabPanel>
+            <Box>Coming soon</Box>
+          </TabPanel>
+        </TabPanels>
+      </TabGroup>
     </ModalBody>
   );
 };
 
 AttributeOptions.propTypes = {
   attributes: PropTypes.array.isRequired,
-  forTarget: PropTypes.string.isRequired,
-  kind: PropTypes.string.isRequired,
 };
 
 export default AttributeOptions;

--- a/packages/core/content-type-builder/admin/src/components/AttributeOptions/tests/__snapshots__/index.test.js.snap
+++ b/packages/core/content-type-builder/admin/src/components/AttributeOptions/tests/__snapshots__/index.test.js.snap
@@ -1,0 +1,1232 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AttributeOptions renders and matches the snapshot 1`] = `
+.c24 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+}
+
+.c8 {
+  padding-bottom: 24px;
+}
+
+.c15 {
+  padding-right: 8px;
+  padding-bottom: 8px;
+  padding-left: 0px;
+}
+
+.c16 {
+  padding: 16px;
+  border-radius: 4px;
+}
+
+.c20 {
+  padding-left: 16px;
+}
+
+.c23 {
+  padding-right: 0px;
+  padding-bottom: 8px;
+  padding-left: 8px;
+}
+
+.c18 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+}
+
+.c11 {
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c12 > * {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.c12 > * + * {
+  margin-top: 40px;
+}
+
+.c21 {
+  font-weight: 600;
+  color: #32324d;
+  font-size: 0.875rem;
+  line-height: 1.43;
+}
+
+.c22 {
+  color: #666687;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
+.c9 {
+  background: #eaeaef;
+}
+
+.c10 {
+  height: 1px;
+  border: none;
+  margin: 0;
+}
+
+.c13 {
+  display: grid;
+  grid-template-columns: repeat(12,1fr);
+  gap: 0px;
+}
+
+.c14 {
+  grid-column: span 6;
+  max-width: 100%;
+}
+
+.c0 {
+  padding: 12px;
+  padding-right: 24px;
+  padding-left: 24px;
+}
+
+.c1 {
+  overflow: auto;
+  max-height: 60vh;
+}
+
+.c5 {
+  color: #4945ff;
+  font-weight: 600;
+  font-size: 0.6875rem;
+  line-height: 1.45;
+  text-transform: uppercase;
+}
+
+.c7 {
+  color: #666687;
+  font-weight: 600;
+  font-size: 0.6875rem;
+  line-height: 1.45;
+  text-transform: uppercase;
+}
+
+.c3 {
+  padding: 16px;
+}
+
+.c4 {
+  border-bottom: 2px solid #4945ff;
+}
+
+.c6 {
+  border-bottom: 2px solid transparent;
+}
+
+.c2[aria-disabled='true'] {
+  cursor: not-allowed;
+}
+
+.c19 {
+  width: 2rem;
+  height: 1.5rem;
+  box-sizing: content-box;
+}
+
+.c17 {
+  width: 100%;
+  height: 100%;
+  border: 1px solid #dcdce4;
+  text-align: left;
+}
+
+.c17:hover {
+  background: #f0f0ff;
+  border: 1px solid #d9d8ff;
+}
+
+@media (max-width:68.75rem) {
+  .c14 {
+    grid-column: span;
+  }
+}
+
+@media (max-width:34.375rem) {
+  .c14 {
+    grid-column: span;
+  }
+}
+
+<div>
+  <div
+    class="c0 c1"
+  >
+    <div>
+      <div
+        aria-label="Attribute type tabs"
+        role="tablist"
+      >
+        <button
+          aria-controls="attribute-type-tabs-0-tabpanel"
+          aria-disabled="false"
+          aria-selected="true"
+          class="c2"
+          id="attribute-type-tabs-0-tab"
+          role="tab"
+          tabindex="0"
+          type="button"
+        >
+          <div
+            class="c3 c4"
+          >
+            <span
+              class="c5"
+            >
+              Default
+            </span>
+          </div>
+        </button>
+        <button
+          aria-disabled="false"
+          aria-selected="false"
+          class="c2"
+          id="attribute-type-tabs-1-tab"
+          role="tab"
+          tabindex="-1"
+          type="button"
+        >
+          <div
+            class="c3 c6"
+          >
+            <span
+              class="c7"
+            >
+              Custom
+            </span>
+          </div>
+        </button>
+      </div>
+      <div
+        class="c8"
+      >
+        <hr
+          class="c9 c10"
+        />
+      </div>
+      <div>
+        <div
+          aria-labelledby="attribute-type-tabs-0-tab"
+          id="attribute-type-tabs-0-tabpanel"
+          role="tabpanel"
+          tabindex="0"
+        >
+          <div
+            class=""
+          >
+            <div
+              class="c11 c12"
+              spacing="8"
+            >
+              <div
+                class="c13"
+              >
+                <div
+                  class="c14"
+                >
+                  <div
+                    class=""
+                    style="height: 100%;"
+                  >
+                    <div
+                      class="c15"
+                      style="height: 100%;"
+                    >
+                      <button
+                        class="c16 c17"
+                        type="button"
+                      >
+                        <div
+                          class="c18"
+                        >
+                          <svg
+                            class="c19"
+                            fill="none"
+                            height="1em"
+                            viewBox="0 0 32 24"
+                            width="1em"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <rect
+                              fill="#EAFBE7"
+                              height="23"
+                              rx="2.5"
+                              stroke="#C6F0C2"
+                              width="31"
+                              x="0.5"
+                              y="0.5"
+                            />
+                            <path
+                              d="M8.62 16h1.857l.627-2.05h2.982l.627 2.05h1.863l-2.941-8.455h-2.08L8.619 16zm3.925-6.768h.105l1.032 3.393h-2.174l1.037-3.393zM21.65 16.1c1.612 0 2.62-1.26 2.62-3.323v-.011c0-2.075-.985-3.323-2.62-3.323-.884 0-1.605.434-1.933 1.137h-.106V7.082h-1.71V16h1.71v-1.002h.106c.334.697 1.02 1.102 1.933 1.102zm-.585-1.418c-.903 0-1.471-.715-1.471-1.899v-.011c0-1.184.574-1.91 1.47-1.91.903 0 1.465.726 1.465 1.904v.011c0 1.19-.556 1.905-1.465 1.905z"
+                              fill="#328048"
+                            />
+                          </svg>
+                          <div
+                            class="c20"
+                          >
+                            <div
+                              class="c18"
+                            >
+                              <span
+                                class="c21"
+                              >
+                                Text
+                              </span>
+                            </div>
+                            <div
+                              class="c18"
+                            >
+                              <span
+                                class="c22"
+                              >
+                                Small or long text like title or description
+                              </span>
+                            </div>
+                          </div>
+                        </div>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="c14"
+                >
+                  <div
+                    class=""
+                    style="height: 100%;"
+                  >
+                    <div
+                      class="c23"
+                      style="height: 100%;"
+                    >
+                      <button
+                        class="c16 c17"
+                        type="button"
+                      >
+                        <div
+                          class="c18"
+                        >
+                          <svg
+                            class="c19"
+                            fill="none"
+                            height="1em"
+                            viewBox="0 0 32 24"
+                            width="1em"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <rect
+                              fill="#FCECEA"
+                              height="23"
+                              rx="2.5"
+                              stroke="#F5C0B8"
+                              width="31"
+                              x="0.5"
+                              y="0.5"
+                            />
+                            <path
+                              d="M16.767 17.49c.724 0 1.428-.089 1.962-.253v-1.093c-.383.143-1.128.239-1.86.239-2.905 0-4.744-1.764-4.744-4.546v-.014c0-2.734 1.839-4.641 4.484-4.641 2.598 0 4.307 1.62 4.307 4.088v.013c0 1.402-.444 2.304-1.135 2.304-.417 0-.656-.287-.656-.772V9.157h-1.38v.82h-.124c-.273-.608-.868-.97-1.6-.97-1.367 0-2.296 1.135-2.296 2.789v.014c0 1.73.943 2.884 2.365 2.884.793 0 1.353-.362 1.64-1.052h.123l.007.04c.158.636.78 1.033 1.62 1.033 1.655 0 2.687-1.367 2.687-3.534v-.014c0-3.008-2.242-5.072-5.517-5.072-3.418 0-5.776 2.324-5.776 5.694v.014c0 3.431 2.331 5.687 5.893 5.687zm-.342-4.053c-.718 0-1.149-.602-1.149-1.586v-.014c0-.991.431-1.586 1.156-1.586.724 0 1.182.608 1.182 1.586v.014c0 .977-.458 1.585-1.19 1.585z"
+                              fill="#D02B20"
+                            />
+                          </svg>
+                          <div
+                            class="c20"
+                          >
+                            <div
+                              class="c18"
+                            >
+                              <span
+                                class="c21"
+                              >
+                                Email
+                              </span>
+                            </div>
+                            <div
+                              class="c18"
+                            >
+                              <span
+                                class="c22"
+                              >
+                                Email field with validations format
+                              </span>
+                            </div>
+                          </div>
+                        </div>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="c14"
+                >
+                  <div
+                    class=""
+                    style="height: 100%;"
+                  >
+                    <div
+                      class="c15"
+                      style="height: 100%;"
+                    >
+                      <button
+                        class="c16 c17"
+                        type="button"
+                      >
+                        <div
+                          class="c18"
+                        >
+                          <svg
+                            class="c19"
+                            fill="none"
+                            height="1em"
+                            viewBox="0 0 32 24"
+                            width="1em"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <rect
+                              fill="#EAF5FF"
+                              height="23"
+                              rx="2.5"
+                              stroke="#B8E1FF"
+                              width="31"
+                              x="0.5"
+                              y="0.5"
+                            />
+                            <path
+                              clip-rule="evenodd"
+                              d="M19.286 9.286v-.857a.397.397 0 00-.138-.302A.465.465 0 0018.82 8h-8.357a.465.465 0 00-.326.127.397.397 0 00-.138.302v.857c0 .116.046.216.138.301.092.085.2.127.326.127h8.357a.465.465 0 00.327-.127.397.397 0 00.138-.301zm2.785 2.713v.857a.397.397 0 01-.137.301.465.465 0 01-.327.128H10.464a.465.465 0 01-.326-.128.397.397 0 01-.138-.301v-.857c0-.116.046-.217.138-.302a.465.465 0 01.326-.127h11.143c.126 0 .235.043.327.127a.397.397 0 01.137.302zm-1.857 3.574v.857a.397.397 0 01-.137.302.465.465 0 01-.327.127h-9.286a.465.465 0 01-.326-.127.397.397 0 01-.138-.302v-.857c0-.116.046-.216.138-.301a.465.465 0 01.326-.127h9.286c.126 0 .235.042.326.127a.397.397 0 01.138.301z"
+                              fill="#0C75AF"
+                              fill-rule="evenodd"
+                            />
+                          </svg>
+                          <div
+                            class="c20"
+                          >
+                            <div
+                              class="c18"
+                            >
+                              <span
+                                class="c21"
+                              >
+                                Rich text
+                              </span>
+                            </div>
+                            <div
+                              class="c18"
+                            >
+                              <span
+                                class="c22"
+                              >
+                                A rich text editor with formatting options
+                              </span>
+                            </div>
+                          </div>
+                        </div>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="c14"
+                >
+                  <div
+                    class=""
+                    style="height: 100%;"
+                  >
+                    <div
+                      class="c23"
+                      style="height: 100%;"
+                    >
+                      <button
+                        class="c16 c17"
+                        type="button"
+                      >
+                        <div
+                          class="c18"
+                        >
+                          <svg
+                            class="c19"
+                            fill="none"
+                            height="1em"
+                            viewBox="0 0 32 24"
+                            width="1em"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M.5 3A2.5 2.5 0 013 .5h26A2.5 2.5 0 0131.5 3v18a2.5 2.5 0 01-2.5 2.5H3A2.5 2.5 0 01.5 21V3z"
+                              fill="#FDF4DC"
+                              stroke="#FAE7B9"
+                            />
+                            <path
+                              d="M20.158 11.995c0-.591-.463-1.073-1.045-1.11H13.53V9.245a2.05 2.05 0 012.046-2.049c1.13 0 2.048.784 2.049 1.913 0 .24.194.433.433.433h.33a.433.433 0 00.433-.433C18.82 7.32 17.365 5.999 15.577 6a3.246 3.246 0 00-3.241 3.244v1.642h-.223c-.615 0-1.113.499-1.113 1.114v4.887c.001.615.5 1.113 1.115 1.113l6.93-.003c.616 0 1.114-.5 1.114-1.115l-.001-4.887z"
+                              fill="#D9822F"
+                            />
+                          </svg>
+                          <div
+                            class="c20"
+                          >
+                            <div
+                              class="c18"
+                            >
+                              <span
+                                class="c21"
+                              >
+                                Password
+                              </span>
+                            </div>
+                            <div
+                              class="c18"
+                            >
+                              <span
+                                class="c22"
+                              >
+                                Password field with encryption
+                              </span>
+                            </div>
+                          </div>
+                        </div>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="c14"
+                >
+                  <div
+                    class=""
+                    style="height: 100%;"
+                  >
+                    <div
+                      class="c15"
+                      style="height: 100%;"
+                    >
+                      <button
+                        class="c16 c17"
+                        type="button"
+                      >
+                        <div
+                          class="c18"
+                        >
+                          <svg
+                            class="c19"
+                            fill="none"
+                            height="1em"
+                            viewBox="0 0 32 24"
+                            width="1em"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <rect
+                              fill="#FCECEA"
+                              height="23"
+                              rx="2.5"
+                              stroke="#F5C0B8"
+                              width="31"
+                              x="0.5"
+                              y="0.5"
+                            />
+                            <path
+                              d="M9.815 16h1.475V8.954H9.82L8 10.22v1.328l1.729-1.201h.087V16zm3.394 0h5.083v-1.187h-3.106v-.112l1.304-1.216c1.284-1.186 1.7-1.85 1.7-2.651v-.015c0-1.215-1.016-2.046-2.466-2.046-1.543 0-2.598.928-2.598 2.28l.005.02h1.362v-.024c0-.67.474-1.128 1.162-1.128.674 0 1.084.42 1.084 1.02v.015c0 .493-.268.85-1.26 1.812l-2.27 2.24V16zm9.067.156c1.646 0 2.744-.864 2.744-2.143v-.01c0-.957-.683-1.563-1.733-1.66v-.03c.825-.17 1.47-.742 1.47-1.62v-.01c0-1.123-.977-1.885-2.49-1.885-1.48 0-2.471.82-2.574 2.08l-.005.059h1.358l.005-.044c.058-.586.522-.962 1.216-.962.693 0 1.098.361 1.098.947v.01c0 .571-.478.962-1.22.962h-.787v1.05h.806c.855 0 1.357.37 1.357 1.044v.01c0 .596-.493 1.016-1.245 1.016-.761 0-1.264-.39-1.328-.938l-.005-.053h-1.41l.004.063c.098 1.26 1.148 2.114 2.74 2.114z"
+                              fill="#D02B20"
+                            />
+                          </svg>
+                          <div
+                            class="c20"
+                          >
+                            <div
+                              class="c18"
+                            >
+                              <span
+                                class="c21"
+                              >
+                                Number
+                              </span>
+                            </div>
+                            <div
+                              class="c18"
+                            >
+                              <span
+                                class="c22"
+                              >
+                                Numbers (integer, float, decimal)
+                              </span>
+                            </div>
+                          </div>
+                        </div>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="c14"
+                >
+                  <div
+                    class=""
+                    style="height: 100%;"
+                  >
+                    <div
+                      class="c23"
+                      style="height: 100%;"
+                    >
+                      <button
+                        class="c16 c17"
+                        type="button"
+                      >
+                        <div
+                          class="c18"
+                        >
+                          <svg
+                            class="c19"
+                            fill="none"
+                            height="1em"
+                            viewBox="0 0 32 24"
+                            width="1em"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <rect
+                              fill="#F6ECFC"
+                              height="23"
+                              rx="2.5"
+                              stroke="#E0C1F4"
+                              width="31"
+                              x="0.5"
+                              y="0.5"
+                            />
+                            <path
+                              clip-rule="evenodd"
+                              d="M10.167 7a1.167 1.167 0 100 2.333 1.167 1.167 0 000-2.333zm0 4.03a1.167 1.167 0 100 2.334 1.167 1.167 0 000-2.334zM9 16.23a1.167 1.167 0 112.333 0 1.167 1.167 0 01-2.333 0zm4.005-9.02a.4.4 0 00-.4.4v1.11c0 .22.18.4.4.4H22.6a.4.4 0 00.4-.4V7.61a.4.4 0 00-.4-.4h-9.594zm-.399 4.432a.4.4 0 01.4-.4H22.6c.22 0 .4.18.4.4v1.11a.4.4 0 01-.4.4h-9.594a.4.4 0 01-.4-.4v-1.11zm.4 3.63a.4.4 0 00-.4.4v1.11c0 .22.18.4.4.4H22.6a.4.4 0 00.4-.4v-1.11a.4.4 0 00-.4-.4h-9.594z"
+                              fill="#9736E8"
+                              fill-rule="evenodd"
+                            />
+                          </svg>
+                          <div
+                            class="c20"
+                          >
+                            <div
+                              class="c18"
+                            >
+                              <span
+                                class="c21"
+                              >
+                                Enumeration
+                              </span>
+                            </div>
+                            <div
+                              class="c18"
+                            >
+                              <span
+                                class="c22"
+                              >
+                                List of values, then pick one
+                              </span>
+                            </div>
+                          </div>
+                        </div>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="c14"
+                >
+                  <div
+                    class=""
+                    style="height: 100%;"
+                  >
+                    <div
+                      class="c15"
+                      style="height: 100%;"
+                    >
+                      <button
+                        class="c16 c17"
+                        type="button"
+                      >
+                        <div
+                          class="c18"
+                        >
+                          <svg
+                            class="c19"
+                            fill="none"
+                            height="1em"
+                            viewBox="0 0 32 24"
+                            width="1em"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M.5 3A2.5 2.5 0 013 .5h26A2.5 2.5 0 0131.5 3v18a2.5 2.5 0 01-2.5 2.5H3A2.5 2.5 0 01.5 21V3z"
+                              fill="#FDF4DC"
+                              stroke="#FAE7B9"
+                            />
+                            <path
+                              clip-rule="evenodd"
+                              d="M11.934 7.495V6h1.45v1.495h5.232V6h1.45v1.495h.314c1.385 0 1.602.249 1.62 1.463V16.5c0 1.062-.096 1.5-1.4 1.5h-9.19c-1.306 0-1.41-.318-1.41-1.607V9.105c.018-1.025.117-1.61 1.5-1.61h.434zm-.774 8.687c0 .406.123.433.388.433h8.953c.265 0 .34-.007.34-.413v-6.087c-.008-.314-.11-.369-.316-.369h-9.072c-.206 0-.296.045-.293.287v6.15z"
+                              fill="#D9822F"
+                              fill-rule="evenodd"
+                            />
+                          </svg>
+                          <div
+                            class="c20"
+                          >
+                            <div
+                              class="c18"
+                            >
+                              <span
+                                class="c21"
+                              >
+                                Date
+                              </span>
+                            </div>
+                            <div
+                              class="c18"
+                            >
+                              <span
+                                class="c22"
+                              >
+                                A date picker with hours, minutes and seconds
+                              </span>
+                            </div>
+                          </div>
+                        </div>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="c14"
+                >
+                  <div
+                    class=""
+                    style="height: 100%;"
+                  >
+                    <div
+                      class="c23"
+                      style="height: 100%;"
+                    >
+                      <button
+                        class="c16 c17"
+                        type="button"
+                      >
+                        <div
+                          class="c18"
+                        >
+                          <svg
+                            class="c19"
+                            fill="none"
+                            height="1em"
+                            viewBox="0 0 32 24"
+                            width="1em"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <rect
+                              fill="#F6ECFC"
+                              height="23"
+                              rx="2.5"
+                              stroke="#E0C1F4"
+                              width="31"
+                              x="0.5"
+                              y="0.5"
+                            />
+                            <path
+                              clip-rule="evenodd"
+                              d="M22 8.759a2 2 0 00-2-2h-8c-1.105 0-2 .902-2 2.006v6.068a2 2 0 00.985 1.724l3.66-3.74 3.31 3.381 1.471-1.502 1.731 1.769c.51-.363.843-.958.843-1.632V8.76zM18.5 9c-.84 0-1.5.66-1.5 1.5s.66 1.5 1.5 1.5 1.5-.66 1.5-1.5S19.34 9 18.5 9z"
+                              fill="#9736E8"
+                              fill-rule="evenodd"
+                            />
+                          </svg>
+                          <div
+                            class="c20"
+                          >
+                            <div
+                              class="c18"
+                            >
+                              <span
+                                class="c21"
+                              >
+                                Media
+                              </span>
+                            </div>
+                            <div
+                              class="c18"
+                            >
+                              <span
+                                class="c22"
+                              >
+                                Files like images, videos, etc
+                              </span>
+                            </div>
+                          </div>
+                        </div>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="c14"
+                >
+                  <div
+                    class=""
+                    style="height: 100%;"
+                  >
+                    <div
+                      class="c15"
+                      style="height: 100%;"
+                    >
+                      <button
+                        class="c16 c17"
+                        type="button"
+                      >
+                        <div
+                          class="c18"
+                        >
+                          <svg
+                            class="c19"
+                            fill="none"
+                            height="1em"
+                            viewBox="0 0 32 24"
+                            width="1em"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <rect
+                              fill="#EAFBE7"
+                              height="23"
+                              rx="2.5"
+                              stroke="#C6F0C2"
+                              width="31"
+                              x="0.5"
+                              y="0.5"
+                            />
+                            <path
+                              d="M19.5 7h-7A4.505 4.505 0 008 11.5c0 2.481 2.019 4.5 4.5 4.5h7c2.481 0 4.5-2.019 4.5-4.5S21.981 7 19.5 7zm0 8a3.5 3.5 0 110-7 3.5 3.5 0 010 7z"
+                              fill="#328048"
+                            />
+                          </svg>
+                          <div
+                            class="c20"
+                          >
+                            <div
+                              class="c18"
+                            >
+                              <span
+                                class="c21"
+                              >
+                                Boolean
+                              </span>
+                            </div>
+                            <div
+                              class="c18"
+                            >
+                              <span
+                                class="c22"
+                              >
+                                Yes or no, 1 or 0, true or false
+                              </span>
+                            </div>
+                          </div>
+                        </div>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="c14"
+                >
+                  <div
+                    class=""
+                    style="height: 100%;"
+                  >
+                    <div
+                      class="c23"
+                      style="height: 100%;"
+                    >
+                      <button
+                        class="c16 c17"
+                        type="button"
+                      >
+                        <div
+                          class="c18"
+                        >
+                          <svg
+                            class="c19"
+                            fill="none"
+                            height="1em"
+                            viewBox="0 0 32 24"
+                            width="1em"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <rect
+                              fill="#EAF5FF"
+                              height="23"
+                              rx="2.5"
+                              stroke="#B8E1FF"
+                              width="31"
+                              x="0.5"
+                              y="0.5"
+                            />
+                            <path
+                              clip-rule="evenodd"
+                              d="M8.243 11.907v.157c.835.093 1.287.516 1.287 1.223V14.5c0 .693.236.959.855.959h.216V16.5h-.364c-1.459 0-2.078-.56-2.078-1.857v-.973c0-.722-.314-.992-1.159-1.002v-1.366c.84-.005 1.16-.275 1.16-1.002v-.968c0-1.282.618-1.832 2.077-1.832h.364v1.041h-.216c-.624 0-.855.266-.855.958v1.184c0 .713-.452 1.135-1.287 1.224zm15.804.181v-.157c-.835-.088-1.287-.51-1.287-1.223V9.495c0-.693-.236-.954-.855-.954h-.216V7.5h.363c1.454 0 2.073.56 2.073 1.852v.973c0 .722.32.997 1.165 1.002v1.366c-.845.005-1.165.28-1.165 1.002v.973c0 1.282-.613 1.832-2.073 1.832h-.363v-1.046h.216c.619 0 .855-.26.855-.954v-1.188c0-.708.452-1.13 1.287-1.224zM13.15 13a1 1 0 100-2 1 1 0 000 2zm4-1a1 1 0 11-2 0 1 1 0 012 0zm2 1a1 1 0 100-2 1 1 0 000 2z"
+                              fill="#0C75AF"
+                              fill-rule="evenodd"
+                            />
+                          </svg>
+                          <div
+                            class="c20"
+                          >
+                            <div
+                              class="c18"
+                            >
+                              <span
+                                class="c21"
+                              >
+                                JSON
+                              </span>
+                            </div>
+                            <div
+                              class="c18"
+                            >
+                              <span
+                                class="c22"
+                              >
+                                Data in JSON format
+                              </span>
+                            </div>
+                          </div>
+                        </div>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="c14"
+                >
+                  <div
+                    class=""
+                    style="height: 100%;"
+                  >
+                    <div
+                      class="c15"
+                      style="height: 100%;"
+                    >
+                      <button
+                        class="c16 c17"
+                        type="button"
+                      >
+                        <div
+                          class="c18"
+                        >
+                          <svg
+                            class="c19"
+                            fill="none"
+                            height="1em"
+                            viewBox="0 0 32 24"
+                            width="1em"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M.5 3A2.5 2.5 0 013 .5h26A2.5 2.5 0 0131.5 3v18a2.5 2.5 0 01-2.5 2.5H3A2.5 2.5 0 01.5 21V3z"
+                              fill="#F0F0FF"
+                              stroke="#D9D8FF"
+                            />
+                            <path
+                              clip-rule="evenodd"
+                              d="M21.375 16.316c.417-.407.625-.904.625-1.492 0-.589-.206-1.089-.618-1.5l-1.53-1.53a2.042 2.042 0 00-1.5-.617 2.06 2.06 0 00-1.529.646l-.646-.646c.43-.422.646-.934.646-1.537a2.03 2.03 0 00-.61-1.493l-1.515-1.522a2.014 2.014 0 00-1.5-.625 2.03 2.03 0 00-1.492.61l-1.081 1.074A2.006 2.006 0 0010 9.176c0 .589.206 1.089.618 1.5l1.53 1.53c.41.412.91.617 1.5.617a2.06 2.06 0 001.529-.646l.646.646a2.069 2.069 0 00-.646 1.537c0 .588.203 1.086.61 1.493l1.514 1.522c.407.417.907.625 1.5.625a2.03 2.03 0 001.493-.61l1.081-1.074zm-5.956-6.678a.68.68 0 00-.205-.5l-1.515-1.522a.68.68 0 00-.5-.206.71.71 0 00-.5.199l-1.081 1.073a.672.672 0 00-.206.493.68.68 0 00.206.5l1.53 1.53a.678.678 0 00.5.198.71.71 0 00.529-.228l-.14-.136a4.46 4.46 0 01-.158-.158 1.756 1.756 0 01-.11-.14.593.593 0 01-.122-.39.68.68 0 01.206-.5.68.68 0 01.5-.206.59.59 0 01.39.121c.064.047.11.084.14.111.03.027.082.08.158.158l.136.14a.713.713 0 00.242-.537zm5.168 5.187a.68.68 0 00-.206-.5l-1.529-1.53a.68.68 0 00-.5-.205.7.7 0 00-.53.235l.14.136c.079.076.132.129.159.158.027.03.063.076.11.14a.591.591 0 01.121.39.681.681 0 01-.206.5.681.681 0 01-.5.206.591.591 0 01-.39-.121 1.746 1.746 0 01-.14-.111 4.395 4.395 0 01-.157-.158 20.642 20.642 0 00-.136-.14.714.714 0 00-.037 1.037l1.515 1.522a.678.678 0 00.5.198.708.708 0 00.5-.19l1.08-1.074a.672.672 0 00.206-.493z"
+                              fill="#4945FF"
+                              fill-rule="evenodd"
+                            />
+                          </svg>
+                          <div
+                            class="c20"
+                          >
+                            <div
+                              class="c18"
+                            >
+                              <span
+                                class="c21"
+                              >
+                                Relation
+                              </span>
+                            </div>
+                            <div
+                              class="c18"
+                            >
+                              <span
+                                class="c22"
+                              >
+                                Refers to a Collection Type
+                              </span>
+                            </div>
+                          </div>
+                        </div>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="c14"
+                >
+                  <div
+                    class=""
+                    style="height: 100%;"
+                  >
+                    <div
+                      class="c23"
+                      style="height: 100%;"
+                    >
+                      <button
+                        class="c16 c17"
+                        type="button"
+                      >
+                        <div
+                          class="c18"
+                        >
+                          <svg
+                            class="c19"
+                            fill="none"
+                            height="1em"
+                            viewBox="0 0 32 24"
+                            width="1em"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M.5 3A2.5 2.5 0 013 .5h26A2.5 2.5 0 0131.5 3v18a2.5 2.5 0 01-2.5 2.5H3A2.5 2.5 0 01.5 21V3z"
+                              fill="#F0F0FF"
+                              stroke="#D9D8FF"
+                            />
+                            <path
+                              d="M14.907 9.438c0 .375 0 .738.118 1.078-1.243 1.46-4.526 5.317-4.832 5.611a.582.582 0 00-.193.433c0 .245.15.481.277.614.19.2 1.004.952 1.154.808.444-.433.533-.548.715-.727.274-.268-.029-.816.066-1.039.096-.222.197-.265.361-.3.165-.034.456.084.684.087.24.003.369-.098.548-.265.144-.133.248-.257.25-.45.007-.26-.368-.603-.089-.877.28-.274.684.178.981.144.297-.035.658-.447.695-.623.038-.176-.337-.629-.28-.886.02-.086.197-.288.33-.317.132-.029.72.199.853.17.162-.034.35-.205.502-.3.447.193.854.271 1.376.271C20.4 12.87 22 11.33 22 9.432 22 7.534 20.399 6 18.423 6s-3.516 1.54-3.516 3.438zm5.247-.669a.923.923 0 11-1.847 0 .923.923 0 011.847 0z"
+                              fill="#4945FF"
+                            />
+                          </svg>
+                          <div
+                            class="c20"
+                          >
+                            <div
+                              class="c18"
+                            >
+                              <span
+                                class="c21"
+                              >
+                                UID
+                              </span>
+                            </div>
+                            <div
+                              class="c18"
+                            >
+                              <span
+                                class="c22"
+                              >
+                                Unique identifier
+                              </span>
+                            </div>
+                          </div>
+                        </div>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="c13"
+              >
+                <div
+                  class="c14"
+                >
+                  <div
+                    class=""
+                    style="height: 100%;"
+                  >
+                    <div
+                      class="c15"
+                      style="height: 100%;"
+                    >
+                      <button
+                        class="c16 c17"
+                        type="button"
+                      >
+                        <div
+                          class="c18"
+                        >
+                          <svg
+                            class="c19"
+                            fill="none"
+                            height="1em"
+                            viewBox="0 0 32 24"
+                            width="1em"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <rect
+                              fill="#F6F6F9"
+                              height="23"
+                              rx="2.5"
+                              stroke="#DCDCE4"
+                              width="31"
+                              x="0.5"
+                              y="0.5"
+                            />
+                            <path
+                              clip-rule="evenodd"
+                              d="M13.535 8.768c0 .116-.011.229-.032.339l3.013 1.776 2.985-1.76a1.768 1.768 0 11.519.93l-2.982 1.757v2.477a1.768 1.768 0 11-1.048-.044v-2.435l-2.997-1.767a1.768 1.768 0 11.542-1.274z"
+                              fill="#666687"
+                              fill-rule="evenodd"
+                            />
+                            <path
+                              d="M13.503 9.107l-.05-.01-.006.035.03.018.026-.043zm3.013 1.776l-.025.043.025.014.025-.014-.025-.043zm2.985-1.76l.025.044.031-.018-.007-.035-.05.01zm.518.93l.035-.036-.027-.026-.033.02.026.042zm-2.98 1.757l-.026-.043-.025.014v.029h.05zm0 2.477h-.05v.035l.032.012.017-.047zm-1.049-.044l.013.048.037-.01v-.038h-.05zm0-2.435h.05v-.029l-.024-.014-.026.043zm-2.997-1.767l.025-.043-.033-.019-.027.027.035.035zm.559-.925c.022-.113.033-.23.033-.348h-.1c0 .112-.01.223-.031.33l.098.018zm2.99 1.723l-3.014-1.775-.05.086 3.013 1.775.05-.086zm2.933-1.758l-2.984 1.758.05.086 2.985-1.758-.05-.086zm-.06-.313c0 .125.013.247.037.366l.098-.02a1.723 1.723 0 01-.035-.346h-.1zm1.818-1.818a1.818 1.818 0 00-1.818 1.818h.1c0-.949.769-1.718 1.718-1.718v-.1zm1.817 1.818a1.818 1.818 0 00-1.817-1.818v.1c.948 0 1.717.769 1.717 1.718h.1zm-1.817 1.817a1.818 1.818 0 001.817-1.817h-.1c0 .948-.769 1.717-1.717 1.717v.1zm-1.248-.495c.326.307.765.495 1.248.495v-.1c-.457 0-.872-.178-1.18-.468l-.068.073zm-2.921 1.763l2.98-1.757-.05-.086-2.981 1.757.05.086zm.024 2.434V11.81h-.1v2.477h.1zm-.067.047a1.718 1.718 0 011.14 1.618h.1c0-.79-.503-1.46-1.206-1.712l-.034.094zm1.14 1.618c0 .948-.77 1.717-1.718 1.717v.1a1.817 1.817 0 001.817-1.817h-.1zm-1.718 1.717a1.718 1.718 0 01-1.718-1.717h-.1c0 1.004.814 1.817 1.818 1.817v-.1zm-1.718-1.717c0-.797.543-1.467 1.278-1.66l-.026-.098a1.818 1.818 0 00-1.352 1.758h.1zm1.215-4.144v2.435h.1v-2.435h-.1zm-2.973-1.723l2.998 1.766.05-.086-2.997-1.767-.05.087zm-1.2.5c.49 0 .934-.193 1.26-.507l-.069-.072c-.309.296-.728.48-1.19.48v.1zM9.95 8.768c0 1.003.814 1.817 1.818 1.817v-.1a1.718 1.718 0 01-1.718-1.717h-.1zm1.818-1.818A1.818 1.818 0 009.95 8.768h.1c0-.949.769-1.718 1.717-1.718v-.1zm1.817 1.818a1.818 1.818 0 00-1.818-1.818v.1c.95 0 1.718.769 1.718 1.718h.1z"
+                              fill="#666687"
+                            />
+                          </svg>
+                          <div
+                            class="c20"
+                          >
+                            <div
+                              class="c18"
+                            >
+                              <span
+                                class="c21"
+                              >
+                                Component
+                              </span>
+                            </div>
+                            <div
+                              class="c18"
+                            >
+                              <span
+                                class="c22"
+                              >
+                                Group of fields that you can repeat or reuse
+                              </span>
+                            </div>
+                          </div>
+                        </div>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="c14"
+                >
+                  <div
+                    class=""
+                    style="height: 100%;"
+                  >
+                    <div
+                      class="c23"
+                      style="height: 100%;"
+                    >
+                      <button
+                        class="c16 c17"
+                        type="button"
+                      >
+                        <div
+                          class="c18"
+                        >
+                          <svg
+                            class="c19"
+                            fill="none"
+                            height="1em"
+                            viewBox="0 0 32 24"
+                            width="1em"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <rect
+                              fill="#F6F6F9"
+                              height="23"
+                              rx="2.5"
+                              stroke="#DCDCE4"
+                              width="31"
+                              x="0.5"
+                              y="0.5"
+                            />
+                            <path
+                              d="M20.573 8c-1.484 0-2.666.745-3.397 1.37l-.026.023-.416.452.919 1.51.68-.682c.711-.6 1.506-.93 2.24-.93 1.48 0 2.685 1.171 2.685 2.612 0 1.44-1.205 2.613-2.685 2.613-2.25 0-3.78-2.974-3.795-3.004C16.69 11.784 14.75 8 11.428 8 8.985 8 7 9.954 7 12.355c0 2.401 1.986 4.355 4.427 4.355 1.196 0 2.373-.476 3.404-1.376l.022-.02.413-.45-.919-1.51-.683.686c-.712.616-1.465.928-2.237.928-1.48 0-2.685-1.172-2.685-2.613 0-1.44 1.205-2.613 2.685-2.613 2.25 0 3.78 2.974 3.795 3.004.088.18 2.028 3.964 5.35 3.964 2.442 0 4.428-1.954 4.428-4.355C25 9.954 23.014 8 20.573 8z"
+                              fill="#666687"
+                            />
+                          </svg>
+                          <div
+                            class="c20"
+                          >
+                            <div
+                              class="c18"
+                            >
+                              <span
+                                class="c21"
+                              >
+                                Dynamic zone
+                              </span>
+                            </div>
+                            <div
+                              class="c18"
+                            >
+                              <span
+                                class="c22"
+                              >
+                                Dynamically pick component when editing content
+                              </span>
+                            </div>
+                          </div>
+                        </div>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="c24"
+  >
+    <p
+      aria-live="polite"
+      aria-relevant="all"
+      id="live-region-log"
+      role="log"
+    />
+    <p
+      aria-live="polite"
+      aria-relevant="all"
+      id="live-region-status"
+      role="status"
+    />
+    <p
+      aria-live="assertive"
+      aria-relevant="all"
+      id="live-region-alert"
+      role="alert"
+    />
+  </div>
+</div>
+`;

--- a/packages/core/content-type-builder/admin/src/components/AttributeOptions/tests/index.test.js
+++ b/packages/core/content-type-builder/admin/src/components/AttributeOptions/tests/index.test.js
@@ -1,0 +1,105 @@
+import { render, screen, getByText, fireEvent } from '@testing-library/react';
+import { createMemoryHistory } from 'history';
+import React from 'react';
+import { Router } from 'react-router-dom';
+import { lightTheme, darkTheme } from '@strapi/design-system';
+import LanguageProvider from '../../../../../../admin/admin/src/components/LanguageProvider';
+import Theme from '../../../../../../admin/admin/src/components/Theme';
+import ThemeToggleProvider from '../../../../../../admin/admin/src/components/ThemeToggleProvider';
+import en from '../../../../../../admin/admin/src/translations/en.json';
+import FormModalNavigationProvider from '../../FormModalNavigationProvider';
+import pluginEn from '../../../translations/en.json';
+import getTrad from '../../../utils/getTrad';
+import AttributeOptions from '../index';
+
+const mockAttributes = [
+  [
+    'text',
+    'email',
+    'richtext',
+    'password',
+    'number',
+    'enumeration',
+    'date',
+    'media',
+    'boolean',
+    'json',
+    'relation',
+    'uid',
+  ],
+  ['component', 'dynamiczone'],
+];
+
+const makeApp = () => {
+  const history = createMemoryHistory();
+  const messages = {
+    en: Object.keys(pluginEn).reduce(
+      (acc, current) => {
+        acc[getTrad(current)] = pluginEn[current];
+
+        return acc;
+      },
+      { ...en }
+    ),
+  };
+
+  const localeNames = { en: 'English' };
+
+  return (
+    <LanguageProvider messages={messages} localeNames={localeNames}>
+      <ThemeToggleProvider themes={{ light: lightTheme, dark: darkTheme }}>
+        <Theme>
+          <Router history={history}>
+            <FormModalNavigationProvider>
+              <AttributeOptions attributes={mockAttributes} />
+            </FormModalNavigationProvider>
+          </Router>
+        </Theme>
+      </ThemeToggleProvider>
+    </LanguageProvider>
+  );
+};
+
+describe('AttributeOptions', () => {
+  it('renders and matches the snapshot', () => {
+    const App = makeApp();
+    const { container } = render(App);
+
+    expect(container).toMatchSnapshot();
+  });
+
+  it('shows the simple tabs', async () => {
+    const App = makeApp();
+    render(App);
+
+    const tabs = screen.getByLabelText('Attribute type tabs');
+    const defaultTab = await getByText(tabs, 'Default');
+    const customTab = await getByText(tabs, 'Custom');
+
+    expect(defaultTab).toBeVisible();
+    expect(customTab).toBeVisible();
+  });
+
+  it('defaults to the default tab', async () => {
+    const App = makeApp();
+    render(App);
+
+    const comingSoonText = screen.queryByText('Coming soon');
+
+    expect(comingSoonText).toEqual(null);
+  });
+
+  it('switches to the custom tab', async () => {
+    const App = makeApp();
+    render(App);
+
+    const customTab = screen.getByRole('tab', { selected: false });
+    fireEvent.click(customTab);
+    const button = screen.getByRole('tab', { selected: true });
+    const customTabActive = await getByText(button, 'Custom');
+    const comingSoonText = screen.getByText('Coming soon');
+
+    expect(customTabActive).not.toBe(null);
+    expect(comingSoonText).toBeVisible();
+  });
+});

--- a/packages/core/content-type-builder/admin/src/components/FormModal/index.js
+++ b/packages/core/content-type-builder/admin/src/components/FormModal/index.js
@@ -891,8 +891,6 @@ const FormModal = () => {
     advancedFormInputNames.includes(key)
   );
 
-  const schemaKind = get(contentTypes, [targetUid, 'schema', 'kind']);
-
   return (
     <>
       <ModalLayout onClose={handleClosed} labelledBy="title">
@@ -907,13 +905,7 @@ const FormModal = () => {
           targetUid={targetUid}
           attributeType={attributeType}
         />
-        {isPickingAttribute && (
-          <AttributeOptions
-            attributes={displayedAttributes}
-            forTarget={forTarget}
-            kind={schemaKind || 'collectionType'}
-          />
-        )}
+        {isPickingAttribute && <AttributeOptions attributes={displayedAttributes} />}
         {!isPickingAttribute && (
           <form onSubmit={handleSubmit}>
             <ModalBody>

--- a/packages/core/content-type-builder/admin/src/translations/en.json
+++ b/packages/core/content-type-builder/admin/src/translations/en.json
@@ -155,6 +155,8 @@
   "modalForm.sub-header.chooseAttribute.collectionType": "Select a field for your collection type",
   "modalForm.sub-header.chooseAttribute.component": "Select a field for your component",
   "modalForm.sub-header.chooseAttribute.singleType": "Select a field for your single type",
+  "modalForm.tabs.default": "Default",
+  "modalForm.tabs.custom": "Custom",
   "modelPage.attribute.relation-polymorphic": "Relation (polymorphic)",
   "modelPage.attribute.relationWith": "Relation with",
   "notification.error.dynamiczone-min.validation": "At least one component is required in a dynamic zone to be able to save a content type",


### PR DESCRIPTION
### What does it do?

- Adds tabs to the attribute creation modal
- One tab for the default Strapi types, and one tab for Custom Fields
- Displays "Coming Soon" on the custom fields tabs

### Why is it needed?

To accommodate custom fields in the attribute create modal

### How to test it?

- Go to to any content-type or component and click "Add another field", you should see the tabs
- The "Default" tab should be selected by default
- Click the "custom" tab, you should see "Coming soon" text

