### PR TITLE
Fix: knex withSchema.raw error

### DIFF
--- a/packages/core/database/lib/entity-manager/regular-relations.js
+++ b/packages/core/database/lib/entity-manager/regular-relations.js
@@ -242,21 +242,23 @@ const cleanOrderColumns = async ({ id, attribute, db, inverseRelIds, transaction
         )
         .transacting(trx);
       break;
-    default:
-      await db
-        .getConnection()
+    default: {
+      const dbConnection =
+        strapi.db.dialect.client === 'postgres' ? db.connection : db.getConnection();
+      await dbConnection
         .raw(
           `UPDATE ?? as a
-            SET ${update.join(', ')}
-            FROM (
-              SELECT ${select.join(', ')}
-              FROM ??
-              WHERE ${where.join(' OR ')}
-            ) AS b
-            WHERE b.id = a.id`,
+              SET ${update.join(', ')}
+              FROM (
+                SELECT ${select.join(', ')}
+                FROM ??
+                WHERE ${where.join(' OR ')}
+              ) AS b
+              WHERE b.id = a.id`,
           [joinTable.name, ...updateBinding, ...selectBinding, joinTable.name, ...whereBinding]
         )
         .transacting(trx);
+    }
     /*
       `UPDATE :joinTable: as a
         SET :orderColumn: = b.src_order, :inverseOrderColumn: = b.inv_order

--- a/packages/core/database/lib/entity-manager/regular-relations.js
+++ b/packages/core/database/lib/entity-manager/regular-relations.js
@@ -241,13 +241,7 @@ const cleanOrderColumns = async ({ id, attribute, db, inverseRelIds, transaction
         )
         .transacting(trx);
       break;
-    default: {
-      const schemaName = db.connection.getSchemaName();
-      let joinTableName = joinTable.name;
-      if (schemaName) {
-        joinTableName = `${schemaName}.${joinTableName}`;
-      }
-
+    default:
       await db.connection
         .raw(
           `UPDATE ?? as a
@@ -258,10 +252,9 @@ const cleanOrderColumns = async ({ id, attribute, db, inverseRelIds, transaction
                 WHERE ${where.join(' OR ')}
               ) AS b
               WHERE b.id = a.id`,
-          [joinTableName, ...updateBinding, ...selectBinding, joinTableName, ...whereBinding]
+          [joinTable.name, ...updateBinding, ...selectBinding, joinTable.name, ...whereBinding]
         )
         .transacting(trx);
-    }
     /*
       `UPDATE :joinTable: as a
         SET :orderColumn: = b.src_order, :inverseOrderColumn: = b.inv_order

--- a/packages/core/database/lib/entity-manager/regular-relations.js
+++ b/packages/core/database/lib/entity-manager/regular-relations.js
@@ -243,9 +243,8 @@ const cleanOrderColumns = async ({ id, attribute, db, inverseRelIds, transaction
         .transacting(trx);
       break;
     default: {
-      const dbConnection =
-        strapi.db.dialect.client === 'postgres' ? db.connection : db.getConnection();
-      await dbConnection
+      await db
+        .getConnection()
         .raw(
           `UPDATE ?? as a
               SET ${update.join(', ')}

--- a/packages/core/database/lib/entity-manager/regular-relations.js
+++ b/packages/core/database/lib/entity-manager/regular-relations.js
@@ -242,7 +242,7 @@ const cleanOrderColumns = async ({ id, attribute, db, inverseRelIds, transaction
         )
         .transacting(trx);
       break;
-    default: {
+    default:
       await db
         .getConnection()
         .raw(
@@ -257,7 +257,6 @@ const cleanOrderColumns = async ({ id, attribute, db, inverseRelIds, transaction
           [joinTable.name, ...updateBinding, ...selectBinding, joinTable.name, ...whereBinding]
         )
         .transacting(trx);
-    }
     /*
       `UPDATE :joinTable: as a
         SET :orderColumn: = b.src_order, :inverseOrderColumn: = b.inv_order

--- a/packages/core/database/lib/index.js
+++ b/packages/core/database/lib/index.js
@@ -48,7 +48,9 @@ class Database {
   }
 
   getConnection(tableName) {
-    return tableName ? this.connection(tableName) : this.connection;
+    const schema = this.connection.getSchemaName();
+    const connection = tableName ? this.connection(tableName) : this.connection;
+    return schema ? connection.withSchema(schema) : connection;
   }
 
   getSchemaConnection(trx = this.connection) {

--- a/packages/core/database/lib/index.js
+++ b/packages/core/database/lib/index.js
@@ -48,9 +48,7 @@ class Database {
   }
 
   getConnection(tableName) {
-    const schema = this.connection.getSchemaName();
-    const connection = tableName ? this.connection(tableName) : this.connection;
-    return schema ? connection.withSchema(schema) : connection;
+    return tableName ? this.connection(tableName) : this.connection;
   }
 
   getSchemaConnection(trx = this.connection) {


### PR DESCRIPTION
We received a bug report with v4.5.0 for Postgres DBs that are using the `schema` option in `config/database.js`

### What does it do?
fixes #14832

### How to test it?
Follow instructions in #14832 

### Related issue(s)/PR(s)
#14832
closes #14887 - Thank you for the work @zodman 🙏, I just had to make a couple of tweaks

Note: we have decided to not handle multiple PG schemas in this fix to avoid inconsistency. Theres are other places in the codebase where a similar fix will be required. They will all be handled together

<!--
1. We seem to have been using withSchema wrong in `getConnection`.
2. according to the knex docs we should have been using `connection['schema'].withSchema(schema)` not `connection.withSchema(schema)`
3. However even if used correctly that would return a `SchemaBuilder` object as documented at - https://knexjs.org/guide/schema-builder.html
4. SchemaBuilder doesn’t have the functions we use with `getConnection()` such as `[select, insert, del]` etc
5. I therefore think `withSchema` is irrelevant to use in `getConnection` according to the ways the function is used throughout the codebase
6. I have modified `getConnection` to always return the `Knex Query Builder` as this is how it is used throughout the codebase
7. I can now save and modify content type relations using a Postgres DB with schema defined in `examples/getstarted/config/database.js`

@derrickmehaffy @alexandrebodin WDYT?
--!>

<!--
14-11-2022
We are using connection.withSchema(schemaName).raw() from knex in these cases. The connection returned from knex.withSchema contains no raw function. 

The issue is indeed related to the new raw query we introduced. [knex raw query](https://github.com/strapi/strapi/blob/relations-reordering/fractional-orderer/packages/core/database/lib/entity-manager/regular-relations.js#L229)

I am going to raise an issue on Knex to discuss this. In the meantime this change seems to fix the issue.

@alexandrebodin do you know of any side effects this could cause? I've tested the change but am not 100% sure of all the ways our users use PG Schemas
--!>


