### PR TITLE
fix: Strapi default wysiwyg editor cuts preview in expand mode

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/PreviewWysiwyg/Wrapper.js
+++ b/packages/core/admin/admin/src/content-manager/components/PreviewWysiwyg/Wrapper.js
@@ -4,7 +4,7 @@ const Wrapper = styled.div`
   position: absolute;
   top: 0;
   width: 100%;
-  height: calc(100% - 3rem); // ensures the expanded preview is fully displayed.
+  height: calc(100% - 3rem);
   overflow: auto;
   padding: ${({ theme }) => `${theme.spaces[3]} ${theme.spaces[4]}`};
   font-size: ${14 / 16}rem;

--- a/packages/core/admin/admin/src/content-manager/components/PreviewWysiwyg/Wrapper.js
+++ b/packages/core/admin/admin/src/content-manager/components/PreviewWysiwyg/Wrapper.js
@@ -4,7 +4,7 @@ const Wrapper = styled.div`
   position: absolute;
   top: 0;
   width: 100%;
-  height: 100%;
+  height: calc(100% - 3rem); // ensures the expanded preview is fully displayed.
   overflow: auto;
   padding: ${({ theme }) => `${theme.spaces[3]} ${theme.spaces[4]}`};
   font-size: ${14 / 16}rem;


### PR DESCRIPTION
Fixes https://github.com/strapi/strapi/issues/15407

### What does it do?
Fix the bug when in expanded mode where some texts are cut off at the bottom due to some of height being taken by the Collapse div.

### Why is it needed?
So that the preview in expanded more is readable without any text being cut off.

### How to test it?
1. Create a content-type with a rich-text field.
2. Add long content with multiple headers and paragraphs inside RichText field.
3. Click on the Expand Button.
4. You will notice that on the right hand side preview renders all the content correctly unlike before.

### Demo

https://user-images.githubusercontent.com/7220167/214498192-ecbb116b-7aa1-4230-9978-615049e18f15.mov

