### PR TITLE
[ReactSelect]: use grids but not min-content, just 100%

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/RelationInput/tests/__snapshots__/RelationInput.test.js.snap
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInput/tests/__snapshots__/RelationInput.test.js.snap
@@ -621,7 +621,7 @@ exports[`Content-Manager || RelationInput should render and match snapshot 1`] =
                 Select...
               </div>
               <div
-                class=" css-1rkub9f-Input"
+                class=" css-566e1j-Input"
                 data-value=""
               >
                 <input

--- a/packages/core/helper-plugin/lib/src/components/ReactSelect/utils/getSelectStyles.js
+++ b/packages/core/helper-plugin/lib/src/components/ReactSelect/utils/getSelectStyles.js
@@ -39,7 +39,7 @@ const getSelectStyles = (theme, error) => {
       margin: 0,
       padding: 0,
       color: theme.colors.neutral800,
-      gridTemplateColumns: 'unset',
+      gridTemplateColumns: '0 100%',
     }),
     menu(base) {
       return {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* uses 100% as the second column to obey the parent's width

### Why is it needed?

* because if you don't do something it grows with the inner content looking dumb

### Related issue(s)/PR(s)

* resolves CONTENT-936
