### PR TITLE
Fix and updates for plugin translations

### DIFF
--- a/packages/plugins/color-picker/README.md
+++ b/packages/plugins/color-picker/README.md
@@ -1,6 +1,6 @@
 # Strapi plugin Color Picker
 
-A Strapi-maintainted color picker custom field
+A Strapi-maintained color picker custom field.
 
 ## Installation
 

--- a/packages/plugins/color-picker/admin/src/translations/cs.json
+++ b/packages/plugins/color-picker/admin/src/translations/cs.json
@@ -1,12 +1,14 @@
 {
-  "color-picker.label": "Barva",
   "color-picker.description": "Vyberte libovolnou barvu",
-  "color-picker.settings": "Nastavení",
-  "color-picket.input.format": "HEX",
+  "color-picker.input.aria-label": "Vstup pro výběr barvy",
+  "color-picker.input.format": "HEX",
+  "color-picker.label": "Barva",
   "color-picker.options.advanced.regex": "RegExp vzor",
   "color-picker.options.advanced.regex.description": "Zadejte regulární výraz pro ověření hodnoty HEX",
   "color-picker.options.advanced.requiredField": "Povinné pole",
   "color-picker.options.advanced.requiredField.description": "Pokud je toto pole prázdné, nebudete moci vytvořit záznam",
+  "color-picker.settings": "Nastavení",
   "color-picker.toggle.aria-label": "Přepínač výběru barvy",
-  "color-picker.input.aria-label": "Vstup pro výběr barvy"
+  "plugin.description.long": "A Strapi-maintained color picker custom field. Use saturation and hue sliders to select a color and save the value as a HEX string.",
+  "plugin.description.short": "A Strapi-maintained color picker custom field."
 }

--- a/packages/plugins/color-picker/admin/src/translations/en.json
+++ b/packages/plugins/color-picker/admin/src/translations/en.json
@@ -1,12 +1,14 @@
 {
-  "color-picker.label": "Color",
   "color-picker.description": "Select any color",
-  "color-picker.settings": "Settings",
-  "color-picket.input.format": "HEX",
+  "color-picker.input.aria-label": "Color picker input",
+  "color-picker.input.format": "HEX",
+  "color-picker.label": "Color",
   "color-picker.options.advanced.regex": "RegExp pattern",
   "color-picker.options.advanced.regex.description": "Provide a regular expression to validate the HEX value",
   "color-picker.options.advanced.requiredField": "Required field",
   "color-picker.options.advanced.requiredField.description": "You won't be able to create an entry if this field is empty",
+  "color-picker.settings": "Settings",
   "color-picker.toggle.aria-label": "Color picker toggle",
-  "color-picker.input.aria-label": "Color picker input"
+  "plugin.description.long": "A Strapi-maintained color picker custom field. Use saturation and hue sliders to select a color and save the value as a HEX string.",
+  "plugin.description.short": "A Strapi-maintained color picker custom field."
 }

--- a/packages/plugins/color-picker/admin/src/translations/ru.json
+++ b/packages/plugins/color-picker/admin/src/translations/ru.json
@@ -1,0 +1,14 @@
+{
+  "color-picker.description": "Выбирайте любые цвета",
+  "color-picker.input.aria-label": "Введите выбранный цвет",
+  "color-picker.input.format": "HEX",
+  "color-picker.label": "Цвет",
+  "color-picker.options.advanced.regex": "Шаблон регулярного выражения (RegExp)",
+  "color-picker.options.advanced.regex.description": "Обеспечивает проверку с помощью регулярного выражение для HEX (шестнадцатеричного) HEX значения цвета",
+  "color-picker.options.advanced.requiredField": "Обязательное поле",
+  "color-picker.options.advanced.requiredField.description": "Вы не сможете продолжить, если это поле пусто",
+  "color-picker.settings": "Настройки",
+  "color-picker.toggle.aria-label": "Переключатель средства выбора цвета",
+  "plugin.description.long": "Настраиваемое поле средства выбора цвета, поддерживаемое Strapi. Используйте ползунки насыщенности и оттенка, чтобы выбрать цвет и сохранить его HEX (шестнадцатеричное) значение.",
+  "plugin.description.short": "Настраиваемое поле средства выбора цвета, поддерживаемое Strapi."
+}

