### PR TITLE
[fix][RelationInput]: menu placement on options changed

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/RelationInput/RelationInput.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInput/RelationInput.js
@@ -143,6 +143,55 @@ const RelationInput = ({
     };
   }, [paginatedRelations, relations, numberOfRelationsToDisplay, totalNumberOfRelations]);
 
+  /**
+   * This code is being isolated because it's a hack to fix a placement bug in
+   * `react-select` where when the options prop is updated the position of the
+   * menu is not recalculated.
+   */
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+
+  const timeoutRef = useRef();
+
+  useEffect(() => {
+    setIsMenuOpen((isCurrentlyOpened) => {
+      /**
+       * If we're currently open and the options changed
+       * we want to close and open to ensure the menu's
+       * position is correctly calculated
+       */
+      if (isCurrentlyOpened) {
+        timeoutRef.current = setTimeout(() => {
+          setIsMenuOpen(true);
+        }, 10);
+
+        return false;
+      }
+
+      return false;
+    });
+  }, [options]);
+
+  useEffect(() => {
+    return () => {
+      /**
+       * If the component unmounts and a timer is set we should clear that timer
+       */
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  const handleMenuClose = (e) => {
+    setIsMenuOpen(false);
+    onSearchClose(e);
+  };
+
+  const handleMenuOpen = (e) => {
+    setIsMenuOpen(true);
+    onSearchOpen(e);
+  };
+
   return (
     <Field error={error} name={name} hint={description} id={id}>
       <Relation
@@ -157,6 +206,7 @@ const RelationInput = ({
               // position fixed doesn't update position on scroll
               // react select doesn't update menu position on options change
               menuPosition="absolute"
+              menuPlacement="auto"
               components={{ Option }}
               options={options}
               isDisabled={disabled}
@@ -181,8 +231,9 @@ const RelationInput = ({
                 setValue(value);
                 onSearch(value);
               }}
-              onMenuClose={onSearchClose}
-              onMenuOpen={onSearchOpen}
+              onMenuClose={handleMenuClose}
+              onMenuOpen={handleMenuOpen}
+              menuIsOpen={isMenuOpen}
               onMenuScrollToBottom={() => {
                 if (searchResults.hasNextPage) {
                   onSearchNextPage();

--- a/packages/core/admin/admin/src/content-manager/components/RelationInput/RelationInput.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInput/RelationInput.js
@@ -182,14 +182,17 @@ const RelationInput = ({
     };
   }, []);
 
-  const handleMenuClose = (e) => {
+  const handleMenuClose = () => {
     setIsMenuOpen(false);
-    onSearchClose(e);
+
+    if (onSearchClose) {
+      onSearchClose();
+    }
   };
 
-  const handleMenuOpen = (e) => {
+  const handleMenuOpen = () => {
     setIsMenuOpen(true);
-    onSearchOpen(e);
+    onSearchOpen();
   };
 
   return (
@@ -378,6 +381,7 @@ RelationInput.defaultProps = {
   error: undefined,
   labelAction: null,
   labelLoadMore: null,
+  onSearchClose: undefined,
   required: false,
   relations: [],
   searchResults: [],
@@ -399,7 +403,7 @@ RelationInput.propTypes = {
   onRelationLoadMore: PropTypes.func.isRequired,
   onSearch: PropTypes.func.isRequired,
   onSearchNextPage: PropTypes.func.isRequired,
-  onSearchClose: PropTypes.func.isRequired,
+  onSearchClose: PropTypes.func,
   onSearchOpen: PropTypes.func.isRequired,
   placeholder: PropTypes.string.isRequired,
   publicationStateTranslations: PropTypes.shape({

--- a/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/RelationInputDataManager.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/RelationInputDataManager.js
@@ -173,7 +173,6 @@ export const RelationInputDataManger = ({
       onRelationLoadMore={() => handleRelationLoadMore()}
       onSearch={(term) => handleSearch(term)}
       onSearchNextPage={() => handleSearchMore()}
-      onSearchClose={() => {}}
       onSearchOpen={handleOpenSearch}
       placeholder={formatMessage(
         placeholder || {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

This forces the react-select component to open and close the menu when the `options` prop changes to enable a recalculation in menu positioning so the dropdown is always in the viewport.

### Why is it needed?

`react-select` currently has a bug where when the `options` change, the menu isn't recalculated leading to the menu to show offscreen.

### Additional notes

Realistically this is a hack to solve an issue in the library, an alternative approach could be to replace `react-select` with a low level primitive and recreate it. The downfall of this is we most likely would need to create separate components for types of selects we have in the codebase which would then incur a development time cost.
