### PR TITLE
Fix/upload crop folders

### DIFF
--- a/packages/core/upload/admin/src/components/EditAssetDialog/PreviewBox/index.js
+++ b/packages/core/upload/admin/src/components/EditAssetDialog/PreviewBox/index.js
@@ -123,7 +123,7 @@ export const PreviewBox = ({
     const nextAsset = { ...asset, width, height };
     const file = await produceFile(nextAsset.name, nextAsset.mime, nextAsset.updatedAt);
 
-    await upload({ name: file.name, rawFile: file });
+    await upload({ name: file.name, rawFile: file }, asset.folder?.id);
 
     trackUsage('didCropFile', { duplicatedFile: true, location: trackedLocation });
 

--- a/packages/core/upload/admin/src/hooks/useEditAsset.js
+++ b/packages/core/upload/admin/src/hooks/useEditAsset.js
@@ -21,7 +21,7 @@ const editAssetRequest = (asset, file, cancelToken, onProgress) => {
     JSON.stringify({
       alternativeText: asset.alternativeText,
       caption: asset.caption,
-      folder: asset.folder,
+      folder: asset.folder?.id,
       name: asset.name,
     })
   );


### PR DESCRIPTION
### What does it do?

Preserves the folder information, when cropping an image and therefore fixes https://github.com/strapi/strapi/issues/14928.

### Why is it needed?

Preserve folder information when cropping images.

### How to test it?

1. Navigate to the media library
2. Upload an image in a folder
3. Crop image
   3.1 And overwrite
   3.2. And Duplicate

On both cases the image is expected to be in the same folder as the original asset.

### Related issue(s)/PR(s)

- Fixes https://github.com/strapi/strapi/issues/14928
