### PR TITLE
[DEITS] CLI updates and fixes

### DIFF
--- a/packages/core/data-transfer/lib/providers/local-file-destination-provider.ts
+++ b/packages/core/data-transfer/lib/providers/local-file-destination-provider.ts
@@ -134,7 +134,7 @@ class LocalFileDestinationProvider implements IDestinationProvider {
 
     if (pipeline && !pipeline.closed) {
       await new Promise<void>((resolve, reject) => {
-        pipeline.on('close', resolve).on('error', resolve);
+        pipeline.on('close', resolve).on('error', reject);
       });
     }
   }

--- a/packages/core/data-transfer/lib/providers/local-file-destination-provider.ts
+++ b/packages/core/data-transfer/lib/providers/local-file-destination-provider.ts
@@ -134,13 +134,7 @@ class LocalFileDestinationProvider implements IDestinationProvider {
 
     if (pipeline && !pipeline.closed) {
       await new Promise<void>((resolve, reject) => {
-        pipeline
-          .on('close', () => {
-            resolve();
-          })
-          .on('error', (e) => {
-            reject(e);
-          });
+        pipeline.on('close', resolve).on('error', resolve);
       });
     }
   }

--- a/packages/core/strapi/bin/strapi.js
+++ b/packages/core/strapi/bin/strapi.js
@@ -8,6 +8,7 @@ const _ = require('lodash');
 const resolveCwd = require('resolve-cwd');
 const { yellow } = require('chalk');
 const { Command, Option } = require('commander');
+const inquirer = require('inquirer');
 
 const program = new Command();
 
@@ -322,16 +323,34 @@ program
       .choices(['exact', 'strict', 'subset', 'bypass'])
       .default('exact')
   )
+  .requiredOption(
+    '-f, --file <file>',
+    'path and filename to the Strapi export file you want to import'
+  )
   .addOption(
     new Option('--key <string>', 'Provide encryption key in command instead of using a prompt')
   )
-  .addOption(
-    new Option(
-      '-f, --file <file>',
-      'path and filename to the Strapi export file you want to import'
-    )
-  )
   .allowExcessArguments(false)
+  .hook('preAction', async (thisCommand) => {
+    const opts = thisCommand.opts();
+
+    // check extension to guess if we should prompt for key
+    if (String(opts.file).endsWith('.enc')) {
+      if (!opts.key) {
+        const answers = await inquirer.prompt([
+          {
+            type: 'password',
+            message: 'Please enter your decryption key',
+            name: 'key',
+          },
+        ]);
+        if (!answers.key?.length) {
+          process.exit(0);
+        }
+        opts.key = answers.key;
+      }
+    }
+  })
   .hook(
     'preAction',
     confirmKeyValue(

--- a/packages/core/strapi/bin/strapi.js
+++ b/packages/core/strapi/bin/strapi.js
@@ -345,6 +345,7 @@ program
           },
         ]);
         if (!answers.key?.length) {
+          console.log('No key entered, aborting import.');
           process.exit(0);
         }
         opts.key = answers.key;

--- a/packages/core/strapi/bin/strapi.js
+++ b/packages/core/strapi/bin/strapi.js
@@ -285,7 +285,9 @@ program
       .default(true)
       .argParser(parseInputBool)
   )
-  .addOption(new Option('--key', 'Provide encryption key in command instead of using a prompt'))
+  .addOption(
+    new Option('--key <string>', 'Provide encryption key in command instead of using a prompt')
+  )
   .addOption(
     new Option('--max-size <max MB per file>', 'split final file when exceeding size in MB')
   )
@@ -295,8 +297,8 @@ program
       'split internal jsonl files when exceeding max size in MB'
     )
   )
+  .addOption(new Option('-f, --file <file>', 'name to use for exported file (without extensions)'))
   .addOption(excludeOption)
-  .arguments('[filename]')
   .allowExcessArguments(false)
   .hook('preAction', promptEncryptionKey)
   .action(getLocalScript('transfer/export'));
@@ -321,9 +323,14 @@ program
       .default('exact')
   )
   .addOption(
-    new Option('--key [encryptionKey]', 'prompt for [or provide directly] the decryption key')
+    new Option('--key <string>', 'Provide encryption key in command instead of using a prompt')
   )
-  .arguments('<filename>')
+  .addOption(
+    new Option(
+      '-f, --file <file>',
+      'path and filename to the Strapi export file you want to import'
+    )
+  )
   .allowExcessArguments(false)
   .hook(
     'preAction',

--- a/packages/core/strapi/lib/commands/transfer/export.js
+++ b/packages/core/strapi/lib/commands/transfer/export.js
@@ -40,12 +40,14 @@ const logger = console;
 
 const BYTES_IN_MB = 1024 * 1024;
 
-module.exports = async (filename, opts) => {
+module.exports = async (opts) => {
   // validate inputs from Commander
   if (!_.isObject(opts)) {
     logger.error('Could not parse arguments');
     process.exit(1);
   }
+  const filename = opts.file;
+
   /**
    * From local Strapi instance
    */

--- a/packages/core/strapi/lib/commands/transfer/import.js
+++ b/packages/core/strapi/lib/commands/transfer/import.js
@@ -7,12 +7,17 @@ const {
   // TODO: we need to solve this issue with typescript modules
   // eslint-disable-next-line import/no-unresolved, node/no-missing-require
 } = require('@strapi/data-transfer');
-
+const { isObject } = require('lodash/fp');
 const strapi = require('../../index');
 
 const logger = console;
 
 module.exports = async (opts) => {
+  // validate inputs from Commander
+  if (!isObject(opts)) {
+    logger.error('Could not parse arguments');
+    process.exit(1);
+  }
   const filename = opts.file;
 
   /**

--- a/packages/core/strapi/lib/commands/transfer/import.js
+++ b/packages/core/strapi/lib/commands/transfer/import.js
@@ -7,18 +7,13 @@ const {
   // TODO: we need to solve this issue with typescript modules
   // eslint-disable-next-line import/no-unresolved, node/no-missing-require
 } = require('@strapi/data-transfer');
-const _ = require('lodash/fp');
 
 const strapi = require('../../index');
 
 const logger = console;
 
-module.exports = async (filename, opts) => {
-  // validate inputs from Commander
-  if (!_.isString(filename) || !_.isObject(opts)) {
-    logger.error('Could not parse arguments');
-    process.exit(1);
-  }
+module.exports = async (opts) => {
+  const filename = opts.file;
 
   /**
    * From strapi backup file
@@ -59,7 +54,7 @@ module.exports = async (filename, opts) => {
     logger.log('Results:', result);
     process.exit(0);
   } catch (e) {
-    logger.log('Import process failed unexpectedly');
+    logger.log(`Import process failed unexpectedly: ${e.message}`);
     process.exit(1);
   }
 };


### PR DESCRIPTION
### What does it do?

- Changes the CLI to use a `--file` or `-f` option to get the import/export filename
- Changes `--key` option to require a string value
- On import, change `--file` to be required
- On import, if file has .enc extension, prompt for --key if it's not provided
- Fixes the table at the end of export
  - the file destination provider `close()` stage is now awaiting the closing of the correct stream

### Why is it needed?

It matches the behaviour of other Strapi commands and of our discussions

### How to test it?

Run `yarn strapi export --file filename` and `yarn strapi import --file filename` and it should use the filename provided.

Run `yarn strapi export --encrypt false --key anything` and you should get an error for trying to use a key without encryption

Run `yarn strapi export --key` and you should get an error about not providing a key

Run `yarn strapi export --key anything` and the export should create a file encrypted with the key 'anything'

...and similar behaviour for the import command.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
