### PR TITLE
RelationInputDataManager: Fix position of newly connected relations

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/utils/normalizeRelations.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/utils/normalizeRelations.js
@@ -32,7 +32,7 @@ export const normalizeRelations = (
       pages:
         [
           ...(relations?.data?.pages ?? []),
-          ...(modifiedData?.connect ? [{ results: modifiedData?.connect }] : []),
+          ...(modifiedData?.connect ? [{ results: modifiedData.connect }] : []),
         ]
           ?.map((page) =>
             page?.results
@@ -52,8 +52,7 @@ export const normalizeRelations = (
               )
               .filter(Boolean)
           )
-          ?.filter((page) => page.length > 0)
-          ?.reverse() ?? [],
+          ?.filter((page) => page.length > 0) ?? [],
     },
   };
 };


### PR DESCRIPTION
### What does it do?

Removes a leftover of a previous experiment, which caused newly added relations to appear at the top of the list, instead of the bottom, if an entity with existing relations is being edited.

### Why is it needed?

Order!