### PR TITLE
[DEITS] Cleanup (tooling & error handling)

### DIFF
--- a/packages/core/data-transfer/lib/engine/index.ts
+++ b/packages/core/data-transfer/lib/engine/index.ts
@@ -132,8 +132,11 @@ class TransferEngine implements ITransferEngine {
     const inStream = await this.sourceProvider.streamEntities?.();
     const outStream = await this.destinationProvider.getEntitiesStream?.();
 
-    if (!inStream || !outStream) {
-      throw new Error('Unable to transfer entities, one of the stream is missing');
+    if (!inStream) {
+      throw new Error('Unable to transfer entities, source stream is missing');
+    }
+    if (!outStream) {
+      throw new Error('Unable to transfer entities, destination stream is missing');
     }
 
     return new Promise((resolve, reject) => {
@@ -159,8 +162,11 @@ class TransferEngine implements ITransferEngine {
     const inStream = await this.sourceProvider.streamLinks?.();
     const outStream = await this.destinationProvider.getLinksStream?.();
 
-    if (!inStream || !outStream) {
-      throw new Error('Unable to transfer links, one of the stream is missing');
+    if (!inStream) {
+      throw new Error('Unable to transfer links, source stream is missing');
+    }
+    if (!outStream) {
+      throw new Error('Unable to transfer links, destination stream is missing');
     }
 
     return new Promise((resolve, reject) => {

--- a/packages/core/data-transfer/lib/providers/local-strapi-source-provider/index.ts
+++ b/packages/core/data-transfer/lib/providers/local-strapi-source-provider/index.ts
@@ -57,7 +57,7 @@ class LocalStrapiSourceProvider implements ISourceProvider {
     ]);
   }
 
-  streamLinks(): NodeJS.ReadableStream {
+  async streamLinks(): Promise<NodeJS.ReadableStream> {
     if (!this.strapi) {
       throw new Error('Not able to stream links. Strapi instance not found');
     }

--- a/packages/core/data-transfer/lib/providers/local-strapi-source-provider/index.ts
+++ b/packages/core/data-transfer/lib/providers/local-strapi-source-provider/index.ts
@@ -57,7 +57,7 @@ class LocalStrapiSourceProvider implements ISourceProvider {
     ]);
   }
 
-  async streamLinks(): Promise<NodeJS.ReadableStream> {
+  streamLinks(): NodeJS.ReadableStream {
     if (!this.strapi) {
       throw new Error('Not able to stream links. Strapi instance not found');
     }

--- a/packages/core/data-transfer/package.json
+++ b/packages/core/data-transfer/package.json
@@ -28,7 +28,7 @@
   "types": "./dist/index.d.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "clean": "rm -fr ./dist",
+    "clean": "rimraf ./dist",
     "build:clean": "yarn clean && yarn build",
     "watch": "yarn build -w",
     "test:unit": "jest --verbose"
@@ -50,6 +50,7 @@
     "@types/stream-chain": "2.0.1",
     "@types/stream-json": "1.7.2",
     "@types/tar": "6.1.3",
+    "rimraf": "3.0.2",
     "typescript": "4.8.4"
   },
   "engines": {

--- a/packages/core/data-transfer/package.json
+++ b/packages/core/data-transfer/package.json
@@ -28,6 +28,8 @@
   "types": "./dist/index.d.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
+    "clean": "rm -fr ./dist",
+    "build:clean": "yarn clean && yarn build",
     "watch": "yarn build -w",
     "test:unit": "jest --verbose"
   },

--- a/packages/core/strapi/lib/commands/transfer/export.js
+++ b/packages/core/strapi/lib/commands/transfer/export.js
@@ -7,6 +7,7 @@ const {
   // TODO: we need to solve this issue with typescript modules
   // eslint-disable-next-line import/no-unresolved, node/no-missing-require
 } = require('@strapi/data-transfer');
+
 const strapi = require('../../Strapi');
 
 const getDefaultExportBackupName = () => `strapi-backup`;


### PR DESCRIPTION
### What does it do?

- improves logs
- adds a `clean` and `build:clean` to help fix cases where old build files are causing problems

### Why is it needed?

to make things nicer

### How to test it?

Run clean or build:clean from the data-transfer directory.

### Related issue(s)/PR(s)


