### PR TITLE
[build-script]: use / as the path separator for glob.sync

### DIFF
--- a/packages/core/admin/utils/get-plugins-path.js
+++ b/packages/core/admin/utils/get-plugins-path.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { join, resolve } = require('path');
+const { join, resolve, sep, posix } = require('path');
 const fs = require('fs-extra');
 // eslint-disable-next-line import/no-extraneous-dependencies
 const glob = require('glob');
@@ -8,8 +8,22 @@ const glob = require('glob');
 // Only for dev environement
 const getPluginsPath = () => {
   const rootPath = resolve(__dirname, '..', join('..', '..', '..', 'packages'));
-  const corePath = join(rootPath, 'core', '*');
-  const pluginsPath = join(rootPath, 'plugins', '*');
+  /**
+   * So `glob` only supports '/' as a path separator, so we need to replace
+   * the path separator for the current OS with '/'. e.g. on windows it's `\`.
+   *
+   * see https://github.com/isaacs/node-glob/#windows for more information
+   *
+   * and see https://github.com/isaacs/node-glob/issues/467#issuecomment-1114240501 for the recommended fix.
+   */
+  let corePath = join(rootPath, 'core', '*');
+  let pluginsPath = join(rootPath, 'plugins', '*');
+
+  if (process.platform === 'win32') {
+    corePath = corePath.split(sep).join(posix.sep);
+    pluginsPath = pluginsPath.split(sep).join(posix.sep);
+  }
+
   const corePackageDirs = glob.sync(corePath);
   const pluginsPackageDirs = glob.sync(pluginsPath);
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* if windows is the platform, split the path and rejoin with linux path separator.

### Why is it needed?

* `glob` does not support the windows separator as documented [here](https://github.com/isaacs/node-glob/#windows) and you can see the recommended fix [here](https://github.com/isaacs/node-glob/issues/467#issuecomment-1114240501). This seemed to be a big thing for v8.

### How to test it?

* run the build on a windows device (not WSL)

### Related issue(s)/PR(s)

* resolves Ryma's issue that she spoke about internally
* resolves #14982 
