### PR TITLE
Chore: Ignore process.exit eslint warnings

### DIFF
--- a/.eslintrc.back.js
+++ b/.eslintrc.back.js
@@ -28,7 +28,7 @@ module.exports = {
     'no-use-before-define': 'warn',
     'no-param-reassign': 'warn',
     'no-continue': 'warn',
-    'no-process-exit': 'warn',
+    'no-process-exit': 'off',
     'no-plusplus': 'warn',
     'no-loop-func': 'warn',
     'guard-for-in': 'warn',


### PR DESCRIPTION
### What does it do?

Every PR has now a list of attached eslint warnings, which clutters them quite a bit. This PR adds eslint-ignore comments to each call to reduce that cluttering.

<img width="1154" alt="Screenshot 2022-08-17 at 15 42 57" src="https://user-images.githubusercontent.com/2244375/185149678-0b0108c5-dc74-41b2-8fda-1708ac51f2d7.png">

An alternative would be to disable the warnings globally, but I think it is a good idea to leave it on.

### Why is it needed?

Less warnings. They were introduced by https://github.com/strapi/strapi/pull/14017

