### PR TITLE
Adds bucket URL location if S3 host returns empty URL value

### DIFF
--- a/packages/providers/upload-aws-s3/lib/index.js
+++ b/packages/providers/upload-aws-s3/lib/index.js
@@ -41,6 +41,8 @@ module.exports = {
             // set the bucket file url
             if (assertUrlProtocol(data.Location)) {
               file.url = data.Location;
+            } else if (data.Location[0] === '/') {
+              file.url = `https://${config.params.Bucket}.${config.endpoint}${data.Location}`;
             } else {
               // Default protocol to https protocol
               file.url = `https://${data.Location}`;


### PR DESCRIPTION
- added fully qualified URL when a relative path is returned from AWS-SDK

Fix #15144

I was only seeing this issue when using Backblaze's S3 compatible API. Since I don't use AWS I couldn't confirm if this issue exists there as well.

