### PR TITLE
Add details about amending S3 bucket CORS policies to properly show GIFs and videos in the admin panel

### DIFF
--- a/packages/providers/upload-aws-s3/README.md
+++ b/packages/providers/upload-aws-s3/README.md
@@ -124,6 +124,22 @@ module.exports = [
 
 If you use dots in your bucket name, the url of the ressource is in directory style (`s3.yourRegion.amazonaws.com/your.bucket.name/image.jpg`) instead of `yourBucketName.s3.yourRegion.amazonaws.com/image.jpg`. Then only add `s3.yourRegion.amazonaws.com` to img-src and media-src directives.
 
+## Bucket CORS Configuration
+
+If you are planning on uploading content like GIFs and videos to your S3 bucket, you will want to edit its CORS configuration so that thumbnails are properly shown in Strapi. To do so, open your Bucket on the AWS console and locate the _Cross-origin resource sharing (CORS)_ field under the _Permissions_ tab, then amend the policies by writing your own JSON configuration, or copying and pasting the following one:
+
+```json
+[
+  {
+    "AllowedHeaders": ["*"],
+    "AllowedMethods": ["GET"],
+    "AllowedOrigins": ["YOUR STRAPI URL"],
+    "ExposeHeaders": [],
+    "MaxAgeSeconds": 3000
+  }
+]
+```
+
 ## Required AWS Policy Actions
 
 These are the minimum amount of permissions needed for this provider to work.


### PR DESCRIPTION
### What does it do?

Modifies the README of the `upload-aws-s3` provider by adding a *Bucket CORS Configuration* section outlining what users should do to properly display videos and GIFs in the admin panel.

### Why is it needed?

Due to S3's default CORS policies, videos and GIFs are not preview-able in the admin panel unless the domain of the admin panel is added to the `AllowedOrigins` list.

### How to test it?

Upload a video to a bucket and notice how the preview is not shown.
Then, edit the bucket's CORS policies and refresh the admin panel to notice that the preview is showing.
