### PR TITLE
Prevent license ping for api tests

### DIFF
--- a/.github/actions/run-api-tests/script.sh
+++ b/.github/actions/run-api-tests/script.sh
@@ -1,6 +1,8 @@
 ## disable EE if options not set
 if [[ -z "$RUN_EE" ]]; then
   export STRAPI_DISABLE_EE=true
+else
+  export STRAPI_DISABLE_LICENSE_PING=true
 fi
 
 export ENV_PATH="$(pwd)/testApp/.env"


### PR DESCRIPTION
### What does it do?

Set the STRAPI_DISABLE_LICENSE_PING env variable if the API tests are bein run with EE

### Why is it needed?

Lower the useless stressing of the license server.

