### PR TITLE
[DEITS] Build ts files before API tests in Github workflow

### DIFF
--- a/.github/actions/run-api-tests/script.sh
+++ b/.github/actions/run-api-tests/script.sh
@@ -8,5 +8,6 @@ export JWT_SECRET="aSecret"
 
 opts=($DB_OPTIONS)
 
+yarn run -s build:ts
 yarn run -s test:generate-app "${opts[@]}"
 yarn run -s test:api --no-generate-app

--- a/packages/core/strapi/package.json
+++ b/packages/core/strapi/package.json
@@ -81,6 +81,7 @@
     "@koa/cors": "3.4.3",
     "@koa/router": "10.1.1",
     "@strapi/admin": "4.5.5",
+    "@strapi/data-transfer": "4.5.5",
     "@strapi/database": "4.5.5",
     "@strapi/generate-new": "4.5.5",
     "@strapi/generators": "4.5.5",


### PR DESCRIPTION
### What does it do?

Adds a `yarn build:ts` step in the API test script.

### Why is it needed?

API tests are failing because they use `@strapi/data-transfer` which isn't built

### How to test it?

API tests should pass on Github workflow

