### PR TITLE
[DEITS] Fix watch mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "prepare": "husky install",
     "setup": "yarn && yarn clean && yarn build",
     "clean": "lerna run --stream clean --no-private",
-    "watch": "lerna run --stream watch --no-private",
+    "watch": "lerna run --stream watch --no-private --parallel",
     "build": "lerna run --stream build --no-private",
     "generate": "plop --plopfile ./packages/generators/admin/plopfile.js",
     "lint": "npm-run-all -p lint:code lint:css",

--- a/packages/core/data-transfer/package.json
+++ b/packages/core/data-transfer/package.json
@@ -30,7 +30,7 @@
     "build": "tsc -p tsconfig.json",
     "clean": "rimraf ./dist",
     "build:clean": "yarn clean && yarn build",
-    "watch": "yarn build -w",
+    "watch": "yarn build -w --preserveWatchOutput",
     "test:unit": "jest --verbose"
   },
   "directories": {


### PR DESCRIPTION
### What does it do?

- Run lerna watch commands in parallel from the root scripts
- Prevent tsc from clearing the output on watch mode

### Why is it needed?

- Running yarn watch at the monorepository level is not working as expected

### How to test it?

- Run `yarn watch` at the monorepository root. Both the helper plugin & data transfer should start their watch mode in parallel
