### PR TITLE
RelationInputDataManager: Add tests for component id in select

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/utils/tests/select.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/utils/tests/select.test.js
@@ -234,4 +234,48 @@ describe('RelationInputDataManager | select', () => {
       },
     });
   });
+
+  test('returns a component ID', async () => {
+    useCMEditViewDataManager.mockReturnValueOnce({
+      ...CM_DATA_FIXTURE,
+      isCreatingEntry: false,
+      initialData: {
+        repComp: [
+          {
+            id: 1,
+          },
+        ],
+      },
+    });
+
+    const { result } = await setup({
+      ...SELECT_ATTR_FIXTURE,
+      name: 'repComp.0.field-name',
+      componentUid: 'basic.comp-relation',
+    });
+
+    expect(result.current.componentId).toBe(1);
+  });
+
+  test('does not return a component ID if no component UID was passed', async () => {
+    useCMEditViewDataManager.mockReturnValueOnce({
+      ...CM_DATA_FIXTURE,
+      isCreatingEntry: false,
+      initialData: {
+        repComp: [
+          {
+            id: 1,
+          },
+        ],
+      },
+    });
+
+    const { result } = await setup({
+      ...SELECT_ATTR_FIXTURE,
+      name: 'repComp.0.field-name',
+      componentUid: null,
+    });
+
+    expect(result.current.componentId).toBeUndefined();
+  });
 });


### PR DESCRIPTION
### What does it do?

Adds a test for generating component IDs in select.

### Why is it needed?

You know ... tests.