### PR TITLE
Browserslist: exclude dead browsers

### DIFF
--- a/packages/core/admin/.browserslistrc
+++ b/packages/core/admin/.browserslistrc
@@ -1,3 +1,4 @@
 last 3 major versions
 Firefox ESR
 last 2 Opera versions
+not dead

--- a/packages/core/helper-plugin/.browserslistrc
+++ b/packages/core/helper-plugin/.browserslistrc
@@ -1,3 +1,4 @@
 last 3 major versions
 Firefox ESR
 last 2 Opera versions
+not dead


### PR DESCRIPTION
### What does it do?

Excludes dead browser from the compilation target.

### Why is it needed?

It ensures we are not compiling the codebase for dead browsers, such as Internet Explorer.

Overview: https://browsersl.ist/#q=last+3+major+versions%2CFirefox+ESR%2Clast+2+Opera+versions

### Related issue(s)/PR(s)

- Based on https://github.com/strapi/strapi/pull/15369#issuecomment-1404264337
