### PR TITLE
[Custom fields] Display labelAction on example custom field

### DIFF
--- a/examples/getstarted/src/plugins/mycustomfields/admin/src/components/ColorPicker/ColorPickerInput/index.js
+++ b/examples/getstarted/src/plugins/mycustomfields/admin/src/components/ColorPicker/ColorPickerInput/index.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import { Stack } from '@strapi/design-system/Stack';
 import { Typography } from '@strapi/design-system/Typography';
+import { Flex } from '@strapi/design-system/Flex';
+import { Box } from '@strapi/design-system/Box';
 import { Field, FieldHint, FieldError, FieldLabel } from '@strapi/design-system/Field';
 import { useIntl } from 'react-intl';
 import getTrad from '../../../utils/getTrad';
@@ -11,6 +13,7 @@ const ColorPickerInput = ({
   disabled,
   error,
   intlLabel,
+  labelAction,
   name,
   onChange,
   required,
@@ -26,7 +29,12 @@ const ColorPickerInput = ({
       hint={description && formatMessage(description)}
     >
       <Stack spacing={1}>
-        <FieldLabel required={required}>{formatMessage(intlLabel)}</FieldLabel>
+        <Flex>
+          <FieldLabel required={required} labelAction={labelAction}>
+            {formatMessage(intlLabel)}
+          </FieldLabel>
+          {labelAction && <Box paddingLeft={1}>{labelAction}</Box>}
+        </Flex>
         <Typography variant="pi" as="p">
           {formatMessage(
             {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Display labelAction next to the label of the example color picker plugin

### Why is it needed?

To allow i18n to inject the 🌐  icon next to a custom field input, to let the user know if it's localized or not

### How to test it?

- Add a color attribute to a content type that has i18n turned on. Make sure the attribute is localized.
- On the content manager edit view, you should now see the 🌐 icon next to your custom field
- Turn off localization for that attribute in the CTB, then on the edit view you should see a 🌐 ❌ icon

