### PR TITLE
[Audit logs] Make JSON input the size of its content

### DIFF
--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/AuditLogs/ListView/Modal/ActionBody.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/AuditLogs/ListView/Modal/ActionBody.js
@@ -7,7 +7,6 @@ import { Box } from '@strapi/design-system/Box';
 import { Flex } from '@strapi/design-system/Flex';
 import { Typography } from '@strapi/design-system/Typography';
 import { JSONInput } from '@strapi/design-system/JSONInput';
-import { pxToRem } from '@strapi/helper-plugin';
 import getDefaultMessage from '../utils/getActionTypesDefaultMessages';
 import ActionItem from './ActionItem';
 
@@ -83,7 +82,6 @@ const ActionBody = ({ status, data, formattedDate }) => {
       <JSONInput
         value={JSON.stringify(payload, null, 2)}
         disabled
-        height={pxToRem(150)}
         label={formatMessage({
           id: 'Settings.permissions.auditLogs.payload',
           defaultMessage: 'Payload',


### PR DESCRIPTION
### What does it do?

- Removes the fixed on on the JSONInput

_Note_:
_The height and overflow of the Modal are defined in the DS (max-height: 60vh and overflow: auto)_

### Why is it needed?

- To make reading audit logs payload easier

### How to test it?

- Create an entity that is really big, like Address
- Go to the audit logs and open the created entry, the modal should be scrollable.

