### PR TITLE
[Audit Logs] Check auth strategy to log events on audit logs

### DIFF
--- a/packages/core/admin/ee/server/services/audit-logs.js
+++ b/packages/core/admin/ee/server/services/audit-logs.js
@@ -58,6 +58,16 @@ const createAuditLogsService = (strapi) => {
   const eventMap = getEventMap(defaultEvents);
 
   const processEvent = (name, ...args) => {
+    const state = strapi.requestContext.get()?.state;
+
+    // Ignore events with auth strategies different from admin
+    const isUsingAdminAuth = state?.auth?.strategy.name === 'admin';
+    const user = state?.user;
+
+    if (!isUsingAdminAuth || !user) {
+      return null;
+    }
+
     const getPayload = eventMap[name];
 
     // Ignore the event if it's not in the map
@@ -75,7 +85,7 @@ const createAuditLogsService = (strapi) => {
       action: name,
       date: new Date().toISOString(),
       payload: getPayload(...args) || {},
-      userId: strapi.requestContext.get()?.state?.user?.id,
+      userId: user.id,
     };
   };
 


### PR DESCRIPTION
To have previous context about this PR please check this [closed PR](https://github.com/strapi/strapi/pull/15605)

### What does it do?

In the `processEvent` function, before log anything we check if the user is correctly authenticated and if it's using the admin auth strategy, in this way we ignore events triggered by the content API or the U&P plugin

### How to test it
- Run a Strapi application with a valid EE license
- Create a new content type or edit a existing one and wait for Strapi to restart
- Go to the audit logs page, you should see only the create/update event and not the delete permissions events
- Try to create a new entry with the Content API, you should not see any event on the audit logs page

