### PR TITLE
[DEITS] Add force option

### DIFF
--- a/packages/core/strapi/bin/strapi.js
+++ b/packages/core/strapi/bin/strapi.js
@@ -7,7 +7,7 @@
 const _ = require('lodash');
 const path = require('path');
 const resolveCwd = require('resolve-cwd');
-const { yellow } = require('chalk');
+const { yellow, bold } = require('chalk');
 const { Command, Option } = require('commander');
 const inquirer = require('inquirer');
 
@@ -336,6 +336,12 @@ program
     new Option(
       '-k, --key <string>',
       'Provide encryption key in command instead of using the prompt'
+    )
+  )
+  .addOption(
+    new Option(
+      '--force-yes',
+      `Automatic yes to prompts; answer "yes" to ${bold('all')} prompts and run non-interactively.`
     )
   )
   .allowExcessArguments(false)

--- a/packages/core/strapi/bin/strapi.js
+++ b/packages/core/strapi/bin/strapi.js
@@ -18,6 +18,7 @@ const {
   promptEncryptionKey,
   confirmMessage,
   parseURL,
+  forceOption,
 } = require('../lib/commands/utils/commander');
 const { ifOptions, assertUrlHasProtocol, exitWith } = require('../lib/commands/utils/helpers');
 
@@ -338,12 +339,7 @@ program
       'Provide encryption key in command instead of using the prompt'
     )
   )
-  .addOption(
-    new Option(
-      '-f, --force',
-      `Automatically nswer "yes" to all prompts, including potentially destructive requests, and run non-interactively.`
-    )
-  )
+  .addOption(forceOption)
   .allowExcessArguments(false)
   .hook('preAction', async (thisCommand) => {
     const opts = thisCommand.opts();

--- a/packages/core/strapi/bin/strapi.js
+++ b/packages/core/strapi/bin/strapi.js
@@ -7,7 +7,7 @@
 const _ = require('lodash');
 const path = require('path');
 const resolveCwd = require('resolve-cwd');
-const { yellow, bold } = require('chalk');
+const { yellow } = require('chalk');
 const { Command, Option } = require('commander');
 const inquirer = require('inquirer');
 
@@ -340,8 +340,8 @@ program
   )
   .addOption(
     new Option(
-      '--force-yes',
-      `Automatic yes to prompts; answer "yes" to ${bold('all')} prompts and run non-interactively.`
+      '-f, --force',
+      `Automatically nswer "yes" to all prompts, including potentially destructive requests, and run non-interactively.`
     )
   )
   .allowExcessArguments(false)

--- a/packages/core/strapi/lib/commands/utils/commander.js
+++ b/packages/core/strapi/lib/commands/utils/commander.js
@@ -68,7 +68,7 @@ const promptEncryptionKey = async (thisCommand) => {
 };
 
 /**
- * hook: require a confirmation message to be accepted (unless --force option is used)
+ * hook: require a confirmation message to be accepted unless forceOption (-f,--force) is used
  *
  * @param {string} message The message to confirm with user
  * @param {object} options Additional options
@@ -99,7 +99,7 @@ const confirmMessage = (message) => {
 
 const forceOption = new Option(
   '-f, --force',
-  `Automatically nswer "yes" to all prompts, including potentially destructive requests, and run non-interactively.`
+  `Automatically answer "yes" to all prompts, including potentially destructive requests, and run non-interactively.`
 );
 
 module.exports = {

--- a/packages/core/strapi/lib/commands/utils/commander.js
+++ b/packages/core/strapi/lib/commands/utils/commander.js
@@ -6,6 +6,7 @@
 
 const inquirer = require('inquirer');
 const { InvalidOptionArgumentError } = require('commander');
+const { bold, green, cyan } = require('chalk');
 const { exitWith } = require('./helpers');
 
 /**
@@ -68,9 +69,20 @@ const promptEncryptionKey = async (thisCommand) => {
 
 /**
  * hook: require a confirmation message to be accepted
+ *
+ * @param {string} message The message to confirm with user
+ * @param {object} options Additional options
  */
 const confirmMessage = (message) => {
-  return async () => {
+  return async (command) => {
+    // if we have a forceYes option, assume yes
+    const opts = command.opts();
+    if (opts?.forceYes) {
+      // attempt to mimic the inquirer prompt exactly
+      console.warn(`${green('?')} ${bold(message)} ${cyan('Yes')}`);
+      return;
+    }
+
     const answers = await inquirer.prompt([
       {
         type: 'confirm',

--- a/packages/core/strapi/lib/commands/utils/commander.js
+++ b/packages/core/strapi/lib/commands/utils/commander.js
@@ -5,7 +5,7 @@
  */
 
 const inquirer = require('inquirer');
-const { InvalidOptionArgumentError } = require('commander');
+const { InvalidOptionArgumentError, Option } = require('commander');
 const { bold, green, cyan } = require('chalk');
 const { exitWith } = require('./helpers');
 
@@ -77,7 +77,7 @@ const confirmMessage = (message) => {
   return async (command) => {
     // if we have a force option, assume yes
     const opts = command.opts();
-    if (opts?.force) {
+    if (opts?.force === true) {
       // attempt to mimic the inquirer prompt exactly
       console.log(`${green('?')} ${bold(message)} ${cyan('Yes')}`);
       return;
@@ -97,9 +97,15 @@ const confirmMessage = (message) => {
   };
 };
 
+const forceOption = new Option(
+  '-f, --force',
+  `Automatically nswer "yes" to all prompts, including potentially destructive requests, and run non-interactively.`
+);
+
 module.exports = {
   parseInputList,
   parseURL,
   promptEncryptionKey,
   confirmMessage,
+  forceOption,
 };

--- a/packages/core/strapi/lib/commands/utils/commander.js
+++ b/packages/core/strapi/lib/commands/utils/commander.js
@@ -68,16 +68,16 @@ const promptEncryptionKey = async (thisCommand) => {
 };
 
 /**
- * hook: require a confirmation message to be accepted
+ * hook: require a confirmation message to be accepted (unless --force option is used)
  *
  * @param {string} message The message to confirm with user
  * @param {object} options Additional options
  */
 const confirmMessage = (message) => {
   return async (command) => {
-    // if we have a forceYes option, assume yes
+    // if we have a force option, assume yes
     const opts = command.opts();
-    if (opts?.forceYes) {
+    if (opts?.force) {
       // attempt to mimic the inquirer prompt exactly
       console.warn(`${green('?')} ${bold(message)} ${cyan('Yes')}`);
       return;

--- a/packages/core/strapi/lib/commands/utils/commander.js
+++ b/packages/core/strapi/lib/commands/utils/commander.js
@@ -79,7 +79,7 @@ const confirmMessage = (message) => {
     const opts = command.opts();
     if (opts?.force) {
       // attempt to mimic the inquirer prompt exactly
-      console.warn(`${green('?')} ${bold(message)} ${cyan('Yes')}`);
+      console.log(`${green('?')} ${bold(message)} ${cyan('Yes')}`);
       return;
     }
 


### PR DESCRIPTION
NOTE: I accidentally based this off of https://github.com/strapi/strapi/pull/15406 so that should be reviewed and merged before this one so I don't have to rebase 😆

### What does it do?

Adds the --force option to `strapi import`

### Why is it needed?

To allow the command to be run non-interactively

### How to test it?

run `strapi import -f ...` and the restore process should be automatically accepted without interaction
run `strapi import ...` without -f and the restore process should prompt before deleting the database

