### PR TITLE
fix(upload): normalize the string used as basename

### DIFF
--- a/packages/core/upload/server/services/upload.js
+++ b/packages/core/upload/server/services/upload.js
@@ -77,8 +77,8 @@ module.exports = ({ strapi }) => ({
     if (!ext) {
       ext = `.${extension(type)}`;
     }
-    const basename = path.basename(fileInfo.name || filename, ext);
-    const usedName = fileInfo.name || filename;
+    const usedName = (fileInfo.name || filename).normalize();
+    const basename = path.basename(usedName, ext);
 
     const entity = {
       name: usedName,


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Add a little `.normalize();` function call to avoid problem with combined unicode.

See documentation:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/normalize#description



### Why is it needed?

Combine unicode leads to an error in the Mysql database that doesn't use `utf8mb4` charset. We may introduce the use of `utf8mb4` in the future, but for now, it seems to be too big change for little added value.

### How to test it?

Please follow the instruction on the issue:
https://github.com/strapi/strapi/issues/14793

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
https://github.com/strapi/strapi/issues/14793
