### PR TITLE
Fix 90-day API token creation

### DIFF
--- a/packages/core/admin/server/content-types/api-token.js
+++ b/packages/core/admin/server/content-types/api-token.js
@@ -67,7 +67,7 @@ module.exports = {
       required: false,
     },
     lifespan: {
-      type: 'integer',
+      type: 'biginteger',
       configurable: false,
       required: false,
     },

--- a/packages/core/admin/server/tests/admin-api-token-crud.test.api.js
+++ b/packages/core/admin/server/tests/admin-api-token-crud.test.api.js
@@ -177,12 +177,12 @@ describe('Admin API Token v2 CRUD (api)', () => {
     });
   });
 
-  test('Creates a token with a lifespan', async () => {
+  test('Creates a token with a 7-day lifespan', async () => {
     const now = Date.now();
     jest.useFakeTimers('modern').setSystemTime(now);
 
     const body = {
-      name: 'api-token_tests-lifespan',
+      name: 'api-token_tests-lifespan7',
       description: 'api-token_tests-description',
       type: 'read-only',
       lifespan: 7 * 24 * 60 * 60 * 1000, // 7 days
@@ -206,7 +206,85 @@ describe('Admin API Token v2 CRUD (api)', () => {
       lastUsedAt: null,
       updatedAt: expect.toBeISODate(),
       expiresAt: expect.toBeISODate(),
-      lifespan: body.lifespan,
+      lifespan: String(body.lifespan),
+    });
+
+    // Datetime stored in some databases may lose ms accuracy, so allow a range of 2 seconds for timing edge cases
+    expect(Date.parse(res.body.data.expiresAt)).toBeGreaterThan(now + body.lifespan - 2000);
+    expect(Date.parse(res.body.data.expiresAt)).toBeLessThan(now + body.lifespan + 2000);
+
+    jest.useRealTimers();
+  });
+
+  test('Creates a token with a 30-day lifespan', async () => {
+    const now = Date.now();
+    jest.useFakeTimers('modern').setSystemTime(now);
+
+    const body = {
+      name: 'api-token_tests-lifespan30',
+      description: 'api-token_tests-description',
+      type: 'read-only',
+      lifespan: 30 * 24 * 60 * 60 * 1000, // 7 days
+    };
+
+    const res = await rq({
+      url: '/admin/api-tokens',
+      method: 'POST',
+      body,
+    });
+
+    expect(res.statusCode).toBe(201);
+    expect(res.body.data).toStrictEqual({
+      accessKey: expect.any(String),
+      name: body.name,
+      permissions: [],
+      description: body.description,
+      type: body.type,
+      id: expect.any(Number),
+      createdAt: expect.toBeISODate(),
+      lastUsedAt: null,
+      updatedAt: expect.toBeISODate(),
+      expiresAt: expect.toBeISODate(),
+      lifespan: String(body.lifespan),
+    });
+
+    // Datetime stored in some databases may lose ms accuracy, so allow a range of 2 seconds for timing edge cases
+    expect(Date.parse(res.body.data.expiresAt)).toBeGreaterThan(now + body.lifespan - 2000);
+    expect(Date.parse(res.body.data.expiresAt)).toBeLessThan(now + body.lifespan + 2000);
+
+    jest.useRealTimers();
+  });
+
+  test('Creates a token with a 90-day lifespan', async () => {
+    const now = Date.now();
+    jest.useFakeTimers('modern').setSystemTime(now);
+
+    const body = {
+      name: 'api-token_tests-lifespan90',
+      description: 'api-token_tests-description',
+      type: 'read-only',
+      lifespan: 90 * 24 * 60 * 60 * 1000, // 90 days
+    };
+
+    const res = await rq({
+      url: '/admin/api-tokens',
+      method: 'POST',
+      body,
+    });
+
+    expect(res.statusCode).toBe(201);
+    expect(res.body.data).toStrictEqual({
+      accessKey: expect.any(String),
+      name: body.name,
+      permissions: [],
+      description: body.description,
+      type: body.type,
+      id: expect.any(Number),
+      createdAt: expect.toBeISODate(),
+      lastUsedAt: null,
+      updatedAt: expect.toBeISODate(),
+      expiresAt: expect.toBeISODate(),
+      lifespan: String(body.lifespan),
     });
 
     // Datetime stored in some databases may lose ms accuracy, so allow a range of 2 seconds for timing edge cases


### PR DESCRIPTION
### What does it do?

In api token content type, change the field type of `lifespan` from 'integer' to 'biginteger'

### Why is it needed?

Long lifespan values are larger than the maximum integer value, so databases (such as postgres) which use an actual integer for Strapi field type "integer" can not create 30-day or longer tokens.

### How to test it?



On databases without this bug (sqlite):
  - Start with a version of Strapi that does not include this PR
  - create tokens of every available lifespan
  -  shut down Strapi
  - switch to this branch
  - start Strapi
  - check that your created tokens still exist with the exact same data
  - try creating new tokens of all lifespans

On databases with this bug (postgres):
  - Start with a version of Strapi that does not include this PR
  - create tokens of every length that it allows you to create
  - shut down Strapi
  - switch to this branch
  - start Strapi
  - check that your created tokens still exist with the exact same data
  - try creating new tokens of all lifespans, including the ones that were broken before

I'm not sure which category mysql falls under, but the same tests should be performed for it as well.

This should not be a breaking change because the auto-migration from integer -> biginteger does not lose any data, and the creation of API tokens is only via the admin API and not a publicly documented feature.

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/issues/14802
