### PR TITLE
[DEITS] Import: Add specific error messages and only allow importing valid extensions

### DIFF
--- a/packages/core/data-transfer/src/file/providers/source/index.ts
+++ b/packages/core/data-transfer/src/file/providers/source/index.ts
@@ -13,6 +13,7 @@ import type { IAsset, IMetadata, ISourceProvider, ProviderType } from '../../../
 
 import { createDecryptionCipher } from '../../../utils/encryption';
 import { collect } from '../../../utils/stream';
+import { ProviderInitializationError } from '../../../errors/providers';
 
 type StreamItemArray = Parameters<typeof chain>[0];
 
@@ -72,7 +73,12 @@ class LocalFileSourceProvider implements ISourceProvider {
       // Read the metadata to ensure the file can be parsed
       this.#metadata = await this.getMetadata();
     } catch (e) {
-      throw new Error(`Can't read file "${filePath}".`);
+      if (this.options?.encryption?.enabled) {
+        throw new ProviderInitializationError(
+          `Key is incorrect or the file '${filePath}' is not a valid Strapi data file.`
+        );
+      }
+      throw new ProviderInitializationError(`File '${filePath}' is not a valid Strapi data file.`);
     }
   }
 

--- a/packages/core/strapi/bin/strapi.js
+++ b/packages/core/strapi/bin/strapi.js
@@ -410,9 +410,7 @@ program
       thisCommand.opts().decompress = false;
     }
 
-    if (extname(file) === '.tar') {
-      // proceed as expected
-    } else {
+    if (extname(file) !== '.tar') {
       exitWith(
         1,
         `The file '${opts.file}' does not appear to be a valid Strapi data file. It must have an extension ending in .tar[.gz][.enc]`

--- a/packages/core/strapi/bin/strapi.js
+++ b/packages/core/strapi/bin/strapi.js
@@ -415,7 +415,7 @@ program
     } else {
       exitWith(
         1,
-        'The file does not appear to be a valid Strapi data file. It must have an extension ending in .tar[.gz][.enc]'
+        `The file '${opts.file}' does not appear to be a valid Strapi data file. It must have an extension ending in .tar[.gz][.enc]`
       );
     }
   })

--- a/packages/core/strapi/bin/strapi.js
+++ b/packages/core/strapi/bin/strapi.js
@@ -409,6 +409,15 @@ program
     } else {
       thisCommand.opts().decompress = false;
     }
+
+    if (extname(file) === '.tar') {
+      // proceed as expected
+    } else {
+      exitWith(
+        1,
+        'The file does not appear to be a valid Strapi data file. It must have an extension ending in .tar[.gz][.enc]'
+      );
+    }
   })
   .hook(
     'preAction',


### PR DESCRIPTION
### What does it do?

- Prevents importing a file that does not have a valid Strapi data file extension (`.tar[.gz][.enc]`)
- Improves error message when file cannot be opened

### Why is it needed?

Improve user experience with the `strapi import` command

### How to test it?

Attempt to import a file with an invalid extension and the import should halt with an error.

Attempt to import an invalid file with an accepted extension (`.tar[.gz][.enc]`) and a more informative error message should be output.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
