### PR TITLE
Avoid deadlocks for mysql and mariadb when creating a Nth locale

### DIFF
--- a/packages/core/database/lib/entity-manager/regular-relations.js
+++ b/packages/core/database/lib/entity-manager/regular-relations.js
@@ -328,7 +328,7 @@ const cleanOrderColumnsForInnoDB = async ({
       await db.connection
         .raw(
           `
-          CREATE TEMPORARY TABLE ??
+          CREATE TABLE ??
             SELECT
               id,
               (
@@ -361,9 +361,7 @@ const cleanOrderColumnsForInnoDB = async ({
         )
         .transacting(trx);
     } finally {
-      await db.connection
-        .raw(`DROP TEMPORARY TABLE IF EXISTS ??`, [tempInvOrderTableName])
-        .transacting(trx);
+      await db.connection.raw(`DROP TABLE IF EXISTS ??`, [tempInvOrderTableName]).transacting(trx);
     }
   }
 };


### PR DESCRIPTION
### What does it do?

Remove the use of temporary tables for mysql dialect for the inverse order usecase

### Why is it needed?

It was forgotten in this PR : #15143

### How to test it?

Run the test `packages/plugins/i18n/tests/content-manager/crud.test.api.js` multiple times with mysql and see that it always passes.

### Related issue(s)/PR(s)

#15143
