### PR TITLE
[DEITS] Transfer: Pass tokens from CLI to remote provider

### DIFF
--- a/packages/core/data-transfer/src/strapi/providers/remote-destination/index.ts
+++ b/packages/core/data-transfer/src/strapi/providers/remote-destination/index.ts
@@ -18,21 +18,15 @@ import type { ILocalStrapiDestinationProviderOptions } from '../local-destinatio
 import { TRANSFER_PATH } from '../../remote/constants';
 import { ProviderTransferError, ProviderValidationError } from '../../../errors/providers';
 
-interface ITokenAuth {
+interface ITransferTokenAuth {
   type: 'token';
   token: string;
-}
-
-interface ICredentialsAuth {
-  type: 'credentials';
-  email: string;
-  password: string;
 }
 
 export interface IRemoteStrapiDestinationProviderOptions
   extends Pick<ILocalStrapiDestinationProviderOptions, 'restore' | 'strategy'> {
   url: URL;
-  auth?: ITokenAuth | ICredentialsAuth;
+  auth?: ITransferTokenAuth;
 }
 
 class RemoteStrapiDestinationProvider implements IDestinationProvider {

--- a/packages/core/strapi/bin/strapi.js
+++ b/packages/core/strapi/bin/strapi.js
@@ -297,7 +297,8 @@ program
   .addOption(forceOption)
   .addOption(excludeOption)
   .addOption(onlyOption)
-  // Validate URLs
+  .hook('preAction', validateExcludeOnly)
+  // If --from is used, valudate the URL and token
   .hook(
     'preAction',
     ifOptions(
@@ -313,7 +314,7 @@ program
       }
     )
   )
-  .hook('preAction', validateExcludeOnly)
+  // If --to is used, valudate the URL, token, and confirm restore
   .hook(
     'preAction',
     ifOptions(

--- a/packages/core/strapi/bin/strapi.js
+++ b/packages/core/strapi/bin/strapi.js
@@ -284,9 +284,7 @@ program
       .hideHelp() // Hidden until pull feature is released
   )
   .addOption(
-    new Option('--from-token <token>', `Transfer token for the remote Strapi source`)
-      .argParser(parseURL)
-      .hideHelp() // Hidden until pull feature is released
+    new Option('--from-token <token>', `Transfer token for the remote Strapi source`).hideHelp() // Hidden until pull feature is released
   )
   .addOption(
     new Option(
@@ -294,25 +292,37 @@ program
       `URL of the remote Strapi instance to send data to`
     ).argParser(parseURL)
   )
-  .addOption(
-    new Option('--to-token <token>', `Transfer token for the remote Strapi destination`).argParser(
-      parseURL
-    )
-  )
+  .addOption(new Option('--to-token <token>', `Transfer token for the remote Strapi destination`))
   .addOption(forceOption)
   // Validate URLs
   .hook(
     'preAction',
     ifOptions(
       (opts) => opts.from,
-      (thisCommand) => assertUrlHasProtocol(thisCommand.opts().from, ['https:', 'http:'])
+      (thisCommand) => {
+        assertUrlHasProtocol(thisCommand.opts().from, ['https:', 'http:']);
+        if (!thisCommand.opts().fromToken) {
+          exitWith(
+            1,
+            'A transfer token is required to initiate a transfer from a remote Strapi source.'
+          );
+        }
+      }
     )
   )
   .hook(
     'preAction',
     ifOptions(
       (opts) => opts.to,
-      (thisCommand) => assertUrlHasProtocol(thisCommand.opts().to, ['https:', 'http:'])
+      (thisCommand) => {
+        assertUrlHasProtocol(thisCommand.opts().to, ['https:', 'http:']);
+        if (!thisCommand.opts().toToken) {
+          exitWith(
+            1,
+            'A transfer token is required to initiate a transfer to a remote Strapi destination.'
+          );
+        }
+      }
     )
   )
   .hook(

--- a/packages/core/strapi/bin/strapi.js
+++ b/packages/core/strapi/bin/strapi.js
@@ -273,59 +273,66 @@ program
   .option('-s, --silent', `Run the generation silently, without any output`, false)
   .action(getLocalScript('ts/generate-types'));
 
-if (process.env.STRAPI_EXPERIMENTAL === 'true') {
-  // `$ strapi transfer`
-  program
-    .command('transfer')
-    .description('Transfer data from one source to another')
-    .allowExcessArguments(false)
-    .addOption(
-      new Option(
-        '--from <sourceURL>',
-        `URL of the remote Strapi instance to get data from`
-      ).argParser(parseURL)
+// `$ strapi transfer`
+program
+  .command('transfer')
+  .description('Transfer data from one source to another')
+  .allowExcessArguments(false)
+  .addOption(
+    new Option('--from <sourceURL>', `URL of the remote Strapi instance to get data from`)
+      .argParser(parseURL)
+      .hideHelp() // Hidden until pull feature is released
+  )
+  .addOption(
+    new Option('--from-token <token>', `Transfer token for the remote Strapi source`)
+      .argParser(parseURL)
+      .hideHelp() // Hidden until pull feature is released
+  )
+  .addOption(
+    new Option(
+      '--to <destinationURL>',
+      `URL of the remote Strapi instance to send data to`
+    ).argParser(parseURL)
+  )
+  .addOption(
+    new Option('--to-token <token>', `Transfer token for the remote Strapi destination`).argParser(
+      parseURL
     )
-    .addOption(
-      new Option(
-        '--to <destinationURL>',
-        `URL of the remote Strapi instance to send data to`
-      ).argParser(parseURL)
+  )
+  .addOption(forceOption)
+  // Validate URLs
+  .hook(
+    'preAction',
+    ifOptions(
+      (opts) => opts.from,
+      (thisCommand) => assertUrlHasProtocol(thisCommand.opts().from, ['https:', 'http:'])
     )
-    .addOption(forceOption)
-    // Validate URLs
-    .hook(
-      'preAction',
-      ifOptions(
-        (opts) => opts.from,
-        (thisCommand) => assertUrlHasProtocol(thisCommand.opts().from, ['https:', 'http:'])
-      )
+  )
+  .hook(
+    'preAction',
+    ifOptions(
+      (opts) => opts.to,
+      (thisCommand) => assertUrlHasProtocol(thisCommand.opts().to, ['https:', 'http:'])
     )
-    .hook(
-      'preAction',
-      ifOptions(
-        (opts) => opts.to,
-        (thisCommand) => assertUrlHasProtocol(thisCommand.opts().to, ['https:', 'http:'])
-      )
+  )
+  .hook(
+    'preAction',
+    ifOptions(
+      (opts) => !opts.from && !opts.to,
+      () => exitWith(1, 'At least one source (from) or destination (to) option must be provided')
     )
-    .hook(
-      'preAction',
-      ifOptions(
-        (opts) => !opts.from && !opts.to,
-        () => exitWith(1, 'At least one source (from) or destination (to) option must be provided')
-      )
+  )
+  .addOption(forceOption)
+  .addOption(excludeOption)
+  .addOption(onlyOption)
+  .hook('preAction', validateExcludeOnly)
+  .hook(
+    'preAction',
+    confirmMessage(
+      'The import will delete all data in the remote database. Are you sure you want to proceed?'
     )
-    .addOption(forceOption)
-    .addOption(excludeOption)
-    .addOption(onlyOption)
-    .hook('preAction', validateExcludeOnly)
-    .hook(
-      'preAction',
-      confirmMessage(
-        'The import will delete all data in the remote database. Are you sure you want to proceed?'
-      )
-    )
-    .action(getLocalScript('transfer/transfer'));
-}
+  )
+  .action(getLocalScript('transfer/transfer'));
 
 // `$ strapi export`
 program

--- a/packages/core/strapi/bin/strapi.js
+++ b/packages/core/strapi/bin/strapi.js
@@ -298,7 +298,7 @@ program
   .addOption(excludeOption)
   .addOption(onlyOption)
   .hook('preAction', validateExcludeOnly)
-  // If --from is used, valudate the URL and token
+  // If --from is used, validate the URL and token
   .hook(
     'preAction',
     ifOptions(
@@ -314,7 +314,7 @@ program
       }
     )
   )
-  // If --to is used, valudate the URL, token, and confirm restore
+  // If --to is used, validate the URL, token, and confirm restore
   .hook(
     'preAction',
     ifOptions(

--- a/packages/core/strapi/bin/strapi.js
+++ b/packages/core/strapi/bin/strapi.js
@@ -322,11 +322,19 @@ program
       async (thisCommand) => {
         assertUrlHasProtocol(thisCommand.opts().to, ['https:', 'http:']);
         if (!thisCommand.opts().toToken) {
-          exitWith(
-            1,
-            'A transfer token is required to initiate a transfer to a remote Strapi destination.'
-          );
+          const answers = await inquirer.prompt([
+            {
+              type: 'password',
+              message: 'Please enter your transfer token for the remote Strapi destination',
+              name: 'toToken',
+            },
+          ]);
+          if (!answers.toToken?.length) {
+            exitWith(0, 'No token entered, aborting transfer.');
+          }
+          thisCommand.opts().toToken = answers.toToken;
         }
+
         await confirmMessage(
           'The transfer will delete all data in the remote database and media files. Are you sure you want to proceed?'
         )(thisCommand);

--- a/packages/core/strapi/lib/commands/transfer/transfer.js
+++ b/packages/core/strapi/lib/commands/transfer/transfer.js
@@ -25,6 +25,8 @@ const logger = console;
  *
  * @property {URL|undefined} [to] The url of a remote Strapi to use as remote destination
  * @property {URL|undefined} [from] The url of a remote Strapi to use as remote source
+ * @property {string|undefined} [toToken] The transfer token for the remote Strapi destination
+ * @property {string|undefined} [fromToken] The transfer token for the remote Strapi source
  */
 
 /**
@@ -90,7 +92,7 @@ module.exports = async (opts) => {
   }
 
   const engine = createTransferEngine(source, destination, {
-    versionStrategy: 'strict',
+    versionStrategy: 'exact',
     schemaStrategy: 'strict',
     transforms: {
       links: [

--- a/packages/core/strapi/lib/commands/transfer/transfer.js
+++ b/packages/core/strapi/lib/commands/transfer/transfer.js
@@ -73,7 +73,10 @@ module.exports = async (opts) => {
   else {
     destination = createRemoteStrapiDestinationProvider({
       url: opts.to,
-      auth: false,
+      auth: {
+        type: 'token',
+        token: opts.toToken,
+      },
       strategy: 'restore',
       restore: {
         entities: { exclude: DEFAULT_IGNORED_CONTENT_TYPES },


### PR DESCRIPTION
### What does it do?

- Turns the transfer commands back on without STRAPI_EXPERIMENTAL
- Adds --to-token (and hidden --from-token) and passes them to remote provider
- Adds a prompt for transfer tokens that are not sent in the CLI
- Tokens are always required for remote transfers, unless someone can provide a use-case where it shouldn't be. Unlimited lifespan tokens exist, so there should be no reason to ever need unrestricted transfer access outside of that.

### Why is it needed?

So the transfer command accepts and sends transfer tokens

### How to test it?

Run `yarn strapi transfer --to=http://strapiurl/admin --to-token=someToken` and the token should be sent to the websocket as a Bearer token (although it currently won't work and that part will likely change once we develop the actual transfer token system)

Run `yarn strapi transfer --to=http://strapiurl/admin` and you should be prompted for a token (and if you don't enter one, transfer should abort)

~~Run `yarn strapi transfer` without a --to and you should not be prompted for a restore~~ (doesn't really matter for now since --to is the only option that works)
