### PR TITLE
Add custom fields to Typescript generators

### DIFF
--- a/packages/core/strapi/lib/types/core/attributes/common.d.ts
+++ b/packages/core/strapi/lib/types/core/attributes/common.d.ts
@@ -29,6 +29,9 @@ export type NonUniqueAttribute = { unique: false };
 export type ConfigurableAttribute = { configurable: true };
 export type NonConfigurableAttribute = { configurable: false };
 
+// custom field
+export type CustomField<T extends string, P extends object = undefined> = { customField: T, options?: P };
+
 // min/max
 export type SetMinMax<T extends MinMaxOption<U>, U = number> = T;
 

--- a/packages/utils/typescript/lib/__tests__/generators/schemas/attributes.test.js
+++ b/packages/utils/typescript/lib/__tests__/generators/schemas/attributes.test.js
@@ -438,6 +438,8 @@ describe('Attributes', () => {
         });
       });
 
+      // TODO custom field
+
       describe('Plugin Options', () => {
         test('No plugin options', () => {
           const attribute = {};

--- a/packages/utils/typescript/lib/__tests__/generators/schemas/attributes.test.js
+++ b/packages/utils/typescript/lib/__tests__/generators/schemas/attributes.test.js
@@ -448,7 +448,7 @@ describe('Attributes', () => {
 
         test('Basic custom field', () => {
           const attribute = {
-            type: 'customField',
+            type: 'string',
             customField: 'plugin::color-picker.color',
           };
           const modifiers = getAttributeModifiers(attribute);
@@ -463,7 +463,7 @@ describe('Attributes', () => {
 
         test('Advanced custom field', () => {
           const attribute = {
-            type: 'customField',
+            type: 'string',
             customField: 'plugin::color-picker.color',
             options: {
               format: 'hex',

--- a/packages/utils/typescript/lib/__tests__/generators/schemas/attributes.test.js
+++ b/packages/utils/typescript/lib/__tests__/generators/schemas/attributes.test.js
@@ -438,7 +438,60 @@ describe('Attributes', () => {
         });
       });
 
-      // TODO custom field
+      describe('Custom field', () => {
+        test('No custom field', () => {
+          const attribute = {};
+          const modifiers = getAttributeModifiers(attribute);
+
+          expect(modifiers).toHaveLength(0);
+        });
+
+        test('Basic custom field', () => {
+          const attribute = {
+            type: 'customField',
+            customField: 'plugin::color-picker.color',
+          };
+          const modifiers = getAttributeModifiers(attribute);
+
+          expect(modifiers).toHaveLength(1);
+          expect(modifiers[0].kind).toBe(ts.SyntaxKind.TypeReference);
+          expect(modifiers[0].typeName.escapedText).toBe('CustomField');
+          expect(modifiers[0].typeArguments).toHaveLength(1);
+          expect(modifiers[0].typeArguments[0].kind).toBe(ts.SyntaxKind.StringLiteral);
+          expect(modifiers[0].typeArguments[0].text).toBe('plugin::color-picker.color');
+        });
+
+        test('Advanced custom field', () => {
+          const attribute = {
+            type: 'customField',
+            customField: 'plugin::color-picker.color',
+            options: {
+              format: 'hex',
+            },
+          };
+          const modifiers = getAttributeModifiers(attribute);
+
+          expect(modifiers).toHaveLength(1);
+          expect(modifiers[0].kind).toBe(ts.SyntaxKind.TypeReference);
+          expect(modifiers[0].typeName.escapedText).toBe('CustomField');
+          expect(modifiers[0].typeArguments).toHaveLength(2);
+          expect(modifiers[0].typeArguments[0].kind).toBe(ts.SyntaxKind.StringLiteral);
+          expect(modifiers[0].typeArguments[0].text).toBe('plugin::color-picker.color');
+          expect(modifiers[0].typeArguments[1].kind).toBe(ts.SyntaxKind.TypeLiteral);
+          expect(modifiers[0].typeArguments[1].members).toHaveLength(1);
+          expect(modifiers[0].typeArguments[1].members[0].kind).toBe(
+            ts.SyntaxKind.PropertyDeclaration
+          );
+          expect(modifiers[0].typeArguments[1].members[0].name.escapedText).toBe('format');
+          expect(modifiers[0].typeArguments[1].members[0].kind).toBe(
+            ts.SyntaxKind.PropertyDeclaration
+          );
+          expect(modifiers[0].typeArguments[1].members[0].type.kind).toBe(
+            ts.SyntaxKind.StringLiteral
+          );
+          expect(modifiers[0].typeArguments[1].members[0].type.text).toBe('hex');
+        });
+      });
 
       describe('Plugin Options', () => {
         test('No plugin options', () => {

--- a/packages/utils/typescript/lib/generators/schemas/attributes.js
+++ b/packages/utils/typescript/lib/generators/schemas/attributes.js
@@ -70,6 +70,22 @@ const getAttributeModifiers = (attribute) => {
     );
   }
 
+  // Custom field
+  if (attribute.customField) {
+    addImport('CustomField');
+
+    const customFieldUid = factory.createStringLiteral(attribute.customField);
+    const typeParams = [customFieldUid];
+
+    if (attribute.options) {
+      typeParams.push(toTypeLiteral(attribute.options));
+    }
+
+    modifiers.push(
+      factory.createTypeReferenceNode(factory.createIdentifier('CustomField'), typeParams)
+    );
+  }
+
   // Plugin Options
   if (!_.isEmpty(attribute.pluginOptions)) {
     addImport('SetPluginOptions');

--- a/packages/utils/typescript/lib/generators/schemas/attributes.js
+++ b/packages/utils/typescript/lib/generators/schemas/attributes.js
@@ -75,14 +75,14 @@ const getAttributeModifiers = (attribute) => {
     addImport('CustomField');
 
     const customFieldUid = factory.createStringLiteral(attribute.customField);
-    const typeParams = [customFieldUid];
+    const typeArguments = [customFieldUid];
 
     if (attribute.options) {
-      typeParams.push(toTypeLiteral(attribute.options));
+      typeArguments.push(toTypeLiteral(attribute.options));
     }
 
     modifiers.push(
-      factory.createTypeReferenceNode(factory.createIdentifier('CustomField'), typeParams)
+      factory.createTypeReferenceNode(factory.createIdentifier('CustomField'), typeArguments)
     );
   }
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Updates the command that generates TS types for a content type so that it handles custom fields properly.

### Why is it needed?

Custom fields were being treated like they were the underlying type. So the key `customField`, as well as the optional `options` object were missing from the types for a custom field attribute.

### How to test it?

- Run `yarn strapi ts:generate-types` in a Strapi application that uses a custom field (like getstarted)
- View the generated `schema.d.ts` file. The type for the custom field attribute should combine the underlying type attribute, as well as the custom field one with the custom field uid as a parameter. For example:  
```ts
field: StringAttribute & CustomField<'plugin::color-picker.color'>;
```

made with @Convly in peer programming