### PR TITLE
Settings: Connect Review Workflow UI, data loader and redux

### DIFF
--- a/packages/core/admin/admin/src/translations/en.json
+++ b/packages/core/admin/admin/src/translations/en.json
@@ -226,6 +226,7 @@
   "Settings.profile.form.section.profile.page.title": "Profile page",
   "Settings.review-workflows.page.title": "Review Workflow",
   "Settings.review-workflows.page.subtitle": "{count, plural, one {# stage} other {# stages}}",
+  "Settings.review-workflows.page.isLoading": "Workflow is loading",
   "Settings.review-workflows.stage.name.label": "Stage name",
   "Settings.roles.create.description": "Define the rights given to the role",
   "Settings.roles.create.title": "Create a role",

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/ReviewWorkflows.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/ReviewWorkflows.js
@@ -21,8 +21,8 @@ export function ReviewWorkflowsPage() {
   useInjectReducer(REDUX_NAMESPACE, reducer);
 
   useEffect(() => {
-    dispatch(setWorkflows(workflowsData));
-  }, [workflowsData, dispatch]);
+    dispatch(setWorkflows({ status: workflowsData.status, data: workflowsData.data }));
+  }, [workflowsData.status, workflowsData.data, dispatch]);
 
   // useInjectReducer() runs on the first rendering after useSelector
   // which will return undefined. This helps to avoid too many optional

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/ReviewWorkflows.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/ReviewWorkflows.js
@@ -15,7 +15,7 @@ import { setWorkflow } from './actions';
 export function ReviewWorkflowsPage() {
   const { formatMessage } = useIntl();
   const { workflows: workflowsData } = useReviewWorkflows();
-  const workflow = useSelector((state) => state?.[REDUX_NAMESPACE]);
+  const state = useSelector((state) => state?.[REDUX_NAMESPACE]);
   const dispatch = useDispatch();
 
   useInjectReducer(REDUX_NAMESPACE, reducer);
@@ -27,9 +27,11 @@ export function ReviewWorkflowsPage() {
   // useInjectReducer() runs on the first rendering after useSelector
   // which will return undefined. This helps to avoid too many optional
   // chaining operators down the component.
-  if (!workflow) {
+  if (!state) {
     return null;
   }
+
+  const { workflows } = state;
 
   return (
     <Layout>
@@ -58,11 +60,11 @@ export function ReviewWorkflowsPage() {
               id: 'Settings.review-workflows.page.subtitle',
               defaultMessage: '{count, plural, one {# stage} other {# stages}}',
             },
-            { count: workflow.workflows.stages.length }
+            { count: workflows.stages.length }
           )}
         />
         <ContentLayout>
-          {workflow.workflows.state === 'loading' ? (
+          {workflows.state === 'loading' ? (
             <Loader>
               {formatMessage({
                 id: 'Settings.review-workflows.page.isLoading',
@@ -70,7 +72,7 @@ export function ReviewWorkflowsPage() {
               })}
             </Loader>
           ) : (
-            <Stages stages={workflow.workflows.stages} />
+            <Stages stages={workflows.stages} />
           )}
         </ContentLayout>
       </Main>

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/ReviewWorkflows.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/ReviewWorkflows.js
@@ -10,7 +10,7 @@ import { reducer } from './reducer';
 import { REDUX_NAMESPACE } from './constants';
 import { useInjectReducer } from '../../../../../../admin/src/hooks/useInjectReducer';
 import { useReviewWorkflows } from './hooks/useReviewWorkflows';
-import { setWorkflowLoadingState, setWorkflowStages } from './actions';
+import { setWorkflow } from './actions';
 
 export function ReviewWorkflowsPage() {
   const { formatMessage } = useIntl();
@@ -21,12 +21,8 @@ export function ReviewWorkflowsPage() {
   useInjectReducer(REDUX_NAMESPACE, reducer);
 
   useEffect(() => {
-    dispatch(setWorkflowLoadingState(workflowsData.status));
-
-    if (workflowsData.status === 'success') {
-      dispatch(setWorkflowStages(workflowsData.data));
-    }
-  }, [workflowsData.status, workflowsData.data, dispatch]);
+    dispatch(setWorkflow(workflowsData));
+  }, [workflowsData, dispatch]);
 
   // useInjectReducer() runs on the first rendering after useSelector
   // which will return undefined. This helps to avoid too many optional

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/ReviewWorkflows.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/ReviewWorkflows.js
@@ -64,7 +64,7 @@ export function ReviewWorkflowsPage() {
           )}
         />
         <ContentLayout>
-          {workflows.state === 'loading' ? (
+          {workflows.status === 'loading' ? (
             <Loader>
               {formatMessage({
                 id: 'Settings.review-workflows.page.isLoading',

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/ReviewWorkflows.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/ReviewWorkflows.js
@@ -10,7 +10,7 @@ import { reducer } from './reducer';
 import { REDUX_NAMESPACE } from './constants';
 import { useInjectReducer } from '../../../../../../admin/src/hooks/useInjectReducer';
 import { useReviewWorkflows } from './hooks/useReviewWorkflows';
-import { setWorkflow } from './actions';
+import { setWorkflows } from './actions';
 
 export function ReviewWorkflowsPage() {
   const { formatMessage } = useIntl();
@@ -21,7 +21,7 @@ export function ReviewWorkflowsPage() {
   useInjectReducer(REDUX_NAMESPACE, reducer);
 
   useEffect(() => {
-    dispatch(setWorkflow(workflowsData));
+    dispatch(setWorkflows(workflowsData));
   }, [workflowsData, dispatch]);
 
   // useInjectReducer() runs on the first rendering after useSelector
@@ -31,7 +31,12 @@ export function ReviewWorkflowsPage() {
     return null;
   }
 
-  const { workflows } = state;
+  const {
+    status,
+    serverState: { workflows },
+  } = state;
+
+  const defaultWorkflow = workflows[0] ?? {};
 
   return (
     <Layout>
@@ -60,11 +65,11 @@ export function ReviewWorkflowsPage() {
               id: 'Settings.review-workflows.page.subtitle',
               defaultMessage: '{count, plural, one {# stage} other {# stages}}',
             },
-            { count: workflows.stages.length }
+            { count: defaultWorkflow.stages?.length ?? 0 }
           )}
         />
         <ContentLayout>
-          {workflows.status === 'loading' ? (
+          {status === 'loading' ? (
             <Loader>
               {formatMessage({
                 id: 'Settings.review-workflows.page.isLoading',
@@ -72,7 +77,7 @@ export function ReviewWorkflowsPage() {
               })}
             </Loader>
           ) : (
-            <Stages stages={workflows.stages} />
+            <Stages stages={defaultWorkflow.stages} />
           )}
         </ContentLayout>
       </Main>

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/actions/index.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/actions/index.js
@@ -1,11 +1,13 @@
-import { ACTION_SET_WORKFLOW } from '../constants';
+import { ACTION_SET_WORKFLOWS } from '../constants';
 
-export function setWorkflow(reactQueryWorkflowResponse) {
+export function setWorkflows(reactQueryWorkflowResponse) {
+  const payload = {
+    status: reactQueryWorkflowResponse.status,
+    workflows: reactQueryWorkflowResponse.data,
+  };
+
   return {
-    type: ACTION_SET_WORKFLOW,
-    payload: {
-      status: reactQueryWorkflowResponse.status,
-      stages: reactQueryWorkflowResponse.data,
-    },
+    type: ACTION_SET_WORKFLOWS,
+    payload,
   };
 }

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/actions/index.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/actions/index.js
@@ -1,0 +1,19 @@
+import { ACTION_SET_LOADING_STATE, ACTION_SET_STAGES } from '../constants';
+
+export function setWorkflowLoadingState(state) {
+  return {
+    type: ACTION_SET_LOADING_STATE,
+    payload: {
+      state,
+    },
+  };
+}
+
+export function setWorkflowStages(stages) {
+  return {
+    type: ACTION_SET_STAGES,
+    payload: {
+      stages,
+    },
+  };
+}

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/actions/index.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/actions/index.js
@@ -1,13 +1,11 @@
 import { ACTION_SET_WORKFLOWS } from '../constants';
 
-export function setWorkflows(reactQueryWorkflowResponse) {
-  const payload = {
-    status: reactQueryWorkflowResponse.status,
-    workflows: reactQueryWorkflowResponse.data,
-  };
-
+export function setWorkflows({ status, data }) {
   return {
     type: ACTION_SET_WORKFLOWS,
-    payload,
+    payload: {
+      status,
+      workflows: data,
+    },
   };
 }

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/actions/index.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/actions/index.js
@@ -1,19 +1,11 @@
-import { ACTION_SET_LOADING_STATE, ACTION_SET_STAGES } from '../constants';
+import { ACTION_SET_WORKFLOW } from '../constants';
 
-export function setWorkflowLoadingState(state) {
+export function setWorkflow(reactQueryWorkflowResponse) {
   return {
-    type: ACTION_SET_LOADING_STATE,
+    type: ACTION_SET_WORKFLOW,
     payload: {
-      state,
-    },
-  };
-}
-
-export function setWorkflowStages(stages) {
-  return {
-    type: ACTION_SET_STAGES,
-    payload: {
-      stages,
+      state: reactQueryWorkflowResponse.status,
+      stages: reactQueryWorkflowResponse.data,
     },
   };
 }

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/actions/index.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/actions/index.js
@@ -4,7 +4,7 @@ export function setWorkflow(reactQueryWorkflowResponse) {
   return {
     type: ACTION_SET_WORKFLOW,
     payload: {
-      state: reactQueryWorkflowResponse.status,
+      status: reactQueryWorkflowResponse.status,
       stages: reactQueryWorkflowResponse.data,
     },
   };

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/actions/tests/index.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/actions/tests/index.test.js
@@ -1,0 +1,15 @@
+import { setWorkflow } from '..';
+
+import { ACTION_SET_WORKFLOW } from '../../constants';
+
+describe('Admin | Settings | Review Workflow | actions', () => {
+  test('setWorkflow()', () => {
+    expect(setWorkflow({ status: 'loading', data: null, something: 'else' })).toStrictEqual({
+      type: ACTION_SET_WORKFLOW,
+      payload: {
+        status: 'loading',
+        stages: null,
+      },
+    });
+  });
+});

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/actions/tests/index.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/actions/tests/index.test.js
@@ -1,14 +1,14 @@
-import { setWorkflow } from '..';
+import { setWorkflows } from '..';
 
-import { ACTION_SET_WORKFLOW } from '../../constants';
+import { ACTION_SET_WORKFLOWS } from '../../constants';
 
 describe('Admin | Settings | Review Workflow | actions', () => {
-  test('setWorkflow()', () => {
-    expect(setWorkflow({ status: 'loading', data: null, something: 'else' })).toStrictEqual({
-      type: ACTION_SET_WORKFLOW,
+  test('setWorkflows()', () => {
+    expect(setWorkflows({ status: 'loading', data: null, something: 'else' })).toStrictEqual({
+      type: ACTION_SET_WORKFLOWS,
       payload: {
         status: 'loading',
-        stages: null,
+        workflows: null,
       },
     });
   });

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/Stages/Stage/Stage.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/Stages/Stage/Stage.js
@@ -22,7 +22,7 @@ const StyledAccordion = styled(Box)`
   }
 `;
 
-function Stage({ uid, name }) {
+function Stage({ id, name }) {
   const { formatMessage } = useIntl();
   const [isOpen, setIsOpen] = useState(false);
 
@@ -34,7 +34,7 @@ function Stage({ uid, name }) {
           <Grid gap={4}>
             <GridItem col={6}>
               <TextInput
-                name={`stage_name[${uid}]`}
+                name={`stage_name[${id}]`}
                 disabled
                 label={formatMessage({
                   id: 'Settings.review-workflows.stage.name.label',

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/Stages/Stage/tests/Stage.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/Stages/Stage/tests/Stage.test.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { IntlProvider } from 'react-intl';
+
+import { ThemeProvider, lightTheme } from '@strapi/design-system';
+
+import { Stage } from '../Stage';
+
+const STAGES_FIXTURE = {
+  id: 1,
+  name: 'stage-1',
+};
+
+const ComponentFixture = (props) => (
+  <IntlProvider locale="en" messages={{}}>
+    <ThemeProvider theme={lightTheme}>
+      <Stage {...STAGES_FIXTURE} {...props} />
+    </ThemeProvider>
+  </IntlProvider>
+);
+
+const setup = (props) => render(<ComponentFixture {...props} />);
+
+const user = userEvent.setup();
+
+describe('Admin | Settings | Revie Workflow | Stage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render a stage', async () => {
+    const { getByRole, queryByRole } = setup();
+
+    expect(queryByRole('textbox')).not.toBeInTheDocument();
+
+    await user.click(getByRole('button'));
+
+    expect(queryByRole('textbox')).toBeInTheDocument();
+    expect(getByRole('textbox').value).toBe(STAGES_FIXTURE.name);
+  });
+});

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/Stages/Stage/tests/Stage.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/Stages/Stage/tests/Stage.test.js
@@ -24,7 +24,7 @@ const setup = (props) => render(<ComponentFixture {...props} />);
 
 const user = userEvent.setup();
 
-describe('Admin | Settings | Revie Workflow | Stage', () => {
+describe('Admin | Settings | Review Workflow | Stage', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/Stages/Stages.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/Stages/Stages.js
@@ -23,9 +23,9 @@ function Stages({ stages }) {
       <Background background="neutral200" height="100%" width={2} zIndex={1} />
 
       <Stack spacing={6} zIndex={2} position="relative" as="ol">
-        {stages.map(({ uid, ...stage }) => (
-          <Box key={`stage-${uid}`} as="li">
-            <Stage {...{ ...stage, uid }} />
+        {stages.map(({ id, ...stage }) => (
+          <Box key={`stage-${id}`} as="li">
+            <Stage {...{ ...stage, id }} />
           </Box>
         ))}
       </Stack>

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/Stages/tests/Stages.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/Stages/tests/Stages.test.js
@@ -28,7 +28,7 @@ const ComponentFixture = (props) => (
 
 const setup = (props) => render(<ComponentFixture {...props} />);
 
-describe('Admin | Settings | Revie Workflow | Stages', () => {
+describe('Admin | Settings | Review Workflow | Stages', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/Stages/tests/Stages.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/Stages/tests/Stages.test.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
+
+import { ThemeProvider, lightTheme } from '@strapi/design-system';
+
+import { Stages } from '../Stages';
+
+const STAGES_FIXTURE = [
+  {
+    id: 1,
+    name: 'stage-1',
+  },
+
+  {
+    id: 2,
+    name: 'stage-2',
+  },
+];
+
+const ComponentFixture = (props) => (
+  <IntlProvider locale="en" messages={{}}>
+    <ThemeProvider theme={lightTheme}>
+      <Stages stages={STAGES_FIXTURE} {...props} />
+    </ThemeProvider>
+  </IntlProvider>
+);
+
+const setup = (props) => render(<ComponentFixture {...props} />);
+
+describe('Admin | Settings | Revie Workflow | Stages', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render a list of stages', () => {
+    const { getByText } = setup();
+
+    expect(getByText(STAGES_FIXTURE[0].name)).toBeInTheDocument();
+    expect(getByText(STAGES_FIXTURE[1].name)).toBeInTheDocument();
+  });
+});

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/constants.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/constants.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 
 export const REDUX_NAMESPACE = 'settings_review-workflows';
 
-export const ACTION_SET_WORKFLOW = `Settings/Review_Workflows/SET_WORKFLOW`;
+export const ACTION_SET_WORKFLOWS = `Settings/Review_Workflows/SET_WORKFLOWS`;
 
 export const StageType = PropTypes.shape({
   id: PropTypes.number.isRequired,

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/constants.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/constants.js
@@ -2,8 +2,7 @@ import PropTypes from 'prop-types';
 
 export const REDUX_NAMESPACE = 'settings_review-workflows';
 
-export const ACTION_SET_LOADING_STATE = `Settings/Review_Workflows/SET_STATE`;
-export const ACTION_SET_STAGES = `Settings/Review_Workflows/SET_DATA`;
+export const ACTION_SET_WORKFLOW = `Settings/Review_Workflows/SET_WORKFLOW`;
 
 export const StageType = PropTypes.shape({
   id: PropTypes.number.isRequired,

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/constants.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/constants.js
@@ -1,6 +1,11 @@
 import PropTypes from 'prop-types';
 
+export const REDUX_NAMESPACE = 'settings_review-workflows';
+
+export const ACTION_SET_LOADING_STATE = `Settings/Review_Workflows/SET_STATE`;
+export const ACTION_SET_STAGES = `Settings/Review_Workflows/SET_DATA`;
+
 export const StageType = PropTypes.shape({
-  uid: PropTypes.string.isRequired,
+  id: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
 });

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/constants.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/constants.js
@@ -6,6 +6,6 @@ export const ACTION_SET_LOADING_STATE = `Settings/Review_Workflows/SET_STATE`;
 export const ACTION_SET_STAGES = `Settings/Review_Workflows/SET_DATA`;
 
 export const StageType = PropTypes.shape({
-  id: PropTypes.string.isRequired,
+  id: PropTypes.number.isRequired,
   name: PropTypes.string.isRequired,
 });

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/hooks/tests/useReviewWorkflows.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/hooks/tests/useReviewWorkflows.test.js
@@ -34,7 +34,7 @@ function setup(id) {
   });
 }
 
-describe('useReviewWorkflows', () => {
+describe.skip('useReviewWorkflows', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/hooks/tests/useReviewWorkflows.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/hooks/tests/useReviewWorkflows.test.js
@@ -34,7 +34,7 @@ function setup(id) {
   });
 }
 
-describe.skip('useReviewWorkflows', () => {
+describe('useReviewWorkflows', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
@@ -43,30 +43,32 @@ describe.skip('useReviewWorkflows', () => {
     const { get } = useFetchClient();
 
     get.mockResolvedValue({
-      data: [
-        {
-          id: 1,
-          stages: [],
-        },
+      data: {
+        data: [
+          {
+            id: 1,
+            stages: [],
+          },
 
-        {
-          id: 2,
-          stages: [],
-        },
-      ],
+          {
+            id: 2,
+            stages: [],
+          },
+        ],
+      },
     });
 
     const { result, waitFor } = await setup();
 
     expect(result.current.workflows.isLoading).toBe(true);
-    expect(get).toBeCalledWith('/admin/review-workflows/workflows/');
+    expect(get).toBeCalledWith('/admin/review-workflows/workflows/?populate=stages');
 
     await waitFor(() => expect(result.current.workflows.isLoading).toBe(false));
 
     expect(result.current).toStrictEqual(
       expect.objectContaining({
         workflows: expect.objectContaining({
-          data: expect.arrayContaining([{ id: expect.any(String), stages: expect.any(Array) }]),
+          data: expect.arrayContaining([{ id: expect.any(Number), stages: expect.any(Array) }]),
         }),
       })
     );
@@ -78,22 +80,24 @@ describe.skip('useReviewWorkflows', () => {
 
     get.mockResolvedValue({
       data: {
-        id: idFixture,
-        stages: [],
+        data: {
+          id: idFixture,
+          stages: [],
+        },
       },
     });
 
     const { result, waitFor } = await setup(idFixture);
 
     expect(result.current.workflows.isLoading).toBe(true);
-    expect(get).toBeCalledWith(`/admin/review-workflows/workflows/${idFixture}`);
+    expect(get).toBeCalledWith(`/admin/review-workflows/workflows/${idFixture}?populate=stages`);
 
     await waitFor(() => expect(result.current.workflows.isLoading).toBe(false));
 
     expect(result.current).toStrictEqual(
       expect.objectContaining({
         workflows: expect.objectContaining({
-          data: expect.objectContaining({ id: expect.any(String), stages: expect.any(Array) }),
+          data: expect.objectContaining({ id: expect.any(Number), stages: expect.any(Array) }),
         }),
       })
     );

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/hooks/tests/useReviewWorkflows.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/hooks/tests/useReviewWorkflows.test.js
@@ -45,12 +45,12 @@ describe('useReviewWorkflows', () => {
     get.mockResolvedValue({
       data: [
         {
-          id: 'bdb46de2-9b0d-11ed-a8fc-0242ac120002',
+          id: 1,
           stages: [],
         },
 
         {
-          id: 'c57bc2dc-9b0d-11ed-a8fc-0242ac120002',
+          id: 2,
           stages: [],
         },
       ],

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/hooks/tests/useReviewWorkflows.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/hooks/tests/useReviewWorkflows.test.js
@@ -26,10 +26,10 @@ const ComponentFixture = ({ children }) => (
   <QueryClientProvider client={client}>{children}</QueryClientProvider>
 );
 
-function setup(uid) {
+function setup(id) {
   return new Promise((resolve) => {
     act(() => {
-      resolve(renderHook(() => useReviewWorkflows(uid), { wrapper: ComponentFixture }));
+      resolve(renderHook(() => useReviewWorkflows(id), { wrapper: ComponentFixture }));
     });
   });
 }
@@ -39,18 +39,18 @@ describe('useReviewWorkflows', () => {
     jest.clearAllMocks();
   });
 
-  test('fetch all workflows when calling the hook without a workflow uid', async () => {
+  test('fetch all workflows when calling the hook without a workflow id', async () => {
     const { get } = useFetchClient();
 
     get.mockResolvedValue({
       data: [
         {
-          uid: 'bdb46de2-9b0d-11ed-a8fc-0242ac120002',
+          id: 'bdb46de2-9b0d-11ed-a8fc-0242ac120002',
           stages: [],
         },
 
         {
-          uid: 'c57bc2dc-9b0d-11ed-a8fc-0242ac120002',
+          id: 'c57bc2dc-9b0d-11ed-a8fc-0242ac120002',
           stages: [],
         },
       ],
@@ -66,34 +66,34 @@ describe('useReviewWorkflows', () => {
     expect(result.current).toStrictEqual(
       expect.objectContaining({
         workflows: expect.objectContaining({
-          data: expect.arrayContaining([{ uid: expect.any(String), stages: expect.any(Array) }]),
+          data: expect.arrayContaining([{ id: expect.any(String), stages: expect.any(Array) }]),
         }),
       })
     );
   });
 
-  test('fetch a single workflow when calling the hook with a workflow uid', async () => {
+  test('fetch a single workflow when calling the hook with a workflow id', async () => {
     const { get } = useFetchClient();
-    const uidFixture = 'bdb46de2-9b0d-11ed-a8fc-0242ac120002';
+    const idFixture = 1;
 
     get.mockResolvedValue({
       data: {
-        uid: uidFixture,
+        id: idFixture,
         stages: [],
       },
     });
 
-    const { result, waitFor } = await setup(uidFixture);
+    const { result, waitFor } = await setup(idFixture);
 
     expect(result.current.workflows.isLoading).toBe(true);
-    expect(get).toBeCalledWith(`/admin/review-workflows/workflows/${uidFixture}`);
+    expect(get).toBeCalledWith(`/admin/review-workflows/workflows/${idFixture}`);
 
     await waitFor(() => expect(result.current.workflows.isLoading).toBe(false));
 
     expect(result.current).toStrictEqual(
       expect.objectContaining({
         workflows: expect.objectContaining({
-          data: expect.objectContaining({ uid: expect.any(String), stages: expect.any(Array) }),
+          data: expect.objectContaining({ id: expect.any(String), stages: expect.any(Array) }),
         }),
       })
     );

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/hooks/useReviewWorkflows.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/hooks/useReviewWorkflows.js
@@ -2,12 +2,36 @@ import { useQuery } from 'react-query';
 
 import { useFetchClient } from '@strapi/helper-plugin';
 
-export function useReviewWorkflows(workflowUid) {
+export function useReviewWorkflows(workflowId) {
   const { get } = useFetchClient();
 
   async function fetchWorkflows() {
+    /* TODO: mocked for now until the API is ready */
+    return [
+      {
+        id: 'id-1',
+        name: 'To do',
+      },
+
+      {
+        id: 'id-2',
+        name: 'Ready to review',
+      },
+
+      {
+        id: 'id-3',
+        name: 'In progress',
+      },
+
+      {
+        id: 'id-4',
+        name: 'Reviewed',
+      },
+    ];
+
+    // eslint-disable-next-line no-unreachable
     try {
-      const { data } = await get(`/admin/review-workflows/workflows/${workflowUid ?? ''}`);
+      const { data } = await get(`/admin/review-workflows/workflows/${workflowId ?? ''}`);
 
       return data;
     } catch (err) {
@@ -15,7 +39,7 @@ export function useReviewWorkflows(workflowUid) {
     }
   }
 
-  const workflows = useQuery(['review-workflows', workflowUid ?? 'default'], fetchWorkflows);
+  const workflows = useQuery(['review-workflows', workflowId ?? 'default'], fetchWorkflows);
 
   return {
     workflows,

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/hooks/useReviewWorkflows.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/hooks/useReviewWorkflows.js
@@ -6,39 +6,11 @@ export function useReviewWorkflows(workflowId) {
   const { get } = useFetchClient();
 
   async function fetchWorkflows() {
-    /* TODO: mocked for now until the API is ready */
-    return [
-      {
-        id: 1,
-        stages: [
-          {
-            id: 'id-1',
-            name: 'To do',
-          },
-
-          {
-            id: 'id-2',
-            name: 'Ready to review',
-          },
-
-          {
-            id: 'id-3',
-            name: 'In progress',
-          },
-
-          {
-            id: 'id-4',
-            name: 'Reviewed',
-          },
-        ],
-      },
-    ];
-
     // eslint-disable-next-line no-unreachable
     try {
-      const { data } = await get(
-        `/admin/review-workflows/workflows/${workflowId ?? ''}?populate=stages`
-      );
+      const {
+        data: { data },
+      } = await get(`/admin/review-workflows/workflows/${workflowId ?? ''}?populate=stages`);
 
       return data;
     } catch (err) {

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/hooks/useReviewWorkflows.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/hooks/useReviewWorkflows.js
@@ -9,29 +9,36 @@ export function useReviewWorkflows(workflowId) {
     /* TODO: mocked for now until the API is ready */
     return [
       {
-        id: 'id-1',
-        name: 'To do',
-      },
+        id: 1,
+        stages: [
+          {
+            id: 'id-1',
+            name: 'To do',
+          },
 
-      {
-        id: 'id-2',
-        name: 'Ready to review',
-      },
+          {
+            id: 'id-2',
+            name: 'Ready to review',
+          },
 
-      {
-        id: 'id-3',
-        name: 'In progress',
-      },
+          {
+            id: 'id-3',
+            name: 'In progress',
+          },
 
-      {
-        id: 'id-4',
-        name: 'Reviewed',
+          {
+            id: 'id-4',
+            name: 'Reviewed',
+          },
+        ],
       },
     ];
 
     // eslint-disable-next-line no-unreachable
     try {
-      const { data } = await get(`/admin/review-workflows/workflows/${workflowId ?? ''}`);
+      const { data } = await get(
+        `/admin/review-workflows/workflows/${workflowId ?? ''}?populate=stages`
+      );
 
       return data;
     } catch (err) {

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/index.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/index.js
@@ -2,7 +2,7 @@ import produce from 'immer';
 
 import { ACTION_SET_STAGES, ACTION_SET_LOADING_STATE } from '../constants';
 
-const initialState = {
+export const initialState = {
   workflows: {
     state: 'loading',
     stages: [],

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/index.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/index.js
@@ -1,20 +1,29 @@
 import produce from 'immer';
 
-import { ACTION_SET_WORKFLOW } from '../constants';
+import { ACTION_SET_WORKFLOWS } from '../constants';
 
 export const initialState = {
-  workflows: {
-    state: 'loading',
-    stages: [],
+  status: 'loading',
+  serverState: {
+    workflows: [],
+  },
+  clientState: {
+    workflows: [],
   },
 };
 
 export function reducer(state = initialState, action) {
   return produce(state, (draft) => {
     switch (action.type) {
-      case ACTION_SET_WORKFLOW:
-        draft.workflows.status = action.payload.status;
-        draft.workflows.stages = action.payload.stages ?? [];
+      case ACTION_SET_WORKFLOWS:
+        draft.status = action.payload.status;
+
+        if (action.payload.workflows) {
+          draft.serverState.workflows = [
+            ...state.serverState.workflows,
+            ...action.payload.workflows,
+          ];
+        }
         break;
 
       default:

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/index.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/index.js
@@ -1,6 +1,6 @@
 import produce from 'immer';
 
-import { ACTION_SET_STAGES, ACTION_SET_LOADING_STATE } from '../constants';
+import { ACTION_SET_WORKFLOW } from '../constants';
 
 export const initialState = {
   workflows: {
@@ -12,12 +12,9 @@ export const initialState = {
 export function reducer(state = initialState, action) {
   return produce(state, (draft) => {
     switch (action.type) {
-      case ACTION_SET_LOADING_STATE:
+      case ACTION_SET_WORKFLOW:
         draft.workflows.state = action.payload.state;
-        break;
-
-      case ACTION_SET_STAGES:
-        draft.workflows.stages = action.payload.stages;
+        draft.workflows.stages = action.payload.stages ?? [];
         break;
 
       default:

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/index.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/index.js
@@ -13,7 +13,7 @@ export function reducer(state = initialState, action) {
   return produce(state, (draft) => {
     switch (action.type) {
       case ACTION_SET_WORKFLOW:
-        draft.workflows.state = action.payload.state;
+        draft.workflows.status = action.payload.status;
         draft.workflows.stages = action.payload.stages ?? [];
         break;
 

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/index.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/index.js
@@ -1,0 +1,27 @@
+import produce from 'immer';
+
+import { ACTION_SET_STAGES, ACTION_SET_LOADING_STATE } from '../constants';
+
+const initialState = {
+  workflows: {
+    state: 'loading',
+    stages: [],
+  },
+};
+
+export function reducer(state = initialState, action) {
+  return produce(state, (draft) => {
+    switch (action.type) {
+      case ACTION_SET_LOADING_STATE:
+        draft.workflows.state = action.payload.state;
+        break;
+
+      case ACTION_SET_STAGES:
+        draft.workflows.stages = action.payload.stages;
+        break;
+
+      default:
+        break;
+    }
+  });
+}

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/tests/index.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/tests/index.test.js
@@ -28,14 +28,14 @@ describe('Admin | Settings | Review Workflows | reducer', () => {
   test('should handle ACTION_SET_LOADING_STATE', () => {
     const action = {
       type: ACTION_SET_WORKFLOW,
-      payload: { state: 'loading-state', stages: STAGES_FIXTURE },
+      payload: { status: 'loading-state', stages: STAGES_FIXTURE },
     };
 
     expect(reducer(state, action)).toEqual({
       ...initialState,
       workflows: {
         ...initialState.workflows,
-        state: 'loading-state',
+        status: 'loading-state',
         stages: STAGES_FIXTURE,
       },
     });

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/tests/index.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/tests/index.test.js
@@ -1,16 +1,21 @@
 import { initialState, reducer } from '..';
 
-import { ACTION_SET_WORKFLOW } from '../../constants';
+import { ACTION_SET_WORKFLOWS } from '../../constants';
 
-const STAGES_FIXTURE = [
+const WORKFLOWS_FIXTURE = [
   {
     id: 1,
-    name: 'stage-1',
-  },
+    stages: [
+      {
+        id: 1,
+        name: 'stage-1',
+      },
 
-  {
-    id: 2,
-    name: 'stage-2',
+      {
+        id: 2,
+        name: 'stage-2',
+      },
+    ],
   },
 ];
 
@@ -22,21 +27,24 @@ describe('Admin | Settings | Review Workflows | reducer', () => {
   });
 
   test('should return the initialState', () => {
-    expect(reducer(state, {})).toEqual(initialState);
+    expect(reducer(state, {})).toStrictEqual(initialState);
   });
 
-  test('should handle ACTION_SET_WORKFLOW', () => {
+  test('should handle ACTION_SET_WORKFLOWS', () => {
     const action = {
-      type: ACTION_SET_WORKFLOW,
-      payload: { status: 'loading-state', stages: STAGES_FIXTURE },
+      type: ACTION_SET_WORKFLOWS,
+      payload: { status: 'loading-state', workflows: WORKFLOWS_FIXTURE },
     };
 
     expect(reducer(state, action)).toEqual({
       ...initialState,
-      workflows: {
-        ...initialState.workflows,
-        status: 'loading-state',
-        stages: STAGES_FIXTURE,
+      status: 'loading-state',
+      serverState: {
+        ...initialState.serverState,
+        workflows: [...initialState.serverState.workflows, ...WORKFLOWS_FIXTURE],
+      },
+      clientState: {
+        workflows: [],
       },
     });
   });

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/tests/index.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/tests/index.test.js
@@ -25,7 +25,7 @@ describe('Admin | Settings | Review Workflows | reducer', () => {
     expect(reducer(state, {})).toEqual(initialState);
   });
 
-  test('should handle ACTION_SET_LOADING_STATE', () => {
+  test('should handle ACTION_SET_WORKFLOW', () => {
     const action = {
       type: ACTION_SET_WORKFLOW,
       payload: { status: 'loading-state', stages: STAGES_FIXTURE },

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/tests/index.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/tests/index.test.js
@@ -1,6 +1,6 @@
 import { initialState, reducer } from '..';
 
-import { ACTION_SET_LOADING_STATE, ACTION_SET_STAGES } from '../../constants';
+import { ACTION_SET_WORKFLOW } from '../../constants';
 
 const STAGES_FIXTURE = [
   {
@@ -26,24 +26,16 @@ describe('Admin | Settings | Review Workflows | reducer', () => {
   });
 
   test('should handle ACTION_SET_LOADING_STATE', () => {
-    const action = { type: ACTION_SET_LOADING_STATE, payload: { state: 'loading-state' } };
+    const action = {
+      type: ACTION_SET_WORKFLOW,
+      payload: { state: 'loading-state', stages: STAGES_FIXTURE },
+    };
 
     expect(reducer(state, action)).toEqual({
       ...initialState,
       workflows: {
         ...initialState.workflows,
         state: 'loading-state',
-      },
-    });
-  });
-
-  test('should handle ACTION_SET_STAGES', () => {
-    const action = { type: ACTION_SET_STAGES, payload: { stages: STAGES_FIXTURE } };
-
-    expect(reducer(state, action)).toEqual({
-      ...initialState,
-      workflows: {
-        ...initialState.workflows,
         stages: STAGES_FIXTURE,
       },
     });

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/tests/index.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/tests/index.test.js
@@ -30,7 +30,7 @@ describe('Admin | Settings | Review Workflows | reducer', () => {
     expect(reducer(state, {})).toStrictEqual(initialState);
   });
 
-  test('should handle ACTION_SET_WORKFLOWS', () => {
+  test('should handle ACTION_SET_WORKFLOWS with workflows', () => {
     const action = {
       type: ACTION_SET_WORKFLOWS,
       payload: { status: 'loading-state', workflows: WORKFLOWS_FIXTURE },
@@ -42,6 +42,24 @@ describe('Admin | Settings | Review Workflows | reducer', () => {
       serverState: {
         ...initialState.serverState,
         workflows: [...initialState.serverState.workflows, ...WORKFLOWS_FIXTURE],
+      },
+      clientState: {
+        workflows: [],
+      },
+    });
+  });
+
+  test('should handle ACTION_SET_WORKFLOWS without workflows', () => {
+    const action = {
+      type: ACTION_SET_WORKFLOWS,
+      payload: { status: 'loading', workflows: null },
+    };
+
+    expect(reducer(state, action)).toEqual({
+      ...initialState,
+      serverState: {
+        ...initialState.serverState,
+        workflows: [],
       },
       clientState: {
         workflows: [],

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/tests/index.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/tests/index.test.js
@@ -1,0 +1,51 @@
+import { initialState, reducer } from '..';
+
+import { ACTION_SET_LOADING_STATE, ACTION_SET_STAGES } from '../../constants';
+
+const STAGES_FIXTURE = [
+  {
+    id: 1,
+    name: 'stage-1',
+  },
+
+  {
+    id: 2,
+    name: 'stage-2',
+  },
+];
+
+describe('Admin | Settings | Review Workflows | reducer', () => {
+  let state;
+
+  beforeEach(() => {
+    state = initialState;
+  });
+
+  test('should return the initialState', () => {
+    expect(reducer(state, {})).toEqual(initialState);
+  });
+
+  test('should handle ACTION_SET_LOADING_STATE', () => {
+    const action = { type: ACTION_SET_LOADING_STATE, payload: { state: 'loading-state' } };
+
+    expect(reducer(state, action)).toEqual({
+      ...initialState,
+      workflows: {
+        ...initialState.workflows,
+        state: 'loading-state',
+      },
+    });
+  });
+
+  test('should handle ACTION_SET_STAGES', () => {
+    const action = { type: ACTION_SET_STAGES, payload: { stages: STAGES_FIXTURE } };
+
+    expect(reducer(state, action)).toEqual({
+      ...initialState,
+      workflows: {
+        ...initialState.workflows,
+        stages: STAGES_FIXTURE,
+      },
+    });
+  });
+});

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/tests/ReviewWorkflows.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/tests/ReviewWorkflows.test.js
@@ -1,0 +1,86 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
+import { Provider } from 'react-redux';
+import { QueryClientProvider, QueryClient } from 'react-query';
+
+import { ThemeProvider, lightTheme } from '@strapi/design-system';
+
+import configureStore from '../../../../../../../admin/src/core/store/configureStore';
+import ReviewWorkflowsPage from '..';
+import { reducer } from '../reducer';
+import { useReviewWorkflows } from '../hooks/useReviewWorkflows';
+
+jest.mock('../hooks/useReviewWorkflows', () => ({
+  ...jest.requireActual('../hooks/useReviewWorkflows'),
+  useReviewWorkflows: jest.fn().mockReturnValue({
+    workflows: {
+      status: 'loading',
+      data: null,
+    },
+  }),
+}));
+
+const client = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+    },
+  },
+});
+
+const ComponentFixture = () => {
+  const store = configureStore([], [reducer]);
+
+  return (
+    <QueryClientProvider client={client}>
+      <Provider store={store}>
+        <IntlProvider locale="en" messages={{}}>
+          <ThemeProvider theme={lightTheme}>
+            <ReviewWorkflowsPage />
+          </ThemeProvider>
+        </IntlProvider>
+      </Provider>
+    </QueryClientProvider>
+  );
+};
+
+const setup = (props) => render(<ComponentFixture {...props} />);
+
+describe('Admin | Settings | Review Workflow | ReviewWorkflowsPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('handle initial loading state', () => {
+    const { getByText } = setup();
+
+    expect(getByText('0 stages')).toBeInTheDocument();
+    expect(getByText('Workflow is loading')).toBeInTheDocument();
+  });
+
+  test('handle loaded stage', () => {
+    useReviewWorkflows.mockReturnValue({
+      workflows: {
+        status: 'success',
+        data: [
+          {
+            id: 1,
+            stages: [
+              {
+                id: 1,
+                name: 'stage-1',
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const { getByText, queryByText } = setup();
+
+    expect(getByText('1 stage')).toBeInTheDocument();
+    expect(queryByText('Workflow is loading')).not.toBeInTheDocument();
+    expect(getByText('stage-1')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
### What does it do?

This PR wires up a few things:

- `useInjectReducer`: https://github.com/strapi/strapi/pull/15570
- `useReviewWorkflows`: https://github.com/strapi/strapi/pull/15528
- the UI

### Why is it needed?

With this PR we have a working implementation of the various pieces and can glue together data-fetching, state-management and the UI.

I will add more tests in a follow-up PR.