### PR TITLE
[ReactSelect]: the indicator should not be a dropdown according to their spec

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/RelationInput/components/tests/Option.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInput/components/tests/Option.test.js
@@ -21,7 +21,7 @@ describe('Content-Manager || RelationInput || Option', () => {
     setup({ options: [{ id: 1, mainField: 'relation 1', publicationState: 'published' }] });
 
     act(() => {
-      fireEvent.mouseDown(screen.getByRole('button'));
+      fireEvent.mouseDown(screen.getByRole('combobox'));
     });
 
     expect(screen.getByText('relation 1')).toBeInTheDocument();
@@ -32,7 +32,7 @@ describe('Content-Manager || RelationInput || Option', () => {
     setup({ options: [{ id: 1, mainField: 'relation 1', publicationState: 'draft' }] });
 
     act(() => {
-      fireEvent.mouseDown(screen.getByRole('button'));
+      fireEvent.mouseDown(screen.getByRole('combobox'));
     });
 
     expect(screen.getByText('relation 1')).toBeInTheDocument();

--- a/packages/core/admin/admin/src/content-manager/components/RelationInput/tests/__snapshots__/RelationInput.test.js.snap
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInput/tests/__snapshots__/RelationInput.test.js.snap
@@ -647,9 +647,9 @@ exports[`Content-Manager || RelationInput should render and match snapshot 1`] =
             <div
               class=" css-1hb7zxy-IndicatorsContainer"
             >
-              <button
+              <div
+                aria-hidden="true"
                 class="c8 c9 c10"
-                type="button"
               >
                 <svg
                   fill="none"
@@ -665,7 +665,7 @@ exports[`Content-Manager || RelationInput should render and match snapshot 1`] =
                     fill-rule="evenodd"
                   />
                 </svg>
-              </button>
+              </div>
             </div>
           </div>
           <input

--- a/packages/core/helper-plugin/lib/src/components/ReactSelect/components/DropdownIndicator.js
+++ b/packages/core/helper-plugin/lib/src/components/ReactSelect/components/DropdownIndicator.js
@@ -13,9 +13,13 @@ export const CarretBox = styled(IconBox)`
   }
 `;
 
-const DropdownIndicator = () => {
+/**
+ * These props come from `react-select`.
+ */
+// eslint-disable-next-line react/prop-types
+const DropdownIndicator = ({ innerRef, innerProps }) => {
   return (
-    <CarretBox as="button" type="button" paddingRight={3}>
+    <CarretBox ref={innerRef} paddingRight={3} {...innerProps}>
       <CarretDown />
     </CarretBox>
   );

--- a/packages/core/upload/admin/src/components/BulkMoveDialog/tests/__snapshots__/BulkMoveDialog.test.js.snap
+++ b/packages/core/upload/admin/src/components/BulkMoveDialog/tests/__snapshots__/BulkMoveDialog.test.js.snap
@@ -608,9 +608,9 @@ exports[`BulkMoveDialog renders and matches the snapshot 1`] = `
                             <div
                               class=" css-1hb7zxy-IndicatorsContainer"
                             >
-                              <button
+                              <div
+                                aria-hidden="true"
                                 class="c2 c21 c22 c23"
-                                type="button"
                               >
                                 <svg
                                   fill="none"
@@ -626,7 +626,7 @@ exports[`BulkMoveDialog renders and matches the snapshot 1`] = `
                                     fill-rule="evenodd"
                                   />
                                 </svg>
-                              </button>
+                              </div>
                             </div>
                           </div>
                           <input

--- a/packages/core/upload/admin/src/components/EditAssetDialog/tests/__snapshots__/EditAssetDialog.test.js.snap
+++ b/packages/core/upload/admin/src/components/EditAssetDialog/tests/__snapshots__/EditAssetDialog.test.js.snap
@@ -1263,9 +1263,9 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
                               <div
                                 class=" css-1hb7zxy-IndicatorsContainer"
                               >
-                                <button
+                                <div
+                                  aria-hidden="true"
                                   class="c2 c36 c37 c38"
-                                  type="button"
                                 >
                                   <svg
                                     fill="none"
@@ -1281,7 +1281,7 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
                                       fill-rule="evenodd"
                                     />
                                   </svg>
-                                </button>
+                                </div>
                               </div>
                             </div>
                             <input

--- a/packages/core/upload/admin/src/components/EditAssetDialog/tests/__snapshots__/index.test.js.snap
+++ b/packages/core/upload/admin/src/components/EditAssetDialog/tests/__snapshots__/index.test.js.snap
@@ -1263,9 +1263,9 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
                               <div
                                 class=" css-1hb7zxy-IndicatorsContainer"
                               >
-                                <button
+                                <div
+                                  aria-hidden="true"
                                   class="c2 c36 c37 c38"
-                                  type="button"
                                 >
                                   <svg
                                     fill="none"
@@ -1281,7 +1281,7 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
                                       fill-rule="evenodd"
                                     />
                                   </svg>
-                                </button>
+                                </div>
                               </div>
                             </div>
                             <input

--- a/packages/core/upload/admin/src/components/EditFolderDialog/tests/__snapshots__/EditFolderDialog.test.js.snap
+++ b/packages/core/upload/admin/src/components/EditFolderDialog/tests/__snapshots__/EditFolderDialog.test.js.snap
@@ -718,9 +718,9 @@ exports[`EditFolderDialog renders and matches the snapshot 1`] = `
                             <div
                               class=" css-1hb7zxy-IndicatorsContainer"
                             >
-                              <button
+                              <div
+                                aria-hidden="true"
                                 class="c2 c23 c24 c25"
-                                type="button"
                               >
                                 <svg
                                   fill="none"
@@ -736,7 +736,7 @@ exports[`EditFolderDialog renders and matches the snapshot 1`] = `
                                     fill-rule="evenodd"
                                   />
                                 </svg>
-                              </button>
+                              </div>
                             </div>
                           </div>
                           <input

--- a/packages/core/upload/admin/src/components/SelectTree/tests/__snapshots__/SelectTree.test.js.snap
+++ b/packages/core/upload/admin/src/components/SelectTree/tests/__snapshots__/SelectTree.test.js.snap
@@ -89,9 +89,9 @@ exports[`SelectTree renders 1`] = `
           <div
             class=" css-1hb7zxy-IndicatorsContainer"
           >
-            <button
+            <div
+              aria-hidden="true"
               class="c0 c1 c2"
-              type="button"
             >
               <svg
                 fill="none"
@@ -107,7 +107,7 @@ exports[`SelectTree renders 1`] = `
                   fill-rule="evenodd"
                 />
               </svg>
-            </button>
+            </div>
           </div>
         </div>
       </div>
@@ -220,9 +220,9 @@ exports[`SelectTree renders 1`] = `
         <div
           class=" css-1hb7zxy-IndicatorsContainer"
         >
-          <button
+          <div
+            aria-hidden="true"
             class="c0 c1 c2"
-            type="button"
           >
             <svg
               fill="none"
@@ -238,7 +238,7 @@ exports[`SelectTree renders 1`] = `
                 fill-rule="evenodd"
               />
             </svg>
-          </button>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* removes the focus ability from the DropdownIndicator component

### Why is it needed?

* This shouldn't be a button, if you look at their original version you cannot focus it, this is why the menu doesn't autoclose when you blur from the button.

### Related issue(s)/PR(s)

* resolves CONTENT-943
