### PR TITLE
Update documentation link in CustomFieldsList for the stable release

### DIFF
--- a/packages/core/content-type-builder/admin/src/components/AttributeOptions/CustomFieldsList/index.js
+++ b/packages/core/content-type-builder/admin/src/components/AttributeOptions/CustomFieldsList/index.js
@@ -45,7 +45,7 @@ const CustomFieldsList = () => {
           })}
         </Grid>
         <Link
-          href="https://docs-next.strapi.io/developer-docs/latest/development/custom-fields.html"
+          href="https://docs.strapi.io/developer-docs/latest/development/custom-fields.html"
           isExternal
         >
           {formatMessage({


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

It updates the documentation link used in `CustomFieldsList/index.js` to the production documentation instead of using docs-next.

**Please don't merge before getting ready for the General Availability of custom fields, the link will only be active on the release day.

### Related issue(s)/PR(s)

This is a follow-up to #14232, now updating the link for the final release.
