### PR TITLE
CTB: Update SubNav styles using improved DS properties

### DIFF
--- a/packages/core/content-type-builder/admin/src/components/ContentTypeBuilderNav/index.js
+++ b/packages/core/content-type-builder/admin/src/components/ContentTypeBuilderNav/index.js
@@ -42,61 +42,56 @@ const ContentTypeBuilderNav = () => {
         })}
       />
       <SubNavSections>
-        {menu.map(section => {
-          const title = section.title.id;
-
-          return (
-            <React.Fragment key={section.name}>
-              <SubNavSection
-                label={formatMessage({ id: title, defaultMessage: title })}
-                collapsable
-                badgeLabel={section.links.length.toString()}
-              >
-                {section.links.map(link => {
-                  if (link.links) {
-                    return (
-                      <SubNavLinkSection key={link.name} label={upperFirst(link.title)}>
-                        {link.links.map(subLink => (
-                          <SubNavLink
-                            as={NavLink}
-                            to={subLink.to}
-                            active={subLink.active}
-                            key={subLink.name}
-                            isSubSectionChild
-                          >
-                            {upperFirst(
-                              formatMessage({ id: subLink.name, defaultMessage: subLink.title })
-                            )}
-                          </SubNavLink>
-                        ))}
-                      </SubNavLinkSection>
-                    );
-                  }
-
+        {menu.map(section => (
+          <React.Fragment key={section.name}>
+            <SubNavSection
+              label={formatMessage({
+                id: section.title.id,
+                defaultMessage: section.title.defaultMessage,
+              })}
+              collapsable
+              badgeLabel={section.links.length.toString()}
+            >
+              {section.links.map(link => {
+                if (link.links) {
                   return (
-                    <SubNavLink as={NavLink} to={link.to} active={link.active} key={link.name}>
-                      {upperFirst(formatMessage({ id: link.name, defaultMessage: link.title }))}
-                    </SubNavLink>
+                    <SubNavLinkSection key={link.name} label={upperFirst(link.title)}>
+                      {link.links.map(subLink => (
+                        <SubNavLink
+                          as={NavLink}
+                          to={subLink.to}
+                          active={subLink.active}
+                          key={subLink.name}
+                          isSubSectionChild
+                        >
+                          {upperFirst(
+                            formatMessage({ id: subLink.name, defaultMessage: subLink.title })
+                          )}
+                        </SubNavLink>
+                      ))}
+                    </SubNavLinkSection>
                   );
-                })}
-              </SubNavSection>
-              {section.customLink && (
-                <Box paddingLeft={7}>
-                  <TextButton
-                    onClick={section.customLink.onClick}
-                    startIcon={<Plus />}
-                    marginTop={2}
-                  >
-                    {formatMessage({
-                      id: section.customLink.id,
-                      defaultMessage: section.customLink.defaultMessage,
-                    })}
-                  </TextButton>
-                </Box>
-              )}
-            </React.Fragment>
-          );
-        })}
+                }
+
+                return (
+                  <SubNavLink as={NavLink} to={link.to} active={link.active} key={link.name}>
+                    {upperFirst(formatMessage({ id: link.name, defaultMessage: link.title }))}
+                  </SubNavLink>
+                );
+              })}
+            </SubNavSection>
+            {section.customLink && (
+              <Box paddingLeft={7}>
+                <TextButton onClick={section.customLink.onClick} startIcon={<Plus />} marginTop={2}>
+                  {formatMessage({
+                    id: section.customLink.id,
+                    defaultMessage: section.customLink.defaultMessage,
+                  })}
+                </TextButton>
+              </Box>
+            )}
+          </React.Fragment>
+        ))}
       </SubNavSections>
     </SubNav>
   );

