### PR TITLE
[fix][Relations]: flash of old content after submitting

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/utils/normalizeRelations.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/utils/normalizeRelations.js
@@ -23,43 +23,68 @@ export const normalizeRelation = (relation, { shouldAddLink, mainFieldName, targ
 };
 
 /*
+
+ */
+
+/**
  * Applies some transformations to existing and new relations in order to display them correctly
- * relations: raw relations data coming from useRelations
- * shouldAddLink: comes from generateRelationQueryInfos, if true we display a link to the relation (TO FIX: explanation)
+ *
+ * @param {{ data?: { pages?: [{results: []}] } }} relations - raw relations data coming from useRelations
+ * @param {{ modifiedData?: { connect: [], disconnect: [] }, shouldAddLink?: boolean, mainFieldName: string, targetModel: string }} options
+ *
+ * shouldAddLink: comes from generateRelationQueryInfos, if true we display a link to the relation (TODO:: explanation)
  * mainFieldName: name of the main field inside the relation (e.g. text field), if no displayable main field exists (e.g. date field) we use the id of the entry
  * targetModel: the model on which the relation is based on, used to create an URL link
  */
-
 export const normalizeRelations = (
   relations,
   { modifiedData = {}, shouldAddLink = false, mainFieldName, targetModel }
 ) => {
+  const { data } = relations;
+  const { pages: relationsPages = [] } = data ?? {};
+
+  const { connect = [], disconnect = [], results: modifiedDataResults = [] } = modifiedData;
+
+  const [initialRelationsPage] = relationsPages;
+
+  /**
+   * When relations are mutated and updated in the document, the current "fetched" version is
+   * temporarily out of date (whilst being fetched), so we use the modifiedData to render the relations
+   * until the `relations` data is in sync with the browser data.
+   */
+  const mismatchInRelations =
+    modifiedDataResults.length > 0 &&
+    initialRelationsPage &&
+    Array.isArray(initialRelationsPage.results) &&
+    initialRelationsPage.results.length !== modifiedDataResults.length;
+
+  /**
+   * So, depending on the above boolean, we either use the modifiedData or the relations data
+   */
+  const pagesToMutate = mismatchInRelations
+    ? [{ results: modifiedDataResults }]
+    : [...relationsPages.reverse(), ...(connect.length > 0 ? [{ results: connect }] : [])];
+
   return {
     ...relations,
     data: {
-      pages:
-        [
-          ...(relations?.data?.pages.reverse() ?? []),
-          ...(modifiedData?.connect ? [{ results: modifiedData.connect }] : []),
-        ]
-          ?.map((page) =>
-            page?.results
-              .filter(
-                (relation) =>
-                  !modifiedData?.disconnect?.find(
-                    (disconnectRelation) => disconnectRelation.id === relation.id
-                  )
-              )
-              .map((relation) =>
-                normalizeRelation(relation, {
-                  shouldAddLink,
-                  mainFieldName,
-                  targetModel,
-                })
-              )
-              .filter(Boolean)
-          )
-          ?.filter((page) => page.length > 0) ?? [],
+      pages: pagesToMutate
+        .map((page) =>
+          page.results
+            .filter(
+              (relation) =>
+                !disconnect.find((disconnectRelation) => disconnectRelation.id === relation.id)
+            )
+            .map((relation) =>
+              normalizeRelation(relation, {
+                shouldAddLink,
+                mainFieldName,
+                targetModel,
+              })
+            )
+            .filter(Boolean)
+        )
+        .filter((page) => page.length > 0),
     },
   };
 };


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

This checks when we have `results` inside the `modifiedData` if the length is equal to that of the passed `relations` from our query and if they are not equal, use the browser's data temporarily until it's back in sync to avoid flashes of old data.
This also creates layout shifts which should be actively discouraged.

### Why is it needed?

Because the flash in the UI is confusing and looks broken and no other input component does this. The other reason is the query hook doesn't refresh till after the first paint post submitting and receiving the updated data from the server & because the fetch is client side.

### How to test it?

* Add three relations
* Save document
* Remove 2 relations
* Save document (there should be no change in the relations list)

### Related issue(s)/PR(s)

CONTENT-545
