### PR TITLE
Fixing issue #15413

### DIFF
--- a/packages/core/content-type-builder/admin/src/components/AttributeIcon/index.js
+++ b/packages/core/content-type-builder/admin/src/components/AttributeIcon/index.js
@@ -56,6 +56,7 @@ const IconBox = styled(Box)`
   width: ${pxToRem(32)};
   height: ${pxToRem(24)};
   box-sizing: content-box;
+  flex-shrink: 0;
 `;
 
 const AttributeIcon = ({ type, customField, ...rest }) => {


### PR DESCRIPTION


### What does it do?

Fix issue #15413

### Why is it needed?

Icons dimension in the CTB is correct now, regardless of the length of the attribute text description.

### How to test it?

Edit the text of a CTB attribute, making it longer and longer.

### Related issue(s)/PR(s)

#15413
