### PR TITLE
Fix wrong file location when editing a file from the content-manager

### DIFF
--- a/packages/core/content-manager/server/services/entity-manager.js
+++ b/packages/core/content-manager/server/services/entity-manager.js
@@ -61,7 +61,7 @@ const getDeepPopulate = (uid, populate) => {
     }
 
     if (attribute.type === 'media') {
-      populateAcc[attributeName] = true;
+      populateAcc[attributeName] = { populate: 'folder' };
     }
 
     if (attribute.type === 'dynamiczone') {


### PR DESCRIPTION
### What does it do?

It populates the folder field for media

### Why is it needed?

To fix #13887

### How to test it?

1. upload a file inside a folder
2. create a content-type entry with this file
3. open this entry, edit the file
4. see the correct location displayed

### Related issue(s)/PR(s)

#13887

Congrats @ronronscelestes for spotting the cause of the issue
