### PR TITLE
[Fix] xToOne relations not showing

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/RelationInputDataManager.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/RelationInputDataManager.js
@@ -30,12 +30,11 @@ export const RelationInputDataManger = ({
   const { formatMessage } = useIntl();
   const { connectRelation, disconnectRelation, loadRelation, modifiedData, slug, initialData } =
     useCMEditViewDataManager();
-  const relationsCount = initialData[name]?.count ?? 0;
   const [{ query }] = useQueryParams();
 
   const { relations, search, searchFor } = useRelation(`${slug}-${name}-${initialData?.id ?? ''}`, {
     relation: {
-      enabled: relationsCount > 0 && !!endpoints.relation,
+      enabled: initialData[name]?.count !== 0 && !!endpoints.relation,
       endpoint: endpoints.relation,
       pageParams: {
         ...defaultParams,
@@ -141,13 +140,10 @@ export const RelationInputDataManger = ({
       description={description}
       disabled={isDisabled}
       id={name}
-      label={formatMessage(
-        {
-          id: intlLabel.id,
-          defaultMessage: `${intlLabel.defaultMessage} ({numberOfEntries})`,
-        },
-        { numberOfEntries: relationsCount }
-      )}
+      label={`${formatMessage({
+        id: intlLabel.id,
+        defaultMessage: intlLabel.defaultMessage,
+      })} ${initialData[name]?.count ? `(${initialData[name].count})` : ''}`}
       labelAction={labelAction}
       labelLoadMore={
         // TODO: only display if there are more; derive from count

--- a/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/RelationInputDataManager.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/RelationInputDataManager.js
@@ -143,7 +143,7 @@ export const RelationInputDataManger = ({
       label={`${formatMessage({
         id: intlLabel.id,
         defaultMessage: intlLabel.defaultMessage,
-      })} ${initialData[name]?.count ? `(${initialData[name].count})` : ''}`}
+      })} ${initialData[name]?.count !== undefined ? `(${initialData[name].count})` : ''}`}
       labelAction={labelAction}
       labelLoadMore={
         // TODO: only display if there are more; derive from count

--- a/packages/core/content-manager/server/controllers/relations.js
+++ b/packages/core/content-manager/server/controllers/relations.js
@@ -208,7 +208,8 @@ module.exports = {
       ctx.body = await strapi.entityService.findPage(targetedModel.uid, queryParams);
     } else {
       const results = await strapi.entityService.findMany(targetedModel.uid, queryParams);
-      ctx.body = results[0];
+      // TODO: Temporary fix (use data instead)
+      ctx.body = { results, pagination: { page: 1, pageSize: 5, pageCount: 1, total: 1 } };
     }
   },
 };

--- a/packages/core/content-manager/server/tests/find-existing-relations.test.e2e.js
+++ b/packages/core/content-manager/server/tests/find-existing-relations.test.e2e.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const { isEmpty } = require('lodash/fp');
 const { createTestBuilder } = require('../../../../../test/helpers/builder');
 const { createStrapiInstance } = require('../../../../../test/helpers/strapi');
 const { createAuthRequest } = require('../../../../../test/helpers/request');
@@ -204,7 +203,7 @@ describe.each([false, true])('Relations, with d&p: %s', (withDraftAndPublish) =>
             },
           ]);
         } else {
-          expect(res.body).toMatchObject({
+          expect(res.body.results[0]).toMatchObject({
             id: expect.any(Number),
             name: 'Skate',
             ...addPublishedAtCheck(expect.any(String)),
@@ -237,13 +236,8 @@ describe.each([false, true])('Relations, with d&p: %s', (withDraftAndPublish) =>
           url: `/content-manager/collection-types/api::shop.shop/${data.shops[1].id}/${fieldName}`,
         });
 
-        if (isManyRelation) {
-          expect(res.status).toBe(200);
-          expect(res.body.results).toHaveLength(0);
-        } else {
-          expect(res.status).toBe(204);
-          expect(isEmpty(res.body)).toBe(true);
-        }
+        expect(res.status).toBe(200);
+        expect(res.body.results).toHaveLength(0);
       });
 
       if (isManyRelation) {
@@ -321,7 +315,7 @@ describe.each([false, true])('Relations, with d&p: %s', (withDraftAndPublish) =>
             },
           ]);
         } else {
-          expect(res.body).toMatchObject({
+          expect(res.body.results[0]).toMatchObject({
             id: expect.any(Number),
             name: 'Skate',
             ...addPublishedAtCheck(expect.any(String)),

--- a/packages/core/content-manager/server/tests/index.test.e2e.js
+++ b/packages/core/content-manager/server/tests/index.test.e2e.js
@@ -585,7 +585,7 @@ describe('Relations', () => {
       expect(tags.length).toBe(0);
 
       const category = await getRelations('article', 'category', body.id);
-      expect(category.name).toBe(data.categories[0].name);
+      expect(category[0].name).toBe(data.categories[0].name);
     });
 
     test('Update article1 with cat2', async () => {
@@ -619,7 +619,7 @@ describe('Relations', () => {
       expect(tags.length).toBe(0);
 
       const category = await getRelations('article', 'category', body.id);
-      expect(category.name).toBe(data.categories[1].name);
+      expect(category[0].name).toBe(data.categories[1].name);
     });
 
     test('Create article2', async () => {
@@ -687,7 +687,7 @@ describe('Relations', () => {
       expect(tags.length).toBe(0);
 
       const category = await getRelations('article', 'category', body.id);
-      expect(category.name).toBe(data.categories[1].name);
+      expect(category[0].name).toBe(data.categories[1].name);
     });
 
     test('Update cat1 with article1', async () => {
@@ -760,7 +760,8 @@ describe('Relations', () => {
       });
 
       expect(body).toMatchObject({
-        name: 'cat3',
+        results: [{ name: 'cat3' }],
+        pagination: { page: 1, pageSize: 5, pageCount: 1, total: 1 },
       });
     });
 
@@ -771,7 +772,8 @@ describe('Relations', () => {
       });
 
       expect(body).toMatchObject({
-        name: 'cat2',
+        results: [{ name: 'cat2' }],
+        pagination: { page: 1, pageSize: 5, pageCount: 1, total: 1 },
       });
     });
 
@@ -916,7 +918,7 @@ describe('Relations', () => {
       });
 
       const reference = await getRelations('article', 'reference', body.id);
-      expect(reference.id).toBe(data.references[0].id);
+      expect(reference[0].id).toBe(data.references[0].id);
     });
 
     test('Create article2 with ref1', async () => {
@@ -950,7 +952,7 @@ describe('Relations', () => {
         username: null,
       });
       const reference = await getRelations('article', 'reference', body.id);
-      expect(reference.id).toBe(data.references[0].id);
+      expect(reference[0].id).toBe(data.references[0].id);
     });
   });
 
@@ -976,7 +978,7 @@ describe('Relations', () => {
       expect(createdReference.id).toBeDefined();
 
       const tag = await getRelations('reference', 'tag', createdReference.id);
-      expect(tag.id).toBe(createdTag.id);
+      expect(tag[0].id).toBe(createdTag.id);
     });
 
     test('Detach Tag to a Reference', async () => {
@@ -998,7 +1000,7 @@ describe('Relations', () => {
       });
 
       let tag = await getRelations('reference', 'tag', createdReference.id);
-      expect(tag.id).toBe(createdTag.id);
+      expect(tag[0].id).toBe(createdTag.id);
 
       const { body: referenceToUpdate } = await rq({
         url: `/content-manager/collection-types/api::reference.reference/${createdReference.id}`,


### PR DESCRIPTION
## What

There is a difference in the response format for when it is a xToMany relation or a xToOne relations.
```
xToMany :
{
  results: [],
  pagination: {
    page: 1,
    pageSize: 5,
    total: 10,
  }
}
```

```
xToOne :
{
  data: {}
}
```

Frontend did not know about it and only implemented the first format so it is not equipped today to handle the second one.
As a temporary fix for the alpha, we implemented the first format for the xToOne too in the backend. 
Later we will need to revert that and change the frontend instead as a pagination is not relevant for a xToOne.

## Test

Create xToOne relation
Save
Relation should show up