### PR TITLE
[fix] Boolean field validation in component

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/utils/schema.js
+++ b/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/utils/schema.js
@@ -284,7 +284,8 @@ const createYupSchemaAttribute = (type, validations, options) => {
                   }
 
                   if (type === 'boolean') {
-                    return value !== null;
+                    // Boolean value can be undefined/unset in modifiedData when generated in a new component
+                    return value !== null && value !== undefined;
                   }
 
                   if (type === 'date' || type === 'datetime') {


### PR DESCRIPTION
## What

fixes #15270 

When we generate a new component in the CM, `modifiedData` state will look like this:
```js
componentField: {}
```

Making the value of the `boolean` field, `undefined` 
When publishing we don't only need to check if the value is `null` but also `undefined` when the field is required

### Iteration

We will need to create `createYupSchema` tests for every use-cases 