### PR TITLE
Fix creator fields in REST API

### DIFF
--- a/packages/core/utils/lib/__tests__/visitors.test.js
+++ b/packages/core/utils/lib/__tests__/visitors.test.js
@@ -57,6 +57,7 @@ describe('Sanitize visitors util', () => {
       );
       expect(remove).toHaveBeenCalledWith(keyCreatedBy);
 
+      remove.mockClear();
       await rrr(
         {
           data,
@@ -66,7 +67,7 @@ describe('Sanitize visitors util', () => {
         },
         { remove, set }
       );
-      expect(remove).toHaveBeenCalledWith(keyCreatedBy);
+      expect(remove).toHaveBeenCalledWith(keyUpdatedBy);
 
       expect(set).toBeCalledTimes(0);
     });

--- a/packages/core/utils/lib/__tests__/visitors.test.js
+++ b/packages/core/utils/lib/__tests__/visitors.test.js
@@ -1,0 +1,71 @@
+'use strict';
+
+const visitors = require('../sanitize/visitors');
+
+const { CREATED_BY_ATTRIBUTE, UPDATED_BY_ATTRIBUTE } = require('../content-types').constants;
+
+describe('Sanitize visitors util', () => {
+  describe('removeRestrictedRelations', () => {
+    const auth = {};
+    const data = {};
+    const keyCreatedBy = CREATED_BY_ATTRIBUTE;
+    const keyUpdatedBy = UPDATED_BY_ATTRIBUTE;
+
+    const attribute = {
+      type: 'relation',
+      relation: 'oneToOne',
+      target: 'admin::user',
+    };
+
+    test('keeps creator relations with populateCreatorFields true', async () => {
+      const remove = jest.fn();
+      const set = jest.fn();
+      const rrr = visitors.removeRestrictedRelations(auth);
+      await rrr(
+        {
+          data,
+          key: keyCreatedBy,
+          attribute,
+          schema: { options: { populateCreatorFields: true } },
+        },
+        { remove, set }
+      );
+      await rrr(
+        {
+          data,
+          key: keyUpdatedBy,
+          attribute,
+          schema: { options: { populateCreatorFields: true } },
+        },
+        { remove, set }
+      );
+      expect(remove).toBeCalledTimes(0);
+      expect(set).toBeCalledTimes(0);
+    });
+    test('removes creator relations with populateCreatorFields false', async () => {
+      const remove = jest.fn();
+      const set = jest.fn();
+      const rrr = visitors.removeRestrictedRelations(auth);
+      await rrr(
+        {
+          data,
+          key: keyCreatedBy,
+          attribute,
+          schema: { options: { populateCreatorFields: false } },
+        },
+        { remove, set }
+      );
+      await rrr(
+        {
+          data,
+          key: keyUpdatedBy,
+          attribute,
+          schema: { options: { populateCreatorFields: false } },
+        },
+        { remove, set }
+      );
+      expect(remove).toBeCalledTimes(2);
+      expect(set).toBeCalledTimes(0);
+    });
+  });
+});

--- a/packages/core/utils/lib/__tests__/visitors.test.js
+++ b/packages/core/utils/lib/__tests__/visitors.test.js
@@ -55,6 +55,7 @@ describe('Sanitize visitors util', () => {
         },
         { remove, set }
       );
+      expect(remove).toHaveBeenCalledTimes(1);
       expect(remove).toHaveBeenCalledWith(keyCreatedBy);
 
       remove.mockClear();
@@ -67,6 +68,7 @@ describe('Sanitize visitors util', () => {
         },
         { remove, set }
       );
+      expect(remove).toHaveBeenCalledTimes(1);
       expect(remove).toHaveBeenCalledWith(keyUpdatedBy);
 
       expect(set).toBeCalledTimes(0);

--- a/packages/core/utils/lib/__tests__/visitors.test.js
+++ b/packages/core/utils/lib/__tests__/visitors.test.js
@@ -55,6 +55,8 @@ describe('Sanitize visitors util', () => {
         },
         { remove, set }
       );
+      expect(remove).toHaveBeenCalledWith(keyCreatedBy);
+
       await rrr(
         {
           data,
@@ -64,7 +66,8 @@ describe('Sanitize visitors util', () => {
         },
         { remove, set }
       );
-      expect(remove).toBeCalledTimes(2);
+      expect(remove).toHaveBeenCalledWith(keyCreatedBy);
+
       expect(set).toBeCalledTimes(0);
     });
   });

