### PR TITLE
[Audit logs] Find one audit log endpoint

### DIFF
--- a/packages/core/admin/ee/server/controllers/audit-logs.js
+++ b/packages/core/admin/ee/server/controllers/audit-logs.js
@@ -3,12 +3,21 @@
 const { validateFindMany } = require('../validation/audit-logs');
 
 module.exports = {
-  async getAuditLogs(ctx) {
+  async findMany(ctx) {
     const { query } = ctx.request;
     await validateFindMany(query);
 
     const auditLogs = strapi.container.get('audit-logs');
     const body = await auditLogs.findMany(query);
+
+    ctx.body = body;
+  },
+
+  async findOne(ctx) {
+    const { id } = ctx.params;
+
+    const auditLogs = strapi.container.get('audit-logs');
+    const body = await auditLogs.findOne(id);
 
     ctx.body = body;
   },

--- a/packages/core/admin/ee/server/routes/features-routes.js
+++ b/packages/core/admin/ee/server/routes/features-routes.js
@@ -47,7 +47,16 @@ module.exports = {
     {
       method: 'GET',
       path: '/audit-logs',
-      handler: 'auditLogs.getAuditLogs',
+      handler: 'auditLogs.findMany',
+      config: {
+        // @TODO: Check to right permissions
+        policies: ['admin::isAuthenticatedAdmin'],
+      },
+    },
+    {
+      method: 'GET',
+      path: '/audit-logs/:id',
+      handler: 'auditLogs.findOne',
       config: {
         // @TODO: Check to right permissions
         policies: ['admin::isAuthenticatedAdmin'],

--- a/packages/core/admin/ee/server/services/audit-logs.js
+++ b/packages/core/admin/ee/server/services/audit-logs.js
@@ -93,6 +93,20 @@ const createAuditLogsService = (strapi) => {
       };
     },
 
+    async findOne(id) {
+      const result = await this._provider.findOne(id);
+
+      if (!result) {
+        return null;
+      }
+
+      const { user, ...rest } = result;
+      return {
+        ...rest,
+        user: user ? getService('user').sanitizeUser(user) : null,
+      };
+    },
+
     unsubscribe() {
       if (this._eventHubUnsubscribe) {
         this._eventHubUnsubscribe();

--- a/packages/providers/audit-logs-local/lib/index.js
+++ b/packages/providers/audit-logs-local/lib/index.js
@@ -22,7 +22,15 @@ const provider = {
       findMany(query) {
         return strapi.entityService.findPage('admin::audit-log', {
           populate: ['user'],
+          fields: ['action', 'date'],
           ...query,
+        });
+      },
+
+      findOne(id) {
+        return strapi.entityService.findOne('admin::audit-log', id, {
+          populate: ['user'],
+          fields: ['action', 'date', 'payload'],
         });
       },
     };


### PR DESCRIPTION
### What does it do?

I created a new endpoint to find one audit log and its details (this includes the payload field) and change the findMany endpoint to don't return the payload

### How to test it?

Make calls to GET `/admin/audit-logs`, you should get the pagination info and the audit logs results. 

Make calls to GET `/admin/audit-logs/:id`, you should get the info about a specific audit log, including its payload
