### PR TITLE
useTracking: Respect the users choice when sending telemetry events in the admin app

### DIFF
--- a/packages/core/admin/admin/src/index.js
+++ b/packages/core/admin/admin/src/index.js
@@ -9,6 +9,7 @@ import appReducers from './reducers';
 window.strapi = {
   backendURL: process.env.STRAPI_ADMIN_BACKEND_URL,
   isEE: false,
+  telemetryDisabled: process.env.STRAPI_TELEMETRY_DISABLED ?? false,
   features: {
     SSO: 'sso',
   },

--- a/packages/core/admin/env.js
+++ b/packages/core/admin/env.js
@@ -25,6 +25,7 @@ const getClientEnvironment = (options) => {
         ADMIN_PATH: options.adminPath,
         NODE_ENV: options.env || 'development',
         STRAPI_ADMIN_BACKEND_URL: options.backend,
+        STRAPI_TELEMETRY_DISABLED: options.telemetryDisabled,
       }
     );
 

--- a/packages/core/admin/scripts/build.js
+++ b/packages/core/admin/scripts/build.js
@@ -41,6 +41,17 @@ const buildAdmin = async () => {
     options: {
       backend: 'http://localhost:1337',
       adminPath: '/admin/',
+
+      /**
+       * Ideally this would take more scenarios into account, such
+       * as the `telemetryDisabled` property in the package.json
+       * of the users project. For builds based on an app we are
+       * passing this information throgh, but here we do not have access
+       * to the app's package.json. By using at least an environment variable
+       * we can make sure developers can actually test this functionality.
+       */
+
+      telemetryDisabled: process.env.STRAPI_TELEMETRY_DISABLED === 'true' ?? false,
     },
     tsConfigFilePath,
   };

