### PR TITLE
Treat email as lowercase when creating a user

### DIFF
--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Users/ListPage/ModalForm/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Users/ListPage/ModalForm/index.js
@@ -69,8 +69,8 @@ const ModalForm = ({ queryName, onToggle }) => {
     } catch (err) {
       unlockApp();
 
-      if (err?.response?.data.message === 'Email already taken') {
-        setErrors({ email: err.response.data.message });
+      if (err?.response?.data?.error.message === 'Email already taken') {
+        setErrors({ email: err.response.data.error.message });
       }
     }
   };

--- a/packages/core/admin/ee/server/controllers/user.js
+++ b/packages/core/admin/ee/server/controllers/user.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { get } = require('lodash');
 const { pick } = require('lodash/fp');
 const { ApplicationError } = require('@strapi/utils').errors;
 const { validateUserCreationInput } = require('../validation/user');
@@ -10,11 +11,12 @@ const pickUserCreationAttributes = pick(['firstname', 'lastname', 'email', 'role
 module.exports = {
   async create(ctx) {
     const { body } = ctx.request;
+    const cleanData = { ...body, email: get(body, `email`, ``).toLowerCase() };
 
-    await validateUserCreationInput(body);
+    await validateUserCreationInput(cleanData);
 
-    const attributes = pickUserCreationAttributes(body);
-    const { useSSORegistration } = body;
+    const attributes = pickUserCreationAttributes(cleanData);
+    const { useSSORegistration } = cleanData;
 
     const userAlreadyExists = await getService('user').exists({ email: attributes.email });
 

--- a/packages/core/admin/server/controllers/__tests__/user.test.js
+++ b/packages/core/admin/server/controllers/__tests__/user.test.js
@@ -65,6 +65,38 @@ describe('User Controller', () => {
       expect(sanitizeUser).toHaveBeenCalled();
       expect(created).toHaveBeenCalled();
     });
+
+    test('Create User Successfully with camelCase email', async () => {
+      const camelCaseBody = { ...body, email: 'kAiDoE@CamelCaSE.com' };
+      const create = jest.fn(() => Promise.resolve(camelCaseBody));
+      const exists = jest.fn(() => Promise.resolve(false));
+      const sanitizeUser = jest.fn((user) => Promise.resolve(user));
+      const created = jest.fn();
+      const ctx = createContext({ body: camelCaseBody }, { created });
+
+      global.strapi = {
+        admin: {
+          services: {
+            user: {
+              exists,
+              create,
+              sanitizeUser,
+            },
+          },
+        },
+      };
+
+      await userController.create(ctx);
+
+      const lowerEmail = camelCaseBody.email.toLowerCase();
+      expect(exists).toHaveBeenCalledWith({ email: lowerEmail });
+      expect(create).toHaveBeenCalledWith({
+        ...camelCaseBody,
+        email: lowerEmail,
+      });
+      expect(sanitizeUser).toHaveBeenCalled();
+      expect(created).toHaveBeenCalled();
+    });
   });
 
   describe('Find a user by its ID', () => {

--- a/packages/core/admin/server/controllers/user.js
+++ b/packages/core/admin/server/controllers/user.js
@@ -13,10 +13,11 @@ const { getService } = require('../utils');
 module.exports = {
   async create(ctx) {
     const { body } = ctx.request;
+    const cleanData = { ...body, email: _.get(body, `email`, ``).toLowerCase() };
 
-    await validateUserCreationInput(body);
+    await validateUserCreationInput(cleanData);
 
-    const attributes = _.pick(body, [
+    const attributes = _.pick(cleanData, [
       'firstname',
       'lastname',
       'email',

--- a/packages/core/admin/server/tests/admin-user.test.e2e.js
+++ b/packages/core/admin/server/tests/admin-user.test.e2e.js
@@ -112,7 +112,7 @@ describe('Admin User CRUD (e2e)', () => {
 
   test('2. Creates a user (successfully)', async () => {
     const body = {
-      email: 'user-tests@strapi-e2e.com',
+      email: 'uSer-tEsTs@strapi-e2e.com', // Tested with a camelCase email address
       firstname: 'user_tests-firstname',
       lastname: 'user_tests-lastname',
       roles: [testData.role.id],


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

- Fixes an issue where inviting an admin user with a camel cased email address would cause an API error (failing the Yup email validation logic)
- `POST /users` now transforms all email addresses to lower case

### Why is it needed?

Emails should be assumed to be lower case as discussed on the related issue

### How to test it?

1. Go to Settings / Users
2. Click on "Invite new user"
3. Fill the form with an email like "ExamPle@example.com"
4. Click on "Invite user"

### Related issue(s)/PR(s)

Fixes #13360 
