### PR TITLE
CM: Remove editrelations from useFetchContentTypeLayout

### DIFF
--- a/packages/core/admin/admin/src/content-manager/hooks/useFetchContentTypeLayout/utils/formatLayouts.js
+++ b/packages/core/admin/admin/src/content-manager/hooks/useFetchContentTypeLayout/utils/formatLayouts.js
@@ -3,47 +3,14 @@ import { getRequestUrl, mergeMetasWithSchema } from '../../../utils';
 
 const getRelationModel = (targetModel, models) => models.find(model => model.uid === targetModel);
 
-// editRelations is an array of strings...
-const formatEditRelationsLayoutWithMetas = (contentTypeConfiguration, models) => {
-  const formatted = contentTypeConfiguration.layouts.editRelations.reduce((acc, current) => {
-    const fieldSchema = get(contentTypeConfiguration, ['attributes', current], {});
-    const targetModelUID = get(
-      contentTypeConfiguration,
-      ['attributes', current, 'targetModel'],
-      null
-    );
-    const targetModelSchema = getRelationModel(targetModelUID, models);
-    const targetModelPluginOptions = targetModelSchema.pluginOptions || {};
-    const metadatas = get(contentTypeConfiguration, ['metadatas', current, 'edit'], {});
-    const size = 6;
-
-    const queryInfos = generateRelationQueryInfos(contentTypeConfiguration, current, models);
-
-    acc.push({
-      name: current,
-      size,
-      fieldSchema,
-      metadatas,
-      queryInfos,
-      targetModelPluginOptions,
-    });
-
-    return acc;
-  }, []);
-
-  return formatted;
-};
-
 const formatLayouts = (initialData, models) => {
   const data = createMetasSchema(initialData, models);
 
   const formattedCTEditLayout = formatLayoutWithMetas(data.contentType, null, models);
   const ctUid = data.contentType.uid;
-  const formattedEditRelationsLayout = formatEditRelationsLayoutWithMetas(data.contentType, models);
   const formattedListLayout = formatListLayoutWithMetas(data.contentType, data.components);
 
   set(data, ['contentType', 'layouts', 'edit'], formattedCTEditLayout);
-  set(data, ['contentType', 'layouts', 'editRelations'], formattedEditRelationsLayout);
   set(data, ['contentType', 'layouts', 'list'], formattedListLayout);
 
   Object.keys(data.components).forEach(compoUID => {
@@ -246,7 +213,6 @@ const getDisplayedModels = models =>
 
 export default formatLayouts;
 export {
-  formatEditRelationsLayoutWithMetas,
   formatLayoutWithMetas,
   formatListLayoutWithMetas,
   generateRelationQueryInfos,

--- a/packages/core/admin/admin/src/content-manager/hooks/useFetchContentTypeLayout/utils/tests/formatLayouts.test.js
+++ b/packages/core/admin/admin/src/content-manager/hooks/useFetchContentTypeLayout/utils/tests/formatLayouts.test.js
@@ -1,5 +1,4 @@
 import formatLayouts, {
-  formatEditRelationsLayoutWithMetas,
   formatLayoutWithMetas,
   formatListLayoutWithMetas,
   generateRelationQueryInfos,
@@ -41,37 +40,6 @@ const simpleModels = [
 ];
 
 describe('Content Manager | hooks | useFetchContentTypeLayout | utils ', () => {
-  describe('formatEditRelationsLayoutWithMetas', () => {
-    it('should format editRelations layout correctly', () => {
-      const expectedLayout = [
-        {
-          name: 'categories',
-          size: 6,
-          fieldSchema: {
-            targetModel: 'api::category.category',
-          },
-          metadatas: {
-            mainField: {
-              name: 'name',
-              type: 'string',
-            },
-          },
-          queryInfos: {
-            endPoint: '/content-manager/relations/api::address.address/categories',
-            containsKey: 'name',
-            defaultParams: {},
-            shouldDisplayRelationLink: true,
-          },
-          targetModelPluginOptions: {},
-        },
-      ];
-
-      expect(formatEditRelationsLayoutWithMetas(addressSchema, simpleModels)).toEqual(
-        expectedLayout
-      );
-    });
-  });
-
   describe('formatLayouts', () => {
     it('should format the content type and components layouts', () => {
       const models = [

--- a/packages/core/admin/admin/src/content-manager/utils/formatLayoutToApi.js
+++ b/packages/core/admin/admin/src/content-manager/utils/formatLayoutToApi.js
@@ -8,8 +8,6 @@ const formatLayoutToApi = ({ layouts, metadatas, ...rest }) => {
 
     return obj;
   });
-  const editRelations = layouts.editRelations.map(({ name }) => name);
-
   const formattedMetadatas = Object.keys(metadatas).reduce((acc, current) => {
     const currentMetadatas = get(metadatas, [current], {});
     let editMetadatas = currentMetadatas.edit;
@@ -36,7 +34,7 @@ const formatLayoutToApi = ({ layouts, metadatas, ...rest }) => {
 
   return {
     ...rest,
-    layouts: { edit, editRelations, list },
+    layouts: { edit, list },
     metadatas: formattedMetadatas,
   };
 };


### PR DESCRIPTION
### What does it do?

With https://github.com/strapi/strapi/pull/13979 `editRelations` were removed, which breaks parts of the CM. This PR removes more code for the special treatment of relations in the content-manager.

### Why is it needed?

This will unblock QA for https://strapi-inc.atlassian.net/browse/CONTENT-208

### Related issue(s)/PR(s)

- https://github.com/strapi/strapi/pull/13979
- https://github.com/strapi/strapi/pull/13821