--- a/packages/plugins/color-picker/admin/src/translations/sv.json
+++ b/packages/plugins/color-picker/admin/src/translations/sv.json
@@ -1,12 +1,14 @@
 {
-  "color-picker.label": "Färgväljare",
   "color-picker.description": "Välj färger",
-  "color-picker.settings": "Inställningar",
-  "color-picket.input.format": "HEX",
+  "color-picker.input.aria-label": "Färgväljarinmatning",
+  "color-picker.input.format": "HEX",
+  "color-picker.label": "Färgväljare",
   "color-picker.options.advanced.regex": "RegEx-mönster",
   "color-picker.options.advanced.regex.description": "Ange ett regex-mönster för att validera HEX-värdet",
   "color-picker.options.advanced.requiredField": "Obligatoriskt fält",
   "color-picker.options.advanced.requiredField.description": "Du kommer inte att kunna skapa en post om det här fältet är tomt",
+  "color-picker.settings": "Inställningar",
   "color-picker.toggle.aria-label": "Växla färgväljare",
-  "color-picker.input.aria-label": "Färgväljarinmatning"
+  "plugin.description.long": "A Strapi-maintained color picker custom field. Use saturation and hue sliders to select a color and save the value as a HEX string.",
+  "plugin.description.short": "A Strapi-maintained color picker custom field."
 }

--- a/packages/plugins/color-picker/admin/src/translations/tr.json
+++ b/packages/plugins/color-picker/admin/src/translations/tr.json
@@ -1,12 +1,14 @@
 {
-  "color-picker.label": "Renk",
   "color-picker.description": "Herhangi bir renk seç",
-  "color-picker.settings": "Ayarlar",
-  "color-picket.input.format": "HEX",
+  "color-picker.input.aria-label": "Renk seçici girişi",
+  "color-picker.input.format": "HEX",
+  "color-picker.label": "Renk",
   "color-picker.options.advanced.regex": "RegExp ifadesi",
   "color-picker.options.advanced.regex.description": "HEX değerini doğrulamak için bir RegExp ifadesi sağla",
   "color-picker.options.advanced.requiredField": "Zorunlu alan",
   "color-picker.options.advanced.requiredField.description": "Bu alan boş olursa yeni bir girdi oluşturamazsın",
+  "color-picker.settings": "Ayarlar",
   "color-picker.toggle.aria-label": "Renk seçici anahtarı",
-  "color-picker.input.aria-label": "Renk seçici girişi"
+  "plugin.description.long": "A Strapi-maintained color picker custom field. Use saturation and hue sliders to select a color and save the value as a HEX string.",
+  "plugin.description.short": "A Strapi-maintained color picker custom field."
 }

--- a/packages/plugins/color-picker/admin/src/translations/zh.json
+++ b/packages/plugins/color-picker/admin/src/translations/zh.json
@@ -1,12 +1,14 @@
 {
-  "color-picker.label": "顏色",
   "color-picker.description": "選擇任意顏色",
-  "color-picker.settings": "設定",
-  "color-picket.input.format": "HEX",
+  "color-picker.input.aria-label": "選色器輸入",
+  "color-picker.input.format": "HEX",
+  "color-picker.label": "顏色",
   "color-picker.options.advanced.regex": "正則表達模式",
   "color-picker.options.advanced.regex.description": "提供正則表達式以驗證 HEX 值",
   "color-picker.options.advanced.requiredField": "必填欄位",
   "color-picker.options.advanced.requiredField.description": "若此欄位為空，您將無法建立項目",
+  "color-picker.settings": "設定",
   "color-picker.toggle.aria-label": "選色器開關",
-  "color-picker.input.aria-label": "選色器輸入"
+  "plugin.description.long": "A Strapi-maintained color picker custom field. Use saturation and hue sliders to select a color and save the value as a HEX string.",
+  "plugin.description.short": "A Strapi-maintained color picker custom field."
 }


### PR DESCRIPTION
### What does it do?

1. Fixed typo with key "color-picke**t**.input.format" to "color-picke**r**.input.format". This problem was in all current translations. So I fixed it at all.
2. Added two strings (see below). Now this plugin has description as other plugins.
```
"plugin.description.long": "A Strapi-maintained color picker custom field. Use saturation and hue sliders to select a color and save the value as a HEX string.",
"plugin.description.short": "A Strapi-maintained color picker custom field."
```

3. Created translation into Russian.
4. Fixed typo in readme.md.

### Why is it needed?

This plugin for now has +1 language, fixed strings with typo, added strings with description.

### How to test it?

No need to test, this is json files with strings. You may just look into changes to see it all.

