### PR TITLE
Trim admin's first name when validating

### DIFF
--- a/packages/core/admin/admin/src/pages/AuthPage/utils/forms.js
+++ b/packages/core/admin/admin/src/pages/AuthPage/utils/forms.js
@@ -52,7 +52,7 @@ const forms = {
     fieldsToDisable: ['email'],
     fieldsToOmit: ['userInfo.confirmPassword', 'userInfo.news', 'userInfo.email'],
     schema: yup.object().shape({
-      firstname: yup.string().required(translatedErrors.required),
+      firstname: yup.string().trim().required(translatedErrors.required),
       lastname: yup.string(),
       password: yup
         .string()
@@ -76,7 +76,7 @@ const forms = {
     fieldsToDisable: [],
     fieldsToOmit: ['confirmPassword', 'news'],
     schema: yup.object().shape({
-      firstname: yup.string().required(translatedErrors.required),
+      firstname: yup.string().trim().required(translatedErrors.required),
       lastname: yup.string(),
       password: yup
         .string()

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Users/ListPage/ModalForm/utils/schema.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Users/ListPage/ModalForm/utils/schema.js
@@ -2,7 +2,7 @@ import * as yup from 'yup';
 import { translatedErrors } from '@strapi/helper-plugin';
 
 const schema = yup.object().shape({
-  firstname: yup.string().required(translatedErrors.required),
+  firstname: yup.string().trim().required(translatedErrors.required),
   lastname: yup.string(),
   email: yup.string().email(translatedErrors.email).required(translatedErrors.required),
   roles: yup.array().min(1, translatedErrors.required).required(translatedErrors.required),

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Users/utils/validations/users/profile.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Users/utils/validations/users/profile.js
@@ -2,8 +2,8 @@ import * as yup from 'yup';
 import { translatedErrors } from '@strapi/helper-plugin';
 
 export const commonUserSchema = {
-  firstname: yup.mixed().required(translatedErrors.required),
-  lastname: yup.mixed(),
+  firstname: yup.string().trim().required(translatedErrors.required),
+  lastname: yup.string(),
   email: yup.string().email(translatedErrors.email).lowercase().required(translatedErrors.required),
   username: yup.string().nullable(),
   password: yup

--- a/packages/core/admin/server/validation/common-validators.js
+++ b/packages/core/admin/server/validation/common-validators.js
@@ -16,7 +16,7 @@ const getActionFromProvider = (actionId) => {
 
 const email = yup.string().email().lowercase();
 
-const firstname = yup.string().min(1);
+const firstname = yup.string().trim().min(1);
 
 const lastname = yup.string();
 

--- a/packages/core/strapi/lib/commands/admin-create.js
+++ b/packages/core/strapi/lib/commands/admin-create.js
@@ -17,7 +17,7 @@ const passwordValidator = yup
 const adminCreateSchema = yup.object().shape({
   email: emailValidator,
   password: passwordValidator,
-  firstname: yup.string().required('First name is required'),
+  firstname: yup.string().trim().required('First name is required'),
   lastname: yup.string(),
 });
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Fixes #13648.

### Why is it needed?

At the moment, the schema used to validate objects during admin creation/update does not trim `firstname`, allowing empty strings to be used as the admin's first name.

### How to test it?

Try creating/updating an admin using "   " as their first name.
