### PR TITLE
fix: wrong editor focus checking method

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/Wysiwyg/Editor.js
+++ b/packages/core/admin/admin/src/content-manager/components/Wysiwyg/Editor.js
@@ -43,7 +43,7 @@ const Editor = ({
   }, [editorRef, textareaRef, name, placeholder]);
 
   useEffect(() => {
-    if (value && !editorRef.current.state.focused) {
+    if (value && !editorRef.current.hasFocus()) {
       editorRef.current.setValue(value);
     }
   }, [editorRef, value]);


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Use `editorRef.current.hasFocus()` instead of `editorRef.current.state.focused` for checking focus state in `Editor`

### Why is it needed?

`editorRef.current.state.focused` didn't work well in https://github.com/strapi/strapi/issues/14967 case, so it caused `editorRef.current.setValue(value);` this call move the pointer to the start.

### How to test it?

Follow the steps described in https://github.com/strapi/strapi/issues/14967 but the issue doesn't happen in this PR

### Related issue(s)/PR(s)

Fixes https://github.com/strapi/strapi/issues/14967

## Demo

https://user-images.githubusercontent.com/45232708/205022873-acf95a3c-b2ee-4dca-a671-d4fab188b96b.mov
