### PR TITLE
Fix: Publishing single-type if config is true, and allow updating the drafts - api

### DIFF
--- a/packages/core/strapi/lib/core-api/service/__tests__/index.test.js
+++ b/packages/core/strapi/lib/core-api/service/__tests__/index.test.js
@@ -61,7 +61,7 @@ describe('Default Service', () => {
         await service.createOrUpdate({ data: input });
 
         expect(strapi.entityService.findMany).toHaveBeenCalledWith('testModel', {
-          publicationState: 'live',
+          publicationState: 'preview',
         });
 
         expect(strapi.entityService.create).toHaveBeenCalledWith('testModel', { data: input });
@@ -90,7 +90,7 @@ describe('Default Service', () => {
 
         expect(strapi.entityService.findMany).toHaveBeenCalledWith('testModel', {
           populate: undefined,
-          publicationState: 'live',
+          publicationState: 'preview',
         });
 
         expect(strapi.entityService.update).toHaveBeenCalledWith('testModel', 1, {

--- a/packages/core/strapi/tests/single-type.test.api.js
+++ b/packages/core/strapi/tests/single-type.test.api.js
@@ -16,6 +16,7 @@ const model = {
   displayName: 'single-type',
   singularName: 'single-type',
   pluralName: 'single-types',
+  draftAndPublish: true,
   attributes: {
     title: {
       type: 'string',
@@ -64,6 +65,8 @@ describe('Content Manager single types', () => {
         title: 'Title',
       },
     });
+
+    expect(res.body.data.attributes.publishedAt).toBeISODate();
 
     data.id = res.body.data.id;
   });


### PR DESCRIPTION
Signed-off-by: iifawzi <iifawzie@gmail.com>

### What does it do?

Hi, this PR is addressing #14719, which mainly had two issues: 

1- Creating a single type entry using API results in the type not being published (draft):
To handle this, I've added a check as we do in the collection types, that will publish based on the config
```JS
        if (hasDraftAndPublish(contentType)) {
          setPublishedAt(data);
        }
```

2- The second issue is that, if the type is draft, it can't be updated using the API: 

This is caused because of the query filters
https://github.com/strapi/strapi/blob/788ea22ba6fc367f4d260e21e04e345bda0a12d9/packages/core/utils/lib/convert-query-params.js#L384-L388

I've fixed it with a `onlyPublished` parameter, that will be propagated to the function, to set the `$notNull` operator to false. 
I feel like this's more of a hacky solution than a fix, let me know if you do suggest any better solutions, my only concern was that I didn't want to mess around with the `transformParamsToQuery` method, since it's used in a lot of places. 

### Related issue(s)/PR(s)

Fix #14719
