### PR TITLE
RelationInputWrapper: Pass down the current locale as query parameter

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/RelationInputWrapper/RelationInputWrapper.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInputWrapper/RelationInputWrapper.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React, { memo, useEffect, useMemo } from 'react';
 import { useIntl } from 'react-intl';
 
-import { useCMEditViewDataManager, NotAllowedInput } from '@strapi/helper-plugin';
+import { useCMEditViewDataManager, NotAllowedInput, useQueryParams } from '@strapi/helper-plugin';
 
 import { RelationInput } from '../RelationInput';
 import { useRelation } from '../../hooks/useRelation';
@@ -28,6 +28,7 @@ export const RelationInputWrapper = ({
   const { formatMessage } = useIntl();
   const { connectRelation, disconnectRelation, loadRelation, modifiedData, slug, initialData } =
     useCMEditViewDataManager();
+  const [{ query }] = useQueryParams();
 
   const { relations, search, searchFor } = useRelation(`${slug}-${name}-${initialData?.id ?? ''}`, {
     relation: {
@@ -37,6 +38,7 @@ export const RelationInputWrapper = ({
       },
       pageParams: {
         ...defaultParams,
+        locale: query?.plugins?.i18n?.locale,
         pageSize: RELATIONS_TO_DISPLAY,
       },
     },
@@ -46,6 +48,7 @@ export const RelationInputWrapper = ({
       pageParams: {
         ...defaultParams,
         entityId: isCreatingEntry ? undefined : initialData.id,
+        locale: query?.plugins?.i18n?.locale,
         pageSize: SEARCH_RESULTS_TO_DISPLAY,
       },
     },


### PR DESCRIPTION
### What does it do?

Passes down the current locale when querying for relations.

### Why is it needed?

To properly support i18n.
