### PR TITLE
[fix] ML Video preview size

### DIFF
--- a/packages/core/upload/admin/src/components/TableList/PreviewCell.js
+++ b/packages/core/upload/admin/src/components/TableList/PreviewCell.js
@@ -13,8 +13,8 @@ import { VideoPreview } from '../AssetCard/VideoPreview';
 
 const VideoPreviewWrapper = styled(Box)`
   figure {
-    width: 26px;
-    height: 26px;
+    width: ${({ theme }) => theme.spaces[7]};
+    height: ${({ theme }) => theme.spaces[7]};
   }
 
   canvas,


### PR DESCRIPTION
## What

Update `VideoPreviewWrapper` to have the same `width` and `height` as the Avatar
Following the [DS update](https://github.com/strapi/strapi/pull/15547)

| Before | After |
|-|-|
| <img width="576" alt="image" src="https://user-images.githubusercontent.com/71838159/214343176-bfacc375-228a-4241-8105-fdc75e59d8d8.png"> | <img width="570" alt="image" src="https://user-images.githubusercontent.com/71838159/214343088-6aa8d647-c6ea-44ef-9a17-e1f810963750.png">| 