### PR TITLE
Replace directory to be able to get license.txt using a typescript project

### DIFF
--- a/packages/core/strapi/lib/Strapi.js
+++ b/packages/core/strapi/lib/Strapi.js
@@ -127,7 +127,7 @@ class Strapi {
   }
 
   get EE() {
-    return ee({ dir: this.dirs.dist.root, logger: this.log });
+    return ee({ dir: this.dirs.app.root, logger: this.log });
   }
 
   get services() {


### PR DESCRIPTION
### What does it do?

It fixes the problem of reading the license.txt file in the EE edition using Typescript. 

### Why is it needed?

Because before this fix, using the license in the license.txt file was not possible

### How to test it?
At the moment there isn't any tests on this.

### Related issue(s)/PR(s)
https://github.com/strapi/strapi/issues/14328
