### PR TITLE
[DEITS] Clean up import,export,transfer commands and tests

### DIFF
--- a/packages/core/strapi/lib/commands/__tests__/data-transfer/export.test.js
+++ b/packages/core/strapi/lib/commands/__tests__/data-transfer/export.test.js
@@ -5,6 +5,10 @@ const { expectExit } = require('./shared/transfer.test.utils');
 describe('Export', () => {
   const defaultFileName = 'defaultFilename';
 
+  jest.mock('fs-extra', () => ({
+    pathExists: jest.fn(() => Promise.resolve(true)),
+  }));
+
   const mockDataTransfer = {
     file: {
       providers: {
@@ -19,7 +23,16 @@ describe('Export', () => {
     engine: {
       createTransferEngine() {
         return {
-          transfer: jest.fn().mockReturnValue(Promise.resolve({})),
+          transfer: jest.fn(() => {
+            return {
+              engine: {},
+              destination: {
+                file: {
+                  path: 'path',
+                },
+              },
+            };
+          }),
           progress: {
             on: jest.fn(),
             stream: {
@@ -52,6 +65,13 @@ describe('Export', () => {
       };
     },
     getDefaultExportName: jest.fn(() => defaultFileName),
+    buildTransferTable: jest.fn(() => {
+      return {
+        toString() {
+          return 'table';
+        },
+      };
+    }),
   };
   jest.mock(
     '../../transfer/utils',
@@ -61,7 +81,7 @@ describe('Export', () => {
     { virtual: true }
   );
 
-  // other spies
+  // console spies
   jest.spyOn(console, 'log').mockImplementation(() => {});
   jest.spyOn(console, 'warn').mockImplementation(() => {});
   jest.spyOn(console, 'info').mockImplementation(() => {});
@@ -77,10 +97,11 @@ describe('Export', () => {
   it('uses path provided by user', async () => {
     const filename = 'test';
 
-    await expectExit(1, async () => {
+    await expectExit(0, async () => {
       await exportCommand({ file: filename });
     });
 
+    expect(console.error).not.toHaveBeenCalled();
     expect(mockDataTransfer.file.providers.createLocalFileDestinationProvider).toHaveBeenCalledWith(
       expect.objectContaining({
         file: { path: filename },
@@ -90,7 +111,7 @@ describe('Export', () => {
   });
 
   it('uses default path if not provided by user', async () => {
-    await expectExit(1, async () => {
+    await expectExit(0, async () => {
       await exportCommand({});
     });
 
@@ -104,7 +125,7 @@ describe('Export', () => {
 
   it('encrypts the output file if specified', async () => {
     const encrypt = true;
-    await expectExit(1, async () => {
+    await expectExit(0, async () => {
       await exportCommand({ encrypt });
     });
 
@@ -118,7 +139,7 @@ describe('Export', () => {
   it('encrypts the output file with the given key', async () => {
     const key = 'secret-key';
     const encrypt = true;
-    await expectExit(1, async () => {
+    await expectExit(0, async () => {
       await exportCommand({ encrypt, key });
     });
 
@@ -130,7 +151,7 @@ describe('Export', () => {
   });
 
   it('uses compress option', async () => {
-    await expectExit(1, async () => {
+    await expectExit(0, async () => {
       await exportCommand({ compress: false });
     });
 
@@ -139,7 +160,7 @@ describe('Export', () => {
         compression: { enabled: false },
       })
     );
-    await expectExit(1, async () => {
+    await expectExit(0, async () => {
       await exportCommand({ compress: true });
     });
     expect(mockDataTransfer.file.providers.createLocalFileDestinationProvider).toHaveBeenCalledWith(

--- a/packages/core/strapi/lib/commands/__tests__/data-transfer/import.test.js
+++ b/packages/core/strapi/lib/commands/__tests__/data-transfer/import.test.js
@@ -10,7 +10,11 @@ const { expectExit } = require('./shared/transfer.test.utils');
 
 const createTransferEngine = jest.fn(() => {
   return {
-    transfer: jest.fn().mockReturnValue(Promise.resolve({})),
+    transfer: jest.fn(() => {
+      return {
+        engine: {},
+      };
+    }),
     progress: {
       on: jest.fn(),
       stream: {
@@ -64,7 +68,13 @@ describe('Import', () => {
       },
       destroy: jest.fn(),
     }),
-    buildTransferTable: jest.fn(() => 'table'),
+    buildTransferTable: jest.fn(() => {
+      return {
+        toString() {
+          return 'table';
+        },
+      };
+    }),
   };
   jest.mock(
     '../../transfer/utils',
@@ -74,11 +84,11 @@ describe('Import', () => {
     { virtual: true }
   );
 
-  // other spies
-  // jest.spyOn(console, 'log').mockImplementation(() => {});
-  // jest.spyOn(console, 'warn').mockImplementation(() => {});
-  // jest.spyOn(console, 'info').mockImplementation(() => {});
-  // jest.spyOn(console, 'error').mockImplementation(() => {});
+  // console spies
+  jest.spyOn(console, 'log').mockImplementation(() => {});
+  jest.spyOn(console, 'warn').mockImplementation(() => {});
+  jest.spyOn(console, 'info').mockImplementation(() => {});
+  jest.spyOn(console, 'error').mockImplementation(() => {});
 
   // Now that everything is mocked, load the 'import' command
   const importCommand = require('../../transfer/import');

--- a/packages/core/strapi/lib/commands/__tests__/data-transfer/transfer.test.js
+++ b/packages/core/strapi/lib/commands/__tests__/data-transfer/transfer.test.js
@@ -83,6 +83,18 @@ describe('Transfer', () => {
     jest.clearAllMocks();
   });
 
+  it('exits with error when no --to or --from is provided', async () => {
+    await expectExit(1, async () => {
+      await transferCommand({ from: undefined, to: undefined });
+    });
+
+    expect(console.error).toHaveBeenCalledWith(expect.stringMatching(/source/i));
+
+    expect(
+      mockDataTransfer.strapi.providers.createRemoteStrapiDestinationProvider
+    ).not.toHaveBeenCalled();
+  });
+
   describe('--to', () => {
     it('exits with error when auth is not provided', async () => {
       await expectExit(1, async () => {
@@ -114,6 +126,18 @@ describe('Transfer', () => {
         })
       );
     });
+
+    it('uses local Strapi source when from is not specified', async () => {
+      await expectExit(0, async () => {
+        await transferCommand({ from: undefined, to: destinationUrl, toToken: destinationToken });
+      });
+
+      expect(console.error).not.toHaveBeenCalled();
+      expect(mockDataTransfer.strapi.providers.createLocalStrapiSourceProvider).toHaveBeenCalled();
+      expect(
+        mockDataTransfer.strapi.providers.createRemoteStrapiDestinationProvider
+      ).toHaveBeenCalled();
+    });
   });
 
   it('uses restore as the default strategy', async () => {
@@ -129,17 +153,5 @@ describe('Transfer', () => {
         strategy: 'restore',
       })
     );
-  });
-
-  it('uses local Strapi source when from is not specified', async () => {
-    await expectExit(0, async () => {
-      await transferCommand({ from: undefined, to: destinationUrl, toToken: destinationToken });
-    });
-
-    expect(console.error).not.toHaveBeenCalled();
-    expect(mockDataTransfer.strapi.providers.createLocalStrapiSourceProvider).toHaveBeenCalled();
-    expect(
-      mockDataTransfer.strapi.providers.createRemoteStrapiDestinationProvider
-    ).toHaveBeenCalled();
   });
 });

--- a/packages/core/strapi/lib/commands/__tests__/data-transfer/transfer.test.js
+++ b/packages/core/strapi/lib/commands/__tests__/data-transfer/transfer.test.js
@@ -88,7 +88,7 @@ describe('Transfer', () => {
       await transferCommand({ from: undefined, to: undefined });
     });
 
-    expect(console.error).toHaveBeenCalledWith(expect.stringMatching(/source/i));
+    expect(console.error).toHaveBeenCalledWith(expect.stringMatching(/at least one source/i));
 
     expect(
       mockDataTransfer.strapi.providers.createRemoteStrapiDestinationProvider
@@ -101,7 +101,7 @@ describe('Transfer', () => {
         await transferCommand({ from: undefined, to: destinationUrl });
       });
 
-      expect(console.error).toHaveBeenCalledWith(expect.stringMatching(/missing/i));
+      expect(console.error).toHaveBeenCalledWith(expect.stringMatching(/missing token/i));
 
       expect(
         mockDataTransfer.strapi.providers.createRemoteStrapiDestinationProvider

--- a/packages/core/strapi/lib/commands/transfer/export.js
+++ b/packages/core/strapi/lib/commands/transfer/export.js
@@ -97,9 +97,7 @@ module.exports = async (opts) => {
   let results;
   let outFile;
   try {
-    console.log('before transfer');
     results = await engine.transfer();
-    console.log('after transfer');
     outFile = results.destination.file.path;
     const outFileExists = await fs.pathExists(outFile);
     if (!outFileExists) {
@@ -119,9 +117,7 @@ module.exports = async (opts) => {
   }
 
   console.log(`${chalk.bold('Export process has been completed successfully!')}`);
-  console.log(`Export archive is in ${chalk.green(outFile)}`);
-  console.log('ABout to exit');
-  exitWith(0);
+  exitWith(0, `Export archive is in ${chalk.green(outFile)}`);
 };
 
 /**

--- a/packages/core/strapi/lib/commands/transfer/export.js
+++ b/packages/core/strapi/lib/commands/transfer/export.js
@@ -19,6 +19,7 @@ const {
   createStrapiInstance,
   formatDiagnostic,
 } = require('./utils');
+const { exitWith } = require('../utils/helpers');
 
 /**
  * @typedef ExportCommandOptions Options given to the CLI import command
@@ -28,8 +29,6 @@ const {
  * @property {string} [key] Encryption key, only useful when encryption is enabled
  * @property {boolean} [compress] Used to compress the final archive
  */
-
-const logger = console;
 
 const BYTES_IN_MB = 1024 * 1024;
 
@@ -43,8 +42,7 @@ const BYTES_IN_MB = 1024 * 1024;
 module.exports = async (opts) => {
   // Validate inputs from Commander
   if (!isObject(opts)) {
-    logger.error('Could not parse command arguments');
-    process.exit(1);
+    exitWith(1, 'Could not parse command arguments');
   }
 
   const strapi = await createStrapiInstance();
@@ -92,33 +90,38 @@ module.exports = async (opts) => {
   };
 
   progress.on('transfer::start', async () => {
-    logger.log(`Starting export...`);
+    console.log(`Starting export...`);
     await strapi.telemetry.send('didDEITSProcessStart', getTelemetryPayload());
   });
 
+  let results;
+  let outFile;
   try {
-    const results = await engine.transfer();
-    const outFile = results.destination.file.path;
-
-    const table = buildTransferTable(results.engine);
-    logger.log(table.toString());
-
+    console.log('before transfer');
+    results = await engine.transfer();
+    console.log('after transfer');
+    outFile = results.destination.file.path;
     const outFileExists = await fs.pathExists(outFile);
     if (!outFileExists) {
       throw new TransferEngineTransferError(`Export file not created "${outFile}"`);
     }
-
-    logger.log(`${chalk.bold('Export process has been completed successfully!')}`);
-    logger.log(`Export archive is in ${chalk.green(outFile)}`);
   } catch {
     await strapi.telemetry.send('didDEITSProcessFail', getTelemetryPayload());
-    logger.error('Export process failed.');
-    process.exit(1);
+    exitWith(1, 'Export process failed.');
   }
 
-  // Note: Telemetry can't be sent in a finish event, because it runs async after this block but we can't await it, so if process.exit is used it won't send
   await strapi.telemetry.send('didDEITSProcessFinish', getTelemetryPayload());
-  process.exit(0);
+  try {
+    const table = buildTransferTable(results.engine);
+    console.log(table.toString());
+  } catch (e) {
+    console.error('There was an error displaying the results of the transfer.');
+  }
+
+  console.log(`${chalk.bold('Export process has been completed successfully!')}`);
+  console.log(`Export archive is in ${chalk.green(outFile)}`);
+  console.log('ABout to exit');
+  exitWith(0);
 };
 
 /**

--- a/packages/core/strapi/lib/commands/transfer/import.js
+++ b/packages/core/strapi/lib/commands/transfer/import.js
@@ -20,18 +20,16 @@ const {
   createStrapiInstance,
   formatDiagnostic,
 } = require('./utils');
+const { exitWith } = require('../utils/helpers');
 
 /**
  * @typedef {import('@strapi/data-transfer').ILocalFileSourceProviderOptions} ILocalFileSourceProviderOptions
  */
 
-const logger = console;
-
 module.exports = async (opts) => {
   // validate inputs from Commander
   if (!isObject(opts)) {
-    logger.error('Could not parse arguments');
-    process.exit(1);
+    exitWith(1, 'Could not parse arguments');
   }
 
   /**
@@ -100,27 +98,30 @@ module.exports = async (opts) => {
   };
 
   progress.on('transfer::start', async () => {
-    logger.info('Starting import...');
+    console.log('Starting import...');
     await strapiInstance.telemetry.send('didDEITSProcessStart', getTelemetryPayload());
   });
 
+  let results;
   try {
-    const results = await engine.transfer();
-    const table = buildTransferTable(results.engine);
-    logger.info(table.toString());
-
-    logger.info('Import process has been completed successfully!');
+    results = await engine.transfer();
   } catch (e) {
     await strapiInstance.telemetry.send('didDEITSProcessFail', getTelemetryPayload());
-    logger.error('Import process failed.');
+    console.error('Import process failed.');
     process.exit(1);
   }
 
-  // Note: Telemetry can't be sent in a finish event, because it runs async after this block but we can't await it, so if process.exit is used it won't send
+  try {
+    const table = buildTransferTable(results.engine);
+    console.log(table.toString());
+  } catch (e) {
+    console.error('There was an error displaying the results of the transfer.');
+  }
+
   await strapiInstance.telemetry.send('didDEITSProcessFinish', getTelemetryPayload());
   await strapiInstance.destroy();
 
-  process.exit(0);
+  exitWith(0, 'Import process has been completed successfully!');
 };
 
 /**

--- a/packages/core/strapi/lib/commands/utils/helpers.js
+++ b/packages/core/strapi/lib/commands/utils/helpers.js
@@ -36,22 +36,29 @@ const readableBytes = (bytes, decimals = 1, padStart = 0) => {
  *
  * @param {number} code Code to exit process with
  * @param {string | Array} message Message(s) to display before exiting
+ * @param {Object} options
+ * @param {console} options.logger - logger object, defaults to console
+ * @param {process} options.prc - process object, defaults to process
+ *
  */
-const exitWith = (code, message = undefined) => {
-  const logger = (message) => {
+const exitWith = (code, message = undefined, options = {}) => {
+  const { logger = console, prc = process } = options;
+
+  const log = (message) => {
     if (code === 0) {
-      console.log(chalk.green(message));
+      logger.log(chalk.green(message));
     } else {
-      console.error(chalk.red(message));
+      logger.error(chalk.red(message));
     }
   };
 
   if (isString(message)) {
-    logger(message);
+    log(message);
   } else if (isArray(message)) {
-    message.forEach((msg) => logger(msg));
+    message.forEach((msg) => log(msg));
   }
-  process.exit(code);
+
+  prc.exit(code);
 };
 
 /**


### PR DESCRIPTION
### What does it do?

- Improves exiting and error handling for import, export, and transfer commands
  - if there is an error in the data reporting, a transfer/import/export is now still reported as successful
  - import now uses console.log instead of console.info to be consistent with the other commands
- improves tests for import and export
- adds tests for transfer that actually work
- removes the useless `logger = console` at the top of each command; if we actually switch to using a logger, we can add it back in later but for now it was only complicating things

### Why is it needed?

To improve testing, refactoring, and fix minor messaging issues for import, export, and transfer

### How to test it?

Tests should still pass
Import, export, and transfer commands should still work

Now if there is an error in the printing of the results table, the transfer is still 
