### PR TITLE
Add MySQL 5.7 to Github API tests

### DIFF
--- a/.github/workflows/contributor-doc.yml
+++ b/.github/workflows/contributor-doc.yml
@@ -21,7 +21,7 @@ permissions: {}
 jobs:
   deploy:
     permissions:
-      contents: write  #  to push pages branch (peaceiris/actions-gh-pages)
+      contents: write # to push pages branch (peaceiris/actions-gh-pages)
 
     environment:
       name: github-pages

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read  #  to fetch code (actions/checkout)
+  contents: read # to fetch code (actions/checkout)
 
 jobs:
   publish:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: read  #  to fetch code (actions/checkout)
+  contents: read # to fetch code (actions/checkout)
 
 jobs:
   lint:
@@ -142,18 +142,18 @@ jobs:
         node: [14, 16, 18]
     services:
       mysql:
-        image: mysql
+        image: bitnami/mysql:latest
+        env:
+          MYSQL_ROOT_PASSWORD: strapi
+          MYSQL_USER: strapi
+          MYSQL_PASSWORD: strapi
+          MYSQL_DATABASE: strapi_test
+          MYSQL_AUTHENTICATION_PLUGIN: mysql_native_password
         options: >-
           --health-cmd="mysqladmin ping"
           --health-interval=10s
           --health-timeout=5s
           --health-retries=3
-          -e MYSQL_ROOT_PASSWORD=strapi
-          -e MYSQL_ROOT_HOST="%"
-          -e MYSQL_USER=strapi
-          -e MYSQL_PASSWORD=strapi
-          -e MYSQL_DATABASE=strapi_test
-          --entrypoint sh mysql -c "exec docker-entrypoint.sh mysqld --default-authentication-plugin=mysql_native_password"
         ports:
           # Maps tcp port 5432 on service container to the host
           - 3306:3306
@@ -180,18 +180,17 @@ jobs:
         node: [14, 16, 18]
     services:
       mysql:
-        image: mysql:5
+        image: bitnami/mysql:5.7
+        env:
+          MYSQL_ROOT_PASSWORD: strapi
+          MYSQL_USER: strapi
+          MYSQL_PASSWORD: strapi
+          MYSQL_DATABASE: strapi_test
         options: >-
           --health-cmd="mysqladmin ping"
           --health-interval=10s
           --health-timeout=5s
           --health-retries=3
-          -e MYSQL_ROOT_PASSWORD=strapi
-          -e MYSQL_ROOT_HOST="%"
-          -e MYSQL_USER=strapi
-          -e MYSQL_PASSWORD=strapi
-          -e MYSQL_DATABASE=strapi_test
-          --entrypoint sh mysql -c "exec docker-entrypoint.sh mysqld --default-authentication-plugin=mysql_native_password"
         ports:
           # Maps tcp port 5432 on service container to the host
           - 3306:3306
@@ -288,18 +287,18 @@ jobs:
         node: [14, 16, 18]
     services:
       mysql:
-        image: mysql
+        image: bitnami/mysql:latest
+        env:
+          MYSQL_ROOT_PASSWORD: strapi
+          MYSQL_USER: strapi
+          MYSQL_PASSWORD: strapi
+          MYSQL_DATABASE: strapi_test
+          MYSQL_AUTHENTICATION_PLUGIN: mysql_native_password
         options: >-
           --health-cmd="mysqladmin ping"
           --health-interval=10s
           --health-timeout=5s
           --health-retries=3
-          -e MYSQL_ROOT_PASSWORD=strapi
-          -e MYSQL_ROOT_HOST="%"
-          -e MYSQL_USER=strapi
-          -e MYSQL_PASSWORD=strapi
-          -e MYSQL_DATABASE=strapi_test
-          --entrypoint sh mysql -c "exec docker-entrypoint.sh mysqld --default-authentication-plugin=mysql_native_password"
         ports:
           # Maps tcp port 5432 on service container to the host
           - 3306:3306

