### PR TITLE
[Fix] Folder location AssetDialog

### DIFF
--- a/packages/core/upload/admin/src/components/AssetDialog/index.js
+++ b/packages/core/upload/admin/src/components/AssetDialog/index.js
@@ -185,6 +185,7 @@ export const AssetDialog = ({
         folder={folderToEdit}
         onClose={() => setFolderToEdit(undefined)}
         location="content-manager"
+        parentFolderId={queryObject?.folder}
       />
     );
   }


### PR DESCRIPTION
## What

when investigating this issue #13887 I found that:
`parentFolderId` wasn't properly given to `EditFolderDialog` in `AssetDialog` causing not showing the current folder location when editing a folder in the content-manager modal

#14040 will fix the edit asset issue.

## Snapshots

**before:**
<img width="907" alt="image" src="https://user-images.githubusercontent.com/71838159/183705107-cbd70671-8801-47b2-9931-86d6d7448c12.png">

**after:**
<img width="888" alt="image" src="https://user-images.githubusercontent.com/71838159/183705160-d12781a3-e87e-499c-bbfb-f6182b4af824.png">

## Test

- Browse folders/assets in the content-manager
- Edit a folder
- See current folder location as default value in the location select

