### PR TITLE
Update the AWS S3 provider README

### DIFF
--- a/packages/providers/upload-aws-s3/README.md
+++ b/packages/providers/upload-aws-s3/README.md
@@ -31,7 +31,7 @@ See the [documentation about using a provider](https://docs.strapi.io/developer-
 
 ### Provider Configuration
 
-`./config/plugins.js`
+`./config/plugins.js` or `./config/plugins.ts` for TypeScript projects:
 
 ```js
 module.exports = ({ env }) => ({


### PR DESCRIPTION
Multiple users working with TypeScript have had issues because the README specifies adding `./config/plugins.js` and does not mention adding a `.ts` config file.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Mention the `.ts` config file for TypeScript projects

### Why is it needed?

Several users have reported trouble with the provider until they added the correct file extension. 

### How to test it?

n/a

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
