### PR TITLE
Use commander to 8.2.0 everywhere

### DIFF
--- a/packages/cli/create-strapi-app/package.json
+++ b/packages/cli/create-strapi-app/package.json
@@ -4,7 +4,7 @@
   "description": "Generate a new Strapi application.",
   "dependencies": {
     "@strapi/generate-new": "4.5.2",
-    "commander": "7.2.0",
+    "commander": "8.2.0",
     "inquirer": "8.2.4"
   },
   "keywords": [

--- a/packages/cli/create-strapi-starter/package.json
+++ b/packages/cli/create-strapi-starter/package.json
@@ -41,7 +41,7 @@
     "@strapi/generate-new": "4.5.2",
     "chalk": "4.1.1",
     "ci-info": "3.5.0",
-    "commander": "7.2.0",
+    "commander": "8.2.0",
     "execa": "5.1.1",
     "fs-extra": "10.0.0",
     "inquirer": "8.2.4",

--- a/packages/core/strapi/package.json
+++ b/packages/core/strapi/package.json
@@ -98,7 +98,7 @@
     "chokidar": "3.5.2",
     "ci-info": "3.5.0",
     "cli-table3": "0.6.2",
-    "commander": "7.2.0",
+    "commander": "8.2.0",
     "configstore": "5.0.1",
     "debug": "4.3.2",
     "delegates": "1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9403,10 +9403,10 @@ comma-separated-tokens@^1.0.0:
   resolved "https://registry.yarnpkg.com/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz#632b80b6117867a158f1080ad498b2fbe7e3f5ea"
   integrity sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==
 
-commander@7.2.0, commander@^7.0.0, commander@^7.2.0:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-7.2.0.tgz#a36cb57d0b501ce108e4d20559a150a391d97ab7"
-  integrity sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==
+commander@8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-8.2.0.tgz#37fe2bde301d87d47a53adeff8b5915db1381ca8"
+  integrity sha512-LLKxDvHeL91/8MIyTAD5BFMNtoIwztGPMiM/7Bl8rIPmHCZXRxmSWr91h57dpOpnQ6jIUqEWdXE/uBYMfiVZDA==
 
 commander@^2.19.0, commander@^2.20.0, commander@^2.20.3:
   version "2.20.3"
@@ -9422,6 +9422,11 @@ commander@^6.2.1:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.1.tgz#0792eb682dfbc325999bb2b84fddddba110ac73c"
   integrity sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==
+
+commander@^7.0.0, commander@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-7.2.0.tgz#a36cb57d0b501ce108e4d20559a150a391d97ab7"
+  integrity sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==
 
 commander@^8.3.0:
   version "8.3.0"


### PR DESCRIPTION
### What does it do?

Sets the version of `commmander` package to `8.2.0` everywhere it's used.

### Why is it needed?

1) A [commit by dependabot](https://github.com/strapi/strapi/commit/c16f5b9ebb45eed7fa3d6da50b218309bc0f3205) incorrectly downgraded the strapi CLI to 7.2.0 from 8.2.0 and this reverts that change
2) Use the same version of commander everywhere to reduce complexity and size of dependencies 

### How to test it?

`create-strapi-app`
Updated from 6.1.0(previous)/7.2.0(bot last week) -> 8.2.0, and should work as before.

`create-strapi-project`
Updated from 7.1.0(previous)/7.2.0(bot last week) -> 8.2.0, and should work as before.

`strapi` command should work the same as it did last week, since 8.2.0 is the version it was previously using before the bot downgraded it.

### Breaking changes

[Commander Changelog](https://github.com/tj/commander.js/blob/master/CHANGELOG.md)

There are no breaking changes in methods used by our CLI from the commander changelog between 7.1.0 and 8.2.0. There may be some issues between 6.1.0 and 8.2.0 but I've tested that `create-strapi-app` still seems to work fine.

However, there are very likely some minor text output changes internal to commander that could affect text matching in CI systems that use our CLI commands.

For the `strapi` command, those breaking changes _already happened_ when the bot downgraded the package and this PR aims to revert it back to how it was working before.

For the other commands, we need to discuss if it's an issue, and if so I can split them off into a separate PR.

### Related issue(s)/PR(s)

Bad dependabot commit: c16f5b9ebb45eed7fa3d6da50b218309bc0f3205

[PR that would allow us to more easily test in the future to ensure command output does not change between versions
](https://github.com/strapi/strapi/pull/14637)