--- a/packages/core/admin/webpack.config.dev.js
+++ b/packages/core/admin/webpack.config.dev.js
@@ -20,6 +20,18 @@ module.exports = () => {
   const options = {
     backend: 'http://localhost:1337',
     adminPath: '/admin/',
+
+    /**
+     * Ideally this would take more scenarios into account, such
+     * as the `telemetryDisabled` property in the package.json
+     * of the users project. For builds based on an app we are
+     * passing this information throgh, but here we do not have access
+     * to the app's package.json. By using at least an environment variable
+     * we can make sure developers can actually test this functionality in
+     * dev-mode.
+     */
+
+    telemetryDisabled: process.env.STRAPI_TELEMETRY_DISABLED === 'true',
   };
   const pluginsPath = getPluginsPath();
 

--- a/packages/core/helper-plugin/lib/src/hooks/useAppInfos/__mocks__/index.js
+++ b/packages/core/helper-plugin/lib/src/hooks/useAppInfos/__mocks__/index.js
@@ -1,0 +1,3 @@
+const useAppInfosMock = jest.fn().mockReturnValue({});
+
+export default useAppInfosMock;

--- a/packages/core/helper-plugin/lib/src/hooks/useTracking/index.js
+++ b/packages/core/helper-plugin/lib/src/hooks/useTracking/index.js
@@ -9,14 +9,14 @@ const useTracking = () => {
   const appInfo = useAppInfos();
 
   trackRef.current = async (event, properties) => {
-    if (uuid) {
+    if (uuid && !window.strapi.telemetryDisabled) {
       try {
         await axios.post('https://analytics.strapi.io/track', {
           event,
           properties: {
             ...telemetryProperties,
             ...properties,
-            projectType: strapi.projectType,
+            projectType: window.strapi.projectType,
             environment: appInfo.currentEnvironment,
           },
           uuid,

--- a/packages/core/helper-plugin/lib/src/hooks/useTracking/tests/index.test.js
+++ b/packages/core/helper-plugin/lib/src/hooks/useTracking/tests/index.test.js
@@ -1,0 +1,96 @@
+import React from 'react';
+import { renderHook, act } from '@testing-library/react-hooks';
+import axios from 'axios';
+
+import TrackingContext from '../../../contexts/TrackingContext';
+import useTracking from '..';
+import useAppInfos from '../../useAppInfos';
+
+jest.mock('../../useAppInfos');
+
+jest.mock('axios', () => ({
+  ...jest.requireActual('axios'),
+  post: jest.fn(),
+}));
+
+function setup(props) {
+  return new Promise((resolve) => {
+    act(() => {
+      resolve(
+        renderHook(() => useTracking(), {
+          wrapper: ({ children }) => (
+            <TrackingContext.Provider
+              value={{
+                uuid: 1,
+                telemetryProperties: {
+                  nestedProperty: true,
+                },
+                ...props,
+              }}
+            >
+              {children}
+            </TrackingContext.Provider>
+          ),
+        })
+      );
+    });
+  });
+}
+
+describe('useTracking', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('Call trackUsage() with all attributes', async () => {
+    useAppInfos.mockReturnValue({
+      currentEnvironment: 'testing',
+    });
+
+    const { result } = await setup();
+
+    result.current.trackUsage('event', { trackingProperty: true });
+
+    expect(axios.post).toBeCalledWith(expect.any(String), {
+      event: 'event',
+      uuid: 1,
+      properties: expect.objectContaining({
+        environment: 'testing',
+        nestedProperty: true,
+        trackingProperty: true,
+      }),
+    });
+  });
+
+  test('Do not track if it has been disabled', async () => {
+    window.strapi.telemetryDisabled = true;
+
+    const { result } = await setup();
+
+    result.current.trackUsage();
+
+    expect(axios.post).not.toBeCalled();
+  });
+
+  test('Do not track if no uuid was set', async () => {
+    window.strapi.telemetryDisabled = true;
+
+    const { result } = await setup({
+      uuid: null,
+    });
+
+    result.current.trackUsage();
+
+    expect(axios.post).not.toBeCalled();
+
+    window.strapi.telemetryDisabled = false;
+  });
+
+  test('Should fail gracefully if the request does not work', async () => {
+    axios.post = jest.fn().mockRejectedValueOnce({});
+
+    const { result } = await setup();
+
+    expect(result.current.trackUsage).not.toThrow();
+  });
+});

--- a/packages/core/strapi/lib/commands/builders/admin.js
+++ b/packages/core/strapi/lib/commands/builders/admin.js
@@ -44,6 +44,7 @@ module.exports = async ({ buildDestDir, forceBuild = true, optimization, srcDir 
       options: {
         backend: serverUrl,
         adminPath: addSlash(adminPath),
+        telemetryIsDisabled: strapiInstance.telemetry.isDisabled,
       },
     })
     .then(() => {


### PR DESCRIPTION
### What does it do?

Currently frontend tracking events are sent, regardless if the telemetry is disabled. There are at least two ways to disable tracking:

- through an environment variable called `STRAPI_TELEMETRY_DISABLED`
- through a property `telemetryDisabled` in the package.json https://docs.strapi.io/developer-docs/latest/getting-started/usage-information.html

This PR passes down the environment variable and the setting and stores the preference on `window.strapi`, so that the `useTracking()` hook can check the user preference before sending the request.

For the development environment an easier solution, which only looks at the environment variable, was implemented to make it testable (see the comment in the code).

### Why is it needed?

To respect if a user has opted out from tracking.

### How to test it?

#### Tracking enabled (Example)

1. Run `yarn develop` in the getstarted example app
2. Open the content-manager `/admin/content-manager/collectionType/`
3. Verify a tracking event is sent

#### Tracking disabled (Example)

1. Run `npm run strapi telemetry:disable` or set `STRAPI_TELEMETRY_DISABLED` to `"true"` in the getstarted example app
2. Open the content-manager `/admin/content-manager/collectionType/`
3. Verify a tracking event is NOT sent

 #### Tracking enabled (Dev)

1. Run `yarn develop` for the admin app
2. Open the content-manager `/admin/content-manager/collectionType/`
3. Verify a tracking event is sent

 #### Tracking disabled (Dev)

1. Run `STRAPI_TELEMETRY_DISABLED=true yarn develop` for the admin app
2. Open the content-manager `/admin/content-manager/collectionType/`
3. Verify a tracking event is NOT sent

### Related issue(s)/PR(s)

- Fixes https://github.com/strapi/strapi/issues/9240
