### PR TITLE
Fix: Make favicon middleware backwards compatible with pngs

### DIFF
--- a/packages/core/strapi/lib/middlewares/favicon.js
+++ b/packages/core/strapi/lib/middlewares/favicon.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { existsSync } = require('fs');
 const { resolve } = require('path');
 const { defaultsDeep } = require('lodash/fp');
 const favicon = require('koa-favicon');
@@ -13,7 +14,19 @@ const defaults = {
  * @type {import('./').MiddlewareFactory}
  */
 module.exports = (config, { strapi }) => {
-  const { maxAge, path: faviconPath } = defaultsDeep(defaults, config);
+  const { maxAge, path: faviconDefaultPath } = defaultsDeep(defaults, config);
+  const { root: appRoot } = strapi.dirs.app;
+  let faviconPath = faviconDefaultPath;
 
-  return favicon(resolve(strapi.dirs.app.root, faviconPath), { maxAge });
+  /** TODO (v5): Updating the favicon to use a png caused
+   *  https://github.com/strapi/strapi/issues/14693
+   *
+   *  This check ensures backwards compatibility until
+   *  the next major version
+   */
+  if (!existsSync(resolve(appRoot, faviconPath))) {
+    faviconPath = 'favicon.ico';
+  }
+
+  return favicon(resolve(appRoot, faviconPath), { maxAge });
 };


### PR DESCRIPTION
### What does it do?

Makes the switch to png favicons in https://github.com/strapi/strapi/pull/14655 backward compatible. In case the `.png` doesn't exist in the app it falls back to use the `.ico` version.

### Why is it needed?

Ensures backward compatibility.

### How to test it?

1. Rename the `favicon.png` to `favicon.ico` from the getstarted example
2. Restart the server
3. Validate it does not crash or log an error.

### Related issue(s)/PR(s)

- Fixes https://github.com/strapi/strapi/issues/14693

