### PR TITLE
[Marketplace] Exp-320 Change wording in marketplace card

### DIFF
--- a/packages/core/admin/admin/src/pages/MarketplacePage/components/NpmPackageCard/index.js
+++ b/packages/core/admin/admin/src/pages/MarketplacePage/components/NpmPackageCard/index.js
@@ -133,7 +133,7 @@ const NpmPackageCard = ({
         >
           {formatMessage({
             id: 'admin.pages.MarketPlacePage.plugin.info.text',
-            defaultMessage: 'Learn more',
+            defaultMessage: 'More',
           })}
         </LinkButton>
         <InstallPluginButton

--- a/packages/core/admin/admin/src/pages/MarketplacePage/tests/__snapshots__/index.test.js.snap
+++ b/packages/core/admin/admin/src/pages/MarketplacePage/tests/__snapshots__/index.test.js.snap
@@ -1063,7 +1063,7 @@ exports[`Marketplace page renders and matches the plugin tab snapshot 1`] = `
                           <span
                             class="c13 c14"
                           >
-                            Learn more
+                            More
                           </span>
                           <div
                             aria-hidden="true"
@@ -1203,7 +1203,7 @@ exports[`Marketplace page renders and matches the plugin tab snapshot 1`] = `
                           <span
                             class="c13 c14"
                           >
-                            Learn more
+                            More
                           </span>
                           <div
                             aria-hidden="true"
@@ -1328,7 +1328,7 @@ exports[`Marketplace page renders and matches the plugin tab snapshot 1`] = `
                           <span
                             class="c13 c14"
                           >
-                            Learn more
+                            More
                           </span>
                           <div
                             aria-hidden="true"
@@ -1469,7 +1469,7 @@ exports[`Marketplace page renders and matches the plugin tab snapshot 1`] = `
                           <span
                             class="c13 c14"
                           >
-                            Learn more
+                            More
                           </span>
                           <div
                             aria-hidden="true"
@@ -1576,7 +1576,7 @@ exports[`Marketplace page renders and matches the plugin tab snapshot 1`] = `
                           <span
                             class="c13 c14"
                           >
-                            Learn more
+                            More
                           </span>
                           <div
                             aria-hidden="true"
@@ -2792,7 +2792,7 @@ exports[`Marketplace page renders and matches the provider tab snapshot 1`] = `
                           <span
                             class="c13 c14"
                           >
-                            Learn more
+                            More
                           </span>
                           <div
                             aria-hidden="true"
@@ -2924,7 +2924,7 @@ exports[`Marketplace page renders and matches the provider tab snapshot 1`] = `
                           <span
                             class="c13 c14"
                           >
-                            Learn more
+                            More
                           </span>
                           <div
                             aria-hidden="true"
@@ -3056,7 +3056,7 @@ exports[`Marketplace page renders and matches the provider tab snapshot 1`] = `
                           <span
                             class="c13 c14"
                           >
-                            Learn more
+                            More
                           </span>
                           <div
                             aria-hidden="true"
@@ -3178,7 +3178,7 @@ exports[`Marketplace page renders and matches the provider tab snapshot 1`] = `
                           <span
                             class="c13 c14"
                           >
-                            Learn more
+                            More
                           </span>
                           <div
                             aria-hidden="true"
@@ -3310,7 +3310,7 @@ exports[`Marketplace page renders and matches the provider tab snapshot 1`] = `
                           <span
                             class="c13 c14"
                           >
-                            Learn more
+                            More
                           </span>
                           <div
                             aria-hidden="true"
@@ -3442,7 +3442,7 @@ exports[`Marketplace page renders and matches the provider tab snapshot 1`] = `
                           <span
                             class="c13 c14"
                           >
-                            Learn more
+                            More
                           </span>
                           <div
                             aria-hidden="true"
@@ -3574,7 +3574,7 @@ exports[`Marketplace page renders and matches the provider tab snapshot 1`] = `
                           <span
                             class="c13 c14"
                           >
-                            Learn more
+                            More
                           </span>
                           <div
                             aria-hidden="true"
@@ -3706,7 +3706,7 @@ exports[`Marketplace page renders and matches the provider tab snapshot 1`] = `
                           <span
                             class="c13 c14"
                           >
-                            Learn more
+                            More
                           </span>
                           <div
                             aria-hidden="true"
@@ -3838,7 +3838,7 @@ exports[`Marketplace page renders and matches the provider tab snapshot 1`] = `
                           <span
                             class="c13 c14"
                           >
-                            Learn more
+                            More
                           </span>
                           <div
                             aria-hidden="true"

--- a/packages/core/admin/admin/src/translations/en.json
+++ b/packages/core/admin/admin/src/translations/en.json
@@ -266,7 +266,7 @@
   "admin.pages.MarketPlacePage.plugin.copy.success": "Install command ready to be pasted in your terminal",
   "admin.pages.MarketPlacePage.plugin.info": "Learn more",
   "admin.pages.MarketPlacePage.plugin.info.label": "Learn more about {pluginName}",
-  "admin.pages.MarketPlacePage.plugin.info.text": "Learn more",
+  "admin.pages.MarketPlacePage.plugin.info.text": "More",
   "admin.pages.MarketPlacePage.plugin.installed": "Installed",
   "admin.pages.MarketPlacePage.plugin.tooltip.madeByStrapi": "Made by Strapi",
   "admin.pages.MarketPlacePage.plugin.tooltip.verified": "Plugin verified by Strapi",


### PR DESCRIPTION
### What does it do?

Changed marketplace card “Learn more” button text to “More”.

### Why is it needed?

When the main navigation is extended in Strapi, the button text in English version is on a double line which is not really aesthetic. This won’t solve the issue for every language, but will solve the issue in the default language of the admin: English. [Reference](https://strapi-inc.atlassian.net/browse/EXPANSION-320)

### How to test it?

Go to Marketplace > plugins/providers tab
