### PR TITLE
EditViewDataManagerProvider: Store loaded relations in initialData

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/index.js
@@ -164,6 +164,14 @@ const EditViewDataManagerProvider = ({
     });
   }, []);
 
+  const loadRelation = useCallback(({ target: { name, value } }) => {
+    dispatch({
+      type: 'LOAD_RELATION',
+      keys: name.split('.'),
+      value,
+    });
+  }, []);
+
   const addRepeatableComponentToField = useCallback(
     (keys, componentUid, shouldCheckErrors = false) => {
       dispatch({
@@ -475,6 +483,7 @@ const EditViewDataManagerProvider = ({
         shouldNotRunValidations,
         status,
         layout: currentContentTypeLayout,
+        loadRelation,
         modifiedData,
         moveComponentDown,
         moveComponentField,

--- a/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/reducer.js
+++ b/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/reducer.js
@@ -72,6 +72,19 @@ const reducer = (state, action) =>
 
         break;
       }
+      case 'LOAD_RELATION': {
+        const path = ['initialData', ...action.keys];
+        const currentValue = get(state, path);
+        const { value } = action;
+
+        if (Array.isArray(currentValue)) {
+          set(draftState, path, [...value, ...currentValue]);
+        } else {
+          set(draftState, path, value);
+        }
+
+        break;
+      }
       case 'ADD_RELATION': {
         const path = ['modifiedData', ...action.keys, 'add'];
         const currentValue = get(state, path);

--- a/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/tests/reducer.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/tests/reducer.test.js
@@ -294,6 +294,41 @@ describe('CONTENT MANAGER | COMPONENTS | EditViewDataManagerProvider | reducer',
     });
   });
 
+  describe('LOAD_RELATION', () => {
+    it('should add loaded relations to initalData', () => {
+      const state = {
+        ...initialState,
+        initialData: {},
+      };
+
+      let nextState = reducer(state, {
+        type: 'LOAD_RELATION',
+        keys: ['relation'],
+        value: [{ id: 1 }],
+      });
+
+      expect(nextState).toEqual({
+        ...initialState,
+        initialData: {
+          relation: [{ id: 1 }],
+        },
+      });
+
+      expect(
+        reducer(nextState, {
+          type: 'LOAD_RELATION',
+          keys: ['relation'],
+          value: [{ id: 2 }],
+        })
+      ).toEqual({
+        ...initialState,
+        initialData: {
+          relation: [{ id: 2 }, { id: 1 }],
+        },
+      });
+    });
+  });
+
   describe('REMOVE_RELATION', () => {
     it('should remove a relation from modifiedData', () => {
       const state = {

--- a/packages/core/admin/admin/src/content-manager/components/RelationInputWrapper/RelationInputWrapper.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInputWrapper/RelationInputWrapper.js
@@ -23,11 +23,14 @@ export const RelationInputWrapper = ({
   targetModel,
 }) => {
   const { formatMessage } = useIntl();
-  const { addRelation, removeRelation, modifiedData } = useCMEditViewDataManager();
+  const { addRelation, removeRelation, loadRelation, modifiedData } = useCMEditViewDataManager();
 
   const { relations, search, searchFor } = useRelation(name, {
     relation: {
       endpoint: endpoints.relation,
+      onload(data) {
+        loadRelation({ target: { name, value: data } });
+      },
       pageParams: {
         pageSize: 10,
       },

--- a/packages/core/admin/admin/src/content-manager/hooks/useFetchContentTypeLayout/utils/formatLayouts.js
+++ b/packages/core/admin/admin/src/content-manager/hooks/useFetchContentTypeLayout/utils/formatLayouts.js
@@ -122,7 +122,9 @@ const formatListLayoutWithMetas = (contentTypeConfiguration, components) => {
 
     if (type === 'relation') {
       const queryInfos = {
-        endPoint: `collection-types/${contentTypeConfiguration.uid}`,
+        endpoints: {
+          search: `collection-types/${contentTypeConfiguration.uid}`,
+        },
         defaultParams: {},
       };
 

--- a/packages/core/admin/admin/src/content-manager/hooks/useFetchContentTypeLayout/utils/tests/formatLayouts.test.js
+++ b/packages/core/admin/admin/src/content-manager/hooks/useFetchContentTypeLayout/utils/tests/formatLayouts.test.js
@@ -557,7 +557,7 @@ describe('Content Manager | hooks | useFetchContentTypeLayout | utils ', () => {
     it('should return an object with the correct keys', () => {
       expect(generateRelationQueryInfos(addressSchema, 'categories', simpleModels)).toEqual({
         endpoints: {
-          search: '/content-manager/relations/api::address.address/categories',
+          search: '/content-manager/api::address.address/categories',
         },
         defaultParams: {},
         shouldDisplayRelationLink: true,
@@ -576,7 +576,7 @@ describe('Content Manager | hooks | useFetchContentTypeLayout | utils ', () => {
         )
       ).toEqual({
         endpoints: {
-          search: '/content-manager/relations/api::address.address/categories',
+          search: '/content-manager/api::address.address/categories',
         },
         defaultParams: {
           _component: 'api::address.address',

--- a/packages/core/admin/admin/src/content-manager/hooks/useRelation/tests/useRelation.test.js
+++ b/packages/core/admin/admin/src/content-manager/hooks/useRelation/tests/useRelation.test.js
@@ -75,6 +75,30 @@ describe('useRelation', () => {
     });
   });
 
+  test('calls onLoad callback', async () => {
+    const spy = jest.fn();
+    const FIXTURE_DATA = {
+      values: [1, 2],
+      pagination: {
+        page: 1,
+        total: 3,
+      },
+    };
+    axiosInstance.get = jest.fn().mockResolvedValue({
+      data: FIXTURE_DATA,
+    });
+    const { waitForNextUpdate } = await setup(undefined, {
+      relation: {
+        onLoad: spy,
+      },
+    });
+
+    await waitForNextUpdate();
+
+    expect(spy).toBeCalledTimes(1);
+    expect(spy).toBeCalledWith(FIXTURE_DATA);
+  });
+
   test('fetch relations with different limit', async () => {
     const { waitForNextUpdate } = await setup(undefined, {
       relation: { pageParams: { limit: 5 } },

--- a/packages/core/admin/admin/src/content-manager/hooks/useRelation/useRelation.js
+++ b/packages/core/admin/admin/src/content-manager/hooks/useRelation/useRelation.js
@@ -12,6 +12,10 @@ export const useRelation = (name, { relation, search }) => {
       page: pageParam,
     });
 
+    if (relation?.onLoad) {
+      relation.onLoad(data);
+    }
+
     return data;
   };
 


### PR DESCRIPTION
### What does it do?

As part of https://github.com/strapi/strapi/issues/14217 we discussed that we store the loaded relations in `initialData` to allow plugin authors to access this data. It seems to be broken currently and we want to make sure we fix this with the next relation implementation.

### Why is it needed?

To support plugin-authors.

### How to test it?

tbd

### Related issue(s)/PR(s)

Builds on top of https://github.com/strapi/strapi/pull/14092
