### PR TITLE
[fix] Relation path setup 

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/utils/findLeafByPathAndReplace.js
+++ b/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/utils/findLeafByPathAndReplace.js
@@ -24,7 +24,8 @@ export const findLeafByPathAndReplace = (endpath, replaceWith) => {
      * and the current path is not undefined in the accumulator
      * then we assume it's a leaf and we can replace it.
      */
-    if (endpath === curr && acc[curr] !== undefined) {
+
+    if (ind === currentArr.length - 1 && endpath === curr && acc[curr] !== undefined) {
       set(acc, curr, replaceWith);
 
       return acc;

--- a/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/utils/tests/findLeafByPathAndReplace.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/utils/tests/findLeafByPathAndReplace.test.js
@@ -122,4 +122,34 @@ describe('findLeafByPathAndReplace', () => {
       },
     });
   });
+
+  it('should only replace the leaf if it is the last item in the array of paths', () => {
+    const obj = {
+      a: {
+        a: [
+          {
+            a: 'd',
+          },
+        ],
+      },
+    };
+
+    const path = ['a', 'a', 'a'];
+
+    const [lastPath] = path.slice(-1);
+
+    const findLeaf = findLeafByPathAndReplace(lastPath, []);
+
+    path.reduce(findLeaf, obj);
+
+    expect(obj).toMatchObject({
+      a: {
+        a: [
+          {
+            a: [],
+          },
+        ],
+      },
+    });
+  });
 });


### PR DESCRIPTION
## What

fixes #14968 

When a path to relations included direct duplicate keys as
```js
['units', 'units', 'units']
```
`findLeafAndReplace` would replace the first leaf instead of making sure it is the last item in the array of paths - as recommended in the comment:

> If this is the last item in the array of paths

e.g. for a relation inside a repeatable component, it would cause the repeatable component to not be renderer as the state would reflect
```js
units: []
```
instead of 
```js
units: {
  units: [{
    units: []
  }]
}
```

## Test

I think this fix needs a thorough QA with relations in:
- components
- repeatable components
- dynamic zones 

**example:** 

CTB:
- create a Unit content-type with a `text` field named _name_ 
- create a component Test with a `relation` field to Unit and name this relation field **units**
- create a Module content-type with Test as `repeatable component` and name this field **units**

CM:
- create some Unit entries
- create a Module entry and populate the repeatable component
- the repeatable component field **units** should render on save and on reload

### Shoutout

with @petersg83 huge help 👑
