### PR TITLE
Update dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,21 @@
 version: 2
 updates:
-  - package-ecosystem: 'npm'
-    directory: '/'
+  - package-ecosystem: npm
+    directory: /
     schedule:
-      interval: 'daily'
+      interval: daily
     versioning-strategy: increase
     ignore:
+      # Only allow patch as minor babel versions need to be upgraded all together
+      - dependency-name: '@babel/*'
+        update-types:
+          - 'version-update:semver-major'
+          - 'version-update:semver-minor'
+
       - dependency-name: '*'
-        update-types: ['version-update:semver-major']
+        update-types:
+          - 'version-update:semver-major'
+
     labels:
       - 'source: dependencies'
       - 'pr: chore'


### PR DESCRIPTION
### What does it do?

Update dependabot config to prevent bump PR on babel minor versions as they can be breaking without noticing

### Why is it needed?

Babel minor upgrade need to be done one multiple packages at once. Dependabot only upgrades packages one by one thus creating breaking changes without us noticing (test still pass)

### How to test it?

/

### Related issue(s)/PR(s)

/
