### PR TITLE
fix: Subscriber type to partial action maps and allow models property in maps

### DIFF
--- a/packages/core/database/lib/lifecycles/subscribers/index.d.ts
+++ b/packages/core/database/lib/lifecycles/subscribers/index.d.ts
@@ -3,7 +3,11 @@ import { Event, Action } from '../';
 type SubscriberFn = (event: Event) => Promise<void> | void;
 
 type SubscriberMap = {
-  [k in Action]: SubscriberFn;
+  [k in Action]?: SubscriberFn;
 };
 
-export type Subscriber = SubscriberFn | SubscriberMap;
+interface ModelsSubscriberMap extends SubscriberMap {
+  models: string[]
+}
+
+export type Subscriber = SubscriberFn | SubscriberMap | ModelsSubscriberMap;


### PR DESCRIPTION
### What does it do?

Allow for SubscriberMap that do not implement all Action methods.
Allow for `models` property to be included in SubscriberMap.

### Why is it needed?

`Subscriber` type currently results in unnecessary TS errors when `models` is provided and when a SubscriberMap does not have all `Actions` implemented.

### How to test it?

See #14165 and [CodeSandbox example](https://codesandbox.io/s/strapi-typescript-4-3-4-typecheck-error-models-does-not-exist-in-type-subscriber-kock3w?file=/src/index.ts:0-845)

### Related issue(s)/PR(s)

resolves: issue #14165