### PR TITLE
[Reordering]: fix indicies order

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/RepeatableComponent/tests/index.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/RepeatableComponent/tests/index.test.js
@@ -229,9 +229,9 @@ describe('RepeatableComponents', () => {
       fireEvent.drop(dropZone);
 
       expect(moveComponentField).toHaveBeenCalledWith({
-        currentIndex: 1,
+        currentIndex: 0,
         name: 'repeatable-component',
-        newIndex: 0,
+        newIndex: 1,
       });
     });
 

--- a/packages/core/admin/admin/src/content-manager/hooks/useDragAndDrop.js
+++ b/packages/core/admin/admin/src/content-manager/hooks/useDragAndDrop.js
@@ -55,10 +55,10 @@ export const useDragAndDrop = (
         return;
       }
       const dragIndex = item.index;
-      const currentIndex = index;
+      const newInd = index;
 
       // Don't replace items with themselves
-      if (dragIndex === currentIndex) {
+      if (dragIndex === newInd) {
         return;
       }
 
@@ -68,18 +68,18 @@ export const useDragAndDrop = (
       const hoverClientY = clientOffset.y - hoverBoundingRect.top;
 
       // Dragging downwards
-      if (dragIndex < currentIndex && hoverClientY < hoverMiddleY) {
+      if (dragIndex < newInd && hoverClientY < hoverMiddleY) {
         return;
       }
 
       // Dragging upwards
-      if (dragIndex > currentIndex && hoverClientY > hoverMiddleY) {
+      if (dragIndex > newInd && hoverClientY > hoverMiddleY) {
         return;
       }
 
       // Time to actually perform the action
-      onMoveItem(dragIndex, currentIndex);
-      item.index = currentIndex;
+      onMoveItem(newInd, dragIndex);
+      item.index = newInd;
     },
   });
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* Turns out the indicies were passed the wrong way round, this didnt cause an issue with moving by one, but when you move a greater number, it gets very confused

### Why is it needed?

* Solves re-ordering issues

### How to test

Move a relation around a lot, put it at the end then move it to the top by **not** moving it all the way up through the order, it should replace itself correctly.

### Related issue(s)/PR(s)

* resolves CONTENT-779
* resolves CONTENT-786
