### PR TITLE
fix(content-manager): close ListSettingsView/EditFieldForm with escape

### DIFF
--- a/packages/core/admin/admin/src/content-manager/pages/ListSettingsView/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/ListSettingsView/index.js
@@ -5,6 +5,7 @@ import isEqual from 'lodash/isEqual';
 import upperFirst from 'lodash/upperFirst';
 import pick from 'lodash/pick';
 import get from 'lodash/get';
+import isEmpty from 'lodash/isEmpty';
 import { stringify } from 'qs';
 import { useNotification, useTracking, ConfirmDialog, Link } from '@strapi/helper-plugin';
 import { useIntl } from 'react-intl';
@@ -35,12 +36,12 @@ const ListSettingsView = ({ layout, slug }) => {
 
   const [showWarningSubmit, setWarningSubmit] = useState(false);
   const toggleWarningSubmit = () => setWarningSubmit((prevState) => !prevState);
-  const [isModalFormOpen, setIsModalFormOpen] = useState(false);
-  const toggleModalForm = () => setIsModalFormOpen((prevState) => !prevState);
   const [reducerState, dispatch] = useReducer(reducer, initialState, () =>
     init(initialState, layout)
   );
   const { fieldToEdit, fieldForm, initialData, modifiedData } = reducerState;
+  const isModalFormOpen = !isEmpty(fieldForm);
+
   const { attributes } = layout;
   const displayedFields = modifiedData.layouts.list;
 
@@ -110,19 +111,16 @@ const ListSettingsView = ({ layout, slug }) => {
       type: 'SET_FIELD_TO_EDIT',
       fieldToEdit,
     });
-    toggleModalForm();
   };
 
   const handleCloseModal = () => {
     dispatch({
       type: 'UNSET_FIELD_TO_EDIT',
     });
-    toggleModalForm();
   };
 
   const handleSubmitFieldEdit = (e) => {
     e.preventDefault();
-    toggleModalForm();
     dispatch({
       type: 'SUBMIT_FIELD_FORM',
     });


### PR DESCRIPTION
### What does it do?

- Fixes an issue where using the 'esc' key to close `content-manager/pages/ListSettingsView/components/EditFieldForm.js` would cause a blank screen in the admin panel
- EditFieldForm would be mounted with `fieldToEdit` set to 'empty string' causing the error.

### How to test it?

Follow linked issues

### Related issue(s)/PR(s)

fixes https://github.com/strapi/strapi/issues/14942
fixes https://github.com/strapi/strapi/issues/14981

