### PR TITLE
feat: added authLogo setting

### DIFF
--- a/packages/core/admin/server/controllers/__tests__/admin.test.js
+++ b/packages/core/admin/server/controllers/__tests__/admin.test.js
@@ -32,7 +32,7 @@ describe('Admin Controller', () => {
               exists: jest.fn(() => true),
             },
             'project-settings': {
-              getProjectSettings: jest.fn(() => ({ menuLogo: null })),
+              getProjectSettings: jest.fn(() => ({ menuLogo: null, authLogo: null })),
             },
           },
         },
@@ -53,6 +53,7 @@ describe('Admin Controller', () => {
         uuid: 'foo',
         hasAdmin: true,
         menuLogo: null,
+        authLogo: null,
       });
     });
   });

--- a/packages/core/admin/server/controllers/admin.js
+++ b/packages/core/admin/server/controllers/admin.js
@@ -46,7 +46,7 @@ module.exports = {
   async init() {
     let uuid = strapi.config.get('uuid', false);
     const hasAdmin = await getService('user').exists();
-    const { menuLogo } = await getService('project-settings').getProjectSettings();
+    const { menuLogo, authLogo } = await getService('project-settings').getProjectSettings();
     // set to null if telemetryDisabled flag not avaialble in package.json
     const telemetryDisabled = strapi.config.get('packageJsonStrapi.telemetryDisabled', null);
 
@@ -59,6 +59,7 @@ module.exports = {
         uuid,
         hasAdmin,
         menuLogo: menuLogo ? menuLogo.url : null,
+        authLogo: authLogo ? authLogo.url : null,
       },
     };
   },

--- a/packages/core/admin/server/services/__tests__/project-settings.test.js
+++ b/packages/core/admin/server/services/__tests__/project-settings.test.js
@@ -58,6 +58,15 @@ global.strapi = {
         size: 123,
         provider: 'local',
       },
+      authLogo: {
+        name: 'name',
+        url: 'file/url',
+        width: 100,
+        height: 100,
+        ext: 'png',
+        size: 123,
+        provider: 'local',
+      },
     }),
     set: storeSet,
   }),
