### PR TITLE
add db dialect to startup info log

### DIFF
--- a/packages/core/strapi/lib/utils/startup-logger.js
+++ b/packages/core/strapi/lib/utils/startup-logger.js
@@ -27,7 +27,8 @@ module.exports = (app) => {
         [chalk.blue('Environment'), app.config.environment],
         [chalk.blue('Process PID'), process.pid],
         [chalk.blue('Version'), `${app.config.info.strapi} (node ${process.version})`],
-        [chalk.blue('Edition'), isEE ? 'Enterprise' : 'Community']
+        [chalk.blue('Edition'), isEE ? 'Enterprise' : 'Community'],
+        [chalk.blue('Database'), app.db.dialect.client]
       );
 
       console.log(infoTable.toString());


### PR DESCRIPTION
### What does it do?

Added the dialect to the startup log.

### Why is it needed?

Helpful when running the same Strapi app on multiple databases

### How to test it?

NA

