### PR TITLE
Upload: Handle file upload errors gracefully

### DIFF
--- a/packages/core/upload/admin/src/components/AssetCard/UploadingAssetCard.js
+++ b/packages/core/upload/admin/src/components/AssetCard/UploadingAssetCard.js
@@ -108,10 +108,21 @@ export const UploadingAssetCard = ({
       </Card>
       {error ? (
         <Typography variant="pi" fontWeight="bold" textColor="danger600">
-          {formatMessage({
-            id: getTrad(`apiError.${error.response.data.error.message}`),
-            defaultMessage: error.response.data.error.message,
-          })}
+          {formatMessage(
+            error?.response?.data?.error?.message
+              ? {
+                  id: getTrad(`apiError.${error.response.data.error.message}`),
+                  defaultMessage: error.response.data.error.message,
+                  /* See issue: https://github.com/strapi/strapi/issues/13867
+             A proxy might return an error, before the request reaches Strapi
+             and therefore we need to handle errors gracefully.
+          */
+                }
+              : {
+                  id: getTrad('upload.generic-error'),
+                  defaultMessage: 'An error occured while uploading the file.',
+                }
+          )}
         </Typography>
       ) : (
         undefined

--- a/packages/core/upload/admin/src/translations/en.json
+++ b/packages/core/upload/admin/src/translations/en.json
@@ -1,5 +1,6 @@
 {
   "apiError.FileTooBig": "The uploaded file exceeds the maximum allowed asset size.",
+  "upload.generic-error": "An error occurred while uploading the file.",
   "bulk.select.label": "Select all assets",
   "button.next": "Next",
   "checkControl.crop-duplicate": "Duplicate & crop the asset",


### PR DESCRIPTION

### What does it do?

Currently the UI crashes if the `UploadingAssetCard` does not receive a standard strapi error, if e.g. a proxy returns an early error. The issue was reported in https://github.com/strapi/strapi/issues/13867 and introduced by https://github.com/strapi/strapi/pull/13768.

This PR handles error messages more gracefully and displays a generic error message instead of crashing the UI.

### Why is it needed?

To not crash the UI, if a proxy is used in front of a strapi instance.

### Related issue(s)/PR(s)

- Fixes https://github.com/strapi/strapi/issues/13867
