### PR TITLE
[Audit logs] Fix entity service events tests

### DIFF
--- a/packages/core/strapi/lib/services/entity-service/__tests__/entity-service-events.test.js
+++ b/packages/core/strapi/lib/services/entity-service/__tests__/entity-service-events.test.js
@@ -53,6 +53,7 @@ describe('Entity service triggers webhooks', () => {
     expect(eventHub.emit).toHaveBeenCalledWith('entry.create', {
       entry: entity,
       model: 'test-model',
+      uid: 'api::test.test',
     });
 
     eventHub.emit.mockClear();
@@ -66,6 +67,7 @@ describe('Entity service triggers webhooks', () => {
     expect(eventHub.emit).toHaveBeenCalledWith('entry.update', {
       entry: entity,
       model: 'test-model',
+      uid: 'api::test.test',
     });
 
     eventHub.emit.mockClear();
@@ -79,6 +81,7 @@ describe('Entity service triggers webhooks', () => {
     expect(eventHub.emit).toHaveBeenCalledWith('entry.delete', {
       entry: entity,
       model: 'test-model',
+      uid: 'api::test.test',
     });
 
     eventHub.emit.mockClear();
@@ -92,6 +95,7 @@ describe('Entity service triggers webhooks', () => {
     expect(eventHub.emit).toHaveBeenCalledWith('entry.delete', {
       entry: entity,
       model: 'test-model',
+      uid: 'api::test.test',
     });
     // One event per each entity deleted
     expect(eventHub.emit).toHaveBeenCalledTimes(2);


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Fix the tests for entity service failing

### Why is it needed?

Because I added the UID to the events payload in #15489 (see why in the PR notes), and hadn't checked these tests. 

### How to test it?

Run "yarn test:unit" from the root of the monorepo. On the feature branch it fails, here it should work
