### PR TITLE
Update content-api.yaml

### DIFF
--- a/packages/plugins/users-permissions/documentation/content-api.yaml
+++ b/packages/plugins/users-permissions/documentation/content-api.yaml
@@ -44,7 +44,7 @@ paths:
                 password:
                   type: string
             example:
-              identier: foobar
+              identifier: foobar
               password: Test1234
         required: true
       responses:


### PR DESCRIPTION
### What does it do?

Fixed typo in documentation

### Why is it needed?

Solve the error when test in Swagger:
```
curl -X 'POST' \
  'http://localhost:1337/api/auth/local' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -d '{
  "identier": "username@email.com",
  "password": "password"
}'
```

<img width="452" alt="image" src="https://user-images.githubusercontent.com/14073668/184008952-fe81ed8e-7826-4ce6-96af-21eb4cc2286b.png">


### How to test it?

Make test request in Swagger

### Related issue(s)/PR(s)

#13911
