### PR TITLE
Fix role assign on user collection type

### DIFF
--- a/packages/plugins/users-permissions/server/controllers/validation/user.js
+++ b/packages/plugins/users-permissions/server/controllers/validation/user.js
@@ -10,13 +10,37 @@ const createUserBodySchema = yup.object().shape({
   email: yup.string().email().required(),
   username: yup.string().min(1).required(),
   password: yup.string().min(1).required(),
-  role: yup.strapiID(),
+  role: yup.lazy((value) =>
+    typeof value === 'object'
+      ? yup
+          .object()
+          .shape({
+            connect: yup
+              .array()
+              .of(yup.object().shape({ id: yup.strapiID().required() }))
+              .min(1)
+              .required(),
+          })
+          .required()
+      : yup.strapiID().required()
+  ),
 });
 
 const updateUserBodySchema = yup.object().shape({
   email: yup.string().email().min(1),
   username: yup.string().min(1),
   password: yup.string().min(1),
+  role: yup.lazy((value) =>
+    typeof value === 'object'
+      ? yup.object().shape({
+          connect: yup
+            .array()
+            .of(yup.object().shape({ id: yup.strapiID().required() }))
+            .min(1)
+            .required(),
+        })
+      : yup.strapiID()
+  ),
 });
 
 module.exports = {


### PR DESCRIPTION
### What does it do?

You could not create user from the content manager now.

![image](https://user-images.githubusercontent.com/20578351/193240925-48301d75-6ea8-49e8-9bb1-b2c45231d865.png)

user-permissions plugin was not expecting the connect / disconnect format.

### How to test it?

Create a user from the content manager.
