### PR TITLE
[DEITS] Use max size jsonl instead of max size for the file destination provider

### DIFF
--- a/packages/core/data-transfer/lib/providers/local-file-destination-provider.ts
+++ b/packages/core/data-transfer/lib/providers/local-file-destination-provider.ts
@@ -181,7 +181,7 @@ class LocalFileDestinationProvider implements IDestinationProvider {
     const entryStream = createTarEntryStream(
       this.#archive.stream,
       filePathFactory,
-      this.options.file.maxSize
+      this.options.file.maxSizeJsonl
     );
 
     return chain([stringer(), entryStream]);
@@ -197,7 +197,7 @@ class LocalFileDestinationProvider implements IDestinationProvider {
     const entryStream = createTarEntryStream(
       this.#archive.stream,
       filePathFactory,
-      this.options.file.maxSize
+      this.options.file.maxSizeJsonl
     );
 
     return chain([stringer(), entryStream]);
@@ -213,7 +213,7 @@ class LocalFileDestinationProvider implements IDestinationProvider {
     const entryStream = createTarEntryStream(
       this.#archive.stream,
       filePathFactory,
-      this.options.file.maxSize
+      this.options.file.maxSizeJsonl
     );
 
     return chain([stringer(), entryStream]);
@@ -229,7 +229,7 @@ class LocalFileDestinationProvider implements IDestinationProvider {
     const entryStream = createTarEntryStream(
       this.#archive.stream,
       filePathFactory,
-      this.options.file.maxSize
+      this.options.file.maxSizeJsonl
     );
 
     return chain([stringer(), entryStream]);


### PR DESCRIPTION
### What does it do?

Use max size jsonl instead of max size for the file destination provider

### Why is it needed?

Being able to use the max size jsonl option correctly

### How to test it?

Run `yarn strapi export --max-size-jsonl=1` in an app that have more than 1MB of entities, configuration or links

