### PR TITLE
Update parse-type.js

### DIFF
--- a/packages/core/utils/lib/parse-type.js
+++ b/packages/core/utils/lib/parse-type.js
@@ -77,7 +77,6 @@ const parseType = ({ type, value, forceCast = false }) => {
       throw new Error('Invalid boolean input. Expected "t","1","true","false","0","f"');
     }
     case 'integer':
-    case 'biginteger':
     case 'float':
     case 'decimal': {
       return _.toNumber(value);


### PR DESCRIPTION
do not parse value to number when type is 'biginteger' to avoid loss of precision

### What does it do?

avoid loss of precision when write a too large number to `bigint(20) unsigned`

### Why is it needed?

write a too large number to `bigint(20) unsigned` will lead to lossing precision

### How to test it?

create a biginteger attr and write a arbitrary number more than MAX SAFE INTEGER

