### PR TITLE
useCMEditViewDataManager: Remove moveRelation dispatcher

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/index.js
@@ -404,15 +404,6 @@ const EditViewDataManagerProvider = ({
     });
   }, []);
 
-  const moveRelation = useCallback((dragIndex, overIndex, name) => {
-    dispatch({
-      type: 'MOVE_FIELD',
-      dragIndex,
-      overIndex,
-      keys: name.split('.'),
-    });
-  }, []);
-
   const onRemoveRelation = useCallback(keys => {
     dispatch({
       type: 'REMOVE_RELATION',
@@ -487,7 +478,6 @@ const EditViewDataManagerProvider = ({
         moveComponentDown,
         moveComponentField,
         moveComponentUp,
-        moveRelation,
         onChange: handleChange,
         onPublish: handlePublish,
         onUnpublish,

--- a/packages/core/admin/admin/src/content-manager/components/SelectWrapper/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/SelectWrapper/index.js
@@ -64,13 +64,7 @@ function SelectWrapper({
   const [{ query }] = useQueryParams();
   // Disable the input in case of a polymorphic relation
   const isMorph = useMemo(() => relationType.toLowerCase().includes('morph'), [relationType]);
-  const {
-    addRelation,
-    modifiedData,
-    moveRelation,
-    onChange,
-    onRemoveRelation,
-  } = useCMEditViewDataManager();
+  const { addRelation, modifiedData, onChange, onRemoveRelation } = useCMEditViewDataManager();
   const { pathname } = useLocation();
 
   const value = get(modifiedData, name, null);
@@ -293,7 +287,6 @@ function SelectWrapper({
         isLoading={isLoading}
         isClearable
         mainField={mainField}
-        move={moveRelation}
         name={name}
         options={filteredOptions}
         onChange={handleChange}

--- a/packages/core/helper-plugin/lib/src/content-manager/hooks/useCMEditViewDataManager/useCMEditViewDataManager.stories.mdx
+++ b/packages/core/helper-plugin/lib/src/content-manager/hooks/useCMEditViewDataManager/useCMEditViewDataManager.stories.mdx
@@ -41,7 +41,6 @@ const MyCompo = () => {
     moveComponentDown: () => {},
     moveComponentField: () => {},
     moveComponentUp: () => {},
-    moveRelation: () => {},
     onChange: () => {},
     onRemoveRelation: () => {},
     removeComponentFromDynamicZone: () => {},


### PR DESCRIPTION
### What does it do?

Removes `moveRelation()` dispatcher. I'm not sure what it was being used for, but it is not implemented at the moment and I can't imagine a use-case, since relations are now fields as any others.

### Why is it needed?

Cleanup the codebase.

