### PR TITLE
Prevent updating an API token's lifespan from the admin API

### DIFF
--- a/packages/core/admin/server/validation/api-tokens.js
+++ b/packages/core/admin/server/validation/api-tokens.js
@@ -27,12 +27,6 @@ const apiTokenUpdateSchema = yup
     description: yup.string().nullable(),
     type: yup.string().oneOf(Object.values(constants.API_TOKEN_TYPE)).notNull(),
     permissions: yup.array().of(yup.string()).nullable(),
-    lifespan: yup
-      .number()
-      .integer()
-      .min(1)
-      .oneOf(Object.values(constants.API_TOKEN_LIFESPANS))
-      .nullable(),
   })
   .noUnknown()
   .strict();


### PR DESCRIPTION
### What does it do?

Prevents lifespan from being updated in controller validation

I didn't prevent at the service level because it doesn't do any harm to change lifespan, and we will probably revert this change when we add the refresh feature.

### Why is it needed?

Changing lifespan has no purpose because we don't have the refresh feature.

### How to test it?

Try updating the lifespan field, it should give a validation error.

### Related issue(s)/PR(s)
