### PR TITLE
Throw if --template flag is immediately followed by another flag when creating app via CLI

### DIFF
--- a/packages/cli/create-strapi-app/create-strapi-app.js
+++ b/packages/cli/create-strapi-app/create-strapi-app.js
@@ -62,6 +62,15 @@ async function initProject(projectName, program) {
     await checkInstallPath(resolve(projectName));
   }
 
+  const programFlags = program.options
+    .reduce((acc, { short, long }) => [...acc, short, long], [])
+    .filter(Boolean);
+
+  if (program.template && programFlags.includes(program.template)) {
+    console.error(`${program.template} is not a valid template`);
+    process.exit(1);
+  }
+
   const hasDatabaseOptions = databaseOptions.some((opt) => program[opt]);
 
   if (program.quickstart && hasDatabaseOptions) {


### PR DESCRIPTION
### What does it do?

Solves #14114 by exiting the app creation process when the `--template` flag is immediately followed by another of the allowed flags.

### Why is it needed?

At the moment launching something like `create-strapi-app --template --ts` parses `--ts` as the template name the users wants to use when creating the app, which implies that the `--ts` flag is completely omitted and the creation fails because there is no `--ts` template.

### How to test it?

Try creating an app with `create-strapi-app --template <OTHER SUPPORTED FLAG>` and notice how an error is shown and the process exists.

### Related issue(s)/PR(s)

#14114

### Additional information

Is there a regex that template names must follow? If so, it would probably be better to check whether the argument is matching such regex rather than simply excluding the other flags.