### PR TITLE
Removed secrets exposed

### DIFF
--- a/packages/generators/app/lib/resources/templates/js/admin-config.template
+++ b/packages/generators/app/lib/resources/templates/js/admin-config.template
@@ -1,5 +1,5 @@
 module.exports = ({ env }) => ({
   auth: {
-    secret: env('ADMIN_JWT_SECRET', '<%= adminJwtToken %>'),
+    secret: env('ADMIN_JWT_SECRET'),
   },
 });

--- a/packages/generators/app/lib/resources/templates/ts/admin-config.template
+++ b/packages/generators/app/lib/resources/templates/ts/admin-config.template
@@ -1,5 +1,5 @@
 export default ({ env }) => ({
   auth: {
-    secret: env('ADMIN_JWT_SECRET', '<%= adminJwtToken %>'),
+    secret: env('ADMIN_JWT_SECRET'),
   },
 });


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?
When strapi generates a project, it will automatically inject a `fallback` secret to  `config/admin.js`
This can be a security risk.

Let's make a scenario of this.

User generates the project. then publishes to production.
User doesn't check `admin.js` and assumes everything is working as strapi is not failing. They added all env variables but forgot to add the `ADMIN_JWT_SECRET` 🙈
Somone finds their repo and now have access to the _used in production JWT_SECRET__

By not injecting the a fallback key, the user will be aware on startup if it's forgotten and can easy add this. Increasing security.
We also solve the problem where we are then pushing random **fallback keys** to a repo.

### Why is it needed?
☝️ Please see above it increases security.

### How to test it?
Remove the `ADMIN_JWT_SECRET` from `.env` and try startup strapi and it should fail.

### Related issue(s)/PR(s)