### PR TITLE
[DEITS] CLI: use --no prefix and fix max-size options

### DIFF
--- a/packages/cli/create-strapi-app/package.json
+++ b/packages/cli/create-strapi-app/package.json
@@ -4,7 +4,7 @@
   "description": "Generate a new Strapi application.",
   "dependencies": {
     "@strapi/generate-new": "4.5.2",
-    "commander": "9.4.1",
+    "commander": "8.2.0",
     "inquirer": "8.2.4"
   },
   "keywords": [

--- a/packages/cli/create-strapi-starter/package.json
+++ b/packages/cli/create-strapi-starter/package.json
@@ -41,7 +41,7 @@
     "@strapi/generate-new": "4.5.2",
     "chalk": "4.1.1",
     "ci-info": "3.5.0",
-    "commander": "9.4.1",
+    "commander": "8.2.0",
     "execa": "5.1.1",
     "fs-extra": "10.0.0",
     "inquirer": "8.2.4",

--- a/packages/core/data-transfer/lib/providers/local-file-destination-provider.ts
+++ b/packages/core/data-transfer/lib/providers/local-file-destination-provider.ts
@@ -181,7 +181,7 @@ class LocalFileDestinationProvider implements IDestinationProvider {
     const entryStream = createTarEntryStream(
       this.#archive.stream,
       filePathFactory,
-      this.options.file.maxSize
+      this.options.file.maxSizeJsonl
     );
 
     return chain([stringer(), entryStream]);
@@ -197,7 +197,7 @@ class LocalFileDestinationProvider implements IDestinationProvider {
     const entryStream = createTarEntryStream(
       this.#archive.stream,
       filePathFactory,
-      this.options.file.maxSize
+      this.options.file.maxSizeJsonl
     );
 
     return chain([stringer(), entryStream]);
@@ -213,7 +213,7 @@ class LocalFileDestinationProvider implements IDestinationProvider {
     const entryStream = createTarEntryStream(
       this.#archive.stream,
       filePathFactory,
-      this.options.file.maxSize
+      this.options.file.maxSizeJsonl
     );
 
     return chain([stringer(), entryStream]);
@@ -229,7 +229,7 @@ class LocalFileDestinationProvider implements IDestinationProvider {
     const entryStream = createTarEntryStream(
       this.#archive.stream,
       filePathFactory,
-      this.options.file.maxSize
+      this.options.file.maxSizeJsonl
     );
 
     return chain([stringer(), entryStream]);

--- a/packages/core/strapi/bin/strapi.js
+++ b/packages/core/strapi/bin/strapi.js
@@ -276,11 +276,21 @@ program
     new Option(
       '--max-size-jsonl <max MB per internal backup file>',
       'split internal jsonl files when exceeding max size in MB'
-    ).default(256)
+    )
+      .argParser(parseFloat)
+      .default(256)
   )
   .addOption(new Option('-f, --file <file>', 'name to use for exported file (without extensions)'))
   .allowExcessArguments(false)
   .hook('preAction', promptEncryptionKey)
+  // validate inputs
+  .hook('preAction', (thisCommand) => {
+    const opts = thisCommand.opts();
+    if (!opts.maxSizeJsonl) {
+      console.error('Invalid max-size-jsonl provided. Must be a number value.');
+      process.exit(1);
+    }
+  })
   .action(getLocalScript('transfer/export'));
 
 // `$ strapi import`

--- a/packages/core/strapi/bin/strapi.js
+++ b/packages/core/strapi/bin/strapi.js
@@ -68,10 +68,10 @@ const getLocalScript =
 
 // option to exclude types of data for the export, import, and transfer commands
 // TODO: validate these inputs. Hopefully here, but worst case it may require adding a hook on each command
-const excludeOption = new Option(
-  '--exclude <data,to,exclude>',
-  'Comma-separated list of data to exclude (files [localMediaFiles, providerMediaFiles], content [entities, links], schema, configuration)' // ['webhooks', 'content', 'localmedia', 'providermedia', 'relations']
-).argParser(parseInputList);
+// const excludeOption = new Option(
+//   '--exclude <data,to,exclude>',
+//   'Comma-separated list of data to exclude (files [localMediaFiles, providerMediaFiles], content [entities, links], schema, configuration)' // ['webhooks', 'content', 'localmedia', 'providermedia', 'relations']
+// ).argParser(parseInputList);
 
 // Initial program setup
 program.storeOptionsAsProperties(false).allowUnknownOption(true);
@@ -289,7 +289,7 @@ program
     )
   )
   .addOption(new Option('-f, --file <file>', 'name to use for exported file (without extensions)'))
-  .addOption(excludeOption)
+  // .addOption(excludeOption)
   .allowExcessArguments(false)
   .hook('preAction', promptEncryptionKey)
   .action(getLocalScript('transfer/export'));
@@ -303,7 +303,7 @@ program
       .choices(['restore', 'abort', 'keep', 'replace'])
       .default('restore')
   )
