### PR TITLE
[deits] Upgrade commander package

### DIFF
--- a/packages/cli/create-strapi-app/package.json
+++ b/packages/cli/create-strapi-app/package.json
@@ -4,7 +4,7 @@
   "description": "Generate a new Strapi application.",
   "dependencies": {
     "@strapi/generate-new": "4.5.2",
-    "commander": "7.2.0",
+    "commander": "9.4.1",
     "inquirer": "8.2.4"
   },
   "keywords": [

--- a/packages/cli/create-strapi-starter/package.json
+++ b/packages/cli/create-strapi-starter/package.json
@@ -41,7 +41,7 @@
     "@strapi/generate-new": "4.5.2",
     "chalk": "4.1.1",
     "ci-info": "3.5.0",
-    "commander": "7.2.0",
+    "commander": "9.4.1",
     "execa": "5.1.1",
     "fs-extra": "10.0.0",
     "inquirer": "8.2.4",

--- a/packages/core/strapi/package.json
+++ b/packages/core/strapi/package.json
@@ -99,7 +99,7 @@
     "chokidar": "3.5.2",
     "ci-info": "3.5.0",
     "cli-table3": "0.6.2",
-    "commander": "7.2.0",
+    "commander": "9.4.1",
     "configstore": "5.0.1",
     "debug": "4.3.2",
     "delegates": "1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9104,10 +9104,10 @@ comma-separated-tokens@^1.0.0:
   resolved "https://registry.yarnpkg.com/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz#632b80b6117867a158f1080ad498b2fbe7e3f5ea"
   integrity sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==
 
-commander@7.2.0, commander@^7.0.0, commander@^7.2.0:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-7.2.0.tgz#a36cb57d0b501ce108e4d20559a150a391d97ab7"
-  integrity sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==
+commander@9.4.1, commander@^9.1.0, commander@^9.3.0:
+  version "9.4.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-9.4.1.tgz#d1dd8f2ce6faf93147295c0df13c7c21141cfbdd"
+  integrity sha512-5EEkTNyHNGFPD2H+c/dXXfQZYa/scCKasxWcXJaWnNJ99pnQN9Vnmqow+p+PlFPE63Q6mThaZws1T+HxfpgtPw==
 
 commander@^2.19.0, commander@^2.20.0, commander@^2.20.3:
   version "2.20.3"
@@ -9124,15 +9124,15 @@ commander@^6.2.1:
   resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.1.tgz#0792eb682dfbc325999bb2b84fddddba110ac73c"
   integrity sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==
 
+commander@^7.0.0, commander@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-7.2.0.tgz#a36cb57d0b501ce108e4d20559a150a391d97ab7"
+  integrity sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==
+
 commander@^8.3.0:
   version "8.3.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-8.3.0.tgz#4837ea1b2da67b9c616a67afbb0fafee567bca66"
   integrity sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==
-
-commander@^9.1.0, commander@^9.3.0:
-  version "9.4.1"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-9.4.1.tgz#d1dd8f2ce6faf93147295c0df13c7c21141cfbdd"
-  integrity sha512-5EEkTNyHNGFPD2H+c/dXXfQZYa/scCKasxWcXJaWnNJ99pnQN9Vnmqow+p+PlFPE63Q6mThaZws1T+HxfpgtPw==
 
 common-ancestor-path@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
### What does it do?

Upgrades the commander package from `7.2.0` to `9.4.1`

### Why is it needed?

7.2.0 doesn't have the `command.hook` method that we need and use, so I'm not even sure how it was working the past few months.

### How to test it?

Test all the Strapi commands and they should still work exactly as before.

From their [changelog](https://github.com/tj/commander.js/blob/master/CHANGELOG.md), the only breaking changes in between that seem like they might be a concern is the one about default values for boolean options.
