### PR TITLE
Setup timeout for logo update page due to slow image fetching

### DIFF
--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/ApplicationInfosPage/components/LogoInput/tests/index.test.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/ApplicationInfosPage/components/LogoInput/tests/index.test.js
@@ -1,8 +1,10 @@
 import React from 'react';
 import { IntlProvider } from 'react-intl';
-import { render as renderTL, fireEvent, screen, waitFor } from '@testing-library/react';
+import { render as renderTL, fireEvent, screen, waitFor, configure } from '@testing-library/react';
 import { ThemeProvider, lightTheme } from '@strapi/design-system';
 import LogoInput from '../index';
+
+configure({ asyncUtilTimeout: 8000 });
 
 const getFakeSize = jest.fn(() => ({
   width: 500,
@@ -28,7 +30,7 @@ const render = (props) =>
         <LogoInput
           {...props}
           defaultLogo="/admin/defaultLogo.png"
-          onChangeLogo={() => jest.fn()}
+          onChangeLogo={jest.fn()}
           onResetMenuLogo={jest.fn()}
         />
       </IntlProvider>
@@ -172,7 +174,7 @@ describe('ApplicationsInfosPage || LogoInput', () => {
 
     it('should show error message when uploading wrong file format', async () => {
       render();
-      const changeLogoButton = document.querySelector('button');
+      const changeLogoButton = screen.getByRole('button');
       fireEvent.click(changeLogoButton);
       fireEvent.click(screen.getByText('From url'));
 
@@ -247,8 +249,11 @@ describe('ApplicationsInfosPage || LogoInput', () => {
 
     it('should accept upload and lead user to next modal', async () => {
       render();
+
       const changeLogoButton = document.querySelector('button');
+
       fireEvent.click(changeLogoButton);
+
       fireEvent.click(screen.getByText('From url'));
 
       const textInput = document.querySelector('input[name="logo-url"]');


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Adds a timeout for logo update tests that failed because of waitFor timeouts due to axios.get being called.

A future approach would be to mock axios for those tests instead.

### How to test it?

`yarn test:front`

### Related issue(s)/PR(s)
/
