### PR TITLE
Add czech translate color-picker plugin

### DIFF
--- a/packages/plugins/color-picker/admin/src/translations/cs.json
+++ b/packages/plugins/color-picker/admin/src/translations/cs.json
@@ -1,0 +1,12 @@
+{
+  "color-picker.label": "Barva",
+  "color-picker.description": "Vyberte libovolnou barvu",
+  "color-picker.settings": "Nastavení",
+  "color-picket.input.format": "HEX",
+  "color-picker.options.advanced.regex": "RegExp vzor",
+  "color-picker.options.advanced.regex.description": "Zadejte regulární výraz pro ověření hodnoty HEX",
+  "color-picker.options.advanced.requiredField": "Povinné pole",
+  "color-picker.options.advanced.requiredField.description": "Pokud je toto pole prázdné, nebudete moci vytvořit záznam",
+  "color-picker.toggle.aria-label": "Přepínač výběru barvy",
+  "color-picker.input.aria-label": "Vstup pro výběr barvy"
+}


### PR DESCRIPTION
Add cs.json with czech translation of color-picker plugin

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Add czech translate of color-picker plugin

