### PR TITLE
Fix/trigger webhook on bulk delete

### DIFF
--- a/packages/core/strapi/lib/services/entity-service/__tests__/entity-service-events.test.js
+++ b/packages/core/strapi/lib/services/entity-service/__tests__/entity-service-events.test.js
@@ -1,0 +1,116 @@
+'use strict';
+
+jest.mock('bcryptjs', () => ({ hashSync: () => 'secret-password' }));
+
+const createEntityService = require('../');
+const entityValidator = require('../../entity-validator');
+
+describe('Entity service triggers webhooks', () => {
+  global.strapi = {
+    getModel: () => ({}),
+    config: {
+      get: () => [],
+    },
+  };
+
+  let instance;
+  let eventHub = { emit: jest.fn() };
+  let fakeDB = {
+    query: () => ({
+      count: () => 0,
+      create: ({ data }) => data,
+      update: ({ data }) => data,
+      findOne: () => ({ attr: 'value' }),
+      findMany: () => [{ attr: 'value' }, { attr: 'value2' }],
+      delete: () => ({}),
+      deleteMany: () => ({}),
+    }),
+  };
+
+  beforeAll(() => {
+    instance = createEntityService({
+      strapi: {
+        getModel: () => ({
+          kind: 'singleType',
+          modelName: 'test-model',
+          privateAttributes: [],
+          attributes: {
+            attr: { type: 'string' },
+          },
+        }),
+      },
+      db: fakeDB,
+      eventHub,
+      entityValidator,
+    });
+  });
+
+  test('Emit event: Create', async () => {
+    const data = { attr: 'value' };
+
+    // Create entity
+    await instance.create('test-model', { data });
+
+    // Expect entry.create event to be emitted
+    expect(eventHub.emit).toHaveBeenCalledWith('entry.create', {
+      entry: data,
+      model: 'test-model',
+    });
+
+    eventHub.emit.mockClear();
+  });
+
+  test('Emit event: Update', async () => {
+    const data = { attr: 'value' };
+
+    // Update entity
+    await instance.update('test-model', 'entity-id', { data });
+
+    // Expect entry.update event to be emitted
+    expect(eventHub.emit).toHaveBeenCalledWith('entry.update', {
+      entry: data,
+      model: 'test-model',
+    });
+
+    eventHub.emit.mockClear();
+  });
+
+  test('Emit event: Delete', async () => {
+    // Delete entity
+    await instance.delete('test-model', 'entity-id', {});
+
+    // Expect entry.create event to be emitted
+    expect(eventHub.emit).toHaveBeenCalledWith('entry.delete', {
+      entry: { attr: 'value' },
+      model: 'test-model',
+    });
+
+    eventHub.emit.mockClear();
+  });
+
+  test('Emit event: Delete Many', async () => {
+    // Delete entity
+    await instance.deleteMany('test-model', {});
+
+    // Expect entry.create event to be emitted
+    expect(eventHub.emit).toHaveBeenCalledWith('entry.delete', {
+      entry: { attr: 'value' },
+      model: 'test-model',
+    });
+    // One event per each entity deleted
+    expect(eventHub.emit).toHaveBeenCalledTimes(2);
+
+    eventHub.emit.mockClear();
+  });
+
+  test('Do not emit event when no deleted entity', async () => {
+    fakeDB.query = () => ({ findOne: () => null });
+    // Delete entity
+    await instance.delete('test-model', 'entity-id', {});
+
+    // Expect entry.create event to be emitted
+    expect(eventHub.emit).toHaveBeenCalledTimes(0);
+
+    eventHub.emit.mockClear();
+  });
+});

--- a/packages/core/strapi/lib/services/entity-service/__tests__/entity-service-events.test.js
+++ b/packages/core/strapi/lib/services/entity-service/__tests__/entity-service-events.test.js
@@ -1,7 +1,5 @@
 'use strict';
 
-jest.mock('bcryptjs', () => ({ hashSync: () => 'secret-password' }));
-
 const createEntityService = require('../');
 const entityValidator = require('../../entity-validator');
 

--- a/packages/core/strapi/lib/services/entity-service/index.js
+++ b/packages/core/strapi/lib/services/entity-service/index.js
@@ -265,7 +265,6 @@ const createDefaultImplementation = ({ strapi, db, eventHub, entityValidator }) 
     await deleteComponents(uid, entityToDelete);
     await db.query(uid).delete({ where: { id: entityToDelete.id } });
 
