### PR TITLE
Update documentation link for custom fields

### DIFF
--- a/packages/core/content-type-builder/admin/src/components/AttributeOptions/CustomFieldsList/index.js
+++ b/packages/core/content-type-builder/admin/src/components/AttributeOptions/CustomFieldsList/index.js
@@ -45,7 +45,7 @@ const CustomFieldsList = () => {
           })}
         </Grid>
         <Link
-          href="https://docs.strapi.io/developer-docs/latest/getting-started/introduction.html"
+          href="https://docs-next.strapi.io/developer-docs/latest/development/custom-fields.html"
           isExternal
         >
           {formatMessage({


### PR DESCRIPTION
This URL will have to be changed again after the stable release
(docs-next.strapi.io will become docs.strapi.io)

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

It updates the link to the documentation introduced in PR #13823 

***

_Note:_ 
This link will have to be updated again for the stable release, changing the base URL:  `docs-next.strapi.io` → `docs.strapi.io`. I can handle this change if you want ^^