### PR TITLE
[content manager] Return required error if empty for json input

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/utils/schema.js
+++ b/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/utils/schema.js
@@ -212,23 +212,31 @@ const createYupSchemaAttribute = (type, validations, options) => {
     schema = yup.string();
   }
 
+  console.log({ type, validations, options });
+
   if (type === 'json') {
-    schema = yup
-      .mixed(errorsTrads.json)
-      .test('isJSON', errorsTrads.json, (value) => {
-        if (value === undefined) {
-          return true;
-        }
+    if (validations.required) {
+      schema = yup.mixed(errorsTrads.required).test('required', errorsTrads.required, (value) => {
+        return value === undefined;
+      });
+    } else {
+      schema = yup
+        .mixed(errorsTrads.json)
+        .test('isJSON', errorsTrads.json, (value) => {
+          if (value === undefined) {
+            return true;
+          }
 
-        try {
-          JSON.parse(value);
+          try {
+            JSON.parse(value);
 
-          return true;
-        } catch (err) {
-          return false;
-        }
-      })
-      .nullable();
+            return true;
+          } catch (err) {
+            return false;
+          }
+        })
+        .nullable();
+    }
   }
 
   if (type === 'email') {


### PR DESCRIPTION
### What does it do?

- Uses the expected error message if the JSONInput is left empty and it is marked as required

### Why is it needed?

Currently the input throws invalid json when the input is marked required and left empty

### How to test it?

- Set a json type as required on any content-type
- Go to create an entry
- Remove all content from the json input
- Try to save, you should get "Value is required" error

- Do the same thing for a non-required json input
- You should get value is invalid JSON


### Related issue(s)/PR(s)

https://github.com/strapi/strapi/pull/15606
