### PR TITLE
Automatically synchronize and cleanup API tokens' permissions in database

### DIFF
--- a/packages/core/admin/server/bootstrap.js
+++ b/packages/core/admin/server/bootstrap.js
@@ -63,11 +63,9 @@ const syncAPITokensPermissions = async () => {
   const unknownPermissions = uniq(difference(permissionsInDB, validPermissions));
 
   if (unknownPermissions.length > 0) {
-    await Promise.all(
-      unknownPermissions.map((action) =>
-        strapi.query('admin::api-token-permission').deleteMany({ where: { action } })
-      )
-    );
+    await strapi
+      .query('admin::api-token-permission')
+      .deleteMany({ where: { action: { $in: unknownPermissions } } });
   }
 };
 

--- a/packages/core/admin/server/bootstrap.js
+++ b/packages/core/admin/server/bootstrap.js
@@ -63,21 +63,10 @@ const syncAPITokensPermissions = async () => {
   const unknownPermissions = uniq(difference(permissionsInDB, validPermissions));
 
   if (unknownPermissions.length > 0) {
-    console.log('about to delete', unknownPermissions.length, 'permissions from db');
-    console.log(JSON.stringify(unknownPermissions, null, 2));
-
     await Promise.all(
       unknownPermissions.map((action) =>
         strapi.query('admin::api-token-permission').deleteMany({ where: { action } })
       )
-    );
-  } else {
-    console.log(
-      'No permission outdated, step ignored... (check made on ',
-      permissionsInDB.length,
-      '-',
-      validPermissions.length,
-      'permissions)'
     );
   }
 };

--- a/packages/core/strapi/lib/Strapi.js
+++ b/packages/core/strapi/lib/Strapi.js
@@ -451,10 +451,9 @@ class Strapi {
     await this.server.initMiddlewares();
     await this.server.initRouting();
 
-    await this.runLifecyclesFunctions(LIFECYCLES.BOOTSTRAP);
-
-    // TODO: is this the best place for this?
     await this.contentAPI.permissions.registerActions();
+
+    await this.runLifecyclesFunctions(LIFECYCLES.BOOTSTRAP);
 
     this.cron.start();
 


### PR DESCRIPTION

### What does it do?

On application startup, check if some permissions in the database do not match the allowed ones (from the content API action provider). If this is the case, delete the obsolete ones.

### Why is it needed?

Handle the scenario where an API token's permissions reference an old controller's method that has been deleted (particularly useful to cleanup the permissions when deleting a content type)

### How to test it?

- Create a custom API token that references CRUD actions from a specific content type
- Delete the content type
- Check that the token does not reference those permissions anymore

