### PR TITLE
Docs: Update productboard link in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ We highly appreciate your effort to contribute, but we recommend you talk to a m
 
 ## Feature Requests
 
-Feature Requests by the community are highly encouraged. Feel free to submit a new one or upvote an existing feature request on [ProductBoard](https://portal.productboard.com/strapi).
+Feature Requests by the community are highly encouraged. Feel free to submit a new one or upvote an existing feature request on [feedback.strapi.io](https://feedback.strapi.io/).
 
 ## Request For Comments (RFC)
 


### PR DESCRIPTION
### What does it do?

Updates the roadmap link on the contributing guide.

### Why is it needed?

Keeps docs up-to-date.

### Related issue(s)/PR(s)

- Fixes https://github.com/strapi/strapi/issues/15478
