### PR TITLE
feat: added Apple auth provider

### DIFF
--- a/packages/plugins/users-permissions/admin/src/components/FormModal/Input/index.js
+++ b/packages/plugins/users-permissions/admin/src/components/FormModal/Input/index.js
@@ -8,6 +8,7 @@ import React from 'react';
 import { useIntl } from 'react-intl';
 import { ToggleInput } from '@strapi/design-system/ToggleInput';
 import { TextInput } from '@strapi/design-system/TextInput';
+import { Textarea } from '@strapi/design-system/Textarea';
 import PropTypes from 'prop-types';
 
 const Input = ({
@@ -23,8 +24,6 @@ const Input = ({
   value,
 }) => {
   const { formatMessage } = useIntl();
-  const inputValue =
-    name === 'noName' ? `${strapi.backendURL}/api/connect/${providerToEditName}/callback` : value;
 
   const label = formatMessage(
     { id: intlLabel.id, defaultMessage: intlLabel.defaultMessage },
@@ -70,8 +69,10 @@ const Input = ({
 
   const errorMessage = error ? formatMessage({ id: error, defaultMessage: error }) : '';
 
+  const InputComponent = type === 'textarea' ? Textarea : TextInput;
+
   return (
-    <TextInput
+    <InputComponent
       aria-label={name}
       disabled={disabled}
       error={errorMessage}
@@ -80,7 +81,7 @@ const Input = ({
       onChange={onChange}
       placeholder={formattedPlaceholder}
       type={type}
-      value={inputValue}
+      value={value}
     />
   );
 };

--- a/packages/plugins/users-permissions/admin/src/components/FormModal/index.js
+++ b/packages/plugins/users-permissions/admin/src/components/FormModal/index.js
@@ -66,7 +66,9 @@ const FormModal = ({
                               {...input}
                               error={errors[input.name]}
                               onChange={handleChange}
-                              value={values[input.name]}
+                              value={
+                                input.name === 'noName' ? values.redirectUri : values[input.name]
+                              }
                               providerToEditName={providerToEditName}
                             />
                           </GridItem>

--- a/packages/plugins/users-permissions/admin/src/pages/Providers/index.js
+++ b/packages/plugins/users-permissions/admin/src/pages/Providers/index.js
@@ -118,6 +118,10 @@ export const ProvidersPage = () => {
       return forms.email;
     }
 
+    if (providerToEditName === 'apple') {
+      return forms.providerApple;
+    }
+
     if (isProviderWithSubdomain) {
       return forms.providersWithSubdomain;
     }

--- a/packages/plugins/users-permissions/server/bootstrap/grant-config.js
+++ b/packages/plugins/users-permissions/server/bootstrap/grant-config.js
@@ -120,4 +120,20 @@ module.exports = (baseURL) => ({
     scope: ['openid email'], // scopes should be space delimited
     subdomain: 'my.subdomain.com/cas',
   },
+  apple: {
+    enabled: false,
+    icon: 'apple',
+    key: '',
+    secret: '',
+    teamId: '',
+    keyIdentifier: '',
+    callback: `${baseURL}/apple/callback`,
+    scope: ['name', 'email'],
+    nonce: true,
+    state: true,
+    custom_params: {
+      response_type: 'code id_token',
+      response_mode: 'form_post',
+    },
+  },
 });

--- a/packages/plugins/users-permissions/server/controllers/auth.js
+++ b/packages/plugins/users-permissions/server/controllers/auth.js
@@ -199,6 +199,18 @@ module.exports = {
       grantConfig[provider].callback;
     grantConfig[provider].redirect_uri = getService('providers').buildRedirectUri(provider);
 
+    if (provider === 'apple') {
+      grantConfig.apple = {
+        ...grantConfig.apple,
+        secret: getService('providers').createAppleSecret({
+          key: grantConfig.apple.key,
+          teamId: grantConfig.apple.teamId,
+          keyIdentifier: grantConfig.apple.keyIdentifier,
+          privateKey: grantConfig.apple.secret,
+        }),
+      };
+    }
+
     return grant(grantConfig)(ctx, next);
   },
 

--- a/packages/plugins/users-permissions/server/routes/content-api/auth.js
+++ b/packages/plugins/users-permissions/server/routes/content-api/auth.js
@@ -12,6 +12,15 @@ module.exports = [
   },
   {
     method: 'POST',
+    path: '/connect/(.*)',
+    handler: 'auth.connect',
+    config: {
+      middlewares: ['plugin::users-permissions.rateLimit'],
+      prefix: '',
+    },
+  },
+  {
+    method: 'POST',
     path: '/auth/local',
     handler: 'auth.callback',
     config: {

--- a/packages/plugins/users-permissions/server/services/providers-registry.js
+++ b/packages/plugins/users-permissions/server/services/providers-registry.js
@@ -264,6 +264,20 @@ const getInitialProviders = ({ purest }) => ({
         };
       });
   },
+  async apple({ query }) {
+    // get the id_token
+    const idToken = query.id_token;
+    // decode the jwt token
+    const tokenPayload = jwt.decode(idToken);
+    if (!tokenPayload) {
+      throw new Error('unable to decode jwt token');
+    } else {
+      return {
+        username: tokenPayload.sub,
+        email: tokenPayload.email,
+      };
+    }
+  },
 });
 
 module.exports = () => {

--- a/packages/plugins/users-permissions/server/services/providers.js
+++ b/packages/plugins/users-permissions/server/services/providers.js
@@ -7,6 +7,7 @@
 // Public node modules.
 const _ = require('lodash');
 const urlJoin = require('url-join');
+const jwt = require('jsonwebtoken');
 
 const { getAbsoluteServerUrl } = require('@strapi/utils');
 const { getService } = require('../utils');
@@ -108,8 +109,26 @@ module.exports = ({ strapi }) => {
     return urlJoin(getAbsoluteServerUrl(strapi.config), apiPrefix, 'connect', provider, 'callback');
   };
 
+  const createAppleSecret = ({ key, teamId, keyIdentifier, secret }) => {
+    const headers = {
+      kid: keyIdentifier,
+      typ: undefined,
+    };
+    const claims = {
+      iss: teamId,
+      aud: 'https://appleid.apple.com',
+      sub: key,
+    };
+    return jwt.sign(claims, secret, {
+      algorithm: 'ES256',
+      header: headers,
+      expiresIn: strapi.config.get('plugin.users-permissions.jwt.expiresIn'),
+    });
+  };
+
   return {
     connect,
     buildRedirectUri,
+    createAppleSecret,
   };
 };


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

I've added Apple auth provider.

The biggest change is in `packages/plugins/users-permissions/admin/src/pages/Providers/utils/forms.js`. It might look like a lot of changes but mostly extraction of code into `commonFields` and `commonSchema` that I reuse to create each form layout/schema.

### Why is it needed?

Apple has a policy that you NEED to include Apple ID in mobile app if you include other OAuth providers. iOS is very important for App development. To make Strapi more competitive alternative on the market I think this should be included.
https://developer.apple.com/app-store/review/guidelines/#sign-in-with-apple

### How to test it?

Works like any other OAuth provider. Visit https://yourstrapi.com/api/connect/apple.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
https://github.com/strapi/rfcs/pull/20

<img width="1792" alt="Screenshot 2023-01-23 at 02 06 40" src="https://user-images.githubusercontent.com/476567/213950915-26d7e306-f2ad-42cb-a139-ba7b98dd40e8.png">

My first Strapi PR :)