### PR TITLE
[DEITS] Make encryption key type optional

### DIFF
--- a/packages/core/data-transfer/lib/providers/local-file-destination-provider.ts
+++ b/packages/core/data-transfer/lib/providers/local-file-destination-provider.ts
@@ -12,7 +12,7 @@ export interface ILocalFileDestinationProviderOptions {
   // Encryption
   encryption: {
     enabled: boolean;
-    key: string;
+    key?: string;
   };
 
   // Compressions
@@ -56,6 +56,9 @@ class LocalFileDestinationProvider implements IDestinationProvider {
 
     // Encryption
     if (this.options.encryption.enabled) {
+      if (!this.options.encryption.key) {
+        throw new Error("Can't encrypt without a key");
+      }
       const cipher = createCipher(this.options.encryption.key);
       transforms.push(cipher);
     }

--- a/packages/core/data-transfer/lib/providers/local-file-destination-provider.ts
+++ b/packages/core/data-transfer/lib/providers/local-file-destination-provider.ts
@@ -74,6 +74,12 @@ class LocalFileDestinationProvider implements IDestinationProvider {
       fs.rmSync(rootDir, { force: true, recursive: true });
     }
 
+    if (this.options.encryption.enabled) {
+      if (!this.options.encryption.key) {
+        throw new Error("Can't encrypt without a key");
+      }
+    }
+
     fs.mkdirSync(rootDir, { recursive: true });
     fs.mkdirSync(path.join(rootDir, 'schemas'));
     fs.mkdirSync(path.join(rootDir, 'entities'));


### PR DESCRIPTION
### What does it do?

Makes file destination provider `key` optional in the type definition

### Why is it needed?

`key` is only required if encryption is true and isn't otherwise needed

### How to test it?

create a local file destination provider without a key and it should work without type errors

### Related issue(s)/PR(s)