--- a/packages/core/content-type-builder/admin/src/components/ContentTypeBuilderNav/index.js
+++ b/packages/core/content-type-builder/admin/src/components/ContentTypeBuilderNav/index.js
@@ -62,6 +62,7 @@ const ContentTypeBuilderNav = () => {
                             to={subLink.to}
                             active={subLink.active}
                             key={subLink.name}
+                            isSubSectionChild
                           >
                             {upperFirst(
                               formatMessage({ id: subLink.name, defaultMessage: subLink.title })
@@ -81,7 +82,11 @@ const ContentTypeBuilderNav = () => {
               </SubNavSection>
               {section.customLink && (
                 <Box paddingLeft={7}>
-                  <TextButton onClick={section.customLink.onClick} startIcon={<Plus />}>
+                  <TextButton
+                    onClick={section.customLink.onClick}
+                    startIcon={<Plus />}
+                    marginTop={2}
+                  >
                     {formatMessage({
                       id: section.customLink.id,
                       defaultMessage: section.customLink.defaultMessage,

--- a/packages/core/content-type-builder/admin/src/components/ContentTypeBuilderNav/tests/__snapshots__/index.test.js.snap
+++ b/packages/core/content-type-builder/admin/src/components/ContentTypeBuilderNav/tests/__snapshots__/index.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
-.c43 {
+.c45 {
   padding-bottom: 56px;
 }
 
@@ -10,11 +10,11 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
   grid-template-columns: auto 1fr;
 }
 
-.c44 {
+.c46 {
   overflow-x: hidden;
 }
 
-.c45 {
+.c47 {
   border: 0;
   -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
@@ -94,11 +94,18 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
   padding-left: 8px;
 }
 
-.c37 {
+.c38 {
   padding-top: 8px;
   padding-right: 16px;
   padding-bottom: 8px;
   padding-left: 32px;
+}
+
+.c44 {
+  background: #f6f6f9;
+  padding-top: 8px;
+  padding-bottom: 8px;
+  padding-left: 48px;
 }
 
 .c1 {
@@ -177,7 +184,7 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
   justify-content: center;
 }
 
-.c39 {
+.c40 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -216,7 +223,7 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
   line-height: 1.43;
 }
 
-.c42 {
+.c43 {
   font-weight: 500;
   color: #32324d;
   font-size: 0.875rem;
@@ -381,15 +388,15 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
   fill: #666687;
 }
 
-.c38 svg {
+.c39 svg {
   height: 0.25rem;
 }
 
-.c38 svg path {
+.c39 svg path {
   fill: #4a4a6a;
 }
 
-.c40 {
+.c41 {
   border: none;
   padding: 0;
   background: transparent;
@@ -403,7 +410,7 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
   align-items: center;
 }
 
-.c41 {
+.c42 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -464,17 +471,21 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
   fill: #8e8ea9;
 }
 
-.c35 {
-  padding-right: 8px;
+.c33 {
+  margin-top: 8px;
 }
 
 .c36 {
+  padding-right: 8px;
+}
+
+.c37 {
   color: #4945ff;
   font-size: 0.75rem;
   line-height: 1.33;
 }
 
-.c33 {
+.c34 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -488,22 +499,22 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
   flex-direction: row;
 }
 
-.c34 {
+.c35 {
   background: transparent;
   border: none;
   position: relative;
   outline: none;
 }
 
-.c34[aria-disabled='true'] {
+.c35[aria-disabled='true'] {
   pointer-events: none;
 }
 
-.c34[aria-disabled='true'] svg path {
+.c35[aria-disabled='true'] svg path {
   fill: #666687;
 }
 
-.c34 svg {
+.c35 svg {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -511,11 +522,11 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
   font-size: 0.625rem;
 }
 
-.c34 svg path {
+.c35 svg path {
   fill: #4945ff;
 }
 
-.c34:after {
+.c35:after {
   -webkit-transition-property: all;
   transition-property: all;
   -webkit-transition-duration: 0.2s;
@@ -530,11 +541,11 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
   border: 2px solid transparent;
 }
 
-.c34:focus-visible {
+.c35:focus-visible {
   outline: none;
 }
 
-.c34:focus-visible:after {
+.c35:focus-visible:after {
   border-radius: 8px;
   content: '';
   position: absolute;
@@ -626,7 +637,7 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
                       <span
                         class="c4 c23"
                       >
-                        content-type-builder.menu.section.models.name.
+                        Collection Types
                       </span>
                     </div>
                     <div
@@ -741,12 +752,12 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
             >
               <button
                 aria-disabled="false"
-                class="c33 c34"
+                class="c33 c34 c35"
                 type="button"
               >
                 <span
                   aria-hidden="true"
-                  class="c35"
+                  class="c36"
                 >
                   <svg
                     fill="none"
@@ -762,7 +773,7 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
                   </svg>
                 </span>
                 <span
-                  class="c36"
+                  class="c37"
                 >
                   Create new collection type
                 </span>
@@ -791,7 +802,7 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
                       <span
                         class="c4 c23"
                       >
-                        content-type-builder.menu.section.single-types.name.
+                        Single Types
                       </span>
                     </div>
                     <div
@@ -871,12 +882,12 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
             >
               <button
                 aria-disabled="false"
-                class="c33 c34"
+                class="c33 c34 c35"
                 type="button"
               >
                 <span
                   aria-hidden="true"
-                  class="c35"
+                  class="c36"
                 >
                   <svg
                     fill="none"
@@ -892,7 +903,7 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
                   </svg>
                 </span>
                 <span
-                  class="c36"
+                  class="c37"
                 >
                   Create new single type
                 </span>
@@ -921,7 +932,7 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
                       <span
                         class="c4 c23"
                       >
-                        content-type-builder.menu.section.components.name.
+                        Components
                       </span>
                     </div>
                     <div
@@ -964,18 +975,18 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
                     class=""
                   >
                     <div
-                      class="c37 c38"
+                      class="c38 c39"
                     >
                       <div
-                        class="c39"
+                        class="c40"
                       >
                         <button
                           aria-controls="subnav-list-7"
                           aria-expanded="true"
-                          class="c40"
+                          class="c41"
                         >
                           <div
-                            class="c41"
+                            class="c42"
                           >
                             <svg
                               aria-hidden="true"
@@ -997,7 +1008,7 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
                             class="c30"
                           >
                             <span
-                              class="c4 c42"
+                              class="c4 c43"
                             >
                               Basic
                             </span>
@@ -1010,7 +1021,7 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
                     >
                       <li>
                         <a
-                          class="c27 c28"
+                          class="c44 c28"
                           href="/plugins/content-type-builder/component-categories/basic/basic.simple"
                         >
                           <div
@@ -1051,18 +1062,18 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
                     class=""
                   >
                     <div
-                      class="c37 c38"
+                      class="c38 c39"
                     >
                       <div
-                        class="c39"
+                        class="c40"
                       >
                         <button
                           aria-controls="subnav-list-8"
                           aria-expanded="true"
-                          class="c40"
+                          class="c41"
                         >
                           <div
-                            class="c41"
+                            class="c42"
                           >
                             <svg
                               aria-hidden="true"
@@ -1084,7 +1095,7 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
                             class="c30"
                           >
                             <span
-                              class="c4 c42"
+                              class="c4 c43"
                             >
                               Default
                             </span>
@@ -1097,7 +1108,7 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
                     >
                       <li>
                         <a
-                          class="c27 c28"
+                          class="c44 c28"
                           href="/plugins/content-type-builder/component-categories/default/default.closingperiod"
                         >
                           <div
@@ -1132,7 +1143,7 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
                       </li>
                       <li>
                         <a
-                          class="c27 c28"
+                          class="c44 c28"
                           href="/plugins/content-type-builder/component-categories/default/default.dish"
                         >
                           <div
@@ -1175,12 +1186,12 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
             >
               <button
                 aria-disabled="false"
-                class="c33 c34"
+                class="c33 c34 c35"
                 type="button"
               >
                 <span
                   aria-hidden="true"
-                  class="c35"
+                  class="c36"
                 >
                   <svg
                     fill="none"
@@ -1196,7 +1207,7 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
                   </svg>
                 </span>
                 <span
-                  class="c36"
+                  class="c37"
                 >
                   Create a new component
                 </span>
@@ -1207,13 +1218,13 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
       </div>
     </nav>
     <div
-      class="c43 c44"
+      class="c45 c46"
     >
       <div />
     </div>
   </div>
   <div
-    class="c45"
+    class="c47"
   >
     <p
       aria-live="polite"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2640,7 +2640,7 @@
   resolved "https://registry.yarnpkg.com/@hutson/parse-repository-url/-/parse-repository-url-3.0.2.tgz#98c23c950a3d9b6c8f0daed06da6c3af06981340"
   integrity sha512-H9XAx3hc0BQHY6l+IFSWHDySypcXsvsuLhgYLUGywmJ5pswRVQJUHpOsobnLYp2ZUaUlKiKDrgWWhosOwAEM8Q==
 
-"@internationalized/number@^3.1.1":
+"@internationalized/number@^3.0.2", "@internationalized/number@^3.1.1":
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/@internationalized/number/-/number-3.1.1.tgz#160584316741de4381689ab759001603ee17b595"
   integrity sha512-dBxCQKIxvsZvW2IBt3KsqrCfaw2nV6o6a8xsloJn/hjW0ayeyhKuiiMtTwW3/WGNPP7ZRyDbtuiUEjMwif1ENQ==


### PR DESCRIPTION
### What does it do?

Updates the `SubNav` component in the CTB, to make use out of [recently introduced props](https://github.com/strapi/design-system/pull/635), which aim to improve the overall vertial rhythm and properly indents components.

### Why is it needed?

Improves the UI.

### How to test it?

| Before | After |
|-|-|
| <img width="868" alt="Screenshot 2022-08-02 at 13 12 10" src="https://user-images.githubusercontent.com/2244375/182362007-9ae7833b-3be4-4c06-aa3f-353a33dd9476.png"> | <img width="868" alt="Screenshot 2022-08-02 at 13 12 00" src="https://user-images.githubusercontent.com/2244375/182362026-417509eb-9b47-4afb-af8f-e620f2923bbb.png"> |

### Related issue(s)/PR(s)

- Fixes https://github.com/strapi/design-system/issues/637
- Builds on top of https://github.com/strapi/strapi/pull/13799
