### PR TITLE
Admin: Allow reducers to be injected async into the store

### DIFF
--- a/packages/core/admin/admin/src/core/store/createReducer.js
+++ b/packages/core/admin/admin/src/core/store/createReducer.js
@@ -1,5 +1,0 @@
-import { combineReducers } from 'redux';
-
-const createReducer = (reducers) => combineReducers(reducers);
-
-export default createReducer;

--- a/packages/core/admin/admin/src/core/store/tests/configureStore.test.js
+++ b/packages/core/admin/admin/src/core/store/tests/configureStore.test.js
@@ -1,0 +1,69 @@
+import configureStore from '../configureStore';
+
+function middlewareFixture(callback) {
+  return () =>
+    ({ getState }) =>
+    (next) =>
+    (action) => {
+      callback(getState());
+
+      return next(action);
+    };
+}
+
+function reducer(state = {}, action) {
+  switch (action.type) {
+    case 'something': {
+      return {
+        ...state,
+        ...action.payload,
+      };
+    }
+
+    default:
+      return state;
+  }
+}
+
+function asyncReducer(state = {}, action) {
+  switch (action.type) {
+    case 'async': {
+      return {
+        ...state,
+        async: action.payload,
+      };
+    }
+
+    default:
+      return state;
+  }
+}
+
+describe('configureStore', () => {
+  test('applies middlewares and reducers', () => {
+    const spy = jest.fn();
+
+    const store = configureStore([middlewareFixture(spy)], [reducer]);
+
+    store.dispatch({ type: 'something', payload: { redux: true } });
+    store.dispatch({ type: 'something', payload: { redux: 1 } });
+    store.dispatch({ type: 'something', payload: { redux: 2 } });
+
+    expect(spy).toBeCalledTimes(3);
+    expect(spy).toHaveBeenNthCalledWith(1, { 0: {} });
+    expect(spy).toHaveBeenNthCalledWith(2, { 0: { redux: true } });
+    expect(spy).toHaveBeenNthCalledWith(3, { 0: { redux: 1 } });
+  });
+
+  test('adds injectReducer() method', () => {
+    const store = configureStore([middlewareFixture(() => {})], [reducer]);
+
+    expect(store.injectReducer).toBeDefined();
+
+    store.injectReducer('asyncReducer', asyncReducer);
+
+    store.dispatch({ type: 'async', payload: true });
+
+    expect(store.getState()).toStrictEqual({ 0: {}, asyncReducer: { async: true } });
+  });
+});


### PR DESCRIPTION
### What does it do?

Registers a new method `injectReducer()` on the redux-store which allows us to dynamically inject reducers.

### Why is it needed?

Review Workflows will use redux as state management. Currently it is impossible to extend the core-store without writing our own strapi-plugin and [extending reducers in the bootstrap phase](https://docs.strapi.io/developer-docs/latest/developer-resources/plugin-api-reference/admin-panel.html#reducers-api).

This allows us to extend the store for individual views (such as any EE view) and follows a recommended pattern for code splitting from the redux documentation: https://redux.js.org/usage/code-splitting

```js
import { useEffect } from 'react';
import reducer from './reducer';

export function Component() {
  useEffect(() => {
    store.injectReducer('NS', reducer);
  }, [])

  return null;
}
```
