### PR TITLE
Jest: Collect coverage for ee admin folders

### DIFF
--- a/jest.base-config.front.js
+++ b/jest.base-config.front.js
@@ -30,6 +30,7 @@ module.exports = {
   moduleNameMapper,
   collectCoverageFrom: [
     '<rootDir>/packages/core/*/admin/src/**/*.js',
+    '<rootDir>/packages/core/admin/ee/admin/**/*.js',
     '<rootDir>/packages/plugins/*/admin/src/**/*.js',
   ],
   testPathIgnorePatterns: [


### PR DESCRIPTION
### What does it do?

Adds `ee/admin` directory for jest to collect coverage from.

### Why is it needed?

Right now we don't get a coverage report about this directory structure. Adding this directory will help us to keep track of code coverage.

### How to test it?

The coverage report of the PR lists `ee/admin` files now: https://app.codecov.io/gh/strapi/strapi/pull/15695
