### PR TITLE
[relations]: Add ability to save relations

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/utils/cleanData.js
+++ b/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/utils/cleanData.js
@@ -84,14 +84,28 @@ const cleanData = ({ browserState, serverState }, currentSchema, componentsSchem
            */
           let actualOldValue = oldValue ?? [];
 
+          const valuesWithPositions = value.map((relation, index, allRelations) => {
+            const nextRelation = allRelations[index + 1];
+
+            if (nextRelation) {
+              return { ...relation, position: { before: nextRelation.id } };
+            }
+
+            return { ...relation, position: { end: true } };
+          });
+
           /**
            * Instead of the full relation object, we only want to send its ID
            *  connectedRelations are the items that are in the browserState
            * array but not in the serverState
            */
-          const connectedRelations = value.reduce((acc, relation) => {
-            if (!actualOldValue.find((oldRelation) => oldRelation.id === relation.id)) {
-              return [...acc, { id: relation.id }];
+          const connectedRelations = valuesWithPositions.reduce((acc, relation, currentIndex) => {
+            const indexOfRelationOnServer = actualOldValue.findIndex(
+              (oldRelation) => oldRelation.id === relation.id
+            );
+
+            if (indexOfRelationOnServer === -1 || indexOfRelationOnServer !== currentIndex) {
+              return [...acc, { id: relation.id, position: relation.position }];
             }
 
             return acc;
@@ -102,7 +116,7 @@ const cleanData = ({ browserState, serverState }, currentSchema, componentsSchem
            * are no longer in the browserState
            */
           const disconnectedRelations = actualOldValue.reduce((acc, relation) => {
-            if (!value.find((newRelation) => newRelation.id === relation.id)) {
+            if (!valuesWithPositions.find((newRelation) => newRelation.id === relation.id)) {
               return [...acc, { id: relation.id }];
             }
 

--- a/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/utils/tests/cleanData.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/utils/tests/cleanData.test.js
@@ -198,7 +198,7 @@ describe('CM || components || EditViewDataManagerProvider || utils || cleanData'
       expect(result).toEqual({
         component: {
           relation: {
-            connect: [{ id: 1 }],
+            connect: [{ id: 1, position: { end: true } }],
             disconnect: [],
           },
         },
@@ -254,7 +254,7 @@ describe('CM || components || EditViewDataManagerProvider || utils || cleanData'
         component: {
           component2: {
             relation: {
-              connect: [{ id: 1 }],
+              connect: [{ id: 1, position: { end: true } }],
               disconnect: [],
             },
           },
@@ -419,7 +419,7 @@ describe('CM || components || EditViewDataManagerProvider || utils || cleanData'
 
       expect(result).toStrictEqual({
         relation: {
-          connect: [{ id: 1 }],
+          connect: [{ id: 1, position: { end: true } }],
           disconnect: [{ id: 2 }],
         },
       });
@@ -441,7 +441,7 @@ describe('CM || components || EditViewDataManagerProvider || utils || cleanData'
 
       expect(result).toStrictEqual({
         relation: {
-          connect: [{ id: 1 }],
+          connect: [{ id: 1, position: { end: true } }],
           disconnect: [],
         },
       });
@@ -510,7 +510,7 @@ describe('CM || components || EditViewDataManagerProvider || utils || cleanData'
             relation_component: {
               relation: {
                 disconnect: [],
-                connect: [{ id: 1 }],
+                connect: [{ id: 1, position: { end: true } }],
               },
             },
           },
@@ -519,7 +519,7 @@ describe('CM || components || EditViewDataManagerProvider || utils || cleanData'
             relation_component: {
               relation: {
                 disconnect: [],
-                connect: [{ id: 2 }],
+                connect: [{ id: 2, position: { end: true } }],
               },
             },
           },
@@ -659,7 +659,7 @@ describe('CM || components || EditViewDataManagerProvider || utils || cleanData'
             __component: 'basic.relation',
             id: 1,
             relation: {
-              connect: [{ id: 1 }],
+              connect: [{ id: 1, position: { end: true } }],
               disconnect: [],
             },
           },
@@ -668,7 +668,7 @@ describe('CM || components || EditViewDataManagerProvider || utils || cleanData'
             id: 2,
             relation_component: {
               relation: {
-                connect: [{ id: 2 }],
+                connect: [{ id: 2, position: { end: true } }],
                 disconnect: [],
               },
             },
@@ -681,7 +681,7 @@ describe('CM || components || EditViewDataManagerProvider || utils || cleanData'
                 __component: 'basic.relation',
                 id: 1,
                 relation: {
-                  connect: [{ id: 3 }],
+                  connect: [{ id: 3, position: { end: true } }],
                   disconnect: [],
                 },
               },
@@ -806,6 +806,91 @@ describe('CM || components || EditViewDataManagerProvider || utils || cleanData'
             ],
           },
         ],
+      });
+    });
+
+    test('given that a relation is reordered it should be in the connect array with its new position', () => {
+      const result = cleanData(
+        {
+          browserState: {
+            relation: [{ id: 1 }, { id: 2 }],
+          },
+          serverState: {
+            relation: [{ id: 2 }, { id: 1 }],
+          },
+        },
+        schema,
+        componentsSchema
+      );
+
+      expect(result).toStrictEqual({
+        relation: {
+          connect: [
+            { id: 1, position: { before: 2 } },
+            { id: 2, position: { end: true } },
+          ],
+          disconnect: [],
+        },
+      });
+    });
+
+    test('given a relation is not in the serverState but is added and then re-ordered to another position, it should appear in the connect array with the correct position', () => {
+      const result = cleanData(
+        {
+          browserState: {
+            relation: [{ id: 3 }, { id: 1 }, { id: 2 }],
+          },
+          serverState: {
+            relation: [{ id: 1 }, { id: 2 }],
+          },
+        },
+        schema,
+        componentsSchema
+      );
+
+      expect(result).toStrictEqual({
+        relation: {
+          connect: [
+            {
+              id: 3,
+              position: { before: 1 },
+            },
+            { id: 1, position: { before: 2 } },
+            { id: 2, position: { end: true } },
+          ],
+          disconnect: [],
+        },
+      });
+    });
+
+    test('given relations are added that are infront of the existing relations, it should only return the new relations', () => {
+      const result = cleanData(
+        {
+          browserState: {
+            relation: [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }],
+          },
+          serverState: {
+            relation: [{ id: 1 }, { id: 2 }],
+          },
+        },
+        schema,
+        componentsSchema
+      );
+
+      expect(result).toStrictEqual({
+        relation: {
+          connect: [
+            {
+              id: 3,
+              position: { before: 4 },
+            },
+            {
+              id: 4,
+              position: { end: true },
+            },
+          ],
+          disconnect: [],
+        },
       });
     });
   });


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* Adds `position` object to the `connect` array for saving relations
* `connect` array now includes any relations that have changed their index

### Why is it needed?

* So we can save relation positions to the API

### How to test it?

* There are unit tests
* The backend needs a small refactor to handle certain cases but you can add one relation and move it to the top of your array and it'll save.

### Related issue(s)/PR(s)

* resolves CONTENT-557

### NOTE

we **must** use `before` and `end` notation because we do not know the entire list of relations, therefore `start` can never be fully trusted without a flag (same with `after`) but realistically it's better we use one approach for this.
