### PR TITLE
SelectOne: Fix component styles

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/SelectOne/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/SelectOne/index.js
@@ -5,7 +5,7 @@ import { Stack } from '@strapi/design-system/Stack';
 import { Typography } from '@strapi/design-system/Typography';
 import get from 'lodash/get';
 import isNull from 'lodash/isNull';
-import Select from 'react-select';
+import { ReactSelect as Select } from '@strapi/helper-plugin';
 import SingleValue from './SingleValue';
 
 function SelectOne({
@@ -21,7 +21,6 @@ function SelectOne({
   onMenuScrollToBottom,
   options,
   placeholder,
-  styles,
   value,
   description,
 }) {
@@ -48,7 +47,6 @@ function SelectOne({
         placeholder={formatMessage(
           placeholder || { id: 'global.select', defaultMessage: 'Select...' }
         )}
-        styles={styles}
         value={isNull(value) ? null : { label: get(value, [mainField.name], ''), value }}
       />
 
@@ -89,7 +87,6 @@ SelectOne.propTypes = {
     id: PropTypes.string.isRequired,
     defaultMessage: PropTypes.string.isRequired,
   }),
-  styles: PropTypes.object.isRequired,
   value: PropTypes.object,
   description: PropTypes.string,
 };

--- a/packages/core/admin/package.json
+++ b/packages/core/admin/package.json
@@ -119,7 +119,6 @@
     "react-refresh": "0.11.0",
     "react-router": "5.2.0",
     "react-router-dom": "5.2.0",
-    "react-select": "^4.0.2",
     "react-virtualized": "^9.22.3",
     "redux": "^4.0.1",
     "redux-saga": "^0.16.0",


### PR DESCRIPTION
### What does it do?

In https://github.com/strapi/strapi/pull/13073 I forgot to apply the new `ReactSelect` component to `SelectOne` and did it only for `SelectMany`, which leads to missing styles.

This PR:

- uses `ReactSelect` as base component for `SelectOne` instead the the default from `react-select`
- removes `react-select` from `admin` dependencies, since it is now only a dependecy for the `helper-plugin`
- removes the `styles` prop; I could not find any instance on where this would get passed on

### Why is it needed?

Styling regressed in 4.3.

### How to test it?

You can use use the kitchen-sink example in dark-mode.

### Related issue(s)/PR(s)

- Refs: https://github.com/strapi/strapi/issues/13868
