### PR TITLE
[Audit logs] Create a new admin-actions file for EE and add audit logs actions

### DIFF
--- a/packages/core/admin/ee/server/bootstrap.js
+++ b/packages/core/admin/ee/server/bootstrap.js
@@ -4,31 +4,17 @@
 const { features } = require('@strapi/strapi/lib/utils/ee');
 const executeCEBootstrap = require('../../server/bootstrap');
 const { getService } = require('../../server/utils');
-
-const SSO_ACTIONS = [
-  {
-    uid: 'provider-login.read',
-    displayName: 'Read',
-    pluginName: 'admin',
-    section: 'settings',
-    category: 'single sign on',
-    subCategory: 'options',
-  },
-  {
-    uid: 'provider-login.update',
-    displayName: 'Update',
-    pluginName: 'admin',
-    section: 'settings',
-    category: 'single sign on',
-    subCategory: 'options',
-  },
-];
+const actions = require('./config/admin-actions');
 
 module.exports = async () => {
   const { actionProvider } = getService('permission');
 
   if (features.isEnabled('sso')) {
-    await actionProvider.registerMany(SSO_ACTIONS);
+    await actionProvider.registerMany(actions.sso);
+  }
+
+  if (features.isEnabled('audit-logs')) {
+    await actionProvider.registerMany(actions.auditLogs);
   }
 
   await executeCEBootstrap();

--- a/packages/core/admin/ee/server/config/admin-actions.js
+++ b/packages/core/admin/ee/server/config/admin-actions.js
@@ -1,0 +1,32 @@
+'use strict';
+
+module.exports = {
+  sso: [
+    {
+      uid: 'provider-login.read',
+      displayName: 'Read',
+      pluginName: 'admin',
+      section: 'settings',
+      category: 'single sign on',
+      subCategory: 'options',
+    },
+    {
+      uid: 'provider-login.update',
+      displayName: 'Update',
+      pluginName: 'admin',
+      section: 'settings',
+      category: 'single sign on',
+      subCategory: 'options',
+    },
+  ],
+  auditLogs: [
+    {
+      uid: 'audit-logs.read',
+      displayName: 'Read',
+      pluginName: 'admin',
+      section: 'settings',
+      category: 'audit logs',
+      subCategory: 'options',
+    },
+  ],
+};


### PR DESCRIPTION
### What does it do?

I create a new admin-actions file to register EE actions (Before we were doing in the same bootstrap file) and I add the actions for audit logs

### How to test it?

Run a Strapi application with EE and go to any role and try to edit it, in the settings tab you should see a section for audit logs.

In other hand, the super admin should have the audit log enabled permission by default
