### PR TITLE
Add config/database.ts to package gitignore

### DIFF
--- a/packages/cli/create-strapi-starter/resources/gitignore
+++ b/packages/cli/create-strapi-starter/resources/gitignore
@@ -112,3 +112,4 @@ exports
 *.cache
 build
 .strapi-updater.json
+config/database.ts


### PR DESCRIPTION
It is unacceptable to check-in credentials to git.  I propose adding config/database.ts to gitignore.
The alternative would be to reference the credentials to .env, but that would require more change to the strapi codebase.