### PR TITLE
[DEITS] fix cli key

### DIFF
--- a/packages/core/strapi/bin/strapi.js
+++ b/packages/core/strapi/bin/strapi.js
@@ -289,7 +289,12 @@ program
       .default(true)
       .argParser(parseInputBool)
   )
-  .addOption(new Option('--key', 'Provide encryption key in command instead of using a prompt'))
+  .addOption(
+    new Option(
+      '--key [encryption key]',
+      'Provide encryption key in command instead of using a prompt'
+    )
+  )
   .addOption(
     new Option('--max-size <max MB per file>', 'split final file when exceeding size in MB')
   )

--- a/packages/core/strapi/bin/strapi.js
+++ b/packages/core/strapi/bin/strapi.js
@@ -272,18 +272,21 @@ program
   .command('export')
   .description('Export data from Strapi to file')
   .addOption(
-    new Option('--encrypt [boolean]', `Encrypt output file using the 'aes-128-ecb' algorithm`)
+    new Option(
+      '--encrypt <boolean>',
+      `Encrypt output file using the 'aes-128-ecb' algorithm. Prompts for key unless key option is used.`
+    )
       .default(true)
       .argParser(parseInputBool)
   )
   .addOption(
-    new Option('--compress [boolean]', 'Compress output file using gzip compression')
+    new Option('--compress <boolean>', 'Compress output file using gzip compression')
       .default(true)
       .argParser(parseInputBool)
   )
   .addOption(
     new Option(
-      '--archive [boolean]',
+      '--archive <boolean>',
       'Export all backup files into a single tar archive instead of a folder'
     )
       .default(true)
@@ -291,8 +294,8 @@ program
   )
   .addOption(
     new Option(
-      '--key [encryption key]',
-      'Provide encryption key in command instead of using a prompt'
+      '--key <encryption key>',
+      'Provide encryption key directly instead of being prompted'
     )
   )
   .addOption(

--- a/packages/core/strapi/lib/commands/utils/commander.js
+++ b/packages/core/strapi/lib/commands/utils/commander.js
@@ -28,8 +28,12 @@ const parseInputList = (value) => {
 const promptEncryptionKey = async (thisCommand) => {
   const opts = thisCommand.opts();
 
+  if (!opts.encrypt && opts.key) {
+    return 'Key may not be present unless encryption is used';
+  }
+
   // if encrypt is set but we have no key, prompt for it
-  if (opts.encrypt && !opts.key) {
+  if (opts.encrypt && !(opts.key && opts.key.length > 0)) {
     try {
       const answers = await inquirer.prompt([
         {

--- a/packages/core/strapi/lib/commands/utils/commander.js
+++ b/packages/core/strapi/lib/commands/utils/commander.js
@@ -29,7 +29,8 @@ const promptEncryptionKey = async (thisCommand) => {
   const opts = thisCommand.opts();
 
   if (!opts.encrypt && opts.key) {
-    return 'Key may not be present unless encryption is used';
+    console.error('Key may not be present unless encryption is used');
+    process.exit(1);
   }
 
   // if encrypt is set but we have no key, prompt for it
@@ -50,12 +51,10 @@ const promptEncryptionKey = async (thisCommand) => {
       opts.key = answers.key;
     } catch (e) {
       console.error('Failed to get encryption key');
-      console.error('Export process failed unexpectedly');
       process.exit(1);
     }
     if (!opts.key) {
       console.error('Failed to get encryption key');
-      console.error('Export process failed unexpectedly');
       process.exit(1);
     }
   }


### PR DESCRIPTION
### What does it do?

Fixes the functionality of the --key option. It adds the following fixes:
- if encrypt is false but a key is provided, it should give an error and halt
- if encrypt is true...
  - ...and empty key is provided, it should prompt
  - ...and no key is provided, it should prompt
  - ...and a key is provided, it should use that as the key and not prompt

### Why is it needed?

Key option was broken and not working as intended

### How to test it?

Test these scenarios:
- if encrypt is false but a key is provided, it should give an error and halt
- if encrypt is true...
  - ...and empty key is provided, it should prompt
  - ...and no key is provided, it should prompt
  - ...and a key is provided, it should use that as the key and not prompt
