### PR TITLE
SelectMany/ SelectOne: Fix loadingMessage prop-types

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/SelectMany/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/SelectMany/index.js
@@ -121,7 +121,7 @@ SelectMany.propTypes = {
   displayNavigationLink: PropTypes.bool.isRequired,
   isDisabled: PropTypes.bool.isRequired,
   isLoading: PropTypes.bool.isRequired,
-  loadingMessage: PropTypes.string.isRequired,
+  loadingMessage: PropTypes.func.isRequired,
   mainField: PropTypes.shape({
     name: PropTypes.string.isRequired,
     schema: PropTypes.shape({

--- a/packages/core/admin/admin/src/content-manager/components/SelectOne/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/SelectOne/index.js
@@ -72,7 +72,7 @@ SelectOne.propTypes = {
   components: PropTypes.object,
   isDisabled: PropTypes.bool.isRequired,
   isLoading: PropTypes.bool.isRequired,
-  loadingMessage: PropTypes.string.isRequired,
+  loadingMessage: PropTypes.func.isRequired,
   mainField: PropTypes.shape({
     name: PropTypes.string.isRequired,
     schema: PropTypes.shape({


### PR DESCRIPTION
### What does it do?

Fixes the prop-type for `loadingMessage` on `SelectMany` and `SelectOne` components. It was introduced in https://github.com/strapi/strapi/pull/14246.

### Why is it needed?

To resolve prop-type errors.
