### PR TITLE
Use cache for lint-staged scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,10 +57,10 @@
   },
   "lint-staged": {
     "*.{js,md,css,scss,yaml,yml}": [
-      "prettier --write"
+      "prettier --cache --cache-strategy content --write"
     ],
     "*.js": [
-      "eslint --fix"
+      "eslint --cache --cache-strategy content --cache-location ./node_modules/.cache/eslint --fix"
     ]
   },
   "devDependencies": {


### PR DESCRIPTION
### What does it do?

Use eslint and prettier cache on the lint-staged scripts

### Why is it needed?

It will save nearly a minute of time avoiding re-linting for every commit to Strapi

### How to test it?

Commits should still run fine with no problems.
Files that have been modified should be linted again.

### Related issue(s)/PR(s)
[Caching was added to scripts but not lint-staged in this PR](https://github.com/strapi/strapi/pull/15213)