### PR TITLE
CM: Implement useRelation hook to fetch relation data asynchronous

### DIFF
--- a/packages/core/admin/admin/src/content-manager/hooks/useRelation/index.js
+++ b/packages/core/admin/admin/src/content-manager/hooks/useRelation/index.js
@@ -1,0 +1,1 @@
+export { useRelation } from './useRelation';

--- a/packages/core/admin/admin/src/content-manager/hooks/useRelation/tests/useRelation.test.js
+++ b/packages/core/admin/admin/src/content-manager/hooks/useRelation/tests/useRelation.test.js
@@ -55,7 +55,19 @@ describe('useRelation', () => {
     expect(result.current.relations.isSuccess).toBe(true);
     expect(axiosInstance.get).toBeCalledTimes(1);
     expect(axiosInstance.get).toBeCalledWith('/', {
+      limit: 10,
       page: 1,
+    });
+  });
+
+  test('fetch relations with different limit', async () => {
+    const { waitForNextUpdate } = await setup(undefined, { relationsToShow: 5 });
+
+    await waitForNextUpdate();
+
+    expect(axiosInstance.get).toBeCalledWith(expect.any(String), {
+      limit: 5,
+      page: expect.any(Number),
     });
   });
 
@@ -73,6 +85,7 @@ describe('useRelation', () => {
     expect(result.current.relations.isSuccess).toBe(true);
     expect(axiosInstance.get).toBeCalledTimes(1);
     expect(axiosInstance.get).toBeCalledWith('/', {
+      limit: 10,
       page: 1,
     });
   });
