### PR TITLE
return full_documentation.json file

### DIFF
--- a/packages/plugins/documentation/server/controllers/documentation.js
+++ b/packages/plugins/documentation/server/controllers/documentation.js
@@ -55,6 +55,8 @@ module.exports = {
 
       try {
         const documentation = fs.readFileSync(openAPISpecsPath, 'utf8');
+        if ('json' in ctx.query)
+          return ctx.send(JSON.parse(documentation));
         const layout = fs.readFileSync(
           path.resolve(__dirname, '..', 'public', 'index.html'),
           'utf8'


### PR DESCRIPTION
is another way to realize it?

### What does it do?

return full_documentation.json file

### Why is it needed?

to use this file for swagger editor/generator or personal use

### How to test it?

to get file add to url ?json  http://strapi_root/documentation?json 
