### PR TITLE
chore: Unify template spacing

### DIFF
--- a/examples/getstarted/src/middlewares/test-middleware.js
+++ b/examples/getstarted/src/middlewares/test-middleware.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /**
- * `test-middleware` middleware.
+ * `test-middleware` middleware
  */
 
 module.exports = (config, { strapi }) => {

--- a/examples/getstarted/src/policies/test-policy.js
+++ b/examples/getstarted/src/policies/test-policy.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /**
- * `test-policy` policy.
+ * `test-policy` policy
  */
 
 module.exports = (policyCtx, config, { strapi }) => {

--- a/packages/core/admin/ee/server/services/__tests__/sso.test.js
+++ b/packages/core/admin/ee/server/services/__tests__/sso.test.js
@@ -47,11 +47,11 @@ describe('SSO', () => {
   });
 
   describe('Get Strategy Callback URL', () => {
-    const BASE_URL = '/admin/connect/{{provider}}';
+    const BASE_URL = '/admin/connect/{{ provider }}';
 
     test.each(['foo', 'bar', 'foobar'])('Get a correct callback url for %s', providerName => {
       expect(getStrategyCallbackURL(providerName)).toBe(
-        BASE_URL.replace('{{provider}}', providerName)
+        BASE_URL.replace('{{ provider }}', providerName)
       );
     });
   });

--- a/packages/core/content-manager/server/services/utils/configuration/index.js
+++ b/packages/core/content-manager/server/services/utils/configuration/index.js
@@ -12,7 +12,7 @@ async function validateCustomConfig(schema) {
     }).validate(schema.config);
   } catch (error) {
     throw new Error(
-      `Invalid Model configuration for model ${schema.uid}. Verify your {{modelName}}.config.js(on) file:\n  - ${error.message}\n`
+      `Invalid Model configuration for model ${schema.uid}. Verify your {{ modelName }}.config.js(on) file:\n  - ${error.message}\n`
     );
   }
 }

