### PR TITLE
Improve pk management in schema builder

### DIFF
--- a/packages/core/database/lib/schema/builder.js
+++ b/packages/core/database/lib/schema/builder.js
@@ -295,7 +295,11 @@ const createHelpers = (db) => {
 
         const { object } = updatedColumn;
 
-        createColumn(tableBuilder, object).alter();
+        if (object.type === 'increments') {
+          createColumn(tableBuilder, { ...object, type: 'integer' }).alter();
+        } else {
+          createColumn(tableBuilder, object).alter();
+        }
       }
 
       for (const updatedForeignKey of table.foreignKeys.updated) {
@@ -312,7 +316,7 @@ const createHelpers = (db) => {
         debug(`Creating column ${addedColumn.name}`);
 
         if (addedColumn.type === 'increments' && !db.dialect.canAddIncrements()) {
-          tableBuilder.integer(addedColumn.name).unsigned();
+          tableBuilder.integer(addedColumn.name).unsigned().notNullable();
           tableBuilder.primary(addedColumn.name);
         } else {
           createColumn(tableBuilder, addedColumn);


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Improve pk management in schema builder

### Why is it needed?

- When adding id columns to link tables it was missing notNullable. Thus trying to update an increment later when a user changes any field in the CTB. This PR makes sure users will get the right id column directly for and that the increments column can be updated if necessary

### How to test it?

- You can go back to v4.3.6. recreate a db. then move to main and restart it should had the wrongly set id column. then add a field and see the startup error. 

- Now do the same steps but instead of going to main go to this PR.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
