### PR TITLE
Fix: Catch all errors when sending tracking requests

### DIFF
--- a/packages/core/admin/admin/src/pages/App/index.js
+++ b/packages/core/admin/admin/src/pages/App/index.js
@@ -91,7 +91,7 @@ function App() {
           try {
             const deviceId = await getUID();
 
-            fetch('https://analytics.strapi.io/track', {
+            await fetch('https://analytics.strapi.io/track', {
               method: 'POST',
               body: JSON.stringify({
                 event: 'didInitializeAdministration',

--- a/packages/core/helper-plugin/lib/src/hooks/useTracking/index.js
+++ b/packages/core/helper-plugin/lib/src/hooks/useTracking/index.js
@@ -8,10 +8,10 @@ const useTracking = () => {
   const { uuid, telemetryProperties } = useContext(TrackingContext);
   const appInfo = useAppInfos();
 
-  trackRef.current = (event, properties) => {
+  trackRef.current = async (event, properties) => {
     if (uuid) {
       try {
-        axios.post('https://analytics.strapi.io/track', {
+        await axios.post('https://analytics.strapi.io/track', {
           event,
           properties: {
             ...telemetryProperties,


### PR DESCRIPTION
### What does it do?

It properly awaits `fetch()` and `axios.post()` calls, when sending tracking requests. If an error was thrown previously, we did not wait for the promise to be rejected, which caused a bug where the error was not being watched by the `try {} catch {}` blocks.

A good read on the topic: https://jakearchibald.com/2017/await-vs-return-vs-return-await/

### Why is it needed?

There are many reasons why the tracking request might fail: 1) Network Error 2) Ad blockers 3) Service outage ... In these cases, there is a good chance the Strapi app crashes currently, which we should avoid by any means.

### How to test it?

> **Warning**
>  Do not forget to rebuild or to watch for changes in `@strapi/helper-plugin`.

1. Open Strapi in development mode
2. Block either: 1) the URL https://analytics.strapi.io/track or the full domain in your browser dev tools
3. Reload http://localhost:4000/admin/
4. Verify no error is being thrown and displayed

### Related issue(s)/PR(s)

- Fixes https://github.com/strapi/strapi/issues/14433
