### PR TITLE
[POC] Fix i18n overriding initialData

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/index.js
@@ -420,6 +420,20 @@ const EditViewDataManagerProvider = ({
     });
   }, []);
 
+  // This is meant to be a temporary fix
+  // When using "fill in from another locale"
+  // i18n dispatch an update in the store which causes EditViewDataManagerProvider to INIT_FORM (see useEffect)
+  // We then lose initialData and cannot watch for differences with modifiedData
+  // This fix should allow user to save after editing an entity with "fill in from another locale"
+
+  // This solution doesn't work as the recover dispatch happens before the INIT_FORM one
+  // const recoverInitialData = (initialData) => {
+  //   dispatch({
+  //     type: 'RECOVER_INITIALDATA',
+  //     previousInitialData: initialData,
+  //   });
+  // };
+
   const removeComponentFromDynamicZone = useCallback(
     (dynamicZoneName, index) => {
       trackUsageRef.current('removeComponentFromDynamicZone');
@@ -493,6 +507,7 @@ const EditViewDataManagerProvider = ({
         onUnpublish,
         onRemoveRelation,
         readActionAllowedFields,
+        // recoverInitialData,
         redirectToPreviousPage,
         removeComponentFromDynamicZone,
         removeComponentFromField,

--- a/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/reducer.js
+++ b/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/reducer.js
@@ -176,6 +176,10 @@ const reducer = (state, action) =>
 
         break;
       }
+      // case 'RECOVER_INITIALDATA': {
+      //   draftState.initialData = action.previousInitialData;
+      //   break;
+      // }
       case 'REMOVE_COMPONENT_FROM_DYNAMIC_ZONE': {
         if (action.shouldCheckErrors) {
           draftState.shouldCheckErrors = !state.shouldCheckErrors;

--- a/packages/core/admin/admin/src/content-manager/sharedReducers/crudReducer/reducer.js
+++ b/packages/core/admin/admin/src/content-manager/sharedReducers/crudReducer/reducer.js
@@ -21,6 +21,7 @@ const crudInitialState = {
   componentsDataStructure: {},
   contentTypeDataStructure: {},
   isLoading: true,
+  isUpdateComingFromI18N: false,
   data: null,
   status: 'resolved',
 };
@@ -66,6 +67,10 @@ const crudReducer = (state = crudInitialState, action) =>
         draftState.data = action.data;
         break;
       }
+      // We could create a separate dispatch here
+      // localizedValues could be watched in EditViewDataManagerProvider and fire a dispatch to update only modifiedData
+      // but then we might need to clean this data after everything is set in CM?
+      // it implies that content-manager will know about what is happening with i18n, which is a change of paradigm
       default:
         return draftState;
     }

--- a/packages/plugins/i18n/admin/src/components/CMEditViewInjectedComponents/CMEditViewCopyLocale/index.js
+++ b/packages/plugins/i18n/admin/src/components/CMEditViewInjectedComponents/CMEditViewCopyLocale/index.js
@@ -45,7 +45,12 @@ const Content = ({ appLocales, currentLocale, localizations, readPermissions }) 
   const toggleNotification = useNotification();
   const { formatMessage } = useIntl();
   const dispatch = useDispatch();
-  const { allLayoutData, initialData, slug } = useCMEditViewDataManager();
+  const {
+    allLayoutData,
+    initialData,
+    slug,
+    // recoverInitialData
+  } = useCMEditViewDataManager();
   const [isLoading, setIsLoading] = useState(false);
   const [isOpen, setIsOpen] = useState(false);
   const [value, setValue] = useState(options[0]?.value || '');
@@ -61,6 +66,7 @@ const Content = ({ appLocales, currentLocale, localizations, readPermissions }) 
 
     setIsLoading(true);
     try {
+      // const previousInitialData = initialData;
       const { data: response } = await axiosInstance.get(requestURL);
 
       const cleanedData = cleanData(response, allLayoutData, localizations);
@@ -70,6 +76,16 @@ const Content = ({ appLocales, currentLocale, localizations, readPermissions }) 
       });
 
       dispatch({ type: 'ContentManager/CrudReducer/GET_DATA_SUCCEEDED', data: cleanedData });
+
+      // This is meant to be a temporary fix
+      // initialData from localized entity is lost after the previous dispatch (just above)
+      // This dispatch causes initialValues from EditViewDataManagerProvider to change
+      // Which causes an INIT_FORM dispatch (useEffect in EditViewDataManagerProvider) making initialData and modifiedData equal
+      // We need to recover previous initialData to watch for difference and allow the user to save this change
+      // We might need to consider including i18n in Strapi core or at least share knowledge about each other
+
+      // This solution doesn't work as the recover dispatch happens before the INIT_FORM one
+      // recoverInitialData(previousInitialData);
 
       toggleNotification({
         type: 'success',


### PR DESCRIPTION
## What

As stated in the #13988 issue, the content-manager is not supposed to know anything about what is coming from i18n.
It means that when we are "filling from another locale" we are actually updating the `redux-store`, updating `initialValues` passed to `EditViewDataManagerProvider`, which in response dispatch `INIT_FORM`. It causes `initialData` to be replaced by the i18n values.
The Save button then stays disabled because `modifiedData` and `initialData` are equal.

<img width="484" alt="image" src="https://user-images.githubusercontent.com/71838159/192578283-29353e8b-5c28-4ce0-8e0c-996b74250ae8.png">

## Solutions opened to discussion

**1. Create a content-manager dispatch that would allow recovering lost values**

This is the redux dispatch that causes `initialValues` to change:

```
dispatch({ type: 'ContentManager/CrudReducer/GET_DATA_SUCCEEDED', data: cleanedData });
```

First solution explored was to dispatch a `RECOVER_INITIALDATA` accessible through `useCMEditViewDataManager` that would recover this data
This solution doesn't work because we cannot control in which order those dispatches are done.

**2. Create another dispatch in the crudReducer**

We could create another kind of dispatch in the `ContentManager/CrudReducer` which could pass information to the `content-manager` to let it know it is an update coming from `i18n`.
There could be different ways to do that but they all involve a change of paradigm which is to let the `content-manager` know something about `i18n`.


**3. Strapi in core and/or update the state management**

This could be a v5 conversation:
We also could question why i18n is not included in the core of Strapi.
Could we reconsider the usage of Context and closed reducers, to move most concerns to the redux store?