### PR TITLE
Titles too long do not render properly in content manager

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/DynamicTable/CellContent/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/DynamicTable/CellContent/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { Typography } from '@strapi/design-system/Typography';
+import { Tooltip } from '@strapi/design-system/Tooltip';
 import Media from './Media';
 import MultipleMedias from './MultipleMedias';
 import RelationMultiple from './RelationMultiple';
@@ -54,6 +55,15 @@ const CellContent = ({ content, fieldSchema, metadatas, name, queryInfos, rowId 
       }
 
       return <SingleComponent value={content} metadatas={metadatas} />;
+
+    case 'string':
+      return (
+        <Tooltip description={<CellValue type={type} value={content} />}>
+          <TypographyMaxWidth ellipsis textColor="neutral800">
+            <CellValue type={type} value={content} />
+          </TypographyMaxWidth>
+        </Tooltip>
+      );
 
     default:
       return (

--- a/packages/core/admin/admin/src/content-manager/components/DynamicTable/CellContent/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/DynamicTable/CellContent/index.js
@@ -58,7 +58,7 @@ const CellContent = ({ content, fieldSchema, metadatas, name, queryInfos, rowId 
 
     case 'string':
       return (
-        <Tooltip description={<CellValue type={type} value={content} />}>
+        <Tooltip description={content}>
           <TypographyMaxWidth ellipsis textColor="neutral800">
             <CellValue type={type} value={content} />
           </TypographyMaxWidth>

--- a/packages/core/admin/admin/src/content-manager/components/SelectOne/SingleValue.js
+++ b/packages/core/admin/admin/src/content-manager/components/SelectOne/SingleValue.js
@@ -9,6 +9,7 @@ import { Typography } from '@strapi/design-system/Typography';
 import get from 'lodash/get';
 import has from 'lodash/has';
 import isEmpty from 'lodash/isEmpty';
+import { Tooltip } from '@strapi/design-system/Tooltip';
 import { getTrad } from '../../utils';
 
 const StyledBullet = styled.div`
@@ -43,7 +44,9 @@ const SingleValue = (props) => {
       <Component {...props}>
         <Flex>
           <StyledBullet title={title} isDraft={isDraft} />
-          <Typography ellipsis>{props.data.label ?? '-'}</Typography>
+          <Tooltip description={props.data.label ?? '-'}>
+            <Typography ellipsis>{props.data.label ?? '-'}</Typography>
+          </Tooltip>
         </Flex>
       </Component>
     );


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

fixes #13719

### What does it do?
shows the whole text which are truncated

### Why is it needed?

Titles too long do not render properly in content manager

### How to test it?

step1: create a content-builder => with type of any string => add text on the contentmanager and  check it out on the table it will be truncated but when hovering it will show thw whole text both for relation single type select and dynamic table 

[DEMO_link](https://www.loom.com/share/e221b54ec4294d9dbe148e47b1bd120e)

### Related issue(s)/PR(s)

#13719