### PR TITLE
Fix ts types on FindParams now accept nested obj

### DIFF
--- a/packages/core/database/lib/index.d.ts
+++ b/packages/core/database/lib/index.d.ts
@@ -53,7 +53,11 @@ interface FindParams<T> {
     | { [K in Sortables<T>]?: Direction }
     | { [K in Sortables<T>]?: Direction }[];
   // TODO: define nested obj
-  populate?: (keyof T)[];
+  populate?:
+    | (keyof T)[]
+    | {
+        [key: T];
+      };
 }
 
 interface CreateParams<T> {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

populate property of FindParams interface now accept nested object.

### Why is it needed?

As mentioned in the issue (look Related Issue below) when use typescript template and try to pass object to populate property during a query, server go down because "populate" not accepted object type.

### How to test it?

Try to query, according to documentation, using ts template: 
`strapi.db.query('api::article.article').findMany({
  populate: {
    componentB: true,
    dynamiczoneA: true,
    relation: someLogic || true,
  },
});`

### Related issue(s)/PR(s)

#14286 