### PR TITLE
[DEITS] Monorepository "clean" script

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   ],
   "scripts": {
     "prepare": "husky install",
-    "setup": "yarn && yarn build",
+    "setup": "yarn && yarn clean && yarn build",
+    "clean": "lerna run --stream clean --no-private",
     "watch": "lerna run --stream watch --no-private",
     "build": "lerna run --stream build --no-private",
     "generate": "plop --plopfile ./packages/generators/admin/plopfile.js",


### PR DESCRIPTION
### What does it do?

- Add a `clean` script to the root package.json
- Update the yarn setup command to also run a `clean` between dependency installation & `build`

### Why is it needed?

- When running `yarn setup`, we need to be sure the repository is clean & everything is ready to be built from scratch (no incremental build or cache)

### How to test it?

- Run `yarn clean`, it should execute the clean script from @strapi/data-transfer
- Run `yarn setup`, it should execute the monorepo-level clean script
