### PR TITLE
fix: zh translations of content-manager.containers.Edit.information.by

### DIFF
--- a/packages/core/admin/admin/src/translations/zh.json
+++ b/packages/core/admin/admin/src/translations/zh.json
@@ -597,7 +597,7 @@
   "content-manager.containers.Edit.delete-entry": "刪除這個項目",
   "content-manager.containers.Edit.editing": "編輯中...",
   "content-manager.containers.Edit.information": "資訊",
-  "content-manager.containers.Edit.information.by": "By",
+  "content-manager.containers.Edit.information.by": "操作人",
   "content-manager.containers.Edit.information.created": "已新增",
   "content-manager.containers.Edit.information.draftVersion": "草稿版本",
   "content-manager.containers.Edit.information.editing": "編輯中",


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Fix the zh translation of `content-manager.containers.Edit.information.by`

![SCR-20221229-hka](https://user-images.githubusercontent.com/20895743/209904262-9a1b67f5-53ed-4781-a981-d6179f2d387b.png)

### How to test it?

Change language to zh, the mentioned text should display `操作人`

### Related issue(s)/PR(s)

NIL
