### PR TITLE
Updating koa/cors to 3.4.2 in order to fix cors filter origin problem #14357

### DIFF
--- a/packages/core/strapi/package.json
+++ b/packages/core/strapi/package.json
@@ -78,7 +78,7 @@
     "test:unit": "jest --verbose"
   },
   "dependencies": {
-    "@koa/cors": "3.4.1",
+    "@koa/cors": "3.4.2",
     "@koa/router": "10.1.1",
     "@strapi/admin": "4.4.3",
     "@strapi/database": "4.4.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2478,7 +2478,14 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@koa/cors@3.4.1", "@koa/cors@^3.1.0":
+"@koa/cors@3.4.2":
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/@koa/cors/-/cors-3.4.2.tgz#70c13e5843d1762ce78fd8767162cd916132c946"
+  integrity sha512-NJU7/+h9XAfw/W/dLadDg8JYrQ5EDxstBl9a9G0A++EqvrQpabWcZ4tBxOdW57QjketX66zkOcXE+5V7IjLWYA==
+  dependencies:
+    vary "^1.1.2"
+
+"@koa/cors@^3.1.0":
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/@koa/cors/-/cors-3.4.1.tgz#ddd5c6ff07a1e60831e1281411a3b9fdb95a5b26"
   integrity sha512-/sG9NlpGZ/aBpnRamIlGs+wX+C/IJ5DodNK7iPQIVCG4eUQdGeshGhWQ6JCi7tpnD9sCtFXcS04iTimuaJfh4Q==


### PR DESCRIPTION
Updating koa/cors to 3.4.2 in order to fix cors filter origin problem  #14357

There was a bug that is fixed on koa/cors 3.4.2 version.


Fixes #14357

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests (ok)
- Create or update the documentation at https://github.com/strapi/documentation (ok)
- Refer to the issue you are closing in the PR description: Fix #14357 (OK) 
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR) (done)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?
In order to fix #14357 I had to fix another bug on koa/cors, as my PR was merged -> https://github.com/koajs/cors/pull/87 I'm creating this PR in order to update the lib

### Why is it needed?
Koa/cors was not calling origin middleware when the origin header was not present. Hence, even when you set credentials as false, the middleware was not called and people could not get Access-Control-Allow-Origin as '*'.

### How to test it?

Set credentials as false on config/middlewares.js, call any API in order to retrive Access-Control-Allow-Origin as '*' as DEFAULT.

```
{
    name: 'strapi::cors',
    config: {
      credentials: false,
    },
  },
```

### Related issue(s)/PR(s)

Fix  #14357

Please, could you add https://hacktoberfest.com/ label?

