### PR TITLE
CM: Stop passing defaultParams down (not needed any longer)

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/RelationInputDataManager.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/RelationInputDataManager.js
@@ -215,6 +215,7 @@ export const RelationInputDataManager = ({
 
 RelationInputDataManager.defaultProps = {
   componentId: undefined,
+  componentUid: undefined,
   editable: true,
   error: undefined,
   description: '',
@@ -226,6 +227,7 @@ RelationInputDataManager.defaultProps = {
 
 RelationInputDataManager.propTypes = {
   componentId: PropTypes.number,
+  componentUid: PropTypes.string,
   editable: PropTypes.bool,
   error: PropTypes.string,
   description: PropTypes.string,

--- a/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/RelationInputDataManager.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/RelationInputDataManager.js
@@ -23,7 +23,7 @@ export const RelationInputDataManager = ({
   labelAction,
   mainField,
   name,
-  queryInfos: { endpoints, defaultParams, shouldDisplayRelationLink },
+  queryInfos: { endpoints, shouldDisplayRelationLink },
   placeholder,
   required,
   relationType,
@@ -39,7 +39,6 @@ export const RelationInputDataManager = ({
       enabled: get(initialData, name)?.count !== 0 && !!endpoints.relation,
       endpoint: endpoints.relation,
       pageParams: {
-        ...defaultParams,
         pageSize: RELATIONS_TO_DISPLAY,
       },
     },
@@ -47,7 +46,6 @@ export const RelationInputDataManager = ({
     search: {
       endpoint: endpoints.search,
       pageParams: {
-        ...defaultParams,
         entityId: isCreatingEntry ? undefined : componentId ?? initialData.id,
         pageSize: SEARCH_RESULTS_TO_DISPLAY,
       },
@@ -249,9 +247,6 @@ RelationInputDataManager.propTypes = {
   size: PropTypes.number.isRequired,
   targetModel: PropTypes.string.isRequired,
   queryInfos: PropTypes.shape({
-    defaultParams: PropTypes.shape({
-      _component: PropTypes.string,
-    }),
     endpoints: PropTypes.shape({
       relation: PropTypes.string,
       search: PropTypes.string.isRequired,

--- a/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/RelationInputDataManager.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/RelationInputDataManager.js
@@ -19,6 +19,7 @@ import { connect, select, normalizeSearchResults, diffRelations, normalizeRelati
 export const RelationInputDataManager = ({
   error,
   componentId,
+  // eslint-disable-next-line react/prop-types
   componentUid,
   editable,
   description,
@@ -217,7 +218,6 @@ export const RelationInputDataManager = ({
 
 RelationInputDataManager.defaultProps = {
   componentId: undefined,
-  componentUid: undefined,
   editable: true,
   error: undefined,
   description: '',
@@ -229,7 +229,6 @@ RelationInputDataManager.defaultProps = {
 
 RelationInputDataManager.propTypes = {
   componentId: PropTypes.number,
-  componentUid: PropTypes.string,
   editable: PropTypes.bool,
   error: PropTypes.string,
   description: PropTypes.string,

--- a/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/RelationInputDataManager.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/RelationInputDataManager.js
@@ -29,7 +29,7 @@ export const RelationInputDataManager = ({
   labelAction,
   mainField,
   name,
-  queryInfos: { endpoints, shouldDisplayRelationLink },
+  queryInfos: { endpoints, defaultParams, shouldDisplayRelationLink },
   placeholder,
   required,
   relationType,
@@ -51,6 +51,7 @@ export const RelationInputDataManager = ({
       endpoint: endpoints.relation,
       pageGoal: currentLastPage,
       pageParams: {
+        ...defaultParams,
         pageSize: RELATIONS_TO_DISPLAY,
       },
       onLoad: loadRelation,
@@ -64,6 +65,7 @@ export const RelationInputDataManager = ({
     search: {
       endpoint: endpoints.search,
       pageParams: {
+        ...defaultParams,
         // TODO: fix me cause this sucks
         entityId: isCreatingEntry
           ? undefined
@@ -257,6 +259,9 @@ RelationInputDataManager.propTypes = {
   size: PropTypes.number.isRequired,
   targetModel: PropTypes.string.isRequired,
   queryInfos: PropTypes.shape({
+    defaultParams: PropTypes.shape({
+      locale: PropTypes.string,
+    }),
     endpoints: PropTypes.shape({
       relation: PropTypes.string,
       search: PropTypes.string.isRequired,

--- a/packages/core/admin/admin/src/content-manager/hooks/useFetchContentTypeLayout/utils/formatLayouts.js
+++ b/packages/core/admin/admin/src/content-manager/hooks/useFetchContentTypeLayout/utils/formatLayouts.js
@@ -87,6 +87,7 @@ const formatLayoutWithMetas = (contentTypeConfiguration, models) =>
         const targetModelSchema = getRelationModel(targetModelUID, models);
         const targetModelPluginOptions = targetModelSchema.pluginOptions || {};
 
+        /** We inject  */
         const queryInfos = generateRelationQueryInfos(
           contentTypeConfiguration,
           attribute.name,

--- a/packages/core/admin/admin/src/content-manager/hooks/useFetchContentTypeLayout/utils/formatLayouts.js
+++ b/packages/core/admin/admin/src/content-manager/hooks/useFetchContentTypeLayout/utils/formatLayouts.js
@@ -83,19 +83,17 @@ const formatLayoutWithMetas = (contentTypeConfiguration, models) =>
       };
 
       if (fieldSchema.type === 'relation') {
-        const targetModelUID = fieldSchema.targetModel;
-        const targetModelSchema = getRelationModel(targetModelUID, models);
+        const targetModelSchema = getRelationModel(fieldSchema.targetModel, models);
         const targetModelPluginOptions = targetModelSchema.pluginOptions || {};
 
-        /** We inject  */
-        const queryInfos = generateRelationQueryInfos(
-          contentTypeConfiguration,
-          attribute.name,
-          models
-        );
-
         set(data, 'targetModelPluginOptions', targetModelPluginOptions);
-        set(data, 'queryInfos', queryInfos);
+        set(data, 'queryInfos', {
+          shouldDisplayRelationLink: shouldDisplayRelationLink(
+            contentTypeConfiguration,
+            attribute.name,
+            models
+          ),
+        });
       }
 
       return data;
@@ -148,13 +146,10 @@ const formatListLayoutWithMetas = (contentTypeConfiguration, components) => {
   return formatted;
 };
 
-const generateRelationQueryInfos = (contentTypeConfiguration, fieldName, models) => {
+const shouldDisplayRelationLink = (contentTypeConfiguration, fieldName, models) => {
   const targetModel = get(contentTypeConfiguration, ['attributes', fieldName, 'targetModel'], '');
-  const shouldDisplayRelationLink = getDisplayedModels(models).includes(targetModel);
 
-  return {
-    shouldDisplayRelationLink,
-  };
+  return getDisplayedModels(models).includes(targetModel);
 };
 
 const getDisplayedModels = (models) =>
@@ -164,6 +159,6 @@ export default formatLayouts;
 export {
   formatLayoutWithMetas,
   formatListLayoutWithMetas,
-  generateRelationQueryInfos,
+  shouldDisplayRelationLink,
   getDisplayedModels,
 };

--- a/packages/core/admin/admin/src/content-manager/hooks/useFetchContentTypeLayout/utils/formatLayouts.js
+++ b/packages/core/admin/admin/src/content-manager/hooks/useFetchContentTypeLayout/utils/formatLayouts.js
@@ -163,7 +163,6 @@ const generateRelationQueryInfos = (contentTypeConfiguration, fieldName, models)
   const shouldDisplayRelationLink = getDisplayedModels(models).includes(targetModel);
 
   return {
-    defaultParams: {},
     shouldDisplayRelationLink,
   };
 };
@@ -173,9 +172,6 @@ const generateRelationQueryInfosForComponents = (contentTypeConfiguration, field
   const shouldDisplayRelationLink = getDisplayedModels(models).includes(targetModel);
 
   return {
-    defaultParams: {
-      component: contentTypeConfiguration.uid,
-    },
     shouldDisplayRelationLink,
   };
 };

--- a/packages/core/admin/admin/src/content-manager/hooks/useFetchContentTypeLayout/utils/formatLayouts.js
+++ b/packages/core/admin/admin/src/content-manager/hooks/useFetchContentTypeLayout/utils/formatLayouts.js
@@ -89,13 +89,11 @@ const formatLayoutWithMetas = (contentTypeConfiguration, ctUid, models) => {
         const targetModelSchema = getRelationModel(targetModelUID, models);
         const targetModelPluginOptions = targetModelSchema.pluginOptions || {};
 
-        const queryInfos = ctUid
-          ? generateRelationQueryInfosForComponents(
-              contentTypeConfiguration,
-              attribute.name,
-              models
-            )
-          : generateRelationQueryInfos(contentTypeConfiguration, attribute.name, models);
+        const queryInfos = generateRelationQueryInfos(
+          contentTypeConfiguration,
+          attribute.name,
+          models
+        );
 
         set(data, 'targetModelPluginOptions', targetModelPluginOptions);
         set(data, 'queryInfos', queryInfos);
@@ -120,11 +118,7 @@ const formatListLayoutWithMetas = (contentTypeConfiguration, components) => {
     const type = fieldSchema.type;
 
     if (type === 'relation') {
-      const queryInfos = {
-        defaultParams: {},
-      };
-
-      acc.push({ key: `__${current}_key__`, name: current, fieldSchema, metadatas, queryInfos });
+      acc.push({ key: `__${current}_key__`, name: current, fieldSchema, metadatas });
 
       return acc;
     }
@@ -167,15 +161,6 @@ const generateRelationQueryInfos = (contentTypeConfiguration, fieldName, models)
   };
 };
 
-const generateRelationQueryInfosForComponents = (contentTypeConfiguration, fieldName, models) => {
-  const targetModel = get(contentTypeConfiguration, ['attributes', fieldName, 'targetModel'], '');
-  const shouldDisplayRelationLink = getDisplayedModels(models).includes(targetModel);
-
-  return {
-    shouldDisplayRelationLink,
-  };
-};
-
 const getDisplayedModels = (models) =>
   models.filter((model) => model.isDisplayed).map(({ uid }) => uid);
 
@@ -184,6 +169,5 @@ export {
   formatLayoutWithMetas,
   formatListLayoutWithMetas,
   generateRelationQueryInfos,
-  generateRelationQueryInfosForComponents,
   getDisplayedModels,
 };

--- a/packages/core/admin/admin/src/content-manager/hooks/useFetchContentTypeLayout/utils/formatLayouts.js
+++ b/packages/core/admin/admin/src/content-manager/hooks/useFetchContentTypeLayout/utils/formatLayouts.js
@@ -6,21 +6,19 @@ const getRelationModel = (targetModel, models) => models.find((model) => model.u
 const formatLayouts = (initialData, models) => {
   const data = createMetasSchema(initialData, models);
 
-  const formattedCTEditLayout = formatLayoutWithMetas(data.contentType, null, models);
-  const ctUid = data.contentType.uid;
+  const formattedCTEditLayout = formatLayoutWithMetas(data.contentType, models);
   const formattedListLayout = formatListLayoutWithMetas(data.contentType, data.components);
 
   set(data, ['contentType', 'layouts', 'edit'], formattedCTEditLayout);
   set(data, ['contentType', 'layouts', 'list'], formattedListLayout);
 
-  Object.keys(data.components).forEach((compoUID) => {
-    const formattedCompoEditLayout = formatLayoutWithMetas(
-      data.components[compoUID],
-      ctUid,
+  Object.keys(data.components).forEach((componentUid) => {
+    const formattedComponentEditLayout = formatLayoutWithMetas(
+      data.components[componentUid],
       models
     );
 
-    set(data, ['components', compoUID, 'layouts', 'edit'], formattedCompoEditLayout);
+    set(data, ['components', componentUid, 'layouts', 'edit'], formattedComponentEditLayout);
   });
 
   return data;
@@ -73,8 +71,8 @@ const createMetasSchema = (initialData, models) => {
   return data;
 };
 
-const formatLayoutWithMetas = (contentTypeConfiguration, ctUid, models) => {
-  const formatted = contentTypeConfiguration.layouts.edit.reduce((acc, current) => {
+const formatLayoutWithMetas = (contentTypeConfiguration, models) =>
+  contentTypeConfiguration.layouts.edit.reduce((acc, current) => {
     const row = current.map((attribute) => {
       const fieldSchema = get(contentTypeConfiguration, ['attributes', attribute.name], {});
 
@@ -106,9 +104,6 @@ const formatLayoutWithMetas = (contentTypeConfiguration, ctUid, models) => {
 
     return acc;
   }, []);
-
-  return formatted;
-};
 
 const formatListLayoutWithMetas = (contentTypeConfiguration, components) => {
   const formatted = contentTypeConfiguration.layouts.list.reduce((acc, current) => {

--- a/packages/core/admin/admin/src/content-manager/hooks/useFetchContentTypeLayout/utils/tests/formatLayouts.test.js
+++ b/packages/core/admin/admin/src/content-manager/hooks/useFetchContentTypeLayout/utils/tests/formatLayouts.test.js
@@ -2,7 +2,6 @@ import formatLayouts, {
   formatLayoutWithMetas,
   formatListLayoutWithMetas,
   generateRelationQueryInfos,
-  generateRelationQueryInfosForComponents,
   getDisplayedModels,
 } from '../formatLayouts';
 
@@ -556,16 +555,6 @@ describe('Content Manager | hooks | useFetchContentTypeLayout | utils ', () => {
   describe('generateRelationQueryInfos', () => {
     it('should return an object with the correct keys', () => {
       expect(generateRelationQueryInfos(addressSchema, 'categories', simpleModels)).toEqual({
-        shouldDisplayRelationLink: true,
-      });
-    });
-  });
-
-  describe('generateRelationQueryInfosForComponents', () => {
-    it('should return an object with the correct keys', () => {
-      expect(
-        generateRelationQueryInfosForComponents(addressSchema, 'categories', simpleModels)
-      ).toEqual({
         shouldDisplayRelationLink: true,
       });
     });

--- a/packages/core/admin/admin/src/content-manager/hooks/useFetchContentTypeLayout/utils/tests/formatLayouts.test.js
+++ b/packages/core/admin/admin/src/content-manager/hooks/useFetchContentTypeLayout/utils/tests/formatLayouts.test.js
@@ -1,7 +1,7 @@
 import formatLayouts, {
   formatLayoutWithMetas,
   formatListLayoutWithMetas,
-  generateRelationQueryInfos,
+  shouldDisplayRelationLink,
   getDisplayedModels,
 } from '../formatLayouts';
 
@@ -520,7 +520,7 @@ describe('Content Manager | hooks | useFetchContentTypeLayout | utils ', () => {
     });
   });
 
-  describe('generateRelationQueryInfos', () => {
+  describe('shouldDisplayRelationLink', () => {
     it('should generate shouldDisplayRelationLink = true for displayed models', () => {
       const MODELS = [
         {
@@ -538,9 +538,7 @@ describe('Content Manager | hooks | useFetchContentTypeLayout | utils ', () => {
         },
       };
 
-      expect(generateRelationQueryInfos(SCHEMA_ADDRESS, 'categories', MODELS)).toEqual({
-        shouldDisplayRelationLink: true,
-      });
+      expect(shouldDisplayRelationLink(SCHEMA_ADDRESS, 'categories', MODELS)).toBeTruthy();
     });
 
     it('should generate shouldDisplayRelationLink = false for non displayed models', () => {
@@ -560,9 +558,7 @@ describe('Content Manager | hooks | useFetchContentTypeLayout | utils ', () => {
         },
       };
 
-      expect(generateRelationQueryInfos(SCHEMA_ADDRESS, 'categories', MODELS)).toEqual({
-        shouldDisplayRelationLink: false,
-      });
+      expect(shouldDisplayRelationLink(SCHEMA_ADDRESS, 'categories', MODELS)).toBeFalsy();
     });
   });
 

--- a/packages/core/admin/admin/src/content-manager/hooks/useFetchContentTypeLayout/utils/tests/formatLayouts.test.js
+++ b/packages/core/admin/admin/src/content-manager/hooks/useFetchContentTypeLayout/utils/tests/formatLayouts.test.js
@@ -531,7 +531,7 @@ describe('Content Manager | hooks | useFetchContentTypeLayout | utils ', () => {
             },
           },
           fieldSchema: { type: 'relation', targetModel: 'category' },
-          queryInfos: { defaultParams: {} },
+          queryInfos: {},
         },
         {
           name: 'component',
@@ -556,7 +556,6 @@ describe('Content Manager | hooks | useFetchContentTypeLayout | utils ', () => {
   describe('generateRelationQueryInfos', () => {
     it('should return an object with the correct keys', () => {
       expect(generateRelationQueryInfos(addressSchema, 'categories', simpleModels)).toEqual({
-        defaultParams: {},
         shouldDisplayRelationLink: true,
       });
     });
@@ -567,9 +566,6 @@ describe('Content Manager | hooks | useFetchContentTypeLayout | utils ', () => {
       expect(
         generateRelationQueryInfosForComponents(addressSchema, 'categories', simpleModels)
       ).toEqual({
-        defaultParams: {
-          component: 'api::address.address',
-        },
         shouldDisplayRelationLink: true,
       });
     });

--- a/packages/core/admin/admin/src/content-manager/hooks/useFetchContentTypeLayout/utils/tests/formatLayouts.test.js
+++ b/packages/core/admin/admin/src/content-manager/hooks/useFetchContentTypeLayout/utils/tests/formatLayouts.test.js
@@ -5,37 +5,6 @@ import formatLayouts, {
   getDisplayedModels,
 } from '../formatLayouts';
 
-const addressSchema = {
-  uid: 'api::address.address',
-  attributes: {
-    categories: {
-      targetModel: 'api::category.category',
-    },
-  },
-  layouts: {},
-  metadatas: {
-    categories: {
-      edit: {
-        mainField: {
-          name: 'name',
-          type: 'string',
-        },
-      },
-    },
-  },
-};
-const simpleModels = [
-  {
-    uid: 'api::category.category',
-    isDisplayed: true,
-    attributes: {
-      name: {
-        type: 'string',
-      },
-    },
-  },
-];
-
 describe('Content Manager | hooks | useFetchContentTypeLayout | utils ', () => {
   describe('formatLayouts', () => {
     it('should format the content type and components layouts', () => {
@@ -530,7 +499,6 @@ describe('Content Manager | hooks | useFetchContentTypeLayout | utils ', () => {
             },
           },
           fieldSchema: { type: 'relation', targetModel: 'category' },
-          queryInfos: {},
         },
         {
           name: 'component',
@@ -553,9 +521,47 @@ describe('Content Manager | hooks | useFetchContentTypeLayout | utils ', () => {
   });
 
   describe('generateRelationQueryInfos', () => {
-    it('should return an object with the correct keys', () => {
-      expect(generateRelationQueryInfos(addressSchema, 'categories', simpleModels)).toEqual({
+    it('should generate shouldDisplayRelationLink = true for displayed models', () => {
+      const MODELS = [
+        {
+          uid: 'api::category.category',
+          isDisplayed: true,
+        },
+      ];
+
+      const SCHEMA_ADDRESS = {
+        uid: 'api::address.address',
+        attributes: {
+          categories: {
+            targetModel: 'api::category.category',
+          },
+        },
+      };
+
+      expect(generateRelationQueryInfos(SCHEMA_ADDRESS, 'categories', MODELS)).toEqual({
         shouldDisplayRelationLink: true,
+      });
+    });
+
+    it('should generate shouldDisplayRelationLink = false for non displayed models', () => {
+      const MODELS = [
+        {
+          uid: 'api::category.category',
+          isDisplayed: false,
+        },
+      ];
+
+      const SCHEMA_ADDRESS = {
+        uid: 'api::address.address',
+        attributes: {
+          categories: {
+            targetModel: 'api::category.category',
+          },
+        },
+      };
+
+      expect(generateRelationQueryInfos(SCHEMA_ADDRESS, 'categories', MODELS)).toEqual({
+        shouldDisplayRelationLink: false,
       });
     });
   });


### PR DESCRIPTION
### What does it do?

We can stop passing down `defaultParams` from the layout.

### Why is it needed?

Simplifies the code.