--- a/packages/core/utils/lib/__tests__/visitors.test.js
+++ b/packages/core/utils/lib/__tests__/visitors.test.js
@@ -18,59 +18,48 @@ describe('Sanitize visitors util', () => {
     };
 
     test('keeps creator relations with populateCreatorFields true', async () => {
+      const populateCreatorFields = true;
+      const creatorKeys = [keyCreatedBy, keyUpdatedBy];
       const remove = jest.fn();
       const set = jest.fn();
       const rrr = visitors.removeRestrictedRelations(auth);
-      await rrr(
-        {
-          data,
-          key: keyCreatedBy,
-          attribute,
-          schema: { options: { populateCreatorFields: true } },
-        },
-        { remove, set }
-      );
-      await rrr(
-        {
-          data,
-          key: keyUpdatedBy,
-          attribute,
-          schema: { options: { populateCreatorFields: true } },
-        },
-        { remove, set }
-      );
-      expect(remove).toBeCalledTimes(0);
+      const promises = creatorKeys.map(async key => {
+        await rrr(
+          {
+            data,
+            key,
+            attribute,
+            schema: { options: { populateCreatorFields } },
+          },
+          { remove, set }
+        );
+      });
+      await Promise.all(promises);
+
+      expect(remove).toHaveBeenCalledTimes(0);
       expect(set).toBeCalledTimes(0);
     });
     test('removes creator relations with populateCreatorFields false', async () => {
+      const populateCreatorFields = false;
+      const creatorKeys = [keyCreatedBy, keyUpdatedBy];
       const remove = jest.fn();
       const set = jest.fn();
       const rrr = visitors.removeRestrictedRelations(auth);
-      await rrr(
-        {
-          data,
-          key: keyCreatedBy,
-          attribute,
-          schema: { options: { populateCreatorFields: false } },
-        },
-        { remove, set }
-      );
-      expect(remove).toHaveBeenCalledTimes(1);
-      expect(remove).toHaveBeenCalledWith(keyCreatedBy);
+      const promises = creatorKeys.map(async key => {
+        await rrr(
+          {
+            data,
+            key,
+            attribute,
+            schema: { options: { populateCreatorFields } },
+          },
+          { remove, set }
+        );
+      });
+      await Promise.all(promises);
 
-      remove.mockClear();
-      await rrr(
-        {
-          data,
-          key: keyUpdatedBy,
-          attribute,
-          schema: { options: { populateCreatorFields: false } },
-        },
-        { remove, set }
-      );
-      expect(remove).toHaveBeenCalledTimes(1);
-      expect(remove).toHaveBeenCalledWith(keyUpdatedBy);
-
+      expect(remove).toHaveBeenCalledTimes(creatorKeys.length);
+      creatorKeys.forEach(key => expect(remove).toHaveBeenCalledWith(key));
       expect(set).toBeCalledTimes(0);
     });
   });

