### PR TITLE
Fix: many to many relationship to the same content type gives error on save

### DIFF
--- a/packages/core/database/lib/metadata/relations.js
+++ b/packages/core/database/lib/metadata/relations.js
@@ -411,7 +411,7 @@ const createJoinTable = (metadata, { attributeName, attribute, meta }) => {
   let inverseOrderColumnName = _.snakeCase(`${meta.singularName}_order`);
 
   // if relation is self referencing
-  if (attribute.relation === 'manyToMany' && joinColumnName === inverseJoinColumnName) {
+  if (attribute.relation === 'manyToMany' && orderColumnName === inverseOrderColumnName) {
     inverseOrderColumnName = `inv_${inverseOrderColumnName}`;
   }
 


### PR DESCRIPTION
### What does it do?
Inverse Order column name was not properly set when relationship pointed to the same content type.

### Why is it needed?
To have many to many relationships pointing to the same content type. 

### How to test it?
Use this schema in User content-type
```
"managers": {
  "type": "relation",
  "relation": "manyToMany",
  "target": "plugin::users-permissions.user",
  "inversedBy": "users"
},
"users": {
  "type": "relation",
  "relation": "manyToMany",
  "target": "plugin::users-permissions.user",
  "mappedBy": "managers"
}
```
### Related issue(s)/PR(s)

fix #14918
