### PR TITLE
[DEITS] Emit a definition file on package build

### DIFF
--- a/packages/core/data-transfer/.npmignore
+++ b/packages/core/data-transfer/.npmignore
@@ -1,0 +1,140 @@
+#############################
+# DATA TRANSFER X
+############################
+
+*.js.map
+lib/
+types/
+tsconfig.json
+
+############################
+# OS X
+############################
+
+.DS_Store
+.AppleDouble
+.LSOverride
+Icon
+.Spotlight-V100
+.Trashes
+._*
+
+
+############################
+# Linux
+############################
+
+*~
+
+
+############################
+# Windows
+############################
+
+Thumbs.db
+ehthumbs.db
+Desktop.ini
+$RECYCLE.BIN/
+*.cab
+*.msi
+*.msm
+*.msp
+
+
+############################
+# Packages
+############################
+
+*.7z
+*.csv
+*.dat
+*.dmg
+*.gz
+*.iso
+*.jar
+*.rar
+*.tar
+*.zip
+*.com
+*.class
+*.dll
+*.exe
+*.o
+*.seed
+*.so
+*.swo
+*.swp
+*.swn
+*.swm
+*.out
+*.pid
+
+
+############################
+# Logs and databases
+############################
+
+.tmp
+*.log
+*.sql
+*.sqlite
+
+
+############################
+# Misc.
+############################
+
+*#
+.idea
+nbproject
+.vscode/
+
+
+############################
+# Node.js
+############################
+
+lib-cov
+lcov.info
+pids
+logs
+results
+build
+node_modules
+.node_history
+package-lock.json
+**/package-lock.json
+!docs/package-lock.json
+*.heapsnapshot
+
+
+############################
+# Tests
+############################
+
+testApp
+coverage
+cypress/screenshots
+cypress/videos
+
+############################
+# Builds
+############################
+
+packages/generators/app/files/public/
+schema.graphql
+
+############################
+# Example app
+############################
+
+.dev
+# *.cache
+
+############################
+# Visual Studio Code
+############################
+
+front-workspace.code-workspace
+.yarn
+.yarnrc

--- a/packages/core/data-transfer/package.json
+++ b/packages/core/data-transfer/package.json
@@ -25,7 +25,7 @@
     }
   ],
   "main": "./dist/index.js",
-  "types": "./src/index.ts",
+  "types": "./dist/index.d.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "watch": "yarn build -w"

--- a/packages/core/data-transfer/tsconfig.json
+++ b/packages/core/data-transfer/tsconfig.json
@@ -5,7 +5,8 @@
     "lib": ["ESNEXT"],
     "skipLibCheck": true,
     "outDir": "dist",
-    "declaration": true
+    "declaration": true,
+    "sourceMap": true
   },
   "include": ["types", "lib/**/*.ts"],
   "exclude": ["node_modules"]

--- a/packages/core/data-transfer/tsconfig.json
+++ b/packages/core/data-transfer/tsconfig.json
@@ -4,7 +4,8 @@
     "strict": true,
     "lib": ["ESNEXT"],
     "skipLibCheck": true,
-    "outDir": "dist"
+    "outDir": "dist",
+    "declaration": true
   },
   "include": ["types", "lib/**/*.ts"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
### What does it do?

Emit an index.d.ts along with the source files when compiling.

### Why is it needed?

Export typings for the library

### How to test it?

- `cd packages/core/data-transfer`
- `yarn build`
- Check that the `index.d.ts` file has been created in the generated `dist` folder.
