### PR TITLE
EditViewDataManagerProvider: Progressively extend loaded relations

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/reducer.js
+++ b/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/reducer.js
@@ -75,9 +75,15 @@ const reducer = (state, action) =>
       case 'LOAD_RELATION': {
         const initialDataPath = ['initialData', ...action.keys, 'results'];
         const modifiedDataPath = ['modifiedData', ...action.keys, 'results'];
+        const currentState = get(state, initialDataPath, []);
         const { value } = action;
+        const newValues = value.filter(
+          (newRelation) =>
+            !currentState.find((existingRelation) => existingRelation.id === newRelation.id)
+        );
+        const nextState = [...newValues, ...currentState];
 
-        set(draftState, initialDataPath, value);
+        set(draftState, initialDataPath, nextState);
 
         /**
          * We need to set the value also on modifiedData, because initialData
@@ -85,7 +91,7 @@ const reducer = (state, action) =>
          * both states, to render the dirty UI state
          */
 
-        set(draftState, modifiedDataPath, value);
+        set(draftState, modifiedDataPath, nextState);
 
         break;
       }

--- a/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/tests/reducer.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/tests/reducer.test.js
@@ -377,7 +377,7 @@ describe('CONTENT MANAGER | COMPONENTS | EditViewDataManagerProvider | reducer',
   });
 
   describe('LOAD_RELATION', () => {
-    it.skip('should add loaded relations to initalData', () => {
+    it('should add loaded relations to initalData', () => {
       const state = {
         ...initialState,
         initialData: {},
@@ -398,8 +398,7 @@ describe('CONTENT MANAGER | COMPONENTS | EditViewDataManagerProvider | reducer',
         },
         modifiedData: {
           relation: {
-            connect: [],
-            disconnect: [],
+            results: [{ id: 1 }],
           },
         },
       });
@@ -417,8 +416,42 @@ describe('CONTENT MANAGER | COMPONENTS | EditViewDataManagerProvider | reducer',
         },
         modifiedData: {
           relation: {
-            connect: [],
-            disconnect: [],
+            results: [{ id: 2 }, { id: 1 }],
+          },
+        },
+      });
+    });
+
+    it('should add loaded relations to initalData and remove duplicates', () => {
+      const state = {
+        ...initialState,
+        initialData: {
+          relation: {
+            results: [{ id: 1 }, { id: 2 }],
+          },
+        },
+
+        modifiedData: {
+          relation: {
+            results: [{ id: 1 }, { id: 2 }],
+          },
+        },
+      };
+
+      let nextState = reducer(state, {
+        type: 'LOAD_RELATION',
+        keys: ['relation'],
+        value: [{ id: 1 }, { id: 2 }, { id: 3 }],
+      });
+
+      expect(nextState).toStrictEqual({
+        ...initialState,
+        initialData: {
+          relation: { results: [{ id: 3 }, { id: 1 }, { id: 2 }] },
+        },
+        modifiedData: {
+          relation: {
+            results: [{ id: 3 }, { id: 1 }, { id: 2 }],
           },
         },
       });


### PR DESCRIPTION
### What does it do?

The `LOAD_RELATION` action may run several times (e.g. when more relations are loaded). Instead of replacing the current ones, we need to extend the array with the unique values.

### Why is it needed?

To properly store loaded relations in the store.
