### PR TITLE
i18n: Inject i18n queryInfos for relations

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/RelationInputDataManager.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/RelationInputDataManager.js
@@ -3,7 +3,7 @@ import React, { memo, useEffect, useMemo } from 'react';
 import { useIntl } from 'react-intl';
 import get from 'lodash/get';
 
-import { useCMEditViewDataManager, NotAllowedInput, useQueryParams } from '@strapi/helper-plugin';
+import { useCMEditViewDataManager, NotAllowedInput } from '@strapi/helper-plugin';
 
 import { RelationInput } from '../RelationInput';
 import { useRelation } from '../../hooks/useRelation';
@@ -31,15 +31,12 @@ export const RelationInputDataManager = ({
   const { formatMessage } = useIntl();
   const { connectRelation, disconnectRelation, loadRelation, modifiedData, slug, initialData } =
     useCMEditViewDataManager();
-  const [{ query }] = useQueryParams();
-
   const { relations, search, searchFor } = useRelation(`${slug}-${name}-${initialData?.id ?? ''}`, {
     relation: {
       enabled: get(initialData, name)?.count !== 0 && !!endpoints.relation,
       endpoint: endpoints.relation,
       pageParams: {
         ...defaultParams,
-        locale: query?.plugins?.i18n?.locale,
         pageSize: RELATIONS_TO_DISPLAY,
       },
     },
@@ -49,7 +46,6 @@ export const RelationInputDataManager = ({
       pageParams: {
         ...defaultParams,
         entityId: isCreatingEntry ? undefined : initialData.id,
-        locale: query?.plugins?.i18n?.locale,
         pageSize: SEARCH_RESULTS_TO_DISPLAY,
       },
     },
@@ -126,8 +122,7 @@ export const RelationInputDataManager = ({
 
   const handleOpenSearch = () => {
     searchFor('', {
-      idsToInclude:
-        !isCreatingEntry && relationsFromModifiedData?.disconnect?.map((relation) => relation.id),
+      idsToInclude: relationsFromModifiedData?.disconnect?.map((relation) => relation.id),
       idsToOmit: relationsFromModifiedData?.connect?.map((relation) => relation.id),
     });
   };

--- a/packages/plugins/i18n/admin/src/contentManagerHooks/mutateEditViewLayout.js
+++ b/packages/plugins/i18n/admin/src/contentManagerHooks/mutateEditViewLayout.js
@@ -5,16 +5,24 @@ import StrikedWorld from '@strapi/icons/EarthStriked';
 import LabelAction from '../components/LabelAction';
 import { getTrad } from '../utils';
 
-const enhanceEditLayout = (layout) =>
+const getRelationFieldQueryInfos = (field, currentLocale) => ({
+  queryInfos: {
+    ...field.queryInfos,
+    defaultParams: { ...field.queryInfos.defaultParams, locale: currentLocale },
+    paramsToKeep: ['plugins.i18n.locale'],
+  },
+});
+
+const shouldLocalizeRelationField = (field) =>
+  field?.fieldSchema?.type === 'relation' && field?.targetModelPluginOptions?.i18n?.localized;
+
+const enhanceEditLayout = (layout, currentLocale) =>
   layout.map((row) => {
     const enhancedRow = row.reduce((acc, field) => {
-      const type = get(field, ['fieldSchema', 'type'], null);
-      const hasI18nEnabled = get(
-        field,
-        ['fieldSchema', 'pluginOptions', 'i18n', 'localized'],
-        type === 'uid'
-      );
-
+      const type = field?.fieldSchema?.type ?? null;
+      // uid and relation fields are always localized
+      const hasI18nEnabled =
+        field?.fieldSchema?.pluginOptions?.i18n?.localized ?? ['uid', 'relation'].includes(type);
       const labelActionProps = {
         title: {
           id: hasI18nEnabled ? getTrad('Field.localized') : getTrad('Field.not-localized'),
@@ -24,8 +32,19 @@ const enhanceEditLayout = (layout) =>
         },
         icon: hasI18nEnabled ? <I18N aria-hidden /> : <StrikedWorld aria-hidden />,
       };
+      const labelAction = <LabelAction {...labelActionProps} />;
 
-      acc.push({ ...field, labelAction: <LabelAction {...labelActionProps} /> });
+      if (shouldLocalizeRelationField(field)) {
+        acc.push({
+          ...field,
+          labelAction,
+          ...getRelationFieldQueryInfos(field, currentLocale),
+        });
+
+        return acc;
+      }
+
+      acc.push({ ...field, labelAction });
 
       return acc;
     }, []);
@@ -54,22 +73,13 @@ const enhanceComponentsLayout = (components, locale) => {
 const enhanceComponentLayoutForRelations = (layout, locale) =>
   layout.map((row) => {
     const enhancedRow = row.reduce((acc, field) => {
-      if (
-        get(field, ['fieldSchema', 'type']) === 'relation' &&
-        get(field, ['targetModelPluginOptions', 'i18n', 'localized'], false)
-      ) {
-        const queryInfos = {
-          ...field.queryInfos,
-          defaultParams: { ...field.queryInfos.defaultParams, locale },
-          paramsToKeep: ['plugins.i18n.locale'],
-        };
-
-        acc.push({ ...field, queryInfos });
+      if (shouldLocalizeRelationField(field)) {
+        acc.push({ ...field, ...getRelationFieldQueryInfos(field, locale) });
 
         return acc;
       }
 
-      acc.push({ ...field });
+      acc.push(field);
 
       return acc;
     }, []);
@@ -99,7 +109,7 @@ const mutateEditViewLayoutHook = ({ layout, query }) => {
 
   const editLayoutPath = getPathToContentType(['layouts', 'edit']);
   const editLayout = get(layout, editLayoutPath);
-  const nextEditLayout = enhanceEditLayout(editLayout);
+  const nextEditLayout = enhanceEditLayout(editLayout, currentLocale);
 
   const enhancedLayouts = {
     ...layout.contentType.layouts,

--- a/packages/plugins/i18n/admin/src/contentManagerHooks/tests/mutateEditViewLayout.test.js
+++ b/packages/plugins/i18n/admin/src/contentManagerHooks/tests/mutateEditViewLayout.test.js
@@ -55,7 +55,7 @@ describe('i18n | contentManagerHooks | mutateEditViewLayout', () => {
   });
 
   describe('enhanceComponentsLayout', () => {
-    it('should not enhance the field when the type is not relation', () => {
+    it('should not enhance the field', () => {
       const components = {
         test: {
           test: true,
@@ -69,6 +69,10 @@ describe('i18n | contentManagerHooks | mutateEditViewLayout', () => {
                 {
                   name: 'content',
                   fieldSchema: { type: 'string' },
+                },
+                {
+                  name: 'relation',
+                  fieldSchema: { type: 'relation' },
                 },
               ],
             ],
@@ -88,6 +92,10 @@ describe('i18n | contentManagerHooks | mutateEditViewLayout', () => {
                 {
                   name: 'content',
                   fieldSchema: { type: 'string' },
+                },
+                {
+                  name: 'relation',
+                  fieldSchema: { type: 'relation' },
                 },
               ],
             ],
@@ -268,6 +276,13 @@ describe('i18n | contentManagerHooks | mutateEditViewLayout', () => {
               type: 'uid',
             },
           },
+          {
+            name: 'relation',
+            size: 6,
+            fieldSchema: {
+              type: 'relation',
+            },
+          },
         ],
       ];
       const expected = [
@@ -315,10 +330,23 @@ describe('i18n | contentManagerHooks | mutateEditViewLayout', () => {
               />
             ),
           },
+          {
+            name: 'relation',
+            size: 6,
+            fieldSchema: {
+              type: 'relation',
+            },
+            labelAction: (
+              <LabelAction
+                title={{ id: localizedTrad, defaultMessage: localizedTradDefaultMessage }}
+                icon={<I18N aria-hidden />}
+              />
+            ),
+          },
         ],
       ];
 
-      expect(enhanceEditLayout(edit)).toEqual(expected);
+      expect(enhanceEditLayout(edit, 'en')).toEqual(expected);
     });
 
     it('should add the label icon to all fields with the not localized translation when i18n is disabled', () => {
@@ -340,6 +368,16 @@ describe('i18n | contentManagerHooks | mutateEditViewLayout', () => {
             fieldSchema: {
               pluginOptions: { i18n: { localized: false } },
               type: 'string',
+            },
+          },
+        ],
+        [
+          {
+            name: 'relation',
+            size: 6,
+            fieldSchema: {
+              pluginOptions: { i18n: { localized: false } },
+              type: 'relation',
             },
           },
         ],
@@ -377,9 +415,26 @@ describe('i18n | contentManagerHooks | mutateEditViewLayout', () => {
             ),
           },
         ],
+
+        [
+          {
+            name: 'relation',
+            size: 6,
+            fieldSchema: {
+              pluginOptions: { i18n: { localized: false } },
+              type: 'relation',
+            },
+            labelAction: (
+              <LabelAction
+                title={{ id: notLocalizedTrad, defaultMessage: notLocalizedTradDefaultMessage }}
+                icon={<StrikedWorld aria-hidden />}
+              />
+            ),
+          },
+        ],
       ];
 
-      expect(enhanceEditLayout(edit)).toEqual(expected);
+      expect(enhanceEditLayout(edit, 'en')).toEqual(expected);
     });
   });
 });


### PR DESCRIPTION
### What does it do?

Currently, the i18n plugin does not inject `queryInfos` for relational fields in the main layout if they are not part of a component. This PR adds the required properties to the i18n plugin.

### Why is it needed?

To properly support i18n and to not hard-code knowledge about the i18n plugin in the CM. Plugins inject their properties into the main app and the main app shouldn't have any knowledge about the plugins.

- https://strapi-inc.atlassian.net/browse/CONTENT-538
