### PR TITLE
[Enh] Store app theme 

### DIFF
--- a/packages/core/admin/admin/src/components/ThemeToggleProvider/index.js
+++ b/packages/core/admin/admin/src/components/ThemeToggleProvider/index.js
@@ -4,7 +4,7 @@
  *
  */
 
-import React, { useState } from 'react';
+import React, { useState, useMemo, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { ThemeToggleContext } from '../../contexts';
 
@@ -14,22 +14,33 @@ const getDefaultTheme = () => {
   const browserTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
   const persistedTheme = localStorage.getItem(THEME_KEY);
 
+  if (!persistedTheme) {
+    localStorage.setItem(THEME_KEY, browserTheme);
+  }
+
   return persistedTheme || browserTheme;
 };
 
 const ThemeToggleProvider = ({ children, themes }) => {
   const [currentTheme, setCurrentTheme] = useState(getDefaultTheme());
 
-  const handleChangeTheme = (nextTheme) => {
-    setCurrentTheme(nextTheme);
-    localStorage.setItem(THEME_KEY, nextTheme);
-  };
-
-  return (
-    <ThemeToggleContext.Provider value={{ currentTheme, onChangeTheme: handleChangeTheme, themes }}>
-      {children}
-    </ThemeToggleContext.Provider>
+  const handleChangeTheme = useCallback(
+    (nextTheme) => {
+      setCurrentTheme(nextTheme);
+      localStorage.setItem(THEME_KEY, nextTheme);
+    },
+    [setCurrentTheme]
   );
+
+  const themeValues = useMemo(() => {
+    return {
+      currentTheme,
+      onChangeTheme: handleChangeTheme,
+      themes,
+    };
+  }, [currentTheme, handleChangeTheme, themes]);
+
+  return <ThemeToggleContext.Provider value={themeValues}>{children}</ThemeToggleContext.Provider>;
 };
 
 ThemeToggleProvider.propTypes = {


### PR DESCRIPTION
## What

Fixes #14364 
Store STRAPI_THEME in locale storage if it doesn't exist
Before it was only stored if the theme was changed on the Profile page
This will allow developers to always access the user theme and apply customization depending on the theme

It also fixes an eslint warning:
<img width="716" alt="image" src="https://user-images.githubusercontent.com/71838159/189391031-a8acaa85-916a-4d4d-9dc0-d34bd17937a3.png">


## Test

1. test that it doesn't break or change anything for the existing accounts
2. test that it stores the theme in locale storage if it wasn't set or for new accounts 