### PR TITLE
[FIX] LeftMenu collection type name sorting

### DIFF
--- a/packages/core/admin/admin/src/content-manager/pages/App/LeftMenu/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/App/LeftMenu/index.js
@@ -7,12 +7,7 @@
 import React, { useMemo, useState } from 'react';
 import { useSelector, shallowEqual } from 'react-redux';
 import { useIntl } from 'react-intl';
-import matchSorter from 'match-sorter';
 import { NavLink } from 'react-router-dom';
-
-import sortBy from 'lodash/sortBy';
-import toLower from 'lodash/toLower';
-import camelCase from 'lodash/camelCase';
 
 import {
   SubNav,
@@ -22,13 +17,9 @@ import {
   SubNavLink,
 } from '@strapi/design-system/v2/SubNav';
 
+import { matchByTitle } from './utils';
 import getTrad from '../../../utils/getTrad';
 import { makeSelectModelLinks } from '../selectors';
-
-const matchByTitle = (links, search) =>
-  search
-    ? matchSorter(links, toLower(search), { keys: [(item) => toLower(item.title)] })
-    : sortBy(links, (object) => camelCase(object.title));
 
 const LeftMenu = () => {
   const [search, setSearch] = useState('');

--- a/packages/core/admin/admin/src/content-manager/pages/App/LeftMenu/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/App/LeftMenu/index.js
@@ -8,9 +8,12 @@ import React, { useMemo, useState } from 'react';
 import { useSelector, shallowEqual } from 'react-redux';
 import { useIntl } from 'react-intl';
 import matchSorter from 'match-sorter';
+import { NavLink } from 'react-router-dom';
+
 import sortBy from 'lodash/sortBy';
 import toLower from 'lodash/toLower';
-import { NavLink } from 'react-router-dom';
+import camelCase from 'lodash/camelCase';
+
 import {
   SubNav,
   SubNavHeader,
@@ -18,13 +21,14 @@ import {
   SubNavSections,
   SubNavLink,
 } from '@strapi/design-system/v2/SubNav';
+
 import getTrad from '../../../utils/getTrad';
 import { makeSelectModelLinks } from '../selectors';
 
 const matchByTitle = (links, search) =>
   search
     ? matchSorter(links, toLower(search), { keys: [(item) => toLower(item.title)] })
-    : sortBy(links, (object) => object.title.toLowerCase());
+    : sortBy(links, (object) => camelCase(object.title));
 
 const LeftMenu = () => {
   const [search, setSearch] = useState('');

--- a/packages/core/admin/admin/src/content-manager/pages/App/LeftMenu/utils/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/App/LeftMenu/utils/index.js
@@ -1,0 +1,1 @@
+export { default as matchByTitle } from './matchByTitle';

--- a/packages/core/admin/admin/src/content-manager/pages/App/LeftMenu/utils/matchByTitle.js
+++ b/packages/core/admin/admin/src/content-manager/pages/App/LeftMenu/utils/matchByTitle.js
@@ -7,9 +7,9 @@ import camelCase from 'lodash/camelCase';
 const matchByTitle = (links, search) =>
   search
     ? matchSorter(links, search.toLowerCase(), { keys: [(item) => item.title.toLowerCase()] })
-    : links.sort((link, linkNext) => {
+    : links.sort((link, nextLink) => {
         const title = camelCase(link.title);
-        const nextTitle = camelCase(linkNext.title);
+        const nextTitle = camelCase(nextLink.title);
 
         if (title < nextTitle) {
           return -1;

--- a/packages/core/admin/admin/src/content-manager/pages/App/LeftMenu/utils/matchByTitle.js
+++ b/packages/core/admin/admin/src/content-manager/pages/App/LeftMenu/utils/matchByTitle.js
@@ -1,0 +1,24 @@
+import matchSorter from 'match-sorter';
+import camelCase from 'lodash/camelCase';
+
+/**
+ * @type {(links: array, search? : string) => array }
+ */
+const matchByTitle = (links, search) =>
+  search
+    ? matchSorter(links, search.toLowerCase(), { keys: [(item) => item.title.toLowerCase()] })
+    : links.sort((link, linkNext) => {
+        const title = camelCase(link.title);
+        const nextTitle = camelCase(linkNext.title);
+
+        if (title < nextTitle) {
+          return -1;
+        }
+        if (title > nextTitle) {
+          return 1;
+        }
+
+        return 0;
+      });
+
+export default matchByTitle;

--- a/packages/core/admin/admin/src/content-manager/pages/App/LeftMenu/utils/tests/matchByTitle.test.js
+++ b/packages/core/admin/admin/src/content-manager/pages/App/LeftMenu/utils/tests/matchByTitle.test.js
@@ -1,0 +1,43 @@
+import { matchByTitle } from '../index';
+
+describe('Content Manager | Pages | LeftMenu | Utils', () => {
+  describe('matchByTitle', () => {
+    it('correctly sorts a list of links with special characters', () => {
+      const links = [
+        {
+          title: 'zebra',
+        },
+        {
+          title: 'Address',
+        },
+        {
+          title: 'dog',
+        },
+        {
+          title: 'škola',
+        },
+        {
+          title: 'Članky',
+        },
+      ];
+
+      expect(matchByTitle(links)).toEqual([
+        {
+          title: 'Address',
+        },
+        {
+          title: 'Članky',
+        },
+        {
+          title: 'dog',
+        },
+        {
+          title: 'škola',
+        },
+        {
+          title: 'zebra',
+        },
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md

-->


### What does it do?

Sorts collection type names in the CM the same way as the CTB (see `packages/core/content-type-builder/admin/src/components/DataManagerProvider/utils/cleanData.js`)

![image](https://user-images.githubusercontent.com/48524071/213494756-bf6e2037-479c-4092-960a-44a793576cd1.png)

### Why is it needed?

The order of content types in Content Manager was not alphabetical. It puts special letters like Č, Š, ... at the end. On the other hand, Content type builder have correct order.

### Related issue(s)/PR(s)

Fixes https://github.com/strapi/strapi/issues/15342


