### PR TITLE
[Custom fields] Display custom field Input component in the CM edit view

### DIFF
--- a/examples/getstarted/src/api/kitchensink/content-types/kitchensink/schema.json
+++ b/examples/getstarted/src/api/kitchensink/content-types/kitchensink/schema.json
@@ -133,7 +133,10 @@
     },
     "custom_field": {
       "type": "customField",
-      "customField": "plugin::mycustomfields.color"
+      "customField": "plugin::mycustomfields.color",
+      "options": {
+        "format": "hex"
+      }
     }
   }
 }

--- a/examples/getstarted/src/plugins/mycustomfields/admin/src/components/ColorPicker/ColorPickerInput/index.js
+++ b/examples/getstarted/src/plugins/mycustomfields/admin/src/components/ColorPicker/ColorPickerInput/index.js
@@ -8,6 +8,7 @@ import getTrad from '../../../utils/getTrad';
 const ColorPickerInput = ({
   attribute,
   description,
+  disabled,
   error,
   intlLabel,
   name,
@@ -37,7 +38,14 @@ const ColorPickerInput = ({
             }
           )}
         </Typography>
-        <input type="color" id={name} name={name} value={value || ''} onChange={onChange} />
+        <input
+          type="color"
+          id={name}
+          name={name}
+          value={value || ''}
+          onChange={onChange}
+          disabled={disabled}
+        />
         <FieldHint />
         <FieldError />
       </Stack>

--- a/examples/getstarted/src/plugins/mycustomfields/admin/src/components/ColorPicker/ColorPickerInput/index.js
+++ b/examples/getstarted/src/plugins/mycustomfields/admin/src/components/ColorPicker/ColorPickerInput/index.js
@@ -1,7 +1,37 @@
 import React from 'react';
+import { Stack } from '@strapi/design-system/Stack';
+import { Field, FieldHint, FieldError, FieldLabel } from '@strapi/design-system/Field';
+import { useIntl } from 'react-intl';
 
-const ColorPickerInput = () => {
-  return <div>TODO: Color Picker Input Component</div>;
+const ColorPickerInput = ({
+  attribute,
+  description,
+  error,
+  hint,
+  id,
+  intlLabel,
+  name,
+  onChange,
+  required,
+  value,
+}) => {
+  const { formatMessage } = useIntl();
+
+  return (
+    <Stack spacing={1}>
+      <Field
+        name={name}
+        id={name}
+        error={error && formatMessage(error)}
+        hint={description && formatMessage(description)}
+      >
+        <FieldLabel required={required}>{formatMessage(intlLabel)}</FieldLabel>
+        <input type="color" id={name} name={name} value={value || ''} onChange={onChange} />
+        <FieldHint />
+        <FieldError />
+      </Field>
+    </Stack>
+  );
 };
 
 export default ColorPickerInput;

--- a/examples/getstarted/src/plugins/mycustomfields/admin/src/components/ColorPicker/ColorPickerInput/index.js
+++ b/examples/getstarted/src/plugins/mycustomfields/admin/src/components/ColorPicker/ColorPickerInput/index.js
@@ -1,14 +1,14 @@
 import React from 'react';
 import { Stack } from '@strapi/design-system/Stack';
+import { Typography } from '@strapi/design-system/Typography';
 import { Field, FieldHint, FieldError, FieldLabel } from '@strapi/design-system/Field';
 import { useIntl } from 'react-intl';
+import getTrad from '../../../utils/getTrad';
 
 const ColorPickerInput = ({
   attribute,
   description,
   error,
-  hint,
-  id,
   intlLabel,
   name,
   onChange,
@@ -18,19 +18,30 @@ const ColorPickerInput = ({
   const { formatMessage } = useIntl();
 
   return (
-    <Stack spacing={1}>
-      <Field
-        name={name}
-        id={name}
-        error={error && formatMessage(error)}
-        hint={description && formatMessage(description)}
-      >
+    <Field
+      name={name}
+      id={name}
+      error={error && formatMessage(error)}
+      hint={description && formatMessage(description)}
+    >
+      <Stack spacing={1}>
         <FieldLabel required={required}>{formatMessage(intlLabel)}</FieldLabel>
+        <Typography variant="pi" as="p">
+          {formatMessage(
+            {
+              id: getTrad('input.format'),
+              defaultMessage: 'Using color format {format}',
+            },
+            {
+              format: attribute.options.format,
+            }
+          )}
+        </Typography>
         <input type="color" id={name} name={name} value={value || ''} onChange={onChange} />
         <FieldHint />
         <FieldError />
-      </Field>
-    </Stack>
+      </Stack>
+    </Field>
   );
 };
 

--- a/examples/getstarted/src/plugins/mycustomfields/admin/src/index.js
+++ b/examples/getstarted/src/plugins/mycustomfields/admin/src/index.js
@@ -26,7 +26,7 @@ export default {
       {
         name: 'color',
         pluginId: 'mycustomfields',
-        type: 'text',
+        type: 'string',
         icon: ColorPickerIcon,
         intlLabel: {
           id: 'mycustomfields.color.label',
@@ -121,7 +121,7 @@ export default {
               ],
             },
           ],
-          validator: args => ({
+          validator: (args) => ({
             format: yup.string().required({
               id: 'options.color-picker.format.error',
               defaultMessage: 'The color format is required',
@@ -134,7 +134,7 @@ export default {
   bootstrap(app) {},
   async registerTrads({ locales }) {
     const importedTrads = await Promise.all(
-      locales.map(locale => {
+      locales.map((locale) => {
         return import(`./translations/${locale}.json`)
           .then(({ default: data }) => {
             return {

--- a/examples/getstarted/src/plugins/mycustomfields/admin/src/translations/en.json
+++ b/examples/getstarted/src/plugins/mycustomfields/admin/src/translations/en.json
@@ -1,1 +1,3 @@
-{}
+{
+  "input.format": "Using color format {format}"
+}

--- a/examples/getstarted/src/plugins/mycustomfields/server/register.js
+++ b/examples/getstarted/src/plugins/mycustomfields/server/register.js
@@ -1,8 +1,6 @@
 'use strict';
 
 module.exports = ({ strapi }) => {
-  console.log('Running register in customfields plugin');
-
   strapi.customFields.register([
     {
       name: 'color',

--- a/examples/getstarted/src/plugins/mycustomfields/server/register.js
+++ b/examples/getstarted/src/plugins/mycustomfields/server/register.js
@@ -7,7 +7,7 @@ module.exports = ({ strapi }) => {
     {
       name: 'color',
       plugin: 'mycustomfields',
-      type: 'text',
+      type: 'string',
     },
     {
       name: 'map',

--- a/packages/core/admin/admin/src/content-manager/components/FieldTypeIcon/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/FieldTypeIcon/index.js
@@ -1,5 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Box } from '@strapi/design-system/Box';
+import { useCustomFields } from '@strapi/helper-plugin';
 import Date from '@strapi/icons/Date';
 import Boolean from '@strapi/icons/Boolean';
 import Email from '@strapi/icons/Email';
@@ -40,10 +42,38 @@ const iconByTypes = {
   dynamiczone: <DynamicZone />,
 };
 
-const FieldTypeIcon = ({ type }) => iconByTypes[type] || null;
+const FieldTypeIcon = ({ type, customFieldUid }) => {
+  const customFieldsRegistry = useCustomFields();
+
+  let Compo = iconByTypes[type];
+
+  if (customFieldUid) {
+    const customField = customFieldsRegistry.get(customFieldUid);
+    const CustomFieldIcon = customField.icon;
+
+    if (CustomFieldIcon) {
+      Compo = (
+        <Box marginRight={3} width={7} height={6}>
+          <CustomFieldIcon />
+        </Box>
+      );
+    }
+  }
+
+  if (!iconByTypes[type]) {
+    return null;
+  }
+
+  return Compo;
+};
+
+FieldTypeIcon.defaultProps = {
+  customFieldUid: null,
+};
 
 FieldTypeIcon.propTypes = {
   type: PropTypes.string.isRequired,
+  customFieldUid: PropTypes.string,
 };
 
 export default FieldTypeIcon;

--- a/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/components/FormModal.js
+++ b/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/components/FormModal.js
@@ -26,7 +26,7 @@ const HeaderContainer = styled(Flex)`
   }
 `;
 
-const FormModal = ({ onToggle, onMetaChange, onSizeChange, onSubmit, type }) => {
+const FormModal = ({ onToggle, onMetaChange, onSizeChange, onSubmit, type, customFieldUid }) => {
   const { selectedField } = useLayoutDnd();
   const { formatMessage } = useIntl();
 
@@ -47,7 +47,7 @@ const FormModal = ({ onToggle, onMetaChange, onSizeChange, onSubmit, type }) => 
       <form onSubmit={onSubmit}>
         <ModalHeader>
           <HeaderContainer>
-            <FieldTypeIcon type={getAttrType(type)} />
+            <FieldTypeIcon type={getAttrType()} customFieldUid={customFieldUid} />
             <Typography fontWeight="bold" textColor="neutral800" as="h2" id="title">
               {formatMessage(
                 {
@@ -81,7 +81,12 @@ const FormModal = ({ onToggle, onMetaChange, onSizeChange, onSubmit, type }) => 
   );
 };
 
+FormModal.defaultProps = {
+  customFieldUid: null,
+};
+
 FormModal.propTypes = {
+  customFieldUid: PropTypes.string,
   onSubmit: PropTypes.func.isRequired,
   onToggle: PropTypes.func.isRequired,
   onMetaChange: PropTypes.func.isRequired,

--- a/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/index.js
@@ -371,9 +371,10 @@ const EditSettingsView = ({ mainLayout, components, isContentTypeView, slug, upd
           <ModalForm
             onSubmit={handleMetaSubmit}
             onToggle={handleToggleModal}
-            type={get(attributes, [metaToEdit, 'type'], '')}
             onMetaChange={handleMetaChange}
             onSizeChange={handleSizeChange}
+            type={get(attributes, [metaToEdit, 'type'], '')}
+            customFieldUid={get(attributes, [metaToEdit, 'customField'], '')}
           />
         )}
       </Main>

--- a/packages/core/admin/admin/src/content-manager/pages/EditView/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/EditView/index.js
@@ -1,7 +1,12 @@
-import React, { memo, useCallback, useMemo } from 'react';
+import React, { Suspense, memo, useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import get from 'lodash/get';
-import { CheckPermissions, useTracking, LinkButton } from '@strapi/helper-plugin';
+import {
+  CheckPermissions,
+  LoadingIndicatorPage,
+  useTracking,
+  LinkButton,
+} from '@strapi/helper-plugin';
 import { useIntl } from 'react-intl';
 import { ContentLayout } from '@strapi/design-system/Layout';
 import { Box } from '@strapi/design-system/Box';
@@ -131,99 +136,101 @@ const EditView = ({
               <ContentLayout>
                 <Grid gap={4}>
                   <GridItem col={9} s={12}>
-                    <Stack spacing={6}>
-                      {formattedContentTypeLayout.map((row, index) => {
-                        if (isDynamicZone(row)) {
-                          const {
-                            0: {
-                              0: { name, fieldSchema, metadatas, labelAction },
-                            },
-                          } = row;
+                    <Suspense fallback={<LoadingIndicatorPage />}>
+                      <Stack spacing={6}>
+                        {formattedContentTypeLayout.map((row, index) => {
+                          if (isDynamicZone(row)) {
+                            const {
+                              0: {
+                                0: { name, fieldSchema, metadatas, labelAction },
+                              },
+                            } = row;
+
+                            return (
+                              <Box key={index}>
+                                <Grid gap={4}>
+                                  <GridItem col={12} s={12} xs={12}>
+                                    <DynamicZone
+                                      name={name}
+                                      fieldSchema={fieldSchema}
+                                      labelAction={labelAction}
+                                      metadatas={metadatas}
+                                    />
+                                  </GridItem>
+                                </Grid>
+                              </Box>
+                            );
+                          }
 
                           return (
-                            <Box key={index}>
-                              <Grid gap={4}>
-                                <GridItem col={12} s={12} xs={12}>
-                                  <DynamicZone
-                                    name={name}
-                                    fieldSchema={fieldSchema}
-                                    labelAction={labelAction}
-                                    metadatas={metadatas}
-                                  />
-                                </GridItem>
-                              </Grid>
-                            </Box>
-                          );
-                        }
+                            <Box
+                              key={index}
+                              hasRadius
+                              background="neutral0"
+                              shadow="tableShadow"
+                              paddingLeft={6}
+                              paddingRight={6}
+                              paddingTop={6}
+                              paddingBottom={6}
+                              borderColor="neutral150"
+                            >
+                              <Stack spacing={6}>
+                                {row.map((grid, gridIndex) => {
+                                  return (
+                                    <Grid gap={4} key={gridIndex}>
+                                      {grid.map(
+                                        ({ fieldSchema, labelAction, metadatas, name, size }) => {
+                                          const isComponent = fieldSchema.type === 'component';
 
-                        return (
-                          <Box
-                            key={index}
-                            hasRadius
-                            background="neutral0"
-                            shadow="tableShadow"
-                            paddingLeft={6}
-                            paddingRight={6}
-                            paddingTop={6}
-                            paddingBottom={6}
-                            borderColor="neutral150"
-                          >
-                            <Stack spacing={6}>
-                              {row.map((grid, gridIndex) => {
-                                return (
-                                  <Grid gap={4} key={gridIndex}>
-                                    {grid.map(
-                                      ({ fieldSchema, labelAction, metadatas, name, size }) => {
-                                        const isComponent = fieldSchema.type === 'component';
+                                          if (isComponent) {
+                                            const {
+                                              component,
+                                              max,
+                                              min,
+                                              repeatable = false,
+                                              required = false,
+                                            } = fieldSchema;
 
-                                        if (isComponent) {
-                                          const {
-                                            component,
-                                            max,
-                                            min,
-                                            repeatable = false,
-                                            required = false,
-                                          } = fieldSchema;
+                                            return (
+                                              <GridItem col={size} s={12} xs={12} key={component}>
+                                                <FieldComponent
+                                                  componentUid={component}
+                                                  labelAction={labelAction}
+                                                  isRepeatable={repeatable}
+                                                  intlLabel={{
+                                                    id: metadatas.label,
+                                                    defaultMessage: metadatas.label,
+                                                  }}
+                                                  max={max}
+                                                  min={min}
+                                                  name={name}
+                                                  required={required}
+                                                />
+                                              </GridItem>
+                                            );
+                                          }
 
                                           return (
-                                            <GridItem col={size} s={12} xs={12} key={component}>
-                                              <FieldComponent
-                                                componentUid={component}
+                                            <GridItem col={size} key={name} s={12} xs={12}>
+                                              <Inputs
+                                                fieldSchema={fieldSchema}
+                                                keys={name}
                                                 labelAction={labelAction}
-                                                isRepeatable={repeatable}
-                                                intlLabel={{
-                                                  id: metadatas.label,
-                                                  defaultMessage: metadatas.label,
-                                                }}
-                                                max={max}
-                                                min={min}
-                                                name={name}
-                                                required={required}
+                                                metadatas={metadatas}
                                               />
                                             </GridItem>
                                           );
                                         }
-
-                                        return (
-                                          <GridItem col={size} key={name} s={12} xs={12}>
-                                            <Inputs
-                                              fieldSchema={fieldSchema}
-                                              keys={name}
-                                              labelAction={labelAction}
-                                              metadatas={metadatas}
-                                            />
-                                          </GridItem>
-                                        );
-                                      }
-                                    )}
-                                  </Grid>
-                                );
-                              })}
-                            </Stack>
-                          </Box>
-                        );
-                      })}
-                    </Stack>
+                                      )}
+                                    </Grid>
+                                  );
+                                })}
+                              </Stack>
+                            </Box>
+                          );
+                        })}
+                      </Stack>
+                    </Suspense>
                   </GridItem>
                   <GridItem col={3} s={12}>
                     <Stack spacing={2}>


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

- Lazy loads a custom field's input component in the content manager's edit view
- Updates the sample color picker component as a POC
- Show custom field icon on the edit attribute modal in the "edit the view" page
- Display attribute options on custom field component to make sure they're accessible via the props

### Why is it needed?

To integrate custom fields in the content manager

### How to test it?

- Run the getstarted example app using `yarn develop --watch-admin`
- Open the app on port 8000: `http://localhost:8000/admin`
- Go to `/admin/content-manager/collectionType/api::kitchensink.kitchensink/create`
- See the `custom_field` attribute which uses a custom field, try the input, change the color, save, refresh, the data should persist with the new color
- Click on "configure the view"
- Make "custom_field" the title of the entry
- Edit the custom_field attribute, change its label and add a description
- The changes should be reflected on the edit view

### Related issue(s)/PR(s)

This PR combines #14130 and #14137. It's only meant for QA
