### PR TITLE
Use custom field labels in ListSettingsView component

### DIFF
--- a/packages/core/admin/admin/src/content-manager/pages/ListSettingsView/components/DraggableCard.js
+++ b/packages/core/admin/admin/src/content-manager/pages/ListSettingsView/components/DraggableCard.js
@@ -201,7 +201,7 @@ const DraggableCard = ({
                   id: getTrad('components.DraggableCard.move.field'),
                   defaultMessage: 'Move {item}',
                 },
-                { item: name }
+                { item: labelField }
               )}
               onClick={(e) => e.stopPropagation()}
               ref={refs.dragRef}
@@ -223,7 +223,7 @@ const DraggableCard = ({
                   id: getTrad('components.DraggableCard.edit.field'),
                   defaultMessage: 'Edit {item}',
                 },
-                { item: name }
+                { item: labelField }
               )}
               type="button"
             >
@@ -237,7 +237,7 @@ const DraggableCard = ({
                   id: getTrad('components.DraggableCard.delete.field'),
                   defaultMessage: 'Delete {item}',
                 },
-                { item: name }
+                { item: labelField }
               )}
               type="button"
             >

--- a/packages/core/admin/admin/src/content-manager/pages/ListSettingsView/components/Settings.js
+++ b/packages/core/admin/admin/src/content-manager/pages/ListSettingsView/components/Settings.js
@@ -16,7 +16,7 @@ const FlexGap = styled(Flex)`
 
 const Settings = ({ modifiedData, onChange, sortOptions }) => {
   const { formatMessage } = useIntl();
-  const { settings } = modifiedData;
+  const { settings, metadatas } = modifiedData;
 
   return (
     <>
@@ -122,7 +122,7 @@ const Settings = ({ modifiedData, onChange, sortOptions }) => {
           >
             {sortOptions.map((sortBy) => (
               <Option key={sortBy} value={sortBy}>
-                {sortBy}
+                {metadatas[sortBy].list.label || sortBy}
               </Option>
             ))}
           </Select>

--- a/packages/core/admin/admin/src/content-manager/pages/ListSettingsView/components/SortDisplayedFields.js
+++ b/packages/core/admin/admin/src/content-manager/pages/ListSettingsView/components/SortDisplayedFields.js
@@ -104,7 +104,7 @@ const SortDisplayedFields = ({
           >
             {listRemainingFields.map((field) => (
               <MenuItem key={field} onClick={() => handleAddField(field)}>
-                {field}
+                {metadatas[field].list.label || field}
               </MenuItem>
             ))}
           </SimpleMenu>

--- a/packages/core/admin/admin/src/content-manager/pages/ListSettingsView/tests/__snapshots__/index.test.js.snap
+++ b/packages/core/admin/admin/src/content-manager/pages/ListSettingsView/tests/__snapshots__/index.test.js.snap
@@ -1448,7 +1448,7 @@ exports[`ADMIN | CM | LV | Configure the view renders and matches the snapshot 1
                                   class="c56"
                                   id="select-2-content"
                                 >
-                                  id
+                                  hey
                                 </span>
                               </div>
                             </div>
