### PR TITLE
adds styling to icon to support dark mode

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/RepeatableComponent/DraggedItem/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/RepeatableComponent/DraggedItem/index.js
@@ -27,13 +27,24 @@ const DragButton = styled.span`
   display: flex;
   align-items: center;
   height: ${({ theme }) => theme.spaces[7]};
-
+  background-color: transparent;
   padding: 0 ${({ theme }) => theme.spaces[3]};
   cursor: all-scroll;
 
   svg {
     width: ${12 / 16}rem;
     height: ${12 / 16}rem;
+    path {
+      fill: ${({ theme, expanded }) =>
+        expanded ? theme.colors.primary600 : theme.colors.neutral600};
+    }
+  }
+  &:hover {
+    svg {
+      path {
+        fill: ${({ theme }) => theme.colors.primary600};
+      }
+    }
   }
 `;
 


### PR DESCRIPTION

- Refer to the issue you are closing in the PR description: Fix #15141 

### What does it do?

It adds additional styling to the drag icon.

### Why is it needed?

Before applying this style the drag icon was nearly invisible to see in dark mode.