### PR TITLE
RelationInputWrapper: Fix and properly transform query params for components

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/RelationInputWrapper/utils/select.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInputWrapper/utils/select.js
@@ -48,12 +48,14 @@ function useSelect({ isUserAllowedToEditField, isUserAllowedToReadField, name, q
       return null;
     }
 
-    return getRequestUrl(`${collectionTypePrefix}/${slug}/${initialData.id}/${name}`);
+    return getRequestUrl(
+      `${collectionTypePrefix}/${slug}/${initialData.id}/${name.split('.').at(-1)}`
+    );
   }, [isCreatingEntry, slug, initialData, name, isSingleType]);
 
   // /content-manager/relations/[content-type]/[field-name]
   const relationSearchEndpoint = useMemo(() => {
-    return getRequestUrl(`relations/${slug}/${name}`);
+    return getRequestUrl(`relations/${slug}/${name.split('.').at(-1)}`);
   }, [slug, name]);
 
   return {

--- a/packages/core/admin/admin/src/content-manager/components/RelationInputWrapper/utils/tests/select.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInputWrapper/utils/tests/select.test.js
@@ -163,4 +163,23 @@ describe('RelationInputWrapper | select', () => {
       },
     });
   });
+
+  test('splits the name properly, so that components are handled for endpoints', async () => {
+    useCMEditViewDataManager.mockReturnValueOnce({
+      ...CM_DATA_FIXTURE,
+      isCreatingEntry: false,
+    });
+
+    const { result } = await setup({
+      ...SELECT_ATTR_FIXTURE,
+      name: 'someting.component-name.field-name',
+    });
+
+    expect(result.current.queryInfos).toStrictEqual({
+      endpoints: {
+        relation: '/content-manager/collection-types/slug/2/field-name',
+        search: '/content-manager/relations/slug/field-name',
+      },
+    });
+  });
 });

--- a/packages/core/admin/admin/src/content-manager/hooks/useFetchContentTypeLayout/utils/formatLayouts.js
+++ b/packages/core/admin/admin/src/content-manager/hooks/useFetchContentTypeLayout/utils/formatLayouts.js
@@ -174,7 +174,7 @@ const generateRelationQueryInfosForComponents = (contentTypeConfiguration, field
 
   return {
     defaultParams: {
-      _component: contentTypeConfiguration.uid,
+      component: contentTypeConfiguration.uid,
     },
     shouldDisplayRelationLink,
   };

--- a/packages/core/admin/admin/src/content-manager/hooks/useFetchContentTypeLayout/utils/tests/formatLayouts.test.js
+++ b/packages/core/admin/admin/src/content-manager/hooks/useFetchContentTypeLayout/utils/tests/formatLayouts.test.js
@@ -568,7 +568,7 @@ describe('Content Manager | hooks | useFetchContentTypeLayout | utils ', () => {
         generateRelationQueryInfosForComponents(addressSchema, 'categories', simpleModels)
       ).toEqual({
         defaultParams: {
-          _component: 'api::address.address',
+          component: 'api::address.address',
         },
         shouldDisplayRelationLink: true,
       });


### PR DESCRIPTION
### What does it do?

1. the name of the component parameter was changed from `_component` to `component`
2. for fields within components we need to extract field field-name, hence the last of the name

### Why is it needed?

It fixes loading of existing relations within components.
