### PR TITLE
[DEITS] Fix local file source provider unit tests

### DIFF
--- a/packages/core/data-transfer/lib/providers/local-strapi-source-provider/__tests__/test-utils.ts
+++ b/packages/core/data-transfer/lib/providers/local-strapi-source-provider/__tests__/test-utils.ts
@@ -55,3 +55,23 @@ export const createMockedReadableFactory = <T extends string = ContentType>(sour
   jest.fn((uid: T) => {
     return Readable.from(source[uid] || []);
   });
+
+/**
+ * Create a factory of mocked query builders
+ */
+export const createMockedQueryBuilder = <T extends string = ContentType>(data: {
+  [key in T]: unknown[];
+}) =>
+  jest.fn((uid: T) => {
+    const state: { [key: string]: unknown } = { populate: undefined };
+
+    return {
+      populate(populate: unknown) {
+        state.populate = populate;
+        return this;
+      },
+      stream() {
+        return Readable.from(data[uid]);
+      },
+    };
+  });


### PR DESCRIPTION

### What does it do?

Fix the failing unit tests

### Why is it needed?

Unit tests were broken because they were defining the entityService.stream API although the source code is using the new query builder stream API

### How to test it?

- Run `yarn test:unit data-transfer`
- Every test should pass
