### PR TITLE
fix(content-manager): reordering within dynamicZones

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/reducer.js
+++ b/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/reducer.js
@@ -134,8 +134,8 @@ const reducer = (state, action) =>
         const modifiedDataPath = ['modifiedData', ...action.keys];
         const { value } = action;
 
-        const initialDataRelations = get(state, initialDataPath);
-        const modifiedDataRelations = get(state, modifiedDataPath);
+        const initialDataRelations = get(state, initialDataPath, []);
+        const modifiedDataRelations = get(state, modifiedDataPath, []);
 
         set(draftState, initialDataPath, uniqBy([...value, ...initialDataRelations], 'id'));
 


### PR DESCRIPTION
### What does it do?

Fixes an issue that was causing the Admin UI to error when reordering DZ components

This was caused by the value of `initialDataRelations` being undefined

### How to test it?

- Following description in https://github.com/strapi/strapi/issues/14908
- Use project files and DB dump from project linked in - https://github.com/strapi/strapi/issues/14908#issuecomment-1339366300

### Related issue(s)/PR(s)

fixes https://github.com/strapi/strapi/issues/14908
