### PR TITLE
Add connection property for database interface

### DIFF
--- a/packages/core/database/lib/index.d.ts
+++ b/packages/core/database/lib/index.d.ts
@@ -1,3 +1,4 @@
+import { Knex } from 'knex';
 import { LifecycleProvider } from './lifecycles';
 import { MigrationProvider } from './migrations';
 import { SchemaProvideer } from './schema';
@@ -158,7 +159,7 @@ export interface Database {
   lifecycles: LifecycleProvider;
   migrations: MigrationProvider;
   entityManager: EntityManager;
-
+  connection: Knex;
   query<T extends keyof AllTypes>(uid: T): QueryFromContentType<T>;
 }
 export class Database implements Database {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Added 'connection' property to database interface, which should be a Knex type.

### Why is it needed?

When using `strapi.db.connection` the server would crash because no connection property was provided for the database interface.

### How to test it?

Use `strapi.db.connection.raw()`

### Related issue(s)/PR(s)

#14469

