### PR TITLE
[DEITS] add destination provider backbone

### DIFF
--- a/packages/core/data-transfer/lib/providers/local-file-destination-provider.ts
+++ b/packages/core/data-transfer/lib/providers/local-file-destination-provider.ts
@@ -17,7 +17,7 @@ export interface ILocalFileDestinationProviderOptions {
 }
 
 export class LocalFileDestinationProvider implements IDestinationProvider {
-  name: string = 'provider::destination.local-file';
+  name: string = 'destination::local-file';
   type: ProviderType = 'destination';
   options: ILocalFileDestinationProviderOptions;
 

--- a/packages/core/data-transfer/lib/providers/local-file-destination-provider.ts
+++ b/packages/core/data-transfer/lib/providers/local-file-destination-provider.ts
@@ -16,7 +16,12 @@ export interface ILocalFileDestinationProviderOptions {
   encryptionKey?: string;
 }
 
-export class LocalFileDestinationProvider implements IDestinationProvider {
+export const createLocalFileDestinationProvider = (options: ILocalFileDestinationProviderOptions) => {
+  return new LocalFileDestinationProvider(options);
+};
+
+
+class LocalFileDestinationProvider implements IDestinationProvider {
   name: string = 'destination::local-file';
   type: ProviderType = 'destination';
   options: ILocalFileDestinationProviderOptions;

--- a/packages/core/data-transfer/lib/providers/local-file-destination-provider.ts
+++ b/packages/core/data-transfer/lib/providers/local-file-destination-provider.ts
@@ -1,0 +1,195 @@
+import fs from 'fs';
+import path from 'path';
+import zip from 'zlib';
+import { Duplex } from 'stream';
+import { chain } from 'stream-chain';
+import { stringer } from 'stream-json/jsonl/Stringer';
+
+import { IDestinationProvider, ProviderType, Stream } from '../../types';
+// import { encrypt } from '../encryption';
+
+export interface ILocalFileDestinationProviderOptions {
+  backupFilePath: string;
+
+  // Encryption
+  encrypted?: boolean;
+  encryptionKey?: string;
+}
+
+export class LocalFileDestinationProvider implements IDestinationProvider {
+  name: string = 'provider::destination.local-file';
+  type: ProviderType = 'destination';
+  options: ILocalFileDestinationProviderOptions;
+
+  constructor(options: ILocalFileDestinationProviderOptions) {
+    this.options = options;
+  }
+
+  bootstrap(): void | Promise<void> {
+    const rootDir = this.options.backupFilePath;
+    const dirExists = fs.existsSync(rootDir);
+
+    if (dirExists) {
+      fs.rmSync(rootDir, { force: true, recursive: true });
+    }
+
+    fs.mkdirSync(rootDir, { recursive: true });
+    fs.mkdirSync(path.join(rootDir, 'entities'));
+    fs.mkdirSync(path.join(rootDir, 'links'));
+    fs.mkdirSync(path.join(rootDir, 'media'));
+    fs.mkdirSync(path.join(rootDir, 'configuration'));
+  }
+
+  rollback(): void | Promise<void> {
+    fs.rmSync(this.options.backupFilePath, { force: true, recursive: true });
+  }
+
+  getMetadata() {
+    return null;
+  }
+
+  getEntitiesStream(): Duplex {
+    const options = {
+      encryption: {
+        enabled: true,
+        key: 'Hello World!',
+      },
+      compression: {
+        enabled: false,
+      },
+      file: {
+        maxSize: 100000,
+      },
+    };
+
+    const filePathFactory = (fileIndex: number = 0) => {
+      return path.join(
+        // Backup path
+        this.options.backupFilePath,
+        // "entities/" directory
+        'entities',
+        // "entities_00000.jsonl" file
+        `entities_${String(fileIndex).padStart(5, '0')}.jsonl`
+      );
+    };
+
+    const streams: any[] = [
+      // create jsonl strings from object entities
+      stringer(),
+    ];
+
+    // Compression
+    if (options.compression?.enabled) {
+      streams.push(zip.createGzip());
+    }
+
+    // Encryption
+    // if (options.encryption?.enabled) {
+    //   streams.push(encrypt(options.encryption.key).cipher());
+    // }
+
+    // FS write stream
+    streams.push(createMultiFilesWriteStream(filePathFactory, options.file?.maxSize));
+
+    return chain(streams);
+  }
+
+  getLinksStream(): Duplex | Promise<Duplex> {
+    const options = {
+      encryption: {
+        enabled: true,
+        key: 'Hello World!',
+      },
+      compression: {
+        enabled: false,
+      },
+      file: {
+        maxSize: 100000,
+      },
+    };
+
+    const filePathFactory = (fileIndex: number = 0) => {
+      return path.join(
+        // Backup path
+        this.options.backupFilePath,
+        // "links/" directory
+        'links',
+        // "links_00000.jsonl" file
+        `links_${String(fileIndex).padStart(5, '0')}.jsonl`
+      );
+    };
+
+    const streams: any[] = [
+      // create jsonl strings from object links
+      stringer(),
+    ];
+
+    // Compression
+    if (options.compression?.enabled) {
+      streams.push(zip.createGzip());
+    }
+
+    // Encryption
+    // if (options.encryption?.enabled) {
+    //   streams.push(encrypt(options.encryption.key).cipher());
+    // }
+
+    // FS write stream
+    streams.push(createMultiFilesWriteStream(filePathFactory, options.file?.maxSize));
+
+    return chain(streams);
+  }
+}
+
+/**
+ * Create a writable stream that can split the streamed data into
+ * multiple files based on a provided maximum file size value.
+ */
+const createMultiFilesWriteStream = (
+  filePathFactory: (index?: number) => string,
+  maxFileSize?: number
+): WritableStream => {
+  let fileIndex = 0;
+  let fileSize = 0;
+  let maxSize = maxFileSize;
+
+  let writeStream: Duplex;
+
+  const createIndexedWriteStream = () => fs.createWriteStream(filePathFactory(fileIndex));
+
+  // If no maximum file size is provided, then return a basic fs write stream
+  if (maxFileSize === undefined) {
+    return createIndexedWriteStream();
+  }
+
+  if (maxFileSize <= 0) {
+    throw new Error('Max file size must be a positive number');
+  }
+
+  return new Writable({
+    write(chunk, encoding, callback) {
+      // Initialize the write stream value if undefined
+      if (!writeStream) {
+        writeStream = createIndexedWriteStream();
+      }
+
+      // Check that by adding this new chunk of data, we
+      // are not going to reach the maximum file size.
+      if (fileSize + chunk.length > maxSize) {
+        // Update the counters' value
+        fileIndex++;
+        fileSize = 0;
+
+        // Replace old write stream
+        writeStream.destroy();
+        writeStream = createIndexedWriteStream();
+      }
+
+      // Update the actual file size
+      fileSize += chunk.length;
+
+      // Transfer the data to the up-to-date write stream
+      writeStream.write(chunk, encoding, callback);
+    },
+  });
+};

--- a/packages/core/data-transfer/lib/providers/local-file-destination-provider.ts
+++ b/packages/core/data-transfer/lib/providers/local-file-destination-provider.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import zip from 'zlib';
 import { Duplex } from 'stream';
-import { chain } from 'stream-chain';
+import { chain, Writable } from 'stream-chain';
 import { stringer } from 'stream-json/jsonl/Stringer';
 
 import { IDestinationProvider, ProviderType, Stream } from '../../types';
@@ -148,12 +148,12 @@ export class LocalFileDestinationProvider implements IDestinationProvider {
 const createMultiFilesWriteStream = (
   filePathFactory: (index?: number) => string,
   maxFileSize?: number
-): WritableStream => {
+): Stream => {
   let fileIndex = 0;
   let fileSize = 0;
   let maxSize = maxFileSize;
 
-  let writeStream: Duplex;
+  let writeStream: fs.WriteStream;
 
   const createIndexedWriteStream = () => fs.createWriteStream(filePathFactory(fileIndex));
 
@@ -175,7 +175,7 @@ const createMultiFilesWriteStream = (
 
       // Check that by adding this new chunk of data, we
       // are not going to reach the maximum file size.
-      if (fileSize + chunk.length > maxSize) {
+      if (maxSize && (fileSize + chunk.length > maxSize)) {
         // Update the counters' value
         fileIndex++;
         fileSize = 0;

--- a/packages/core/data-transfer/lib/providers/local-strapi-destination-provider.ts
+++ b/packages/core/data-transfer/lib/providers/local-strapi-destination-provider.ts
@@ -7,6 +7,7 @@ interface ILocalStrapiDestinationProviderOptions {
   getStrapi(): Promise<Strapi.Strapi>;
 }
 
+// TODO: getting some type errors with @strapi/logger that need to be resolved first
 // const log = createLogger();
 const log = console;
 

--- a/packages/core/data-transfer/lib/providers/local-strapi-destination-provider.ts
+++ b/packages/core/data-transfer/lib/providers/local-strapi-destination-provider.ts
@@ -10,7 +10,11 @@ interface ILocalStrapiDestinationProviderOptions {
 // const log = createLogger();
 const log = console;
 
-export class LocalStrapiDestinationProvider implements IDestinationProvider {
+export const createLocalStrapiDestinationProvider = (options: ILocalStrapiDestinationProviderOptions) => {
+  return new LocalStrapiDestinationProvider(options);
+};
+
+class LocalStrapiDestinationProvider implements IDestinationProvider {
   name: string = 'destination::local-strapi';
   type: ProviderType = 'destination';
 

--- a/packages/core/data-transfer/lib/providers/local-strapi-destination-provider.ts
+++ b/packages/core/data-transfer/lib/providers/local-strapi-destination-provider.ts
@@ -1,0 +1,71 @@
+import { createLogger } from '@strapi/logger';
+import chalk from 'chalk';
+import { Duplex } from 'stream';
+import type { IDestinationProvider, IMetadata, ProviderType, Stream } from '../../types';
+
+interface ILocalStrapiDestinationProviderOptions {
+  getStrapi(): Promise<Strapi.Strapi>;
+}
+
+const log = createLogger();
+
+export class LocalStrapiDestinationProvider implements IDestinationProvider {
+  name: string = 'provider::destination.local-strapi';
+  type: ProviderType = 'destination';
+
+  options: ILocalStrapiDestinationProviderOptions;
+  strapi?: Strapi.Strapi;
+
+  constructor(options: ILocalStrapiDestinationProviderOptions) {
+    this.options = options;
+  }
+
+  async bootstrap(): Promise<void> {
+    this.strapi = await this.options.getStrapi();
+  }
+
+  async close(): Promise<void> {
+    await this.strapi.destroy?.();
+  }
+
+  getMetadata(): IMetadata | Promise<IMetadata> {
+    return null;
+  }
+
+  getEntitiesStream(): Stream {
+    const self = this;
+
+    return new Writable({
+      objectMode: true,
+      async write(entity, _encoding, callback) {
+        if (!self.strapi) {
+          callback(new Error('Strapi instance not found'));
+        }
+
+        const { type: uid, id, data } = entity;
+
+        try {
+          await strapi.entityService.create(uid, { data });
+        } catch (e) {
+          log.warn(
+            chalk.bold(`Failed to import ${chalk.yellowBright(uid)} (${chalk.greenBright(id)})`)
+          );
+          e.details.errors
+            .map((err, i) => {
+              const info = {
+                uid: chalk.yellowBright(`[${uid}]`),
+                path: chalk.blueBright(`[${err.path.join('.')}]`),
+                id: chalk.greenBright(`[${id}]`),
+                message: err.message,
+              };
+
+              return `(${i}) ${info.uid}${info.id}${info.path}: ${info.message}`;
+            })
+            .forEach((message) => log.warn(message));
+        } finally {
+          callback();
+        }
+      },
+    });
+  }
+}


### PR DESCRIPTION
### What does it do?

Adds the local file and strapi destination providers.

WIP - they don't necessarily work yet, they have only been copied from the `deits/poc` branch, updated with the latest structure.

### Why is it needed?

So we have all the pieces in place and can start making it work together.

### How to test it?

.

### Related issue(s)/PR(s)

.
