### PR TITLE
Add Nightly Release build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
   <a href="https://discord.strapi.io">
     <img src="https://img.shields.io/discord/811989166782021633?label=Discord" alt="Strapi on Discord" />
   </a>
+  [![Nightly Releases](https://github.com/strapi/strapi/actions/workflows/nightly.yml/badge.svg)](https://github.com/strapi/strapi/actions/workflows/nightly.yml)
 </p>
 
 <br>

--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@
   <a href="https://discord.strapi.io">
     <img src="https://img.shields.io/discord/811989166782021633?label=Discord" alt="Strapi on Discord" />
   </a>
-  [![Nightly Releases](https://github.com/strapi/strapi/actions/workflows/nightly.yml/badge.svg)](https://github.com/strapi/strapi/actions/workflows/nightly.yml)
+  <a href="https://github.com/strapi/strapi/actions/workflows/nightly.yml">
+    <img src="https://github.com/strapi/strapi/actions/workflows/nightly.yml/badge.svg" alt="Strapi Nightly Release Build Status" />
+  </a>
 </p>
 
 <br>


### PR DESCRIPTION

### What does it do?

adds the badge to the readme on the nightly build status

### Why is it needed?

Looks Pretty :)

### How to test it?

Look at the readme of this branch

### Related issue(s)/PR(s)

N/A
