### PR TITLE
CM: Update endpoint where to load relations from

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/DynamicTable/CellContent/RelationMultiple/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/DynamicTable/CellContent/RelationMultiple/index.js
@@ -31,9 +31,10 @@ const fetchRelation = async (endPoint, notifyStatus) => {
 const RelationMultiple = ({ fieldSchema, metadatas, name, entityId, value, contentType }) => {
   const { formatMessage } = useIntl();
   const { notifyStatus } = useNotifyAT();
-  const relationFetchEndpoint = useMemo(() => {
-    return getRequestUrl(`collection-types/${contentType.uid}/${entityId}/${name.split('.')[0]}`);
-  }, [entityId, name, contentType]);
+  const relationFetchEndpoint = useMemo(
+    () => getRequestUrl(`relations/${contentType.uid}/${entityId}/${name.split('.')[0]}`),
+    [entityId, name, contentType]
+  );
   const [isOpen, setIsOpen] = useState(false);
 
   const Label = (
@@ -106,7 +107,7 @@ const RelationMultiple = ({ fieldSchema, metadatas, name, entityId, value, conte
                   defaultMessage: 'This relation contains more entities than displayed',
                 })}
               >
-                <Typography>...</Typography>
+                <Typography>…</Typography>
               </MenuItem>
             )}
           </>


### PR DESCRIPTION
### What does it do?

When the endpoint, where relations are being fetched from, was updated, the list view was forgotten. This PR updates the endpoint.

### Why is it needed?

In the list view of the CM, relational fields can be previewed. To keep that functionality we need to fetch them from a proper endpoint.
