### PR TITLE
Fix inline relations not being selected automatically when populated

### DIFF
--- a/packages/core/database/lib/query/helpers/populate.js
+++ b/packages/core/database/lib/query/helpers/populate.js
@@ -83,7 +83,13 @@ const processPopulate = (populate, ctx) => {
       continue;
     }
 
-    // make sure id is present for future populate queries
+    // Make sure to query the join column value if needed,
+    // so that we can apply the populate later on
+    if (attribute.joinColumn) {
+      qb.addSelect(attribute.joinColumn.name);
+    }
+
+    // Make sure id is present for future populate queries
     if (_.has('id', meta.attributes)) {
       qb.addSelect('id');
     }


### PR DESCRIPTION
### What does it do?

When dealing with relations not using join tables, it appears that they're not automatically selected when populated.

### Why is it needed?

Allow populating inline relations without having to select all the fields.

### How to test it?

- Use a content type having creators fields (createdBy, updatedBy)
- Create some entities from the content manager (so that createdBy and updatedBy are filled)
- Make a query to this content type
```js
await strapi.entityService.findMany("<uid>", {
  fields: ["id"],
  populate: {
    createdBy: {
      fields: ["id"]
    }
  }
});
```
- You should have both the `id` of your entity and a `createdBy: { id: X }` property.

