### PR TITLE
Api token v2/Cleanup

### DIFF
--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/ApiTokens/EditView/tests/__snapshots__/index.test.js.snap
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/ApiTokens/EditView/tests/__snapshots__/index.test.js.snap
@@ -642,8 +642,8 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
 
 .c6 {
   color: #4945ff;
-  font-size: 0.75rem;
-  line-height: 1.33;
+  font-size: 0.875rem;
+  line-height: 1.43;
 }
 
 .c4 {
@@ -2545,8 +2545,8 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
 
 .c6 {
   color: #4945ff;
-  font-size: 0.75rem;
-  line-height: 1.33;
+  font-size: 0.875rem;
+  line-height: 1.43;
 }
 
 .c4 {

--- a/packages/core/admin/server/routes/api-tokens.js
+++ b/packages/core/admin/server/routes/api-tokens.js
@@ -67,12 +67,4 @@ module.exports = [
       ],
     },
   },
-  {
-    method: 'GET',
-    path: '/api-token-layout',
-    handler: 'api-token.getLayout',
-    config: {
-      policies: ['admin::isAuthenticatedAdmin'],
-    },
-  },
 ];

--- a/packages/core/admin/server/services/__tests__/api-token.test.js
+++ b/packages/core/admin/server/services/__tests__/api-token.test.js
@@ -248,6 +248,7 @@ describe('API Token', () => {
       );
 
       global.strapi = {
+        ...getActionProvider(['admin::content.content.read']),
         query() {
           return {
             findOne,


### PR DESCRIPTION
### What does it do?

- fixes a broken unit test
- fixes a snapshot for a broken front-end test
- removes unused broken route /api-token-layout

### Why is it needed?

- fixes a broken unit test
- fixes a snapshot for a broken front-end test
- removes unused broken route /api-token-layout

### How to test it?

Run tests - should pass
GET /api-token-layout - should return 404

### Related issue(s)/PR(s)
