### PR TITLE
[Fix] CM LV custom labels

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/DynamicTable/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/DynamicTable/index.js
@@ -47,7 +47,7 @@ const DynamicTable = ({
             ...metadatas,
             label: formatMessage({
               id: getTrad(`containers.ListPage.table-headers.${header.name}`),
-              defaultMessage: header.name,
+              defaultMessage: metadatas.label,
             }),
           },
           name: sortFieldValue,
@@ -60,7 +60,7 @@ const DynamicTable = ({
           ...metadatas,
           label: formatMessage({
             id: getTrad(`containers.ListPage.table-headers.${header.name}`),
-            defaultMessage: header.name,
+            defaultMessage: metadatas.label,
           }),
         },
       };


### PR DESCRIPTION
## What

Fixes #14395 

With #14111, improving content-manager list view headers labels traduction, custom labels (configurable in the configure the view page) ended up being ignored

This PR reintegrates the usage of `metadatas.label` 

## Test

- Customize a field label in list view Configure the view
- It should appear in the Table header

<img width="661" alt="image" src="https://user-images.githubusercontent.com/71838159/189858574-c15bb014-8d58-4c79-9d25-3189d65c57d1.png">
