### PR TITLE
[DEITS] Fix component with relation import

### DIFF
--- a/packages/core/data-transfer/lib/providers/local-strapi-destination-provider/strategies/restore/entities.ts
+++ b/packages/core/data-transfer/lib/providers/local-strapi-destination-provider/strategies/restore/entities.ts
@@ -1,4 +1,9 @@
 import type { SchemaUID } from '@strapi/strapi/lib/types/utils';
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import { traverseEntity } from '@strapi/utils';
+import { castArray, get } from 'lodash/fp';
 import { Writable } from 'stream';
 
 import type { IEntity } from '../../../../../types';
@@ -9,6 +14,8 @@ interface IEntitiesRestoreStreamOptions {
   updateMappingTable<T extends SchemaUID | string>(type: T, oldID: number, newID: number): void;
 }
 
+type EntityIDMap = { [path: string]: { type: string; old?: number; new?: number } };
+
 const createEntitiesWriteStream = (options: IEntitiesRestoreStreamOptions) => {
   const { strapi, updateMappingTable } = options;
   const query = shared.strapi.entity.createEntityQuery(strapi);
@@ -18,11 +25,40 @@ const createEntitiesWriteStream = (options: IEntitiesRestoreStreamOptions) => {
 
     async write(entity: IEntity, _encoding, callback) {
       const { type, id, data } = entity;
+      const { create, getDeepPopulateComponentLikeQuery } = query(type);
+      const contentType = strapi.getModel(type);
+
+      const ids: EntityIDMap = {
+        // Register current entity ID
+        id: { type, old: id },
+      };
+
+      const extractOldIDs = extractEntityIDs(ids, 'old');
+      const extractNewIDs = extractEntityIDs(ids, 'new');
 
       try {
-        const created = await query(type).create({ data });
+        // Register old IDs
+        await traverseEntity(extractOldIDs, { schema: contentType }, data);
 
-        updateMappingTable(type, id, created.id);
+        // Create the entity
+        const created = await create({
+          data,
+          populate: getDeepPopulateComponentLikeQuery(contentType, { select: 'id' }),
+          select: 'id',
+        });
+
+        // Register new IDs
+        ids.id.new = parseInt(created.id, 10);
+        await traverseEntity(extractNewIDs, { schema: contentType }, created);
+
+        // Save old/new IDs in the mapping table
+        for (const idMap of Object.values(ids)) {
+          const { new: newID, old: oldID } = idMap;
+
+          if (oldID && newID) {
+            updateMappingTable(idMap.type, oldID, newID);
+          }
+        }
       } catch (e) {
         if (e instanceof Error) {
           return callback(e);
@@ -34,6 +70,34 @@ const createEntitiesWriteStream = (options: IEntitiesRestoreStreamOptions) => {
       return callback(null);
     },
   });
+};
+
+const extractEntityIDs = (ids: EntityIDMap, property: 'old' | 'new') => (opts: any) => {
+  const { path, attribute, value } = opts;
+
+  const extract = (type: string, id: string) => {
+    const parsedID = parseInt(id, 10);
+
+    if (!(path in ids)) {
+      Object.assign(ids, { [path]: { type } });
+    }
+
+    Object.assign(ids[path], { [property]: parsedID });
+  };
+
+  if (attribute.type === 'component') {
+    const { component } = attribute;
+
+    castArray(value)
+      .map(get('id'))
+      .forEach((componentID: string) => extract(component, componentID));
+  }
+
+  if (attribute.type === 'dynamiczone') {
+    value.forEach((item: { __component: string; id: string }) =>
+      extract(item.__component, item.id)
+    );
+  }
 };
 
 export { createEntitiesWriteStream };

--- a/packages/core/data-transfer/lib/providers/local-strapi-source-provider/__tests__/entities.test.ts
+++ b/packages/core/data-transfer/lib/providers/local-strapi-source-provider/__tests__/entities.test.ts
@@ -46,10 +46,13 @@ describe('Local Strapi Source Provider - Entities Streaming', () => {
           { id: 2, age: 84 },
         ],
       });
-
+      const contentTypes = getContentTypes();
       const strapi = getStrapiFactory({
-        contentTypes: getContentTypes(),
+        contentTypes,
         db: { queryBuilder },
+        getModel: jest.fn((uid) => {
+          return contentTypes[uid];
+        }),
       })();
 
       const entitiesStream = createEntitiesStream(strapi);

--- a/packages/core/data-transfer/lib/providers/local-strapi-source-provider/__tests__/index.test.ts
+++ b/packages/core/data-transfer/lib/providers/local-strapi-source-provider/__tests__/index.test.ts
@@ -95,6 +95,9 @@ describe('Local Strapi Source Provider', () => {
           db: {
             queryBuilder,
           },
+          getModel: jest.fn((uid) => {
+            return contentTypes[uid];
+          }),
         }),
       });
 

--- a/packages/core/data-transfer/package.json
+++ b/packages/core/data-transfer/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "@strapi/logger": "4.5.4",
     "@strapi/strapi": "4.5.4",
+    "@strapi/utils": "4.5.4",
     "chalk": "4.1.2",
     "fs-extra": "10.0.0",
     "lodash": "4.17.21",


### PR DESCRIPTION
### What does it do?

Update the local strapi destination provider's ID mapping table with the components' ID.


### Why is it needed?

It enables links to or from components to be imported correctly.

### How to test it?

- Create data with relational fields in components
- Run an export
- Try to import the exported file
- The component's relations should be imported as well

