### PR TITLE
[Audit logs] Emit logout event

### DIFF
--- a/packages/core/admin/admin/src/components/LeftMenu/index.js
+++ b/packages/core/admin/admin/src/components/LeftMenu/index.js
@@ -2,7 +2,7 @@ import React, { useRef, useState } from 'react';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
-import { NavLink as RouterNavLink, useLocation } from 'react-router-dom';
+import { NavLink as RouterNavLink, useLocation, useHistory } from 'react-router-dom';
 import { Divider } from '@strapi/design-system/Divider';
 import {
   MainNav,
@@ -20,7 +20,8 @@ import { Stack } from '@strapi/design-system/Stack';
 import Write from '@strapi/icons/Write';
 import Exit from '@strapi/icons/Exit';
 import { auth, usePersistentState, useAppInfos, useTracking } from '@strapi/helper-plugin';
-import useConfigurations from '../../hooks/useConfigurations';
+import { useConfigurations } from '../../hooks';
+import { axiosInstance } from '../../core/utils';
 
 const LinkUserWrapper = styled(Box)`
   width: ${150 / 16}rem;
@@ -61,6 +62,7 @@ const LeftMenu = ({ generalSectionLinks, pluginsSectionLinks }) => {
   const { formatMessage } = useIntl();
   const { trackUsage } = useTracking();
   const { pathname } = useLocation();
+  const history = useHistory();
 
   const initials = userDisplayName
     .split(' ')
@@ -70,9 +72,11 @@ const LeftMenu = ({ generalSectionLinks, pluginsSectionLinks }) => {
 
   const handleToggleUserLinks = () => setUserLinksVisible((prev) => !prev);
 
-  const handleLogout = () => {
+  const handleLogout = async () => {
+    await axiosInstance.post('/admin/logout');
     auth.clearAppStorage();
     handleToggleUserLinks();
+    history.push('/auth/login');
   };
 
   const handleBlur = (e) => {
@@ -205,7 +209,7 @@ const LeftMenu = ({ generalSectionLinks, pluginsSectionLinks }) => {
                   })}
                 </Typography>
               </LinkUser>
-              <LinkUser tabIndex={0} onClick={handleLogout} logout="logout" to="/auth/login">
+              <LinkUser as="button" tabIndex={0} onClick={handleLogout} logout="logout">
                 <Typography textColor="danger600">
                   {formatMessage({
                     id: 'app.components.LeftMenu.logout',

--- a/packages/core/admin/ee/server/services/audit-logs.js
+++ b/packages/core/admin/ee/server/services/audit-logs.js
@@ -13,6 +13,7 @@ const defaultEvents = [
   'user.update',
   'user.delete',
   'admin.auth.success',
+  'admin.logout',
 ];
 
 const getEventMap = (defaultEvents) => {

--- a/packages/core/admin/server/controllers/authentication.js
+++ b/packages/core/admin/server/controllers/authentication.js
@@ -157,4 +157,10 @@ module.exports = {
       },
     };
   },
+
+  logout(ctx) {
+    const sanitizedUser = getService('user').sanitizeUser(ctx.state.user);
+    strapi.eventHub.emit('admin.logout', { user: sanitizedUser });
+    ctx.body = { data: {} };
+  },
 };

--- a/packages/core/admin/server/routes/authentication.js
+++ b/packages/core/admin/server/routes/authentication.js
@@ -43,4 +43,12 @@ module.exports = [
     handler: 'authentication.resetPassword',
     config: { auth: false },
   },
+  {
+    method: 'POST',
+    path: '/logout',
+    handler: 'authentication.logout',
+    config: {
+      policies: ['admin::isAuthenticatedAdmin'],
+    },
+  },
 ];


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Logs logout events in audit logs. To do that, I had to add a new logout route, as the logout used to be frontend-only, and we only have access to the event hub in the backend.

### How to test it?

Log out, check out your logs
