### PR TITLE
useRelation: Do not clear the cache before each search

### DIFF
--- a/packages/core/admin/admin/src/content-manager/hooks/useRelation/useRelation.js
+++ b/packages/core/admin/admin/src/content-manager/hooks/useRelation/useRelation.js
@@ -67,7 +67,6 @@ export const useRelation = (cacheKey, { relation, search }) => {
   );
 
   const searchFor = (term, options = {}) => {
-    searchRes.remove();
     setSearchParams({
       ...options,
       _q: encodeURIComponent(term),


### PR DESCRIPTION
### What does it do?

Previously we always cleared the cache before each search, which defeats the purpose of react-query. I initially thought it is necessary 🤦🏼 

This improves the performance of the search-field, when a user focuses the field a second time, because now results don't need to be fetched a second time.

### Why is it needed?

Improves performance.

### How to test it?

Focus a relational field twice: the 2nd time you won't see a new request.


