### PR TITLE
Return Amazon SES response from the send method

### DIFF
--- a/packages/providers/email-amazon-ses/lib/index.js
+++ b/packages/providers/email-amazon-ses/lib/index.js
@@ -23,7 +23,7 @@ module.exports = {
             message: html,
             ...rest,
           };
-          client.sendEmail(removeUndefined(msg), (err) => {
+          client.sendEmail(removeUndefined(msg), (err, _, response) => {
             if (err) {
               if (err.Message) {
                 // eslint-disable-next-line prefer-promise-reject-errors


### PR DESCRIPTION

### What does it do?

Makes `provider-email-amazon-ses` return the response from AWS SES.

### Why is it needed?

Currently the `send` method returns empty promise and the client has no way to receive details of the actual request from AWS. In case there is a need to investigate issues with sending emails via AWS SES, it is useful to retrieve the response that AWS SES provides. The response contains unique request id that can be given to AWS customer service for investigation.

### How to test it?

To test this change one should have configured `node-ses` account. Then the test should verify that the successful execution of the `send` method of the provider returns an object that contains various fields that node-ses `response` object provides.

### Related issue(s)/PR(s)

N/A
