### PR TITLE
add ability to list and remove cron jobs

### DIFF
--- a/packages/core/strapi/lib/services/cron.js
+++ b/packages/core/strapi/lib/services/cron.js
@@ -37,6 +37,12 @@ const createCronService = () => {
       }
       return this;
     },
+    remove(name) {
+      const matchingJobsSpecs = jobsSpecs.filter(({ options }) => options.name === name);
+      matchingJobsSpecs.forEach(({ job }) => job.cancel());
+      jobsSpecs = jobsSpecs.filter(({ options }) => options.name !== name);
+      return this;
+    },
     start() {
       jobsSpecs.forEach(({ job, options }) => job.schedule(options));
       running = true;

--- a/packages/core/strapi/lib/services/cron.js
+++ b/packages/core/strapi/lib/services/cron.js
@@ -63,6 +63,7 @@ const createCronService = () => {
       jobsSpecs = [];
       return this;
     },
+    jobs: jobsSpecs,
   };
 };
 

--- a/packages/core/strapi/lib/services/cron.js
+++ b/packages/core/strapi/lib/services/cron.js
@@ -14,10 +14,15 @@ const createCronService = () => {
 
         let fn;
         let options;
+        let taskName;
         if (isFunction(taskValue)) {
+          // don't use task name if key is the rule
+          taskName = null;
           fn = taskValue.bind(tasks);
           options = taskExpression;
         } else if (isFunction(taskValue.task)) {
+          // set task name if key is not the rule
+          taskName = taskExpression;
           fn = taskValue.task.bind(taskValue);
           options = taskValue.options;
         } else {
@@ -28,8 +33,8 @@ const createCronService = () => {
 
         const fnWithStrapi = (...args) => fn({ strapi }, ...args);
 
-        const job = new Job(taskValue.name || null, fnWithStrapi);
-        jobsSpecs.push({ job, options, name: taskValue.name });
+        const job = new Job(null, fnWithStrapi);
+        jobsSpecs.push({ job, options, name: taskName });
 
         if (running) {
           job.schedule(options);

--- a/packages/core/strapi/lib/services/cron.js
+++ b/packages/core/strapi/lib/services/cron.js
@@ -28,8 +28,8 @@ const createCronService = () => {
 
         const fnWithStrapi = (...args) => fn({ strapi }, ...args);
 
-        const job = new Job(null, fnWithStrapi);
-        jobsSpecs.push({ job, options });
+        const job = new Job(taskValue.name || null, fnWithStrapi);
+        jobsSpecs.push({ job, options, name: taskValue.name });
 
         if (running) {
           job.schedule(options);
@@ -38,9 +38,9 @@ const createCronService = () => {
       return this;
     },
     remove(name) {
-      const matchingJobsSpecs = jobsSpecs.filter(({ options }) => options.name === name);
+      const matchingJobsSpecs = jobsSpecs.filter(({ name: jobSpecName }) => jobSpecName === name);
       matchingJobsSpecs.forEach(({ job }) => job.cancel());
-      jobsSpecs = jobsSpecs.filter(({ options }) => options.name !== name);
+      jobsSpecs = jobsSpecs.filter(({ name: jobSpecName }) => jobSpecName !== name);
       return this;
     },
     start() {

--- a/packages/core/strapi/lib/services/cron.js
+++ b/packages/core/strapi/lib/services/cron.js
@@ -43,6 +43,7 @@ const createCronService = () => {
       return this;
     },
     remove(name) {
+      if (!name) throw new Error('You must provide a name to remove a cron job.');
       const matchingJobsSpecs = jobsSpecs.filter(({ name: jobSpecName }) => jobSpecName === name);
       matchingJobsSpecs.forEach(({ job }) => job.cancel());
       jobsSpecs = jobsSpecs.filter(({ name: jobSpecName }) => jobSpecName !== name);


### PR DESCRIPTION
### What does it do?

Add `remove()` function to allow users to remove cron jobs when they set the `name` property in the `options` config

### Why is it needed?

Unable to remove a cron job programmatically

### How to test it?

Strapi --quickstart


```js
module.exports = {
// this will allow users to cancel the myJob cron job by doing strapi.cron.remove('myJob');
  myJob: {
    task: ({ strapi }) => {/* Add your own logic here */ },
    options: {
      rule: '0 0 1 * * 1',
    },
    // This will not allow removals
    '0 0 1 * * 1': ({ strapi }) => {/* Add your own logic here */ },
  },
};
```

`strapi.cron.remove("myJob");`

```js
//list cron jobs
strapi.cron.jobs
```

returns
```js
[
  {
    job: Job {
      pendingInvocations: [Array],
      job: [Function: fnWithStrapi],
      callback: false,
      running: 0,
      name: '<Anonymous Job 2 2023-03-02T22:20:27.506Z>',
      trackInvocation: [Function (anonymous)],
      stopTrackingInvocation: [Function (anonymous)],
      triggeredJobs: [Function (anonymous)],
      setTriggeredJobs: [Function (anonymous)],
      deleteFromSchedule: [Function (anonymous)],
      cancel: [Function (anonymous)],
      cancelNext: [Function (anonymous)],
      reschedule: [Function (anonymous)],
      nextInvocation: [Function (anonymous)]
    },
    options: '0 0 1 * * 1',
    name: myJob
  }
]
```

### Related issue(s)/PR(s)

https://github.com/strapi/documentation/pull/1452
