### PR TITLE
Ignore if populating a scalar attribute

### DIFF
--- a/packages/core/content-manager/server/tests/api/populate-dz.test.e2e.js
+++ b/packages/core/content-manager/server/tests/api/populate-dz.test.e2e.js
@@ -32,6 +32,10 @@ const compo2 = {
     name: {
       type: 'string',
     },
+    category: {
+      // same field name as in compo1 but different type
+      type: 'string',
+    },
     category_diff: {
       type: 'relation',
       relation: 'oneToOne',
@@ -136,7 +140,7 @@ describe('CM API - Populate dz', () => {
           },
           {
             __component: 'default.compo-b',
-            items: { id: 2, name: 'BBBB', category_diff: data.categories[0].id },
+            items: { id: 2, name: 'BBBB', category_diff: data.categories[0].id, category: 'smthg' },
           },
         ],
       },
@@ -162,6 +166,7 @@ describe('CM API - Populate dz', () => {
           __component: 'default.compo-b',
           items: {
             name: 'BBBB',
+            category: 'smthg',
             category_diff: {
               name: 'name',
             },

--- a/packages/core/database/lib/query/helpers/populate.js
+++ b/packages/core/database/lib/query/helpers/populate.js
@@ -80,7 +80,7 @@ const processPopulate = (populate, ctx) => {
     }
 
     if (!types.isRelation(attribute.type)) {
-      throw new Error(`Invalid populate field. Expected a relation, got ${attribute.type}`);
+      continue;
     }
 
     // make sure id is present for future populate queries


### PR DESCRIPTION
### What does it do?

Ignore instead of throwing an error when a query tried to populate a scalar attributes
NB: it is already this behavior when trying to populate an attribute that doesn't exist

### Why is it needed?

To avoid error 500 in certain usecases.
Example : 
When 2 components in a dynamic zone have the same field name but one is a relation and the other is a string.

### How to test it?

The test was updated
