### PR TITLE
fix(compile): support forwarding options to internal getConfigPath API

### DIFF
--- a/packages/core/strapi/lib/compile.js
+++ b/packages/core/strapi/lib/compile.js
@@ -10,7 +10,7 @@ module.exports = async (dir) => {
   if (isTSProject) {
     await tsUtils.compile(appDir, {
       watch: false,
-      configOptions: { options: { incremental: true } },
+      compileOptions: { options: { incremental: true } },
     });
   }
 

--- a/packages/utils/typescript/lib/compile.js
+++ b/packages/utils/typescript/lib/compile.js
@@ -3,12 +3,12 @@
 const compilers = require('./compilers');
 const getConfigPath = require('./utils/get-config-path');
 
-module.exports = async (srcDir, { watch = false, configOptions = {} } = {}) => {
+module.exports = async (srcDir = "", { watch = false, configOptions = {}, compileOptions = {} } = {}) => {
   // TODO: Use the Strapi debug logger instead or don't log at all
   console.log(`Starting the compilation for TypeScript files in ${srcDir}`);
 
   const compiler = watch ? compilers.watch : compilers.basic;
-  const configPath = getConfigPath(srcDir);
+  const configPath = getConfigPath(srcDir, configOptions);
 
-  compiler.run(configPath, configOptions);
+  compiler.run(configPath, compileOptions);
 };

--- a/packages/utils/typescript/lib/utils/get-config-path.js
+++ b/packages/utils/typescript/lib/utils/get-config-path.js
@@ -15,7 +15,7 @@ const DEFAULT_TS_CONFIG_FILENAME = 'tsconfig.json';
  *
  * @return {string | undefined}
  */
-module.exports = (dir, { filename = DEFAULT_TS_CONFIG_FILENAME, ancestorsLookup = false } = {}) => {
+module.exports = (dir = "", { filename = DEFAULT_TS_CONFIG_FILENAME, ancestorsLookup = false } = {}) => {
   const dirAbsolutePath = path.resolve(dir);
   const configFilePath = ts.findConfigFile(dirAbsolutePath, ts.sys.fileExists, filename);
 


### PR DESCRIPTION
### What does it do?

Updated `compile()` in `@strapi/typescript-utils` to support forwarding options to internal `getConfigPath` API

Additional items:
Adding default param value for compile `srcPath` property.
Adding default param value for get-config-path `dir` property.
Replace instances where `configOptions` was used with new `compileOptions` property.

### Why is it needed?

Existing `getConfigPath` functionality could not be accessed via the current `compile` API
Lack of default params was causing `TypeError: The "path" argument must be of type string. Received undefined`

### How to test it?

`compile` is mostly used by users author Unit Tests, who need to compile Strapi before Jest tests run. Likely an Developer / SDET / or DevOps would need to confirm.

### Related issue(s)/PR(s)

Closes issue: #14149
