### PR TITLE
Update UP e2e test following API token V2 release

### DIFF
--- a/packages/plugins/users-permissions/tests/content-api/auth.test.e2e.js
+++ b/packages/plugins/users-permissions/tests/content-api/auth.test.e2e.js
@@ -45,9 +45,9 @@ describe('Auth API', () => {
         body: {},
       });
 
-      expect(res.statusCode).toBe(400);
-      expect(res.body.error.name).toBe('ApplicationError');
-      expect(res.body.error.message).toBe('You must be authenticated to reset your password');
+      expect(res.statusCode).toBe(403);
+      expect(res.body.error.name).toBe('ForbiddenError');
+      expect(res.body.error.message).toBe('Forbidden');
     });
 
     test('Fails on invalid confirmation password', async () => {


### PR DESCRIPTION
### What does it do?

Fix unauthenticated request error following the changes made during API Token V2 development

### Why is it needed?

Fix a failing e2e test which has a wrong behavior

### How to test it?

`node test/e2e.js -- packages/plugins/users-permissions/tests/content-api/auth.test.e2e.js`
