### PR TITLE
[DEITS] import / export should require being in local Strapi folder

### DIFF
--- a/packages/core/strapi/bin/strapi.js
+++ b/packages/core/strapi/bin/strapi.js
@@ -303,7 +303,7 @@ program
   .arguments('[filename]')
   .allowExcessArguments(false)
   .hook('preAction', promptEncryptionKey)
-  .action(require('../lib/commands/transfer/export'));
+  .action(getLocalScript('transfer/export'));
 
 // `$ strapi import`
 program
@@ -329,6 +329,6 @@ program
   )
   .arguments('<filename>')
   .allowExcessArguments(false)
-  .action(require('../lib/commands/transfer/import'));
+  .action(getLocalScript('transfer/import'));
 
 program.parseAsync(process.argv);


### PR DESCRIPTION
### What does it do?

CLI commands for import and export will check that the user is in a local Strapi directory before running

### Why is it needed?

We were allowing the commands to be run anywhere which would cause a strapi-updater.json to be created since we attempt to load an instance of Strapi.

### How to test it?

Run import + export in a Strapi project and it should still work
Run import + export in a non-Strapi folder and it should give an error instead of attempting import/export

