### PR TITLE
removed encodeURIComponent as axios is already encoding params

### DIFF
--- a/packages/core/admin/admin/src/content-manager/hooks/useRelation/useRelation.js
+++ b/packages/core/admin/admin/src/content-manager/hooks/useRelation/useRelation.js
@@ -65,7 +65,7 @@ export const useRelation = (cacheKey, { relation, search }) => {
   const searchFor = (term, options = {}) => {
     setSearchParams({
       ...options,
-      _q: encodeURIComponent(term),
+      _q: term,
     });
   };
 


### PR DESCRIPTION
## What

Removing `encodeURIComponent` on `_q` when searching as `axios` is already encoding it
By encoding it twice it broke the search