### PR TITLE
[DEITS] import configs

### DIFF
--- a/packages/core/data-transfer/lib/providers/local-strapi-destination-provider/restore.ts
+++ b/packages/core/data-transfer/lib/providers/local-strapi-destination-provider/restore.ts
@@ -45,3 +45,28 @@ export const deleteAllRecords = async (strapi: Strapi.Strapi, deleteOptions?: De
 
   return { count };
 };
+
+const restoreCoreStore = async (strapi: Strapi.Strapi, data: any) => {
+  return await strapi.db.query('strapi::core-store').create({
+    data: {
+      ...data,
+      value: JSON.stringify(data.value),
+    },
+  });
+};
+
+const restoreWebhooks = async (strapi: Strapi.Strapi, data: any) => {
+  return await strapi.db.query('webhook').create({
+    data,
+  });
+};
+
+export const restoreConfigs = async (strapi: Strapi.Strapi, config: any) => {
+  if (config.type === 'core-store') {
+    return await restoreCoreStore(strapi, config.value);
+  }
+
+  if (config.type === 'webhook') {
+    return await restoreWebhooks(strapi, config.value);
+  }
+};


### PR DESCRIPTION
### What does it do?

- add ability to import configs (webhooks and core_store )

### How to test it?

- Export a strapi project with some webhooks and some specific configs.
- Revert the project back to it's previous state (delete webhooks for example)
- then try importing again using `yarn strapi import -f file_name`
- run strapi and the configs should be imported