### PR TITLE
RelationInputDataManager: Add integration tests

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/RelationInput/RelationInput.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInput/RelationInput.js
@@ -61,9 +61,9 @@ const RelationInput = ({
   labelLoadMore,
   labelDisconnectRelation,
   loadingMessage,
-  onRelationAdd,
+  onRelationConnect,
   onRelationLoadMore,
-  onRelationRemove,
+  onRelationDisconnect,
   onSearchClose,
   onSearchNextPage,
   onSearchOpen,
@@ -234,7 +234,7 @@ const RelationInput = ({
               loadingMessage={loadingMessage}
               onChange={(relation) => {
                 setValue(null);
-                onRelationAdd(relation);
+                onRelationConnect(relation);
 
                 // scroll to the end of the list
                 if (relations.length > 0) {
@@ -297,7 +297,7 @@ const RelationInput = ({
                       data-testid={`remove-relation-${id}`}
                       disabled={disabled}
                       type="button"
-                      onClick={() => onRelationRemove(data[index])}
+                      onClick={() => onRelationDisconnect(data[index])}
                       aria-label={labelDisconnectRelation}
                     >
                       <Icon width="12px" as={Cross} />
@@ -406,8 +406,8 @@ RelationInput.propTypes = {
   loadingMessage: PropTypes.func.isRequired,
   name: PropTypes.string.isRequired,
   numberOfRelationsToDisplay: PropTypes.number.isRequired,
-  onRelationAdd: PropTypes.func.isRequired,
-  onRelationRemove: PropTypes.func.isRequired,
+  onRelationConnect: PropTypes.func.isRequired,
+  onRelationDisconnect: PropTypes.func.isRequired,
   onRelationLoadMore: PropTypes.func.isRequired,
   onSearch: PropTypes.func.isRequired,
   onSearchNextPage: PropTypes.func.isRequired,

--- a/packages/core/admin/admin/src/content-manager/components/RelationInput/tests/RelationInput.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInput/tests/RelationInput.test.js
@@ -66,10 +66,10 @@ const setup = (props) =>
             loadingMessage={() => 'Relations are loading'}
             labelDisconnectRelation="Remove"
             numberOfRelationsToDisplay={5}
-            onRelationAdd={() => jest.fn()}
+            onRelationConnect={() => jest.fn()}
             onSearchOpen={() => jest.fn()}
             onSearchClose={() => jest.fn()}
-            onRelationRemove={() => jest.fn()}
+            onRelationDisconnect={() => jest.fn()}
             onRelationLoadMore={() => jest.fn()}
             onSearch={() => jest.fn()}
             onSearchNextPage={() => jest.fn()}
@@ -113,10 +113,10 @@ describe('Content-Manager || RelationInput', () => {
       expect(spy).toHaveBeenCalled();
     });
 
-    test('should call onRelationAdd and onSearchClose', () => {
+    test('should call onRelationConnect and onSearchClose', () => {
       const onAddSpy = jest.fn();
       const onCloseSpy = jest.fn();
-      setup({ onRelationAdd: onAddSpy, onSearchClose: onCloseSpy });
+      setup({ onRelationConnect: onAddSpy, onSearchClose: onCloseSpy });
 
       fireEvent.mouseDown(screen.getByText(/select\.\.\./i));
       expect(screen.getByText('Relation 4')).toBeInTheDocument();
@@ -127,9 +127,9 @@ describe('Content-Manager || RelationInput', () => {
       expect(onCloseSpy).toHaveBeenCalled();
     });
 
-    test('should call onRelationRemove', () => {
+    test('should call onRelationDisconnect', () => {
       const spy = jest.fn();
-      setup({ onRelationRemove: spy });
+      setup({ onRelationDisconnect: spy });
 
       fireEvent.click(screen.getByTestId('remove-relation-1'));
 

--- a/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/RelationInputDataManager.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/RelationInputDataManager.js
@@ -105,11 +105,11 @@ export const RelationInputDataManager = ({
     return !editable;
   }, [isMorph, isCreatingEntry, editable, isFieldAllowed, isFieldReadable]);
 
-  const handleRelationAdd = (relation) => {
+  const handleRelationConnect = (relation) => {
     connectRelation({ target: { name, value: relation, replace: isSingleRelation } });
   };
 
-  const handleRelationRemove = (relation) => {
+  const handleRelationDisconnect = (relation) => {
     disconnectRelation({ target: { name, value: relation } });
   };
 
@@ -139,7 +139,7 @@ export const RelationInputDataManager = ({
     (!isFieldAllowed && isCreatingEntry) ||
     (!isCreatingEntry && !isFieldAllowed && !isFieldReadable)
   ) {
-    return <NotAllowedInput intlLabel={intlLabel} labelAction={labelAction} />;
+    return <NotAllowedInput name={name} intlLabel={intlLabel} labelAction={labelAction} />;
   }
 
   return (
@@ -174,8 +174,8 @@ export const RelationInputDataManager = ({
       }
       name={name}
       numberOfRelationsToDisplay={RELATIONS_TO_DISPLAY}
-      onRelationAdd={(relation) => handleRelationAdd(relation)}
-      onRelationRemove={(relation) => handleRelationRemove(relation)}
+      onRelationConnect={(relation) => handleRelationConnect(relation)}
+      onRelationDisconnect={(relation) => handleRelationDisconnect(relation)}
       onRelationLoadMore={() => handleRelationLoadMore()}
       onSearch={(term) => handleSearch(term)}
       onSearchNextPage={() => handleSearchMore()}

--- a/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/RelationInputDataManager.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/RelationInputDataManager.js
@@ -221,11 +221,7 @@ RelationInputDataManager.defaultProps = {
 RelationInputDataManager.propTypes = {
   componentId: PropTypes.number,
   editable: PropTypes.bool,
-  error: PropTypes.shape({
-    id: PropTypes.string.isRequired,
-    defaultMessage: PropTypes.string.isRequired,
-    values: PropTypes.object,
-  }),
+  error: PropTypes.string,
   description: PropTypes.string,
   intlLabel: PropTypes.shape({
     id: PropTypes.string.isRequired,

--- a/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/RelationInputDataManager.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/RelationInputDataManager.js
@@ -12,6 +12,7 @@ import { PUBLICATION_STATES, RELATIONS_TO_DISPLAY, SEARCH_RESULTS_TO_DISPLAY } f
 import { getTrad } from '../../utils';
 
 export const RelationInputDataManager = ({
+  error,
   componentId,
   editable,
   description,
@@ -143,6 +144,7 @@ export const RelationInputDataManager = ({
 
   return (
     <RelationInput
+      error={error}
       description={description}
       disabled={isDisabled}
       id={name}
@@ -208,6 +210,7 @@ export const RelationInputDataManager = ({
 RelationInputDataManager.defaultProps = {
   componentId: undefined,
   editable: true,
+  error: undefined,
   description: '',
   labelAction: null,
   isFieldAllowed: true,
@@ -218,6 +221,11 @@ RelationInputDataManager.defaultProps = {
 RelationInputDataManager.propTypes = {
   componentId: PropTypes.number,
   editable: PropTypes.bool,
+  error: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    defaultMessage: PropTypes.string.isRequired,
+    values: PropTypes.object,
+  }),
   description: PropTypes.string,
   intlLabel: PropTypes.shape({
     id: PropTypes.string.isRequired,

--- a/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/tests/RelationInputDataManger.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/tests/RelationInputDataManger.test.js
@@ -1,0 +1,164 @@
+import React from 'react';
+import { IntlProvider } from 'react-intl';
+import { render } from '@testing-library/react';
+import { ThemeProvider, lightTheme } from '@strapi/design-system';
+import { QueryClientProvider, QueryClient } from 'react-query';
+import { MemoryRouter } from 'react-router-dom';
+
+import { useCMEditViewDataManager } from '@strapi/helper-plugin';
+
+import { RelationInputDataManager } from '..';
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+    },
+  },
+});
+
+jest.mock('../../../hooks/useRelation', () => ({
+  useRelation: jest.fn().mockReturnValue({
+    relations: {
+      data: {
+        pages: [
+          {
+            results: [
+              {
+                id: 1,
+              },
+            ],
+          },
+        ],
+      },
+      isFetchingNextPage: false,
+      isLoading: false,
+      isSuccess: true,
+      status: 'success',
+    },
+
+    search: {
+      data: {},
+      isLoading: false,
+      isSuccess: true,
+    },
+
+    searchFor: jest.fn(),
+  }),
+}));
+
+jest.mock('@strapi/helper-plugin', () => ({
+  ...jest.requireActual('@strapi/helper-plugin'),
+  useCMEditViewDataManager: jest.fn().mockImplementation(() => ({
+    isCreatingEntry: true,
+    createActionAllowedFields: ['relation'],
+    readActionAllowedFields: ['relation'],
+    updateActionAllowedFields: ['relation'],
+    slug: 'test',
+    initialData: {},
+    loadRelation: jest.fn(),
+  })),
+}));
+
+const setup = (props) =>
+  render(
+    <MemoryRouter>
+      <QueryClientProvider client={queryClient}>
+        <ThemeProvider theme={lightTheme}>
+          <IntlProvider locale="en">
+            <RelationInputDataManager
+              description="Description"
+              intlLabel={{
+                id: 'label',
+                defaultMessage: 'Label',
+              }}
+              labelAction={<>Action</>}
+              mainField={{
+                name: 'relation',
+                schema: {
+                  type: 'relation',
+                },
+              }}
+              name="relation"
+              placeholder={{
+                id: 'placeholder',
+                defaultMessage: 'Placeholder',
+              }}
+              relationType="oneToOne"
+              size={6}
+              targetModel="something"
+              queryInfos={{
+                shouldDisplayRelationLink: true,
+              }}
+              {...props}
+            />
+          </IntlProvider>
+        </ThemeProvider>
+      </QueryClientProvider>
+    </MemoryRouter>
+  );
+
+describe('RelationInputDataManager', () => {
+  test('Does pass through props from the CM', async () => {
+    const { findByText } = setup();
+
+    expect(await findByText('Label')).toBeInTheDocument();
+    expect(await findByText('Description')).toBeInTheDocument();
+    expect(await findByText('Action')).toBeInTheDocument();
+    expect(await findByText('Placeholder')).toBeInTheDocument();
+  });
+
+  test('Does pass through an error from the CM', async () => {
+    const { findByText } = setup({
+      error: 'Error',
+    });
+
+    expect(await findByText('Error')).toBeInTheDocument();
+  });
+
+  test('Sets the disabled prop for morphed relations', async () => {
+    const { container } = setup({
+      relationType: 'morph',
+    });
+
+    expect(container.querySelector('input')).toHaveAttribute('disabled');
+  });
+
+  test('Sets the disabled prop for non editable relations (edit entity)', async () => {
+    const { container } = setup({
+      editable: false,
+    });
+
+    expect(container.querySelector('input')).toHaveAttribute('disabled');
+  });
+
+  test('Sets the disabled prop for non editable relations (create entity)', async () => {
+    const { container } = setup({
+      isCreatingEntry: true,
+      editable: false,
+    });
+
+    expect(container.querySelector('input')).toHaveAttribute('disabled');
+  });
+
+  test('Sets the disabled prop if the user does not have all permissions', async () => {
+    useCMEditViewDataManager.mockReturnValueOnce({
+      isCreatingEntry: false,
+      createActionAllowedFields: [],
+      readActionAllowedFields: ['relation'],
+      updateActionAllowedFields: [],
+      slug: 'test',
+      initialData: {},
+      loadRelation: jest.fn(),
+    });
+
+    const { container } = setup({
+      isFieldAllowed: false,
+      isFieldReadable: true,
+    });
+
+    expect(container.querySelector('input')).toHaveAttribute('disabled');
+  });
+
+  test('Normalizes relations', () => {});
+});

--- a/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/tests/RelationInputDataManger.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/tests/RelationInputDataManger.test.js
@@ -162,6 +162,33 @@ describe('RelationInputDataManager', () => {
     expect(container.querySelector('input')).toHaveAttribute('disabled');
   });
 
+  test('Passes down defaultParams to the relation and search endpoints', async () => {
+    setup({
+      queryInfos: {
+        defaultParams: {
+          something: true,
+        },
+        shouldDisplayRelationLink: true,
+      },
+    });
+
+    expect(useRelation).toBeCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        search: expect.objectContaining({
+          pageParams: expect.objectContaining({
+            something: true,
+          }),
+        }),
+        relation: expect.objectContaining({
+          pageParams: expect.objectContaining({
+            something: true,
+          }),
+        }),
+      })
+    );
+  });
+
   test('Sets the disabled prop for non editable relations (edit entity)', async () => {
     const { container } = setup({
       editable: false,

--- a/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/tests/RelationInputDataManger.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/tests/RelationInputDataManger.test.js
@@ -35,9 +35,16 @@ jest.mock('../../../hooks/useRelation', () => ({
                 title: 'Relation 2',
               },
             ],
+
+            pagination: {
+              page: 1,
+              pageCount: 2,
+            },
           },
         ],
       },
+      fetchNextPage: jest.fn(),
+      hasNextPage: true,
       isFetchingNextPage: false,
       isLoading: false,
       isSuccess: true,
@@ -269,16 +276,35 @@ describe('RelationInputDataManager', () => {
     );
   });
 
-  test('Search relations', async () => {});
+  test('Do not render Load More when an entity is created', async () => {
+    const { queryByText } = setup();
 
-  test('Load more', async () => {
-    const { container } = setup();
+    expect(await queryByText('Load More')).not.toBeInTheDocument();
+  });
 
-    fireEvent.change(container.querySelector('input[name=relation]'), {
-      target: { value: 'search' },
+  test('Load more entities', async () => {
+    const { relations } = useRelation();
+
+    useCMEditViewDataManager.mockReturnValueOnce({
+      isCreatingEntry: false,
+      createActionAllowedFields: ['relation'],
+      readActionAllowedFields: ['relation'],
+      updateActionAllowedFields: ['relation'],
+      slug: 'test',
+      initialData: {},
+      loadRelation: jest.fn(),
     });
 
-    screen.logTestingPlaygroundURL();
+    const { queryByText } = setup();
+    const loadMoreNode = await queryByText('Load More');
+
+    expect(loadMoreNode).toBeInTheDocument();
+
+    act(() => {
+      fireEvent.click(loadMoreNode);
+    });
+
+    expect(relations.fetchNextPage).toBeCalledTimes(1);
   });
 
   test('Open search', async () => {

--- a/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/tests/RelationInputDataManger.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/tests/RelationInputDataManger.test.js
@@ -225,6 +225,19 @@ describe('RelationInputDataManager', () => {
     expect(container.querySelector('input')).toHaveAttribute('disabled');
   });
 
+  test('Stores the loaded translations in the store', async () => {
+    const { loadRelation } = useCMEditViewDataManager();
+
+    setup();
+
+    expect(loadRelation).toBeCalledWith({
+      target: {
+        name: 'relation',
+        value: [expect.objectContaining({ id: 1 }), expect.objectContaining({ id: 2 })],
+      },
+    });
+  });
+
   test('Renders <NotAllowedInput /> if entity is created and field is not allowed', async () => {
     useCMEditViewDataManager.mockReturnValueOnce({
       isCreatingEntry: true,


### PR DESCRIPTION
### What does it do?

Adds integration tests for `RelationInputDataManager` to test if all integrations with `RelationInput` are working well.

### Why is it needed?

Tests.
