### PR TITLE
fix(aws-provider): add https protocol when missing in file url

### DIFF
--- a/packages/providers/upload-aws-s3/jest.config.js
+++ b/packages/providers/upload-aws-s3/jest.config.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const baseConfig = require('../../../jest.base-config');
+const pkg = require('./package.json');
+
+module.exports = {
+  ...baseConfig,
+  displayName: pkg.name,
+  roots: [__dirname],
+};

--- a/packages/providers/upload-aws-s3/lib/__tests__/upload-aws-s3.test.js
+++ b/packages/providers/upload-aws-s3/lib/__tests__/upload-aws-s3.test.js
@@ -1,0 +1,60 @@
+'use strict';
+
+const AWS = require('aws-sdk');
+const awsProvider = require('../index');
+
+jest.mock('aws-sdk');
+
+const S3InstanceMock = {
+  upload: jest.fn((params, callback) => callback(null, {})),
+};
+
+AWS.S3.mockReturnValue(S3InstanceMock);
+
+describe('AWS-S3 provider', () => {
+  const providerInstance = awsProvider.init({});
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('upload', () => {
+    test('Should add url to file object', async () => {
+      S3InstanceMock.upload.mockImplementationOnce((params, callback) =>
+        callback(null, { Location: 'https://validurl.test' })
+      );
+      const file = {
+        path: '/tmp/',
+        hash: 'test',
+        ext: 'json',
+        mime: 'application/json',
+        buffer: '',
+      };
+
+      await providerInstance.upload(file);
+
+      expect(S3InstanceMock.upload).toBeCalled();
+      expect(file.url).toBeDefined();
+      expect(file.url).toEqual('https://validurl.test');
+    });
+
+    test('Should add to the url the https protocol as it is missing', async () => {
+      S3InstanceMock.upload.mockImplementationOnce((params, callback) =>
+        callback(null, { Location: 'uri.test' })
+      );
+      const file = {
+        path: '/tmp/',
+        hash: 'test',
+        ext: 'json',
+        mime: 'application/json',
+        buffer: '',
+      };
+
+      await providerInstance.upload(file);
+
+      expect(S3InstanceMock.upload).toBeCalled();
+      expect(file.url).toBeDefined();
+      expect(file.url).toEqual('https://uri.test');
+    });
+  });
+});

--- a/packages/providers/upload-aws-s3/lib/index.js
+++ b/packages/providers/upload-aws-s3/lib/index.js
@@ -9,6 +9,11 @@
 const _ = require('lodash');
 const AWS = require('aws-sdk');
 
+function assertUrlProtocol(url) {
+  // Regex to test protocol like "http://", "https://"
+  return /^\w*:\/\//.test(url);
+}
+
 module.exports = {
   init(config) {
     const S3 = new AWS.S3({
@@ -34,7 +39,12 @@ module.exports = {
             }
 
             // set the bucket file url
-            file.url = data.Location;
+            if (assertUrlProtocol(data.Location)) {
+              file.url = data.Location;
+            } else {
+              // Default protocol to https protocol
+              file.url = `https://${data.Location}`;
+            }
 
             resolve();
           }


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Adding https:// to url that doesn't have any.
Also adding unit tests to this provider.

### Why is it needed?

Digital Ocean only gives the URI without protocol in response to the upload.

### How to test it?

The steps to reproduce are defined in the issue #14288 

Steps to reproduce the behavior
- Add an S3 provider to a Strapi project (AWS or community DO for example).
- Connect to a DO spaces account
- Add a video to the media library
- Inspect the uploaded video with the browser dev tools and see the incorrect address.

### Related issue(s)/PR(s)

Fix #14288 
