### PR TITLE
Add suspense boundary in dynamic zones

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/DynamicZone/components/Component/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/DynamicZone/components/Component/index.js
@@ -153,7 +153,7 @@ const Component = ({
                 <Suspense
                   fallback={
                     <Flex justifyContent="center" paddingTop={4} paddingBottom={4}>
-                      <Loader />
+                      <Loader>Loading content.</Loader>
                     </Flex>
                   }
                 >

--- a/packages/core/admin/admin/src/content-manager/components/DynamicZone/components/Component/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/DynamicZone/components/Component/index.js
@@ -1,4 +1,4 @@
-import React, { memo, useMemo } from 'react';
+import React, { memo, Suspense, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import isEqual from 'react-fast-compare';
@@ -8,7 +8,9 @@ import { Accordion, AccordionToggle, AccordionContent } from '@strapi/design-sys
 import { IconButton } from '@strapi/design-system/IconButton';
 import { FocusTrap } from '@strapi/design-system/FocusTrap';
 import { Box } from '@strapi/design-system/Box';
+import { Flex } from '@strapi/design-system/Flex';
 import { Stack } from '@strapi/design-system/Stack';
+import { Loader } from '@strapi/design-system/Loader';
 import Trash from '@strapi/icons/Trash';
 import ArrowDown from '@strapi/icons/ArrowDown';
 import ArrowUp from '@strapi/icons/ArrowUp';
@@ -148,12 +150,20 @@ const Component = ({
           <AccordionContent>
             <AccordionContentRadius background="neutral0">
               <FocusTrap onEscape={() => onToggle(index)}>
-                <FieldComponent
-                  componentUid={componentUid}
-                  icon={icon}
-                  name={`${name}.${index}`}
-                  isFromDynamicZone
-                />
+                <Suspense
+                  fallback={
+                    <Flex justifyContent="center" paddingTop={4} paddingBottom={4}>
+                      <Loader />
+                    </Flex>
+                  }
+                >
+                  <FieldComponent
+                    componentUid={componentUid}
+                    icon={icon}
+                    name={`${name}.${index}`}
+                    isFromDynamicZone
+                  />
+                </Suspense>
               </FocusTrap>
             </AccordionContentRadius>
           </AccordionContent>

--- a/packages/core/admin/admin/src/content-manager/components/DynamicZone/components/Component/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/DynamicZone/components/Component/index.js
@@ -149,22 +149,22 @@ const Component = ({
           />
           <AccordionContent>
             <AccordionContentRadius background="neutral0">
-              <FocusTrap onEscape={() => onToggle(index)}>
-                <Suspense
-                  fallback={
-                    <Flex justifyContent="center" paddingTop={4} paddingBottom={4}>
-                      <Loader>Loading content.</Loader>
-                    </Flex>
-                  }
-                >
+              <Suspense
+                fallback={
+                  <Flex justifyContent="center" paddingTop={4} paddingBottom={4}>
+                    <Loader>Loading content.</Loader>
+                  </Flex>
+                }
+              >
+                <FocusTrap onEscape={() => onToggle(index)}>
                   <FieldComponent
                     componentUid={componentUid}
                     icon={icon}
                     name={`${name}.${index}`}
                     isFromDynamicZone
                   />
-                </Suspense>
-              </FocusTrap>
+                </FocusTrap>
+              </Suspense>
             </AccordionContentRadius>
           </AccordionContent>
         </Accordion>

--- a/packages/core/admin/admin/src/translations/en.json
+++ b/packages/core/admin/admin/src/translations/en.json
@@ -408,7 +408,7 @@
   "app.containers.Users.EditPage.roles-bloc-title": "Attributed roles",
   "app.containers.Users.ModalForm.footer.button-success": "Invite user",
   "app.links.configure-view": "Configure the view",
-  "app.page.not.found": "Oops! We can't seem to find the page you're looging for...",
+  "app.page.not.found": "Oops! We can't seem to find the page you're looking for...",
   "app.static.links.cheatsheet": "CheatSheet",
   "app.utils.SelectOption.defaultMessage": " ",
   "app.utils.add-filter": "Add filter",


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Wraps the form of a dynamic zone's component inside a suspense boundary.

You can see it in [this video](https://www.loom.com/share/6823b4d0e2a94c3b8d64cb3627f24528) around 3:30

### Why is it needed?

It ensures that when opening a DZ's component that uses a custom field, the loader is contained within the accordion, instead of hiding the entire page

### How to test it?

- Create a content type
- Add dynamic zone inside
- Inside the dz, add a component with an attribute that uses a custom field
- In the edit view for that content type, open the DZ accordion and open the component
- Watch the loading state (you may need to turn on throttling in your devtools to see it)

### Related issue(s)/PR(s)

Issue identified by @soupette [there](https://github.com/strapi/strapi/pull/14163#discussion_r980828686)
