### PR TITLE
[FE] Integrate the BE to Save a Token in Creation and Update

### DIFF
--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/ApiTokens/EditView/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/ApiTokens/EditView/index.js
@@ -249,7 +249,7 @@ const ApiTokenCreateView = () => {
             name: apiToken?.name || '',
             description: apiToken?.description || '',
             type: apiToken?.type,
-            duration: apiToken?.duration,
+            lifespan: apiToken?.lifespan,
           }}
           onSubmit={handleSubmit}
         >
@@ -356,49 +356,49 @@ const ApiTokenCreateView = () => {
                               {values.description}
                             </Textarea>
                           </GridItem>
-                          <GridItem key="duration" col={6} xs={12}>
+                          <GridItem key="lifespan" col={6} xs={12}>
                             <Select
-                              name="duration"
+                              name="lifespan"
                               label={formatMessage({
                                 id: 'Settings.apiTokens.form.duration',
                                 defaultMessage: 'Token duration',
                               })}
-                              value={isCreating ? values.duration : '7'}
+                              value={values.lifespan}
                               error={
-                                errors.duration
+                                errors.lifespan
                                   ? formatMessage(
-                                      errors.duration?.id
-                                        ? errors.duration
-                                        : { id: errors.duration, defaultMessage: errors.duration }
+                                      errors.lifespan?.id
+                                        ? errors.lifespan
+                                        : { id: errors.lifespan, defaultMessage: errors.lifespan }
                                     )
                                   : null
                               }
                               onChange={(value) => {
-                                handleChange({ target: { name: 'duration', value } });
+                                handleChange({ target: { name: 'lifespan', value } });
                               }}
                               required
                               disabled={!isCreating}
                               placeholder="Select"
                             >
-                              <Option value="7">
+                              <Option value={7}>
                                 {formatMessage({
                                   id: 'Settings.apiTokens.duration.7-days',
                                   defaultMessage: '7 days',
                                 })}
                               </Option>
-                              <Option value="30">
+                              <Option value={30}>
                                 {formatMessage({
                                   id: 'Settings.apiTokens.duration.30-days',
                                   defaultMessage: '30 days',
                                 })}
                               </Option>
-                              <Option value="90">
+                              <Option value={90}>
                                 {formatMessage({
                                   id: 'Settings.apiTokens.duration.90-days',
                                   defaultMessage: '90 days',
                                 })}
                               </Option>
-                              <Option value="unlimited">
+                              <Option>
                                 {formatMessage({
                                   id: 'Settings.apiTokens.duration.unlimited',
                                   defaultMessage: 'Unlimited',
@@ -412,7 +412,7 @@ const ApiTokenCreateView = () => {
                                   defaultMessage: 'Expiration date',
                                 })}: ${getDateOfExpiration(
                                   apiToken?.createdAt,
-                                  values.duration || '7',
+                                  values.lifespan || 7,
                                   lang
                                 )}`}
                             </Typography>

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/ApiTokens/EditView/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/ApiTokens/EditView/index.js
@@ -183,6 +183,8 @@ const ApiTokenCreateView = () => {
     return 'custom';
   }, [hasAllActionsSelected, hasReadOnlyActionsSelected, hasAllActionsNotSelected]);
 
+  console.log('tokenType', tokenTypeValue);
+
   const handleChangeCheckbox = ({ target: { name, value } }) => {
     dispatch({
       type: 'ON_CHANGE',
@@ -425,7 +427,7 @@ const ApiTokenCreateView = () => {
                                 id: 'Settings.apiTokens.form.type',
                                 defaultMessage: 'Token type',
                               })}
-                              value={tokenTypeValue}
+                              value={values.type}
                               error={
                                 errors.type
                                   ? formatMessage(

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/ApiTokens/EditView/tests/__snapshots__/index.test.js.snap
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/ApiTokens/EditView/tests/__snapshots__/index.test.js.snap
@@ -1394,7 +1394,7 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
                             aria-labelledby="select-1-label select-1-content"
                             class="c48"
                             id="select-1"
-                            name="duration"
+                            name="lifespan"
                             type="button"
                           />
                           <div
@@ -1410,7 +1410,7 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
                                   class="c52"
                                   id="select-1-content"
                                 >
-                                  Select
+                                  Unlimited
                                 </span>
                               </div>
                             </div>
@@ -2083,7 +2083,7 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
 }
 
 .c60 {
-  color: #32324d;
+  color: #666687;
   display: block;
   white-space: nowrap;
   overflow: hidden;
@@ -2093,7 +2093,7 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
 }
 
 .c66 {
-  color: #666687;
+  color: #32324d;
   display: block;
   white-space: nowrap;
   overflow: hidden;
@@ -3354,7 +3354,7 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
                             aria-labelledby="select-3-label select-3-content"
                             class="c56"
                             id="select-3"
-                            name="duration"
+                            name="lifespan"
                             type="button"
                           />
                           <div
@@ -3370,7 +3370,7 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
                                   class="c60"
                                   id="select-3-content"
                                 >
-                                  7 days
+                                  Unlimited
                                 </span>
                               </div>
                             </div>
@@ -3465,7 +3465,7 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
                                   class="c66"
                                   id="select-4-content"
                                 >
-                                  Select
+                                  Read-only
                                 </span>
                               </div>
                             </div>

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/ApiTokens/EditView/utils/schema.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/ApiTokens/EditView/utils/schema.js
@@ -8,10 +8,7 @@ const schema = yup.object().shape({
     .oneOf(['read-only', 'full-access', 'custom'])
     .required(translatedErrors.required),
   description: yup.string().nullable(),
-  duration: yup
-    .string(translatedErrors.string)
-    .oneOf(['7', '30', '90', 'unlimited'])
-    .required(translatedErrors.required),
+  lifespan: yup.number().integer().min(1).nullable(),
 });
 
 export default schema;


### PR DESCRIPTION
As a user who has access to the API tokens settings, when I generate a new token or when I edit an existing token, I want to save the token with the chosen expiration time and permissions.

👨🏼‍🎨 Design
[https://www.figma.com/file/lADY9wlnGvOX1blL19UYcG/%5BWIP%5D-DX---API-Tokens?node-id=1485%3A10299 - Connect to preview](https://www.figma.com/file/lADY9wlnGvOX1blL19UYcG/%5BWIP%5D-DX---API-Tokens?node-id=1485%3A10299)

☑️ Acceptance criteria
 - As an admin who has access to the API tokens settings
   - when I create or edit a token, specifying some permissions and an expiration time
   - and when I save successfully
     - then I want the UI to show a confirmation message and the token to reflect the edits applied
 - The confirmation messages are:
   - edit view: API Token successfully edited
   - creation view: API Token successfully created