### PR TITLE
Settings: Add workflow management to settings page

### DIFF
--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/ReviewWorkflows.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/ReviewWorkflows.js
@@ -16,7 +16,7 @@ import { setWorkflows } from './actions';
 
 export function ReviewWorkflowsPage() {
   const { formatMessage } = useIntl();
-  const { workflows: workflowsData, updateWorkflow } = useReviewWorkflows();
+  const { workflows: workflowsData, updateWorkflowStages } = useReviewWorkflows();
   const {
     status,
     clientState: {
@@ -26,7 +26,7 @@ export function ReviewWorkflowsPage() {
   const dispatch = useDispatch();
 
   const onSubmit = async () => {
-    await updateWorkflow(currentWorkflow);
+    await updateWorkflowStages(currentWorkflow.id, currentWorkflow.stages);
   };
 
   useInjectReducer(REDUX_NAMESPACE, reducer);

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/ReviewWorkflows.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/ReviewWorkflows.js
@@ -9,10 +9,11 @@ import { Check } from '@strapi/icons';
 
 import { Stages } from './components/Stages';
 import { reducer, initialState } from './reducer';
-import { REDUX_NAMESPACE, stagesSchema } from './constants';
+import { REDUX_NAMESPACE } from './constants';
 import { useInjectReducer } from '../../../../../../admin/src/hooks/useInjectReducer';
 import { useReviewWorkflows } from './hooks/useReviewWorkflows';
 import { setWorkflows } from './actions';
+import { getWorkflowValidationSchema } from './utils/getWorkflowValidationSchema';
 
 export function ReviewWorkflowsPage() {
   const { formatMessage } = useIntl();
@@ -27,18 +28,12 @@ export function ReviewWorkflowsPage() {
 
   const formik = useFormik({
     enableReinitialize: true,
-    initialValues: {
-      stages: currentWorkflow
-        ? currentWorkflow.stages.map((stage) => ({
-            name: stage.name,
-          }))
-        : null,
-    },
+    initialValues: currentWorkflow,
     async onSubmit() {
       await updateWorkflowStages(currentWorkflow.id, currentWorkflow.stages);
       refetchWorkflow();
     },
-    validationSchema: stagesSchema,
+    validationSchema: getWorkflowValidationSchema({ formatMessage }),
     validateOnChange: false,
   });
 
@@ -48,7 +43,7 @@ export function ReviewWorkflowsPage() {
     dispatch(setWorkflows({ status: workflowsData.status, data: workflowsData.data }));
   }, [workflowsData.status, workflowsData.data, dispatch]);
 
-  if (!currentWorkflow) {
+  if (!formik.values?.stages) {
     return null;
   }
 
@@ -98,7 +93,7 @@ export function ReviewWorkflowsPage() {
                   })}
                 </Loader>
               ) : (
-                <Stages stages={currentWorkflow.stages} />
+                <Stages stages={formik.values.stages} />
               )}
             </ContentLayout>
           </Form>

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/ReviewWorkflows.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/ReviewWorkflows.js
@@ -16,24 +16,14 @@ import { setWorkflows } from './actions';
 
 export function ReviewWorkflowsPage() {
   const { formatMessage } = useIntl();
-  const { workflows: workflowsData, updateWorkflowStages } = useReviewWorkflows();
+  const dispatch = useDispatch();
+  const { workflows: workflowsData, updateWorkflowStages, refetchWorkflow } = useReviewWorkflows();
   const {
     status,
     clientState: {
       currentWorkflow: { data: currentWorkflow, isDirty: currentWorkflowIsDirty },
     },
   } = useSelector((state) => state?.[REDUX_NAMESPACE] ?? initialState);
-  const dispatch = useDispatch();
-
-  const onSubmit = async () => {
-    await updateWorkflowStages(currentWorkflow.id, currentWorkflow.stages);
-  };
-
-  useInjectReducer(REDUX_NAMESPACE, reducer);
-
-  useEffect(() => {
-    dispatch(setWorkflows({ status: workflowsData.status, data: workflowsData.data }));
-  }, [workflowsData.status, workflowsData.data, dispatch]);
 
   const formik = useFormik({
     enableReinitialize: true,
@@ -44,10 +34,19 @@ export function ReviewWorkflowsPage() {
           }))
         : null,
     },
-    onSubmit,
+    async onSubmit() {
+      await updateWorkflowStages(currentWorkflow.id, currentWorkflow.stages);
+      refetchWorkflow();
+    },
     validationSchema: stagesSchema,
     validateOnChange: false,
   });
+
+  useInjectReducer(REDUX_NAMESPACE, reducer);
+
+  useEffect(() => {
+    dispatch(setWorkflows({ status: workflowsData.status, data: workflowsData.data }));
+  }, [workflowsData.status, workflowsData.data, dispatch]);
 
   if (!currentWorkflow) {
     return null;

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/ReviewWorkflows.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/ReviewWorkflows.js
@@ -90,7 +90,7 @@ export function ReviewWorkflowsPage() {
                 </Loader>
               )}
 
-              {formik.values?.stages && <Stages stages={formik.values.stages} />}
+              <Stages stages={formik.values?.stages} />
             </ContentLayout>
           </Form>
         </FormikProvider>

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/ReviewWorkflows.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/ReviewWorkflows.js
@@ -1,22 +1,33 @@
 import React, { useEffect } from 'react';
+import { FormikProvider, useFormik, Form } from 'formik';
 import { useIntl } from 'react-intl';
 import { useSelector, useDispatch } from 'react-redux';
+
 import { SettingsPageTitle } from '@strapi/helper-plugin';
 import { Button, ContentLayout, HeaderLayout, Layout, Loader, Main } from '@strapi/design-system';
 import { Check } from '@strapi/icons';
 
 import { Stages } from './components/Stages';
-import { reducer } from './reducer';
-import { REDUX_NAMESPACE } from './constants';
+import { reducer, initialState } from './reducer';
+import { REDUX_NAMESPACE, stagesSchema } from './constants';
 import { useInjectReducer } from '../../../../../../admin/src/hooks/useInjectReducer';
 import { useReviewWorkflows } from './hooks/useReviewWorkflows';
 import { setWorkflows } from './actions';
 
 export function ReviewWorkflowsPage() {
   const { formatMessage } = useIntl();
-  const { workflows: workflowsData } = useReviewWorkflows();
-  const state = useSelector((state) => state?.[REDUX_NAMESPACE]);
+  const { workflows: workflowsData, updateWorkflow } = useReviewWorkflows();
+  const {
+    status,
+    clientState: {
+      currentWorkflow: { data: currentWorkflow, isDirty: currentWorkflowIsDirty },
+    },
+  } = useSelector((state) => state?.[REDUX_NAMESPACE] ?? initialState);
   const dispatch = useDispatch();
+
+  const onSubmit = async () => {
+    await updateWorkflow(currentWorkflow);
+  };
 
   useInjectReducer(REDUX_NAMESPACE, reducer);
 
@@ -24,19 +35,23 @@ export function ReviewWorkflowsPage() {
     dispatch(setWorkflows({ status: workflowsData.status, data: workflowsData.data }));
   }, [workflowsData.status, workflowsData.data, dispatch]);
 
-  // useInjectReducer() runs on the first rendering after useSelector
-  // which will return undefined. This helps to avoid too many optional
-  // chaining operators down the component.
-  if (!state) {
+  const formik = useFormik({
+    enableReinitialize: true,
+    initialValues: {
+      stages: currentWorkflow
+        ? currentWorkflow.stages.map((stage) => ({
+            name: stage.name,
+          }))
+        : null,
+    },
+    onSubmit,
+    validationSchema: stagesSchema,
+    validateOnChange: false,
+  });
+
+  if (!currentWorkflow) {
     return null;
   }
-
-  const {
-    status,
-    serverState: { workflows },
-  } = state;
-
-  const defaultWorkflow = workflows[0] ?? {};
 
   return (
     <Layout>
@@ -47,39 +62,48 @@ export function ReviewWorkflowsPage() {
         })}
       />
       <Main tabIndex={-1}>
