### PR TITLE
fix: translations of CarouselAssetActions

### DIFF
--- a/packages/core/upload/admin/src/components/MediaLibraryInput/Carousel/CarouselAssetActions.js
+++ b/packages/core/upload/admin/src/components/MediaLibraryInput/Carousel/CarouselAssetActions.js
@@ -43,7 +43,7 @@ export const CarouselAssetActions = ({ asset, onDeleteAsset, onAddAsset, onEditA
       {onEditAsset && (
         <IconButton
           label={formatMessage({
-            id: getTrad('app.utils.edit'),
+            id: 'app.utils.edit',
             defaultMessage: 'edit',
           })}
           icon={<PencilIcon />}

--- a/packages/core/upload/admin/src/components/MediaLibraryInput/Carousel/CarouselAssetActions.js
+++ b/packages/core/upload/admin/src/components/MediaLibraryInput/Carousel/CarouselAssetActions.js
@@ -43,7 +43,7 @@ export const CarouselAssetActions = ({ asset, onDeleteAsset, onAddAsset, onEditA
       {onEditAsset && (
         <IconButton
           label={formatMessage({
-            id: 'app.utils.edit',
+            id: getTrad('control-card.edit'),
             defaultMessage: 'edit',
           })}
           icon={<PencilIcon />}


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

![SCR-20221223-poc](https://user-images.githubusercontent.com/20895743/209320103-c2e85865-d2aa-485a-b781-3e71cdd20be3.png)

when hovering on this button, currently always shows `edit` (the `defaultMessage`) regardless of the language setting, this PR is to fix the issue.

### How to test it?

change to a non-EN language, hover on abovementioned button, you should see the correct text

### Related issue(s)/PR(s)

NIL
