### PR TITLE
EditViewDataManagerProvider: Progressively enhance relations state

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/index.js
@@ -130,12 +130,17 @@ const EditViewDataManagerProvider = ({
 
   useEffect(() => {
     if (initialValues) {
+      const relationalFields = Object.keys(initialValues).filter(
+        (key) => currentContentTypeLayout?.attributes[key]?.type === 'relation'
+      );
+
       dispatch({
         type: 'INIT_FORM',
         initialValues,
+        relationalFields,
       });
     }
-  }, [initialValues]);
+  }, [initialValues, currentContentTypeLayout]);
 
   const addComponentToDynamicZone = useCallback((keys, componentUid, shouldCheckErrors = false) => {
     trackUsageRef.current('didAddComponentToDynamicZone');

--- a/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/reducer.js
+++ b/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/reducer.js
@@ -74,9 +74,17 @@ const reducer = (state, action) =>
       }
       case 'LOAD_RELATION': {
         const initialDataPath = ['initialData', ...action.keys, 'results'];
+        const modifiedDataPath = ['modifiedData', ...action.keys, 'results'];
         const { value } = action;
 
         set(draftState, initialDataPath, value);
+
+        /**
+         * We set the value also on modifiedData, because initialData and
+         * modifiedData need to stay in sync, so that the CM can comare
+         * both states, to render the diry UI state
+         */
+        set(draftState, modifiedDataPath, value);
 
         break;
       }

--- a/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/reducer.js
+++ b/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/reducer.js
@@ -122,7 +122,7 @@ const reducer = (state, action) =>
         break;
       }
       case 'INIT_FORM': {
-        const { initialValues, relationalFields } = action;
+        const { initialValues, relationalFields = [] } = action;
 
         draftState.formErrors = {};
 
@@ -142,10 +142,12 @@ const reducer = (state, action) =>
            */
 
           ...relationalFields.reduce((acc, name) => {
-            return (acc[name] = {
-              ...(initialValues?.[name] ?? {}),
+            acc[name] = {
               ...(state.initialData?.[name] ?? {}),
-            });
+              ...(initialValues?.[name] ?? {}),
+            };
+
+            return acc;
           }, {}),
         };
 
@@ -171,10 +173,12 @@ const reducer = (state, action) =>
           ...relationalFields.reduce((acc, name) => {
             const { connect, disconnect, ...currentState } = state.modifiedData?.[name] ?? {};
 
-            return (acc[name] = {
+            acc[name] = {
               ...(initialValues?.[name] ?? {}),
               ...(currentState ?? {}),
-            });
+            };
+
+            return acc;
           }, {}),
         };
 

--- a/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/reducer.js
+++ b/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/reducer.js
@@ -80,10 +80,11 @@ const reducer = (state, action) =>
         set(draftState, initialDataPath, value);
 
         /**
-         * We set the value also on modifiedData, because initialData and
-         * modifiedData need to stay in sync, so that the CM can comare
-         * both states, to render the diry UI state
+         * We need to set the value also on modifiedData, because initialData
+         * and modifiedData need to stay in sync, so that the CM can compare
+         * both states, to render the dirty UI state
          */
+
         set(draftState, modifiedDataPath, value);
 
         break;
@@ -132,13 +133,14 @@ const reducer = (state, action) =>
            * The state we keep in the client for relations looks like:
            *
            * {
-           *   count: int
+           *   count: <int>
            *   results: [<Relation>]
            * }
            *
-           * but the content API only returns `count`, which is why we need
-           * to extend the existing state rather than overwriting it.
+           * The content API only returns { count: <int> }, which is why
+           * we need to extend the existing state rather than overwriting it.
            */
