### PR TITLE
Validate & throw on unknown permissions for API tokens

### DIFF
--- a/packages/core/admin/server/controllers/__tests__/api-token.test.js
+++ b/packages/core/admin/server/controllers/__tests__/api-token.test.js
@@ -18,6 +18,17 @@ describe('API Token Controller', () => {
       const ctx = createContext({ body });
 
       global.strapi = {
+        contentAPI: {
+          permissions: {
+            providers: {
+              action: {
+                keys() {
+                  return ['foo', 'bar'];
+                },
+              },
+            },
+          },
+        },
         admin: {
           services: {
             'api-token': {

--- a/packages/core/admin/server/services/__tests__/api-token.test.js
+++ b/packages/core/admin/server/services/__tests__/api-token.test.js
@@ -784,10 +784,19 @@ describe('API Token', () => {
   test('Updates permissions field of a custom token with unknown permissions', async () => {
     const id = 1;
 
+    const originalToken = {
+      id,
+      name: 'api-token_tests-name',
+      description: 'api-token_tests-description',
+      type: 'custom',
+      permissions: ['admin::subject.keepThisAction', 'admin::subject.oldAction'],
+    };
+
     const updatedAttributes = {
       permissions: ['valid-permission-A', 'unknown-permission'],
     };
 
+    const findOne = jest.fn().mockResolvedValue(omit('permissions', originalToken));
     const update = jest.fn(({ data }) => Promise.resolve(data));
     const deleteFn = jest.fn();
     const create = jest.fn();
@@ -798,6 +807,7 @@ describe('API Token', () => {
       query() {
         return {
           update,
+          findOne,
           delete: deleteFn,
           create,
         };

--- a/packages/core/admin/server/services/__tests__/api-token.test.js
+++ b/packages/core/admin/server/services/__tests__/api-token.test.js
@@ -789,7 +789,7 @@ describe('API Token', () => {
       name: 'api-token_tests-name',
       description: 'api-token_tests-description',
       type: 'custom',
-      permissions: ['admin::subject.keepThisAction', 'admin::subject.oldAction'],
+      permissions: ['valid-permission-A'],
     };
 
     const updatedAttributes = {

--- a/packages/core/admin/server/services/__tests__/api-token.test.js
+++ b/packages/core/admin/server/services/__tests__/api-token.test.js
@@ -283,7 +283,7 @@ describe('API Token', () => {
         },
       };
 
-      expect(() => apiTokenService.create(attributes)).rejects.toThrowError(
+      await expect(() => apiTokenService.create(attributes)).rejects.toThrowError(
         new ApplicationError(
           `Unknown permissions provided: unknown-permission-A, unknown-permission-B`
         )

--- a/packages/core/admin/server/services/api-token.js
+++ b/packages/core/admin/server/services/api-token.js
@@ -65,6 +65,16 @@ const assertCustomTokenPermissionsValidity = (attributes) => {
   if (attributes.type === constants.API_TOKEN_TYPE.CUSTOM && isEmpty(attributes.permissions)) {
     throw new ValidationError('Missing permissions attribute for custom token');
   }
+
+  // Permissions provided for a custom type token should be valid/registered permissions UID
+  if (attributes.type === constants.API_TOKEN_TYPE.CUSTOM) {
+    const validPermissions = strapi.contentAPI.permissions.providers.action.keys();
+    const invalidPermissions = difference(attributes.permissions, validPermissions);
+
+    if (!isEmpty(invalidPermissions)) {
+      throw new ValidationError(`Unknown permissions provided: ${invalidPermissions.join(', ')}`);
+    }
+  }
 };
 
 /**


### PR DESCRIPTION
### What does it do?

Validate that permissions are valid when creating or updating a token

### Why is it needed?

Prevent storing invalid permissions in database for API tokens

### How to test it?

1. Run the tests (unit or e2e)
2. Try creating a custom token with permissions both from the admin API and from the code

