### PR TITLE
fix: filter path because a dynamic zone is a component but it should be classified as a dynamic zone

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/DynamicZone/components/DynamicComponent.js
+++ b/packages/core/admin/admin/src/content-manager/components/DynamicZone/components/DynamicComponent.js
@@ -111,7 +111,7 @@ const DynamicZoneComponent = ({
       <StyledBox hasRadius>
         <Accordion expanded={isOpen} onToggle={handleToggle} size="S" error={errorMessage}>
           <AccordionToggle
-            startIcon={<FontAwesomeIcon icon={icon} />}
+            startIcon={icon && <FontAwesomeIcon icon={icon} />}
             action={
               <Stack horizontal spacing={0} expanded={isOpen}>
                 {showDownIcon && (

--- a/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/utils/recursivelyFindPathsBasedOnCondition.js
+++ b/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/utils/recursivelyFindPathsBasedOnCondition.js
@@ -55,8 +55,15 @@ const recursivelyFindPathsBasedOnConditionSetup = (components, predicate = () =>
                *
                * NOTE: we don't need to know the path to the `array` because it's about data shape not about the actual data
                */
-            }).map((path) => path.split(`${componentName}.`)[1]);
+            }).map((path) => {
+              return path.split(`${componentName}.`)[1];
+            });
           })
+          /**
+           * We filter because this will give you `dynamiczone.undefined` because the dynamic_zone component
+           * is not required to be returned in this circumstance.
+           */
+          .filter((path) => Boolean(path))
           .map((path) => `${key}.${path}`);
 
         acc = [...acc, attributesInDynamicComponents];

--- a/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/utils/tests/recursivelyFindPathsBasedOnCondition.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/utils/tests/recursivelyFindPathsBasedOnCondition.test.js
@@ -611,4 +611,79 @@ describe('recursivelyFindPathsBasedOnCondition', () => {
       expect(actual).toEqual(['dynamic_relations', 'dynamic_relations.simple']);
     });
   });
+
+  describe('components', () => {
+    test('given that a component exits, it should be returned', () => {
+      const components = {
+        'basic.simple': {
+          attributes: {
+            id: {
+              type: 'integer',
+            },
+            categories: {
+              type: 'relation',
+              relation: 'oneToMany',
+              target: 'api::category.category',
+              targetModel: 'api::category.category',
+              relationType: 'oneToMany',
+            },
+            my_name: {
+              type: 'string',
+            },
+          },
+        },
+      };
+
+      const attributes = {
+        relation: {
+          type: 'component',
+          component: 'basic.simple',
+          repeatable: false,
+        },
+      };
+
+      const actual = recursivelyFindPathsBasedOnCondition(
+        components,
+        (value) => value.type === 'component' && !value.repeatable
+      )(attributes);
+
+      expect(actual).toEqual(['relation']);
+    });
+
+    test('given that a component is in a dynamic zone it should not return the name of the dynamic zone', () => {
+      const components = {
+        'basic.simple': {
+          attributes: {
+            id: {
+              type: 'integer',
+            },
+            categories: {
+              type: 'relation',
+              relation: 'oneToMany',
+              target: 'api::category.category',
+              targetModel: 'api::category.category',
+              relationType: 'oneToMany',
+            },
+            my_name: {
+              type: 'string',
+            },
+          },
+        },
+      };
+
+      const attributes = {
+        dynamic_relations: {
+          type: 'dynamiczone',
+          components: ['basic.simple'],
+        },
+      };
+
+      const actual = recursivelyFindPathsBasedOnCondition(
+        components,
+        (value) => value.type === 'component' && value.repeatable === false
+      )(attributes);
+
+      expect(actual).toEqual([]);
+    });
+  });
 });

--- a/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/RelationInputDataManager.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/RelationInputDataManager.js
@@ -40,7 +40,7 @@ export const RelationInputDataManager = ({
   const { connectRelation, disconnectRelation, loadRelation, modifiedData, slug, initialData } =
     useCMEditViewDataManager();
 
-  const relationsFromModifiedData = get(modifiedData, name) ?? [];
+  const relationsFromModifiedData = get(modifiedData, name, []);
 
   const currentLastPage = Math.ceil(get(initialData, name, []).length / RELATIONS_TO_DISPLAY);
 


### PR DESCRIPTION


<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* avoids undefined sections of paths in the recursive finding functions that have something like `path.undefined` with dynamic zones

### Why is it needed?

* dynamic zone indicies are components but the path to the component would just be `dynamiczone.0` but we don't want the index in these paths so it thinks it should just be `dynamiczone.undefined` when looking for components, however this should actually be captured by the dynamic zone findings. It's a bit confusing.

### Related issue(s)/PR(s)

* related to #14968
* related to CONTENT-766
