### PR TITLE
added an ignore for in-place .test.js for policies and API

### DIFF
--- a/packages/core/strapi/lib/core/loaders/apis.js
+++ b/packages/core/strapi/lib/core/loaders/apis.js
@@ -144,6 +144,7 @@ const loadDir = async (dir) => {
 };
 
 const loadFile = (file) => {
+  if (file.endsWith('.test.js')) return {};
   const ext = extname(file);
 
   switch (ext) {

--- a/packages/core/strapi/lib/core/loaders/policies.js
+++ b/packages/core/strapi/lib/core/loaders/policies.js
@@ -19,7 +19,6 @@ module.exports = async function loadPolicies(strapi) {
   for (const fd of paths) {
     const { name } = fd;
     const fullPath = join(dir, name);
-    console.log(name);
     if (fd.isFile() && !name.endsWith('.test.js') && extname(name) === '.js') {
       const key = basename(name, '.js');
       policies[key] = importDefault(fullPath);

--- a/packages/core/strapi/lib/core/loaders/policies.js
+++ b/packages/core/strapi/lib/core/loaders/policies.js
@@ -19,8 +19,8 @@ module.exports = async function loadPolicies(strapi) {
   for (const fd of paths) {
     const { name } = fd;
     const fullPath = join(dir, name);
-
-    if (fd.isFile() && extname(name) === '.js') {
+    console.log(name);
+    if (fd.isFile() && !name.endsWith('.test.js') && extname(name) === '.js') {
       const key = basename(name, '.js');
       policies[key] = importDefault(fullPath);
     }


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

This change introduces a file extension test for files ending with `.test.js` that are in-folder in both `api` and `policies`. The idea is that now a service such as `restaurants/services/doSomething.js` can have `restaurants/services/doSomething.test.js` as a set of unit tests for the function it exports.

### Why is it needed?

If you want to write an in-folder unit test, Strapi currently attempts to load it as if it were a service/controller etc. In doing this, if your unit test file uses a framework such as Jest which populates the global namespace with functions and objects such as `describe()`, `test()` etc. Strapi will crash because these namespaces are no longer populated. 

It makes sense therefore to ignore files in sub-directories of the API folder which end with `.test.js`. `.test.js` is unlikely to be used to mean anything other than a unit test within the context of these sub-directories, and it's unlikely that the any user's intended behaviour is for a `.test.js` to be imported an included in the Strapi namespace. 

The same is true for global policies in the `policies` directory and so I have also updated the loader for this folder to behave similarly.

### How to test it?

To test this functionality, create a new Strapi instance, and a new API within. In any auto-generated folder insert a `.test.js`, and then introduce a function such as `describe()` that would only be available if executed with a test framework. When executing `npx strapi develop` or `npx strapi start`, Strapi should **no longer** crash with `describe is not defined`.

### Related issue(s)/PR(s)

I haven't found any open related issues to this, but I believe this forum post is the closest this has come to being a requested feature:
https://forum.strapi.io/t/ignore-file-patter-for-test/1391

I'm happy to revise this PR, and make the ignore extension either a list, or a configurable option. 