### PR TITLE
[DEITS] CLI command updates

### DIFF
--- a/packages/core/data-transfer/lib/providers/local-file-destination-provider.ts
+++ b/packages/core/data-transfer/lib/providers/local-file-destination-provider.ts
@@ -25,6 +25,7 @@ export interface ILocalFileDestinationProviderOptions {
   file: {
     path: string;
     maxSize?: number;
+    maxSizeJsonl?: number;
   };
 }
 
@@ -94,25 +95,12 @@ class LocalFileDestinationProvider implements IDestinationProvider {
     }
 
     // FS write stream
-    streams.push(createMultiFilesWriteStream(filePathFactory, this.options.file.maxSize));
+    streams.push(createMultiFilesWriteStream(filePathFactory, this.options.file.maxSizeJsonl));
 
     return chain(streams);
   }
 
   getLinksStream(): Duplex | Promise<Duplex> {
-    const options = {
-      encryption: {
-        enabled: true,
-        key: 'Hello World!',
-      },
-      compression: {
-        enabled: false,
-      },
-      file: {
-        maxSize: 100000,
-      },
-    };
-
     const filePathFactory = (fileIndex: number = 0) => {
       return path.join(
         // Backup path
@@ -130,7 +118,7 @@ class LocalFileDestinationProvider implements IDestinationProvider {
     ];
 
     // Compression
-    if (options.compression.enabled) {
+    if (this.options.compression.enabled) {
       streams.push(zip.createGzip());
     }
 
@@ -140,7 +128,7 @@ class LocalFileDestinationProvider implements IDestinationProvider {
     // }
 
     // FS write stream
-    streams.push(createMultiFilesWriteStream(filePathFactory, options.file.maxSize));
+    streams.push(createMultiFilesWriteStream(filePathFactory, this.options.file.maxSizeJsonl));
 
     return chain(streams);
   }

--- a/packages/core/strapi/bin/strapi.js
+++ b/packages/core/strapi/bin/strapi.js
@@ -267,9 +267,9 @@ const parseBool = (arg) => {
   }
 };
 // // Will be used for the options that accept a list
-// const listOption = (value) => {
-//   return value.split(',');
-// };
+const listOption = (value) => {
+  return value.split(',');
+};
 
 program
   .command('export')
@@ -351,66 +351,42 @@ program
   .action(require('../lib/commands/transfer/export'));
 
 // `$ strapi import`
-// program
-//   .command('import')
-//   .description('Import data from file to Strapi')
-//   // TODO: Final version should be possible to provide all options on the CLI instead of config file
-//   // .option('--config <configFile>', 'Path to the config file')
-//   .option('--input <input filename>', 'Path to the file to be imported')
-//   // .addOption(
-//   //   new Option('--destinationUrl', 'Remote url to use instead of local instance of Strapi') // required if remote === true
-//   // )
-//   // .addOption(
-//   //   new Option('--destinationToken', 'Auth token for remote Strapi') // required if remote === true
-//   // )
-//   // .addOption(
-//   //   new Option('--destinationAllowInsecure', 'Bypass check for https on remote destination', false)
-//   // )
-//   // .addOption(
-//   //   new Option('--conflictStrategy <conflictStrategy>', 'Which strategy to use for ID conflicts')
-//   //     .choices(['restore', 'abort', 'replace', 'keep'])
-//   //     .default('keep')
-//   // )
-//   // .addOption(
-//   //   new Option(
-//   //     '--only <data,to,include>',
-//   //     'Comma-separated list of data to include (webhooks,content,localmedia,providermedia,config)', // ['webhooks', 'content', 'localmedia', 'providermedia', 'relations']
-//   //     listOption
-//   //   )
-//   // )
-//   // .addOption(
-//   //   new Option(
-//   //     '--exclude <data,to,exclude>',
-//   //     'Comma-separated list of data to exclude (webhooks,content,localmedia,providermedia,config,relations)', // ['webhooks', 'content', 'localmedia', 'providermedia', 'relations']
-//   //     listOption
-//   //   )
-//   // )
-//   // .addOption(
-//   //   new Option(
-//   //     '--schemaComparison <schemaComparison>',
-//   //     'exact requires every field to match, strict requires Strapi version and schemas to match, subset requires source schema to exist in destination, bypass skips checks'
-//   //   )
-//   //     .choices(['exact', 'strict', 'subset', 'bypass'])
-//   //     .default('exact')
-//   // )
-//   // .addOption(
-//   //   new Option(
-//   //     '--requireEmptyDestination',
-//   //     'Require the destination to not contain any entities before starting',
-//   //     true
-//   //   )
-//   // )
-//   // We do not need a compressed content option. We autodetect by "brute force"; try reading the file and within a few bytes it will fail and we try the other method
-//   // .addOption(new Option('--decompress', 'decompress content', true)) // we should be able to autodetect
-//   // A --decrypt option is superfluous. If user provides a password, we try it. Otherwise it fails and we notify user.
-//   .addOption(new Option('-password, -p', 'prompt for password'))
-//   // .addOption(
-//   //   new Option(
-//   //     '--encryptionCipher <crypto cipher>',
-//   //     'node crypto cipher to use for decryption',
-//   //     'aes-256'
-//   //   ) // .choices(crypto.getCiphers())
-//   // )
-//   .action(require('../lib/commands/transfer/import'));
+program
+  .command('import')
+  .description('Import data from file to Strapi')
+  // TODO: Final version should be possible to provide all options on the CLI instead of config file
+  // .option('--config <configFile>', 'Path to the config file')
+  .option('--input <input filename>', 'Path to the file to be imported')
+  .addOption(
+    new Option('--conflictStrategy <conflictStrategy>', 'Which strategy to use for ID conflicts')
+      .choices(['restore', 'abort', 'keep', 'replace'])
+      .default('restore')
+  )
+  .addOption(
+    new Option(
+      '--only <data,to,include>',
+      'Comma-separated list of data to include (webhooks,content,localmedia,providermedia,config)', // ['webhooks', 'content', 'localmedia', 'providermedia', 'relations']
+      listOption
+    )
+  )
+  .addOption(
+    new Option(
+      '--exclude <data,to,exclude>',
+      'Comma-separated list of data to exclude (webhooks,content,localmedia,providermedia,config,relations)', // ['webhooks', 'content', 'localmedia', 'providermedia', 'relations']
+      listOption
+    )
+  )
+  .addOption(
+    new Option(
+      '--schemaComparison <schemaComparison>',
+      'exact requires every field to match, strict requires Strapi version and schemas to match, subset requires source schema to exist in destination, bypass skips checks',
+      listOption
+    )
+      .choices(['exact', 'strict', 'subset', 'bypass'])
+      .default('exact')
+  )
+  // A --decrypt option is superfluous. If user provides a password, we try it. Otherwise it fails and we notify user.
+  .addOption(new Option('--key [encryptionKey]', 'prompt for [or provide] the decryption key'))
+  .action(require('../lib/commands/transfer/import'));
 
 program.parseAsync(process.argv);

--- a/packages/core/strapi/bin/strapi.js
+++ b/packages/core/strapi/bin/strapi.js
@@ -11,9 +11,9 @@ const { Command, Option } = require('commander');
 
 const program = new Command();
 
-const { parseType } = require('@strapi/utils/lib');
 const inquirer = require('inquirer');
 const packageJSON = require('../package.json');
+const { parseInputList, parseInputBool } = require('../lib/commands/utils/commander');
 
 const checkCwdIsStrapiApp = (name) => {
   const logErrorAndExit = () => {
@@ -258,19 +258,6 @@ program
   .action(getLocalScript('ts/generate-types'));
 
 // `$ strapi export`
-const parseBool = (arg) => {
-  try {
-    return parseType({ type: 'boolean', value: arg });
-  } catch (e) {
-    console.error(e.message);
-    process.exit(1);
-  }
-};
-// // Will be used for the options that accept a list
-const listOption = (value) => {
-  return value.split(',');
-};
-
 program
   .command('export')
   .description('Export data from Strapi to file')
@@ -281,12 +268,12 @@ program
     )
   )
   .addOption(
-    new Option('--encrypt [boolean]', 'Encrypt output file').default(true).argParser(parseBool)
+    new Option('--encrypt [boolean]', 'Encrypt output file').default(true).argParser(parseInputBool)
   )
   .addOption(
     new Option('--compress [boolean]', 'Compress output file using gz')
       .default(true)
-      .argParser(parseBool)
+      .argParser(parseInputBool)
   )
   .addOption(new Option('--key', 'Provide encryption key in command instead of using a prompt'))
   // Options we plan to add in the future:
@@ -366,21 +353,21 @@ program
     new Option(
       '--only <data,to,include>',
       'Comma-separated list of data to include (webhooks,content,localmedia,providermedia,config)', // ['webhooks', 'content', 'localmedia', 'providermedia', 'relations']
-      listOption
+      parseInputList
     )
   )
   .addOption(
     new Option(
       '--exclude <data,to,exclude>',
       'Comma-separated list of data to exclude (webhooks,content,localmedia,providermedia,config,relations)', // ['webhooks', 'content', 'localmedia', 'providermedia', 'relations']
-      listOption
+      parseInputList
     )
   )
   .addOption(
     new Option(
       '--schemaComparison <schemaComparison>',
       'exact requires every field to match, strict requires Strapi version and schemas to match, subset requires source schema to exist in destination, bypass skips checks',
-      listOption
+      parseInputList
     )
       .choices(['exact', 'strict', 'subset', 'bypass'])
       .default('exact')

--- a/packages/core/strapi/bin/strapi.js
+++ b/packages/core/strapi/bin/strapi.js
@@ -269,12 +269,6 @@ program
   .command('export')
   .description('Export data from Strapi to file')
   .addOption(
-    new Option(
-      '--output <outputFilename>',
-      'Filename to output (without extension) [Default: "export_{yyyymmddHHMMSS}[.tar.gz][.gpg]"]'
-    )
-  )
-  .addOption(
     new Option('--encrypt [boolean]', `Encrypt output file using 'aes-128-ecb'`) // TODO: we should get a default from @strapi/data-transfer and display it here
       .default(true)
       .argParser(parseInputBool)
@@ -332,7 +326,6 @@ program
 program
   .command('import')
   .description('Import data from file to Strapi')
-  .option('--input <input filename>', 'Path to the file to be imported')
   .addOption(
     new Option('--conflictStrategy <conflictStrategy>', 'Which strategy to use for ID conflicts')
       .choices(['restore', 'abort', 'keep', 'replace'])

--- a/packages/core/strapi/bin/strapi.js
+++ b/packages/core/strapi/bin/strapi.js
@@ -275,7 +275,7 @@ program
     )
   )
   .addOption(
-    new Option('--encrypt [boolean]', `Encrypt output file using 'aes-128-ecb'`) // TODO: we should set export a default from data-transfer and display it here
+    new Option('--encrypt [boolean]', `Encrypt output file using 'aes-128-ecb'`) // TODO: we should get a default from @strapi/data-transfer and display it here
       .default(true)
       .argParser(parseInputBool)
   )

--- a/packages/core/strapi/bin/strapi.js
+++ b/packages/core/strapi/bin/strapi.js
@@ -269,7 +269,7 @@ program
   .command('export')
   .description('Export data from Strapi to file')
   .addOption(
-    new Option('--encrypt [boolean]', `Encrypt output file using 'aes-128-ecb'`) // TODO: we should get a default from @strapi/data-transfer and display it here
+    new Option('--encrypt [boolean]', `Encrypt output file using the 'aes-128-ecb' algorithm`)
       .default(true)
       .argParser(parseInputBool)
   )

--- a/packages/core/strapi/lib/commands/transfer/export.js
+++ b/packages/core/strapi/lib/commands/transfer/export.js
@@ -35,7 +35,7 @@ module.exports = async (args, unknownArgs) => {
     process.exit(1);
   }
   const outputFile = unknownArgs.args?.[0] || getDefaultExportBackupName();
-  console.log('output file', outputFile);
+
   const BYTES_IN_MB = 1024 * 1024;
 
   const destinationOptions = {

--- a/packages/core/strapi/lib/commands/transfer/export.js
+++ b/packages/core/strapi/lib/commands/transfer/export.js
@@ -15,7 +15,9 @@ const getDefaultExportBackupName = () => `strapi-backup`;
 const logger = console;
 
 module.exports = async (args) => {
-  // From strapi
+  /**
+   * From local Strapi instance
+   */
   const inputOptions = {
     getStrapi() {
       return strapi().load();
@@ -23,7 +25,9 @@ module.exports = async (args) => {
   };
   const source = createLocalStrapiSourceProvider(inputOptions);
 
-  // To file
+  /**
+   * To a Strapi backup file
+   */
   const outputOptions = {
     file: {
       path: args.output || getDefaultExportBackupName(),
@@ -38,7 +42,9 @@ module.exports = async (args) => {
   };
   const destination = createLocalFileDestinationProvider(outputOptions);
 
-  // create transfer engine
+  /**
+   * Configure and run the transfer engine
+   */
   const engine = createTransferEngine(source, destination, {
     strategy: 'restore',
     versionMatching: 'minor',

--- a/packages/core/strapi/lib/commands/transfer/export.js
+++ b/packages/core/strapi/lib/commands/transfer/export.js
@@ -14,7 +14,7 @@ const getDefaultExportBackupName = () => `strapi-backup`;
 
 const logger = console;
 
-module.exports = async (args) => {
+module.exports = async (args, unknownArgs) => {
   /**
    * From local Strapi instance
    */
@@ -28,11 +28,19 @@ module.exports = async (args) => {
   /**
    * To a Strapi backup file
    */
+  // treat any unknown arguments as filenames
+  if (unknownArgs.args.length > 1) {
+    logger.error('Please enter exactly one filename to export to');
+    logger.error(`Received filenames: ${unknownArgs.args.join(', ')}`);
+    process.exit(1);
+  }
+  const outputFile = unknownArgs.args?.[0] || getDefaultExportBackupName();
+  console.log('output file', outputFile);
   const BYTES_IN_MB = 1024;
 
   const destinationOptions = {
     file: {
-      path: args.output || getDefaultExportBackupName(),
+      path: outputFile,
       maxSize: Math.floor(args.maxSize) * BYTES_IN_MB,
       maxSizeJsonl: Math.floor(args.maxSizeJsonl) * BYTES_IN_MB,
     },

--- a/packages/core/strapi/lib/commands/transfer/export.js
+++ b/packages/core/strapi/lib/commands/transfer/export.js
@@ -36,7 +36,7 @@ module.exports = async (args, unknownArgs) => {
   }
   const outputFile = unknownArgs.args?.[0] || getDefaultExportBackupName();
   console.log('output file', outputFile);
-  const BYTES_IN_MB = 1024;
+  const BYTES_IN_MB = 1024 * 1024;
 
   const destinationOptions = {
     file: {

--- a/packages/core/strapi/lib/commands/transfer/export.js
+++ b/packages/core/strapi/lib/commands/transfer/export.js
@@ -7,12 +7,15 @@ const {
   // TODO: we need to solve this issue with typescript modules
   // eslint-disable-next-line import/no-unresolved, node/no-missing-require
 } = require('@strapi/data-transfer');
+const _ = require('lodash/fp');
 
 const strapi = require('../../Strapi');
 
 const getDefaultExportBackupName = () => `strapi-backup`;
 
 const logger = console;
+
+const BYTES_IN_MB = 1024 * 1024;
 
 module.exports = async (args, unknownArgs) => {
   /**
@@ -36,13 +39,13 @@ module.exports = async (args, unknownArgs) => {
   }
   const outputFile = unknownArgs.args?.[0] || getDefaultExportBackupName();
 
-  const BYTES_IN_MB = 1024 * 1024;
-
   const destinationOptions = {
     file: {
       path: outputFile,
-      maxSize: Math.floor(args.maxSize) * BYTES_IN_MB,
-      maxSizeJsonl: Math.floor(args.maxSizeJsonl) * BYTES_IN_MB,
+      maxSize: _.isFinite(args.maxSize) ? Math.floor(args.maxSize) * BYTES_IN_MB : undefined,
+      maxSizeJsonl: _.isFinite(args.maxSizeJsonl)
+        ? Math.floor(args.maxSizeJsonl) * BYTES_IN_MB
+        : undefined,
     },
     encryption: {
       enabled: args.encrypt,

--- a/packages/core/strapi/lib/commands/transfer/import.js
+++ b/packages/core/strapi/lib/commands/transfer/import.js
@@ -8,6 +8,8 @@ const {
   // eslint-disable-next-line import/no-unresolved, node/no-missing-require
 } = require('@strapi/data-transfer');
 
+const strapi = require('../../Strapi');
+
 const logger = console;
 
 module.exports = async (args, unknownArgs) => {

--- a/packages/core/strapi/lib/commands/transfer/import.js
+++ b/packages/core/strapi/lib/commands/transfer/import.js
@@ -7,27 +7,26 @@ const {
   // TODO: we need to solve this issue with typescript modules
   // eslint-disable-next-line import/no-unresolved, node/no-missing-require
 } = require('@strapi/data-transfer');
+const _ = require('lodash/fp');
 
 const strapi = require('../../Strapi');
 
 const logger = console;
 
-module.exports = async (args, unknownArgs) => {
+module.exports = async (filename, opts) => {
+  // validate inputs from Commander
+  if (!_.isString(filename) || !_.isObject(opts)) {
+    logger.error('Could not parse arguments');
+    process.exit(1);
+  }
+
   /**
    * From strapi backup file
    */
 
   // treat any unknown arguments as filenames
-  if (unknownArgs.args.length !== 1) {
-    logger.error('Please enter exactly one filename to import');
-    if (unknownArgs.args.length > 1) {
-      logger.error(`Received filenames: ${unknownArgs.args.join(', ')}`);
-    }
-    process.exit(1);
-  }
-  const inputFile = unknownArgs.args[0];
   const sourceOptions = {
-    backupFilePath: inputFile,
+    backupFilePath: filename,
   };
   const source = createLocalFileSourceProvider(sourceOptions);
 
@@ -45,9 +44,9 @@ module.exports = async (args, unknownArgs) => {
    * Configure and run the transfer engine
    */
   const engineOptions = {
-    strategy: args.conflictStrategy,
-    versionMatching: args.schemaComparison,
-    exclude: args.exclude,
+    strategy: opts.conflictStrategy,
+    versionMatching: opts.schemaComparison,
+    exclude: opts.exclude,
   };
   const engine = createTransferEngine(source, destination, engineOptions);
 

--- a/packages/core/strapi/lib/commands/transfer/import.js
+++ b/packages/core/strapi/lib/commands/transfer/import.js
@@ -44,12 +44,12 @@ module.exports = async (args, unknownArgs) => {
   /**
    * Configure and run the transfer engine
    */
-  const transferEngineOptions = {
+  const engineOptions = {
     strategy: args.conflictStrategy,
     versionMatching: args.schemaComparison,
     exclude: args.exclude,
   };
-  const engine = createTransferEngine(source, destination, transferEngineOptions);
+  const engine = createTransferEngine(source, destination, engineOptions);
 
   try {
     logger.log('Importing data...');

--- a/packages/core/strapi/lib/commands/transfer/import.js
+++ b/packages/core/strapi/lib/commands/transfer/import.js
@@ -13,6 +13,11 @@ const strapi = require('../../Strapi');
 const logger = console;
 
 module.exports = async (args, unknownArgs) => {
+  /**
+   * From strapi backup file
+   */
+
+  // treat any unknown arguments as filenames
   if (unknownArgs.args.length !== 1) {
     logger.error('Please enter exactly one filename to import');
     if (unknownArgs.args.length > 1) {
@@ -20,16 +25,15 @@ module.exports = async (args, unknownArgs) => {
     }
     process.exit(1);
   }
-
   const inputFile = unknownArgs.args[0];
-
-  // From file
   const sourceOptions = {
     backupFilePath: inputFile,
   };
   const source = createLocalFileSourceProvider(sourceOptions);
 
-  // To Strapi
+  /**
+   * To local Strapi instance
+   */
   const destinationOptions = {
     getStrapi() {
       return strapi().load();
@@ -37,6 +41,9 @@ module.exports = async (args, unknownArgs) => {
   };
   const destination = createLocalStrapiDestinationProvider(destinationOptions);
 
+  /**
+   * Configure and run the transfer engine
+   */
   const transferEngineOptions = {
     strategy: args.conflictStrategy,
     versionMatching: args.schemaComparison,

--- a/packages/core/strapi/lib/commands/utils/commander.js
+++ b/packages/core/strapi/lib/commands/utils/commander.js
@@ -1,9 +1,10 @@
 'use strict';
 
 const { parseType } = require('@strapi/utils/lib');
+const inquirer = require('inquirer');
 
 /**
- * Parse a string argument from the command line as a boolean
+ * argsParser: Parse a string argument from the command line as a boolean
  */
 const parseInputBool = (arg) => {
   try {
@@ -15,13 +16,49 @@ const parseInputBool = (arg) => {
 };
 
 /**
- * Parse a comma-delimited string as an array
+ * argsParser: Parse a comma-delimited string as an array
  */
 const parseInputList = (value) => {
   return value.split(',');
 };
 
+/**
+ * hook: if encrpyt=true and key not provided, prompt for it
+ */
+const promptEncryptionKey = async (thisCommand) => {
+  const opts = thisCommand.opts();
+
+  // if encrypt is set but we have no key, prompt for it
+  if (opts.encrypt && !opts.key) {
+    try {
+      const answers = await inquirer.prompt([
+        {
+          type: 'password',
+          message: 'Please enter an encryption key',
+          name: 'key',
+          validate(key) {
+            if (key.length > 0) return true;
+
+            return 'Key must be present when using the encrypt option';
+          },
+        },
+      ]);
+      opts.key = answers.key;
+    } catch (e) {
+      console.error('Failed to get encryption key');
+      console.error('Export process failed unexpectedly');
+      process.exit(1);
+    }
+    if (!opts.key) {
+      console.error('Failed to get encryption key');
+      console.error('Export process failed unexpectedly');
+      process.exit(1);
+    }
+  }
+};
+
 module.exports = {
   parseInputList,
   parseInputBool,
+  promptEncryptionKey,
 };

--- a/packages/core/strapi/lib/commands/utils/commander.js
+++ b/packages/core/strapi/lib/commands/utils/commander.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const { parseType } = require('@strapi/utils/lib');
+
+/**
+ * Parse a string argument from the command line as a boolean
+ */
+const parseInputBool = (arg) => {
+  try {
+    return parseType({ type: 'boolean', value: arg });
+  } catch (e) {
+    console.error(e.message);
+    process.exit(1);
+  }
+};
+
+/**
+ * Parse a comma-delimited string as an array
+ */
+const parseInputList = (value) => {
+  return value.split(',');
+};
+
+module.exports = {
+  parseInputList,
+  parseInputBool,
+};


### PR DESCRIPTION
### What does it do?

- Adds the `strapi import` command to CLI
- import+export: now accept the filename without an `--input` or `--output` option
- pass through `maxSize` and `maxSizeJsonl` to file destination provider so it's ready once implemented
  - local-file-destination-provider links+entities updated to use `options.maxSizeJsonl`
  - local-file-destination-provider links updated to use received options instead of hard-coded [will conflict with #14766 but I'll handle it once that is merged]
- pass through `exclude` option to transfer engine so it's ready once implemented [PR for this will come next week]
- refactor a lot of the CLI code

### Why is it needed?

To run the DEITS features from the CLI

### How to test it?

Run variations of the `strapi import ` and `strapi export` command.  See `strapi help export` and `strapi help import` for full list of options.

### Related issue(s)/PR(s)