-    // Trigger webhook
     await this.emitEvent(uid, ENTRY_DELETE, entityToDelete);
 
     return entityToDelete;
@@ -290,7 +289,7 @@ const createDefaultImplementation = ({ strapi, db, eventHub, entityValidator }) 
     await Promise.all(entitiesToDelete.map(entity => deleteComponents(uid, entity)));
     const result = await db.query(uid).deleteMany(query);
 
-    // Trigger the webhooks. One for each entity
+    // Trigger webhooks. One for each entity
     await Promise.all(entitiesToDelete.map(entity => this.emitEvent(uid, ENTRY_DELETE, entity)));
 
     return result;

--- a/packages/core/strapi/lib/services/entity-service/index.js
+++ b/packages/core/strapi/lib/services/entity-service/index.js
@@ -261,9 +261,11 @@ const createDefaultImplementation = ({ strapi, db, eventHub, entityValidator }) 
       return null;
     }
 
+    // Delete entity components first, and then the entity
     await deleteComponents(uid, entityToDelete);
     await db.query(uid).delete({ where: { id: entityToDelete.id } });
 
+    // Trigger webhook
     await this.emitEvent(uid, ENTRY_DELETE, entityToDelete);
 
     return entityToDelete;
@@ -284,11 +286,11 @@ const createDefaultImplementation = ({ strapi, db, eventHub, entityValidator }) 
       return null;
     }
 
-    // Delete all the entities components first and then the entities
+    // Delete all the entities components first, and then the entities
     await Promise.all(entitiesToDelete.map(entity => deleteComponents(uid, entity)));
     const result = await db.query(uid).deleteMany(query);
 
-    // Trigger the webhook events. One for each entity
+    // Trigger the webhooks. One for each entity
     await Promise.all(entitiesToDelete.map(entity => this.emitEvent(uid, ENTRY_DELETE, entity)));
 
     return result;

--- a/packages/core/strapi/lib/services/entity-service/index.js
+++ b/packages/core/strapi/lib/services/entity-service/index.js
@@ -261,8 +261,8 @@ const createDefaultImplementation = ({ strapi, db, eventHub, entityValidator }) 
       return null;
     }
 
-    await db.query(uid).delete({ where: { id: entityToDelete.id } });
     await deleteComponents(uid, entityToDelete);
+    await db.query(uid).delete({ where: { id: entityToDelete.id } });
 
     await this.emitEvent(uid, ENTRY_DELETE, entityToDelete);
 

--- a/packages/core/strapi/lib/services/entity-service/index.js
+++ b/packages/core/strapi/lib/services/entity-service/index.js
@@ -277,9 +277,7 @@ const createDefaultImplementation = ({ strapi, db, eventHub, entityValidator }) 
     // select / populate
     const query = transformParamsToQuery(uid, wrappedParams);
 
-    const entitiesToDelete = await db.query(uid).findMany({
-      ...query,
-    });
+    const entitiesToDelete = await db.query(uid).findMany(query);
 
     if (!entitiesToDelete.length) {
       return null;

--- a/packages/core/strapi/lib/services/entity-service/index.js
+++ b/packages/core/strapi/lib/services/entity-service/index.js
@@ -261,9 +261,8 @@ const createDefaultImplementation = ({ strapi, db, eventHub, entityValidator }) 
       return null;
     }
 
-    // Delete entity components first, and then the entity
-    await deleteComponents(uid, entityToDelete);
     await db.query(uid).delete({ where: { id: entityToDelete.id } });
+    await deleteComponents(uid, entityToDelete);
 
     await this.emitEvent(uid, ENTRY_DELETE, entityToDelete);
 
@@ -283,9 +282,8 @@ const createDefaultImplementation = ({ strapi, db, eventHub, entityValidator }) 
       return null;
     }
 
-    // Delete all the entities components first, and then the entities
-    await Promise.all(entitiesToDelete.map(entity => deleteComponents(uid, entity)));
     const deletedEntities = await db.query(uid).deleteMany(query);
+    await Promise.all(entitiesToDelete.map(entity => deleteComponents(uid, entity)));
 
     // Trigger webhooks. One for each entity
     await Promise.all(entitiesToDelete.map(entity => this.emitEvent(uid, ENTRY_DELETE, entity)));

