### PR TITLE
Use transformLoadParamsToQuery instead of transformParamsToQuery to f…

### DIFF
--- a/packages/core/content-manager/server/controllers/relations.js
+++ b/packages/core/content-manager/server/controllers/relations.js
@@ -192,12 +192,19 @@ module.exports = {
     };
 
     if (isAnyToMany(attribute)) {
-      const res = await strapi.entityService.loadPages(sourceModelUid, { id }, targetField, {
-        ...queryParams,
-        page: query.page,
-        pageSize: query.pageSize,
-        ordering: 'desc',
-      });
+      const res = await strapi.entityService.loadPages(
+        sourceModelUid,
+        { id },
+        targetField,
+        {
+          ...queryParams,
+          ordering: 'desc',
+        },
+        {
+          page: query.page,
+          pageSize: query.pageSize,
+        }
+      );
 
       ctx.body = res;
     } else {

--- a/packages/core/content-manager/server/tests/find-existing-relations.test.e2e.js
+++ b/packages/core/content-manager/server/tests/find-existing-relations.test.e2e.js
@@ -193,13 +193,13 @@ describe.each([false, true])('Relations, with d&p: %s', (withDraftAndPublish) =>
           expect(res.body.results).toMatchObject([
             {
               id: expect.any(Number),
-              name: 'Skate',
-              ...addPublishedAtCheck(expect.any(String)),
+              name: 'Candle',
+              ...addPublishedAtCheck(null),
             },
             {
               id: expect.any(Number),
-              name: 'Candle',
-              ...addPublishedAtCheck(null),
+              name: 'Skate',
+              ...addPublishedAtCheck(expect.any(String)),
             },
           ]);
         } else {
@@ -235,13 +235,13 @@ describe.each([false, true])('Relations, with d&p: %s', (withDraftAndPublish) =>
           expect(res.body.results).toMatchObject([
             {
               id: expect.any(Number),
-              name: 'Skate',
-              ...addPublishedAtCheck(expect.any(String)),
+              name: 'Candle',
+              ...addPublishedAtCheck(null),
             },
             {
               id: expect.any(Number),
-              name: 'Candle',
-              ...addPublishedAtCheck(null),
+              name: 'Skate',
+              ...addPublishedAtCheck(expect.any(String)),
             },
           ]);
         });
@@ -267,13 +267,13 @@ describe.each([false, true])('Relations, with d&p: %s', (withDraftAndPublish) =>
           expect(res.body.results).toMatchObject([
             {
               id: expect.any(Number),
-              name: 'Skate',
-              ...addPublishedAtCheck(expect.any(String)),
+              name: 'Candle',
+              ...addPublishedAtCheck(null),
             },
             {
               id: expect.any(Number),
-              name: 'Candle',
-              ...addPublishedAtCheck(null),
+              name: 'Skate',
+              ...addPublishedAtCheck(expect.any(String)),
             },
           ]);
         } else {

--- a/packages/core/database/lib/query/helpers/populate/apply.js
+++ b/packages/core/database/lib/query/helpers/populate/apply.js
@@ -543,17 +543,15 @@ const morphToOne = async (input, ctx) => {
 };
 
 //  TODO: Omit limit & offset to avoid needing a query per result to avoid making too many queries
-const pickPopulateParams = _.pick([
-  'select',
-  'count',
-  'where',
-  'populate',
-  'orderBy',
-  'limit',
-  'offset',
-  'filters',
-  'ordering',
-]);
+const pickPopulateParams = (populate) => {
+  const fieldsToPick = ['select', 'count', 'where', 'populate', 'orderBy', 'filters', 'ordering'];
+
+  if (populate.count !== true) {
+    fieldsToPick.push('limit', 'offset');
+  }
+
+  return _.pick(fieldsToPick, populate);
+};
 
 const applyPopulate = async (results, populate, ctx) => {
   const { db, uid, qb } = ctx;

--- a/packages/core/utils/lib/convert-query-params.js
+++ b/packages/core/utils/lib/convert-query-params.js
@@ -49,6 +49,10 @@ const convertCountQueryParams = (countQuery) => {
   return parseType({ type: 'boolean', value: countQuery });
 };
 
+const convertOrderingQueryParams = (ordering) => {
+  return ordering;
+};
+
 /**
  * Sort query parser
  * @param {string} sortQuery - ex: id:asc,price:desc
@@ -248,7 +252,7 @@ const convertNestedPopulate = (subPopulate, schema) => {
   }
 
   // TODO: We will need to consider a way to add limitation / pagination
-  const { sort, filters, fields, populate, count } = subPopulate;
+  const { sort, filters, fields, populate, count, ordering } = subPopulate;
 
   const query = {};
 
@@ -270,6 +274,10 @@ const convertNestedPopulate = (subPopulate, schema) => {
 
   if (count) {
     query.count = convertCountQueryParams(count);
+  }
+
+  if (ordering) {
+    query.ordering = convertOrderingQueryParams(ordering);
   }
 
   return query;


### PR DESCRIPTION
### What does it do?

Allow `ordering` param in subPopulates.

### Why is it needed?

Fix the loadPages function as `ordering` argument was ignored.
