### PR TITLE
fixes #15497 : fix server error on taken username or email

### DIFF
--- a/packages/plugins/users-permissions/server/content-types/user/index.js
+++ b/packages/plugins/users-permissions/server/content-types/user/index.js
@@ -28,6 +28,7 @@ module.exports = {
       minLength: 6,
       configurable: false,
       required: true,
+      unique: true
     },
     provider: {
       type: 'string',

--- a/packages/plugins/users-permissions/server/controllers/auth.js
+++ b/packages/plugins/users-permissions/server/controllers/auth.js
@@ -294,34 +294,7 @@ module.exports = {
       throw new ApplicationError('Impossible to find the default role');
     }
 
-    const { email, username, provider } = params;
-
-    const identifierFilter = {
-      $or: [
-        { email: email.toLowerCase() },
-        { username: email.toLowerCase() },
-        { username },
-        { email: username },
-      ],
-    };
-
-    const conflictingUserCount = await strapi.query('plugin::users-permissions.user').count({
-      where: { ...identifierFilter, provider },
-    });
-
-    if (conflictingUserCount > 0) {
-      throw new ApplicationError('Email or Username are already taken');
-    }
-
-    if (settings.unique_email) {
-      const conflictingUserCount = await strapi.query('plugin::users-permissions.user').count({
-        where: { ...identifierFilter },
-      });
-
-      if (conflictingUserCount > 0) {
-        throw new ApplicationError('Email or Username are already taken');
-      }
-    }
+    const { email, username } = params;
 
     const newUser = {
       ...params,


### PR DESCRIPTION
### What does it do?

Remove bad input data checks on the user registration, make emails unique as the default setting in `users-permissions`

### Why is it needed?

Currently, when registering with a taken username or email, strapi wrongfully throws a server error, logs "username already taken" to the console and gives you this uninformative API response: 

```
{
    "data": null,
    "error": {
        "status": 500,
        "name": "InternalServerError",
        "message": "Internal Server Error"
    }
}
```

With this PR, the registration data is being forwarded to the actual schema verification, resulting in a proper API response:
```
{
    "data": null,
    "error": {
        "status": 400,
        "name": "ValidationError",
        "message": "2 errors occurred",
        "details": {
            "errors": [
                {
                    "path": [
                        "username"
                    ],
                    "message": "This attribute must be unique",
                    "name": "ValidationError"
                },
                {
                    "path": [
                        "email"
                    ],
                    "message": "This attribute must be unique",
                    "name": "ValidationError"
                }
            ]
        }
    }
}
```

Because of the old checks, it didn't seem necessary to set the email attribute to `unique` in the `user-permissions` schema, which I've fixed for the verification to work properly. 

### How to test it?

Create a user with a taken username or password. 

### Related issue(s)/PR(s)

Fixes https://github.com/strapi/strapi/issues/15497
