### PR TITLE
[DEITS] fix tests that are creating output files

### DIFF
--- a/packages/core/data-transfer/lib/providers/local-file-destination-provider/__tests__/index.test.ts
+++ b/packages/core/data-transfer/lib/providers/local-file-destination-provider/__tests__/index.test.ts
@@ -1,18 +1,27 @@
+/* eslint-disable import/first */
 import stream from 'stream';
 
-import { createLocalFileDestinationProvider, ILocalFileDestinationProviderOptions } from '../';
+jest.mock('fs');
+
+import fs from 'fs-extra';
+import { Writable } from 'stream-chain';
+import { createLocalFileDestinationProvider, ILocalFileDestinationProviderOptions } from '..';
 import * as encryption from '../../../encryption/encrypt';
-import {
-  createFilePathFactory,
-  createTarEntryStream,
-} from '../../local-file-destination-provider/utils';
+import { createFilePathFactory, createTarEntryStream } from '../utils';
+
+fs.createWriteStream = jest.fn().mockReturnValue(
+  new Writable({
+    objectMode: true,
+    write() {},
+  })
+);
 
 const filePath = './test-file';
 
 jest.mock('../../../encryption/encrypt', () => {
   return {
     __esModule: true,
-    createEncryptionCipher: (key: string) => {},
+    createEncryptionCipher(key: string) {},
   };
 });
 


### PR DESCRIPTION
### What does it do?

Tests file now mocks 'fs-extra' so that the tests don't actually write a file

### Why is it needed?

Currently our tests are writing an output file

### How to test it?

Run unit tests and they should pass without writing any files to disk

