### PR TITLE
EditViewDataManagerProvider: Fix publish button state comparison

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/reducer.js
+++ b/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/reducer.js
@@ -199,8 +199,8 @@ const reducer = (state, action) =>
             const { connect, disconnect, ...currentState } = state.modifiedData?.[name] ?? {};
 
             acc[name] = {
-              ...(initialValues?.[name] ?? {}),
               ...(currentState ?? {}),
+              ...(initialValues?.[name] ?? {}),
             };
 
             return acc;


### PR DESCRIPTION
### What does it do?

The source of the disabled "Publish" button lies in the order of which the state update after "Save" is applied. Previously `count` wasn't overwritten in the state, which makes the state unequal, dirty and not publishable. This PR fixes that.

### Why is it needed?

Allows entities to be published.