--- a/packages/core/utils/lib/__tests__/visitors.test.js
+++ b/packages/core/utils/lib/__tests__/visitors.test.js
@@ -8,9 +8,8 @@ describe('Sanitize visitors util', () => {
   describe('removeRestrictedRelations', () => {
     const auth = {};
     const data = {};
-    const keyCreatedBy = CREATED_BY_ATTRIBUTE;
-    const keyUpdatedBy = UPDATED_BY_ATTRIBUTE;
-
+    const creatorKeys = [CREATED_BY_ATTRIBUTE, UPDATED_BY_ATTRIBUTE];
+    const rrrFunction = visitors.removeRestrictedRelations(auth);
     const attribute = {
       type: 'relation',
       relation: 'oneToOne',
@@ -18,18 +17,15 @@ describe('Sanitize visitors util', () => {
     };
 
     test('keeps creator relations with populateCreatorFields true', async () => {
-      const populateCreatorFields = true;
-      const creatorKeys = [keyCreatedBy, keyUpdatedBy];
       const remove = jest.fn();
       const set = jest.fn();
-      const rrr = visitors.removeRestrictedRelations(auth);
       const promises = creatorKeys.map(async key => {
-        await rrr(
+        await rrrFunction(
           {
             data,
             key,
             attribute,
-            schema: { options: { populateCreatorFields } },
+            schema: { options: { populateCreatorFields: true } },
           },
           { remove, set }
         );
@@ -39,19 +35,17 @@ describe('Sanitize visitors util', () => {
       expect(remove).toHaveBeenCalledTimes(0);
       expect(set).toBeCalledTimes(0);
     });
+
     test('removes creator relations with populateCreatorFields false', async () => {
-      const populateCreatorFields = false;
-      const creatorKeys = [keyCreatedBy, keyUpdatedBy];
       const remove = jest.fn();
       const set = jest.fn();
-      const rrr = visitors.removeRestrictedRelations(auth);
       const promises = creatorKeys.map(async key => {
-        await rrr(
+        await rrrFunction(
           {
             data,
             key,
             attribute,
-            schema: { options: { populateCreatorFields } },
+            schema: { options: { populateCreatorFields: false } },
           },
           { remove, set }
         );

--- a/packages/core/utils/lib/sanitize/visitors/remove-restricted-relations.js
+++ b/packages/core/utils/lib/sanitize/visitors/remove-restricted-relations.js
@@ -53,7 +53,7 @@ module.exports = auth => async ({ data, key, attribute }, { remove, set }) => {
   // Creator relations
   else if (isCreatorRelation) {
     // do nothing
-    // collections will transform/remove in api response based on populateCreatorFields
+    // allow 'private' flag to used instead of regular relation access
   }
 
   // Regular relations

--- a/packages/core/utils/lib/sanitize/visitors/remove-restricted-relations.js
+++ b/packages/core/utils/lib/sanitize/visitors/remove-restricted-relations.js
@@ -4,7 +4,7 @@ const ACTIONS_TO_VERIFY = ['find'];
 
 const { CREATED_BY_ATTRIBUTE, UPDATED_BY_ATTRIBUTE } = require('../../content-types').constants;
 
-module.exports = auth => async ({ data, key, attribute }, { remove, set }) => {
+module.exports = auth => async ({ data, key, attribute, schema }, { remove, set }) => {
   const isRelation = attribute.type === 'relation';
 
   if (!isRelation) {
@@ -51,7 +51,7 @@ module.exports = auth => async ({ data, key, attribute }, { remove, set }) => {
   }
 
   // Creator relations
-  else if (isCreatorRelation) {
+  else if (isCreatorRelation && schema.options.populateCreatorFields) {
     // do nothing
     // allow 'private' flag to used instead of regular relation access
   }

--- a/packages/core/utils/lib/sanitize/visitors/remove-restricted-relations.js
+++ b/packages/core/utils/lib/sanitize/visitors/remove-restricted-relations.js
@@ -2,7 +2,8 @@
 
 const ACTIONS_TO_VERIFY = ['find'];
 
-// FIXME: Support populating creator fields
+const { CREATED_BY_ATTRIBUTE, UPDATED_BY_ATTRIBUTE } = require('../../content-types').constants;
+
 module.exports = auth => async ({ data, key, attribute }, { remove, set }) => {
   const isRelation = attribute.type === 'relation';
 
@@ -42,10 +43,17 @@ module.exports = auth => async ({ data, key, attribute }, { remove, set }) => {
   };
 
   const isMorphRelation = attribute.relation.toLowerCase().startsWith('morph');
+  const isCreatorRelation = [CREATED_BY_ATTRIBUTE, UPDATED_BY_ATTRIBUTE].includes(key);
 
   // Polymorphic relations
   if (isMorphRelation) {
     await handleMorphRelation();
+  }
+
+  // Creator relations
+  else if (isCreatorRelation) {
+    // do nothing
+    // collections will transform/remove in api response based on populateCreatorFields
   }
 
   // Regular relations

--- a/packages/core/utils/lib/sanitize/visitors/remove-restricted-relations.js
+++ b/packages/core/utils/lib/sanitize/visitors/remove-restricted-relations.js
@@ -48,17 +48,17 @@ module.exports = auth => async ({ data, key, attribute, schema }, { remove, set 
   // Polymorphic relations
   if (isMorphRelation) {
     await handleMorphRelation();
+    return;
   }
 
   // Creator relations
-  else if (isCreatorRelation && schema.options.populateCreatorFields) {
+  if (isCreatorRelation && schema.options.populateCreatorFields) {
     // do nothing
+    return;
   }
 
   // Regular relations
-  else {
-    await handleRegularRelation();
-  }
+  await handleRegularRelation();
 };
 
 const hasAccessToSomeScopes = async (scopes, auth) => {

--- a/packages/core/utils/lib/sanitize/visitors/remove-restricted-relations.js
+++ b/packages/core/utils/lib/sanitize/visitors/remove-restricted-relations.js
@@ -53,7 +53,6 @@ module.exports = auth => async ({ data, key, attribute, schema }, { remove, set 
   // Creator relations
   else if (isCreatorRelation && schema.options.populateCreatorFields) {
     // do nothing
-    // allow 'private' flag to used instead of regular relation access
   }
 
   // Regular relations


### PR DESCRIPTION
### What does it do?

`removeRestrictedRelations` now uses the value of `populateCreatorFields` to determine if `createdBy` and `updatedBy` should be removed, rather than checking the `'admin::user'` permission for those creator fields.

### Why is it needed?

Creator fields were available in v3, but in v4 `createdBy`and `updatedBy` fields are no longer available in the API when `populateCreatorFields` is true, because they are being removed when the user does not have `'admin::user'` permissions (which cannot be granted in the admin)

### How to test it?

- Create a content type 
- create an item of that type
- set the content type config `options.populateCreatorFields` to `true`
- without this PR, the REST API still does not return the createdBy user
- with this PR, the REST API will return the createdBy user (same functionality as v3)

Unit tests for this functionality are included

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/issues/12228

There's a separate issue with the GraphQL schema for creator fields that needs to be fixed before it will be available in GraphQL