### PR TITLE
rename token-permission to api-token-permission

### DIFF
--- a/packages/core/admin/server/content-types/api-token-permission.js
+++ b/packages/core/admin/server/content-types/api-token-permission.js
@@ -1,12 +1,12 @@
 'use strict';
 
 module.exports = {
-  collectionName: 'strapi_token_permissions',
+  collectionName: 'strapi_api_token_permissions',
   info: {
     name: 'API Token Permission',
     description: '',
-    singularName: 'token-permission',
-    pluralName: 'token-permissions',
+    singularName: 'api-token-permission',
+    pluralName: 'api-token-permissions',
     displayName: 'API Token Permission',
   },
   options: {},

--- a/packages/core/admin/server/content-types/api-token.js
+++ b/packages/core/admin/server/content-types/api-token.js
@@ -55,7 +55,7 @@ module.exports = {
     },
     permissions: {
       type: 'relation',
-      target: 'admin::token-permission',
+      target: 'admin::api-token-permission',
       relation: 'oneToMany',
       mappedBy: 'token',
       configurable: false,

--- a/packages/core/admin/server/content-types/index.js
+++ b/packages/core/admin/server/content-types/index.js
@@ -5,5 +5,5 @@ module.exports = {
   user: { schema: require('./User') },
   role: { schema: require('./Role') },
   'api-token': { schema: require('./api-token') },
-  'token-permission': { schema: require('./token-permission') },
+  'api-token-permission': { schema: require('./api-token-permission') },
 };

--- a/packages/core/admin/server/services/api-token.js
+++ b/packages/core/admin/server/services/api-token.js
@@ -190,13 +190,13 @@ const create = async (attributes) => {
   // If this is a custom type token, create and the related permissions
   if (attributes.type === constants.API_TOKEN_TYPE.CUSTOM) {
     // TODO: createMany doesn't seem to create relation properly, implement a better way rather than a ton of queries
-    // const permissionsCount = await strapi.query('admin::token-permission').createMany({
+    // const permissionsCount = await strapi.query('admin::api-token-permission').createMany({
     //   populate: POPULATE_FIELDS,
     //   data: attributes.permissions.map(action => ({ action, token: apiToken })),
     // });
     await Promise.all(
       uniq(attributes.permissions).map((action) =>
-        strapi.query('admin::token-permission').create({
+        strapi.query('admin::api-token-permission').create({
           data: { action, token: apiToken },
         })
       )
@@ -373,7 +373,7 @@ const update = async (id, attributes) => {
     // method using a loop -- works but very inefficient
     await Promise.all(
       actionsToDelete.map((action) =>
-        strapi.query('admin::token-permission').delete({
+        strapi.query('admin::api-token-permission').delete({
           where: { action, token: id },
         })
       )
@@ -383,7 +383,7 @@ const update = async (id, attributes) => {
     // using a loop -- works but very inefficient
     await Promise.all(
       actionsToAdd.map((action) =>
-        strapi.query('admin::token-permission').create({
+        strapi.query('admin::api-token-permission').create({
           data: { action, token: id },
         })
       )
@@ -391,7 +391,7 @@ const update = async (id, attributes) => {
   }
   // if type is not custom, make sure any old permissions get removed
   else if (updatedToken.type !== constants.API_TOKEN_TYPE.CUSTOM) {
-    await strapi.query('admin::token-permission').delete({
+    await strapi.query('admin::api-token-permission').delete({
       where: { token: id },
     });
   }


### PR DESCRIPTION
### What does it do?

Rename 'token-permission' to 'api-token-permission'

### Why is it needed?

For consistency and clarity. Since they are called 'api-tokens' their permissions should be 'api-token-permissions'

### How to test it?

Everything regarding api-tokens should still work

