### PR TITLE
EditViewDataManagerProvider: Fix missing params getAPIInnerErrors

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/index.js
@@ -310,7 +310,7 @@ const EditViewDataManagerProvider = ({
       } catch (err) {
         errors = {
           ...errors,
-          ...getAPIInnerErrors(err),
+          ...getAPIInnerErrors(err, { getTrad }),
         };
       }
 
@@ -346,7 +346,7 @@ const EditViewDataManagerProvider = ({
     } catch (err) {
       errors = {
         ...errors,
-        ...getAPIInnerErrors(err),
+        ...getAPIInnerErrors(err, { getTrad }),
       };
     }
 


### PR DESCRIPTION
### What does it do?

I forgot to properly pass down `getTrad` for all `getAPIInnerErrors` calls - this PR fixes that.

### Why is it needed?

Otherwise we'd see errors.

### Related issue(s)/PR(s)

- Fixes https://github.com/strapi/strapi/issues/13853
