### PR TITLE
Fix some usecases where deadlocks can happen

### DIFF
--- a/packages/core/database/lib/entity-manager/index.js
+++ b/packages/core/database/lib/entity-manager/index.js
@@ -223,6 +223,7 @@ const createEntityManager = (db) => {
         await trx.commit();
       } catch (e) {
         await trx.rollback();
+        await this.createQueryBuilder(uid).where({ id }).delete().execute();
         throw e;
       }
 
@@ -281,7 +282,11 @@ const createEntityManager = (db) => {
         throw new Error('Update requires a where parameter');
       }
 
-      const entity = await this.createQueryBuilder(uid).select('id').where(where).first().execute();
+      const entity = await this.createQueryBuilder(uid)
+        .select('*')
+        .where(where)
+        .first()
+        .execute({ mapResults: false });
 
       if (!entity) {
         return null;
@@ -298,10 +303,10 @@ const createEntityManager = (db) => {
       const trx = await strapi.db.transaction();
       try {
         await this.updateRelations(uid, id, data, { transaction: trx });
-
         await trx.commit();
       } catch (e) {
         await trx.rollback();
+        await this.createQueryBuilder(uid).where({ id }).update(entity).execute();
         throw e;
       }
 

--- a/packages/core/database/lib/entity-manager/regular-relations.js
+++ b/packages/core/database/lib/entity-manager/regular-relations.js
@@ -296,7 +296,7 @@ const cleanOrderColumnsForOldDatabases = async ({
   const randomHex = randomBytes(16).toString('hex');
 
   if (hasOrderColumn(attribute) && id) {
-    const tempOrderTableName = `tempOrderTableName_${now}_${randomHex}`;
+    const tempOrderTableName = `orderTable_${now}_${randomHex}`;
     try {
       await db.connection
         .raw(
@@ -333,7 +333,7 @@ const cleanOrderColumnsForOldDatabases = async ({
   }
 
   if (hasInverseOrderColumn(attribute) && !isEmpty(inverseRelIds)) {
-    const tempInvOrderTableName = `tempInvOrderTableName_${now}_${randomHex}`;
+    const tempInvOrderTableName = `invOrderTable_${now}_${randomHex}`;
     try {
       await db.connection
         .raw(

--- a/packages/core/strapi/lib/services/entity-service/components.js
+++ b/packages/core/strapi/lib/services/entity-service/components.js
@@ -43,12 +43,9 @@ const createComponents = async (uid, data) => {
           throw new Error('Expected an array to create repeatable component');
         }
 
-        // No Promise.all to avoid deadlocks
-        const components = [];
-        for (const value of componentValue) {
-          const compo = await createComponent(componentUID, value);
-          components.push(compo);
-        }
+        const components = await Promise.all(
+          componentValue.map((value) => createComponent(componentUID, value))
+        );
 
         componentBody[attributeName] = components.map(({ id }) => {
           return {
@@ -80,18 +77,18 @@ const createComponents = async (uid, data) => {
         throw new Error('Expected an array to create repeatable component');
       }
 
-      // No Promise.all to avoid deadlocks
-      componentBody[attributeName] = [];
-      for (const value of dynamiczoneValues) {
-        const { id } = await createComponent(value.__component, value);
-        componentBody[attributeName].push({
-          id,
-          __component: value.__component,
-          __pivot: {
-            field: attributeName,
-          },
-        });
-      }
+      componentBody[attributeName] = await Promise.all(
+        dynamiczoneValues.map(async (value) => {
+          const { id } = await createComponent(value.__component, value);
+          return {
+            id,
+            __component: value.__component,
+            __pivot: {
+              field: attributeName,
+            },
+          };
+        })
+      );
 
       continue;
     }
@@ -140,12 +137,9 @@ const updateComponents = async (uid, entityToUpdate, data) => {
           throw new Error('Expected an array to create repeatable component');
         }
 
-        // No Promise.all to avoid deadlocks
-        const components = [];
-        for (const value of componentValue) {
-          const compo = await updateOrCreateComponent(componentUID, value);
-          components.push(compo);
-        }
+        const components = await Promise.all(
+          componentValue.map((value) => updateOrCreateComponent(componentUID, value))
+        );
 
         componentBody[attributeName] = components.filter(_.negate(_.isNil)).map(({ id }) => {
           return {
@@ -179,18 +173,19 @@ const updateComponents = async (uid, entityToUpdate, data) => {
         throw new Error('Expected an array to create repeatable component');
       }
 
-      // No Promise.all to avoid deadlocks
-      componentBody[attributeName] = [];
-      for (const value of dynamiczoneValues) {
-        const { id } = await updateOrCreateComponent(value.__component, value);
-        componentBody[attributeName].push({
-          id,
-          __component: value.__component,
-          __pivot: {
-            field: attributeName,
-          },
-        });
-      }
+      componentBody[attributeName] = await Promise.all(
+        dynamiczoneValues.map(async (value) => {
+          const { id } = await updateOrCreateComponent(value.__component, value);
+
+          return {
+            id,
+            __component: value.__component,
+            __pivot: {
+              field: attributeName,
+            },
+          };
+        })
+      );
 
       continue;
     }
@@ -292,14 +287,14 @@ const deleteComponents = async (uid, entityToDelete, { loadComponents = true } =
 
       if (attribute.type === 'component') {
         const { component: componentUID } = attribute;
-        for (const subValue of _.castArray(value)) {
-          await deleteComponent(componentUID, subValue);
-        }
+        await Promise.all(
+          _.castArray(value).map((subValue) => deleteComponent(componentUID, subValue))
+        );
       } else {
         // delete dynamic zone components
-        for (const subValue of _.castArray(value)) {
-          await deleteComponent(subValue.__component, subValue);
-        }
+        await Promise.all(
+          _.castArray(value).map((subValue) => deleteComponent(subValue.__component, subValue))
+        );
       }
 
       continue;

--- a/packages/plugins/i18n/tests/content-manager/crud.test.api.js
+++ b/packages/plugins/i18n/tests/content-manager/crud.test.api.js
@@ -103,6 +103,8 @@ describe('i18n - Content API', () => {
       data.categories.push(res.body);
     });
 
+    // This tests is sensible to foreign keys deadlocks
+    // foreign keys deadlock example: https://gist.github.com/roustem/db2398aa38be0cc88364
     test('all related locales', async () => {
       let res;
       for (const locale of ['ko', 'it', 'fr', 'es-AR']) {

--- a/packages/plugins/i18n/tests/content-manager/crud.test.api.js
+++ b/packages/plugins/i18n/tests/content-manager/crud.test.api.js
@@ -45,7 +45,12 @@ describe('i18n - Content API', () => {
   beforeAll(async () => {
     await builder
       .addContentTypes([categoryModel])
-      .addFixtures('plugin::i18n.locale', [{ name: 'Ko', code: 'ko' }])
+      .addFixtures('plugin::i18n.locale', [
+        { name: 'Korean', code: 'ko' },
+        { name: 'Italian', code: 'it' },
+        { name: 'French', code: 'fr' },
+        { name: 'Spanish (Argentina)', code: 'es-AR' },
+      ])
       .build();
 
     strapi = await createStrapiInstance();
@@ -95,6 +100,29 @@ describe('i18n - Content API', () => {
         localizations: [],
         name: 'category in korean',
       });
+      data.categories.push(res.body);
+    });
+
+    test('all related locales', async () => {
+      let res;
+      for (const locale of ['ko', 'it', 'fr', 'es-AR']) {
+        res = await rq({
+          method: 'POST',
+          url: `/content-manager/collection-types/api::category.category`,
+          qs: {
+            plugins: { i18n: { locale, relatedEntityId: data.categories[0].id } },
+          },
+          body: {
+            name: `category in ${locale}`,
+          },
+        });
+        expect(res.statusCode).toBe(200);
+      }
+
+      const { statusCode, body } = res;
+
+      expect(statusCode).toBe(200);
+      expect(body.localizations).toHaveLength(4);
       data.categories.push(res.body);
     });
   });


### PR DESCRIPTION
### What does it do?

Wraps in a transaction only `relation updates` instead of `entry update + relation updates`.


### Why is it needed?

Since recently, relations management is done using transactions. When updating different relations simultaneously it can lead to dead locks. It's most likely to happen when handling repeatable components/dynamic zones as they are all updated independently in their own transaction and as the updates are run in parallel.
Same when updating localizations of all locales of an entry when a new locale is added (see https://github.com/VirtusLab-Open-Source/strapi-plugin-navigation/issues/290).
The deadlock is happening only on MySQL and MariaDB because of a foreign key contraint deadlock (see this example https://gist.github.com/roustem/db2398aa38be0cc88364)
To fix that, the chosen solution is to remove the entry/parent update from the transaction.
Other solutions might have been:
- Avoid parallelizing certain queries, but it would have performance consequences (multiplying some entry update time by 3 to 4)
- Putting all updates in the same big transaction, but there are too many uncertainties (how to handle users lifecycles, will it create deadlocks in some other scenario)

### How to test it?

Follow the steps described in #14937

### Related issue(s)/PR(s)

- Fix https://github.com/strapi/strapi/issues/15066
- Fix #14937
