### PR TITLE
[DEITS] Strapi File Source Provider bootstrap checks that file can be opened

### DIFF
--- a/packages/core/data-transfer/lib/engine/index.ts
+++ b/packages/core/data-transfer/lib/engine/index.ts
@@ -159,7 +159,7 @@ class TransferEngine<
     });
   }
 
-  #emitTransferUpdate(type: 'start' | 'finish' | 'error', payload?: object) {
+  #emitTransferUpdate(type: 'init' | 'start' | 'finish' | 'error', payload?: object) {
     this.progress.stream.emit(`transfer::${type}`, payload);
   }
 
@@ -336,9 +336,8 @@ class TransferEngine<
     // reset data between transfers
     this.progress.data = {};
 
-    this.#emitTransferUpdate('start');
-
     try {
+      this.#emitTransferUpdate('init');
       await this.bootstrap();
       await this.init();
 
@@ -350,6 +349,8 @@ class TransferEngine<
           `Unable to transfer the data between ${this.sourceProvider.name} and ${this.destinationProvider.name}.\nPlease refer to the log above for more information.`
         );
       }
+
+      this.#emitTransferUpdate('start');
 
       await this.beforeTransfer();
 

--- a/packages/core/data-transfer/lib/providers/local-file-source-provider/index.ts
+++ b/packages/core/data-transfer/lib/providers/local-file-source-provider/index.ts
@@ -74,9 +74,6 @@ class LocalFileSourceProvider implements ISourceProvider {
       throw new Error(`Can't read file "${filePath}".`);
     }
 
-    if (!this.#metadata) {
-      throw new Error('Can\'t read file "metadata.json"');
-    }
   }
 
   getMetadata() {

--- a/packages/core/data-transfer/lib/providers/local-file-source-provider/index.ts
+++ b/packages/core/data-transfer/lib/providers/local-file-source-provider/index.ts
@@ -73,7 +73,6 @@ class LocalFileSourceProvider implements ISourceProvider {
     } catch (e) {
       throw new Error(`Can't read file "${filePath}".`);
     }
-
   }
 
   getMetadata() {

--- a/packages/core/strapi/lib/commands/transfer/export.js
+++ b/packages/core/strapi/lib/commands/transfer/export.js
@@ -75,8 +75,6 @@ module.exports = async (opts) => {
   });
 
   try {
-    logger.log(`Starting export...`);
-
     const progress = engine.progress.stream;
 
     const telemetryPayload = (/* payload */) => {
@@ -89,6 +87,7 @@ module.exports = async (opts) => {
     };
 
     progress.on('transfer::start', (payload) => {
+      logger.log(`Starting export...`);
       strapi.telemetry.send('didDEITSProcessStart', telemetryPayload(payload));
     });
 

--- a/packages/core/strapi/lib/commands/transfer/import.js
+++ b/packages/core/strapi/lib/commands/transfer/import.js
@@ -80,8 +80,6 @@ module.exports = async (opts) => {
   const engine = createTransferEngine(source, destination, engineOptions);
 
   try {
-    logger.info('Starting import...');
-
     const progress = engine.progress.stream;
     const telemetryPayload = (/* payload */) => {
       return {
@@ -93,6 +91,7 @@ module.exports = async (opts) => {
     };
 
     progress.on('transfer::start', (payload) => {
+      logger.info('Starting import...');
       strapiInstance.telemetry.send('didDEITSProcessStart', telemetryPayload(payload));
     });
 


### PR DESCRIPTION
### What does it do?

Strapi File Source Provider `bootstrap` now requires that metadata.json can be read from the file rather than just checking the file is accessible. That ensures that the file can be decompressed and decrypted properly, and if not, throw an error.

This allows (among other things) aborting the transfer before getting to the preTransfer stage, so a "restore" won't be done if the source can't be read.

### Why is it needed?

Currently, entering an incorrect password or importing an invalid file doesn't throw an error until the transfer starts, which means the pretransfer stage is run and local Strapi destination deletes all data.

### How to test it?

Try importing with an incorrect password and it should now abort before deleting a database.

### Related issue(s)/PR(s)

[Alternate method to check directly in CLI](https://github.com/strapi/strapi/pull/15236) (keeping that branch separate because it has some ideas I may clean up and reopen)
