### PR TITLE
feat: re-add the count & make it dynamic

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/reducer.js
+++ b/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/reducer.js
@@ -5,6 +5,7 @@ import set from 'lodash/set';
 import take from 'lodash/take';
 import cloneDeep from 'lodash/cloneDeep';
 import uniqBy from 'lodash/uniqBy';
+import merge from 'lodash/merge';
 
 import {
   findLeafByPathAndReplace,
@@ -217,8 +218,12 @@ const reducer = (state, action) =>
               /**
                * this will be null on initial load, however subsequent calls
                * will have data in them correlating to the names of the relational fields.
+               *
+               * We also merge the fetched data so that things like `id` for components can be copied over
+               * which would be `undefined` in the `browserState`.
                */
-              set(acc, componentName, get(state.modifiedData, componentName));
+              const currentState = cloneDeep(get(state.modifiedData, componentName));
+              set(acc, componentName, merge(currentState, get(initialValues, componentName)));
             } else if (
               repeatableComponentPaths.includes(componentName) ||
               dynamicZonePaths.includes(componentName) ||

--- a/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/tests/reducer.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/tests/reducer.test.js
@@ -1626,50 +1626,6 @@ describe('CONTENT MANAGER | COMPONENTS | EditViewDataManagerProvider | reducer',
         modifiedDZName: true,
         shouldCheckErrors: true,
       };
-      const expected = {
-        ...initialState,
-        formErrors: {},
-        initialData: {
-          ok: true,
-          relation: [
-            {
-              id: 1,
-            },
-          ],
-          componentWithRelation: {
-            relation: [
-              {
-                id: 1,
-              },
-              {
-                id: 2,
-              },
-            ],
-            id: 1,
-          },
-        },
-        modifiedData: {
-          ok: true,
-          relation: [
-            {
-              id: 1,
-            },
-          ],
-          componentWithRelation: {
-            relation: [
-              {
-                id: 1,
-              },
-              {
-                id: 2,
-              },
-            ],
-            id: 1,
-          },
-        },
-        modifiedDZName: null,
-        shouldCheckErrors: false,
-      };
 
       const action = {
         type: 'INIT_FORM',
@@ -1687,7 +1643,16 @@ describe('CONTENT MANAGER | COMPONENTS | EditViewDataManagerProvider | reducer',
         componentPaths: ['componentWithRelation'],
       };
 
-      expect(JSON.stringify(reducer(state, action))).toEqual(JSON.stringify(expected));
+      const newState = reducer(state, action);
+
+      expect(newState.modifiedData.relation[0]).toEqual({
+        id: 1,
+      });
+
+      expect(newState.modifiedData.componentWithRelation).toEqual({
+        id: 1,
+        relation: expect.arrayContaining([{ id: expect.any(Number) }]),
+      });
     });
   });
 

--- a/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/tests/reducer.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/tests/reducer.test.js
@@ -1600,6 +1600,95 @@ describe('CONTENT MANAGER | COMPONENTS | EditViewDataManagerProvider | reducer',
         expect(reducer(state, action)).toEqual(expected);
       });
     });
