### PR TITLE
Make the BoundRoute section sticky in the Roles editor

### DIFF
--- a/packages/plugins/users-permissions/admin/src/components/UsersPermissions/index.js
+++ b/packages/plugins/users-permissions/admin/src/components/UsersPermissions/index.js
@@ -4,12 +4,21 @@ import { Typography } from '@strapi/design-system/Typography';
 import { Stack } from '@strapi/design-system/Stack';
 import { Grid, GridItem } from '@strapi/design-system/Grid';
 import { useIntl } from 'react-intl';
+import styled from 'styled-components';
 import getTrad from '../../utils/getTrad';
 import Policies from '../Policies';
 import Permissions from '../Permissions';
 import reducer, { initialState } from './reducer';
 import { UsersPermissionsProvider } from '../../contexts/UsersPermissionsContext';
 import init from './init';
+
+const PermissionSection = styled(Stack)`
+  overflow-y: scroll;
+  height: 70vh;
+  &::-webkit-scrollbar {
+    display: none;
+  }
+`;
 
 const UsersPermissions = forwardRef(({ permissions, routes }, ref) => {
   const { formatMessage } = useIntl();
@@ -62,7 +71,7 @@ const UsersPermissions = forwardRef(({ permissions, routes }, ref) => {
     <UsersPermissionsProvider value={providerValue}>
       <Grid gap={0} shadow="filterShadow" hasRadius background="neutral0">
         <GridItem col={7} paddingTop={6} paddingBottom={6} paddingLeft={7} paddingRight={7}>
-          <Stack spacing={6}>
+          <PermissionSection spacing={6}>
             <Stack spacing={2}>
               <Typography variant="delta" as="h2">
                 {formatMessage({
@@ -78,7 +87,7 @@ const UsersPermissions = forwardRef(({ permissions, routes }, ref) => {
               </Typography>
             </Stack>
             <Permissions />
-          </Stack>
+          </PermissionSection>
         </GridItem>
         <Policies />
       </Grid>


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->
### What does it do?
This PR is supposed making the `BoundRoute` section sticky in the Roles editor but another solution has been found out.
fixes #12300

### Why is it needed?
we have found out that  making the `BoundRoute` section position sticky was not really important at all since `BoundRoute` section can not exceed more than five `BoundRoutes` at the time. We've ended up by making the `UserPermission` section `scrollable` instead and fixing the height.
### Describe the issue you are solving.
We are giving user ability of having a look at `BoundRoutes` on BoundRoute section when he is selecting roles, instead of scrolling to the top all the time when he wants to see `BoundRoutes` selected. Video demo will describe it clearly.
[video](https://www.loom.com/share/b21e6791ef1d418e94fbcb5b3cbf8dc5)
### How to test it?
-  make sure you are in the project folder
-  execute  `cd ./packages/core/admin` and run the server by typing `yarn develop`
-  changes made on the Dashboard can be accessed the this link  this `http://localhost:4000/admin/settings/users-permissions/roles`
-  [video demo](https://www.loom.com/share/1d2217ab14844b7694b526cccaa71b5c) 
