### PR TITLE
[Relations/DynamicZones]: manage refetching and cleanData

### DIFF
--- a/examples/getstarted/src/api/kitchensink/content-types/kitchensink/schema.json
+++ b/examples/getstarted/src/api/kitchensink/content-types/kitchensink/schema.json
@@ -156,6 +156,13 @@
       "type": "customField",
       "regex": "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$",
       "customField": "plugin::color-picker.color"
+    },
+    "cats": {
+      "type": "dynamiczone",
+      "components": [
+        "basic.relation",
+        "basic.simple"
+      ]
     }
   }
 }

--- a/examples/getstarted/src/components/basic/relation.json
+++ b/examples/getstarted/src/components/basic/relation.json
@@ -1,0 +1,14 @@
+{
+  "collectionName": "components_basic_relations",
+  "info": {
+    "displayName": "Relation"
+  },
+  "options": {},
+  "attributes": {
+    "categories": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::category.category"
+    }
+  }
+}

--- a/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/index.js
@@ -21,7 +21,7 @@ import {
   getAPIInnerErrors,
 } from '@strapi/helper-plugin';
 
-import { getTrad, removeKeyInObject } from '../../utils';
+import { getTrad } from '../../utils';
 
 import selectCrudReducer from '../../sharedReducers/crudReducer/selectors';
 
