### PR TITLE
Fix API tokens' update due to wrong enum values

### DIFF
--- a/packages/core/admin/server/services/api-token.js
+++ b/packages/core/admin/server/services/api-token.js
@@ -300,8 +300,8 @@ const update = async (id, attributes) => {
   }
 
   const changingTypeToCustom =
-    attributes.type === constants.API_TOKEN_TYPE.custom &&
-    originalToken.type !== constants.API_TOKEN_TYPE.custom;
+    attributes.type === constants.API_TOKEN_TYPE.CUSTOM &&
+    originalToken.type !== constants.API_TOKEN_TYPE.CUSTOM;
 
   // if we're updating the permissions on any token type, or changing from non-custom to custom, ensure they're still valid
   // if neither type nor permissions are changing, we don't need to validate again or else we can't allow partial update


### PR DESCRIPTION
### What does it do?

It uses the correct API_TOKEN_TYPES enum values to assert if we're changing the token type to custom

### Why is it needed?

Right now, it considers we're trying to update the token to the custom type on every call.

### How to test it?

- Create a custom token
- Try to run a query on the content API using this token
- It shouldn't throw the following error
```json
{
  "data": null,
  "error": {
    "status": 400,
    "name": "ValidationError",
    "message": "Missing permissions attribute for custom token",
    "details": {}
  }
}
```