-        <HeaderLayout
-          primaryAction={
-            <Button startIcon={<Check />} type="submit" size="L" disabled>
-              {formatMessage({
-                id: 'global.save',
-                defaultMessage: 'Save',
+        <FormikProvider value={formik}>
+          <Form onSubmit={formik.handleSubmit}>
+            <HeaderLayout
+              primaryAction={
+                <Button
+                  startIcon={<Check />}
+                  type="submit"
+                  size="M"
+                  disabled={!currentWorkflowIsDirty}
+                >
+                  {formatMessage({
+                    id: 'global.save',
+                    defaultMessage: 'Save',
+                  })}
+                </Button>
+              }
+              title={formatMessage({
+                id: 'Settings.review-workflows.page.title',
+                defaultMessage: 'Review Workflows',
               })}
-            </Button>
-          }
-          title={formatMessage({
-            id: 'Settings.review-workflows.page.title',
-            defaultMessage: 'Review Workflows',
-          })}
-          subtitle={formatMessage(
-            {
-              id: 'Settings.review-workflows.page.subtitle',
-              defaultMessage: '{count, plural, one {# stage} other {# stages}}',
-            },
-            { count: defaultWorkflow.stages?.length ?? 0 }
-          )}
-        />
-        <ContentLayout>
-          {status === 'loading' ? (
-            <Loader>
-              {formatMessage({
-                id: 'Settings.review-workflows.page.isLoading',
-                defaultMessage: 'Workflow is loading',
-              })}
-            </Loader>
-          ) : (
-            <Stages stages={defaultWorkflow.stages} />
-          )}
-        </ContentLayout>
+              subtitle={formatMessage(
+                {
+                  id: 'Settings.review-workflows.page.subtitle',
+                  defaultMessage: '{count, plural, one {# stage} other {# stages}}',
+                },
+                { count: currentWorkflow.stages?.length ?? 0 }
+              )}
+            />
+            <ContentLayout>
+              {status === 'loading' ? (
+                <Loader>
+                  {formatMessage({
+                    id: 'Settings.review-workflows.page.isLoading',
+                    defaultMessage: 'Workflow is loading',
+                  })}
+                </Loader>
+              ) : (
+                <Stages stages={currentWorkflow.stages} />
+              )}
+            </ContentLayout>
+          </Form>
+        </FormikProvider>
       </Main>
     </Layout>
   );

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/ReviewWorkflows.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/ReviewWorkflows.js
@@ -43,10 +43,6 @@ export function ReviewWorkflowsPage() {
     dispatch(setWorkflows({ status: workflowsData.status, data: workflowsData.data }));
   }, [workflowsData.status, workflowsData.data, dispatch]);
 
-  if (!formik.values?.stages) {
-    return null;
-  }
-
   return (
     <Layout>
       <SettingsPageTitle
@@ -81,20 +77,20 @@ export function ReviewWorkflowsPage() {
                   id: 'Settings.review-workflows.page.subtitle',
                   defaultMessage: '{count, plural, one {# stage} other {# stages}}',
                 },
-                { count: currentWorkflow.stages?.length ?? 0 }
+                { count: currentWorkflow?.stages?.length ?? 0 }
               )}
             />
             <ContentLayout>
