### PR TITLE
fix: reset `gridTemplateColumns` otherwise component breaks out of grid

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/RelationInput/tests/__snapshots__/RelationInput.test.js.snap
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInput/tests/__snapshots__/RelationInput.test.js.snap
@@ -620,7 +620,7 @@ exports[`Content-Manager || RelationInput should render and match snapshot 1`] =
                 Select...
               </div>
               <div
-                class=" css-aaf1np-Input"
+                class=" css-1rkub9f-Input"
                 data-value=""
               >
                 <input

--- a/packages/core/helper-plugin/lib/src/components/ReactSelect/utils/getSelectStyles.js
+++ b/packages/core/helper-plugin/lib/src/components/ReactSelect/utils/getSelectStyles.js
@@ -34,7 +34,13 @@ const getSelectStyles = (theme, error) => {
       };
     },
     indicatorContainer: (base) => ({ ...base, padding: 0, paddingRight: theme.spaces[3] }),
-    input: (base) => ({ ...base, margin: 0, padding: 0, color: theme.colors.neutral800 }),
+    input: (base) => ({
+      ...base,
+      margin: 0,
+      padding: 0,
+      color: theme.colors.neutral800,
+      gridTemplateColumns: 'unset',
+    }),
     menu(base) {
       return {
         ...base,


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* fix the styling

### Why is it needed?

* Because the input grows infinitely

### Related issue(s)/PR(s)

* resolves CONTENT-787
