### PR TITLE
[DEITS] process tar files that use ./ path prefixes

### DIFF
--- a/packages/core/data-transfer/src/file/providers/source/index.ts
+++ b/packages/core/data-transfer/src/file/providers/source/index.ts
@@ -177,8 +177,9 @@ class LocalFileSourceProvider implements ISourceProvider {
               return false;
             }
 
-            const parts = filePath.split('/');
+            const parts = path.relative('.', filePath).split('/');
 
+            // TODO: this method is limiting us from having additional subdirectories and is requiring us to remove any "./" prefixes (the path.relative line above)
             if (parts.length !== 2) {
               return false;
             }
@@ -225,7 +226,7 @@ class LocalFileSourceProvider implements ISourceProvider {
              * Filter the parsed entries to only keep the one that matches the given filepath
              */
             filter(entryPath, entry) {
-              return entryPath === filePath && entry.type === 'File';
+              return !path.relative(filePath, entryPath).length && entry.type === 'File';
             },
 
             async onentry(entry) {


### PR DESCRIPTION
### What does it do?

Fixes our tar processing so that if a tar stores a file such as "metadata.json" with the internal path "./metadata.json" we recognize it as the same file path as without the "./"

### Why is it needed?

Currently, our export process creates tars with paths stored internally like "metadata.json" at the root of the tar. However, other tools such as the `tar` command store the internal path as "./metadata.json".  Since we were simply doing a string comparison on the path, it was failing to recognize they were the same file.

With this change, Strapi export files created with the `tar` command should now work with `strapi import`

### How to test it?

- Create a valid Strapi backup folder (by running an export, then unarchiving it into a folder)
- Use a tar command such as `tar -czvf backup.tar.gz -C yourFolderName .` to archive the folder
- `strapi import` should still work correctly with that archive