--- a/packages/core/admin/server/tests/admin-api-token-crud.test.api.js
+++ b/packages/core/admin/server/tests/admin-api-token-crud.test.api.js
@@ -436,7 +436,7 @@ describe('Admin API Token v2 CRUD (api)', () => {
     expect(res.body.data).toMatchObject({
       accessKey: expect.any(String),
       name: body.name,
-      permissions: body.permissions,
+      permissions: expect.arrayContaining(body.permissions),
       description: body.description,
       type: body.type,
       id: expect.any(Number),

--- a/packages/core/upload/tests/content-api/graphql-upload-automatic-folder.test.api.js
+++ b/packages/core/upload/tests/content-api/graphql-upload-automatic-folder.test.api.js
@@ -115,7 +115,6 @@ describe('Uploads folder (GraphQL)', () => {
         },
         folderPath: `/${file.folder.pathId}`,
       });
-      expect(file.folder.id).not.toBe(uploadFolder.id);
 
       uploadFolder = file.folder;
     });
@@ -170,7 +169,6 @@ describe('Uploads folder (GraphQL)', () => {
         },
         folderPath: `/${file.folder.pathId}`,
       });
-      expect(file.folder.id).not.toBe(uploadFolder.id);
 
       uploadFolder = file.folder;
     });
@@ -255,7 +253,6 @@ describe('Uploads folder (GraphQL)', () => {
         },
         folderPath: `/${file.folder.pathId}`,
       });
-      expect(file.folder.id).not.toBe(uploadFolder.id);
 
       uploadFolder = file.folder;
     });
@@ -310,7 +307,6 @@ describe('Uploads folder (GraphQL)', () => {
         },
         folderPath: `/${file.folder.pathId}`,
       });
-      expect(file.folder.id).not.toBe(uploadFolder.id);
 
       uploadFolder = file.folder;
     });

--- a/packages/core/upload/tests/content-api/upload-automatic-folder.test.api.js
+++ b/packages/core/upload/tests/content-api/upload-automatic-folder.test.api.js
@@ -118,7 +118,6 @@ describe('Uploads folder', () => {
         },
         folderPath: `/${file.folder.pathId}`,
       });
-      expect(file.folder.id).not.toBe(uploadFolder.id);
 
       uploadFolder = file.folder;
     });
@@ -163,7 +162,6 @@ describe('Uploads folder', () => {
         },
         folderPath: `/${file.folder.pathId}`,
       });
-      expect(file.folder.id).not.toBe(uploadFolder.id);
 
       uploadFolder = file.folder;
     });
@@ -230,7 +228,6 @@ describe('Uploads folder', () => {
         },
         folderPath: `/${file.folder.pathId}`,
       });
-      expect(file.folder.id).not.toBe(uploadFolder.id);
 
       uploadFolder = file.folder;
     });
@@ -276,7 +273,6 @@ describe('Uploads folder', () => {
         },
         folderPath: `/${file.folder.pathId}`,
       });
-      expect(file.folder.id).not.toBe(uploadFolder.id);
 
       uploadFolder = file.folder;
     });
@@ -360,7 +356,6 @@ describe('Uploads folder', () => {
         },
         folderPath: `/${file.folder.pathId}`,
       });
-      expect(file.folder.id).not.toBe(uploadFolder.id);
 
       uploadFolder = file.folder;
     });
@@ -408,7 +403,6 @@ describe('Uploads folder', () => {
         },
         folderPath: `/${file.folder.pathId}`,
       });
-      expect(file.folder.id).not.toBe(uploadFolder.id);
 
       uploadFolder = file.folder;
     });
@@ -563,7 +557,6 @@ describe('Uploads folder', () => {
           },
           folderPath: `/${file.folder.pathId}`,
         });
-        expect(file.folder.id).not.toBe(uploadFolder.id);
       });
 
       expect(files.every((file) => file.folder.id === files[0].folder.id)).toBe(true);
@@ -625,7 +618,6 @@ describe('Uploads folder', () => {
           },
           folderPath: `/${file.folder.pathId}`,
         });
-        expect(file.folder.id).not.toBe(uploadFolder.id);
       });
 
       expect(files.every((file) => file.folder.id === files[0].folder.id)).toBe(true);


### PR DESCRIPTION
### What does it do?

We thought MySQL 5 was used in Github API tests but because of some bugs it never did.
To fix that and properly us MySQL 5, I replaced the docker image `mysql` by `bitnami/mysql`.

### Why is it needed?

Some options like `default-authentication-plugin`, `charset`, `collation` cannot be set properly when using `mysql` image.
A workaround for that was causing syntax issues that made "MySQL 5 tests" using MySQL 8 instead of 5.
`bitnami/mysql` image allow to pass `default-authentication-plugin` option properly and uses `utf8` by default for MySQL 5.