@@ -75,10 +84,30 @@ describe('Project setting', () => {
           name: 'file.png',
           type: 'image/png',
         },
+        authLogo: {
+          size: 123,
+          path: '/tmp/filename_123',
+          name: 'file.png',
+          type: 'image/png',
+        },
       };
 
       const expectedOutput = {
         menuLogo: {
+          name: 'filename.png',
+          alternativeText: null,
+          caption: null,
+          hash: 'filename_123',
+          ext: '.png',
+          mime: 'image/png',
+          provider: 'local',
+          size: 123,
+          stream: null,
+          width: 100,
+          height: 100,
+          tmpPath: '/tmp/filename_123',
+        },
+        authLogo: {
           name: 'filename.png',
           alternativeText: null,
           caption: null,
@@ -121,6 +150,14 @@ describe('Project setting', () => {
           ext: 'png',
           size: 123,
         },
+        authLogo: {
+          name: 'name',
+          url: 'file/url',
+          width: 100,
+          height: 100,
+          ext: 'png',
+          size: 123,
+        },
       };
 
       expect(projectSettings).toStrictEqual(expectedOutput);
@@ -131,10 +168,17 @@ describe('Project setting', () => {
     it('Does not delete when there was no previous file', async () => {
       const previousSettings = {
         menuLogo: null,
+        authLogo: null,
       };
 
       const newSettings = {
         menuLogo: {
+          size: 24085,
+          name: 'file.png',
+          type: 'image/png',
+          url: 'file/url',
+        },
+        authLogo: {
           size: 24085,
           name: 'file.png',
           type: 'image/png',
@@ -150,6 +194,13 @@ describe('Project setting', () => {
     it('Does not delete when there is no new file uploaded', async () => {
       const previousSettings = {
         menuLogo: {
+          size: 24085,
+          name: 'file.png',
+          type: 'image/png',
+          provider: 'local',
+          url: 'file/url',
+        },
+        authLogo: {
           size: 24085,
           name: 'file.png',
           type: 'image/png',
@@ -174,18 +225,33 @@ describe('Project setting', () => {
           provider: 'local',
           url: 'file/url',
         },
+        authLogo: {
+          size: 24085,
+          name: 'file.png',
+          type: 'image/png',
+          provider: 'local',
+          url: 'file/url',
+        },
       };
 
-      const newSettings = { menuLogo: null };
+      const newSettings = { menuLogo: null, authLogo: null };
 
       await deleteOldFiles({ previousSettings, newSettings });
 
-      expect(providerDelete).toBeCalledTimes(1);
+      expect(providerDelete).toBeCalledTimes(2);
     });
 
     it('Deletes when new files are uploaded', async () => {
       const previousSettings = {
         menuLogo: {
+          size: 24085,
+          name: 'file.png',
+          type: 'image/png',
+          provider: 'local',
+          url: 'file/url',
+          hash: '123',
+        },
+        authLogo: {
           size: 24085,
           name: 'file.png',
           type: 'image/png',
@@ -200,11 +266,15 @@ describe('Project setting', () => {
           ...previousSettings.menuLogo,
           hash: '456',
         },
+        authLogo: {
+          ...previousSettings.menuLogo,
+          hash: '456',
+        },
       };
 
       await deleteOldFiles({ previousSettings, newSettings });
 
-      expect(providerDelete).toBeCalledTimes(1);
+      expect(providerDelete).toBeCalledTimes(2);
     });
   });
 
@@ -213,6 +283,20 @@ describe('Project setting', () => {
       const body = {};
       const files = {
         menuLogo: {
+          name: 'filename.png',
+          alternativeText: null,
+          caption: null,
+          hash: 'filename_123',
+          ext: '.png',
+          mime: 'image/png',
+          size: 123,
+          stream: null,
+          width: 100,
+          height: 100,
+          tmpPath: '/tmp/filename_123',
+          url: '/uploads/filename_123.png',
+        },
+        authLogo: {
           name: 'filename.png',
           alternativeText: null,
           caption: null,
@@ -238,6 +322,15 @@ describe('Project setting', () => {
           ext: '.png',
           size: 123,
         },
+        authLogo: {
+          name: 'filename.png',
+          hash: 'filename_123',
+          url: '/uploads/filename_123.png',
+          width: 100,
+          height: 100,
+          ext: '.png',
+          size: 123,
+        },
       };
 
       await updateProjectSettings({ ...body, ...files });
@@ -250,11 +343,12 @@ describe('Project setting', () => {
     });
 
     it('Updates the project settings (delete)', async () => {
-      const body = { menuLogo: '' };
+      const body = { menuLogo: '', authLogo: '' };
       const files = {};
 
       const expectedOutput = {
         menuLogo: null,
+        authLogo: null,
       };
 
       await updateProjectSettings({ ...body, ...files });
@@ -272,6 +366,15 @@ describe('Project setting', () => {
 
       const expectedOutput = {
         menuLogo: {
+          name: 'name',
+          url: 'file/url',
+          width: 100,
+          height: 100,
+          ext: 'png',
+          size: 123,
+          provider: 'local',
+        },
+        authLogo: {
           name: 'name',
           url: 'file/url',
           width: 100,

--- a/packages/core/admin/server/services/project-settings.js
+++ b/packages/core/admin/server/services/project-settings.js
@@ -3,10 +3,7 @@
 const fs = require('fs');
 const { pick } = require('lodash');
 
-const PROJECT_SETTINGS_FILE_INPUTS = ['menuLogo'];
-const DEFAULT_PROJECT_SETTINGS = {
-  menuLogo: null,
-};
+const PROJECT_SETTINGS_FILE_INPUTS = ['menuLogo', 'authLogo'];
 
 const parseFilesData = async (files) => {
   const formatedFilesData = {};
@@ -52,8 +49,15 @@ const parseFilesData = async (files) => {
 
 const getProjectSettings = async () => {
   const store = strapi.store({ type: 'core', name: 'admin' });
+
+  // Returns an object with file inputs names as key and null as value
+  const defaultProjectSettings = PROJECT_SETTINGS_FILE_INPUTS.reduce((prev, cur) => {
+    prev[cur] = null;
+    return prev;
+  }, {});
+
   const projectSettings = {
-    ...DEFAULT_PROJECT_SETTINGS,
+    ...defaultProjectSettings,
     ...(await store.get({ key: 'project-settings' })),
   };
 

--- a/packages/core/admin/server/services/project-settings.js
+++ b/packages/core/admin/server/services/project-settings.js
@@ -137,7 +137,7 @@ const updateProjectSettings = async (newSettings) => {
     }
 
     // If the user input is undefined reuse previous setting (do not update field)
-    if (!newSettings[inputName]) {
+    if (!newSettings[inputName] && previousSettings) {
       newSettings[inputName] = previousSettings[inputName];
       return;
     }

--- a/packages/core/admin/server/validation/project-settings.js
+++ b/packages/core/admin/server/validation/project-settings.js
@@ -10,25 +10,34 @@ const ALLOWED_IMAGE_FILE_TYPES = ['image/jpeg', 'image/png', 'image/svg+xml'];
 const updateProjectSettings = yup
   .object({
     menuLogo: yup.string(),
+    authLogo: yup.string(),
   })
   .noUnknown();
+
+const updateProjectSettingsLogo = yup.object({
+  name: yup.string(),
+  type: yup.string().oneOf(ALLOWED_IMAGE_FILE_TYPES),
+  size: yup.number().max(MAX_IMAGE_FILE_SIZE),
+});
 
 const updateProjectSettingsFiles = yup
   .object({
-    menuLogo: yup.object({
-      name: yup.string(),
-      type: yup.string().oneOf(ALLOWED_IMAGE_FILE_TYPES),
-      size: yup.number().max(MAX_IMAGE_FILE_SIZE),
-    }),
+    menuLogo: updateProjectSettingsLogo,
+    authLogo: updateProjectSettingsLogo,
   })
   .noUnknown();
 
-const updateProjectSettingsImagesDimensions = yup.object({
-  menuLogo: yup.object({
-    width: yup.number().max(MAX_IMAGE_WIDTH),
-    height: yup.number().max(MAX_IMAGE_HEIGHT),
-  }),
+const logoDimensions = yup.object({
+  width: yup.number().max(MAX_IMAGE_WIDTH),
+  height: yup.number().max(MAX_IMAGE_HEIGHT),
 });
+
+const updateProjectSettingsImagesDimensions = yup
+  .object({
+    menuLogo: logoDimensions,
+    authLogo: logoDimensions,
+  })
+  .noUnknown();
 
 module.exports = {
   validateUpdateProjectSettings: validateYupSchemaSync(updateProjectSettings),


### PR DESCRIPTION
### What does it do?

It adds a setting for `authLogo` (back-end)

### Why is it needed?

It's needed to allow uploading and setting a custom auth logo like it's done currently for the menu logo

### How to test it?

The easiest way to test is to start the backend from this branch, start the fronetend from the `authLogo/frontend` branch, and test the auth logo customization feature.
