### PR TITLE
Remove --detectOpenHandles from "api" tests

### DIFF
--- a/test/api.js
+++ b/test/api.js
@@ -42,10 +42,7 @@ const databases = {
   },
 };
 
-const jestCmd =
-  'jest --config jest.config.api.js --verbose --runInBand --forceExit --detectOpenHandles'.split(
-    ' '
-  );
+const jestCmd = 'jest --config jest.config.api.js --verbose --runInBand --forceExit'.split(' ');
 
 const runAllTests = async (args) => {
   return execa('yarn', [...jestCmd, ...args], {


### PR DESCRIPTION
### What does it do?

Simply removes the `--detectOpenHandles` from the "api" tests.

### Why is it needed?

Taken from the documentation:
<img width="834" alt="image" src="https://user-images.githubusercontent.com/16194089/214651348-ca906fb2-d1f3-4815-a72f-dbe32bbf4659.png">
