### PR TITLE
Add configuration export

### DIFF
--- a/packages/core/data-transfer/lib/engine/index.ts
+++ b/packages/core/data-transfer/lib/engine/index.ts
@@ -190,8 +190,29 @@ class TransferEngine implements ITransferEngine {
   }
 
   async transferConfiguration(): Promise<void> {
-    console.log('transferConfiguration not yet implemented');
-    return new Promise((resolve) => resolve());
+    const inStream = await this.sourceProvider.streamConfiguration?.();
+    const outStream = await this.destinationProvider.getConfigurationStream?.();
+
+    if (!inStream) {
+      throw new Error('Unable to transfer configuration, source stream is missing');
+    }
+    if (!outStream) {
+      throw new Error('Unable to transfer configuration, destination stream is missing');
+    }
+
+    return new Promise((resolve, reject) => {
+      inStream
+        // Throw on error in the source
+        .on('error', reject);
+
+      outStream
+        // Throw on error in the destination
+        .on('error', reject)
+        // Resolve the promise when the destination has finished reading all the data from the source
+        .on('close', resolve);
+
+      inStream.pipe(outStream);
+    });
   }
 }
 

--- a/packages/core/data-transfer/lib/providers/local-file-destination-provider.ts
+++ b/packages/core/data-transfer/lib/providers/local-file-destination-provider.ts
@@ -1,10 +1,9 @@
 import fs from 'fs';
 import path from 'path';
 import zip from 'zlib';
-import { Duplex } from 'stream';
-import { chain, Writable } from 'stream-chain';
+import { Writable } from 'stream';
+import { chain } from 'stream-chain';
 import { stringer } from 'stream-json/jsonl/Stringer';
-import type { Cipher } from 'crypto';
 
 import type { IDestinationProvider, ProviderType, Stream } from '../../types';
 import { createCipher } from '../encryption/encrypt';
@@ -43,6 +42,26 @@ class LocalFileDestinationProvider implements IDestinationProvider {
     this.options = options;
   }
 
