### PR TITLE
Clean markdown files with prettier

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -72,12 +72,12 @@ Community leaders will follow these Community Impact Guidelines in determining t
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
 
-Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][mozilla coc].
 
-For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][faq]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
 
 [homepage]: https://www.contributor-covenant.org
 [v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
-[Mozilla CoC]: https://github.com/mozilla/diversity
-[FAQ]: https://www.contributor-covenant.org/faq
+[mozilla coc]: https://github.com/mozilla/diversity
+[faq]: https://www.contributor-covenant.org/faq
 [translations]: https://www.contributor-covenant.org/translations

--- a/packages/plugins/sentry/README.md
+++ b/packages/plugins/sentry/README.md
@@ -68,10 +68,7 @@ try {
   // Your code here
 } catch (error) {
   // Either send a simple error
-  strapi
-    .plugin('sentry')
-    .service('sentry')
-    .sendError(error);
+  strapi.plugin('sentry').service('sentry').sendError(error);
 
   // Or send an error with a customized Sentry scope
   strapi
@@ -92,16 +89,13 @@ Use it if you need direct access to the Sentry instance, which should already al
 **Example**
 
 ```js
-const sentryInstance = strapi
-  .plugin('sentry')
-  .service('sentry')
-  .getInstance();
+const sentryInstance = strapi.plugin('sentry').service('sentry').getInstance();
 ```
 
 ## Disabling for non-production environments
 
 If the `dsn` property is set to a nil value (`null` or `undefined`) while `enabled` is true, the Sentry plugin will be available to use in the running Strapi instance, but the service will not actually send errors to Sentry. That allows you to write code that runs on every environment without additional checks, but only send errors to Sentry in production.
-  
+
 When you start Strapi with a nil `dsn` config property, the plugin will print a warning:  
 `info: @strapi/plugin-sentry is disabled because no Sentry DSN was provided`
 
@@ -137,7 +131,7 @@ Like every other plugin, you can also disable this plugin in the plugins configu
 module.exports = ({ env }) => ({
   // ...
   sentry: {
-    enabled: false
+    enabled: false,
   },
   // ...
 });

--- a/packages/providers/email-nodemailer/README.md
+++ b/packages/providers/email-nodemailer/README.md
@@ -112,16 +112,13 @@ module.exports = ({ env }) => ({
 To send an email from anywhere inside Strapi:
 
 ```js
-await strapi
-  .plugin('email')
-  .service('email')
-  .send({
-    to: 'someone@example.com',
-    from: 'someone2@example.com',
-    subject: 'Hello world',
-    text: 'Hello world',
-    html: `<h4>Hello world</h4>`,
-  });
+await strapi.plugin('email').service('email').send({
+  to: 'someone@example.com',
+  from: 'someone2@example.com',
+  subject: 'Hello world',
+  text: 'Hello world',
+  html: `<h4>Hello world</h4>`,
+});
 ```
 
 The following fields are supported:


### PR DESCRIPTION
### What does it do?

Cleans up .md files that needed to have prettier run on them.

### Why is it needed?

They don't follow the `prettier` configuration standards

### How to test it?

Run `yarn format:other` and nothing should change because now they pass.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