-              {status === 'loading' ? (
+              {status === 'loading' && (
                 <Loader>
                   {formatMessage({
                     id: 'Settings.review-workflows.page.isLoading',
                     defaultMessage: 'Workflow is loading',
                   })}
                 </Loader>
-              ) : (
-                <Stages stages={formik.values.stages} />
               )}
+
+              {formik.values?.stages && <Stages stages={formik.values.stages} />}
             </ContentLayout>
           </Form>
         </FormikProvider>

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/actions/index.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/actions/index.js
@@ -1,4 +1,9 @@
-import { ACTION_SET_WORKFLOWS } from '../constants';
+import {
+  ACTION_SET_WORKFLOWS,
+  ACTION_DELETE_STAGE,
+  ACTION_ADD_STAGE,
+  ACTION_UPDATE_STAGE,
+} from '../constants';
 
 export function setWorkflows({ status, data }) {
   return {
@@ -6,6 +11,32 @@ export function setWorkflows({ status, data }) {
     payload: {
       status,
       workflows: data,
+    },
+  };
+}
+
+export function deleteStage(stageId) {
+  return {
+    type: ACTION_DELETE_STAGE,
+    payload: {
+      stageId,
+    },
+  };
+}
+
+export function addStage(stage = {}) {
+  return {
+    type: ACTION_ADD_STAGE,
+    payload: stage,
+  };
+}
+
+export function updateStage(stageId, payload) {
+  return {
+    type: ACTION_UPDATE_STAGE,
+    payload: {
+      stageId,
+      ...payload,
     },
   };
 }

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/actions/tests/index.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/actions/tests/index.test.js
@@ -1,6 +1,11 @@
-import { setWorkflows } from '..';
+import { setWorkflows, deleteStage, updateStage, addStage } from '..';
 
-import { ACTION_SET_WORKFLOWS } from '../../constants';
+import {
+  ACTION_SET_WORKFLOWS,
+  ACTION_DELETE_STAGE,
+  ACTION_ADD_STAGE,
+  ACTION_UPDATE_STAGE,
+} from '../../constants';
 
 describe('Admin | Settings | Review Workflow | actions', () => {
   test('setWorkflows()', () => {
@@ -9,6 +14,39 @@ describe('Admin | Settings | Review Workflow | actions', () => {
       payload: {
         status: 'loading',
         workflows: null,
+      },
+    });
+  });
+
+  test('deleteStage()', () => {
+    expect(deleteStage(1)).toStrictEqual({
+      type: ACTION_DELETE_STAGE,
+      payload: {
+        stageId: 1,
+      },
+    });
+  });
+
+  test('addStage()', () => {
+    expect(addStage({ something: '' })).toStrictEqual({
+      type: ACTION_ADD_STAGE,
+      payload: {
+        something: '',
+      },
+    });
+
+    expect(addStage()).toStrictEqual({
+      type: ACTION_ADD_STAGE,
+      payload: {},
+    });
+  });
+
+  test('updateStage()', () => {
+    expect(updateStage(1, { something: '' })).toStrictEqual({
+      type: ACTION_UPDATE_STAGE,
+      payload: {
+        stageId: 1,
+        something: '',
       },
     });
   });

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/AddStage/AddStage.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/AddStage/AddStage.js
@@ -1,0 +1,87 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+
+import { Box, Flex, Typography } from '@strapi/design-system';
+import { PlusCircle } from '@strapi/icons';
+
+const StyledAddIcon = styled(PlusCircle)`
+  > circle {
+    fill: ${({ theme }) => theme.colors.neutral150};
+  }
+  > path {
+    fill: ${({ theme }) => theme.colors.neutral600};
+  }
+`;
+
+const StyledButton = styled(Box)`
+  border-radius: 26px;
+
+  svg {
+    height: ${({ theme }) => theme.spaces[6]};
+    width: ${({ theme }) => theme.spaces[6]};
+
+    > path {
+      fill: ${({ theme }) => theme.colors.neutral600};
+    }
+  }
+
+  &:hover {
+    color: ${({ theme }) => theme.colors.primary600} !important;
+    ${Typography} {
+      color: ${({ theme }) => theme.colors.primary600} !important;
+    }
+
+    ${StyledAddIcon} {
+      > circle {
+        fill: ${({ theme }) => theme.colors.primary600};
+      }
+      > path {
+        fill: ${({ theme }) => theme.colors.neutral100};
+      }
+    }
+  }
+
+  &:active {
+    ${Typography} {
+      color: ${({ theme }) => theme.colors.primary600};
+    }
+
+    ${StyledAddIcon} {
+      > circle {
+        fill: ${({ theme }) => theme.colors.primary600};
+      }
+      > path {
+        fill: ${({ theme }) => theme.colors.neutral100};
+      }
+    }
+  }
+`;
+
+export function AddStage({ children, ...props }) {
+  return (
+    <StyledButton
+      as="button"
+      background="neutral0"
+      border="neutral150"
+      paddingBottom={3}
+      paddingLeft={4}
+      paddingRight={4}
+      paddingTop={3}
+      shadow="filterShadow"
+      {...props}
+    >
+      <Flex gap={2}>
+        <StyledAddIcon aria-hidden />
+
+        <Typography variant="pi" fontWeight="bold" textColor="neutral500">
+          {children}
+        </Typography>
+      </Flex>
+    </StyledButton>
+  );
+}
+
+AddStage.propTypes = {
+  children: PropTypes.node.isRequired,
+};

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/AddStage/index.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/AddStage/index.js
@@ -1,0 +1,1 @@
+export * from './AddStage';

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/AddStage/tests/AddStage.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/AddStage/tests/AddStage.test.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import { ThemeProvider, lightTheme } from '@strapi/design-system';
+
+import { AddStage } from '../AddStage';
+
+const ComponentFixture = () => (
+  <ThemeProvider theme={lightTheme}>
+    <AddStage>Add stage</AddStage>
+  </ThemeProvider>
+);
+
+const setup = (props) => render(<ComponentFixture {...props} />);
+
+describe('Admin | Settings | Review Workflow | AddStage', () => {
+  it('should render a list of stages', () => {
+    const { container, getByText } = setup();
+
+    expect(container).toMatchSnapshot();
+    expect(getByText('Add stage')).toBeInTheDocument();
+  });
+});

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/AddStage/tests/__snapshots__/AddStage.test.js.snap
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/AddStage/tests/__snapshots__/AddStage.test.js.snap
@@ -1,0 +1,153 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Admin | Settings | Review Workflow | AddStage should render a list of stages 1`] = `
+.c6 {
+  font-size: 0.75rem;
+  line-height: 1.33;
+  font-weight: 600;
+  color: #8e8ea9;
+}
+
+.c0 {
+  background: #ffffff;
+  padding-top: 12px;
+  padding-right: 16px;
+  padding-bottom: 12px;
+  padding-left: 16px;
+  box-shadow: 0px 1px 4px rgba(33,33,52,0.1);
+}
+
+.c2 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 8px;
+}
+
+.c7 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+}
+
+.c4 > circle {
+  fill: #eaeaef;
+}
+
+.c4 > path {
+  fill: #666687;
+}
+
+.c1 {
+  border-radius: 26px;
+}
+
+.c1 svg {
+  height: 24px;
+  width: 24px;
+}
+
+.c1 svg > path {
+  fill: #666687;
+}
+
+.c1:hover {
+  color: #4945ff !important;
+}
+
+.c1:hover .c5 {
+  color: #4945ff !important;
+}
+
+.c1:hover .c3 > circle {
+  fill: #4945ff;
+}
+
+.c1:hover .c3 > path {
+  fill: #f6f6f9;
+}
+
+.c1:active .c5 {
+  color: #4945ff;
+}
+
+.c1:active .c3 > circle {
+  fill: #4945ff;
+}
+
+.c1:active .c3 > path {
+  fill: #f6f6f9;
+}
+
+<div>
+  <button
+    class="c0 c1"
+  >
+    <div
+      class="c2"
+    >
+      <svg
+        aria-hidden="true"
+        class="c3 c4"
+        fill="none"
+        height="1em"
+        viewBox="0 0 24 24"
+        width="1em"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <circle
+          cx="12"
+          cy="12"
+          fill="#212134"
+          r="12"
+        />
+        <path
+          d="M17 12.569c0 .124-.1.224-.225.224h-3.981v3.982c0 .124-.101.225-.226.225h-1.136a.225.225 0 01-.226-.225v-3.981H7.226A.225.225 0 017 12.567v-1.136c0-.125.1-.226.225-.226h3.982V7.226c0-.124.1-.225.224-.225h1.138c.124 0 .224.1.224.225v3.982h3.982c.124 0 .225.1.225.224v1.138z"
+          fill="#F6F6F9"
+        />
+      </svg>
+      <span
+        class="c5 c6"
+      >
+        Add stage
+      </span>
+    </div>
+  </button>
+  <div
+    class="c7"
+  >
+    <p
+      aria-live="polite"
+      aria-relevant="all"
+      id="live-region-log"
+      role="log"
+    />
+    <p
+      aria-live="polite"
+      aria-relevant="all"
+      id="live-region-status"
+      role="status"
+    />
+    <p
+      aria-live="assertive"
+      aria-relevant="all"
+      id="live-region-alert"
+      role="alert"
+    />
+  </div>
+</div>
+`;

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/Stages/Stage/Stage.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/Stages/Stage/Stage.js
@@ -1,7 +1,9 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
+import { useField } from 'formik';
 import { useIntl } from 'react-intl';
+import { useDispatch } from 'react-redux';
 import {
   Accordion,
   AccordionToggle,
@@ -9,10 +11,13 @@ import {
   Box,
   Grid,
   GridItem,
+  IconButton,
   TextInput,
 } from '@strapi/design-system';
 
-import { StageType } from '../../../constants';
+import { Trash } from '@strapi/icons';
+
+import { deleteStage, updateStage } from '../../../actions';
 
 // TODO: Delete once https://github.com/strapi/design-system/pull/858
 // is merged and released.
@@ -22,25 +27,54 @@ const StyledAccordion = styled(Box)`
   }
 `;
 
-function Stage({ id, name }) {
+// TODO: Keep an eye on https://github.com/strapi/design-system/pull/878
+const DeleteButton = styled(IconButton)`
+  background-color: transparent;
+`;
+
+function Stage({ id, name, index, canDelete, isOpen: isOpenDefault = false }) {
   const { formatMessage } = useIntl();
-  const [isOpen, setIsOpen] = useState(false);
+  const [isOpen, setIsOpen] = useState(isOpenDefault);
+  const fieldIdentifier = `stages.${index}.name`;
+  const [field, meta] = useField(fieldIdentifier);
+  const dispatch = useDispatch();
 
   return (
     <StyledAccordion>
       <Accordion size="S" variant="primary" onToggle={() => setIsOpen(!isOpen)} expanded={isOpen}>
-        <AccordionToggle title={name} togglePosition="left" />
+        <AccordionToggle
+          title={name}
+          togglePosition="left"
+          action={
+            canDelete ? (
+              <DeleteButton
+                noBorder
+                onClick={() => dispatch(deleteStage(id))}
+                label={formatMessage({
+                  id: 'Settings.review-workflows.stage.delete',
+                  defaultMessage: 'Delete stage',
+                })}
+                icon={<Trash />}
+              />
+            ) : null
+          }
+        />
         <AccordionContent padding={6} background="neutral0">
           <Grid gap={4}>
             <GridItem col={6}>
               <TextInput
-                name={`stage_name[${id}]`}
-                disabled
+                {...field}
+                id={fieldIdentifier}
+                value={name}
                 label={formatMessage({
                   id: 'Settings.review-workflows.stage.name.label',
                   defaultMessage: 'Stage name',
                 })}
-                value={name}
+                error={meta.error ?? false}
+                onChange={(event) => {
+                  dispatch(updateStage(id, { name: event.target.value }));
+                  field.onChange(event);
+                }}
               />
             </GridItem>
           </Grid>
@@ -52,4 +86,8 @@ function Stage({ id, name }) {
 
 export { Stage };
 
-Stage.propTypes = PropTypes.shape(StageType).isRequired;
+Stage.propTypes = PropTypes.shape({
+  id: PropTypes.number.isRequired,
+  name: PropTypes.string.isRequired,
+  canDelete: PropTypes.bool.isRequired,
+}).isRequired;

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/Stages/Stage/Stage.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/Stages/Stage/Stage.js
@@ -71,10 +71,7 @@ function Stage({ id, name, index, canDelete, isOpen: isOpenDefault = false }) {
                   defaultMessage: 'Stage name',
                 })}
                 error={meta.error ?? false}
-                onChange={(event) => {
-                  dispatch(updateStage(id, { name: event.target.value }));
-                  field.onChange(event);
-                }}
+                onBlur={(event) => dispatch(updateStage(id, { name: event.target.value }))}
               />
             </GridItem>
           </Grid>

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/Stages/Stage/tests/Stage.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/Stages/Stage/tests/Stage.test.js
@@ -2,23 +2,48 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { IntlProvider } from 'react-intl';
+import { FormikProvider, useFormik } from 'formik';
+import { Provider } from 'react-redux';
 
 import { ThemeProvider, lightTheme } from '@strapi/design-system';
 
+import configureStore from '../../../../../../../../../../admin/src/core/store/configureStore';
 import { Stage } from '../Stage';
+import { reducer } from '../../../../reducer';
 
 const STAGES_FIXTURE = {
   id: 1,
   name: 'stage-1',
+  index: 1,
 };
 
-const ComponentFixture = (props) => (
-  <IntlProvider locale="en" messages={{}}>
-    <ThemeProvider theme={lightTheme}>
-      <Stage {...STAGES_FIXTURE} {...props} />
-    </ThemeProvider>
-  </IntlProvider>
-);
+const ComponentFixture = (props) => {
+  const store = configureStore([], [reducer]);
+
+  const formik = useFormik({
+    enableReinitialize: true,
+    initialValues: {
+      stages: [
+        {
+          name: 'something',
+        },
+      ],
+    },
+    validateOnChange: false,
+  });
+
+  return (
+    <Provider store={store}>
+      <FormikProvider value={formik}>
+        <IntlProvider locale="en" messages={{}}>
+          <ThemeProvider theme={lightTheme}>
+            <Stage {...STAGES_FIXTURE} {...props} />
+          </ThemeProvider>
+        </IntlProvider>
+      </FormikProvider>
+    </Provider>
+  );
+};
 
 const setup = (props) => render(<ComponentFixture {...props} />);
 
@@ -38,5 +63,27 @@ describe('Admin | Settings | Review Workflow | Stage', () => {
 
     expect(queryByRole('textbox')).toBeInTheDocument();
     expect(getByRole('textbox').value).toBe(STAGES_FIXTURE.name);
+    expect(getByRole('textbox').getAttribute('name')).toBe('stages.1.name');
+    expect(
+      queryByRole('button', {
+        name: /delete stage/i,
+      })
+    ).not.toBeInTheDocument();
+  });
+
+  it('should open the accordion panel if isOpen = true', async () => {
+    const { queryByRole } = setup({ isOpen: true });
+
+    expect(queryByRole('textbox')).toBeInTheDocument();
+  });
+
+  it('should not render delete button if canDelete=false', async () => {
+    const { queryByRole } = setup({ isOpen: true, canDelete: false });
+
+    expect(
+      queryByRole('button', {
+        name: /delete stage/i,
+      })
+    ).not.toBeInTheDocument();
   });
 });

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/Stages/Stages.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/Stages/Stages.js
@@ -70,6 +70,7 @@ Stages.propTypes = {
   stages: PropTypes.arrayOf(
     PropTypes.shape({
       id: PropTypes.number,
+      __temp_key__: PropTypes.number,
       name: PropTypes.string.isRequired,
     })
   ),

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/Stages/Stages.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/Stages/Stages.js
@@ -69,7 +69,7 @@ Stages.defaultProps = {
 Stages.propTypes = {
   stages: PropTypes.arrayOf(
     PropTypes.shape({
-      id: PropTypes.number.isRequired,
+      id: PropTypes.number,
       name: PropTypes.string.isRequired,
     })
   ),

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/Stages/Stages.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/Stages/Stages.js
@@ -31,13 +31,13 @@ function Stages({ stages }) {
 
         <Stack spacing={6} zIndex={2} position="relative" as="ol">
           {stages.map((stage, index) => {
-            const stableStageId = stage?.id ?? stage.__temp_key__;
+            const id = stage?.id ?? stage.__temp_key__;
 
             return (
-              <Box key={`stage-${stableStageId}`} as="li">
+              <Box key={`stage-${id}`} as="li">
                 <Stage
                   {...stage}
-                  id={stableStageId}
+                  id={id}
                   index={index}
                   canDelete={stages.length > 1}
                   isOpen={!stage.id}

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/Stages/Stages.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/Stages/Stages.js
@@ -1,9 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { Box, Stack } from '@strapi/design-system';
+import { useIntl } from 'react-intl';
+import { useDispatch } from 'react-redux';
+import { Box, Flex, Stack } from '@strapi/design-system';
 
-import { StageType } from '../../constants';
+import { addStage } from '../../actions';
+import { AddStage } from '../AddStage';
 import { Stage } from './Stage';
 
 const StagesContainer = styled(Box)`
@@ -18,18 +21,42 @@ const Background = styled(Box)`
 `;
 
 function Stages({ stages }) {
-  return (
-    <StagesContainer spacing={4}>
-      <Background background="neutral200" height="100%" width={2} zIndex={1} />
+  const { formatMessage } = useIntl();
+  const dispatch = useDispatch();
 
-      <Stack spacing={6} zIndex={2} position="relative" as="ol">
-        {stages.map(({ id, ...stage }) => (
-          <Box key={`stage-${id}`} as="li">
-            <Stage {...{ ...stage, id }} />
-          </Box>
-        ))}
-      </Stack>
-    </StagesContainer>
+  return (
+    <Flex direction="column" gap={6} width="100%">
+      <StagesContainer spacing={4} width="100%">
+        <Background background="neutral200" height="100%" width={2} zIndex={1} />
+
+        <Stack spacing={6} zIndex={2} position="relative" as="ol">
+          {stages.map((stage, index) => {
+            const stableStageId = stage?.id ?? stage.__temp_key__;
+
+            return (
+              <Box key={`stage-${stableStageId}`} as="li">
+                <Stage
+                  {...stage}
+                  id={stableStageId}
+                  index={index}
+                  canDelete={stages.length > 1}
+                  isOpen={!stage.id}
+                />
+              </Box>
+            );
+          })}
+        </Stack>
+      </StagesContainer>
+
+      <Flex spacing={6}>
+        <AddStage type="button" onClick={() => dispatch(addStage({ name: '' }))}>
+          {formatMessage({
+            id: 'Settings.review-workflows.stage.add',
+            defaultMessage: 'Add new stage',
+          })}
+        </AddStage>
+      </Flex>
+    </Flex>
   );
 }
 
@@ -40,5 +67,10 @@ Stages.defaultProps = {
 };
 
 Stages.propTypes = {
-  stages: PropTypes.arrayOf(StageType),
+  stages: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.number.isRequired,
+      name: PropTypes.string.isRequired,
+    })
+  ),
 };

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/Stages/tests/Stages.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/Stages/tests/Stages.test.js
@@ -1,10 +1,22 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { IntlProvider } from 'react-intl';
+import { Provider } from 'react-redux';
+import { FormikProvider, useFormik } from 'formik';
+import userEvent from '@testing-library/user-event';
 
 import { ThemeProvider, lightTheme } from '@strapi/design-system';
 
