### PR TITLE
[DEITS] Always include schemas when --only option is used

### DIFF
--- a/packages/core/data-transfer/src/engine/index.ts
+++ b/packages/core/data-transfer/src/engine/index.ts
@@ -273,6 +273,11 @@ class TransferEngine<
   shouldSkipStage(stage: TransferStage) {
     const { exclude, only } = this.options;
 
+    // schemas must always be included
+    if (stage === 'schemas') {
+      return false;
+    }
+
     // everything is included by default unless 'only' has been set
     let included = isEmpty(only);
     if (only?.length > 0) {

--- a/packages/core/strapi/lib/commands/transfer/utils.js
+++ b/packages/core/strapi/lib/commands/transfer/utils.js
@@ -99,7 +99,7 @@ const excludeOption = new Option(
 
 const onlyOption = new Option(
   '--only <command-separated data types>',
-  `Include only this data. Available types: ${transferDataTypes.join(',')}`
+  `Include only this data (plus schemas). Available types: ${transferDataTypes.join(',')}`
 ).argParser(getParseListWithChoices(transferDataTypes, 'Invalid options for "only"'));
 
 const validateExcludeOnly = (command) => {


### PR DESCRIPTION
### What does it do?

Always includes schemas when --only option is used, so that schema checks can be performed.

### Why is it needed?

Without the schema stage, import and transfer will throw an error because the schema checks cannot be performed.

### How to test it?

Run export with the --only option and ensure that schemas are present. Then import the file and it should still succeed.