@@ -361,11 +361,9 @@ const EditViewDataManagerProvider = ({
 
   const createFormData = useCallback(
     (modifiedData, initialData) => {
-      // First we need to remove the added keys needed for the dnd
-      const preparedData = removeKeyInObject(cloneDeep(modifiedData), '__temp_key__');
       // Then we need to apply our helper
       const cleanedData = cleanData(
-        { browserState: preparedData, serverState: initialData },
+        { browserState: modifiedData, serverState: initialData },
         currentContentTypeLayout,
         allLayoutData.components
       );

--- a/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/reducer.js
+++ b/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/reducer.js
@@ -155,14 +155,28 @@ const reducer = (state, action) =>
         const initialDataRelations = get(state, initialDataPath);
         const modifiedDataRelations = get(state, modifiedDataPath);
 
-        set(draftState, initialDataPath, uniqBy([...value, ...initialDataRelations], 'id'));
+        /**
+         * Check if the values we're loading are already in initial
+         * data if they are then we don't need to load them at all
+         */
+        const valuesToLoad = value.filter((relation) => {
+          return !initialDataRelations.some((initialDataRelation) => {
+            return initialDataRelation.id === relation.id;
+          });
+        });
+
+        set(draftState, initialDataPath, uniqBy([...valuesToLoad, ...initialDataRelations], 'id'));
 
         /**
          * We need to set the value also on modifiedData, because initialData
          * and modifiedData need to stay in sync, so that the CM can compare
          * both states, to render the dirty UI state
          */
-        set(draftState, modifiedDataPath, uniqBy([...value, ...modifiedDataRelations], 'id'));
+        set(
+          draftState,
+          modifiedDataPath,
+          uniqBy([...valuesToLoad, ...modifiedDataRelations], 'id')
+        );
 
         break;
       }

--- a/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/utils/cleanData.js
+++ b/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/utils/cleanData.js
@@ -23,7 +23,7 @@ const cleanData = ({ browserState, serverState }, currentSchema, componentsSchem
    * @param {object} browserState – the modifiedData from REDUX
    * @param {object} serverState – the initialData from REDUX
    * @param {*} schema
-   * @param {string} path
+   * @param {string} pathToParent - the path to the parent of the current entry
    * @returns
    */
   const recursiveCleanData = (browserState, serverState, schema, pathToParent) => {

--- a/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/utils/cleanData.js
+++ b/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/utils/cleanData.js
@@ -1,6 +1,7 @@
 import get from 'lodash/get';
 import isArray from 'lodash/isArray';
 import isObject from 'lodash/isObject';
+import { getInitialDataPathUsingTempKeys } from '../../../utils/paths';
 
 /* eslint-disable indent */
 
@@ -12,6 +13,8 @@ import isObject from 'lodash/isObject';
  * @returns
  */
 const cleanData = ({ browserState, serverState }, currentSchema, componentsSchema) => {
+  const rootServerState = serverState;
+  const rootBrowserState = browserState;
   const getType = (schema, attrName) => get(schema, ['attributes', attrName, 'type'], '');
   const getOtherInfos = (schema, arr) => get(schema, ['attributes', ...arr], '');
 
@@ -20,10 +23,12 @@ const cleanData = ({ browserState, serverState }, currentSchema, componentsSchem
    * @param {object} browserState – the modifiedData from REDUX
    * @param {object} serverState – the initialData from REDUX
    * @param {*} schema
+   * @param {string} path
    * @returns
    */
-  const recursiveCleanData = (browserState, serverState, schema) => {
+  const recursiveCleanData = (browserState, serverState, schema, pathToParent) => {
     return Object.keys(browserState).reduce((acc, current) => {
+      const path = pathToParent ? `${pathToParent}.${current}` : current;
       const attrType = getType(schema, current);
 
       // This is the field value
@@ -61,7 +66,8 @@ const cleanData = ({ browserState, serverState }, currentSchema, componentsSchem
                   const subCleanedData = recursiveCleanData(
                     data,
                     (oldValue ?? [])[index],
-                    componentsSchema[component]
+                    componentsSchema[component],
+                    `${path}.${index}`
                   );
 
                   return subCleanedData;
@@ -69,20 +75,25 @@ const cleanData = ({ browserState, serverState }, currentSchema, componentsSchem
               : value;
           } else {
             cleanedData = value
-              ? recursiveCleanData(value, oldValue, componentsSchema[component])
+              ? recursiveCleanData(value, oldValue, componentsSchema[component], path)
               : value;
           }
 
           break;
 
         case 'relation': {
+          const trueInitialDataPath = getInitialDataPathUsingTempKeys(
+            rootServerState,
+            rootBrowserState
+          )(path).join('.');
+
           /**
            * Because of how repeatable components work when you dig into them the server
            * will have no object to compare too therefore no relation array will be setup
            * because the component has not been initialised, therefore we can safely assume
            * it needs to be added and provide a default empty array.
            */
-          let actualOldValue = oldValue ?? [];
+          let actualOldValue = get(rootServerState, trueInitialDataPath, []);
 
           const valuesWithPositions = value.map((relation, index, allRelations) => {
             const nextRelation = allRelations[index + 1];
@@ -141,7 +152,8 @@ const cleanData = ({ browserState, serverState }, currentSchema, componentsSchem
             const subCleanedData = recursiveCleanData(
               componentData,
               (oldValue ?? [])[index],
-              componentsSchema[componentData.__component]
+              componentsSchema[componentData.__component],
+              `${path}.${index}`
             );
 
             return subCleanedData;
@@ -157,7 +169,7 @@ const cleanData = ({ browserState, serverState }, currentSchema, componentsSchem
     }, {});
   };
 
-  return recursiveCleanData(browserState, serverState, currentSchema);
+  return recursiveCleanData(browserState, serverState, currentSchema, '');
 };
 
 // TODO: check which parts are still needed: I suspect the

--- a/packages/core/admin/admin/src/content-manager/components/RelationInput/tests/__snapshots__/RelationInput.test.js.snap
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInput/tests/__snapshots__/RelationInput.test.js.snap
@@ -617,7 +617,7 @@ exports[`Content-Manager || RelationInput should render and match snapshot 1`] =
                 Select...
               </div>
               <div
-                class=" css-1rkub9f-Input"
+                class=" css-aaf1np-Input"
                 data-value=""
               >
                 <input

--- a/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/RelationInputDataManager.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/RelationInputDataManager.js
@@ -15,6 +15,7 @@ import { getTrad } from '../../utils';
 
 import { PUBLICATION_STATES, RELATIONS_TO_DISPLAY, SEARCH_RESULTS_TO_DISPLAY } from './constants';
 import { connect, select, normalizeSearchResults, diffRelations, normalizeRelation } from './utils';
+import { getInitialDataPathUsingTempKeys } from '../../utils/paths';
 
 export const RelationInputDataManager = ({
   error,
@@ -50,28 +51,7 @@ export const RelationInputDataManager = ({
 
   const nameSplit = name.split('.');
 
-  const initialDataPath = nameSplit.reduce((acc, currentValue, index) => {
-    const initialDataParent = get(initialData, acc);
-    const modifiedDataTempKey = get(modifiedData, [
-      ...nameSplit.slice(0, index),
-      currentValue,
-      '__temp_key__',
-    ]);
-
-    if (Array.isArray(initialDataParent) && typeof modifiedDataTempKey === 'number') {
-      const initialDataIndex = initialDataParent.findIndex(
-        (entry) => entry.__temp_key__ === modifiedDataTempKey
-      );
-
-      acc.push(initialDataIndex.toString());
-
-      return acc;
-    }
-
-    acc.push(currentValue);
-
-    return acc;
-  }, []);
+  const initialDataPath = getInitialDataPathUsingTempKeys(initialData, modifiedData)(name);
 
   const relationsFromModifiedData = get(modifiedData, name, []);
 

--- a/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/tests/RelationInputDataManger.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/tests/RelationInputDataManger.test.js
@@ -205,20 +205,6 @@ describe('RelationInputDataManager', () => {
     );
   });
 
-  test('Correctly computes modified and initial data paths and passes this to useRelation', async () => {
-    setup({
-      name: 'relation.1.subRelation',
-    });
-
-    expect(useRelation).toBeCalledWith(
-      expect.any(String),
-      expect.objectContaining({
-        initialDataPath: ['initialData', 'relation', '1', 'subRelation'],
-        modifiedDataPath: ['modifiedData', 'relation', '1', 'subRelation'],
-      })
-    );
-  });
-
   test('Sets the disabled prop for non editable relations (edit entity)', async () => {
     const { container } = setup({
       editable: false,
@@ -683,79 +669,5 @@ describe('RelationInputDataManager', () => {
 
       expect(queryByText(/\(7\)/)).toBeInTheDocument();
     });
-  });
-
-  test('correctly computes modified and initial data paths for nested content and passes this to useRelation', async () => {
-    const initialData = {
-      dz: [
-        {
-          __component: 'default.withToManyComponentRelation',
-          __temp_key__: 7,
-          toManyRelation: [
-            {
-              id: 14,
-              publishers: [],
-              __temp_key__: 1,
-            },
-            {
-              id: 13,
-              publishers: [],
-              __temp_key__: 0,
-            },
-          ],
-        },
-        {
-          __component: 'default.blank',
-          __temp_key__: 6,
-        },
-      ],
-    };
-
-    const modifiedData = {
-      dz: [
-        {
-          __component: 'default.blank',
-          __temp_key__: 6,
-        },
-        {
-          __component: 'default.withToManyComponentRelation',
-          __temp_key__: 7,
-          toManyRelation: [
-            {
-              id: 13,
-              publishers: [],
-              __temp_key__: 0,
-            },
-            {
-              id: 14,
-              publishers: [],
-              __temp_key__: 1,
-            },
-          ],
-        },
-      ],
-    };
-
-    useCMEditViewDataManager.mockImplementation(() => ({
-      isCreatingEntry: true,
-      createActionAllowedFields: ['relation'],
-      readActionAllowedFields: ['relation'],
-      updateActionAllowedFields: ['relation'],
-      slug: 'test',
-      initialData,
-      modifiedData,
-    }));
-
-    setup({
-      name: 'dz.1.toManyRelation.0.publishers',
-    });
-
-    expect(useRelation).toBeCalledWith(
-      expect.any(String),
-      expect.objectContaining({
-        initialDataPath: ['initialData', 'dz', '0', 'toManyRelation', '1', 'publishers'],
-        modifiedDataPath: ['modifiedData', 'dz', '1', 'toManyRelation', '0', 'publishers'],
-      })
-    );
   });
 });

--- a/packages/core/admin/admin/src/content-manager/hooks/useCallbackRef.js
+++ b/packages/core/admin/admin/src/content-manager/hooks/useCallbackRef.js
@@ -1,0 +1,23 @@
+import * as React from 'react';
+
+/**
+ * A custom hook that converts a callback to a ref to avoid triggering re-renders when passed as a
+ * prop or avoid re-executing effects when passed as a dependency
+ *
+ * @type {<T extends (...args: any[]) => any>(callback: T | undefined) => T}
+ */
+export const useCallbackRef = (callback) => {
+  const callbackRef = React.useRef(callback);
+
+  React.useEffect(() => {
+    callbackRef.current = callback;
+  });
+
+  // https://github.com/facebook/react/issues/19240
+  return React.useMemo(
+    () =>
+      (...args) =>
+        callbackRef.current?.(...args),
+    []
+  );
+};

--- a/packages/core/admin/admin/src/content-manager/hooks/useRelation/tests/useRelation.test.js
+++ b/packages/core/admin/admin/src/content-manager/hooks/useRelation/tests/useRelation.test.js
@@ -99,13 +99,10 @@ describe('useRelation', () => {
     });
 
     await waitFor(() =>
-      expect(onLoadMock).toBeCalledWith({
-        target: {
-          initialDataPath,
-          modifiedDataPath,
-          value: [expect.objectContaining({ id: 1 }), expect.objectContaining({ id: 2 })],
-        },
-      })
+      expect(onLoadMock).toBeCalledWith([
+        expect.objectContaining({ id: 1 }),
+        expect.objectContaining({ id: 2 }),
+      ])
     );
   });
 
@@ -131,15 +128,7 @@ describe('useRelation', () => {
 
     await waitFor(() => expect(result.current.relations.isSuccess).toBe(true));
 
-    await waitFor(() =>
-      expect(onLoadMock).toBeCalledWith({
-        target: {
-          initialDataPath,
-          modifiedDataPath,
-          value: [expect.objectContaining({ id: 1 })],
-        },
-      })
-    );
+    await waitFor(() => expect(onLoadMock).toBeCalledWith([expect.objectContaining({ id: 1 })]));
   });
 
   test('fetch relations with different limit', async () => {

--- a/packages/core/admin/admin/src/content-manager/hooks/useRelation/useRelation.js
+++ b/packages/core/admin/admin/src/content-manager/hooks/useRelation/useRelation.js
@@ -5,7 +5,9 @@ import { axiosInstance } from '../../../core/utils';
 
 import { normalizeRelations } from '../../components/RelationInputDataManager/utils';
 
-export const useRelation = (cacheKey, { modifiedDataPath, initialDataPath, relation, search }) => {
+import { useCallbackRef } from '../useCallbackRef';
+
+export const useRelation = (cacheKey, { relation, search }) => {
   const [searchParams, setSearchParams] = useState({});
   const [currentPage, setCurrentPage] = useState(0);
 
@@ -45,7 +47,7 @@ export const useRelation = (cacheKey, { modifiedDataPath, initialDataPath, relat
     }
   };
 
-  const { onLoad: onLoadRelationsCallback, normalizeArguments = {} } = relation;
+  const { onLoad: onLoadRelations, normalizeArguments = {} } = relation;
 
   const relationsRes = useInfiniteQuery(['relation', cacheKey], fetchRelations, {
     cacheTime: 0,
@@ -121,15 +123,15 @@ export const useRelation = (cacheKey, { modifiedDataPath, initialDataPath, relat
     }
   }, [pageGoal, currentPage, fetchNextPage, hasNextPage, status]);
 
+  const onLoadRelationsCallback = useCallbackRef(onLoadRelations);
+
   useEffect(() => {
     if (status === 'success' && data && data.pages?.at(-1)?.results && onLoadRelationsCallback) {
       // everytime we fetch, we normalize prior to adding to redux
       const normalizedResults = normalizeRelations(data.pages.at(-1).results, normalizeArguments);
 
       // this is loadRelation from EditViewDataManagerProvider
-      onLoadRelationsCallback({
-        target: { initialDataPath, modifiedDataPath, value: normalizedResults },
-      });
+      onLoadRelationsCallback(normalizedResults);
     }
 
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/core/admin/admin/src/content-manager/utils/getMaxTempKey.js
+++ b/packages/core/admin/admin/src/content-manager/utils/getMaxTempKey.js
@@ -5,7 +5,7 @@ const getMaxTempKey = (arr) => {
 
   const maxTempKey = Math.max.apply(
     Math,
-    arr.map((o) => o.__temp_key__ ?? o.id)
+    arr.map((o) => o.__temp_key__ ?? 0)
   );
 
   return Number.isNaN(maxTempKey) ? -1 : maxTempKey;

--- a/packages/core/admin/admin/src/content-manager/utils/paths.js
+++ b/packages/core/admin/admin/src/content-manager/utils/paths.js
@@ -1,0 +1,37 @@
+/**
+ * This file is for all helpers related to `paths` in the CM.
+ */
+import { get } from 'lodash';
+
+/**
+ * This is typically used in circumstances where there are re-orderable pieces e.g. Dynamic Zones
+ * or Repeatable fields. It finds the _original_ location of the initial data using `__temp_key__` values
+ * which are added to the fields in the `INIT_FORM` reducer to give array data a stable (when you add
+ * a new item they wont have a server ID).
+ */
+export const getInitialDataPathUsingTempKeys = (initialData, modifiedData) => (currentPath) => {
+  const splitPath = currentPath.split('.');
+
+  return splitPath.reduce((acc, currentValue, index) => {
+    const initialDataParent = get(initialData, acc);
+    const modifiedDataTempKey = get(modifiedData, [
+      ...splitPath.slice(0, index),
+      currentValue,
+      '__temp_key__',
+    ]);
+
+    if (Array.isArray(initialDataParent) && typeof modifiedDataTempKey === 'number') {
+      const initialDataIndex = initialDataParent.findIndex(
+        (entry) => entry.__temp_key__ === modifiedDataTempKey
+      );
+
+      acc.push(initialDataIndex.toString());
+
+      return acc;
+    }
+
+    acc.push(currentValue);
+
+    return acc;
+  }, []);
+};


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

- [x] handles refetching after reordering so if you remove a relation and then reorder the dynamic zone that old relation won't appear
- [x] handles the cleanData so we still disconnect and connect the correct relations even if you've reordered the dynamic zone
