### PR TITLE
[Audit logs] Fix route policy

### DIFF
--- a/packages/core/admin/ee/server/routes/features-routes.js
+++ b/packages/core/admin/ee/server/routes/features-routes.js
@@ -49,8 +49,15 @@ module.exports = {
       path: '/audit-logs',
       handler: 'auditLogs.findMany',
       config: {
-        // @TODO: Check to right permissions
-        policies: ['admin::isAuthenticatedAdmin'],
+        policies: [
+          'admin::isAuthenticatedAdmin',
+          {
+            name: 'admin::hasPermissions',
+            config: {
+              actions: ['admin::audit-logs.read'],
+            },
+          },
+        ],
       },
     },
     {
@@ -58,8 +65,15 @@ module.exports = {
       path: '/audit-logs/:id',
       handler: 'auditLogs.findOne',
       config: {
-        // @TODO: Check to right permissions
-        policies: ['admin::isAuthenticatedAdmin'],
+        policies: [
+          'admin::isAuthenticatedAdmin',
+          {
+            name: 'admin::hasPermissions',
+            config: {
+              actions: ['admin::audit-logs.read'],
+            },
+          },
+        ],
       },
     },
   ],


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Ensure only admin users with the `admin::audit-logs.read` can query audit log API routes

### Why is it needed?

Security reasons, to complete the RBAC implementation

### How to test it?

First see the problem on the `feature/audit-logs` branch:

- Log in as a non-super admin user
- Get the JWT for that user
- Using that JWT, make a get request to `/admin/audit-logs`, and `/admin/audit-logs/1`
- You get the response (you shouldn't)

Now do the same thing on this branch. You should get a 403 error with the "policy failed" error.

### Related issue(s)/PR(s)

Uses the action defined in #15315