### PR TITLE
Fix false positive results for ts utils' getConfigPath

### DIFF
--- a/packages/utils/typescript/lib/utils/get-config-path.js
+++ b/packages/utils/typescript/lib/utils/get-config-path.js
@@ -1,9 +1,17 @@
 'use strict';
 
+const path = require('path');
 const ts = require('typescript');
 
 const DEFAULT_TS_CONFIG_FILENAME = 'tsconfig.json';
 
-module.exports = (dir, filename = DEFAULT_TS_CONFIG_FILENAME) => {
-  return ts.findConfigFile(dir, ts.sys.fileExists, filename);
+module.exports = (dir, { filename = DEFAULT_TS_CONFIG_FILENAME, ancestorsLookup = false } = {}) => {
+  const dirAbsolutePath = path.resolve(dir);
+  const configFilePath = ts.findConfigFile(dirAbsolutePath, ts.sys.fileExists, filename);
+
+  if (!configFilePath || ancestorsLookup) {
+    return configFilePath;
+  }
+
+  return configFilePath.startsWith(dirAbsolutePath);
 };

--- a/packages/utils/typescript/lib/utils/is-using-typescript-sync.js
+++ b/packages/utils/typescript/lib/utils/is-using-typescript-sync.js
@@ -11,7 +11,7 @@ const getConfigPath = require('./get-config-path');
  * @returns {boolean}
  */
 module.exports = (dir, filename = undefined) => {
-  const filePath = getConfigPath(dir, filename);
+  const filePath = getConfigPath(dir, { filename });
 
   return fse.pathExistsSync(filePath);
 };

--- a/packages/utils/typescript/lib/utils/is-using-typescript.js
+++ b/packages/utils/typescript/lib/utils/is-using-typescript.js
@@ -11,7 +11,7 @@ const getConfigPath = require('./get-config-path');
  * @returns {Promise<boolean>}
  */
 module.exports = (dir, filename = undefined) => {
-  const filePath = getConfigPath(dir, filename);
+  const filePath = getConfigPath(dir, { filename });
 
   return fse.pathExists(filePath);
 };


### PR DESCRIPTION
### What does it do?

Make sure getConfigPath does not check ancestors when searching for the typescript configuration file

### Why is it needed?

Because ts.findConfigFile looks in the given directory's ancestors to find the configuration file, Strapi projects can incorrectly detect JS project as TS projects.  

### How to test it?

- Create a tsconfig.json file in a directory
- Run yarn create strapi-app app --quickstart
- It should detect the project is a JavaScript one and start normally

### Related issue(s)/PR(s)

fix https://github.com/strapi/strapi/issues/13866
