### PR TITLE
Fix: Prevent CNAME file from being overwritten by the GH action

### DIFF
--- a/.github/workflows/contributor-doc.yml
+++ b/.github/workflows/contributor-doc.yml
@@ -48,3 +48,4 @@ jobs:
           publish_dir: ./docs/build
           user_name: github-actions[bot]
           user_email: 41898282+github-actions[bot]@users.noreply.github.com
+          cname: contributor.strapi.io


### PR DESCRIPTION
### What does it do?

Adds the CNAME file via a config option of the GH action according to: https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-add-cname-file-cname

### Why is it needed?

The GH Action seems to overwrite all files in the `gh-pages` branch on every deployment, which caused the `CNAME` file to get lost. Alex committed the CNAME file already twice (I guess because it was lost):

<img width="1247" alt="Screenshot 2023-01-03 at 09 15 44" src="https://user-images.githubusercontent.com/2244375/210320640-12230385-242b-4f5b-a137-8a5de91dcd78.png">

but the file still is not present in the latest version of the branch: https://github.com/strapi/strapi/tree/0cc83d7b02a7411a2df20693b5c2d2eb52a96275

### How to test it?

https://contributor.strapi.io should be assigned again and not return a 404.
