### PR TITLE
fix: Content manager crashing when dynamic zone entry field is not of type string

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/DynamicZone/components/DynamicComponent.js
+++ b/packages/core/admin/admin/src/content-manager/components/DynamicZone/components/DynamicComponent.js
@@ -73,7 +73,7 @@ const DynamicZoneComponent = ({
 
     const mainField = get(modifiedData, [name, index, mainFieldKey]) ?? '';
 
-    const displayedValue = mainFieldKey === 'id' ? '' : mainField.trim();
+    const displayedValue = mainFieldKey === 'id' ? '' : String(mainField).trim();
 
     const mainValue = displayedValue.length > 0 ? ` - ${displayedValue}` : displayedValue;
 


### PR DESCRIPTION
### What does it do?
Add support for using a Numeric field as the `Entry title` for a dynamic zone display.

### Why is it needed?
We call the `.trim()` method on the dynamic zone display's `Entry title` which works fine when the field is of `String` type. The `Entry Title` could be a number in some cases as highlighted in the related issue. These cases would cause a crash since the `.trim()` method is not available in type `Number`.

### How to test it?

 - Add a dynamic zone as content type to a collection type.
 - Add a component containing a field of type number.
 - Configure the view of the component and use that field as entry title.
 - Go back to the content manager.
 - Add the component, and add type values within the numeric field.
 - Notice there are no errors or crash 🎉

### Related issue(s)/PR(s)

Fixes https://github.com/strapi/strapi/issues/15210

### Demo


https://user-images.githubusercontent.com/45232708/208887434-97b77a78-4f86-41ed-a7c1-621e1095bcd6.mov

