### PR TITLE
move logic of cron enable check

### DIFF
--- a/packages/core/strapi/lib/Strapi.js
+++ b/packages/core/strapi/lib/Strapi.js
@@ -114,7 +114,7 @@ class Strapi {
     this.eventHub = createEventHub();
     this.startupLogger = createStartupLogger(this);
     this.log = createLogger(this.config.get('logger', {}));
-    this.cron = createCronService();
+    this.cron = createCronService(this);
     this.telemetry = createTelemetry(this);
     this.requestContext = requestContext;
 
@@ -430,10 +430,8 @@ class Strapi {
       entityValidator: this.entityValidator,
     });
 
-    if (strapi.config.get('server.cron.enabled', true)) {
-      const cronTasks = this.config.get('server.cron.tasks', {});
-      this.cron.add(cronTasks);
-    }
+    const cronTasks = this.config.get('server.cron.tasks', {});
+    this.cron.add(cronTasks);
 
     this.telemetry.bootstrap();
 

--- a/packages/core/strapi/lib/services/cron.js
+++ b/packages/core/strapi/lib/services/cron.js
@@ -3,12 +3,15 @@
 const { Job } = require('node-schedule');
 const { isFunction } = require('lodash/fp');
 
-const createCronService = () => {
+const createCronService = (strapi) => {
   let jobsSpecs = [];
   let running = false;
 
   return {
     add(tasks = {}) {
+      if (!strapi.config.get('server.cron.enabled', false)) {
+        return this;
+      }
       for (const taskExpression of Object.keys(tasks)) {
         const taskValue = tasks[taskExpression];
 


### PR DESCRIPTION


### What does it do?

Moves the config check to the add function of the `add()` function to prevent bypassing enabled flag

### Why is it needed?

If the user doesn't explicitly set the cron.enabled to true it shouldn't be allowed to add cron jobs.

### How to test it?

strapi --quickstart

try and create a cron job without enabling it in the config. (should fail)

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/issues/15588
