### PR TITLE
fix: reducer for required single components relation

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/reducer.js
+++ b/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/reducer.js
@@ -192,7 +192,7 @@ const reducer = (state, action) =>
           set(draftState, path, [value]);
         } else {
           const modifiedDataRelations = get(state, path);
-          const newRelations = [...modifiedDataRelations, value];
+          const newRelations = modifiedDataRelations ? [...modifiedDataRelations, value] : [value];
           set(draftState, path, newRelations);
         }
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does this do?

To be able to add when creating a new required single component relationship.

### Why is it necessary?

When creating a new single component relationship, you will get a spread syntax error because `modifiedDataRelations` will be `undefined`. Fix to spread syntax when there is a value.

### How will you test it?

Tested that it can be added without error when modifying the sample project and creating a new single component relation.

### Related Issues/PRs.

https://github.com/strapi/strapi/issues/15150

