### PR TITLE
refactor(entity-manager): getDeepPopulate

### DIFF
--- a/packages/core/content-manager/server/services/entity-manager.js
+++ b/packages/core/content-manager/server/services/entity-manager.js
@@ -62,40 +62,40 @@ module.exports = ({ strapi }) => ({
     return assoc(`${CREATED_BY_ATTRIBUTE}.roles`, roles, entity);
   },
 
-  find(opts, uid, populate) {
-    const params = { ...opts, populate: getDeepPopulate(uid, populate) };
+  find(opts, uid) {
+    const params = { ...opts, populate: getDeepPopulate(uid) };
 
     return strapi.entityService.findMany(uid, params);
   },
 
-  findPage(opts, uid, populate) {
-    const params = { ...opts, populate: getDeepPopulate(uid, populate, { maxLevel: 1 }) };
+  findPage(opts, uid) {
+    const params = { ...opts, populate: getDeepPopulate(uid, { maxLevel: 1 }) };
 
     return strapi.entityService.findPage(uid, params);
   },
 
-  findWithRelationCountsPage(opts, uid, populate) {
-    const counterPopulate = getDeepPopulate(uid, populate, { countMany: true, maxLevel: 1 });
+  findWithRelationCountsPage(opts, uid) {
+    const counterPopulate = getDeepPopulate(uid, { countMany: true, maxLevel: 1 });
     const params = { ...opts, populate: addCreatedByRolesPopulate(counterPopulate) };
 
     return strapi.entityService.findWithRelationCountsPage(uid, params);
   },
 
-  findOneWithCreatorRolesAndCount(id, uid, populate) {
-    const counterPopulate = getDeepPopulate(uid, populate, { countMany: true, countOne: true });
+  findOneWithCreatorRolesAndCount(id, uid) {
+    const counterPopulate = getDeepPopulate(uid, { countMany: true, countOne: true });
     const params = { populate: addCreatedByRolesPopulate(counterPopulate) };
 
     return strapi.entityService.findOne(uid, id, params);
   },
 
-  async findOne(id, uid, populate) {
-    const params = { populate: getDeepPopulate(uid, populate) };
+  async findOne(id, uid) {
+    const params = { populate: getDeepPopulate(uid) };
 
     return strapi.entityService.findOne(uid, id, params);
   },
 
-  async findOneWithCreatorRoles(id, uid, populate) {
-    const entity = await this.findOne(id, uid, populate);
+  async findOneWithCreatorRoles(id, uid) {
+    const entity = await this.findOne(id, uid);
 
     if (!entity) {
       return entity;
@@ -114,7 +114,7 @@ module.exports = ({ strapi }) => ({
 
     const params = {
       data: publishData,
-      populate: getDeepPopulate(uid, null, { countMany: true, countOne: true }),
+      populate: getDeepPopulate(uid, { countMany: true, countOne: true }),
     };
 
     return strapi.entityService.create(uid, params);
@@ -125,14 +125,14 @@ module.exports = ({ strapi }) => ({
 
     const params = {
       data: publishData,
-      populate: getDeepPopulate(uid, null, { countMany: true, countOne: true }),
+      populate: getDeepPopulate(uid, { countMany: true, countOne: true }),
     };
 
     return strapi.entityService.update(uid, entity.id, params);
   },
 
   delete(entity, uid) {
-    const params = { populate: getDeepPopulate(uid, null, { countMany: true, countOne: true }) };
+    const params = { populate: getDeepPopulate(uid, { countMany: true, countOne: true }) };
 
     return strapi.entityService.delete(uid, entity.id, params);
   },
@@ -161,7 +161,7 @@ module.exports = ({ strapi }) => ({
 
     const params = {
       data,
-      populate: getDeepPopulate(uid, null, { countMany: true, countOne: true }),
+      populate: getDeepPopulate(uid, { countMany: true, countOne: true }),
     };
 
     return strapi.entityService.update(uid, entity.id, params);
@@ -176,7 +176,7 @@ module.exports = ({ strapi }) => ({
 
     const params = {
       data,
-      populate: getDeepPopulate(uid, null, { countMany: true, countOne: true }),
+      populate: getDeepPopulate(uid, { countMany: true, countOne: true }),
     };
 
     return strapi.entityService.update(uid, entity.id, params);

--- a/packages/core/content-manager/server/services/utils/__tests__/populate.test.js
+++ b/packages/core/content-manager/server/services/utils/__tests__/populate.test.js
@@ -1,0 +1,152 @@
+'use strict';
+
+const { getDeepPopulate } = require('../populate');
+
+describe('Populate', () => {
+  const fakeModels = {
+    empty: {
+      modelName: 'Fake empty model',
+      attributes: {},
+    },
+    component: {
+      modelName: 'Fake component model',
+      attributes: {
+        componentAttrName: {
+          type: 'component',
+          component: 'empty',
+        },
+      },
+    },
+    dynZone: {
+      modelName: 'Fake dynamic zone model',
+      attributes: {
+        dynZoneAttrName: {
+          type: 'dynamiczone',
+          components: ['empty', 'component'],
+        },
+      },
+    },
+    relationOTM: {
+      modelName: 'Fake relation oneToMany model',
+      attributes: {
+        relationAttrName: {
+          type: 'relation',
+          relation: 'oneToMany',
+        },
+      },
+    },
+    relationOTO: {
+      modelName: 'Fake relation oneToOne model',
+      attributes: {
+        relationAttrName: {
+          type: 'relation',
+          relation: 'oneToOne',
+        },
+      },
+    },
+    media: {
+      modelName: 'Fake media model',
+      attributes: {
+        mediaAttrName: {
+          type: 'media',
+        },
+      },
+    },
+  };
+
+  describe('getDeepPopulate', () => {
+    beforeEach(() => {
+      global.strapi = {
+        getModel: jest.fn((uid) => fakeModels[uid]),
+      };
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    test('with empty model', async () => {
+      const uid = 'empty';
+
+      const result = getDeepPopulate(uid);
+
+      expect(result).toEqual({});
+    });
+
+    test('with component model', async () => {
+      const uid = 'component';
+
+      const result = getDeepPopulate(uid);
+
+      expect(result).toEqual({
+        componentAttrName: { populate: {} },
+      });
+    });
+
+    test('with dynamic zone model', async () => {
+      const uid = 'dynZone';
+
+      const result = getDeepPopulate(uid);
+
+      expect(result).toEqual({
+        dynZoneAttrName: {
+          populate: {
+            componentAttrName: {
+              populate: {},
+            },
+          },
+        },
+      });
+    });
+
+    test('with relation model - oneToMany', async () => {
+      const uid = 'relationOTM';
+
+      const result = getDeepPopulate(uid);
+
+      expect(result).toEqual({
+        relationAttrName: true,
+      });
+    });
+
+    test('with relation model - oneToMany - with countMany', async () => {
+      const uid = 'relationOTM';
+
+      const result = getDeepPopulate(uid, { countMany: true });
+
+      expect(result).toEqual({
+        relationAttrName: { count: true },
+      });
+    });
+
+    test('with relation model - oneToOne', async () => {
+      const uid = 'relationOTO';
+
+      const result = getDeepPopulate(uid);
+
+      expect(result).toEqual({
+        relationAttrName: true,
+      });
+    });
+
+    test('with relation model - oneToOne - with countOne', async () => {
+      const uid = 'relationOTO';
+
+      const result = getDeepPopulate(uid, { countOne: true });
+
+      expect(result).toEqual({
+        relationAttrName: { count: true },
+      });
+    });
+
+    test('with media model', async () => {
+      const uid = 'media';
+
+      const result = getDeepPopulate(uid);
+
+      expect(result).toEqual({
+        mediaAttrName: { populate: 'folder' },
+      });
+    });
+  });
+});

--- a/packages/core/content-manager/server/services/utils/populate.js
+++ b/packages/core/content-manager/server/services/utils/populate.js
@@ -18,7 +18,7 @@ const { PUBLISHED_AT_ATTRIBUTE } = strapiUtils.contentTypes.constants;
  * @param {Boolean} options.countOne
  * @returns {true|{count: true}}
  */
-function getRelationPopulate(attribute, model, attributeName, { countMany, countOne }) {
+function getPopulateForRelation(attribute, model, attributeName, { countMany, countOne }) {
   const isManyRelation = isAnyToMany(attribute);
 
   // always populate createdBy, updatedBy, localizations etc.
@@ -33,7 +33,7 @@ function getRelationPopulate(attribute, model, attributeName, { countMany, count
 }
 
 /**
- * Populate the model for components
+ * Populate the model for Dynamic Zone components
  * @param {Object} attribute - Attribute containing the components
  * @param {String[]} attribute.components - IDs of components
  * @param {Object} options - Options to apply while populating
@@ -43,7 +43,7 @@ function getRelationPopulate(attribute, model, attributeName, { countMany, count
  * @param {Number} level
  * @returns {{populate: Object}}
  */
-function getPopulateForComponents(attribute, options, level) {
+function getPopulateForDZ(attribute, options, level) {
   const populatedComponents = (attribute.components || []).map((componentUID) =>
     getDeepPopulate(componentUID, options, level + 1)
   );
@@ -63,13 +63,13 @@ function getPopulateForComponents(attribute, options, level) {
  * @param {Number} level
  * @returns {Object}
  */
-function getPopulateByType(attributeName, model, options, level) {
+function getPopulateFor(attributeName, model, options, level) {
   const attribute = model.attributes[attributeName];
 
   switch (attribute.type) {
     case 'relation':
       return {
-        [attributeName]: getRelationPopulate(attribute, model, attributeName, options),
+        [attributeName]: getPopulateForRelation(attribute, model, attributeName, options),
       };
     case 'component':
       return {
@@ -83,7 +83,7 @@ function getPopulateByType(attributeName, model, options, level) {
       };
     case 'dynamiczone':
       return {
-        [attributeName]: getPopulateForComponents(attribute, options, level),
+        [attributeName]: getPopulateForDZ(attribute, options, level),
       };
     default:
       return {};
@@ -115,7 +115,7 @@ const getDeepPopulate = (
     (populateAcc, attributeName) =>
       merge(
         populateAcc,
-        getPopulateByType(attributeName, model, { countMany, countOne, maxLevel }, level)
+        getPopulateFor(attributeName, model, { countMany, countOne, maxLevel }, level)
       ),
     {}
   );


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

It split the getDeepPopulate function into smaller ones and clean unused parameter.

### Why is it needed?

Reduce maintenance cost

### How to test it?

As getDeepPopulate is used everywhere in the Entity manager, you can test pretty much any functionality about entities in the admin panel.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