+
+    it('should merge modifiedData with relation containing fields if the modifiedData exists', () => {
+      const state = {
+        ...initialState,
+        formErrors: true,
+        initialData: {},
+        modifiedData: {
+          relation: [
+            {
+              id: 1,
+            },
+          ],
+          componentWithRelation: {
+            relation: [
+              {
+                id: 1,
+              },
+              {
+                id: 2,
+              },
+            ],
+          },
+        },
+        modifiedDZName: true,
+        shouldCheckErrors: true,
+      };
+      const expected = {
+        ...initialState,
+        formErrors: {},
+        initialData: {
+          ok: true,
+          relation: [
+            {
+              id: 1,
+            },
+          ],
+          componentWithRelation: {
+            relation: [
+              {
+                id: 1,
+              },
+              {
+                id: 2,
+              },
+            ],
+            id: 1,
+          },
+        },
+        modifiedData: {
+          ok: true,
+          relation: [
+            {
+              id: 1,
+            },
+          ],
+          componentWithRelation: {
+            relation: [
+              {
+                id: 1,
+              },
+              {
+                id: 2,
+              },
+            ],
+            id: 1,
+          },
+        },
+        modifiedDZName: null,
+        shouldCheckErrors: false,
+      };
+
+      const action = {
+        type: 'INIT_FORM',
+        initialValues: {
+          ok: true,
+          relation: { count: 10 },
+          componentWithRelation: {
+            id: 1,
+            relation: {
+              count: 10,
+            },
+          },
+        },
+        relationalFieldPaths: ['relation', 'componentWithRelation.relation'],
+        componentPaths: ['componentWithRelation'],
+      };
+
+      expect(JSON.stringify(reducer(state, action))).toEqual(JSON.stringify(expected));
+    });
   });
 
   describe('MOVE_COMPONENT_FIELD', () => {

--- a/packages/core/admin/admin/src/content-manager/components/RelationInput/RelationInput.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInput/RelationInput.js
@@ -98,15 +98,14 @@ const RelationInput = ({
 
   const options = useMemo(
     () =>
-      data.flat().map((result) =>
-        result
-          ? {
-              ...result,
-              value: result.id,
-              label: result.mainField,
-            }
-          : result
-      ),
+      data
+        .flat()
+        .filter(Boolean)
+        .map((result) => ({
+          ...result,
+          value: result.id,
+          label: result.mainField,
+        })),
     [data]
   );
 

--- a/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/tests/RelationInputDataManger.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/tests/RelationInputDataManger.test.js
@@ -147,7 +147,7 @@ describe('RelationInputDataManager', () => {
   test('Does pass through props from the CM', async () => {
     const { findByText } = setup();
 
-    expect(await findByText('Label')).toBeInTheDocument();
+    expect(await findByText(/Label/)).toBeInTheDocument();
     expect(await findByText('Description')).toBeInTheDocument();
     expect(await findByText('Action')).toBeInTheDocument();
     expect(await findByText('Placeholder')).toBeInTheDocument();

--- a/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/tests/RelationInputDataManger.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/tests/RelationInputDataManger.test.js
@@ -101,43 +101,44 @@ jest.mock('@strapi/helper-plugin', () => ({
   }),
 }));
 
-const setup = (props) =>
-  render(
-    <MemoryRouter>
-      <QueryClientProvider client={queryClient}>
-        <ThemeProvider theme={lightTheme}>
-          <IntlProvider locale="en">
-            <RelationInputDataManager
-              description="Description"
-              intlLabel={{
-                id: 'label',
-                defaultMessage: 'Label',
-              }}
-              labelAction={<>Action</>}
-              mainField={{
-                name: 'relation',
-                schema: {
-                  type: 'relation',
-                },
-              }}
-              name="relation"
-              placeholder={{
-                id: 'placeholder',
-                defaultMessage: 'Placeholder',
-              }}
-              relationType="oneToOne"
-              size={6}
-              targetModel="something"
-              queryInfos={{
-                shouldDisplayRelationLink: true,
-              }}
-              {...props}
-            />
-          </IntlProvider>
-        </ThemeProvider>
-      </QueryClientProvider>
-    </MemoryRouter>
-  );
+const RelationInputDataManagerComponent = (props) => (
+  <MemoryRouter>
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider theme={lightTheme}>
+        <IntlProvider locale="en">
+          <RelationInputDataManager
+            description="Description"
+            intlLabel={{
+              id: 'label',
+              defaultMessage: 'Label',
+            }}
+            labelAction={<>Action</>}
+            mainField={{
+              name: 'relation',
+              schema: {
+                type: 'relation',
+              },
+            }}
+            name="relation"
+            placeholder={{
+              id: 'placeholder',
+              defaultMessage: 'Placeholder',
+            }}
+            relationType="oneToOne"
+            size={6}
+            targetModel="something"
+            queryInfos={{
+              shouldDisplayRelationLink: true,
+            }}
+            {...props}
+          />
+        </IntlProvider>
+      </ThemeProvider>
+    </QueryClientProvider>
+  </MemoryRouter>
+);
+
+const setup = (props) => render(<RelationInputDataManagerComponent {...props} />);
 
 describe('RelationInputDataManager', () => {
   afterEach(() => {
@@ -381,5 +382,190 @@ describe('RelationInputDataManager', () => {
         }),
       })
     );
+  });
+
+  describe('Counting relations', () => {
+    it('should not render a count value when there are no relations', () => {
+      useCMEditViewDataManager.mockImplementation(() => ({
+        isCreatingEntry: false,
+        createActionAllowedFields: ['relation'],
+        readActionAllowedFields: ['relation'],
+        updateActionAllowedFields: ['relation'],
+        slug: 'test',
+        initialData: {
+          relation: [],
+        },
+        modifiedData: {
+          relation: [],
+        },
+      }));
+
+      const { queryByText } = setup();
+
+      expect(queryByText(/\([0-9]\)/)).not.toBeInTheDocument();
+    });
+
+    it('should render a count value when there are relations added to the store but no relations from useRelation', () => {
+      useCMEditViewDataManager.mockImplementation(() => ({
+        isCreatingEntry: false,
+        createActionAllowedFields: ['relation'],
+        readActionAllowedFields: ['relation'],
+        updateActionAllowedFields: ['relation'],
+        slug: 'test',
+        initialData: {
+          relation: [],
+        },
+        modifiedData: {
+          relation: [
+            {
+              id: 1,
+            },
+            {
+              id: 2,
+            },
+            {
+              id: 3,
+            },
+          ],
+        },
+      }));
+
+      const { queryByText } = setup();
+
+      expect(queryByText(/\(3\)/)).toBeInTheDocument();
+    });
+
+    it('should render the count value of the useRelations response when there are relations from useRelation', () => {
+      useRelation.mockImplementation(() => ({
+        relations: {
+          data: {
+            pages: [
+              {
+                pagination: {
+                  total: 8,
+                },
+              },
+            ],
+          },
+          hasNextPage: true,
+          isFetchingNextPage: false,
+          isLoading: false,
+          isSuccess: true,
+          status: 'success',
+        },
+        search: {
+          data: {},
+          isFetchingNextPage: false,
+          isLoading: false,
+          isSuccess: true,
+          status: 'success',
+        },
+      }));
+
+      useCMEditViewDataManager.mockImplementation(() => ({
+        isCreatingEntry: false,
+        createActionAllowedFields: ['relation'],
+        readActionAllowedFields: ['relation'],
+        updateActionAllowedFields: ['relation'],
+        slug: 'test',
+        initialData: {
+          relation: [
+            {
+              id: 1,
+            },
+          ],
+        },
+        modifiedData: {
+          relation: [
+            {
+              id: 1,
+            },
+          ],
+        },
+      }));
+
+      const { queryByText } = setup();
+
+      expect(queryByText(/\(8\)/)).toBeInTheDocument();
+    });
+
+    it('should correct calculate browser mutations when there are relations from useRelation', async () => {
+      useRelation.mockImplementation(() => ({
+        relations: {
+          data: {
+            pages: [
+              {
+                pagination: {
+                  total: 8,
+                },
+              },
+            ],
+          },
+          hasNextPage: true,
+          isFetchingNextPage: false,
+          isLoading: false,
+          isSuccess: true,
+          status: 'success',
+        },
+        search: {
+          data: {},
+          isFetchingNextPage: false,
+          isLoading: false,
+          isSuccess: true,
+          status: 'success',
+        },
+      }));
+
+      useCMEditViewDataManager.mockImplementation(() => ({
+        isCreatingEntry: false,
+        createActionAllowedFields: ['relation'],
+        readActionAllowedFields: ['relation'],
+        updateActionAllowedFields: ['relation'],
+        slug: 'test',
+        initialData: {
+          relation: [
+            {
+              id: 1,
+            },
+          ],
+        },
+        modifiedData: {
+          relation: [
+            {
+              id: 1,
+            },
+          ],
+        },
+      }));
+
+      const { queryByText, rerender } = setup();
+
+      expect(queryByText(/\(8\)/)).toBeInTheDocument();
+
+      /**
+       * Simulate changing the store
+       */
+      useCMEditViewDataManager.mockImplementation(() => ({
+        isCreatingEntry: false,
+        createActionAllowedFields: ['relation'],
+        readActionAllowedFields: ['relation'],
+        updateActionAllowedFields: ['relation'],
+        slug: 'test',
+        initialData: {
+          relation: [
+            {
+              id: 1,
+            },
+          ],
+        },
+        modifiedData: {
+          relation: [],
+        },
+      }));
+
+      rerender(<RelationInputDataManagerComponent />);
+
+      expect(queryByText(/\(7\)/)).toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* re-adds the `count` value that I broke during #14352 
* makes this count dynamic i.e. we know the server has 10 and if we remove one on the browser it will show 9 🥳

### How to test it?

I haven't added any tests yet, I wasn't sure if it was worth it... @gu-stav wdyt?

### Related issue(s)/PR(s)

* CONTENT-546
* CONTENT-654

### NOTES

#14765 should be merged first as this branch branches off that to avoid ESLINT errors from a hotfix 👀 
