### PR TITLE
Fix breaking sidebar when have a lot of plugins

### DIFF
--- a/packages/core/admin/admin/src/components/LeftMenu/index.js
+++ b/packages/core/admin/admin/src/components/LeftMenu/index.js
@@ -50,6 +50,13 @@ const LinkUser = styled(RouterNavLink)`
   }
 `;
 
+const StyledMainNav = styled(MainNav)`
+  > div:first-of-type {
+    height: calc(100vh - 126px);
+    overflow-y: auto;
+  }
+`;
+
 const LeftMenu = ({ generalSectionLinks, pluginsSectionLinks }) => {
   const buttonRef = useRef();
   const [userLinksVisible, setUserLinksVisible] = useState(false);
@@ -94,7 +101,7 @@ const LeftMenu = ({ generalSectionLinks, pluginsSectionLinks }) => {
   });
 
   return (
-    <MainNav condensed={condensed}>
+    <StyledMainNav condensed={condensed}>
       <NavBrand
         as={RouterNavLink}
         workplace={formatMessage({
@@ -230,7 +237,7 @@ const LeftMenu = ({ generalSectionLinks, pluginsSectionLinks }) => {
               defaultMessage: 'Collapse the navbar',
             })}
       </NavCondense>
-    </MainNav>
+    </StyledMainNav>
   );
 };
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

I fixed a sidebar bug. When we have a lot plugins installed (or created), the sidebar breaks, see image bellow:

![image](https://user-images.githubusercontent.com/30677819/211172135-e9b14e03-b1ca-4289-9f34-fbd23a4d6cf4.png)

If you want to reproduce this bug, you don't need to install plugins, just zoom in the page. I just added a styled component with some CSS to fix it. I searched and could not find an issue about it, so instead to open a new one I decided to open a PR

If you don't want to wait for this PR to be merged, you can [patch](https://www.npmjs.com/package/patch-package) Strapi:

```
diff --git a/node_modules/@strapi/admin/admin/src/components/LeftMenu/index.js b/node_modules/@strapi/admin/admin/src/components/LeftMenu/index.js
index 752f3a6..e693d10 100644
--- a/node_modules/@strapi/admin/admin/src/components/LeftMenu/index.js
+++ b/node_modules/@strapi/admin/admin/src/components/LeftMenu/index.js
@@ -22,6 +22,13 @@ import Exit from '@strapi/icons/Exit';
 import { auth, usePersistentState, useAppInfos, useTracking } from '@strapi/helper-plugin';
 import useConfigurations from '../../hooks/useConfigurations';
 
+const StyledMainNav = styled(MainNav)`
+  > div:first-of-type {
+    height: calc(100vh - 126px);
+    overflow-y: auto;
+  }
+`
+
 const LinkUserWrapper = styled(Box)`
   width: ${150 / 16}rem;
   position: absolute;
@@ -94,7 +101,7 @@ const LeftMenu = ({ generalSectionLinks, pluginsSectionLinks }) => {
   });
 
   return (
-    <MainNav condensed={condensed}>
+    <StyledMainNav condensed={condensed} id="MainNav">
       <NavBrand
         as={RouterNavLink}
         workplace={formatMessage({
@@ -116,14 +123,14 @@ const LeftMenu = ({ generalSectionLinks, pluginsSectionLinks }) => {
       <Divider />
 
       <NavSections>
-        <NavLink
+        {/* <NavLink
           as={RouterNavLink}
           to="/content-manager"
           icon={<Write />}
           onClick={() => handleClickOnLink('/content-manager')}
         >
           {formatMessage({ id: 'global.content-manager', defaultMessage: 'Content manager' })}
-        </NavLink>
+        </NavLink> */}
 
         {pluginsSectionLinks.length > 0 ? (
           <NavSection
@@ -230,7 +237,7 @@ const LeftMenu = ({ generalSectionLinks, pluginsSectionLinks }) => {
               defaultMessage: 'Collapse the navbar',
             })}
       </NavCondense>
-    </MainNav>
+    </StyledMainNav>
   );
 };
 
```
