### PR TITLE
add badgeContent to pluginsSectionsLinks

### DIFF
--- a/packages/core/admin/admin/src/components/LeftMenu/index.js
+++ b/packages/core/admin/admin/src/components/LeftMenu/index.js
@@ -125,7 +125,13 @@ const LeftMenu = ({ generalSectionLinks, pluginsSectionLinks }) => {
               const Icon = link.icon;
 
               return (
-                <NavLink as={RouterNavLink} to={link.to} key={link.to} icon={<Icon />}>
+                <NavLink
+                  as={RouterNavLink}
+                  to={link.to}
+                  key={link.to}
+                  icon={<Icon />}
+                  badgeContent={link.badge}
+                >
                   {formatMessage(link.intlLabel)}
                 </NavLink>
               );


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

add badge to link in plugins sections so plugin developers can add  badge near link. like in settings if new strapi release is available 

### Why is it needed?

it is cool to have the available to add this badge

### How to test it?

to use and test it you need to add `badge` key to `app.addMenuLink` in register function:

`path: plugins/{your-plugin-name}/admin/src/index.js`


```javascript
    //....
    register(app) {
        app.addMenuLink({
          to: `/plugins/${pluginId}`,
          badge: "v4.3.2", <--- this what you need to add cool badge 
          icon: PluginIcon,
          intlLabel: {
            id: `${pluginId}.plugin.name`,
            defaultMessage: 'Documentation',
          },
    //...
      
```
