### PR TITLE
Improve SQL queries when cleaning orders

### DIFF
--- a/packages/core/database/lib/entity-manager/regular-relations.js
+++ b/packages/core/database/lib/entity-manager/regular-relations.js
@@ -250,6 +250,20 @@ const cleanOrderColumns = async ({ id, attribute, db, inverseRelIds, transaction
         )
         .transacting(trx);
       break;
+    /*
+      UPDATE
+        :joinTable: as a,
+        (
+          SELECT
+            id,
+            ROW_NUMBER() OVER ( PARTITION BY :joinColumn: ORDER BY :orderColumn:) AS src_order,
+            ROW_NUMBER() OVER ( PARTITION BY :inverseJoinColumn: ORDER BY :inverseOrderColumn:) AS inv_order
+          FROM :joinTable:
+          WHERE :joinColumn: = :id OR :inverseJoinColumn: IN (:inverseRelIds)
+        ) AS b
+      SET :orderColumn: = b.src_order, :inverseOrderColumn: = b.inv_order
+      WHERE b.id = a.id;
+    */
     default: {
       const joinTableName = addSchema(joinTable.name);
 
@@ -270,17 +284,17 @@ const cleanOrderColumns = async ({ id, attribute, db, inverseRelIds, transaction
         .transacting(trx);
 
       /*
-        `UPDATE :joinTable: as a
-          SET :orderColumn: = b.src_order, :inverseOrderColumn: = b.inv_order
-          FROM (
-            SELECT
-              id,
-              ROW_NUMBER() OVER ( PARTITION BY :joinColumn: ORDER BY :orderColumn:) AS src_order,
-              ROW_NUMBER() OVER ( PARTITION BY :inverseJoinColumn: ORDER BY :inverseOrderColumn:) AS inv_order
-            FROM :joinTable:
-            WHERE :joinColumn: = :id OR :inverseJoinColumn: IN (:inverseRelIds)
-          ) AS b
-          WHERE b.id = a.id`,
+        UPDATE :joinTable: as a
+        SET :orderColumn: = b.src_order, :inverseOrderColumn: = b.inv_order
+        FROM (
+          SELECT
+            id,
+            ROW_NUMBER() OVER ( PARTITION BY :joinColumn: ORDER BY :orderColumn:) AS src_order,
+            ROW_NUMBER() OVER ( PARTITION BY :inverseJoinColumn: ORDER BY :inverseOrderColumn:) AS inv_order
+          FROM :joinTable:
+          WHERE :joinColumn: = :id OR :inverseJoinColumn: IN (:inverseRelIds)
+        ) AS b
+        WHERE b.id = a.id;
       */
     }
   }


### PR DESCRIPTION
### What does it do?

Change the way we create order values

### Why is it needed?

The current way is no efficient enough

### How to test it?

You can create a `many-to-many` relation between `category` and `country` and fill an entity with 10000 relations and then removing one and see that the request time is not of 3 minutes anymore.
You need to be on MySQL.
```js
  async bootstrap({ strapi }) {
    const country = await strapi.entityService.create('api::country.country', {
      data: {
        name: 'Spain',
      }
    });
    for (let i=0; i < 10000; i++) {
      await strapi.entityService.create('api::category.category', {
        data: {
          name: `cat-${i}`,
          countries: [country.id],
        }
      });
    }
  },
```

### Related issue(s)/PR(s)
Fix #15246
Fix #15202
Fix #15539
Fix #15472
