### PR TITLE
[Relations - Front] Reverse order of relations

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/RelationInputDataManager.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/RelationInputDataManager.js
@@ -195,7 +195,6 @@ export const RelationInputDataManger = ({
       required={required}
       searchResults={normalizeRelations(search, {
         mainFieldName: mainField.name,
-        search: 'search',
       })}
       size={size}
     />

--- a/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/RelationInputDataManager.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/RelationInputDataManager.js
@@ -126,8 +126,7 @@ export const RelationInputDataManager = ({
 
   const handleOpenSearch = () => {
     searchFor('', {
-      idsToInclude:
-        !isCreatingEntry && relationsFromModifiedData?.disconnect?.map((relation) => relation.id),
+      idsToInclude: relationsFromModifiedData?.disconnect?.map((relation) => relation.id),
       idsToOmit: relationsFromModifiedData?.connect?.map((relation) => relation.id),
     });
   };

--- a/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/RelationInputDataManager.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/RelationInputDataManager.js
@@ -195,6 +195,7 @@ export const RelationInputDataManger = ({
       required={required}
       searchResults={normalizeRelations(search, {
         mainFieldName: mainField.name,
+        isSearch: true,
       })}
       size={size}
     />

--- a/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/RelationInputDataManager.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/RelationInputDataManager.js
@@ -7,7 +7,7 @@ import { useCMEditViewDataManager, NotAllowedInput, useQueryParams } from '@stra
 
 import { RelationInput } from '../RelationInput';
 import { useRelation } from '../../hooks/useRelation';
-import { connect, select, normalizeRelations } from './utils';
+import { connect, select, normalizeRelations, normalizeSearchResults } from './utils';
 import { PUBLICATION_STATES, RELATIONS_TO_DISPLAY, SEARCH_RESULTS_TO_DISPLAY } from './constants';
 import { getTrad } from '../../utils';
 
@@ -193,9 +193,8 @@ export const RelationInputDataManger = ({
       }}
       relations={normalizedRelations}
       required={required}
-      searchResults={normalizeRelations(search, {
+      searchResults={normalizeSearchResults(search, {
         mainFieldName: mainField.name,
-        isSearch: true,
       })}
       size={size}
     />

--- a/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/utils/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/utils/index.js
@@ -1,3 +1,4 @@
 export { default as connect } from './connect';
 export { default as select } from './select';
 export { normalizeRelations } from './normalizeRelations';
+export { normalizeSearchResults } from './normalizeSearchResults';

--- a/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/utils/normalizeRelations.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/utils/normalizeRelations.js
@@ -2,7 +2,7 @@ import { getRelationLink } from './getRelationLink';
 
 import { PUBLICATION_STATES } from '../constants';
 
-const normalizeRelation = (relation, { shouldAddLink, mainFieldName, targetModel }) => {
+export const normalizeRelation = (relation, { shouldAddLink, mainFieldName, targetModel }) => {
   const nextRelation = { ...relation };
 
   if (shouldAddLink) {
@@ -32,25 +32,14 @@ const normalizeRelation = (relation, { shouldAddLink, mainFieldName, targetModel
 
 export const normalizeRelations = (
   relations,
-  { modifiedData = {}, shouldAddLink = false, mainFieldName, targetModel, isSearch = false }
+  { modifiedData = {}, shouldAddLink = false, mainFieldName, targetModel }
 ) => {
-  // To display oldest to newest relations we need to reverse each elements in array of results
-  // and reverse each arrays itself
-  const existingRelationsReversed = Array.isArray(relations?.data?.pages)
-    ? relations?.data?.pages
-        .map((relation) => ({
-          ...relation,
-          results: relation.results.slice().reverse(),
-        }))
-        .reverse()
-    : [];
-
   return {
     ...relations,
     data: {
       pages:
         [
-          ...(!isSearch ? existingRelationsReversed : relations?.data?.pages ?? []),
+          ...(relations?.data?.pages.reverse() ?? []),
           ...(modifiedData?.connect ? [{ results: modifiedData.connect }] : []),
         ]
           ?.map((page) =>
@@ -63,7 +52,6 @@ export const normalizeRelations = (
               )
               .map((relation) =>
                 normalizeRelation(relation, {
-                  modifiedData,
                   shouldAddLink,
                   mainFieldName,
                   targetModel,

--- a/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/utils/normalizeRelations.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/utils/normalizeRelations.js
@@ -22,25 +22,35 @@ const normalizeRelation = (relation, { shouldAddLink, mainFieldName, targetModel
   return nextRelation;
 };
 
+/*
+ * Applies some transformations to existing and new relations in order to display them correctly
+ * relations: raw relations data coming from useRelations
+ * shouldAddLink: comes from generateRelationQueryInfos, if true we display a link to the relation (TO FIX: explanation)
+ * mainFieldName: name of the main field inside the relation (e.g. text field), if no displayable main field exists (e.g. date field) we use the id of the entry
+ * targetModel: the model on which the relation is based on, used to create an URL link
+ */
+
 export const normalizeRelations = (
   relations,
-  { modifiedData = {}, shouldAddLink = false, mainFieldName, targetModel }
+  { modifiedData = {}, shouldAddLink = false, mainFieldName, targetModel, isSearch = false }
 ) => {
   // To display oldest to newest relations we need to reverse each elements in array of results
   // and reverse each arrays itself
-  const existingRelationsReversed = [...(relations?.data?.pages ?? [])]
-    .map((relation) => ({
-      ...relation,
-      results: relation.results.slice().reverse(),
-    }))
-    .reverse();
+  const existingRelationsReversed = Array.isArray(relations?.data?.pages)
+    ? relations?.data?.pages
+        .map((relation) => ({
+          ...relation,
+          results: relation.results.slice().reverse(),
+        }))
+        .reverse()
+    : [];
 
   return {
     ...relations,
     data: {
       pages:
         [
-          ...(targetModel ? existingRelationsReversed : relations?.data?.pages ?? []),
+          ...(!isSearch ? existingRelationsReversed : relations?.data?.pages ?? []),
           ...(modifiedData?.connect ? [{ results: modifiedData.connect }] : []),
         ]
           ?.map((page) =>

--- a/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/utils/normalizeRelations.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/utils/normalizeRelations.js
@@ -26,12 +26,21 @@ export const normalizeRelations = (
   relations,
   { modifiedData = {}, shouldAddLink = false, mainFieldName, targetModel }
 ) => {
+  // To display oldest to newest relations we need to reverse each elements in array of results
+  // and reverse each arrays itself
+  const existingRelationsReversed = [...(relations?.data?.pages ?? [])]
+    .map((relation) => ({
+      ...relation,
+      results: relation.results.slice().reverse(),
+    }))
+    .reverse();
+
   return {
     ...relations,
     data: {
       pages:
         [
-          ...(relations?.data?.pages ?? []),
+          ...(targetModel ? existingRelationsReversed : relations?.data?.pages ?? []),
           ...(modifiedData?.connect ? [{ results: modifiedData.connect }] : []),
         ]
           ?.map((page) =>

--- a/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/utils/normalizeSearchResults.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/utils/normalizeSearchResults.js
@@ -1,0 +1,12 @@
+import { normalizeRelation } from './normalizeRelations';
+
+export const normalizeSearchResults = (relations, { mainFieldName }) => {
+  return {
+    ...relations,
+    data: {
+      pages: [...(relations?.data?.pages ?? [])]?.map((page) =>
+        page?.results.map((relation) => normalizeRelation(relation, { mainFieldName }))
+      ),
+    },
+  };
+};

--- a/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/utils/tests/normalizeRelations.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/utils/tests/normalizeRelations.test.js
@@ -85,9 +85,9 @@ describe('normalizeRelations', () => {
       data: {
         pages: [
           [
-            expect.objectContaining({ href: '/content-manager/collectionType/something/1' }),
-            expect.objectContaining({ href: '/content-manager/collectionType/something/2' }),
             expect.objectContaining({ href: '/content-manager/collectionType/something/3' }),
+            expect.objectContaining({ href: '/content-manager/collectionType/something/2' }),
+            expect.objectContaining({ href: '/content-manager/collectionType/something/1' }),
           ],
         ],
       },
@@ -157,6 +157,27 @@ describe('normalizeRelations', () => {
               id: 1,
             }),
           ],
+        ],
+      },
+    });
+  });
+
+  test.only('reverse order of existing relations', () => {
+    expect(
+      normalizeRelations(FIXTURE_RELATIONS, {
+        modifiedData: { connect: [{ id: 4 }, { id: 5 }] },
+        shouldAddLink: true,
+        targetModel: 'something',
+      })
+    ).toStrictEqual({
+      data: {
+        pages: [
+          [
+            expect.objectContaining({ id: 3 }),
+            expect.objectContaining({ id: 2 }),
+            expect.objectContaining({ id: 1 }),
+          ],
+          [expect.objectContaining({ id: 4 }), expect.objectContaining({ id: 5 })],
         ],
       },
     });

--- a/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/utils/tests/normalizeRelations.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/utils/tests/normalizeRelations.test.js
@@ -27,8 +27,8 @@ const FIXTURE_RELATIONS = {
   },
 };
 
-describe('normalizeRelations', () => {
-  test('filters out deleted releations', () => {
+describe('RelationInputDataManager || normalizeRelations', () => {
+  test('filters out deleted relations', () => {
     expect(
       normalizeRelations(FIXTURE_RELATIONS, {
         modifiedData: { disconnect: [{ id: 1 }] },
@@ -137,7 +137,7 @@ describe('normalizeRelations', () => {
     });
   });
 
-  test('allows to connect new relations, eventhough pages is empty', () => {
+  test('allows to connect new relations, even though pages is empty', () => {
     expect(
       normalizeRelations(
         {

--- a/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/utils/tests/normalizeRelations.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/utils/tests/normalizeRelations.test.js
@@ -6,8 +6,8 @@ const FIXTURE_RELATIONS = {
       {
         results: [
           {
-            id: 1,
-            name: 'Relation 1',
+            id: 3,
+            name: 'Relation 3',
             publishedAt: '2022-08-24T09:29:11.38',
           },
 
@@ -18,8 +18,8 @@ const FIXTURE_RELATIONS = {
           },
 
           {
-            id: 3,
-            name: 'Relation 3',
+            id: 1,
+            name: 'Relation 1',
           },
         ],
       },
@@ -37,8 +37,8 @@ describe('normalizeRelations', () => {
       data: {
         pages: [
           [
+            expect.objectContaining(FIXTURE_RELATIONS.data.pages[0].results[0]),
             expect.objectContaining(FIXTURE_RELATIONS.data.pages[0].results[1]),
-            expect.objectContaining(FIXTURE_RELATIONS.data.pages[0].results[2]),
           ],
         ],
       },
@@ -162,22 +162,56 @@ describe('normalizeRelations', () => {
     });
   });
 
-  test.only('reverse order of existing relations', () => {
+  test('reverse order of relations pages', () => {
+    const fixtureExtended = {
+      pages: [
+        ...FIXTURE_RELATIONS.data.pages,
+        {
+          results: [
+            {
+              id: 6,
+              name: 'Relation 6',
+              publishedAt: '2022-08-24T09:29:11.38',
+            },
+
+            {
+              id: 5,
+              name: 'Relation 5',
+              publishedAt: '',
+            },
+
+            {
+              id: 4,
+              name: 'Relation 4',
+            },
+          ],
+        },
+      ],
+    };
+
     expect(
-      normalizeRelations(FIXTURE_RELATIONS, {
-        modifiedData: { connect: [{ id: 4 }, { id: 5 }] },
-        shouldAddLink: true,
-        targetModel: 'something',
-      })
+      normalizeRelations(
+        {
+          data: fixtureExtended,
+        },
+        {
+          modifiedData: { connect: [{ id: 6 }] },
+        }
+      )
     ).toStrictEqual({
       data: {
         pages: [
+          [
+            expect.objectContaining({ id: 6 }),
+            expect.objectContaining({ id: 5 }),
+            expect.objectContaining({ id: 4 }),
+          ],
           [
             expect.objectContaining({ id: 3 }),
             expect.objectContaining({ id: 2 }),
             expect.objectContaining({ id: 1 }),
           ],
-          [expect.objectContaining({ id: 4 }), expect.objectContaining({ id: 5 })],
+          [expect.objectContaining({ id: 6 })],
         ],
       },
     });

--- a/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/utils/tests/normalizeSearchResults.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/utils/tests/normalizeSearchResults.test.js
@@ -27,7 +27,7 @@ const FIXTURE_RELATIONS = {
   },
 };
 
-describe('RelationInputDataManager || normalizeRelations', () => {
+describe('RelationInputDataManager || normalizeSearchResults', () => {
   test('add publicationState attribute to each relation', () => {
     expect(normalizeSearchResults(FIXTURE_RELATIONS, {})).toStrictEqual({
       data: {

--- a/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/utils/tests/normalizeSearchResults.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/utils/tests/normalizeSearchResults.test.js
@@ -1,0 +1,68 @@
+import { normalizeSearchResults } from '../normalizeSearchResults';
+
+const FIXTURE_RELATIONS = {
+  data: {
+    pages: [
+      {
+        results: [
+          {
+            id: 3,
+            name: 'Relation 3',
+            publishedAt: '2022-08-24T09:29:11.38',
+          },
+
+          {
+            id: 2,
+            name: 'Relation 2',
+            publishedAt: '',
+          },
+
+          {
+            id: 1,
+            name: 'Relation 1',
+          },
+        ],
+      },
+    ],
+  },
+};
+
+describe('RelationInputDataManager || normalizeRelations', () => {
+  test('add publicationState attribute to each relation', () => {
+    expect(normalizeSearchResults(FIXTURE_RELATIONS, {})).toStrictEqual({
+      data: {
+        pages: [
+          [
+            expect.objectContaining({ publicationState: 'published' }),
+            expect.objectContaining({ publicationState: 'draft' }),
+            expect.objectContaining({ publicationState: false }),
+          ],
+        ],
+      },
+    });
+  });
+
+  test('add mainField attribute to each relation', () => {
+    expect(
+      normalizeSearchResults(FIXTURE_RELATIONS, {
+        mainFieldName: 'name',
+      })
+    ).toStrictEqual({
+      data: {
+        pages: [
+          [
+            expect.objectContaining({
+              mainField: FIXTURE_RELATIONS.data.pages[0].results[0].name,
+            }),
+            expect.objectContaining({
+              mainField: FIXTURE_RELATIONS.data.pages[0].results[1].name,
+            }),
+            expect.objectContaining({
+              mainField: FIXTURE_RELATIONS.data.pages[0].results[2].name,
+            }),
+          ],
+        ],
+      },
+    });
+  });
+});

--- a/packages/core/admin/admin/src/content-manager/hooks/useRelation/tests/useRelation.test.js
+++ b/packages/core/admin/admin/src/content-manager/hooks/useRelation/tests/useRelation.test.js
@@ -238,65 +238,63 @@ describe('useRelation', () => {
     });
   });
 
-  // TOFIX: 2 tests breaking (infinite loop & || time out depending on firing them alone or all at the same time)
+  test('fetch search next page, if there is one', async () => {
+    const { result, waitForNextUpdate } = await setup(undefined);
 
-  // test('fetch search next page, if there is one', async () => {
-  //   const { result, waitForNextUpdate } = await setup(undefined);
+    const spy = jest
+      .fn()
+      .mockResolvedValue({ data: { results: [], pagination: { page: 1, pageCount: 2 } } });
+    axiosInstance.get = spy;
 
-  //   const spy = jest
-  //     .fn()
-  //     .mockResolvedValue({ data: { results: [], pagination: { page: 1, pageCount: 2 } } });
-  //   axiosInstance.get = spy;
+    act(() => {
+      result.current.searchFor('something');
+    });
 
-  //   act(() => {
-  //     result.current.searchFor('something');
-  //   });
+    await waitForNextUpdate();
 
-  //   await waitForNextUpdate();
+    act(() => {
+      result.current.search.fetchNextPage();
+    });
 
-  //   act(() => {
-  //     result.current.search.fetchNextPage();
-  //   });
+    await waitForNextUpdate();
 
-  //   await waitForNextUpdate();
+    expect(spy).toBeCalledTimes(2);
+    expect(spy).toHaveBeenNthCalledWith(1, expect.any(String), {
+      params: {
+        _q: 'something',
+        limit: expect.any(Number),
+        page: 1,
+      },
+    });
+    expect(spy).toHaveBeenNthCalledWith(2, expect.any(String), {
+      params: {
+        _q: 'something',
+        limit: expect.any(Number),
+        page: 2,
+      },
+    });
+  });
 
-  //   expect(spy).toBeCalledTimes(2);
-  //   expect(spy).toHaveBeenNthCalledWith(1, expect.any(String), {
-  //     params: {
-  //       _q: 'something',
-  //       limit: expect.any(Number),
-  //       page: 1,
-  //     },
-  //   });
-  //   expect(spy).toHaveBeenNthCalledWith(2, expect.any(String), {
-  //     params: {
-  //       _q: 'something',
-  //       limit: expect.any(Number),
-  //       page: 2,
-  //     },
-  //   });
-  // });
+  test("does not fetch search next page, if there isn't one", async () => {
+    const { result, waitForNextUpdate } = await setup(undefined);
 
-  // test("does not fetch search next page, if there isn't one", async () => {
-  //   const { result, waitForNextUpdate } = await setup(undefined);
+    const spy = jest.fn().mockResolvedValue({
+      data: { results: [], pagination: { page: 1, pageCount: 1 } },
+    });
+    axiosInstance.get = spy;
 
-  //   const spy = jest.fn().mockResolvedValue({
-  //     data: { results: [], pagination: { page: 1, pageCount: 1 }, spy: 'hello' },
-  //   });
-  //   axiosInstance.get = spy;
+    act(() => {
+      result.current.searchFor('something');
+    });
 
-  //   act(() => {
-  //     result.current.searchFor('something');
-  //   });
+    await waitForNextUpdate();
 
-  //   await waitForNextUpdate();
+    act(() => {
+      result.current.search.fetchNextPage();
+    });
 
-  //   act(() => {
-  //     result.current.search.fetchNextPage();
-  //   });
+    await waitForNextUpdate();
 
-  //   await waitForNextUpdate();
-
-  //   expect(spy).toBeCalledTimes(1);
-  // });
+    expect(spy).toBeCalledTimes(1);
+  });
 });

--- a/packages/core/admin/admin/src/content-manager/hooks/useRelation/tests/useRelation.test.js
+++ b/packages/core/admin/admin/src/content-manager/hooks/useRelation/tests/useRelation.test.js
@@ -8,9 +8,15 @@ import { useRelation } from '../useRelation';
 jest.mock('../../../../core/utils', () => ({
   ...jest.requireActual('../../../../core/utils'),
   axiosInstance: {
-    get: jest
-      .fn()
-      .mockResolvedValue({ data: { values: [], pagination: { page: 1, pageCount: 10 } } }),
+    get: jest.fn().mockResolvedValue({
+      data: {
+        results: [
+          { id: 2, name: 'newest', publishedAt: null },
+          { id: 1, name: 'oldest', publishedAt: null },
+        ],
+        pagination: { page: 1, pageCount: 10 },
+      },
+    }),
   },
 }));
 
@@ -95,7 +101,7 @@ describe('useRelation', () => {
     });
   });
 
-  test('doesn not fetch relations if it was not enabled', async () => {
+  test('does not fetch relations if it was not enabled', async () => {
     await setup(undefined, { relation: { enabled: false } });
 
     expect(axiosInstance.get).not.toBeCalled();
@@ -119,7 +125,7 @@ describe('useRelation', () => {
   test('fetch relations next page, if there is one', async () => {
     axiosInstance.get = jest.fn().mockResolvedValue({
       data: {
-        values: [],
+        results: [],
         pagination: {
           page: 1,
           pageCount: 3,
@@ -155,7 +161,7 @@ describe('useRelation', () => {
   test("does not fetch relations next page, if there isn't one", async () => {
     axiosInstance.get = jest.fn().mockResolvedValue({
       data: {
-        values: [],
+        results: [],
         pagination: {
           page: 1,
           pageCount: 1,
@@ -191,7 +197,7 @@ describe('useRelation', () => {
 
     const spy = jest
       .fn()
-      .mockResolvedValue({ data: { values: [], pagination: { page: 1, pageCount: 2 } } });
+      .mockResolvedValue({ data: { results: [], pagination: { page: 1, pageCount: 2 } } });
     axiosInstance.get = spy;
 
     act(() => {
@@ -232,63 +238,65 @@ describe('useRelation', () => {
     });
   });
 
-  test('fetch search next page, if there is one', async () => {
-    const { result, waitForNextUpdate } = await setup(undefined);
+  // TOFIX: 2 tests breaking (infinite loop & || time out depending on firing them alone or all at the same time)
 
-    const spy = jest
-      .fn()
-      .mockResolvedValue({ data: { values: [], pagination: { page: 1, pageCount: 2 } } });
-    axiosInstance.get = spy;
+  // test('fetch search next page, if there is one', async () => {
+  //   const { result, waitForNextUpdate } = await setup(undefined);
 
-    act(() => {
-      result.current.searchFor('something');
-    });
+  //   const spy = jest
+  //     .fn()
+  //     .mockResolvedValue({ data: { results: [], pagination: { page: 1, pageCount: 2 } } });
+  //   axiosInstance.get = spy;
 
-    await waitForNextUpdate();
+  //   act(() => {
+  //     result.current.searchFor('something');
+  //   });
 
-    act(() => {
-      result.current.search.fetchNextPage();
-    });
+  //   await waitForNextUpdate();
 
-    await waitForNextUpdate();
+  //   act(() => {
+  //     result.current.search.fetchNextPage();
+  //   });
 
-    expect(spy).toBeCalledTimes(2);
-    expect(spy).toHaveBeenNthCalledWith(1, expect.any(String), {
-      params: {
-        _q: 'something',
-        limit: expect.any(Number),
-        page: 1,
-      },
-    });
-    expect(spy).toHaveBeenNthCalledWith(2, expect.any(String), {
-      params: {
-        _q: 'something',
-        limit: expect.any(Number),
-        page: 2,
-      },
-    });
-  });
+  //   await waitForNextUpdate();
 
-  test("doesn not fetch search next page, if there isn't one", async () => {
-    const { result, waitForNextUpdate } = await setup(undefined);
+  //   expect(spy).toBeCalledTimes(2);
+  //   expect(spy).toHaveBeenNthCalledWith(1, expect.any(String), {
+  //     params: {
+  //       _q: 'something',
+  //       limit: expect.any(Number),
+  //       page: 1,
+  //     },
+  //   });
+  //   expect(spy).toHaveBeenNthCalledWith(2, expect.any(String), {
+  //     params: {
+  //       _q: 'something',
+  //       limit: expect.any(Number),
+  //       page: 2,
+  //     },
+  //   });
+  // });
 
-    const spy = jest
-      .fn()
-      .mockResolvedValue({ data: { values: [], pagination: { page: 1, pageCount: 1 } } });
-    axiosInstance.get = spy;
+  // test("does not fetch search next page, if there isn't one", async () => {
+  //   const { result, waitForNextUpdate } = await setup(undefined);
 
-    act(() => {
-      result.current.searchFor('something');
-    });
+  //   const spy = jest.fn().mockResolvedValue({
+  //     data: { results: [], pagination: { page: 1, pageCount: 1 }, spy: 'hello' },
+  //   });
+  //   axiosInstance.get = spy;
 
-    await waitForNextUpdate();
+  //   act(() => {
+  //     result.current.searchFor('something');
+  //   });
 
-    act(() => {
-      result.current.search.fetchNextPage();
-    });
+  //   await waitForNextUpdate();
 
-    await waitForNextUpdate();
+  //   act(() => {
+  //     result.current.search.fetchNextPage();
+  //   });
 
-    expect(spy).toBeCalledTimes(1);
-  });
+  //   await waitForNextUpdate();
+
+  //   expect(spy).toBeCalledTimes(1);
+  // });
 });

--- a/packages/core/admin/admin/src/content-manager/hooks/useRelation/useRelation.js
+++ b/packages/core/admin/admin/src/content-manager/hooks/useRelation/useRelation.js
@@ -44,6 +44,9 @@ export const useRelation = (cacheKey, { relation, search }) => {
       // eslint-disable-next-line consistent-return
       return lastPage.pagination.page + 1;
     },
+    select: (data) => ({
+      pages: data.pages.map((page) => ({ ...page, results: page.results.slice().reverse() })),
+    }),
   });
 
   const searchRes = useInfiniteQuery(

--- a/packages/core/admin/admin/src/content-manager/hooks/useRelation/useRelation.js
+++ b/packages/core/admin/admin/src/content-manager/hooks/useRelation/useRelation.js
@@ -22,15 +22,19 @@ export const useRelation = (cacheKey, { relation, search }) => {
   };
 
   const fetchSearch = async ({ pageParam = 1 }) => {
-    const { data } = await axiosInstance.get(search.endpoint, {
-      params: {
-        ...(search.pageParams ?? {}),
-        ...searchParams,
-        page: pageParam,
-      },
-    });
+    try {
+      const { data } = await axiosInstance.get(search.endpoint, {
+        params: {
+          ...(search.pageParams ?? {}),
+          ...searchParams,
+          page: pageParam,
+        },
+      });
 
-    return data;
+      return data;
+    } catch (err) {
+      return null;
+    }
   };
 
   const relationsRes = useInfiniteQuery(['relation', cacheKey], fetchRelations, {
@@ -45,7 +49,7 @@ export const useRelation = (cacheKey, { relation, search }) => {
       return lastPage.pagination.page + 1;
     },
     select: (data) => ({
-      pages: data.pages.map((page) => ({ ...page, results: page.results.slice().reverse() })),
+      pages: data.pages.map((page) => ({ ...page, results: [...(page.results ?? [])].reverse() })),
     }),
   });
 


### PR DESCRIPTION
## What

The front receives:
```
[
    {
      results: [
        { id: 1, label: 'newest' },
        { id: 2, label: 'second' },
      ],
    },
    {
      results: [
        { id: 3, label: 'third' },
        { id: 4, label: 'oldest' },
      ],
    },
]
```

and needs to display it like this:

```
  [
    {
      results: [
        { id: 4, label: 'oldest' },
        { id: 3, label: 'third' },
      ],
    },
    {
      results: [
        { id: 2, label: 'second' },
        { id: 1, label: 'newest' },
      ],
    },
  ];
```

Updated `normalizeRelations` to reverse arrays of relations and relations inside those arrays
We don't want to reverse relations in `connect` 

## Test

Add at least 7 relations from oldest to newest added
Save
Load relations
See them displayed from latest to newest
Add a new relation
See it displayed at the bottom