### PR TITLE
CM: Pass queryInfos to Inputs, to have it available for relations

### DIFF
--- a/packages/core/admin/admin/src/content-manager/pages/EditView/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/EditView/index.js
@@ -170,7 +170,14 @@ const EditView = ({
                                 return (
                                   <Grid gap={4} key={gridIndex}>
                                     {grid.map(
-                                      ({ fieldSchema, labelAction, metadatas, name, size }) => {
+                                      ({
+                                        fieldSchema,
+                                        labelAction,
+                                        metadatas,
+                                        name,
+                                        size,
+                                        queryInfos,
+                                      }) => {
                                         const isComponent = fieldSchema.type === 'component';
 
                                         if (isComponent) {
@@ -208,6 +215,7 @@ const EditView = ({
                                               keys={name}
                                               labelAction={labelAction}
                                               metadatas={metadatas}
+                                              queryInfos={queryInfos}
                                             />
                                           </GridItem>
                                         );


### PR DESCRIPTION
### What does it do?

With the `editRelations` cleanup done in https://github.com/strapi/strapi/pull/14013 and https://github.com/strapi/strapi/pull/13982 `queryInfos` were no longer passed to relational fields in the `EditView`. This information is needed to properly fetch data from the internal content API.

### Why is it needed?

Relation fields need `queryInfos` to perform requests.
