### PR TITLE
properly reject promise in cloudinary provider

### DIFF
--- a/packages/core/strapi/lib/services/entity-service/__tests__/entity-service-events.test.js
+++ b/packages/core/strapi/lib/services/entity-service/__tests__/entity-service-events.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const createEntityService = require('../');
+const createEntityService = require('..');
 const entityValidator = require('../../entity-validator');
 
 describe('Entity service triggers webhooks', () => {
@@ -12,7 +12,7 @@ describe('Entity service triggers webhooks', () => {
   };
 
   let instance;
-  let eventHub = { emit: jest.fn() };
+  const eventHub = { emit: jest.fn() };
   let entity = { attr: 'value' };
 
   beforeAll(() => {

--- a/packages/core/strapi/lib/services/entity-service/index.js
+++ b/packages/core/strapi/lib/services/entity-service/index.js
@@ -235,10 +235,10 @@ const createDefaultImplementation = ({ strapi, db, eventHub, entityValidator }) 
     }
 
     const deletedEntities = await db.query(uid).deleteMany(query);
-    await Promise.all(entitiesToDelete.map(entity => deleteComponents(uid, entity)));
+    await Promise.all(entitiesToDelete.map((entity) => deleteComponents(uid, entity)));
 
     // Trigger webhooks. One for each entity
-    await Promise.all(entitiesToDelete.map(entity => this.emitEvent(uid, ENTRY_DELETE, entity)));
+    await Promise.all(entitiesToDelete.map((entity) => this.emitEvent(uid, ENTRY_DELETE, entity)));
 
     return deletedEntities;
   },

--- a/packages/core/upload/server/services/upload.js
+++ b/packages/core/upload/server/services/upload.js
@@ -190,37 +190,47 @@ module.exports = ({ strapi }) => ({
     // Store width and height of the original image
     const { width, height } = await getDimensions(fileData);
 
-    // Make sure this is assigned before calling upload
+    // Make sure this is assigned before calling any upload
     // That way it can mutate the width and height
     _.assign(fileData, {
       width,
       height,
     });
 
-    // Upload image
-    await getService('provider').upload(fileData);
+    // For performance reasons, all uploads are wrapped in a single Promise.all
+    const uploadThumbnail = async thumbnailFile => {
+      await getService('provider').upload(thumbnailFile);
+      _.set(fileData, 'formats.thumbnail', thumbnailFile);
+    };
 
-    // Generate thumbnail and responsive formats
+    const uploadResponsiveFormat = async format => {
+      const { key, file } = format;
+      await getService('provider').upload(file);
+      _.set(fileData, ['formats', key], file);
+    };
+
+    let uploadPromises = [];
+
+    // Upload image
+    uploadPromises.push(getService('provider').upload(fileData));
+
+    // Generate & Upload thumbnail and responsive formats
     if (await isOptimizableImage(fileData)) {
       const thumbnailFile = await generateThumbnail(fileData);
       if (thumbnailFile) {
-        await getService('provider').upload(thumbnailFile);
-        _.set(fileData, 'formats.thumbnail', thumbnailFile);
+        uploadPromises.push(uploadThumbnail(thumbnailFile));
       }
 
       const formats = await generateResponsiveFormats(fileData);
       if (Array.isArray(formats) && formats.length > 0) {
         for (const format of formats) {
           if (!format) continue;
-
-          const { key, file } = format;
-
-          await getService('provider').upload(file);
-
-          _.set(fileData, ['formats', key], file);
+          uploadPromises.push(uploadResponsiveFormat(format));
         }
       }
     }
+    // Wait for all uploads to finish
+    await Promise.all(uploadPromises);
   },
 
   /**

--- a/packages/core/upload/server/services/upload.js
+++ b/packages/core/upload/server/services/upload.js
@@ -198,18 +198,18 @@ module.exports = ({ strapi }) => ({
     });
 
     // For performance reasons, all uploads are wrapped in a single Promise.all
-    const uploadThumbnail = async thumbnailFile => {
+    const uploadThumbnail = async (thumbnailFile) => {
       await getService('provider').upload(thumbnailFile);
       _.set(fileData, 'formats.thumbnail', thumbnailFile);
     };
 
-    const uploadResponsiveFormat = async format => {
+    const uploadResponsiveFormat = async (format) => {
       const { key, file } = format;
       await getService('provider').upload(file);
       _.set(fileData, ['formats', key], file);
     };
 
-    let uploadPromises = [];
+    const uploadPromises = [];
 
     // Upload image
     uploadPromises.push(getService('provider').upload(fileData));

--- a/packages/providers/upload-cloudinary/lib/index.js
+++ b/packages/providers/upload-cloudinary/lib/index.js
@@ -14,7 +14,7 @@ module.exports = {
     cloudinary.config(config);
 
     const upload = (file, customConfig = {}) =>
-      new Promise((resolve) => {
+      new Promise((resolve, reject) => {
         const config = {
           resource_type: 'auto',
           public_id: file.hash,
@@ -29,9 +29,9 @@ module.exports = {
           (err, image) => {
             if (err) {
               if (err.message.includes('File size too large')) {
-                throw new PayloadTooLargeError();
+                reject(new PayloadTooLargeError());
               }
-              throw new Error(`Error uploading to cloudinary: ${err.message}`);
+              reject(new Error(`Error uploading to cloudinary: ${err.message}`));
             }
 
             if (image.resource_type === 'video') {

--- a/packages/providers/upload-cloudinary/lib/index.js
+++ b/packages/providers/upload-cloudinary/lib/index.js
@@ -30,8 +30,10 @@ module.exports = {
             if (err) {
               if (err.message.includes('File size too large')) {
                 reject(new PayloadTooLargeError());
+              } else {
+                reject(new Error(`Error uploading to cloudinary: ${err.message}`));
               }
-              reject(new Error(`Error uploading to cloudinary: ${err.message}`));
+              return;
             }
 
             if (image.resource_type === 'video') {


### PR DESCRIPTION
## 👋🏻  What does it do?
- Properly reject and throw an error when there is an issue uploading a file to cloudinary.

@gvocale provided the [solution](https://github.com/strapi/strapi/issues/13316#issuecomment-1183230884) for the issue already.

##  ❓ Why is it needed?
Cloudinary errors were not handled properly, and the server was crashing.

## 🧪  How to test it?
- Have a Cloudinary account for the provider options ( ask me if you need some and feel lazy ). Add them to the plugin configuration.
- Upload a pdf bigger than 10Mb in the media folder (Cloudinary free tier limit) ([PDF I used](https://cartographicperspectives.org/index.php/journal/article/view/cp13-full/pdf))

You should see this error when trying to upload it:
![image](https://user-images.githubusercontent.com/20578351/183052860-c0008a4b-cdf1-47c1-9b02-6c832cbbb740.png)

## 🤔  Concerns
- When rejecting the promise with the `PayloadTooLargeError` error (or any other) I see this log on the console:
```
info: In application test-middleware middleware.
This error originated either by throwing inside an async function without a catch block or rejecting a promise not handled with .catch(). The promise was rejected with the reason:
{
  message: 'File size too large. Got 10615705. Maximum is 10485760.',
  name: 'Error',
  http_code: 400
}
```
I am not understanding why it is appearing or how to prevent it.
## 🔗  Related issue(s)/PR(s)
[Let us know if this is related to any issue/pull request](https://github.com/strapi/strapi/issues/13316)