+import configureStore from '../../../../../../../../../admin/src/core/store/configureStore';
 import { Stages } from '../Stages';
+import { reducer } from '../../../reducer';
+import { ACTION_SET_WORKFLOWS, ACTION_ADD_STAGE } from '../../../constants';
+import { addStage } from '../../../actions';
+
+jest.mock('../../../actions', () => ({
+  ...jest.requireActual('../../../actions'),
+  addStage: jest.fn(),
+}));
 
 const STAGES_FIXTURE = [
   {
@@ -18,15 +30,42 @@ const STAGES_FIXTURE = [
   },
 ];
 
-const ComponentFixture = (props) => (
-  <IntlProvider locale="en" messages={{}}>
-    <ThemeProvider theme={lightTheme}>
-      <Stages stages={STAGES_FIXTURE} {...props} />
-    </ThemeProvider>
-  </IntlProvider>
-);
+const WORKFLOWS_FIXTURE = [
+  {
+    id: 1,
+    stages: STAGES_FIXTURE,
+  },
+];
+
+const ComponentFixture = (props) => {
+  const store = configureStore([], [reducer]);
+
+  store.dispatch({ type: ACTION_SET_WORKFLOWS, payload: { workflows: WORKFLOWS_FIXTURE } });
+
+  const formik = useFormik({
+    enableReinitialize: true,
+    initialValues: {
+      stages: STAGES_FIXTURE,
+    },
+    validateOnChange: false,
+  });
+
+  return (
+    <Provider store={store}>
+      <FormikProvider value={formik}>
+        <IntlProvider locale="en" messages={{}}>
+          <ThemeProvider theme={lightTheme}>
+            <Stages stages={STAGES_FIXTURE} {...props} />
+          </ThemeProvider>
+        </IntlProvider>
+      </FormikProvider>
+    </Provider>
+  );
+};
 
 const setup = (props) => render(<ComponentFixture {...props} />);
+
+const user = userEvent.setup();
 
 describe('Admin | Settings | Review Workflow | Stages', () => {
   beforeEach(() => {
@@ -38,5 +77,26 @@ describe('Admin | Settings | Review Workflow | Stages', () => {
 
     expect(getByText(STAGES_FIXTURE[0].name)).toBeInTheDocument();
     expect(getByText(STAGES_FIXTURE[1].name)).toBeInTheDocument();
+  });
+
+  it('should render a "add new stage" button', () => {
+    const { getByText } = setup();
+
+    expect(getByText('Add new stage')).toBeInTheDocument();
+  });
+
+  it('should append a new stage when clicking "add new stage"', async () => {
+    const { getByRole } = setup();
+
+    addStage.mockReturnValue({ type: ACTION_ADD_STAGE });
+
+    await user.click(
+      getByRole('button', {
+        name: /add new stage/i,
+      })
+    );
+
+    expect(addStage).toBeCalledTimes(1);
+    expect(addStage).toBeCalledWith({ name: '' });
   });
 });

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/constants.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/constants.js
@@ -1,16 +1,6 @@
-import * as yup from 'yup';
-
 export const REDUX_NAMESPACE = 'settings_review-workflows';
 
 export const ACTION_SET_WORKFLOWS = `Settings/Review_Workflows/SET_WORKFLOWS`;
 export const ACTION_DELETE_STAGE = `Settings/Review_Workflows/WORKFLOW_DELETE_STAGE`;
 export const ACTION_ADD_STAGE = `Settings/Review_Workflows/WORKFLOW_ADD_STAGE`;
 export const ACTION_UPDATE_STAGE = `Settings/Review_Workflows/WORKFLOW_UPDATE_STAGE`;
-
-export const stagesSchema = yup.object({
-  stages: yup.array().of(
-    yup.object().shape({
-      name: yup.string().required('Name is required'),
-    })
-  ),
-});

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/constants.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/constants.js
@@ -1,10 +1,16 @@
-import PropTypes from 'prop-types';
+import * as yup from 'yup';
 
 export const REDUX_NAMESPACE = 'settings_review-workflows';
 
 export const ACTION_SET_WORKFLOWS = `Settings/Review_Workflows/SET_WORKFLOWS`;
+export const ACTION_DELETE_STAGE = `Settings/Review_Workflows/WORKFLOW_DELETE_STAGE`;
+export const ACTION_ADD_STAGE = `Settings/Review_Workflows/WORKFLOW_ADD_STAGE`;
+export const ACTION_UPDATE_STAGE = `Settings/Review_Workflows/WORKFLOW_UPDATE_STAGE`;
 
-export const StageType = PropTypes.shape({
-  id: PropTypes.number.isRequired,
-  name: PropTypes.string.isRequired,
+export const stagesSchema = yup.object({
+  stages: yup.array().of(
+    yup.object().shape({
+      name: yup.string().required('Name is required'),
+    })
+  ),
 });

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/hooks/tests/useReviewWorkflows.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/hooks/tests/useReviewWorkflows.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { QueryClientProvider, QueryClient, useQueryClient } from 'react-query';
+import { QueryClientProvider, QueryClient } from 'react-query';
 import { renderHook, act } from '@testing-library/react-hooks';
 
 import { useFetchClient } from '@strapi/helper-plugin';
@@ -31,15 +31,7 @@ const ComponentFixture = ({ children }) => (
 function setup(id) {
   return new Promise((resolve) => {
     act(() => {
-      resolve(
-        renderHook(
-          () => ({
-            ...useReviewWorkflows(id),
-            queryClient: useQueryClient(),
-          }),
-          { wrapper: ComponentFixture }
-        )
-      );
+      resolve(renderHook(() => useReviewWorkflows(id), { wrapper: ComponentFixture }));
     });
   });
 }

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/hooks/tests/useReviewWorkflows.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/hooks/tests/useReviewWorkflows.test.js
@@ -10,7 +10,9 @@ jest.mock('@strapi/helper-plugin', () => ({
   ...jest.requireActual('@strapi/helper-plugin'),
   useFetchClient: jest.fn().mockReturnValue({
     get: jest.fn(),
+    put: jest.fn(),
   }),
+  useNotification: jest.fn().mockReturnValue(() => {}),
 }));
 
 const client = new QueryClient({
@@ -101,5 +103,25 @@ describe('useReviewWorkflows', () => {
         }),
       })
     );
+  });
+
+  test('send put request on the updateWorkflowStages mutation', async () => {
+    const { put } = useFetchClient();
+    const idFixture = 1;
+    const stagesFixture = [{ id: 2, name: 'stage' }];
+
+    put.mockResolvedValue({});
+
+    const { result, waitFor } = await setup(idFixture);
+
+    await act(async () => {
+      await result.current.updateWorkflowStages(idFixture, stagesFixture);
+    });
+
+    await waitFor(() => expect(result.current.workflows.isLoading).toBe(false));
+
+    expect(put).toBeCalledWith(`/admin/review-workflows/workflows/${idFixture}/stages`, {
+      data: stagesFixture,
+    });
   });
 });

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/hooks/tests/useReviewWorkflows.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/hooks/tests/useReviewWorkflows.test.js
@@ -9,8 +9,8 @@ import { useReviewWorkflows } from '../useReviewWorkflows';
 jest.mock('@strapi/helper-plugin', () => ({
   ...jest.requireActual('@strapi/helper-plugin'),
   useFetchClient: jest.fn().mockReturnValue({
-    get: jest.fn(),
-    put: jest.fn(),
+    get: jest.fn().mockResolvedValue({ data: {} }),
+    put: jest.fn().mockResolvedValue({ data: {} }),
   }),
   useNotification: jest.fn().mockReturnValue(() => {}),
 }));
@@ -94,7 +94,10 @@ describe('useReviewWorkflows', () => {
     const { result, waitFor } = await setup(idFixture);
 
     expect(result.current.workflows.isLoading).toBe(true);
-    expect(get).toBeCalledWith(`/admin/review-workflows/workflows/${idFixture}?populate=stages`);
+    expect(get).toBeCalledWith(
+      `/admin/review-workflows/workflows/${idFixture}`,
+      expect.any(Object)
+    );
 
     await waitFor(() => expect(result.current.workflows.isLoading).toBe(false));
 
@@ -112,7 +115,9 @@ describe('useReviewWorkflows', () => {
     const idFixture = 1;
     const stagesFixture = [{ id: 2, name: 'stage' }];
 
-    put.mockResolvedValue({});
+    put.mockResolvedValue({
+      data: {},
+    });
 
     const { result, waitFor } = await setup(idFixture);
 

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/hooks/tests/useReviewWorkflows.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/hooks/tests/useReviewWorkflows.test.js
@@ -63,7 +63,9 @@ describe('useReviewWorkflows', () => {
     const { result, waitFor } = await setup();
 
     expect(result.current.workflows.isLoading).toBe(true);
-    expect(get).toBeCalledWith('/admin/review-workflows/workflows/?populate=stages');
+    expect(get).toBeCalledWith('/admin/review-workflows/workflows/', {
+      params: { populate: 'stages' },
+    });
 
     await waitFor(() => expect(result.current.workflows.isLoading).toBe(false));
 

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/hooks/useReviewWorkflows.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/hooks/useReviewWorkflows.js
@@ -42,7 +42,7 @@ export function useReviewWorkflows(workflowId) {
     async onError() {
       // TODO: this should return the proper error thrown by the API
       toggleNotification({
-        type: 'error',
+        type: 'warning',
         message: { id: 'notification.error', defaultMessage: 'An error occured' },
       });
     },

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/hooks/useReviewWorkflows.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/hooks/useReviewWorkflows.js
@@ -32,7 +32,6 @@ export function useReviewWorkflows(workflowId) {
     return workflowUpdateMutation.mutateAsync({ workflowId, stages });
   }
 
-  // TODO needs testing
   function refetchWorkflow() {
     client.refetchQueries(workflowQueryKey);
   }

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/hooks/useReviewWorkflows.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/hooks/useReviewWorkflows.js
@@ -3,8 +3,6 @@ import { useFetchClient, useNotification } from '@strapi/helper-plugin';
 
 const QUERY_BASE_KEY = 'review-workflows';
 
-/* eslint-disable no-unreachable */
-
 export function useReviewWorkflows(workflowId) {
   const { get, put } = useFetchClient();
   const toggleNotification = useNotification();
@@ -12,19 +10,6 @@ export function useReviewWorkflows(workflowId) {
 
   async function fetchWorkflows() {
     try {
-      return [
-        {
-          id: 1,
-          stages: [
-            {
-              id: 1,
-              name: `Something ${Math.random()}`,
-            },
-          ],
-        },
-      ];
-
-      // TODO
       const {
         data: { data },
       } = await get(`/admin/review-workflows/workflows/${workflowId ?? ''}?populate=stages`);
@@ -35,22 +20,13 @@ export function useReviewWorkflows(workflowId) {
     }
   }
 
-  async function updateRemoteWorkflow(payload) {
-    return {
-      id: 1,
-      stages: [
-        {
-          id: 1,
-          name: 'Something',
-        },
-      ],
-    };
-
-    // TODO
+  async function updateRemoteWorkflowStages({ workflowId, stages }) {
     try {
       const {
         data: { data },
-      } = await put(`/admin/review-workflows/workflows/${payload.id}`, payload);
+      } = await put(`/admin/review-workflows/workflows/${workflowId}/stages`, {
+        data: stages,
+      });
 
       return data;
     } catch (err) {
@@ -58,13 +34,13 @@ export function useReviewWorkflows(workflowId) {
     }
   }
 
-  function updateWorkflow(payload) {
-    return workflowUpdateMutation.mutateAsync(payload);
+  function updateWorkflowStages(workflowId, stages) {
+    return workflowUpdateMutation.mutateAsync({ workflowId, stages });
   }
 
   const workflows = useQuery([QUERY_BASE_KEY, workflowId ?? 'default'], fetchWorkflows);
 
-  const workflowUpdateMutation = useMutation(updateRemoteWorkflow, {
+  const workflowUpdateMutation = useMutation(updateRemoteWorkflowStages, {
     async onError() {
       toggleNotification({
         type: 'error',
@@ -84,6 +60,6 @@ export function useReviewWorkflows(workflowId) {
 
   return {
     workflows,
-    updateWorkflow,
+    updateWorkflowStages,
   };
 }

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/index.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/index.js
@@ -60,7 +60,7 @@ export function reducer(state = initialState, action) {
           ...currentWorkflow.data.stages,
           {
             ...payload,
-            __temp_key__: state.clientState.currentWorkflow.data.stages.length + 1,
+            __temp_key__: currentWorkflow.data.stages.length + 1,
           },
         ];
 
@@ -69,19 +69,16 @@ export function reducer(state = initialState, action) {
 
       case ACTION_UPDATE_STAGE: {
         const { currentWorkflow } = state.clientState;
+        const { stageId, ...modified } = payload;
 
-        draft.clientState.currentWorkflow.data.stages = currentWorkflow.data.stages.map((stage) => {
-          if ((stage.id ?? stage.__temp_key__) === payload.stageId) {
-            const { stageId, ...modified } = payload;
-
-            return {
-              ...stage,
-              ...modified,
-            };
-          }
-
-          return stage;
-        });
+        draft.clientState.currentWorkflow.data.stages = currentWorkflow.data.stages.map((stage) =>
+          (stage.id ?? stage.__temp_key__) === stageId
+            ? {
+                ...stage,
+                ...modified,
+              }
+            : stage
+        );
 
         break;
       }

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/index.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/index.js
@@ -56,13 +56,16 @@ export function reducer(state = initialState, action) {
       case ACTION_ADD_STAGE: {
         const { currentWorkflow } = state.clientState;
 
-        draft.clientState.currentWorkflow.data.stages = [
-          ...currentWorkflow.data.stages,
-          {
-            ...payload,
-            __temp_key__: currentWorkflow.data.stages.length + 1,
-          },
-        ];
+        if (!currentWorkflow.data) {
+          draft.clientState.currentWorkflow.data = {
+            stages: [],
+          };
+        }
+
+        draft.clientState.currentWorkflow.data.stages.push({
+          ...payload,
+          __temp_key__: (currentWorkflow.data?.stages?.length ?? 0) + 1,
+        });
 
         break;
       }

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/index.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/index.js
@@ -30,9 +30,11 @@ export function reducer(state = initialState, action) {
         draft.status = status;
 
         if (workflows) {
+          const defaultWorkflow = workflows[0];
+
           draft.serverState.workflows = workflows;
-          draft.serverState.currentWorkflow = workflows[0];
-          draft.clientState.currentWorkflow.data = workflows[0];
+          draft.serverState.currentWorkflow = defaultWorkflow;
+          draft.clientState.currentWorkflow.data = defaultWorkflow;
         }
         break;
       }
@@ -59,16 +61,13 @@ export function reducer(state = initialState, action) {
       case ACTION_ADD_STAGE: {
         const { currentWorkflow } = state.clientState;
 
-        draft.clientState.currentWorkflow.data = {
-          ...currentWorkflow.data,
-          stages: [
-            ...currentWorkflow.data.stages,
-            {
-              ...payload,
-              __temp_key__: state.clientState.currentWorkflow.data.stages.length + 1,
-            },
-          ],
-        };
+        draft.clientState.currentWorkflow.data.stages = [
+          ...currentWorkflow.data.stages,
+          {
+            ...payload,
+            __temp_key__: state.clientState.currentWorkflow.data.stages.length + 1,
+          },
+        ];
 
         draft.clientState.currentWorkflow.isDirty = !isEqual(
           current(draft.clientState.currentWorkflow).data,
@@ -81,21 +80,18 @@ export function reducer(state = initialState, action) {
       case ACTION_UPDATE_STAGE: {
         const { currentWorkflow } = state.clientState;
 
-        draft.clientState.currentWorkflow.data = {
-          ...currentWorkflow.data,
-          stages: currentWorkflow.data.stages.map((stage) => {
-            if ((stage.id ?? stage.__temp_key__) === payload.stageId) {
-              const { stageId, ...modified } = payload;
+        draft.clientState.currentWorkflow.data.stages = currentWorkflow.data.stages.map((stage) => {
+          if ((stage.id ?? stage.__temp_key__) === payload.stageId) {
+            const { stageId, ...modified } = payload;
 
-              return {
-                ...stage,
-                ...modified,
-              };
-            }
+            return {
+              ...stage,
+              ...modified,
+            };
+          }
 
-            return stage;
-          }),
-        };
+          return stage;
+        });
 
         draft.clientState.currentWorkflow.isDirty = !isEqual(
           current(draft.clientState.currentWorkflow).data,

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/index.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/index.js
@@ -46,14 +46,9 @@ export function reducer(state = initialState, action) {
         draft.clientState.currentWorkflow.data = {
           ...currentWorkflow.data,
           stages: currentWorkflow.data.stages.filter(
-            (stage) => stage?.id ?? stage.__temp_key__ !== stageId
+            (stage) => (stage?.id ?? stage.__temp_key__) !== stageId
           ),
         };
-
-        draft.clientState.currentWorkflow.isDirty = !isEqual(
-          current(draft.clientState.currentWorkflow).data,
-          state.clientState.currentWorkflow.data
-        );
 
         break;
       }
@@ -68,11 +63,6 @@ export function reducer(state = initialState, action) {
             __temp_key__: state.clientState.currentWorkflow.data.stages.length + 1,
           },
         ];
-
-        draft.clientState.currentWorkflow.isDirty = !isEqual(
-          current(draft.clientState.currentWorkflow).data,
-          state.clientState.currentWorkflow.data
-        );
 
         break;
       }
@@ -93,16 +83,18 @@ export function reducer(state = initialState, action) {
           return stage;
         });
 
-        draft.clientState.currentWorkflow.isDirty = !isEqual(
-          current(draft.clientState.currentWorkflow).data,
-          state.clientState.currentWorkflow.data
-        );
-
         break;
       }
 
       default:
         break;
+    }
+
+    if (state.clientState.currentWorkflow.data) {
+      draft.clientState.currentWorkflow.isDirty = !isEqual(
+        current(draft.clientState.currentWorkflow).data,
+        state.serverState.currentWorkflow
+      );
     }
   });
 }

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/tests/index.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/tests/index.test.js
@@ -41,20 +41,21 @@ describe('Admin | Settings | Review Workflows | reducer', () => {
       payload: { status: 'loading-state', workflows: WORKFLOWS_FIXTURE },
     };
 
-    expect(reducer(state, action)).toStrictEqual({
-      ...initialState,
-      status: 'loading-state',
-      serverState: {
-        currentWorkflow: WORKFLOWS_FIXTURE[0],
-        workflows: WORKFLOWS_FIXTURE,
-      },
-      clientState: {
-        currentWorkflow: {
-          data: WORKFLOWS_FIXTURE[0],
-          isDirty: false,
+    expect(reducer(state, action)).toStrictEqual(
+      expect.objectContaining({
+        status: 'loading-state',
+        serverState: {
+          currentWorkflow: WORKFLOWS_FIXTURE[0],
+          workflows: WORKFLOWS_FIXTURE,
         },
-      },
-    });
+        clientState: {
+          currentWorkflow: {
+            data: WORKFLOWS_FIXTURE[0],
+            isDirty: false,
+          },
+        },
+      })
+    );
   });
 
   test('ACTION_SET_WORKFLOWS without workflows', () => {
@@ -79,19 +80,25 @@ describe('Admin | Settings | Review Workflows | reducer', () => {
 
     state = {
       status: expect.any(String),
-      serverState: expect.any(Object),
+      serverState: {
+        currentWorkflow: WORKFLOWS_FIXTURE[0],
+      },
       clientState: {
         currentWorkflow: { data: WORKFLOWS_FIXTURE[0], isDirty: false },
       },
     };
 
-    expect(reducer(state, action)).toStrictEqual({
-      status: expect.any(String),
-      serverState: expect.any(Object),
-      clientState: {
-        currentWorkflow: { data: WORKFLOWS_FIXTURE[0], isDirty: false },
-      },
-    });
+    expect(reducer(state, action)).toStrictEqual(
+      expect.objectContaining({
+        clientState: expect.objectContaining({
+          currentWorkflow: expect.objectContaining({
+            data: expect.objectContaining({
+              stages: expect.arrayContaining([WORKFLOWS_FIXTURE[0].stages[1]]),
+            }),
+          }),
+        }),
+      })
+    );
   });
 
   test('ACTION_ADD_STAGE', () => {
@@ -108,24 +115,22 @@ describe('Admin | Settings | Review Workflows | reducer', () => {
       },
     };
 
-    expect(reducer(state, action)).toStrictEqual({
-      status: expect.any(String),
-      serverState: expect.any(Object),
-      clientState: {
-        currentWorkflow: {
-          data: {
-            ...WORKFLOWS_FIXTURE[0],
-            stages: expect.arrayContaining([
-              {
-                __temp_key__: 3,
-                name: 'something',
-              },
-            ]),
-          },
-          isDirty: true,
-        },
-      },
-    });
+    expect(reducer(state, action)).toStrictEqual(
+      expect.objectContaining({
+        clientState: expect.objectContaining({
+          currentWorkflow: expect.objectContaining({
+            data: expect.objectContaining({
+              stages: expect.arrayContaining([
+                {
+                  __temp_key__: 3,
+                  name: 'something',
+                },
+              ]),
+            }),
+          }),
+        }),
+      })
+    );
   });
 
   test('ACTION_UPDATE_STAGE', () => {
@@ -142,23 +147,67 @@ describe('Admin | Settings | Review Workflows | reducer', () => {
       },
     };
 
-    expect(reducer(state, action)).toStrictEqual({
+    expect(reducer(state, action)).toStrictEqual(
+      expect.objectContaining({
+        clientState: expect.objectContaining({
+          currentWorkflow: expect.objectContaining({
+            data: expect.objectContaining({
+              stages: expect.arrayContaining([
+                {
+                  id: 1,
+                  name: 'stage-1-modified',
+                },
+              ]),
+            }),
+          }),
+        }),
+      })
+    );
+  });
+
+  test('properly compare serverState and clientState and set isDirty accordingly', () => {
+    const actionAddStage = {
+      type: ACTION_ADD_STAGE,
+      payload: { name: 'something' },
+    };
+
+    state = {
       status: expect.any(String),
-      serverState: expect.any(Object),
-      clientState: {
-        currentWorkflow: {
-          data: {
-            ...WORKFLOWS_FIXTURE[0],
-            stages: expect.arrayContaining([
-              {
-                id: 1,
-                name: 'stage-1-modified',
-              },
-            ]),
-          },
-          isDirty: true,
-        },
+      serverState: {
+        currentWorkflow: WORKFLOWS_FIXTURE[0],
       },
-    });
+      clientState: {
+        currentWorkflow: { data: WORKFLOWS_FIXTURE[0], isDirty: false },
+      },
+    };
+
+    state = reducer(state, actionAddStage);
+
+    expect(state).toStrictEqual(
+      expect.objectContaining({
+        clientState: expect.objectContaining({
+          currentWorkflow: expect.objectContaining({
+            isDirty: true,
+          }),
+        }),
+      })
+    );
+
+    const actionDeleteStage = {
+      type: ACTION_DELETE_STAGE,
+      payload: { stageId: 3 },
+    };
+
+    state = reducer(state, actionDeleteStage);
+
+    expect(state).toStrictEqual(
+      expect.objectContaining({
+        clientState: expect.objectContaining({
+          currentWorkflow: expect.objectContaining({
+            isDirty: false,
+          }),
+        }),
+      })
+    );
   });
 });

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/tests/index.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/tests/index.test.js
@@ -133,6 +133,38 @@ describe('Admin | Settings | Review Workflows | reducer', () => {
     );
   });
 
+  test('ACTION_ADD_STAGE when there are not stages yet', () => {
+    const action = {
+      type: ACTION_ADD_STAGE,
+      payload: { name: 'something' },
+    };
+
+    state = {
+      status: expect.any(String),
+      serverState: expect.any(Object),
+      clientState: {
+        currentWorkflow: { data: null, isDirty: false },
+      },
+    };
+
+    expect(reducer(state, action)).toStrictEqual(
+      expect.objectContaining({
+        clientState: expect.objectContaining({
+          currentWorkflow: expect.objectContaining({
+            data: expect.objectContaining({
+              stages: expect.arrayContaining([
+                {
+                  __temp_key__: 1,
+                  name: 'something',
+                },
+              ]),
+            }),
+          }),
+        }),
+      })
+    );
+  });
+
   test('ACTION_UPDATE_STAGE', () => {
     const action = {
       type: ACTION_UPDATE_STAGE,

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/tests/index.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/tests/index.test.js
@@ -1,6 +1,11 @@
 import { initialState, reducer } from '..';
 
-import { ACTION_SET_WORKFLOWS } from '../../constants';
+import {
+  ACTION_SET_WORKFLOWS,
+  ACTION_DELETE_STAGE,
+  ACTION_ADD_STAGE,
+  ACTION_UPDATE_STAGE,
+} from '../../constants';
 
 const WORKFLOWS_FIXTURE = [
   {
@@ -30,39 +35,129 @@ describe('Admin | Settings | Review Workflows | reducer', () => {
     expect(reducer(state, {})).toStrictEqual(initialState);
   });
 
-  test('should handle ACTION_SET_WORKFLOWS with workflows', () => {
+  test('ACTION_SET_WORKFLOWS with workflows', () => {
     const action = {
       type: ACTION_SET_WORKFLOWS,
       payload: { status: 'loading-state', workflows: WORKFLOWS_FIXTURE },
     };
 
-    expect(reducer(state, action)).toEqual({
+    expect(reducer(state, action)).toStrictEqual({
       ...initialState,
       status: 'loading-state',
       serverState: {
-        ...initialState.serverState,
-        workflows: [...initialState.serverState.workflows, ...WORKFLOWS_FIXTURE],
+        currentWorkflow: WORKFLOWS_FIXTURE[0],
+        workflows: WORKFLOWS_FIXTURE,
       },
       clientState: {
-        workflows: [],
+        currentWorkflow: {
+          data: WORKFLOWS_FIXTURE[0],
+          isDirty: false,
+        },
       },
     });
   });
 
-  test('should handle ACTION_SET_WORKFLOWS without workflows', () => {
+  test('ACTION_SET_WORKFLOWS without workflows', () => {
     const action = {
       type: ACTION_SET_WORKFLOWS,
       payload: { status: 'loading', workflows: null },
     };
 
-    expect(reducer(state, action)).toEqual({
+    expect(reducer(state, action)).toStrictEqual({
       ...initialState,
-      serverState: {
-        ...initialState.serverState,
-        workflows: [],
-      },
+      serverState: expect.objectContaining({
+        currentWorkflow: null,
+      }),
+    });
+  });
+
+  test('ACTION_DELETE_STAGE', () => {
+    const action = {
+      type: ACTION_DELETE_STAGE,
+      payload: { stageId: 1 },
+    };
+
+    state = {
+      status: expect.any(String),
+      serverState: expect.any(Object),
       clientState: {
-        workflows: [],
+        currentWorkflow: { data: WORKFLOWS_FIXTURE[0], isDirty: false },
+      },
+    };
+
+    expect(reducer(state, action)).toStrictEqual({
+      status: expect.any(String),
+      serverState: expect.any(Object),
+      clientState: {
+        currentWorkflow: { data: WORKFLOWS_FIXTURE[0], isDirty: false },
+      },
+    });
+  });
+
+  test('ACTION_ADD_STAGE', () => {
+    const action = {
+      type: ACTION_ADD_STAGE,
+      payload: { name: 'something' },
+    };
+
+    state = {
+      status: expect.any(String),
+      serverState: expect.any(Object),
+      clientState: {
+        currentWorkflow: { data: WORKFLOWS_FIXTURE[0], isDirty: false },
+      },
+    };
+
+    expect(reducer(state, action)).toStrictEqual({
+      status: expect.any(String),
+      serverState: expect.any(Object),
+      clientState: {
+        currentWorkflow: {
+          data: {
+            ...WORKFLOWS_FIXTURE[0],
+            stages: expect.arrayContaining([
+              {
+                __temp_key__: 3,
+                name: 'something',
+              },
+            ]),
+          },
+          isDirty: true,
+        },
+      },
+    });
+  });
+
+  test('ACTION_UPDATE_STAGE', () => {
+    const action = {
+      type: ACTION_UPDATE_STAGE,
+      payload: { stageId: 1, name: 'stage-1-modified' },
+    };
+
+    state = {
+      status: expect.any(String),
+      serverState: expect.any(Object),
+      clientState: {
+        currentWorkflow: { data: WORKFLOWS_FIXTURE[0], isDirty: false },
+      },
+    };
+
+    expect(reducer(state, action)).toStrictEqual({
+      status: expect.any(String),
+      serverState: expect.any(Object),
+      clientState: {
+        currentWorkflow: {
+          data: {
+            ...WORKFLOWS_FIXTURE[0],
+            stages: expect.arrayContaining([
+              {
+                id: 1,
+                name: 'stage-1-modified',
+              },
+            ]),
+          },
+          isDirty: true,
+        },
       },
     });
   });

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/tests/ReviewWorkflows.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/tests/ReviewWorkflows.test.js
@@ -59,7 +59,7 @@ describe('Admin | Settings | Review Workflow | ReviewWorkflowsPage', () => {
     expect(getByText('Workflow is loading')).toBeInTheDocument();
   });
 
-  test('handle loaded stage', () => {
+  test('display stages', () => {
     useReviewWorkflows.mockReturnValue({
       workflows: {
         status: 'success',

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/tests/ReviewWorkflows.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/tests/ReviewWorkflows.test.js
@@ -3,6 +3,7 @@ import { render } from '@testing-library/react';
 import { IntlProvider } from 'react-intl';
 import { Provider } from 'react-redux';
 import { QueryClientProvider, QueryClient } from 'react-query';
+import userEvent from '@testing-library/user-event';
 
 import { ThemeProvider, lightTheme } from '@strapi/design-system';
 
@@ -13,12 +14,7 @@ import { useReviewWorkflows } from '../hooks/useReviewWorkflows';
 
 jest.mock('../hooks/useReviewWorkflows', () => ({
   ...jest.requireActual('../hooks/useReviewWorkflows'),
-  useReviewWorkflows: jest.fn().mockReturnValue({
-    workflows: {
-      status: 'loading',
-      data: null,
-    },
-  }),
+  useReviewWorkflows: jest.fn().mockReturnValue(),
 }));
 
 const client = new QueryClient({
@@ -47,19 +43,12 @@ const ComponentFixture = () => {
 
 const setup = (props) => render(<ComponentFixture {...props} />);
 
+const user = userEvent.setup();
+
 describe('Admin | Settings | Review Workflow | ReviewWorkflowsPage', () => {
   beforeEach(() => {
-    jest.clearAllMocks();
-  });
+    jest.restoreAllMocks();
 
-  test('handle initial loading state', () => {
-    const { getByText } = setup();
-
-    expect(getByText('0 stages')).toBeInTheDocument();
-    expect(getByText('Workflow is loading')).toBeInTheDocument();
-  });
-
-  test('display stages', () => {
     useReviewWorkflows.mockReturnValue({
       workflows: {
         status: 'success',
@@ -76,11 +65,56 @@ describe('Admin | Settings | Review Workflow | ReviewWorkflowsPage', () => {
         ],
       },
     });
+  });
 
-    const { getByText, queryByText } = setup();
+  test('handle initial loading state', () => {
+    useReviewWorkflows.mockReturnValue({
+      workflows: {
+        status: 'loading',
+        data: [],
+      },
+    });
+
+    const { getByText } = setup();
+
+    expect(getByText('0 stages')).toBeInTheDocument();
+    expect(getByText('Workflow is loading')).toBeInTheDocument();
+  });
+
+  test('loading state is not present', () => {
+    const { queryByText } = setup();
+
+    expect(queryByText('Workflow is loading')).not.toBeInTheDocument();
+  });
+
+  test('display stages', () => {
+    const { getByText } = setup();
 
     expect(getByText('1 stage')).toBeInTheDocument();
-    expect(queryByText('Workflow is loading')).not.toBeInTheDocument();
     expect(getByText('stage-1')).toBeInTheDocument();
+  });
+
+  test('Save button is disabled by default', async () => {
+    const { getByRole } = setup();
+
+    const saveButton = getByRole('button', { name: /save/i });
+
+    expect(saveButton).toBeInTheDocument();
+    expect(saveButton.getAttribute('disabled')).toBeDefined();
+  });
+
+  test('Save button is enabled after a stage has been added', async () => {
+    const { getByText, getByRole } = setup();
+
+    await user.click(
+      getByRole('button', {
+        name: /add new stage/i,
+      })
+    );
+
+    const saveButton = getByRole('button', { name: /save/i });
+
+    expect(getByText('2 stages')).toBeInTheDocument();
+    expect(saveButton.hasAttribute('disabled')).toBeFalsy();
   });
 });

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/utils/getWorkflowValidationSchema.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/utils/getWorkflowValidationSchema.js
@@ -1,0 +1,25 @@
+import * as yup from 'yup';
+
+export function getWorkflowValidationSchema({ formatMessage }) {
+  return yup.object({
+    stages: yup.array().of(
+      yup.object().shape({
+        name: yup
+          .string()
+          .required(
+            formatMessage({
+              id: 'Settings.review-workflows.validation.stage.name',
+              defaultMessage: 'Name is required',
+            })
+          )
+          .max(
+            255,
+            formatMessage({
+              id: 'Settings.review-workflows.validation.stage.max-length',
+              defaultMessage: 'Name can not be longer than 255 characters',
+            })
+          ),
+      })
+    ),
+  });
+}


### PR DESCRIPTION
### What does it do?

Adds the following abilities to the workflow management settings page:

- Allows to add new stages
- Allows the edit the name of existing stages
- Allows to save the current workflow
- Allows to delete stages (except the last one): we will have a confirmation dialog if the user has deleted stages - this is not part of this PR and will be done in a follow-up.

> **Note**
> The admin API is not ready yet.

#### State management

The state has the following structure:

```
clientState                         // copy of the fetched state for FE comparisons
  currentWorkflow: {          // copy of the default workflow (which is the first one fetched for the MVP)
    data: {}                          // workflow data
    isDirty: false                 // boolean flag that indicates whether the current workflow has been edited
  }
serverState                      // raw data fetched from the API
  currentWorkflow: {}      // the default workflow (which is the first one fetched for the MVP)
  workflows: []                 // all workflows fetched from the API
```

The state is used to setup initial values in Formik - formik handles field values (un-controlled) and only onBlur the value of the stage-name field is synched with redux for performance reasons.

On each change the `isDirty` flag is calculated.

### Why is it needed?

Implements the workflow management part of the feature.

### How to test it?

I will add tests if you agree with the overall approach.

