### PR TITLE
[feat][AttributeModal]: add attribute description to field modal in content builder

### DIFF
--- a/packages/core/content-type-builder/admin/src/components/FormModalSubHeader/index.js
+++ b/packages/core/content-type-builder/admin/src/components/FormModalSubHeader/index.js
@@ -11,11 +11,11 @@ import { getTrad } from '../../utils';
 import getModalTitleSubHeader from './getModalTitleSubHeader';
 
 const SubHeaderContainer = styled(Flex)`
-  margin-bottom: 10px;
+  margin-bottom: ${(props) => props.theme.spaces[2]};
 `;
 
 const Subtitle = styled(Typography)`
-  margin-top: 4px;
+  margin-top: ${(props) => props.theme.spaces[1]};
 `;
 
 const FormModalSubHeader = ({

--- a/packages/core/content-type-builder/admin/src/components/FormModalSubHeader/index.js
+++ b/packages/core/content-type-builder/admin/src/components/FormModalSubHeader/index.js
@@ -1,22 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
-import styled from 'styled-components';
 import upperFirst from 'lodash/upperFirst';
-import { Flex } from '@strapi/design-system/Flex';
+import { Stack } from '@strapi/design-system/Stack';
 import { Typography } from '@strapi/design-system/Typography';
 
 import { getTrad } from '../../utils';
 
 import getModalTitleSubHeader from './getModalTitleSubHeader';
-
-const SubHeaderContainer = styled(Flex)`
-  margin-bottom: ${(props) => props.theme.spaces[2]};
-`;
-
-const Subtitle = styled(Typography)`
-  margin-top: ${(props) => props.theme.spaces[1]};
-`;
 
 const FormModalSubHeader = ({
   actionType,
@@ -35,7 +26,7 @@ const FormModalSubHeader = ({
       : { id: getTrad(`attribute.${attributeType}`) };
 
   return (
-    <SubHeaderContainer direction="column" alignItems="flex-start">
+    <Stack direction="column" alignItems="flex-start" paddingBottom={2} gap={1}>
       <Typography as="h2" variant="beta">
         {formatMessage(
           {
@@ -55,13 +46,13 @@ const FormModalSubHeader = ({
           }
         )}
       </Typography>
-      <Subtitle variant="pi" textColor="neutral600">
+      <Typography variant="pi" textColor="neutral600">
         {formatMessage({
           id: getTrad(`attribute.${attributeType}.description`),
           defaultMessage: 'A type for modeling data',
         })}
-      </Subtitle>
-    </SubHeaderContainer>
+      </Typography>
+    </Stack>
   );
 };
 

--- a/packages/core/content-type-builder/admin/src/components/FormModalSubHeader/index.js
+++ b/packages/core/content-type-builder/admin/src/components/FormModalSubHeader/index.js
@@ -1,10 +1,22 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
-import { Typography } from '@strapi/design-system/Typography';
+import styled from 'styled-components';
 import upperFirst from 'lodash/upperFirst';
+import { Flex } from '@strapi/design-system/Flex';
+import { Typography } from '@strapi/design-system/Typography';
+
 import { getTrad } from '../../utils';
+
 import getModalTitleSubHeader from './getModalTitleSubHeader';
+
+const SubHeaderContainer = styled(Flex)`
+  margin-bottom: 10px;
+`;
+
+const Subtitle = styled(Typography)`
+  margin-top: 4px;
+`;
 
 const FormModalSubHeader = ({
   actionType,
@@ -23,25 +35,33 @@ const FormModalSubHeader = ({
       : { id: getTrad(`attribute.${attributeType}`) };
 
   return (
-    <Typography as="h2" variant="beta">
-      {formatMessage(
-        {
-          id: getModalTitleSubHeader({
-            actionType,
-            forTarget,
-            kind,
+    <SubHeaderContainer direction="column" alignItems="flex-start">
+      <Typography as="h2" variant="beta">
+        {formatMessage(
+          {
+            id: getModalTitleSubHeader({
+              actionType,
+              forTarget,
+              kind,
+              step,
+              modalType,
+            }),
+            defaultMessage: 'Add new field',
+          },
+          {
+            type: upperFirst(formatMessage(intlLabel)),
+            name: upperFirst(attributeName),
             step,
-            modalType,
-          }),
-          defaultMessage: 'Add new field',
-        },
-        {
-          type: upperFirst(formatMessage(intlLabel)),
-          name: upperFirst(attributeName),
-          step,
-        }
-      )}
-    </Typography>
+          }
+        )}
+      </Typography>
+      <Subtitle variant="pi" textColor="neutral600">
+        {formatMessage({
+          id: getTrad(`attribute.${attributeType}.description`),
+          defaultMessage: 'A type for modeling data',
+        })}
+      </Subtitle>
+    </SubHeaderContainer>
   );
 };
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Adds the attributes description to the SubHeader of the modal

### How to test it?

* Go to Content Builder
* Add a field
* Select an attribute
* View the modal and see the attribute description

### Related issue(s)/PR(s)

* resolves CONTENT-239
