### PR TITLE
[RelationInput] Loading state and label ellipsis

### DIFF
--- a/packages/core/admin/admin/src/translations/en.json
+++ b/packages/core/admin/admin/src/translations/en.json
@@ -489,7 +489,6 @@
   "content-manager.App.schemas.data-loaded": "The schemas have been successfully loaded",
   "content-manager.DynamicTable.relation-loaded": "Relations have been loaded",
   "content-manager.DynamicTable.relation-loading": "Relations are loading",
-  "content-manager.DynamicTable.relation-search-loading": "Entries are loading",
   "content-manager.DynamicTable.relation-more": "This relation contains more entities than displayed",
   "content-manager.EditRelations.title": "Relational data",
   "content-manager.HeaderLayout.button.label-add-entry": "Create new entry",

--- a/packages/core/admin/admin/src/translations/en.json
+++ b/packages/core/admin/admin/src/translations/en.json
@@ -489,6 +489,7 @@
   "content-manager.App.schemas.data-loaded": "The schemas have been successfully loaded",
   "content-manager.DynamicTable.relation-loaded": "Relations have been loaded",
   "content-manager.DynamicTable.relation-loading": "Relations are loading",
+  "content-manager.DynamicTable.relation-search-loading": "Entries are loading",
   "content-manager.DynamicTable.relation-more": "This relation contains more entities than displayed",
   "content-manager.EditRelations.title": "Relational data",
   "content-manager.HeaderLayout.button.label-add-entry": "Create new entry",

--- a/packages/core/helper-plugin/lib/src/components/ReactSelect/ReactSelect.js
+++ b/packages/core/helper-plugin/lib/src/components/ReactSelect/ReactSelect.js
@@ -6,7 +6,6 @@ import { useTheme } from 'styled-components';
 import ClearIndicator from './components/ClearIndicator';
 import DropdownIndicator from './components/DropdownIndicator';
 import IndicatorSeparator from './components/IndicatorSeparator';
-import LoadingMessage from './components/LoadingMessage';
 
 import getSelectStyles from './utils/getSelectStyles';
 
@@ -22,7 +21,6 @@ const ReactSelect = ({ components, styles, error, ariaErrorMessage, ...props }) 
         ClearIndicator,
         DropdownIndicator,
         IndicatorSeparator,
-        LoadingMessage,
         ...components,
       }}
       aria-errormessage={error && ariaErrorMessage}

--- a/packages/core/helper-plugin/lib/src/components/ReactSelect/ReactSelect.js
+++ b/packages/core/helper-plugin/lib/src/components/ReactSelect/ReactSelect.js
@@ -6,6 +6,7 @@ import { useTheme } from 'styled-components';
 import ClearIndicator from './components/ClearIndicator';
 import DropdownIndicator from './components/DropdownIndicator';
 import IndicatorSeparator from './components/IndicatorSeparator';
+import LoadingMessage from './components/LoadingMessage';
 
 import getSelectStyles from './utils/getSelectStyles';
 
@@ -17,7 +18,13 @@ const ReactSelect = ({ components, styles, error, ariaErrorMessage, ...props }) 
     <Select
       {...props}
       menuPosition="fixed"
-      components={{ ClearIndicator, DropdownIndicator, IndicatorSeparator, ...components }}
+      components={{
+        ClearIndicator,
+        DropdownIndicator,
+        IndicatorSeparator,
+        LoadingMessage,
+        ...components,
+      }}
       aria-errormessage={error && ariaErrorMessage}
       aria-invalid={!!error}
       styles={{ ...customStyles, ...styles }}

--- a/packages/core/helper-plugin/lib/src/components/RelationInput/RelationInput.js
+++ b/packages/core/helper-plugin/lib/src/components/RelationInput/RelationInput.js
@@ -9,6 +9,7 @@ import { BaseLink } from '@strapi/design-system/BaseLink';
 import { Icon } from '@strapi/design-system/Icon';
 import { FieldLabel, FieldError, FieldHint, Field } from '@strapi/design-system/Field';
 import { TextButton } from '@strapi/design-system/TextButton';
+import { Typography } from '@strapi/design-system/Typography';
 import { Loader } from '@strapi/design-system/Loader';
 
 import Cross from '@strapi/icons/Cross';
@@ -21,10 +22,10 @@ import { Option } from './components/Option';
 
 import ReactSelect from '../ReactSelect';
 