-  .addOption(excludeOption)
+  // .addOption(excludeOption)
   .addOption(
     new Option(
       '--schemaComparison <schemaComparison>',

--- a/packages/core/strapi/bin/strapi.js
+++ b/packages/core/strapi/bin/strapi.js
@@ -66,13 +66,6 @@ const getLocalScript =
       });
   };
 
-// option to exclude types of data for the export, import, and transfer commands
-// TODO: validate these inputs. Hopefully here, but worst case it may require adding a hook on each command
-// const excludeOption = new Option(
-//   '--exclude <data,to,exclude>',
-//   'Comma-separated list of data to exclude (files [localMediaFiles, providerMediaFiles], content [entities, links], schema, configuration)' // ['webhooks', 'content', 'localmedia', 'providermedia', 'relations']
-// ).argParser(parseInputList);
-
 // Initial program setup
 program.storeOptionsAsProperties(false).allowUnknownOption(true);
 
@@ -289,7 +282,6 @@ program
     )
   )
   .addOption(new Option('-f, --file <file>', 'name to use for exported file (without extensions)'))
-  // .addOption(excludeOption)
   .allowExcessArguments(false)
   .hook('preAction', promptEncryptionKey)
   .action(getLocalScript('transfer/export'));
@@ -303,7 +295,6 @@ program
       .choices(['restore', 'abort', 'keep', 'replace'])
       .default('restore')
   )
-  // .addOption(excludeOption)
   .addOption(
     new Option(
       '--schemaComparison <schemaComparison>',

--- a/packages/core/strapi/bin/strapi.js
+++ b/packages/core/strapi/bin/strapi.js
@@ -273,13 +273,10 @@ program
     new Option('--key <string>', 'Provide encryption key in command instead of using a prompt')
   )
   .addOption(
-    new Option('--max-size <max MB per file>', 'split final file when exceeding size in MB')
-  )
-  .addOption(
     new Option(
       '--max-size-jsonl <max MB per internal backup file>',
       'split internal jsonl files when exceeding max size in MB'
-    )
+    ).default(256)
   )
   .addOption(new Option('-f, --file <file>', 'name to use for exported file (without extensions)'))
   .allowExcessArguments(false)

--- a/packages/core/strapi/bin/strapi.js
+++ b/packages/core/strapi/bin/strapi.js
@@ -15,7 +15,6 @@ const program = new Command();
 const packageJSON = require('../package.json');
 const {
   parseInputList,
-  parseInputBool,
   promptEncryptionKey,
   confirmKeyValue,
 } = require('../lib/commands/utils/commander');
@@ -274,18 +273,9 @@ program
   .command('export')
   .description('Export data from Strapi to file')
   .addOption(
-    new Option(
-      '--encrypt <boolean>',
-      `Encrypt output file using the 'aes-128-ecb' algorithm. Prompts for key unless key option is used.`
-    )
-      .default(true)
-      .argParser(parseInputBool)
+    new Option('--no-encrypt', `Disable 'aes-128-ecb' encryption of the output file`).default(true)
   )
-  .addOption(
-    new Option('--compress <boolean>', 'Compress output file using gzip compression')
-      .default(true)
-      .argParser(parseInputBool)
-  )
+  .addOption(new Option('--no-compress', 'Disable gzip compression of output file').default(true))
   .addOption(
     new Option('--key <string>', 'Provide encryption key in command instead of using a prompt')
   )

