### PR TITLE
[features][ML listview] Modals

### DIFF
--- a/packages/core/upload/admin/src/components/AssetCard/AssetCard.js
+++ b/packages/core/upload/admin/src/components/AssetCard/AssetCard.js
@@ -6,8 +6,7 @@ import { VideoAssetCard } from './VideoAssetCard';
 import { DocAssetCard } from './DocAssetCard';
 import { AudioAssetCard } from './AudioAssetCard';
 import { AssetType, AssetDefinition } from '../../constants';
-import { createAssetUrl } from '../../utils/createAssetUrl';
-import toSingularTypes from '../../utils/toSingularTypes';
+import { createAssetUrl, toSingularTypes } from '../../utils';
 
 export const AssetCard = ({
   allowedTypes,

--- a/packages/core/upload/admin/src/components/AssetDialog/BrowseStep/index.js
+++ b/packages/core/upload/admin/src/components/AssetDialog/BrowseStep/index.js
@@ -301,7 +301,9 @@ export const BrowseStep = ({
                           <Flex as="h2" direction="column" alignItems="start" maxWidth="100%">
                             <TypographyMaxWidth fontWeight="semiBold" ellipsis>
                               {folder.name}
-                              <VisuallyHidden>:</VisuallyHidden>
+                              {/* VisuallyHidden dash here allows to separate folder title and count informations 
+                              for voice reading structure purpose */}
+                              <VisuallyHidden>-</VisuallyHidden>
                             </TypographyMaxWidth>
                             <TypographyMaxWidth
                               as="span"

--- a/packages/core/upload/admin/src/components/AssetDialog/BrowseStep/index.js
+++ b/packages/core/upload/admin/src/components/AssetDialog/BrowseStep/index.js
@@ -20,6 +20,7 @@ import { getBreadcrumbDataCM } from '../../../utils';
 import getAllowedFiles from '../../../utils/getAllowedFiles';
 import { AssetGridList } from '../../AssetGridList';
 import { FolderList } from '../../FolderList';
+import { TableList } from '../../TableList';
 import { EmptyAssets } from '../../EmptyAssets';
 import { Breadcrumbs } from '../../Breadcrumbs';
 import SortPicker from '../../SortPicker';
@@ -69,6 +70,9 @@ export const BrowseStep = ({
 }) => {
   const { formatMessage } = useIntl();
 
+  // TODO: remove and replace with data when available stored
+  const isGridView = true;
+
   const { data: currentFolder, isLoading: isCurrentFolderLoading } = useFolder(
     queryObject?.folder,
     {
@@ -101,11 +105,11 @@ export const BrowseStep = ({
   return (
     <Box>
       {onSelectAllAsset && (
-        <Box>
+        <Box paddingBottom={4}>
           <Flex justifyContent="space-between" alignItems="flex-start">
             {(assetCount > 0 || folderCount > 0 || isFiltering) && (
               <StartBlockActions wrap="wrap">
-                {multiple && (
+                {multiple && isGridView && (
                   <Flex
                     paddingLeft={2}
                     paddingRight={2}
@@ -125,7 +129,7 @@ export const BrowseStep = ({
                     />
                   </Flex>
                 )}
-                <SortPicker onChangeSort={onChangeSort} />
+                {isGridView && <SortPicker onChangeSort={onChangeSort} />}
                 <Filters
                   appliedFilters={queryObject?.filters?.$and}
                   onChangeFilters={onChangeFilters}
@@ -195,99 +199,136 @@ export const BrowseStep = ({
         </Box>
       )}
 
-      {folderCount > 0 && (
-        <FolderList
-          title={
-            (((isSearchingOrFiltering && assetCount > 0) || !isSearchingOrFiltering) &&
-              formatMessage(
-                {
-                  id: getTrad('list.folders.title'),
-                  defaultMessage: 'Folders ({count})',
-                },
-                { count: folderCount }
-              )) ||
-            ''
+      {!isGridView && (
+        <TableList
+          allowedTypes={allowedTypes}
+          assetCount={assetCount}
+          folderCount={folderCount}
+          indeterminate={!areAllAssetSelected && hasSomeAssetSelected}
+          isFolderSelectionAllowed={false}
+          onChangeSort={onChangeSort}
+          onChangeFolder={handleClickFolderCard}
+          onEditAsset={onEditAsset}
+          onEditFolder={onEditFolder}
+          onSelectOne={onSelectAsset}
+          onSelectAll={onSelectAllAsset}
+          rows={
+            // TODO: remove when fixed on DS side
+            // when number of rows in Table changes, the keyboard tab from a row to another
+            // is not working for 1st and last column
+            [
+              ...folders.map((folder) => ({ ...folder, type: 'folder' })),
+              ...assets.map((asset) => ({ ...asset, type: 'asset' })),
+            ]
           }
-        >
-          {folders.map((folder) => {
-            return (
-              <GridItem col={3} key={`folder-${folder.id}`}>
-                <FolderCard
-                  ariaLabel={folder.name}
-                  id={`folder-${folder.id}`}
-                  onClick={() => handleClickFolderCard(folder.id)}
-                  cardActions={
-                    onEditFolder && (
-                      <IconButton
-                        icon={<PencilIcon />}
-                        aria-label={formatMessage({
-                          id: getTrad('list.folder.edit'),
-                          defaultMessage: 'Edit folder',
-                        })}
-                        onClick={() => onEditFolder(folder)}
-                      />
-                    )
-                  }
-                >
-                  <FolderCardBody>
-                    <FolderCardBodyAction onClick={() => handleClickFolderCard(folder.id)}>
-                      <Flex as="h2" direction="column" alignItems="start" maxWidth="100%">
-                        <TypographyMaxWidth fontWeight="semiBold" ellipsis>
-                          {folder.name}
-                          <VisuallyHidden>:</VisuallyHidden>
-                        </TypographyMaxWidth>
-                        <TypographyMaxWidth as="span" textColor="neutral600" variant="pi" ellipsis>
-                          {formatMessage(
-                            {
-                              id: getTrad('list.folder.subtitle'),
-                              defaultMessage:
-                                '{folderCount, plural, =0 {# folder} one {# folder} other {# folders}}, {filesCount, plural, =0 {# asset} one {# asset} other {# assets}}',
-                            },
-                            {
-                              folderCount: folder.children.count,
-                              filesCount: folder.files.count,
-                            }
-                          )}
-                        </TypographyMaxWidth>
-                      </Flex>
-                    </FolderCardBodyAction>
-                  </FolderCardBody>
-                </FolderCard>
-              </GridItem>
-            );
-          })}
-        </FolderList>
+          selected={selectedAssets}
+          shouldDisableBulkSelect={!multiple}
+          sortQuery={queryObject?.sort ?? ''}
+        />
       )}
 
-      {assetCount > 0 && folderCount > 0 && (
-        <Box paddingTop={6}>
-          <Divider />
-        </Box>
-      )}
+      {isGridView && (
+        <>
+          {folderCount > 0 && (
+            <FolderList
+              title={
+                (((isSearchingOrFiltering && assetCount > 0) || !isSearchingOrFiltering) &&
+                  formatMessage(
+                    {
+                      id: getTrad('list.folders.title'),
+                      defaultMessage: 'Folders ({count})',
+                    },
+                    { count: folderCount }
+                  )) ||
+                ''
+              }
+            >
+              {folders.map((folder) => {
+                return (
+                  <GridItem col={3} key={`folder-${folder.id}`}>
+                    <FolderCard
+                      ariaLabel={folder.name}
+                      id={`folder-${folder.id}`}
+                      onClick={() => handleClickFolderCard(folder.id)}
+                      cardActions={
+                        onEditFolder && (
+                          <IconButton
+                            icon={<PencilIcon />}
+                            aria-label={formatMessage({
+                              id: getTrad('list.folder.edit'),
+                              defaultMessage: 'Edit folder',
+                            })}
+                            onClick={() => onEditFolder(folder)}
+                          />
+                        )
+                      }
+                    >
+                      <FolderCardBody>
+                        <FolderCardBodyAction onClick={() => handleClickFolderCard(folder.id)}>
+                          <Flex as="h2" direction="column" alignItems="start" maxWidth="100%">
+                            <TypographyMaxWidth fontWeight="semiBold" ellipsis>
+                              {folder.name}
+                              <VisuallyHidden>:</VisuallyHidden>
+                            </TypographyMaxWidth>
+                            <TypographyMaxWidth
+                              as="span"
+                              textColor="neutral600"
+                              variant="pi"
+                              ellipsis
+                            >
+                              {formatMessage(
+                                {
+                                  id: getTrad('list.folder.subtitle'),
+                                  defaultMessage:
+                                    '{folderCount, plural, =0 {# folder} one {# folder} other {# folders}}, {filesCount, plural, =0 {# asset} one {# asset} other {# assets}}',
+                                },
+                                {
+                                  folderCount: folder.children.count,
+                                  filesCount: folder.files.count,
+                                }
+                              )}
+                            </TypographyMaxWidth>
+                          </Flex>
+                        </FolderCardBodyAction>
+                      </FolderCardBody>
+                    </FolderCard>
+                  </GridItem>
+                );
+              })}
+            </FolderList>
+          )}
 
-      {assetCount > 0 && (
-        <Box paddingTop={6}>
-          <AssetGridList
-            allowedTypes={allowedTypes}
-            size="S"
-            assets={assets}
-            onSelectAsset={onSelectAsset}
-            selectedAssets={selectedAssets}
-            onEditAsset={onEditAsset}
-            title={
-              ((!isSearchingOrFiltering || (isSearchingOrFiltering && folderCount > 0)) &&
-                queryObject.page === 1 &&
-                formatMessage(
-                  {
-                    id: getTrad('list.assets.title'),
-                    defaultMessage: 'Assets ({count})',
-                  },
-                  { count: assetCount }
-                )) ||
-              ''
-            }
-          />
-        </Box>
+          {assetCount > 0 && folderCount > 0 && (
+            <Box paddingTop={6}>
+              <Divider />
+            </Box>
+          )}
+
+          {assetCount > 0 && (
+            <Box paddingTop={6}>
+              <AssetGridList
+                allowedTypes={allowedTypes}
+                size="S"
+                assets={assets}
+                onSelectAsset={onSelectAsset}
+                selectedAssets={selectedAssets}
+                onEditAsset={onEditAsset}
+                title={
+                  ((!isSearchingOrFiltering || (isSearchingOrFiltering && folderCount > 0)) &&
+                    queryObject.page === 1 &&
+                    formatMessage(
+                      {
+                        id: getTrad('list.assets.title'),
+                        defaultMessage: 'Assets ({count})',
+                      },
+                      { count: assetCount }
+                    )) ||
+                  ''
+                }
+              />
+            </Box>
+          )}
+        </>
       )}
 
       {pagination.pageCount > 0 && (
@@ -335,6 +376,7 @@ BrowseStep.propTypes = {
     page: PropTypes.number.isRequired,
     pageSize: PropTypes.number.isRequired,
     _q: PropTypes.string,
+    sort: PropTypes.string,
     folder: PropTypes.number,
   }).isRequired,
   pagination: PropTypes.shape({ pageCount: PropTypes.number.isRequired }).isRequired,

--- a/packages/core/upload/admin/src/components/AssetDialog/BrowseStep/tests/__snapshots__/index.test.js.snap
+++ b/packages/core/upload/admin/src/components/AssetDialog/BrowseStep/tests/__snapshots__/index.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`BrowseStep renders and match snapshot 1`] = `
-.c70 {
+.c73 {
   border: 0;
   -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
@@ -11,59 +11,62 @@ exports[`BrowseStep renders and match snapshot 1`] = `
   padding: 0;
   position: absolute;
   width: 1px;
-}
-
-.c18 {
-  border: 0;
-  -webkit-clip: rect(0 0 0 0);
-  clip: rect(0 0 0 0);
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  width: 1px;
-}
-
-.c8 {
-  padding-left: 8px;
-}
-
-.c10 {
-  padding-right: 8px;
-}
-
-.c15 {
-  padding-top: 4px;
-  padding-bottom: 4px;
 }
 
 .c19 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+}
+
+.c1 {
+  padding-bottom: 16px;
+}
+
+.c9 {
+  padding-left: 8px;
+}
+
+.c11 {
+  padding-right: 8px;
+}
+
+.c16 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.c20 {
   padding-top: 12px;
 }
 
-.c22 {
+.c23 {
   padding-top: 4px;
   padding-right: 8px;
   padding-bottom: 4px;
   padding-left: 8px;
 }
 
-.c24 {
+.c25 {
   padding-right: 4px;
   padding-left: 4px;
 }
 
-.c27 {
-  padding-top: 8px;
+.c28 {
   padding-bottom: 8px;
 }
 
-.c31 {
+.c32 {
   position: relative;
 }
 
-.c33 {
+.c35 {
   background: #ffffff;
   padding: 12px;
   border-radius: 4px;
@@ -75,7 +78,7 @@ exports[`BrowseStep renders and match snapshot 1`] = `
   cursor: pointer;
 }
 
-.c35 {
+.c37 {
   background: #eaf5ff;
   color: #66b7f1;
   padding-top: 8px;
@@ -85,39 +88,39 @@ exports[`BrowseStep renders and match snapshot 1`] = `
   border-radius: 4px;
 }
 
-.c37 {
+.c39 {
   position: relative;
   overflow: hidden;
   max-width: 100%;
 }
 
-.c40 {
+.c42 {
   padding: 4px;
   max-width: 100%;
 }
 
-.c42 {
+.c44 {
   max-width: 100%;
 }
 
-.c48 {
+.c51 {
   right: 16px;
 }
 
-.c50 {
+.c53 {
   padding-top: 16px;
 }
 
-.c57 {
+.c60 {
   padding-right: 16px;
   padding-left: 16px;
 }
 
-.c59 {
+.c62 {
   padding-left: 12px;
 }
 
-.c1 {
+.c2 {
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -135,7 +138,7 @@ exports[`BrowseStep renders and match snapshot 1`] = `
   justify-content: space-between;
 }
 
-.c2 {
+.c3 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -152,7 +155,7 @@ exports[`BrowseStep renders and match snapshot 1`] = `
   flex-wrap: wrap;
 }
 
-.c12 {
+.c13 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -166,7 +169,7 @@ exports[`BrowseStep renders and match snapshot 1`] = `
   flex-direction: row;
 }
 
-.c21 {
+.c22 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -180,7 +183,7 @@ exports[`BrowseStep renders and match snapshot 1`] = `
   flex-direction: row;
 }
 
-.c38 {
+.c40 {
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -194,7 +197,7 @@ exports[`BrowseStep renders and match snapshot 1`] = `
   flex-direction: column;
 }
 
-.c43 {
+.c45 {
   -webkit-align-items: start;
   -webkit-box-align: start;
   -ms-flex-align: start;
@@ -208,7 +211,7 @@ exports[`BrowseStep renders and match snapshot 1`] = `
   flex-direction: column;
 }
 
-.c51 {
+.c54 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -226,7 +229,7 @@ exports[`BrowseStep renders and match snapshot 1`] = `
   justify-content: space-between;
 }
 
-.c52 {
+.c55 {
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -240,7 +243,7 @@ exports[`BrowseStep renders and match snapshot 1`] = `
   flex-direction: column;
 }
 
-.c7 {
+.c8 {
   font-size: 0.75rem;
   line-height: 1.33;
   font-weight: 600;
@@ -248,19 +251,19 @@ exports[`BrowseStep renders and match snapshot 1`] = `
   color: #32324d;
 }
 
-.c23 {
+.c24 {
   font-size: 0.75rem;
   line-height: 1.33;
   color: #32324d;
 }
 
-.c25 {
+.c26 {
   font-size: 0.75rem;
   line-height: 1.33;
   color: #8e8ea9;
 }
 
-.c28 {
+.c29 {
   font-weight: 500;
   font-size: 1rem;
   line-height: 1.25;
@@ -268,7 +271,7 @@ exports[`BrowseStep renders and match snapshot 1`] = `
   color: #32324d;
 }
 
-.c44 {
+.c46 {
   font-size: 0.875rem;
   line-height: 1.43;
   display: block;
@@ -279,7 +282,7 @@ exports[`BrowseStep renders and match snapshot 1`] = `
   color: #32324d;
 }
 
-.c46 {
+.c48 {
   font-size: 0.75rem;
   line-height: 1.33;
   display: block;
@@ -289,7 +292,7 @@ exports[`BrowseStep renders and match snapshot 1`] = `
   color: #666687;
 }
 
-.c58 {
+.c61 {
   font-size: 0.875rem;
   line-height: 1.43;
   display: block;
@@ -299,34 +302,34 @@ exports[`BrowseStep renders and match snapshot 1`] = `
   color: #32324d;
 }
 
-.c62 {
+.c65 {
   font-size: 0.875rem;
   line-height: 1.43;
   color: #666687;
 }
 
-.c68 {
+.c71 {
   font-size: 0.75rem;
   line-height: 1.33;
   font-weight: 600;
   color: #32324d;
 }
 
-.c53 > * {
+.c56 > * {
   margin-top: 0;
   margin-bottom: 0;
 }
 
-.c34 > * {
+.c36 > * {
   margin-left: 0;
   margin-right: 0;
 }
 
-.c34 > * + * {
+.c36 > * + * {
   margin-left: 8px;
 }
 
-.c4 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -340,21 +343,21 @@ exports[`BrowseStep renders and match snapshot 1`] = `
   outline: none;
 }
 
-.c4 svg {
+.c5 svg {
   height: 12px;
   width: 12px;
 }
 
-.c4 svg > g,
-.c4 svg path {
+.c5 svg > g,
+.c5 svg path {
   fill: #ffffff;
 }
 
-.c4[aria-disabled='true'] {
+.c5[aria-disabled='true'] {
   pointer-events: none;
 }
 
-.c4:after {
+.c5:after {
   -webkit-transition-property: all;
   transition-property: all;
   -webkit-transition-duration: 0.2s;
@@ -369,11 +372,11 @@ exports[`BrowseStep renders and match snapshot 1`] = `
   border: 2px solid transparent;
 }
 
-.c4:focus-visible {
+.c5:focus-visible {
   outline: none;
 }
 
-.c4:focus-visible:after {
+.c5:focus-visible:after {
   border-radius: 8px;
   content: '';
   position: absolute;
@@ -384,11 +387,11 @@ exports[`BrowseStep renders and match snapshot 1`] = `
   border: 2px solid #4945ff;
 }
 
-.c11 {
+.c12 {
   height: 100%;
 }
 
-.c5 {
+.c6 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -402,7 +405,7 @@ exports[`BrowseStep renders and match snapshot 1`] = `
   background: #ffffff;
 }
 
-.c5 .c0 {
+.c6 .c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -413,56 +416,56 @@ exports[`BrowseStep renders and match snapshot 1`] = `
   align-items: center;
 }
 
-.c5 .c6 {
+.c6 .c7 {
   color: #ffffff;
 }
 
-.c5[aria-disabled='true'] {
+.c6[aria-disabled='true'] {
   border: 1px solid #dcdce4;
   background: #eaeaef;
 }
 
-.c5[aria-disabled='true'] .c6 {
+.c6[aria-disabled='true'] .c7 {
   color: #666687;
 }
 
-.c5[aria-disabled='true'] svg > g,
-.c5[aria-disabled='true'] svg path {
+.c6[aria-disabled='true'] svg > g,
+.c6[aria-disabled='true'] svg path {
   fill: #666687;
 }
 
-.c5[aria-disabled='true']:active {
+.c6[aria-disabled='true']:active {
   border: 1px solid #dcdce4;
   background: #eaeaef;
 }
 
-.c5[aria-disabled='true']:active .c6 {
+.c6[aria-disabled='true']:active .c7 {
   color: #666687;
 }
 
-.c5[aria-disabled='true']:active svg > g,
-.c5[aria-disabled='true']:active svg path {
+.c6[aria-disabled='true']:active svg > g,
+.c6[aria-disabled='true']:active svg path {
   fill: #666687;
 }
 
-.c5:hover {
+.c6:hover {
   background-color: #f6f6f9;
 }
 
-.c5:active {
+.c6:active {
   background-color: #eaeaef;
 }
 
-.c5 .c6 {
+.c6 .c7 {
   color: #32324d;
 }
 
-.c5 svg > g,
-.c5 svg path {
+.c6 svg > g,
+.c6 svg path {
   fill: #32324d;
 }
 
-.c17 {
+.c18 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -479,30 +482,30 @@ exports[`BrowseStep renders and match snapshot 1`] = `
   width: 2rem;
 }
 
-.c17 svg > g,
-.c17 svg path {
+.c18 svg > g,
+.c18 svg path {
   fill: #8e8ea9;
 }
 
-.c17:hover svg > g,
-.c17:hover svg path {
+.c18:hover svg > g,
+.c18:hover svg path {
   fill: #666687;
 }
 
-.c17:active svg > g,
-.c17:active svg path {
+.c18:active svg > g,
+.c18:active svg path {
   fill: #a5a5ba;
 }
 
-.c17[aria-disabled='true'] {
+.c18[aria-disabled='true'] {
   background-color: #eaeaef;
 }
 
-.c17[aria-disabled='true'] svg path {
+.c18[aria-disabled='true'] svg path {
   fill: #666687;
 }
 
-.c9 {
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -513,12 +516,12 @@ exports[`BrowseStep renders and match snapshot 1`] = `
   align-items: center;
 }
 
-.c9 svg {
+.c10 svg {
   height: 4px;
   width: 6px;
 }
 
-.c55 {
+.c58 {
   position: absolute;
   left: 0;
   right: 0;
@@ -529,15 +532,15 @@ exports[`BrowseStep renders and match snapshot 1`] = `
   border: none;
 }
 
-.c55:focus {
+.c58:focus {
   outline: none;
 }
 
-.c55[aria-disabled='true'] {
+.c58[aria-disabled='true'] {
   cursor: not-allowed;
 }
 
-.c54 {
+.c57 {
   position: relative;
   border: 1px solid #dcdce4;
   padding-right: 12px;
@@ -553,28 +556,28 @@ exports[`BrowseStep renders and match snapshot 1`] = `
   transition-duration: 0.2s;
 }
 
-.c54:focus-within {
+.c57:focus-within {
   border: 1px solid #4945ff;
   box-shadow: #4945ff 0px 0px 0px 2px;
 }
 
-.c60 {
+.c63 {
   background: transparent;
   border: none;
   position: relative;
   z-index: 1;
 }
 
-.c60 svg {
+.c63 svg {
   height: 0.6875rem;
   width: 0.6875rem;
 }
 
-.c60 svg path {
+.c63 svg path {
   fill: #666687;
 }
 
-.c61 {
+.c64 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -583,35 +586,35 @@ exports[`BrowseStep renders and match snapshot 1`] = `
   border: none;
 }
 
-.c61 svg {
+.c64 svg {
   width: 0.375rem;
 }
 
-.c56 {
+.c59 {
   width: 100%;
 }
 
-.c29 {
+.c30 {
   display: grid;
   grid-template-columns: repeat(12,1fr);
   gap: 16px;
 }
 
-.c30 {
+.c31 {
   grid-column: span 3;
   max-width: 100%;
 }
 
-.c49 {
+.c52 {
   position: absolute;
   top: 12px;
 }
 
-.c20:first-child {
+.c21:first-child {
   margin-left: calc(-1*8px);
 }
 
-.c26 {
+.c27 {
   border-radius: 4px;
   color: #666687;
   font-size: 0.75rem;
@@ -621,13 +624,13 @@ exports[`BrowseStep renders and match snapshot 1`] = `
   text-decoration: none;
 }
 
-.c26:hover,
-.c26:focus {
+.c27:hover,
+.c27:focus {
   background-color: #dcdce4;
   color: #4a4a6a;
 }
 
-.c32 {
+.c34 {
   height: 100%;
   left: 0;
   position: absolute;
@@ -636,41 +639,46 @@ exports[`BrowseStep renders and match snapshot 1`] = `
   width: 100%;
 }
 
-.c32:hover,
-.c32:focus {
+.c34:hover,
+.c34:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c36 path {
+.c38 path {
   fill: currentColor;
 }
 
-.c47 {
+.c50 {
   display: none;
 }
 
-.c39 {
+.c33:hover .c49,
+.c33:focus-within .c49 {
+  display: block;
+}
+
+.c41 {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
 }
 
-.c41:focus {
+.c43:focus {
   outline: 2px solid #4945ff;
   outline-offset: -2px;
 }
 
-.c63 > * + * {
+.c66 > * + * {
   margin-left: 4px;
 }
 
-.c69 {
+.c72 {
   line-height: revert;
 }
 
-.c64 {
+.c67 {
   padding: 12px;
   border-radius: 4px;
   -webkit-text-decoration: none;
@@ -683,7 +691,7 @@ exports[`BrowseStep renders and match snapshot 1`] = `
   outline: none;
 }
 
-.c64:after {
+.c67:after {
   -webkit-transition-property: all;
   transition-property: all;
   -webkit-transition-duration: 0.2s;
@@ -698,11 +706,11 @@ exports[`BrowseStep renders and match snapshot 1`] = `
   border: 2px solid transparent;
 }
 
-.c64:focus-visible {
+.c67:focus-visible {
   outline: none;
 }
 
-.c64:focus-visible:after {
+.c67:focus-visible:after {
   border-radius: 8px;
   content: '';
   position: absolute;
@@ -713,7 +721,7 @@ exports[`BrowseStep renders and match snapshot 1`] = `
   border: 2px solid #4945ff;
 }
 
-.c66 {
+.c69 {
   padding: 12px;
   border-radius: 4px;
   box-shadow: 0px 1px 4px rgba(33,33,52,0.1);
@@ -727,7 +735,7 @@ exports[`BrowseStep renders and match snapshot 1`] = `
   outline: none;
 }
 
-.c66:after {
+.c69:after {
   -webkit-transition-property: all;
   transition-property: all;
   -webkit-transition-duration: 0.2s;
@@ -742,11 +750,11 @@ exports[`BrowseStep renders and match snapshot 1`] = `
   border: 2px solid transparent;
 }
 
-.c66:focus-visible {
+.c69:focus-visible {
   outline: none;
 }
 
-.c66:focus-visible:after {
+.c69:focus-visible:after {
   border-radius: 8px;
   content: '';
   position: absolute;
@@ -757,63 +765,63 @@ exports[`BrowseStep renders and match snapshot 1`] = `
   border: 2px solid #4945ff;
 }
 
-.c67 {
+.c70 {
   color: #271fe0;
   background: #ffffff;
 }
 
-.c67:hover {
+.c70:hover {
   box-shadow: 0px 1px 4px rgba(33,33,52,0.1);
 }
 
-.c65 {
+.c68 {
   font-size: 0.7rem;
   pointer-events: none;
 }
 
-.c65 svg path {
+.c68 svg path {
   fill: #c0c0cf;
 }
 
-.c65:focus svg path,
-.c65:hover svg path {
+.c68:focus svg path,
+.c68:hover svg path {
   fill: #c0c0cf;
 }
 
-.c3 > * + * {
-  margin-left: 8px;
-}
-
-.c13 {
-  margin-left: auto;
-}
-
-.c13 > * + * {
+.c4 > * + * {
   margin-left: 8px;
 }
 
 .c14 {
+  margin-left: auto;
+}
+
+.c14 > * + * {
+  margin-left: 8px;
+}
+
+.c15 {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.c45 {
+.c47 {
   max-width: 100%;
 }
 
-.c16 svg path {
+.c17 svg path {
   fill: #8e8ea9;
 }
 
 @media (max-width:68.75rem) {
-  .c30 {
+  .c31 {
     grid-column: span;
   }
 }
 
 @media (max-width:34.375rem) {
-  .c30 {
+  .c31 {
     grid-column: span;
   }
 }
@@ -823,13 +831,13 @@ exports[`BrowseStep renders and match snapshot 1`] = `
     class="c0 "
   >
     <div
-      class="c0 "
+      class="c0 c1"
     >
       <div
-        class="c0 c1"
+        class="c0 c2"
       >
         <div
-          class="c0 c2 c3"
+          class="c0 c3 c4"
           wrap="wrap"
         >
           <div>
@@ -838,21 +846,21 @@ exports[`BrowseStep renders and match snapshot 1`] = `
               aria-disabled="false"
               aria-expanded="false"
               aria-haspopup="true"
-              class="c4 c5"
+              class="c5 c6"
               label="Sort by"
               type="button"
             >
               <span
-                class="c6 c7"
+                class="c7 c8"
               >
                 Sort by
               </span>
               <div
                 aria-hidden="true"
-                class="c0 c8"
+                class="c0 c9"
               >
                 <span
-                  class="c9"
+                  class="c10"
                 >
                   <svg
                     aria-hidden="true"
@@ -875,12 +883,12 @@ exports[`BrowseStep renders and match snapshot 1`] = `
           </div>
           <button
             aria-disabled="false"
-            class="c4 c5"
+            class="c5 c6"
             type="button"
           >
             <div
               aria-hidden="true"
-              class="c0 c10 c11"
+              class="c0 c11 c12"
             >
               <svg
                 fill="none"
@@ -898,28 +906,28 @@ exports[`BrowseStep renders and match snapshot 1`] = `
               </svg>
             </div>
             <span
-              class="c6 c7"
+              class="c7 c8"
             >
               Filters
             </span>
           </button>
         </div>
         <div
-          class="c0 c12 c13 c14"
+          class="c0 c13 c14 c15"
         >
           <div
-            class="c0 c15 c16"
+            class="c0 c16 c17"
           >
             <span>
               <button
                 aria-disabled="false"
                 aria-labelledby="tooltip-2"
-                class="c4 c17"
+                class="c5 c18"
                 tabindex="0"
                 type="button"
               >
                 <span
-                  class="c18"
+                  class="c19"
                 >
                   List View
                 </span>
@@ -944,12 +952,12 @@ exports[`BrowseStep renders and match snapshot 1`] = `
             <button
               aria-disabled="false"
               aria-labelledby="tooltip-4"
-              class="c4 c17"
+              class="c5 c18"
               tabindex="0"
               type="button"
             >
               <span
-                class="c18"
+                class="c19"
               >
                 Search
               </span>
@@ -975,64 +983,64 @@ exports[`BrowseStep renders and match snapshot 1`] = `
       </div>
     </div>
     <div
-      class="c0 c19"
+      class="c0 c20"
     >
       <nav
         aria-label="Folders navigation"
         class="c0 "
       >
         <ol
-          class="c0 c12 c20"
+          class="c0 c13 c21"
         >
           <li
-            class="c0 c21"
+            class="c0 c22"
           >
             <div
-              class="c0 c22"
+              class="c0 c23"
             >
               <span
                 aria-current="false"
-                class="c6 c23"
+                class="c7 c24"
               >
                 Media Library
               </span>
             </div>
             <div
               aria-hidden="true"
-              class="c0 c24"
+              class="c0 c25"
             >
               <span
-                class="c6 c25"
+                class="c7 c26"
               >
                 /
               </span>
             </div>
           </li>
           <li
-            class="c0 c21"
+            class="c0 c22"
           >
             <button
-              class="c26"
+              class="c27"
               type="button"
             >
               Folder 2
             </button>
             <div
               aria-hidden="true"
-              class="c0 c24"
+              class="c0 c25"
             >
               <span
-                class="c6 c25"
+                class="c7 c26"
               >
                 /
               </span>
             </div>
           </li>
           <li
-            class="c0 c21"
+            class="c0 c22"
           >
             <button
-              class="c26"
+              class="c27"
               type="button"
             >
               Folder 1
@@ -1045,44 +1053,44 @@ exports[`BrowseStep renders and match snapshot 1`] = `
       class="c0 "
     >
       <div
-        class="c0 c27"
+        class="c0 c28"
       >
         <h2
-          class="c6 c28"
+          class="c7 c29"
         >
           Folders (1)
         </h2>
       </div>
       <div
-        class="c0 c29"
+        class="c0 c30"
       >
         <div
-          class="c30"
+          class="c31"
         >
           <div
             class="c0 "
           >
             <div
-              class="c0 c31 "
+              class="c0 c32 c33"
               tabindex="0"
             >
               <button
                 aria-hidden="true"
                 aria-label="Folder 1"
-                class="c32"
+                class="c34"
                 tabindex="-1"
                 type="button"
               />
               <div
-                class="c0 c33 c12 c34"
+                class="c0 c35 c13 c36"
                 cursor="pointer"
                 spacing="2"
               >
                 <div
-                  class="c0 c35"
+                  class="c0 c37"
                 >
                   <svg
-                    class="c36"
+                    class="c38"
                     fill="none"
                     height="1.5rem"
                     viewBox="0 0 24 24"
@@ -1096,29 +1104,29 @@ exports[`BrowseStep renders and match snapshot 1`] = `
                   </svg>
                 </div>
                 <div
-                  class="c0 c37 c38 c39"
+                  class="c0 c39 c40 c41"
                   id="folder-1-1-title"
                   overflow="hidden"
                 >
                   <button
-                    class="c0 c40 c41"
+                    class="c0 c42 c43"
                     type="button"
                   >
                     <h2
-                      class="c0 c42 c43"
+                      class="c0 c44 c45"
                     >
                       <span
-                        class="c6 c44 c45"
+                        class="c7 c46 c47"
                       >
                         Folder 1
                         <div
-                          class="c18"
+                          class="c19"
                         >
                           :
                         </div>
                       </span>
                       <span
-                        class="c6 c46 c45"
+                        class="c7 c48 c47"
                       >
                         1 folder, 1 asset
                       </span>
@@ -1126,12 +1134,40 @@ exports[`BrowseStep renders and match snapshot 1`] = `
                   </button>
                 </div>
                 <div
-                  class="c0 c47"
+                  class="c0 c49 c50"
                 >
                   <div
-                    class="c0 c48 c12 c34 c49"
+                    class="c0 c51 c13 c36 c52"
                     spacing="2"
-                  />
+                  >
+                    <button
+                      aria-disabled="false"
+                      class="c5 c18"
+                      type="button"
+                    >
+                      <span
+                        class="c19"
+                      >
+                        Edit folder
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        fill="none"
+                        focusable="false"
+                        height="1em"
+                        viewBox="0 0 24 24"
+                        width="1em"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M23.604 3.514c.528.528.528 1.36 0 1.887l-2.622 2.607-4.99-4.99L18.6.396a1.322 1.322 0 011.887 0l3.118 3.118zM0 24v-4.99l14.2-14.2 4.99 4.99L4.99 24H0z"
+                          fill="#212134"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>
@@ -1140,17 +1176,17 @@ exports[`BrowseStep renders and match snapshot 1`] = `
       </div>
     </div>
     <div
-      class="c0 c50 c51"
+      class="c0 c53 c54"
     >
       <div
-        class="c0 c12"
+        class="c0 c13"
       >
         <div>
           <div
-            class="c0 c52 c53"
+            class="c0 c55 c56"
           >
             <div
-              class="c0 c12 c54"
+              class="c0 c13 c57"
             >
               <button
                 aria-disabled="false"
@@ -1158,21 +1194,21 @@ exports[`BrowseStep renders and match snapshot 1`] = `
                 aria-haspopup="listbox"
                 aria-label="Entries per page"
                 aria-labelledby="select-6-label select-6-content"
-                class="c55"
+                class="c58"
                 id="select-6"
                 type="button"
               />
               <div
-                class="c0 c51 c56"
+                class="c0 c54 c59"
               >
                 <div
-                  class="c0 c12"
+                  class="c0 c13"
                 >
                   <div
-                    class="c0 c57"
+                    class="c0 c60"
                   >
                     <span
-                      class="c6 c58"
+                      class="c7 c61"
                       id="select-6-content"
                     >
                       10
@@ -1180,11 +1216,11 @@ exports[`BrowseStep renders and match snapshot 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c0 c12"
+                  class="c0 c13"
                 >
                   <button
                     aria-hidden="true"
-                    class="c0 c59 c60 c61"
+                    class="c0 c62 c63 c64"
                     tabindex="-1"
                     type="button"
                   >
@@ -1209,10 +1245,10 @@ exports[`BrowseStep renders and match snapshot 1`] = `
           </div>
         </div>
         <div
-          class="c0 c8"
+          class="c0 c9"
         >
           <label
-            class="c6 c62"
+            class="c7 c65"
             for="page-size"
           >
             Entries per page
@@ -1221,20 +1257,20 @@ exports[`BrowseStep renders and match snapshot 1`] = `
       </div>
       <nav
         aria-label="pagination"
-        class="sc-eMHfQD"
+        class="sc-hrjYtz"
       >
         <ul
-          class="c0 c12 c63"
+          class="c0 c13 c66"
         >
           <li>
             <button
               aria-disabled="true"
-              class="c64 c65"
+              class="c67 c68"
               tabindex="-1"
               type="button"
             >
               <div
-                class="c18"
+                class="c19"
               >
                 Go to previous page
               </div>
@@ -1255,17 +1291,17 @@ exports[`BrowseStep renders and match snapshot 1`] = `
           </li>
           <li>
             <button
-              class="c66 c67"
+              class="c69 c70"
               type="button"
             >
               <div
-                class="c18"
+                class="c19"
               >
                 Go to page 1
               </div>
               <span
                 aria-hidden="true"
-                class="c6 c68 c69"
+                class="c7 c71 c72"
               >
                 1
               </span>
@@ -1274,12 +1310,12 @@ exports[`BrowseStep renders and match snapshot 1`] = `
           <li>
             <button
               aria-disabled="true"
-              class="c64 c65"
+              class="c67 c68"
               tabindex="-1"
               type="button"
             >
               <div
-                class="c18"
+                class="c19"
               >
                 Go to next page
               </div>
@@ -1303,7 +1339,7 @@ exports[`BrowseStep renders and match snapshot 1`] = `
     </div>
   </div>
   <div
-    class="c70"
+    class="c73"
   >
     <p
       aria-live="polite"

--- a/packages/core/upload/admin/src/components/AssetDialog/BrowseStep/tests/__snapshots__/index.test.js.snap
+++ b/packages/core/upload/admin/src/components/AssetDialog/BrowseStep/tests/__snapshots__/index.test.js.snap
@@ -1122,7 +1122,7 @@ exports[`BrowseStep renders and match snapshot 1`] = `
                         <div
                           class="c19"
                         >
-                          :
+                          -
                         </div>
                       </span>
                       <span

--- a/packages/core/upload/admin/src/components/AssetDialog/BrowseStep/tests/index.test.js
+++ b/packages/core/upload/admin/src/components/AssetDialog/BrowseStep/tests/index.test.js
@@ -161,7 +161,7 @@ describe('BrowseStep', () => {
     const { getByRole } = setup({ onChangeFolder: spy });
     fireEvent.click(
       getByRole('button', {
-        name: /folder 1 : 1 folder, 1 asset/i,
+        name: /folder 1 - 1 folder, 1 asset/i,
       })
     );
     expect(spy).toHaveBeenCalled();

--- a/packages/core/upload/admin/src/components/AssetDialog/BrowseStep/tests/index.test.js
+++ b/packages/core/upload/admin/src/components/AssetDialog/BrowseStep/tests/index.test.js
@@ -97,6 +97,7 @@ const ComponentFixture = (props) => {
                 onChangeSort={jest.fn()}
                 onChangeFolder={jest.fn()}
                 onEditAsset={jest.fn()}
+                onEditFolder={jest.fn()}
                 onSelectAllAsset={jest.fn()}
                 onSelectAsset={jest.fn()}
                 pagination={{ pageCount: 1 }}
@@ -118,7 +119,7 @@ describe('BrowseStep', () => {
     jest.clearAllMocks();
   });
 
-  it('renders and match snapshot', () => {
+  it.only('renders and match snapshot', () => {
     const { container } = setup();
     expect(container).toMatchSnapshot();
   });

--- a/packages/core/upload/admin/src/components/AssetDialog/BrowseStep/tests/index.test.js
+++ b/packages/core/upload/admin/src/components/AssetDialog/BrowseStep/tests/index.test.js
@@ -119,7 +119,7 @@ describe('BrowseStep', () => {
     jest.clearAllMocks();
   });
 
-  it.only('renders and match snapshot', () => {
+  it('renders and match snapshot', () => {
     const { container } = setup();
     expect(container).toMatchSnapshot();
   });

--- a/packages/core/upload/admin/src/components/Breadcrumbs/CrumbSimpleMenuAsync.js
+++ b/packages/core/upload/admin/src/components/Breadcrumbs/CrumbSimpleMenuAsync.js
@@ -58,7 +58,7 @@ export const CrumbSimpleMenuAsync = ({ parentsToOmit, currentFolderId, onChangeF
             );
           }
 
-          const url = getFolderURL(pathname, query, ascendant);
+          const url = getFolderURL(pathname, query, ascendant?.id);
 
           return (
             <MenuItem isLink as={NavLink} to={url} key={ascendant.id}>

--- a/packages/core/upload/admin/src/components/EditAssetDialog/PreviewBox/index.js
+++ b/packages/core/upload/admin/src/components/EditAssetDialog/PreviewBox/index.js
@@ -25,7 +25,7 @@ import { CopyLinkButton } from '../../CopyLinkButton';
 import { UploadProgress } from '../../UploadProgress';
 import { AssetType, AssetDefinition } from '../../../constants';
 import { AssetPreview } from './AssetPreview';
-import { createAssetUrl } from '../../../utils/createAssetUrl';
+import { createAssetUrl } from '../../../utils';
 
 export const PreviewBox = ({
   asset,

--- a/packages/core/upload/admin/src/components/FolderGridList/tests/__snapshots__/FolderGridList.test.js.snap
+++ b/packages/core/upload/admin/src/components/FolderGridList/tests/__snapshots__/FolderGridList.test.js.snap
@@ -14,7 +14,6 @@ exports[`FolderGridList renders and match snapshots 1`] = `
 }
 
 .c0 {
-  padding-top: 8px;
   padding-bottom: 8px;
 }
 

--- a/packages/core/upload/admin/src/components/FolderList/FolderList.js
+++ b/packages/core/upload/admin/src/components/FolderList/FolderList.js
@@ -9,7 +9,7 @@ export const FolderList = ({ title, children }) => {
   return (
     <KeyboardNavigable tagName="article">
       {title && (
-        <Box paddingTop={2} paddingBottom={2}>
+        <Box paddingBottom={2}>
           <Typography as="h2" variant="delta" fontWeight="semiBold">
             {title}
           </Typography>

--- a/packages/core/upload/admin/src/components/MediaLibraryInput/Carousel/CarouselAsset.js
+++ b/packages/core/upload/admin/src/components/MediaLibraryInput/Carousel/CarouselAsset.js
@@ -7,7 +7,7 @@ import { Flex } from '@strapi/design-system/Flex';
 import { AssetType, AssetDefinition } from '../../../constants';
 import { VideoPreview } from '../../AssetCard/VideoPreview';
 import { AudioPreview } from '../../AssetCard/AudioPreview';
-import { createAssetUrl } from '../../../utils/createAssetUrl';
+import { createAssetUrl } from '../../../utils';
 
 const DocAsset = styled(Flex)`
   background: linear-gradient(180deg, #ffffff 0%, #f6f6f9 121.48%);

--- a/packages/core/upload/admin/src/components/TableList/TableRows.js
+++ b/packages/core/upload/admin/src/components/TableList/TableRows.js
@@ -28,11 +28,11 @@ export const TableRows = ({
 }) => {
   const { formatMessage } = useIntl();
 
-  const handleRowClickFn = (element, elementType) => {
+  const handleRowClickFn = (element, elementType, id) => {
     if (elementType === 'asset') {
       onEditAsset(element);
     } else {
-      onChangeFolder(element.id);
+      onChangeFolder(id);
     }
   };
 
@@ -41,7 +41,17 @@ export const TableRows = ({
   return (
     <Tbody>
       {rows.map((element) => {
-        const { alternativeText, id, name, ext, url, mime, formats, type: elementType } = element;
+        const {
+          alternativeText,
+          id,
+          name,
+          ext,
+          url,
+          mime,
+          folderURL,
+          formats,
+          type: elementType,
+        } = element;
 
         const fileType = mime?.split('/')?.[0];
         const canBeSelected =
@@ -53,7 +63,7 @@ export const TableRows = ({
           <Tr
             key={id}
             {...onRowClick({
-              fn: () => handleRowClickFn(element, elementType),
+              fn: () => handleRowClickFn(element, elementType, id),
             })}
           >
             <Td {...stopPropagation}>
@@ -92,12 +102,13 @@ export const TableRows = ({
               <Flex justifyContent="flex-end">
                 {elementType === 'folder' && (
                   <IconButton
-                    forwardedAs={Link}
+                    forwardedAs={folderURL ? Link : 'button'}
                     label={formatMessage({
                       id: getTrad('list.folders.link-label'),
                       defaultMessage: 'Access folder',
                     })}
-                    // to={getFolderURL(pathname, query, element)}
+                    to={folderURL}
+                    onClick={() => !folderURL && onChangeFolder(id)}
                     noBorder
                   >
                     <Eye />

--- a/packages/core/upload/admin/src/components/TableList/TableRows.js
+++ b/packages/core/upload/admin/src/components/TableList/TableRows.js
@@ -47,13 +47,13 @@ export const TableRows = ({
           name,
           ext,
           url,
-          mime,
+          mime = '',
           folderURL,
           formats,
           type: elementType,
         } = element;
 
-        const fileType = mime?.split('/')?.[0];
+        const fileType = mime.split('/')[0];
         const canBeSelected =
           isSelectable(singularTypes, elementType, fileType, isFolderSelectionAllowed) && canUpdate;
 
@@ -102,7 +102,7 @@ export const TableRows = ({
               <Flex justifyContent="flex-end">
                 {elementType === 'folder' && (
                   <IconButton
-                    forwardedAs={folderURL ? Link : 'button'}
+                    forwardedAs={folderURL ? Link : undefined}
                     label={formatMessage({
                       id: getTrad('list.folders.link-label'),
                       defaultMessage: 'Access folder',

--- a/packages/core/upload/admin/src/components/TableList/TableRows.js
+++ b/packages/core/upload/admin/src/components/TableList/TableRows.js
@@ -1,13 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
-import { useHistory, useLocation, Link } from 'react-router-dom';
-import {
-  getFileExtension,
-  onRowClick,
-  stopPropagation,
-  useQueryParams,
-} from '@strapi/helper-plugin';
+import { Link } from 'react-router-dom';
+import { getFileExtension, onRowClick, stopPropagation } from '@strapi/helper-plugin';
 import { BaseCheckbox } from '@strapi/design-system/BaseCheckbox';
 import { Flex } from '@strapi/design-system/Flex';
 import { IconButton } from '@strapi/design-system/IconButton';
@@ -16,11 +11,15 @@ import Pencil from '@strapi/icons/Pencil';
 import Eye from '@strapi/icons/Eye';
 
 import { CellContent } from './CellContent';
+import { isSelectable } from './utils/isSelectable';
 import { AssetDefinition, FolderDefinition, tableHeaders as cells } from '../../constants';
-import { getFolderURL, getTrad } from '../../utils';
+import { getTrad, toSingularTypes } from '../../utils';
 
 export const TableRows = ({
+  allowedTypes,
   canUpdate,
+  isFolderSelectionAllowed,
+  onChangeFolder,
   onEditAsset,
   onEditFolder,
   onSelectOne,
@@ -28,22 +27,25 @@ export const TableRows = ({
   selected,
 }) => {
   const { formatMessage } = useIntl();
-  const { pathname } = useLocation();
-  const [{ query }] = useQueryParams();
-  const { push } = useHistory();
 
   const handleRowClickFn = (element, elementType) => {
     if (elementType === 'asset') {
       onEditAsset(element);
     } else {
-      push(getFolderURL(pathname, query, element));
+      onChangeFolder(element.id);
     }
   };
+
+  const singularTypes = toSingularTypes(allowedTypes);
 
   return (
     <Tbody>
       {rows.map((element) => {
         const { alternativeText, id, name, ext, url, mime, formats, type: elementType } = element;
+
+        const fileType = mime?.split('/')?.[0];
+        const canBeSelected =
+          isSelectable(singularTypes, elementType, fileType, isFolderSelectionAllowed) && canUpdate;
 
         const isSelected = !!selected.find((currentRow) => currentRow.id === id);
 
@@ -64,7 +66,7 @@ export const TableRows = ({
                   },
                   { name }
                 )}
-                disabled={!canUpdate}
+                disabled={!canBeSelected}
                 onValueChange={() => onSelectOne(element)}
                 checked={isSelected}
               />
@@ -95,7 +97,7 @@ export const TableRows = ({
                       id: getTrad('list.folders.link-label'),
                       defaultMessage: 'Access folder',
                     })}
-                    to={getFolderURL(pathname, query, element)}
+                    // to={getFolderURL(pathname, query, element)}
                     noBorder
                   >
                     <Eye />
@@ -123,14 +125,20 @@ export const TableRows = ({
 };
 
 TableRows.defaultProps = {
-  canUpdate: false,
+  allowedTypes: ['images', 'files', 'videos', 'audios'],
+  canUpdate: true,
+  onChangeFolder: null,
+  isFolderSelectionAllowed: true,
   rows: [],
   selected: [],
 };
 
 TableRows.propTypes = {
+  allowedTypes: PropTypes.arrayOf(PropTypes.string),
   canUpdate: PropTypes.bool,
+  isFolderSelectionAllowed: PropTypes.bool,
   rows: PropTypes.arrayOf(AssetDefinition, FolderDefinition),
+  onChangeFolder: PropTypes.func,
   onEditAsset: PropTypes.func.isRequired,
   onEditFolder: PropTypes.func.isRequired,
   onSelectOne: PropTypes.func.isRequired,

--- a/packages/core/upload/admin/src/components/TableList/index.js
+++ b/packages/core/upload/admin/src/components/TableList/index.js
@@ -15,16 +15,20 @@ import { TableRows } from './TableRows';
 
 export const TableList = ({
   assetCount,
+  isFolderSelectionAllowed,
+  allowedTypes,
   canUpdate,
   folderCount,
   indeterminate,
   onChangeSort,
+  onChangeFolder,
   onEditAsset,
   onEditFolder,
   onSelectAll,
   onSelectOne,
   rows,
   selected,
+  shouldDisableBulkSelect,
   sortQuery,
 }) => {
   const { formatMessage } = useIntl();
@@ -47,8 +51,8 @@ export const TableList = ({
                 id: getTrad('bulk.select.label'),
                 defaultMessage: 'Select all folders & assets',
               })}
-              disabled={!canUpdate}
-              indeterminate={indeterminate}
+              disabled={shouldDisableBulkSelect}
+              indeterminate={indeterminate && !shouldDisableBulkSelect}
               onChange={(e) => onSelectAll(e, rows)}
               value={
                 (assetCount > 0 || folderCount > 0) && selected.length === assetCount + folderCount
@@ -110,7 +114,10 @@ export const TableList = ({
         </Tr>
       </Thead>
       <TableRows
+        isFolderSelectionAllowed={isFolderSelectionAllowed}
+        allowedTypes={allowedTypes}
         canUpdate={canUpdate}
+        onChangeFolder={onChangeFolder}
         onEditAsset={onEditAsset}
         onEditFolder={onEditFolder}
         rows={rows}
@@ -123,28 +130,36 @@ export const TableList = ({
 
 TableList.defaultProps = {
   assetCount: 0,
-  canUpdate: false,
+  allowedTypes: ['images', 'files', 'videos', 'audios'],
+  canUpdate: true,
   folderCount: 0,
   indeterminate: false,
+  isFolderSelectionAllowed: true,
   onChangeSort: null,
+  onChangeFolder: null,
   onEditAsset: null,
   onEditFolder: null,
   rows: [],
   selected: [],
+  shouldDisableBulkSelect: false,
   sortQuery: '',
 };
 
 TableList.propTypes = {
+  allowedTypes: PropTypes.arrayOf(PropTypes.string),
   assetCount: PropTypes.number,
   canUpdate: PropTypes.bool,
   folderCount: PropTypes.number,
   indeterminate: PropTypes.bool,
+  isFolderSelectionAllowed: PropTypes.bool,
   onChangeSort: PropTypes.func,
+  onChangeFolder: PropTypes.func,
   onEditAsset: PropTypes.func,
   onEditFolder: PropTypes.func,
   onSelectAll: PropTypes.func.isRequired,
   onSelectOne: PropTypes.func.isRequired,
   rows: PropTypes.arrayOf(AssetDefinition, FolderDefinition),
   selected: PropTypes.arrayOf(AssetDefinition, FolderDefinition),
+  shouldDisableBulkSelect: PropTypes.bool,
   sortQuery: PropTypes.string,
 };

--- a/packages/core/upload/admin/src/components/TableList/tests/TableList.test.js
+++ b/packages/core/upload/admin/src/components/TableList/tests/TableList.test.js
@@ -13,7 +13,8 @@ jest.mock('@strapi/helper-plugin', () => ({
 }));
 
 const PROPS_FIXTURE = {
-  canUpdate: false,
+  canUpdate: true,
+  indeterminate: false,
   rows: [
     {
       alternativeText: 'alternative text',
@@ -110,8 +111,22 @@ describe('TableList', () => {
     expect(onSelectAllSpy).toHaveBeenCalledTimes(1);
   });
 
+  it('should display indeterminate state of bulk select checkbox', () => {
+    const { getByRole } = setup({ indeterminate: true });
+
+    expect(getByRole('checkbox', { name: 'Select all folders & assets' })).toBePartiallyChecked();
+  });
+
+  it('should not display indeterminate state of bulk select checkbox if checkbox is disabled', () => {
+    const { getByRole } = setup({ indeterminate: true, shouldDisableBulkSelect: true });
+
+    expect(
+      getByRole('checkbox', { name: 'Select all folders & assets' })
+    ).not.toBePartiallyChecked();
+  });
+
   it('should disable bulk select when users do not have update permissions', () => {
-    const { getByRole } = setup({ canUpdate: false });
+    const { getByRole } = setup({ shouldDisableBulkSelect: true });
 
     expect(getByRole('checkbox', { name: 'Select all folders & assets' })).toBeDisabled();
   });

--- a/packages/core/upload/admin/src/components/TableList/tests/TableRows.test.js
+++ b/packages/core/upload/admin/src/components/TableList/tests/TableRows.test.js
@@ -110,6 +110,12 @@ describe('TableList | TableRows', () => {
       expect(getByRole('checkbox', { name: 'Select michka asset', hidden: true })).toBeDisabled();
     });
 
+    it('should disable select asset checkbox when users if the file type is not allowed', () => {
+      const { getByRole } = setup({ allowedTypes: [] });
+
+      expect(getByRole('checkbox', { name: 'Select michka asset', hidden: true })).toBeDisabled();
+    });
+
     it('should call onEditAsset callback', () => {
       const onEditAssetSpy = jest.fn();
       const { getByRole } = setup({ onEditAsset: onEditAssetSpy });
@@ -141,10 +147,25 @@ describe('TableList | TableRows', () => {
       expect(onEditFolderSpy).toHaveBeenCalledTimes(1);
     });
 
-    it('should display folder link', () => {
-      const { getByRole } = setup({ rows: [FOLDER_FIXTURE] });
+    it('should display folder navigation as a link if no folder url exists', () => {
+      const { getByRole } = setup({ rows: [{ ...FOLDER_FIXTURE, folderURL: 'plugins/upload' }] });
 
       expect(getByRole('link', { name: 'Access folder', hidden: true })).toBeInTheDocument();
+    });
+
+    it('should display folder nagivation as a button if a folder url exists', () => {
+      const { getByRole } = setup({ rows: [FOLDER_FIXTURE] });
+
+      expect(getByRole('button', { name: 'Access folder', hidden: true })).toBeInTheDocument();
+    });
+
+    it('should call onChangeFolder when clicking on folder navigation button', () => {
+      const onChangeFolderSpy = jest.fn();
+      const { getByRole } = setup({ rows: [FOLDER_FIXTURE], onChangeFolder: onChangeFolderSpy });
+
+      fireEvent.click(getByRole('button', { name: 'Access folder', hidden: true }));
+
+      expect(onChangeFolderSpy).toHaveBeenCalledWith(2);
     });
 
     it('should reflect non selected folder state', () => {
@@ -163,6 +184,14 @@ describe('TableList | TableRows', () => {
 
     it('should disable select folder checkbox when users do not have the permission to update', () => {
       const { getByRole } = setup({ rows: [FOLDER_FIXTURE], canUpdate: false });
+
+      expect(
+        getByRole('checkbox', { name: 'Select folder 1 folder', hidden: true })
+      ).toBeDisabled();
+    });
+
+    it('should disable select folder checkbox when folder selection is not allowed', () => {
+      const { getByRole } = setup({ rows: [FOLDER_FIXTURE], isFolderSelectionAllowed: false });
 
       expect(
         getByRole('checkbox', { name: 'Select folder 1 folder', hidden: true })

--- a/packages/core/upload/admin/src/components/TableList/utils/isSelectable.js
+++ b/packages/core/upload/admin/src/components/TableList/utils/isSelectable.js
@@ -1,0 +1,13 @@
+export const isSelectable = (allowedTypes, elementType, fileType, isFolderSelectionAllowed) => {
+  let canSelectElement;
+
+  if (elementType === 'folder') {
+    canSelectElement = isFolderSelectionAllowed;
+  } else {
+    canSelectElement =
+      allowedTypes.includes(fileType) ||
+      (allowedTypes.includes('file') && !['video', 'image', 'audio'].includes(fileType));
+  }
+
+  return canSelectElement;
+};

--- a/packages/core/upload/admin/src/components/TableList/utils/tests/isSelectable.test.js
+++ b/packages/core/upload/admin/src/components/TableList/utils/tests/isSelectable.test.js
@@ -1,0 +1,74 @@
+import { isSelectable } from '../isSelectable';
+
+const ALLOWED_TYPES_FIXTURE = ['image', 'file', 'video', 'audio'];
+const ELEMENT_TYPE_FIXTURE = 'asset';
+const FILE_TYPE_FIXTURE = 'image';
+const IS_FOLDER_SELECTION_ALLOWED_FIXTURE = true;
+
+describe('TableList | isSelectable', () => {
+  it('should return true if asset is an allowed file type', () => {
+    expect(
+      isSelectable(
+        ALLOWED_TYPES_FIXTURE,
+        ELEMENT_TYPE_FIXTURE,
+        FILE_TYPE_FIXTURE,
+        IS_FOLDER_SELECTION_ALLOWED_FIXTURE
+      )
+    ).toEqual(true);
+  });
+
+  it('should return true if asset type is not contained in allowed types array but file type is contained', () => {
+    expect(
+      isSelectable(
+        ['video', 'audio', 'file'],
+        ELEMENT_TYPE_FIXTURE,
+        'pdf',
+        IS_FOLDER_SELECTION_ALLOWED_FIXTURE
+      )
+    ).toEqual(true);
+  });
+
+  it('should return false if asset type is not contained in allowed types array and file type is image, video or audio', () => {
+    expect(
+      isSelectable(
+        ['video', 'audio', 'file'],
+        ELEMENT_TYPE_FIXTURE,
+        'image',
+        IS_FOLDER_SELECTION_ALLOWED_FIXTURE
+      )
+    ).toEqual(false);
+
+    expect(
+      isSelectable(
+        ['image', 'audio', 'file'],
+        ELEMENT_TYPE_FIXTURE,
+        'video',
+        IS_FOLDER_SELECTION_ALLOWED_FIXTURE
+      )
+    ).toEqual(false);
+
+    expect(
+      isSelectable(
+        ['image', 'video', 'file'],
+        ELEMENT_TYPE_FIXTURE,
+        'audio',
+        IS_FOLDER_SELECTION_ALLOWED_FIXTURE
+      )
+    ).toEqual(false);
+  });
+
+  it('should return true if folder is allowed', () => {
+    expect(
+      isSelectable(
+        ALLOWED_TYPES_FIXTURE,
+        'folder',
+        FILE_TYPE_FIXTURE,
+        IS_FOLDER_SELECTION_ALLOWED_FIXTURE
+      )
+    ).toEqual(true);
+  });
+
+  it('should return false if folder is not allowed', () => {
+    expect(isSelectable(ALLOWED_TYPES_FIXTURE, 'folder', FILE_TYPE_FIXTURE, false)).toEqual(false);
+  });
+});

--- a/packages/core/upload/admin/src/pages/App/MediaLibrary.js
+++ b/packages/core/upload/admin/src/pages/App/MediaLibrary.js
@@ -119,7 +119,12 @@ export const MediaLibrary = () => {
     push(pathname);
   }
 
-  const folders = foldersData?.map((folder) => ({ ...folder, type: 'folder' })) ?? [];
+  const folders =
+    foldersData?.map((folder) => ({
+      ...folder,
+      type: 'folder',
+      folderURL: getFolderURL(pathname, query, folder.id),
+    })) ?? [];
   const folderCount = folders?.length || 0;
   const assets = assetsData?.results?.map((asset) => ({ ...asset, type: 'asset' })) || [];
   const assetCount = assets?.length ?? 0;
@@ -275,6 +280,7 @@ export const MediaLibrary = () => {
               assetCount={assetCount}
               canUpdate={canUpdate}
               folderCount={folderCount}
+              // folderURL={getFolderURL(pathname, query, folderID)}
               indeterminate={indeterminateBulkSelect}
               onChangeSort={handleChangeSort}
               onChangeFolder={(folderID) => push(getFolderURL(pathname, query, folderID))}

--- a/packages/core/upload/admin/src/pages/App/MediaLibrary.js
+++ b/packages/core/upload/admin/src/pages/App/MediaLibrary.js
@@ -246,6 +246,7 @@ export const MediaLibrary = () => {
               folderCount={folderCount}
               indeterminate={indeterminateBulkSelect}
               onChangeSort={handleChangeSort}
+              onChangeFolder={(folderID) => push(getFolderURL(pathname, query, folderID))}
               onEditAsset={setAssetToEdit}
               onEditFolder={handleEditFolder}
               onSelectOne={selectOne}
@@ -257,6 +258,7 @@ export const MediaLibrary = () => {
                 !assetsLoading && !foldersLoading ? [...folders, ...assets] : []
               }
               selected={selected}
+              shouldDisableBulkSelect={!canUpdate}
               sortQuery={query?.sort ?? ''}
             />
           )}
@@ -286,7 +288,7 @@ export const MediaLibrary = () => {
                       (currentFolder) => currentFolder.id === folder.id
                     );
 
-                    const url = getFolderURL(pathname, query, folder);
+                    const url = getFolderURL(pathname, query, folder?.id);
 
                     return (
                       <GridItem col={3} key={`folder-${folder.id}`}>

--- a/packages/core/upload/admin/src/utils/createAssetUrl.js
+++ b/packages/core/upload/admin/src/utils/createAssetUrl.js
@@ -7,7 +7,7 @@ import { prefixFileUrlWithBackendUrl } from '@strapi/helper-plugin';
  * if there's no thumbnail, return the URL of the original image.
  * @return {String} URL
  */
-export const createAssetUrl = (asset, forThumbnail = true) => {
+const createAssetUrl = (asset, forThumbnail = true) => {
   if (asset.isLocal) {
     return asset.url;
   }
@@ -17,3 +17,5 @@ export const createAssetUrl = (asset, forThumbnail = true) => {
 
   return `${backendUrl}?updated_at=${asset.updatedAt}`;
 };
+
+export default createAssetUrl;

--- a/packages/core/upload/admin/src/utils/getBreadcrumbDataML.js
+++ b/packages/core/upload/admin/src/utils/getBreadcrumbDataML.js
@@ -18,7 +18,7 @@ const getBreadcrumbDataML = (folder, { pathname, query }) => {
     data.push({
       id: folder.parent.id,
       label: folder.parent.name,
-      href: getFolderURL(pathname, query, folder.parent),
+      href: getFolderURL(pathname, query, folder.parent?.id),
     });
   }
 

--- a/packages/core/upload/admin/src/utils/getFolderURL.js
+++ b/packages/core/upload/admin/src/utils/getFolderURL.js
@@ -1,11 +1,11 @@
 import { stringify } from 'qs';
 
-const getFolderURL = (pathname, query, folder) => {
+const getFolderURL = (pathname, query, folderID) => {
   const { _q, ...queryParamsWithoutQ } = query;
   const queryParamsString = stringify(
     {
       ...queryParamsWithoutQ,
-      folder: folder?.id,
+      folder: folderID,
     },
     { encode: false }
   );

--- a/packages/core/upload/admin/src/utils/index.js
+++ b/packages/core/upload/admin/src/utils/index.js
@@ -1,4 +1,5 @@
 export { default as axiosInstance } from './axiosInstance';
+export { default as createAssetUrl } from './createAssetUrl';
 export { default as formatBytes } from './formatBytes';
 export { default as getRequestUrl } from './getRequestUrl';
 export { default as getTrad } from './getTrad';
@@ -9,4 +10,5 @@ export { default as getBreadcrumbDataML } from './getBreadcrumbDataML';
 export { default as getBreadcrumbDataCM } from './getBreadcrumbDataCM';
 export { default as getFolderURL } from './getFolderURL';
 export { default as getFolderParents } from './getFolderParents';
+export { default as toSingularTypes } from './toSingularTypes';
 export * from './formatDuration';

--- a/packages/core/upload/admin/src/utils/tests/getFolderURL.test.js
+++ b/packages/core/upload/admin/src/utils/tests/getFolderURL.test.js
@@ -2,9 +2,7 @@ import { getFolderURL } from '..';
 
 const FIXTURE_PATHNAME = '/media-library';
 const FIXTURE_QUERY = {};
-const FIXTURE_FOLDER = {
-  id: 1,
-};
+const FIXTURE_FOLDER = 1;
 
 describe('getFolderURL', () => {
   test('returns a path for the root of the media library', () => {
@@ -13,19 +11,19 @@ describe('getFolderURL', () => {
 
   test('returns a path for a folder', () => {
     expect(getFolderURL(FIXTURE_PATHNAME, FIXTURE_QUERY, FIXTURE_FOLDER)).toStrictEqual(
-      `${FIXTURE_PATHNAME}?folder=${FIXTURE_FOLDER.id}`
+      `${FIXTURE_PATHNAME}?folder=${FIXTURE_FOLDER}`
     );
   });
 
   test('removes _q query parameter', () => {
     expect(
       getFolderURL(FIXTURE_PATHNAME, { ...FIXTURE_QUERY, _q: 'search' }, FIXTURE_FOLDER)
-    ).toStrictEqual(`${FIXTURE_PATHNAME}?folder=${FIXTURE_FOLDER.id}`);
+    ).toStrictEqual(`${FIXTURE_PATHNAME}?folder=${FIXTURE_FOLDER}`);
   });
 
   test('keeps and stringifies query parameter', () => {
     expect(
       getFolderURL(FIXTURE_PATHNAME, { ...FIXTURE_QUERY, some: 'thing' }, FIXTURE_FOLDER)
-    ).toStrictEqual(`${FIXTURE_PATHNAME}?some=thing&folder=${FIXTURE_FOLDER.id}`);
+    ).toStrictEqual(`${FIXTURE_PATHNAME}?some=thing&folder=${FIXTURE_FOLDER}`);
   });
 });


### PR DESCRIPTION
## What

- [x] made `TableList` compatible with `BrowseStep`
- [x] made folder navigation a button in modal / a link in ML
- [x] passed `allowedTypes` logic to components 

## What will be fixed in future PRs

- after discussing with design, user should be able to access edit folder/asset in ML modals
  - should be added to grid view
  - should fix fields not disabled in list view
- checkboxes disabled or not will be refactored to fix grid view at the same time (see `isSelectable`) 
=> refactor on this PR #14998
- deeper tests for ML / BrowseStep 

## Snapshots

<img width="1439" alt="image" src="https://user-images.githubusercontent.com/71838159/203833095-139f7d54-c512-446f-a2d6-6be8feab2685.png">
