### PR TITLE
Make REST parameters schema-susceptible

### DIFF
--- a/packages/core/strapi/lib/services/entity-service/params.js
+++ b/packages/core/strapi/lib/services/entity-service/params.js
@@ -28,7 +28,7 @@ const transformParamsToQuery = (uid, params) => {
   }
 
   if (!isNil(sort)) {
-    query.orderBy = convertSortQueryParams(sort);
+    query.orderBy = convertSortQueryParams(sort, schema);
   }
 
   if (!isNil(filters)) {
@@ -36,7 +36,7 @@ const transformParamsToQuery = (uid, params) => {
   }
 
   if (!isNil(fields)) {
-    query.select = convertFieldsQueryParams(fields);
+    query.select = convertFieldsQueryParams(fields, 0, schema);
   }
 
   if (!isNil(populate)) {

--- a/packages/core/utils/lib/convert-query-params.js
+++ b/packages/core/utils/lib/convert-query-params.js
@@ -87,7 +87,7 @@ const convertSingleSortQueryParam = (sortQuery, schema) => {
     throw new Error('Field cannot be empty');
   }
 
-  if (!_.get(schema, `attributes.${field}`)) {
+  if (!_.get(schema, `attributes.${field}` && field !== 'id')) {
     return {};
   }
 
@@ -336,7 +336,7 @@ const convertAndSanitizeFilters = (filters, schema) => {
 
   // Here, `key` can either be an operator or an attribute name
   for (const [key, value] of Object.entries(filters)) {
-    const attribute = get(key, schema.attributes);
+    const attribute = key === 'id' ? { type: 'integer' } : get(key, schema.attributes);
 
     // Handle attributes
     if (attribute) {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Alters `convertSortQueryParams`, `convertFiltersQueryParams` and `convertFieldsQueryParams` so that all attributes not present in the schema are automatically removed from the query.

### Why is it needed?

At the moment, trying to sort by, filter on or select a field that does not exist in the schema throws an Internal Server Error.

### How to test it?

Run queries that have a `fields`, `sort` or `filters` parameter that contain a field that does not exist on the schema and notice how the server automatically ignores those parameters.

This, of course, also applies to `fields`, `sort` or `filters` nested inside a `populate` object.

### Related issue(s)/PR(s)

Should fix #14060

