### PR TITLE
re-creating .gitkeep

### DIFF
--- a/packages/core/data-transfer/src/strapi/providers/local-destination/index.ts
+++ b/packages/core/data-transfer/src/strapi/providers/local-destination/index.ts
@@ -166,6 +166,8 @@ class LocalStrapiDestinationProvider implements IDestinationProvider {
 
     await fse.rename(assetsDirectory, backupDirectory);
     await fse.mkdir(assetsDirectory);
+    // Create a .gitkeep file to ensure the directory is not empty
+    await fse.outputFile(path.join(assetsDirectory, '.gitkeep'), '');
 
     return new Writable({
       objectMode: true,


### PR DESCRIPTION
### What does it do?

re-creates `.gitkeep` in uploads directory during the import process

### Why is it needed?

to make sure that the uploads folder is not empty 

### How to test it?

perform an import, `.gitkeep` should exist in the uploads folder

