### PR TITLE
[DEITS] remove -f shortcut for force

### DIFF
--- a/packages/core/strapi/lib/commands/utils/commander.js
+++ b/packages/core/strapi/lib/commands/utils/commander.js
@@ -122,7 +122,7 @@ const confirmMessage = (message) => {
 };
 
 const forceOption = new Option(
-  '-f, --force',
+  '--force',
   `Automatically answer "yes" to all prompts, including potentially destructive requests, and run non-interactively.`
 );
 


### PR DESCRIPTION
### What does it do?

Removes the -f shortcut for --force because -f is for --file

### Why is it needed?

It was added by mistake and shouldn't be there.

### How to test it?

strapi export/import/transfer --help should only show --force for the force option. -f should only appear as a shortcut for --file.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
