### PR TITLE
Chore: Update and unpin @babel/template

### DIFF
--- a/packages/utils/babel-plugin-switch-ee-ce/package.json
+++ b/packages/utils/babel-plugin-switch-ee-ce/package.json
@@ -19,7 +19,7 @@
   ],
   "main": "lib/index.js",
   "dependencies": {
-    "@babel/template": "7.18.10",
+    "@babel/template": "^7.20.7",
     "reselect": "4.0.0",
     "resolve": "1.20.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1718,7 +1718,7 @@
   dependencies:
     regenerator-runtime "^0.13.11"
 
-"@babel/template@7.18.10", "@babel/template@^7.12.7", "@babel/template@^7.18.10", "@babel/template@^7.18.6", "@babel/template@^7.3.3":
+"@babel/template@^7.12.7", "@babel/template@^7.18.10", "@babel/template@^7.18.6", "@babel/template@^7.3.3":
   version "7.18.10"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.18.10.tgz#6f9134835970d1dbf0835c0d100c9f38de0c5e71"
   integrity sha512-TI+rCtooWHr3QJ27kJxfjutghu44DLnasDMwpDqCXVTal9RLp3RSYNh4NdBrRP2cQAoG9A8juOQl6P6oZG4JxA==


### PR DESCRIPTION
### What does it do?

Updates `@babel/template`.

### Why is it needed?

It was forgotten in https://github.com/strapi/strapi/pull/15627.
