### PR TITLE
Add free-form filters to the query parameters

### DIFF
--- a/packages/plugins/documentation/server/services/helpers/utils/query-params.js
+++ b/packages/plugins/documentation/server/services/helpers/utils/query-params.js
@@ -81,4 +81,15 @@ module.exports = [
       type: 'string',
     },
   },
+  {
+    name: 'filters',
+    in: 'query',
+    description: 'Filters to apply',
+    deprecated: false,
+    required: false,
+    schema: {
+      type: 'object',
+    },
+    style: 'deepObject',
+  },
 ];


### PR DESCRIPTION
### What does it do?

Add the `filters` query parameter to the generated OpenAPI spec.
Tested with the Swagger UI in the Strapi admin and seems to work.

### Why is it needed?

When using an OpenAPI generator it's not possible to add filters as they weren't included in the query parameters list.

### How to test it?

- Regenerate documentation
- Test with the Swagger UI

### Related issue(s)/PR(s)

N/a
