### PR TITLE
[DEITS] Metadata export from the local file destination provider

### DIFF
--- a/packages/core/admin/ee/server/services/__tests__/sso.test.js
+++ b/packages/core/admin/ee/server/services/__tests__/sso.test.js
@@ -71,12 +71,12 @@ describe('SSO', () => {
       jest.clearAllMocks();
     });
 
-    test('Cannot register after boostrap', () => {
+    test('Cannot register after bootstrap', () => {
       global.strapi = { isLoaded: true };
 
       const fn = () => registry.register(fooProvider);
 
-      expect(fn).toThrowError(`You can't register new provider after the boostrap`);
+      expect(fn).toThrowError(`You can't register new provider after the bootstrap`);
       expect(registry.size).toBe(0);
     });
 

--- a/packages/core/admin/ee/server/services/passport/provider-registry.js
+++ b/packages/core/admin/ee/server/services/passport/provider-registry.js
@@ -6,7 +6,7 @@ module.exports = () => {
   Object.assign(registry, {
     register(provider) {
       if (strapi.isLoaded) {
-        throw new Error(`You can't register new provider after the boostrap`);
+        throw new Error(`You can't register new provider after the bootstrap`);
       }
 
       this.set(provider.uid, provider);

--- a/packages/core/data-transfer/lib/engine/index.ts
+++ b/packages/core/data-transfer/lib/engine/index.ts
@@ -57,7 +57,7 @@ class TransferEngine implements ITransferEngine {
     );
   }
 
-  async boostrap(): Promise<void> {
+  async bootstrap(): Promise<void> {
     await Promise.all([
       // bootstrap source provider
       this.sourceProvider.bootstrap?.(),
@@ -115,7 +115,7 @@ class TransferEngine implements ITransferEngine {
   async transfer(): Promise<void> {
     try {
       // Bootstrap the providers
-      await this.boostrap();
+      await this.bootstrap();
 
       // Resolve providers' resource and store
       // them in the engine's internal state

--- a/packages/core/data-transfer/lib/providers/local-file-destination-provider.ts
+++ b/packages/core/data-transfer/lib/providers/local-file-destination-provider.ts
@@ -5,7 +5,7 @@ import { Writable } from 'stream';
 import { chain } from 'stream-chain';
 import { stringer } from 'stream-json/jsonl/Stringer';
 
-import type { IDestinationProvider, IMetadata, ProviderType, Stream } from '../../types';
+import type { IDestinationProvider, IMetadata, ProviderType } from '../../types';
 import { createEncryptionCipher } from '../encryption/encrypt';
 
 export interface ILocalFileDestinationProviderOptions {

--- a/packages/core/data-transfer/lib/providers/local-file-destination-provider.ts
+++ b/packages/core/data-transfer/lib/providers/local-file-destination-provider.ts
@@ -97,7 +97,7 @@ class LocalFileDestinationProvider implements IDestinationProvider {
     fs.mkdirSync(path.join(rootDir, 'configuration'));
   }
 
-  close(): void | Promise<void> {
+  close(): void {
     const metadata = this.#providersMetadata.source;
 
     if (metadata !== undefined) {
@@ -108,7 +108,7 @@ class LocalFileDestinationProvider implements IDestinationProvider {
     }
   }
 
-  rollback(): void | Promise<void> {
+  rollback(): void {
     fs.rmSync(this.options.file.path, { force: true, recursive: true });
   }
 

--- a/packages/core/data-transfer/lib/providers/local-strapi-source-provider/__tests__/index.test.ts
+++ b/packages/core/data-transfer/lib/providers/local-strapi-source-provider/__tests__/index.test.ts
@@ -6,7 +6,7 @@ import { collect, createMockedQueryBuilder, getStrapiFactory } from './test-util
 import { createLocalStrapiSourceProvider } from '../';
 
 describe('Local Strapi Source Provider', () => {
-  describe('Boostrap', () => {
+  describe('Bootstrap', () => {
     test('Should not have a defined Strapi instance if bootstrap has not been called', () => {
       const provider = createLocalStrapiSourceProvider({ getStrapi: getStrapiFactory() });
 
@@ -128,24 +128,24 @@ describe('Local Strapi Source Provider', () => {
         bar: { uid: 'bar', attributes: { age: { type: 'number' } } },
       };
 
-      const components ={
+      const components = {
         'basic.simple': {
           collectionName: 'components_basic_simples',
           info: { displayName: 'simple', icon: 'ambulance', description: '' },
           options: {},
-          attributes: { name: {type:'string'} },
+          attributes: { name: { type: 'string' } },
           uid: 'basic.simple',
           category: 'basic',
           modelType: 'component',
           modelName: 'simple',
-          globalId: 'ComponentBasicSimple'
+          globalId: 'ComponentBasicSimple',
         },
         'blog.test-como': {
           collectionName: 'components_blog_test_comos',
           info: {
             displayName: 'test comp',
             icon: 'air-freshener',
-            description: ''
+            description: '',
           },
           options: {},
           attributes: { name: { type: 'string' } },
@@ -153,14 +153,16 @@ describe('Local Strapi Source Provider', () => {
           category: 'blog',
           modelType: 'component',
           modelName: 'test-como',
-          globalId: 'ComponentBlogTestComo'
+          globalId: 'ComponentBlogTestComo',
         },
-      }
+      };
 
-      const provider = createLocalStrapiSourceProvider({ getStrapi: getStrapiFactory({
-        contentTypes,
-        components
-      }) });
+      const provider = createLocalStrapiSourceProvider({
+        getStrapi: getStrapiFactory({
+          contentTypes,
+          components,
+        }),
+      });
 
       await provider.bootstrap();
 
@@ -177,19 +179,19 @@ describe('Local Strapi Source Provider', () => {
           collectionName: 'components_basic_simples',
           info: { displayName: 'simple', icon: 'ambulance', description: '' },
           options: {},
-          attributes: { name: {type:'string'} },
+          attributes: { name: { type: 'string' } },
           uid: 'basic.simple',
           category: 'basic',
           modelType: 'component',
           modelName: 'simple',
-          globalId: 'ComponentBasicSimple'
+          globalId: 'ComponentBasicSimple',
         },
         {
           collectionName: 'components_blog_test_comos',
           info: {
             displayName: 'test comp',
             icon: 'air-freshener',
-            description: ''
+            description: '',
           },
           options: {},
           attributes: { name: { type: 'string' } },
@@ -197,9 +199,9 @@ describe('Local Strapi Source Provider', () => {
           category: 'blog',
           modelType: 'component',
           modelName: 'test-como',
-          globalId: 'ComponentBlogTestComo'
-        }
-      ])
+          globalId: 'ComponentBlogTestComo',
+        },
+      ]);
     });
-  })
+  });
 });

--- a/packages/core/data-transfer/lib/providers/local-strapi-source-provider/index.ts
+++ b/packages/core/data-transfer/lib/providers/local-strapi-source-provider/index.ts
@@ -41,8 +41,6 @@ class LocalStrapiSourceProvider implements ISourceProvider {
   }
 
   getMetadata(): IMetadata {
-    console.log(strapi.plugin('graphql').config('version'));
-
     const strapiVersion = strapi.config.get('info.strapi');
     const createdAt = new Date().toISOString();
 

--- a/packages/core/data-transfer/lib/providers/local-strapi-source-provider/index.ts
+++ b/packages/core/data-transfer/lib/providers/local-strapi-source-provider/index.ts
@@ -1,4 +1,4 @@
-import type { ISourceProvider, ProviderType } from '../../../types';
+import type { IMedia, IMetadata, ISourceProvider, ProviderType } from '../../../types';
 
 import { chain } from 'stream-chain';
 import { Readable } from 'stream';
@@ -40,9 +40,25 @@ class LocalStrapiSourceProvider implements ISourceProvider {
     }
   }
 
-  // TODO: Implement the get metadata
-  async getMetadata() {
-    return null;
+  getMetadata(): IMetadata {
+    console.log(strapi.plugin('graphql').config('version'));
+
+    const strapiVersion = strapi.config.get('info.strapi');
+    const createdAt = new Date().toISOString();
+
+    const plugins = Object.keys(strapi.plugins);
+
+    return {
+      createdAt,
+      strapi: {
+        version: strapiVersion,
+        plugins: plugins.map((name) => ({
+          name,
+          // TODO: Get the plugin actual version when it'll be available
+          version: strapiVersion,
+        })),
+      },
+    };
   }
 
   async streamEntities(): Promise<NodeJS.ReadableStream> {

--- a/packages/core/data-transfer/types/providers.d.ts
+++ b/packages/core/data-transfer/types/providers.d.ts
@@ -9,6 +9,7 @@ interface IProvider {
   name: string;
 
   bootstrap?(): Promise<void> | void;
+  getSchemas?(): any;
   close?(): Promise<void> | void;
   getMetadata(): IMetadata | null | Promise<IMetadata | null>;
 }
@@ -19,15 +20,18 @@ export interface ISourceProvider extends IProvider {
   streamLinks?(): NodeJS.ReadableStream | Promise<NodeJS.ReadableStream>;
   streamMedia?(): NodeJS.ReadableStream | Promise<NodeJS.ReadableStream>;
   streamConfiguration?(): NodeJS.ReadableStream | Promise<NodeJS.ReadableStream>;
-  getSchemas?(): any;
   streamSchemas?(): NodeJS.ReadableStream | Promise<NodeJS.ReadableStream>;
 }
 
 export interface IDestinationProvider extends IProvider {
+  #providersMetadata?: { source?: IMetadata; destination?: IMetadata };
+
   /**
    * Optional rollback implementation
    */
   rollback?<T extends Error = Error>(e: T): void | Promise<void>;
+
+  setMetadata?(target: ProviderType, metadata: IMetadata): IDestinationProvider;
 
   // Getters for the destination's transfer streams
   getEntitiesStream?(): NodeJS.WritableStream | Promise<NodeJS.WritableStream>;

--- a/packages/core/data-transfer/types/transfer-engine.d.ts
+++ b/packages/core/data-transfer/types/transfer-engine.d.ts
@@ -2,6 +2,7 @@ import { SchemaUID } from '@strapi/strapi/lib/types/utils';
 import { IEntity, ILink, IMedia } from './common-entities';
 import { ITransferRule } from './utils';
 import { ISourceProvider, IDestinationProvider } from './provider';
+import { init } from 'lodash/fp';
 
 /**
  * Defines the capabilities and properties of the transfer engine
@@ -40,6 +41,11 @@ export interface ITransferEngine {
    * connections, open files, etc...
    */
   bootstrap(): Promise<void>;
+
+  /**
+   * Engine init step. Must be called after the providers bootstrap.
+   */
+  init(): Promise<void>;
 
   /**
    * Run the close lifecycle method of each provider

--- a/packages/core/data-transfer/types/transfer-engine.d.ts
+++ b/packages/core/data-transfer/types/transfer-engine.d.ts
@@ -2,7 +2,6 @@ import { SchemaUID } from '@strapi/strapi/lib/types/utils';
 import { IEntity, ILink, IMedia } from './common-entities';
 import { ITransferRule } from './utils';
 import { ISourceProvider, IDestinationProvider } from './provider';
-import { init } from 'lodash/fp';
 
 /**
  * Defines the capabilities and properties of the transfer engine

--- a/packages/core/data-transfer/types/transfer-engine.d.ts
+++ b/packages/core/data-transfer/types/transfer-engine.d.ts
@@ -39,7 +39,7 @@ export interface ITransferEngine {
    * Note: The bootstrap method can be used to initialize database
    * connections, open files, etc...
    */
-  boostrap(): Promise<void>;
+  bootstrap(): Promise<void>;
 
   /**
    * Run the close lifecycle method of each provider

--- a/yarn.lock
+++ b/yarn.lock
@@ -5859,14 +5859,6 @@
   resolved "https://registry.yarnpkg.com/@strapi/icons/-/icons-1.2.7.tgz#35862d7f6a088f9a0016b1d81687294c77526d0d"
   integrity sha512-Uae7t/N4d+9zolgPFsbU4bq4+Y9zE90Lv1HKFKvF/3DFWX5W8Q1HRMN+sawdno7LXlHqav2TUXssJ18wwYfrRw==
 
-"@strapi/logger@4.4.6":
-  version "4.4.6"
-  resolved "https://registry.yarnpkg.com/@strapi/logger/-/logger-4.4.6.tgz#25b16279dc27512612f00fd1806e140004bd6b42"
-  integrity sha512-NPJ/9CsiqbvH9VL2ApVPOnUwJ204xsrEpyDklpEtCYmedepjtjPsEaW4uA7OSOzSNhmXrI2KC3ltsT3MRHhpTA==
-  dependencies:
-    lodash "4.17.21"
-    winston "3.3.3"
-
 "@stylelint/postcss-css-in-js@^0.37.2":
   version "0.37.3"
   resolved "https://registry.yarnpkg.com/@stylelint/postcss-css-in-js/-/postcss-css-in-js-0.37.3.tgz#d149a385e07ae365b0107314c084cb6c11adbf49"


### PR DESCRIPTION
### What does it do?

When using the file destination provider during a transfer process, export the metadata from the source provider (if defined) in a metadata.json file in the final archive.

### Why is it needed?

This is needed to match the excepted archive structure as we will need those metadata when importing data from a file.

### How to test it?

- `yarn strapi export`
- The metadata.json file should be created

### Note
- For now, we're using the strapi version as the version for each plugin, but it'll have to change when we'll store the plugins' versions in their state. Currently, it's not accessible.