### PR TITLE
Settings: wrap check to display review workflows in a feature flag

### DIFF
--- a/packages/core/admin/admin/src/index.js
+++ b/packages/core/admin/admin/src/index.js
@@ -13,6 +13,7 @@ window.strapi = {
   features: {
     SSO: 'sso',
     AUDIT_LOGS: 'audit-logs',
+    REVIEW_WORKFLOWS: 'review-workflows',
   },
   projectType: 'Community',
 };

--- a/packages/core/admin/ee/admin/hooks/useSettingsMenu/utils/customAdminLinks.js
+++ b/packages/core/admin/ee/admin/hooks/useSettingsMenu/utils/customAdminLinks.js
@@ -1,17 +1,17 @@
 import adminPermissions from '../../../../../admin/src/permissions';
 
-const auditLogsRoutes = strapi.features.isEnabled(strapi.features.AUDIT_LOGS)
-  ? [
-      {
-        intlLabel: { id: 'global.auditLogs', defaultMessage: 'Audit Logs' },
-        to: '/settings/audit-logs?pageSize=50&page=1&sort=date:DESC',
-        id: 'auditLogs',
-        isDisplayed: false,
-        permissions: adminPermissions.settings.auditLogs.main,
-      },
-    ]
-  : [];
+const items = [];
 
-const customAdminLinks = [...auditLogsRoutes];
+if (window.strapi.features.isEnabled(window.strapi.features.AUDIT_LOGS)) {
+  items.push({
+    intlLabel: { id: 'global.auditLogs', defaultMessage: 'Audit Logs' },
+    to: '/settings/audit-logs?pageSize=50&page=1&sort=date:DESC',
+    id: 'auditLogs',
+    isDisplayed: false,
+    permissions: adminPermissions.settings.auditLogs.main,
+  });
+}
+
+const customAdminLinks = items;
 
 export default customAdminLinks;

--- a/packages/core/admin/ee/admin/hooks/useSettingsMenu/utils/customGlobalLinks.js
+++ b/packages/core/admin/ee/admin/hooks/useSettingsMenu/utils/customGlobalLinks.js
@@ -2,7 +2,7 @@ import adminPermissions from '../../../../../admin/src/permissions';
 
 const items = [];
 
-if (window.strapi.features.isEnabled(strapi.features.SSO)) {
+if (window.strapi.features.isEnabled(window.strapi.features.SSO)) {
   items.push({
     intlLabel: { id: 'Settings.sso.title', defaultMessage: 'Single Sign-On' },
     to: '/settings/single-sign-on',
@@ -12,7 +12,7 @@ if (window.strapi.features.isEnabled(strapi.features.SSO)) {
   });
 }
 
-if (window.strapi.isEE) {
+if (window.strapi.features.isEnabled(window.strapi.features.REVIEW_WORKFLOWS)) {
   items.push({
     intlLabel: { id: 'Settings.review-workflows.title', defaultMessage: 'Review Workflow' },
     to: '/settings/review-workflows',


### PR DESCRIPTION
### What does it do?

Instead of checking whether strapi is in EE mode we need to check if the feature is enabled according to the license. It also makes it explicit `strapi` refers to `window.strapi`.

### Why is it needed?

Properly support the new licensing system.

