### PR TITLE
Ignore folder 'dist' in sample project

### DIFF
--- a/examples/getstarted/.gitignore
+++ b/examples/getstarted/.gitignore
@@ -113,3 +113,4 @@ exports
 build
 documentation
 .strapi-updater.json
+dist

--- a/examples/kitchensink-ts/.gitignore
+++ b/examples/kitchensink-ts/.gitignore
@@ -112,3 +112,4 @@ exports
 *.cache
 build
 .strapi-updater.json
+dist

--- a/examples/kitchensink/.gitignore
+++ b/examples/kitchensink/.gitignore
@@ -112,3 +112,4 @@ exports
 *.cache
 build
 .strapi-updater.json
+dist


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Ignore folder `dist` in sample project.

### Why is it needed?

When using TS version, its generate folder `dist`. It's make git dirty

### How to test it?

Just try to install using TS version, and make sure `dist` folder is ignored.

### Related issue(s)/PR(s)

_None_
