### PR TITLE
[fix] RelationInput read-only

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/RelationInput/RelationInput.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInput/RelationInput.js
@@ -38,12 +38,13 @@ export const LinkEllipsis = styled(Link)`
 
 export const DisconnectButton = styled.button`
   svg path {
-    fill: ${({ theme }) => theme.colors.neutral500};
+    fill: ${({ theme, disabled }) =>
+      !disabled ? theme.colors.neutral500 : theme.colors.neutral600};
   }
 
   &:hover svg path,
   &:focus svg path {
-    fill: ${({ theme }) => theme.colors.neutral600};
+    fill: ${({ theme, disabled }) => !disabled && theme.colors.neutral600};
   }
 `;
 
@@ -103,8 +104,7 @@ const RelationInput = ({
   );
 
   const shouldDisplayLoadMoreButton =
-    (!!labelLoadMore && !disabled && paginatedRelations.hasNextPage) ||
-    paginatedRelations.isLoading;
+    (!!labelLoadMore && paginatedRelations.hasNextPage) || paginatedRelations.isLoading;
 
   const options = useMemo(
     () =>
@@ -503,9 +503,7 @@ const ListItem = ({ data, index, style }) => {
       <Box minWidth={0} paddingTop={1} paddingBottom={1} paddingRight={4}>
         <Tooltip description={mainField ?? `${id}`}>
           {href ? (
-            <LinkEllipsis to={href} disabled={disabled}>
-              {mainField ?? id}
-            </LinkEllipsis>
+            <LinkEllipsis to={href}>{mainField ?? id}</LinkEllipsis>
           ) : (
             <Typography textColor={disabled ? 'neutral600' : 'primary600'} ellipsis>
               {mainField ?? id}

--- a/packages/core/admin/admin/src/content-manager/components/RelationInput/RelationInput.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInput/RelationInput.js
@@ -39,7 +39,7 @@ export const LinkEllipsis = styled(Link)`
 export const DisconnectButton = styled.button`
   svg path {
     fill: ${({ theme, disabled }) =>
-      !disabled ? theme.colors.neutral500 : theme.colors.neutral600};
+      disabled ? theme.colors.neutral600 : theme.colors.neutral500};
   }
 
   &:hover svg path,

--- a/packages/core/admin/admin/src/content-manager/components/RelationInput/components/RelationItem.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInput/components/RelationItem.js
@@ -83,8 +83,8 @@ export const RelationItem = ({
           paddingRight={4}
           hasRadius
           borderSize={1}
-          background="neutral0"
           borderColor="neutral200"
+          background={disabled ? 'neutral150' : 'neutral0'}
           justifyContent="space-between"
           ref={canDrag ? composedRefs : undefined}
           data-handler-id={handlerId}

--- a/packages/core/admin/admin/src/content-manager/components/RelationInput/components/RelationItem.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInput/components/RelationItem.js
@@ -83,7 +83,7 @@ export const RelationItem = ({
           paddingRight={4}
           hasRadius
           borderSize={1}
-          background={disabled ? 'neutral150' : 'neutral0'}
+          background="neutral0"
           borderColor="neutral200"
           justifyContent="space-between"
           ref={canDrag ? composedRefs : undefined}
@@ -99,6 +99,7 @@ export const RelationItem = ({
                 aria-label={iconButtonAriaLabel}
                 noBorder
                 onKeyDown={handleKeyDown}
+                disabled={disabled}
               >
                 <Drag />
               </IconButton>

--- a/packages/core/admin/admin/src/content-manager/components/RelationInput/tests/RelationInput.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInput/tests/RelationInput.test.js
@@ -136,12 +136,12 @@ describe('Content-Manager || RelationInput', () => {
     });
 
     test('should call onRelationLoadMore', () => {
-      const spy = jest.fn();
-      setup({ onRelationLoadMore: spy });
+      const onRelationLoadMoreSpy = jest.fn();
+      setup({ onRelationLoadMore: onRelationLoadMoreSpy });
 
       fireEvent.click(screen.getByText('Load more'));
 
-      expect(spy).toHaveBeenCalled();
+      expect(onRelationLoadMoreSpy).toHaveBeenCalled();
     });
 
     test('should call onSearch', () => {
@@ -306,7 +306,7 @@ describe('Content-Manager || RelationInput', () => {
         },
       });
 
-      expect(screen.getByRole('button', { name: /load more/i })).toHaveAttribute(
+      expect(screen.getByRole('button', { name: 'Load more' })).toHaveAttribute(
         'aria-disabled',
         'true'
       );
@@ -318,12 +318,21 @@ describe('Content-Manager || RelationInput', () => {
       expect(screen.getByText('This is an error')).toBeInTheDocument();
     });
 
-    test('should apply disabled state', () => {
-      const { queryByText, getByTestId, container } = setup({ disabled: true });
+    test('should display disabled state with only read permission', () => {
+      const onRelationLoadMoreSpy = jest.fn();
+      const { getAllByRole, getByRole, getByTestId, getByText, container } = setup({
+        disabled: true,
+        onRelationLoadMore: onRelationLoadMoreSpy,
+      });
 
-      expect(queryByText('Load more')).not.toBeInTheDocument();
+      fireEvent.click(getByText('Load more'));
+      expect(onRelationLoadMoreSpy).toHaveBeenCalledTimes(1);
+
       expect(container.querySelector('input')).toBeDisabled();
       expect(getByTestId('remove-relation-1')).toBeDisabled();
+      const [dragButton] = getAllByRole('button', { name: 'Drag' });
+      expect(dragButton).toHaveAttribute('aria-disabled', 'true');
+      expect(getByRole('link', { name: 'Relation 1' })).toBeInTheDocument();
     });
   });
 });

--- a/packages/core/admin/admin/src/content-manager/components/RelationInput/tests/__snapshots__/RelationInput.test.js.snap
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInput/tests/__snapshots__/RelationInput.test.js.snap
@@ -617,7 +617,7 @@ exports[`Content-Manager || RelationInput should render and match snapshot 1`] =
                 Select...
               </div>
               <div
-                class=" css-aaf1np-Input"
+                class=" css-1rkub9f-Input"
                 data-value=""
               >
                 <input


### PR DESCRIPTION
⚠️ UI of disabled state (read-only) need to be discussed and approved by design before merging
do not merge before design review

## What

When a relational field was read-only, we disabled the entire component

**With read-only permission**
the user should be able to:
- load more relations
- access the link to the relation entry


the user should not be able to:
- select new relation
- remove relation
- reorder relations

### Test

when only read permission on relational field you should see:
![image](https://user-images.githubusercontent.com/71838159/209645843-05536333-1f62-482f-a7f7-bf23efbf6b6f.png)

when no read permission on relational field you should see:
<img width="674" alt="image" src="https://user-images.githubusercontent.com/71838159/209313970-71c82ce7-c3a7-4598-9390-cf9cc9b7385b.png">


### Follow-up

Relational field permissions need more discussion about permissions
(e.g. what happens if the user has permission to read the field but not to read the Content-type linked to this relational field)
This will be fixed later 