### PR TITLE
Only return access token in Microsoft's OAuth response

### DIFF
--- a/packages/plugins/users-permissions/server/bootstrap/grant-config.js
+++ b/packages/plugins/users-permissions/server/bootstrap/grant-config.js
@@ -42,6 +42,7 @@ module.exports = (baseURL) => ({
     icon: 'windows',
     key: '',
     secret: '',
+    response: ['tokens'],
     callback: `${baseURL}/microsoft/callback`,
     scope: ['user.read'],
   },


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Fixes #13752 by setting the `response` key in Grant's Microsoft config to `tokens`, so that the raw response is not included in the callback URL.

### Additional information

If this is merged, a migration script should be created to automatically update the config in the db's core store as well.