### PR TITLE
Rewrite invalid uid prefix error message

### DIFF
--- a/packages/core/strapi/lib/core/domain/content-type/index.js
+++ b/packages/core/strapi/lib/core/domain/content-type/index.js
@@ -54,7 +54,7 @@ const createContentType = (uid, definition) => {
     });
   } else {
     throw new Error(
-      `Incorrect Content Type UID "${uid}". The UID should start with api::, plugin:: or strapi::.`
+      `Incorrect Content Type UID "${uid}". The UID should start with api::, plugin:: or admin::.`
     );
   }
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Improve the quality of the error thrown when a new content type is registered with an invalid uid.

### Why is it needed?

The code is checking that uid starts with `api`, `plugin` or `admin` but is throwing a message with a incorrect message.

### How to test it?

Register a contentType with a no valid uid prefix.

### Related issue(s)/PR(s)

Resolves #14869 
