### PR TITLE
[Fix]: Support avif and heif image formats in upload plugin

### DIFF
--- a/packages/core/upload/server/services/image-manipulation.js
+++ b/packages/core/upload/server/services/image-manipulation.js
@@ -10,8 +10,8 @@ const sharp = require('sharp');
 const { getService } = require('../utils');
 const { bytesToKbytes, writableDiscardStream } = require('../utils/file');
 
-const FORMATS_TO_PROCESS = ['jpeg', 'png', 'webp', 'tiff', 'svg', 'gif', 'avif', 'heif'];
-const FORMATS_TO_OPTIMIZE = ['jpeg', 'png', 'webp', 'tiff', 'avif', 'heif'];
+const FORMATS_TO_PROCESS = ['jpeg', 'png', 'webp', 'tiff', 'svg', 'gif', 'avif'];
+const FORMATS_TO_OPTIMIZE = ['jpeg', 'png', 'webp', 'tiff', 'avif'];
 
 const writeStreamToFile = (stream, path) =>
   new Promise((resolve, reject) => {

--- a/packages/core/upload/server/services/image-manipulation.js
+++ b/packages/core/upload/server/services/image-manipulation.js
@@ -10,8 +10,8 @@ const sharp = require('sharp');
 const { getService } = require('../utils');
 const { bytesToKbytes, writableDiscardStream } = require('../utils/file');
 
-const FORMATS_TO_PROCESS = ['jpeg', 'png', 'webp', 'tiff', 'svg', 'gif'];
-const FORMATS_TO_OPTIMIZE = ['jpeg', 'png', 'webp', 'tiff'];
+const FORMATS_TO_PROCESS = ['jpeg', 'png', 'webp', 'tiff', 'svg', 'gif', 'avif', 'heif'];
+const FORMATS_TO_OPTIMIZE = ['jpeg', 'png', 'webp', 'tiff', 'avif', 'heif'];
 
 const writeStreamToFile = (stream, path) =>
   new Promise((resolve, reject) => {


### PR DESCRIPTION
### What does it do?

Support avif and heif formats in upload plugin. Specially avif is commonly used in web dev because of the compression rate it gives.

### Why is it needed?

Fixes https://github.com/strapi/strapi/issues/14857

### How to test it?

Upload [avif image ](https://libre-software.net/wp-content/uploads/AVIF/AVIF%20test%20file%20-%20Your%20browser%20%28software%29%20supports%20AVIF%20%28Quality%2025%29.avif) . 

And you should see the dimensions of the image.


### Related issue(s)/PR(s)

https://github.com/strapi/strapi/issues/14857
