### PR TITLE
Improve ML reactivity when there are many files

### DIFF
--- a/packages/core/upload/server/content-types/file/schema.js
+++ b/packages/core/upload/server/content-types/file/schema.js
@@ -108,5 +108,30 @@ module.exports = {
       columns: ['folder_path'],
       type: null,
     },
+    {
+      name: `upload_files_created_at_index`,
+      columns: ['created_at'],
+      type: null,
+    },
+    {
+      name: `upload_files_updated_at_index`,
+      columns: ['updated_at'],
+      type: null,
+    },
+    {
+      name: `upload_files_name_index`,
+      columns: ['name'],
+      type: null,
+    },
+    {
+      name: `upload_files_size_index`,
+      columns: ['size'],
+      type: null,
+    },
+    {
+      name: `upload_files_ext_index`,
+      columns: ['ext'],
+      type: null,
+    },
   ],
 };


### PR DESCRIPTION
### What does it do?

Add indexes for sortable columns of files

### Why is it needed?

When files are retrieved, they are sorted by a field like `created_at`. When there are many files, like 300k, the API response becomes slower (~1 to 2 sec). Adding an index improve the speed of the sort operation.

### How to test it?

1. Upload a file to the ML
2. Go to your database, in the files table
3. Copy the file row (without the ID) and paste it 200k times (it's a bit long to do but you can copy several rows at the same time. You can also do an SQL loop but not on SQLite)
4. Go to the ML and check the request time before and after the fix.

### Related issue(s)/PR(s)

Fix #14954
