### PR TITLE
fix package script dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "setup": "yarn && yarn clean && yarn build",
     "clean": "lerna run --stream clean --no-private",
     "watch": "lerna run --stream watch --no-private --parallel",
-    "build": "lerna run --stream build --no-private",
+    "build": "yarn build:ts && lerna run --stream build --no-private",
     "build:ts": "lerna run --stream build:ts --no-private",
     "generate": "plop --plopfile ./packages/generators/admin/plopfile.js",
     "lint": "npm-run-all -p lint:code lint:css",

--- a/packages/core/data-transfer/package.json
+++ b/packages/core/data-transfer/package.json
@@ -27,11 +27,9 @@
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "scripts": {
-    "build": "yarn build:ts",
     "build:ts": "tsc -p tsconfig.json",
-    "build:clean": "yarn clean && yarn build",
     "clean": "rimraf ./lib",
-    "prepublishOnly": "yarn build:clean",
+    "prepublishOnly": "yarn clean && yarn build:ts",
     "test:unit": "jest --verbose",
     "watch": "yarn build:ts -w --preserveWatchOutput"
   },


### PR DESCRIPTION
### What does it do?

Fixes the lerna task graph circulary dependency error that is currently happening on `yarn build` with @strapi/data-transfer.

Requires TypeScript packages to only build their ts in the "build:ts" script and not a "build" step, because that would either cause the circular dependency or (if written without a `yarn build` statement) would still cause the build to trigger twice.

### Why is it needed?

Context: "build:ts" should in theory be part of the "build" step. However, building typescript is necessary prior to running lint or unit tests, whereas a full build is not necessary for those. In order to reduce the amount of "build" that needs to be run, especially in regards to the GitHub workflow, we needed to separate it into a substep that could be run independently with `yarn build:ts`.

The actual circular dependency happened because in the root level, "yarn build" uses lerna to call "yarn build" in every module. But when it saw data-transfer/package.json included `"build": "yarn build"` it would have triggered the root level yarn build again.

The minor downside to this is that we can't run `yarn build` from within the data-transfer package and instead have to run `yarn build:ts`.

### How to test it?

Run `yarn setup` or `yarn build` or `yarn build:ts` from the root level of the monorepo and there should no longer be a circular task dependency warning.

`yarn watch` should also still work in the root level as well as the Typescript package.