### PR TITLE
Add missing permissions to webhook triggering endpoint

### DIFF
--- a/packages/core/admin/server/routes/webhooks.js
+++ b/packages/core/admin/server/routes/webhooks.js
@@ -72,7 +72,10 @@ module.exports = [
     path: '/webhooks/:id/trigger',
     handler: 'webhooks.triggerWebhook',
     config: {
-      policies: [],
+      policies: [
+        'admin::isAuthenticatedAdmin',
+        { name: 'admin::hasPermissions', config: { actions: ['admin::webhooks.trigger'] } },
+      ],
     },
   },
 ];

--- a/packages/core/admin/server/routes/webhooks.js
+++ b/packages/core/admin/server/routes/webhooks.js
@@ -74,7 +74,7 @@ module.exports = [
     config: {
       policies: [
         'admin::isAuthenticatedAdmin',
-        { name: 'admin::hasPermissions', config: { actions: ['admin::webhooks.trigger'] } },
+        { name: 'admin::hasPermissions', config: { actions: ['admin::webhooks.update'] } },
       ],
     },
   },


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Fixes #13970 by adding missing policies to the affected route.

### Why is it needed?

Admins can trigger webhooks even if they don't have permission to do so.

### How to test it?

Replicate the process outlined in #13970 and notice that you get a policy error.