--- a/packages/core/strapi/lib/commands/transfer/export.js
+++ b/packages/core/strapi/lib/commands/transfer/export.js
@@ -63,7 +63,6 @@ module.exports = async (opts) => {
   /**
    * To a Strapi backup file
    */
-  // treat any unknown arguments as filenames
   const maxSize = _.isFinite(_.toNumber(opts.maxSize))
     ? _.toNumber(opts.maxSize) * BYTES_IN_MB
     : undefined;

--- a/packages/core/strapi/lib/commands/transfer/export.js
+++ b/packages/core/strapi/lib/commands/transfer/export.js
@@ -64,13 +64,19 @@ module.exports = async (opts) => {
    * To a Strapi backup file
    */
   // treat any unknown arguments as filenames
+  const maxSize = _.isFinite(_.toNumber(opts.maxSize))
+    ? _.toNumber(opts.maxSize) * BYTES_IN_MB
+    : undefined;
+
+  const maxSizeJsonl = _.isFinite(_.toNumber(opts.maxSizeJsonl))
+    ? _.toNumber(opts.maxSizeJsonl) * BYTES_IN_MB
+    : undefined;
+
   const destinationOptions = {
     file: {
       path: file,
-      maxSize: _.isFinite(opts.maxSize) ? Math.floor(opts.maxSize) * BYTES_IN_MB : undefined,
-      maxSizeJsonl: _.isFinite(opts.maxSizeJsonl)
-        ? Math.floor(opts.maxSizeJsonl) * BYTES_IN_MB
-        : undefined,
+      maxSize,
+      maxSizeJsonl,
     },
     encryption: {
       enabled: opts.encrypt,

--- a/packages/core/strapi/lib/commands/transfer/import.js
+++ b/packages/core/strapi/lib/commands/transfer/import.js
@@ -23,8 +23,6 @@ module.exports = async (opts) => {
   /**
    * From strapi backup file
    */
-
-  // treat any unknown arguments as filenames
   const sourceOptions = {
     backupFilePath: filename,
   };

--- a/packages/core/strapi/lib/commands/utils/commander.js
+++ b/packages/core/strapi/lib/commands/utils/commander.js
@@ -1,19 +1,6 @@
 'use strict';
 
-const { parseType } = require('@strapi/utils/lib');
 const inquirer = require('inquirer');
-
-/**
- * argsParser: Parse a string argument from the command line as a boolean
- */
-const parseInputBool = (arg) => {
-  try {
-    return parseType({ type: 'boolean', value: arg });
-  } catch (e) {
-    console.error(e.message);
-    process.exit(1);
-  }
-};
 
 /**
  * argsParser: Parse a comma-delimited string as an array
@@ -86,7 +73,6 @@ const confirmKeyValue = (key, value, message) => {
 
 module.exports = {
   parseInputList,
-  parseInputBool,
   promptEncryptionKey,
   confirmKeyValue,
 };

--- a/packages/core/strapi/lib/commands/utils/commander.js
+++ b/packages/core/strapi/lib/commands/utils/commander.js
@@ -10,7 +10,7 @@ const parseInputList = (value) => {
 };
 
 /**
- * hook: if encrpyt=true and key not provided, prompt for it
+ * hook: if encrypt==true and key not provided, prompt for it
  */
 const promptEncryptionKey = async (thisCommand) => {
   const opts = thisCommand.opts();
@@ -20,7 +20,7 @@ const promptEncryptionKey = async (thisCommand) => {
     process.exit(1);
   }
 
-  // if encrypt is set but we have no key, prompt for it
+  // if encrypt==true but we have no key, prompt for it
   if (opts.encrypt && !(opts.key && opts.key.length > 0)) {
     try {
       const answers = await inquirer.prompt([

--- a/packages/core/strapi/package.json
+++ b/packages/core/strapi/package.json
@@ -99,7 +99,7 @@
     "chokidar": "3.5.2",
     "ci-info": "3.5.0",
     "cli-table3": "0.6.2",
-    "commander": "9.4.1",
+    "commander": "8.2.0",
     "configstore": "5.0.1",
     "debug": "4.3.2",
     "delegates": "1.0.0",


### PR DESCRIPTION
### What does it do?

Replace `--encrypt <bool>` and `--compress <bool>` with `--no-encrypt` and `--no-compress`

Remove `--max-size` option for now because it hasn't been implemented yet

Allows `--max-size-jsonl` to accept a decimal value

### Why is it needed?

None of the other Strapi CLI commands use booleans, they all use default values that can be turned off with a `--no-` prefixed option.

### How to test it?

`yarn strapi export --no-compress` should now disable the compression (and `yarn strapi export --compress false` should give an error because it no longer exists as an option)

 `yarn strapi export --no-encrypt` disables the key prompt and the encryption (and `yarn strapi export --encrypt false` should give an error because it no longer exists as an option)

 `yarn strapi export --no-encrypt --key some_string` should still give an error about key only working when encryption is enabled.

 `yarn strapi export --key some_string` should work

`yarn strapi export --no-encrypt --max-size-jsonl 0.1` should split the internal files down to max 100kb (more or less)
