### PR TITLE
Chore: Remove legacy travis config file

### DIFF
--- a/_travis/mysql.cnf
+++ b/_travis/mysql.cnf
@@ -1,3 +1,0 @@
-[mysqld]
-collation-server=utf8_unicode_ci
-character-set-server=utf8


### PR DESCRIPTION
### What does it do?

Since @alexandrebodin is doing some repo cleanup, it might be a good chance to get rid of this legacy travis config file. It is the second file after the `.github` directory on the github overpage page and annoys me a lot.

### Why is it needed?

To have a clean repository, file structure.
