### PR TITLE
fix: filter dropped files before trying to upload

### DIFF
--- a/packages/core/admin/admin/src/components/Notifications/Notification/index.js
+++ b/packages/core/admin/admin/src/components/Notifications/Notification/index.js
@@ -77,6 +77,7 @@ const Notification = ({ dispatch, notification }) => {
       {formattedMessage({
         id: message?.id || message,
         defaultMessage: message?.defaultMessage || message?.id || message,
+        values: message?.values,
       })}
     </Alert>
   );

--- a/packages/core/upload/admin/src/components/MediaLibraryInput/index.js
+++ b/packages/core/upload/admin/src/components/MediaLibraryInput/index.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
+import { useNotification } from '@strapi/helper-plugin';
 
 import { AssetDialog } from '../AssetDialog';
 import { AssetDefinition } from '../../constants';
@@ -35,6 +36,7 @@ export const MediaLibraryInput = ({
   const [droppedAssets, setDroppedAssets] = useState();
   const [folderId, setFolderId] = useState(null);
   const { formatMessage } = useIntl();
+  const toggleNotification = useNotification();
 
   useEffect(() => {
     // Clear the uploaded files on close
@@ -100,8 +102,24 @@ export const MediaLibraryInput = ({
   };
 
   const handleAssetDrop = (assets) => {
-    setDroppedAssets(assets);
-    setStep(STEPS.AssetUpload);
+    const allowedAssets = getAllowedFiles(fieldAllowedTypes, assets);
+
+    if (allowedAssets.length > 0) {
+      setDroppedAssets(allowedAssets);
+      setStep(STEPS.AssetUpload);
+    } else {
+      toggleNotification({
+        type: 'warning',
+        timeout: 4000,
+        message: {
+          id: 'input.notification.not-supported',
+          defaultMessage: `You can't upload this type of file, only the following types are accepted – ${fieldAllowedTypes.join(
+            ','
+          )}`,
+          assetTypes: fieldAllowedTypes.join(','),
+        },
+      });
+    }
   };
 
   let label = intlLabel.id ? formatMessage(intlLabel) : '';

--- a/packages/core/upload/admin/src/components/MediaLibraryInput/index.js
+++ b/packages/core/upload/admin/src/components/MediaLibraryInput/index.js
@@ -9,6 +9,7 @@ import { CarouselAssets } from './Carousel/CarouselAssets';
 import { EditFolderDialog } from '../EditFolderDialog';
 import { UploadAssetDialog } from '../UploadAssetDialog/UploadAssetDialog';
 import getAllowedFiles from '../../utils/getAllowedFiles';
+import getTrad from '../../utils/getTrad';
 
 const STEPS = {
   AssetSelect: 'SelectAsset',
@@ -112,11 +113,11 @@ export const MediaLibraryInput = ({
         type: 'warning',
         timeout: 4000,
         message: {
-          id: 'input.notification.not-supported',
-          defaultMessage: `You can't upload this type of file, only the following types are accepted – ${fieldAllowedTypes.join(
-            ','
-          )}`,
-          assetTypes: fieldAllowedTypes.join(','),
+          id: getTrad('input.notification.not-supported'),
+          defaultMessage: `You can't upload this type of file.`,
+          values: {
+            fileTypes: fieldAllowedTypes.join(','),
+          },
         },
       });
     }

--- a/packages/core/upload/admin/src/translations/en.json
+++ b/packages/core/upload/admin/src/translations/en.json
@@ -38,6 +38,7 @@
   "input.placeholder.icon": "Drop the asset in this zone",
   "input.url.description": "Separate your URL links by a carriage return.",
   "input.url.label": "URL",
+  "input.notification.not-supported": "You can't upload this type of file.",
   "list.assets.title": "Assets ({count})",
   "list.asset.at.finished": "The assets have finished loading.",
   "list.assets-empty.search": "No result found",

--- a/packages/core/upload/admin/src/translations/en.json
+++ b/packages/core/upload/admin/src/translations/en.json
@@ -38,7 +38,7 @@
   "input.placeholder.icon": "Drop the asset in this zone",
   "input.url.description": "Separate your URL links by a carriage return.",
   "input.url.label": "URL",
-  "input.notification.not-supported": "You can't upload this type of file.",
+  "input.notification.not-supported": "You can't upload this type of file, only the following types are accepted – {fileTypes}",
   "list.assets.title": "Assets ({count})",
   "list.asset.at.finished": "The assets have finished loading.",
   "list.assets-empty.search": "No result found",


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* Stops users being able to upload files into inputs where the input does not allow the type e.g. the input allows "image" and i try upload a "file"
* Shows notification if the file cannot be uploaded.

### Why is it needed?

* In response to a community PR (#15328)

### How to test it?

* Add a media field and set allowedTypes to "image"
* Try upload a PDF in that field
* It should show you a notification

### Related issue(s)/PR(s)

* Closes #15328 in favour of this.
