### PR TITLE
[CRUDReducer]: Add flag to only set modified data

### DIFF
--- a/packages/admin-test-utils/lib/fixtures/store/index.js
+++ b/packages/admin-test-utils/lib/fixtures/store/index.js
@@ -29,6 +29,7 @@ const reducers = {
     contentTypeDataStructure: {},
     isLoading: true,
     data: null,
+    setModifiedDataOnly: false,
     status: 'resolved',
   })),
   rbacProvider: jest.fn(() => ({ allPermissions: null, collectionTypesRelatedPermissions: {} })),

--- a/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/reducer.js
+++ b/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/reducer.js
@@ -192,6 +192,7 @@ const reducer = (state, action) =>
           componentPaths = [],
           repeatableComponentPaths = [],
           dynamicZonePaths = [],
+          setModifiedDataOnly,
         } = action;
 
         /**
@@ -243,7 +244,10 @@ const reducer = (state, action) =>
             return acc;
           }, data);
 
-        draftState.initialData = mergeDataWithPreparedRelations;
+        if (!setModifiedDataOnly) {
+          draftState.initialData = mergeDataWithPreparedRelations;
+        }
+
         draftState.modifiedData = mergeDataWithPreparedRelations;
 
         draftState.formErrors = {};

--- a/packages/core/admin/admin/src/content-manager/sharedReducers/crudReducer/actions.js
+++ b/packages/core/admin/admin/src/content-manager/sharedReducers/crudReducer/actions.js
@@ -6,6 +6,7 @@ import {
   SET_DATA_STRUCTURES,
   SET_STATUS,
   SUBMIT_SUCCEEDED,
+  CLEAR_SET_MODIFIED_DATA_ONLY,
 } from './constants';
 
 export const getData = () => {
@@ -41,4 +42,8 @@ export const setStatus = (status) => ({
 export const submitSucceeded = (data) => ({
   type: SUBMIT_SUCCEEDED,
   data,
+});
+
+export const clearSetModifiedDataOnly = () => ({
+  type: CLEAR_SET_MODIFIED_DATA_ONLY,
 });

--- a/packages/core/admin/admin/src/content-manager/sharedReducers/crudReducer/constants.js
+++ b/packages/core/admin/admin/src/content-manager/sharedReducers/crudReducer/constants.js
@@ -5,3 +5,5 @@ export const RESET_PROPS = 'ContentManager/CrudReducer/RESET_PROPS';
 export const SET_DATA_STRUCTURES = 'ContentManager/CrudReducer/SET_DATA_STRUCTURES';
 export const SET_STATUS = 'ContentManager/CrudReducer/SET_STATUS';
 export const SUBMIT_SUCCEEDED = 'ContentManager/CrudReducer/SUBMIT_SUCCEEDED';
+export const CLEAR_SET_MODIFIED_DATA_ONLY =
+  'ContentManager/CrudReducer/CLEAR_SET_MODIFIED_DATA_ONLY';

--- a/packages/core/admin/admin/src/content-manager/sharedReducers/crudReducer/reducer.js
+++ b/packages/core/admin/admin/src/content-manager/sharedReducers/crudReducer/reducer.js
@@ -8,6 +8,7 @@ import produce from 'immer';
 // to do any of this.
 
 import {
+  CLEAR_SET_MODIFIED_DATA_ONLY,
   GET_DATA,
   GET_DATA_SUCCEEDED,
   INIT_FORM,
@@ -23,6 +24,7 @@ const crudInitialState = {
   isLoading: true,
   data: null,
   status: 'resolved',
+  setModifiedDataOnly: false,
 };
 
 const crudReducer = (state = crudInitialState, action) =>
@@ -36,6 +38,7 @@ const crudReducer = (state = crudInitialState, action) =>
       case GET_DATA_SUCCEEDED: {
         draftState.isLoading = false;
         draftState.data = action.data;
+        draftState.setModifiedDataOnly = action.setModifiedDataOnly ?? false;
         break;
       }
       case INIT_FORM: {
@@ -64,6 +67,10 @@ const crudReducer = (state = crudInitialState, action) =>
       }
       case SUBMIT_SUCCEEDED: {
         draftState.data = action.data;
+        break;
+      }
+      case CLEAR_SET_MODIFIED_DATA_ONLY: {
+        draftState.setModifiedDataOnly = false;
         break;
       }
       default:

--- a/packages/core/admin/admin/src/content-manager/sharedReducers/crudReducer/tests/crudReducer.test.js
+++ b/packages/core/admin/admin/src/content-manager/sharedReducers/crudReducer/tests/crudReducer.test.js
@@ -18,6 +18,7 @@ describe('CONTENT MANAGER | sharedReducers | crudReducer', () => {
       contentTypeDataStructure: {},
       isLoading: true,
       data: {},
+      setModifiedDataOnly: false,
       status: 'resolved',
     };
   });

--- a/packages/plugins/i18n/admin/src/components/CMEditViewInjectedComponents/CMEditViewCopyLocale/index.js
+++ b/packages/plugins/i18n/admin/src/components/CMEditViewInjectedComponents/CMEditViewCopyLocale/index.js
@@ -69,7 +69,11 @@ const Content = ({ appLocales, currentLocale, localizations, readPermissions }) 
         cleanedData[key] = initialData[key];
       });
 
-      dispatch({ type: 'ContentManager/CrudReducer/GET_DATA_SUCCEEDED', data: cleanedData });
+      dispatch({
+        type: 'ContentManager/CrudReducer/GET_DATA_SUCCEEDED',
+        data: cleanedData,
+        setModifiedDataOnly: true,
+      });
 
       toggleNotification({
         type: 'success',


### PR DESCRIPTION

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* Adds `setModifiedDataOnly` to the `CRUDReducer`
* Passes this flag to `INIT_FORM` in `EditViewDataManager`

### Why is it needed?

The way the CMS works is that the save button is only activated when theres a diff between modifiedData and initialData, because i18n can only load data and have the CM initialise it, it assumes this is data from the server, which is not the case for i18n. Therefore i've added a flag to imply this behaviour and then remove the flag to avoid contamination.

We also now compare initialValues from what it used to be to avoid the effect being fired too soon.

### Related issue(s)/PR(s)

* resolves #13988

### Notes

I do recognise this is a bit "hacky" IMO whether the save button can be used or not should be a side effect to updates to the store but that requires a rewrite of our redux store. I also think this highlights a need for writing all business logic in the redux store (e.g. using redux-thunks / redux-sagas for async actions) therefore giving loads more freedom to plugin developers and centralising the logic instead of having complicated component patterns.
