### PR TITLE
Update get-config-path.js to return correct path on Windows OS

### DIFF
--- a/packages/utils/typescript/lib/utils/get-config-path.js
+++ b/packages/utils/typescript/lib/utils/get-config-path.js
@@ -17,7 +17,7 @@ const DEFAULT_TS_CONFIG_FILENAME = 'tsconfig.json';
  */
 module.exports = (dir, { filename = DEFAULT_TS_CONFIG_FILENAME, ancestorsLookup = false } = {}) => {
   const dirAbsolutePath = path.resolve(dir);
-  const configFilePath = ts.findConfigFile(dirAbsolutePath, ts.sys.fileExists, filename);
+  const configFilePath = path.resolve(ts.findConfigFile(dirAbsolutePath, ts.sys.fileExists, filename));
 
   if (!configFilePath || ancestorsLookup) {
     return configFilePath;


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?
https://github.com/strapi/strapi/issues/14450
current version of `get-config-path` utils does not returned correct path in windows os
so it should be changed to return correct path

### Why is it needed?
if config path does not correct in windows os than it couldn't run

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)
https://github.com/strapi/strapi/issues/14450

Let us know if this is related to any issue/pull request
