### PR TITLE
Fix invalid return for ts get-config-path

### DIFF
--- a/packages/utils/typescript/lib/utils/get-config-path.js
+++ b/packages/utils/typescript/lib/utils/get-config-path.js
@@ -5,6 +5,16 @@ const ts = require('typescript');
 
 const DEFAULT_TS_CONFIG_FILENAME = 'tsconfig.json';
 
+/**
+ * Get the path of the typescript config file for a given directory
+ *
+ * @param {string} dir
+ * @param {object} [options]
+ * @param {string} [options.filename]
+ * @param {boolean} [options.ancestorsLookup]
+ *
+ * @return {string}
+ */
 module.exports = (dir, { filename = DEFAULT_TS_CONFIG_FILENAME, ancestorsLookup = false } = {}) => {
   const dirAbsolutePath = path.resolve(dir);
   const configFilePath = ts.findConfigFile(dirAbsolutePath, ts.sys.fileExists, filename);
@@ -13,5 +23,5 @@ module.exports = (dir, { filename = DEFAULT_TS_CONFIG_FILENAME, ancestorsLookup 
     return configFilePath;
   }
 
-  return configFilePath.startsWith(dirAbsolutePath);
+  return configFilePath.startsWith(dirAbsolutePath) ? configFilePath : undefined;
 };

--- a/packages/utils/typescript/lib/utils/get-config-path.js
+++ b/packages/utils/typescript/lib/utils/get-config-path.js
@@ -13,7 +13,7 @@ const DEFAULT_TS_CONFIG_FILENAME = 'tsconfig.json';
  * @param {string} [options.filename]
  * @param {boolean} [options.ancestorsLookup]
  *
- * @return {string}
+ * @return {string | undefined}
  */
 module.exports = (dir, { filename = DEFAULT_TS_CONFIG_FILENAME, ancestorsLookup = false } = {}) => {
   const dirAbsolutePath = path.resolve(dir);


### PR DESCRIPTION

### What does it do?

Update the return value of the ts `getConfigPath` util.

### Why is it needed?

getConfigPath should always return a string or undefined, but it was possibly returning a boolean.

### Related issue(s)/PR(s)

fix https://github.com/strapi/strapi/pull/13937
