### PR TITLE
App: Extend theme extension tests and swallow deprecation message

### DIFF
--- a/packages/core/admin/admin/src/tests/StrapiApp.test.js
+++ b/packages/core/admin/admin/src/tests/StrapiApp.test.js
@@ -13,45 +13,7 @@ describe('ADMIN | StrapiApp', () => {
     const app = StrapiApp({ middlewares, reducers, library });
     const { container } = render(app.render());
 
-    expect(container.firstChild).toMatchInlineSnapshot(`
-      .c0 {
-        margin-left: -250px;
-        position: fixed;
-        left: 50%;
-        top: 2.875rem;
-        z-index: 10;
-        width: 31.25rem;
-      }
-
-      .c1 {
-        -webkit-align-items: stretch;
-        -webkit-box-align: stretch;
-        -ms-flex-align: stretch;
-        align-items: stretch;
-        display: -webkit-box;
-        display: -webkit-flex;
-        display: -ms-flexbox;
-        display: flex;
-        -webkit-flex-direction: column;
-        -ms-flex-direction: column;
-        flex-direction: column;
-      }
-
-      .c2 > * {
-        margin-top: 0;
-        margin-bottom: 0;
-      }
-
-      .c2 > * + * {
-        margin-top: 8px;
-      }
-
-      <div
-        class="c0 c1 c2"
-        spacing="2"
-        width="31.25rem"
-      />
-    `);
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   it('should create a valid store', () => {
@@ -418,7 +380,33 @@ describe('ADMIN | StrapiApp', () => {
       expect(app.configurations.head.favicon).toBe('fr');
     });
 
-    it('should override the theme', () => {
+    it('should override the light theme', () => {
+      const adminConfig = {
+        config: { theme: { light: { colors: { red: 'black' } } } },
+      };
+      const app = StrapiApp({ middlewares, reducers, library, adminConfig });
+
+      app.createCustomConfigurations();
+
+      expect(app.configurations.themes.light.colors.red).toBe('black');
+    });
+
+    it('should override the dark theme', () => {
+      const adminConfig = {
+        config: { theme: { dark: { colors: { red: 'black' } } } },
+      };
+      const app = StrapiApp({ middlewares, reducers, library, adminConfig });
+
+      app.createCustomConfigurations();
+
+      expect(app.configurations.themes.dark.colors.red).toBe('black');
+    });
+
+    it('should override the light theme with a legacy syntax (without light or dark keys) and log a warning', () => {
+      const origalConsoleWarning = console.warn;
+
+      console.warn = jest.fn();
+
       const adminConfig = {
         config: { theme: { colors: { red: 'black' } } },
       };
@@ -427,6 +415,9 @@ describe('ADMIN | StrapiApp', () => {
       app.createCustomConfigurations();
 
       expect(app.configurations.themes.light.colors.red).toBe('black');
+      expect(console.warn).toBeCalledTimes(1);
+
+      console.warn = origalConsoleWarning;
     });
 
     it('should override the tutorials', () => {

--- a/packages/core/admin/admin/src/tests/__snapshots__/StrapiApp.test.js.snap
+++ b/packages/core/admin/admin/src/tests/__snapshots__/StrapiApp.test.js.snap
@@ -1,0 +1,41 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ADMIN | StrapiApp should render the app without plugins 1`] = `
+.c0 {
+  margin-left: -250px;
+  position: fixed;
+  left: 50%;
+  top: 2.875rem;
+  z-index: 10;
+  width: 31.25rem;
+}
+
+.c1 {
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c2 > * {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.c2 > * + * {
+  margin-top: 8px;
+}
+
+<div
+  class="c0 c1 c2"
+  spacing="2"
+  width="31.25rem"
+/>
+`;


### PR DESCRIPTION
### What does it do?

With https://github.com/strapi/strapi/pull/14001 it is possible to customize both (light and dark) themes. This PR adds tests for that and fixes a deprecation warning.

### Why is it needed?

Currently, the tests print the deprecation warning.

<img width="1433" alt="Screenshot 2022-10-24 at 09 19 49" src="https://user-images.githubusercontent.com/2244375/197469426-790c805a-bef5-4354-9de8-be00fa77c456.png">

### How to test it?

Trust in jest.
