### PR TITLE
[Custom fields] Apply content manager settings on custom fields

### DIFF
--- a/examples/getstarted/src/plugins/mycustomfields/admin/src/components/ColorPicker/ColorPickerInput/index.js
+++ b/examples/getstarted/src/plugins/mycustomfields/admin/src/components/ColorPicker/ColorPickerInput/index.js
@@ -3,13 +3,12 @@ import { Stack } from '@strapi/design-system/Stack';
 import { Typography } from '@strapi/design-system/Typography';
 import { Field, FieldHint, FieldError, FieldLabel } from '@strapi/design-system/Field';
 import { useIntl } from 'react-intl';
+import getTrad from '../../../utils/getTrad';
 
 const ColorPickerInput = ({
   attribute,
   description,
   error,
-  hint,
-  id,
   intlLabel,
   name,
   onChange,
@@ -28,7 +27,15 @@ const ColorPickerInput = ({
       <Stack spacing={1}>
         <FieldLabel required={required}>{formatMessage(intlLabel)}</FieldLabel>
         <Typography variant="pi" as="p">
-          Format: {attribute.options.format}
+          {formatMessage(
+            {
+              id: getTrad('input.format'),
+              defaultMessage: 'Using color format {format}',
+            },
+            {
+              format: attribute.options.format,
+            }
+          )}
         </Typography>
         <input type="color" id={name} name={name} value={value || ''} onChange={onChange} />
         <FieldHint />

--- a/examples/getstarted/src/plugins/mycustomfields/admin/src/components/ColorPicker/ColorPickerInput/index.js
+++ b/examples/getstarted/src/plugins/mycustomfields/admin/src/components/ColorPicker/ColorPickerInput/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Stack } from '@strapi/design-system/Stack';
+import { Typography } from '@strapi/design-system/Typography';
 import { Field, FieldHint, FieldError, FieldLabel } from '@strapi/design-system/Field';
 import { useIntl } from 'react-intl';
 
@@ -18,19 +19,22 @@ const ColorPickerInput = ({
   const { formatMessage } = useIntl();
 
   return (
-    <Stack spacing={1}>
-      <Field
-        name={name}
-        id={name}
-        error={error && formatMessage(error)}
-        hint={description && formatMessage(description)}
-      >
+    <Field
+      name={name}
+      id={name}
+      error={error && formatMessage(error)}
+      hint={description && formatMessage(description)}
+    >
+      <Stack spacing={1}>
         <FieldLabel required={required}>{formatMessage(intlLabel)}</FieldLabel>
+        <Typography variant="pi" as="p">
+          Format: {attribute.options.format}
+        </Typography>
         <input type="color" id={name} name={name} value={value || ''} onChange={onChange} />
         <FieldHint />
         <FieldError />
-      </Field>
-    </Stack>
+      </Stack>
+    </Field>
   );
 };
 

--- a/examples/getstarted/src/plugins/mycustomfields/admin/src/index.js
+++ b/examples/getstarted/src/plugins/mycustomfields/admin/src/index.js
@@ -26,7 +26,7 @@ export default {
       {
         name: 'color',
         pluginId: 'mycustomfields',
-        type: 'text',
+        type: 'string',
         icon: ColorPickerIcon,
         intlLabel: {
           id: 'mycustomfields.color.label',
@@ -121,7 +121,7 @@ export default {
               ],
             },
           ],
-          validator: args => ({
+          validator: (args) => ({
             format: yup.string().required({
               id: 'options.color-picker.format.error',
               defaultMessage: 'The color format is required',
@@ -134,7 +134,7 @@ export default {
   bootstrap(app) {},
   async registerTrads({ locales }) {
     const importedTrads = await Promise.all(
-      locales.map(locale => {
+      locales.map((locale) => {
         return import(`./translations/${locale}.json`)
           .then(({ default: data }) => {
             return {

--- a/examples/getstarted/src/plugins/mycustomfields/admin/src/translations/en.json
+++ b/examples/getstarted/src/plugins/mycustomfields/admin/src/translations/en.json
@@ -1,1 +1,3 @@
-{}
+{
+  "input.format": "Using color format {format}"
+}

--- a/examples/getstarted/src/plugins/mycustomfields/server/register.js
+++ b/examples/getstarted/src/plugins/mycustomfields/server/register.js
@@ -7,7 +7,7 @@ module.exports = ({ strapi }) => {
     {
       name: 'color',
       plugin: 'mycustomfields',
-      type: 'text',
+      type: 'string',
     },
     {
       name: 'map',

--- a/packages/core/admin/admin/src/content-manager/components/FieldTypeIcon/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/FieldTypeIcon/index.js
@@ -1,5 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Box } from '@strapi/design-system/Box';
+import { useCustomFields } from '@strapi/helper-plugin';
 import Date from '@strapi/icons/Date';
 import Boolean from '@strapi/icons/Boolean';
 import Email from '@strapi/icons/Email';
@@ -40,10 +42,38 @@ const iconByTypes = {
   dynamiczone: <DynamicZone />,
 };
 
-const FieldTypeIcon = ({ type }) => iconByTypes[type] || null;
+const FieldTypeIcon = ({ type, customFieldUid }) => {
+  const customFieldsRegistry = useCustomFields();
+
+  let Compo = iconByTypes[type];
+
+  if (customFieldUid) {
+    const customField = customFieldsRegistry.get(customFieldUid);
+    const CustomFieldIcon = customField.icon;
+
+    if (CustomFieldIcon) {
+      Compo = (
+        <Box marginRight={3} width={7} height={6}>
+          <CustomFieldIcon />
+        </Box>
+      );
+    }
+  }
+
+  if (!iconByTypes[type]) {
+    return null;
+  }
+
+  return Compo;
+};
+
+FieldTypeIcon.defaultProps = {
+  customFieldUid: null,
+};
 
 FieldTypeIcon.propTypes = {
   type: PropTypes.string.isRequired,
+  customFieldUid: PropTypes.string,
 };
 
 export default FieldTypeIcon;

--- a/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/components/FormModal.js
+++ b/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/components/FormModal.js
@@ -26,7 +26,7 @@ const HeaderContainer = styled(Flex)`
   }
 `;
 
-const FormModal = ({ onToggle, onMetaChange, onSizeChange, onSubmit, type }) => {
+const FormModal = ({ onToggle, onMetaChange, onSizeChange, onSubmit, type, customFieldUid }) => {
   const { selectedField } = useLayoutDnd();
   const { formatMessage } = useIntl();
 
@@ -47,7 +47,7 @@ const FormModal = ({ onToggle, onMetaChange, onSizeChange, onSubmit, type }) => 
       <form onSubmit={onSubmit}>
         <ModalHeader>
           <HeaderContainer>
-            <FieldTypeIcon type={getAttrType(type)} />
+            <FieldTypeIcon type={getAttrType()} customFieldUid={customFieldUid} />
             <Typography fontWeight="bold" textColor="neutral800" as="h2" id="title">
               {formatMessage(
                 {
@@ -81,7 +81,12 @@ const FormModal = ({ onToggle, onMetaChange, onSizeChange, onSubmit, type }) => 
   );
 };
 
+FormModal.defaultProps = {
+  customFieldUid: null,
+};
+
 FormModal.propTypes = {
+  customFieldUid: PropTypes.string,
   onSubmit: PropTypes.func.isRequired,
   onToggle: PropTypes.func.isRequired,
   onMetaChange: PropTypes.func.isRequired,

--- a/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/index.js
@@ -371,9 +371,10 @@ const EditSettingsView = ({ mainLayout, components, isContentTypeView, slug, upd
           <ModalForm
             onSubmit={handleMetaSubmit}
             onToggle={handleToggleModal}
-            type={get(attributes, [metaToEdit, 'type'], '')}
             onMetaChange={handleMetaChange}
             onSizeChange={handleSizeChange}
+            type={get(attributes, [metaToEdit, 'type'], '')}
+            customFieldUid={get(attributes, [metaToEdit, 'customField'], '')}
           />
         )}
       </Main>


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Apply custom-field defined settings in the Edit view.

- Show custom field icon on the edit attribute modal in the "edit the view" page
- Display attribute options on custom field component to make sure they're accessible via the props
- Update the example color custom field to use string instead of text

### Why is it needed?

To make custom fields behave like other fields in the content manager

### How to test it?

- Edit an attribute using the color custom field to try both hex and rgba options. The format should be displayed on the edit view input component
- Use the CM "edit view" button to add a description and move or resize the field

### Related issue(s)/PR(s)

To be reviewed/merged after #14130
