### PR TITLE
Prevent uploading files that have unallowed file type

### DIFF
--- a/packages/core/upload/admin/src/components/MediaLibraryInput/index.js
+++ b/packages/core/upload/admin/src/components/MediaLibraryInput/index.js
@@ -102,11 +102,12 @@ export const MediaLibraryInput = ({
     });
   };
 
-  const validateAssetsTypes = (assets, cb) => {
+  const validateAssetsTypes = (assets, callback) => {
     const allowedAssets = getAllowedFiles(fieldAllowedTypes, assets);
 
-    if (allowedAssets.length > 0) cb(allowedAssets);
-    else {
+    if (allowedAssets.length > 0) {
+      callback(allowedAssets);
+    } else {
       toggleNotification({
         type: 'warning',
         timeout: 4000,

--- a/packages/core/upload/admin/src/components/MediaLibraryInput/index.js
+++ b/packages/core/upload/admin/src/components/MediaLibraryInput/index.js
@@ -102,13 +102,11 @@ export const MediaLibraryInput = ({
     });
   };
 
-  const handleAssetDrop = (assets) => {
+  const validateAssetsTypes = (assets, cb) => {
     const allowedAssets = getAllowedFiles(fieldAllowedTypes, assets);
 
-    if (allowedAssets.length > 0) {
-      setDroppedAssets(allowedAssets);
-      setStep(STEPS.AssetUpload);
-    } else {
+    if (allowedAssets.length > 0) cb(allowedAssets);
+    else {
       toggleNotification({
         type: 'warning',
         timeout: 4000,
@@ -121,6 +119,13 @@ export const MediaLibraryInput = ({
         },
       });
     }
+  };
+
+  const handleAssetDrop = (assets) => {
+    validateAssetsTypes(assets, (allowedAssets) => {
+      setDroppedAssets(allowedAssets);
+      setStep(STEPS.AssetUpload);
+    });
   };
 
   let label = intlLabel.id ? formatMessage(intlLabel) : '';
@@ -204,6 +209,7 @@ export const MediaLibraryInput = ({
           addUploadedFiles={handleFilesUploadSucceeded}
           trackedLocation="content-manager"
           folderId={folderId}
+          validateAssetsTypes={validateAssetsTypes}
         />
       )}
 

--- a/packages/core/upload/admin/src/components/UploadAssetDialog/UploadAssetDialog.js
+++ b/packages/core/upload/admin/src/components/UploadAssetDialog/UploadAssetDialog.js
@@ -19,6 +19,7 @@ export const UploadAssetDialog = ({
   onClose,
   addUploadedFiles,
   trackedLocation,
+  validateAssetsTypes,
 }) => {
   const { formatMessage } = useIntl();
   const [step, setStep] = useState(initialAssetsToAdd ? Steps.PendingAsset : Steps.AddAsset);
@@ -26,8 +27,10 @@ export const UploadAssetDialog = ({
   const [assetToEdit, setAssetToEdit] = useState(undefined);
 
   const handleAddToPendingAssets = (nextAssets) => {
-    setAssets((prevAssets) => prevAssets.concat(nextAssets));
-    setStep(Steps.PendingAsset);
+    validateAssetsTypes(nextAssets, () => {
+      setAssets((prevAssets) => prevAssets.concat(nextAssets));
+      setStep(Steps.PendingAsset);
+    });
   };
 
   const moveToAddAsset = () => {
@@ -130,6 +133,7 @@ UploadAssetDialog.defaultProps = {
   folderId: null,
   initialAssetsToAdd: undefined,
   trackedLocation: undefined,
+  validateAssetsTypes: undefined,
 };
 
 UploadAssetDialog.propTypes = {
@@ -138,4 +142,5 @@ UploadAssetDialog.propTypes = {
   initialAssetsToAdd: PropTypes.arrayOf(AssetDefinition),
   onClose: PropTypes.func.isRequired,
   trackedLocation: PropTypes.string,
+  validateAssetsTypes: PropTypes.func,
 };

--- a/packages/core/upload/admin/src/components/UploadAssetDialog/UploadAssetDialog.js
+++ b/packages/core/upload/admin/src/components/UploadAssetDialog/UploadAssetDialog.js
@@ -19,7 +19,7 @@ export const UploadAssetDialog = ({
   onClose,
   addUploadedFiles,
   trackedLocation,
-  validateAssetsTypes,
+  validateAssetsTypes = (_, cb) => cb(),
 }) => {
   const { formatMessage } = useIntl();
   const [step, setStep] = useState(initialAssetsToAdd ? Steps.PendingAsset : Steps.AddAsset);


### PR DESCRIPTION
### What does it do?
It prevents admin panel users from uploading different file types than the allowed types.
Ex: A user trying to upload a pdf while the field restricts uploads to only images.
Instead, it shows a notification telling the user that the file type isn't allowed.
### Why is it needed?
I tried the same issue after the latest release version(4.6.0) and found it fixed in dropped files but still exists in the normal upload flow(when someone select a file). So, I have added the validation to the normal flow too.
The `handleAssetDrop` only works whet files are dragged and dropped in the field and it doesn't get invoked when someone uploads a file by selecting it. I used `handleAddToPendingAssets` to validate the uploaded file on the normal flow.
### How to test it?
- Start a new project.
- Create a single-type (ex: about-us) that has a media file and restricts to choose images.
- Try to upload a PDF file.
#### Before: 
![Before](https://user-images.githubusercontent.com/52703729/215449022-e8fa46b2-593f-4f84-be74-f89673044c9b.gif)
![Screenshot from 2023-01-30 11-53-06](https://user-images.githubusercontent.com/52703729/215449612-498b6f19-b139-4b3c-9f9e-559e41d7e21e.png)
#### After:
![After](https://user-images.githubusercontent.com/52703729/215449373-840766cf-07b5-475a-bbb5-5c3f67e4240f.gif)
### Related issue(s)/PR(s)

### Related issues
* resolves [#15608](https://github.com/strapi/strapi/issues/15608)
* resolves [#15486](https://github.com/strapi/strapi/issues/15486)
* resolves [#15326](https://github.com/strapi/strapi/issues/15326)

Related to:
[#15458](https://github.com/strapi/strapi/pull/15458)
[#15328](https://github.com/strapi/strapi/pull/15328)