### PR TITLE
fix: issue-11955 dynamicZone populate same key error

### DIFF
--- a/packages/core/utils/lib/convert-query-params.js
+++ b/packages/core/utils/lib/convert-query-params.js
@@ -170,17 +170,13 @@ const convertPopulateObject = (populate, schema) => {
     // FIXME: This is a temporary solution for dynamic zones that should be
     // fixed when we'll implement a more accurate way to query them
     if (attribute.type === 'dynamiczone') {
-      const generatedFakeDynamicZoneSchema = {
-        uid: `${schema.uid}.${key}`,
-        attributes: attribute.components
-          .sort()
-          .map(uid => strapi.getModel(uid).attributes)
-          .reduce((acc, componentAttributes) => ({ ...acc, ...componentAttributes }), {}),
-      };
+      const attributeComponents = attribute.components
+        .sort()
+        .map(uid => strapi.getModel(uid).attributes);
 
       return {
         ...acc,
-        [key]: convertNestedPopulate(subPopulate, generatedFakeDynamicZoneSchema),
+        [key]: convertDynamicZonePopulate(`${schema.uid}.${key}`, subPopulate, attributeComponents),
       };
     }
 
@@ -209,6 +205,17 @@ const convertPopulateObject = (populate, schema) => {
       ...acc,
       [key]: convertNestedPopulate(subPopulate, targetSchema),
     };
+  }, {});
+};
+
+const convertDynamicZonePopulate = (uid, subPopulate, components) => {
+  return components.reduce((result, componet) => {
+    const generatedFakeDynamicZoneSchema = {
+      uid,
+      attributes: componet,
+    };
+    const componetPopulate = convertNestedPopulate(subPopulate, generatedFakeDynamicZoneSchema);
+    return _.merge(result, componetPopulate);
   }, {});
 };
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

fixed issue #11955, When "dynamicZone" has the same field name, part of "populate" will be omitted

### Why is it needed?

fix issue #11955 

### How to test it?

Replicate steps of https://github.com/strapi/strapi/issues/11955

### Related issue(s)/PR(s)

[#11955 ](https://github.com/strapi/strapi/issues/11955)
