### PR TITLE
[fix]: use router link for actions that route places in Content Manager ListView & DynamicTable

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/DynamicTable/TableRows/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/DynamicTable/TableRows/index.js
@@ -1,19 +1,25 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Link, useHistory } from 'react-router-dom';
+import { useIntl } from 'react-intl';
+
 import { BaseCheckbox } from '@strapi/design-system/BaseCheckbox';
 import { Box } from '@strapi/design-system/Box';
 import { IconButton } from '@strapi/design-system/IconButton';
 import { Tbody, Td, Tr } from '@strapi/design-system/Table';
 import { Flex } from '@strapi/design-system/Flex';
+
 import Trash from '@strapi/icons/Trash';
 import Duplicate from '@strapi/icons/Duplicate';
 import Pencil from '@strapi/icons/Pencil';
+
 import { useTracking, stopPropagation, onRowClick } from '@strapi/helper-plugin';
-import { useHistory } from 'react-router-dom';
-import { useIntl } from 'react-intl';
+
 import { usePluginsQueryParams } from '../../../hooks';
-import CellContent from '../CellContent';
+
 import { getFullName } from '../../../../utils';
+
+import CellContent from '../CellContent';
 
 const TableRows = ({
   canCreate,
@@ -100,13 +106,14 @@ const TableRows = ({
               <Td>
                 <Flex justifyContent="end" {...stopPropagation}>
                   <IconButton
+                    forwardedAs={Link}
                     onClick={() => {
                       trackUsage('willEditEntryFromButton');
-                      push({
-                        pathname: `${pathname}/${data.id}`,
-                        state: { from: pathname },
-                        search: pluginsQueryParams,
-                      });
+                    }}
+                    to={{
+                      pathname: `${pathname}/${data.id}`,
+                      state: { from: pathname },
+                      search: pluginsQueryParams,
                     }}
                     label={formatMessage(
                       { id: 'app.component.table.edit', defaultMessage: 'Edit {target}' },
@@ -119,12 +126,11 @@ const TableRows = ({
                   {canCreate && (
                     <Box paddingLeft={1}>
                       <IconButton
-                        onClick={() => {
-                          push({
-                            pathname: `${pathname}/create/clone/${data.id}`,
-                            state: { from: pathname },
-                            search: pluginsQueryParams,
-                          });
+                        forwardedAs={Link}
+                        to={{
+                          pathname: `${pathname}/create/clone/${data.id}`,
+                          state: { from: pathname },
+                          search: pluginsQueryParams,
                         }}
                         label={formatMessage(
                           {
@@ -144,7 +150,6 @@ const TableRows = ({
                       <IconButton
                         onClick={() => {
                           trackUsage('willDeleteEntryFromList');
-
                           onClickDelete(data.id);
                         }}
                         label={formatMessage(

--- a/packages/core/admin/admin/src/content-manager/pages/ListView/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/ListView/index.js
@@ -5,9 +5,11 @@ import { connect } from 'react-redux';
 import isEqual from 'react-fast-compare';
 import { bindActionCreators, compose } from 'redux';
 import { useIntl } from 'react-intl';
-import { useHistory, useLocation } from 'react-router-dom';
+import { useHistory, useLocation, Link as ReactRouterLink } from 'react-router-dom';
 import get from 'lodash/get';
 import { stringify } from 'qs';
+import axios from 'axios';
+
 import {
   NoPermissions,
   CheckPermissions,
@@ -19,31 +21,37 @@ import {
   useTracking,
   Link,
 } from '@strapi/helper-plugin';
+
 import { IconButton } from '@strapi/design-system/IconButton';
 import { Main } from '@strapi/design-system/Main';
 import { Box } from '@strapi/design-system/Box';
 import { ActionLayout, ContentLayout, HeaderLayout } from '@strapi/design-system/Layout';
 import { useNotifyAT } from '@strapi/design-system/LiveRegions';
 import { Button } from '@strapi/design-system/Button';
+
 import ArrowLeft from '@strapi/icons/ArrowLeft';
 import Plus from '@strapi/icons/Plus';
 import Cog from '@strapi/icons/Cog';
-import axios from 'axios';
+
 import { axiosInstance } from '../../../core/utils';
-import { InjectionZone } from '../../../shared/components';
+
 import DynamicTable from '../../components/DynamicTable';
+import AttributeFilter from '../../components/AttributeFilter';
+import { InjectionZone } from '../../../shared/components';
+
 import permissions from '../../../permissions';
+
 import { getRequestUrl, getTrad } from '../../utils';
+
 import FieldPicker from './FieldPicker';
 import PaginationFooter from './PaginationFooter';
 import { getData, getDataSucceeded, onChangeListHeaders, onResetListHeaders } from './actions';
 import makeSelectListView from './selectors';
 import { buildQueryString } from './utils';
-import AttributeFilter from '../../components/AttributeFilter';
 
 const cmPermissions = permissions.contentManager;
 
-const IconButtonCustom = styled(IconButton)`
+const ConfigureLayoutBox = styled(Box)`
   svg {
     path {
       fill: ${({ theme }) => theme.colors.neutral900};
@@ -51,7 +59,6 @@ const IconButtonCustom = styled(IconButton)`
   }
 `;
 
-/* eslint-disable react/no-array-index-key */
 function ListView({
   canCreate,
   canDelete,
@@ -240,16 +247,18 @@ function ListView({
     canCreate ? (
       <Button
         {...props}
+        forwardedAs={ReactRouterLink}
         onClick={() => {
           const trackerProperty = hasDraftAndPublish ? { status: 'draft' } : {};
 
           trackUsageRef.current('willCreateEntry', trackerProperty);
-          push({
-            pathname: `${pathname}/create`,
-            search: query.plugins ? pluginsQueryParams : '',
-          });
+        }}
+        to={{
+          pathname: `${pathname}/create`,
+          search: query.plugins ? pluginsQueryParams : '',
         }}
         startIcon={<Plus />}
+        style={{ textDecoration: 'none' }}
       >
         {formatMessage({
           id: getTrad('HeaderLayout.button.label-add-entry'),
@@ -283,20 +292,20 @@ function ListView({
               <InjectionZone area="contentManager.listView.actions" />
               <FieldPicker layout={layout} />
               <CheckPermissions permissions={cmPermissions.collectionTypesConfigurations}>
-                <Box paddingTop={1} paddingBottom={1}>
-                  <IconButtonCustom
+                <ConfigureLayoutBox paddingTop={1} paddingBottom={1}>
+                  <IconButton
                     onClick={() => {
                       trackUsage('willEditListLayout');
-
-                      push({ pathname: `${slug}/configurations/list`, search: pluginsQueryParams });
                     }}
+                    forwardedAs={ReactRouterLink}
+                    to={{ pathname: `${slug}/configurations/list`, search: pluginsQueryParams }}
                     icon={<Cog />}
                     label={formatMessage({
                       id: 'app.links.configure-view',
                       defaultMessage: 'Configure the view',
                     })}
                   />
-                </Box>
+                </ConfigureLayoutBox>
               </CheckPermissions>
             </>
           }


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* Refactors IconButtons in `DynamicTable` to use `Link` from `react-router-dom` underneath so links are accessible as anchors as opposed to `button`
* Refactors the main `create entry` button in `ListView` to use `Link` from `react-router-dom`

### Why is it needed?

Because it's semantically incorrect to use a button to route somewhere (anchors can have `onClick` events therefore allowing the tracking events to still occur)

### How to test it?

Go to content manager and view table of content

### Related issue(s)/PR(s)

* resolves #10356
