### PR TITLE
Fix initiallySelectedAsset containing undefined value

### DIFF
--- a/packages/core/upload/admin/src/components/MediaLibraryInput/index.js
+++ b/packages/core/upload/admin/src/components/MediaLibraryInput/index.js
@@ -134,9 +134,11 @@ export const MediaLibraryInput = ({
   if (uploadedFiles.length > 0) {
     const allowedUploadedFiles = getAllowedFiles(fieldAllowedTypes, uploadedFiles);
 
-    initiallySelectedAssets = multiple
-      ? [...allowedUploadedFiles, ...selectedAssets]
-      : [allowedUploadedFiles[0]];
+    if (allowedUploadedFiles.length) {
+      initiallySelectedAssets = multiple
+        ? [...allowedUploadedFiles, ...selectedAssets]
+        : [allowedUploadedFiles[0]];
+    }
   }
 
   return (


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

If someone uploads a file of different type, The current code sets `initiallySelectedAsset` as `[undefined]`
So, We need to check if `allowedUploadedFiles` has values before we set `initiallySelectedAsset=[allowedUploadedFiles[0]]`

### Why is it needed?

It fixes an error when someone uploads a file that has a not-allowed type.

### How to test it?

- Create a single-type (ex: about-us) that has a media file and restricts to choose images.
```
{
  "kind": "singleType",
  "collectionName": "about_us_pages",
  "info": {
    "singularName": "about-us",
    "pluralName": "about-us-pages",
    "displayName": "About Us"
  },
  "options": {
    "draftAndPublish": true
  },
  "pluginOptions": {
    "i18n": {
      "localized": true
    }
  },
  "attributes": {
    "Image": {
      "allowedTypes": [
        "images"
      ],
      "type": "media",
      "multiple": false,
      "pluginOptions": {
        "i18n": {
          "localized": false
        }
      },
      "required": true
    }
  }
}
```
- Fill the single-type data by selecting an other type of files (ex: pdf)
- It throws the following error
[<img src="https://i.ibb.co/7JqsNT5/Screenshot-from-2023-01-02-23-48-43.png">](#)
and a blank page if not using `--watch-admin`