@@ -93,8 +106,14 @@ describe('useRelation', () => {
     await waitForNextUpdate();
 
     expect(axiosInstance.get).toBeCalledTimes(2);
-    expect(axiosInstance.get).toHaveBeenNthCalledWith(1, '/', { page: 1 });
-    expect(axiosInstance.get).toHaveBeenNthCalledWith(2, '/', { page: 2 });
+    expect(axiosInstance.get).toHaveBeenNthCalledWith(1, '/', {
+      limit: expect.any(Number),
+      page: 1,
+    });
+    expect(axiosInstance.get).toHaveBeenNthCalledWith(2, '/', {
+      limit: expect.any(Number),
+      page: 2,
+    });
   });
 
   test('does not fetch relations next page, if a full page was not returned', async () => {
@@ -138,7 +157,25 @@ describe('useRelation', () => {
     await waitForNextUpdate();
 
     expect(spy).toBeCalledTimes(1);
-    expect(spy).toBeCalledWith('/', { page: 1 });
+    expect(spy).toBeCalledWith('/', { limit: 10, page: 1 });
+  });
+
+  test('does fetch search results with a different limit', async () => {
+    const { result, waitForNextUpdate } = await setup(undefined, { searchResultsToShow: 5 });
+
+    await waitForNextUpdate();
+
+    const spy = jest.fn().mockResolvedValue({ data: [] });
+    axiosInstance.get = spy;
+
+    act(() => {
+      result.current.searchFor('something');
+    });
+
+    await waitForNextUpdate();
+
+    expect(spy).toBeCalledTimes(1);
+    expect(spy).toBeCalledWith(expect.any(String), { limit: 5, page: expect.any(Number) });
   });
 
   test('does not fetch search results once a term was provided, but no endpoint was set', async () => {
@@ -177,8 +214,8 @@ describe('useRelation', () => {
     await waitForNextUpdate();
 
     expect(spy).toBeCalledTimes(2);
-    expect(spy).toHaveBeenNthCalledWith(1, '/', { page: 1 });
-    expect(spy).toHaveBeenNthCalledWith(2, '/', { page: 2 });
+    expect(spy).toHaveBeenNthCalledWith(1, '/', { limit: expect.any(Number), page: 1 });
+    expect(spy).toHaveBeenNthCalledWith(2, '/', { limit: expect.any(Number), page: 2 });
   });
 
   test('doesn not fetch search next page, if a full page was not returned', async () => {

--- a/packages/core/admin/admin/src/content-manager/hooks/useRelation/tests/useRelation.test.js
+++ b/packages/core/admin/admin/src/content-manager/hooks/useRelation/tests/useRelation.test.js
@@ -106,11 +106,11 @@ describe('useRelation', () => {
     await waitForNextUpdate();
 
     expect(axiosInstance.get).toBeCalledTimes(2);
-    expect(axiosInstance.get).toHaveBeenNthCalledWith(1, '/', {
+    expect(axiosInstance.get).toHaveBeenNthCalledWith(1, expect.any(String), {
       limit: expect.any(Number),
       page: 1,
     });
-    expect(axiosInstance.get).toHaveBeenNthCalledWith(2, '/', {
+    expect(axiosInstance.get).toHaveBeenNthCalledWith(2, expect.any(String), {
       limit: expect.any(Number),
       page: 2,
     });
@@ -214,8 +214,14 @@ describe('useRelation', () => {
     await waitForNextUpdate();
 
     expect(spy).toBeCalledTimes(2);
-    expect(spy).toHaveBeenNthCalledWith(1, '/', { limit: expect.any(Number), page: 1 });
-    expect(spy).toHaveBeenNthCalledWith(2, '/', { limit: expect.any(Number), page: 2 });
+    expect(spy).toHaveBeenNthCalledWith(1, expect.any(String), {
+      limit: expect.any(Number),
+      page: 1,
+    });
+    expect(spy).toHaveBeenNthCalledWith(2, expect.any(String), {
+      limit: expect.any(Number),
+      page: 2,
+    });
   });
 
   test('doesn not fetch search next page, if a full page was not returned', async () => {

--- a/packages/core/admin/admin/src/content-manager/hooks/useRelation/tests/useRelation.test.js
+++ b/packages/core/admin/admin/src/content-manager/hooks/useRelation/tests/useRelation.test.js
@@ -1,0 +1,158 @@
+import React from 'react';
+import { QueryClientProvider, QueryClient } from 'react-query';
+import { renderHook, act } from '@testing-library/react-hooks';
+
+import { axiosInstance } from '../../../../core/utils';
+import { useRelation } from '../useRelation';
+
+jest.mock('../../../../core/utils', () => ({
+  ...jest.requireActual('../../../../core/utils'),
+  axiosInstance: {
+    get: jest.fn().mockResolvedValue({ data: [] }),
+  },
+}));
+
+const client = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+    },
+  },
+});
+
+// eslint-disable-next-line react/prop-types
+const ComponentFixture = ({ children }) => (
+  <QueryClientProvider client={client}>{children}</QueryClientProvider>
+);
+
+function setup(...args) {
+  return new Promise((resolve) => {
+    act(() => {
+      resolve(renderHook(() => useRelation(...args), { wrapper: ComponentFixture }));
+    });
+  });
+}
+
+describe('useRelation', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('fetch relations', async () => {
+    const { result, waitForNextUpdate } = await setup({ name: 'test' });
+
+    await waitForNextUpdate();
+
+    expect(result.current.relations.isSuccess).toBe(true);
+    expect(axiosInstance.get).toBeCalledTimes(1);
+    expect(axiosInstance.get).toBeCalledWith('?page=1');
+  });
+
+  test('fetch relations next page, if a full page was returned', async () => {
+    axiosInstance.get = jest.fn().mockResolvedValue({
+      data: [1, 2],
+    });
+
+    const { result, waitForNextUpdate } = await setup({ name: 'test', relationsToShow: 1 });
+
+    await waitForNextUpdate();
+
+    act(() => {
+      result.current.relations.fetchNextPage();
+    });
+
+    await waitForNextUpdate();
+
+    expect(axiosInstance.get).toBeCalledTimes(2);
+    expect(axiosInstance.get).toHaveBeenNthCalledWith(1, '?page=1');
+    expect(axiosInstance.get).toHaveBeenNthCalledWith(2, '?page=2');
+  });
+
+  test('does not fetch relations next page, if a full page was not returned', async () => {
+    axiosInstance.get = jest.fn().mockResolvedValue({
+      data: [1, 2],
+    });
+
+    const { result, waitForNextUpdate } = await setup({ name: 'test', relationsToShow: 3 });
+
+    await waitForNextUpdate();
+
+    act(() => {
+      result.current.relations.fetchNextPage();
+    });
+
+    await waitForNextUpdate();
+
+    expect(axiosInstance.get).toBeCalledTimes(1);
+  });
+
+  test('does not fetch search by default', async () => {
+    const { result, waitForNextUpdate } = await setup({ name: 'test' });
+
+    await waitForNextUpdate();
+
+    expect(result.current.search.isLoading).toBe(false);
+  });
+
+  test('does fetch search results once a term was provided', async () => {
+    const { result, waitForNextUpdate } = await setup({ name: 'test' });
+
+    await waitForNextUpdate();
+
+    const spy = jest.fn().mockResolvedValue({ data: [] });
+    axiosInstance.get = spy;
+
+    act(() => {
+      result.current.searchFor('something');
+    });
+
+    await waitForNextUpdate();
+
+    expect(spy).toBeCalledTimes(1);
+    expect(spy).toBeCalledWith('?page=1');
+  });
+
+  test('fetch search next page, if a full page was returned', async () => {
+    const { result, waitForNextUpdate } = await setup({ name: 'test', searchResultsToShow: 1 });
+
+    const spy = jest.fn().mockResolvedValue({ data: [1, 2] });
+    axiosInstance.get = spy;
+
+    act(() => {
+      result.current.searchFor('something');
+    });
+
+    await waitForNextUpdate();
+
+    act(() => {
+      result.current.search.fetchNextPage();
+    });
+
+    await waitForNextUpdate();
+
+    expect(spy).toBeCalledTimes(2);
+    expect(spy).toHaveBeenNthCalledWith(1, '?page=1');
+    expect(spy).toHaveBeenNthCalledWith(2, '?page=2');
+  });
+
+  test('doesn not fetch search next page, if a full page was not returned', async () => {
+    const { result, waitForNextUpdate } = await setup({ name: 'test', searchResultsToShow: 3 });
+
+    const spy = jest.fn().mockResolvedValue({ data: [1, 2] });
+    axiosInstance.get = spy;
+
+    act(() => {
+      result.current.searchFor('something');
+    });
+
+    await waitForNextUpdate();
+
+    act(() => {
+      result.current.search.fetchNextPage();
+    });
+
+    await waitForNextUpdate();
+
+    expect(spy).toBeCalledTimes(1);
+  });
+});

--- a/packages/core/admin/admin/src/content-manager/hooks/useRelation/tests/useRelation.test.js
+++ b/packages/core/admin/admin/src/content-manager/hooks/useRelation/tests/useRelation.test.js
@@ -54,7 +54,9 @@ describe('useRelation', () => {
 
     expect(result.current.relations.isSuccess).toBe(true);
     expect(axiosInstance.get).toBeCalledTimes(1);
-    expect(axiosInstance.get).toBeCalledWith('?page=1');
+    expect(axiosInstance.get).toBeCalledWith('/', {
+      page: 1,
+    });
   });
 
   test('doesn not fetch relations if a relation endpoint was not passed', async () => {
@@ -70,7 +72,9 @@ describe('useRelation', () => {
 
     expect(result.current.relations.isSuccess).toBe(true);
     expect(axiosInstance.get).toBeCalledTimes(1);
-    expect(axiosInstance.get).toBeCalledWith('?page=1');
+    expect(axiosInstance.get).toBeCalledWith('/', {
+      page: 1,
+    });
   });
 
   test('fetch relations next page, if a full page was returned', async () => {
@@ -89,8 +93,8 @@ describe('useRelation', () => {
     await waitForNextUpdate();
 
     expect(axiosInstance.get).toBeCalledTimes(2);
-    expect(axiosInstance.get).toHaveBeenNthCalledWith(1, '?page=1');
-    expect(axiosInstance.get).toHaveBeenNthCalledWith(2, '?page=2');
+    expect(axiosInstance.get).toHaveBeenNthCalledWith(1, '/', { page: 1 });
+    expect(axiosInstance.get).toHaveBeenNthCalledWith(2, '/', { page: 2 });
   });
 
   test('does not fetch relations next page, if a full page was not returned', async () => {
@@ -134,7 +138,7 @@ describe('useRelation', () => {
     await waitForNextUpdate();
 
     expect(spy).toBeCalledTimes(1);
-    expect(spy).toBeCalledWith('?page=1');
+    expect(spy).toBeCalledWith('/', { page: 1 });
   });
 
   test('does not fetch search results once a term was provided, but no endpoint was set', async () => {
@@ -173,8 +177,8 @@ describe('useRelation', () => {
     await waitForNextUpdate();
 
     expect(spy).toBeCalledTimes(2);
-    expect(spy).toHaveBeenNthCalledWith(1, '?page=1');
-    expect(spy).toHaveBeenNthCalledWith(2, '?page=2');
+    expect(spy).toHaveBeenNthCalledWith(1, '/', { page: 1 });
+    expect(spy).toHaveBeenNthCalledWith(2, '/', { page: 2 });
   });
 
   test('doesn not fetch search next page, if a full page was not returned', async () => {

--- a/packages/core/admin/admin/src/content-manager/hooks/useRelation/useRelation.js
+++ b/packages/core/admin/admin/src/content-manager/hooks/useRelation/useRelation.js
@@ -11,6 +11,7 @@ export const useRelation = (
 
   const fetchRelations = async ({ pageParam = 1 }) => {
     const { data } = await axiosInstance.get(endpoints?.relation, {
+      limit: relationsToShow,
       page: pageParam,
     });
 
@@ -19,6 +20,7 @@ export const useRelation = (
 
   const fetchSearch = async ({ pageParam = 1 }) => {
     const { data } = await axiosInstance.get(endpoints?.search, {
+      limit: searchResultsToShow,
       page: pageParam,
     });
 

--- a/packages/core/admin/admin/src/content-manager/hooks/useRelation/useRelation.js
+++ b/packages/core/admin/admin/src/content-manager/hooks/useRelation/useRelation.js
@@ -3,7 +3,10 @@ import { useInfiniteQuery } from 'react-query';
 
 import { axiosInstance } from '../../../core/utils';
 
-export const useRelation = ({ name, relationsToShow = 10, searchResultsToShow = 10 }) => {
+export const useRelation = (
+  name,
+  { endpoints, relationsToShow = 10, searchResultsToShow = 10 }
+) => {
   const [searchTerm, setSearchTerm] = useState(null);
 
   const fetchRelations = async ({ pageParam = 1 }) => {
@@ -21,6 +24,7 @@ export const useRelation = ({ name, relationsToShow = 10, searchResultsToShow = 
   };
 
   const relationsRes = useInfiniteQuery(['relation', name], fetchRelations, {
+    enabled: !!endpoints?.relation,
     getNextPageParam(lastPage, pages) {
       if (lastPage.length < relationsToShow) {
         return undefined;
@@ -32,7 +36,7 @@ export const useRelation = ({ name, relationsToShow = 10, searchResultsToShow = 
   });
 
   const searchRes = useInfiniteQuery(['relation', name, 'search', searchTerm], fetchSearch, {
-    enabled: !!searchTerm,
+    enabled: !!endpoints?.search && !!searchTerm,
     getNextPageParam(lastPage, pages) {
       if (lastPage.length < searchResultsToShow) {
         return undefined;

--- a/packages/core/admin/admin/src/content-manager/hooks/useRelation/useRelation.js
+++ b/packages/core/admin/admin/src/content-manager/hooks/useRelation/useRelation.js
@@ -1,0 +1,52 @@
+import { useState } from 'react';
+import { useInfiniteQuery } from 'react-query';
+
+import { axiosInstance } from '../../../core/utils';
+
+export const useRelation = ({ name, relationsToShow = 10, searchResultsToShow = 10 }) => {
+  const [searchTerm, setSearchTerm] = useState(null);
+
+  const fetchRelations = async ({ pageParam = 1 }) => {
+    // TODO: use relations endpoint
+    const { data } = await axiosInstance.get(`?page=${pageParam}`);
+
+    return data;
+  };
+
+  const fetchSearch = async ({ pageParam = 1 }) => {
+    // TODO: use search endpoint
+    const { data } = await axiosInstance.get(`?page=${pageParam}`);
+
+    return data;
+  };
+
+  const relationsRes = useInfiniteQuery(['relation', name], fetchRelations, {
+    getNextPageParam(lastPage, pages) {
+      if (lastPage.length < relationsToShow) {
+        return undefined;
+      }
+
+      // eslint-disable-next-line consistent-return
+      return (pages?.length || 0) + 1;
+    },
+  });
+
+  const searchRes = useInfiniteQuery(['relation', name, 'search', searchTerm], fetchSearch, {
+    enabled: !!searchTerm,
+    getNextPageParam(lastPage, pages) {
+      if (lastPage.length < searchResultsToShow) {
+        return undefined;
+      }
+
+      // eslint-disable-next-line consistent-return
+      return (pages?.length || 0) + 1;
+    },
+  });
+
+  const searchFor = (term) => {
+    searchRes.remove();
+    setSearchTerm(term);
+  };
+
+  return { relations: relationsRes, search: searchRes, searchFor };
+};

--- a/packages/core/admin/admin/src/content-manager/hooks/useRelation/useRelation.js
+++ b/packages/core/admin/admin/src/content-manager/hooks/useRelation/useRelation.js
@@ -10,15 +10,17 @@ export const useRelation = (
   const [searchTerm, setSearchTerm] = useState(null);
 
   const fetchRelations = async ({ pageParam = 1 }) => {
-    // TODO: use relations endpoint
-    const { data } = await axiosInstance.get(`?page=${pageParam}`);
+    const { data } = await axiosInstance.get(endpoints?.relation, {
+      page: pageParam,
+    });
 
     return data;
   };
 
   const fetchSearch = async ({ pageParam = 1 }) => {
-    // TODO: use search endpoint
-    const { data } = await axiosInstance.get(`?page=${pageParam}`);
+    const { data } = await axiosInstance.get(endpoints?.search, {
+      page: pageParam,
+    });
 
     return data;
   };


### PR DESCRIPTION
### What does it do?

This PR implements a new `useRelation()` hook, which can be used to fetch and search relations for a given field. It leverages [`useInfiniteQuery()`](https://tanstack.com/query/v4/docs/guides/infinite-queries), to avoid re-renders because of internal state changes.

### Why is it needed?

To create an utility which allowes us to fetch remote relations. By isolating it, we make it testable and re-usable, in case the community needs access to it one day.

### How to test it?

Rely on the automated tests.

### Related issue(s)/PR(s)

This builds the data-fetching foundation for https://github.com/strapi/strapi/pull/14092 and on top of a previous POC https://github.com/strapi/strapi/pull/14082
