### PR TITLE
Fix: Remove @strapi/provider-audit-logs-local from @strapi/admin

### DIFF
--- a/packages/core/admin/package.json
+++ b/packages/core/admin/package.json
@@ -51,7 +51,6 @@
     "@strapi/helper-plugin": "4.5.6",
     "@strapi/icons": "1.6.1",
     "@strapi/permissions": "4.5.6",
-    "@strapi/provider-audit-logs-local": "4.5.6",
     "@strapi/typescript-utils": "4.5.6",
     "@strapi/utils": "4.5.6",
     "axios": "1.2.2",


### PR DESCRIPTION
### What does it do?

Remove `@strapi/provider-audit-logs-local` dependency from `@strapi/admin`.

### Why is it needed?

The admin package doesn't have a dependency on the provider.

