### PR TITLE
useRelation/ normalizeRelations: Handle empty 204 API responses

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/RelationInputWrapper/utils/normalizeRelations.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInputWrapper/utils/normalizeRelations.js
@@ -12,7 +12,7 @@ export const normalizeRelations = (
       pages:
         relations?.data?.pages
           ?.map((page) => [
-            ...[...page.results, ...(modifiedData?.connect ?? [])]
+            ...[...(page?.results ?? []), ...(modifiedData?.connect ?? [])]
               .map((relation) => {
                 const nextRelation = { ...relation };
 

--- a/packages/core/admin/admin/src/content-manager/hooks/useRelation/useRelation.js
+++ b/packages/core/admin/admin/src/content-manager/hooks/useRelation/useRelation.js
@@ -40,7 +40,8 @@ export const useRelation = (cacheKey, { relation, search }) => {
   const relationsRes = useInfiniteQuery(['relation', cacheKey], fetchRelations, {
     enabled: !!relation?.endpoint,
     getNextPageParam(lastPage) {
-      if (lastPage.pagination.page >= lastPage.pagination.pageCount) {
+      // the API may send an empty 204 response
+      if (!lastPage || lastPage.pagination.page >= lastPage.pagination.pageCount) {
         return undefined;
       }
 


### PR DESCRIPTION
### What does it do?

As discussed the content API may send empty 204 responses, which currently breaks the frontend. This PR gracefully handles the case where the response does: 1) not contain a pagination 2) does not contain a values array.