--- a/packages/generators/admin/component/index.js
+++ b/packages/generators/admin/component/index.js
@@ -63,7 +63,7 @@ const actions = answers => {
   answers.plugin = plugin;
   const templatesFolder = 'component/templates';
   const pattern = useRedux ? '**/**.hbs' : '**/index.*.hbs';
-  const path = join(packagesFolder, pluginFolder, '{{plugin}}/admin/src/components/{{name}}');
+  const path = join(packagesFolder, pluginFolder, '{{ plugin }}/admin/src/components/{{ name }}');
   return [
     {
       type: 'addMany',

--- a/packages/generators/admin/component/templates/actions.js.hbs
+++ b/packages/generators/admin/component/templates/actions.js.hbs
@@ -1,6 +1,6 @@
 /**
  *
- * {{name}} actions
+ * {{ name }} actions
  *
  */
 

--- a/packages/generators/admin/component/templates/constants.js.hbs
+++ b/packages/generators/admin/component/templates/constants.js.hbs
@@ -1,8 +1,8 @@
 /**
  *
- * {{name}} constants
+ * {{ name }} constants
  *
  */
 
 // eslint-disable-next-line import/prefer-default-export
-export const DEFAULT_ACTION = '{{plugin}}/{{name}}/DEFAULT_ACTION';
+export const DEFAULT_ACTION = '{{ plugin }}/{{ name }}/DEFAULT_ACTION';

--- a/packages/generators/admin/component/templates/index.js.hbs
+++ b/packages/generators/admin/component/templates/index.js.hbs
@@ -3,7 +3,7 @@
 {{else}}
   /**
    *
-   * {{name}}
+   * {{ name }}
    *
    */
 
@@ -17,22 +17,22 @@
   {{/if}}
   {{#if useRedux}}
     import { useDispatch, useSelector } from 'react-redux';
-    import { select{{name}}Domain } from './selectors';
+    import { select{{ name }}Domain } from './selectors';
     import { defaultAction } from './actions';
   {{/if}}
 {{/if}}
 
 {{#if styled}}
-  const {{name}} = styled.{{ htmlTag }}``;
+  const {{ name }} = styled.{{ htmlTag }}``;
 {{else}}
-  const {{name}} = () => {
+  const {{ name }} = () => {
     {{#if useI18n}}
       const { formatMessage } = useIntl();
     {{/if}}
     {{#if useRedux}}
       const dispatch = useDispatch();
       // eslint-disable-next-line no-unused-vars
-      const state = useSelector(select{{name}}Domain);
+      const state = useSelector(select{{ name }}Domain);
 
       const handleClick = () => dispatch(defaultAction())
     {{/if}}
@@ -55,7 +55,7 @@
     );
   };
 
-  {{name}}.propTypes = {};
+  {{ name }}.propTypes = {};
 {{/if}}
 
-export default {{name}};
+export default {{ name }};

--- a/packages/generators/admin/component/templates/reducer.js.hbs
+++ b/packages/generators/admin/component/templates/reducer.js.hbs
@@ -1,6 +1,6 @@
 /*
  *
- * {{name}} reducer
+ * {{ name }} reducer
  *
  */
 

--- a/packages/generators/admin/component/templates/reducer.js.hbs
+++ b/packages/generators/admin/component/templates/reducer.js.hbs
@@ -9,7 +9,7 @@ import { DEFAULT_ACTION } from './constants';
 
 export const initialState = {};
 
-const {{camelCase name}}Reducer = (state = initialState, action) =>
+const {{ camelCase name }}Reducer = (state = initialState, action) =>
   // eslint-disable-next-line consistent-return
   produce(state, draftState => {
     switch (action.type) {
@@ -21,4 +21,4 @@ const {{camelCase name}}Reducer = (state = initialState, action) =>
     }
   });
 
-export default {{camelCase name}}Reducer;
+export default {{ camelCase name }}Reducer;

--- a/packages/generators/admin/component/templates/selectors.js.hbs
+++ b/packages/generators/admin/component/templates/selectors.js.hbs
@@ -4,13 +4,13 @@ import { initialState } from './reducer';
 {{/unless}}
 
 /**
- * Direct selector to the {{name}} state domain
+ * Direct selector to the {{ name }} state domain
  */
 
 // eslint-disable-next-line import/prefer-default-export
-export const select{{name}}Domain = state => state[`
+export const select{{ name }}Domain = state => state[`
 {{~#if plugin "===" "admin"~}}
-  {{plugin}}
+  {{ plugin }}
 {{~else~}}
   ${pluginId}
 {{~/if~}}

--- a/packages/generators/admin/component/templates/selectors.js.hbs
+++ b/packages/generators/admin/component/templates/selectors.js.hbs
@@ -14,4 +14,4 @@ export const select{{ name }}Domain = state => state[`
 {{~else~}}
   ${pluginId}
 {{~/if~}}
-_{{camelCase name}}`] || initialState;
+_{{ camelCase name }}`] || initialState;

--- a/packages/generators/admin/component/templates/tests/actions.test.js.hbs
+++ b/packages/generators/admin/component/templates/tests/actions.test.js.hbs
@@ -1,7 +1,7 @@
 import { defaultAction } from '../actions';
 import { DEFAULT_ACTION } from '../constants';
 
-describe('{{plugin}} | components | {{name}} actions', () => {
+describe('{{ plugin }} | components | {{ name }} actions', () => {
   describe('Default Action', () => {
     it('has a type of DEFAULT_ACTION', () => {
       const expected = {

--- a/packages/generators/admin/component/templates/tests/index.test.js.hbs
+++ b/packages/generators/admin/component/templates/tests/index.test.js.hbs
@@ -1,6 +1,6 @@
 /**
  *
- * Tests for {{name}}
+ * Tests for {{ name }}
  *
  */
 
@@ -16,7 +16,7 @@ import { ThemeProvider, lightTheme } from '@strapi/design-system';
 {{#if useI18n}}
   import { IntlProvider } from 'react-intl';
 {{/if}}
-import {{name}} from '../index';
+import {{ name }} from '../index';
 
 {{#if useRedux}}
   const rootReducer = combineReducers(reducers);
@@ -25,7 +25,7 @@ import {{name}} from '../index';
     ui,
     {
       preloadedState = initialState,
-      store = createStore(rootReducer, { '{{plugin}}_{{camelCase name}}': preloadedState }),
+      store = createStore(rootReducer, { '{{ plugin }}_{{camelCase name}}': preloadedState }),
       ...renderOptions
     } = {},
   ) => {
@@ -40,11 +40,11 @@ import {{name}} from '../index';
 {{/if}}
 {{#if useI18n}}
   const messages = {
-    '{{plugin}}.component.name': '{{titleCase name}}',
+    '{{ plugin }}.component.name': '{{titleCase name}}',
   };
 
 {{/if}}
-describe('<{{name}} />', () => {
+describe('<{{ name }} />', () => {
   it('renders and matches the snapshot', () => {
     const {
       container: { firstChild },
@@ -52,12 +52,12 @@ describe('<{{name}} />', () => {
       {{#if useI18n}}
         <ThemeProvider theme={lightTheme}>
           <IntlProvider locale="en" messages={messages} defaultLocale="en">
-            <{{name}} />
+            <{{ name }} />
           </IntlProvider>
         </ThemeProvider>
       {{else}}
         <ThemeProvider theme={lightTheme}>
-          <{{name}} />
+          <{{ name }} />
         </ThemeProvider>
       {{/if}}
     );

--- a/packages/generators/admin/component/templates/tests/index.test.js.hbs
+++ b/packages/generators/admin/component/templates/tests/index.test.js.hbs
@@ -25,7 +25,7 @@ import {{ name }} from '../index';
     ui,
     {
       preloadedState = initialState,
-      store = createStore(rootReducer, { '{{ plugin }}_{{camelCase name}}': preloadedState }),
+      store = createStore(rootReducer, { '{{ plugin }}_{{ camelCase name }}': preloadedState }),
       ...renderOptions
     } = {},
   ) => {

--- a/packages/generators/admin/component/templates/tests/reducer.test.js.hbs
+++ b/packages/generators/admin/component/templates/tests/reducer.test.js.hbs
@@ -9,12 +9,12 @@ describe('{{camelCase name}}Reducer', () => {
   beforeEach(() => {
     state = {
       ...fixtures.store.state,
-      '{{plugin}}_{{camelCase name}}': initialState,
+      '{{ plugin }}_{{camelCase name}}': initialState,
     };
   });
 
   it('returns the initial state', () => {
-    const expectedResult = state['{{plugin}}_{{camelCase name}}'];
+    const expectedResult = state['{{ plugin }}_{{camelCase name}}'];
 
     expect({{camelCase name}}Reducer(undefined, {})).toEqual(expectedResult);
   });

--- a/packages/generators/admin/component/templates/tests/reducer.test.js.hbs
+++ b/packages/generators/admin/component/templates/tests/reducer.test.js.hbs
@@ -1,21 +1,21 @@
 // import produce from 'immer';
-import {{camelCase name}}Reducer, { initialState } from '../reducer';
+import {{ camelCase name }}Reducer, { initialState } from '../reducer';
 import { fixtures } from '../../../../../../../admin-test-utils';
 // import { someAction } from '../actions';
 
 /* eslint-disable default-case, no-param-reassign */
-describe('{{camelCase name}}Reducer', () => {
+describe('{{ camelCase name }}Reducer', () => {
   let state;
   beforeEach(() => {
     state = {
       ...fixtures.store.state,
-      '{{ plugin }}_{{camelCase name}}': initialState,
+      '{{ plugin }}_{{ camelCase name }}': initialState,
     };
   });
 
   it('returns the initial state', () => {
-    const expectedResult = state['{{ plugin }}_{{camelCase name}}'];
+    const expectedResult = state['{{ plugin }}_{{ camelCase name }}'];
 
-    expect({{camelCase name}}Reducer(undefined, {})).toEqual(expectedResult);
+    expect({{ camelCase name }}Reducer(undefined, {})).toEqual(expectedResult);
   });
 });

--- a/packages/generators/admin/component/templates/tests/selectors.test.js.hbs
+++ b/packages/generators/admin/component/templates/tests/selectors.test.js.hbs
@@ -1,17 +1,17 @@
 import { fixtures } from '../../../../../../../admin-test-utils';
-import { select{{name}}Domain } from '../selectors';
+import { select{{ name }}Domain } from '../selectors';
 
-describe('select{{name}}Domain', () => {
+describe('select{{ name }}Domain', () => {
   let store;
 
   beforeEach(() => {
-    store = { ...fixtures.store.state, '{{plugin}}_{{camelCase name}}': {} };
+    store = { ...fixtures.store.state, '{{ plugin }}_{{camelCase name}}': {} };
   });
 
   it('expects to have unit tests specified', () => {
-    const actual = select{{name}}Domain(store);
+    const actual = select{{ name }}Domain(store);
 
 		// TBC
-		expect(actual).toEqual(store['{{plugin}}_{{camelCase name}}']);
+		expect(actual).toEqual(store['{{ plugin }}_{{camelCase name}}']);
   });
 });

--- a/packages/generators/admin/component/templates/tests/selectors.test.js.hbs
+++ b/packages/generators/admin/component/templates/tests/selectors.test.js.hbs
@@ -5,13 +5,13 @@ describe('select{{ name }}Domain', () => {
   let store;
 
   beforeEach(() => {
-    store = { ...fixtures.store.state, '{{ plugin }}_{{camelCase name}}': {} };
+    store = { ...fixtures.store.state, '{{ plugin }}_{{ camelCase name }}': {} };
   });
 
   it('expects to have unit tests specified', () => {
     const actual = select{{ name }}Domain(store);
 
 		// TBC
-		expect(actual).toEqual(store['{{ plugin }}_{{camelCase name}}']);
+		expect(actual).toEqual(store['{{ plugin }}_{{ camelCase name }}']);
   });
 });

--- a/packages/generators/generators/lib/plops/api.js
+++ b/packages/generators/generators/lib/plops/api.js
@@ -47,19 +47,19 @@ module.exports = plop => {
       },
     ],
     actions(answers) {
-      const filePath = answers.isPluginApi && answers.plugin ? 'plugins/{{plugin}}' : 'api/{{id}}';
+      const filePath = answers.isPluginApi && answers.plugin ? 'plugins/{{ plugin }}' : 'api/{{ id }}';
       const currentDir = process.cwd();
       const language = tsUtils.isUsingTypeScriptSync(currentDir) ? 'ts' : 'js';
 
       const baseActions = [
         {
           type: 'add',
-          path: `${filePath}/controllers/{{id}}.${language}`,
+          path: `${filePath}/controllers/{{ id }}.${language}`,
           templateFile: `templates/${language}/controller.${language}.hbs`,
         },
         {
           type: 'add',
-          path: `${filePath}/services/{{id}}.${language}`,
+          path: `${filePath}/services/{{ id }}.${language}`,
           templateFile: `templates/${language}/service.${language}.hbs`,
         },
       ];
@@ -71,7 +71,7 @@ module.exports = plop => {
       return [
         {
           type: 'add',
-          path: `${filePath}/routes/{{id}}.${language}`,
+          path: `${filePath}/routes/{{ id }}.${language}`,
           templateFile: `templates/${language}/single-route.${language}.hbs`,
         },
         ...baseActions,

--- a/packages/generators/generators/lib/plops/content-type.js
+++ b/packages/generators/generators/lib/plops/content-type.js
@@ -123,19 +123,19 @@ module.exports = plop => {
         baseActions.push(
           {
             type: 'add',
-            path: `${filePath}/controllers/{{singularName}}.${language}`,
+            path: `${filePath}/controllers/{{ singularName }}.${language}`,
             templateFile: `templates/${language}/core-controller.${language}.hbs`,
             data: { uid },
           },
           {
             type: 'add',
-            path: `${filePath}/services/{{singularName}}.${language}`,
+            path: `${filePath}/services/{{ singularName }}.${language}`,
             templateFile: `templates/${language}/core-service.${language}.hbs`,
             data: { uid },
           },
           {
             type: 'add',
-            path: `${filePath}/routes/{{singularName}}.${language}`,
+            path: `${filePath}/routes/{{ singularName }}.${language}`,
             templateFile: `templates/${language}/core-router.${language}.hbs`,
             data: { uid },
           }

--- a/packages/generators/generators/lib/plops/policy.js
+++ b/packages/generators/generators/lib/plops/policy.js
@@ -27,7 +27,7 @@ module.exports = plop => {
       return [
         {
           type: 'add',
-          path: `${filePath}/policies/{{id}}.${language}`,
+          path: `${filePath}/policies/{{ id }}.${language}`,
           templateFile: `templates/${language}/policy.${language}.hbs`,
         },
       ];

--- a/packages/generators/generators/lib/templates/js/collection-type-routes.js.hbs
+++ b/packages/generators/generators/lib/templates/js/collection-type-routes.js.hbs
@@ -2,8 +2,8 @@ module.exports = {
   routes: [
     {
       method: 'GET',
-      path: '/{{pluralize id}}',
-      handler: '{{id}}.find',
+      path: '/{{ pluralize id }}',
+      handler: '{{ id }}.find',
       config: {
         policies: [],
         middlewares: [],
@@ -11,8 +11,8 @@ module.exports = {
     },
     {
       method: 'GET',
-      path: '/{{pluralize id}}/:id',
-      handler: '{{id}}.findOne',
+      path: '/{{ pluralize id }}/:id',
+      handler: '{{ id }}.findOne',
       config: {
         policies: [],
         middlewares: [],
@@ -20,8 +20,8 @@ module.exports = {
     },
     {
       method: 'POST',
-      path: '/{{pluralize id}}',
-      handler: '{{id}}.create',
+      path: '/{{ pluralize id }}',
+      handler: '{{ id }}.create',
       config: {
         policies: [],
         middlewares: [],
@@ -29,8 +29,8 @@ module.exports = {
     },
     {
       method: 'PUT',
-      path: '/{{pluralize id}}/:id',
-      handler: '{{id}}.update',
+      path: '/{{ pluralize id }}/:id',
+      handler: '{{ id }}.update',
       config: {
         policies: [],
         middlewares: [],
@@ -38,8 +38,8 @@ module.exports = {
     },
     {
       method: 'DELETE',
-      path: '/{{pluralize id}}/:id',
-      handler: '{{id}}.delete',
+      path: '/{{ pluralize id }}/:id',
+      handler: '{{ id }}.delete',
       config: {
         policies: [],
         middlewares: [],

--- a/packages/generators/generators/lib/templates/js/controller.js.hbs
+++ b/packages/generators/generators/lib/templates/js/controller.js.hbs
@@ -1,7 +1,7 @@
 'use strict';
 
 /**
- * A set of functions called "actions" for `{{id}}`
+ * A set of functions called "actions" for `{{ id }}`
  */
 
 module.exports = {

--- a/packages/generators/generators/lib/templates/js/core-controller.js.hbs
+++ b/packages/generators/generators/lib/templates/js/core-controller.js.hbs
@@ -1,7 +1,7 @@
 'use strict';
 
 /**
- *  {{ id }} controller
+ * {{ id }} controller
  */
 
 const { createCoreController } = require('@strapi/strapi').factories;

--- a/packages/generators/generators/lib/templates/js/core-router.js.hbs
+++ b/packages/generators/generators/lib/templates/js/core-router.js.hbs
@@ -1,7 +1,7 @@
 'use strict';
 
 /**
- * {{ id }} router.
+ * {{ id }} router
  */
 
 const { createCoreRouter } = require('@strapi/strapi').factories;

--- a/packages/generators/generators/lib/templates/js/core-service.js.hbs
+++ b/packages/generators/generators/lib/templates/js/core-service.js.hbs
@@ -1,7 +1,7 @@
 'use strict';
 
 /**
- * {{ id }} service.
+ * {{ id }} service
  */
 
 const { createCoreService } = require('@strapi/strapi').factories;

--- a/packages/generators/generators/lib/templates/js/middleware.js.hbs
+++ b/packages/generators/generators/lib/templates/js/middleware.js.hbs
@@ -1,7 +1,7 @@
 'use strict';
 
 /**
- * `{{ name }}` middleware.
+ * `{{ name }}` middleware
  */
 
 module.exports = (config, { strapi }) => {

--- a/packages/generators/generators/lib/templates/js/policy.js.hbs
+++ b/packages/generators/generators/lib/templates/js/policy.js.hbs
@@ -1,7 +1,7 @@
 'use strict';
 
 /**
- * `{{ id }}` policy.
+ * `{{ id }}` policy
  */
 
 module.exports = (policyContext, config, { strapi }) => {

--- a/packages/generators/generators/lib/templates/js/policy.js.hbs
+++ b/packages/generators/generators/lib/templates/js/policy.js.hbs
@@ -1,12 +1,12 @@
 'use strict';
 
 /**
- * `{{id}}` policy.
+ * `{{ id }}` policy.
  */
 
 module.exports = (policyContext, config, { strapi }) => {
     // Add your own logic here.
-    strapi.log.info('In {{id}} policy.');
+    strapi.log.info('In {{ id }} policy.');
 
     const canDoSomething = true;
 

--- a/packages/generators/generators/lib/templates/js/service.js.hbs
+++ b/packages/generators/generators/lib/templates/js/service.js.hbs
@@ -1,7 +1,7 @@
 'use strict';
 
 /**
- * {{id}} service.
+ * {{ id }} service
  */
 
 module.exports = () => ({});

--- a/packages/generators/generators/lib/templates/js/single-route.js.hbs
+++ b/packages/generators/generators/lib/templates/js/single-route.js.hbs
@@ -2,8 +2,8 @@ module.exports = {
   routes: [
     // {
     //  method: 'GET',
-    //  path: '/{{id}}',
-    //  handler: '{{id}}.exampleAction',
+    //  path: '/{{ id }}',
+    //  handler: '{{ id }}.exampleAction',
     //  config: {
     //    policies: [],
     //    middlewares: [],

--- a/packages/generators/generators/lib/templates/js/single-type-routes.js.hbs
+++ b/packages/generators/generators/lib/templates/js/single-type-routes.js.hbs
@@ -4,8 +4,8 @@ module.exports = {
   routes: [
     {
       method: 'GET',
-      path: '/{{id}}',
-      handler: '{{id}}.find',
+      path: '/{{ id }}',
+      handler: '{{ id }}.find',
       config: {
         policies: [],
         middlewares: [],
@@ -13,8 +13,8 @@ module.exports = {
     },
     {
       method: 'PUT',
-      path: '/{{id}}',
-      handler: '{{id}}.update',
+      path: '/{{ id }}',
+      handler: '{{ id }}.update',
       config: {
         policies: [],
         middlewares: [],
@@ -22,8 +22,8 @@ module.exports = {
     },
     {
       method: 'DELETE',
-      path: '/{{id}}',
-      handler: '{{id}}.delete',
+      path: '/{{ id }}',
+      handler: '{{ id }}.delete',
       config: {
         policies: [],
         middlewares: [],

--- a/packages/generators/generators/lib/templates/ts/collection-type-routes.ts.hbs
+++ b/packages/generators/generators/lib/templates/ts/collection-type-routes.ts.hbs
@@ -2,8 +2,8 @@ export default {
   routes: [
     {
       method: 'GET',
-      path: '/{{pluralize id}}',
-      handler: '{{id}}.find',
+      path: '/{{ pluralize id }}',
+      handler: '{{ id }}.find',
       config: {
         policies: [],
         middlewares: [],
@@ -11,8 +11,8 @@ export default {
     },
     {
       method: 'GET',
-      path: '/{{pluralize id}}/:id',
-      handler: '{{id}}.findOne',
+      path: '/{{ pluralize id }}/:id',
+      handler: '{{ id }}.findOne',
       config: {
         policies: [],
         middlewares: [],
@@ -20,8 +20,8 @@ export default {
     },
     {
       method: 'POST',
-      path: '/{{pluralize id}}',
-      handler: '{{id}}.create',
+      path: '/{{ pluralize id }}',
+      handler: '{{ id }}.create',
       config: {
         policies: [],
         middlewares: [],
@@ -29,8 +29,8 @@ export default {
     },
     {
       method: 'PUT',
-      path: '/{{pluralize id}}/:id',
-      handler: '{{id}}.update',
+      path: '/{{ pluralize id }}/:id',
+      handler: '{{ id }}.update',
       config: {
         policies: [],
         middlewares: [],
@@ -38,8 +38,8 @@ export default {
     },
     {
       method: 'DELETE',
-      path: '/{{pluralize id}}/:id',
-      handler: '{{id}}.delete',
+      path: '/{{ pluralize id }}/:id',
+      handler: '{{ id }}.delete',
       config: {
         policies: [],
         middlewares: [],

--- a/packages/generators/generators/lib/templates/ts/controller.ts.hbs
+++ b/packages/generators/generators/lib/templates/ts/controller.ts.hbs
@@ -1,5 +1,5 @@
 /**
- * A set of functions called "actions" for `{{id}}`
+ * A set of functions called "actions" for `{{ id }}`
  */
 
 export default {

--- a/packages/generators/generators/lib/templates/ts/core-controller.ts.hbs
+++ b/packages/generators/generators/lib/templates/ts/core-controller.ts.hbs
@@ -1,5 +1,5 @@
 /**
- *  {{ id }} controller
+ * {{ id }} controller
  */
 
 import { factories } from '@strapi/strapi'

--- a/packages/generators/generators/lib/templates/ts/core-router.ts.hbs
+++ b/packages/generators/generators/lib/templates/ts/core-router.ts.hbs
@@ -1,5 +1,5 @@
 /**
- * {{ id }} router.
+ * {{ id }} router
  */
 
 import { factories } from '@strapi/strapi';

--- a/packages/generators/generators/lib/templates/ts/core-service.ts.hbs
+++ b/packages/generators/generators/lib/templates/ts/core-service.ts.hbs
@@ -1,5 +1,5 @@
 /**
- * {{ id }} service.
+ * {{ id }} service
  */
 
 import { factories } from '@strapi/strapi';

--- a/packages/generators/generators/lib/templates/ts/middleware.ts.hbs
+++ b/packages/generators/generators/lib/templates/ts/middleware.ts.hbs
@@ -1,5 +1,5 @@
 /**
- * `{{ name }}` middleware.
+ * `{{ name }}` middleware
  */
 
 import '@strapi/strapi';

--- a/packages/generators/generators/lib/templates/ts/policy.ts.hbs
+++ b/packages/generators/generators/lib/templates/ts/policy.ts.hbs
@@ -1,10 +1,10 @@
 /**
- * `{{id}}` policy.
+ * {{ id }} policy
  */
 
 export default (policyContext, config, { strapi }) => {
     // Add your own logic here.
-    strapi.log.info('In {{id}} policy.');
+    strapi.log.info('In {{ id }} policy.');
 
     const canDoSomething = true;
 

--- a/packages/generators/generators/lib/templates/ts/service.ts.hbs
+++ b/packages/generators/generators/lib/templates/ts/service.ts.hbs
@@ -1,5 +1,5 @@
 /**
- * {{id}} service.
+ * {{ id }} service
  */
 
 export default () => ({});

--- a/packages/generators/generators/lib/templates/ts/single-route.ts.hbs
+++ b/packages/generators/generators/lib/templates/ts/single-route.ts.hbs
@@ -2,8 +2,8 @@ export default {
   routes: [
     // {
     //  method: 'GET',
-    //  path: '/{{id}}',
-    //  handler: '{{id}}.exampleAction',
+    //  path: '/{{ id }}',
+    //  handler: '{{ id }}.exampleAction',
     //  config: {
     //    policies: [],
     //    middlewares: [],

--- a/packages/generators/generators/lib/templates/ts/single-type-routes.ts.hbs
+++ b/packages/generators/generators/lib/templates/ts/single-type-routes.ts.hbs
@@ -2,8 +2,8 @@ export default {
   routes: [
     {
       method: 'GET',
-      path: '/{{id}}',
-      handler: '{{id}}.find',
+      path: '/{{ id }}',
+      handler: '{{ id }}.find',
       config: {
         policies: [],
         middlewares: [],
@@ -11,8 +11,8 @@ export default {
     },
     {
       method: 'PUT',
-      path: '/{{id}}',
-      handler: '{{id}}.update',
+      path: '/{{ id }}',
+      handler: '{{ id }}.update',
       config: {
         policies: [],
         middlewares: [],
@@ -20,8 +20,8 @@ export default {
     },
     {
       method: 'DELETE',
-      path: '/{{id}}',
-      handler: '{{id}}.delete',
+      path: '/{{ id }}',
+      handler: '{{ id }}.delete',
       config: {
         policies: [],
         middlewares: [],

--- a/packages/plugins/users-permissions/server/services/providers.js
+++ b/packages/plugins/users-permissions/server/services/providers.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /**
- * Module dependencies.
+ * Module dependencies
  */
 
 // Public node modules.


### PR DESCRIPTION
### What does it do?
Unify spacing with literals in Strapi repo

### Describe the technical changes you did.
Changed every `{{variable}}` to `{{ variable }}`

### Why is it needed?
Unification of code. Some parts has variables without spaces, some has with spaces

### How to test it?

### Related issue(s)/PR(s)

### Screenshots
