### PR TITLE
POC: Lazy load relations in the CM using a new useRelation() hook

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/SelectWrapper/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/SelectWrapper/index.js
@@ -7,24 +7,26 @@ import { useRelation } from '../../hooks/useRelation';
 
 function SelectWrapper() {
   const { addRelation, removeRelation, modifiedData } = useCMEditViewDataManager();
-  const { relations, searchResults, search, load } = useRelation({ relationsToShow: 2 });
+  const { relations, searchResults, search } = useRelation({ relationsToShow: 2 });
 
   const relationWillBeDeleted = relation =>
     !modifiedData?.something?.remove?.find(curr => curr.title === relation.title);
 
   return (
     <>
-      <button type="button" onClick={() => load(relations?.data?.length ?? 0, 2)}>
-        Load 2 more
-      </button>
+      {relations.hasNextPage ? (
+        <button type="button" onClick={() => relations.fetchNextPage()}>
+          Load 2 more
+        </button>
+      ) : 'No more pages'}
 
       <hr />
 
       {!relations.isLoading && (
         <ol>
-          {relations?.data?.filter(relationWillBeDeleted).map(relation => (
+          {relations?.data?.pages?.flat().reverse().filter(relationWillBeDeleted).map(relation => (
             <li key={`relation-${relation.title}`}>
-              Existing Relation: {relation.title}{' '}
+              Existing: {relation.title}{' '}
               <button
                 type="button"
                 onClick={() => removeRelation({ target: { name: 'something', value: relation } })}
@@ -36,7 +38,7 @@ function SelectWrapper() {
 
           {modifiedData?.something?.add?.filter(relationWillBeDeleted).map(relationToAdd => (
             <li key={`relation-add-${relationToAdd.title}`}>
-              Relation to add : {relationToAdd.title}{' '}
+              Add: {relationToAdd.title}{' '}
               <button
                 type="button"
                 onClick={() =>
@@ -59,7 +61,7 @@ function SelectWrapper() {
         <ol>
           {searchResults?.data?.map(search => (
             <li key={`search-result-${search.title}`}>
-              Search Result:{' '}
+              Search:{' '}
               <button
                 type="button"
                 onClick={() => addRelation({ target: { name: 'something', value: search } })}

--- a/packages/core/admin/admin/src/content-manager/components/SelectWrapper/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/SelectWrapper/index.js
@@ -7,7 +7,7 @@ import { useRelation } from '../../hooks/useRelation';
 
 function SelectWrapper({ name }) {
   const { addRelation, removeRelation, modifiedData } = useCMEditViewDataManager();
-  const { relations, searchResults, search } = useRelation({ relationsToShow: 2 });
+  const { relations, search, searchFor } = useRelation({ relationsToShow: 2, relationsToSearch: 2 });
 
   const relationWillBeDeleted = relation =>
     !modifiedData?.[name]?.remove?.find(curr => curr.title === relation.title);
@@ -53,13 +53,13 @@ function SelectWrapper({ name }) {
 
       <hr />
 
-      <input type="text" onKeyUp={event => search(event.target.value)} />
+      <input type="text" onKeyUp={event => searchFor(event.target.value)} />
 
       <hr />
 
-      {!searchResults.isLoading && (
+      {!search.isLoading && (
         <ol>
-          {searchResults?.data?.map(search => (
+          {search?.data?.pages?.flat().map(search => (
             <li key={`search-result-${search.title}`}>
               Search:{' '}
               <button
@@ -70,6 +70,10 @@ function SelectWrapper({ name }) {
               </button>
             </li>
           ))}
+
+          {search.hasNextPage && (
+            <button type="button" onClick={() => search.fetchNextPage()}>more results</button>
+          )}
         </ol>
       )}
     </>

--- a/packages/core/admin/admin/src/content-manager/components/SelectWrapper/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/SelectWrapper/index.js
@@ -1,355 +1,78 @@
-import React, { useCallback, useState, useEffect, useMemo, memo } from 'react';
-import PropTypes from 'prop-types';
-import { useIntl } from 'react-intl';
-import { useLocation } from 'react-router-dom';
-import { Stack } from '@strapi/design-system/Stack';
-import findIndex from 'lodash/findIndex';
-import get from 'lodash/get';
-import isArray from 'lodash/isArray';
-import isEmpty from 'lodash/isEmpty';
-import set from 'lodash/set';
-import {
-  NotAllowedInput,
-  useCMEditViewDataManager,
-  useQueryParams,
-  Link,
-} from '@strapi/helper-plugin';
-import { stringify } from 'qs';
-import axios from 'axios';
-import { axiosInstance } from '../../../core/utils';
-import { getTrad } from '../../utils';
-import Label from './Label';
-import SelectOne from '../SelectOne';
-import SelectMany from '../SelectMany';
-import Option from './Option';
+import React, { memo } from 'react';
+
+import { useCMEditViewDataManager } from '@strapi/helper-plugin';
+
 import { connect, select } from './utils';
+import { useRelation } from '../../hooks/useRelation';
 
-const initialPaginationState = {
-  contains: '',
-  limit: 20,
-  start: 0,
-};
+function SelectWrapper() {
+  const { addRelation, removeRelation, modifiedData } = useCMEditViewDataManager();
+  const { relations, searchResults, search, load } = useRelation({ relationsToShow: 2 });
 
-const buildParams = (query, paramsToKeep) => {
-  if (!paramsToKeep) {
-    return {};
-  }
-
-  return paramsToKeep.reduce((acc, current) => {
-    const value = get(query, current, null);
-
-    if (value) {
-      set(acc, current, value);
-    }
-
-    return acc;
-  }, {});
-};
-function SelectWrapper({
-  description,
-  editable,
-  labelAction,
-  intlLabel,
-  isCreatingEntry,
-  isFieldAllowed,
-  isFieldReadable,
-  mainField,
-  name,
-  relationType,
-  targetModel,
-  placeholder,
-  queryInfos,
-}) {
-  const { formatMessage } = useIntl();
-  const [{ query }] = useQueryParams();
-  // Disable the input in case of a polymorphic relation
-  const isMorph = useMemo(() => relationType.toLowerCase().includes('morph'), [relationType]);
-
-  const { addRelation, modifiedData, onChange, removeRelation } = useCMEditViewDataManager();
-  const { pathname } = useLocation();
-
-  const value = get(modifiedData, name, null);
-  const [state, setState] = useState(initialPaginationState);
-  const [options, setOptions] = useState([]);
-  const [isLoading, setIsLoading] = useState(false);
-  const [isOpen, setIsOpen] = useState(false);
-
-  const filteredOptions = useMemo(() => {
-    return options.filter(option => {
-      if (!isEmpty(value)) {
-        // SelectMany
-        if (Array.isArray(value)) {
-          return findIndex(value, o => o.id === option.value.id) === -1;
-        }
-
-        // SelectOne
-        return get(value, 'id', '') !== option.value.id;
-      }
-
-      return true;
-    });
-  }, [options, value]);
-
-  const {
-    endPoint,
-    containsKey,
-    defaultParams,
-    shouldDisplayRelationLink,
-    paramsToKeep,
-  } = queryInfos;
-
-  const isSingle = ['oneWay', 'oneToOne', 'manyToOne', 'oneToManyMorph', 'oneToOneMorph'].includes(
-    relationType
-  );
-
-  const idsToOmit = useMemo(() => {
-    if (!value) {
-      return [];
-    }
-
-    if (isSingle) {
-      return [value.id];
-    }
-
-    return value.map(val => val.id);
-  }, [isSingle, value]);
-
-  const getData = useCallback(
-    async source => {
-      // Currently polymorphic relations are not handled
-      if (isMorph) {
-        setIsLoading(false);
-
-        return;
-      }
-
-      if (!isFieldAllowed) {
-        setIsLoading(false);
-
-        return;
-      }
-
-      setIsLoading(true);
-
-      const params = { limit: state.limit, ...defaultParams, start: state.start };
-
-      if (state.contains) {
-        params[`filters[${containsKey}][$contains]`] = state.contains;
-      }
-
-      try {
-        const { data } = await axiosInstance.post(
-          endPoint,
-          { idsToOmit },
-          { params, cancelToken: source.token }
-        );
-
-        const formattedData = data.map(obj => {
-          return { value: obj, label: obj[mainField.name] };
-        });
-
-        setOptions(prevState =>
-          prevState.concat(formattedData).filter((obj, index) => {
-            const objIndex = prevState.findIndex(el => el.value.id === obj.value.id);
-
-            if (objIndex === -1) {
-              return true;
-            }
-
-            return prevState.findIndex(el => el.value.id === obj.value.id) === index;
-          })
-        );
-        setIsLoading(false);
-      } catch (err) {
-        // Silent
-        setIsLoading(false);
-      }
-    },
-    [
-      containsKey,
-      defaultParams,
-      endPoint,
-      idsToOmit,
-      isFieldAllowed,
-      isMorph,
-      mainField.name,
-      state.contains,
-      state.limit,
-      state.start,
-    ]
-  );
-
-  useEffect(() => {
-    const CancelToken = axios.CancelToken;
-    const source = CancelToken.source();
-
-    if (isOpen) {
-      getData(source);
-    }
-
-    return () => source.cancel('Operation canceled by the user.');
-  }, [getData, isOpen]);
-
-  const handleInputChange = (inputValue, { action }) => {
-    if (action === 'input-change') {
-      setState(prevState => {
-        if (prevState.contains === inputValue) {
-          return prevState;
-        }
-
-        return { ...prevState, contains: inputValue, start: 0 };
-      });
-    }
-
-    return inputValue;
-  };
-
-  const handleMenuScrollToBottom = () => {
-    setState(prevState => ({
-      ...prevState,
-      start: prevState.start + 20,
-    }));
-  };
-
-  const handleMenuClose = () => {
-    setState(initialPaginationState);
-    setIsOpen(false);
-  };
-
-  const handleChange = value => {
-    onChange({ target: { name, value: value ? value.value : value } });
-  };
-
-  const handleAddRelation = value => {
-    addRelation({ target: { name, value } });
-  };
-
-  const handleRemoveRelation = value => {
-    removeRelation({ target: { name, value } });
-  };
-
-  const handleMenuOpen = () => {
-    setIsOpen(true);
-  };
-
-  const to = `/content-manager/collectionType/${targetModel}/${value ? value.id : null}`;
-
-  const searchToPersist = stringify(buildParams(query, paramsToKeep), { encode: false });
-
-  let link = null;
-
-  if (isSingle && value && shouldDisplayRelationLink) {
-    link = (
-      <Link to={{ pathname: to, state: { from: pathname }, search: searchToPersist }}>
-        {formatMessage({ id: getTrad('containers.Edit.seeDetails'), defaultMessage: 'Details' })}
-      </Link>
-    );
-  }
-
-  const Component = isSingle ? SelectOne : SelectMany;
-  const associationsLength = isArray(value) ? value.length : 0;
-
-  const isDisabled = useMemo(() => {
-    if (isMorph) {
-      return true;
-    }
-
-    if (!isCreatingEntry) {
-      return (!isFieldAllowed && isFieldReadable) || !editable;
-    }
-
-    return !editable;
-  }, [isMorph, isCreatingEntry, editable, isFieldAllowed, isFieldReadable]);
-
-  if (!isFieldAllowed && isCreatingEntry) {
-    return <NotAllowedInput intlLabel={intlLabel} labelAction={labelAction} />;
-  }
-
-  if (!isCreatingEntry && !isFieldAllowed && !isFieldReadable) {
-    return <NotAllowedInput intlLabel={intlLabel} labelAction={labelAction} />;
-  }
+  const relationWillBeDeleted = relation =>
+    !modifiedData?.something?.remove?.find(curr => curr.title === relation.title);
 
   return (
-    <Stack spacing={1}>
-      <Label
-        intlLabel={intlLabel}
-        isSingle={isSingle}
-        labelAction={labelAction}
-        link={link}
-        name={name}
-        numberOfEntries={associationsLength}
-      />
-      <Component
-        addRelation={handleAddRelation}
-        components={{
-          Option,
-        }}
-        displayNavigationLink={shouldDisplayRelationLink}
-        id={name}
-        isDisabled={isDisabled}
-        isLoading={isLoading}
-        isClearable
-        mainField={mainField}
-        name={name}
-        options={filteredOptions}
-        onChange={handleChange}
-        onInputChange={handleInputChange}
-        onMenuClose={handleMenuClose}
-        onMenuOpen={handleMenuOpen}
-        onMenuScrollToBottom={handleMenuScrollToBottom}
-        onRemove={handleRemoveRelation}
-        placeholder={placeholder}
-        searchToPersist={searchToPersist}
-        targetModel={targetModel}
-        value={value}
-        description={description}
-      />
-    </Stack>
+    <>
+      <button type="button" onClick={() => load(relations?.data?.length ?? 0, 2)}>
+        Load 2 more
+      </button>
+
+      <hr />
+
+      {!relations.isLoading && (
+        <ol>
+          {relations?.data?.filter(relationWillBeDeleted).map(relation => (
+            <li key={`relation-${relation.title}`}>
+              Existing Relation: {relation.title}{' '}
+              <button
+                type="button"
+                onClick={() => removeRelation({ target: { name: 'something', value: relation } })}
+              >
+                Remove
+              </button>
+            </li>
+          ))}
+
+          {modifiedData?.something?.add?.filter(relationWillBeDeleted).map(relationToAdd => (
+            <li key={`relation-add-${relationToAdd.title}`}>
+              Relation to add : {relationToAdd.title}{' '}
+              <button
+                type="button"
+                onClick={() =>
+                  removeRelation({ target: { name: 'something', value: relationToAdd } })}
+              >
+                Remove
+              </button>
+            </li>
+          ))}
+        </ol>
+      )}
+
+      <hr />
+
+      <input type="text" onKeyUp={event => search(event.target.value)} />
+
+      <hr />
+
+      {!searchResults.isLoading && (
+        <ol>
+          {searchResults?.data?.map(search => (
+            <li key={`search-result-${search.title}`}>
+              Search Result:{' '}
+              <button
+                type="button"
+                onClick={() => addRelation({ target: { name: 'something', value: search } })}
+              >
+                {search.title}
+              </button>
+            </li>
+          ))}
+        </ol>
+      )}
+    </>
   );
 }
-
-SelectWrapper.defaultProps = {
-  editable: true,
-  description: '',
-  labelAction: null,
-  isFieldAllowed: true,
-  placeholder: null,
-};
-
-SelectWrapper.propTypes = {
-  editable: PropTypes.bool,
-  description: PropTypes.string,
-  intlLabel: PropTypes.shape({
-    id: PropTypes.string.isRequired,
-    defaultMessage: PropTypes.string.isRequired,
-    values: PropTypes.object,
-  }).isRequired,
-  labelAction: PropTypes.element,
-  isCreatingEntry: PropTypes.bool.isRequired,
-  isFieldAllowed: PropTypes.bool,
-  isFieldReadable: PropTypes.bool.isRequired,
-  mainField: PropTypes.shape({
-    name: PropTypes.string.isRequired,
-    schema: PropTypes.shape({
-      type: PropTypes.string.isRequired,
-    }).isRequired,
-  }).isRequired,
-  name: PropTypes.string.isRequired,
-  placeholder: PropTypes.shape({
-    id: PropTypes.string.isRequired,
-    defaultMessage: PropTypes.string.isRequired,
-    values: PropTypes.object,
-  }),
-  relationType: PropTypes.string.isRequired,
-  targetModel: PropTypes.string.isRequired,
-  queryInfos: PropTypes.shape({
-    containsKey: PropTypes.string.isRequired,
-    defaultParams: PropTypes.object,
-    endPoint: PropTypes.string.isRequired,
-    shouldDisplayRelationLink: PropTypes.bool.isRequired,
-    paramsToKeep: PropTypes.array,
-  }).isRequired,
-};
 
 const Memoized = memo(SelectWrapper);
 

--- a/packages/core/admin/admin/src/content-manager/components/SelectWrapper/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/SelectWrapper/index.js
@@ -7,7 +7,7 @@ import { useRelation } from '../../hooks/useRelation';
 
 function SelectWrapper({ name }) {
   const { addRelation, removeRelation, modifiedData } = useCMEditViewDataManager();
-  const { relations, search, searchFor } = useRelation({ relationsToShow: 2, relationsToSearch: 2 });
+  const { relations, search, searchFor } = useRelation({ name, relationsToShow: 2, relationsToSearch: 2 });
 
   const relationWillBeDeleted = relation =>
     !modifiedData?.[name]?.remove?.find(curr => curr.title === relation.title);

--- a/packages/core/admin/admin/src/content-manager/components/SelectWrapper/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/SelectWrapper/index.js
@@ -5,12 +5,12 @@ import { useCMEditViewDataManager } from '@strapi/helper-plugin';
 import { connect, select } from './utils';
 import { useRelation } from '../../hooks/useRelation';
 
-function SelectWrapper() {
+function SelectWrapper({ name }) {
   const { addRelation, removeRelation, modifiedData } = useCMEditViewDataManager();
   const { relations, searchResults, search } = useRelation({ relationsToShow: 2 });
 
   const relationWillBeDeleted = relation =>
-    !modifiedData?.something?.remove?.find(curr => curr.title === relation.title);
+    !modifiedData?.[name]?.remove?.find(curr => curr.title === relation.title);
 
   return (
     <>
@@ -29,7 +29,7 @@ function SelectWrapper() {
               Existing: {relation.title}{' '}
               <button
                 type="button"
-                onClick={() => removeRelation({ target: { name: 'something', value: relation } })}
+                onClick={() => removeRelation({ target: { name, value: relation } })}
               >
                 Remove
               </button>
@@ -42,7 +42,7 @@ function SelectWrapper() {
               <button
                 type="button"
                 onClick={() =>
-                  removeRelation({ target: { name: 'something', value: relationToAdd } })}
+                  removeRelation({ target: { name, value: relationToAdd } })}
               >
                 Remove
               </button>

--- a/packages/core/admin/admin/src/content-manager/hooks/useRelation/index.js
+++ b/packages/core/admin/admin/src/content-manager/hooks/useRelation/index.js
@@ -1,0 +1,1 @@
+export { useRelation } from './useRelation';

--- a/packages/core/admin/admin/src/content-manager/hooks/useRelation/useRelation.js
+++ b/packages/core/admin/admin/src/content-manager/hooks/useRelation/useRelation.js
@@ -1,0 +1,87 @@
+import { useState } from 'react';
+import { useQuery } from 'react-query';
+
+const FIXTURE_RELATIONS = [
+  {
+    title: '1',
+  },
+
+  {
+    title: '2',
+  },
+
+  {
+    title: '3',
+  },
+
+  {
+    title: '4',
+  },
+
+  {
+    title: '5',
+  },
+
+  {
+    title: '6',
+  },
+
+  {
+    title: '7',
+  },
+
+  {
+    title: '8',
+  },
+
+  {
+    title: '9',
+  },
+];
+
+const FIXTURE_SEARCH = [
+  {
+    title: 'Julie',
+  },
+
+  {
+    title: 'Pierre',
+  },
+
+  {
+    title: 'Gustav',
+  },
+
+  {
+    title: 'Marc',
+  },
+];
+
+export const useRelation = ({ relationsToShow = 10 }) => {
+  const [searchTerm, setSearchTerm] = useState(null);
+  const [relationsRange, setRelationsLoadRange] = useState([0, relationsToShow]);
+
+  const fetchRelations = () => {
+    return Promise.resolve(FIXTURE_RELATIONS.slice(-1 * relationsRange[1]));
+  };
+
+  const fetchSearch = () => {
+    return Promise.resolve(FIXTURE_SEARCH.filter(curr => curr.title.includes(searchTerm)));
+  };
+
+  const relationsRes = useQuery(['relations', ...relationsRange], fetchRelations);
+
+  const searchRes = useQuery(['relation', 'search', searchTerm], fetchSearch, {
+    enabled: !!searchTerm,
+  });
+
+  const search = term => {
+    setSearchTerm(term);
+  };
+
+  const load = (startIndex, count) => {
+    setRelationsLoadRange([startIndex, startIndex + count]);
+  };
+
+  return { relations: relationsRes, searchResults: searchRes, search, load };
+};

--- a/packages/core/admin/admin/src/content-manager/hooks/useRelation/useRelation.js
+++ b/packages/core/admin/admin/src/content-manager/hooks/useRelation/useRelation.js
@@ -69,7 +69,7 @@ const FIXTURE_SEARCH = [
   }
 ];
 
-export const useRelation = ({ relationsToShow = 10, relationsToSearch = 10 }) => {
+export const useRelation = ({ name, relationsToShow = 10, relationsToSearch = 10 }) => {
   const [searchTerm, setSearchTerm] = useState(null);
 
   const fetchRelations = ({ pageParam = 1 }) => {
@@ -84,7 +84,7 @@ export const useRelation = ({ relationsToShow = 10, relationsToSearch = 10 }) =>
     return Promise.resolve(results.slice(startIndex, startIndex + relationsToSearch));
   };
 
-  const relationsRes = useInfiniteQuery(['relations'], fetchRelations, {
+  const relationsRes = useInfiniteQuery(['relation', name], fetchRelations, {
     getNextPageParam: (lastPage, pages) => {
       if (lastPage.length < relationsToShow) {
         return undefined;
@@ -94,7 +94,7 @@ export const useRelation = ({ relationsToShow = 10, relationsToSearch = 10 }) =>
     },
   });
 
-  const searchRes = useInfiniteQuery(['relations', 'search'], fetchSearch, {
+  const searchRes = useInfiniteQuery(['relation', name, 'search'], fetchSearch, {
     enabled: !!searchTerm,
     getNextPageParam: (lastPage, pages) => {
       if (lastPage.length < relationsToSearch) {

--- a/packages/core/admin/admin/src/content-manager/hooks/useRelation/useRelation.js
+++ b/packages/core/admin/admin/src/content-manager/hooks/useRelation/useRelation.js
@@ -94,7 +94,7 @@ export const useRelation = ({ name, relationsToShow = 10, relationsToSearch = 10
     },
   });
 
-  const searchRes = useInfiniteQuery(['relation', name, 'search'], fetchSearch, {
+  const searchRes = useInfiniteQuery(['relation', name, 'search', searchTerm], fetchSearch, {
     enabled: !!searchTerm,
     getNextPageParam: (lastPage, pages) => {
       if (lastPage.length < relationsToSearch) {


### PR DESCRIPTION
### What does it do?

This is a POC to discuss a first draft of lazy loading relations in the content-manager. Nothing is fetched from the content API yet and dummy data is used, but it should be easy to swap out.

The goal for me would be in this case to come with something that can easily be re-used and is easy to test. The main idea of this implementation is, to keep all relation state local to the component, until relations are marked to `add` or `remove`. This way the CM would never know about the state each relation component holds, which makes re-rendering less of an issue (I think).

Another approach would be, to store the loaded relations in the global CM store, but except from collaborative editing (at some point far in the future) I don't see the benefit of doing that.

#### Feedback welcome

- ~should the local state of `relations` be internal to the `useRelation()`hook?  that would simplify the signature of the `load` call from `load(startIndex, count)` to `load(count)`~
- can you think of a good way to couple `addRelation`, `removeRelation` and what the hook does? Maybe new dispatchers such as `loadRelations`, `searchRelations`? I think it doesn't make sense to perform `searchRelations` as part of the global dispatchers, but loading could certainly live there.
- does the state of a relation need to exposed to `useCMEditViewDataManager` so that plugins can access it? Would that be an argument to put it into the global state?

### Why is it needed?

I want to get some input on how feasible this approach is to others.
