### PR TITLE
Refactoring API tokens v2 frontend code

### DIFF
--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/ApiTokens/EditView/components/FormApiToken/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/ApiTokens/EditView/components/FormApiToken/index.js
@@ -1,0 +1,237 @@
+import React from 'react';
+import { useIntl } from 'react-intl';
+import { usePersistentState } from '@strapi/helper-plugin';
+import PropTypes from 'prop-types';
+import { Box } from '@strapi/design-system/Box';
+import { Grid, GridItem } from '@strapi/design-system/Grid';
+import { Select, Option } from '@strapi/design-system/Select';
+import { Stack } from '@strapi/design-system/Stack';
+import { Textarea } from '@strapi/design-system/Textarea';
+import { TextInput } from '@strapi/design-system/TextInput';
+import { Typography } from '@strapi/design-system/Typography';
+import { getDateOfExpiration } from '../../utils';
+
+const FormApiToken = ({
+  errors,
+  onChange,
+  canEditInputs,
+  isCreating,
+  values,
+  apiToken,
+  onChangeSelectApiTokenType,
+}) => {
+  const { formatMessage } = useIntl();
+  const [lang] = usePersistentState('strapi-admin-language', 'en');
+
+  return (
+    <Box
+      background="neutral0"
+      hasRadius
+      shadow="filterShadow"
+      paddingTop={6}
+      paddingBottom={6}
+      paddingLeft={7}
+      paddingRight={7}
+    >
+      <Stack spacing={4}>
+        <Typography variant="delta" as="h2">
+          {formatMessage({
+            id: 'global.details',
+            defaultMessage: 'Details',
+          })}
+        </Typography>
+        <Grid gap={5}>
+          <GridItem key="name" col={6} xs={12}>
+            <TextInput
+              name="name"
+              error={
+                errors.name
+                  ? formatMessage(
+                      errors.name?.id
+                        ? errors.name
+                        : { id: errors.name, defaultMessage: errors.name }
+                    )
+                  : null
+              }
+              label={formatMessage({
+                id: 'Settings.apiTokens.form.name',
+                defaultMessage: 'Name',
+              })}
+              onChange={onChange}
+              value={values.name}
+              disabled={!canEditInputs}
+              required
+            />
+          </GridItem>
+          <GridItem key="description" col={6} xs={12}>
+            <Textarea
+              label={formatMessage({
+                id: 'Settings.apiTokens.form.description',
+                defaultMessage: 'Description',
+              })}
+              name="description"
+              error={
+                errors.description
+                  ? formatMessage(
+                      errors.description?.id
+                        ? errors.description
+                        : {
+                            id: errors.description,
+                            defaultMessage: errors.description,
+                          }
+                    )
+                  : null
+              }
+              onChange={onChange}
+              disabled={!canEditInputs}
+            >
+              {values.description}
+            </Textarea>
+          </GridItem>
+          <GridItem key="lifespan" col={6} xs={12}>
+            <Select
+              name="lifespan"
+              label={formatMessage({
+                id: 'Settings.apiTokens.form.duration',
+                defaultMessage: 'Token duration',
+              })}
+              value={values.lifespan}
+              error={
+                errors.lifespan
+                  ? formatMessage(
+                      errors.lifespan?.id
+                        ? errors.lifespan
+                        : { id: errors.lifespan, defaultMessage: errors.lifespan }
+                    )
+                  : null
+              }
+              onChange={(value) => {
+                onChange({ target: { name: 'lifespan', value } });
+              }}
+              required
+              disabled={!isCreating}
+              placeholder="Select"
+            >
+              <Option value="604800000">
+                {formatMessage({
+                  id: 'Settings.apiTokens.duration.7-days',
+                  defaultMessage: '7 days',
+                })}
+              </Option>
+              <Option value="2592000000">
+                {formatMessage({
+                  id: 'Settings.apiTokens.duration.30-days',
+                  defaultMessage: '30 days',
+                })}
+              </Option>
+              <Option value="7776000000">
+                {formatMessage({
+                  id: 'Settings.apiTokens.duration.90-days',
+                  defaultMessage: '90 days',
+                })}
+              </Option>
+              <Option value={null}>
+                {formatMessage({
+                  id: 'Settings.apiTokens.duration.unlimited',
+                  defaultMessage: 'Unlimited',
+                })}
+              </Option>
+            </Select>
+            <Typography variant="pi" textColor="neutral600">
+              {!isCreating &&
+                `${formatMessage({
+                  id: 'Settings.apiTokens.duration.expiration-date',
+                  defaultMessage: 'Expiration date',
+                })}: ${getDateOfExpiration(
+                  apiToken?.createdAt,
+                  parseInt(values.lifespan, 10),
+                  lang
+                )}`}
+            </Typography>
+          </GridItem>
+
+          <GridItem key="type" col={6} xs={12}>
+            <Select
+              name="type"
+              label={formatMessage({
+                id: 'Settings.apiTokens.form.type',
+                defaultMessage: 'Token type',
+              })}
+              value={values?.type}
+              error={
+                errors.type
+                  ? formatMessage(
+                      errors.type?.id
+                        ? errors.type
+                        : { id: errors.type, defaultMessage: errors.type }
+                    )
+                  : null
+              }
+              onChange={(value) => {
+                onChangeSelectApiTokenType({ target: { value } });
+                onChange({ target: { name: 'type', value } });
+              }}
+              placeholder="Select"
+              required
+              disabled={!canEditInputs}
+            >
+              <Option value="read-only">
+                {formatMessage({
+                  id: 'Settings.apiTokens.types.read-only',
+                  defaultMessage: 'Read-only',
+                })}
+              </Option>
+              <Option value="full-access">
+                {formatMessage({
+                  id: 'Settings.apiTokens.types.full-access',
+                  defaultMessage: 'Full access',
+                })}
+              </Option>
+              <Option value="custom">
+                {formatMessage({
+                  id: 'Settings.apiTokens.types.custom',
+                  defaultMessage: 'Custom',
+                })}
+              </Option>
+            </Select>
+          </GridItem>
+        </Grid>
+      </Stack>
+    </Box>
+  );
+};
+
+FormApiToken.propTypes = {
+  errors: PropTypes.shape({
+    name: PropTypes.string,
+    description: PropTypes.string,
+    lifespan: PropTypes.string,
+    type: PropTypes.string,
+  }),
+  onChange: PropTypes.func.isRequired,
+  canEditInputs: PropTypes.bool.isRequired,
+  values: PropTypes.shape({
+    name: PropTypes.string,
+    description: PropTypes.string,
+    lifespan: PropTypes.string,
+    type: PropTypes.string,
+  }).isRequired,
+  isCreating: PropTypes.bool.isRequired,
+  apiToken: PropTypes.shape({
+    id: PropTypes.string,
+    type: PropTypes.string,
+    lifespan: PropTypes.number,
+    name: PropTypes.string,
+    accessKey: PropTypes.string,
+    permissions: PropTypes.array,
+    description: PropTypes.string,
+    createdAt: PropTypes.string,
+  }).isRequired,
+  onChangeSelectApiTokenType: PropTypes.func.isRequired,
+};
+
+FormApiToken.defaultProps = {
+  errors: {},
+};
+
+export default FormApiToken;

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/ApiTokens/EditView/components/FormApiTokenContainer/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/ApiTokens/EditView/components/FormApiTokenContainer/index.js
@@ -11,17 +11,33 @@ import { TextInput } from '@strapi/design-system/TextInput';
 import { Typography } from '@strapi/design-system/Typography';
 import { getDateOfExpiration } from '../../utils';
 
