### PR TITLE
EditViewDataManagerProvider: Ensure 0 is not converted to null

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/index.js
@@ -238,7 +238,8 @@ const EditViewDataManagerProvider = ({
         ['text', 'textarea', 'string', 'email', 'uid', 'select', 'select-one', 'number'].includes(
           type
         ) &&
-        !value
+        !value &&
+        value !== 0
       ) {
         inputValue = null;
       }


### PR DESCRIPTION
### What does it do?

Currently we convert `0` to `null`, when a field of type `number` is saved. This PR excludes `0` from the conversion. I'll try to open a follow-up PR to add more tests for these cases.

Bug was introduced in https://github.com/strapi/strapi/pull/13313

### Why is it needed?

To properly support `0` for number fields.

### How to test it?

See issue attached.

### Related issue(s)/PR(s)

- Fixes https://github.com/strapi/strapi/issues/13859
