### PR TITLE
CM: Fix edit form for dynamiczones (allow label + description)

### DIFF
--- a/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/components/ModalForm.js
+++ b/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/components/ModalForm.js
@@ -59,8 +59,8 @@ const ModalForm = ({ onMetaChange, onSizeChange }) => {
     const formType = get(attributes, [selectedField, 'type']);
 
     if (
-      formType === 'dynamiczone' ||
-      (formType === 'component' && !['label', 'description'].includes(meta))
+      ['component', 'dynamiczone'].includes(formType) &&
+      !['label', 'description'].includes(meta)
     ) {
       return null;
     }


### PR DESCRIPTION
### What does it do?

Fixes a bug, where the label and description of dynamiczones couldn't be edited any longer. 

### Why is it needed?

To support adding a custom label + description to dynamiczone fields.

### How to test it?

1. Navigation to "configure the view" in the content-manager
2. Edit a dynamiczone field and validate "label" and "description" are displayed

### Related issue(s)/PR(s)

- Fixes https://github.com/strapi/strapi/issues/13407
