### PR TITLE
Admin: add missing webpack chunk-names

### DIFF
--- a/packages/core/admin/admin/src/index.js
+++ b/packages/core/admin/admin/src/index.js
@@ -48,7 +48,7 @@ const run = async () => {
 
   // We need to make sure to fetch the project type before importing the StrapiApp
   // otherwise the strapi-babel-plugin does not work correctly
-  const StrapiApp = await import('./StrapiApp');
+  const StrapiApp = await import(/* webpackChunkName: "admin-app" */ './StrapiApp');
 
   const app = StrapiApp.default({
     appPlugins: plugins,

--- a/packages/core/admin/admin/src/pages/Admin/index.js
+++ b/packages/core/admin/admin/src/pages/Admin/index.js
@@ -27,8 +27,12 @@ const InstalledPluginsPage = lazy(() =>
 const MarketplacePage = lazy(() =>
   import(/* webpackChunkName: "Admin_marketplace" */ '../MarketplacePage')
 );
-const NotFoundPage = lazy(() => import('../NotFoundPage'));
-const InternalErrorPage = lazy(() => import('../InternalErrorPage'));
+const NotFoundPage = lazy(() =>
+  import(/* webpackChunkName: "Admin_NotFoundPage" */ '../NotFoundPage')
+);
+const InternalErrorPage = lazy(() =>
+  import(/* webpackChunkName: "Admin_InternalErrorPage" */ '../InternalErrorPage')
+);
 
 const ProfilePage = lazy(() =>
   import(/* webpackChunkName: "Admin_profilePage" */ '../ProfilePage')

--- a/packages/core/admin/webpack.config.js
+++ b/packages/core/admin/webpack.config.js
@@ -73,6 +73,7 @@ module.exports = ({
           css: true, // Apply minification to CSS assets
         }),
       ],
+      moduleIds: 'deterministic',
       runtimeChunk: true,
     },
     module: {

--- a/packages/core/content-type-builder/admin/src/pages/App/index.js
+++ b/packages/core/content-type-builder/admin/src/pages/App/index.js
@@ -18,7 +18,9 @@ import RecursivePath from '../RecursivePath';
 import icons from './utils/icons.json';
 import ContentTypeBuilderNav from '../../components/ContentTypeBuilderNav';
 
-const ListView = lazy(() => import('../ListView'));
+const ListView = lazy(() =>
+  import(/* webpackChunkName: "content-type-builder-list-view" */ '../ListView')
+);
 
 const App = () => {
   const { formatMessage } = useIntl();

--- a/packages/core/content-type-builder/admin/src/pages/RecursivePath/index.js
+++ b/packages/core/content-type-builder/admin/src/pages/RecursivePath/index.js
@@ -2,7 +2,9 @@ import React, { Suspense, lazy } from 'react';
 import { Switch, Route, useRouteMatch, useParams } from 'react-router-dom';
 import { LoadingIndicatorPage } from '@strapi/helper-plugin';
 
-const ListView = lazy(() => import('../ListView'));
+const ListView = lazy(() =>
+  import(/* webpackChunkName: "content-type-builder-recursive-path" */ '../ListView')
+);
 
 const RecursivePath = () => {
   const { url } = useRouteMatch();

--- a/packages/generators/generators/lib/files/plugin/admin/src/index.js
+++ b/packages/generators/generators/lib/files/plugin/admin/src/index.js
@@ -40,7 +40,9 @@ export default {
   async registerTrads({ locales }) {
     const importedTrads = await Promise.all(
       locales.map(locale => {
-        return import(`./translations/${locale}.json`)
+        return import(
+          /* webpackChunkName: "translation-[request]" */ `./translations/${locale}.json`
+        )
           .then(({ default: data }) => {
             return {
               data: prefixPluginTranslations(data, pluginId),


### PR DESCRIPTION
### What does it do?

In https://github.com/strapi/strapi/pull/13785, where I wanted to setup a admin bundle-size reporter, I realized that we have many unnamed chunks.

1. Which is bad for long-term caching

The name of the chunks might change, based on the overall chunk configuration and therefore be different on each deployment. That means users may need to download these over and over again, eventhough nothing has changed with their content.

2. Which makes it impossible to track the bundle-size

Renamed chunks are being reported twice: deleted and added, which makes the report unusable. To track the size of a file over time, it should not be renamed.

This PR should fix all cases missing from the admin bundle. However: there are more unnamed chunks. I don't fully understand yet, where there are coming from - I suspect these are design-system bundles, but this needs more digging. This PR is therefore a first step in the right direction, but won't be the last one.

### Why is it needed?

Reasons above.

### How to test it?

1. Build the admin panel with `NODE_ENV=production`
2. Compare file-names before and after: a new unnamed chunks are gone

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