--- a/packages/core/strapi/lib/services/entity-service/index.js
+++ b/packages/core/strapi/lib/services/entity-service/index.js
@@ -287,12 +287,12 @@ const createDefaultImplementation = ({ strapi, db, eventHub, entityValidator }) 
 
     // Delete all the entities components first, and then the entities
     await Promise.all(entitiesToDelete.map(entity => deleteComponents(uid, entity)));
-    const result = await db.query(uid).deleteMany(query);
+    const deletedEntities = await db.query(uid).deleteMany(query);
 
     // Trigger webhooks. One for each entity
     await Promise.all(entitiesToDelete.map(entity => this.emitEvent(uid, ENTRY_DELETE, entity)));
 
-    return result;
+    return deletedEntities;
   },
 
   load(uid, entity, field, params = {}) {

--- a/packages/core/strapi/tests/api/basic-dp-compo.test.e2e.js
+++ b/packages/core/strapi/tests/api/basic-dp-compo.test.e2e.js
@@ -163,9 +163,7 @@ describe('Core API - Basic + compo + draftAndPublish', () => {
 
   describe('database state', () => {
     test('components have been removed from the database', async () => {
-      const dbComponents = await strapi.db
-        .query('default.compo')
-        .findMany({ name: 'compo name updated' });
+      const dbComponents = await strapi.db.query('default.compo').findMany({});
       expect(dbComponents).toHaveLength(0);
     });
   });

--- a/packages/core/strapi/tests/api/basic-dp-compo.test.e2e.js
+++ b/packages/core/strapi/tests/api/basic-dp-compo.test.e2e.js
@@ -163,7 +163,9 @@ describe('Core API - Basic + compo + draftAndPublish', () => {
 
   describe('database state', () => {
     test('components have been removed from the database', async () => {
-      const dbComponents = await strapi.db.query('default.compo').findMany({});
+      const dbComponents = await strapi.db
+        .query('default.compo')
+        .findMany({ name: 'compo name updated' });
       expect(dbComponents).toHaveLength(0);
     });
   });

--- a/packages/core/strapi/tests/api/basic-dp-compo.test.e2e.js
+++ b/packages/core/strapi/tests/api/basic-dp-compo.test.e2e.js
@@ -161,6 +161,13 @@ describe('Core API - Basic + compo + draftAndPublish', () => {
     data.productsWithCompoAndDP.shift();
   });
 
+  describe('database state', () => {
+    test('components have been removed from the database', async () => {
+      const dbComponents = await strapi.db.query('default.compo').findMany({});
+      expect(dbComponents).toHaveLength(0);
+    });
+  });
+
   describe('validation', () => {
     test('Cannot create product with compo - compo required', async () => {
       const product = {

--- a/packages/core/strapi/tests/api/basic-dp-compo.test.e2e.js
+++ b/packages/core/strapi/tests/api/basic-dp-compo.test.e2e.js
@@ -161,15 +161,6 @@ describe('Core API - Basic + compo + draftAndPublish', () => {
     data.productsWithCompoAndDP.shift();
   });
 
-  describe('database state', () => {
-    test('components have been removed from the database', async () => {
-      const dbComponents = await strapi.db
-        .query('default.compo')
-        .findMany({ name: 'compo name updated' });
-      expect(dbComponents).toHaveLength(0);
-    });
-  });
-
   describe('validation', () => {
     test('Cannot create product with compo - compo required', async () => {
       const product = {


### PR DESCRIPTION
## 👋🏻  What does it do?

- Webhook was not triggered when doing a bulk delete.

## ❓ Why is it needed?

It was triggered when deleting a single entity but not for a bulk delete. 

## 🧪  How to test it?

1. Create your webhook. ( [example](https://scribehow.com/shared/Create_webhook__gNj4Ww6AQIOZBImzXBJMLg) )
You can use this site to test the webhook https://webhook.site/
2. Delete a single entity from any content type.
3. Webhook (entry.delete) should have been triggered
4. Bulk delete entities from any content type
5. One webhook (entry.delete) should have been triggered **for each entity deleted**.

## 🔗 Related issue(s)/PR(s)

https://github.com/strapi/strapi/issues/12290