-const BoxEllipsis = styled(Box)`
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+const RelationItemCenterChildren = styled(RelationItem)`
+  div {
+    justify-content: center;
+  }
 `;
 
 export const RelationInput = ({
@@ -36,6 +37,7 @@ export const RelationInput = ({
   label,
   labelLoadMore,
   listHeight,
+  loadingMessage,
   relations,
   onRelationClose,
   onRelationAdd,
@@ -65,13 +67,7 @@ export const RelationInput = ({
               inputId={id}
               isSearchable
               isClear
-              loadingMessage={() =>
-                // To fix: use getTrad utils from CM once component is migrated into CM components
-                formatMessage({
-                  id: 'content-manager.DynamicTable.relation-search-loading',
-                  defaultMessage: 'Entries are loading',
-                })
-              }
+              loadingMessage={() => <Loader small>{formatMessage(loadingMessage)}</Loader>}
               onChange={onRelationAdd}
               onInputChange={onSearch}
               onMenuClose={onRelationOpen}
@@ -109,15 +105,19 @@ export const RelationInput = ({
                     </button>
                   }
                 >
-                  <BoxEllipsis paddingTop={1} paddingBottom={1} paddingRight={4}>
+                  <Box minWidth={0} paddingTop={1} paddingBottom={1} paddingRight={4}>
                     {href ? (
                       <BaseLink disabled={disabled} href={href}>
-                        {mainField}
+                        <Typography textColor={disabled ? 'neutral600' : 'primary600'} ellipsis>
+                          {mainField}
+                        </Typography>
                       </BaseLink>
                     ) : (
-                      mainField
+                      <Typography textColor={disabled ? 'neutral600' : 'primary600'} ellipsis>
+                        {mainField}
+                      </Typography>
                     )}
-                  </BoxEllipsis>
+                  </Box>
 
                   {publicationState && (
                     <Badge
@@ -134,14 +134,9 @@ export const RelationInput = ({
               );
             })}
           {relations.isLoading && (
-            <RelationItem>
-              <Loader small>
-                {formatMessage({
-                  id: 'content-manager.DynamicTable.relation-loading',
-                  defaultMessage: 'Relations are loading',
-                })}
-              </Loader>
-            </RelationItem>
+            <RelationItemCenterChildren>
+              <Loader small>{formatMessage(loadingMessage)}</Loader>
+            </RelationItemCenterChildren>
           )}
         </RelationList>
         <Box paddingTop={2}>
@@ -203,6 +198,10 @@ RelationInput.propTypes = {
   label: PropTypes.string.isRequired,
   labelLoadMore: PropTypes.string.isRequired,
   listHeight: PropTypes.string,
+  loadingMessage: PropTypes.shape({
+    id: PropTypes.string,
+    defaultMessage: PropTypes.string,
+  }).isRequired,
   name: PropTypes.string.isRequired,
   onRelationAdd: PropTypes.func.isRequired,
   onRelationOpen: PropTypes.func.isRequired,

--- a/packages/core/helper-plugin/lib/src/components/RelationInput/RelationInput.js
+++ b/packages/core/helper-plugin/lib/src/components/RelationInput/RelationInput.js
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'styled-components';
-import { useIntl } from 'react-intl';
 
 import { Badge } from '@strapi/design-system/Badge';
 import { Box } from '@strapi/design-system/Box';
@@ -50,8 +49,6 @@ export const RelationInput = ({
   publicationStateTranslations,
   searchResults,
 }) => {
-  const { formatMessage } = useIntl();
-
   return (
     <Field error={error} name={name} hint={description} id={id}>
       <Relation
@@ -67,7 +64,7 @@ export const RelationInput = ({
               inputId={id}
               isSearchable
               isClear
-              loadingMessage={() => <Loader small>{formatMessage(loadingMessage)}</Loader>}
+              loadingMessage={() => loadingMessage}
               onChange={onRelationAdd}
               onInputChange={onSearch}
               onMenuClose={onRelationOpen}
@@ -135,7 +132,7 @@ export const RelationInput = ({
             })}
           {relations.isLoading && (
             <RelationItemCenterChildren>
-              <Loader small>{formatMessage(loadingMessage)}</Loader>
+              <Loader small>{loadingMessage}</Loader>
             </RelationItemCenterChildren>
           )}
         </RelationList>
@@ -198,10 +195,7 @@ RelationInput.propTypes = {
   label: PropTypes.string.isRequired,
   labelLoadMore: PropTypes.string.isRequired,
   listHeight: PropTypes.string,
-  loadingMessage: PropTypes.shape({
-    id: PropTypes.string,
-    defaultMessage: PropTypes.string,
-  }).isRequired,
+  loadingMessage: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
   onRelationAdd: PropTypes.func.isRequired,
   onRelationOpen: PropTypes.func.isRequired,

--- a/packages/core/helper-plugin/lib/src/components/RelationInput/RelationInput.js
+++ b/packages/core/helper-plugin/lib/src/components/RelationInput/RelationInput.js
@@ -1,5 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import styled from 'styled-components';
+import { useIntl } from 'react-intl';
 
 import { Badge } from '@strapi/design-system/Badge';
 import { Box } from '@strapi/design-system/Box';
@@ -7,6 +9,7 @@ import { BaseLink } from '@strapi/design-system/BaseLink';
 import { Icon } from '@strapi/design-system/Icon';
 import { FieldLabel, FieldError, FieldHint, Field } from '@strapi/design-system/Field';
 import { TextButton } from '@strapi/design-system/TextButton';
+import { Loader } from '@strapi/design-system/Loader';
 
 import Cross from '@strapi/icons/Cross';
 import Refresh from '@strapi/icons/Refresh';
@@ -17,6 +20,12 @@ import { RelationList } from './components/RelationList';
 import { Option } from './components/Option';
 
 import ReactSelect from '../ReactSelect';
+
+const BoxEllipsis = styled(Box)`
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
 
 export const RelationInput = ({
   description,
@@ -39,6 +48,8 @@ export const RelationInput = ({
   publicationStateTranslations,
   searchResults,
 }) => {
+  const { formatMessage } = useIntl();
+
   return (
     <Field error={error} name={name} hint={description} id={id}>
       <Relation
@@ -49,10 +60,18 @@ export const RelationInput = ({
               components={{ Option }}
               options={searchResults.data.pages.flat()}
               isDisabled={disabled}
+              isLoading={searchResults.isLoading}
               error={error}
               inputId={id}
               isSearchable
               isClear
+              loadingMessage={() =>
+                // To fix: use getTrad utils from CM once component is migrated into CM components
+                formatMessage({
+                  id: 'content-manager.DynamicTable.relation-search-loading',
+                  defaultMessage: 'Entries are loading',
+                })
+              }
               onChange={onRelationAdd}
               onInputChange={onSearch}
               onMenuClose={onRelationOpen}
@@ -90,7 +109,7 @@ export const RelationInput = ({
                     </button>
                   }
                 >
-                  <Box paddingTop={1} paddingBottom={1}>
+                  <BoxEllipsis paddingTop={1} paddingBottom={1} paddingRight={4}>
                     {href ? (
                       <BaseLink disabled={disabled} href={href}>
                         {mainField}
@@ -98,7 +117,7 @@ export const RelationInput = ({
                     ) : (
                       mainField
                     )}
-                  </Box>
+                  </BoxEllipsis>
 
                   {publicationState && (
                     <Badge
@@ -106,6 +125,7 @@ export const RelationInput = ({
                       borderColor={`${badgeColor}200`}
                       backgroundColor={`${badgeColor}100`}
                       textColor={`${badgeColor}700`}
+                      shrink={0}
                     >
                       {publicationStateTranslations[publicationState]}
                     </Badge>
@@ -113,6 +133,16 @@ export const RelationInput = ({
                 </RelationItem>
               );
             })}
+          {relations.isLoading && (
+            <RelationItem>
+              <Loader small>
+                {formatMessage({
+                  id: 'content-manager.DynamicTable.relation-loading',
+                  defaultMessage: 'Relations are loading',
+                })}
+              </Loader>
+            </RelationItem>
+          )}
         </RelationList>
         <Box paddingTop={2}>
           <FieldHint />

--- a/packages/core/helper-plugin/lib/src/components/RelationInput/RelationInput.stories.mdx
+++ b/packages/core/helper-plugin/lib/src/components/RelationInput/RelationInput.stories.mdx
@@ -25,7 +25,7 @@ WIP
         label="Relations"
         labelLoadMore="Load More"
         listHeight="200px"
-        loadingMessage={{ id: 'translation-key', defaultMessage: 'Relations are loading' }}
+        loadingMessage='Relations are loading'
         name="options"
         publicationStateTranslations={{ draft: 'Draft', published: 'Published' }}
         searchResults={{

--- a/packages/core/helper-plugin/lib/src/components/RelationInput/RelationInput.stories.mdx
+++ b/packages/core/helper-plugin/lib/src/components/RelationInput/RelationInput.stories.mdx
@@ -32,7 +32,7 @@ WIP
             pages: [
               [
                 {
-                  id: 6
+                  id: 6,
                   mainField: 'Relation 6',
                   publicationState: 'draft',
                 },
@@ -48,9 +48,9 @@ WIP
                 },
               ],
             ],
-            isLoading: false,
-            isSuccess: true,
           },
+          isLoading: false,
+          isSuccess: true,
         }}
         relations={{
           data: {
@@ -59,14 +59,14 @@ WIP
                 {
                   id: 1,
                   href: '/',
-                  mainField: 'Relation 1',
+                  mainField: 'Relation 1 with a very very very very very very very very very very very very very very very very very very very super huge really really long title',
                   publicationState: 'draft',
                 },
                 {
                   id: 2,
                   href: '',
-                  mainField: 'Relation 2',
-                  publicationState: false,
+                  mainField: 'Relation 2 with a very very very very very very very very very very very very very very very very very very very super huge really really long title',
+                  publicationState: 'published',
                 },
                 {
                   id: 3,
@@ -89,7 +89,7 @@ WIP
               ],
             ],
           },
-          isLoading: false,
+          isLoading: true,
           isSuccess: true,
         }}
       />

--- a/packages/core/helper-plugin/lib/src/components/RelationInput/RelationInput.stories.mdx
+++ b/packages/core/helper-plugin/lib/src/components/RelationInput/RelationInput.stories.mdx
@@ -25,6 +25,7 @@ WIP
         label="Relations"
         labelLoadMore="Load More"
         listHeight="200px"
+        loadingMessage={{ id: 'translation-key', defaultMessage: 'Relations are loading' }}
         name="options"
         publicationStateTranslations={{ draft: 'Draft', published: 'Published' }}
         searchResults={{
@@ -59,13 +60,15 @@ WIP
                 {
                   id: 1,
                   href: '/',
-                  mainField: 'Relation 1 with a very very very very very very very very very very very very very very very very very very very super huge really really long title',
+                  mainField:
+                    'Relation 1 with a very very very very very very very very very very very very very very very very very very very super huge really really long title',
                   publicationState: 'draft',
                 },
                 {
                   id: 2,
                   href: '',
-                  mainField: 'Relation 2 with a very very very very very very very very very very very very very very very very very very very super huge really really long title',
+                  mainField:
+                    'Relation 2 with a very very very very very very very very very very very very very very very very very very very super huge really really long title',
                   publicationState: 'published',
                 },
                 {
@@ -89,7 +92,7 @@ WIP
               ],
             ],
           },
-          isLoading: true,
+          isLoading: false,
           isSuccess: true,
         }}
       />

--- a/packages/core/helper-plugin/lib/src/components/RelationInput/components/RelationItem.js
+++ b/packages/core/helper-plugin/lib/src/components/RelationInput/components/RelationItem.js
@@ -3,19 +3,11 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { Box } from '@strapi/design-system/Box';
 import { Flex } from '@strapi/design-system/Flex';
-import { Typography } from '@strapi/design-system/Typography';
 
-const TypographyWrapper = styled(Typography)`
+const ChildrenWrapper = styled(Flex)`
   width: 100%;
   // Used to prevent endAction to be pushed out of container
   min-width: 0;
-`;
-
-const ChildrenWrapper = styled(Flex)`
-  div > a {
-    color: currentColor;
-    text-decoration: none;
-  }
 `;
 
 export const RelationItem = ({ children, disabled, endAction, ...props }) => {
@@ -33,11 +25,7 @@ export const RelationItem = ({ children, disabled, endAction, ...props }) => {
       as="li"
       {...props}
     >
-      <TypographyWrapper textColor={disabled ? 'neutral600' : 'primary600'} as="div">
-        <ChildrenWrapper justifyContent="space-between" color="currentColor">
-          {children}
-        </ChildrenWrapper>
-      </TypographyWrapper>
+      <ChildrenWrapper justifyContent="space-between">{children}</ChildrenWrapper>
       {endAction && <Box paddingLeft={4}>{endAction}</Box>}
     </Flex>
   );

--- a/packages/core/helper-plugin/lib/src/components/RelationInput/components/RelationItem.js
+++ b/packages/core/helper-plugin/lib/src/components/RelationInput/components/RelationItem.js
@@ -7,6 +7,8 @@ import { Typography } from '@strapi/design-system/Typography';
 
 const TypographyWrapper = styled(Typography)`
   width: 100%;
+  // Used to prevent endAction to be pushed out of container
+  min-width: 0;
 `;
 
 const ChildrenWrapper = styled(Flex)`
@@ -32,7 +34,7 @@ export const RelationItem = ({ children, disabled, endAction, ...props }) => {
       {...props}
     >
       <TypographyWrapper textColor={disabled ? 'neutral600' : 'primary600'} as="div">
-        <ChildrenWrapper width="100%" justifyContent="space-between" color="currentColor">
+        <ChildrenWrapper justifyContent="space-between" color="currentColor">
           {children}
         </ChildrenWrapper>
       </TypographyWrapper>

--- a/packages/core/helper-plugin/lib/src/components/RelationInput/components/tests/__snapshots__/RelationItem.test.js.snap
+++ b/packages/core/helper-plugin/lib/src/components/RelationInput/components/tests/__snapshots__/RelationItem.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`RelationItem should render and match snapshot 1`] = `
-.c6 {
+.c3 {
   border: 0;
   -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
@@ -24,10 +24,6 @@ exports[`RelationItem should render and match snapshot 1`] = `
   border: 1px solid #dcdce4;
 }
 
-.c4 {
-  width: 100%;
-}
-
 .c1 {
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -47,19 +43,8 @@ exports[`RelationItem should render and match snapshot 1`] = `
 }
 
 .c2 {
-  color: #4945ff;
-  font-size: 0.875rem;
-  line-height: 1.43;
-}
-
-.c3 {
   width: 100%;
-}
-
-.c5 div > a {
-  color: currentColor;
-  -webkit-text-decoration: none;
-  text-decoration: none;
+  min-width: 0;
 }
 
 <div>
@@ -67,18 +52,13 @@ exports[`RelationItem should render and match snapshot 1`] = `
     class="c0 c1"
   >
     <div
-      class="c2 c3"
+      class="c1 c2"
     >
-      <div
-        class="c4 c1 c5"
-        width="100%"
-      >
-        First relation
-      </div>
+      First relation
     </div>
   </li>
   <div
-    class="c6"
+    class="c3"
   >
     <p
       aria-live="polite"

--- a/packages/core/helper-plugin/lib/src/components/RelationInput/components/tests/__snapshots__/RelationList.test.js.snap
+++ b/packages/core/helper-plugin/lib/src/components/RelationInput/components/tests/__snapshots__/RelationList.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`RelationList should render and match snapshot 1`] = `
-.c9 {
+.c6 {
   border: 0;
   -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
@@ -24,10 +24,6 @@ exports[`RelationList should render and match snapshot 1`] = `
   border: 1px solid #dcdce4;
 }
 
-.c7 {
-  width: 100%;
-}
-
 .c4 {
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -47,19 +43,8 @@ exports[`RelationList should render and match snapshot 1`] = `
 }
 
 .c5 {
-  color: #4945ff;
-  font-size: 0.875rem;
-  line-height: 1.43;
-}
-
-.c6 {
   width: 100%;
-}
-
-.c8 div > a {
-  color: currentColor;
-  -webkit-text-decoration: none;
-  text-decoration: none;
+  min-width: 0;
 }
 
 .c1 {
@@ -121,20 +106,15 @@ exports[`RelationList should render and match snapshot 1`] = `
         class="c3 c4"
       >
         <div
-          class="c5 c6"
+          class="c4 c5"
         >
-          <div
-            class="c7 c4 c8"
-            width="100%"
-          >
-            First relation
-          </div>
+          First relation
         </div>
       </li>
     </ol>
   </div>
   <div
-    class="c9"
+    class="c6"
   >
     <p
       aria-live="polite"


### PR DESCRIPTION
## What

- **Loading state for searchResults on ReactSelect:** Default style from the component but added translated `loadingMessage`
- **Loading state for relations:** Integrated it as last item of `RelationList` from `RelationInput`. Will allow us to keep previous items visible while the next relations are loading. Used `RelationItem` to easily track it's height needed when we'll integrate `react-window` 
  - Check with design for approval/changes
- Since loading state is mainly handled in `RelationInput` directly, tests will be added when creating all other `RelationInput` tests (will be the next PR)

<img width="695" alt="image" src="https://user-images.githubusercontent.com/71838159/186668512-ebc834ae-8cb3-4fc0-81ed-4d4a55cd1542.png">


- **Ellipsis on RelationItem label:** Handled in `RelationInput` since `RelationItem` doesn't provide the granularity to access only the label (without impacting other components passed as `children`, e.g. `Badge`)

<img width="687" alt="image" src="https://user-images.githubusercontent.com/71838159/186668331-005e4ec1-4fa8-4152-91b5-bc01b7e00020.png">

## Test

Launch storybook and test loading states + long labels


