### PR TITLE
[Audit logs] Make audit log content type invisible

### DIFF
--- a/packages/providers/audit-logs-local/lib/content-types/audit-log/schema.js
+++ b/packages/providers/audit-logs-local/lib/content-types/audit-log/schema.js
@@ -11,6 +11,8 @@ module.exports = {
   options: {
     draftAndPublish: false,
     timestamps: false,
+  },
+  pluginOptions: {
     'content-manager': {
       visible: false,
     },
@@ -18,7 +20,6 @@ module.exports = {
       visible: false,
     },
   },
-  pluginOptions: {},
   attributes: {
     action: {
       type: 'string',


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Makes sure audit logs isn't visible in the CM or the CTB
