### PR TITLE
Add default app keys to the server config

### DIFF
--- a/examples/kitchensink-ts/config/server.ts
+++ b/examples/kitchensink-ts/config/server.ts
@@ -2,6 +2,6 @@ export default ({ env }) => ({
   host: env('HOST', '0.0.0.0'),
   port: env.int('PORT', 1337),
   app: {
-    keys: env.array('APP_KEYS'),
+    keys: env.array('APP_KEYS', ['toBeModified1', 'toBeModified2']),
   },
 });


### PR DESCRIPTION
### What does it do?

Add default APP_KEYS to the kitchensink-ts project

### Why is it needed?

Before it was not possible to launch the kitchensink-ts project without providing the APP_KEYS through a .env file.

### How to test it?

Launch the kitchensink-ts project and see that it works without providing APP_KEYS through a .env file.

### Related issue(s)/PR(s)
