### PR TITLE
[DEITS] Groundwork for transfer authorization

### DIFF
--- a/packages/core/admin/server/register.js
+++ b/packages/core/admin/server/register.js
@@ -17,10 +17,7 @@ module.exports = ({ strapi }) => {
     registerAdminPanelRoute({ strapi });
   }
 
-  if (
-    process.env.STRAPI_EXPERIMENTAL === 'true' &&
-    process.env.STRAPI_DISABLE_REMOTE_DATA_TRANSFER !== 'true'
-  ) {
+  if (process.env.STRAPI_DISABLE_REMOTE_DATA_TRANSFER !== 'true') {
     registerDataTransferRoute(strapi);
   }
 };

--- a/packages/core/data-transfer/src/strapi/remote/constants.ts
+++ b/packages/core/data-transfer/src/strapi/remote/constants.ts
@@ -1,2 +1,3 @@
 export const TRANSFER_PATH = '/transfer';
 export const TRANSFER_METHODS = ['push', 'pull'];
+export const TRANSFER_KEY_HEADER_KEY = 'StrapiTransferKey';

--- a/packages/core/data-transfer/src/strapi/remote/constants.ts
+++ b/packages/core/data-transfer/src/strapi/remote/constants.ts
@@ -1,3 +1,3 @@
 export const TRANSFER_PATH = '/transfer';
 export const TRANSFER_METHODS = ['push', 'pull'];
-export const TRANSFER_KEY_HEADER_KEY = 'StrapiTransferKey';
+export const TRANSFER_KEY_HEADER_KEY = 'strapitransferkey'; // needs to be lowercase because that's how it gets converted in koa ctx.headers

--- a/packages/core/data-transfer/src/strapi/remote/handlers.ts
+++ b/packages/core/data-transfer/src/strapi/remote/handlers.ts
@@ -17,26 +17,28 @@ interface ITransferState {
 }
 
 /**
- * retrieve the token permissions from the database
+ * TODO: This is just a stub until we implement the actual transfer keys
  */
