### PR TITLE
RelationInputWrapper: Remove data fixture and fix frontend tests

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/RelationInputWrapper/utils/tests/normalizeRelations.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInputWrapper/utils/tests/normalizeRelations.test.js
@@ -3,24 +3,26 @@ import { normalizeRelations } from '../normalizeRelations';
 const FIXTURE_RELATIONS = {
   data: {
     pages: [
-      [
-        {
-          id: 1,
-          name: 'Relation 1',
-          publishedAt: '2022-08-24T09:29:11.38',
-        },
+      {
+        values: [
+          {
+            id: 1,
+            name: 'Relation 1',
+            publishedAt: '2022-08-24T09:29:11.38',
+          },
 
-        {
-          id: 2,
-          name: 'Relation 2',
-          publishedAt: '',
-        },
+          {
+            id: 2,
+            name: 'Relation 2',
+            publishedAt: '',
+          },
 
-        {
-          id: 3,
-          name: 'Relation 3',
-        },
-      ],
+          {
+            id: 3,
+            name: 'Relation 3',
+          },
+        ],
+      },
     ],
   },
 };
@@ -29,14 +31,14 @@ describe('normalizeRelations', () => {
   test('filters out deleted releations', () => {
     expect(
       normalizeRelations(FIXTURE_RELATIONS, {
-        deletions: [{ id: 1 }],
+        modifiedData: { remove: [{ id: 1 }] },
       })
     ).toStrictEqual({
       data: {
         pages: [
           [
-            expect.objectContaining(FIXTURE_RELATIONS.data.pages[0][1]),
-            expect.objectContaining(FIXTURE_RELATIONS.data.pages[0][2]),
+            expect.objectContaining(FIXTURE_RELATIONS.data.pages[0].values[1]),
+            expect.objectContaining(FIXTURE_RELATIONS.data.pages[0].values[2]),
           ],
         ],
       },
@@ -46,7 +48,7 @@ describe('normalizeRelations', () => {
   test('returns empty array if all relations are deleted', () => {
     expect(
       normalizeRelations(FIXTURE_RELATIONS, {
-        deletions: [{ id: 1 }, { id: 2 }, { id: 3 }],
+        modifiedData: { remove: [{ id: 1 }, { id: 2 }, { id: 3 }] },
       })
     ).toStrictEqual({
       data: {
@@ -58,7 +60,7 @@ describe('normalizeRelations', () => {
   test('add link to each relation', () => {
     expect(
       normalizeRelations(FIXTURE_RELATIONS, {
-        deletions: [],
+        modifiedData: { remove: [] },
         shouldAddLink: true,
         targetModel: 'something',
       })
@@ -66,9 +68,9 @@ describe('normalizeRelations', () => {
       data: {
         pages: [
           [
-            expect.objectContaining({ href: '/content-manager/collectionType/something/1' }),
-            expect.objectContaining({ href: '/content-manager/collectionType/something/2' }),
-            expect.objectContaining({ href: '/content-manager/collectionType/something/3' }),
+            expect.objectContaining({ href: '/admin/content-manager/collectionType/something/1' }),
+            expect.objectContaining({ href: '/admin/content-manager/collectionType/something/2' }),
+            expect.objectContaining({ href: '/admin/content-manager/collectionType/something/3' }),
           ],
         ],
       },
@@ -103,9 +105,15 @@ describe('normalizeRelations', () => {
       data: {
         pages: [
           [
-            expect.objectContaining({ mainField: FIXTURE_RELATIONS.data.pages[0][0].name }),
-            expect.objectContaining({ mainField: FIXTURE_RELATIONS.data.pages[0][1].name }),
-            expect.objectContaining({ mainField: FIXTURE_RELATIONS.data.pages[0][2].name }),
+            expect.objectContaining({
+              mainField: FIXTURE_RELATIONS.data.pages[0].values[0].name,
+            }),
+            expect.objectContaining({
+              mainField: FIXTURE_RELATIONS.data.pages[0].values[1].name,
+            }),
+            expect.objectContaining({
+              mainField: FIXTURE_RELATIONS.data.pages[0].values[2].name,
+            }),
           ],
         ],
       },

--- a/packages/core/admin/admin/src/content-manager/components/RelationInputWrapper/utils/tests/select.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInputWrapper/utils/tests/select.test.js
@@ -126,7 +126,7 @@ describe('RelationInputWrapper | select', () => {
   test('returns empty fetch endpoint if the user is creating an entity', async () => {
     const { result } = await setup(SELECT_ATTR_FIXTURE);
 
-    expect(result.current.queryInfos.endpoints.fetch).toBe(null);
+    expect(result.current.queryInfos.endpoints.relation).toBe(null);
   });
 
   test('returns fetch endpoint if the user is editing an entity', async () => {
@@ -137,7 +137,7 @@ describe('RelationInputWrapper | select', () => {
 
     const { result } = await setup(SELECT_ATTR_FIXTURE);
 
-    expect(result.current.queryInfos.endpoints.fetch).toBe('/content-manager/slug/2/test');
+    expect(result.current.queryInfos.endpoints.relation).toBe('/content-manager/slug/2/test');
   });
 
   test('returns the original queryInfos and queryInfos.endpoints', async () => {
@@ -157,7 +157,7 @@ describe('RelationInputWrapper | select', () => {
       ...FIXTURE_QUERY_INFOS,
       endpoints: {
         ...FIXTURE_QUERY_INFOS.endpoints,
-        fetch: null,
+        relation: null,
       },
     });
   });

--- a/packages/core/admin/admin/src/content-manager/hooks/useRelation/useRelation.js
+++ b/packages/core/admin/admin/src/content-manager/hooks/useRelation/useRelation.js
@@ -1,132 +1,35 @@
 import { useState } from 'react';
 import { useInfiniteQuery } from 'react-query';
 
-// import { axiosInstance } from '../../../core/utils';
+import { axiosInstance } from '../../../core/utils';
 
-const FIXTURE_RELATIONS = {
-  values: [
-    {
-      id: 1,
-      title: 'Relation 1',
-      publishedAt: '2022',
-    },
-
-    {
-      id: 2,
-      title: 'Relation 2',
-      publishedAt: '',
-    },
-
-    {
-      id: 3,
-      title: 'Relation 3',
-    },
-
-    {
-      id: 4,
-      title: 'Relation with a very long title',
-    },
-
-    {
-      id: 5,
-      title: 'Another important entity',
-    },
-
-    {
-      id: 6,
-      title: 'Are we going to play this game really?',
-    },
-
-    {
-      id: 7,
-      title: 'Indeed ...',
-    },
-  ],
-
-  pagination: {
-    page: 1,
-    total: 3,
-  },
-};
-
-const FIXTURE_SEARCH = {
-  values: [
-    {
-      id: 1,
-      title: 'Relation 1',
-      publishedAt: '2022',
-    },
-
-    {
-      id: 2,
-      title: 'Relation 2',
-      publishedAt: '',
-    },
-
-    {
-      id: 3,
-      title: 'Relation 3',
-    },
-
-    {
-      id: 4,
-      title: 'Relation with a very long title',
-    },
-
-    {
-      id: 5,
-      title: 'Another important entity',
-    },
-
-    {
-      id: 6,
-      title: 'Are we going to play this game really?',
-    },
-
-    {
-      id: 7,
-      title: 'Indeed ...',
-    },
-  ],
-
-  pagination: {
-    page: 1,
-    total: 1,
-  },
-};
-
-export const useRelation = (cacheKey, { relation /* search */ }) => {
+export const useRelation = (cacheKey, { relation, search }) => {
   const [searchTerm, setSearchTerm] = useState(null);
 
-  const fetchRelations = async (/* { pageParam = 1 } */) => {
+  const fetchRelations = async ({ pageParam = 1 }) => {
     try {
-      // const { data } = await axiosInstance.get(relation?.endpoint, {
-      //   ...(relation.pageParams ?? {}),
-      //   page: pageParam,
-      // });
+      const { data } = await axiosInstance.get(relation?.endpoint, {
+        ...(relation.pageParams ?? {}),
+        page: pageParam,
+      });
 
       if (relation?.onLoad) {
-        relation.onLoad(FIXTURE_RELATIONS);
-        // relation.onLoad(data);
+        relation.onLoad(data);
       }
 
-      // TODO: remove
-      return FIXTURE_RELATIONS;
-      // return data;
+      return data;
     } catch (err) {
-      // TODO: remove
-      return FIXTURE_RELATIONS;
+      return null;
     }
   };
 
-  const fetchSearch = async (/* { pageParam = 1 } */) => {
-    // const { data } = await axiosInstance.get(search.endpoint, {
-    //   ...(search.pageParams ?? {}),
-    //   page: pageParam,
-    // });
+  const fetchSearch = async ({ pageParam = 1 }) => {
+    const { data } = await axiosInstance.get(search.endpoint, {
+      ...(search.pageParams ?? {}),
+      page: pageParam,
+    });
 
-    return FIXTURE_SEARCH;
-    // return data;
+    return data;
   };
 
   const relationsRes = useInfiniteQuery(['relation', cacheKey], fetchRelations, {


### PR DESCRIPTION
### What does it do?

Removes the data fixture introduced to make testing easier and fixes the broken frontend tests.

### Why is it needed?

To have full test-runs on the backend PRs.

