### PR TITLE
FIX: Support new axios wrapper format

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/SingleTypeFormWrapper/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/SingleTypeFormWrapper/index.js
@@ -103,7 +103,7 @@ const SingleTypeFormWrapper = ({ allLayoutData, children, slug }) => {
       setIsCreatingEntry(true);
 
       try {
-        const { data } = await axiosInstance(getRequestUrl(`${slug}${searchToSend}`), {
+        const { data } = await axiosInstance.get(getRequestUrl(`${slug}${searchToSend}`), {
           cancelToken: source.token,
         });
 

--- a/packages/core/content-type-builder/admin/src/components/DataManagerProvider/index.js
+++ b/packages/core/content-type-builder/admin/src/components/DataManagerProvider/index.js
@@ -351,7 +351,7 @@ const DataManagerProvider = ({
 
       // Update the category
       // TODO: remember to pass also the pluginId when you use the new get, post, put, delete methods from getFetchClient
-      await axiosInstance({ url: requestURL, method: 'PUT', data: body });
+      await axiosInstance.put(requestURL, body);
 
       // Make sure the server has restarted
       await serverRestartWatcher(true);
@@ -501,19 +501,18 @@ const DataManagerProvider = ({
         trackUsage('willSaveComponent');
       }
 
-      const method = isCreating ? 'POST' : 'PUT';
+      // Lock the app
+      lockAppWithAutoreload();
 
       const baseURL = `/${endPoint}`;
       const requestURL = isCreating ? baseURL : `${baseURL}/${currentUid}`;
 
-      // Lock the app
-      lockAppWithAutoreload();
       // TODO: remember to pass also the pluginId when you use the new get, post, put, delete methods from getFetchClient
-      await axiosInstance({
-        url: requestURL,
-        method,
-        data: body,
-      });
+      if (isCreating) {
+        await axiosInstance.post(requestURL, body);
+      } else {
+        await axiosInstance.put(requestURL, body);
+      }
 
       // Make sure the server has restarted
       await serverRestartWatcher(true);


### PR DESCRIPTION
### What does it do?

Support the new axiosInstance format in places where it was incompatible

### Why is it needed?

So API requests can be successfully sent

### How to test it?

- View single types in the content manager
- Save content in the CTB
- Modify a component category in the CTB

