### PR TITLE
Prevent `InputJSON` from crashing when field value is `0`

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/InputJSON/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/InputJSON/index.js
@@ -79,6 +79,8 @@ class InputJSON extends React.Component {
     try {
       if (value === null) return this.codeMirror.setValue('');
 
+      if (value === 0) return this.codeMirror.setValue('0');
+
       return this.codeMirror.setValue(value);
     } catch (err) {
       return this.setState({ error: true });


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Prevents  `InputJSON` from crashing when field value is `0` by stringifying the integer before render.

### Why is it needed?

The `InputJSON` displays an error when the field value is set to `0` due to CodeMirror possibly seeing it as a falsy value.

### How to test it?

Set a JSON field to `0` and notice how it displays an error before the PR and doesn't afterwards.
