### PR TITLE
Fixing  connection.withSchema().raw is not a function

### DIFF
--- a/packages/core/database/lib/entity-manager/regular-relations.js
+++ b/packages/core/database/lib/entity-manager/regular-relations.js
@@ -249,7 +249,7 @@ const cleanOrderColumns = async ({ id, attribute, db, inverseRelIds, transaction
         joinTableName = `${schemaName}.${joinTableName}`
       }
       await db
-        .getConnection()
+        .connection
         .raw(
           `UPDATE ?? as a
             SET ${update.join(', ')}

--- a/packages/core/database/lib/entity-manager/regular-relations.js
+++ b/packages/core/database/lib/entity-manager/regular-relations.js
@@ -243,6 +243,11 @@ const cleanOrderColumns = async ({ id, attribute, db, inverseRelIds, transaction
         .transacting(trx);
       break;
     default:
+      const schemaName = db.connection.getSchemaName()
+      let joinTableName = joinTable.name;
+      if(schemaName) {
+        joinTableName = `${schemaName}.${joinTableName}`
+      }
       await db
         .getConnection()
         .raw(
@@ -254,7 +259,7 @@ const cleanOrderColumns = async ({ id, attribute, db, inverseRelIds, transaction
               WHERE ${where.join(' OR ')}
             ) AS b
             WHERE b.id = a.id`,
-          [joinTable.name, ...updateBinding, ...selectBinding, joinTable.name, ...whereBinding]
+          [joinTableName, ...updateBinding, ...selectBinding, joinTableName, ...whereBinding]
         )
         .transacting(trx);
     /*


### PR DESCRIPTION

### What does it do?
Strapi 4.5.0 fails to update content When you  define a custom schema:

```
module.exports = ({
  env
}) => ({
  connection: {
    client: "postgres",
    connection: {
...
      schema: config.schema 
    },
  },
});
```

this is because @strapi/database use the  `knex.withSchema('schema').raw()` instead of `knex.raw()`

### Why is it needed?

This change make strapi working again with a custom schema

### How to test it?

Locally

### Related issue(s)/PR(s)

https://github.com/knex/knex/issues/5380
https://github.com/strapi/strapi/issues/14832
