### PR TITLE
Limit the amount of GitHub Actions time consumed by tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,13 @@ on:
     branches:
       - main
   pull_request:
+    paths-ignore:
+      - 'docs'
+      - '**/**.md'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
 
 jobs:
   lint:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ on:
       - main
   pull_request:
     paths-ignore:
-      - 'docs'
+      - 'docs/**'
       - '**/**.md'
 
 concurrency:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
     paths-ignore:
       - 'docs/**'
-      - '**/**.md'
+      - '**.mdx?'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}


### PR DESCRIPTION
### What does it do?

Add `concurrency` and `paths-ignore` settings to limit the amount of time the GitHub Actions runner is used.
It should make so consecutive pushes on a PR will not all lead to a full run of tests.

Also, you can notice that I have removed the `push` trigger on `main` as I don't think it's needed since this branch should be protected and it would lead to unnecessary runs.

One thing that is worth mentioning is that GitHub Actions does not provide a long grace period when canceling runs, so if our `tests` workflow needs time to clean up stuff, then this PR shouldn't go through as is with this `concurrency` setting.

### Why is it needed?

Computation power and GitHub Actions time are wasted unnecessarily,