-const validateTransferToken = (token?: string): string[] => {
-  if (!token) {
-    // TODO: should be a @strapi/utils.error.ForbiddenError
-    throw new Error('A valid transfer token is required to access this route');
+const PULL_PERMISSION = 'data-transfer::pull';
+const PUSH_PERMISSION = 'data-transfer::push';
+const validateTransferKey = (key?: string): string[] => {
+  if (!key) {
+    // TODO: should be a @strapi/utils.error.ForbiddenError but we need to add typings for it
+    throw new Error('A valid transfer key is required to access this route');
   }
 
   const actions = [];
-  // TODO: add token validation
-  if (token.includes('push')) {
-    actions.push('data-transfer::push');
+  // TODO: add actual validation
+  if (key.includes('push')) {
+    actions.push(PUSH_PERMISSION);
   }
-  if (token.includes('pull')) {
-    actions.push('data-transfer::pull');
+  if (key.includes('pull')) {
+    actions.push(PULL_PERMISSION);
   }
 
   if (actions.length <= 0) {
-    // TODO: should be a @strapi/utils.error.AuthorizationError
-    throw new Error('Invalid transfer token');
+    // TODO: should be a @strapi/utils.error.ForbiddenError but we need to add typings for it
+    throw new Error('Invalid transfer key');
   }
 
   return actions;
@@ -53,7 +55,7 @@ export const createTransferHandler = (options: ServerOptions = {}) => {
       .map((s) => s.trim().toLowerCase());
 
     if (upgradeHeader.includes('websocket')) {
-      const actions = validateTransferToken(ctx.request.headers.authorization);
+      const actions = validateTransferKey(ctx.request.headers.authorization);
 
       wss.handleUpgrade(ctx.req, ctx.request.socket, Buffer.alloc(0), (ws) => {
         // Create a connection between the client & the server
@@ -126,8 +128,8 @@ export const createTransferHandler = (options: ServerOptions = {}) => {
 
           // Push transfer
           if (transfer === 'push') {
-            if (actions.includes('data-transfer::push')) {
-              throw new ProviderTransferError('Token does not include push permission');
+            if (actions.includes(PUSH_PERMISSION)) {
+              throw new ProviderTransferError('Transfer key does not allow push permission');
             }
             const { options: controllerOptions } = msg.params;
 

--- a/packages/core/data-transfer/src/strapi/remote/handlers.ts
+++ b/packages/core/data-transfer/src/strapi/remote/handlers.ts
@@ -23,7 +23,7 @@ const PULL_PERMISSION = 'data-transfer::pull';
 const PUSH_PERMISSION = 'data-transfer::push';
 const validateTransferKey = (key?: string): string[] => {
   if (!key) {
-    // TODO: should be a @strapi/utils.error.ForbiddenError but we need to add typings for it
+    // TODO: should be a @strapi/utils.error.Unauthorized but we need to add typings for it
     throw new Error('A valid transfer key is required to access this route');
   }
 

--- a/packages/core/data-transfer/src/strapi/remote/routes.ts
+++ b/packages/core/data-transfer/src/strapi/remote/routes.ts
@@ -32,7 +32,7 @@ export const registerAdminTransferRoute = (strapi: Strapi.Strapi) => {
     path: TRANSFER_PATH,
     handler: createTransferHandler(),
     config: {
-      auth: false,
+      auth: false, // anyone can access, but if transfer token is not included it will not allow a connection
     },
   });
 };

--- a/packages/core/data-transfer/src/strapi/remote/routes.ts
+++ b/packages/core/data-transfer/src/strapi/remote/routes.ts
@@ -31,6 +31,8 @@ export const registerAdminTransferRoute = (strapi: Strapi.Strapi) => {
     method: 'GET',
     path: TRANSFER_PATH,
     handler: createTransferHandler(),
-    config: { auth: false },
+    config: {
+      policies: ['admin::isAuthenticatedAdmin'],
+    },
   });
 };

--- a/packages/core/data-transfer/src/strapi/remote/routes.ts
+++ b/packages/core/data-transfer/src/strapi/remote/routes.ts
@@ -32,7 +32,7 @@ export const registerAdminTransferRoute = (strapi: Strapi.Strapi) => {
     path: TRANSFER_PATH,
     handler: createTransferHandler(),
     config: {
-      policies: ['admin::isAuthenticatedAdmin'],
+      auth: false,
     },
   });
 };

--- a/packages/core/data-transfer/src/strapi/remote/routes.ts
+++ b/packages/core/data-transfer/src/strapi/remote/routes.ts
@@ -32,7 +32,7 @@ export const registerAdminTransferRoute = (strapi: Strapi.Strapi) => {
     path: TRANSFER_PATH,
     handler: createTransferHandler(),
     config: {
-      auth: false, // anyone can access, but if transfer token is not included it will not allow a connection
+      auth: false, // anyone can access, but if transfer key is not included it will not allow a connection
     },
   });
 };

--- a/packages/core/strapi/bin/strapi.js
+++ b/packages/core/strapi/bin/strapi.js
@@ -273,59 +273,63 @@ program
   .option('-s, --silent', `Run the generation silently, without any output`, false)
   .action(getLocalScript('ts/generate-types'));
 
-if (process.env.STRAPI_EXPERIMENTAL === 'true') {
-  // `$ strapi transfer`
-  program
-    .command('transfer')
-    .description('Transfer data from one source to another')
-    .allowExcessArguments(false)
-    .addOption(
-      new Option(
-        '--from <sourceURL>',
-        `URL of the remote Strapi instance to get data from`
-      ).argParser(parseURL)
+// `$ strapi transfer`
+program
+  .command('transfer')
+  .description('Transfer data from one source to another')
+  .allowExcessArguments(false)
+  .addOption(
+    new Option(
+      '--from <sourceURL>',
+      `URL of the remote Strapi instance to get data from`
+    ).argParser(parseURL)
+  )
+  .addOption(
+    new Option('--fromToken <token>', `transfer token for remote Strapi instance to pull data from`)
+  )
+  .addOption(
+    new Option(
+      '--to <destinationURL>',
+      `URL of the remote Strapi instance to send data to`
+    ).argParser(parseURL)
+  )
+  .addOption(
+    new Option('--toToken <token>', `transfer token for remote Strapi instance to push data to`)
+  )
+  .addOption(forceOption)
+  // Validate URLs
+  .hook(
+    'preAction',
+    ifOptions(
+      (opts) => opts.from,
+      (thisCommand) => assertUrlHasProtocol(thisCommand.opts().from, ['https:', 'http:'])
     )
-    .addOption(
-      new Option(
-        '--to <destinationURL>',
-        `URL of the remote Strapi instance to send data to`
-      ).argParser(parseURL)
+  )
+  .hook(
+    'preAction',
+    ifOptions(
+      (opts) => opts.to,
+      (thisCommand) => assertUrlHasProtocol(thisCommand.opts().to, ['https:', 'http:'])
     )
-    .addOption(forceOption)
-    // Validate URLs
-    .hook(
-      'preAction',
-      ifOptions(
-        (opts) => opts.from,
-        (thisCommand) => assertUrlHasProtocol(thisCommand.opts().from, ['https:', 'http:'])
-      )
+  )
+  .hook(
+    'preAction',
+    ifOptions(
+      (opts) => !opts.from && !opts.to,
+      () => exitWith(1, 'At least one source (from) or destination (to) option must be provided')
     )
-    .hook(
-      'preAction',
-      ifOptions(
-        (opts) => opts.to,
-        (thisCommand) => assertUrlHasProtocol(thisCommand.opts().to, ['https:', 'http:'])
-      )
+  )
+  .addOption(forceOption)
+  .addOption(excludeOption)
+  .addOption(onlyOption)
+  .hook('preAction', validateExcludeOnly)
+  .hook(
+    'preAction',
+    confirmMessage(
+      'The import will delete all data in the remote database. Are you sure you want to proceed?'
     )
-    .hook(
-      'preAction',
-      ifOptions(
-        (opts) => !opts.from && !opts.to,
-        () => exitWith(1, 'At least one source (from) or destination (to) option must be provided')
-      )
-    )
-    .addOption(forceOption)
-    .addOption(excludeOption)
-    .addOption(onlyOption)
-    .hook('preAction', validateExcludeOnly)
-    .hook(
-      'preAction',
-      confirmMessage(
-        'The import will delete all data in the remote database. Are you sure you want to proceed?'
-      )
-    )
-    .action(getLocalScript('transfer/transfer'));
-}
+  )
+  .action(getLocalScript('transfer/transfer'));
 
 // `$ strapi export`
 program

--- a/packages/core/strapi/bin/strapi.js
+++ b/packages/core/strapi/bin/strapi.js
@@ -285,7 +285,7 @@ program
     ).argParser(parseURL)
   )
   .addOption(
-    new Option('--fromToken <token>', `transfer token for remote Strapi instance to pull data from`)
+    new Option('--from-key <key>', `transfer key for remote Strapi instance to pull data from`)
   )
   .addOption(
     new Option(
@@ -294,7 +294,7 @@ program
     ).argParser(parseURL)
   )
   .addOption(
-    new Option('--toToken <token>', `transfer token for remote Strapi instance to push data to`)
+    new Option('--to-key <key>', `transfer key for remote Strapi instance to push data to`)
   )
   .addOption(forceOption)
   // Validate URLs

--- a/packages/core/strapi/lib/commands/transfer/transfer.js
+++ b/packages/core/strapi/lib/commands/transfer/transfer.js
@@ -25,12 +25,14 @@ const logger = console;
  *
  * @property {URL|undefined} [to] The url of a remote Strapi to use as remote destination
  * @property {URL|undefined} [from] The url of a remote Strapi to use as remote source
+ * @property {string|undefined} [toKey] The transfer key to use for a remote destination
+ * @property {string|undefined} [fromKey] The transfer key to use for a remote source
  */
 
 /**
  * Transfer command.
  *
- * It transfers data from a local file to a local strapi instance
+ * Transfers data between local Strapi and remote Strapi instances
  *
  * @param {TransferCommandOptions} opts
  */

--- a/packages/core/strapi/lib/commands/transfer/transfer.js
+++ b/packages/core/strapi/lib/commands/transfer/transfer.js
@@ -73,7 +73,10 @@ module.exports = async (opts) => {
   else {
     destination = createRemoteStrapiDestinationProvider({
       url: opts.to,
-      auth: false,
+      auth: {
+        type: 'key',
+        key: opts.toKey,
+      },
       strategy: 'restore',
       restore: {
         entities: { exclude: DEFAULT_IGNORED_CONTENT_TYPES },


### PR DESCRIPTION
Draft until we decide on terminology

### What does it do?

- enables the transfer CLI without experimental options
- adds toKey and fromKey to CLI
- passes keys from CLI to remote provider
- passes keys from remote provider to remote Strapi websocket via custom header **
- [Stub only; to be implemented later] adds key validation before opening a websocket
- only instantiate the websocket server on registration, not on every call to the transfer route
- rename token -> key everywhere throughout the transfer code

** I didn't use the "Authorization: Bearer (key)" header because a transfer key does not provide admin authorization, and we could in theory still use that for, for example, requiring an admin auth login PLUS a transfer key, using the websocket for a non-transfer operation, etc. Additionally, I didn't want to add an "authStrategy" to Strapi because so far those only exist for the content API whereas the admin API just has a singular passport authentication, and these transfer keys also don't provide general admin API authorization.

Update: After thinking about it more in regards to status codes, that might mean that we should always return a 403 FORBIDDEN because the spec says 401 UNAUTHORIZED specifically relates to a missing Authorization header. If anyone has any opinions here, please share.

### Why is it needed?

To officially start the transfer command implementation

### How to test it?

- Start a Strapi instance
- Run `yarn strapi transfer --to http://yourstrapiURL/admin --toKey=push` and a websocket connection should be opened, then a push transfer should be initiated
- Run `yarn strapi transfer --to http://yourstrapiURL/admin --toKey=wrong` and you should receive an http FORBIDDEN error instead of a websocket connection
- Run `yarn strapi transfer --to http://yourstrapiURL/admin` and you should receive an http UNAUTHORIZED instead of a websocket connection

### What this doesn't do

- This does not provide the final architecture for validateTransferKey, but this is an initial implementation to start building on. The call to that method will probably remain the same, but the use of actions will almost certainly differ
- No pretty error messages for the transfer responses; we'll improve those later
