### PR TITLE
Put inversedBy only once for manyToMany and oneToOne relations when creating a content-type

### DIFF
--- a/packages/core/content-type-builder/server/services/schema-builder/content-type-builder.js
+++ b/packages/core/content-type-builder/server/services/schema-builder/content-type-builder.js
@@ -117,6 +117,10 @@ module.exports = function createComponentBuilder() {
         const attribute = infos.attributes[key];
 
         if (isRelation(attribute)) {
+          if (['manyToMany', 'oneToOne'].includes(attribute.relation)) {
+            attribute.dominant = true;
+          }
+
           this.setRelation({
             key,
             uid,


### PR DESCRIPTION
### What does it do?

Put inversedBy only once for manyToMany and oneToOne relations when creating a content-type

### Why is it needed?

A fix was already done [here](https://github.com/strapi/strapi/pull/15037) but it was partial (only fixing the issue when updating a content-type, not when creating it)

### How to test it?

1. Create a content-type with a many-to-many relation.
2. Check the schemas

### Related issue(s)/PR(s)

#15037
