### PR TITLE
Add baseUrl and rootPath properties to upload-aws-s3 plugin's configuration

### DIFF
--- a/packages/providers/upload-aws-s3/README.md
+++ b/packages/providers/upload-aws-s3/README.md
@@ -29,6 +29,8 @@ npm install @strapi/provider-upload-aws-s3 --save
 
 See the [documentation about using a provider](https://docs.strapi.io/developer-docs/latest/plugins/upload.html#using-a-provider) for information on installing and using a provider. To understand how environment variables are used in Strapi, please refer to the [documentation about environment variables](https://docs.strapi.io/developer-docs/latest/setup-deployment-guides/configurations/optional/environment.html#environment-variables).
 
+If you're using the bucket as a CDN and deliver the content on a custom domain, you can get use of the `baseUrl` and `rootPath` properties to configure how your assets' urls will be saved inside Strapi.
+
 ### Provider Configuration
 
 `./config/plugins.js`
@@ -40,11 +42,15 @@ module.exports = ({ env }) => ({
     config: {
       provider: 'aws-s3',
       providerOptions: {
-        accessKeyId: env('AWS_ACCESS_KEY_ID'),
-        secretAccessKey: env('AWS_ACCESS_SECRET'),
-        region: env('AWS_REGION'),
-        params: {
-          Bucket: env('AWS_BUCKET'),
+        baseUrl: env('CDN_URL'),
+        rootPath: env('CDN_ROOT_PATH'),
+        s3Options: {
+          accessKeyId: env('AWS_ACCESS_KEY_ID'),
+          secretAccessKey: env('AWS_ACCESS_SECRET'),
+          region: env('AWS_REGION'),
+          params: {
+            Bucket: env('AWS_BUCKET'),
+          },
         },
       },
       actionOptions: {

--- a/packages/providers/upload-aws-s3/lib/__tests__/upload-aws-s3.test.js
+++ b/packages/providers/upload-aws-s3/lib/__tests__/upload-aws-s3.test.js
@@ -21,12 +21,12 @@ describe('AWS-S3 provider', () => {
   describe('upload', () => {
     test('Should add url to file object', async () => {
       S3InstanceMock.upload.mockImplementationOnce((params, callback) =>
-        callback(null, { Location: 'https://validurl.test' })
+        callback(null, { Location: 'https://validurl.test/tmp/test.json' })
       );
       const file = {
         path: '/tmp/',
         hash: 'test',
-        ext: 'json',
+        ext: '.json',
         mime: 'application/json',
         buffer: '',
       };
@@ -35,17 +35,17 @@ describe('AWS-S3 provider', () => {
 
       expect(S3InstanceMock.upload).toBeCalled();
       expect(file.url).toBeDefined();
-      expect(file.url).toEqual('https://validurl.test');
+      expect(file.url).toEqual('https://validurl.test/tmp/test.json');
     });
 
     test('Should add to the url the https protocol as it is missing', async () => {
       S3InstanceMock.upload.mockImplementationOnce((params, callback) =>
-        callback(null, { Location: 'uri.test' })
+        callback(null, { Location: 'uri.test/tmp/test.json' })
       );
       const file = {
         path: '/tmp/',
         hash: 'test',
-        ext: 'json',
+        ext: '.json',
         mime: 'application/json',
         buffer: '',
       };
@@ -54,7 +54,7 @@ describe('AWS-S3 provider', () => {
 
       expect(S3InstanceMock.upload).toBeCalled();
       expect(file.url).toBeDefined();
-      expect(file.url).toEqual('https://uri.test');
+      expect(file.url).toEqual('https://uri.test/tmp/test.json');
     });
 
     test('Should prepend the baseUrl to the url of the file object', async () => {
@@ -79,7 +79,10 @@ describe('AWS-S3 provider', () => {
     });
 
     test('Should prepend the baseUrl and rootPath to the url of the file object', async () => {
-      const providerInstance = awsProvider.init({ baseUrl: 'https://cdn.test', rootPath: 'dir/' });
+      const providerInstance = awsProvider.init({
+        baseUrl: 'https://cdn.test',
+        rootPath: 'dir/dir2',
+      });
 
       S3InstanceMock.upload.mockImplementationOnce((params, callback) =>
         callback(null, { Location: 'https://validurl.test' })
@@ -96,7 +99,7 @@ describe('AWS-S3 provider', () => {
 
       expect(S3InstanceMock.upload).toBeCalled();
       expect(file.url).toBeDefined();
-      expect(file.url).toEqual('https://cdn.test/dir/tmp/test/test.json');
+      expect(file.url).toEqual('https://cdn.test/dir/dir2/tmp/test/test.json');
     });
   });
 });

--- a/packages/providers/upload-aws-s3/lib/__tests__/upload-aws-s3.test.js
+++ b/packages/providers/upload-aws-s3/lib/__tests__/upload-aws-s3.test.js
@@ -56,5 +56,47 @@ describe('AWS-S3 provider', () => {
       expect(file.url).toBeDefined();
       expect(file.url).toEqual('https://uri.test');
     });
+
+    test('Should prepend the baseUrl to the url of the file object', async () => {
+      const providerInstance = awsProvider.init({ baseUrl: 'https://cdn.test' });
+
+      S3InstanceMock.upload.mockImplementationOnce((params, callback) =>
+        callback(null, { Location: 'https://validurl.test' })
+      );
+      const file = {
+        path: 'tmp/test',
+        hash: 'test',
+        ext: '.json',
+        mime: 'application/json',
+        buffer: '',
+      };
+
+      await providerInstance.upload(file);
+
+      expect(S3InstanceMock.upload).toBeCalled();
+      expect(file.url).toBeDefined();
+      expect(file.url).toEqual('https://cdn.test/tmp/test/test.json');
+    });
+
+    test('Should prepend the baseUrl and rootPath to the url of the file object', async () => {
+      const providerInstance = awsProvider.init({ baseUrl: 'https://cdn.test', rootPath: 'dir/' });
+
+      S3InstanceMock.upload.mockImplementationOnce((params, callback) =>
+        callback(null, { Location: 'https://validurl.test' })
+      );
+      const file = {
+        path: 'tmp/test',
+        hash: 'test',
+        ext: '.json',
+        mime: 'application/json',
+        buffer: '',
+      };
+
+      await providerInstance.upload(file);
+
+      expect(S3InstanceMock.upload).toBeCalled();
+      expect(file.url).toBeDefined();
+      expect(file.url).toEqual('https://cdn.test/dir/tmp/test/test.json');
+    });
   });
 });

--- a/packages/providers/upload-aws-s3/lib/index.js
+++ b/packages/providers/upload-aws-s3/lib/index.js
@@ -15,19 +15,28 @@ function assertUrlProtocol(url) {
 }
 
 module.exports = {
-  init(config) {
+  init({ baseUrl = null, rootPath = null, s3Options, ...legacyS3Options }) {
+    if (legacyS3Options && process.env.NODE_ENV !== 'production')
+      console.log(
+        "S3 configuration options passed at root level of the plugin's providerOptions is deprecated and will be removed in a future release. You wrap them inside the 's3Options:{}' property."
+      );
+
     const S3 = new AWS.S3({
       apiVersion: '2006-03-01',
-      ...config,
+      ...s3Options,
+      ...legacyS3Options,
     });
 
     const upload = (file, customParams = {}) =>
       new Promise((resolve, reject) => {
         // upload file on S3 bucket
         const path = file.path ? `${file.path}/` : '';
+        const fileKey = `${rootPath ? `${rootPath.replace(/\/+$/, '')}/` : ''}${path}${file.hash}${
+          file.ext
+        }`;
         S3.upload(
           {
-            Key: `${path}${file.hash}${file.ext}`,
+            Key: fileKey,
             Body: file.stream || Buffer.from(file.buffer, 'binary'),
             ACL: 'public-read',
             ContentType: file.mime,
@@ -40,7 +49,7 @@ module.exports = {
 
             // set the bucket file url
             if (assertUrlProtocol(data.Location)) {
-              file.url = data.Location;
+              file.url = baseUrl ? `${baseUrl}/${fileKey}` : data.Location;
             } else {
               // Default protocol to https protocol
               file.url = `https://${data.Location}`;
@@ -64,10 +73,10 @@ module.exports = {
           const path = file.path ? `${file.path}/` : '';
           S3.deleteObject(
             {
-              Key: `${path}${file.hash}${file.ext}`,
+              Key: `${rootPath}${path}${file.hash}${file.ext}`,
               ...customParams,
             },
-            (err, data) => {
+            (err) => {
               if (err) {
                 return reject(err);
               }

--- a/packages/providers/upload-aws-s3/lib/index.js
+++ b/packages/providers/upload-aws-s3/lib/index.js
@@ -16,9 +16,9 @@ function assertUrlProtocol(url) {
 
 module.exports = {
   init({ baseUrl = null, rootPath = null, s3Options, ...legacyS3Options }) {
-    if (legacyS3Options && process.env.NODE_ENV !== 'production')
+    if (legacyS3Options)
       process.emitWarning(
-        "S3 configuration options passed at root level of the plugin's providerOptions is deprecated and will be removed in a future release. You wrap them inside the 's3Options:{}' property."
+        "S3 configuration options passed at root level of the plugin's providerOptions is deprecated and will be removed in a future release. Please wrap them inside the 's3Options:{}' property."
       );
 
     const S3 = new AWS.S3({

--- a/packages/providers/upload-aws-s3/lib/index.js
+++ b/packages/providers/upload-aws-s3/lib/index.js
@@ -17,7 +17,7 @@ function assertUrlProtocol(url) {
 module.exports = {
   init({ baseUrl = null, rootPath = null, s3Options, ...legacyS3Options }) {
     if (legacyS3Options && process.env.NODE_ENV !== 'production')
-      console.log(
+      process.emitWarning(
         "S3 configuration options passed at root level of the plugin's providerOptions is deprecated and will be removed in a future release. You wrap them inside the 's3Options:{}' property."
       );
 
@@ -27,13 +27,13 @@ module.exports = {
       ...legacyS3Options,
     });
 
+    const filePrefix = rootPath ? `${rootPath.replace(/\/+$/, '')}/` : '';
+
     const upload = (file, customParams = {}) =>
       new Promise((resolve, reject) => {
         // upload file on S3 bucket
         const path = file.path ? `${file.path}/` : '';
-        const fileKey = `${rootPath ? `${rootPath.replace(/\/+$/, '')}/` : ''}${path}${file.hash}${
-          file.ext
-        }`;
+        const fileKey = `${filePrefix}${path}${file.hash}${file.ext}`;
         S3.upload(
           {
             Key: fileKey,
@@ -71,9 +71,10 @@ module.exports = {
         return new Promise((resolve, reject) => {
           // delete file on S3 bucket
           const path = file.path ? `${file.path}/` : '';
+          const fileKey = `${filePrefix}${path}${file.hash}${file.ext}`;
           S3.deleteObject(
             {
-              Key: `${rootPath}${path}${file.hash}${file.ext}`,
+              Key: fileKey,
               ...customParams,
             },
             (err) => {

--- a/packages/providers/upload-aws-s3/lib/index.js
+++ b/packages/providers/upload-aws-s3/lib/index.js
@@ -29,11 +29,16 @@ module.exports = {
 
     const filePrefix = rootPath ? `${rootPath.replace(/\/+$/, '')}/` : '';
 
+    function getFileKey(file) {
+      const path = file.path ? `${file.path}/` : '';
+
+      return `${filePrefix}${path}${file.hash}${file.ext}`;
+    }
+
     const upload = (file, customParams = {}) =>
       new Promise((resolve, reject) => {
         // upload file on S3 bucket
-        const path = file.path ? `${file.path}/` : '';
-        const fileKey = `${filePrefix}${path}${file.hash}${file.ext}`;
+        const fileKey = getFileKey(file);
         S3.upload(
           {
             Key: fileKey,
@@ -70,8 +75,7 @@ module.exports = {
       delete(file, customParams = {}) {
         return new Promise((resolve, reject) => {
           // delete file on S3 bucket
-          const path = file.path ? `${file.path}/` : '';
-          const fileKey = `${filePrefix}${path}${file.hash}${file.ext}`;
+          const fileKey = getFileKey(file);
           S3.deleteObject(
             {
               Key: fileKey,


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

This is an updated PR for https://github.com/strapi/strapi/pull/13040 as the author doesn't have capacity to continue working on it. It contains all changes plus addressing all open PR feedback and adding some tests

> This PR allows the upload-aws-s3 plugin to be configured to work with a bucket served through a CDN.
It provides the interface to specify the domain of the CDN through the baseUrl variable and also pick a specific path inside the CDN to store assets from Strapi with the rootPath variable

### Why is it needed?

> It is a very common case users will already have some content and assets served from a CDN and integration with Strapi should not break this set up.

### How to test it?

Configure upload-aws-s3 plugin and set `baseUrl` and/or `rootPath` config and upload a file

### Related issue(s)/PR(s)

Opened as a replacement for https://github.com/strapi/strapi/pull/13040 due to inactive contributor.
