### PR TITLE
Jest: Fail tests on failing prop-types

### DIFF
--- a/jest.base-config.front.js
+++ b/jest.base-config.front.js
@@ -50,6 +50,7 @@ module.exports = {
   setupFilesAfterEnv: [
     '<rootDir>/packages/admin-test-utils/lib/setup/styled-components.js',
     '<rootDir>/packages/admin-test-utils/lib/setup/strapi.js',
+    '<rootDir>/packages/admin-test-utils/lib/setup/prop-types.js',
   ],
   testEnvironment: 'jsdom',
   transform: {

--- a/packages/admin-test-utils/lib/setup/prop-types.js
+++ b/packages/admin-test-utils/lib/setup/prop-types.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const { format } = require('util');
+
+const originalConsoleError = console.error;
+
+beforeEach(() => {
+  console.error = (...args) => {
+    originalConsoleError(...args);
+
+    const message = format(...args);
+
+    if (/(Invalid prop|Failed prop type)/gi.test(message)) {
+      throw new Error(message);
+    }
+  };
+});
+
+afterEach(() => {
+  console.error = originalConsoleError;
+});


### PR DESCRIPTION
### What does it do?

> **Note**
> This PR is meant to be a discussion starter.

The PR extends the jest setup so that every thrown prop-type error would result in a 💥  test failure 💥 .

### Why is it needed?

@simotae14 and I are currently cleaning up the frontend tests, which contain many prop-type errors. Once these are cleaned, I'd like to ensure we do not regress on this.

What does everybody think about that?

### How to test it?

Jest will test itself.
