### PR TITLE
[relations]: Fix connect same relation id multiple times

### DIFF
--- a/packages/core/database/lib/entity-manager/index.js
+++ b/packages/core/database/lib/entity-manager/index.js
@@ -19,6 +19,7 @@ const {
   isNumber,
   map,
   difference,
+  uniqBy,
 } = require('lodash/fp');
 const types = require('../types');
 const { createField } = require('../fields');
@@ -569,7 +570,7 @@ const createEntityManager = (db) => {
           }
 
           // prepare new relations to insert
-          const insert = relsToAdd.map((data) => {
+          const insert = uniqBy('id', relsToAdd).map((data) => {
             return {
               [joinColumn.name]: id,
               [inverseJoinColumn.name]: data.id,
@@ -623,13 +624,7 @@ const createEntityManager = (db) => {
           }
 
           // insert new relations
-          // ignore duplicates, as connect syntax can contain duplicated ids to add
-          await this.createQueryBuilder(joinTable.name)
-            .insert(insert)
-            .onConflict(joinTable.pivotColumns)
-            .ignore()
-            .transacting(trx)
-            .execute();
+          await this.createQueryBuilder(joinTable.name).insert(insert).transacting(trx).execute();
         }
       }
     },
@@ -841,7 +836,7 @@ const createEntityManager = (db) => {
               }
 
               // prepare relations to insert
-              const insert = cleanRelationData.connect.map((relToAdd) => ({
+              const insert = uniqBy('id', cleanRelationData.connect).map((relToAdd) => ({
                 [joinColumn.name]: id,
                 [inverseJoinColumn.name]: relToAdd.id,
                 ...(joinTable.on || {}),
@@ -953,7 +948,7 @@ const createEntityManager = (db) => {
                 continue;
               }
 
-              const insert = cleanRelationData.set.map((relToAdd) => ({
+              const insert = uniqBy('id', cleanRelationData.set).map((relToAdd) => ({
                 [joinColumn.name]: id,
                 [inverseJoinColumn.name]: relToAdd.id,
                 ...(joinTable.on || {}),

--- a/packages/core/strapi/tests/api/relations.test.api.js
+++ b/packages/core/strapi/tests/api/relations.test.api.js
@@ -832,4 +832,26 @@ describe('Relations', () => {
       expect(updatedShop).toMatchObject(expectedShop);
     });
   });
+
+  test.only('Update relations using the same id multiple times', async () => {
+    const shop = await createShop({
+      anyToManyRel: [
+        { id: id1, position: { end: true } },
+        { id: id2, position: { end: true } },
+      ],
+    });
+
+    const updatedShop = await updateShop(shop, {
+      anyToManyRel: [
+        { id: id1, position: { end: true } },
+        { id: id1, position: { start: true } },
+        { id: id1, position: { after: id2 } },
+      ],
+    });
+
+    const expectedShop = shopFactory({
+      anyToManyRel: [{ id: id2 }, { id: id1 }],
+    });
+    expect(updatedShop).toMatchObject(expectedShop);
+  });
 });


### PR DESCRIPTION
### What does it do?

When trying to connect the same relations multiple times like:
```js
connect: [
  { id: 1, end: true },
  { id: 1, before: 3 }
]
```
We were inserting that same id multiple times in the database:

```js
insertDBArr = [{ id: 1 }, { id: 1 }]
```
This PR filters the insert array so we are not inserting the same id more than once in DB.


### How to test it?

See added test.

