### PR TITLE
Fix load-files import

### DIFF
--- a/packages/core/strapi/lib/load/load-files.js
+++ b/packages/core/strapi/lib/load/load-files.js
@@ -4,7 +4,7 @@ const path = require('path');
 const _ = require('lodash');
 const fse = require('fs-extra');
 
-const { importDefault } = require('../utils');
+const { importDefault } = require('@strapi/utils');
 const glob = require('./glob');
 const filePathToPath = require('./filepath-to-prop-path');
 

--- a/packages/core/utils/jest.config.js
+++ b/packages/core/utils/jest.config.js
@@ -7,4 +7,5 @@ module.exports = {
   ...baseConfig,
   displayName: (pkg.strapi && pkg.strapi.name) || pkg.name,
   roots: [__dirname],
+  testMatch: ['<rootDir>/**/*.test.js'],
 };

--- a/packages/core/utils/lib/__tests__/import-default/cjs.js
+++ b/packages/core/utils/lib/__tests__/import-default/cjs.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = {
+  foo: 'bar',
+  cb() {
+    return 42;
+  },
+};

--- a/packages/core/utils/lib/__tests__/import-default/esm.js
+++ b/packages/core/utils/lib/__tests__/import-default/esm.js
@@ -1,0 +1,11 @@
+'use strict';
+
+module.exports = {
+  __esModule: true,
+  default: {
+    foo: 'bar',
+    cb() {
+      return 42;
+    },
+  },
+};

--- a/packages/core/utils/lib/__tests__/import-default/index.test.js
+++ b/packages/core/utils/lib/__tests__/import-default/index.test.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const path = require('path');
+const importDefault = require('../../import-default');
+
+const getPath = (file) => path.resolve(__dirname, file);
+
+describe('Import Default', () => {
+  test('ESM', () => {
+    const content = importDefault(getPath('./esm'));
+
+    expect(content).toBeDefined();
+    expect(content).toMatchObject(
+      expect.objectContaining({
+        foo: 'bar',
+        cb: expect.any(Function),
+      })
+    );
+    expect(content.cb()).toBe(42);
+  });
+
+  test('CJS', () => {
+    const content = importDefault(getPath('./cjs'));
+
+    expect(content).toBeDefined();
+    expect(content).toMatchObject(
+      expect.objectContaining({
+        foo: 'bar',
+        cb: expect.any(Function),
+      })
+    );
+    expect(content.cb()).toBe(42);
+  });
+});


### PR DESCRIPTION
### What does it do?

Fix load-files (bad import)

### Why is it needed?

- Currently, it's not possible to run a strapi application as it will break on the load-files

### How to test it?

- Go to `examples/getstarted`
- Run `yarn develop`
- The application should start normally

