### PR TITLE
Reads parsed options using program.opts() in create-strapi-app.

### DIFF
--- a/packages/cli/create-strapi-app/create-strapi-app.js
+++ b/packages/cli/create-strapi-app/create-strapi-app.js
@@ -66,14 +66,16 @@ async function initProject(projectName, program) {
     .reduce((acc, { short, long }) => [...acc, short, long], [])
     .filter(Boolean);
 
-  if (program.template && programFlags.includes(program.template)) {
-    console.error(`${program.template} is not a valid template`);
+  const options = program.opts();
+
+  if (options.template && programFlags.includes(options.template)) {
+    console.error(`${options.template} is not a valid template`);
     process.exit(1);
   }
 
-  const hasDatabaseOptions = databaseOptions.some((opt) => program[opt]);
+  const hasDatabaseOptions = databaseOptions.some((opt) => options[opt]);
 
-  if (program.quickstart && hasDatabaseOptions) {
+  if (options.quickstart && hasDatabaseOptions) {
     console.error(
       `The quickstart option is incompatible with the following options: ${databaseOptions.join(
         ', '
@@ -83,25 +85,25 @@ async function initProject(projectName, program) {
   }
 
   if (hasDatabaseOptions) {
-    program.quickstart = false; // Will disable the quickstart question because != 'undefined'
+    options.quickstart = false; // Will disable the quickstart question because != 'undefined'
   }
 
-  if (program.quickstart) {
-    return generateApp(projectName, program);
+  if (options.quickstart) {
+    return generateApp(projectName, options);
   }
 
-  const prompt = await promptUser(projectName, program, hasDatabaseOptions);
+  const prompt = await promptUser(projectName, options, hasDatabaseOptions);
   const directory = prompt.directory || projectName;
   await checkInstallPath(resolve(directory));
 
-  const options = {
-    template: program.template,
-    quickstart: prompt.quick || program.quickstart,
+  const generateOptions = {
+    template: options.template,
+    quickstart: prompt.quick || options.quickstart,
   };
 
   const generateStrapiAppOptions = {
-    ...program,
     ...options,
+    ...generateOptions,
   };
 
   return generateApp(directory, generateStrapiAppOptions);

--- a/packages/cli/create-strapi-app/utils/prompt-user.js
+++ b/packages/cli/create-strapi-app/utils/prompt-user.js
@@ -4,20 +4,22 @@ const inquirer = require('inquirer');
 
 /**
  * @param {string|null} projectName - The name/path of project
- * @param {string|null} template - The Github repo of the template
+ * @param {object} options - Parsed CLI options
+ * @param {boolean} hasDatabaseOptions - Whether database options has been passed via CLI options
  * @returns Object containting prompt answers
  */
-module.exports = async function promptUser(projectName, program, hasDatabaseOptions) {
-  const questions = await getPromptQuestions(projectName, program, hasDatabaseOptions);
+module.exports = async function promptUser(projectName, options, hasDatabaseOptions) {
+  const questions = await getPromptQuestions(projectName, options, hasDatabaseOptions);
   return inquirer.prompt(questions);
 };
 
 /**
  * @param {string|null} projectName - The name of the project
- * @param {string|null} template - The template the project should use
+ * @param {object} options - Prased CLI options
+ * @param {boolean} hasDatabaseOptions - Whether database options has been passed via CLI options
  * @returns Array of prompt question objects
  */
-async function getPromptQuestions(projectName, program, hasDatabaseOptions) {
+async function getPromptQuestions(projectName, options, hasDatabaseOptions) {
   return [
     {
       type: 'input',
@@ -30,7 +32,7 @@ async function getPromptQuestions(projectName, program, hasDatabaseOptions) {
       type: 'list',
       name: 'quick',
       message: 'Choose your installation type',
-      when: !program.quickstart && !hasDatabaseOptions,
+      when: !options.quickstart && !hasDatabaseOptions,
       choices: [
         {
           name: 'Quickstart (recommended)',


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Fixes reading options passed to `create-strapi-app` command via CLI.

`create-strapi-app` is using [commander](https://github.com/tj/commander.js)@`v8.2.0` to handle CLI operations. Breaking change was introduced in `v7.0.0` where options are no longer present as properties on command instance - [see related CHANGELOG entry](https://github.com/tj/commander.js/blob/master/CHANGELOG.md#changed-8). Users should read parsed options by using `program.opts()`. This is exactly what I'm trying to fix.

### Why is it needed?

Currently options are not read correctly which is causing bad DX.

Examples:
* Setting `--quickstart` option still prompts user for installation type.
* Setting `--template` is being ignored resulting in "basic" Strapi application being generated without merging it with selected template.

### How to test it?

Testing would be pretty straightforward, just use `--quickstart` or `--template` options and check whether they're not being ignore.

### Related issue(s)/PR(s)

Most likely fixes recently reported #14970