@@ -1605,7 +1605,7 @@ exports[`ADMIN | CM | LV | Configure the view renders and matches the snapshot 1
                           spacing="3"
                         >
                           <span
-                            aria-label="Move id"
+                            aria-label="Move hey"
                             class="c75 c76 c77"
                             draggable="true"
                             type="button"
@@ -1657,7 +1657,7 @@ exports[`ADMIN | CM | LV | Configure the view renders and matches the snapshot 1
                           class="c79 c66"
                         >
                           <button
-                            aria-label="Edit id"
+                            aria-label="Edit hey"
                             class="c76"
                             type="button"
                           >
@@ -1677,7 +1677,7 @@ exports[`ADMIN | CM | LV | Configure the view renders and matches the snapshot 1
                             </svg>
                           </button>
                           <button
-                            aria-label="Delete id"
+                            aria-label="Delete hey"
                             class="c76"
                             data-testid="delete-id"
                             type="button"

--- a/packages/core/admin/admin/src/content-manager/pages/ListSettingsView/tests/__snapshots__/index.test.js.snap
+++ b/packages/core/admin/admin/src/content-manager/pages/ListSettingsView/tests/__snapshots__/index.test.js.snap
@@ -1448,7 +1448,7 @@ exports[`ADMIN | CM | LV | Configure the view renders and matches the snapshot 1
                                   class="c56"
                                   id="select-2-content"
                                 >
-                                  hey
+                                  id
                                 </span>
                               </div>
                             </div>
@@ -1605,7 +1605,7 @@ exports[`ADMIN | CM | LV | Configure the view renders and matches the snapshot 1
                           spacing="3"
                         >
                           <span
-                            aria-label="Move hey"
+                            aria-label="Move id"
                             class="c75 c76 c77"
                             draggable="true"
                             type="button"
@@ -1650,14 +1650,14 @@ exports[`ADMIN | CM | LV | Configure the view renders and matches the snapshot 1
                           <span
                             class="c24 c78"
                           >
-                            hey
+                            id
                           </span>
                         </div>
                         <div
                           class="c79 c66"
                         >
                           <button
-                            aria-label="Edit hey"
+                            aria-label="Edit id"
                             class="c76"
                             type="button"
                           >
@@ -1677,7 +1677,7 @@ exports[`ADMIN | CM | LV | Configure the view renders and matches the snapshot 1
                             </svg>
                           </button>
                           <button
-                            aria-label="Delete hey"
+                            aria-label="Delete id"
                             class="c76"
                             data-testid="delete-id"
                             type="button"
@@ -3517,7 +3517,7 @@ exports[`ADMIN | CM | LV | Configure the view should add field 1`] = `
                           <span
                             class="c24 c78"
                           >
-                            hey
+                            id
                           </span>
                         </div>
                         <div
@@ -3680,7 +3680,7 @@ exports[`ADMIN | CM | LV | Configure the view should add field 1`] = `
                           spacing="3"
                         >
                           <span
-                            aria-label="Move cover"
+                            aria-label="Move Cover"
                             class="c75 c76 c77"
                             draggable="true"
                             type="button"
@@ -3725,14 +3725,14 @@ exports[`ADMIN | CM | LV | Configure the view should add field 1`] = `
                           <span
                             class="c24 c78"
                           >
-                            michka
+                            Cover
                           </span>
                         </div>
                         <div
                           class="c79 c66"
                         >
                           <button
-                            aria-label="Edit cover"
+                            aria-label="Edit Cover"
                             class="c76"
                             type="button"
                           >
@@ -3752,7 +3752,7 @@ exports[`ADMIN | CM | LV | Configure the view should add field 1`] = `
                             </svg>
                           </button>
                           <button
-                            aria-label="Delete cover"
+                            aria-label="Delete Cover"
                             class="c76"
                             data-testid="delete-cover"
                             type="button"

--- a/packages/core/admin/admin/src/content-manager/pages/ListSettingsView/tests/index.test.js
+++ b/packages/core/admin/admin/src/content-manager/pages/ListSettingsView/tests/index.test.js
@@ -60,13 +60,13 @@ const layout = {
     },
     cover: {
       list: {
-        label: 'michka',
+        label: 'Cover',
         sortable: false,
       },
     },
     id: {
       list: {
-        label: 'hey',
+        label: 'id',
         sortable: true,
       },
     },
@@ -153,9 +153,9 @@ describe('ADMIN | CM | LV | Configure the view', () => {
 
     fireEvent.mouseDown(screen.getByTestId('add-field'));
 
-    await waitFor(() => expect(screen.getByText('cover')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText('Cover')).toBeInTheDocument());
 
-    fireEvent.mouseDown(screen.getByText('cover'));
+    fireEvent.mouseDown(screen.getByText('Cover'));
     fireEvent.mouseDown(screen.getByTestId('add-field'));
 
     expect(container).toMatchSnapshot();


### PR DESCRIPTION
### What does it do?

Use the custom labels for fields in the `ListSettingsView` component, the component where the headers of the list view can be adjusted. This changes to use the user specified labels in the following components:
- "Default sort attribute" dropdown (1)
- "Add a field" dropdown (2)
- Aria labels for the DraggableCard components (3)

![image](https://user-images.githubusercontent.com/8062112/185158775-b1801840-f60f-41f2-8c4a-7223a10ea71d.png)


### Why is it needed?

From a UX perspective, the custom labels are sometimes used, e.g. in the `AttributeFilter` or the `FieldPicker` component, but sometimes it's using the raw field names, as it was the case for the three places listed above.
In my case, I usually write my internal field names in camelCase and in English, while I want the end user using the admin panel to see a nicely formatted label in perhaps a different language.

### How to test it?

Add an example collection, add a field to it and give it a custom label via the list view settings. The listed components above should now display the custom label instead of the raw field name.

### Related issue(s)/PR(s)
