### PR TITLE
Chore: fix spelling of SchemaProvideer to SchemaProvider

### DIFF
--- a/packages/core/database/lib/index.d.ts
+++ b/packages/core/database/lib/index.d.ts
@@ -1,6 +1,6 @@
 import { LifecycleProvider } from './lifecycles';
 import { MigrationProvider } from './migrations';
-import { SchemaProvideer } from './schema';
+import { SchemaProvider } from './schema';
 
 type LogicalOperators<T> = {
   $and?: WhereParams<T>[];
@@ -154,7 +154,7 @@ interface DatabaseConfig {
   models: ModelConfig[];
 }
 export interface Database {
-  schema: SchemaProvideer;
+  schema: SchemaProvider;
   lifecycles: LifecycleProvider;
   migrations: MigrationProvider;
   entityManager: EntityManager;

--- a/packages/core/database/lib/schema/index.d.ts
+++ b/packages/core/database/lib/schema/index.d.ts
@@ -38,7 +38,7 @@ export interface Model {
   };
 }
 
-export interface SchemaProvideer {
+export interface SchemaProvider {
   sync(): Promise<void>;
   syncSchema(): Promise<void>;
   reset(): Promise<void>;
@@ -46,4 +46,4 @@ export interface SchemaProvideer {
   drop(): Promise<void>;
 }
 
-export default function(db: Database): SchemaProvideer;
+export default function(db: Database): SchemaProvider;


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Renamed all instances of the "SchemaProvideer" interface in the core/database to correct spelling "SchemaProvider"

### Why is it needed?

Minor spelling correction, not remotely important, but I saw it and felt it needed to be corrected

### How to test it?

All references of "SchemaProvideer" were renamed, shouldn't be any issues, all tests passed locally

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
