### PR TITLE
Graphql - Fix required attributes when in a content type with D&P enabled

### DIFF
--- a/packages/plugins/graphql/server/services/builders/type.js
+++ b/packages/plugins/graphql/server/services/builders/type.js
@@ -276,6 +276,7 @@ module.exports = (context) => {
         null,
         contentType
       );
+      const hasDraftAndPublish = contentTypes.hasDraftAndPublish(contentType);
 
       return objectType({
         name,
@@ -312,7 +313,7 @@ module.exports = (context) => {
               // rules only on the current attribute (eg: nonNull, list, ...)
               let builder = t;
 
-              if (attribute.required) {
+              if (attribute.required && !hasDraftAndPublish) {
                 builder = builder.nonNull;
               }
 


### PR DESCRIPTION
### What does it do?

Set attributes to optional even if they're required in Strapi when present in a content type with draft and publish enabled.

### Why is it needed?

When a content type has D&P enabled, we allow setting empty values (even for required attributes). Up until now, the generated GraphQL schema was ignoring this and set required attributes as non-nullable.
It caused issues such as the following screenshot
![image](https://user-images.githubusercontent.com/25851739/186110939-98ae0a23-5aef-4d85-8461-ee9dee54d315.png)

### How to test it?

- Create a content type with Draft & Publish enabled
- Add a required attribute to this content type
- Create a new entry in draft without filling the created attribute
- Head over to /graphql and try to query all the entries with `publicationState: PREVIEW`
- You shouldn't get any error and get the entry back

