### PR TITLE
Fix the bulk delete of files in the Media Library

### DIFF
--- a/packages/core/upload/server/services/folder.js
+++ b/packages/core/upload/server/services/folder.js
@@ -46,7 +46,11 @@ const create = async (folderData, { user } = {}) => {
 const deleteByIds = async (ids = []) => {
   const folders = await strapi.db.query(FOLDER_MODEL_UID).findMany({ where: { id: { $in: ids } } });
   if (folders.length === 0) {
-    return [];
+    return {
+      folders: [],
+      totalFolderNumber: 0,
+      totalFileNumber: 0,
+    };
   }
 
   const pathsToDelete = map('path', folders);


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

It allows the user to delete files.

Fix https://github.com/strapi/strapi/issues/13870

### Why is it needed?

To fix the deleting issue

### How to test it?

1. Select a file in the ML
2. Click _delete_
3. See the file correctly been delete

+ there is a test now

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/issues/13870
