### PR TITLE
[DEITS] Make remote transfer experimental

### DIFF
--- a/packages/core/strapi/bin/strapi.js
+++ b/packages/core/strapi/bin/strapi.js
@@ -258,22 +258,24 @@ program
   .option('-s, --silent', `Run the generation silently, without any output`, false)
   .action(getLocalScript('ts/generate-types'));
 
-// `$ strapi transfer`
-program
-  .command('transfer')
-  .description('Transfer data from one source to another')
-  .addOption(new Option('--from <sourceURL>', `URL of remote Strapi instance to get data from.`))
-  .addOption(new Option('--to <destinationURL>', `URL of remote Strapi instance to send data to`))
-  .hook('preAction', async (thisCommand) => {
-    const opts = thisCommand.opts();
+if (process.env.STRAPI_EXPERIMENTAL) {
+  // `$ strapi transfer`
+  program
+    .command('transfer')
+    .description('Transfer data from one source to another')
+    .addOption(new Option('--from <sourceURL>', `URL of remote Strapi instance to get data from.`))
+    .addOption(new Option('--to <destinationURL>', `URL of remote Strapi instance to send data to`))
+    .hook('preAction', async (thisCommand) => {
+      const opts = thisCommand.opts();
 
-    if (!opts.from && !opts.to) {
-      console.error('At least one source (from) or destination (to) option must be provided');
-      process.exit(1);
-    }
-  })
-  .allowExcessArguments(false)
-  .action(getLocalScript('transfer/transfer'));
+      if (!opts.from && !opts.to) {
+        console.error('At least one source (from) or destination (to) option must be provided');
+        process.exit(1);
+      }
+    })
+    .allowExcessArguments(false)
+    .action(getLocalScript('transfer/transfer'));
+}
 
 // `$ strapi export`
 program


### PR DESCRIPTION
### What does it do?

Force the usage of `STRAPI_EXPERIMENTAL=true` in the env variables in order to use the `yarn strapi transfer` command.

### Why is it needed?

The remote transfer command is meant to be released in 4.7 and should be as experimental in the meantime.

### How to test it?

- `yarn strapi transfer` Should fail saying transfer is an invalid command name
- `STRAPI_EXPERIMENTAL=true yarn strapi transfer` Should invoke the remote data transfer command
