### PR TITLE
Fix several issues in the users-permissions OpenAPI specification

### DIFF
--- a/packages/plugins/users-permissions/documentation/content-api.yaml
+++ b/packages/plugins/users-permissions/documentation/content-api.yaml
@@ -102,6 +102,13 @@ paths:
       tags:
         - Users-Permissions - Auth
       summary: Default Callback from provider auth
+      parameters:
+        - name: provider
+          in: path
+          required: true
+          description: Provider name
+          schema:
+            type: string
       responses:
         200:
           description: Returns a jwt token and user info
@@ -196,15 +203,16 @@ paths:
           application/json:
             schema:
               type: object
+              required:
+                - password
+                - currentPassword
+                - passwordConfirmation
               properties:
                 password:
-                  required: true
                   type: string
                 currentPassword:
-                  required: true
                   type: string
                 passwordConfirmation:
-                  required: true
                   type: string
       responses:
         200:
@@ -219,7 +227,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-
   /auth/email-confirmation:
     get:
       tags:
@@ -228,7 +235,8 @@ paths:
       parameters:
         - in: query
           name: confirmation
-          type: string
+          schema:
+            type: string
           description: confirmation token received by email
       responses:
         301:
@@ -319,7 +327,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-
   /users-permissions/roles:
     get:
       tags:
@@ -364,7 +371,7 @@ paths:
         - Users-Permissions - Users & Roles
       summary: Create a role
       requestBody:
-        $ref: '#/components/schemas/Users-Permissions-RoleRequest'
+        $ref: '#/components/requestBodies/Users-Permissions-RoleRequest'
       responses:
         200:
           description: Returns ok if the role was create
@@ -391,10 +398,13 @@ paths:
       parameters:
         - in: path
           name: id
-          type: string
+          required: true
+          schema:
+            type: string
           description: role Id
       responses:
         200:
+          description: Returns the role
           content:
             application/json:
               schema:
@@ -431,10 +441,12 @@ paths:
       parameters:
         - in: path
           name: role
-          type: string
+          required: true
+          schema:
+            type: string
           description: role Id
       requestBody:
-        $ref: '#/components/schemas/Users-Permissions-RoleRequest'
+        $ref: '#/components/requestBodies/Users-Permissions-RoleRequest'
       responses:
         200:
           description: Returns ok if the role was udpated
@@ -460,7 +472,9 @@ paths:
       parameters:
         - in: path
           name: role
-          type: string
+          required: true
+          schema:
+            type: string
           description: role Id
       responses:
         200:
@@ -487,7 +501,7 @@ paths:
       summary: Get list of users
       responses:
         200:
-          summary: Returns an array of users
+          description: Returns an array of users
           content:
             application/json:
               schema:
@@ -520,17 +534,17 @@ paths:
           application/json:
             schema:
               type: object
+              required:
+                - username
+                - email
+                - password
               properties:
                 email:
                   type: string
-                  required: true
                 username:
                   type: string
-                  required: true
                 password:
                   type: string
-                  required: true
-
             example:
               username: foo
               email: foo@strapi.io
@@ -569,7 +583,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-
   /users/{id}:
     get:
       tags:
@@ -578,10 +591,13 @@ paths:
       parameters:
         - in: path
           name: id
-          type: string
+          required: true
+          schema:
+            type: string
           description: user Id
       responses:
         200:
+          description: Returns a user
           content:
             application/json:
               schema:
@@ -601,7 +617,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-
     put:
       tags:
         - Users-Permissions - Users & Roles
@@ -609,7 +624,9 @@ paths:
       parameters:
         - in: path
           name: id
-          type: string
+          required: true
+          schema:
+            type: string
           description: user Id
       requestBody:
         required: true
@@ -617,17 +634,17 @@ paths:
           application/json:
             schema:
               type: object
+              required:
+                - username
+                - email
+                - password
               properties:
                 email:
                   type: string
-                  required: true
                 username:
                   type: string
-                  required: true
                 password:
                   type: string
-                  required: true
-
             example:
               username: foo
               email: foo@strapi.io
@@ -666,13 +683,19 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-
     delete:
       tags:
         - Users-Permissions - Users & Roles
       summary: Delete a user
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+          description: user Id
       responses:
-        200:
+        "200":
           description: Returns deleted user info
           content:
             application/json:
@@ -817,6 +840,10 @@ components:
                   policy:
                     type: string
 
+  parameters:
+  responses:
+  examples:
+  requestBodies:
     Users-Permissions-RoleRequest:
       required: true
       content:
@@ -842,7 +869,3 @@ components:
                     find:
                       enabled: true
 
-  parameters:
-  responses:
-  examples:
-  requestBodies:


### PR DESCRIPTION
### What does it do?

The OpenAPI specification for the `users-permissions` plugin contained several errors.
This MR fixes all of the errors so that the OpenAPI spec is valid.

### Why is it needed?

Most OpenAPI Generators are quite strict meaning that generating automated API clients for Strapi won't work if the specification(s) aren't valid.

### How to test it?

Run OpenAPI validator.

### Related issue(s)/PR(s)

N/a
