### PR TITLE
[RepeatableComponents]: overflow in repeatable components

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/RelationInput/RelationInput.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInput/RelationInput.js
@@ -325,35 +325,37 @@ const RelationInput = ({
           )
         }
       >
-        <RelationList overflow={overflow}>
-          <VisuallyHidden id={ariaDescriptionId}>{listAriaDescription}</VisuallyHidden>
-          <VisuallyHidden aria-live="assertive">{liveText}</VisuallyHidden>
-          <List
-            height={dynamicListHeight}
-            ref={listRef}
-            outerRef={outerListRef}
-            itemCount={totalNumberOfRelations}
-            itemSize={RELATION_ITEM_HEIGHT + RELATION_GUTTER}
-            itemData={{
-              ariaDescribedBy: ariaDescriptionId,
-              canDrag: canReorder,
-              disabled,
-              handleCancel: onCancel,
-              handleDropItem: onDropItem,
-              handleGrabItem: onGrabItem,
-              iconButtonAriaLabel,
-              labelDisconnectRelation,
-              onRelationDisconnect,
-              publicationStateTranslations,
-              relations,
-              updatePositionOfRelation: handleUpdatePositionOfRelation,
-            }}
-            itemKey={(index, { relations: relationsItems }) => relationsItems[index].id}
-            innerElementType="ol"
-          >
-            {ListItem}
-          </List>
-        </RelationList>
+        {relations.length > 0 ? (
+          <RelationList overflow={overflow}>
+            <VisuallyHidden id={ariaDescriptionId}>{listAriaDescription}</VisuallyHidden>
+            <VisuallyHidden aria-live="assertive">{liveText}</VisuallyHidden>
+            <List
+              height={dynamicListHeight}
+              ref={listRef}
+              outerRef={outerListRef}
+              itemCount={totalNumberOfRelations}
+              itemSize={RELATION_ITEM_HEIGHT + RELATION_GUTTER}
+              itemData={{
+                ariaDescribedBy: ariaDescriptionId,
+                canDrag: canReorder,
+                disabled,
+                handleCancel: onCancel,
+                handleDropItem: onDropItem,
+                handleGrabItem: onGrabItem,
+                iconButtonAriaLabel,
+                labelDisconnectRelation,
+                onRelationDisconnect,
+                publicationStateTranslations,
+                relations,
+                updatePositionOfRelation: handleUpdatePositionOfRelation,
+              }}
+              itemKey={(index, { relations: relationsItems }) => relationsItems[index].id}
+              innerElementType="ol"
+            >
+              {ListItem}
+            </List>
+          </RelationList>
+        ) : null}
         {(description || error) && (
           <Box paddingTop={2}>
             <FieldHint />

--- a/packages/core/admin/admin/src/content-manager/components/RepeatableComponent/components/Accordion.js
+++ b/packages/core/admin/admin/src/content-manager/components/RepeatableComponent/components/Accordion.js
@@ -14,7 +14,6 @@ export const Footer = styled(Box)`
 
 export const Content = styled(Box)`
   border-bottom: none;
-  overflow: hidden;
 
   /* add the borders and make sure the top is transparent to avoid jumping with the hover effect  */
   & > div > div {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* only show the relation list if we have relations (makes DOM cleaner)
* removes `overflow:hidden` from `Accordion.Group` to let react-selects menu break out of container

### Why is it needed?

* Menus are masked otherwise

### Related issue(s)/PR(s)

* resolves CONTENT-780
