### PR TITLE
[Relations] Fix nested data for relations in component

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/NonRepeatableComponent/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/NonRepeatableComponent/index.js
@@ -65,6 +65,7 @@ const NonRepeatableComponent = ({ componentUid, isFromDynamicZone, isNested, nam
                       fieldSchema={fieldSchema}
                       metadatas={metadatas}
                       queryInfos={queryInfos}
+                      size={size}
                     />
                   </GridItem>
                 );

--- a/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/RelationInputDataManager.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/RelationInputDataManager.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React, { memo, useEffect, useMemo } from 'react';
 import { useIntl } from 'react-intl';
+import get from 'lodash/get';
 
 import { useCMEditViewDataManager, NotAllowedInput, useQueryParams } from '@strapi/helper-plugin';
 
@@ -34,7 +35,7 @@ export const RelationInputDataManger = ({
 
   const { relations, search, searchFor } = useRelation(`${slug}-${name}-${initialData?.id ?? ''}`, {
     relation: {
-      enabled: initialData[name]?.count !== 0 && !!endpoints.relation,
+      enabled: get(initialData, name)?.count !== 0 && !!endpoints.relation,
       endpoint: endpoints.relation,
       pageParams: {
         ...defaultParams,
@@ -54,11 +55,12 @@ export const RelationInputDataManger = ({
     },
   });
 
+  const relationsFromModifiedData = get(modifiedData, name);
   const stringifiedRelations = JSON.stringify(relations);
   const normalizedRelations = useMemo(
     () =>
       normalizeRelations(relations, {
-        modifiedData: modifiedData?.[name],
+        modifiedData: relationsFromModifiedData,
         mainFieldName: mainField.name,
         shouldAddLink: shouldDisplayRelationLink,
         targetModel,
@@ -117,11 +119,15 @@ export const RelationInputDataManger = ({
   };
 
   const handleSearch = (term) => {
-    searchFor(term, { idsToOmit: modifiedData?.[name]?.connect?.map((relation) => relation.id) });
+    searchFor(term, {
+      idsToOmit: relationsFromModifiedData?.connect?.map((relation) => relation.id),
+    });
   };
 
   const handleOpenSearch = () => {
-    searchFor('', { idsToOmit: modifiedData?.[name]?.connect?.map((relation) => relation.id) });
+    searchFor('', {
+      idsToOmit: relationsFromModifiedData?.connect?.map((relation) => relation.id),
+    });
   };
 
   const handleSearchMore = () => {
@@ -190,6 +196,7 @@ export const RelationInputDataManger = ({
       required={required}
       searchResults={normalizeRelations(search, {
         mainFieldName: mainField.name,
+        search: 'search',
       })}
       size={size}
     />

--- a/packages/core/admin/admin/src/content-manager/components/RepeatableComponent/DraggedItem/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/RepeatableComponent/DraggedItem/index.js
@@ -270,6 +270,7 @@ const DraggedItem = ({
                             metadatas={metadatas}
                             // onBlur={hasErrors ? checkFormErrors : null}
                             queryInfos={queryInfos}
+                            size={size}
                           />
                         </GridItem>
                       );


### PR DESCRIPTION
## What

Relations didn't appear for relations inside a component (single, rep, dz)
It was caused by data being nested making `modifiedData?.[name]` with `name` syntax being `openingTimes.0.dishrep.1.categories`
Fixed by using `get` from `lodash` allowing to easily get nested data 

Also fix some `proptypes` error with size passed to component `Inputs`

⚠️ this PR doesn't fix entirely relations in component since we don't query the right `id` for component yet

## Test

This fix needs to be tested by pulling `relations-main-view/QA` branch into this one
Create a Restaurant entity with openingTimes/dishrep/categories relation
See categories relations displayed

