### PR TITLE
RelationInputWrapper: Fix normalization of relations, if results are empty

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/RelationInput/RelationInput.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInput/RelationInput.js
@@ -71,8 +71,8 @@ const RelationInput = ({
   const outerListRef = useRef();
   const [overflow, setOverflow] = useState('');
 
-  const relations = useMemo(() => paginatedRelations.data?.pages.flat(), [paginatedRelations]);
-  const totalNumberOfRelations = relations?.length ?? 0;
+  const relations = useMemo(() => paginatedRelations.data.pages.flat(), [paginatedRelations]);
+  const totalNumberOfRelations = relations.length ?? 0;
 
   const dynamicListHeight = useMemo(
     () =>
@@ -89,7 +89,7 @@ const RelationInput = ({
 
   const options = useMemo(
     () =>
-      searchResults?.data?.pages?.flat().map((result) => ({
+      searchResults.data.pages.flat().map((result) => ({
         ...result,
         value: result.id,
         label: result.mainField,
@@ -98,7 +98,7 @@ const RelationInput = ({
   );
 
   useEffect(() => {
-    if (!paginatedRelations.isLoading && relations?.length > 0) {
+    if (!paginatedRelations.isLoading && relations.length > 0) {
       listRef.current.scrollToItem(relations.length, 'end');
     }
 
@@ -124,7 +124,7 @@ const RelationInput = ({
 
     const outerListRefCurrent = outerListRef?.current;
 
-    if (!paginatedRelations.isLoading && relations?.length > 0 && outerListRefCurrent) {
+    if (!paginatedRelations.isLoading && relations.length > 0 && outerListRefCurrent) {
       outerListRef.current.addEventListener('scroll', handleNativeScroll);
     }
 
@@ -156,7 +156,7 @@ const RelationInput = ({
                 onRelationAdd(relation);
 
                 // scroll to the end of the list
-                if (relations?.length > 0) {
+                if (relations.length > 0) {
                   setTimeout(() => {
                     listRef.current.scrollToItem(relations.length, 'end');
                   });

--- a/packages/core/admin/admin/src/content-manager/components/RelationInputWrapper/utils/normalizeRelations.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInputWrapper/utils/normalizeRelations.js
@@ -2,6 +2,33 @@ import { getRelationLink } from './getRelationLink';
 
 import { PUBLICATION_STATES } from '../constants';
 
+const normalizeRelation = (
+  relation,
+  { modifiedData, shouldAddLink, mainFieldName, targetModel }
+) => {
+  const nextRelation = { ...relation };
+
+  if (modifiedData?.disconnect?.find((relation) => relation.id === nextRelation.id)) {
+    return null;
+  }
+
+  if (shouldAddLink) {
+    nextRelation.href = getRelationLink(targetModel, nextRelation.id);
+  }
+
+  nextRelation.publicationState = false;
+
+  if (nextRelation?.publishedAt !== undefined) {
+    nextRelation.publicationState = nextRelation.publishedAt
+      ? PUBLICATION_STATES.PUBLISHED
+      : PUBLICATION_STATES.DRAFT;
+  }
+
+  nextRelation.mainField = nextRelation[mainFieldName];
+
+  return nextRelation;
+};
+
 export const normalizeRelations = (
   relations,
   { modifiedData = {}, shouldAddLink = false, mainFieldName, targetModel }
@@ -10,34 +37,22 @@ export const normalizeRelations = (
     ...relations,
     data: {
       pages:
-        relations?.data?.pages
-          ?.map((page) => [
-            ...[...(page?.results ?? []), ...(modifiedData?.connect ?? [])]
-              .map((relation) => {
-                const nextRelation = { ...relation };
-
-                if (modifiedData?.disconnect?.find((relation) => relation.id === nextRelation.id)) {
-                  return null;
-                }
-
-                if (shouldAddLink) {
-                  nextRelation.href = getRelationLink(targetModel, nextRelation.id);
-                }
-
-                nextRelation.publicationState = false;
-
-                if (nextRelation?.publishedAt !== undefined) {
-                  nextRelation.publicationState = nextRelation.publishedAt
-                    ? PUBLICATION_STATES.PUBLISHED
-                    : PUBLICATION_STATES.DRAFT;
-                }
-
-                nextRelation.mainField = nextRelation[mainFieldName];
-
-                return nextRelation;
-              })
-              .filter(Boolean),
-          ])
+        [
+          ...(relations?.data?.pages ?? []),
+          ...(modifiedData?.connect ? [{ results: modifiedData?.connect }] : []),
+        ]
+          ?.map((page) =>
+            page?.results
+              .map((relation) =>
+                normalizeRelation(relation, {
+                  modifiedData,
+                  shouldAddLink,
+                  mainFieldName,
+                  targetModel,
+                })
+              )
+              .filter(Boolean)
+          )
           ?.filter((page) => page.length > 0)
           ?.reverse() ?? [],
     },

--- a/packages/core/admin/admin/src/content-manager/components/RelationInputWrapper/utils/tests/normalizeRelations.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInputWrapper/utils/tests/normalizeRelations.test.js
@@ -119,4 +119,29 @@ describe('normalizeRelations', () => {
       },
     });
   });
+
+  test('allows to connect new relations, eventhough pages is empty', () => {
+    expect(
+      normalizeRelations(
+        {
+          data: {
+            pages: [],
+          },
+        },
+        {
+          modifiedData: { connect: [{ id: 1 }] },
+        }
+      )
+    ).toStrictEqual({
+      data: {
+        pages: [
+          [
+            expect.objectContaining({
+              id: 1,
+            }),
+          ],
+        ],
+      },
+    });
+  });
 });


### PR DESCRIPTION
### What does it do?

Previously it was not possible to add new relations, if an entity is created / if the paginated response was empty. This PR fixes that and improves the way relations are normalized.

### Why is it needed?

To support the creation of an entity and to make the code more readable.
