### PR TITLE
ReactSelect: Export styled async component from react-select

### DIFF
--- a/packages/core/helper-plugin/lib/src/components/ReactSelect/Async/Async.js
+++ b/packages/core/helper-plugin/lib/src/components/ReactSelect/Async/Async.js
@@ -1,0 +1,41 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import SelectAsync from 'react-select/async';
+import { useTheme } from 'styled-components';
+
+import ClearIndicator from '../components/ClearIndicator';
+import DropdownIndicator from '../components/DropdownIndicator';
+import IndicatorSeparator from '../components/IndicatorSeparator';
+
+import getSelectStyles from '../utils/getSelectStyles';
+
+const ReactSelectAsync = ({ components, styles, error, ariaErrorMessage, ...props }) => {
+  const theme = useTheme();
+  const customStyles = getSelectStyles(theme, error);
+
+  return (
+    <SelectAsync
+      {...props}
+      components={{ ClearIndicator, DropdownIndicator, IndicatorSeparator, ...components }}
+      aria-errormessage={error && ariaErrorMessage}
+      aria-invalid={!!error}
+      styles={{ ...customStyles, ...styles }}
+    />
+  );
+};
+
+export default ReactSelectAsync;
+
+ReactSelectAsync.defaultProps = {
+  ariaErrorMessage: undefined,
+  components: undefined,
+  error: undefined,
+  styles: undefined,
+};
+
+ReactSelectAsync.propTypes = {
+  ariaErrorMessage: PropTypes.string,
+  components: PropTypes.object,
+  error: PropTypes.string,
+  styles: PropTypes.object,
+};

--- a/packages/core/helper-plugin/lib/src/components/ReactSelect/Async/index.js
+++ b/packages/core/helper-plugin/lib/src/components/ReactSelect/Async/index.js
@@ -1,0 +1,1 @@
+export default from './Async';

--- a/packages/core/helper-plugin/lib/src/components/ReactSelect/index.js
+++ b/packages/core/helper-plugin/lib/src/components/ReactSelect/index.js
@@ -1,3 +1,1 @@
-import ReactSelect from './ReactSelect';
-
-export default ReactSelect;
+export default from './ReactSelect';

--- a/packages/core/helper-plugin/lib/src/components/ReactSelect/utils/getSelectStyles.js
+++ b/packages/core/helper-plugin/lib/src/components/ReactSelect/utils/getSelectStyles.js
@@ -7,16 +7,16 @@ const getSelectStyles = (theme, error) => {
       lineHeight: 'normal',
     }),
     control: (base, state) => {
-      let border = `1px solid ${theme.colors.neutral200} !important`;
-      let boxShadow = 0;
+      let borderColor = theme.colors.neutral200;
+      let boxShadowColor;
       let backgroundColor;
 
       if (state.isFocused) {
-        border = `1px solid ${theme.colors.primary600} !important`;
-        boxShadow = `${theme.colors.primary600} 0px 0px 0px 2px`;
+        borderColor = theme.colors.primary600;
+        boxShadowColor = theme.colors.primary600;
       } else if (error) {
-        border = `1px solid ${theme.colors.danger600} !important`;
-        boxShadow = `${theme.colors.danger600} 0px 0px 0px 2px`;
+        borderColor = theme.colors.danger600;
+        boxShadowColor = theme.colors.danger600;
       }
 
       if (state.isDisabled) {
@@ -27,7 +27,7 @@ const getSelectStyles = (theme, error) => {
         ...base,
         fontSize: 14,
         height: 40,
-        border,
+        border: `1px solid ${borderColor} !important`,
         outline: 0,
         borderRadius: '2px !important',
         backgroundColor,
@@ -35,7 +35,7 @@ const getSelectStyles = (theme, error) => {
         borderTopRightRadius: '4px !important',
         borderBottomLeftRadius: '4px !important',
         borderBottomRightRadius: '4px !important',
-        boxShadow,
+        boxShadow: boxShadowColor ? `${boxShadowColor} 0px 0px 0px 2px` : 0,
       };
     },
     indicatorContainer: base => ({ ...base, padding: 0, paddingRight: theme.spaces[3] }),

--- a/packages/core/helper-plugin/lib/src/index.js
+++ b/packages/core/helper-plugin/lib/src/index.js
@@ -64,6 +64,7 @@ export { default as PageSizeURLQuery } from './components/PageSizeURLQuery';
 export { default as RelativeTime } from './components/RelativeTime';
 export { default as DateTimePicker } from './components/DateTimePicker';
 export { default as ReactSelect } from './components/ReactSelect';
+export { default as ReactSelectAsync } from './components/ReactSelect/Async';
 export { default as Link } from './components/Link';
 export { default as LinkButton } from './components/LinkButton';
 


### PR DESCRIPTION
### What does it do?

Exports the `react-select/async` component from `react-select` and applies our default styles.

### Why is it needed?

To support `react-select/async` to relation components at some point.
