### PR TITLE
useRelation: Disable query cache for relations

### DIFF
--- a/packages/core/admin/admin/src/content-manager/hooks/useRelation/useRelation.js
+++ b/packages/core/admin/admin/src/content-manager/hooks/useRelation/useRelation.js
@@ -38,6 +38,7 @@ export const useRelation = (cacheKey, { relation, search }) => {
   };
 
   const relationsRes = useInfiniteQuery(['relation', cacheKey], fetchRelations, {
+    cacheTime: 0,
     enabled: relation.enabled,
     getNextPageParam(lastPage) {
       // the API may send an empty 204 response


### PR DESCRIPTION
### What does it do?

Disables the query cache when fetching relations.

### Why is it needed?

Every load of an entity should give the user a fresh set of data, which we can achieve by disabling the cache.

### How to test it?

1. Create more than 10 relations
2. Navigate to list view
3. Navigate back to the entity
4. Validate the `RelationInput` component is in the default state

### Related issue(s)/PR(s)

- https://strapi-inc.atlassian.net/browse/CONTENT-551
