### PR TITLE
allow empty array of permissions

### DIFF
--- a/packages/core/admin/server/services/api-token.js
+++ b/packages/core/admin/server/services/api-token.js
@@ -62,7 +62,7 @@ const assertCustomTokenPermissionsValidity = (attributes) => {
   }
 
   // Custom type tokens should always have permissions attached to them
-  if (attributes.type === constants.API_TOKEN_TYPE.CUSTOM && isEmpty(attributes.permissions)) {
+  if (attributes.type === constants.API_TOKEN_TYPE.CUSTOM && !isArray(attributes.permissions)) {
     throw new ValidationError('Missing permissions attribute for custom token');
   }
 };

--- a/packages/core/admin/server/tests/admin-api-token-crud.test.e2e.js
+++ b/packages/core/admin/server/tests/admin-api-token-crud.test.e2e.js
@@ -304,11 +304,6 @@ describe('Admin API Token v2 CRUD (e2e)', () => {
     });
   });
 
-  /**
-   * TODO: Discuss: Which behaviour do we want? Should an empty array be treated the same as omitted/undefined?
-   * Easy to change in assertCustomTokenPermissionsValidity by checking isEmpty (to allow empty) vs !attributes.permissions
-   */
-
   test('Creates a non-custom api token with empty permissions attribute', async () => {
     const body = {
       name: 'api-token_tests-fullAccessFailWithEmptyPermissions',
@@ -374,7 +369,6 @@ describe('Admin API Token v2 CRUD (e2e)', () => {
       name: 'api-token_tests-customFail',
       description: 'api-token_tests-description',
       type: 'custom',
-      permissions: [],
     };
 
     const res = await rq({


### PR DESCRIPTION
### What does it do?

Allows an empty permissions array to be sent when creating a custom token

### Why is it needed?

To allow creating a token with no permissions

### How to test it?

Create a custom token with an empty permissions array and it should work
Created token should not have permission to perform any action
lastUsedAt should still be updated on each attempt

### Related issue(s)/PR(s)
