### PR TITLE
Fix sourcemaps for development environments

### DIFF
--- a/packages/core/admin/webpack.config.js
+++ b/packages/core/admin/webpack.config.js
@@ -52,7 +52,7 @@ module.exports = ({
   return {
     mode: isProduction ? 'production' : 'development',
     bail: isProduction ? true : false,
-    devtool: false,
+    devtool: isProduction ? false : 'eval-source-map',
     experiments: {
       topLevelAwait: true,
     },

--- a/packages/core/helper-plugin/webpack.config.js
+++ b/packages/core/helper-plugin/webpack.config.js
@@ -15,7 +15,7 @@ module.exports = {
   entry: `${__dirname}/lib/src/index.js`,
   externals: nodeModules,
   mode: process.env.NODE_ENV,
-  devtool: process.env.NODE_ENV === 'development' ? 'eval-source-map' : false,
+  devtool: process.env.NODE_ENV === 'production' ? false : 'eval-source-map',
   output: {
     path: `${__dirname}/build`,
     filename: `helper-plugin.${process.env.NODE_ENV}.js`,


### PR DESCRIPTION
### What does it do?

Currently sourcemaps are disabled even in the development environment, which makes debugging sometimes very hard. This PR:

- enables sourcemaps for development environments in `admin`
- fixes sourcemaps for the helper-plugin

| Before | After |
|-|-|
| <img width="1256" alt="Screenshot 2022-07-19 at 14 39 25" src="https://user-images.githubusercontent.com/2244375/179752905-1d3122a9-cae2-466c-a714-003e189fc0b2.png"> | <img width="1256" alt="Screenshot 2022-07-19 at 14 38 32" src="https://user-images.githubusercontent.com/2244375/179752922-96f12c57-73a1-4226-ba60-8bd63dc29d3a.png"> |

### Why is it needed?

Sourcemaps are very valuable for every developer, to understand where an error occurred. 

### How to test it?

Run the development enviroment and make a mistake somewhere: you will see the proper files being referenced in the error log of your browser.
