### PR TITLE
Generate fileInfo for every file when uploading in bulk

### DIFF
--- a/packages/core/upload/server/controllers/content-api.js
+++ b/packages/core/upload/server/controllers/content-api.js
@@ -89,7 +89,7 @@ module.exports = {
       request: { body, files: { files } = {} },
     } = ctx;
 
-    const data = await validateUploadBody(body);
+    const data = await validateUploadBody(body, Array.isArray(files));
 
     const apiUploadFolderService = getService('api-upload-folder');
 

--- a/packages/core/upload/server/controllers/content-api.js
+++ b/packages/core/upload/server/controllers/content-api.js
@@ -95,14 +95,12 @@ module.exports = {
 
     const apiUploadFolder = await apiUploadFolderService.getAPIUploadFolder();
 
-    data.fileInfo = data.fileInfo || {};
-
-    data.fileInfo =
-      Array.isArray(data.fileInfo) && data.fileInfo.length === files.length
-        ? data.fileInfo
-        : Array.from({ length: files.length || 1 }, () => data.fileInfo);
-
-    data.fileInfo.forEach(fileInfo => (fileInfo.folder = apiUploadFolder.id));
+    if (Array.isArray(files)) {
+      data.fileInfo = data.fileInfo || [];
+      data.fileInfo = files.map((_f, i) => ({ ...data.fileInfo[i], folder: apiUploadFolder.id }));
+    } else {
+      data.fileInfo = { ...data.fileInfo, folder: apiUploadFolder.id };
+    }
 
     const uploadedFiles = await getService('upload').upload({
       data,

--- a/packages/core/upload/server/controllers/content-api.js
+++ b/packages/core/upload/server/controllers/content-api.js
@@ -94,8 +94,14 @@ module.exports = {
     const apiUploadFolderService = getService('api-upload-folder');
 
     const apiUploadFolder = await apiUploadFolderService.getAPIUploadFolder();
+
     data.fileInfo = data.fileInfo || {};
-    data.fileInfo = Array.isArray(data.fileInfo) ? data.fileInfo : [data.fileInfo];
+
+    data.fileInfo =
+      Array.isArray(data.fileInfo) && data.fileInfo.length === files.length
+        ? data.fileInfo
+        : Array.from({ length: files.length || 1 }, () => data.fileInfo);
+
     data.fileInfo.forEach(fileInfo => (fileInfo.folder = apiUploadFolder.id));
 
     const uploadedFiles = await getService('upload').upload({

--- a/packages/core/upload/tests/content-api/upload-automatic-folder.test.e2e.js
+++ b/packages/core/upload/tests/content-api/upload-automatic-folder.test.e2e.js
@@ -433,11 +433,78 @@ describe('Uploads folder', () => {
         body: { results: files },
       } = await rqAdmin({
         method: 'GET',
-        url: `/upload/files?filters[id][$in][0]=${res.body[0].id}&filters[id][$in][1]=${res.body[1].id}`,
+        url: '/upload/files',
+        qs: {
+          filters: {
+            id: {
+              $in: res.body.map(({ id }) => id),
+            },
+          },
+          populate: '*',
+        },
       });
 
       files.forEach(file =>
         expect(file).toMatchObject({
+          folder: {
+            name: 'API Uploads (3)',
+            pathId: expect.any(Number),
+          },
+          folderPath: `/${file.folder.pathId}`,
+        })
+      );
+
+      expect(files.every(file => file.folder.id === files[0].folder.id)).toBe(true);
+
+      uploadFolder = files[0].folder;
+    });
+
+    test('Uploaded files with fileInfo', async () => {
+      const fileInfo = [
+        {
+          name: 'file1',
+          alternativeText: 'file1',
+          caption: 'file1',
+        },
+        {
+          name: 'file2',
+          alternativeText: 'file2',
+          caption: 'file2',
+        },
+      ];
+
+      const res = await rq({
+        method: 'POST',
+        url: '/upload',
+        formData: {
+          files: [
+            fs.createReadStream(path.join(__dirname, '../utils/rec.jpg')),
+            fs.createReadStream(path.join(__dirname, '../utils/strapi.jpg')),
+          ],
+          fileInfo: fileInfo.map(JSON.stringify),
+        },
+      });
+
+      expect(res.statusCode).toBe(200);
+
+      const {
+        body: { results: files },
+      } = await rqAdmin({
+        method: 'GET',
+        url: '/upload/files',
+        qs: {
+          filters: {
+            id: {
+              $in: res.body.map(({ id }) => id),
+            },
+          },
+          populate: '*',
+        },
+      });
+
+      files.forEach((file, index) =>
+        expect(file).toMatchObject({
+          ...fileInfo[index],
           folder: {
             name: 'API Uploads (3)',
             pathId: expect.any(Number),
@@ -477,7 +544,15 @@ describe('Uploads folder', () => {
         body: { results: files },
       } = await rqAdmin({
         method: 'GET',
-        url: `/upload/files?filters[id][$in][0]=${res.body[0].id}&filters[id][$in][1]=${res.body[1].id}`,
+        url: '/upload/files',
+        qs: {
+          filters: {
+            id: {
+              $in: res.body.map(({ id }) => id),
+            },
+          },
+          populate: '*',
+        },
       });
 
       files.forEach(file => {
@@ -531,7 +606,15 @@ describe('Uploads folder', () => {
         body: { results: files },
       } = await rqAdmin({
         method: 'GET',
-        url: `/upload/files?filters[id][$in][0]=${res.body[0].id}&filters[id][$in][1]=${res.body[1].id}`,
+        url: '/upload/files',
+        qs: {
+          filters: {
+            id: {
+              $in: res.body.map(({ id }) => id),
+            },
+          },
+          populate: '*',
+        },
       });
 
       files.forEach(file => {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Fixes #13999.

### Why is it needed?

Uploading multiple files via API only moves the first file to the _API Uploads_ folder instead of all of them.

### How to test it?

Try uploading multiple files via API and notice that all end up in the appropriate folder.

### Related issue(s)/PR(s)

#13999 