### PR TITLE
Move cropper CSS import from main bundle to upload plugin

### DIFF
--- a/packages/core/admin/admin/src/components/GlobalStyle/index.js
+++ b/packages/core/admin/admin/src/components/GlobalStyle/index.js
@@ -1,11 +1,5 @@
 import { createGlobalStyle } from 'styled-components';
 
-const loadCss = async () => {
-  await import(/* webpackChunkName: "cropper-css" */ 'cropperjs/dist/cropper.css');
-};
-
-loadCss();
-
 const GlobalStyle = createGlobalStyle`
   body {
     background: ${({ theme }) => theme.colors.neutral100};

--- a/packages/core/upload/admin/src/components/EditAssetDialog/PreviewBox/index.js
+++ b/packages/core/upload/admin/src/components/EditAssetDialog/PreviewBox/index.js
@@ -27,6 +27,8 @@ import { AssetType, AssetDefinition } from '../../../constants';
 import { AssetPreview } from './AssetPreview';
 import { createAssetUrl } from '../../../utils';
 
+import 'cropperjs/dist/cropper.css';
+
 export const PreviewBox = ({
   asset,
   canUpdate,


### PR DESCRIPTION
### What does it do?

Moves the cropperjs CSS import from the main bundle into the upload plugin.

### Why is it needed?

- it belongs in the plugin, because it is only used as part the edit asset dialog
- decreases size of the main bundle by about ~30kb because the upload plugin is code-splitted

### How to test it?

1. Navigate to the media library
2. Edit an asset
3. Crop the asset
4. Verify everything works as expected

### Related issue(s)/PR(s)

- Follow up of https://github.com/strapi/strapi/pull/15133
