### PR TITLE
Relations main view/count one relations

### DIFF
--- a/packages/core/content-manager/server/services/entity-manager.js
+++ b/packages/core/content-manager/server/services/entity-manager.js
@@ -82,7 +82,7 @@ module.exports = ({ strapi }) => ({
   },
 
   findOneWithCreatorRolesAndCount(id, uid, populate) {
-    const counterPopulate = getDeepPopulate(uid, populate, { onlyMany: true, countMany: true });
+    const counterPopulate = getDeepPopulate(uid, populate, { countMany: true, countOne: true });
     const params = { populate: addCreatedByRolesPopulate(counterPopulate) };
 
     return strapi.entityService.findOne(uid, id, params);
@@ -114,7 +114,7 @@ module.exports = ({ strapi }) => ({
 
     const params = {
       data: publishData,
-      populate: getDeepPopulate(uid, null, { onlyMany: true, countMany: true }),
+      populate: getDeepPopulate(uid, null, { countMany: true, countOne: true }),
     };
 
     return strapi.entityService.create(uid, params);
@@ -125,14 +125,14 @@ module.exports = ({ strapi }) => ({
 
     const params = {
       data: publishData,
-      populate: getDeepPopulate(uid, null, { onlyMany: true, countMany: true }),
+      populate: getDeepPopulate(uid, null, { countMany: true, countOne: true }),
     };
 
     return strapi.entityService.update(uid, entity.id, params);
   },
 
   delete(entity, uid) {
-    const params = { populate: getDeepPopulate(uid, null, { onlyMany: true, countMany: true }) };
+    const params = { populate: getDeepPopulate(uid, null, { countMany: true, countOne: true }) };
 
     return strapi.entityService.delete(uid, entity.id, params);
   },
@@ -161,7 +161,7 @@ module.exports = ({ strapi }) => ({
 
     const params = {
       data,
-      populate: getDeepPopulate(uid, null, { onlyMany: true, countMany: true }),
+      populate: getDeepPopulate(uid, null, { countMany: true, countOne: true }),
     };
 
     return strapi.entityService.update(uid, entity.id, params);
@@ -176,7 +176,7 @@ module.exports = ({ strapi }) => ({
 
     const params = {
       data,
-      populate: getDeepPopulate(uid, null, { onlyMany: true, countMany: true }),
+      populate: getDeepPopulate(uid, null, { countMany: true, countOne: true }),
     };
 
     return strapi.entityService.update(uid, entity.id, params);

--- a/packages/core/content-manager/server/services/utils/populate.js
+++ b/packages/core/content-manager/server/services/utils/populate.js
@@ -10,7 +10,7 @@ const { PUBLISHED_AT_ATTRIBUTE } = strapiUtils.contentTypes.constants;
 const getDeepPopulate = (
   uid,
   populate,
-  { onlyMany = false, countMany = false, maxLevel = Infinity } = {},
+  { countMany = false, countOne = false, maxLevel = Infinity } = {},
   level = 1
 ) => {
   if (populate) {
@@ -31,9 +31,10 @@ const getDeepPopulate = (
       // always populate createdBy, updatedBy, localizations etc.
       if (!isVisibleAttribute(model, attributeName)) {
         populateAcc[attributeName] = true;
-      } else if (!onlyMany || isManyRelation) {
-        // Only populate one level of relations
-        populateAcc[attributeName] = countMany && isManyRelation ? { count: true } : true;
+      } else if ((isManyRelation && countMany) || (!isManyRelation && countOne)) {
+        populateAcc[attributeName] = { count: true };
+      } else {
+        populateAcc[attributeName] = true;
       }
     }
 
@@ -42,7 +43,7 @@ const getDeepPopulate = (
         populate: getDeepPopulate(
           attribute.component,
           null,
-          { onlyMany, countMany, maxLevel },
+          { countOne, countMany, maxLevel },
           level + 1
         ),
       };
@@ -57,7 +58,7 @@ const getDeepPopulate = (
         populate: (attribute.components || []).reduce((acc, componentUID) => {
           return merge(
             acc,
-            getDeepPopulate(componentUID, null, { onlyMany, countMany, maxLevel }, level + 1)
+            getDeepPopulate(componentUID, null, { countOne, countMany, maxLevel }, level + 1)
           );
         }, {}),
       };

--- a/packages/core/content-manager/server/tests/api/basic-relations.test.e2e.js
+++ b/packages/core/content-manager/server/tests/api/basic-relations.test.e2e.js
@@ -211,7 +211,6 @@ describe('CM API', () => {
       });
 
       expect(res.statusCode).toBe(200);
-      // only xToMany relations are populated and counted
       expect(res.body).toMatchObject({
         age: 25,
         id: 1,
@@ -219,6 +218,8 @@ describe('CM API', () => {
         stamps: { count: 2 },
         stamps_m2m: { count: 1 },
         stamps_one_many: { count: 0 },
+        stamps_one_one: { count: 1 },
+        stamps_one_way: { count: 1 },
         createdBy: null,
         updatedBy: null,
       });

--- a/packages/core/content-manager/server/tests/index.test.e2e.js
+++ b/packages/core/content-manager/server/tests/index.test.e2e.js
@@ -949,9 +949,7 @@ describe('Relations', () => {
         method: 'GET',
       });
 
-      if (!foundReference.tag || Object.keys(foundReference.tag).length === 0) return;
-
-      expect(foundReference.tag).toBe(null);
+      expect(foundReference.tag.count).toBe(0);
     });
   });
 });


### PR DESCRIPTION
### What does it do?

Content-Manager findOne route : It counts the number of relations for the xToOne relations

### Why is it needed?

The xToOne relations were not populated neither counted.
Counting is helpful for the admin panel so that all fields are present + to know if there is 0 or 1 relation.

### How to test it?

e2e tests were updated.

### Related issue(s)/PR(s)

none
