### PR TITLE
Allow the use of 'true', 't', 'false', 'f', '1', '0' in addition to '*' when populating a field in REST API

### DIFF
--- a/packages/core/database/lib/query/helpers/populate.js
+++ b/packages/core/database/lib/query/helpers/populate.js
@@ -83,6 +83,10 @@ const processPopulate = (populate, ctx) => {
       continue;
     }
 
+    if (populateMap[key] === false) {
+      continue;
+    }
+
     // make sure id is present for future populate queries
     if (_.has('id', meta.attributes)) {
       qb.addSelect('id');

--- a/packages/core/database/lib/query/helpers/populate.js
+++ b/packages/core/database/lib/query/helpers/populate.js
@@ -83,10 +83,6 @@ const processPopulate = (populate, ctx) => {
       continue;
     }
 
-    if (populateMap[key] === false) {
-      continue;
-    }
-
     // make sure id is present for future populate queries
     if (_.has('id', meta.attributes)) {
       qb.addSelect('id');

--- a/packages/core/strapi/tests/api/populate/filtering/index.test.e2e.js
+++ b/packages/core/strapi/tests/api/populate/filtering/index.test.e2e.js
@@ -300,5 +300,19 @@ describe('Populate filters', () => {
 
       expect(body.data[0].attributes.third.data[0].attributes.fooRef).toBeUndefined();
     });
+
+    test("Don't populate with object and 'f'", async () => {
+      const qs = {
+        populate: {
+          third: 'f',
+        },
+      };
+      const { status, body } = await rq.get(`/${schemas.contentTypes.c.pluralName}`, { qs });
+
+      expect(status).toBe(200);
+      expect(body.data).toHaveLength(2);
+
+      expect(body.data[0].attributes.third).toBeUndefined();
+    });
   });
 });

--- a/packages/core/strapi/tests/api/populate/filtering/index.test.e2e.js
+++ b/packages/core/strapi/tests/api/populate/filtering/index.test.e2e.js
@@ -286,5 +286,19 @@ describe('Populate filters', () => {
       expect(secondItem.attributes.third.data[0].attributes.fooRef).not.toBeNull();
       expect(secondItem.attributes.third.data[1].attributes.fooRef).toBeNull();
     });
+
+    test("Populate with object and 't'", async () => {
+      const qs = {
+        populate: {
+          third: 't',
+        },
+      };
+      const { status, body } = await rq.get(`/${schemas.contentTypes.c.pluralName}`, { qs });
+
+      expect(status).toBe(200);
+      expect(body.data).toHaveLength(2);
+
+      expect(body.data[0].attributes.third.data[0].attributes.fooRef).toBeUndefined();
+    });
   });
 });

--- a/packages/core/utils/lib/convert-query-params.js
+++ b/packages/core/utils/lib/convert-query-params.js
@@ -215,6 +215,10 @@ const convertNestedPopulate = (subPopulate, schema) => {
     return true;
   }
 
+  if (_.isString(subPopulate)) {
+    return parseType({ type: 'boolean', value: subPopulate, forceCast: true });
+  }
+
   if (_.isBoolean(subPopulate)) {
     return subPopulate;
   }

--- a/packages/core/utils/lib/convert-query-params.js
+++ b/packages/core/utils/lib/convert-query-params.js
@@ -6,16 +6,7 @@
  * Converts the standard Strapi REST query params to a more usable format for querying
  * You can read more here: https://docs.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/rest-api.html#filters
  */
-const {
-  has,
-  isEmpty,
-  isObject,
-  isPlainObject,
-  cloneDeep,
-  get,
-  mergeAll,
-  isBoolean,
-} = require('lodash/fp');
+const { has, isEmpty, isObject, isPlainObject, cloneDeep, get, mergeAll } = require('lodash/fp');
 const _ = require('lodash');
 const parseType = require('./parse-type');
 const contentTypesUtils = require('./content-types');
@@ -183,10 +174,8 @@ const convertPopulateObject = (populate, schema) => {
     if (attribute.type === 'dynamiczone') {
       const populates = attribute.components
         .map((uid) => strapi.getModel(uid))
-        .map((schema) => {
-          const populate = convertNestedPopulate(subPopulate, schema);
-          return isBoolean(populate) && populate ? {} : populate;
-        })
+        .map((schema) => convertNestedPopulate(subPopulate, schema))
+        .map((populate) => (populate === true ? {} : populate)) // cast boolean to empty object to avoid merging issues
         .filter((populate) => populate !== false);
 
       if (isEmpty(populates)) {

--- a/packages/core/utils/lib/convert-query-params.js
+++ b/packages/core/utils/lib/convert-query-params.js
@@ -234,10 +234,6 @@ const convertPopulateObject = (populate, schema) => {
 };
 
 const convertNestedPopulate = (subPopulate, schema) => {
-  if (subPopulate === '*') {
-    return true;
-  }
-
   if (_.isString(subPopulate)) {
     return parseType({ type: 'boolean', value: subPopulate, forceCast: true });
   }


### PR DESCRIPTION
### What does it do?

To populate a field, we can now do:
```js
populate: {
  image: 'true', // same with 't', 'false', 'f', '1', '0' and '*'
}
```

### Why is it needed?

Before we could only do `image: '*'` which may not be explicit about what it does :
- does it populate everything in the image like `{ populate: '*' }` would do
- does it populate only with the scalar attributes (it's this one)

Using `true` may be more explicit that it doesn't populate relation under `image`

### How to test it?

A test was added

### Related issue(s)/PR(s)

fix #13945
