### PR TITLE
RelationInput: Overwrite default react-select no-options message

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/RelationInput/RelationInput.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInput/RelationInput.js
@@ -61,6 +61,7 @@ const RelationInput = ({
   labelLoadMore,
   labelDisconnectRelation,
   loadingMessage,
+  noRelationsMessage,
   onRelationConnect,
   onRelationLoadMore,
   onRelationDisconnect,
@@ -226,7 +227,7 @@ const RelationInput = ({
               inputId={id}
               isSearchable
               isClear
-              loadingMessage={loadingMessage}
+              loadingMessage={() => loadingMessage}
               onChange={(relation) => {
                 setValue(null);
                 onRelationConnect(relation);
@@ -245,6 +246,7 @@ const RelationInput = ({
               onMenuClose={handleMenuClose}
               onMenuOpen={handleMenuOpen}
               menuIsOpen={isMenuOpen}
+              noOptionsMessage={() => noRelationsMessage}
               onMenuScrollToBottom={() => {
                 if (searchResults.hasNextPage) {
                   onSearchNextPage();
@@ -386,8 +388,9 @@ RelationInput.propTypes = {
   labelAction: PropTypes.element,
   labelLoadMore: PropTypes.string,
   labelDisconnectRelation: PropTypes.string.isRequired,
-  loadingMessage: PropTypes.func.isRequired,
+  loadingMessage: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
+  noRelationsMessage: PropTypes.string.isRequired,
   numberOfRelationsToDisplay: PropTypes.number.isRequired,
   onRelationConnect: PropTypes.func.isRequired,
   onRelationDisconnect: PropTypes.func.isRequired,

--- a/packages/core/admin/admin/src/content-manager/components/RelationInput/tests/RelationInput.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInput/tests/RelationInput.test.js
@@ -56,9 +56,10 @@ const setup = (props) =>
             name="some-relation-1"
             label="Some Relation"
             labelLoadMore="Load more"
-            loadingMessage={() => 'Relations are loading'}
+            loadingMessage="Relations are loading"
             labelDisconnectRelation="Remove"
             numberOfRelationsToDisplay={5}
+            noRelationsMessage="No relations available"
             onRelationConnect={() => jest.fn()}
             onRelationDisconnect={() => jest.fn()}
             onRelationLoadMore={() => jest.fn()}

--- a/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/RelationInputDataManager.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/RelationInputDataManager.js
@@ -184,13 +184,15 @@ export const RelationInputDataManager = ({
         defaultMessage: 'Remove',
       })}
       listHeight={320}
-      loadingMessage={() =>
-        formatMessage({
-          id: getTrad('relation.isLoading'),
-          defaultMessage: 'Relations are loading',
-        })
-      }
+      loadingMessage={formatMessage({
+        id: getTrad('relation.isLoading'),
+        defaultMessage: 'Relations are loading',
+      })}
       name={name}
+      noRelationsMessage={formatMessage({
+        id: getTrad('relation.notAvailable'),
+        defaultMessage: 'No relations available',
+      })}
       numberOfRelationsToDisplay={RELATIONS_TO_DISPLAY}
       onRelationConnect={(relation) => handleRelationConnect(relation)}
       onRelationDisconnect={(relation) => handleRelationDisconnect(relation)}


### PR DESCRIPTION
### What does it do?

Overwrites the default message from react-select "No options" with "No relations available". It also hides the fact that react-select expects functions as props, which is an implementation detail we want to abstract away.

### Why is it needed?

Users are dealing with relations and since there is a good chance for this message to be visible, it should be as precise as possible.

### How to test it?

Type something into a relational field that can not be found.
