### PR TITLE
fix bad json parsing

### DIFF
--- a/packages/core/database/lib/fields/json.js
+++ b/packages/core/database/lib/fields/json.js
@@ -4,11 +4,14 @@ const Field = require('./field');
 
 class JSONField extends Field {
   toDB(value) {
-    try {
-      JSON.parse(value);
-    } catch (e) {
-      throw new Error(`Invalid JSON value`);
+    if (typeof value !== 'object') {
+      try {
+        JSON.parse(value);
+      } catch (e) {
+        throw new Error(`Invalid JSON value`);
+      }
     }
+
     return JSON.stringify(value);
   }
 

--- a/packages/core/database/lib/fields/json.js
+++ b/packages/core/database/lib/fields/json.js
@@ -4,11 +4,22 @@ const Field = require('./field');
 
 class JSONField extends Field {
   toDB(value) {
+    try {
+      JSON.parse(value);
+    } catch (e) {
+      throw new Error(`Invalid JSON value`);
+    }
     return JSON.stringify(value);
   }
 
   fromDB(value) {
-    if (typeof value === 'string') return JSON.parse(value);
+    if (typeof value === 'string') {
+      try {
+        return JSON.parse(value);
+      } catch (e) {
+        throw new Error(`Invalid JSON value`);
+      }
+    }
     return value;
   }
 }


### PR DESCRIPTION
Fixes: https://github.com/strapi/strapi/issues/15496

This will check that the JSON is valid when added to the database. This will also throw an error if there is an invalid JSON in the database already but it seems like the admin panel still doesn't handle the error well (infinite loading). What I could do is return an empty JSON object but then it would show a blank field without any reason as to why. Either way, this prevents bad JSON from entering the database. 
