### PR TITLE
[Audit logs] Return only necessary info on audit logs endpoints

### DIFF
--- a/packages/core/admin/ee/server/services/__tests__/audit-logs.test.js
+++ b/packages/core/admin/ee/server/services/__tests__/audit-logs.test.js
@@ -192,7 +192,7 @@ describe('Audit logs service', () => {
         populate: ['user'],
         fields: ['action', 'date', 'payload'],
       });
-      expect(result).toEqual({ id: 1, fullname: null });
+      expect(result).toEqual({ id: 1, user: null });
     });
   });
 });

--- a/packages/core/admin/ee/server/services/audit-logs.js
+++ b/packages/core/admin/ee/server/services/audit-logs.js
@@ -30,7 +30,11 @@ const defaultEvents = [
   'permission.delete',
 ];
 
-const getFullName = (user) => `${user.firstname} ${user.lastname}`;
+const getSanitizedUser = (user) => ({
+  id: user.id,
+  email: user.email,
+  fullname: `${user.firstname} ${user.lastname}`,
+});
 
 const getEventMap = (defaultEvents) => {
   const getDefaultPayload = (...args) => args[0];
@@ -84,7 +88,7 @@ const createAuditLogsService = (strapi) => {
         const { user, ...rest } = result;
         return {
           ...rest,
-          fullname: user ? getFullName(user) : null,
+          user: user ? getSanitizedUser(user) : null,
         };
       });
 
@@ -104,7 +108,7 @@ const createAuditLogsService = (strapi) => {
       const { user, ...rest } = result;
       return {
         ...rest,
-        fullname: user ? getFullName(user) : null,
+        user: user ? getSanitizedUser(user) : null,
       };
     },
 


### PR DESCRIPTION
### What does it do?

Change the audit logs endpoints to return just the relevant information and not a lot.

### How to test it?

Make sure you have a test license and make calls to `/admin/audit-logs` and `/admin/audit-logs/:id` endpoints