### PR TITLE
[fix] Guided tour documentation link

### DIFF
--- a/packages/core/admin/admin/src/components/GuidedTour/Modal/components/Content.js
+++ b/packages/core/admin/admin/src/components/GuidedTour/Modal/components/Content.js
@@ -8,6 +8,9 @@ import { useIntl } from 'react-intl';
 
 const LiStyled = styled.li`
   list-style: disc;
+  &::marker {
+    color: ${({ theme }) => theme.colors.neutral800};
+  }
 `;
 
 const Content = ({ id, defaultMessage }) => {
@@ -19,13 +22,15 @@ const Content = ({ id, defaultMessage }) => {
         { id, defaultMessage },
         {
           documentationLink: (children) => (
-            <a
+            <Typography
+              as="a"
+              textColor="primary600"
               target="_blank"
               rel="noopener noreferrer"
               href="https://docs.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/rest-api.html#api-parameters"
             >
               {children}
-            </a>
+            </Typography>
           ),
           b: (children) => <Typography fontWeight="semiBold">{children}</Typography>,
           p: (children) => <Typography>{children}</Typography>,


### PR DESCRIPTION
## What

fixes #15146 

- [x] Fixed documentation link color
- [x] Bullet list color

| light mode  | dark mode  |  
|---|---|
| <img width="739" alt="Screenshot 2022-12-28 at 14 50 47" src="https://user-images.githubusercontent.com/71838159/209834475-d8703583-1379-4d5a-b4b9-fac16e852fda.png">  | <img width="728" alt="Screenshot 2022-12-28 at 14 51 28" src="https://user-images.githubusercontent.com/71838159/209834502-ba0b384e-50a0-41a4-a93d-020577a12b9e.png">  |  


