### PR TITLE
Chore: Update codecov uploader

### DIFF
--- a/.github/actions/install-modules/action.yml
+++ b/.github/actions/install-modules/action.yml
@@ -1,12 +1,7 @@
 name: 'Install modules'
-description: 'Run yarn install and add global modules'
-inputs:
-  globalPackages:
-    description: 'Global packages to install'
+description: 'Install yarn dependencies'
 runs:
   using: 'composite'
   steps:
     - run: $GITHUB_ACTION_PATH/script.sh
-      env:
-        GLOBAL_PACKAGES: ${{ inputs.globalPackages }}
       shell: bash

--- a/.github/actions/install-modules/script.sh
+++ b/.github/actions/install-modules/script.sh
@@ -1,8 +1,2 @@
-# install global packages if set
-if [[ -n "$GLOBAL_PACKAGES" ]]; then
-  yarn global add "$GLOBAL_PACKAGES"
-  yarn global bin >>$GITHUB_PATH
-fi
-
 # run yarn
 yarn

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,8 +34,6 @@ jobs:
     name: 'unit_back (node: ${{ matrix.node }})'
     needs: [lint]
     runs-on: ubuntu-latest
-    env:
-      CODECOV_TOKEN: ${{ secrets.codecov }}
     strategy:
       matrix:
         node: [14, 16, 18]
@@ -46,17 +44,19 @@ jobs:
           node-version: ${{ matrix.node }}
           cache: yarn
       - uses: ./.github/actions/install-modules
-        with:
-          globalPackages: codecov
       - name: Run tests
-        run: yarn run -s test:unit --coverage && codecov -C -F unit
+        run: yarn run -s test:unit --coverage
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          directory: ./coverage
+          flags: back,unit_back
 
   unit_front:
     name: 'unit_front (node: ${{ matrix.node }})'
     needs: [lint]
     runs-on: ubuntu-latest
-    env:
-      CODECOV_TOKEN: ${{ secrets.codecov }}
     strategy:
       matrix:
         node: [14, 16, 18]
@@ -67,12 +67,16 @@ jobs:
           node-version: ${{ matrix.node }}
           cache: yarn
       - uses: ./.github/actions/install-modules
-        with:
-          globalPackages: codecov
       - name: Build
         run: yarn build
       - name: Run test
-        run: yarn run -s test:front --coverage && codecov -C -F front
+        run: yarn run -s test:front --coverage
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          directory: ./coverage
+          flags: front,unit_front
 
   api_ce_pg:
     runs-on: ubuntu-latest

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,6 @@
 'use strict';
 
 module.exports = {
+  coverageDirectory: '<rootDir>/coverage',
   projects: ['<rootDir>/packages/**/jest.config.js', '<rootDir>/.github'],
 };

--- a/packages/core/admin/jest.config.front.js
+++ b/packages/core/admin/jest.config.front.js
@@ -8,5 +8,4 @@ module.exports = {
   displayName: (pkg.strapi && pkg.strapi.name) || pkg.name,
   roots: [__dirname],
   collectCoverageFrom: ['<rootDir>/packages/core/admin/admin/**/*.js'],
-  coverageDirectory: '<rootDir>/packages/core/admin/coverage',
 };

--- a/packages/core/helper-plugin/jest.config.front.js
+++ b/packages/core/helper-plugin/jest.config.front.js
@@ -6,5 +6,4 @@ module.exports = {
   displayName: (pkg.strapi && pkg.strapi.name) || pkg.name,
   roots: [__dirname],
   collectCoverageFrom: ['<rootDir>/packages/core/helper-plugin/lib/src/**/*.js'],
-  coverageDirectory: '<rootDir>/packages/core/helper-plugin/coverage',
 };


### PR DESCRIPTION
### What does it do?

This PR replaces the codecov node package with a GitHub action.

### Why is it needed?

The codecov node-package is deprecated and it is recommended to use the codecov GitHub action instead.

### Related issue(s)/PR(s)

- https://about.codecov.io/blog/codecov-uploader-deprecation-plan/
