### PR TITLE
fix(VideoAssetCard): dissalow pointer-events on videoPreview

### DIFF
--- a/packages/core/upload/admin/src/components/AssetCard/VideoAssetCard.js
+++ b/packages/core/upload/admin/src/components/AssetCard/VideoAssetCard.js
@@ -13,6 +13,7 @@ const VideoPreviewWrapper = styled(Box)`
   canvas,
   video {
     display: block;
+    pointer-events: none;
     max-width: 100%;
     max-height: ${({ size }) => (size === 'M' ? 164 / 16 : 88 / 16)}rem;
   }

--- a/packages/core/upload/admin/src/components/AssetGridList/tests/__snapshots__/AssetGridList.test.js.snap
+++ b/packages/core/upload/admin/src/components/AssetGridList/tests/__snapshots__/AssetGridList.test.js.snap
@@ -332,6 +332,7 @@ exports[`MediaLibrary / AssetList snapshots the asset list 1`] = `
 .c28 canvas,
 .c28 video {
   display: block;
+  pointer-events: none;
   max-width: 100%;
   max-height: 10.25rem;
 }

--- a/packages/core/upload/admin/src/components/UploadAssetDialog/PendingAssetStep/tests/__snapshots__/PendingAssetStep.test.js.snap
+++ b/packages/core/upload/admin/src/components/UploadAssetDialog/PendingAssetStep/tests/__snapshots__/PendingAssetStep.test.js.snap
@@ -680,6 +680,7 @@ exports[`PendingAssetStep snapshots the component with valid cards 1`] = `
 .c50 canvas,
 .c50 video {
   display: block;
+  pointer-events: none;
   max-width: 100%;
   max-height: 5.5rem;
 }


### PR DESCRIPTION
Fix #15275 

### What does it do?

Remove pointer events on the video preview element

### Why is it needed?

Cannot select or de-select a video in the content manager, this issue only appears when the canvas does not replace the video element due to being unable to load the preview. 

### How to test it?

1- Create content with media with video enabled
2- Upload video to media in wmv format 
3- Go to the content manager
4- Create a new entry with a media field
5- Click on click to add an asset

### Related issue(s)/PR(s)

#15275
