### PR TITLE
[Relations] Filter refacto & UI fixes

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/RelationInput/RelationInput.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInput/RelationInput.js
@@ -99,16 +99,11 @@ const RelationInput = ({
   );
 
   useEffect(() => {
-    if (!paginatedRelations.isLoading && relations.length > 0) {
-      listRef.current.scrollToItem(relations.length, 'end');
+    if (totalNumberOfRelations <= numberOfRelationsToDisplay) {
+      return setOverflow('');
     }
 
-    // TODO: should we use useCallback instead?
     const handleNativeScroll = (e) => {
-      if (totalNumberOfRelations <= numberOfRelationsToDisplay) {
-        return setOverflow('');
-      }
-
       const parentScrollContainerHeight = e.target.parentNode.scrollHeight;
       const maxScrollBottom = e.target.scrollHeight - e.target.scrollTop;
 

--- a/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/utils/normalizeRelations.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/utils/normalizeRelations.js
@@ -36,12 +36,11 @@ export const normalizeRelations = (
         ]
           ?.map((page) =>
             page?.results
-              .filter((relation) =>
-                modifiedData?.disconnect?.find(
-                  (disconnectRelation) => disconnectRelation.id === relation.id
-                )
-                  ? null
-                  : relation
+              .filter(
+                (relation) =>
+                  !modifiedData?.disconnect?.find(
+                    (disconnectRelation) => disconnectRelation.id === relation.id
+                  )
               )
               .map((relation) =>
                 normalizeRelation(relation, {

--- a/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/utils/normalizeRelations.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/utils/normalizeRelations.js
@@ -2,15 +2,8 @@ import { getRelationLink } from './getRelationLink';
 
 import { PUBLICATION_STATES } from '../constants';
 
-const normalizeRelation = (
-  relation,
-  { modifiedData, shouldAddLink, mainFieldName, targetModel }
-) => {
+const normalizeRelation = (relation, { shouldAddLink, mainFieldName, targetModel }) => {
   const nextRelation = { ...relation };
-
-  if (modifiedData?.disconnect?.find((relation) => relation.id === nextRelation.id)) {
-    return null;
-  }
 
   if (shouldAddLink) {
     nextRelation.href = getRelationLink(targetModel, nextRelation.id);
@@ -43,6 +36,13 @@ export const normalizeRelations = (
         ]
           ?.map((page) =>
             page?.results
+              .filter((relation) =>
+                modifiedData?.disconnect?.find(
+                  (disconnectRelation) => disconnectRelation.id === relation.id
+                )
+                  ? null
+                  : relation
+              )
               .map((relation) =>
                 normalizeRelation(relation, {
                   modifiedData,

--- a/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/utils/tests/normalizeRelations.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/utils/tests/normalizeRelations.test.js
@@ -57,6 +57,23 @@ describe('normalizeRelations', () => {
     });
   });
 
+  test('filter disconnected relations', () => {
+    expect(
+      normalizeRelations(FIXTURE_RELATIONS, {
+        modifiedData: { disconnect: [{ id: 2 }] },
+      })
+    ).toStrictEqual({
+      data: {
+        pages: [
+          [
+            expect.objectContaining(FIXTURE_RELATIONS.data.pages[0].results[0]),
+            expect.objectContaining(FIXTURE_RELATIONS.data.pages[0].results[2]),
+          ],
+        ],
+      },
+    });
+  });
+
   test('add link to each relation', () => {
     expect(
       normalizeRelations(FIXTURE_RELATIONS, {


### PR DESCRIPTION
## What

- Refactoring of filtering disconnected relations in `normalizeRelations`
- UI fixes:
  - removed scrolling bottom every time (it caused scrolling bottom after removing a relation)
  - fixed shadows still showing after deleting enough items to not be in a scrolling list

## Test

Add/remove relations to test filtering is working the way it is intended 