### PR TITLE
fix: Unknown Dialect Windows issue

### DIFF
--- a/packages/utils/typescript/lib/utils/get-config-path.js
+++ b/packages/utils/typescript/lib/utils/get-config-path.js
@@ -17,7 +17,9 @@ const DEFAULT_TS_CONFIG_FILENAME = 'tsconfig.json';
  */
 module.exports = (dir, { filename = DEFAULT_TS_CONFIG_FILENAME, ancestorsLookup = false } = {}) => {
   const dirAbsolutePath = path.resolve(dir);
-  const configFilePath = ts.findConfigFile(dirAbsolutePath, ts.sys.fileExists, filename);
+  let configFilePath = ts.findConfigFile(dirAbsolutePath, ts.sys.fileExists, filename);
+
+  if (configFilePath) configFilePath = path.resolve(configFilePath);
 
   if (!configFilePath || ancestorsLookup) {
     return configFilePath;


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Resolves path on Windows OS If tsconfig file is provided. 
It doesn't affect strapi if tsconfig is not provided, but if it does it changes the path with correct backslashes

### Why is it needed?

People with Windows machines also want to use strapi ts.

### How to test it?



Before : C:/Users/currentUser/project/server/tsconfig.json
After:  C:\Users\currentUser\project\server\tsconfig.json

### Related issue(s)/PR(s)


[issue link](https://github.com/strapi/strapi/issues/13237)