### PR TITLE
Fix the findParams argument to be passed correctly

### DIFF
--- a/packages/plugins/graphql/server/services/builders/mutations/single-type.js
+++ b/packages/plugins/graphql/server/services/builders/mutations/single-type.js
@@ -54,7 +54,7 @@ module.exports = ({ strapi }) => {
           .buildMutationsResolvers({ contentType });
 
         const findParams = omit(['data', 'files'], transformedArgs);
-        const entity = await strapi.entityService.findMany(uid, { params: findParams });
+        const entity = await strapi.entityService.findMany(uid, findParams);
 
         // Create or update
         const value = isNil(entity)
@@ -84,7 +84,7 @@ module.exports = ({ strapi }) => {
           .get('content-api')
           .buildMutationsResolvers({ contentType });
 
-        const entity = await strapi.entityService.findMany(uid, { params: transformedArgs });
+        const entity = await strapi.entityService.findMany(uid, transformedArgs);
 
         if (!entity) {
           throw new NotFoundError('Entity not found');


### PR DESCRIPTION
### What does it do?

It passes the find parameters and arguments in the right way to the findMany function

### Why is it needed?

To allow filtering the right entity with the specified locale in the request

### How to test it?

1. Activate the GraphQL and the i18n plugins
2. Create 2 locales
3. Create a Single Type and enable 2 locales for it
4. Try to update the non-default locale with a GraphQL mutation
5. Create a GraphQL query to retrieve the updated locale
6. Check that it was updated

### Related issue(s)/PR(s)
[#14662](https://github.com/strapi/strapi/issues/14662)

