### PR TITLE
Remove S3 file when given a path

### DIFF
--- a/packages/core/upload/server/content-types/file/schema.js
+++ b/packages/core/upload/server/content-types/file/schema.js
@@ -87,6 +87,10 @@ module.exports = {
       relation: 'morphToMany',
       configurable: false,
     },
+    path: {
+      type: 'string',
+      configurable: false,
+    },
     folder: {
       type: 'relation',
       relation: 'manyToOne',


### PR DESCRIPTION
## ❓ Why is it needed?
To fix #13744 

A little explanation of my approach:
- Storing `path` as a new table column seems the cleanest solution for me. Some other reasons that make me believe this:
    - The codebase was already expecting the db to have a `path` column. [Example](https://github.com/strapi/strapi/blob/main/packages/core/upload/server/services/upload.js#L276)
    - All formats except the original image have the ``path`` attribute already.

- One other approach I tried was to update the file.hash, to store that same path. But that affects many things:
    - The image hash is used to store the images in a temp folder.
    - That means, If you change how the hash is generated in the first place.  You should also generate the path of folders. 

So.. I ask you what do you think is the best approach here.

## 🧪 How to test it?

Create and send a POST request with the following properties:
- Endpoint: {host:port}/api/upload
- In body form-data:
   - files: A file to upload
   - path: A path where the files will be uploaded in S3. /test for example

##  🔗 Related issue(s)/PR(s)
#13744
