### PR TITLE
Exclude source maps when loading APIs

### DIFF
--- a/packages/core/strapi/lib/core/loaders/apis.js
+++ b/packages/core/strapi/lib/core/loaders/apis.js
@@ -131,11 +131,12 @@ const loadDir = async (dir) => {
 
   const root = {};
   for (const fd of fds) {
-    if (!fd.isFile()) {
+    if (!fd.isFile() || extname(fd.name) === '.map') {
       continue;
     }
 
     const key = basename(fd.name, extname(fd.name));
+
     root[normalizeName(key)] = await loadFile(join(dir, fd.name));
   }
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Fixes #14160.

### Why is it needed?

When `sourceMap` is true in `tsconfig.json`, the API loader makes the app crash.

This is caused by `.map.js` having an `extname` of `.map`, which implies [this check](https://github.com/strapi/strapi/blob/e1e4071cf0d0afa8365dbff5659c5c76edf25600/packages/core/strapi/lib/core/loaders/apis.js#L145-L156) returns an empty object for all `.map.js`, which happen to have the same name as valid APIs, which get therefore overridden.

### How to test it?

Repeat the steps in #14160 and notice how the app does not crash anymore.

### Additional details

The components loader specifies a glob of `*/*.*(js|json)` which does not exclude `.map.js` files either, but I believe there is no way to create components that are not in JSON format.
