### PR TITLE
Improve spacing for "Create new ..." button

### DIFF
--- a/packages/core/content-type-builder/admin/src/components/ContentTypeBuilderNav/index.js
+++ b/packages/core/content-type-builder/admin/src/components/ContentTypeBuilderNav/index.js
@@ -80,7 +80,7 @@ const ContentTypeBuilderNav = () => {
                 })}
               </SubNavSection>
               {section.customLink && (
-                <Box paddingLeft={7}>
+                <Box paddingLeft={7} paddingTop={2} paddingBottom={2}>
                   <TextButton onClick={section.customLink.onClick} startIcon={<Plus />}>
                     {formatMessage({
                       id: section.customLink.id,


### PR DESCRIPTION
### What does it do?

Improved padding for the "add new... " button in the content type manager menu.

### Why is it needed?
 
Required to complete work on https://github.com/strapi/strapi/pull/13799, requested by @gu-stav 

All related Issues/PRs:
https://github.com/strapi/strapi/pull/13799
https://github.com/strapi/design-system/pull/635