### PR TITLE
[DEITS] add a check that file can be decrypted before import

### DIFF
--- a/packages/core/strapi/bin/strapi.js
+++ b/packages/core/strapi/bin/strapi.js
@@ -13,6 +13,8 @@ const inquirer = require('inquirer');
 
 const program = new Command();
 
+// TODO: re-enable lint on the next line once we merge the github CI fix
+// eslint-disable-next-line import/no-unresolved, node/no-missing-require
 const { createLocalFileSourceProvider } = require('@strapi/data-transfer');
 const packageJSON = require('../package.json');
 const { promptEncryptionKey, confirmMessage } = require('../lib/commands/utils/commander');


### PR DESCRIPTION
### What does it do?

Checks that file can be decrypted as soon as key is entered, and abort process if it fails.

### Why is it needed?

Currently if an invalid key is provided, extension is wrong, etc (basically if the file cannot properly be opened), the import process continues until it fails to open a stream. That means the user is prompted about restore, the restore happens (deletes the database), and then import fails, leaving the user with an empty strapi 😢

### How to test it?

Run `strapi import` with all combinations of encrypt, compress, and trying both a valid and invalid password. Also try an otherwise valid file that is missing the metadata.json.

If a file is encrypted, the error should always include "...check that key is correct"

If a file is not encrypted, the error should not mention the key.

