### PR TITLE
[docs] Add linking the design system docs

### DIFF
--- a/docs/docs/core/admin/link-strapi-design-system.md
+++ b/docs/docs/core/admin/link-strapi-design-system.md
@@ -1,0 +1,25 @@
+# Linking the Strapi Design System
+
+Follow these steps to use a local version of the Strapi design system with the Strapi monorepo
+
+First, run `yarn build` in `strapi-design-system/packages/strapi-design-system` to generate the bundle.
+
+In your copy of Strapi, you can link the design system using either a [relative path](#relative-path) or [yarn link](#yarn-link).
+
+### Relative path
+
+Replace the version number in both `strapi/packages/core/admin/package.json` and `strapi/packages/core/helper-plugin/package.json` with the relative path to your copy of the design system:
+
+```
+"@strapi/design-system": "link:../../../../strapi-design-system/packages/strapi-design-system"
+```
+
+### Yarn link
+
+Alternatively, you can use [`yarn link`](https://classic.yarnpkg.com/lang/en/docs/cli/link/) by first running `yarn link` in `strapi-design-system/packages/design-system` and then `yarn link @strapi/design-system` in both `strapi/packages/core/admin` and `strapi/packages/core/helper-plugin`. With this approach, no changes need to be made to the `package.json`
+
+Once the link is setup, run the following command from the root of `@strapi/strapi`
+
+```
+yarn lerna clean && yarn setup
+```

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -52,6 +52,17 @@ const sidebars = {
         },
         {
           type: 'category',
+          label: 'Admin',
+          items: [
+            {
+              type: 'doc',
+              label: 'Link Strapi Design System',
+              id: 'core/admin/link-strapi-design-system',
+            },
+          ],
+        },
+        {
+          type: 'category',
           label: 'Content Type Builder',
           link: {
             type: 'doc',


### PR DESCRIPTION
### What does it do?

Adds documentation for linking the design system to complement https://github.com/strapi/design-system/pull/836

### Why is it needed?

Making it easier to test DS component and inspect the bundle

### How to test it?

Run the docs, and follow the steps

### Related issue(s)/PR(s)

https://github.com/strapi/design-system/pull/836
