### PR TITLE
[DND]: Preview images

### DIFF
--- a/docs/docs/core/content-manager/hooks/use-drag-and-drop.mdx
+++ b/docs/docs/core/content-manager/hooks/use-drag-and-drop.mdx
@@ -24,7 +24,7 @@ that you are somewhat familiar with `@strapi/design-system` components.
 ### Basic usage
 
 Below is a basic example usage where we're not interested in rendering custom previews in the DragLayer. However, we do replace
-the current item with a placeholder in the meantime hence why we use the `dragPreviewRef`.
+the current item with a placeholder.
 
 ```jsx
 import { Box, Flex, IconButton } from '@strapi/design-system';
@@ -36,19 +36,18 @@ import { composeRefs } from 'path/to/utils';
 import { Placeholder } from './Placeholder';
 
 const MyComponent = ({ onMoveItem }) => {
-  const [{ handlerId, isDragging, handleKeyDown }, myRef, dropRef, dragRef, dragPreviewRef] =
-    useDragAndDrop(true, {
-      type: 'my-type',
-      index,
-      onMoveItem,
-    });
+  const [{ handlerId, isDragging, handleKeyDown }, myRef, dropRef, dragRef] = useDragAndDrop(true, {
+    type: 'my-type',
+    index,
+    onMoveItem,
+  });
 
   const composedRefs = composeRefs(myRef, dragRef);
 
   return (
     <Box ref={dropRef} cursor={'all-scroll'}>
       {isDragging ? (
-        <Placeholder ref={dragPreviewRef} />
+        <Placeholder />
       ) : (
         <Flex ref={composedRefs} data-handler-id={handlerId}>
           <IconButton
@@ -94,7 +93,7 @@ const MyComponent = ({ onMoveItem }) => {
 
   // highlight-start
   useEffect(() => {
-    dragPreviewRef(getEmptyImage(), { captureDraggingState: false });
+    dragPreviewRef(getEmptyImage());
   }, [dragPreviewRef]);
   // highlight-end
 
@@ -103,7 +102,7 @@ const MyComponent = ({ onMoveItem }) => {
   return (
     <Box ref={dropRef} cursor={'all-scroll'}>
       {isDragging ? (
-        <Placeholder ref={dragPreviewRef} />
+        <Placeholder />
       ) : (
         <Flex ref={composedRefs} data-handler-id={handlerId}>
           <IconButton

--- a/packages/core/admin/admin/src/content-manager/components/DynamicZone/components/DynamicComponent.js
+++ b/packages/core/admin/admin/src/content-manager/components/DynamicZone/components/DynamicComponent.js
@@ -190,7 +190,7 @@ const DynamicZoneComponent = ({
       </Flex>
       <StyledBox ref={composedBoxRefs} hasRadius>
         {isDragging ? (
-          <Preview ref={dragPreviewRef} padding={6} background="primary100" />
+          <Preview padding={6} background="primary100" />
         ) : (
           <Accordion expanded={isOpen} onToggle={handleToggle} size="S" error={errorMessage}>
             <AccordionToggle

--- a/packages/core/admin/admin/src/content-manager/components/RelationInput/components/RelationItem.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInput/components/RelationItem.js
@@ -1,4 +1,4 @@
-import React, { forwardRef, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { getEmptyImage } from 'react-dnd-html5-backend';
@@ -60,8 +60,8 @@ export const RelationItem = ({
   const composedRefs = composeRefs(relationRef, dragRef);
 
   useEffect(() => {
-    dragPreviewRef(getEmptyImage(), { captureDraggingState: false });
-  }, [dragPreviewRef, index]);
+    dragPreviewRef(getEmptyImage());
+  }, [dragPreviewRef]);
 
   return (
     <Box
@@ -72,7 +72,7 @@ export const RelationItem = ({
       cursor={canDrag ? 'all-scroll' : 'default'}
     >
       {isDragging ? (
-        <RelationItemPlaceholder ref={dragPreviewRef} />
+        <RelationItemPlaceholder />
       ) : (
         <Flex
           paddingTop={2}
@@ -110,9 +110,8 @@ export const RelationItem = ({
   );
 };
 
-const RelationItemPlaceholder = forwardRef((_, ref) => (
+const RelationItemPlaceholder = () => (
   <Box
-    ref={ref}
     paddingTop={2}
     paddingBottom={2}
     paddingLeft={4}
@@ -124,7 +123,7 @@ const RelationItemPlaceholder = forwardRef((_, ref) => (
     background="primary100"
     height={`calc(100% - ${RELATION_GUTTER}px)`}
   />
-));
+);
 
 RelationItem.defaultProps = {
   ariaDescribedBy: '',

--- a/packages/core/admin/admin/src/content-manager/components/RepeatableComponent/components/Component.js
+++ b/packages/core/admin/admin/src/content-manager/components/RepeatableComponent/components/Component.js
@@ -132,7 +132,7 @@ const DraggedItem = ({
   return (
     <Box ref={composedBoxRefs}>
       {isDragging ? (
-        <Preview ref={dragPreviewRef} />
+        <Preview />
       ) : (
         <Accordion expanded={isOpen} onToggle={onClickToggle} id={componentFieldName} size="S">
           <AccordionToggle

--- a/packages/core/admin/admin/src/content-manager/components/RepeatableComponent/components/Preview.js
+++ b/packages/core/admin/admin/src/content-manager/components/RepeatableComponent/components/Preview.js
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import React from 'react';
 import styled from 'styled-components';
 
 const StyledSpan = styled.span`
@@ -9,8 +9,8 @@ const StyledSpan = styled.span`
   padding: ${({ theme }) => theme.spaces[6]};
 `;
 
-const Preview = forwardRef((_, ref) => {
-  return <StyledSpan ref={ref} padding={6} background="primary100" />;
-});
+const Preview = () => {
+  return <StyledSpan padding={6} background="primary100" />;
+};
 
 export default Preview;


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* removes passing the preview ref to a react component.

### Why is it needed?

* breaks the empty image and renders a duplicate image on second usage.

### How to test it?

* Drag a relation to one location
* Move the same relation after dropping
* should be no duplicate preview

### Related issue(s)/PR(s)

* resolves CONTENT-805
