### PR TITLE
[Enh] en-PA locale

### DIFF
--- a/packages/plugins/i18n/server/constants/iso-locales.json
+++ b/packages/plugins/i18n/server/constants/iso-locales.json
@@ -536,6 +536,10 @@
     "name":"English (Northern Mariana Islands) (en-MP)"
   },
   {
+    "code":"en-PA",
+    "name":"English (Panama) (en-PA)"
+  },
+  {
     "code":"en-PK",
     "name":"English (Pakistan) (en-PK)"
   },

--- a/packages/plugins/i18n/server/services/__tests__/__snapshots__/iso-locales.test.js.snap
+++ b/packages/plugins/i18n/server/services/__tests__/__snapshots__/iso-locales.test.js.snap
@@ -539,6 +539,10 @@ exports[`ISO locales getIsoLocales 1`] = `
     "name": "English (Northern Mariana Islands) (en-MP)",
   },
   {
+    "code": "en-PA",
+    "name": "English (Panama) (en-PA)",
+  },
+  {
     "code": "en-PK",
     "name": "English (Pakistan) (en-PK)",
   },


### PR DESCRIPTION
## What

Fixes #14427

Added `en-PA` English (Panama) locale to i18n constants

## Test

Go to Internationalization global settings
Add English (Panama) as a new locale

