### PR TITLE
Relations: Fix list-view, store count and results, render count as part of the label

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/DynamicTable/CellContent/RelationMultiple/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/DynamicTable/CellContent/RelationMultiple/index.js
@@ -28,14 +28,12 @@ const fetchRelation = async (endPoint, notifyStatus) => {
   return { results, pagination };
 };
 
-const RelationMultiple = ({ fieldSchema, metadatas, name, entityId, value }) => {
+const RelationMultiple = ({ fieldSchema, metadatas, name, entityId, value, contentType }) => {
   const { formatMessage } = useIntl();
   const { notifyStatus } = useNotifyAT();
   const relationFetchEndpoint = useMemo(() => {
-    return getRequestUrl(
-      `collection-types/${fieldSchema.targetModel}/${entityId}/${name.split('.')[0]}`
-    );
-  }, [entityId, name, fieldSchema]);
+    return getRequestUrl(`collection-types/${contentType.uid}/${entityId}/${name.split('.')[0]}`);
+  }, [entityId, name, contentType]);
   const [isOpen, setIsOpen] = useState(false);
 
   const Label = (
@@ -119,6 +117,9 @@ const RelationMultiple = ({ fieldSchema, metadatas, name, entityId, value }) => 
 };
 
 RelationMultiple.propTypes = {
+  contentType: PropTypes.shape({
+    uid: PropTypes.string.isRequired,
+  }).isRequired,
   fieldSchema: PropTypes.shape({
     relation: PropTypes.string,
     targetModel: PropTypes.string,

--- a/packages/core/admin/admin/src/content-manager/components/DynamicTable/CellContent/RelationMultiple/tests/index.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/DynamicTable/CellContent/RelationMultiple/tests/index.test.js
@@ -23,13 +23,13 @@ jest.spyOn(axiosInstance, 'get').mockResolvedValue({
 });
 
 const DEFAULT_PROPS_FIXTURE = {
+  contentType: {
+    uid: 'api::address.address',
+  },
   fieldSchema: {
     type: 'relation',
     relation: 'manyToMany',
     target: 'api::category.category',
-  },
-  queryInfos: {
-    endPoint: 'collection-types/api::address.address',
   },
   metadatas: {
     mainField: {

--- a/packages/core/admin/admin/src/content-manager/components/DynamicTable/CellContent/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/DynamicTable/CellContent/index.js
@@ -16,7 +16,7 @@ const TypographyMaxWidth = styled(Typography)`
   max-width: 300px;
 `;
 
-const CellContent = ({ content, fieldSchema, metadatas, name, rowId }) => {
+const CellContent = ({ content, fieldSchema, metadatas, name, rowId, contentType }) => {
   const { type } = fieldSchema;
 
   if (!hasContent(type, content, metadatas, fieldSchema)) {
@@ -43,6 +43,7 @@ const CellContent = ({ content, fieldSchema, metadatas, name, rowId }) => {
           value={content}
           name={name}
           entityId={rowId}
+          contentType={contentType}
         />
       );
     }
@@ -69,6 +70,9 @@ CellContent.defaultProps = {
 
 CellContent.propTypes = {
   content: PropTypes.any,
+  contentType: PropTypes.shape({
+    uid: PropTypes.string.isRequired,
+  }).isRequired,
   fieldSchema: PropTypes.shape({
     component: PropTypes.string,
     multiple: PropTypes.bool,

--- a/packages/core/admin/admin/src/content-manager/components/DynamicTable/TableRows/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/DynamicTable/TableRows/index.js
@@ -18,6 +18,7 @@ import { getFullName } from '../../../../utils';
 const TableRows = ({
   canCreate,
   canDelete,
+  contentType,
   headers,
   entriesToDelete,
   onClickDelete,
@@ -88,6 +89,7 @@ const TableRows = ({
                     <CellContent
                       content={data[name.split('.')[0]]}
                       name={name}
+                      contentType={contentType}
                       {...rest}
                       rowId={data.id}
                     />
@@ -180,6 +182,9 @@ TableRows.defaultProps = {
 TableRows.propTypes = {
   canCreate: PropTypes.bool,
   canDelete: PropTypes.bool,
+  contentType: PropTypes.shape({
+    uid: PropTypes.string.isRequired,
+  }).isRequired,
   entriesToDelete: PropTypes.array,
   headers: PropTypes.array.isRequired,
   onClickDelete: PropTypes.func,

--- a/packages/core/admin/admin/src/content-manager/components/DynamicTable/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/DynamicTable/index.js
@@ -112,6 +112,7 @@ const DynamicTable = ({
       <TableRows
         canCreate={canCreate}
         canDelete={canDelete}
+        contentType={layout.contentType}
         headers={tableHeaders}
         rows={rows}
         withBulkActions

--- a/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/reducer.js
+++ b/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/reducer.js
@@ -73,7 +73,7 @@ const reducer = (state, action) =>
         break;
       }
       case 'LOAD_RELATION': {
-        const initialDataPath = ['initialData', ...action.keys];
+        const initialDataPath = ['initialData', ...action.keys, 'results'];
         const modifiedDataPath = ['modifiedData', ...action.keys];
         const { value } = action;
 

--- a/packages/core/admin/admin/src/content-manager/components/RelationInputWrapper/RelationInputWrapper.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInputWrapper/RelationInputWrapper.js
@@ -7,7 +7,7 @@ import { useCMEditViewDataManager, NotAllowedInput } from '@strapi/helper-plugin
 import { RelationInput } from '../RelationInput';
 import { useRelation } from '../../hooks/useRelation';
 import { connect, select, normalizeRelations } from './utils';
-import { PUBLICATION_STATES } from './constants';
+import { PUBLICATION_STATES, RELATIONS_TO_DISPLAY, SEARCH_RESULTS_TO_DISPLAY } from './constants';
 import { getTrad } from '../../utils';
 
 export const RelationInputWrapper = ({
@@ -37,7 +37,7 @@ export const RelationInputWrapper = ({
       },
       pageParams: {
         ...defaultParams,
-        pageSize: 10,
+        pageSize: RELATIONS_TO_DISPLAY,
       },
     },
 
@@ -46,7 +46,7 @@ export const RelationInputWrapper = ({
       pageParams: {
         ...defaultParams,
         entityId: isCreatingEntry ? undefined : initialData.id,
-        pageSize: 10,
+        pageSize: SEARCH_RESULTS_TO_DISPLAY,
       },
     },
   });
@@ -131,7 +131,7 @@ export const RelationInputWrapper = ({
         })
       }
       name={name}
-      numberOfRelationsToDisplay={5}
+      numberOfRelationsToDisplay={RELATIONS_TO_DISPLAY}
       onRelationAdd={(relation) => handleRelationAdd(relation)}
       onRelationRemove={(relation) => handleRelationRemove(relation)}
       onRelationLoadMore={() => handleRelationLoadMore()}

--- a/packages/core/admin/admin/src/content-manager/components/RelationInputWrapper/RelationInputWrapper.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInputWrapper/RelationInputWrapper.js
@@ -45,7 +45,7 @@ export const RelationInputWrapper = ({
       endpoint: endpoints.search,
       pageParams: {
         ...defaultParams,
-        // entityId: isCreatingEntry ? undefined : initialData.id,
+        entityId: isCreatingEntry ? undefined : initialData.id,
         pageSize: 10,
       },
     },
@@ -113,7 +113,7 @@ export const RelationInputWrapper = ({
           id: intlLabel.id,
           defaultMessage: `${intlLabel.defaultMessage} ({numberOfEntries})`,
         },
-        { numberOfEntries: initialData[name].count }
+        { numberOfEntries: initialData[name]?.count ?? 0 }
       )}
       labelLoadMore={
         // TODO: only display if there are more; derive from count

--- a/packages/core/admin/admin/src/content-manager/components/RelationInputWrapper/RelationInputWrapper.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInputWrapper/RelationInputWrapper.js
@@ -108,7 +108,13 @@ export const RelationInputWrapper = ({
       description={description}
       disabled={isDisabled}
       id={name}
-      label={formatMessage(intlLabel)}
+      label={formatMessage(
+        {
+          id: intlLabel.id,
+          defaultMessage: `${intlLabel.defaultMessage} ({numberOfEntries})`,
+        },
+        { numberOfEntries: initialData[name].count }
+      )}
       labelLoadMore={
         // TODO: only display if there are more; derive from count
         !isCreatingEntry &&

--- a/packages/core/admin/admin/src/content-manager/components/RelationInputWrapper/constants.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInputWrapper/constants.js
@@ -2,3 +2,7 @@ export const PUBLICATION_STATES = {
   DRAFT: 'draft',
   PUBLISHED: 'published',
 };
+
+export const RELATIONS_TO_DISPLAY = 5;
+
+export const SEARCH_RESULTS_TO_DISPLAY = 10;


### PR DESCRIPTION
### What does it do?

- Fixes fetching existing relations in the list-view
- Stores count and actual results next to each other in initialState
- renders count as part of the label


