### PR TITLE
Fix `generateUIDField` to not take into account partial matches

### DIFF
--- a/packages/core/content-manager/server/services/__tests__/uid.test.js
+++ b/packages/core/content-manager/server/services/__tests__/uid.test.js
@@ -354,7 +354,7 @@ describe('Test uid service', () => {
       });
 
       expect(findMany).toHaveBeenCalledWith({
-        where: { slug: { $contains: 'my-test-model' } },
+        where: { slug: { $eqi: 'my-test-model' } },
       });
     });
   });

--- a/packages/core/content-manager/server/services/uid.js
+++ b/packages/core/content-manager/server/services/uid.js
@@ -31,7 +31,7 @@ module.exports = ({ strapi }) => ({
 
     const possibleColisions = await query
       .findMany({
-        where: { [field]: { $contains: value } },
+        where: { [field]: { $eqi: value } },
       })
       .then(results => results.map(result => result[field]));
 


### PR DESCRIPTION
### What does it do?

It changes `generateUIDField` function to use `$eqi` filtering operator instead of `$contains` which was incorrectly taking partial matches into account.

I've chosen `$eqi` instead of `$eq` for better UX - otherwise it'd allow generating slugs with the same value, but different casing - `foo` with `Foo` present. With `$eqi` it appends the `-n` suffix regardless of casing, i.e. `foo-1` with `Foo` present.

### Why is it needed?

ATM the generated slugs have `-n` suffix appended even if not needed - i.e. `foo-1` instead of `foo` when there's `foo-bar` slug already present in the database.