### PR TITLE
[DEITS] Run yarn install before yarn clean

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   ],
   "scripts": {
     "prepare": "husky install",
-    "setup": "yarn clean && yarn && yarn build",
+    "setup": "yarn && yarn clean && yarn build",
     "clean": "lerna run --stream clean --no-private",
     "watch": "lerna run --stream watch --no-private",
     "build": "lerna run --stream build --no-private",


### PR DESCRIPTION
### What does it do?

`package.json`
```diff
  "scripts": {
    "prepare": "husky install",
-   "setup": "yarn clean && yarn && yarn build",
+   "setup": "yarn && yarn clean && yarn build",
    "clean": "lerna run --stream clean --no-private",
    "watch": "lerna run --stream watch --no-private",
    "build": "lerna run --stream build --no-private",
```

### Why is it needed?

`yarn clean` implementation in the monorepository packages assumes they have access to their dependencies. When running yarn clean before yarn install in the yarn setup, we're not fulfilling this promise & yarn clean fails.

