### PR TITLE
Admin panel: enable typescript plugins installed from npm

### DIFF
--- a/packages/core/admin/webpack.config.js
+++ b/packages/core/admin/webpack.config.js
@@ -82,7 +82,6 @@ module.exports = ({
           test: /\.tsx?$/,
           loader: require.resolve('esbuild-loader'),
           include: [cacheDir, ...pluginsPath],
-          exclude: /node_modules/,
           options: {
             loader: 'tsx',
             target: 'es2015',

--- a/packages/core/admin/webpack.config.js
+++ b/packages/core/admin/webpack.config.js
@@ -81,7 +81,17 @@ module.exports = ({
         {
           test: /\.tsx?$/,
           loader: require.resolve('esbuild-loader'),
-          include: [cacheDir, ...pluginsPath],
+          include: pluginsPath,
+          options: {
+            loader: 'tsx',
+            target: 'es2015',
+          },
+        },
+        {
+          test: /\.tsx?$/,
+          loader: require.resolve('esbuild-loader'),
+          include: [cacheDir],
+          exclude: /node_modules/,
           options: {
             loader: 'tsx',
             target: 'es2015',


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Fix: #14558 
Removed unnecessary webpack configuration from `.tsx` files loader.

### Why is it needed?

Plugins written in typescript should be able to load from `node_modules` as well as these loaded from `src/plugins/`

### How to test it?

See: #14558
After modifying strapi source code in reproduction example, it seems to work:
![image](https://user-images.githubusercontent.com/67923777/194756261-4c82a146-ccef-4b3a-a4e4-698975ec0aef.png)
![image](https://user-images.githubusercontent.com/67923777/194756243-a7a3590d-6e0e-4bf0-b549-161fb25ad0dd.png)

Unfortunately, I was not able to test this change locally, because admin panel build command throws an error in an unexpected place
![image](https://user-images.githubusercontent.com/67923777/194756327-4e7c5468-8722-42ca-bbb0-7002d4b91dcb.png)

### Related issue(s)/PR(s)

Fix: #14558 