### PR TITLE
Docs: Expand on how to use e2e snapshot tests with jest arguments

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,9 +132,11 @@ $ yarn test:generate-app mysql
 
 A new app is required every time you run the end-to-end tests otherwise, the test suite will fail. A script is available to make this process easier: `node test/e2e.js`. It will delete the current test app, generate a new one and run the test suite.
 
+The script takes a path as optional argument (e.g. `node test/e2e.js path/to/test`). Options for jest can be passed using the double-dash notion: e.g. to update snapshots `node test/e2e.js -- -u`.
+
 ### Changing the database
 
-By default the script `test/e2e,js` creates an app that uses `sqlite`. But you can run the test suites using different databases:
+By default the script `test/e2e.js` creates an app that uses `sqlite`. But you can run the test suites using different databases:
 
 ```bash
 $ node test/e2e.js --db=sqlite


### PR DESCRIPTION
### What does it do?

Adds documentation for the e2e test script:

- it takes an optional path for run e.g. a single test
- how to pass down arguments for jest

### Why is it needed?

It wasn't clear for me how I could update the snapshot tests for e2e tests and neither that the script receives a path as optional argument, which makes running the e2e much easier locally.

### Related issue(s)/PR(s)

- https://github.com/strapi/strapi/pull/14221
