### PR TITLE
Decouple resizing and optimization

### DIFF
--- a/packages/core/upload/server/services/image-manipulation.js
+++ b/packages/core/upload/server/services/image-manipulation.js
@@ -10,6 +10,7 @@ const { getService } = require('../utils');
 const { bytesToKbytes, writableDiscardStream } = require('../utils/file');
 
 const FORMATS_TO_PROCESS = ['jpeg', 'png', 'webp', 'tiff', 'svg', 'gif'];
+const FORMATS_TO_RESIZE = ['jpeg', 'png', 'webp', 'tiff', 'gif'];
 const FORMATS_TO_OPTIMIZE = ['jpeg', 'png', 'webp', 'tiff'];
 
 const writeStreamToFile = (stream, path) =>
@@ -206,6 +207,18 @@ const isOptimizableImage = async file => {
   return format && FORMATS_TO_OPTIMIZE.includes(format);
 };
 
+const isResizableImage = async file => {
+  let format;
+  try {
+    const metadata = await getMetadata(file);
+    format = metadata.format;
+  } catch (e) {
+    // throw when the file is not a supported image
+    return false;
+  }
+  return format && FORMATS_TO_RESIZE.includes(format);
+};
+
 const isImage = async file => {
   let format;
   try {
@@ -222,6 +235,7 @@ module.exports = () => ({
   isSupportedImage,
   isFaultyImage,
   isOptimizableImage,
+  isResizableImage,
   isImage,
   getDimensions,
   generateResponsiveFormats,

--- a/packages/core/upload/server/services/upload.js
+++ b/packages/core/upload/server/services/upload.js
@@ -184,7 +184,7 @@ module.exports = ({ strapi }) => ({
       getDimensions,
       generateThumbnail,
       generateResponsiveFormats,
-      isOptimizableImage,
+      isResizableImage,
     } = getService('image-manipulation');
 
     // Store width and height of the original image
@@ -201,14 +201,16 @@ module.exports = ({ strapi }) => ({
     await getService('provider').upload(fileData);
 
     // Generate thumbnail and responsive formats
-    if (await isOptimizableImage(fileData)) {
+    if (await isResizableImage(fileData)) {
       const thumbnailFile = await generateThumbnail(fileData);
+
       if (thumbnailFile) {
         await getService('provider').upload(thumbnailFile);
         _.set(fileData, 'formats.thumbnail', thumbnailFile);
       }
 
       const formats = await generateResponsiveFormats(fileData);
+
       if (Array.isArray(formats) && formats.length > 0) {
         for (const format of formats) {
           if (!format) continue;


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

No longer runs `isOptimizableImage` when creating responsive image formats during upload, but instead checks whether the format of the image is in a list of resizable formats.

### Why is it needed?

`isOptimizableImage` always fails for GIF images, but GIF images should have responsive formats.

### How to test it?

Try uploading a GIF and notice that responsive formats are generated.
Try uploading an SVG and notice that responsive formats ARE NOT generated.
