### PR TITLE
Fix expiration date checks

### DIFF
--- a/packages/core/admin/server/strategies/__tests__/api-token.test.js
+++ b/packages/core/admin/server/strategies/__tests__/api-token.test.js
@@ -86,7 +86,7 @@ describe('API Token Auth Strategy', () => {
     });
 
     test('Expired token throws on authorize', async () => {
-      const pastDate = Date.now() - 1;
+      const pastDate = new Date(Date.now() - 1).toISOString();
 
       const getBy = jest.fn(() => {
         return {
@@ -109,9 +109,11 @@ describe('API Token Auth Strategy', () => {
         },
       };
 
-      expect(async () => {
-        await apiTokenStrategy.authenticate(ctx);
-      }).rejects.toThrow(new UnauthorizedError('Token expired'));
+      const { authenticated, error } = await apiTokenStrategy.authenticate(ctx);
+
+      expect(authenticated).toBe(false);
+      expect(error).toBeInstanceOf(UnauthorizedError);
+      expect(error.message).toBe('Token expired');
 
       expect(getBy).toHaveBeenCalledWith({ accessKey: 'api-token_tests-hashed-access-key' });
     });

--- a/packages/core/admin/server/strategies/api-token.js
+++ b/packages/core/admin/server/strategies/api-token.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { castArray } = require('lodash/fp');
+const { castArray, isNil } = require('lodash/fp');
 const { UnauthorizedError, ForbiddenError } = require('@strapi/utils').errors;
 const constants = require('../services/constants');
 const { getService } = require('../utils');
@@ -42,12 +42,14 @@ const authenticate = async (ctx) => {
     return { authenticated: false };
   }
 
-  const expirationDate = new Date(apiToken.expiresAt);
   const currentDate = new Date();
 
-  // token has expired
-  if (expirationDate < currentDate) {
-    return { authenticated: false, error: new UnauthorizedError('Token expired') };
+  if (!isNil(apiToken.expiresAt)) {
+    const expirationDate = new Date(apiToken.expiresAt);
+    // token has expired
+    if (expirationDate < currentDate) {
+      return { authenticated: false, error: new UnauthorizedError('Token expired') };
+    }
   }
 
   // update lastUsedAt
@@ -77,12 +79,14 @@ const verify = (auth, config) => {
     throw new UnauthorizedError('Token not found');
   }
 
-  const expirationDate = new Date(apiToken.expiresAt);
   const currentDate = new Date();
 
-  // token has expired
-  if (expirationDate < currentDate) {
-    throw new UnauthorizedError('Token expired');
+  if (!isNil(apiToken.expiresAt)) {
+    const expirationDate = new Date(apiToken.expiresAt);
+    // token has expired
+    if (expirationDate < currentDate) {
+      throw new UnauthorizedError('Token expired');
+    }
   }
 
   // Full access

--- a/packages/core/admin/server/strategies/api-token.js
+++ b/packages/core/admin/server/strategies/api-token.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { castArray, isNil } = require('lodash/fp');
+const { castArray } = require('lodash/fp');
 const { UnauthorizedError, ForbiddenError } = require('@strapi/utils').errors;
 const constants = require('../services/constants');
 const { getService } = require('../utils');
@@ -42,14 +42,17 @@ const authenticate = async (ctx) => {
     return { authenticated: false };
   }
 
+  const expirationDate = new Date(apiToken.expiresAt);
+  const currentDate = new Date();
+
   // token has expired
-  if (!isNil(apiToken.expiresAt) && apiToken.expiresAt < Date.now()) {
+  if (expirationDate < currentDate) {
     throw new UnauthorizedError('Token expired');
   }
 
   // update lastUsedAt
   await apiTokenService.update(apiToken.id, {
-    lastUsedAt: new Date(),
+    lastUsedAt: currentDate,
   });
 
   if (apiToken.type === constants.API_TOKEN_TYPE.CUSTOM) {
@@ -74,8 +77,11 @@ const verify = (auth, config) => {
     throw new UnauthorizedError('Token not found');
   }
 
+  const expirationDate = new Date(apiToken.expiresAt);
+  const currentDate = new Date();
+
   // token has expired
-  if (!isNil(apiToken.expiresAt) && apiToken.expiresAt < Date.now()) {
+  if (expirationDate < currentDate) {
     throw new UnauthorizedError('Token expired');
   }
 

--- a/packages/core/admin/server/strategies/api-token.js
+++ b/packages/core/admin/server/strategies/api-token.js
@@ -47,7 +47,7 @@ const authenticate = async (ctx) => {
 
   // token has expired
   if (expirationDate < currentDate) {
-    throw new UnauthorizedError('Token expired');
+    return { authenticated: false, error: new UnauthorizedError('Token expired') };
   }
 
   // update lastUsedAt


### PR DESCRIPTION
### What does it do?

Fix checks regarding expiration date in the API token strategy

### Why is it needed?

Currently, the code is trying to make a comparison between a date as an ISO string and a time as a number. The token is thus never considered expired.

### How to test it?

- Create a token with a short lifespan
- Try to make an authenticated request -> You should get back your data
- Wait until the token expiration date is reached
- Try to make the same request as in step 2. This time you should get a 401 error with a "Token Expired" message.
