### PR TITLE
[DnD]: reordering and scrolling at the same time

### DIFF
--- a/docs/docs/core/content-manager/hooks/use-drag-and-drop.mdx
+++ b/docs/docs/core/content-manager/hooks/use-drag-and-drop.mdx
@@ -132,7 +132,16 @@ import { ConnectDropTarget, ConnectDragSource, ConnectDragPreview } from 'react-
 interface UseDragAndDropOptions {
   index: number;
   onMoveItem: (newIndex: number, currentIndex: number) => void;
+  /**
+   * @default "regular"
+   * Defines whether the change in index should be immediately over another
+   * dropzone or half way over it (regular).
+   */
+  dropSensitivity?: 'immediate' | 'regular';
   item?: object;
+  /**
+   * @default 'STRAPI_DND'
+   */
   type?: string;
   onCancel?: (index: number) => void;
   onDropItem?: (index: number) => void;

--- a/packages/core/admin/admin/src/content-manager/components/RelationInput/RelationInput.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInput/RelationInput.js
@@ -352,9 +352,7 @@ const RelationInput = ({
                 relations,
                 updatePositionOfRelation: handleUpdatePositionOfRelation,
               }}
-              itemKey={(index, { relations: relationsItems }) =>
-                `${relationsItems[index].mainField}_${relationsItems[index].id}`
-              }
+              itemKey={(index) => `${relations[index].mainField}_${relations[index].id}`}
               innerElementType="ol"
             >
               {ListItem}

--- a/packages/core/admin/admin/src/content-manager/components/RelationInput/components/RelationItem.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInput/components/RelationItem.js
@@ -56,6 +56,7 @@ export const RelationItem = ({
       onDropItem,
       onCancel,
       onMoveItem: updatePositionOfRelation,
+      dropSensitivity: 'immediate',
     });
 
   const composedRefs = composeRefs(relationRef, dragRef);

--- a/packages/core/admin/admin/src/content-manager/components/RelationInput/components/RelationItem.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInput/components/RelationItem.js
@@ -50,6 +50,7 @@ export const RelationItem = ({
       item: {
         displayedValue: displayValue,
         status,
+        id,
       },
       onGrabItem,
       onDropItem,

--- a/packages/core/admin/admin/src/content-manager/hooks/useDragAndDrop.js
+++ b/packages/core/admin/admin/src/content-manager/hooks/useDragAndDrop.js
@@ -12,6 +12,7 @@ import { useKeyboardDragAndDrop } from './useKeyboardDragAndDrop';
  *  item?: object,
  *  onStart?: () => void,
  *  onEnd?: () => void,
+ *  dropSensitivity?: 'regular' | 'immediate'
  * } & import('./useKeyboardDragAndDrop').UseKeyboardDragAndDropCallbacks}
  */
 
@@ -39,6 +40,7 @@ export const useDragAndDrop = (
     onDropItem,
     onCancel,
     onMoveItem,
+    dropSensitivity = 'regular',
   }
 ) => {
   const objectRef = useRef(null);
@@ -62,19 +64,21 @@ export const useDragAndDrop = (
         return;
       }
 
-      const hoverBoundingRect = objectRef.current.getBoundingClientRect();
-      const hoverMiddleY = (hoverBoundingRect.bottom - hoverBoundingRect.top) / 2;
-      const clientOffset = monitor.getClientOffset();
-      const hoverClientY = clientOffset.y - hoverBoundingRect.top;
+      if (dropSensitivity === 'regular') {
+        const hoverBoundingRect = objectRef.current.getBoundingClientRect();
+        const hoverMiddleY = (hoverBoundingRect.bottom - hoverBoundingRect.top) / 2;
+        const clientOffset = monitor.getClientOffset();
+        const hoverClientY = clientOffset.y - hoverBoundingRect.top;
 
-      // Dragging downwards
-      if (dragIndex < newInd && hoverClientY < hoverMiddleY) {
-        return;
-      }
+        // Dragging downwards
+        if (dragIndex < newInd && hoverClientY < hoverMiddleY) {
+          return;
+        }
 
-      // Dragging upwards
-      if (dragIndex > newInd && hoverClientY > hoverMiddleY) {
-        return;
+        // Dragging upwards
+        if (dragIndex > newInd && hoverClientY > hoverMiddleY) {
+          return;
+        }
       }
 
       // Time to actually perform the action

--- a/packages/core/admin/admin/src/content-manager/hooks/useDragAndDrop.js
+++ b/packages/core/admin/admin/src/content-manager/hooks/useDragAndDrop.js
@@ -104,6 +104,16 @@ export const useDragAndDrop = (
       }
     },
     canDrag: active,
+    /**
+     * This is for useful when the item is in a virtualized list.
+     * However, if we don't have an ID then we want the libraries
+     * defaults to take care of this.
+     */
+    isDragging: item.id
+      ? (monitor) => {
+          return item.id === monitor.getItem().id;
+        }
+      : undefined,
     collect: (monitor) => ({
       isDragging: monitor.isDragging(),
     }),


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* uses `isDragging` prop if an id is passed to the hook to force boolean value and not rely on monitor (useful if the component re-renders in the case of a virtualised list)
* Adds `dropSensitivity` prop to alter when an item is recognised to have changed drop zones

### Why is it needed?

* To help users be able to scroll up while dragging we need a more sensitive dropzone so native browser behaviour works

### Related issue(s)/PR(s)

* resolves CONTENT-760
