### PR TITLE
Add apiToken.salt directly in the config of created projects

### DIFF
--- a/packages/generators/app/lib/resources/templates/js/admin-config.template
+++ b/packages/generators/app/lib/resources/templates/js/admin-config.template
@@ -2,4 +2,7 @@ module.exports = ({ env }) => ({
   auth: {
     secret: env('ADMIN_JWT_SECRET', '<%= adminJwtToken %>'),
   },
+  apiToken: {
+    salt: env('API_TOKEN_SALT'),
+  },
 });

--- a/packages/generators/app/lib/resources/templates/ts/admin-config.template
+++ b/packages/generators/app/lib/resources/templates/ts/admin-config.template
@@ -2,4 +2,7 @@ export default ({ env }) => ({
   auth: {
     secret: env('ADMIN_JWT_SECRET', '<%= adminJwtToken %>'),
   },
+  apiToken: {
+    salt: env('API_TOKEN_SALT'),
+  },
 });


### PR DESCRIPTION
**What it does?**
It modifies the config file of the newly created project.

**Why is it needed?**
To avoid the warning message when creating a strapi app:
![Capture d’écran 2022-08-01 à 17 43 14](https://user-images.githubusercontent.com/11708220/182187682-3d750d2e-5b1b-46b5-8f47-264f9e6da496.png)

The config should point to the env var from the beginning.

