### PR TITLE
RelationInput: Render id as fallback, if no mainField was set

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/RelationInput/RelationInput.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInput/RelationInput.js
@@ -233,11 +233,11 @@ const RelationInput = ({
                   <Box minWidth={0} paddingTop={1} paddingBottom={1} paddingRight={4}>
                     {href ? (
                       <LinkEllipsis to={href} disabled={disabled}>
-                        {mainField}
+                        {mainField ?? id}
                       </LinkEllipsis>
                     ) : (
                       <Typography textColor={disabled ? 'neutral600' : 'primary600'} ellipsis>
-                        {mainField}
+                        {mainField ?? id}
                       </Typography>
                     )}
                   </Box>

--- a/packages/core/admin/admin/src/content-manager/components/RelationInput/components/Option.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInput/components/Option.js
@@ -23,7 +23,7 @@ const StyledBullet = styled.div`
 export const Option = (props) => {
   const { formatMessage } = useIntl();
   const Component = components.Option;
-  const { publicationState, mainField } = props.data;
+  const { publicationState, mainField, id } = props.data;
 
   if (publicationState) {
     const isDraft = publicationState === 'draft';
@@ -41,18 +41,19 @@ export const Option = (props) => {
       <Component {...props}>
         <Flex>
           <StyledBullet title={title} isDraft={isDraft} />
-          <Typography ellipsis>{mainField ?? '-'}</Typography>
+          <Typography ellipsis>{mainField ?? id}</Typography>
         </Flex>
       </Component>
     );
   }
 
-  return <Component {...props}>{mainField ?? '-'}</Component>;
+  return <Component {...props}>{mainField ?? id}</Component>;
 };
 
 Option.propTypes = {
   isFocused: PropTypes.bool.isRequired,
   data: PropTypes.shape({
+    id: PropTypes.number.isRequired,
     isDraft: PropTypes.bool,
     mainField: PropTypes.string,
     publicationState: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),


### PR DESCRIPTION
### What does it do?

Render id instead of `-` in case the mainField of a relation is not set.

