### PR TITLE
Custom yup validation for the content-manager edit view

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/index.js
@@ -66,6 +66,7 @@ const EditViewDataManagerProvider = ({
     modifiedDZName,
     shouldCheckErrors,
     publishConfirmation,
+    customYupSchema,
   } = reducerState;
 
   const { setModifiedDataOnly } = useSelector(selectCrudReducer);
@@ -300,6 +301,8 @@ const EditViewDataManagerProvider = ({
       try {
         // Validate the form using yup
         await yupSchema.validate(updatedData, { abortEarly: false });
+        // Validate the form using custom yup schema provided by the user
+        await yup.object().shape(customYupSchema).validate(updatedData, { abortEarly: false });
       } catch (err) {
         errors = getYupInnerErrors(err);
 
@@ -396,7 +399,10 @@ const EditViewDataManagerProvider = ({
       let errors = {};
 
       try {
+        // Validate the form using yup
         await yupSchema.validate(modifiedData, { abortEarly: false });
+        // Validate the form using custom yup schema provided by the user
+        await yup.object().shape(customYupSchema).validate(modifiedData, { abortEarly: false });
       } catch (err) {
         errors = getYupInnerErrors(err);
       }
@@ -581,6 +587,13 @@ const EditViewDataManagerProvider = ({
     });
   }, []);
 
+  const setCustomYupSchema = useCallback((schema) => {
+    dispatch({
+      type: 'SET_CUSTOM_YUP_SCHEMA',
+      schema: schema
+    });
+  }, []);
+
   const triggerFormValidation = useCallback(() => {
     dispatch({
       type: 'TRIGGER_FORM_VALIDATION',
@@ -628,6 +641,7 @@ const EditViewDataManagerProvider = ({
         removeComponentFromDynamicZone,
         removeComponentFromField,
         removeRepeatableField,
+        setCustomYupSchema,
         slug,
         triggerFormValidation,
         updateActionAllowedFields,

--- a/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/reducer.js
+++ b/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/reducer.js
@@ -18,6 +18,7 @@ const initialState = {
   componentsDataStructure: {},
   contentTypeDataStructure: {},
   formErrors: {},
+  customYupSchema: {},
   initialData: {},
   modifiedData: null,
   shouldCheckErrors: false,
@@ -379,6 +380,10 @@ const reducer = (state, action) =>
       case 'SET_FORM_ERRORS': {
         draftState.modifiedDZName = null;
         draftState.formErrors = action.errors;
+        break;
+      }
+      case 'SET_CUSTOM_YUP_SCHEMA': {
+        draftState.customYupSchema = { ...state.customYupSchema, ...action.schema };
         break;
       }
       case 'TRIGGER_FORM_VALIDATION': {

--- a/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/tests/reducer.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/tests/reducer.test.js
@@ -2135,6 +2135,27 @@ describe('CONTENT MANAGER | COMPONENTS | EditViewDataManagerProvider | reducer',
     });
   });
 
+  describe('SET_CUSTOM_YUP_SCHEMA', () => {
+    it('should set the customYupSchema correctly', () => {
+      const state = {
+        ...initialState,
+        customYupSchema: {},
+      };
+
+      const action = {
+        type: 'SET_CUSTOM_YUP_SCHEMA',
+        schema: { fieldName: 'Validation criteria' },
+      };
+
+      const expected = {
+        ...initialState,
+        customYupSchema: { fieldName: 'Validation criteria' },
+      };
+
+      expect(reducer(state, action)).toEqual(expected);
+    });
+  });
+
   describe('SET_PUBLISH_CONFIRMATION', () => {
     it('should set the publish confirmation object', () => {
       const state = {

--- a/packages/core/helper-plugin/lib/src/content-manager/hooks/useCMEditViewDataManager/useCMEditViewDataManager.stories.mdx
+++ b/packages/core/helper-plugin/lib/src/content-manager/hooks/useCMEditViewDataManager/useCMEditViewDataManager.stories.mdx
@@ -29,6 +29,7 @@ const MyCompo = () => {
     isCreatingEntry: true,
     isSingleType: true,
     status: 'resolved',
+    setCustomYupSchema: () => {},
     layout: {}, // Current content type layout
     hasDraftAndPublish: true,
     modifiedData: {},


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

This PR add’s an extra function to the `EditViewDataManagerProvider` called `setCustomYupSchema`. The function can be fired from any component inside the content-manager edit view by using the `useCMEditViewDataManager` hook to import it. The function takes one parameter which is expected to be an object which will be stored in the edit view redux state. In turn this object will be used as a yup schema to valide the edit view form in the `handleSubmit` function.

### Why is it needed?

I was working on a custom field and needed some custom validation for it. If found that there was no way of adding custom yup validation for the content-manager edit view so I created this PR. This way you are able to add any kind of custom yup validation to the edit view. Whether it is validation for your custom field or just extra complex validation for your “normal” fields.

I realise that this is just frontend validation and if you were to create an entry through the API I would be able to bypass this validation. Though I feel like this is already a good step. Next step would be to be able to write custom backend validation at field level.

### How to test it?

1. Install and setup a Strapi instance using this PR.
2. Create a custom plugin.
3. Create a simple custom field inside this plugin. It could just be a text field.
4. Create a content type and add your custom field to it.
5. Make the field NOT required.
6. Import the new function into your custom fied input component like this:

```
import { useCMEditViewDataManager } from ‘@strapi/helper-plugin’;
// The line below needs to be inside the functional component.
const { setCustomYupSchema } = useCMEditViewDataManager();
```

7. Use the function to set a custom validation schema like so:

```
  useEffect(() => {
    setCustomYupSchema({
      [name]: yup.string().required(),
    });
  }, []);
```

i’m using the ‘name’ prop of a custom field input here to specify the field to validate in the schema. You could also just write the hardcoded fieldname here.

8. Rebuild the admin panel
9. Create a new item for your content type.
10. Leave the custom field empty and try to save. If your form will error because of the custom field being required the custom yup validation has worked.

We just validated for a simple required field, but ofc you are able to write complex validations as you are able to with yup.

### Additional info

If you need more documentation or full example components please let me know and I will update the PR.