### PR TITLE
Color-Picker: Add react and react-dom dependencies

### DIFF
--- a/packages/plugins/color-picker/package.json
+++ b/packages/plugins/color-picker/package.json
@@ -9,7 +9,9 @@
     "displayName": "Color Picker"
   },
   "dependencies": {
-    "react-colorful": "5.6.1"
+    "react-colorful": "5.6.1",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2"
   },
   "peerDependencies": {
     "@strapi/strapi": "^4.4.0"


### PR DESCRIPTION
### What does it do?

Adds `react` and `react-dom` to the dependencies of the color-picker plugin.

### Why is it needed?

Currently a fresh installation prints two warnings:

```
warning "workspace-aggregator-5ad7b7e4-8ed7-4fdf-992b-a09d5f97db46 > @strapi/plugin-color-picker > react-colorful@5.6.1" has unmet peer dependency "react@>=16.8.0".
warning "workspace-aggregator-5ad7b7e4-8ed7-4fdf-992b-a09d5f97db46 > @strapi/plugin-color-picker > react-colorful@5.6.1" has unmet peer dependency "react-dom@>=16.8.0".
```

which can be resolved by adding `react` and `react-dom` as dependencies.

### How to test it?

Run a fresh installation and verify no warnings are thrown.
