### PR TITLE
Use explicit path

### DIFF
--- a/packages/generators/app/lib/create-cli-db-project.js
+++ b/packages/generators/app/lib/create-cli-db-project.js
@@ -2,11 +2,11 @@
 
 const { merge } = require('lodash');
 
-const { trackUsage } = require('./utils/usage');
-const defaultConfigs = require('./utils/db-configs');
-const clientDependencies = require('./utils/db-client-dependencies');
-const getClientName = require('./utils/db-client-name');
-const createProject = require('./create-project');
+const { trackUsage } = require('./utils/usage.js');
+const defaultConfigs = require('./utils/db-configs.js');
+const clientDependencies = require('./utils/db-client-dependencies.js');
+const getClientName = require('./utils/db-client-name.js');
+const createProject = require('./create-project.js');
 
 module.exports = async (scope) => {
   console.log('Creating a project from the database CLI arguments.');

--- a/packages/generators/app/lib/create-customized-project.js
+++ b/packages/generators/app/lib/create-customized-project.js
@@ -8,12 +8,12 @@ const inquirer = require('inquirer');
 const execa = require('execa');
 const { merge } = require('lodash');
 
-const stopProcess = require('./utils/stop-process');
-const { trackUsage } = require('./utils/usage');
-const defaultConfigs = require('./utils/db-configs');
-const clientDependencies = require('./utils/db-client-dependencies');
-const dbQuestions = require('./utils/db-questions');
-const createProject = require('./create-project');
+const stopProcess = require('./utils/stop-process.js');
+const { trackUsage } = require('./utils/usage.js');
+const defaultConfigs = require('./utils/db-configs.js');
+const clientDependencies = require('./utils/db-client-dependencies.js');
+const dbQuestions = require('./utils/db-questions.js');
+const createProject = require('./create-project.js');
 
 const LANGUAGES = {
   javascript: 'JavaScript',

--- a/packages/generators/app/lib/create-project.js
+++ b/packages/generators/app/lib/create-project.js
@@ -10,11 +10,11 @@ const execa = require('execa');
 const ora = require('ora');
 const _ = require('lodash');
 
-const stopProcess = require('./utils/stop-process');
-const { trackUsage, captureStderr } = require('./utils/usage');
+const stopProcess = require('./utils/stop-process.js');
+const { trackUsage, captureStderr } = require('./utils/usage.js');
 const mergeTemplate = require('./utils/merge-template.js');
 
-const packageJSON = require('./resources/json/common/package.json');
+const packageJSON = require('./resources/json/common/package.json.js');
 const createDatabaseConfig = require('./resources/templates/database.js');
 const createEnvFile = require('./resources/templates/env.js');
 

--- a/packages/generators/app/lib/create-quickstart-project.js
+++ b/packages/generators/app/lib/create-quickstart-project.js
@@ -3,10 +3,10 @@
 const execa = require('execa');
 // FIXME
 /* eslint-disable import/extensions */
-const { trackUsage, captureStderr } = require('./utils/usage');
+const { trackUsage, captureStderr } = require('./utils/usage.js');
 const defaultConfigs = require('./utils/db-configs.js');
 const clientDependencies = require('./utils/db-client-dependencies.js');
-const createProject = require('./create-project');
+const createProject = require('./create-project.js');
 
 module.exports = async function createQuickStartProject(scope) {
   console.log('Creating a quickstart project.');

--- a/packages/generators/app/lib/generate-new.js
+++ b/packages/generators/app/lib/generate-new.js
@@ -4,11 +4,11 @@
  * Module dependencies
  */
 
-const { trackUsage } = require('./utils/usage');
-const checkInstallPath = require('./utils/check-install-path');
-const createCLIDatabaseProject = require('./create-cli-db-project');
-const createCustomizedProject = require('./create-customized-project');
-const createQuickStartProject = require('./create-quickstart-project');
+const { trackUsage } = require('./utils/usage.js');
+const checkInstallPath = require('./utils/check-install-path.js');
+const createCLIDatabaseProject = require('./create-cli-db-project.js');
+const createCustomizedProject = require('./create-customized-project.js');
+const createQuickStartProject = require('./create-quickstart-project.js');
 
 module.exports = async (scope) => {
   const hasDatabaseConfig = Boolean(scope.database);

--- a/packages/generators/app/lib/index.js
+++ b/packages/generators/app/lib/index.js
@@ -5,13 +5,13 @@ const os = require('os');
 const crypto = require('crypto');
 const { v4: uuidv4 } = require('uuid');
 const sentry = require('@sentry/node');
-const hasYarn = require('./utils/has-yarn');
-const checkRequirements = require('./utils/check-requirements');
-const { trackError, captureException } = require('./utils/usage');
-const parseDatabaseArguments = require('./utils/parse-db-arguments');
-const generateNew = require('./generate-new');
-const checkInstallPath = require('./utils/check-install-path');
-const machineID = require('./utils/machine-id');
+const hasYarn = require('./utils/has-yarn.js');
+const checkRequirements = require('./utils/check-requirements.js');
+const { trackError, captureException } = require('./utils/usage.js');
+const parseDatabaseArguments = require('./utils/parse-db-arguments.js');
+const generateNew = require('./generate-new.js');
+const checkInstallPath = require('./utils/check-install-path.js');
+const machineID = require('./utils/machine-id.js');
 
 sentry.init({
   dsn: 'https://841d2b2c9b4d4b43a4cde92794cb705a@sentry.io/1762059',

--- a/packages/generators/app/lib/utils/check-install-path.js
+++ b/packages/generators/app/lib/utils/check-install-path.js
@@ -2,7 +2,7 @@
 
 const chalk = require('chalk');
 const fse = require('fs-extra');
-const stopProcess = require('./stop-process');
+const stopProcess = require('./stop-process.js');
 
 /**
  * Checks if the an empty directory exists at rootPath

--- a/packages/generators/app/lib/utils/check-requirements.js
+++ b/packages/generators/app/lib/utils/check-requirements.js
@@ -2,7 +2,7 @@
 
 const { red, green, bold, yellow } = require('chalk');
 const semver = require('semver');
-const packageJSON = require('../resources/json/common/package.json');
+const packageJSON = require('../resources/json/common/package.json.js');
 
 module.exports = function checkBeforeInstall() {
   const currentNodeVersion = process.versions.node;

--- a/packages/generators/app/lib/utils/merge-template.js
+++ b/packages/generators/app/lib/utils/merge-template.js
@@ -5,7 +5,7 @@ const path = require('path');
 const fse = require('fs-extra');
 const _ = require('lodash/fp');
 const chalk = require('chalk');
-const { getTemplatePackageInfo, downloadNpmTemplate } = require('./fetch-npm-template');
+const { getTemplatePackageInfo, downloadNpmTemplate } = require('./fetch-npm-template.js');
 
 // Specify all the files and directories a template can have
 const allowFile = Symbol('alloFile');

--- a/packages/generators/app/lib/utils/parse-db-arguments.js
+++ b/packages/generators/app/lib/utils/parse-db-arguments.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const chalk = require('chalk');
-const stopProcess = require('./stop-process');
+const stopProcess = require('./stop-process.js');
 
 const DB_ARGS = ['dbclient', 'dbhost', 'dbport', 'dbname', 'dbusername', 'dbpassword'];
 


### PR DESCRIPTION
It dose not look like you are going to switch to ESM any time soon.
But preparing for it can be good without breaking things.

ESM requires explicit path

> Mandatory file extensions[#](https://nodejs.org/dist/latest-v19.x/docs/api/esm.html#mandatory-file-extensions)
A file extension must be provided when using the import keyword to resolve relative or absolute specifiers. Directory indexes (e.g. './startup/index.js') must also be fully specified.
> 
>  This behavior matches how import behaves in browser environments, assuming a typically configured server.

this is also better for commonjs as it dose not have to 2nd guess what file it needs to import so it is less stat-ing directories and looking for matches. so things loads faster

it should be made a best practices