### PR TITLE
useRelation: Update interface and group relation / search props together

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/RelationInputWrapper/RelationInputWrapper.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInputWrapper/RelationInputWrapper.js
@@ -18,7 +18,7 @@ export const RelationInputWrapper = ({
   labelAction,
   mainField,
   name,
-  queryInfos: { endpoints, shouldDisplayRelationLink },
+  queryInfos: { endpoints, defaultParams, shouldDisplayRelationLink },
   relationType,
   targetModel,
 }) => {
@@ -26,7 +26,22 @@ export const RelationInputWrapper = ({
   const { addRelation, removeRelation, modifiedData } = useCMEditViewDataManager();
 
   const { relations, search, searchFor } = useRelation(name, {
-    endpoints,
+    relation: {
+      endpoint: endpoints.relation,
+      pageParams: {
+        pageSize: 10,
+      },
+    },
+
+    search: {
+      endpoint: endpoints.search,
+      pageParams: {
+        ...defaultParams,
+        entityId: isCreatingEntry ? undefined : 'id',
+        omitIds: isCreatingEntry ? [] : undefined,
+        pageSize: 10,
+      },
+    },
   });
 
   const isMorph = useMemo(() => relationType.toLowerCase().includes('morph'), [relationType]);

--- a/packages/core/admin/admin/src/content-manager/hooks/useRelation/useRelation.js
+++ b/packages/core/admin/admin/src/content-manager/hooks/useRelation/useRelation.js
@@ -3,15 +3,12 @@ import { useInfiniteQuery } from 'react-query';
 
 import { axiosInstance } from '../../../core/utils';
 
-export const useRelation = (
-  name,
-  { endpoints, relationsToShow = 10, searchResultsToShow = 10 }
-) => {
+export const useRelation = (name, { relation, search }) => {
   const [searchTerm, setSearchTerm] = useState(null);
 
   const fetchRelations = async ({ pageParam = 1 }) => {
-    const { data } = await axiosInstance.get(endpoints?.relation, {
-      limit: relationsToShow,
+    const { data } = await axiosInstance.get(relation?.endpoint, {
+      ...(relation.pageParams ?? {}),
       page: pageParam,
     });
 
@@ -19,8 +16,8 @@ export const useRelation = (
   };
 
   const fetchSearch = async ({ pageParam = 1 }) => {
-    const { data } = await axiosInstance.get(endpoints?.search, {
-      limit: searchResultsToShow,
+    const { data } = await axiosInstance.get(search.endpoint, {
+      ...(search.pageParams ?? {}),
       page: pageParam,
     });
 
@@ -28,26 +25,26 @@ export const useRelation = (
   };
 
   const relationsRes = useInfiniteQuery(['relation', name], fetchRelations, {
-    enabled: !!endpoints?.relation,
-    getNextPageParam(lastPage, pages) {
-      if (lastPage.length < relationsToShow) {
+    enabled: !!relation?.endpoint,
+    getNextPageParam(lastPage) {
+      if (lastPage.pagination.page + 1 === lastPage.pagination.total) {
         return undefined;
       }
 
       // eslint-disable-next-line consistent-return
-      return (pages?.length || 0) + 1;
+      return lastPage.pagination.page + 1;
     },
   });
 
   const searchRes = useInfiniteQuery(['relation', name, 'search', searchTerm], fetchSearch, {
-    enabled: !!endpoints?.search && !!searchTerm,
-    getNextPageParam(lastPage, pages) {
-      if (lastPage.length < searchResultsToShow) {
+    enabled: !!searchTerm,
+    getNextPageParam(lastPage) {
+      if (lastPage.pagination.page + 1 === lastPage.pagination.total) {
         return undefined;
       }
 
       // eslint-disable-next-line consistent-return
-      return (pages?.length || 0) + 1;
+      return lastPage.pagination.page + 1;
     },
   });
 


### PR DESCRIPTION
### What does it do?

@petersg83 and I briefly discussed how we'd use pagination for existing relations and relations to search and settled on using the default pagination in both cases.

This PR changes the way properties are grouped for the `useRelation` hook, so that search and relation and be configured as a group. It allows to pass `pageParams` to `react-query` directly (e.g. to include `idsToOmit` or `_component`) and now operates on the default pagination returned.

### Why is it needed?

Less custom options and an API much closer to the internal content API. No custom pagination behavior any longer.
