### PR TITLE
[DEITS] disable remote transfer with environment variable

### DIFF
--- a/packages/core/admin/server/register.js
+++ b/packages/core/admin/server/register.js
@@ -19,7 +19,7 @@ module.exports = ({ strapi }) => {
 
   if (
     process.env.STRAPI_EXPERIMENTAL === 'true' &&
-    process.env.STRAPI_DISABLE_REMOTE_TRANSFER !== 'true'
+    process.env.STRAPI_DISABLE_REMOTE_DATA_TRANSFER !== 'true'
   ) {
     registerDataTransferRoute(strapi);
   }

--- a/packages/core/admin/server/register.js
+++ b/packages/core/admin/server/register.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { register: registerDataTransfer } = require('@strapi/data-transfer/lib/strapi');
+const { register: registerDataTransferRoute } = require('@strapi/data-transfer/lib/strapi');
 
 const registerAdminPanelRoute = require('./routes/serve-admin-panel');
 const adminAuthStrategy = require('./strategies/admin');
@@ -17,5 +17,10 @@ module.exports = ({ strapi }) => {
     registerAdminPanelRoute({ strapi });
   }
 
-  registerDataTransfer(strapi);
+  if (
+    process.env.STRAPI_EXPERIMENTAL === 'true' &&
+    process.env.STRAPI_DISABLE_REMOTE_TRANSFER !== 'true'
+  ) {
+    registerDataTransferRoute(strapi);
+  }
 };

--- a/packages/core/strapi/bin/strapi.js
+++ b/packages/core/strapi/bin/strapi.js
@@ -258,7 +258,7 @@ program
   .option('-s, --silent', `Run the generation silently, without any output`, false)
   .action(getLocalScript('ts/generate-types'));
 
-if (process.env.STRAPI_EXPERIMENTAL) {
+if (process.env.STRAPI_EXPERIMENTAL === 'true') {
   // `$ strapi transfer`
   program
     .command('transfer')


### PR DESCRIPTION
### What does it do?

Disables the remote transfer route when environment has `STRAPI_DISABLE_REMOTE_TRANSFER=true` (and, for now, when `STRAPI_EXPERIMENTAL` is not set)

Note that this also changes the required value of `STRAPI_EXPERIMENTAL` to `'true'` in line with other env in Strapi such as `STRAPI_DISABLE_EE`

### Why is it needed?

To allow completely disabling the websocket for remote transfers.

### How to test it?

Try starting strapi with variations of the environment variables `STRAPI_DISABLE_REMOTE_TRANSFER` and `STRAPI_EXPERIMENTAL` and see if the transfer route exists as expected.
