### PR TITLE
check if set is empty

### DIFF
--- a/packages/core/database/lib/entity-manager/index.js
+++ b/packages/core/database/lib/entity-manager/index.js
@@ -618,6 +618,10 @@ const createEntityManager = (db) => {
 
             const { idColumn, typeColumn } = morphColumn;
 
+            if (isEmpty(cleanRelationData.set)) {
+              continue;
+            }
+
             await this.createQueryBuilder(joinTable.name)
               .delete()
               .where({


### PR DESCRIPTION
### What does it do?

Fixes [Content-505](https://strapi-inc.atlassian.net/browse/CONTENT-505)

Files are stored as a morphToMany relationship in the entity. We were not checking if the `set` was empty.
So it crashed when updating any entry with a file attribute
