### PR TITLE
[Fix] Guided tour visibility on prod mode

### DIFF
--- a/packages/core/admin/admin/src/components/AuthenticatedApp/index.js
+++ b/packages/core/admin/admin/src/components/AuthenticatedApp/index.js
@@ -65,11 +65,11 @@ const AuthenticatedApp = () => {
     if (userRoles) {
       const isUserSuperAdmin = userRoles.find(({ code }) => code === 'strapi-super-admin');
 
-      if (isUserSuperAdmin) {
+      if (isUserSuperAdmin && appInfos?.autoReload) {
         setGuidedTourVisibilityRef.current(true);
       }
     }
-  }, [userRoles]);
+  }, [userRoles, appInfos]);
 
   // We don't need to wait for the release query to be fetched before rendering the plugins
   // however, we need the appInfos and the permissions

--- a/packages/core/admin/admin/src/components/AuthenticatedApp/tests/index.test.js
+++ b/packages/core/admin/admin/src/components/AuthenticatedApp/tests/index.test.js
@@ -175,8 +175,20 @@ describe('Admin | components | AuthenticatedApp', () => {
     await waitFor(() => expect(setGuidedTourVisibility).not.toHaveBeenCalled());
   });
 
-  it('should call setGuidedTourVisibility when user is super admin', async () => {
+  it('should not setGuidedTourVisibility when user is a super admin and autoReload is false ', async () => {
     fetchUserRoles.mockImplementationOnce(() => [{ code: 'strapi-super-admin' }]);
+    fetchAppInfo.mockImplementationOnce(() => ({ autoReload: false }));
+    const setGuidedTourVisibility = jest.fn();
+    useGuidedTour.mockImplementation(() => ({ setGuidedTourVisibility }));
+
+    render(<App />);
+
+    await waitFor(() => expect(setGuidedTourVisibility).not.toHaveBeenCalled());
+  });
+
+  it('should call setGuidedTourVisibility when user is super admin and autoReload is true', async () => {
+    fetchUserRoles.mockImplementationOnce(() => [{ code: 'strapi-super-admin' }]);
+    fetchAppInfo.mockImplementationOnce(() => ({ autoReload: true }));
     const setGuidedTourVisibility = jest.fn();
     useGuidedTour.mockImplementation(() => ({ setGuidedTourVisibility }));
     render(<App />);


### PR DESCRIPTION
## What

Fixed guided tour visible even on production mode 
Used `autoReload` as for CTB
`autoReload` is false when using `strapi start` command which means that we are in a production environment 


## Test

`yarn setup` at strapi root
`yarn build` on getstarted
`yarn start` on `getstarted` while being a super admin
Guided tour shouldn't appear in homepage or any other places