### PR TITLE
Add file ID to Asset Edit View in Upload plugin

### DIFF
--- a/packages/core/upload/admin/src/components/EditAssetDialog/index.js
+++ b/packages/core/upload/admin/src/components/EditAssetDialog/index.js
@@ -229,7 +229,7 @@ export const EditAssetDialog = ({
                         {
                           label: formatMessage({
                             id: getTrad('modal.file-details.id'),
-                            defaultMessage: 'File ID',
+                            defaultMessage: 'Asset ID',
                           }),
                           value: asset.id,
                         },

--- a/packages/core/upload/admin/src/components/EditAssetDialog/index.js
+++ b/packages/core/upload/admin/src/components/EditAssetDialog/index.js
@@ -225,6 +225,14 @@ export const EditAssetDialog = ({
                           }),
                           value: getFileExtension(asset.ext),
                         },
+
+                        {
+                          label: formatMessage({
+                            id: getTrad('modal.file-details.id'),
+                            defaultMessage: 'File ID',
+                          }),
+                          value: asset.id,
+                        },
                       ]}
                     />
 

--- a/packages/core/upload/admin/src/components/EditAssetDialog/tests/__snapshots__/EditAssetDialog.test.js.snap
+++ b/packages/core/upload/admin/src/components/EditAssetDialog/tests/__snapshots__/EditAssetDialog.test.js.snap
@@ -1290,6 +1290,29 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
                               </div>
                             </div>
                           </div>
+                          <div
+                            class="c13"
+                          >
+                            <div
+                              class=""
+                            >
+                              <div
+                                class="c25 c28"
+                                spacing="1"
+                              >
+                                <span
+                                  class="c29"
+                                >
+                                  Asset ID
+                                </span>
+                                <span
+                                  class="c30"
+                                >
+                                  8
+                                </span>
+                              </div>
+                            </div>
+                          </div>
                         </div>
                       </div>
                       <div>

--- a/packages/core/upload/admin/src/components/EditAssetDialog/tests/__snapshots__/index.test.js.snap
+++ b/packages/core/upload/admin/src/components/EditAssetDialog/tests/__snapshots__/index.test.js.snap
@@ -1290,6 +1290,29 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
                               </div>
                             </div>
                           </div>
+                          <div
+                            class="c13"
+                          >
+                            <div
+                              class=""
+                            >
+                              <div
+                                class="c25 c28"
+                                spacing="1"
+                              >
+                                <span
+                                  class="c29"
+                                >
+                                  Asset ID
+                                </span>
+                                <span
+                                  class="c30"
+                                >
+                                  8
+                                </span>
+                              </div>
+                            </div>
+                          </div>
                         </div>
                       </div>
                       <div>

--- a/packages/core/upload/admin/src/translations/en.json
+++ b/packages/core/upload/admin/src/translations/en.json
@@ -64,6 +64,7 @@
   "modal.file-details.dimensions": "Dimensions",
   "modal.file-details.extension": "Extension",
   "modal.file-details.size": "Size",
+  "modal.file-details.id": "Asset ID",
   "modal.folder.elements.count": "{folderCount} folders, {assetCount} assets",
   "modal.header.browse": "Upload assets",
   "modal.header.file-detail": "Details",


### PR DESCRIPTION
## What this PR does

- [x] Adds the `File ID` to the edit view dialog in the upload plugin

## How to test

- Upload a file
- Check right side in the file attributes to see `File ID` and the internal integer ID