### PR TITLE
Add new useInjectReducer() hook

### DIFF
--- a/packages/core/admin/admin/src/hooks/useInjectReducer/index.js
+++ b/packages/core/admin/admin/src/hooks/useInjectReducer/index.js
@@ -1,0 +1,1 @@
+export * from './useInjectReducer';

--- a/packages/core/admin/admin/src/hooks/useInjectReducer/tests/useInjectReducer.test.js
+++ b/packages/core/admin/admin/src/hooks/useInjectReducer/tests/useInjectReducer.test.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import { renderHook } from '@testing-library/react-hooks';
+
+import configureStore from '../../../core/store/configureStore';
+import { useInjectReducer } from '..';
+
+const store = configureStore([], [(state = {}) => state]);
+
+// eslint-disable-next-line no-unused-vars, react/prop-types
+const ComponentFixture = ({ children }) => <Provider store={store}>{children}</Provider>;
+
+function setup(...args) {
+  return renderHook(() => useInjectReducer(...args), { wrapper: ComponentFixture });
+}
+
+function reducerFixture(state = {}, action) {
+  switch (action.type) {
+    case 'namespaced_action':
+      return {
+        ...state,
+        namespacedAction: true,
+      };
+
+    default:
+      return state;
+  }
+}
+
+describe('useInjectReducer', () => {
+  test('injects a new reducer into the global redux store', () => {
+    setup('namespace', reducerFixture);
+
+    expect(store.getState().namespace).toStrictEqual({});
+
+    store.dispatch({ type: 'namespaced_action' });
+
+    expect(store.getState().namespace).toStrictEqual({ namespacedAction: true });
+  });
+});

--- a/packages/core/admin/admin/src/hooks/useInjectReducer/useInjectReducer.js
+++ b/packages/core/admin/admin/src/hooks/useInjectReducer/useInjectReducer.js
@@ -1,0 +1,19 @@
+import { useEffect } from 'react';
+import { useStore } from 'react-redux';
+
+/**
+ * Inject a new reducer into the global redux-store.
+ *
+ * @export
+ * @param {string} namespace - Store namespace of the injected reducer
+ * @param {Function} reducer - Reducer function
+ * @return void
+ */
+
+export function useInjectReducer(namespace, reducer) {
+  const store = useStore();
+
+  useEffect(() => {
+    store.injectReducer(namespace, reducer);
+  }, [store, namespace, reducer]);
+}


### PR DESCRIPTION
### What does it do?

Adds a new hook called `useInjectReducer()` which is a small abstraction around `store.injectReducer`. It can be used to extend the redux store from anywhere in the codebase.

### Why is it needed?

It will allow us to introduce a consistent way to extend the redux store. Right now this is is an internal hook, but it can easily be exposed and opened up to e.g. plugin developers.

### How to test it?

Follow 🐰 jest.

### Related issue(s)/PR(s)

- Builds on top of https://github.com/strapi/strapi/pull/15517
