### PR TITLE
Fix `hasTable` is undefined for schema postgres users

### DIFF
--- a/packages/core/database/lib/validations/relations/bidirectional.js
+++ b/packages/core/database/lib/validations/relations/bidirectional.js
@@ -32,7 +32,7 @@ const getLinksWithoutMappedBy = (db) => {
 
 const isLinkTableEmpty = async (db, linkTableName) => {
   // If the table doesn't exist, it's empty
-  const exists = await db.getConnection().schema.hasTable(linkTableName);
+  const exists = await db.getSchemaConnection().hasTable(linkTableName);
   if (!exists) return true;
 
   const result = await db.getConnection().count('* as count').from(linkTableName);


### PR DESCRIPTION
### What does it do?

Fix #15603 

### Why is it needed?

Users using postgres with a schema and having the double inverseBy bug (#14428) cannot start Strapi.

### How to test it?

1. Create a schema in your postgres DB:
```SQL
# SQL
CREATE SCHEMA myschema;
```
2. Set the schema in the database config `./config/database.js`: 
```JS
module.exports = ({ env }) => ({
  client: 'postgres',
  connection: {
    // ...
    schema: 'myschema',
    // ...
  },
});
```
3. Create a many-many relation between 2 content-types through the content-type builder
4. Identify the content-type schema where the previously created relation has the key `mappedBy`
5. Modify this schema file by replacing the key `mappedBy` by `inversedBy`
6. Restart the app
7. See that there is no error anymore

### Related issue(s)/PR(s)

#15603
