### PR TITLE
AssetDialog: Properly take canRead permissions into account

### DIFF
--- a/packages/core/upload/admin/src/components/AssetDialog/DialogHeader.js
+++ b/packages/core/upload/admin/src/components/AssetDialog/DialogHeader.js
@@ -26,12 +26,15 @@ const BackIcon = styled(Icon)`
   }
 `;
 
-export const DialogHeader = ({ currentFolder, onChangeFolder }) => {
+export const DialogHeader = ({ currentFolder, onChangeFolder, canRead }) => {
   const { formatMessage } = useIntl();
 
-  const { data, isLoading } = useFolderStructure();
+  const { data, isLoading } = useFolderStructure({
+    enabled: canRead,
+  });
 
-  const folderMetadatas = !isLoading && findRecursiveFolderMetadatas(data[0], currentFolder);
+  const folderMetadatas =
+    !isLoading && Array.isArray(data) && findRecursiveFolderMetadatas(data[0], currentFolder);
   const folderLabel =
     folderMetadatas?.currentFolderLabel &&
     (folderMetadatas.currentFolderLabel.length > 60
@@ -82,6 +85,7 @@ DialogHeader.defaultProps = {
 };
 
 DialogHeader.propTypes = {
+  canRead: PropTypes.bool.isRequired,
   currentFolder: PropTypes.number,
   onChangeFolder: PropTypes.func,
 };

--- a/packages/core/upload/admin/src/components/AssetDialog/index.js
+++ b/packages/core/upload/admin/src/components/AssetDialog/index.js
@@ -107,7 +107,7 @@ export const AssetDialog = ({
   if (isLoading) {
     return (
       <ModalLayout onClose={onClose} labelledBy="asset-dialog-title" aria-busy>
-        <DialogHeader />
+        <DialogHeader canRead={canRead} />
         <LoadingBody justifyContent="center" paddingTop={4} paddingBottom={4}>
           <Loader>
             {formatMessage({
@@ -124,7 +124,7 @@ export const AssetDialog = ({
   if (hasError) {
     return (
       <ModalLayout onClose={onClose} labelledBy="asset-dialog-title">
-        <DialogHeader />
+        <DialogHeader canRead={canRead} />
         <AnErrorOccurred />
         <DialogFooter onClose={onClose} />
       </ModalLayout>
@@ -134,7 +134,7 @@ export const AssetDialog = ({
   if (!canRead) {
     return (
       <ModalLayout onClose={onClose} labelledBy="asset-dialog-title">
-        <DialogHeader />
+        <DialogHeader canRead={canRead} />
         <NoPermissions />
         <DialogFooter onClose={onClose} />
       </ModalLayout>
@@ -179,7 +179,11 @@ export const AssetDialog = ({
 
   return (
     <ModalLayout onClose={onClose} labelledBy="asset-dialog-title" aria-busy={isLoading}>
-      <DialogHeader currentFolder={queryObject?.folder} onChangeFolder={handleFolderChange} />
+      <DialogHeader
+        currentFolder={queryObject?.folder}
+        onChangeFolder={handleFolderChange}
+        canRead={canRead}
+      />
 
       <TabGroup
         label={formatMessage({

--- a/packages/core/upload/admin/src/components/AssetDialog/tests/DialogHeader.test.js
+++ b/packages/core/upload/admin/src/components/AssetDialog/tests/DialogHeader.test.js
@@ -10,6 +10,7 @@ jest.mock('../../../hooks/useFolderStructure');
 
 const setup = props => {
   const withDefaults = {
+    canRead: true,
     currentFolder: null,
     onChangeFolder: jest.fn(),
     ...props,
@@ -79,5 +80,17 @@ describe('Upload || components || DialogHeader', () => {
 
     expect(queryByText('Cats')).not.toBeInTheDocument();
     expect(screen.queryByLabelText('Go back')).not.toBeInTheDocument();
+  });
+
+  it('should not attempt to fetch the folder structure, if the user does not have permissions', () => {
+    const spy = jest.fn().mockReturnValueOnce({
+      isLoading: false,
+      error: null,
+    });
+    useFolderStructure.mockImplementation(spy);
+
+    setup({ canRead: false });
+
+    expect(spy).toHaveBeenCalledWith({ enabled: false });
   });
 });


### PR DESCRIPTION
### What does it do?

Currently loading the folder structure in the `AssetDialog` does not properly take the `canRead` permission into account, which leads to request retries, if the user does not have the permissions, as reported in https://github.com/strapi/strapi/issues/13892

### Why is it needed?

To properly support `canRead` permissions.

### How to test it?

- Remove read permissions for a user
- Try to open the asset modal in the content manager

### Related issue(s)/PR(s)

- Refs https://github.com/strapi/strapi/issues/13892
