### PR TITLE
Better handle populating of dynamic-zones

### DIFF
--- a/packages/core/content-manager/server/tests/api/basic-dz.test.e2e.js
+++ b/packages/core/content-manager/server/tests/api/basic-dz.test.e2e.js
@@ -47,7 +47,7 @@ const productWithDz = {
   collectionName: '',
 };
 
-describe('Core API - Basic + dz', () => {
+describe('CM API - Basic + dz', () => {
   beforeAll(async () => {
     await builder
       .addComponent(compo)

--- a/packages/core/content-manager/server/tests/api/populate-dz.test.e2e.js
+++ b/packages/core/content-manager/server/tests/api/populate-dz.test.e2e.js
@@ -1,0 +1,173 @@
+'use strict';
+
+const { createTestBuilder } = require('../../../../../../test/helpers/builder');
+const { createStrapiInstance } = require('../../../../../../test/helpers/strapi');
+const { createAuthRequest } = require('../../../../../../test/helpers/request');
+
+const builder = createTestBuilder();
+let strapi;
+let rq;
+let data = {
+  productsWithDz: [],
+  categories: [],
+};
+
+const compo1 = {
+  displayName: 'compo1',
+  attributes: {
+    title: {
+      type: 'string',
+    },
+    category: {
+      type: 'relation',
+      relation: 'oneToOne',
+      target: 'api::category.category',
+    },
+  },
+};
+
+const compo2 = {
+  displayName: 'compo2',
+  attributes: {
+    name: {
+      type: 'string',
+    },
+    category_diff: {
+      type: 'relation',
+      relation: 'oneToOne',
+      target: 'api::category.category',
+    },
+  },
+};
+
+const compoA = {
+  displayName: 'compoA',
+  attributes: {
+    items: {
+      type: 'component',
+      repeatable: false,
+      component: 'default.compo1',
+    },
+  },
+};
+
+const compoB = {
+  displayName: 'compoB',
+  attributes: {
+    items: {
+      type: 'component',
+      repeatable: false,
+      component: 'default.compo2',
+    },
+  },
+};
+
+const category = {
+  attributes: {
+    name: {
+      type: 'string',
+    },
+  },
+  displayName: 'Category',
+  singularName: 'category',
+  pluralName: 'categories',
+  description: '',
+  collectionName: '',
+};
+
+const productWithDz = {
+  attributes: {
+    name: {
+      type: 'string',
+    },
+    dz: {
+      components: ['default.compo-a', 'default.compo-b'],
+      type: 'dynamiczone',
+      required: true,
+    },
+  },
+  displayName: 'Product with dz',
+  singularName: 'product-with-dz',
+  pluralName: 'product-with-dzs',
+  description: '',
+  collectionName: '',
+};
+
+describe('CM API - Populate dz', () => {
+  beforeAll(async () => {
+    await builder
+      .addContentType(category)
+      .addComponent(compo1)
+      .addComponent(compo2)
+      .addComponent(compoA)
+      .addComponent(compoB)
+      .addContentType(productWithDz)
+      .build();
+
+    strapi = await createStrapiInstance();
+    rq = await createAuthRequest({ strapi });
+  });
+
+  afterAll(async () => {
+    await strapi.destroy();
+    await builder.cleanup();
+  });
+
+  test('Populate works in dz even with same names in different components', async () => {
+    const categoryRes = await rq({
+      method: 'POST',
+      url: '/content-manager/collection-types/api::category.category',
+      body: { name: 'name' },
+    });
+
+    expect(categoryRes.status).toBe(200);
+
+    data.categories.push(categoryRes.body);
+
+    const productRes = await rq({
+      method: 'POST',
+      url: '/content-manager/collection-types/api::product-with-dz.product-with-dz',
+      body: {
+        name: 'name',
+        dz: [
+          {
+            __component: 'default.compo-a',
+            items: { id: 2, title: 'AAAA', category: data.categories[0].id },
+          },
+          {
+            __component: 'default.compo-b',
+            items: { id: 2, name: 'BBBB', category_diff: data.categories[0].id },
+          },
+        ],
+      },
+    });
+
+    expect(productRes.status).toBe(200);
+
+    data.productsWithDz.push(productRes.body);
+
+    expect(productRes.body).toMatchObject({
+      name: 'name',
+      dz: [
+        {
+          __component: 'default.compo-a',
+          items: {
+            title: 'AAAA',
+            category: {
+              name: 'name',
+            },
+          },
+        },
+        {
+          __component: 'default.compo-b',
+          items: {
+            name: 'BBBB',
+            category_diff: {
+              name: 'name',
+            },
+          },
+        },
+      ],
+    });
+  });
+});

--- a/packages/plugins/graphql/server/services/builders/dynamic-zones.js
+++ b/packages/plugins/graphql/server/services/builders/dynamic-zones.js
@@ -3,7 +3,7 @@
 const { Kind, valueFromASTUntyped } = require('graphql');
 const { omit } = require('lodash/fp');
 const { unionType, scalarType } = require('nexus');
-const { ApplicationError } = require('@strapi/utils');
+const { ApplicationError } = require('@strapi/utils').errors;
 
 module.exports = ({ strapi }) => {
   const buildTypeDefinition = (name, components) => {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

It changes the populate process for dynamic-zones.
Instead of assigning the attributes in a fake schema, it does the populate for each component of the dz and then depp merge the results together.
It is better but still not perfect as there is no granularity on which component to populate exactly (ie if 2 components have the same field names, we cannot populate only one, the 2 would be populated). That seems however reasonable to not address this issue for the moment

### Why is it needed?

To fix this issue : https://github.com/strapi/strapi/issues/11955

### How to test it?

A test was added

### Related issue(s)/PR(s)

fix https://github.com/strapi/strapi/issues/11955
https://github.com/strapi/strapi/issues/11909
