### PR TITLE
[Custom fields] Fix content manager field validations

### DIFF
--- a/examples/getstarted/src/plugins/mycustomfields/admin/src/components/ColorPicker/ColorPickerInput/index.js
+++ b/examples/getstarted/src/plugins/mycustomfields/admin/src/components/ColorPicker/ColorPickerInput/index.js
@@ -4,6 +4,7 @@ import { Typography } from '@strapi/design-system/Typography';
 import { Flex } from '@strapi/design-system/Flex';
 import { Box } from '@strapi/design-system/Box';
 import { Field, FieldHint, FieldError, FieldLabel } from '@strapi/design-system/Field';
+import { TextInput } from '@strapi/design-system/TextInput';
 import { useIntl } from 'react-intl';
 import getTrad from '../../../utils/getTrad';
 
@@ -25,7 +26,8 @@ const ColorPickerInput = ({
     <Field
       name={name}
       id={name}
-      error={error && formatMessage(error)}
+      // GenericInput calls formatMessage and returns a string for the error
+      error={error && error}
       hint={description && formatMessage(description)}
     >
       <Stack spacing={1}>

--- a/examples/getstarted/src/plugins/mycustomfields/admin/src/components/ColorPicker/ColorPickerInput/index.js
+++ b/examples/getstarted/src/plugins/mycustomfields/admin/src/components/ColorPicker/ColorPickerInput/index.js
@@ -4,7 +4,6 @@ import { Typography } from '@strapi/design-system/Typography';
 import { Flex } from '@strapi/design-system/Flex';
 import { Box } from '@strapi/design-system/Box';
 import { Field, FieldHint, FieldError, FieldLabel } from '@strapi/design-system/Field';
-import { TextInput } from '@strapi/design-system/TextInput';
 import { useIntl } from 'react-intl';
 import getTrad from '../../../utils/getTrad';
 

--- a/examples/getstarted/src/plugins/mycustomfields/admin/src/components/ColorPicker/ColorPickerInput/index.js
+++ b/examples/getstarted/src/plugins/mycustomfields/admin/src/components/ColorPicker/ColorPickerInput/index.js
@@ -27,7 +27,7 @@ const ColorPickerInput = ({
       name={name}
       id={name}
       // GenericInput calls formatMessage and returns a string for the error
-      error={error && error}
+      error={error}
       hint={description && formatMessage(description)}
     >
       <Stack spacing={1}>

--- a/examples/getstarted/src/plugins/mycustomfields/admin/src/index.js
+++ b/examples/getstarted/src/plugins/mycustomfields/admin/src/index.js
@@ -100,6 +100,19 @@ export default {
                   defaultMessage: 'This field will not show up in the API response',
                 },
               },
+              {
+                name: 'unique',
+                type: 'checkbox',
+                intlLabel: {
+                  id: 'form.attribute.item.uniqueField',
+                  defaultMessage: 'Unique field',
+                },
+                description: {
+                  id: 'form.attribute.item.uniqueField.description',
+                  defaultMessage:
+                    "You won't be able to create an entry if there is an existing entry with identical content",
+                },
+              },
             ],
           },
         ],


### PR DESCRIPTION
### What does it do?

- Fixes the error message in the ColorPickerInput component. GenericInput already formats the message so we should return a string
- Adds a unique checkbox to the advanced form of the colorpicker custom field for testing

### How to test it?

Required
- Add the colorpicker custom field to any content type, mark it as required in the advanced form
- Go to the content manager to create a new entity
- Don't touch the colorpicker, edit something else, try to save (if draft and publish it will save, then try to publish), it should throw an error on the input saying it is required

Unique
- Add the colorpicker custom field to any content type, mark it as unique in the advanced form
- Go to the content manager to create a new entity
- Create a color and copy the hex value, save (and publish)
- Create another entity
- Create a color and with the same hex value
- Try to save, it should throw an error on the input saying it must be unique
