### PR TITLE
[DEITS] Import/Export error full disk

### DIFF
--- a/packages/core/data-transfer/src/file/providers/destination/index.ts
+++ b/packages/core/data-transfer/src/file/providers/destination/index.ts
@@ -101,6 +101,13 @@ class LocalFileDestinationProvider implements IDestinationProvider {
 
     const outStream = createWriteStream(this.#archivePath);
 
+    outStream.on('error', (err: NodeJS.ErrnoException) => {
+      if (err.code === 'ENOSPC') {
+        throw new Error("Your server doesn't have space to proceed with the import.");
+      }
+      throw err;
+    });
+
     const archiveTransforms: Stream[] = [];
 
     if (compression.enabled) {

--- a/packages/core/data-transfer/src/file/providers/destination/index.ts
+++ b/packages/core/data-transfer/src/file/providers/destination/index.ts
@@ -12,7 +12,6 @@ import type {
   IDestinationProvider,
   IDestinationProviderTransferResults,
   IMetadata,
-  MaybePromise,
   ProviderType,
   Stream,
 } from '../../../../types';

--- a/packages/core/data-transfer/src/strapi/providers/local-destination/__tests__/assets.test.ts
+++ b/packages/core/data-transfer/src/strapi/providers/local-destination/__tests__/assets.test.ts
@@ -1,4 +1,4 @@
-import fse from 'fs-extra';
+import fse, { WriteStream } from 'fs-extra';
 import { Writable, Readable } from 'stream';
 import type { IAsset } from '../../../../../types';
 
@@ -10,9 +10,21 @@ const write = jest.fn((_chunk, _encoding, callback) => {
 });
 
 const createWriteStreamMock = jest.fn(() => {
-  return new Writable({
+  return new WriteStream({
     objectMode: true,
     write,
+  });
+});
+
+const createWriteStreamErrorMock = jest.fn().mockImplementation(() => {
+  return new WriteStream({
+    objectMode: true,
+    write: jest.fn().mockImplementation((chunk, _encoding, callback) => {
+      console.log('kladfsj;kasdfjasdj;fk');
+      const error = new Error() as NodeJS.ErrnoException;
+      error.code = 'ENOSPC';
+      callback(error);
+    }),
   });
 });
 
@@ -74,11 +86,70 @@ describe('Local Strapi Destination Provider - Get Assets Stream', () => {
       stream.write(file, resolve);
     });
 
-    expect(error).not.toBeInstanceOf(Error);
-
     expect(write).toHaveBeenCalled();
     expect(createWriteStreamMock).toHaveBeenCalledWith(
       `${assetsDirectory}/uploads/${file.filename}`
     );
+  });
+
+  test.only('Throws a full disk error', async () => {
+    const assetsDirectory = 'static/public/assets';
+    const file: IAsset = {
+      filename: 'test-photo.jpg',
+      filepath: 'strapi-import-folder/assets',
+      stats: { size: 200 },
+      stream: Readable.from(['test', 'test-2']),
+    };
+    (fse.createWriteStream as jest.Mock).mockImplementation(createWriteStreamMock);
+
+    const provider = createLocalStrapiDestinationProvider({
+      getStrapi: getStrapiFactory({
+        dirs: {
+          static: {
+            public: assetsDirectory,
+          },
+        },
+      }),
+      strategy: 'restore',
+    });
+    await provider.bootstrap();
+
+    const assetStream = await provider.createAssetsWriteStream();
+
+    const error = new Error() as NodeJS.ErrnoException;
+    error.code = 'ENOSPC';
+
+    assetStream.on('error', (e) => {
+      console.log('assetstream on error', e);
+    });
+
+    try {
+      await assetStream.write(file, 'utf-8', () => {
+        console.log('CLOSED!');
+      });
+    } catch (e) {
+      console.log('got error', e);
+    }
+    // try {
+    //   await new Promise((resolve, reject) => {
+    //     assetStream.write(file, 'utf-8', console.log);
+    //     reject(new Error('11111'));
+    //   });
+    // } catch (e) {
+    //   console.log('edeeasdfadfs', e);
+    // }
+
+    // await expect(
+    //   async () =>
+    //     new Promise((resolve, reject) => {
+    //       try {
+    //         assetStream.write(file, 'utf-8', reject);
+    //       } catch (e) {
+    //         console.error('error!', e);
+    //       }
+    //     })
+    // ).rejects.toThrow(
+    //   `There was an error during the transfer process. Your server doesn't have space to proceed with the import. The original files have been restored to ${assetsDirectory}`
+    // );
   });
 });

--- a/packages/core/data-transfer/src/strapi/providers/local-destination/__tests__/assets.test.ts
+++ b/packages/core/data-transfer/src/strapi/providers/local-destination/__tests__/assets.test.ts
@@ -1,4 +1,4 @@
-import fse, { WriteStream } from 'fs-extra';
+import fse from 'fs-extra';
 import { Writable, Readable } from 'stream';
 import type { IAsset } from '../../../../../types';
 
@@ -10,25 +10,19 @@ const write = jest.fn((_chunk, _encoding, callback) => {
 });
 
 const createWriteStreamMock = jest.fn(() => {
-  return new WriteStream({
+  return new Writable({
     objectMode: true,
     write,
   });
 });
 
-const createWriteStreamErrorMock = jest.fn().mockImplementation(() => {
-  return new WriteStream({
-    objectMode: true,
-    write: jest.fn().mockImplementation((chunk, _encoding, callback) => {
-      console.log('kladfsj;kasdfjasdj;fk');
-      const error = new Error() as NodeJS.ErrnoException;
-      error.code = 'ENOSPC';
-      callback(error);
-    }),
-  });
-});
-
 jest.mock('fs-extra');
+const transaction = jest.fn(async (cb) => {
+  const trx = {};
+  const rollback = jest.fn();
+  // eslint-disable-next-line node/no-callback-literal
+  await cb({ trx, rollback });
+});
 
 describe('Local Strapi Destination Provider - Get Assets Stream', () => {
   test('Throws an error if the Strapi instance is not provided', async () => {
@@ -49,6 +43,7 @@ describe('Local Strapi Destination Provider - Get Assets Stream', () => {
             public: 'static/public/assets',
           },
         },
+        db: { transaction },
       }),
       strategy: 'restore',
     });
@@ -75,6 +70,7 @@ describe('Local Strapi Destination Provider - Get Assets Stream', () => {
             public: assetsDirectory,
           },
         },
+        db: { transaction },
       }),
       strategy: 'restore',
     });
