### PR TITLE
Fix ts config path resolve on Windows

### DIFF
--- a/packages/utils/typescript/lib/utils/get-config-path.js
+++ b/packages/utils/typescript/lib/utils/get-config-path.js
@@ -16,7 +16,7 @@ const DEFAULT_TS_CONFIG_FILENAME = 'tsconfig.json';
  * @return {string | undefined}
  */
 module.exports = (dir, { filename = DEFAULT_TS_CONFIG_FILENAME, ancestorsLookup = false } = {}) => {
-  const dirAbsolutePath = path.resolve(dir);
+  const dirAbsolutePath = path.resolve(dir).split(path.sep).join(path.posix.sep);
   const configFilePath = ts.findConfigFile(dirAbsolutePath, ts.sys.fileExists, filename);
 
   if (!configFilePath || ancestorsLookup) {


### PR DESCRIPTION
### What does it do?

This fixes the issue described in https://github.com/strapi/strapi/issues/14079

### Why is it needed?

The check for an existing TS config does not work on Windows due to the paths being compared are using different path separators based on the OS in use. Since the POSIX style path will always be different than for example the same path on Windows, the check to see if they are included in one another fails.

### How to test it?

As described in https://github.com/strapi/strapi/issues/14079: start a TS project on Windows.
The config detection will not work.

### Related issue(s)/PR(s)

Related to https://github.com/strapi/strapi/issues/14079
