### PR TITLE
Content-manager: handle complex component nesting in the UI

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/reducer.js
+++ b/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/reducer.js
@@ -104,6 +104,11 @@ const reducer = (state, action) =>
           (value) => value.type === 'component' && value.repeatable
         )(componentLayoutData.attributes);
 
+        const nonRepeatableComponentPaths = recursivelyFindPathsBasedOnCondition(
+          allComponents,
+          (value) => value.type === 'component' && !value.repeatable
+        )(componentLayoutData.attributes);
+
         const componentDataStructure = relationPaths.reduce((acc, current) => {
           const [componentName] = current.split('.');
 
@@ -112,8 +117,21 @@ const reducer = (state, action) =>
            * has another repeatable component inside of it we
            * don't need to attach the array at this point because that will be
            * done again deeper in the nest.
+           *
+           * We also need to handle cases with single components nested within
+           * repeatables by checking that the relation path does not match a
+           * non-repeatable component path. This accounts for component
+           * structures such as:
+           * - outer_single_compo
+           *    - level_one_repeatable
+           *        - level_two_single_component
+           *            - level_three_repeatable
            */
-          if (!repeatableFields.includes(componentName)) {
+
+          if (
+            !repeatableFields.includes(componentName) &&
+            !nonRepeatableComponentPaths.includes(componentName)
+          ) {
             set(acc, current, []);
           }
 
@@ -128,7 +146,6 @@ const reducer = (state, action) =>
 
         break;
       }
-
       case 'LOAD_RELATION': {
         const initialDataPath = ['initialData', ...action.keys];
         const modifiedDataPath = ['modifiedData', ...action.keys];

--- a/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/tests/reducer.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/tests/reducer.test.js
@@ -109,8 +109,8 @@ describe('CONTENT MANAGER | COMPONENTS | EditViewDataManagerProvider | reducer',
             },
           },
         },
-        'basic.repetable-repeatble-relation': {
-          uid: 'basic.repetable-repeatble-relation',
+        'basic.repeatable-repeatble-relation': {
+          uid: 'basic.repeatable-repeatble-relation',
           attributes: {
             repeatable_simple: {
               type: 'component',
@@ -144,7 +144,7 @@ describe('CONTENT MANAGER | COMPONENTS | EditViewDataManagerProvider | reducer',
 
       const action = {
         type: 'ADD_NON_REPEATABLE_COMPONENT_TO_FIELD',
-        componentLayoutData: components['basic.repetable-repeatble-relation'],
+        componentLayoutData: components['basic.repeatable-repeatble-relation'],
         allComponents: components,
         keys: ['component_field', 'sub_component'],
       };
@@ -429,8 +429,8 @@ describe('CONTENT MANAGER | COMPONENTS | EditViewDataManagerProvider | reducer',
             },
           },
         },
-        'basic.repetable-repeatble-relation': {
-          uid: 'basic.repetable-repeatble-relation',
+        'basic.repeatable-repeatble-relation': {
+          uid: 'basic.repeatable-repeatble-relation',
           attributes: {
             id: {
               type: 'integer',
@@ -460,7 +460,7 @@ describe('CONTENT MANAGER | COMPONENTS | EditViewDataManagerProvider | reducer',
         type: 'ADD_REPEATABLE_COMPONENT_TO_FIELD',
         keys: ['repeatable_repeatable_nested_component'],
         componentLayoutData: {
-          uid: 'basic.repetable-repeatble-relation',
+          uid: 'basic.repeatable-repeatble-relation',
           attributes: {
             id: {
               type: 'integer',
@@ -530,6 +530,131 @@ describe('CONTENT MANAGER | COMPONENTS | EditViewDataManagerProvider | reducer',
           ],
         },
       });
+    });
+
+    it('should add a repeatable field and not set up the relational field if its a deeply nested repeatable field within another component', () => {
+      /**
+       * Structurally this component looks like:
+       * - outer_single_compo
+       *    - level_one_repeatable
+       *        - level_two_single_component
+       *            - level_three_repeatable
+       *
+       * The reducer should only handle the repeatable at level_one in this case.
+       */
+
+      const state = {
+        ...initialState,
+        componentsDataStructure: {
+          'basic.outer_single_compo': {},
+          'basic.level_one_repeatable': {},
+          'basic.level_two_single_component': {},
+          'basic.level_three_repeatable': {},
+        },
+        initialData: {},
+        modifiedData: {
+          outer_single_compo: {},
+        },
+      };
+
+      const expected = {
+        ...initialState,
+        componentsDataStructure: {
+          'basic.outer_single_compo': {},
+          'basic.level_one_repeatable': {},
+          'basic.level_two_single_component': {},
+          'basic.level_three_repeatable': {},
+        },
+        initialData: {},
+        modifiedData: {
+          outer_single_compo: {
+            level_one_repeatable: [
+              {
+                __temp_key__: 0,
+              },
+            ],
+          },
+        },
+      };
+
+      const action = {
+        type: 'ADD_REPEATABLE_COMPONENT_TO_FIELD',
+        keys: ['outer_single_compo', 'level_one_repeatable'],
+        componentLayoutData: {
+          uid: 'basic.level_one_repeatable',
+          attributes: {
+            id: {
+              type: 'integer',
+            },
+            level_two_single_component: {
+              displayName: 'level_two_single_component',
+              type: 'component',
+              component: 'basic.level_two_single_component',
+            },
+          },
+        },
+        allComponents: {
+          'basic.outer_single_compo': {
+            uid: 'basic.outer_single_compo',
+            attributes: {
+              id: {
+                type: 'integer',
+              },
+              level_one_repeatable: {
+                displayName: 'level_one_repeatable',
+                type: 'component',
+                repeatable: true,
+                component: 'basic.level_one_repeatable',
+              },
+            },
+          },
+          'basic.level_one_repeatable': {
+            uid: 'basic.level_one_repeatable',
+            attributes: {
+              id: {
+                type: 'integer',
+              },
+              level_two_single_component: {
+                displayName: 'level_two_single_component',
+                type: 'component',
+                component: 'basic.level_two_single_component',
+              },
+            },
+          },
+          'basic.level_two_single_component': {
+            uid: 'basic.level_two_single_component',
+            attributes: {
+              id: {
+                type: 'integer',
+              },
+              level_three_repeatable: {
+                displayName: 'level_three_repeatable',
+                repeatable: true,
+                type: 'component',
+                component: 'basic.level_three_repeatable',
+              },
+            },
+          },
+          'basic.level_three_repeatable': {
+            uid: 'basic.level_three_repeatable',
+            attributes: {
+              id: {
+                type: 'integer',
+              },
+              categories: {
+                type: 'relation',
+                relation: 'oneToMany',
+                target: 'api::category.category',
+                targetModel: 'api::category.category',
+                relationType: 'oneToMany',
+              },
+            },
+          },
+        },
+        shouldCheckErrors: false,
+      };
+
+      expect(reducer(state, action)).toEqual(expected);
     });
   });
 
@@ -1518,7 +1643,7 @@ describe('CONTENT MANAGER | COMPONENTS | EditViewDataManagerProvider | reducer',
             ok: true,
             dynamic_relations: [
               {
-                __component: 'basic.repetable-repeatble-relation',
+                __component: 'basic.repeatable-repeatble-relation',
                 id: 5,
                 repeatable_simple: [
                   {
@@ -1541,7 +1666,7 @@ describe('CONTENT MANAGER | COMPONENTS | EditViewDataManagerProvider | reducer',
             ok: true,
             dynamic_relations: [
               {
-                __component: 'basic.repetable-repeatble-relation',
+                __component: 'basic.repeatable-repeatble-relation',
                 id: 5,
                 repeatable_simple: [
                   {
@@ -1570,7 +1695,7 @@ describe('CONTENT MANAGER | COMPONENTS | EditViewDataManagerProvider | reducer',
             ok: true,
             dynamic_relations: [
               {
-                __component: 'basic.repetable-repeatble-relation',
+                __component: 'basic.repeatable-repeatble-relation',
                 id: 5,
                 repeatable_simple: [
                   {

--- a/packages/core/admin/admin/src/content-manager/components/RepeatableComponent/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/RepeatableComponent/index.js
@@ -54,9 +54,7 @@ const RepeatableComponent = ({
     [componentUid, getComponentLayout]
   );
 
-  const nextTempKey = useMemo(() => {
-    return getMaxTempKey(componentValue || []) + 1;
-  }, [componentValue]);
+  const nextTempKey = useMemo(() => getMaxTempKey(componentValue || []) + 1, [componentValue]);
 
   const componentErrorKeys = getComponentErrorKeys(name, formErrors);
 


### PR DESCRIPTION
### What does it do?

Fixes a bug in `content-manager/components/EditViewDataManagerProvider/reducer.js` that was causing the UI to error with deeply nest content structures

### How to test it?

- Through new test added
- Follow system setup in https://github.com/strapi/strapi/issues/15038 and test through the Admin UI

### Related issue(s)/PR(s)

fixes https://github.com/strapi/strapi/issues/15038