-const FormApiToken = ({
+const FormApiTokenContainer = ({
   errors,
   onChange,
   canEditInputs,
   isCreating,
   values,
   apiToken,
-  onChangeSelectApiTokenType,
+  onDispatch,
+  setHasChangedPermissions,
 }) => {
   const { formatMessage } = useIntl();
   const [lang] = usePersistentState('strapi-admin-language', 'en');
+
+  const handleChangeSelectApiTokenType = ({ target: { value } }) => {
+    setHasChangedPermissions(false);
+
+    if (value === 'full-access') {
+      onDispatch({
+        type: 'SELECT_ALL_ACTIONS',
+      });
+    }
+    if (value === 'read-only') {
+      onDispatch({
+        type: 'ON_CHANGE_READ_ONLY',
+      });
+    }
+  };
 
   return (
     <Box
@@ -168,7 +184,7 @@ const FormApiToken = ({
                   : null
               }
               onChange={(value) => {
-                onChangeSelectApiTokenType({ target: { value } });
+                handleChangeSelectApiTokenType({ target: { value } });
                 onChange({ target: { name: 'type', value } });
               }}
               placeholder="Select"
@@ -201,7 +217,7 @@ const FormApiToken = ({
   );
 };
 
-FormApiToken.propTypes = {
+FormApiTokenContainer.propTypes = {
   errors: PropTypes.shape({
     name: PropTypes.string,
     description: PropTypes.string,
@@ -227,11 +243,12 @@ FormApiToken.propTypes = {
     description: PropTypes.string,
     createdAt: PropTypes.string,
   }).isRequired,
-  onChangeSelectApiTokenType: PropTypes.func.isRequired,
+  onDispatch: PropTypes.func.isRequired,
+  setHasChangedPermissions: PropTypes.func.isRequired,
 };
 
-FormApiToken.defaultProps = {
+FormApiTokenContainer.defaultProps = {
   errors: {},
 };
 
-export default FormApiToken;
+export default FormApiTokenContainer;

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/ApiTokens/EditView/components/FormBody/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/ApiTokens/EditView/components/FormBody/index.js
@@ -1,0 +1,77 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { ContentLayout } from '@strapi/design-system/Layout';
+import { Stack } from '@strapi/design-system/Stack';
+import HeaderContentBox from '../ContentBox';
+import FormApiTokenContainer from '../FormApiTokenContainer';
+import Permissions from '../Permissions';
+
+const FormBody = ({
+  apiToken,
+  errors,
+  onChange,
+  canEditInputs,
+  isCreating,
+  values,
+  onDispatch,
+  setHasChangedPermissions,
+}) => {
+  return (
+    <ContentLayout>
+      <Stack spacing={6}>
+        {Boolean(apiToken?.name) && <HeaderContentBox apiToken={apiToken.accessKey} />}
+        <FormApiTokenContainer
+          errors={errors}
+          onChange={onChange}
+          canEditInputs={canEditInputs}
+          isCreating={isCreating}
+          values={values}
+          apiToken={apiToken}
+          onDispatch={onDispatch}
+          setHasChangedPermissions={setHasChangedPermissions}
+        />
+        <Permissions
+          disabled={
+            !canEditInputs || values?.type === 'read-only' || values?.type === 'full-access'
+          }
+        />
+      </Stack>
+    </ContentLayout>
+  );
+};
+
+FormBody.propTypes = {
+  errors: PropTypes.shape({
+    name: PropTypes.string,
+    description: PropTypes.string,
+    lifespan: PropTypes.string,
+    type: PropTypes.string,
+  }),
+  apiToken: PropTypes.shape({
+    id: PropTypes.string,
+    type: PropTypes.string,
+    lifespan: PropTypes.number,
+    name: PropTypes.string,
+    accessKey: PropTypes.string,
+    permissions: PropTypes.array,
+    description: PropTypes.string,
+    createdAt: PropTypes.string,
+  }).isRequired,
+  onChange: PropTypes.func.isRequired,
+  canEditInputs: PropTypes.bool.isRequired,
+  isCreating: PropTypes.bool.isRequired,
+  values: PropTypes.shape({
+    name: PropTypes.string,
+    description: PropTypes.string,
+    lifespan: PropTypes.string,
+    type: PropTypes.string,
+  }).isRequired,
+  onDispatch: PropTypes.func.isRequired,
+  setHasChangedPermissions: PropTypes.func.isRequired,
+};
+
+FormBody.defaultProps = {
+  errors: {},
+};
+
+export default FormBody;

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/ApiTokens/EditView/components/FormHead/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/ApiTokens/EditView/components/FormHead/index.js
@@ -1,0 +1,85 @@
+import React from 'react';
+import { useIntl } from 'react-intl';
+import { Link } from '@strapi/helper-plugin';
+import PropTypes from 'prop-types';
+import ArrowLeft from '@strapi/icons/ArrowLeft';
+import Check from '@strapi/icons/Check';
+import { Button } from '@strapi/design-system/Button';
+import { HeaderLayout } from '@strapi/design-system/Layout';
+import { Stack } from '@strapi/design-system/Stack';
+import Regenerate from '../Regenerate';
+
+const FormHead = ({ apiToken, setApiToken, canEditInputs, canRegenerate, isSubmitting }) => {
+  const { formatMessage } = useIntl();
+  const handleRegenerate = (newKey) => {
+    setApiToken({
+      ...apiToken,
+      accessKey: newKey,
+    });
+  };
+
+  return (
+    <HeaderLayout
+      title={
+        apiToken?.name ||
+        formatMessage({
+          id: 'Settings.apiTokens.createPage.title',
+          defaultMessage: 'Create API Token',
+        })
+      }
+      primaryAction={
+        canEditInputs ? (
+          <Stack horizontal spacing={2}>
+            {canRegenerate && apiToken?.id && (
+              <Regenerate onRegenerate={handleRegenerate} idToRegenerate={apiToken?.id} />
+            )}
+            <Button
+              disabled={isSubmitting}
+              loading={isSubmitting}
+              startIcon={<Check />}
+              type="submit"
+              size="S"
+            >
+              {formatMessage({
+                id: 'global.save',
+                defaultMessage: 'Save',
+              })}
+            </Button>
+          </Stack>
+        ) : (
+          canRegenerate &&
+          apiToken?.id && (
+            <Regenerate onRegenerate={handleRegenerate} idToRegenerate={apiToken?.id} />
+          )
+        )
+      }
+      navigationAction={
+        <Link startIcon={<ArrowLeft />} to="/settings/api-tokens">
+          {formatMessage({
+            id: 'global.back',
+            defaultMessage: 'Back',
+          })}
+        </Link>
+      }
+    />
+  );
+};
+
+FormHead.propTypes = {
+  apiToken: PropTypes.shape({
+    id: PropTypes.string,
+    type: PropTypes.string,
+    lifespan: PropTypes.number,
+    name: PropTypes.string,
+    accessKey: PropTypes.string,
+    permissions: PropTypes.array,
+    description: PropTypes.string,
+    createdAt: PropTypes.string,
+  }).isRequired,
+  canEditInputs: PropTypes.bool.isRequired,
+  canRegenerate: PropTypes.bool.isRequired,
+  setApiToken: PropTypes.func.isRequired,
+  isSubmitting: PropTypes.bool.isRequired,
+};
+
+export default FormHead;

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/ApiTokens/EditView/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/ApiTokens/EditView/index.js
@@ -9,7 +9,6 @@ import {
   useTracking,
   useGuidedTour,
   Link,
-  usePersistentState,
   useRBAC,
 } from '@strapi/helper-plugin';
 import { HeaderLayout, ContentLayout } from '@strapi/design-system/Layout';
@@ -19,22 +18,17 @@ import Check from '@strapi/icons/Check';
 import ArrowLeft from '@strapi/icons/ArrowLeft';
 import { Formik } from 'formik';
 import { Stack } from '@strapi/design-system/Stack';
-import { Box } from '@strapi/design-system/Box';
-import { Typography } from '@strapi/design-system/Typography';
-import { Grid, GridItem } from '@strapi/design-system/Grid';
-import { TextInput } from '@strapi/design-system/TextInput';
-import { Textarea } from '@strapi/design-system/Textarea';
-import { Select, Option } from '@strapi/design-system/Select';
 import { get } from 'lodash';
 import { useRouteMatch, useHistory } from 'react-router-dom';
 import { useQuery } from 'react-query';
 import { formatAPIErrors } from '../../../../../utils';
 import { axiosInstance } from '../../../../../core/utils';
-import { getDateOfExpiration, schema } from './utils';
+import { schema } from './utils';
 import LoadingView from './components/LoadingView';
 import HeaderContentBox from './components/ContentBox';
 import Permissions from './components/Permissions';
 import Regenerate from './components/Regenerate';
+import FormApiToken from './components/FormApiToken';
 import adminPermissions from '../../../../../permissions';
 import { ApiTokenPermissionsContextProvider } from '../../../../../contexts/ApiTokenPermissions';
 import init from './init';
@@ -61,7 +55,6 @@ const ApiTokenCreateView = () => {
   const {
     allowedActions: { canCreate, canUpdate, canRegenerate },
   } = useRBAC(adminPermissions.settings['api-tokens']);
-  const [lang] = usePersistentState('strapi-admin-language', 'en');
   const [state, dispatch] = useReducer(reducer, initialState, (state) => init(state, {}));
   const {
     params: { id },
@@ -364,180 +357,15 @@ const ApiTokenCreateView = () => {
                 <ContentLayout>
                   <Stack spacing={6}>
                     {Boolean(apiToken?.name) && <HeaderContentBox apiToken={apiToken.accessKey} />}
-                    <Box
-                      background="neutral0"
-                      hasRadius
-                      shadow="filterShadow"
-                      paddingTop={6}
-                      paddingBottom={6}
-                      paddingLeft={7}
-                      paddingRight={7}
-                    >
-                      <Stack spacing={4}>
-                        <Typography variant="delta" as="h2">
-                          {formatMessage({
-                            id: 'global.details',
-                            defaultMessage: 'Details',
-                          })}
-                        </Typography>
-                        <Grid gap={5}>
-                          <GridItem key="name" col={6} xs={12}>
-                            <TextInput
-                              name="name"
-                              error={
-                                errors.name
-                                  ? formatMessage(
-                                      errors.name?.id
-                                        ? errors.name
-                                        : { id: errors.name, defaultMessage: errors.name }
-                                    )
-                                  : null
-                              }
-                              label={formatMessage({
-                                id: 'Settings.apiTokens.form.name',
-                                defaultMessage: 'Name',
-                              })}
-                              onChange={handleChange}
-                              value={values.name}
-                              disabled={!canEditInputs}
-                              required
-                            />
-                          </GridItem>
-                          <GridItem key="description" col={6} xs={12}>
-                            <Textarea
-                              label={formatMessage({
-                                id: 'Settings.apiTokens.form.description',
-                                defaultMessage: 'Description',
-                              })}
-                              name="description"
-                              error={
-                                errors.description
-                                  ? formatMessage(
-                                      errors.description?.id
-                                        ? errors.description
-                                        : {
-                                            id: errors.description,
-                                            defaultMessage: errors.description,
-                                          }
-                                    )
-                                  : null
-                              }
-                              onChange={handleChange}
-                              disabled={!canEditInputs}
-                            >
-                              {values.description}
-                            </Textarea>
-                          </GridItem>
-                          <GridItem key="lifespan" col={6} xs={12}>
-                            <Select
-                              name="lifespan"
-                              label={formatMessage({
-                                id: 'Settings.apiTokens.form.duration',
-                                defaultMessage: 'Token duration',
-                              })}
-                              value={values.lifespan}
-                              error={
-                                errors.lifespan
-                                  ? formatMessage(
-                                      errors.lifespan?.id
-                                        ? errors.lifespan
-                                        : { id: errors.lifespan, defaultMessage: errors.lifespan }
-                                    )
-                                  : null
-                              }
-                              onChange={(value) => {
-                                handleChange({ target: { name: 'lifespan', value } });
-                              }}
-                              required
-                              disabled={!isCreating}
-                              placeholder="Select"
-                            >
-                              <Option value="604800000">
-                                {formatMessage({
-                                  id: 'Settings.apiTokens.duration.7-days',
-                                  defaultMessage: '7 days',
-                                })}
-                              </Option>
-                              <Option value="2592000000">
-                                {formatMessage({
-                                  id: 'Settings.apiTokens.duration.30-days',
-                                  defaultMessage: '30 days',
-                                })}
-                              </Option>
-                              <Option value="7776000000">
-                                {formatMessage({
-                                  id: 'Settings.apiTokens.duration.90-days',
-                                  defaultMessage: '90 days',
-                                })}
-                              </Option>
-                              <Option value={null}>
-                                {formatMessage({
-                                  id: 'Settings.apiTokens.duration.unlimited',
-                                  defaultMessage: 'Unlimited',
-                                })}
-                              </Option>
-                            </Select>
-                            <Typography variant="pi" textColor="neutral600">
-                              {!isCreating &&
-                                `${formatMessage({
-                                  id: 'Settings.apiTokens.duration.expiration-date',
-                                  defaultMessage: 'Expiration date',
-                                })}: ${getDateOfExpiration(
-                                  apiToken?.createdAt,
-                                  parseInt(values.lifespan, 10),
-                                  lang
-                                )}`}
-                            </Typography>
-                          </GridItem>
-
-                          <GridItem key="type" col={6} xs={12}>
-                            <Select
-                              name="type"
-                              label={formatMessage({
-                                id: 'Settings.apiTokens.form.type',
-                                defaultMessage: 'Token type',
-                              })}
-                              value={values?.type}
-                              error={
-                                errors.type
-                                  ? formatMessage(
-                                      errors.type?.id
-                                        ? errors.type
-                                        : { id: errors.type, defaultMessage: errors.type }
-                                    )
-                                  : null
-                              }
-                              onChange={(value) => {
-                                handleChangeSelectApiTokenType({ target: { value } });
-                                handleChange({ target: { name: 'type', value } });
-                              }}
-                              placeholder="Select"
-                              required
-                              disabled={!canEditInputs}
-                            >
-                              <Option value="read-only">
-                                {formatMessage({
-                                  id: 'Settings.apiTokens.types.read-only',
-                                  defaultMessage: 'Read-only',
-                                })}
-                              </Option>
-                              <Option value="full-access">
-                                {formatMessage({
-                                  id: 'Settings.apiTokens.types.full-access',
-                                  defaultMessage: 'Full access',
-                                })}
-                              </Option>
-                              <Option value="custom">
-                                {formatMessage({
-                                  id: 'Settings.apiTokens.types.custom',
-                                  defaultMessage: 'Custom',
-                                })}
-                              </Option>
-                            </Select>
-                          </GridItem>
-                        </Grid>
-                      </Stack>
-                    </Box>
+                    <FormApiToken
+                      errors={errors}
+                      onChange={handleChange}
+                      canEditInputs={canEditInputs}
+                      isCreating={isCreating}
+                      values={values}
+                      apiToken={apiToken}
+                      onChangeSelectApiTokenType={(val) => handleChangeSelectApiTokenType(val)}
+                    />
                     <Permissions
                       disabled={
                         !canEditInputs ||

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/ApiTokens/EditView/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/ApiTokens/EditView/index.js
@@ -8,16 +8,10 @@ import {
   useNotification,
   useTracking,
   useGuidedTour,
-  Link,
   useRBAC,
 } from '@strapi/helper-plugin';
-import { HeaderLayout, ContentLayout } from '@strapi/design-system/Layout';
 import { Main } from '@strapi/design-system/Main';
-import { Button } from '@strapi/design-system/Button';
-import Check from '@strapi/icons/Check';
-import ArrowLeft from '@strapi/icons/ArrowLeft';
 import { Formik } from 'formik';
-import { Stack } from '@strapi/design-system/Stack';
 import { get } from 'lodash';
 import { useRouteMatch, useHistory } from 'react-router-dom';
 import { useQuery } from 'react-query';
@@ -25,10 +19,8 @@ import { formatAPIErrors } from '../../../../../utils';
 import { axiosInstance } from '../../../../../core/utils';
 import { schema } from './utils';
 import LoadingView from './components/LoadingView';
-import HeaderContentBox from './components/ContentBox';
-import Permissions from './components/Permissions';
-import Regenerate from './components/Regenerate';
-import FormApiToken from './components/FormApiToken';
+import FormHead from './components/FormHead';
+import FormBody from './components/FormBody';
 import adminPermissions from '../../../../../permissions';
 import { ApiTokenPermissionsContextProvider } from '../../../../../contexts/ApiTokenPermissions';
 import init from './init';
@@ -242,32 +234,10 @@ const ApiTokenCreateView = () => {
     });
   };
 
-  const handleChangeSelectApiTokenType = ({ target: { value } }) => {
-    setHasChangedPermissions(false);
-
-    if (value === 'full-access') {
-      dispatch({
-        type: 'SELECT_ALL_ACTIONS',
-      });
-    }
-    if (value === 'read-only') {
-      dispatch({
-        type: 'ON_CHANGE_READ_ONLY',
-      });
-    }
-  };
-
   const setSelectedAction = ({ target: { value } }) => {
     dispatch({
       type: 'SET_SELECTED_ACTION',
       value,
-    });
-  };
-
-  const handleRegenerate = (newKey) => {
-    setApiToken({
-      ...apiToken,
-      accessKey: newKey,
     });
   };
 
@@ -308,73 +278,23 @@ const ApiTokenCreateView = () => {
 
             return (
               <Form>
-                <HeaderLayout
-                  title={
-                    apiToken?.name ||
-                    formatMessage({
-                      id: 'Settings.apiTokens.createPage.title',
-                      defaultMessage: 'Create API Token',
-                    })
-                  }
-                  primaryAction={
-                    canEditInputs ? (
-                      <Stack horizontal spacing={2}>
-                        {canRegenerate && apiToken?.id && (
-                          <Regenerate
-                            onRegenerate={handleRegenerate}
-                            idToRegenerate={apiToken?.id}
-                          />
-                        )}
-                        <Button
-                          disabled={isSubmitting}
-                          loading={isSubmitting}
-                          startIcon={<Check />}
-                          type="submit"
-                          size="S"
-                        >
-                          {formatMessage({
-                            id: 'global.save',
-                            defaultMessage: 'Save',
-                          })}
-                        </Button>
-                      </Stack>
-                    ) : (
-                      canRegenerate &&
-                      apiToken?.id && (
-                        <Regenerate onRegenerate={handleRegenerate} idToRegenerate={apiToken?.id} />
-                      )
-                    )
-                  }
-                  navigationAction={
-                    <Link startIcon={<ArrowLeft />} to="/settings/api-tokens">
-                      {formatMessage({
-                        id: 'global.back',
-                        defaultMessage: 'Back',
-                      })}
-                    </Link>
-                  }
+                <FormHead
+                  apiToken={apiToken}
+                  setApiToken={setApiToken}
+                  canEditInputs={canEditInputs}
+                  canRegenerate={canRegenerate}
+                  isSubmitting={isSubmitting}
                 />
-                <ContentLayout>
-                  <Stack spacing={6}>
-                    {Boolean(apiToken?.name) && <HeaderContentBox apiToken={apiToken.accessKey} />}
-                    <FormApiToken
-                      errors={errors}
-                      onChange={handleChange}
-                      canEditInputs={canEditInputs}
-                      isCreating={isCreating}
-                      values={values}
-                      apiToken={apiToken}
-                      onChangeSelectApiTokenType={(val) => handleChangeSelectApiTokenType(val)}
-                    />
-                    <Permissions
-                      disabled={
-                        !canEditInputs ||
-                        values?.type === 'read-only' ||
-                        values?.type === 'full-access'
-                      }
-                    />
-                  </Stack>
-                </ContentLayout>
+                <FormBody
+                  apiToken={apiToken}
+                  errors={errors}
+                  onChange={handleChange}
+                  canEditInputs={canEditInputs}
+                  isCreating={isCreating}
+                  values={values}
+                  onDispatch={dispatch}
+                  setHasChangedPermissions={setHasChangedPermissions}
+                />
               </Form>
             );
           }}

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/ApiTokens/EditView/tests/__snapshots__/index.test.js.snap
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/ApiTokens/EditView/tests/__snapshots__/index.test.js.snap
@@ -756,6 +756,10 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
   width: 1px;
 }
 
+.c0:focus-visible {
+  outline: none;
+}
+
 .c1 {
   background: #f6f6f9;
   padding-top: 24px;
@@ -810,10 +814,6 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
   font-weight: 600;
   font-size: 2rem;
   line-height: 1.25;
-}
-
-.c0:focus-visible {
-  outline: none;
 }
 
 .c59 {
@@ -2725,6 +2725,10 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
   width: 1px;
 }
 
+.c0:focus-visible {
+  outline: none;
+}
+
 .c20 {
   padding-right: 56px;
   padding-left: 56px;
@@ -2779,10 +2783,6 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
   font-weight: 600;
   font-size: 2rem;
   line-height: 1.25;
-}
-
-.c0:focus-visible {
-  outline: none;
 }
 
 .c71 {


### PR DESCRIPTION
### What does it do?

Refactor and split the code of the Edit and Create pages in the Api Token Settings.

### Why is it needed?

Because the code was huge in just one component, we need to split it and have a more readable code.

### How to test it?

We need to test all the possible combinations and possibilities with Api token to check some regression errors.
