### PR TITLE
feat(documentation): download open api doc

### DIFF
--- a/packages/plugins/documentation/admin/src/pages/PluginPage/index.js
+++ b/packages/plugins/documentation/admin/src/pages/PluginPage/index.js
@@ -27,7 +27,9 @@ import { Table, Tr, Thead, Th, Tbody, Td } from '@strapi/design-system/Table';
 import Trash from '@strapi/icons/Trash';
 import Show from '@strapi/icons/Eye';
 import Reload from '@strapi/icons/Refresh';
+import Download from '@strapi/icons/Download';
 
+import { downloadFile } from '@strapi/plugin-upload/admin/src/utils/downloadFile';
 import permissions from '../../permissions';
 import { getTrad } from '../../utils';
 import openWithNewTab from '../../utils/openWithNewTab';
@@ -47,6 +49,13 @@ const PluginPage = () => {
   const openDocVersion = () => {
     const slash = data?.prefix.startsWith('/') ? '' : '/';
     openWithNewTab(`${slash}${data?.prefix}/v${data?.currentVersion}`);
+  };
+
+  const downloadDocVersion = async () => {
+    const slash = data?.prefix.startsWith('/') ? '' : '/';
+    const url = `${strapi.backendURL}${slash}${data?.prefix}/v${data?.currentVersion}/download`;
+
+    return downloadFile(url, 'openapi_documentation_strapi.json');
   };
 
   const handleRegenerateDoc = (version) => {
@@ -133,6 +142,20 @@ const PluginPage = () => {
                       </Td>
                       <Td>
                         <Flex justifyContent="end" {...stopPropagation}>
+                          <CheckPermissions permissions={permissions.open}>
+                            <IconButton
+                              onClick={downloadDocVersion}
+                              noBorder
+                              icon={<Download />}
+                              label={formatMessage(
+                                {
+                                  id: getTrad('pages.PluginPage.table.icon.download'),
+                                  defaultMessage: 'Download OpenAPI Documentation',
+                                },
+                                { target: doc.version }
+                              )}
+                            />
+                          </CheckPermissions>
                           <IconButton
                             onClick={openDocVersion}
                             noBorder

--- a/packages/plugins/documentation/admin/src/translations/en.json
+++ b/packages/plugins/documentation/admin/src/translations/en.json
@@ -28,6 +28,7 @@
   "pages.PluginPage.table.generated": "Last generated",
   "pages.PluginPage.table.icon.regenerate": "Regenerate {target}",
   "pages.PluginPage.table.icon.show": "Open {target}",
+  "pages.PluginPage.table.icon.download": "Download {target}",
   "pages.PluginPage.table.version": "Version",
   "pages.SettingsPage.Button.description": "Configure the documentation plugin",
   "pages.SettingsPage.header.save": "Save",

--- a/packages/plugins/documentation/admin/src/translations/fr.json
+++ b/packages/plugins/documentation/admin/src/translations/fr.json
@@ -20,6 +20,7 @@
   "error.regenerateDoc": "Une erreur est survenue en recréant la documentation",
   "error.regenerateDoc.versionMissing": "La version que vous essayez de créer n'existe pas.",
   "notification.update.success": "Vos paramètres ont été enregistrés",
+  "pages.PluginPage.table.icon.download": "Télécharger {target}",
   "plugin.description.long": "Créez un document OpenAPI et visualisez votre API avec SWAGGER UI.",
   "plugin.description.short": "Créez un document OpenAPI et visualisez votre API avec SWAGGER UI.",
   "plugin.name": "Documentation"

--- a/packages/plugins/documentation/server/routes/index.js
+++ b/packages/plugins/documentation/server/routes/index.js
@@ -48,6 +48,15 @@ module.exports = [
     },
   },
   {
+    method: 'GET',
+    path: '/v:major(\\d+).:minor(\\d+).:patch(\\d+)/download',
+    handler: 'documentation.download',
+    config: {
+      auth: false,
+      middlewares: [restrictAccess],
+    },
+  },
+  {
     method: 'POST',
     path: '/regenerateDoc',
     handler: 'documentation.regenerateDoc',


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Add the possibility to download the open api documentation.

- 1 new endpoint to download the spec
- Adding a button in the documentation plugin page to download the spec

![image](https://user-images.githubusercontent.com/3313498/205266965-d89f0847-f451-4769-9420-7dfd8ddbe257.png)

As we can have password to be able to see the documentation, the download button wont work if a password is set on the documentation.
I haven't find a way to hide the download button when we have password activated.

### Why is it needed?

It is important to be able to download the Open API spec as it can be imported in tools such as Postman.
The documentation is already generated and sent to the Admin Panel through the swagger-ui.

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