+  #getDataTransformers() {
+    const transforms = [];
+
+    // Convert to stringified JSON lines
+    transforms.push(stringer());
+
+    // Compression
+    if (this.options.compression.enabled) {
+      transforms.push(zip.createGzip());
+    }
+
+    // Encryption
+    if (this.options.encryption.enabled) {
+      const cipher = createCipher(this.options.encryption.key);
+      transforms.push(cipher);
+    }
+
+    return transforms;
+  }
+
   bootstrap(): void | Promise<void> {
     const rootDir = this.options.file.path;
     const dirExists = fs.existsSync(rootDir);
@@ -66,81 +85,47 @@ class LocalFileDestinationProvider implements IDestinationProvider {
     return null;
   }
 
-  getEntitiesStream(): Duplex {
-    const filePathFactory = (fileIndex: number = 0) => {
-      return path.join(
-        // Backup path
-        this.options.file.path,
-        // "entities/" directory
-        'entities',
-        // "entities_00000.jsonl" file
-        `entities_${String(fileIndex).padStart(5, '0')}.jsonl`
-      );
-    };
+  getEntitiesStream(): NodeJS.WritableStream {
+    const filePathFactory = createFilePathFactory(this.options.file.path, 'entities');
 
-    const streams: any[] = [
-      // create jsonl strings from object entities
-      stringer(),
-    ];
-
-    // Compression
-    if (this.options.compression.enabled) {
-      streams.push(zip.createGzip());
-    }
-
-    // Encryption
-    if (this.options.encryption.enabled) {
-      streams.push(createCipher(this.options.encryption.key));
-    }
+    // Transform streams
+    const transforms: Writable[] = this.#getDataTransformers();
 
     // FS write stream
-    streams.push(createMultiFilesWriteStream(filePathFactory, this.options.file.maxSize));
+    const fileStream = createMultiFilesWriteStream(filePathFactory, this.options.file.maxSize);
+
+    // Full pipeline
+    const streams = transforms.concat(fileStream);
 
     return chain(streams);
   }
 
-  getLinksStream(): Duplex | Promise<Duplex> {
-    const options = {
-      encryption: {
-        enabled: true,
-        key: 'Hello World!',
-      },
-      compression: {
-        enabled: false,
-      },
-      file: {
-        maxSize: 100000,
-      },
-    };
+  getLinksStream(): NodeJS.WritableStream {
+    const filePathFactory = createFilePathFactory(this.options.file.path, 'links');
 
-    const filePathFactory = (fileIndex: number = 0) => {
-      return path.join(
-        // Backup path
-        this.options.file.path,
-        // "links/" directory
-        'links',
-        // "links_00000.jsonl" file
-        `links_${String(fileIndex).padStart(5, '0')}.jsonl`
-      );
-    };
-
-    const streams: any[] = [
-      // create jsonl strings from object links
-      stringer(),
-    ];
-
-    // Compression
-    if (options.compression.enabled) {
-      streams.push(zip.createGzip());
-    }
-
-    // Encryption
-    // if (options.encryption?.enabled) {
-    //   streams.push(encrypt(options.encryption.key).cipher());
-    // }
+    // Transform streams
+    const transforms: Writable[] = this.#getDataTransformers();
 
     // FS write stream
-    streams.push(createMultiFilesWriteStream(filePathFactory, options.file.maxSize));
+    const fileStream = createMultiFilesWriteStream(filePathFactory, this.options.file.maxSize);
+
+    // Full pipelines
+    const streams = transforms.concat(fileStream);
+
+    return chain(streams);
+  }
+
+  getConfigurationStream(): NodeJS.WritableStream {
+    const filePathFactory = createFilePathFactory(this.options.file.path, 'configuration');
+
+    // Transform streams
+    const transforms: Writable[] = this.#getDataTransformers();
+
+    // FS write stream
+    const fileStream = createMultiFilesWriteStream(filePathFactory, this.options.file.maxSize);
+
+    // Full pipeline
+    const streams = transforms.concat(fileStream);
 
     return chain(streams);
   }
@@ -153,7 +138,7 @@ class LocalFileDestinationProvider implements IDestinationProvider {
 const createMultiFilesWriteStream = (
   filePathFactory: (index?: number) => string,
   maxFileSize?: number
-): Stream => {
+): Writable => {
   let fileIndex = 0;
   let fileSize = 0;
   let maxSize = maxFileSize;
@@ -198,3 +183,20 @@ const createMultiFilesWriteStream = (
     },
   });
 };
+
+/**
+ * Create a file path factory for a given path & prefix.
+ * Upon being called, the factory will return a file path for a given index
+ */
+const createFilePathFactory =
+  (src: string, directory: string, prefix: string = directory) =>
+  (fileIndex: number = 0): string => {
+    return path.join(
+      // Backup path
+      src,
+      // "{directory}/" directory
+      directory,
+      // "${prefix}_XXXXX.jsonl" file
+      `${prefix}_${String(fileIndex).padStart(5, '0')}.jsonl`
+    );
+  };

--- a/packages/core/data-transfer/lib/providers/local-strapi-source-provider/__tests__/configuration.test.ts
+++ b/packages/core/data-transfer/lib/providers/local-strapi-source-provider/__tests__/configuration.test.ts
@@ -1,0 +1,40 @@
+import { Readable } from 'stream';
+
+import { collect, createMockedQueryBuilder, getStrapiFactory } from './test-utils';
+import { createConfigurationStream } from '../configuration';
+
+describe('Configuration', () => {
+  test('Should return configuration from multiple data sources, wrapped in the same data format', async () => {
+    const queryBuilder = createMockedQueryBuilder({
+      'strapi::core-store': [
+        // Values must be stringified JSON for the core-store
+        { id: 1, key: 'foo', value: '{}' },
+        { id: 2, key: 'bar', value: '{}' },
+      ],
+      webhook: [
+        { id: 1, url: '/foo', headers: {}, events: [], enabled: false },
+        { id: 2, url: '/bar', headers: {}, events: [], enabled: true },
+        { id: 3, url: '/foobar', headers: {}, events: [], enabled: true },
+      ],
+    });
+
+    const strapi = getStrapiFactory({ db: { queryBuilder } })();
+
+    const stream = createConfigurationStream(strapi);
+
+    expect(stream).toBeInstanceOf(Readable);
+
+    const results = await collect(stream);
+
+    expect(results).toHaveLength(5);
+
+    results.forEach((result) => {
+      expect(result).toMatchObject(
+        expect.objectContaining({
+          type: expect.stringMatching(/^(core-store|webhook)$/),
+          value: expect.any(Object),
+        })
+      );
+    });
+  });
+});

--- a/packages/core/data-transfer/lib/providers/local-strapi-source-provider/__tests__/links.test.ts
+++ b/packages/core/data-transfer/lib/providers/local-strapi-source-provider/__tests__/links.test.ts
@@ -2,7 +2,7 @@ import { Duplex } from 'stream';
 
 import { createLinksStream } from '../links';
 import { getDeepPopulateQuery } from '../links/utils';
-import { collect, getStrapiFactory, createMockedReadableFactory } from './test-utils';
+import { collect, getStrapiFactory } from './test-utils';
 
 describe('Local Strapi Source Provider - Entities Streaming', () => {
   describe('Create Links Stream', () => {

--- a/packages/core/data-transfer/lib/providers/local-strapi-source-provider/configuration.ts
+++ b/packages/core/data-transfer/lib/providers/local-strapi-source-provider/configuration.ts
@@ -1,0 +1,37 @@
+import { Duplex } from 'stream';
+import { chain } from 'stream-chain';
+import { set } from 'lodash/fp';
+
+/**
+ * Create a readable stream that export the Strapi app configuration
+ */
+export const createConfigurationStream = (strapi: Strapi.Strapi): Duplex => {
+  // Core Store
+  const coreStoreStream = chain([
+    strapi.db.queryBuilder('strapi::core-store').stream(),
+    (data) => set('value', JSON.parse(data.value), data),
+    wrapConfigurationItem('core-store'),
+  ]);
+
+  // Webhook
+  const webhooksStream = chain([
+    strapi.db.queryBuilder('webhook').stream(),
+    wrapConfigurationItem('webhook'),
+  ]);
+
+  const streams = [coreStoreStream, webhooksStream];
+
+  // Readable configuration stream
+  return Duplex.from(async function* () {
+    for (const stream of streams) {
+      for await (const item of stream) {
+        yield item;
+      }
+    }
+  });
+};
+
+const wrapConfigurationItem = (type: 'core-store' | 'webhook') => (value: unknown) => ({
+  type,
+  value,
+});

--- a/packages/core/data-transfer/lib/providers/local-strapi-source-provider/index.ts
+++ b/packages/core/data-transfer/lib/providers/local-strapi-source-provider/index.ts
@@ -4,6 +4,7 @@ import { chain } from 'stream-chain';
 
 import { createEntitiesStream, createEntitiesTransformStream } from './entities';
 import { createLinksStream } from './links';
+import { createConfigurationStream } from './configuration';
 
 export interface ILocalStrapiSourceProviderOptions {
   getStrapi(): Strapi.Strapi | Promise<Strapi.Strapi>;
@@ -63,5 +64,13 @@ class LocalStrapiSourceProvider implements ISourceProvider {
     }
 
     return createLinksStream(this.strapi);
+  }
+
+  streamConfiguration(): NodeJS.ReadableStream {
+    if (!this.strapi) {
+      throw new Error('Not able to stream configuration. Strapi instance not found');
+    }
+
+    return createConfigurationStream(strapi);
   }
 }


### PR DESCRIPTION
### What does it do?

- Add the Strapi configuration export from the local strapi source provider (& handle its data in the local file destination provider)

### Why is it needed?

- Add export capability for the configuration

### How to test it?

- Either run the associated unit test or yarn strapi export --encrypt=false --compress=false and check the exported file
