### PR TITLE
Add peerDependencies for plugin when using generate

### DIFF
--- a/packages/generators/generators/lib/templates/js/plugin-package.json.hbs
+++ b/packages/generators/generators/lib/templates/js/plugin-package.json.hbs
@@ -9,6 +9,9 @@
     "displayName": "{{titleCase pluginName }}"
   },
   "dependencies": {},
+  "peerDependencies": {
+    "@strapi/strapi": "^4.0.0"
+  },
   "author": {
     "name": "A Strapi developer"
   },

--- a/packages/generators/generators/lib/templates/ts/plugin-package.json.hbs
+++ b/packages/generators/generators/lib/templates/ts/plugin-package.json.hbs
@@ -10,6 +10,9 @@
   "dependencies": {
     "@strapi/icons": "^1.3.1"
   },
+  "peerDependencies": {
+    "@strapi/strapi": "^4.0.0"
+  },
   "devDependencies": {
     "typescript": "4.6.3"
   },


### PR DESCRIPTION
### What does it do?

It adds a peerDependency for strapi V4 to any plugin created

### Why is it needed?

So that all plugins that are created have a strapi peerDependency 

### How to test it?

It is just generated in the file when using generate

### Related issue(s)/PR(s)
None
