### PR TITLE
Add Cloudflare R2 Support to AWS S3 Provider

### DIFF
--- a/packages/providers/upload-aws-s3/README.md
+++ b/packages/providers/upload-aws-s3/README.md
@@ -83,6 +83,41 @@ module.exports = ({ env }) => ({
 });
 ```
 
+#### Configuration for S3 compatible services which provide a different domain for Read Access (Like cloudflare R2)
+```js
+module.exports = ({ env }) => ({
+  // ...
+  upload: {
+    config: {
+      provider: 'aws-s3',
+      providerOptions: {
+        accessKeyId: env("AWS_ACCESS_KEY_ID"),
+        secretAccessKey: env("AWS_SECRET_ACCESS_KEY"),
+        endpoint: env("AWS_ENDPOINT"),
+        /**
+         * If this Option is set, the file is stored with this AWS_CUSTOM_READ_ENDPOINT in the DB and not with AWS_ENDPOINT.
+         * Can be used in Cloudflare R2 with Domain-Access or Public URL: https://pub-<YOUR_PULIC_BUCKET_ID>.r2.dev
+         * Check the cloudflare docs for the setup: https://developers.cloudflare.com/r2/data-access/public-buckets/#enable-public-access-for-your-bucket
+         */
+        customReadEndpoint: env("AWS_CUSTOM_READ_ENDPOINT"),
+        /**
+         * defaultAcl: undefined will set ACL option to public-read,
+         * defaultAcl: false will not set any ACL option (needed for cloudflare R2)
+         * defaultAcl: 'some-string' will set 'some-string' as ACL header. See AWS docs for all possible options.
+         */
+        defaultAcl: false,
+        s3BucketEndpoint: false, // Whether the provided endpoint addresses an individual bucket. false if it addresses the root API endpoint
+        s3ForcePathStyle: true, // removes bucket name from Endpoint URL
+        params: {
+          Bucket: env("AWS_BUCKET"),
+        },
+      },
+    },
+  },
+  // ...
+});
+```
+
 ### Security Middleware Configuration
 
 Due to the default settings in the Strapi Security Middleware you will need to modify the `contentSecurityPolicy` settings to properly see thumbnail previews in the Media Library. You should replace `strapi::security` string with the object bellow instead as explained in the [middleware configuration](https://docs.strapi.io/developer-docs/latest/setup-deployment-guides/configurations/required/middlewares.html#loading-order) documentation.


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Cloudflare R2 is using a AWS S3 compatible API but has some slight changes.
1.) No support for 'public-read' ACL. Therefore I added an config option to control the ACL settings of the Provider.
2.) Access of the bucket is performed via a different URL as the write request. Therefore I added another config option to set the read Endpoint URL

### Why is it needed?

This is needed to make cloudflare R2 work with strapi.

### How to test it?

Create a new bucket in cloudflare R2 and assign it a domain. Then setup the config as described in the updated README.

### Related issue(s)/PR(s)

no Related Issues
