### PR TITLE
Setup review-workflows settings page

### DIFF
--- a/packages/core/admin/admin/src/translations/en.json
+++ b/packages/core/admin/admin/src/translations/en.json
@@ -189,6 +189,8 @@
   "Settings.profile.form.section.experience.title": "Experience",
   "Settings.profile.form.section.helmet.title": "User profile",
   "Settings.profile.form.section.profile.page.title": "Profile page",
+  "Settings.review-workflows.page.title": "Review Workflow",
+  "Settings.review-workflows.page.subtitle": "{count, plural, one {# stage} other {# stages}}",
   "Settings.roles.create.description": "Define the rights given to the role",
   "Settings.roles.create.title": "Create a role",
   "Settings.roles.created": "Role created",

--- a/packages/core/admin/ee/admin/hooks/useSettingsMenu/utils/customGlobalLinks.js
+++ b/packages/core/admin/ee/admin/hooks/useSettingsMenu/utils/customGlobalLinks.js
@@ -1,17 +1,25 @@
 import adminPermissions from '../../../../../admin/src/permissions';
 
-const ssoGlobalRoutes = strapi.features.isEnabled(strapi.features.SSO)
-  ? [
-      {
-        intlLabel: { id: 'Settings.sso.title', defaultMessage: 'Single Sign-On' },
-        to: '/settings/single-sign-on',
-        id: 'sso',
-        isDisplayed: false,
-        permissions: adminPermissions.settings.sso.main,
-      },
-    ]
-  : [];
+const items = [];
 
-const customGlobalLinks = [...ssoGlobalRoutes];
+if (window.strapi.features.isEnabled(strapi.features.SSO)) {
+  items.push({
+    intlLabel: { id: 'Settings.sso.title', defaultMessage: 'Single Sign-On' },
+    to: '/settings/single-sign-on',
+    id: 'sso',
+    isDisplayed: false,
+    permissions: adminPermissions.settings.sso.main,
+  });
+}
 
-export default customGlobalLinks;
+if (window.strapi.isEE) {
+  items.push({
+    intlLabel: { id: 'Settings.review-workflows.title', defaultMessage: 'Review Workflow' },
+    to: '/settings/review-workflows',
+    id: 'review-workflows',
+    isDisplayed: false,
+    permissions: adminPermissions.settings.reviewWorkflows.main,
+  });
+}
+
+export default items;

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/ReviewWorkflows.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/ReviewWorkflows.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import { useIntl } from 'react-intl';
+import { SettingsPageTitle } from '@strapi/helper-plugin';
+import { Button, ContentLayout, HeaderLayout, Layout, Main } from '@strapi/design-system';
+import { Check } from '@strapi/icons';
+
+export function ReviewWorkflowsPage() {
+  const { formatMessage } = useIntl();
+
+  return (
+    <Layout>
+      <SettingsPageTitle
+        name={formatMessage({
+          id: 'Settings.review-workflows.page.title',
+          defaultMessage: 'Review Workflow',
+        })}
+      />
+      <Main tabIndex={-1}>
+        <HeaderLayout
+          primaryAction={
+            <Button startIcon={<Check />} type="submit" size="L">
+              {formatMessage({
+                id: 'global.save',
+                defaultMessage: 'Save',
+              })}
+            </Button>
+          }
+          title={formatMessage({
+            id: 'Settings.review-workflows.page.title',
+            defaultMessage: 'Review Workflow',
+          })}
+          subtitle={formatMessage(
+            {
+              id: 'Settings.review-workflows.page.subtitle',
+              defaultMessage: '{count, plural, one {# stage} other {# stages}}',
+            },
+            { count: 0 }
+          )}
+        />
+        <ContentLayout />
+      </Main>
+    </Layout>
+  );
+}

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/index.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/index.js
@@ -1,0 +1,3 @@
+import { ReviewWorkflowsPage } from './ReviewWorkflows';
+
+export default ReviewWorkflowsPage;

--- a/packages/core/admin/ee/admin/pages/SettingsPage/utils/customRoutes.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/utils/customRoutes.js
@@ -1,19 +1,29 @@
-const ssoRoutes = strapi.features.isEnabled(strapi.features.SSO)
-  ? [
-      {
-        async Component() {
-          const component = await import(
-            /* webpackChunkName: "sso-settings-page" */ '../SingleSignOn'
-          );
+const routes = [];
 
-          return component;
-        },
-        to: '/settings/single-sign-on',
-        exact: true,
-      },
-    ]
-  : [];
+if (window.strapi.features.isEnabled(strapi.features.SSO)) {
+  routes.push({
+    async Component() {
+      const component = await import(/* webpackChunkName: "sso-settings-page" */ '../SingleSignOn');
 
-const customRoutes = [...ssoRoutes];
+      return component;
+    },
+    to: '/settings/single-sign-on',
+    exact: true,
+  });
+}
 
-export default customRoutes;
+if (window.strapi.isEE) {
+  routes.push({
+    async Component() {
+      const component = await import(
+        /* webpackChunkName: "review-workflows-settings" */ '../pages/ReviewWorkflows'
+      );
+
+      return component;
+    },
+    to: '/settings/review-workflows',
+    exact: true,
+  });
+}
+
+export default routes;

--- a/packages/core/admin/ee/admin/permissions/customPermissions.js
+++ b/packages/core/admin/ee/admin/permissions/customPermissions.js
@@ -1,5 +1,9 @@
 const customPermissions = {
   settings: {
+    reviewWorkflows: {
+      main: [{ action: 'admin::roles.create', subject: null }],
+    },
+
     sso: {
       main: [{ action: 'admin::provider-login.read', subject: null }],
       read: [{ action: 'admin::provider-login.read', subject: null }],


### PR DESCRIPTION
### What does it do?

Creates a new settings page for review-workflows.

### Why is it needed?

This page will be used to configure the feature.

ℹ️ Tests will follow once the state management is setup.

### How to test it?

1. Navigate to settings
2. Verify "Review Workflow" shows up in the navigation
3. Verify you can open the page and see the feature title rendered
4. Verify the page is only visible in EE mode
