### PR TITLE
Fix typo in inactive issue cron workflow

### DIFF
--- a/.github/workflows/issues_dailyCron.yml
+++ b/.github/workflows/issues_dailyCron.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           actions: 'close-issues'
           token: ${{ secrets.GITHUB_TOKEN }}
-          labels: 'status: pending reproduction'
+          labels: 'status: can not reproduce'
           inactive-day: 14
           close-reason: 'completed'
           body: |


### PR DESCRIPTION
### What does it do?

I set the wrong label :see_no_evil:

### Why is it needed?

It was closing the wrong issues

### How to test it?

N/A

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/pull/14565
