### PR TITLE
Improve API token v2 db performance by removing update population

### DIFF
--- a/packages/core/admin/server/services/__tests__/api-token.test.js
+++ b/packages/core/admin/server/services/__tests__/api-token.test.js
@@ -678,7 +678,6 @@ describe('API Token', () => {
         select: expect.arrayContaining([expect.any(String)]),
         where: { id },
         data: attributes,
-        populate: ['permissions'],
       });
       expect(res).toEqual(attributes);
     });
@@ -799,7 +798,6 @@ describe('API Token', () => {
       select: expect.arrayContaining([expect.any(String)]),
       where: { id },
       data: omit(['permissions'], updatedAttributes),
-      populate: expect.anything(), // it doesn't matter how this is used
     });
 
     expect(res).toEqual(updatedAttributes);
@@ -871,7 +869,6 @@ describe('API Token', () => {
       select: expect.arrayContaining([expect.any(String)]),
       where: { id },
       data: omit(['permissions'], updatedAttributes),
-      populate: expect.anything(), // it doesn't matter how this is used
     });
 
     expect(res).toEqual({

--- a/packages/core/admin/server/services/api-token.js
+++ b/packages/core/admin/server/services/api-token.js
@@ -381,7 +381,6 @@ const update = async (id, attributes) => {
 
   const updatedToken = await strapi.query('admin::api-token').update({
     select: SELECT_FIELDS,
-    populate: POPULATE_FIELDS,
     where: { id },
     data: omit('permissions', attributes),
   });

--- a/packages/core/admin/server/strategies/__tests__/api-token.test.js
+++ b/packages/core/admin/server/strategies/__tests__/api-token.test.js
@@ -32,16 +32,21 @@ describe('API Token Auth Strategy', () => {
             'api-token': {
               getBy,
               hash,
-              update,
             },
           },
+        },
+        query() {
+          return { update };
         },
       };
 
       const response = await apiTokenStrategy.authenticate(ctx);
 
       expect(getBy).toHaveBeenCalledWith({ accessKey: 'api-token_tests-hashed-access-key' });
-      expect(update).toHaveBeenCalledWith(apiToken.id, { lastUsedAt: expect.any(Date) });
+      expect(update).toHaveBeenCalledWith({
+        data: { lastUsedAt: expect.any(Date) },
+        where: { id: apiToken.id },
+      });
       expect(response).toStrictEqual({ authenticated: true, credentials: apiToken });
     });
 

--- a/packages/core/admin/server/strategies/api-token.js
+++ b/packages/core/admin/server/strategies/api-token.js
@@ -52,9 +52,10 @@ const authenticate = async (ctx) => {
     }
   }
 
-  // update lastUsedAt
-  await apiTokenService.update(apiToken.id, {
-    lastUsedAt: currentDate,
+  // update lastUsedAt async without waiting or worrying about result
+  await strapi.query('admin::api-token').update({
+    where: { id: apiToken.id },
+    data: { lastUsedAt: currentDate },
   });
 
   if (apiToken.type === constants.API_TOKEN_TYPE.CUSTOM) {

--- a/packages/core/admin/server/strategies/api-token.js
+++ b/packages/core/admin/server/strategies/api-token.js
@@ -52,7 +52,7 @@ const authenticate = async (ctx) => {
     }
   }
 
-  // update lastUsedAt async without waiting or worrying about result
+  // update lastUsedAt
   await strapi.query('admin::api-token').update({
     where: { id: apiToken.id },
     data: { lastUsedAt: currentDate },


### PR DESCRIPTION
### What does it do?

- `lastUpdatedAt` is updated directly without querying an additional time for the token [solves the performance issue caused on all requests]
- Removes the populate relation from the API Token v2 service update method. Permissions links are handled manually in a later separate step, so the update does not need to worry about populating the relations. [increases performance on token update]

### Why is it needed?

API Token v2 greatly increased the number of DB requests because of these unnecessary calls.

### How to test it?

- Use a DB monitor to view queries with and without this PR
- Make content API calls using an API token
- DB calls should be greatly reduced with this PR

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/issues/14512
