### PR TITLE
[DEITS] data-transfer encryption

### DIFF
--- a/packages/core/data-transfer/lib/encryption/__tests__/encrypt.test.ts
+++ b/packages/core/data-transfer/lib/encryption/__tests__/encrypt.test.ts
@@ -7,7 +7,7 @@ describe('Encryption', () => {
     const encryptedData = cipher.update(textToEncrypt);
 
     expect(cipher).toBeDefined();
-    expect(encryptedData).not.toBe(textToEncrypt);
+    expect(encryptedData.toString()).not.toBe(textToEncrypt);
     expect(encryptedData).toBeInstanceOf(Buffer);
   });
 
@@ -17,7 +17,7 @@ describe('Encryption', () => {
     const encryptedData = cipher.update(textToEncrypt);
 
     expect(cipher).toBeDefined();
-    expect(encryptedData).not.toBe(textToEncrypt);
+    expect(encryptedData.toString()).not.toBe(textToEncrypt);
     expect(encryptedData).toBeInstanceOf(Buffer);
   });
 
@@ -27,7 +27,7 @@ describe('Encryption', () => {
     const encryptedData = cipher.update(textToEncrypt);
 
     expect(cipher).toBeDefined();
-    expect(encryptedData).not.toBe(textToEncrypt);
+    expect(encryptedData.toString()).not.toBe(textToEncrypt);
     expect(encryptedData).toBeInstanceOf(Buffer);
   });
 
@@ -37,7 +37,31 @@ describe('Encryption', () => {
     const encryptedData = cipher.update(textToEncrypt);
 
     expect(cipher).toBeDefined();
-    expect(encryptedData).not.toBe(textToEncrypt);
+    expect(encryptedData.toString()).not.toBe(textToEncrypt);
     expect(encryptedData).toBeInstanceOf(Buffer);
+  });
+
+  test('data encrypted with different algorithms should have different results', () => {
+    const cipherAES256 = createCipher('password', 'aes256');
+    const cipherAES192 = createCipher('password', 'aes192');
+    const cipherDefault = createCipher('password');
+    const textToEncrypt = 'something ate an apple';
+    const encryptedDataAES256 = cipherAES256.update(textToEncrypt).toString();
+    const encryptedDataAES192 = cipherAES192.update(textToEncrypt).toString();
+    const encryptedDataDefault = cipherDefault.update(textToEncrypt).toString();
+
+    expect(encryptedDataAES256).not.toBe(encryptedDataDefault);
+    expect(encryptedDataAES256).not.toBe(encryptedDataAES192);
+    expect(encryptedDataDefault).not.toBe(encryptedDataAES192);
+  });
+
+  test('data encrypted with different key should be different', () => {
+    const cipher1 = createCipher('password');
+    const cipher2 = createCipher('differentpassword');
+    const textToEncrypt = 'something ate an apple';
+    const encryptedData1 = cipher1.update(textToEncrypt).toString();
+    const encryptedData2 = cipher2.update(textToEncrypt).toString();
+
+    expect(encryptedData1).not.toBe(encryptedData2);
   });
 });

--- a/packages/core/data-transfer/lib/encryption/__tests__/encrypt.test.ts
+++ b/packages/core/data-transfer/lib/encryption/__tests__/encrypt.test.ts
@@ -1,0 +1,43 @@
+import { createCipher } from '../encrypt';
+
+describe('Encryption', () => {
+  test('encrypting data with default algorithm aes-128-ecb', () => {
+    const cipher = createCipher('password');
+    const textToEncrypt = 'something ate an apple';
+    const encryptedData = cipher.update(textToEncrypt);
+
+    expect(cipher).toBeDefined();
+    expect(encryptedData).not.toBe(textToEncrypt);
+    expect(encryptedData).toBeInstanceOf(Buffer);
+  });
+
+  test('encrypting data with aes128', () => {
+    const cipher = createCipher('password', 'aes128');
+    const textToEncrypt = 'something ate an apple';
+    const encryptedData = cipher.update(textToEncrypt);
+
+    expect(cipher).toBeDefined();
+    expect(encryptedData).not.toBe(textToEncrypt);
+    expect(encryptedData).toBeInstanceOf(Buffer);
+  });
+
+  test('encrypting data with aes192', () => {
+    const cipher = createCipher('password', 'aes192');
+    const textToEncrypt = 'something ate an apple';
+    const encryptedData = cipher.update(textToEncrypt);
+
+    expect(cipher).toBeDefined();
+    expect(encryptedData).not.toBe(textToEncrypt);
+    expect(encryptedData).toBeInstanceOf(Buffer);
+  });
+
+  test('encrypting data with aes256', () => {
+    const cipher = createCipher('password', 'aes256');
+    const textToEncrypt = 'something ate an apple';
+    const encryptedData = cipher.update(textToEncrypt);
+
+    expect(cipher).toBeDefined();
+    expect(encryptedData).not.toBe(textToEncrypt);
+    expect(encryptedData).toBeInstanceOf(Buffer);
+  });
+});

