### PR TITLE
RelationInputDataManager: Fix crash when relation is inside a component

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/RelationInputDataManager.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/RelationInputDataManager.js
@@ -49,7 +49,7 @@ export const RelationInputDataManager = ({
     relationReorder,
   } = useCMEditViewDataManager();
 
-  const relationsFromModifiedData = get(modifiedData, name);
+  const relationsFromModifiedData = get(modifiedData, name, []);
 
   const currentLastPage = Math.ceil(get(initialData, name, []).length / RELATIONS_TO_DISPLAY);
 

--- a/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/tests/RelationInputDataManger.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/tests/RelationInputDataManger.test.js
@@ -564,6 +564,26 @@ describe('RelationInputDataManager', () => {
       expect(queryByText(/\(8\)/)).toBeInTheDocument();
     });
 
+    it.only('should not crash, if the field is not set in modifiedData (e.g. in components)', () => {
+      useCMEditViewDataManager.mockImplementation(() => ({
+        isCreatingEntry: false,
+        createActionAllowedFields: ['relation'],
+        readActionAllowedFields: ['relation'],
+        updateActionAllowedFields: ['relation'],
+        slug: 'test',
+        initialData: {
+          relation: [
+            {
+              id: 1,
+            },
+          ],
+        },
+        modifiedData: {},
+      }));
+
+      expect(setup).not.toThrow();
+    });
+
     it('should correct calculate browser mutations when there are relations from useRelation', async () => {
       useRelation.mockImplementation(() => ({
         relations: {


### PR DESCRIPTION
### What does it do?

Adds an empty array fallback for `modifiedData` to prevent a crash, if the relational field is inside a component.

### Why is it needed?

Fixes a crash.

### How to test it?

1. Use the Restaurant content-type
2. Open a dish
