### PR TITLE
Chore: Fix prop-type errors

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/DynamicTable/CellContent/RelationMultiple/tests/index.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/DynamicTable/CellContent/RelationMultiple/tests/index.test.js
@@ -26,6 +26,7 @@ const DEFAULT_PROPS_FIXTURE = {
   contentType: {
     uid: 'api::address.address',
   },
+  entityId: 1,
   fieldSchema: {
     type: 'relation',
     relation: 'manyToMany',

--- a/packages/core/admin/admin/src/content-manager/pages/EditView/Header/tests/index.test.js
+++ b/packages/core/admin/admin/src/content-manager/pages/EditView/Header/tests/index.test.js
@@ -23,6 +23,7 @@ const defaultProps = {
   layout: ct,
   modifiedData: {},
   onPublish: jest.fn(),
+  onPublishPromptDismissal: jest.fn(),
   onUnpublish: jest.fn(),
   status: 'resolved',
   publishConfirmation: {


### PR DESCRIPTION
### What does it do?

Fixes prop-types for some FE tests. There is still one failing test which will be fixed by https://github.com/strapi/strapi/pull/14659

### Why is it needed?

Tests now fail if prop-types fail, which proves to be helpful already.