### PR TITLE
[DEITS] Fix imports and misc cleanup

### DIFF
--- a/packages/core/data-transfer/lib/engine/__tests__/engine.test.ts
+++ b/packages/core/data-transfer/lib/engine/__tests__/engine.test.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import { join } from 'path';
 import { cloneDeep } from 'lodash/fp';
 import { Readable, Writable } from 'stream-chain';
 import type { Schema } from '@strapi/strapi';
@@ -47,13 +47,13 @@ const getAssetsMockSourceStream = (
   data: Iterable<IAsset> = [
     {
       filename: 'foo.jpg',
-      filepath: path.join(__dirname, 'foo.jpg'),
+      filepath: join(__dirname, 'foo.jpg'),
       stats: { size: 24 },
       stream: Readable.from([1, 2, 3]),
     },
     {
       filename: 'bar.jpg',
-      filepath: path.join(__dirname, 'bar.jpg'),
+      filepath: join(__dirname, 'bar.jpg'),
       stats: { size: 48 },
       stream: Readable.from([4, 5, 6, 7, 8, 9]),
     },

--- a/packages/core/data-transfer/lib/engine/index.ts
+++ b/packages/core/data-transfer/lib/engine/index.ts
@@ -1,8 +1,8 @@
 import { PassThrough } from 'stream-chain';
-import * as path from 'path';
+import { extname } from 'path';
 import { isEmpty, uniq } from 'lodash/fp';
-import type { Schema } from '@strapi/strapi';
 import { diff as semverDiff } from 'semver';
+import type { Schema } from '@strapi/strapi';
 
 import type {
   Diff,
@@ -435,7 +435,7 @@ class TransferEngine<
         .pipe(
           this.#progressTracker(stageName, {
             size: (value: IAsset) => value.stats.size,
-            key: (value: IAsset) => path.extname(value.filename),
+            key: (value: IAsset) => extname(value.filename),
           })
         )
         .pipe(outStream);

--- a/packages/core/data-transfer/lib/engine/index.ts
+++ b/packages/core/data-transfer/lib/engine/index.ts
@@ -1,7 +1,8 @@
-import { PassThrough, Stream } from 'stream-chain';
+import { PassThrough } from 'stream-chain';
 import * as path from 'path';
 import { isEmpty, uniq } from 'lodash/fp';
 import type { Schema } from '@strapi/strapi';
+import { diff as semverDiff } from 'semver';
 
 import type {
   Diff,
@@ -17,8 +18,6 @@ import type {
 } from '../../types';
 
 import compareSchemas from '../strategies';
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const semverDiff = require('semver/functions/diff');
 
 type TransferProgress = {
   [key in TransferStage]?: {

--- a/packages/core/data-transfer/lib/providers/local-file-destination-provider/index.ts
+++ b/packages/core/data-transfer/lib/providers/local-file-destination-provider/index.ts
@@ -1,4 +1,4 @@
-import fs from 'fs-extra';
+import { rm, createWriteStream } from 'fs-extra';
 import tar from 'tar-stream';
 import path from 'path';
 import zlib from 'zlib';
@@ -111,7 +111,7 @@ class LocalFileDestinationProvider implements IDestinationProvider {
 
     this.#archive.stream = tar.pack();
 
-    const outStream = fs.createWriteStream(this.#archivePath);
+    const outStream = createWriteStream(this.#archivePath);
 
     const archiveTransforms: Stream[] = [];
 
@@ -147,7 +147,7 @@ class LocalFileDestinationProvider implements IDestinationProvider {
 
   async rollback(): Promise<void> {
     await this.close();
-    fs.rmSync(this.#archivePath, { force: true });
+    await rm(this.#archivePath, { force: true });
   }
 
   getMetadata() {

--- a/packages/core/data-transfer/lib/providers/local-file-destination-provider/utils.ts
+++ b/packages/core/data-transfer/lib/providers/local-file-destination-provider/utils.ts
@@ -1,5 +1,5 @@
 import { Writable } from 'stream';
-import path from 'path';
+import { join } from 'path';
 import tar from 'tar-stream';
 
 /**
@@ -9,7 +9,7 @@ import tar from 'tar-stream';
 export const createFilePathFactory =
   (type: string) =>
   (fileIndex = 0): string => {
-    return path.join(
+    return join(
       // "{type}" directory
       type,
       // "${type}_XXXXX.jsonl" file

--- a/packages/core/data-transfer/lib/providers/local-file-source-provider.ts
+++ b/packages/core/data-transfer/lib/providers/local-file-source-provider.ts
@@ -59,7 +59,7 @@ class LocalFileSourceProvider implements ISourceProvider {
   }
 
   /**
-   *  Pre flight checks regarding the provided options (making sure that the provided path is correct, etc...)
+   * Pre flight checks regarding the provided options (making sure that the provided path is correct, etc...)
    */
   async bootstrap() {
     const { path } = this.options.file;
@@ -106,7 +106,6 @@ class LocalFileSourceProvider implements ISourceProvider {
   #getBackupStream() {
     const { file, encryption, compression } = this.options;
 
-    // This should be impossible as long as bootstrap was called first
     const streams: StreamItemArray = [];
 
     try {

--- a/packages/core/data-transfer/lib/providers/local-file-source-provider.ts
+++ b/packages/core/data-transfer/lib/providers/local-file-source-provider.ts
@@ -1,6 +1,6 @@
 import type { Readable } from 'stream';
 
-import fs from 'fs';
+import { createReadStream } from 'fs-extra';
 import zip from 'zlib';
 import tar from 'tar';
 import { keyBy } from 'lodash/fp';
@@ -48,6 +48,8 @@ class LocalFileSourceProvider implements ISourceProvider {
 
   options: ILocalFileSourceProviderOptions;
 
+  #filestream?: Readable;
+
   constructor(options: ILocalFileSourceProviderOptions) {
     this.options = options;
 
@@ -59,17 +61,13 @@ class LocalFileSourceProvider implements ISourceProvider {
   }
 
   /**
-   * Pre flight checks regarding the provided options (making sure that the provided path is correct, etc...)
+   * Pre flight checks regarding the provided options, opening the file
    */
-  bootstrap() {
-    const { path } = this.options.file;
-    const isValidBackupPath = fs.existsSync(path);
-
-    // Check if the provided path exists
-    if (!isValidBackupPath) {
-      throw new Error(
-        `Invalid backup file path provided. "${path}" does not exist on the filesystem.`
-      );
+  async bootstrap() {
+    try {
+      this.#filestream = createReadStream(this.options.file.path);
+    } catch (e) {
+      throw new Error(`Could not read backup file path provided at "${this.options.file.path}"`);
     }
   }
 
@@ -104,10 +102,14 @@ class LocalFileSourceProvider implements ISourceProvider {
   }
 
   #getBackupStream() {
-    const { file, encryption, compression } = this.options;
+    const { encryption, compression } = this.options;
 
-    const fileStream = fs.createReadStream(file.path);
-    const streams: StreamItemArray = [fileStream];
+    // This should be impossible as long as bootstrap was called first
+    if (!this.#filestream) {
+      throw new Error('Could not read file stream');
+    }
+
+    const streams: StreamItemArray = [this.#filestream];
 
     if (encryption.enabled && encryption.key) {
       streams.push(createDecryptionCipher(encryption.key));

--- a/packages/core/data-transfer/lib/providers/local-file-source-provider.ts
+++ b/packages/core/data-transfer/lib/providers/local-file-source-provider.ts
@@ -1,6 +1,6 @@
 import type { Readable } from 'stream';
 
-import * as fs from 'fs-extra';
+import fs from 'fs-extra';
 import zip from 'zlib';
 import tar from 'tar';
 import { keyBy } from 'lodash/fp';
@@ -63,13 +63,11 @@ class LocalFileSourceProvider implements ISourceProvider {
    */
   async bootstrap() {
     const { path } = this.options.file;
-    const isValidBackupPath = await fs.existsSync(path);
-
-    // Check if the provided path exists
-    if (!isValidBackupPath) {
-      throw new Error(
-        `Invalid backup file path provided. "${path}" does not exist on the filesystem.`
-      );
+    try {
+      // This is only to show a nicer error, it doesn't ensure the file will still exist when we try to open it later
+      await fs.access(path, fs.constants.R_OK);
+    } catch (e) {
+      throw new Error(`Can't access file "${path}".`);
     }
   }
 

--- a/packages/core/data-transfer/lib/providers/local-strapi-destination-provider/__tests__/restore.test.ts
+++ b/packages/core/data-transfer/lib/providers/local-strapi-destination-provider/__tests__/restore.test.ts
@@ -1,5 +1,6 @@
 import { deleteAllRecords, restoreConfigs } from '../restore';
 import { getStrapiFactory, getContentTypes } from '../../test-utils';
+import { IConfiguration } from '../../../../types';
 
 const entities = [
   {
@@ -89,7 +90,7 @@ describe('Restore ', () => {
         query,
       },
     })();
-    const config = {
+    const config: IConfiguration = {
       type: 'core-store',
       value: {
         key: 'test-key',
@@ -113,7 +114,7 @@ describe('Restore ', () => {
         query,
       },
     })();
-    const config = {
+    const config: IConfiguration = {
       type: 'webhook',
       value: {
         id: 4,

--- a/packages/core/data-transfer/lib/providers/local-strapi-destination-provider/__tests__/restore.test.ts
+++ b/packages/core/data-transfer/lib/providers/local-strapi-destination-provider/__tests__/restore.test.ts
@@ -1,6 +1,6 @@
 import { deleteAllRecords, restoreConfigs } from '../restore';
 import { getStrapiFactory, getContentTypes } from '../../test-utils';
-import { IConfiguration } from '../../../../types';
+import type { IConfiguration } from '../../../../types';
 
 const entities = [
   {

--- a/packages/core/data-transfer/lib/providers/local-strapi-source-provider/assets.ts
+++ b/packages/core/data-transfer/lib/providers/local-strapi-source-provider/assets.ts
@@ -1,5 +1,5 @@
-import * as path from 'path';
-import * as fse from 'fs-extra';
+import { join } from 'path';
+import { readdir, stat, createReadStream } from 'fs-extra';
 import { Duplex } from 'stream';
 
 import type { IAsset } from '../../../types';
@@ -10,16 +10,16 @@ const IGNORED_FILES = ['.gitkeep'];
  * Generate and consume assets streams in order to stream each file individually
  */
 export const createAssetsStream = (strapi: Strapi.Strapi): Duplex => {
-  const assetsDirectory = path.join(strapi.dirs.static.public, 'uploads');
+  const assetsDirectory = join(strapi.dirs.static.public, 'uploads');
 
   const generator: () => AsyncGenerator<IAsset, void> = async function* () {
-    const files = await fse.readdir(assetsDirectory);
+    const files = await readdir(assetsDirectory);
     const validFiles = files.filter((file) => !IGNORED_FILES.includes(file));
 
     for (const filename of validFiles) {
-      const filepath = path.join(assetsDirectory, filename);
-      const stats = await fse.stat(filepath);
-      const stream = fse.createReadStream(filepath);
+      const filepath = join(assetsDirectory, filename);
+      const stats = await stat(filepath);
+      const stream = createReadStream(filepath);
 
       yield {
         filename,

--- a/packages/core/data-transfer/types/encryption.d.ts
+++ b/packages/core/data-transfer/types/encryption.d.ts
@@ -1,4 +1,4 @@
-import { Cipher, CipherKey, BinaryLike } from 'crypto';
+import type { Cipher, CipherKey, BinaryLike } from 'crypto';
 
 export type EncryptionStrategy = (key: string) => Cipher;
 

--- a/packages/core/data-transfer/types/providers.d.ts
+++ b/packages/core/data-transfer/types/providers.d.ts
@@ -1,11 +1,11 @@
-import {
+import type {
   IDestinationProviderTransferResults,
   IProviderTransferResults,
   ISourceProviderTransferResults,
   Stream,
 } from './utils';
-import { IMetadata } from './common-entities';
-import { PipelineSource, PipelineDestination } from 'stream';
+import type { IMetadata } from './common-entities';
+import type { PipelineSource, PipelineDestination } from 'stream';
 
 type ProviderType = 'source' | 'destination';
 

--- a/packages/core/data-transfer/types/transfer-engine.d.ts
+++ b/packages/core/data-transfer/types/transfer-engine.d.ts
@@ -1,7 +1,7 @@
-import { SchemaUID } from '@strapi/strapi/lib/types/utils';
-import { IEntity, ILink } from './common-entities';
-import { ITransferRule } from './utils';
-import { ISourceProvider, IDestinationProvider } from './provider';
+import type { SchemaUID } from '@strapi/strapi/lib/types/utils';
+import type { IEntity, ILink } from './common-entities';
+import type { ITransferRule } from './utils';
+import type { ISourceProvider, IDestinationProvider } from './provider';
 
 /**
  * Defines the capabilities and properties of the transfer engine


### PR DESCRIPTION
### What does it do?

- only import what is needed from 'fs-extra' and 'path'
- replace some usage of *sync methods with async
- check access to the file rather than if it exists
- fix `import type` where applicable

### Why is it needed?

Fixes a few minor errors

### How to test it?

import and export should still work, tests should still pass.