--- a/packages/core/data-transfer/lib/encryption/encrypt.ts
+++ b/packages/core/data-transfer/lib/encryption/encrypt.ts
@@ -1,0 +1,38 @@
+import { createCipheriv, Cipher, scryptSync, CipherKey, BinaryLike } from 'crypto';
+import { EncryptionStrategy, Strategies, Algorithm } from '../../types';
+
+// different key values depending on algorithm chosen
+const getEncryptionStrategy = (algorithm: Algorithm): EncryptionStrategy => {
+  const strategies: Strategies = {
+    'aes-128-ecb': (key: string): Cipher => {
+      const hashedKey = scryptSync(key, '', 16);
+      const initVector: BinaryLike | null = null;
+      const securityKey: CipherKey = hashedKey;
+      return createCipheriv(algorithm, securityKey, initVector);
+    },
+    aes128: (key: string): Cipher => {
+      const hashedKey = scryptSync(key, '', 32);
+      const initVector: BinaryLike | null = hashedKey.slice(16);
+      const securityKey: CipherKey = hashedKey.slice(0, 16);
+      return createCipheriv(algorithm, securityKey, initVector);
+    },
+    aes192: (key: string): Cipher => {
+      const hashedKey = scryptSync(key, '', 40);
+      const initVector: BinaryLike | null = hashedKey.slice(24);
+      const securityKey: CipherKey = hashedKey.slice(0, 24);
+      return createCipheriv(algorithm, securityKey, initVector);
+    },
+    aes256: (key: string): Cipher => {
+      const hashedKey = scryptSync(key, '', 48);
+      const initVector: BinaryLike | null = hashedKey.slice(32);
+      const securityKey: CipherKey = hashedKey.slice(0, 32);
+      return createCipheriv(algorithm, securityKey, initVector);
+    },
+  };
+
+  return strategies[algorithm];
+};
+
+export const createCipher = (key: string, algorithm: Algorithm = 'aes-128-ecb'): Cipher => {
+  return getEncryptionStrategy(algorithm)(key);
+};

--- a/packages/core/data-transfer/types/encryption.d.ts
+++ b/packages/core/data-transfer/types/encryption.d.ts
@@ -1,0 +1,12 @@
+import { Cipher, CipherKey, BinaryLike } from 'crypto';
+
+export type EncryptionStrategy = (key: string) => Cipher;
+
+export type Strategies = {
+  'aes-128-ecb': (key: string) => Cipher;
+  aes128: (key: string) => Cipher;
+  aes192: (key: string) => Cipher;
+  aes256: (key: string) => Cipher;
+};
+
+export type Algorithm = 'aes-128-ecb' | 'aes128' | 'aes192' | 'aes256';

--- a/packages/core/data-transfer/types/index.d.ts
+++ b/packages/core/data-transfer/types/index.d.ts
@@ -2,3 +2,4 @@ export * from './common-entities';
 export * from './providers';
 export * from './transfer-engine';
 export * from './utils';
+export * from './encryption';


### PR DESCRIPTION
### What does it do?

- Add Encryption module to the data-transfer package
- Allows for the ability to encrypt data using the crypto node package

### Why is it needed?

- So we are able to encrypt the data that we export

### How to test it?

- follow the examples in the test files and see if your data gets encrypted
- run the ts tests (when we integrate that)

