### PR TITLE
[DEITS] Improve error messaging on import schema validation

### DIFF
--- a/packages/core/data-transfer/src/engine/index.ts
+++ b/packages/core/data-transfer/src/engine/index.ts
@@ -346,7 +346,7 @@ class TransferEngine<
     keys.forEach((key) => {
       const sourceSchema = sourceSchemas[key];
       const destinationSchema = destinationSchemas[key];
-      const schemaDiffs = compareSchemas(destinationSchema, sourceSchema, strategy);
+      const schemaDiffs = compareSchemas(sourceSchema, destinationSchema, strategy);
 
       if (schemaDiffs.length) {
         diffs[key] = schemaDiffs;
@@ -364,15 +364,15 @@ class TransferEngine<
               const path = diff.path.join('.');
 
               if (diff.kind === 'added') {
-                return `Added "${path}": "${diff.value}" (${diff.type})`;
+                return `${path} exists in destination schema but not in source schema`;
               }
 
               if (diff.kind === 'deleted') {
-                return `Removed "${path}"`;
+                return `${path} exists in source schema but not in destination schema`;
               }
 
               if (diff.kind === 'modified') {
-                return `Modified "${path}": "${diff.values[0]}" (${diff.types[0]}) => "${diff.values[1]}" (${diff.types[1]})`;
+                return `Schema value changed at "${path}": "${diff.values[0]}" (${diff.types[0]}) => "${diff.values[1]}" (${diff.types[1]})`;
               }
 
               throw new TransferEngineValidationError(`Invalid diff found for "${uid}"`, {

--- a/packages/core/data-transfer/src/engine/index.ts
+++ b/packages/core/data-transfer/src/engine/index.ts
@@ -375,6 +375,10 @@ class TransferEngine<
                 return `Schema value changed at "${path}": "${diff.values[0]}" (${diff.types[0]}) => "${diff.values[1]}" (${diff.types[1]})`;
               }
 
+              if (diff.kind === 'dataType') {
+                return `Schema has differing data types at "${path}": "${diff.values[0]}" (${diff.types[0]}) => "${diff.values[1]}" (${diff.types[1]})`;
+              }
+
               throw new TransferEngineValidationError(`Invalid diff found for "${uid}"`, {
                 check: `schema on ${uid}`,
               });

--- a/packages/core/data-transfer/src/engine/index.ts
+++ b/packages/core/data-transfer/src/engine/index.ts
@@ -372,11 +372,12 @@ class TransferEngine<
               }
 
               if (diff.kind === 'modified') {
-                return `Schema value changed at "${path}": "${diff.values[0]}" (${diff.types[0]}) => "${diff.values[1]}" (${diff.types[1]})`;
-              }
+                // eslint-disable-next-line eqeqeq
+                if (diff.values[0] == diff.values[1]) {
+                  return `Schema has differing data types at "${path}": "${diff.values[0]}" (${diff.types[0]}) => "${diff.values[1]}" (${diff.types[1]})`;
+                }
 
-              if (diff.kind === 'dataType') {
-                return `Schema has differing data types at "${path}": "${diff.values[0]}" (${diff.types[0]}) => "${diff.values[1]}" (${diff.types[1]})`;
+                return `Schema value changed at "${path}": "${diff.values[0]}" (${diff.types[0]}) => "${diff.values[1]}" (${diff.types[1]})`;
               }
 
               throw new TransferEngineValidationError(`Invalid diff found for "${uid}"`, {

--- a/packages/core/data-transfer/src/engine/index.ts
+++ b/packages/core/data-transfer/src/engine/index.ts
@@ -373,11 +373,11 @@ class TransferEngine<
 
               if (diff.kind === 'modified') {
                 // eslint-disable-next-line eqeqeq
-                if (diff.values[0] == diff.values[1]) {
-                  return `Schema has differing data types at "${path}": "${diff.values[0]}" (${diff.types[0]}) => "${diff.values[1]}" (${diff.types[1]})`;
+                if (diff.types[0] === diff.types[1]) {
+                  return `Schema value changed at "${path}": "${diff.values[0]}" (${diff.types[0]}) => "${diff.values[1]}" (${diff.types[1]})`;
                 }
 
-                return `Schema value changed at "${path}": "${diff.values[0]}" (${diff.types[0]}) => "${diff.values[1]}" (${diff.types[1]})`;
+                return `Schema has differing data types at "${path}": "${diff.values[0]}" (${diff.types[0]}) => "${diff.values[1]}" (${diff.types[1]})`;
               }
 
               throw new TransferEngineValidationError(`Invalid diff found for "${uid}"`, {

--- a/packages/core/data-transfer/src/engine/index.ts
+++ b/packages/core/data-transfer/src/engine/index.ts
@@ -372,7 +372,6 @@ class TransferEngine<
               }
 
               if (diff.kind === 'modified') {
-                // eslint-disable-next-line eqeqeq
                 if (diff.types[0] === diff.types[1]) {
                   return `Schema value changed at "${path}": "${diff.values[0]}" (${diff.types[0]}) => "${diff.values[1]}" (${diff.types[1]})`;
                 }

--- a/packages/core/data-transfer/src/engine/validation/schemas/index.ts
+++ b/packages/core/data-transfer/src/engine/validation/schemas/index.ts
@@ -9,15 +9,18 @@ const strategies = {
 
   // Diffs allowed on specific attributes properties
   strict(diffs: Diff[]) {
-    const isIgnorableDiff = ({ path }: Diff) => {
+    const isIgnorableDiff = (diff: Diff) => {
       return (
-        path.length === 3 &&
-        // Root property must be attributes
-        path[0] === 'attributes' &&
-        // Need a valid string attribute name
-        typeof path[1] === 'string' &&
-        // The diff must be on ignorable attribute properties
-        ['private', 'required', 'configurable'].includes(path[2])
+        // Ignore cases where one field is missing and the other is falsey
+        (diff.kind === 'dataType' && diff.types.includes('undefined')) ||
+        // Ignore cases where...
+        (diff.path.length === 3 &&
+          // Root property must be attributes
+          diff.path[0] === 'attributes' &&
+          // Need a valid string attribute name
+          typeof diff.path[1] === 'string' &&
+          // The diff must be on ignorable attribute properties
+          ['private', 'required', 'configurable'].includes(diff.path[2]))
       );
     };
 

--- a/packages/core/data-transfer/src/engine/validation/schemas/index.ts
+++ b/packages/core/data-transfer/src/engine/validation/schemas/index.ts
@@ -9,16 +9,15 @@ const strategies = {
 
   // Diffs allowed on specific attributes properties
   strict(diffs: Diff[]) {
-    const isIgnorableDiff = (diff: Diff) => {
+    const isIgnorableDiff = ({ path }: Diff) => {
       return (
-        // Ignore cases where...
-        diff.path.length === 3 &&
+        path.length === 3 &&
         // Root property must be attributes
-        diff.path[0] === 'attributes' &&
+        path[0] === 'attributes' &&
         // Need a valid string attribute name
-        typeof diff.path[1] === 'string' &&
+        typeof path[1] === 'string' &&
         // The diff must be on ignorable attribute properties
-        ['private', 'required', 'configurable'].includes(diff.path[2])
+        ['private', 'required', 'configurable'].includes(path[2])
       );
     };
 

--- a/packages/core/data-transfer/src/engine/validation/schemas/index.ts
+++ b/packages/core/data-transfer/src/engine/validation/schemas/index.ts
@@ -11,16 +11,14 @@ const strategies = {
   strict(diffs: Diff[]) {
     const isIgnorableDiff = (diff: Diff) => {
       return (
-        // Ignore cases where one field is missing and the other is falsey
-        (diff.kind === 'dataType' && diff.types.includes('undefined')) ||
         // Ignore cases where...
-        (diff.path.length === 3 &&
-          // Root property must be attributes
-          diff.path[0] === 'attributes' &&
-          // Need a valid string attribute name
-          typeof diff.path[1] === 'string' &&
-          // The diff must be on ignorable attribute properties
-          ['private', 'required', 'configurable'].includes(diff.path[2]))
+        diff.path.length === 3 &&
+        // Root property must be attributes
+        diff.path[0] === 'attributes' &&
+        // Need a valid string attribute name
+        typeof diff.path[1] === 'string' &&
+        // The diff must be on ignorable attribute properties
+        ['private', 'required', 'configurable'].includes(diff.path[2])
       );
     };
 

--- a/packages/core/data-transfer/src/utils/json.ts
+++ b/packages/core/data-transfer/src/utils/json.ts
@@ -2,6 +2,14 @@ import { isArray, isObject, zip, isEqual, uniq } from 'lodash/fp';
 
 const createContext = (): Context => ({ path: [] });
 
+const isLooselyEqual = (a: unknown, b: unknown) => {
+  // eslint-disable-next-line eqeqeq
+  if (a == b) {
+    return true;
+  }
+  return false;
+};
+
 /**
  * Compute differences between two JSON objects and returns them
  *
@@ -19,12 +27,12 @@ export const diff = (a: unknown, b: unknown, ctx: Context = createContext()): Di
   // Define helpers
 
   const added = () => {
-    diffs.push({ kind: 'added', path, types: [aType, bType], values: [a, b] });
+    diffs.push({ kind: 'added', path, type: aType, value: a });
     return diffs;
   };
 
   const deleted = () => {
-    diffs.push({ kind: 'deleted', path, types: [aType, bType], values: [a, b] });
+    diffs.push({ kind: 'deleted', path, type: bType, value: b });
     return diffs;
   };
 
@@ -46,14 +54,6 @@ export const diff = (a: unknown, b: unknown, ctx: Context = createContext()): Di
       values: [a, b],
     });
     return diffs;
-  };
-
-  const isLooselyEqual = () => {
-    // eslint-disable-next-line eqeqeq
-    if (a == b) {
-      return true;
-    }
-    return false;
   };
 
   if (isArray(a) && isArray(b)) {
@@ -87,7 +87,7 @@ export const diff = (a: unknown, b: unknown, ctx: Context = createContext()): Di
   }
 
   if (!isEqual(a, b)) {
-    if (isLooselyEqual()) {
+    if (isLooselyEqual(a, b)) {
       return dataType();
     }
 

--- a/packages/core/data-transfer/src/utils/json.ts
+++ b/packages/core/data-transfer/src/utils/json.ts
@@ -2,14 +2,6 @@ import { isArray, isObject, zip, isEqual, uniq } from 'lodash/fp';
 
 const createContext = (): Context => ({ path: [] });
 
-const isLooselyEqual = (a: unknown, b: unknown) => {
-  // eslint-disable-next-line eqeqeq
-  if (a == b) {
-    return true;
-  }
-  return false;
-};
-
 /**
  * Compute differences between two JSON objects and returns them
  *
@@ -39,16 +31,6 @@ export const diff = (a: unknown, b: unknown, ctx: Context = createContext()): Di
   const modified = () => {
     diffs.push({
       kind: 'modified',
-      path,
-      types: [aType, bType],
-      values: [a, b],
-    });
-    return diffs;
-  };
-
-  const dataType = () => {
-    diffs.push({
-      kind: 'dataType',
       path,
       types: [aType, bType],
       values: [a, b],
@@ -87,10 +69,6 @@ export const diff = (a: unknown, b: unknown, ctx: Context = createContext()): Di
   }
 
   if (!isEqual(a, b)) {
-    if (isLooselyEqual(a, b)) {
-      return dataType();
-    }
-
     if (aType === 'undefined') {
       return added();
     }
@@ -126,14 +104,7 @@ export interface DeletedDiff<T = unknown> {
   value: T;
 }
 
-export interface DataTypeDiff<T = unknown, P = unknown> {
-  kind: 'dataType';
-  path: string[];
-  types: [string, string];
-  values: [T, P];
-}
-
-export type Diff = AddedDiff | ModifiedDiff | DeletedDiff | DataTypeDiff;
+export type Diff = AddedDiff | ModifiedDiff | DeletedDiff;
 
 export interface Context {
   path: string[];

--- a/packages/core/data-transfer/src/utils/json.ts
+++ b/packages/core/data-transfer/src/utils/json.ts
@@ -27,12 +27,12 @@ export const diff = (a: unknown, b: unknown, ctx: Context = createContext()): Di
   // Define helpers
 
   const added = () => {
-    diffs.push({ kind: 'added', path, type: aType, value: a });
+    diffs.push({ kind: 'added', path, type: bType, value: b });
     return diffs;
   };
 
   const deleted = () => {
-    diffs.push({ kind: 'deleted', path, type: bType, value: b });
+    diffs.push({ kind: 'deleted', path, type: aType, value: a });
     return diffs;
   };
 

--- a/packages/core/data-transfer/src/utils/json.ts
+++ b/packages/core/data-transfer/src/utils/json.ts
@@ -105,11 +105,11 @@ export const diff = (a: unknown, b: unknown, ctx: Context = createContext()): Di
   return diffs;
 };
 
-export interface AddedDiff<T = unknown, P = unknown> {
+export interface AddedDiff<T = unknown> {
   kind: 'added';
   path: string[];
-  types: [string, string];
-  values: [T, P];
+  type: string;
+  value: T;
 }
 
 export interface ModifiedDiff<T = unknown, P = unknown> {
@@ -119,11 +119,11 @@ export interface ModifiedDiff<T = unknown, P = unknown> {
   values: [T, P];
 }
 
-export interface DeletedDiff<T = unknown, P = unknown> {
+export interface DeletedDiff<T = unknown> {
   kind: 'deleted';
   path: string[];
-  types: [string, string];
-  values: [T, P];
+  type: string;
+  value: T;
 }
 
 export interface DataTypeDiff<T = unknown, P = unknown> {


### PR DESCRIPTION
### What does it do?

- Adds a check for loose equality to the diff method and adds a message for it
- Improves messaging for diff validation errors
- 'strict' schema now allows for the case where a field is not present in one schema, and has a falsey value in the other schema <-- this one I'm not 100% sure we want, but seems reasonable. I'm looking for opinions, I'd be fine removing this until we add additional strategySchemas

### Why is it needed?

The current error messages are confusing to the user.

Adding data type improves the messaging, and will also help with future enhancements when adding additional schemaStrategies.

### How to test it?

Attempt to import a file with a mismatched schema and see the improved errors for added, removed, modified, and data type [the new one] 

