### PR TITLE
[admin] fix left menu sorting behaviour

### DIFF
--- a/packages/core/admin/admin/src/content-manager/pages/App/LeftMenu/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/App/LeftMenu/index.js
@@ -22,7 +22,7 @@ import getTrad from '../../../utils/getTrad';
 import { makeSelectModelLinks } from '../selectors';
 
 const matchByTitle = (links, search) =>
-  matchSorter(links, toLower(search), { keys: [(item) => toLower(item.title)] });
+  search ? matchSorter(links, toLower(search), { keys: [(item) => toLower(item.title)] }) : links;
 
 const LeftMenu = () => {
   const [search, setSearch] = useState('');
@@ -52,9 +52,7 @@ const LeftMenu = () => {
         defaultMessage: 'Collection Types',
       },
       searchable: true,
-      links: sortBy(matchByTitle(intlCollectionTypeLinks, search), (object) =>
-        object.title.toLowerCase()
-      ),
+      links: matchByTitle(intlCollectionTypeLinks, search),
     },
     {
       id: 'singleTypes',
@@ -63,9 +61,7 @@ const LeftMenu = () => {
         defaultMessage: 'Single Types',
       },
       searchable: true,
-      links: sortBy(matchByTitle(intlSingleTypeLinks, search), (object) =>
-        object.title.toLowerCase()
-      ),
+      links: matchByTitle(intlSingleTypeLinks, search),
     },
   ];
 

--- a/packages/core/admin/admin/src/content-manager/pages/App/LeftMenu/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/App/LeftMenu/index.js
@@ -8,7 +8,6 @@ import React, { useMemo, useState } from 'react';
 import { useSelector, shallowEqual } from 'react-redux';
 import { useIntl } from 'react-intl';
 import matchSorter from 'match-sorter';
-import sortBy from 'lodash/sortBy';
 import toLower from 'lodash/toLower';
 import { NavLink } from 'react-router-dom';
 import {

--- a/packages/core/admin/admin/src/content-manager/pages/App/LeftMenu/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/App/LeftMenu/index.js
@@ -8,6 +8,7 @@ import React, { useMemo, useState } from 'react';
 import { useSelector, shallowEqual } from 'react-redux';
 import { useIntl } from 'react-intl';
 import matchSorter from 'match-sorter';
+import sortBy from 'lodash/sortBy';
 import toLower from 'lodash/toLower';
 import { NavLink } from 'react-router-dom';
 import {
@@ -21,7 +22,9 @@ import getTrad from '../../../utils/getTrad';
 import { makeSelectModelLinks } from '../selectors';
 
 const matchByTitle = (links, search) =>
-  search ? matchSorter(links, toLower(search), { keys: [(item) => toLower(item.title)] }) : links;
+  search
+    ? matchSorter(links, toLower(search), { keys: [(item) => toLower(item.title)] })
+    : sortBy(links, (object) => object.title.toLowerCase());
 
 const LeftMenu = () => {
   const [search, setSearch] = useState('');

--- a/packages/core/content-type-builder/admin/src/components/ContentTypeBuilderNav/useContentTypeBuilderMenu.js
+++ b/packages/core/content-type-builder/admin/src/components/ContentTypeBuilderNav/useContentTypeBuilderMenu.js
@@ -162,7 +162,7 @@ const useContentTypeBuilderMenu = () => {
   ];
 
   const matchByTitle = (links) =>
-    matchSorter(links, toLower(search), { keys: [(item) => toLower(item.title)] });
+    search ? matchSorter(links, toLower(search), { keys: [(item) => toLower(item.title)] }) : links;
 
   const getMenu = () => {
     // Maybe we can do it simpler with matchsorter wildcards ?


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Apply `matchSorter` only if searching, otherwise leave the items the default ordering. 

This affects Content-Type Builder and Content Manager

### Related issue(s)/PR(s)

fixes https://github.com/strapi/strapi/issues/15030
