### PR TITLE
show language code

### DIFF
--- a/packages/plugins/i18n/admin/src/components/ModalEdit/BaseForm.js
+++ b/packages/plugins/i18n/admin/src/components/ModalEdit/BaseForm.js
@@ -24,10 +24,12 @@ const BaseForm = ({ locale }) => {
             id: getTrad('Settings.locales.modal.locales.label'),
             defaultMessage: 'Locales',
           })}
-          value={localeDetails.code}
+          value={localeDetails?.code || locale.code}
           disabled
         >
-          <Option value={localeDetails.code}>{localeDetails.name}</Option>
+          <Option value={localeDetails?.code || locale.code}>
+            {localeDetails?.name || locale.code}
+          </Option>
         </Select>
       </GridItem>
 

--- a/packages/plugins/i18n/admin/src/components/ModalEdit/BaseForm.js
+++ b/packages/plugins/i18n/admin/src/components/ModalEdit/BaseForm.js
@@ -6,10 +6,15 @@ import { Grid, GridItem } from '@strapi/design-system/Grid';
 import { TextInput } from '@strapi/design-system/TextInput';
 import { Select, Option } from '@strapi/design-system/Select';
 import { getTrad } from '../../utils';
+import useDefaultLocales from '../../hooks/useDefaultLocales';
 
 const BaseForm = ({ locale }) => {
   const { formatMessage } = useIntl();
   const { values, handleChange, errors } = useFormikContext();
+  const { defaultLocales, isLoading } = useDefaultLocales();
+
+  const localeDetails =
+    !isLoading && defaultLocales.find(defaultLocale => defaultLocale.code === locale.code);
 
   return (
     <Grid gap={4}>
@@ -19,10 +24,10 @@ const BaseForm = ({ locale }) => {
             id: getTrad('Settings.locales.modal.locales.label'),
             defaultMessage: 'Locales',
           })}
-          value={locale.code}
+          value={localeDetails.code}
           disabled
         >
-          <Option value={locale.code}>{locale.name}</Option>
+          <Option value={localeDetails.code}>{localeDetails.name}</Option>
         </Select>
       </GridItem>
 

--- a/packages/plugins/i18n/admin/src/components/ModalEdit/BaseForm.js
+++ b/packages/plugins/i18n/admin/src/components/ModalEdit/BaseForm.js
@@ -13,8 +13,7 @@ const BaseForm = ({ locale }) => {
   const { values, handleChange, errors } = useFormikContext();
   const { defaultLocales, isLoading } = useDefaultLocales();
 
-  const localeDetails =
-    !isLoading && defaultLocales.find(defaultLocale => defaultLocale.code === locale.code);
+  const localeDetails = !isLoading && defaultLocales.find((row) => row.code === locale.code);
 
   return (
     <Grid gap={4}>


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

When editing or adding languages, the display name and language code should not be displayed as the same text.

### Why is it needed?

The language code and the language display name, both of which are shown as the language display name, do not make sense.

### How to test it?

When you edit a language or add a new language

#### example:
**Now it is all displayed as language names**
![image](https://user-images.githubusercontent.com/15223848/183060331-d710e891-7112-48d7-a485-9cbe0a880be0.png)

**I want to see the language code and the language name**
![image](https://user-images.githubusercontent.com/15223848/183059919-71ae63ec-b3ab-4024-b26b-869e2e9bc247.png)


