### PR TITLE
Prevent deadlocks on components and locale updates

### DIFF
--- a/packages/core/upload/server/services/upload.js
+++ b/packages/core/upload/server/services/upload.js
@@ -228,6 +228,7 @@ module.exports = ({ strapi }) => ({
       const formats = await generateResponsiveFormats(fileData);
       if (Array.isArray(formats) && formats.length > 0) {
         for (const format of formats) {
+          // eslint-disable-next-line no-continue
           if (!format) continue;
           uploadPromises.push(uploadResponsiveFormat(format));
         }

--- a/packages/plugins/i18n/server/services/localizations.js
+++ b/packages/plugins/i18n/server/services/localizations.js
@@ -32,7 +32,9 @@ const syncLocalizations = async (entry, { model }) => {
       return strapi.query(model.uid).update({ where: { id }, data: { localizations } });
     };
 
-    await Promise.all(entry.localizations.map(({ id }) => updateLocalization(id)));
+    for (const localization of entry.localizations) {
+      await updateLocalization(localization.id);
+    }
   }
 };
 
@@ -56,7 +58,9 @@ const syncNonLocalizedAttributes = async (entry, { model }) => {
       return strapi.entityService.update(model.uid, id, { data: nonLocalizedAttributes });
     };
 
-    await Promise.all(entry.localizations.map(({ id }) => updateLocalization(id)));
+    for (const localization of entry.localizations) {
+      await updateLocalization(localization.id);
+    }
   }
 };
 


### PR DESCRIPTION
### What does it do?

It uses sequential updates instead of Promise.all to avoid deadlocks

### Why is it needed?

Because otherwise it can prevent to create a new locale for an entity or to save an entry with components

### How to test it?

It's very difficult to test it as the deadlocks are random. Contact @Marc-Roig so he can show you how to :p

### Related issue(s)/PR(s)

#15202
