### PR TITLE
[DEITS] fix broken transfer command

### DIFF
--- a/packages/core/strapi/bin/strapi.js
+++ b/packages/core/strapi/bin/strapi.js
@@ -287,9 +287,10 @@ program
     new Option('--from-token <token>', `Transfer token for the remote Strapi source`).hideHelp() // Hidden until pull feature is released
   )
   .addOption(
-    new Option('--to <destinationURL>', `URL of the remote Strapi instance to send data to`)
-      .argParser(parseURL)
-      .required()
+    new Option(
+      '--to <destinationURL>',
+      `URL of the remote Strapi instance to send data to`
+    ).argParser(parseURL)
   )
   .addOption(new Option('--to-token <token>', `Transfer token for the remote Strapi destination`))
   .addOption(forceOption)


### PR DESCRIPTION
### What does it do?

removed some broken code

### Why is it needed?

fix broken transfer command

### How to test it?

run `strapi transfer --help` and there should not be an error anymore