### PR TITLE
add getNumberOfDraftRelations route

### DIFF
--- a/packages/core/content-manager/server/controllers/collection-types.js
+++ b/packages/core/content-manager/server/controllers/collection-types.js
@@ -261,6 +261,10 @@ module.exports = {
       return ctx.forbidden();
     }
 
-    return entityManager.getNumberOfDraftRelations(id, model);
+    const number = await entityManager.getNumberOfDraftRelations(id, model);
+
+    return {
+      data: number,
+    };
   },
 };

--- a/packages/core/content-manager/server/controllers/collection-types.js
+++ b/packages/core/content-manager/server/controllers/collection-types.js
@@ -239,4 +239,28 @@ module.exports = {
 
     ctx.body = { count };
   },
+
+  async getNumberOfDraftRelations(ctx) {
+    const { userAbility } = ctx.state;
+    const { model, id } = ctx.params;
+
+    const entityManager = getService('entity-manager');
+    const permissionChecker = getService('permission-checker').create({ userAbility, model });
+
+    if (permissionChecker.cannot.read()) {
+      return ctx.forbidden();
+    }
+
+    const entity = await entityManager.findOneWithCreatorRolesAndCount(id, model);
+
+    if (!entity) {
+      return ctx.notFound();
+    }
+
+    if (permissionChecker.cannot.read(entity)) {
+      return ctx.forbidden();
+    }
+
+    return entityManager.getNumberOfDraftRelations(id, model);
+  },
 };

--- a/packages/core/content-manager/server/controllers/single-types.js
+++ b/packages/core/content-manager/server/controllers/single-types.js
@@ -195,6 +195,10 @@ module.exports = {
       return ctx.forbidden();
     }
 
-    return entityManager.getNumberOfDraftRelations(entity.id, model);
+    const number = await entityManager.getNumberOfDraftRelations(entity.id, model);
+
+    return {
+      data: number,
+    };
   },
 };

--- a/packages/core/content-manager/server/controllers/single-types.js
+++ b/packages/core/content-manager/server/controllers/single-types.js
@@ -177,7 +177,7 @@ module.exports = {
 
   async getNumberOfDraftRelations(ctx) {
     const { userAbility } = ctx.state;
-    const { model, id } = ctx.params;
+    const { model } = ctx.params;
 
     const entityManager = getService('entity-manager');
     const permissionChecker = getService('permission-checker').create({ userAbility, model });
@@ -186,8 +186,7 @@ module.exports = {
       return ctx.forbidden();
     }
 
-    const entity = await entityManager.findOneWithCreatorRolesAndCount(id, model);
-
+    const entity = await findEntity({}, model);
     if (!entity) {
       return ctx.notFound();
     }
@@ -196,6 +195,6 @@ module.exports = {
       return ctx.forbidden();
     }
 
-    return entityManager.getNumberOfDraftRelations(id, model);
+    return entityManager.getNumberOfDraftRelations(entity.id, model);
   },
 };

--- a/packages/core/content-manager/server/controllers/single-types.js
+++ b/packages/core/content-manager/server/controllers/single-types.js
@@ -174,4 +174,28 @@ module.exports = {
 
     ctx.body = await permissionChecker.sanitizeOutput(unpublishedEntity);
   },
+
+  async getNumberOfDraftRelations(ctx) {
+    const { userAbility } = ctx.state;
+    const { model, id } = ctx.params;
+
+    const entityManager = getService('entity-manager');
+    const permissionChecker = getService('permission-checker').create({ userAbility, model });
+
+    if (permissionChecker.cannot.read()) {
+      return ctx.forbidden();
+    }
+
+    const entity = await entityManager.findOneWithCreatorRolesAndCount(id, model);
+
+    if (!entity) {
+      return ctx.notFound();
+    }
+
+    if (permissionChecker.cannot.read(entity)) {
+      return ctx.forbidden();
+    }
+
+    return entityManager.getNumberOfDraftRelations(id, model);
+  },
 };

