### PR TITLE
Put inversedBy only once for manyToMany and oneToOne relations

### DIFF
--- a/packages/core/content-type-builder/server/services/schema-builder/content-type-builder.js
+++ b/packages/core/content-type-builder/server/services/schema-builder/content-type-builder.js
@@ -207,6 +207,10 @@ module.exports = function createComponentBuilder() {
         const attribute = newAttributes[key];
 
         if (isRelation(attribute)) {
+          if (['manyToMany', 'oneToOne'].includes(attribute.relation)) {
+            attribute.dominant = true;
+          }
+
           this.setRelation({
             key,
             uid,
@@ -286,10 +290,10 @@ const generateRelation = ({ key, attribute, uid, targetAttribute = {} }) => {
     case 'manyToMany': {
       opts.relation = 'manyToMany';
 
-      if (attribute.dominant === false) {
-        opts.inversedBy = key;
-      } else {
+      if (attribute.dominant) {
         opts.mappedBy = key;
+      } else {
+        opts.inversedBy = key;
       }
 
       break;

--- a/packages/core/content-type-builder/server/services/schema-builder/content-type-builder.js
+++ b/packages/core/content-type-builder/server/services/schema-builder/content-type-builder.js
@@ -286,10 +286,10 @@ const generateRelation = ({ key, attribute, uid, targetAttribute = {} }) => {
     case 'manyToMany': {
       opts.relation = 'manyToMany';
 
-      if (attribute.dominant) {
-        opts.mappedBy = key;
-      } else {
+      if (attribute.dominant === false) {
         opts.inversedBy = key;
+      } else {
+        opts.mappedBy = key;
       }
 
       break;


### PR DESCRIPTION
### What does it do?

Put `inversedBy` only on one side of the many to many relations

### Why is it needed?

`inversedBy` was put in both relation sides whereas it should be `inversedBy` and `mappedBy`.
It was creating 2 join tables 

### How to test it?

Create a many to many relation with the CTB and check the 2 schemas.

### Related issue(s)/PR(s)

Fix #14428
