### PR TITLE
Add tracking property for os.arch() to Amplitude / Sentry (project creation)

### DIFF
--- a/packages/generators/app/lib/index.js
+++ b/packages/generators/app/lib/index.js
@@ -5,8 +5,6 @@ const os = require('os');
 const crypto = require('crypto');
 const { v4: uuidv4 } = require('uuid');
 const sentry = require('@sentry/node');
-// FIXME
-/* eslint-disable import/extensions */
 const hasYarn = require('./utils/has-yarn');
 const checkRequirements = require('./utils/check-requirements');
 const { trackError, captureException } = require('./utils/usage');
@@ -60,6 +58,7 @@ const generateNewApp = (projectDirectory, cliArguments) => {
 
   sentry.configureScope(function scope(sentryScope) {
     const tags = {
+      os_arch: os.arch(),
       os_type: os.type(),
       os_platform: os.platform(),
       os_release: os.release(),

--- a/packages/generators/app/lib/utils/usage.js
+++ b/packages/generators/app/lib/utils/usage.js
@@ -108,6 +108,7 @@ function trackUsage({ event, scope, error }) {
   const properties = {
     error: typeof error === 'string' ? error : error && error.message,
     os: os.type(),
+    os_arch: os.arch(),
     os_platform: os.platform(),
     os_release: os.release(),
     node_version: process.version,


### PR DESCRIPTION
### What does it do?

Following an internal discussion about our current support of M1 processors I got curious to find some numbers on Amplitude / Sentry, but had to learn we are currently not tracking the CPU architecture. I think for the installation this might be an interesting information and therefore I'd like to propse to track it.

`os_arch` could contain the following architectures: 'arm', 'arm64', 'ia32', 'mips', 'mipsel', 'ppc', 'ppc64', 's390', 's390x', and 'x64'.

Node documentation: https://nodejs.org/api/os.html#osarch

This PR adds the current CPU architecture to Amplitude and Sentry when projects are created.

### Why is it needed?

I'd like to understand if users with `arm64` CPU architectures have more problems installing Strapi than others.
