### PR TITLE
Add environment to the admin analytics calls the correct way

### DIFF
--- a/packages/core/admin/admin/src/pages/App/index.js
+++ b/packages/core/admin/admin/src/pages/App/index.js
@@ -13,6 +13,7 @@ import {
   useNotification,
   TrackingContext,
   prefixFileUrlWithBackendUrl,
+  useAppInfos,
 } from '@strapi/helper-plugin';
 import { SkipToContent } from '@strapi/design-system/Main';
 import { useIntl } from 'react-intl';
@@ -34,6 +35,7 @@ function App() {
   const { updateProjectSettings } = useConfigurations();
   const { formatMessage } = useIntl();
   const [{ isLoading, hasAdmin, uuid }, setState] = useState({ isLoading: true, hasAdmin: false });
+  const appInfo = useAppInfos();
 
   const authRoutes = useMemo(() => {
     return makeUniqueRoutes(
@@ -85,8 +87,8 @@ function App() {
                 uuid,
                 deviceId,
                 properties: {
-                  environment: process.env.NODE_ENV
-                }
+                  environment: appInfo.currentEnvironment,
+                },
               }),
               headers: {
                 'Content-Type': 'application/json',
@@ -107,6 +109,7 @@ function App() {
     };
 
     getData();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [toggleNotification, updateProjectSettings]);
 
   const setHasAdmin = hasAdmin => setState(prev => ({ ...prev, hasAdmin }));

--- a/packages/core/helper-plugin/lib/src/hooks/useTracking/index.js
+++ b/packages/core/helper-plugin/lib/src/hooks/useTracking/index.js
@@ -1,17 +1,23 @@
 import { useContext, useRef } from 'react';
 import axios from 'axios';
 import TrackingContext from '../../contexts/TrackingContext';
+import useAppInfos from '../useAppInfos';
 
 const useTracking = () => {
   const trackRef = useRef();
   const uuid = useContext(TrackingContext);
+  const appInfo = useAppInfos();
 
   trackRef.current = (event, properties) => {
     if (uuid) {
       try {
         axios.post('https://analytics.strapi.io/track', {
           event,
-          properties: { ...properties, projectType: strapi.projectType, environment: process.env.NODE_ENV },
+          properties: {
+            ...properties,
+            projectType: strapi.projectType,
+            environment: appInfo.currentEnvironment,
+          },
           uuid,
         });
       } catch (err) {


### PR DESCRIPTION
### What does it do?

Adds environment property to the admin analytics calls the correct way. Previously I have passed `process.env.NODE_ENV` to the analytics calls, but due to how we build our admin panel, `NODE_ENV` will always be `production`. This fix changes the behavior to the correct one.

### Why is it needed?

Fixes this PR https://github.com/strapi/strapi/pull/13765

