### PR TITLE
Use case-insensitive version of `$contains` filtering operator in `SelectWrapper` component

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/SelectWrapper/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/SelectWrapper/index.js
@@ -139,7 +139,7 @@ function SelectWrapper({
       const params = { limit: state.limit, ...defaultParams, start: state.start };
 
       if (state.contains) {
-        params[`filters[${containsKey}][$contains]`] = state.contains;
+        params[`filters[${containsKey}][$containsi]`] = state.contains;
       }
 
       try {


### PR DESCRIPTION
### What does it do?

Fixes #13888