### PR TITLE
Fix: handle missing plugin with proper error message

### DIFF
--- a/packages/core/strapi/lib/core/loaders/plugins/index.js
+++ b/packages/core/strapi/lib/core/loaders/plugins/index.js
@@ -85,7 +85,15 @@ const loadPlugins = async (strapi) => {
   for (const pluginName of Object.keys(enabledPlugins)) {
     const enabledPlugin = enabledPlugins[pluginName];
 
-    const serverEntrypointPath = join(enabledPlugin.pathToPlugin, 'strapi-server.js');
+    let serverEntrypointPath;
+
+    try {
+      serverEntrypointPath = join(enabledPlugin.pathToPlugin, 'strapi-server.js');
+    } catch (e) {
+      throw new Error(
+        `Error loading plugin ${pluginName}, plugin is not installed, please install the plugin or remove it's configuration.`
+      );
+    }
 
     // only load plugins with a server entrypoint
     if (!(await fse.pathExists(serverEntrypointPath))) {

--- a/packages/core/strapi/lib/core/loaders/plugins/index.js
+++ b/packages/core/strapi/lib/core/loaders/plugins/index.js
@@ -91,7 +91,7 @@ const loadPlugins = async (strapi) => {
       serverEntrypointPath = join(enabledPlugin.pathToPlugin, 'strapi-server.js');
     } catch (e) {
       throw new Error(
-        `Error loading plugin ${pluginName}, plugin is not installed, please install the plugin or remove it's configuration.`
+        `Error loading the plugin ${pluginName} because ${pluginName} is not installed. Please either install the plugin or remove it's configuration.`
       );
     }
 


### PR DESCRIPTION
### What does it do?

Wraps the plugin loader in a try/catch to return a more human friendly error when a user uninstalls a plugin but does not remove it's configuration

### Why is it needed?

A lot of users ask questions in Discord/Forum on how to properly uninstall a plugin and they forget to remove the configuration

### How to test it?

Install a plugin, configure it, run Strapi, then uninstall the plugin without removing the configuration.

Before:
![image](https://user-images.githubusercontent.com/8593673/214066956-ba4f1450-3f40-4f88-8d16-7aaa627df46a.png)

After:
![image](https://user-images.githubusercontent.com/8593673/214066999-08b44b25-c100-4eba-8f1a-3d94aa434913.png)
![image](https://user-images.githubusercontent.com/8593673/214067013-56089b74-1ec5-48d9-b263-aac5a220b8b9.png)


### Related issue(s)/PR(s)

N/A