### PR TITLE
Relation: Fix skewed draft/ publish bullet indicator

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/SelectOne/SingleValue.js
+++ b/packages/core/admin/admin/src/content-manager/components/SelectOne/SingleValue.js
@@ -12,10 +12,12 @@ import isEmpty from 'lodash/isEmpty';
 import { getTrad } from '../../utils';
 
 const StyledBullet = styled.div`
+  flex-shrink: 0;
   width: ${pxToRem(6)};
   height: ${pxToRem(6)};
   margin-right: ${({ theme }) => theme.spaces[2]};
-  background: ${({ theme, isDraft }) => theme.colors[isDraft ? 'secondary700' : 'success200']};
+  background-color: ${({ theme, isDraft }) =>
+    theme.colors[isDraft ? 'secondary600' : 'success600']};
   border-radius: 50%;
   cursor: pointer;
 `;

--- a/packages/core/admin/admin/src/content-manager/components/SelectWrapper/Option.js
+++ b/packages/core/admin/admin/src/content-manager/components/SelectWrapper/Option.js
@@ -10,10 +10,12 @@ import { pxToRem } from '@strapi/helper-plugin';
 import { getTrad } from '../../utils';
 
 const StyledBullet = styled.div`
+  flex-shrink: 0;
   width: ${pxToRem(6)};
   height: ${pxToRem(6)};
   margin-right: ${({ theme }) => theme.spaces[2]};
-  background: ${({ theme, isDraft }) => theme.colors[isDraft ? 'secondary600' : 'success600']};
+  background-color: ${({ theme, isDraft }) =>
+    theme.colors[isDraft ? 'secondary600' : 'success600']};
   border-radius: 50%;
   cursor: pointer;
 `;
@@ -22,29 +24,27 @@ const Option = props => {
   const { formatMessage } = useIntl();
   const Component = components.Option;
   const hasDraftAndPublish = has(get(props, 'data.value'), 'publishedAt');
-  const isDraft = isEmpty(get(props, 'data.value.publishedAt'));
 
   if (hasDraftAndPublish) {
-    if (hasDraftAndPublish) {
-      const draftMessage = {
-        id: getTrad('components.Select.draft-info-title'),
-        defaultMessage: 'State: Draft',
-      };
-      const publishedMessage = {
-        id: getTrad('components.Select.publish-info-title'),
-        defaultMessage: 'State: Published',
-      };
-      const title = isDraft ? formatMessage(draftMessage) : formatMessage(publishedMessage);
+    const isDraft = isEmpty(get(props, 'data.value.publishedAt'));
+    const draftMessage = {
+      id: getTrad('components.Select.draft-info-title'),
+      defaultMessage: 'State: Draft',
+    };
+    const publishedMessage = {
+      id: getTrad('components.Select.publish-info-title'),
+      defaultMessage: 'State: Published',
+    };
+    const title = isDraft ? formatMessage(draftMessage) : formatMessage(publishedMessage);
 
-      return (
-        <Component {...props}>
-          <Flex>
-            <StyledBullet title={title} isDraft={isDraft} />
-            <Typography ellipsis>{props.label || '-'}</Typography>
-          </Flex>
-        </Component>
-      );
-    }
+    return (
+      <Component {...props}>
+        <Flex>
+          <StyledBullet title={title} isDraft={isDraft} />
+          <Typography ellipsis>{props.label || '-'}</Typography>
+        </Flex>
+      </Component>
+    );
   }
 
   return <Component {...props}>{props.label || '-'}</Component>;


### PR DESCRIPTION
### What does it do?

Adds `flex-shrink: 0` to draft/ publish bullet indicators in relations and unifies their colors (might be a leftover from v3).

### Why is it needed?

Proper styling of relations.

### How to test it?

Use the kitchensink example, if has everything you need

#### Light mode

|Before|After|
|-|-|
| <img width="240" alt="Screenshot 2022-07-28 at 12 25 24" src="https://user-images.githubusercontent.com/2244375/181483952-567ab87c-2566-4dc9-8ab0-0b340148e253.png"> | <img width="240" alt="Screenshot 2022-07-28 at 12 24 54" src="https://user-images.githubusercontent.com/2244375/181483954-2d02c517-4488-47d1-8dd8-8e9e7bb1ef9f.png"> |

#### Dark mode

> **Note**
> Please ignore the background-color, which will be fixed [by another PR](https://github.com/strapi/strapi/pull/13878).

|Before|After|
|-|-|
| <img width="240" alt="Screenshot 2022-07-28 at 12 25 57" src="https://user-images.githubusercontent.com/2244375/181483934-5447ca75-3163-4ab8-b5fb-e4e11b8d8f1a.png"> | <img width="240" alt="Screenshot 2022-07-28 at 12 26 19" src="https://user-images.githubusercontent.com/2244375/181483929-5bf9a98a-33a0-4ef2-a8ca-6ebdbae0ffde.png"> |

### Related issue(s)/PR(s)

- Refs: https://github.com/strapi/strapi/issues/13868
