### PR TITLE
[CustomInputs]: add global cache to useLazyComponents

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/NonRepeatableComponent/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/NonRepeatableComponent/index.js
@@ -9,6 +9,7 @@ import { Stack } from '@strapi/design-system/Stack';
 import { useContentTypeLayout } from '../../hooks';
 import FieldComponent from '../FieldComponent';
 import Inputs from '../Inputs';
+import useLazyComponents from '../../hooks/useLazyComponents';
 
 const NonRepeatableComponent = ({ componentUid, isFromDynamicZone, isNested, name }) => {
   const { getComponentLayout } = useContentTypeLayout();
@@ -17,6 +18,8 @@ const NonRepeatableComponent = ({ componentUid, isFromDynamicZone, isNested, nam
     [componentUid, getComponentLayout]
   );
   const fields = componentLayoutData.layouts.edit;
+
+  const { lazyComponentStore } = useLazyComponents();
 
   return (
     <Box
@@ -67,6 +70,7 @@ const NonRepeatableComponent = ({ componentUid, isFromDynamicZone, isNested, nam
                       metadatas={metadatas}
                       queryInfos={queryInfos}
                       size={size}
+                      customFieldInputs={lazyComponentStore}
                     />
                   </GridItem>
                 );

--- a/packages/core/admin/admin/src/content-manager/components/RepeatableComponent/DraggedItem/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/RepeatableComponent/DraggedItem/index.js
@@ -21,6 +21,7 @@ import Preview from './Preview';
 import DraggingSibling from './DraggingSibling';
 import { CustomIconButton } from './IconButtonCustoms';
 import { connect, select } from './utils';
+import useLazyComponents from '../../../hooks/useLazyComponents';
 
 const DragButton = styled.span`
   display: flex;
@@ -177,6 +178,8 @@ const DraggedItem = ({
   const accordionTitle = toString(displayedValue);
   const accordionHasError = hasErrors ? 'error' : undefined;
 
+  const { lazyComponentStore } = useLazyComponents();
+
   return (
     <Box ref={refs ? refs.dropRef : null}>
       {isDragging && <Preview />}
@@ -273,6 +276,7 @@ const DraggedItem = ({
                             // onBlur={hasErrors ? checkFormErrors : null}
                             queryInfos={queryInfos}
                             size={size}
+                            customFieldInputs={lazyComponentStore}
                           />
                         </GridItem>
                       );

--- a/packages/core/admin/admin/src/content-manager/hooks/useLazyComponents/index.js
+++ b/packages/core/admin/admin/src/content-manager/hooks/useLazyComponents/index.js
@@ -10,24 +10,14 @@ const componentStore = new Map();
  * @returns object
  */
 const useLazyComponents = (componentUids = []) => {
-  const [lazyComponentStore, setLazyComponentStore] = useState({});
-  const [loading, setLoading] = useState(true);
+  const [lazyComponentStore, setLazyComponentStore] = useState(Object.fromEntries(componentStore));
+  const [loading, setLoading] = useState(componentStore.size === 0);
   const customFieldsRegistry = useCustomFields();
 
   useEffect(() => {
     const setStore = (store) => {
       setLazyComponentStore(store);
       setLoading(false);
-    };
-
-    const populateStoreWithCache = () => {
-      const internalStore = {};
-
-      componentStore.forEach((comp, uid) => {
-        internalStore[uid] = comp;
-      });
-
-      setStore(internalStore);
     };
 
     const lazyLoadComponents = async (uids, components) => {
@@ -43,7 +33,7 @@ const useLazyComponents = (componentUids = []) => {
       setStore(internalStore);
     };
 
-    if (componentUids.length) {
+    if (componentUids.length && loading) {
       /**
        * These uids are not in the component store therefore we need to get the components
        */
@@ -58,10 +48,9 @@ const useLazyComponents = (componentUids = []) => {
       if (componentPromises.length > 0) {
         lazyLoadComponents(newUids, componentPromises);
       } else {
-        populateStoreWithCache();
+        const store = Object.fromEntries(componentStore);
+        setStore(store);
       }
-    } else if (loading) {
-      populateStoreWithCache();
     }
   }, [componentUids, customFieldsRegistry, loading]);
 

--- a/packages/core/admin/admin/src/content-manager/hooks/useLazyComponents/index.js
+++ b/packages/core/admin/admin/src/content-manager/hooks/useLazyComponents/index.js
@@ -1,42 +1,69 @@
 import { useEffect, useState } from 'react';
 import { useCustomFields } from '@strapi/helper-plugin';
 
+const componentStore = new Map();
+
 /**
  * @description
  * A hook to lazy load custom field components
  * @param {Array.<string>} componentUids - The uids to look up components
  * @returns object
  */
-const useLazyComponents = (componentUids) => {
+const useLazyComponents = (componentUids = []) => {
   const [lazyComponentStore, setLazyComponentStore] = useState({});
   const [loading, setLoading] = useState(true);
   const customFieldsRegistry = useCustomFields();
 
   useEffect(() => {
+    const setStore = (store) => {
+      setLazyComponentStore(store);
+      setLoading(false);
+    };
+
+    const populateStoreWithCache = () => {
+      const internalStore = {};
+
+      componentStore.forEach((comp, uid) => {
+        internalStore[uid] = comp;
+      });
+
+      setStore(internalStore);
+    };
+
     const lazyLoadComponents = async (uids, components) => {
       const modules = await Promise.all(components);
 
+      const internalStore = {};
+
       uids.forEach((uid, index) => {
-        if (!Object.keys(lazyComponentStore).includes(uid)) {
-          setLazyComponentStore({ ...lazyComponentStore, [uid]: modules[index].default });
-        }
+        componentStore.set(uid, modules[index].default);
+        internalStore[uid] = modules[index].default;
       });
+
+      setStore(internalStore);
     };
 
     if (componentUids.length) {
-      const componentPromises = componentUids.map((uid) => {
+      /**
+       * These uids are not in the component store therefore we need to get the components
+       */
+      const newUids = componentUids.filter((uid) => !componentStore.get(uid));
+
+      const componentPromises = newUids.map((uid) => {
         const customField = customFieldsRegistry.get(uid);
 
         return customField.components.Input();
       });
 
-      lazyLoadComponents(componentUids, componentPromises);
+      if (componentPromises.length > 0) {
+        lazyLoadComponents(newUids, componentPromises);
+      } else {
+        populateStoreWithCache();
+      }
+    } else if (loading) {
+      populateStoreWithCache();
     }
-
-    if (componentUids.length === Object.keys(lazyComponentStore).length) {
-      setLoading(false);
-    }
-  }, [componentUids, customFieldsRegistry, loading, lazyComponentStore]);
+  }, [componentUids, customFieldsRegistry, loading]);
 
   return { isLazyLoading: loading, lazyComponentStore };
 };

--- a/packages/core/admin/admin/src/content-manager/hooks/useLazyComponents/index.js
+++ b/packages/core/admin/admin/src/content-manager/hooks/useLazyComponents/index.js
@@ -29,14 +29,11 @@ const useLazyComponents = (componentUids = []) => {
     const lazyLoadComponents = async (uids, components) => {
       const modules = await Promise.all(components);
 
-      const internalStore = {};
-
       uids.forEach((uid, index) => {
         componentStore.set(uid, modules[index].default);
-        internalStore[uid] = modules[index].default;
       });
 
-      setStore(internalStore);
+      setStore(Object.fromEntries(componentStore));
     };
 
     if (componentUids.length && loading) {
@@ -53,9 +50,6 @@ const useLazyComponents = (componentUids = []) => {
 
       if (componentPromises.length > 0) {
         lazyLoadComponents(newUids, componentPromises);
-      } else {
-        const store = Object.fromEntries(componentStore);
-        setStore(store);
       }
     }
   }, [componentUids, customFieldsRegistry, loading]);


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* Adds global cache for custom components
* Adds cleanup function to clear cache if required

### Why is it needed?

* Because we don't want to pass the components all the way from the root of the page down 10 levels of components
* Allows components that require the data to access it without the need for suspense

### How to test it?

* Automated test has been added

### Related issue(s)/PR(s)

* resolves #15053 
