### PR TITLE
Allows TS for database migrations files

### DIFF
--- a/packages/core/database/lib/migrations/index.js
+++ b/packages/core/database/lib/migrations/index.js
@@ -34,7 +34,7 @@ const migrationResolver = ({ name, path, context }) => {
 };
 
 const createUmzugProvider = (db) => {
-  const migrationDir = path.join(strapi.dirs.app.root, 'database/migrations');
+  const migrationDir = path.join(strapi.dirs.dist.root, 'database/migrations');
 
   fse.ensureDirSync(migrationDir);
 


### PR DESCRIPTION
### What does it do?

The change is minimal, I updated the migrations directory to be at the root of the `dist` folder, instead of at the root of the app.
I'm pretty sure, in a JS project `app` and `dist` are identical, so no changes for those projects. For TS projects though if they plan to use JS migrations then they'll need to `allowJs` in their `tsconfig.json`.

### Why is it needed?

It allows us to write migrations files in TypeScript.
The added benefit is that sweet sweet auto-completion:

<img width="352" alt="image" src="https://user-images.githubusercontent.com/16194089/193825154-ace0c3dd-59f2-42ba-b59d-39c23d6411ba.png">

### How to test it?

You can write a migration file in TS, and it will be run during the next startup as expected.

⚠️ One thing I'm unsure about though, the default `tsconfig.json` provided by the `create-strapi-app` command should be configured to transpile the TS files in the `database/migrations` folder. It could already be the case, but I just wanted to point it out because I had my own `tsconfig.json` file.