### PR TITLE
[Relations] Fix search encoded

### DIFF
--- a/packages/core/admin/admin/src/content-manager/hooks/useRelation/useRelation.js
+++ b/packages/core/admin/admin/src/content-manager/hooks/useRelation/useRelation.js
@@ -65,7 +65,7 @@ export const useRelation = (cacheKey, { relation, search }) => {
   const searchFor = (term, options = {}) => {
     setSearchParams({
       ...options,
-      _q: encodeURIComponent(term),
+      _q: term,
     });
   };
 

--- a/packages/core/content-manager/server/tests/index.test.e2e.js
+++ b/packages/core/content-manager/server/tests/index.test.e2e.js
@@ -91,15 +91,11 @@ describe('Relations', () => {
       expect(body.id).toBeDefined();
       expect(body.name).toBe('tag1');
       expect(body.createdBy).toMatchObject({
-        firstname: 'admin',
         id: 1,
-        lastname: 'admin',
         username: null,
       });
       expect(body.updatedBy).toMatchObject({
-        firstname: 'admin',
         id: 1,
-        lastname: 'admin',
         username: null,
       });
       expect(body.publishedAt).toBeUndefined();
@@ -119,15 +115,11 @@ describe('Relations', () => {
       expect(body.id).toBeDefined();
       expect(body.name).toBe('tag2');
       expect(body.createdBy).toMatchObject({
-        firstname: 'admin',
         id: 1,
-        lastname: 'admin',
         username: null,
       });
       expect(body.updatedBy).toMatchObject({
-        firstname: 'admin',
         id: 1,
-        lastname: 'admin',
         username: null,
       });
       expect(body.publishedAt).toBeUndefined();
@@ -147,15 +139,11 @@ describe('Relations', () => {
       expect(body.id).toBeDefined();
       expect(body.name).toBe('tag3');
       expect(body.createdBy).toMatchObject({
-        firstname: 'admin',
         id: 1,
-        lastname: 'admin',
         username: null,
       });
       expect(body.updatedBy).toMatchObject({
-        firstname: 'admin',
         id: 1,
-        lastname: 'admin',
         username: null,
       });
       expect(body.publishedAt).toBeUndefined();
@@ -180,15 +168,11 @@ describe('Relations', () => {
       expect(body.title).toBe(entry.title);
       expect(body.content).toBe(entry.content);
       expect(body.createdBy).toMatchObject({
-        firstname: 'admin',
         id: 1,
-        lastname: 'admin',
         username: null,
       });
       expect(body.updatedBy).toMatchObject({
-        firstname: 'admin',
         id: 1,
-        lastname: 'admin',
         username: null,
       });
       expect(body.publishedAt).toBeUndefined();
@@ -216,15 +200,11 @@ describe('Relations', () => {
       expect(body.title).toBe(entry.title);
       expect(body.content).toBe(entry.content);
       expect(body.createdBy).toMatchObject({
-        firstname: 'admin',
         id: 1,
-        lastname: 'admin',
         username: null,
       });
       expect(body.updatedBy).toMatchObject({
-        firstname: 'admin',
         id: 1,
-        lastname: 'admin',
         username: null,
       });
       expect(body.publishedAt).toBeUndefined();
@@ -251,15 +231,11 @@ describe('Relations', () => {
       expect(body.title).toBe(entry.title);
       expect(body.content).toBe(entry.content);
       expect(body.createdBy).toMatchObject({
-        firstname: 'admin',
         id: 1,
-        lastname: 'admin',
         username: null,
       });
       expect(body.updatedBy).toMatchObject({
-        firstname: 'admin',
         id: 1,
-        lastname: 'admin',
         username: null,
       });
       expect(body.publishedAt).toBeUndefined();
@@ -282,15 +258,11 @@ describe('Relations', () => {
       expect(body.title).toBe(data.articles[0].title);
       expect(body.content).toBe(data.articles[0].content);
       expect(body.createdBy).toMatchObject({
-        firstname: 'admin',
         id: 1,
-        lastname: 'admin',
         username: null,
       });
       expect(body.updatedBy).toMatchObject({
-        firstname: 'admin',
         id: 1,
-        lastname: 'admin',
         username: null,
       });
       expect(body.publishedAt).toBeUndefined();
@@ -312,15 +284,11 @@ describe('Relations', () => {
       expect(body.title).toBe(data.articles[0].title);
       expect(body.content).toBe(data.articles[0].content);
       expect(body.createdBy).toMatchObject({
-        firstname: 'admin',
         id: 1,
-        lastname: 'admin',
         username: null,
       });
       expect(body.updatedBy).toMatchObject({
-        firstname: 'admin',
         id: 1,
-        lastname: 'admin',
         username: null,
       });
       expect(body.publishedAt).toBeUndefined();
@@ -346,15 +314,11 @@ describe('Relations', () => {
       expect(body.title).toBe(entry.title);
       expect(body.content).toBe(entry.content);
       expect(body.createdBy).toMatchObject({
-        firstname: 'admin',
         id: 1,
-        lastname: 'admin',
         username: null,
       });
       expect(body.updatedBy).toMatchObject({
-        firstname: 'admin',
         id: 1,
-        lastname: 'admin',
         username: null,
       });
       expect(body.publishedAt).toBeUndefined();
@@ -458,15 +422,11 @@ describe('Relations', () => {
 
       expect(body.id).toBeDefined();
       expect(body.createdBy).toMatchObject({
-        firstname: 'admin',
         id: 1,
-        lastname: 'admin',
         username: null,
       });
       expect(body.updatedBy).toMatchObject({
-        firstname: 'admin',
         id: 1,
-        lastname: 'admin',
         username: null,
       });
 
@@ -502,15 +462,11 @@ describe('Relations', () => {
       expect(body.id).toBeDefined();
       expect(body.name).toBe('cat1');
       expect(body.createdBy).toMatchObject({
-        firstname: 'admin',
         id: 1,
-        lastname: 'admin',
         username: null,
       });
       expect(body.updatedBy).toMatchObject({
-        firstname: 'admin',
         id: 1,
-        lastname: 'admin',
         username: null,
       });
       expect(body.publishedAt).toBeUndefined();
@@ -533,15 +489,11 @@ describe('Relations', () => {
       expect(body.id).toBeDefined();
       expect(body.name).toBe('cat2');
       expect(body.createdBy).toMatchObject({
-        firstname: 'admin',
         id: 1,
-        lastname: 'admin',
         username: null,
       });
       expect(body.updatedBy).toMatchObject({
-        firstname: 'admin',
         id: 1,
-        lastname: 'admin',
         username: null,
       });
       expect(body.publishedAt).toBeUndefined();
@@ -568,15 +520,11 @@ describe('Relations', () => {
       expect(body.title).toBe(entry.title);
       expect(body.content).toBe(entry.content);
       expect(body.createdBy).toMatchObject({
-        firstname: 'admin',
         id: 1,
-        lastname: 'admin',
         username: null,
       });
       expect(body.updatedBy).toMatchObject({
-        firstname: 'admin',
         id: 1,
-        lastname: 'admin',
         username: null,
       });
       expect(body.publishedAt).toBeUndefined();
@@ -603,15 +551,11 @@ describe('Relations', () => {
       expect(body.title).toBe(data.articles[0].title);
       expect(body.content).toBe(data.articles[0].content);
       expect(body.createdBy).toMatchObject({
-        firstname: 'admin',
         id: 1,
-        lastname: 'admin',
         username: null,
       });
       expect(body.updatedBy).toMatchObject({
-        firstname: 'admin',
         id: 1,
-        lastname: 'admin',
         username: null,
       });
 
@@ -640,15 +584,11 @@ describe('Relations', () => {
       expect(body.title).toBe(entry.title);
       expect(body.content).toBe(entry.content);
       expect(body.createdBy).toMatchObject({
-        firstname: 'admin',
         id: 1,
-        lastname: 'admin',
         username: null,
       });
       expect(body.updatedBy).toMatchObject({
-        firstname: 'admin',
         id: 1,
-        lastname: 'admin',
         username: null,
       });
 
@@ -671,15 +611,11 @@ describe('Relations', () => {
       expect(body.title).toBe(data.articles[1].title);
       expect(body.content).toBe(data.articles[1].content);
       expect(body.createdBy).toMatchObject({
-        firstname: 'admin',
         id: 1,
-        lastname: 'admin',
         username: null,
       });
       expect(body.updatedBy).toMatchObject({
-        firstname: 'admin',
         id: 1,
-        lastname: 'admin',
         username: null,
       });
 
@@ -704,15 +640,11 @@ describe('Relations', () => {
       expect(body.id).toBeDefined();
       expect(body.name).toBe(data.categories[0].name);
       expect(body.createdBy).toMatchObject({
-        firstname: 'admin',
         id: 1,
-        lastname: 'admin',
         username: null,
       });
       expect(body.updatedBy).toMatchObject({
-        firstname: 'admin',
         id: 1,
-        lastname: 'admin',
         username: null,
       });
 
@@ -737,15 +669,11 @@ describe('Relations', () => {
       expect(body.id).toBeDefined();
       expect(body.name).toBe(entry.name);
       expect(body.createdBy).toMatchObject({
-        firstname: 'admin',
         id: 1,
-        lastname: 'admin',
         username: null,
       });
       expect(body.updatedBy).toMatchObject({
-        firstname: 'admin',
         id: 1,
-        lastname: 'admin',
         username: null,
       });
 
@@ -845,15 +773,11 @@ describe('Relations', () => {
       expect(body.id).toBeDefined();
       expect(body.name).toBe('ref1');
       expect(body.createdBy).toMatchObject({
-        firstname: 'admin',
         id: 1,
-        lastname: 'admin',
         username: null,
       });
       expect(body.updatedBy).toMatchObject({
-        firstname: 'admin',
         id: 1,
-        lastname: 'admin',
         username: null,
       });
     });
@@ -876,15 +800,11 @@ describe('Relations', () => {
       expect(body.title).toBe(entry.title);
       expect(body.content).toBe(entry.content);
       expect(body.createdBy).toMatchObject({
-        firstname: 'admin',
         id: 1,
-        lastname: 'admin',
         username: null,
       });
       expect(body.updatedBy).toMatchObject({
-        firstname: 'admin',
         id: 1,
-        lastname: 'admin',
         username: null,
       });
       expect(body.publishedAt).toBeUndefined();
@@ -905,15 +825,11 @@ describe('Relations', () => {
       expect(body.title).toBe(data.articles[0].title);
       expect(body.content).toBe(data.articles[0].content);
       expect(body.createdBy).toMatchObject({
-        firstname: 'admin',
         id: 1,
-        lastname: 'admin',
         username: null,
       });
       expect(body.updatedBy).toMatchObject({
-        firstname: 'admin',
         id: 1,
-        lastname: 'admin',
         username: null,
       });
 
@@ -940,15 +856,11 @@ describe('Relations', () => {
       expect(body.title).toBe(entry.title);
       expect(body.content).toBe(entry.content);
       expect(body.createdBy).toMatchObject({
-        firstname: 'admin',
         id: 1,
-        lastname: 'admin',
         username: null,
       });
       expect(body.updatedBy).toMatchObject({
-        firstname: 'admin',
         id: 1,
-        lastname: 'admin',
         username: null,
       });
       const reference = await getRelations('article', 'reference', body.id);

--- a/packages/core/database/lib/entity-manager/index.js
+++ b/packages/core/database/lib/entity-manager/index.js
@@ -485,7 +485,10 @@ const createEntityManager = (db) => {
               .execute();
           }
 
-          const insert = toAssocs(data[attributeName]).map((data, idx) => {
+          const assocs = toAssocs(data[attributeName]);
+
+          const relationsToAdd = assocs.connect || assocs;
+          const insert = relationsToAdd.map((data, idx) => {
             return {
               [joinColumn.name]: id,
               [inverseJoinColumn.name]: data.id,

--- a/packages/core/database/lib/entity-manager/index.js
+++ b/packages/core/database/lib/entity-manager/index.js
@@ -746,11 +746,13 @@ const createEntityManager = (db) => {
                 differenceWith(isEqual, cleanRelationData.disconnect, cleanRelationData.connect)
               );
 
+              if (!isEmpty(relIdsToDelete)) {
+                await deleteRelations({ id, attribute, db, relIdsToDelete });
+              }
+
               if (isEmpty(cleanRelationData.connect)) {
                 continue;
               }
-
-              await deleteRelations({ id, attribute, db, relIdsToDelete });
 
               // Fetch current relations to handle ordering
               let currentMovingRels;

--- a/packages/core/database/lib/entity-manager/index.js
+++ b/packages/core/database/lib/entity-manager/index.js
@@ -511,11 +511,7 @@ const createEntityManager = (db) => {
               for (const relToDelete of currentRelsToDelete) {
                 if (relToDelete[orderColumnName] !== null) {
                   await this.createQueryBuilder(joinTable.name)
-                    .update({
-                      [orderColumnName]: db
-                        .getConnection()
-                        .raw('?? - 1', relToDelete[orderColumnName]),
-                    })
+                    .decrement(orderColumnName, 1)
                     .where({
                       [joinColumn.name]: relToDelete[joinColumn.name],
                       [orderColumnName]: { $gt: relToDelete[orderColumnName] },
@@ -766,11 +762,7 @@ const createEntityManager = (db) => {
                 for (const relToDelete of relsToDelete) {
                   if (relToDelete[inverseOrderColumnName] !== null) {
                     const updatePromise = this.createQueryBuilder(joinTable.name)
-                      .update({
-                        [inverseOrderColumnName]: db
-                          .getConnection()
-                          .raw('?? - 1', relToDelete[inverseOrderColumnName]),
-                      })
+                      .decrement(inverseOrderColumnName, 1)
                       .where({
                         [inverseJoinColumn.name]: relToDelete[inverseJoinColumn.name],
                         [inverseOrderColumnName]: { $gt: relToDelete[inverseOrderColumnName] },
@@ -831,11 +823,7 @@ const createEntityManager = (db) => {
                   for (const relToDelete of relsToDelete) {
                     if (relToDelete[orderColumnName] !== null) {
                       await this.createQueryBuilder(joinTable.name)
-                        .update({
-                          [orderColumnName]: db
-                            .getConnection()
-                            .raw('?? - 1', relToDelete[orderColumnName]),
-                        })
+                        .decrement(orderColumnName, 1)
                         .where({
                           [joinColumn.name]: id,
                           [orderColumnName]: { $gt: relToDelete[orderColumnName] },
@@ -852,11 +840,7 @@ const createEntityManager = (db) => {
                   for (const relToDelete of relsToDelete) {
                     if (relToDelete[inverseOrderColumnName] !== null) {
                       const updatePromise = this.createQueryBuilder(joinTable.name)
-                        .update({
-                          [inverseOrderColumnName]: db
-                            .getConnection()
-                            .raw('?? - 1', relToDelete[inverseOrderColumnName]),
-                        })
+                        .decrement(inverseOrderColumnName, 1)
                         .where({
                           [inverseJoinColumn.name]: relToDelete[inverseJoinColumn.name],
                           [inverseOrderColumnName]: { $gt: relToDelete[inverseOrderColumnName] },
@@ -911,11 +895,7 @@ const createEntityManager = (db) => {
                   const currentOrderIsNull = currentRel[orderColumnName] === null;
                   if (!currentOrderIsNull) {
                     await this.createQueryBuilder(joinTable.name)
-                      .update({
-                        [orderColumnName]: db
-                          .getConnection()
-                          .raw('?? - 1', currentRel[orderColumnName]),
-                      })
+                      .decrement(orderColumnName, 1)
                       .where({
                         [joinColumn.name]: id,
                         [orderColumnName]: { $gt: currentRel[orderColumnName] },
@@ -1001,11 +981,7 @@ const createEntityManager = (db) => {
                     for (const relToDelete of relsToDelete) {
                       if (relToDelete[orderColumnName] !== null) {
                         await this.createQueryBuilder(joinTable.name)
-                          .update({
-                            [orderColumnName]: db
-                              .getConnection()
-                              .raw('?? - 1', relToDelete[orderColumnName]),
-                          })
+                          .decrement(orderColumnName, 1)
                           .where({
                             [joinColumn.name]: id,
                             [orderColumnName]: { $gt: relToDelete[orderColumnName] },
@@ -1023,11 +999,7 @@ const createEntityManager = (db) => {
                     for (const relToDelete of relsToDelete) {
                       if (relToDelete[inverseOrderColumnName] !== null) {
                         const updatePromise = this.createQueryBuilder(joinTable.name)
-                          .update({
-                            [inverseOrderColumnName]: db
-                              .getConnection()
-                              .raw('?? - 1', relToDelete[inverseOrderColumnName]),
-                          })
+                          .decrement(inverseOrderColumnName, 1)
                           .where({
                             [inverseJoinColumn.name]: relToDelete[inverseJoinColumn.name],
                             [inverseOrderColumnName]: { $gt: relToDelete[inverseOrderColumnName] },
@@ -1123,11 +1095,7 @@ const createEntityManager = (db) => {
                 for (const relToDelete of currentRelsToDelete) {
                   if (relToDelete[orderColumnName] !== null) {
                     await this.createQueryBuilder(joinTable.name)
-                      .update({
-                        [orderColumnName]: db
-                          .getConnection()
-                          .raw('?? - 1', relToDelete[orderColumnName]),
-                      })
+                      .decrement(orderColumnName, 1)
                       .where({
                         [joinColumn.name]: relToDelete[joinColumn.name],
                         [orderColumnName]: { $gt: relToDelete[orderColumnName] },
@@ -1289,11 +1257,7 @@ const createEntityManager = (db) => {
               for (const relToDelete of relsToDelete) {
                 if (relToDelete[inverseOrderColumnName] !== null) {
                   const updatePromise = this.createQueryBuilder(joinTable.name)
-                    .update({
-                      [inverseOrderColumnName]: db
-                        .getConnection()
-                        .raw('?? - 1', relToDelete[inverseOrderColumnName]),
-                    })
+                    .decrement(inverseOrderColumnName, 1)
                     .where({
                       [inverseJoinColumn.name]: relToDelete[inverseJoinColumn.name],
                       [inverseOrderColumnName]: { $gt: relToDelete[inverseOrderColumnName] },

--- a/packages/core/database/lib/entity-manager/index.js
+++ b/packages/core/database/lib/entity-manager/index.js
@@ -1125,7 +1125,7 @@ const createEntityManager = (db) => {
                   .select(select)
                   .where({
                     [joinColumn.name]: id,
-                    [inverseJoinColumn.name]: { $ne: relIdsToaddOrMove[0] },
+                    [inverseJoinColumn.name]: { $notIn: relIdsToaddOrMove },
                   })
                   .where(joinTable.on || {})
                   .execute();

--- a/packages/core/database/lib/entity-manager/index.js
+++ b/packages/core/database/lib/entity-manager/index.js
@@ -438,12 +438,13 @@ const createEntityManager = (db) => {
 
           const { idColumn, typeColumn, typeField = '__type' } = morphColumn;
 
-          const rows = cleanRelationData.set.map((data) => ({
+          const rows = cleanRelationData.set.map((data, idx) => ({
             [joinColumn.name]: id,
             [idColumn.name]: data.id,
             [typeColumn.name]: data[typeField],
             ...(joinTable.on || {}),
             ...(data.__pivot || {}),
+            order: idx + 1,
           }));
 
           if (isEmpty(rows)) {
@@ -657,12 +658,13 @@ const createEntityManager = (db) => {
             })
             .execute();
 
-          const rows = cleanRelationData.set.map((data) => ({
+          const rows = cleanRelationData.set.map((data, idx) => ({
             [joinColumn.name]: id,
             [idColumn.name]: data.id,
             [typeColumn.name]: data[typeField],
             ...(joinTable.on || {}),
             ...(data.__pivot || {}),
+            order: idx + 1,
           }));
 
           if (isEmpty(rows)) {

--- a/packages/core/database/lib/entity-manager/regular-relations.js
+++ b/packages/core/database/lib/entity-manager/regular-relations.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { map, isEmpty } = require('lodash/fp');
 const {
   isBidirectional,
   isOneToAny,
@@ -9,51 +10,11 @@ const {
 } = require('../metadata/relations');
 const { createQueryBuilder } = require('../query');
 
-const getSelect = (joinTable, attribute) => {
-  const { joinColumn, orderColumnName, inverseJoinColumn, inverseOrderColumnName } = joinTable;
-  const select = [joinColumn.name, inverseJoinColumn.name];
-  if (isAnyToMany(attribute)) {
-    select.push(orderColumnName);
-  }
-  if (isBidirectional(attribute) && isManyToAny(attribute)) {
-    select.push(inverseOrderColumnName);
-  }
-  return select;
-};
-
 const deletePreviousOneToAnyRelations = async ({ id, attribute, joinTable, relIdsToadd, db }) => {
-  const { joinColumn, inverseJoinColumn, orderColumnName } = joinTable;
-  const select = getSelect(joinTable, attribute);
+  const { joinColumn, inverseJoinColumn } = joinTable;
 
   // need to delete the previous relations for oneToAny relations
   if (isBidirectional(attribute) && isOneToAny(attribute)) {
-    // update orders for previous oneToAny relations that will be deleted if it has order (oneToMany)
-    if (isAnyToMany(attribute)) {
-      const currentRelsToDelete = await createQueryBuilder(joinTable.name, db)
-        .select(select)
-        .where({
-          [inverseJoinColumn.name]: relIdsToadd,
-          [joinColumn.name]: { $ne: id },
-        })
-        .where(joinTable.on || {})
-        .execute();
-
-      currentRelsToDelete.sort((a, b) => b[orderColumnName] - a[orderColumnName]);
-
-      for (const relToDelete of currentRelsToDelete) {
-        if (relToDelete[orderColumnName] !== null) {
-          await createQueryBuilder(joinTable.name, db)
-            .decrement(orderColumnName, 1)
-            .where({
-              [joinColumn.name]: relToDelete[joinColumn.name],
-              [orderColumnName]: { $gt: relToDelete[orderColumnName] },
-            })
-            .where(joinTable.on || {})
-            .execute();
-        }
-      }
-    }
-
     // delete previous oneToAny relations
     await createQueryBuilder(joinTable.name, db)
       .delete()
@@ -63,49 +24,52 @@ const deletePreviousOneToAnyRelations = async ({ id, attribute, joinTable, relId
       })
       .where(joinTable.on || {})
       .execute();
+
+    await cleanOrderColumns({ joinTable, attribute, db, inverseRelIds: relIdsToadd });
   }
 };
 
-const deletePreviousAnyToOneRelations = async ({ id, attribute, joinTable, relIdsToadd, db }) => {
-  const { joinColumn, inverseJoinColumn, inverseOrderColumnName } = joinTable;
-  const select = getSelect(joinTable, attribute);
+const deletePreviousAnyToOneRelations = async ({ id, attribute, joinTable, relIdToadd, db }) => {
+  const { joinColumn, inverseJoinColumn } = joinTable;
 
   // Delete the previous relations for anyToOne relations
   if (isBidirectional(attribute) && isAnyToOne(attribute)) {
     // update orders for previous anyToOne relations that will be deleted if it has order (manyToOne)
     if (isManyToAny(attribute)) {
-      const currentRelsToDelete = await createQueryBuilder(joinTable.name, db)
-        .select(select)
+      // if the database integrity was not broken relsToDelete is supposed to be of length 1
+      const relsToDelete = await createQueryBuilder(joinTable.name, db)
+        .select(inverseJoinColumn.name)
         .where({
           [joinColumn.name]: id,
-          [inverseJoinColumn.name]: { $notIn: relIdsToadd },
+          [inverseJoinColumn.name]: { $ne: relIdToadd },
         })
         .where(joinTable.on || {})
         .execute();
 
-      for (const relToDelete of currentRelsToDelete) {
-        if (relToDelete[inverseOrderColumnName] !== null) {
-          await createQueryBuilder(joinTable.name, db)
-            .decrement(inverseOrderColumnName, 1)
-            .where({
-              [inverseJoinColumn.name]: relToDelete[inverseJoinColumn.name],
-              [inverseOrderColumnName]: { $gt: relToDelete[inverseOrderColumnName] },
-            })
-            .where(joinTable.on || {})
-            .execute();
-        }
-      }
-    }
+      const relIdsToDelete = map(inverseJoinColumn.name, relsToDelete);
 
-    // delete previous oneToAny relations
-    await createQueryBuilder(joinTable.name, db)
-      .delete()
-      .where({
-        [joinColumn.name]: id,
-        [inverseJoinColumn.name]: { $notIn: relIdsToadd },
-      })
-      .where(joinTable.on || {})
-      .execute();
+      // delete previous anyToOne relations
+      await createQueryBuilder(joinTable.name, db)
+        .delete()
+        .where({
+          [joinColumn.name]: id,
+          [inverseJoinColumn.name]: { $in: relIdsToDelete },
+        })
+        .where(joinTable.on || {})
+        .execute();
+
+      await cleanOrderColumns({ joinTable, attribute, db, inverseRelIds: relIdsToDelete });
+    } else {
+      // delete previous anyToOne relations
+      await createQueryBuilder(joinTable.name, db)
+        .delete()
+        .where({
+          [joinColumn.name]: id,
+          [inverseJoinColumn.name]: { $ne: relIdToadd },
+        })
+        .where(joinTable.on || {})
+        .execute();
+    }
   }
 };
 
@@ -114,8 +78,7 @@ const deleteRelations = async (
   { id, attribute, joinTable, db },
   { relIdsToNotDelete = [], relIdsToDelete = [] }
 ) => {
-  const { joinColumn, inverseJoinColumn, orderColumnName, inverseOrderColumnName } = joinTable;
-  const select = getSelect(joinTable, attribute);
+  const { joinColumn, inverseJoinColumn } = joinTable;
   const all = relIdsToDelete === 'all';
 
   if (isAnyToMany(attribute) || (isBidirectional(attribute) && isManyToAny(attribute))) {
@@ -123,8 +86,8 @@ const deleteRelations = async (
     let done = false;
     const batchSize = 100;
     while (!done) {
-      const relsToDelete = await createQueryBuilder(joinTable.name, db)
-        .select(select)
+      const batchToDelete = await createQueryBuilder(joinTable.name, db)
+        .select(inverseJoinColumn.name)
         .where({
           [joinColumn.name]: id,
           id: { $gt: lastId },
@@ -135,63 +98,106 @@ const deleteRelations = async (
         .orderBy('id')
         .limit(batchSize)
         .execute();
-      done = relsToDelete.length < batchSize;
-      lastId = relsToDelete[relsToDelete.length - 1]?.id;
+      done = batchToDelete.length < batchSize;
+      lastId = batchToDelete[batchToDelete.length - 1]?.id;
 
-      // ORDER UPDATE
-      if (isAnyToMany(attribute)) {
-        // sort by order DESC so that the order updates are done in the correct order
-        // avoiding one to interfere with the others
-        relsToDelete.sort((a, b) => b[orderColumnName] - a[orderColumnName]);
+      const batchIds = map(inverseJoinColumn.name, batchToDelete);
 
-        for (const relToDelete of relsToDelete) {
-          if (relToDelete[orderColumnName] !== null) {
-            await createQueryBuilder(joinTable.name, db)
-              .decrement(orderColumnName, 1)
-              .where({
-                [joinColumn.name]: id,
-                [orderColumnName]: { $gt: relToDelete[orderColumnName] },
-              })
-              .where(joinTable.on || {})
-              // manque le pivot ici
-              .execute();
-          }
-        }
-      }
+      await createQueryBuilder(joinTable.name, db)
+        .delete()
+        .where({
+          [joinColumn.name]: id,
+          [inverseJoinColumn.name]: { $in: batchIds },
+        })
+        .where(joinTable.on || {})
+        .execute();
 
-      if (isBidirectional(attribute) && isManyToAny(attribute)) {
-        const updateInverseOrderPromises = [];
-        for (const relToDelete of relsToDelete) {
-          if (relToDelete[inverseOrderColumnName] !== null) {
-            const updatePromise = createQueryBuilder(joinTable.name, db)
-              .decrement(inverseOrderColumnName, 1)
-              .where({
-                [inverseJoinColumn.name]: relToDelete[inverseJoinColumn.name],
-                [inverseOrderColumnName]: { $gt: relToDelete[inverseOrderColumnName] },
-              })
-              .where(joinTable.on || {})
-              .execute();
-            updateInverseOrderPromises.push(updatePromise);
-          }
-        }
-        await Promise.all(updateInverseOrderPromises);
-      }
+      await cleanOrderColumns({ joinTable, attribute, db, id, inverseRelIds: batchIds });
     }
+  } else {
+    await createQueryBuilder(joinTable.name, db)
+      .delete()
+      .where({
+        [joinColumn.name]: id,
+        [inverseJoinColumn.name]: { $notIn: relIdsToNotDelete },
+        ...(all ? {} : { [inverseJoinColumn.name]: { $in: relIdsToDelete } }),
+      })
+      .where(joinTable.on || {})
+      .execute();
+  }
+};
+
+/**
+ * Clean the order columns by ensuring the order value are continuous (ex: 1, 2, 3 and not 1, 5, 10)
+ * @param {Object} params
+ * @param {string} params.joinTable - joinTable of the relation where the clean will be done
+ * @param {string} params.attribute - attribute on which the clean will be done
+ * @param {string} params.db - Database instance
+ * @param {string} params.id - Entity ID for which the clean will be done
+ * @param {string} params.inverseRelIds - Entity ids of the inverse side for which the clean will be done
+ */
+const cleanOrderColumns = async ({ joinTable, attribute, db, id, inverseRelIds }) => {
+  if (
+    !(isAnyToMany(attribute) && id) &&
+    !(isBidirectional(attribute) && isManyToAny(attribute) && !isEmpty(inverseRelIds))
+  ) {
+    return;
   }
 
-  await createQueryBuilder(joinTable.name, db)
-    .delete()
-    .where({
-      [joinColumn.name]: id,
-      [inverseJoinColumn.name]: { $notIn: relIdsToNotDelete },
-      ...(all ? {} : { [inverseJoinColumn.name]: { $in: relIdsToDelete } }),
-    })
-    .where(joinTable.on || {})
-    .execute();
+  const { joinColumn, inverseJoinColumn, orderColumnName, inverseOrderColumnName } = joinTable;
+  const knex = db.getConnection();
+  const update = {};
+  const subQuery = knex(joinTable.name).select('id');
+
+  if (isAnyToMany(attribute) && id) {
+    update[orderColumnName] = knex.raw('t.src_order');
+    const on = [joinColumn.name, ...Object.keys(joinTable.on)];
+    subQuery
+      .select(
+        knex.raw(`ROW_NUMBER() OVER (PARTITION BY ${on.join(', ')} ORDER BY ??) AS src_order`, [
+          ...on,
+          orderColumnName,
+        ])
+      )
+      .where(joinColumn.name, id);
+  }
+
+  if (isBidirectional(attribute) && isManyToAny(attribute) && !isEmpty(inverseRelIds)) {
+    update[inverseOrderColumnName] = knex.raw('t.inv_order');
+    const on = [inverseJoinColumn.name, ...Object.keys(joinTable.on)];
+    subQuery
+      .select(
+        knex.raw(`ROW_NUMBER() OVER (PARTITION BY ${on.join(', ')} ORDER BY ??) AS inv_order`, [
+          ...on,
+          inverseOrderColumnName,
+        ])
+      )
+      .orWhereIn(inverseJoinColumn.name, inverseRelIds);
+  }
+
+  await knex(joinTable.name)
+    .update(update)
+    .from(subQuery)
+    .where('t.id', knex.raw('??.id', joinTable.name));
+
+  /*
+    `UPDATE :joinTable:
+      SET :orderColumn: = t.order, :inverseOrderColumn: = t.inv_order
+      FROM (
+        SELECT
+          id,
+          ROW_NUMBER() OVER ( PARTITION BY :joinColumn: ORDER BY :orderColumn:) AS order,
+          ROW_NUMBER() OVER ( PARTITION BY :inverseJoinColumn: ORDER BY :inverseOrderColumn:) AS inv_order
+        FROM :joinTable:
+        WHERE :joinColumn: = :id OR :inverseJoinColumn: IN (:inverseRelIds)
+      ) AS t
+      WHERE t.id = :joinTable:.id`,
+  */
 };
 
 module.exports = {
   deletePreviousOneToAnyRelations,
   deletePreviousAnyToOneRelations,
   deleteRelations,
+  cleanOrderColumns,
 };

--- a/packages/core/database/lib/entity-manager/regular-relations.js
+++ b/packages/core/database/lib/entity-manager/regular-relations.js
@@ -112,11 +112,11 @@ const deletePreviousAnyToOneRelations = async ({ id, attribute, joinTable, relId
 // INVERSE ORDER UPDATE
 const deleteRelations = async (
   { id, attribute, joinTable, db },
-  { relsToNotDelete = [], relsToDelete = [] }
+  { relIdsToNotDelete = [], relIdsToDelete = [] }
 ) => {
   const { joinColumn, inverseJoinColumn, orderColumnName, inverseOrderColumnName } = joinTable;
   const select = getSelect(joinTable, attribute);
-  const all = relsToDelete === 'all';
+  const all = relIdsToDelete === 'all';
 
   if (isAnyToMany(attribute) || (isBidirectional(attribute) && isManyToAny(attribute))) {
     let lastId = 0;
@@ -128,8 +128,8 @@ const deleteRelations = async (
         .where({
           [joinColumn.name]: id,
           id: { $gt: lastId },
-          [inverseJoinColumn.name]: { $notIn: relsToNotDelete },
-          ...(all ? {} : { [inverseJoinColumn.name]: { $in: relsToDelete } }),
+          [inverseJoinColumn.name]: { $notIn: relIdsToNotDelete },
+          ...(all ? {} : { [inverseJoinColumn.name]: { $in: relIdsToDelete } }),
         })
         .where(joinTable.on || {})
         .orderBy('id')
@@ -183,8 +183,8 @@ const deleteRelations = async (
     .delete()
     .where({
       [joinColumn.name]: id,
-      [inverseJoinColumn.name]: { $notIn: relsToNotDelete },
-      ...(all ? {} : { [inverseJoinColumn.name]: { $in: relsToDelete } }),
+      [inverseJoinColumn.name]: { $notIn: relIdsToNotDelete },
+      ...(all ? {} : { [inverseJoinColumn.name]: { $in: relIdsToDelete } }),
     })
     .where(joinTable.on || {})
     .execute();

--- a/packages/core/database/lib/entity-manager/utils.js
+++ b/packages/core/database/lib/entity-manager/utils.js
@@ -1,0 +1,200 @@
+'use strict';
+
+const {
+  isBidirectional,
+  isOneToAny,
+  isManyToAny,
+  isAnyToOne,
+  isAnyToMany,
+} = require('../metadata/relations');
+const { createQueryBuilder } = require('../query');
+
+const getSelect = (joinTable, attribute) => {
+  const { joinColumn, orderColumnName, inverseJoinColumn, inverseOrderColumnName } = joinTable;
+  const select = [joinColumn.name, inverseJoinColumn.name];
+  if (isAnyToMany(attribute)) {
+    select.push(orderColumnName);
+  }
+  if (isBidirectional(attribute) && isManyToAny(attribute)) {
+    select.push(inverseOrderColumnName);
+  }
+  return select;
+};
+
+const deletePreviousOneToAnyRelations = async ({ id, attribute, joinTable, relIdsToadd, db }) => {
+  const { joinColumn, inverseJoinColumn, orderColumnName } = joinTable;
+  const select = getSelect(joinTable, attribute);
+
+  // need to delete the previous relations for oneToAny relations
+  if (isBidirectional(attribute) && isOneToAny(attribute)) {
+    // update orders for previous oneToAny relations that will be deleted if it has order (oneToMany)
+    if (isAnyToMany(attribute)) {
+      const currentRelsToDelete = await createQueryBuilder(joinTable.name, db)
+        .select(select)
+        .where({
+          [inverseJoinColumn.name]: relIdsToadd,
+          [joinColumn.name]: { $ne: id },
+        })
+        .where(joinTable.on || {})
+        .execute();
+
+      currentRelsToDelete.sort((a, b) => b[orderColumnName] - a[orderColumnName]);
+
+      for (const relToDelete of currentRelsToDelete) {
+        if (relToDelete[orderColumnName] !== null) {
+          await createQueryBuilder(joinTable.name, db)
+            .decrement(orderColumnName, 1)
+            .where({
+              [joinColumn.name]: relToDelete[joinColumn.name],
+              [orderColumnName]: { $gt: relToDelete[orderColumnName] },
+            })
+            .where(joinTable.on || {})
+            .execute();
+        }
+      }
+    }
+
+    // delete previous oneToAny relations
+    await createQueryBuilder(joinTable.name, db)
+      .delete()
+      .where({
+        [inverseJoinColumn.name]: relIdsToadd,
+        [joinColumn.name]: { $ne: id },
+      })
+      .where(joinTable.on || {})
+      .execute();
+  }
+};
+
+const deletePreviousAnyToOneRelations = async ({ id, attribute, joinTable, relIdsToadd, db }) => {
+  const { joinColumn, inverseJoinColumn, inverseOrderColumnName } = joinTable;
+  const select = getSelect(joinTable, attribute);
+
+  // Delete the previous relations for anyToOne relations
+  if (isBidirectional(attribute) && isAnyToOne(attribute)) {
+    // update orders for previous anyToOne relations that will be deleted if it has order (manyToOne)
+    if (isManyToAny(attribute)) {
+      const currentRelsToDelete = await createQueryBuilder(joinTable.name, db)
+        .select(select)
+        .where({
+          [joinColumn.name]: id,
+          [inverseJoinColumn.name]: { $notIn: relIdsToadd },
+        })
+        .where(joinTable.on || {})
+        .execute();
+
+      for (const relToDelete of currentRelsToDelete) {
+        if (relToDelete[inverseOrderColumnName] !== null) {
+          await createQueryBuilder(joinTable.name, db)
+            .decrement(inverseOrderColumnName, 1)
+            .where({
+              [inverseJoinColumn.name]: relToDelete[inverseJoinColumn.name],
+              [inverseOrderColumnName]: { $gt: relToDelete[inverseOrderColumnName] },
+            })
+            .where(joinTable.on || {})
+            .execute();
+        }
+      }
+    }
+
+    // delete previous oneToAny relations
+    await createQueryBuilder(joinTable.name, db)
+      .delete()
+      .where({
+        [joinColumn.name]: id,
+        [inverseJoinColumn.name]: { $notIn: relIdsToadd },
+      })
+      .where(joinTable.on || {})
+      .execute();
+  }
+};
+
+// INVERSE ORDER UPDATE
+const deleteAllRelations = async ({
+  id,
+  attribute,
+  joinTable,
+  except = undefined,
+  onlyFor = undefined,
+  db,
+}) => {
+  const { joinColumn, inverseJoinColumn, orderColumnName, inverseOrderColumnName } = joinTable;
+  const select = getSelect(joinTable, attribute);
+
+  if (isAnyToMany(attribute) || (isBidirectional(attribute) && isManyToAny(attribute))) {
+    let lastId = 0;
+    let done = false;
+    const batchSize = 100;
+    while (!done) {
+      const relsToDelete = await createQueryBuilder(joinTable.name, db)
+        .select(select)
+        .where({
+          [joinColumn.name]: id,
+          id: { $gt: lastId },
+          ...(except ? { [inverseJoinColumn.name]: { $notIn: except } } : {}),
+          ...(onlyFor ? { [inverseJoinColumn.name]: { $in: onlyFor } } : {}),
+        })
+        .where(joinTable.on || {})
+        .orderBy('id')
+        .limit(batchSize)
+        .execute();
+      done = relsToDelete.length < batchSize;
+      lastId = relsToDelete[relsToDelete.length - 1]?.id;
+
+      // ORDER UPDATE
+      if (isAnyToMany(attribute)) {
+        // sort by order DESC so that the order updates are done in the correct order
+        // avoiding one to interfere with the others
+        relsToDelete.sort((a, b) => b[orderColumnName] - a[orderColumnName]);
+
+        for (const relToDelete of relsToDelete) {
+          if (relToDelete[orderColumnName] !== null) {
+            await createQueryBuilder(joinTable.name, db)
+              .decrement(orderColumnName, 1)
+              .where({
+                [joinColumn.name]: id,
+                [orderColumnName]: { $gt: relToDelete[orderColumnName] },
+              })
+              .where(joinTable.on || {})
+              // manque le pivot ici
+              .execute();
+          }
+        }
+      }
+
+      if (isBidirectional(attribute) && isManyToAny(attribute)) {
+        const updateInverseOrderPromises = [];
+        for (const relToDelete of relsToDelete) {
+          if (relToDelete[inverseOrderColumnName] !== null) {
+            const updatePromise = createQueryBuilder(joinTable.name, db)
+              .decrement(inverseOrderColumnName, 1)
+              .where({
+                [inverseJoinColumn.name]: relToDelete[inverseJoinColumn.name],
+                [inverseOrderColumnName]: { $gt: relToDelete[inverseOrderColumnName] },
+              })
+              .where(joinTable.on || {})
+              .execute();
+            updateInverseOrderPromises.push(updatePromise);
+          }
+        }
+        await Promise.all(updateInverseOrderPromises);
+      }
+    }
+  }
+
+  await createQueryBuilder(joinTable.name, db)
+    .delete()
+    .where({
+      [joinColumn.name]: id,
+      ...(except ? { [inverseJoinColumn.name]: { $notIn: except } } : {}),
+      ...(onlyFor ? { [inverseJoinColumn.name]: { $in: onlyFor } } : {}),
+    })
+    .where(joinTable.on || {})
+    .execute();
+};
+
+module.exports = {
+  deletePreviousOneToAnyRelations,
+  deletePreviousAnyToOneRelations,
+  deleteAllRelations,
+};

--- a/packages/core/database/lib/metadata/index.js
+++ b/packages/core/database/lib/metadata/index.js
@@ -208,6 +208,7 @@ const createComponent = (attributeName, attribute, meta) => {
       orderBy: {
         order: 'asc',
       },
+      ...(attribute.repeatable === true ? { orderColumnName: 'order' } : {}),
     },
   });
 };

--- a/packages/core/database/lib/metadata/index.js
+++ b/packages/core/database/lib/metadata/index.js
@@ -215,7 +215,7 @@ const createComponent = (attributeName, attribute, meta) => {
       orderBy: {
         order: 'asc',
       },
-      pivotColumns: ['entity_id', 'component_id', 'field'],
+      pivotColumns: ['entity_id', 'component_id', 'field', 'component_type'],
     },
   });
 };

--- a/packages/core/database/lib/metadata/index.js
+++ b/packages/core/database/lib/metadata/index.js
@@ -144,7 +144,7 @@ const createCompoLinkModelMeta = (baseModelMeta) => {
       },
       {
         name: `${baseModelMeta.tableName}_unique`,
-        columns: ['entity_id', 'component_id', 'field'],
+        columns: ['entity_id', 'component_id', 'field', 'component_type'],
         type: 'unique',
       },
     ],

--- a/packages/core/database/lib/metadata/index.js
+++ b/packages/core/database/lib/metadata/index.js
@@ -123,7 +123,7 @@ const createCompoLinkModelMeta = (baseModelMeta) => {
         type: 'integer',
         column: {
           unsigned: true,
-          defaultTo: 0,
+          defaultTo: null,
         },
       },
     },
@@ -188,6 +188,7 @@ const createDynamicZone = (attributeName, attribute, meta) => {
       orderBy: {
         order: 'asc',
       },
+      pivotColumns: ['entity_id', 'component_id', 'field', 'component_type'],
     },
   });
 };
@@ -210,10 +211,11 @@ const createComponent = (attributeName, attribute, meta) => {
       on: {
         field: attributeName,
       },
+      orderColumnName: 'order',
       orderBy: {
         order: 'asc',
       },
-      ...(attribute.repeatable === true ? { orderColumnName: 'order' } : {}),
+      pivotColumns: ['entity_id', 'component_id', 'field'],
     },
   });
 };

--- a/packages/core/database/lib/metadata/index.js
+++ b/packages/core/database/lib/metadata/index.js
@@ -142,6 +142,11 @@ const createCompoLinkModelMeta = (baseModelMeta) => {
         name: `${baseModelMeta.tableName}_entity_fk`,
         columns: ['entity_id'],
       },
+      {
+        name: `${baseModelMeta.tableName}_unique`,
+        columns: ['entity_id', 'component_id', 'field'],
+        type: 'unique',
+      },
     ],
     foreignKeys: [
       {

--- a/packages/core/database/lib/metadata/relations.js
+++ b/packages/core/database/lib/metadata/relations.js
@@ -481,7 +481,7 @@ const createJoinTable = (metadata, { attributeName, attribute, meta }) => {
       type: 'integer',
       column: {
         unsigned: true,
-        defaultTo: 0,
+        defaultTo: null,
       },
     };
     metadataSchema.indexes.push({
@@ -498,7 +498,7 @@ const createJoinTable = (metadata, { attributeName, attribute, meta }) => {
       type: 'integer',
       column: {
         unsigned: true,
-        defaultTo: 0,
+        defaultTo: null,
       },
     };
 

--- a/packages/core/database/lib/metadata/relations.js
+++ b/packages/core/database/lib/metadata/relations.js
@@ -406,8 +406,8 @@ const createJoinTable = (metadata, { attributeName, attribute, meta }) => {
     inverseJoinColumnName = `inv_${inverseJoinColumnName}`;
   }
 
-  const orderColumnName = _.snakeCase(`${meta.singularName}_order`);
-  let inverseOrderColumnName = _.snakeCase(`${targetMeta.singularName}_order`);
+  const orderColumnName = _.snakeCase(`${targetMeta.singularName}_order`);
+  let inverseOrderColumnName = _.snakeCase(`${meta.singularName}_order`);
 
   // if relation is self referencing
   if (attribute.relation === 'manyToMany' && joinColumnName === inverseJoinColumnName) {

--- a/packages/core/database/lib/metadata/relations.js
+++ b/packages/core/database/lib/metadata/relations.js
@@ -547,6 +547,9 @@ const createJoinTable = (metadata, { attributeName, attribute, meta }) => {
   }
 };
 
+const hasOrderColumn = (attribute) => isAnyToMany(attribute);
+const hasInverseOrderColumn = (attribute) => isBidirectional(attribute) && isManyToAny(attribute);
+
 module.exports = {
   createRelation,
 
@@ -555,4 +558,6 @@ module.exports = {
   isManyToAny,
   isAnyToOne,
   isAnyToMany,
+  hasOrderColumn,
+  hasInverseOrderColumn,
 };

--- a/packages/core/database/lib/metadata/relations.js
+++ b/packages/core/database/lib/metadata/relations.js
@@ -444,6 +444,11 @@ const createJoinTable = (metadata, { attributeName, attribute, meta }) => {
         name: `${joinTableName}_inv_fk`,
         columns: [inverseJoinColumnName],
       },
+      {
+        name: `${joinTableName}_unique`,
+        columns: [joinColumnName, inverseJoinColumnName],
+        type: 'unique',
+      },
     ],
     foreignKeys: [
       {

--- a/packages/core/database/lib/metadata/relations.js
+++ b/packages/core/database/lib/metadata/relations.js
@@ -422,6 +422,13 @@ const createJoinTable = (metadata, { attributeName, attribute, meta }) => {
           unsigned: true,
         },
       },
+      order: {
+        type: 'integer',
+        column: {
+          unsigned: true,
+          defaultTo: 0,
+        },
+      },
       // TODO: add extra pivot attributes -> user should use an intermediate entity
     },
     indexes: [

--- a/packages/core/database/lib/metadata/relations.js
+++ b/packages/core/database/lib/metadata/relations.js
@@ -272,6 +272,7 @@ const createMorphToMany = (attributeName, attribute, meta, metadata) => {
     orderBy: {
       order: 'asc',
     },
+    pivotColumns: [joinColumnName, typeColumnName, idColumnName],
   };
 
   attribute.joinTable = joinTable;
@@ -478,6 +479,7 @@ const createJoinTable = (metadata, { attributeName, attribute, meta }) => {
       name: inverseJoinColumnName,
       referencedColumn: 'id',
     },
+    pivotColumns: [joinColumnName, inverseJoinColumnName],
   };
 
   // order
@@ -532,6 +534,7 @@ const createJoinTable = (metadata, { attributeName, attribute, meta }) => {
       name: joinTableName,
       joinColumn: joinTable.inverseJoinColumn,
       inverseJoinColumn: joinTable.joinColumn,
+      pivotColumns: joinTable.pivotColumns,
     };
 
     if (isManyToAny(attribute)) {

--- a/packages/core/database/lib/query/query-builder.js
+++ b/packages/core/database/lib/query/query-builder.js
@@ -25,6 +25,8 @@ const createQueryBuilder = (uid, db, initialState = {}) => {
       forUpdate: false,
       orderBy: [],
       groupBy: [],
+      increments: [],
+      decrements: [],
       aliasCounter: 0,
     },
     initialState
@@ -80,6 +82,20 @@ const createQueryBuilder = (uid, db, initialState = {}) => {
     update(data) {
       state.type = 'update';
       state.data = data;
+
+      return this;
+    },
+
+    increment(column, amount = 1) {
+      state.type = 'update';
+      state.increments.push({ column, amount });
+
+      return this;
+    },
+
+    decrement(column, amount = 1) {
+      state.type = 'update';
+      state.decrements.push({ column, amount });
 
       return this;
     },
@@ -349,7 +365,9 @@ const createQueryBuilder = (uid, db, initialState = {}) => {
           break;
         }
         case 'update': {
-          qb.update(state.data);
+          if (state.data) {
+            qb.update(state.data);
+          }
           break;
         }
         case 'delete': {
@@ -372,6 +390,14 @@ const createQueryBuilder = (uid, db, initialState = {}) => {
 
       if (state.forUpdate) {
         qb.forUpdate();
+      }
+
+      if (!_.isEmpty(state.increments)) {
+        state.increments.forEach((incr) => qb.increment(incr.column, incr.amount));
+      }
+
+      if (!_.isEmpty(state.decrements)) {
+        state.decrements.forEach((decr) => qb.decrement(decr.column, decr.amount));
       }
 
       if (state.limit) {

--- a/packages/core/database/lib/query/query-builder.js
+++ b/packages/core/database/lib/query/query-builder.js
@@ -23,6 +23,9 @@ const createQueryBuilder = (uid, db, initialState = {}) => {
       offset: null,
       transaction: null,
       forUpdate: false,
+      onConflict: null,
+      merge: null,
+      ignore: false,
       orderBy: [],
       groupBy: [],
       increments: [],
@@ -65,6 +68,24 @@ const createQueryBuilder = (uid, db, initialState = {}) => {
     insert(data) {
       state.type = 'insert';
       state.data = data;
+
+      return this;
+    },
+
+    onConflict(args) {
+      state.onConflict = args;
+
+      return this;
+    },
+
+    merge(args) {
+      state.merge = args;
+
+      return this;
+    },
+
+    ignore() {
+      state.ignore = true;
 
       return this;
     },
@@ -398,6 +419,14 @@ const createQueryBuilder = (uid, db, initialState = {}) => {
 
       if (!_.isEmpty(state.decrements)) {
         state.decrements.forEach((decr) => qb.decrement(decr.column, decr.amount));
+      }
+
+      if (state.onConflict) {
+        if (state.merge) {
+          qb.onConflict(state.onConflict).merge(state.merge);
+        } else if (state.ignore) {
+          qb.onConflict(state.onConflict).ignore();
+        }
       }
 
       if (state.limit) {

--- a/packages/core/strapi/lib/services/entity-service/components.js
+++ b/packages/core/strapi/lib/services/entity-service/components.js
@@ -48,11 +48,10 @@ const createComponents = async (uid, data) => {
         );
 
         // TODO: add order
-        componentBody[attributeName] = components.map(({ id }, idx) => {
+        componentBody[attributeName] = components.map(({ id }) => {
           return {
             id,
             __pivot: {
-              order: idx + 1,
               field: attributeName,
               component_type: componentUID,
             },
@@ -63,7 +62,6 @@ const createComponents = async (uid, data) => {
         componentBody[attributeName] = {
           id: component.id,
           __pivot: {
-            order: 1,
             field: attributeName,
             component_type: componentUID,
           },
@@ -81,13 +79,12 @@ const createComponents = async (uid, data) => {
       }
 
       componentBody[attributeName] = await Promise.all(
-        dynamiczoneValues.map(async (value, idx) => {
+        dynamiczoneValues.map(async (value) => {
           const { id } = await createComponent(value.__component, value);
           return {
             id,
             __component: value.__component,
             __pivot: {
-              order: idx + 1,
               field: attributeName,
             },
           };
@@ -145,11 +142,10 @@ const updateComponents = async (uid, entityToUpdate, data) => {
           componentValue.map((value) => updateOrCreateComponent(componentUID, value))
         );
 
-        componentBody[attributeName] = components.filter(_.negate(_.isNil)).map(({ id }, idx) => {
+        componentBody[attributeName] = components.filter(_.negate(_.isNil)).map(({ id }) => {
           return {
             id,
             __pivot: {
-              order: idx + 1,
               field: attributeName,
               component_type: componentUID,
             },
@@ -160,7 +156,6 @@ const updateComponents = async (uid, entityToUpdate, data) => {
         componentBody[attributeName] = component && {
           id: component.id,
           __pivot: {
-            order: 1,
             field: attributeName,
             component_type: componentUID,
           },
@@ -180,14 +175,13 @@ const updateComponents = async (uid, entityToUpdate, data) => {
       }
 
       componentBody[attributeName] = await Promise.all(
-        dynamiczoneValues.map(async (value, idx) => {
+        dynamiczoneValues.map(async (value) => {
           const { id } = await updateOrCreateComponent(value.__component, value);
 
           return {
             id,
             __component: value.__component,
             __pivot: {
-              order: idx + 1,
               field: attributeName,
             },
           };

--- a/packages/plugins/i18n/tests/content-manager/find-existing-relations.test.e2e.js
+++ b/packages/plugins/i18n/tests/content-manager/find-existing-relations.test.e2e.js
@@ -99,7 +99,6 @@ describe('i18n - Find existing relations', () => {
     rq = await createAuthRequest({ strapi });
 
     data.shops = await builder.sanitizedFixturesFor(shopModel.singularName, strapi);
-    console.log('data.shops', data.shops);
     data.products = await builder.sanitizedFixturesFor(productModel.singularName, strapi);
   });
 


### PR DESCRIPTION
⚠️ don't merge (wrong base branch used)

## What

`_q` was encoded with `encodeURIComponent` which caused searching on multiple words to look like this and to receive no results: 
![image](https://user-images.githubusercontent.com/71838159/193004066-e3c2d70b-786f-41f9-afc2-9d1a79839b80.png)

## Open questions

is `encodeURIComponent` needed here
it isn't used in the list view of the content-manager either
if we want to use it, does it imply something for the backend?