### PR TITLE
Fix issue of broken translation of customize the label of the CM table

### DIFF
--- a/packages/core/helper-plugin/lib/src/components/DynamicTable/TableHead/index.js
+++ b/packages/core/helper-plugin/lib/src/components/DynamicTable/TableHead/index.js
@@ -46,8 +46,8 @@ const TableHead = ({
           const isUp = sortOrder === 'ASC';
 
           const intlLabel = formatMessage({
-            id: name || `global.table.header.${name}`,
-            defaultMessage: label,
+            id: label || name || `global.table.header.${name}`,
+            defaultMessage: label || name,
           });
 
           const sortLabel = formatMessage(

--- a/packages/core/helper-plugin/lib/src/components/DynamicTable/TableHead/index.js
+++ b/packages/core/helper-plugin/lib/src/components/DynamicTable/TableHead/index.js
@@ -46,7 +46,7 @@ const TableHead = ({
           const isUp = sortOrder === 'ASC';
 
           const intlLabel = formatMessage({
-            id: `global.table.header.${name}`,
+            id: name || `global.table.header.${name}`,
             defaultMessage: label,
           });
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Fix issue of broken customize the label of the CM table

### Why is it needed?

[72cb1eb](https://github.com/strapi/strapi/commit/72cb1eb4eecfdb1f90c01c97277a52a613b9942b) fixed translation problem of zh-Hans on the user list page. But it broken translation of customize the label of the CM table. 
All translation in admin/app.js (as in document) like

```
export default {
  config: {
    locales: ['fr'],
    translations: {
      fr: {
        'Auth.form.email.label': 'test',
        Users: 'Utilisateurs',
        City: 'CITY (FRENCH)',
        // Customize the label of the Content Manager table.
        Id: 'ID french',
      },
    },
  },
  bootstrap() {},
};
```
After [72cb1eb](https://github.com/strapi/strapi/commit/72cb1eb4eecfdb1f90c01c97277a52a613b9942b)  commit, the key 'Id' should be 'global.table.header.id', this is ridiculous change.

### How to test it?

### Related issue(s)/PR(s)
