### PR TITLE
add typescript to deveDependencies

### DIFF
--- a/packages/core/admin/package.json
+++ b/packages/core/admin/package.json
@@ -140,6 +140,7 @@
   "devDependencies": {
     "speed-measure-webpack-plugin": "1.5.0",
     "glob": "8.0.3",
+    "typescript": "4.6.2",
     "duplicate-dependencies-webpack-plugin": "^1.0.2",
     "webpack-bundle-analyzer": "^4.5.0"
   },


### PR DESCRIPTION
### What does it do?

Adds typescript module to `core/admin` devDependencies

### Why is it needed?

A typescript project in the /example directory cannot run `yarn build` or it gets a "Error: Cannot find module 'typescript'" error because it's missing

### How to test it?

- Create a typescript project in /examples
- run `yarn build` from that project directory

### Related issue(s)/PR(s)

No, this is only an issue when working with the Strapi monorepo