### PR TITLE
ReactSelect: Add missing box-shadow

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/RelationInput/tests/__snapshots__/RelationInput.test.js.snap
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInput/tests/__snapshots__/RelationInput.test.js.snap
@@ -478,7 +478,7 @@ exports[`Content-Manager || RelationInput should render and match snapshot 1`] =
             class="css-1f43avz-a11yText-A11yText"
           />
           <div
-            class=" css-1sb7bue-control"
+            class=" css-1e1stxh-control"
           >
             <div
               class=" css-do2euy-ValueContainer"

--- a/packages/core/helper-plugin/lib/src/components/ReactSelect/utils/getSelectStyles.js
+++ b/packages/core/helper-plugin/lib/src/components/ReactSelect/utils/getSelectStyles.js
@@ -24,16 +24,12 @@ const getSelectStyles = (theme, error) => {
 
       return {
         ...base,
-        fontSize: 14,
+        fontSize: theme.fontSizes[2],
         height: 40,
         border: `1px solid ${borderColor} !important`,
         outline: 0,
-        borderRadius: '2px !important',
         backgroundColor,
-        borderTopLeftRadius: '4px !important',
-        borderTopRightRadius: '4px !important',
-        borderBottomLeftRadius: '4px !important',
-        borderBottomRightRadius: '4px !important',
+        borderRadius: theme.borderRadius,
         boxShadow: boxShadowColor ? `${boxShadowColor} 0px 0px 0px 2px` : 0,
       };
     },
@@ -46,7 +42,10 @@ const getSelectStyles = (theme, error) => {
         marginTop: theme.spaces[1],
         backgroundColor: theme.colors.neutral0,
         color: theme.colors.neutral800,
+        borderRadius: theme.borderRadius,
+        border: `1px solid ${theme.colors.neutral200}`,
         boxShadow: theme.shadows.tableShadow,
+        fontSize: theme.fontSizes[2],
         zIndex: 2,
       };
     },

--- a/packages/core/helper-plugin/lib/src/components/ReactSelect/utils/getSelectStyles.js
+++ b/packages/core/helper-plugin/lib/src/components/ReactSelect/utils/getSelectStyles.js
@@ -46,12 +46,7 @@ const getSelectStyles = (theme, error) => {
         marginTop: theme.spaces[1],
         backgroundColor: theme.colors.neutral0,
         color: theme.colors.neutral800,
-        borderRadius: '4px !important',
-        borderTopLeftRadius: '4px !important',
-        borderTopRightRadius: '4px !important',
-        border: `1px solid ${theme.colors.neutral200} !important`,
-        boxShadow: 0,
-        fontSize: '14px',
+        boxShadow: theme.shadows.tableShadow,
         zIndex: 2,
       };
     },

--- a/packages/core/upload/admin/src/components/BulkMoveDialog/tests/__snapshots__/BulkMoveDialog.test.js.snap
+++ b/packages/core/upload/admin/src/components/BulkMoveDialog/tests/__snapshots__/BulkMoveDialog.test.js.snap
@@ -634,7 +634,7 @@ exports[`BulkMoveDialog renders and matches the snapshot 1`] = `
                             class="css-1f43avz-a11yText-A11yText"
                           />
                           <div
-                            class=" css-1sb7bue-control"
+                            class=" css-1e1stxh-control"
                           >
                             <div
                               class=" css-do2euy-ValueContainer"

--- a/packages/core/upload/admin/src/components/EditAssetDialog/tests/__snapshots__/EditAssetDialog.test.js.snap
+++ b/packages/core/upload/admin/src/components/EditAssetDialog/tests/__snapshots__/EditAssetDialog.test.js.snap
@@ -1444,7 +1444,7 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
                               class="css-1f43avz-a11yText-A11yText"
                             />
                             <div
-                              class=" css-1sb7bue-control"
+                              class=" css-1e1stxh-control"
                             >
                               <div
                                 class=" css-do2euy-ValueContainer"

--- a/packages/core/upload/admin/src/components/EditAssetDialog/tests/__snapshots__/index.test.js.snap
+++ b/packages/core/upload/admin/src/components/EditAssetDialog/tests/__snapshots__/index.test.js.snap
@@ -1444,7 +1444,7 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
                               class="css-1f43avz-a11yText-A11yText"
                             />
                             <div
-                              class=" css-1sb7bue-control"
+                              class=" css-1e1stxh-control"
                             >
                               <div
                                 class=" css-do2euy-ValueContainer"

--- a/packages/core/upload/admin/src/components/EditFolderDialog/tests/__snapshots__/EditFolderDialog.test.js.snap
+++ b/packages/core/upload/admin/src/components/EditFolderDialog/tests/__snapshots__/EditFolderDialog.test.js.snap
@@ -819,7 +819,7 @@ exports[`EditFolderDialog renders and matches the snapshot 1`] = `
                             class="css-1f43avz-a11yText-A11yText"
                           />
                           <div
-                            class=" css-1sb7bue-control"
+                            class=" css-1e1stxh-control"
                           >
                             <div
                               class=" css-do2euy-ValueContainer"

--- a/packages/core/upload/admin/src/components/SelectTree/tests/__snapshots__/SelectTree.test.js.snap
+++ b/packages/core/upload/admin/src/components/SelectTree/tests/__snapshots__/SelectTree.test.js.snap
@@ -64,7 +64,7 @@ exports[`SelectTree renders 1`] = `
           class="css-1f43avz-a11yText-A11yText"
         />
         <div
-          class=" css-1sb7bue-control"
+          class=" css-1e1stxh-control"
         >
           <div
             class=" css-do2euy-ValueContainer"
@@ -150,7 +150,7 @@ exports[`SelectTree renders 1`] = `
         class="css-1f43avz-a11yText-A11yText"
       />
       <div
-        class=" css-1sb7bue-control"
+        class=" css-1e1stxh-control"
       >
         <div
           class=" css-do2euy-ValueContainer"


### PR DESCRIPTION
### What does it do?

Adds a subtle box-shadow around the react-select menu, to better differentiate it from `RelationItem`s.

| Before | After |
|-|-|
| <img width="426" alt="Screenshot 2022-11-04 at 13 58 40" src="https://user-images.githubusercontent.com/2244375/199978600-160e830e-e023-41f0-915d-3811ffecc4e8.png"> | <img width="426" alt="Screenshot 2022-11-04 at 13 56 52" src="https://user-images.githubusercontent.com/2244375/199978605-22c43b4f-0428-4112-ace2-eab6291cddeb.png"> |

### Why is it needed?

Matches the design & improves readability.