+
           ...relationalFields.reduce((acc, name) => {
             return (acc[name] = {
               ...(initialValues?.[name] ?? {}),
@@ -151,18 +153,19 @@ const reducer = (state, action) =>
           ...initialValues,
 
           /**
-           * The client sends the following to the content API
+           * The client sends the following to the content API:
            *
            * {
            *   connect: [<Relation>],
            *   disconnect: [<Relation>]
            * }
            *
-           * but receives only `count` in return. After save/ publish
-           * we want to:
-           * 1) reset connect/ disconnect
-           * 2) extend the existing state with the API response
+           * but receives only { count: <int> } in return. After save/ publish
+           * we have to:
            *
+           * 1) reset the connect/ disconnect arrays
+           * 2) extend the existing state with the API response, so that `count`
+           *    stays in sync
            */
 
           ...relationalFields.reduce((acc, name) => {

--- a/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/tests/reducer.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/tests/reducer.test.js
@@ -517,6 +517,69 @@ describe('CONTENT MANAGER | COMPONENTS | EditViewDataManagerProvider | reducer',
 
       expect(reducer(state, action)).toEqual(expected);
     });
+
+    it('should take relational fields into account, when setting the state', () => {
+      const state = {
+        ...initialState,
+        formErrors: true,
+        initialData: {
+          relation: {
+            something: true,
+          },
+        },
+        modifiedData: true,
+        modifiedDZName: true,
+        shouldCheckErrors: true,
+      };
+      const expected = {
+        ...initialState,
+        formErrors: {},
+        initialData: { ok: true, relation: { something: true, count: 10 } },
+        modifiedData: { ok: true, relation: { count: 10 } },
+        modifiedDZName: null,
+        shouldCheckErrors: false,
+      };
+
+      const action = {
+        type: 'INIT_FORM',
+        initialValues: { ok: true, relation: { count: 10 } },
+        relationalFields: ['relation'],
+      };
+
+      expect(reducer(state, action)).toEqual(expected);
+    });
+
+    it('should reset connect/ disconnect for relational fields', () => {
+      const state = {
+        ...initialState,
+        formErrors: true,
+        initialData: {},
+        modifiedData: {
+          relation: {
+            connect: [{ id: 1 }],
+            disconnect: [{ id: 2 }],
+          },
+        },
+        modifiedDZName: true,
+        shouldCheckErrors: true,
+      };
+      const expected = {
+        ...initialState,
+        formErrors: {},
+        initialData: { ok: true, relation: { count: 10 } },
+        modifiedData: { ok: true, relation: { count: 10 } },
+        modifiedDZName: null,
+        shouldCheckErrors: false,
+      };
+
+      const action = {
+        type: 'INIT_FORM',
+        initialValues: { ok: true, relation: { count: 10 } },
+        relationalFields: ['relation'],
+      };
+
+      expect(reducer(state, action)).toEqual(expected);
+    });
   });
 
   describe('MOVE_COMPONENT_FIELD', () => {

--- a/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/utils/cleanData.js
+++ b/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/utils/cleanData.js
@@ -54,9 +54,11 @@ const cleanData = (retrievedData, currentSchema, componentsSchema) => {
 
         case 'relation':
           // Instead of the full relation object, we only want to send its ID
-          // and need to clean-up the add|remove arrays
+          // and need to clean-up the connect|disconnect arrays
           cleanedData = Object.entries(value).reduce((acc, [key, value]) => {
-            acc[key] = value.map((currentValue) => ({ id: currentValue.id }));
+            if (['connect', 'disconnect'].includes(key)) {
+              acc[key] = value.map((currentValue) => ({ id: currentValue.id }));
+            }
 
             return acc;
           }, {});

--- a/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/utils/tests/cleanData.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/utils/tests/cleanData.test.js
@@ -187,6 +187,7 @@ describe('CM || components || EditViewDataManagerProvider || utils || cleanData'
     const result = cleanData(
       {
         relation: {
+          count: 10,
           connect: [{ id: 1, something: true }],
           disconnect: [{ id: 2, something: true }],
         },


### PR DESCRIPTION
### What does it do?

Instead of overwriting the whole Edit View CM state, we now progressively enhance it, so that client-side computed state for relations is preserved, eventhough it is decoupled from the format of the API response.

### Why is it needed?

We need to:

- preserve the computed state for e.g. `results` in relational fields for `initialData`
- cleanup `connect`/`disconnect` in `modifiedData`

