### PR TITLE
Update dependabot config to include github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,10 @@ updates:
     labels:
       - 'source: dependencies'
       - 'pr: chore'
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+    labels:
+      - 'source: dependencies'
+      - 'pr: chore'


### PR DESCRIPTION
Signed-off-by: Ashish Kurmi <akurmi@stepsecurity.io>

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?
This PR includes GitHub Actions in dependabot config.

Describe the technical changes you did.

### Why is it needed?
Currently, dependabot is not notifying about GitHub Actions updates.

Describe the issue you are solving.
By updating the dependabot config file, it would auto notify about GitHub Actions updates going forward.

### How to test it?
Once the PR is merged, dependabot will create upgrade PRs for GitHub Actions going forward.

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
