### PR TITLE
ML: Hide bulk actions if not assets or folders exist

### DIFF
--- a/packages/core/upload/admin/src/pages/App/MediaLibrary.js
+++ b/packages/core/upload/admin/src/pages/App/MediaLibrary.js
@@ -161,7 +161,7 @@ export const MediaLibrary = () => {
         <ActionLayout
           startActions={
             <>
-              {canUpdate && (
+              {canUpdate && (assetCount > 0 || folderCount > 0) && (
                 <BoxWithHeight
                   paddingLeft={2}
                   paddingRight={2}

--- a/packages/core/upload/admin/src/pages/App/tests/MediaLibrary.test.js
+++ b/packages/core/upload/admin/src/pages/App/tests/MediaLibrary.test.js
@@ -210,6 +210,24 @@ describe('Media library homepage', () => {
     });
 
     describe('select all', () => {
+      it('is not visible if there are not folders and assets', () => {
+        useAssets.mockReturnValueOnce({
+          isLoading: false,
+          error: null,
+          data: {},
+        });
+        useFolders.mockReturnValueOnce({
+          data: [],
+          isLoading: false,
+          error: null,
+        });
+        renderML();
+
+        expect(
+          screen.queryByText('There are no elements with the applied filters')
+        ).not.toBeInTheDocument();
+      });
+
       it('shows the select all button when the user is allowed to update', () => {
         renderML();
 


### PR DESCRIPTION
### What does it do?

While testing https://github.com/strapi/strapi/issues/13892 I've realized we display the bulk select checkbox, eventhough there are not assets or folders, which looks odd.

### Why is it needed?

To have a clean initial interface.