@@ -86,70 +82,11 @@ describe('Local Strapi Destination Provider - Get Assets Stream', () => {
       stream.write(file, resolve);
     });
 
+    expect(error).not.toBeInstanceOf(Error);
+
     expect(write).toHaveBeenCalled();
     expect(createWriteStreamMock).toHaveBeenCalledWith(
       `${assetsDirectory}/uploads/${file.filename}`
     );
-  });
-
-  test.only('Throws a full disk error', async () => {
-    const assetsDirectory = 'static/public/assets';
-    const file: IAsset = {
-      filename: 'test-photo.jpg',
-      filepath: 'strapi-import-folder/assets',
-      stats: { size: 200 },
-      stream: Readable.from(['test', 'test-2']),
-    };
-    (fse.createWriteStream as jest.Mock).mockImplementation(createWriteStreamMock);
-
-    const provider = createLocalStrapiDestinationProvider({
-      getStrapi: getStrapiFactory({
-        dirs: {
-          static: {
-            public: assetsDirectory,
-          },
-        },
-      }),
-      strategy: 'restore',
-    });
-    await provider.bootstrap();
-
-    const assetStream = await provider.createAssetsWriteStream();
-
-    const error = new Error() as NodeJS.ErrnoException;
-    error.code = 'ENOSPC';
-
-    assetStream.on('error', (e) => {
-      console.log('assetstream on error', e);
-    });
-
-    try {
-      await assetStream.write(file, 'utf-8', () => {
-        console.log('CLOSED!');
-      });
-    } catch (e) {
-      console.log('got error', e);
-    }
-    // try {
-    //   await new Promise((resolve, reject) => {
-    //     assetStream.write(file, 'utf-8', console.log);
-    //     reject(new Error('11111'));
-    //   });
-    // } catch (e) {
-    //   console.log('edeeasdfadfs', e);
-    // }
-
-    // await expect(
-    //   async () =>
-    //     new Promise((resolve, reject) => {
-    //       try {
-    //         assetStream.write(file, 'utf-8', reject);
-    //       } catch (e) {
-    //         console.error('error!', e);
-    //       }
-    //     })
-    // ).rejects.toThrow(
-    //   `There was an error during the transfer process. Your server doesn't have space to proceed with the import. The original files have been restored to ${assetsDirectory}`
-    // );
   });
 });

--- a/packages/core/data-transfer/src/strapi/providers/local-destination/index.ts
+++ b/packages/core/data-transfer/src/strapi/providers/local-destination/index.ts
@@ -154,13 +154,18 @@ class LocalStrapiDestinationProvider implements IDestinationProvider {
         chunk.stream
           .pipe(writableStream)
           .on('close', callback)
-          .on('error', async (error: Error) => {
+          .on('error', async (error: NodeJS.ErrnoException) => {
+            const errorMessage =
+              error.code === 'ENOSPC'
+                ? " Your server doesn't have space to proceed with the import. "
+                : ' ';
+
             try {
               await fse.rm(assetsDirectory, { recursive: true, force: true });
               await fse.rename(backupDirectory, assetsDirectory);
               this.destroy(
                 new Error(
-                  `There was an error during the transfer process. The original files have been restored to ${assetsDirectory}`
+                  `There was an error during the transfer process.${errorMessage}The original files have been restored to ${assetsDirectory}`
                 )
               );
             } catch (err) {


### PR DESCRIPTION
### What does it do?

When receiving an error related to a full disk during the transfer, the error is thrown with the right message

### Why is it needed?

To give the end user more information related to the errors.

### How to test it?

// TODO

### Related issue(s)/PR(s)

