### PR TITLE
GenericInput: Disallow clearing a field, if it is disabled

### DIFF
--- a/packages/core/helper-plugin/lib/src/components/GenericInput/index.js
+++ b/packages/core/helper-plugin/lib/src/components/GenericInput/index.js
@@ -127,16 +127,17 @@ const GenericInput = ({
 
   switch (type) {
     case 'bool': {
+      const isClearable = isNullable && !disabled;
       const clearProps = {
         clearLabel:
-          isNullable &&
+          isClearable &&
           formatMessage({
             id: 'app.components.ToggleCheckbox.clear-label',
             defaultMessage: 'Clear',
           }),
 
         onClear:
-          isNullable &&
+          isClearable &&
           (() => {
             onChange({ target: { name, value: null } });
           }),


### PR DESCRIPTION
### What does it do?

Removes the "clear" function from Boolean fields, if the field is disabled.

### Why is it needed?

Users shouldn't be able to make mistakes - if the field is disabled, they should not be able to interact with it.

### How to test it?

See issue attached.

### Related issue(s)/PR(s)

- Fixes https://github.com/strapi/strapi/issues/13946
