### PR TITLE
ConditionsModal: Fix modal component structure and add missing translations

### DIFF
--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/ConditionsModal/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/ConditionsModal/index.js
@@ -1,10 +1,12 @@
 import React, { useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
-import { Box } from '@strapi/design-system/Box';
 import { Button } from '@strapi/design-system/Button';
-import { Divider } from '@strapi/design-system/Divider';
-import { Stack } from '@strapi/design-system/Stack';
-import { ModalFooter, ModalHeader, ModalLayout } from '@strapi/design-system/ModalLayout';
+import {
+  ModalFooter,
+  ModalHeader,
+  ModalLayout,
+  ModalBody,
+} from '@strapi/design-system/ModalLayout';
 import { Breadcrumbs, Crumb } from '@strapi/design-system/Breadcrumbs';
 import { Typography } from '@strapi/design-system/Typography';
 import produce from 'immer';
@@ -88,48 +90,35 @@ const ConditionsModal = ({ actions, headerBreadCrumbs, isFormDisabled, onClosed,
           ))}
         </Breadcrumbs>
       </ModalHeader>
-      <Box padding={8}>
-        <Stack spacing={6}>
-          <Typography variant="beta" as="h2">
+      <ModalBody>
+        {actionsToDisplay.length === 0 && (
+          <Typography>
             {formatMessage({
-              id: 'Settings.permissions.conditions.define-conditions',
-              defaultMessage: 'Define conditions',
+              id: 'Settings.permissions.conditions.no-actions',
+              defaultMessage:
+                'You first need to select actions (create, read, update, ...) before defining conditions on them.',
             })}
           </Typography>
-          <Box>
-            <Divider />
-          </Box>
-          <Box>
-            {actionsToDisplay.length === 0 && (
-              <Typography>
-                {formatMessage({
-                  id: 'Settings.permissions.conditions.no-actions',
-                  defaultMessage:
-                    'You first need to select actions (create, read, update, ...) before defining conditions on them.',
-                })}
-              </Typography>
-            )}
-            <ul>
-              {actionsToDisplay.map(({ actionId, label, pathToConditionsObject }, index) => {
-                const name = pathToConditionsObject.join('..');
+        )}
+        <ul>
+          {actionsToDisplay.map(({ actionId, label, pathToConditionsObject }, index) => {
+            const name = pathToConditionsObject.join('..');
 
-                return (
-                  <ActionRow
-                    key={actionId}
-                    arrayOfOptionsGroupedByCategory={arrayOfOptionsGroupedByCategory}
-                    label={label}
-                    isFormDisabled={isFormDisabled}
-                    isGrey={index % 2 === 0}
-                    name={name}
-                    onChange={handleChange}
-                    value={get(state, name, {})}
-                  />
-                );
-              })}
-            </ul>
-          </Box>
-        </Stack>
-      </Box>
+            return (
+              <ActionRow
+                key={actionId}
+                arrayOfOptionsGroupedByCategory={arrayOfOptionsGroupedByCategory}
+                label={label}
+                isFormDisabled={isFormDisabled}
+                isGrey={index % 2 === 0}
+                name={name}
+                onChange={handleChange}
+                value={get(state, name, {})}
+              />
+            );
+          })}
+        </ul>
+      </ModalBody>
       <ModalFooter
         startActions={
           <Button variant="tertiary" onClick={onToggle}>

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/ContentTypeCollapse/Collapse/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/ContentTypeCollapse/Collapse/index.js
@@ -232,7 +232,7 @@ const Collapse = ({
         </Flex>
         {isModalOpen && (
           <ConditionsModal
-            headerBreadCrumbs={[label, 'app.components.LeftMenuLinkContainer.settings']}
+            headerBreadCrumbs={[label, 'Settings.permissions.conditions.conditions']}
             actions={checkboxesActions}
             isFormDisabled={isFormDisabled}
             onClosed={handleModalClose}

--- a/packages/core/admin/admin/src/translations/ca.json
+++ b/packages/core/admin/admin/src/translations/ca.json
@@ -107,7 +107,7 @@
   "Settings.permissions.conditions.anytime": "En qualsevol moment",
   "Settings.permissions.conditions.apply": "Aplicar",
   "Settings.permissions.conditions.can": "Poder",
-  "Settings.permissions.conditions.define-conditions": "Definir condicions",
+  "Settings.permissions.conditions.conditions": "Definir condicions",
   "Settings.permissions.conditions.links": "Enllaços",
   "Settings.permissions.conditions.no-actions": "No hi ha acció",
   "Settings.permissions.conditions.none-selected": "En qualsevol moment",

--- a/packages/core/admin/admin/src/translations/de.json
+++ b/packages/core/admin/admin/src/translations/de.json
@@ -107,7 +107,7 @@
   "Settings.permissions.conditions.anytime": "Jederzeit",
   "Settings.permissions.conditions.apply": "Anwenden",
   "Settings.permissions.conditions.can": "Kann",
-  "Settings.permissions.conditions.define-conditions": "Bedingungen definieren",
+  "Settings.permissions.conditions.conditions": "Bedingungen definieren",
   "Settings.permissions.conditions.links": "Links",
   "Settings.permissions.conditions.no-actions": "Keine Aktionen",
   "Settings.permissions.conditions.none-selected": "Jederzeit",

--- a/packages/core/admin/admin/src/translations/dk.json
+++ b/packages/core/admin/admin/src/translations/dk.json
@@ -105,7 +105,7 @@
   "Settings.permissions.conditions.anytime": "Altid",
   "Settings.permissions.conditions.apply": "Godkend",
   "Settings.permissions.conditions.can": "Kan",
-  "Settings.permissions.conditions.define-conditions": "Definér betingelser",
+  "Settings.permissions.conditions.conditions": "Definér betingelser",
   "Settings.permissions.conditions.links": "Links",
   "Settings.permissions.conditions.no-actions": "Der er ingen handling",
   "Settings.permissions.conditions.none-selected": "Når som helst",

--- a/packages/core/admin/admin/src/translations/en.json
+++ b/packages/core/admin/admin/src/translations/en.json
@@ -151,7 +151,7 @@
   "Settings.permissions.conditions.anytime": "Anytime",
   "Settings.permissions.conditions.apply": "Apply",
   "Settings.permissions.conditions.can": "Can",
-  "Settings.permissions.conditions.define-conditions": "Define conditions",
+  "Settings.permissions.conditions.conditions": "Conditions",
   "Settings.permissions.conditions.links": "Links",
   "Settings.permissions.conditions.no-actions": "You first need to select actions (create, read, update, ...) before defining conditions on them.",
   "Settings.permissions.conditions.none-selected": "Anytime",

--- a/packages/core/admin/admin/src/translations/es.json
+++ b/packages/core/admin/admin/src/translations/es.json
@@ -105,7 +105,7 @@
   "Settings.permissions.conditions.anytime": "En cualquier momento",
   "Settings.permissions.conditions.apply": "Aplicar",
   "Settings.permissions.conditions.can": "Poder",
-  "Settings.permissions.conditions.define-conditions": "Definir condiciones",
+  "Settings.permissions.conditions.conditions": "Definir condiciones",
   "Settings.permissions.conditions.links": "Enlaces",
   "Settings.permissions.conditions.no-actions": "No hay acción",
   "Settings.permissions.conditions.none-selected": "En cualquier momento",

--- a/packages/core/admin/admin/src/translations/fr.json
+++ b/packages/core/admin/admin/src/translations/fr.json
@@ -105,7 +105,7 @@
   "Settings.permissions.conditions.anytime": "N'importe quand",
   "Settings.permissions.conditions.apply": "Appliquer",
   "Settings.permissions.conditions.can": "Peut",
-  "Settings.permissions.conditions.define-conditions": "Définir les conditions",
+  "Settings.permissions.conditions.conditions": "Définir les conditions",
   "Settings.permissions.conditions.links": "Liens",
   "Settings.permissions.conditions.no-actions": "Vous devez d'abord sélectionner des actions (créer, lire, mettre à jour, ...) avant de définir des conditions sur celles-ci.",
   "Settings.permissions.conditions.none-selected": "N'importe quand",

--- a/packages/core/admin/admin/src/translations/gu.json
+++ b/packages/core/admin/admin/src/translations/gu.json
@@ -26,7 +26,7 @@
   "Auth.form.error.password.local": "આ વપરાશકર્તાએ ક્યારેય સ્થાનિક પાસવર્ડ સેટ કર્યો નથી, કૃપા કરીને એકાઉન્ટ બનાવતી વખતે ઉપયોગમાં લેવાતા પ્રદાતા દ્વારા લૉગિન કરો",
   "Auth.form.error.password.matching": "પાસવર્ડ મેળ ખાતા નથી",
   "Auth.form.error.password.provide": "કૃપા કરીને તમારો પાસવર્ડ આપો",
-  "Settings.permissions.conditions.define-conditions": "શરતો વ્યાખ્યાયિત કરો",
+  "Settings.permissions.conditions.conditions": "શરતો વ્યાખ્યાયિત કરો",
   "Settings.permissions.conditions.links": "લિંક્સ",
   "Settings.permissions.conditions.no-actions": "તમારે તેના પર શરતો વ્યાખ્યાયિત કરતા પહેલા ક્રિયાઓ (બનાવો, વાંચો, અપડેટ કરો, ...) પસંદ કરો.",
   "Settings.permissions.conditions.none-selected": "કોઈપણ સમયે",

--- a/packages/core/admin/admin/src/translations/he.json
+++ b/packages/core/admin/admin/src/translations/he.json
@@ -77,7 +77,7 @@
   "Settings.permissions.conditions.anytime": "בכל עת",
   "Settings.permissions.conditions.apply": "החל",
   "Settings.permissions.conditions.can": "יכול",
-  "Settings.permissions.conditions.define-conditions": "הגדר תנאים",
+  "Settings.permissions.conditions.conditions": "הגדר תנאים",
   "Settings.permissions.conditions.links": "קישורים",
   "Settings.permissions.conditions.no-actions": "אין שום פעולה",
   "Settings.permissions.conditions.or": "או",

--- a/packages/core/admin/admin/src/translations/hi.json
+++ b/packages/core/admin/admin/src/translations/hi.json
@@ -107,7 +107,7 @@
   "Settings.permissions.conditions.anytime": "किसी भी समय",
   "Settings.permissions.conditions.apply": "आवेदन करना",
   "Settings.permissions.conditions.can": "कर सकना",
-  "Settings.permissions.conditions.define-conditions": "शर्तों को परिभाषित करें",
+  "Settings.permissions.conditions.conditions": "शर्तों को परिभाषित करें",
   "Settings.permissions.conditions.links": "लिंक",
   "Settings.permissions.conditions.no-actions": "उन पर शर्तों को परिभाषित करने से पहले आपको पहले क्रियाओं का चयन करना होगा (बनाएं, पढ़ें, अपडेट करें, ...)",
   "Settings.permissions.conditions.none-selected": "किसी भी समय",

--- a/packages/core/admin/admin/src/translations/hu.json
+++ b/packages/core/admin/admin/src/translations/hu.json
@@ -105,7 +105,7 @@
   "Settings.permissions.conditions.anytime": "Bármikor",
   "Settings.permissions.conditions.apply": "Alkalmaz",
   "Settings.permissions.conditions.can": "Tudja",
-  "Settings.permissions.conditions.define-conditions": "Határozza meg a feltételeket",
+  "Settings.permissions.conditions.conditions": "Határozza meg a feltételeket",
   "Settings.permissions.conditions.links": "Linkek",
   "Settings.permissions.conditions.no-actions": "Először választania kell egy műveletet (create, read, update, ...) mielőtt megadja a feltételeket.",
   "Settings.permissions.conditions.none-selected": "Bármikor",

--- a/packages/core/admin/admin/src/translations/id.json
+++ b/packages/core/admin/admin/src/translations/id.json
@@ -67,7 +67,7 @@
   "Settings.permissions.conditions.anytime": "Kapan saja",
   "Settings.permissions.conditions.apply": "Terapkan",
   "Settings.permissions.conditions.can": "Bisa",
-  "Settings.permissions.conditions.define-conditions": "Tentukan kondisi",
+  "Settings.permissions.conditions.conditions": "Tentukan kondisi",
   "Settings.permissions.conditions.links": "Tautan",
   "Settings.permissions.conditions.no-actions": "Tidak ada tindakan",
   "Settings.permissions.conditions.or": "ATAU",

--- a/packages/core/admin/admin/src/translations/it.json
+++ b/packages/core/admin/admin/src/translations/it.json
@@ -75,7 +75,7 @@
   "Settings.permissions.conditions.anytime": "In ogni momento",
   "Settings.permissions.conditions.apply": "Applica",
   "Settings.permissions.conditions.can": "Può",
-  "Settings.permissions.conditions.define-conditions": "Definisci le condizioni",
+  "Settings.permissions.conditions.conditions": "Definisci le condizioni",
   "Settings.permissions.conditions.links": "Link",
   "Settings.permissions.conditions.no-actions": "Non ci sono azioni",
   "Settings.permissions.conditions.or": "Oppure",

--- a/packages/core/admin/admin/src/translations/ja.json
+++ b/packages/core/admin/admin/src/translations/ja.json
@@ -105,7 +105,7 @@
   "Settings.permissions.conditions.anytime": "いつでも",
   "Settings.permissions.conditions.apply": "適用",
   "Settings.permissions.conditions.can": "可能",
-  "Settings.permissions.conditions.define-conditions": "条件を定義",
+  "Settings.permissions.conditions.conditions": "条件を定義",
   "Settings.permissions.conditions.links": "リンク",
   "Settings.permissions.conditions.no-actions": "条件を定義する前に最初に作業（作成・閲覧・更新等）を選択する必要があります。",
   "Settings.permissions.conditions.none-selected": "Anytime",

--- a/packages/core/admin/admin/src/translations/ko.json
+++ b/packages/core/admin/admin/src/translations/ko.json
@@ -103,7 +103,7 @@
   "Settings.permissions.conditions.anytime": "Anytime",
   "Settings.permissions.conditions.apply": "Apply",
   "Settings.permissions.conditions.can": "Can",
-  "Settings.permissions.conditions.define-conditions": "Define conditions",
+  "Settings.permissions.conditions.conditions": "Define conditions",
   "Settings.permissions.conditions.links": "Links",
   "Settings.permissions.conditions.no-actions": "You first need to select actions (create, read, update, ...) before defining conditions on them.",
   "Settings.permissions.conditions.none-selected": "Anytime",

--- a/packages/core/admin/admin/src/translations/ml.json
+++ b/packages/core/admin/admin/src/translations/ml.json
@@ -107,7 +107,7 @@
   "Settings.permissions.conditions.anytime": "എപ്പോൾ വേണമെങ്കിലും",
   "Settings.permissions.conditions.apply": "അപേക്ഷിക്കുക",
   "Settings.permissions.conditions.can": "കഴിയും",
-  "Settings.permissions.conditions.define-conditions": "നിബന്ധനകൾ നിർവചിക്കുക",
+  "Settings.permissions.conditions.conditions": "നിബന്ധനകൾ നിർവചിക്കുക",
   "Settings.permissions.conditions.links": "ലിങ്കുകൾ",
   "Settings.permissions.conditions.no-actions": "അവയിലെ വ്യവസ്ഥകൾ നിർവചിക്കുന്നതിന് മുമ്പ് നിങ്ങൾ ആദ്യം പ്രവർത്തനങ്ങൾ (സൃഷ്ടിക്കുക, വായിക്കുക, അപ്ഡേറ്റ് ചെയ്യുക, ...) തിരഞ്ഞെടുക്കേണ്ടതുണ്ട്.",
   "Settings.permissions.conditions.none-selected": "എപ്പോൾ വേണമെങ്കിലും",

--- a/packages/core/admin/admin/src/translations/nl.json
+++ b/packages/core/admin/admin/src/translations/nl.json
@@ -105,7 +105,7 @@
   "Settings.permissions.conditions.anytime": "Altijd",
   "Settings.permissions.conditions.apply": "Pas toe",
   "Settings.permissions.conditions.can": "Kan",
-  "Settings.permissions.conditions.define-conditions": "Definieer voorwaarden",
+  "Settings.permissions.conditions.conditions": "Definieer voorwaarden",
   "Settings.permissions.conditions.links": "Links",
   "Settings.permissions.conditions.no-actions": "Selecteer eerst acties (creëer, lees, update, ...) voordat je voorwaarden definieert.",
   "Settings.permissions.conditions.none-selected": "Altijd",

--- a/packages/core/admin/admin/src/translations/no.json
+++ b/packages/core/admin/admin/src/translations/no.json
@@ -75,7 +75,7 @@
   "Settings.permissions.conditions.anytime": "Alltid",
   "Settings.permissions.conditions.apply": "Godkjenn",
   "Settings.permissions.conditions.can": "Kan",
-  "Settings.permissions.conditions.define-conditions": "Definér betingelser",
+  "Settings.permissions.conditions.conditions": "Definér betingelser",
   "Settings.permissions.conditions.links": "Linker",
   "Settings.permissions.conditions.no-actions": "Du må først velge handling (opprette, lese, oppdatere, ...) før du definerer betingelser for de.",
   "Settings.permissions.conditions.or": "ELLER",

--- a/packages/core/admin/admin/src/translations/pl.json
+++ b/packages/core/admin/admin/src/translations/pl.json
@@ -107,7 +107,7 @@
   "Settings.permissions.conditions.anytime": "W dowolnym momencie",
   "Settings.permissions.conditions.apply": "Zastosuj",
   "Settings.permissions.conditions.can": "Może",
-  "Settings.permissions.conditions.define-conditions": "Definiować warunki",
+  "Settings.permissions.conditions.conditions": "Definiować warunki",
   "Settings.permissions.conditions.links": "Linki",
   "Settings.permissions.conditions.no-actions": "Najpierw musisz wybrać akcje (tworzenie, odczytywanie, aktualizowanie, ...) przed zdefiniowaniem dla nich warunków.",
   "Settings.permissions.conditions.none-selected": "W dowolnym momencie",

--- a/packages/core/admin/admin/src/translations/pt-BR.json
+++ b/packages/core/admin/admin/src/translations/pt-BR.json
@@ -133,7 +133,7 @@
   "Settings.permissions.conditions.anytime": "A qualquer hora",
   "Settings.permissions.conditions.apply": "Aplicar",
   "Settings.permissions.conditions.can": "Pode",
-  "Settings.permissions.conditions.define-conditions": "Definir condições",
+  "Settings.permissions.conditions.conditions": "Definir condições",
   "Settings.permissions.conditions.links": "Links",
   "Settings.permissions.conditions.no-actions": "Você precisa selecionar ações (criar, ler, editar, ...) antes de definir uma condição.",
   "Settings.permissions.conditions.none-selected": "A qualquer hora",

--- a/packages/core/admin/admin/src/translations/ru.json
+++ b/packages/core/admin/admin/src/translations/ru.json
@@ -84,7 +84,7 @@
         "Settings.permissions.conditions.anytime": "Всегда",
         "Settings.permissions.conditions.apply": "Применить",
         "Settings.permissions.conditions.can": "Можно",
-        "Settings.permissions.conditions.define-conditions": "Определить условия",
+        "Settings.permissions.conditions.conditions": "Определить условия",
         "Settings.permissions.conditions.links": "Ссылки",
         "Settings.permissions.conditions.no-actions": "Нет действия",
         "Settings.permissions.conditions.none-selected": "Любое время",

--- a/packages/core/admin/admin/src/translations/sa.json
+++ b/packages/core/admin/admin/src/translations/sa.json
@@ -107,7 +107,7 @@
     "Settings.permissions.conditions.anytime": "कदापि",
     "Settings.permissions.conditions.apply": "प्रयोजयन्तु",
     "Settings.permissions.conditions.can": "कर्तुं शक्नुवन्ति",
-    "Settings.permissions.conditions.define-conditions": "शर्ताः परिभाषयन्तु",
+    "Settings.permissions.conditions.conditions": "शर्ताः परिभाषयन्तु",
     "Settings.permissions.conditions.links": "लिङ्क्स्",
     "Settings.permissions.conditions.no-actions": "भवतः प्रथमं क्रियाः (निर्माणं, पठनं, अद्यतनीकरणं, ...) चयनं कर्तव्यं तेषु शर्ताः परिभाषयितुं पूर्वं।",
     "Settings.permissions.conditions.none-selected": "कदापि",

--- a/packages/core/admin/admin/src/translations/sk.json
+++ b/packages/core/admin/admin/src/translations/sk.json
@@ -67,7 +67,7 @@
   "Settings.permissions.conditions.anytime": "Kedykoľvek",
   "Settings.permissions.conditions.apply": "Použiť",
   "Settings.permissions.conditions.can": "Môcť",
-  "Settings.permissions.conditions.define-conditions": "Zadajte podmienky",
+  "Settings.permissions.conditions.conditions": "Zadajte podmienky",
   "Settings.permissions.conditions.links": "Odkazy",
   "Settings.permissions.conditions.no-actions": "Akcia neexistuje",
   "Settings.permissions.conditions.or": "ALEBO",

--- a/packages/core/admin/admin/src/translations/sv.json
+++ b/packages/core/admin/admin/src/translations/sv.json
@@ -133,7 +133,7 @@
   "Settings.permissions.conditions.anytime": "När som helst",
   "Settings.permissions.conditions.apply": "Använd",
   "Settings.permissions.conditions.can": "Kan",
-  "Settings.permissions.conditions.define-conditions": "Definiera behörigheter",
+  "Settings.permissions.conditions.conditions": "Definiera behörigheter",
   "Settings.permissions.conditions.links": "Länkar",
   "Settings.permissions.conditions.no-actions": "Du måste först välja åtgärder (skapa, läsa, uppdatera, ...) innan du definierar behörigheter för dem.",
   "Settings.permissions.conditions.none-selected": "När som helst",

--- a/packages/core/admin/admin/src/translations/th.json
+++ b/packages/core/admin/admin/src/translations/th.json
@@ -67,7 +67,7 @@
   "Settings.permissions.conditions.anytime": "ทุกที่ทุกเวลา",
   "Settings.permissions.conditions.apply": "นำไปใช้",
   "Settings.permissions.conditions.can": "สามารถ",
-  "Settings.permissions.conditions.define-conditions": "กำหนดเงื่อนไข",
+  "Settings.permissions.conditions.conditions": "กำหนดเงื่อนไข",
   "Settings.permissions.conditions.links": "ลิงก์",
   "Settings.permissions.conditions.no-actions": "ไม่มีการดำเนินการ",
   "Settings.permissions.conditions.or": "หรือ",

--- a/packages/core/admin/admin/src/translations/zh-Hans.json
+++ b/packages/core/admin/admin/src/translations/zh-Hans.json
@@ -106,7 +106,7 @@
   "Settings.permissions.conditions.anytime": "任何时候",
   "Settings.permissions.conditions.apply": "启用",
   "Settings.permissions.conditions.can": "可以",
-  "Settings.permissions.conditions.define-conditions": "定义条件",
+  "Settings.permissions.conditions.conditions": "定义条件",
   "Settings.permissions.conditions.links": "链接",
   "Settings.permissions.conditions.no-actions": "你首先需要选择动作（创建、读取、更新......），然后再对其定义条件。",
   "Settings.permissions.conditions.none-selected": "任何时候",

--- a/packages/core/admin/admin/src/translations/zh.json
+++ b/packages/core/admin/admin/src/translations/zh.json
@@ -106,7 +106,7 @@
   "Settings.permissions.conditions.anytime": "隨時",
   "Settings.permissions.conditions.apply": "套用",
   "Settings.permissions.conditions.can": "可以",
-  "Settings.permissions.conditions.define-conditions": "設定條件",
+  "Settings.permissions.conditions.conditions": "設定條件",
   "Settings.permissions.conditions.links": "連結",
   "Settings.permissions.conditions.no-actions": "在設定條件之前，你要先選則動作（新增、讀取、更新...）",
   "Settings.permissions.conditions.none-selected": "隨時",


### PR DESCRIPTION
### What does it do?

Fixes the conditions modal:

- Adds a missing translation to the header
- Removes the duplicated headline
- Fixes the modal padding

| Before | After |
|-|-|
| <img width="935" alt="Screenshot 2022-11-04 at 11 19 49" src="https://user-images.githubusercontent.com/2244375/199951070-b0ea1e16-3cc6-42e5-a1f6-8fa434a53598.png"> | <img width="935" alt="Screenshot 2022-11-04 at 11 19 33" src="https://user-images.githubusercontent.com/2244375/199951078-1b076a88-365f-4119-ba48-3e91a90efb86.png"> |

### Why is it needed?

While looking into https://github.com/strapi/strapi/issues/14763 @maevalienard and I realized neither the padding of the `ModalBody` matches, nor has the header the proper translation.

### How to test it?

1. Start Strapi in EE mode
2. Navigate to http://localhost:4000/admin/settings/roles/2
3. Open settings for one content-type

### Related issue(s)/PR(s)

- Refs https://github.com/strapi/strapi/issues/14763
