### PR TITLE
Throw error when creating/updating content type to have 0 fields

### DIFF
--- a/packages/core/content-type-builder/admin/src/pages/ListView/index.js
+++ b/packages/core/content-type-builder/admin/src/pages/ListView/index.js
@@ -131,7 +131,10 @@ const ListView = () => {
                 startIcon={<Check />}
                 onClick={() => submitData()}
                 type="submit"
-                disabled={isEqual(modifiedData, initialData)}
+                disabled={
+                  isEqual(modifiedData, initialData) ||
+                  modifiedData.contentType.schema.attributes.length === 0
+                }
               >
                 {formatMessage({
                   id: 'global.save',

--- a/packages/core/content-type-builder/server/controllers/validation/content-type.js
+++ b/packages/core/content-type-builder/server/controllers/validation/content-type.js
@@ -66,6 +66,7 @@ const createContentTypeSchema = (data, { isEdition = false } = {}) => {
         .test(forbiddenContentTypeNameValidator())
         .isKebabCase()
         .required(),
+      attributes: yup.object().test(emptyAttributes()),
     })
     .test(
       'singularName-not-equal-pluralName',
@@ -142,6 +143,12 @@ const alreadyUsedContentTypeName = isEdition => {
     },
   };
 };
+
+const emptyAttributes = () => ({
+  name: 'emptyAttributes',
+  message: 'Content types cannot be empty.',
+  test: attributes => Object.keys(attributes).length >= 1,
+});
 
 /**
  * Validates type kind


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Content types can not be created/updated to have 0 fields.
The _Save_ button in the admin panel won't enable when removing the last field from a content type, and the backend will throw an error if a user tried to do so via the API.

### Why is it needed?

Accessing empty content type is currently broken as per #13913, and even bypassing the policy the Content Manager breaks when opening a content type that has no fields.

### How to test it?

- Create a new content type with a field of any kind
- Save
- Try removing the field
- Notice how the save button does not enable
- Repeat the process via the API or force-enable the save button and submit