--- a/packages/core/content-manager/server/routes/admin.js
+++ b/packages/core/content-manager/server/routes/admin.js
@@ -184,7 +184,7 @@ module.exports = {
     },
     {
       method: 'GET',
-      path: '/single-types/:model/:id/actions/numberOfDraftRelations',
+      path: '/single-types/:model/actions/numberOfDraftRelations',
       handler: 'single-types.getNumberOfDraftRelations',
       config: {
         middlewares: [routing],

--- a/packages/core/content-manager/server/routes/admin.js
+++ b/packages/core/content-manager/server/routes/admin.js
@@ -184,6 +184,21 @@ module.exports = {
     },
     {
       method: 'GET',
+      path: '/single-types/:model/:id/actions/numberOfDraftRelations',
+      handler: 'single-types.getNumberOfDraftRelations',
+      config: {
+        middlewares: [routing],
+        policies: [
+          'admin::isAuthenticatedAdmin',
+          {
+            name: 'plugin::content-manager.hasPermissions',
+            config: { actions: ['plugin::content-manager.explorer.read'] },
+          },
+        ],
+      },
+    },
+    {
+      method: 'GET',
       path: '/single-types/:model/:id/:targetField',
       handler: 'relations.findExisting',
       config: {
@@ -330,6 +345,21 @@ module.exports = {
           {
             name: 'plugin::content-manager.hasPermissions',
             config: { actions: ['plugin::content-manager.explorer.delete'] },
+          },
+        ],
+      },
+    },
+    {
+      method: 'GET',
+      path: '/collection-types/:model/:id/actions/numberOfDraftRelations',
+      handler: 'collection-types.getNumberOfDraftRelations',
+      config: {
+        middlewares: [routing],
+        policies: [
+          'admin::isAuthenticatedAdmin',
+          {
+            name: 'plugin::content-manager.hasPermissions',
+            config: { actions: ['plugin::content-manager.explorer.read'] },
           },
         ],
       },

--- a/packages/core/content-manager/server/services/utils/draft.js
+++ b/packages/core/content-manager/server/services/utils/draft.js
@@ -4,7 +4,14 @@ const { castArray } = require('lodash/fp');
 const strapiUtils = require('@strapi/utils');
 
 const { hasDraftAndPublish, isVisibleAttribute } = strapiUtils.contentTypes;
-
+/**
+ * sumDraftCounts works recursively on the attributes of a model counting the
+ * number of draft relations
+ * These relations can be direct to this content type or contained within components/dynamic zones
+ * @param {Object} entity containing the draft relation counts
+ * @param {String} uid of the content type
+ * @returns {Number} of draft relations
+ */
 const sumDraftCounts = (entity, uid) => {
   const model = strapi.getModel(uid);
 

--- a/packages/core/content-manager/server/services/utils/draft.js
+++ b/packages/core/content-manager/server/services/utils/draft.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const { castArray } = require('lodash/fp');
+const strapiUtils = require('@strapi/utils');
+
+const { hasDraftAndPublish, isVisibleAttribute } = strapiUtils.contentTypes;
+
+const sumDraftCounts = (entity, uid) => {
+  const model = strapi.getModel(uid);
+
+  return Object.keys(model.attributes).reduce((sum, attributeName) => {
+    const attribute = model.attributes[attributeName];
+    const value = entity[attributeName];
+    if (!value) {
+      return sum;
+    }
+
+    switch (attribute.type) {
+      case 'relation': {
+        const childModel = strapi.getModel(attribute.target);
+        if (hasDraftAndPublish(childModel) && isVisibleAttribute(model, attributeName)) {
+          return sum + value.count;
+        }
+        return sum;
+      }
+      case 'component': {
+        const compoSum = castArray(value).reduce((acc, componentValue) => {
+          return acc + sumDraftCounts(componentValue, attribute.component);
+        }, 0);
+        return sum + compoSum;
+      }
+      case 'dynamiczone': {
+        const dzSum = value.reduce((acc, componentValue) => {
+          return acc + sumDraftCounts(componentValue, componentValue.__component);
+        }, 0);
+        return sum + dzSum;
+      }
+      default:
+        return sum;
+    }
+  }, 0);
+};
+
+module.exports = {
+  sumDraftCounts,
+};

--- a/packages/core/content-manager/server/services/utils/populate.js
+++ b/packages/core/content-manager/server/services/utils/populate.js
@@ -1,0 +1,127 @@
+'use strict';
+
+const { merge, isEmpty } = require('lodash/fp');
+const strapiUtils = require('@strapi/utils');
+
+const { hasDraftAndPublish, isVisibleAttribute } = strapiUtils.contentTypes;
+const { isAnyToMany } = strapiUtils.relations;
+const { PUBLISHED_AT_ATTRIBUTE } = strapiUtils.contentTypes.constants;
+
+const getDeepPopulate = (
+  uid,
+  populate,
+  { onlyMany = false, countMany = false, maxLevel = Infinity } = {},
+  level = 1
+) => {
+  if (populate) {
+    return populate;
+  }
+
+  if (level > maxLevel) {
+    return {};
+  }
+
+  const model = strapi.getModel(uid);
+
+  return Object.keys(model.attributes).reduce((populateAcc, attributeName) => {
+    const attribute = model.attributes[attributeName];
+
+    if (attribute.type === 'relation') {
+      const isManyRelation = isAnyToMany(attribute);
+      // always populate createdBy, updatedBy, localizations etc.
+      if (!isVisibleAttribute(model, attributeName)) {
+        populateAcc[attributeName] = true;
+      } else if (!onlyMany || isManyRelation) {
+        // Only populate one level of relations
+        populateAcc[attributeName] = countMany && isManyRelation ? { count: true } : true;
+      }
+    }
+
+    if (attribute.type === 'component') {
+      populateAcc[attributeName] = {
+        populate: getDeepPopulate(
+          attribute.component,
+          null,
+          { onlyMany, countMany, maxLevel },
+          level + 1
+        ),
+      };
+    }
+
+    if (attribute.type === 'media') {
+      populateAcc[attributeName] = { populate: 'folder' };
+    }
+
+    if (attribute.type === 'dynamiczone') {
+      populateAcc[attributeName] = {
+        populate: (attribute.components || []).reduce((acc, componentUID) => {
+          return merge(
+            acc,
+            getDeepPopulate(componentUID, null, { onlyMany, countMany, maxLevel }, level + 1)
+          );
+        }, {}),
+      };
+    }
+
+    return populateAcc;
+  }, {});
+};
+
+const getDeepPopulateDraftCount = (uid) => {
+  const model = strapi.getModel(uid);
+  let hasRelations = false;
+
+  const populate = Object.keys(model.attributes).reduce((populateAcc, attributeName) => {
+    const attribute = model.attributes[attributeName];
+
+    switch (attribute.type) {
+      case 'relation': {
+        const childModel = strapi.getModel(attribute.target);
+        if (hasDraftAndPublish(childModel) && isVisibleAttribute(model, attributeName)) {
+          populateAcc[attributeName] = {
+            count: true,
+            filters: { [PUBLISHED_AT_ATTRIBUTE]: { $null: true } },
+          };
+          hasRelations = true;
+        }
+        break;
+      }
+      case 'component': {
+        const { populate, hasRelations: childHasRelations } = getDeepPopulateDraftCount(
+          attribute.component
+        );
+        if (childHasRelations) {
+          populateAcc[attributeName] = { populate };
+          hasRelations = true;
+        }
+        break;
+      }
+      case 'dynamiczone': {
+        const dzPopulate = (attribute.components || []).reduce((acc, componentUID) => {
+          const { populate, hasRelations: childHasRelations } =
+            getDeepPopulateDraftCount(componentUID);
+          if (childHasRelations) {
+            hasRelations = true;
+            return merge(acc, populate);
+          }
+          return acc;
+        }, {});
+
+        if (!isEmpty(dzPopulate)) {
+          populateAcc[attributeName] = { populate: dzPopulate };
+        }
+        break;
+      }
+      default:
+    }
+
+    return populateAcc;
+  }, {});
+
+  return { populate, hasRelations };
+};
+
+module.exports = {
+  getDeepPopulate,
+  getDeepPopulateDraftCount,
+};

--- a/packages/core/content-manager/server/services/utils/populate.js
+++ b/packages/core/content-manager/server/services/utils/populate.js
@@ -67,6 +67,15 @@ const getDeepPopulate = (
   }, {});
 };
 
+/**
+ * getDeepPopulateDraftCount works recursively on the attributes of a model
+ * creating a populate object to count all the unpublished relations within the model
+ * These relations can be direct to this content type or contained within components/dynamic zones
+ * @param {String} uid of the model
+ * @returns {Object} result
+ * @returns {Object} result.populate
+ * @returns {Boolean} result.hasRelations
+ */
 const getDeepPopulateDraftCount = (uid) => {
   const model = strapi.getModel(uid);
   let hasRelations = false;

--- a/packages/core/content-manager/server/tests/api/number-of-draft-relations.test.e2e.js
+++ b/packages/core/content-manager/server/tests/api/number-of-draft-relations.test.e2e.js
@@ -7,8 +7,15 @@ const { createAuthRequest } = require('../../../../../../test/helpers/request');
 const builder = createTestBuilder();
 let strapi;
 let rq;
+const data = {
+  categories: [],
+  categoriesdp: {
+    published: [],
+    draft: [],
+  },
+};
 
-const product = {
+const productModel = {
   displayName: 'Product',
   singularName: 'product',
   pluralName: 'products',
@@ -25,6 +32,12 @@ const product = {
       target: 'api::categorydp.categorydp',
       targetAttribute: 'product',
     },
+    onecategorydp: {
+      type: 'relation',
+      relation: 'oneToOne',
+      target: 'api::categorydp.categorydp',
+      targetAttribute: 'oneproduct',
+    },
     categories: {
       type: 'relation',
       relation: 'oneToMany',
@@ -38,6 +51,7 @@ const product = {
     comporep: {
       component: 'default.compo',
       type: 'component',
+      repeatable: true,
     },
     dz: {
       components: ['default.compo'],
@@ -46,7 +60,7 @@ const product = {
   },
 };
 
-const categoryDP = {
+const categoryDPModel = {
   displayName: 'Category Draft & Publish',
   singularName: 'categorydp',
   pluralName: 'categoriesdp',
@@ -54,41 +68,41 @@ const categoryDP = {
   attributes: {
     name: {
       type: 'string',
-      unique: true,
     },
   },
 };
 
-const category = {
+const categoryModel = {
   displayName: 'Category',
   singularName: 'category',
   pluralName: 'categories',
   attributes: {
     name: {
       type: 'string',
-      unique: true,
     },
   },
 };
 
-const compo = {
+const compoModel = {
   displayName: 'compo',
   attributes: {
     name: {
       type: 'string',
-      required: true,
     },
     categoriesdp: {
       type: 'relation',
       relation: 'oneToMany',
       target: 'api::categorydp.categorydp',
-      targetAttribute: 'product',
     },
     categories: {
       type: 'relation',
       relation: 'oneToMany',
       target: 'api::category.category',
-      targetAttribute: 'product',
+    },
+    onecategorydp: {
+      type: 'relation',
+      relation: 'oneToOne',
+      target: 'api::categorydp.categorydp',
     },
   },
 };
@@ -96,13 +110,45 @@ const compo = {
 describe('CM API - Basic', () => {
   beforeAll(async () => {
     await builder
-      .addContentTypes([categoryDP, category])
-      .addComponent(compo)
-      .addContentTypes([product])
+      .addContentTypes([categoryDPModel, categoryModel])
+      .addComponent(compoModel)
+      .addContentTypes([productModel])
       .build();
 
     strapi = await createStrapiInstance();
     rq = await createAuthRequest({ strapi });
+
+    const { body: category } = await rq({
+      method: 'POST',
+      url: '/content-manager/collection-types/api::category.category',
+      body: { name: 'Food' },
+    });
+    data.categories.push(category);
+
+    const { body: categoryPublished } = await rq({
+      method: 'POST',
+      url: '/content-manager/collection-types/api::categorydp.categorydp',
+      body: { name: 'Food' },
+    });
+    await rq({
+      method: 'POST',
+      url: `/content-manager/collection-types/api::categorydp.categorydp/${categoryPublished.id}/actions/publish`,
+    });
+    data.categoriesdp.published.push(categoryPublished);
+
+    const { body: categoryDraft1 } = await rq({
+      method: 'POST',
+      url: '/content-manager/collection-types/api::categorydp.categorydp',
+      body: { name: 'Food' },
+    });
+    data.categoriesdp.draft.push(categoryDraft1);
+
+    const { body: categoryDraft2 } = await rq({
+      method: 'POST',
+      url: '/content-manager/collection-types/api::categorydp.categorydp',
+      body: { name: 'Food' },
+    });
+    data.categoriesdp.draft.push(categoryDraft2);
   });
 
   afterAll(async () => {
@@ -114,8 +160,37 @@ describe('CM API - Basic', () => {
     const { body: product } = await rq({
       method: 'POST',
       url: '/content-manager/collection-types/api::product.product',
+      body: { name: 'Pizza' },
+    });
+
+    const { body } = await rq({
+      method: 'GET',
+      url: `/content-manager/collection-types/api::product.product/${product.id}/actions/numberOfDraftRelations`,
+    });
+
+    expect(body.data).toBe(0);
+  });
+
+  test('Return 0 when only relations without d&p are set', async () => {
+    const { body: product } = await rq({
+      method: 'POST',
+      url: '/content-manager/collection-types/api::product.product',
       body: {
         name: 'Pizza',
+        onecategorydp: data.categories[0].id,
+        categories: [data.categories[0].id],
+        compo: {
+          onecategorydp: data.categories[0].id,
+          categories: [data.categories[0].id],
+        },
+        comporep: [{ categories: [data.categories[0].id], onecategorydp: data.categories[0].id }],
+        dz: [
+          {
+            __component: 'default.compo',
+            categories: [data.categories[0].id],
+            onecategorydp: data.categories[0].id,
+          },
+        ],
       },
     });
 
@@ -125,5 +200,160 @@ describe('CM API - Basic', () => {
     });
 
     expect(body.data).toBe(0);
+  });
+
+  test('Return 0 when relations without d&p are set & published relations only', async () => {
+    const categoryId = data.categories[0].id;
+    const publishedId = data.categoriesdp.published[0].id;
+
+    const { body: product } = await rq({
+      method: 'POST',
+      url: '/content-manager/collection-types/api::product.product',
+      body: {
+        name: 'Pizza',
+        onecategorydp: publishedId,
+        categories: [categoryId],
+        categoriesdp: [publishedId],
+        compo: {
+          onecategorydp: publishedId,
+          categories: [categoryId],
+          categoriesdp: [publishedId],
+        },
+        comporep: [
+          { onecategorydp: publishedId, categories: [categoryId], categoriesdp: [publishedId] },
+        ],
+        dz: [
+          {
+            __component: 'default.compo',
+            onecategorydp: publishedId,
+            categories: [categoryId],
+            categoriesdp: [publishedId],
+          },
+        ],
+      },
+    });
+
+    const { body } = await rq({
+      method: 'GET',
+      url: `/content-manager/collection-types/api::product.product/${product.id}/actions/numberOfDraftRelations`,
+    });
+
+    expect(body.data).toBe(0);
+  });
+
+  test('Return 8 when there are 8 drafts (1 xToOne & 1 xToMany on ct, compo, comporep, dz)', async () => {
+    const categoryId = data.categories[0].id;
+    const draftId = data.categoriesdp.draft[0].id;
+
+    const { body: product } = await rq({
+      method: 'POST',
+      url: '/content-manager/collection-types/api::product.product',
+      body: {
+        name: 'Pizza',
+        onecategorydp: draftId,
+        categories: [categoryId],
+        categoriesdp: [draftId],
+        compo: {
+          onecategorydp: draftId,
+          categories: [categoryId],
+          categoriesdp: [draftId],
+        },
+        comporep: [{ onecategorydp: draftId, categories: [categoryId], categoriesdp: [draftId] }],
+        dz: [
+          {
+            __component: 'default.compo',
+            onecategorydp: draftId,
+            categories: [categoryId],
+            categoriesdp: [draftId],
+          },
+        ],
+      },
+    });
+
+    const { body } = await rq({
+      method: 'GET',
+      url: `/content-manager/collection-types/api::product.product/${product.id}/actions/numberOfDraftRelations`,
+    });
+
+    expect(body.data).toBe(8);
+  });
+
+  test('Return 8 when there are 8 drafts (1 xToOne & 1/2 xToMany on ct, compo, comporep, dz)', async () => {
+    const categoryId = data.categories[0].id;
+    const draftId = data.categoriesdp.draft[0].id;
+
+    const { body: product } = await rq({
+      method: 'POST',
+      url: '/content-manager/collection-types/api::product.product',
+      body: {
+        name: 'Pizza',
+        onecategorydp: draftId,
+        categories: [categoryId],
+        categoriesdp: [draftId, categoryId],
+        compo: {
+          onecategorydp: draftId,
+          categories: [categoryId],
+          categoriesdp: [draftId, categoryId],
+        },
+        comporep: [
+          { onecategorydp: draftId, categories: [categoryId], categoriesdp: [draftId, categoryId] },
+        ],
+        dz: [
+          {
+            onecategorydp: draftId,
+            __component: 'default.compo',
+            categories: [categoryId],
+            categoriesdp: [draftId, categoryId],
+          },
+        ],
+      },
+    });
+
+    const { body } = await rq({
+      method: 'GET',
+      url: `/content-manager/collection-types/api::product.product/${product.id}/actions/numberOfDraftRelations`,
+    });
+
+    expect(body.data).toBe(8);
+  });
+
+  test('Return 12 when there are 12 drafts (1 xToOne & 2 xToMany on ct, compo, comporep, dz)', async () => {
+    const categoryId = data.categories[0].id;
+    const draft1Id = data.categoriesdp.draft[0].id;
+    const draft2Id = data.categoriesdp.draft[1].id;
+
+    const { body: product } = await rq({
+      method: 'POST',
+      url: '/content-manager/collection-types/api::product.product',
+      body: {
+        name: 'Pizza',
+        onecategorydp: draft1Id,
+        categories: [categoryId],
+        categoriesdp: [draft1Id, draft2Id],
+        compo: {
+          onecategorydp: draft1Id,
+          categories: [categoryId],
+          categoriesdp: [draft1Id, draft2Id],
+        },
+        comporep: [
+          { onecategorydp: draft1Id, categories: [categoryId], categoriesdp: [draft1Id, draft2Id] },
+        ],
+        dz: [
+          {
+            onecategorydp: draft1Id,
+            __component: 'default.compo',
+            categories: [categoryId],
+            categoriesdp: [draft1Id, draft2Id],
+          },
+        ],
+      },
+    });
+
+    const { body } = await rq({
+      method: 'GET',
+      url: `/content-manager/collection-types/api::product.product/${product.id}/actions/numberOfDraftRelations`,
+    });
+
+    expect(body.data).toBe(12);
   });
 });

--- a/packages/core/content-manager/server/tests/api/number-of-draft-relations.test.e2e.js
+++ b/packages/core/content-manager/server/tests/api/number-of-draft-relations.test.e2e.js
@@ -1,0 +1,129 @@
+'use strict';
+
+const { createStrapiInstance } = require('../../../../../../test/helpers/strapi');
+const { createTestBuilder } = require('../../../../../../test/helpers/builder');
+const { createAuthRequest } = require('../../../../../../test/helpers/request');
+
+const builder = createTestBuilder();
+let strapi;
+let rq;
+
+const product = {
+  displayName: 'Product',
+  singularName: 'product',
+  pluralName: 'products',
+  description: '',
+  collectionName: '',
+  attributes: {
+    name: {
+      type: 'string',
+      required: true,
+    },
+    categoriesdp: {
+      type: 'relation',
+      relation: 'oneToMany',
+      target: 'api::categorydp.categorydp',
+      targetAttribute: 'product',
+    },
+    categories: {
+      type: 'relation',
+      relation: 'oneToMany',
+      target: 'api::category.category',
+      targetAttribute: 'product',
+    },
+    compo: {
+      component: 'default.compo',
+      type: 'component',
+    },
+    comporep: {
+      component: 'default.compo',
+      type: 'component',
+    },
+    dz: {
+      components: ['default.compo'],
+      type: 'dynamiczone',
+    },
+  },
+};
+
+const categoryDP = {
+  displayName: 'Category Draft & Publish',
+  singularName: 'categorydp',
+  pluralName: 'categoriesdp',
+  draftAndPublish: true,
+  attributes: {
+    name: {
+      type: 'string',
+      unique: true,
+    },
+  },
+};
+
+const category = {
+  displayName: 'Category',
+  singularName: 'category',
+  pluralName: 'categories',
+  attributes: {
+    name: {
+      type: 'string',
+      unique: true,
+    },
+  },
+};
+
+const compo = {
+  displayName: 'compo',
+  attributes: {
+    name: {
+      type: 'string',
+      required: true,
+    },
+    categoriesdp: {
+      type: 'relation',
+      relation: 'oneToMany',
+      target: 'api::categorydp.categorydp',
+      targetAttribute: 'product',
+    },
+    categories: {
+      type: 'relation',
+      relation: 'oneToMany',
+      target: 'api::category.category',
+      targetAttribute: 'product',
+    },
+  },
+};
+
+describe('CM API - Basic', () => {
+  beforeAll(async () => {
+    await builder
+      .addContentTypes([categoryDP, category])
+      .addComponent(compo)
+      .addContentTypes([product])
+      .build();
+
+    strapi = await createStrapiInstance();
+    rq = await createAuthRequest({ strapi });
+  });
+
+  afterAll(async () => {
+    await strapi.destroy();
+    await builder.cleanup();
+  });
+
+  test('Return 0 when no relations are set', async () => {
+    const { body: product } = await rq({
+      method: 'POST',
+      url: '/content-manager/collection-types/api::product.product',
+      body: {
+        name: 'Pizza',
+      },
+    });
+
+    const { body } = await rq({
+      method: 'GET',
+      url: `/content-manager/collection-types/api::product.product/${product.id}/actions/numberOfDraftRelations`,
+    });
+
+    expect(body.data).toBe(0);
+  });
+});

--- a/packages/core/database/lib/query/helpers/populate/apply.js
+++ b/packages/core/database/lib/query/helpers/populate/apply.js
@@ -11,7 +11,7 @@ const { fromRow } = require('../transform');
  * @returns
  */
 const XtoOne = async (input, ctx) => {
-  const { attribute, attributeName, results, populateValue, targetMeta } = input;
+  const { attribute, attributeName, results, populateValue, targetMeta, isCount } = input;
   const { db, qb } = ctx;
 
   const fromTargetRow = (rowOrRows) => fromRow(targetMeta, rowOrRows);
@@ -60,6 +60,41 @@ const XtoOne = async (input, ctx) => {
     const referencedValues = _.uniq(
       results.map((r) => r[referencedColumnName]).filter((value) => !_.isNil(value))
     );
+
+    if (isCount) {
+      if (_.isEmpty(referencedValues)) {
+        results.forEach((result) => {
+          result[attributeName] = { count: 0 };
+        });
+        return;
+      }
+
+      const rows = await qb
+        .init(populateValue)
+        .join({
+          alias,
+          referencedTable: joinTable.name,
+          referencedColumn: joinTable.inverseJoinColumn.name,
+          rootColumn: joinTable.inverseJoinColumn.referencedColumn,
+          rootTable: qb.alias,
+          on: joinTable.on,
+        })
+        .select([joinColAlias, qb.raw('count(*) AS count')])
+        .where({ [joinColAlias]: referencedValues })
+        .groupBy(joinColAlias)
+        .execute({ mapResults: false });
+
+      const map = rows.reduce((map, row) => {
+        map[row[joinColumnName]] = { count: Number(row.count) };
+        return map;
+      }, {});
+
+      results.forEach((result) => {
+        result[attributeName] = map[result[referencedColumnName]] || { count: 0 };
+      });
+
+      return;
+    }
 
     if (_.isEmpty(referencedValues)) {
       results.forEach((result) => {


### PR DESCRIPTION
### What does it do?

Add a Content-Manager route to get the number of draft relations an entity has.

### Why is it needed?

To display a warning message to the user in case they wants to publish an entity that is still linked to draft entities

### Additional informations
Tests will be added later
