### PR TITLE
[relations]: we should always try and apply the relation paths if they exist

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/tests/reducer.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/tests/reducer.test.js
@@ -1094,14 +1094,6 @@ describe('CONTENT MANAGER | COMPONENTS | EditViewDataManagerProvider | reducer',
           modifiedDZName: true,
           shouldCheckErrors: true,
         };
-        const expected = {
-          ...initialState,
-          formErrors: {},
-          initialData: { ok: true, relation: [] },
-          modifiedData: { ok: true, relation: [] },
-          modifiedDZName: null,
-          shouldCheckErrors: false,
-        };
 
         const action = {
           type: 'INIT_FORM',
@@ -1109,7 +1101,27 @@ describe('CONTENT MANAGER | COMPONENTS | EditViewDataManagerProvider | reducer',
           relationalFieldPaths: ['relation'],
         };
 
-        expect(reducer(state, action)).toEqual(expected);
+        expect(reducer(state, action)).toMatchInlineSnapshot(`
+          {
+            "componentsDataStructure": {},
+            "contentTypeDataStructure": {},
+            "formErrors": {},
+            "initialData": {
+              "ok": true,
+              "relation": [],
+            },
+            "modifiedDZName": null,
+            "modifiedData": {
+              "ok": true,
+              "relation": [],
+            },
+            "publishConfirmation": {
+              "draftCount": 0,
+              "show": false,
+            },
+            "shouldCheckErrors": false,
+          }
+        `);
       });
 
       it('should create an array per relational field even when the relationalFieldPaths path is nested', () => {
@@ -1120,28 +1132,6 @@ describe('CONTENT MANAGER | COMPONENTS | EditViewDataManagerProvider | reducer',
           modifiedData: {},
           modifiedDZName: true,
           shouldCheckErrors: true,
-        };
-        const expected = {
-          ...initialState,
-          formErrors: {},
-          initialData: {
-            ok: true,
-            relation: [],
-            component: {
-              __temp_key__: expect.any(Number),
-              relation: [],
-            },
-          },
-          modifiedData: {
-            ok: true,
-            relation: [],
-            component: {
-              __temp_key__: expect.any(Number),
-              relation: [],
-            },
-          },
-          modifiedDZName: null,
-          shouldCheckErrors: false,
         };
 
         const action = {
@@ -1155,7 +1145,35 @@ describe('CONTENT MANAGER | COMPONENTS | EditViewDataManagerProvider | reducer',
           componentPaths: ['component'],
         };
 
-        expect(reducer(state, action)).toEqual(expected);
+        expect(reducer(state, action)).toMatchInlineSnapshot(`
+          {
+            "componentsDataStructure": {},
+            "contentTypeDataStructure": {},
+            "formErrors": {},
+            "initialData": {
+              "component": {
+                "__temp_key__": 1,
+                "relation": [],
+              },
+              "ok": true,
+              "relation": [],
+            },
+            "modifiedDZName": null,
+            "modifiedData": {
+              "component": {
+                "__temp_key__": 1,
+                "relation": [],
+              },
+              "ok": true,
+              "relation": [],
+            },
+            "publishConfirmation": {
+              "draftCount": 0,
+              "show": false,
+            },
+            "shouldCheckErrors": false,
+          }
+        `);
       });
 
       it('should create an array per relational field even when the relationalFieldPaths path is nested', () => {
@@ -1166,32 +1184,6 @@ describe('CONTENT MANAGER | COMPONENTS | EditViewDataManagerProvider | reducer',
           modifiedData: {},
           modifiedDZName: true,
           shouldCheckErrors: true,
-        };
-        const expected = {
-          ...initialState,
-          formErrors: {},
-          initialData: {
-            ok: true,
-            relation: [],
-            component: {
-              __temp_key__: expect.any(Number),
-              field1: {
-                field2: [],
-              },
-            },
-          },
-          modifiedData: {
-            ok: true,
-            relation: [],
-            component: {
-              __temp_key__: expect.any(Number),
-              field1: {
-                field2: [],
-              },
-            },
-          },
-          modifiedDZName: null,
-          shouldCheckErrors: false,
         };
 
         const action = {
@@ -1211,7 +1203,39 @@ describe('CONTENT MANAGER | COMPONENTS | EditViewDataManagerProvider | reducer',
           componentPaths: ['component', 'component.field1'],
         };
 
-        expect(reducer(state, action)).toEqual(expected);
+        expect(reducer(state, action)).toMatchInlineSnapshot(`
+          {
+            "componentsDataStructure": {},
+            "contentTypeDataStructure": {},
+            "formErrors": {},
+            "initialData": {
+              "component": {
+                "__temp_key__": 1,
+                "field1": {
+                  "field2": [],
+                },
+              },
+              "ok": true,
+              "relation": [],
+            },
+            "modifiedDZName": null,
+            "modifiedData": {
+              "component": {
+                "__temp_key__": 1,
+                "field1": {
+                  "field2": [],
+                },
+              },
+              "ok": true,
+              "relation": [],
+            },
+            "publishConfirmation": {
+              "draftCount": 0,
+              "show": false,
+            },
+            "shouldCheckErrors": false,
+          }
+        `);
       });
     });
 
@@ -1240,35 +1264,6 @@ describe('CONTENT MANAGER | COMPONENTS | EditViewDataManagerProvider | reducer',
           shouldCheckErrors: true,
         };
 
-        const expected = {
-          ...initialState,
-          formErrors: {},
-          initialData: {
-            categories: 'my_category',
-            repeatable_single_component_relation: [
-              {
-                id: 15,
-                my_name: null,
-                categories: [],
-                __temp_key__: 0,
-              },
-            ],
-          },
-          modifiedData: {
-            categories: 'my_category',
-            repeatable_single_component_relation: [
-              {
-                id: 15,
-                my_name: null,
-                categories: [],
-                __temp_key__: 0,
-              },
-            ],
-          },
-          modifiedDZName: null,
-          shouldCheckErrors: false,
-        };
-
         const action = {
           type: 'INIT_FORM',
           initialValues,
@@ -1276,7 +1271,41 @@ describe('CONTENT MANAGER | COMPONENTS | EditViewDataManagerProvider | reducer',
           repeatableComponentPaths: ['repeatable_single_component_relation'],
         };
 
-        expect(reducer(state, action)).toEqual(expected);
+        expect(reducer(state, action)).toMatchInlineSnapshot(`
+          {
+            "componentsDataStructure": {},
+            "contentTypeDataStructure": {},
+            "formErrors": {},
+            "initialData": {
+              "categories": "my_category",
+              "repeatable_single_component_relation": [
+                {
+                  "__temp_key__": 0,
+                  "categories": [],
+                  "id": 15,
+                  "my_name": null,
+                },
+              ],
+            },
+            "modifiedDZName": null,
+            "modifiedData": {
+              "categories": "my_category",
+              "repeatable_single_component_relation": [
+                {
+                  "__temp_key__": 0,
+                  "categories": [],
+                  "id": 15,
+                  "my_name": null,
+                },
+              ],
+            },
+            "publishConfirmation": {
+              "draftCount": 0,
+              "show": false,
+            },
+            "shouldCheckErrors": false,
+          }
+        `);
       });
 
       it('should create an array for a relational field inside a component', () => {
@@ -1306,41 +1335,6 @@ describe('CONTENT MANAGER | COMPONENTS | EditViewDataManagerProvider | reducer',
           shouldCheckErrors: true,
         };
 
-        const expected = {
-          ...initialState,
-          formErrors: {},
-          initialData: {
-            categories: 'my_category',
-            repeatable_nested_component_relation: [
-              {
-                id: 2,
-                simple: {
-                  id: 16,
-                  my_name: null,
-                  categories: [],
-                },
-                __temp_key__: 0,
-              },
-            ],
-          },
-          modifiedData: {
-            categories: 'my_category',
-            repeatable_nested_component_relation: [
-              {
-                id: 2,
-                simple: {
-                  id: 16,
-                  my_name: null,
-                  categories: [],
-                },
-                __temp_key__: 0,
-              },
-            ],
-          },
-          modifiedDZName: null,
-          shouldCheckErrors: false,
-        };
-
         const action = {
           type: 'INIT_FORM',
           initialValues,
@@ -1348,7 +1342,47 @@ describe('CONTENT MANAGER | COMPONENTS | EditViewDataManagerProvider | reducer',
           repeatableComponentPaths: ['repeatable_nested_component_relation'],
         };
 
-        expect(reducer(state, action)).toEqual(expected);
+        expect(reducer(state, action)).toMatchInlineSnapshot(`
+          {
+            "componentsDataStructure": {},
+            "contentTypeDataStructure": {},
+            "formErrors": {},
+            "initialData": {
+              "categories": "my_category",
+              "repeatable_nested_component_relation": [
+                {
+                  "__temp_key__": 0,
+                  "id": 2,
+                  "simple": {
+                    "categories": [],
+                    "id": 16,
+                    "my_name": null,
+                  },
+                },
+              ],
+            },
+            "modifiedDZName": null,
+            "modifiedData": {
+              "categories": "my_category",
+              "repeatable_nested_component_relation": [
+                {
+                  "__temp_key__": 0,
+                  "id": 2,
+                  "simple": {
+                    "categories": [],
+                    "id": 16,
+                    "my_name": null,
+                  },
+                },
+              ],
+            },
+            "publishConfirmation": {
+              "draftCount": 0,
+              "show": false,
+            },
+            "shouldCheckErrors": false,
+          }
+        `);
       });
 
       it('should create an array for a relational field inside a repeatable component which is inside a repeatable component', () => {
@@ -1381,47 +1415,6 @@ describe('CONTENT MANAGER | COMPONENTS | EditViewDataManagerProvider | reducer',
           shouldCheckErrors: true,
         };
 
-        const expected = {
-          ...initialState,
-          formErrors: {},
-          initialData: {
-            categories: 'my_category',
-            repeatable_repeatable_nested_component: [
-              {
-                id: 1,
-                repeatable_simple: [
-                  {
-                    id: 17,
-                    my_name: null,
-                    categories: [],
-                    __temp_key__: 0,
-                  },
-                ],
-                __temp_key__: 0,
-              },
-            ],
-          },
-          modifiedData: {
-            categories: 'my_category',
-            repeatable_repeatable_nested_component: [
-              {
-                id: 1,
-                repeatable_simple: [
-                  {
-                    id: 17,
-                    my_name: null,
-                    categories: [],
-                    __temp_key__: 0,
-                  },
-                ],
-                __temp_key__: 0,
-              },
-            ],
-          },
-          modifiedDZName: null,
-          shouldCheckErrors: false,
-        };
-
         const action = {
           type: 'INIT_FORM',
           initialValues,
@@ -1431,7 +1424,53 @@ describe('CONTENT MANAGER | COMPONENTS | EditViewDataManagerProvider | reducer',
           repeatableComponentPaths: ['repeatable_repeatable_nested_component'],
         };
 
-        expect(reducer(state, action)).toEqual(expected);
+        expect(reducer(state, action)).toMatchInlineSnapshot(`
+          {
+            "componentsDataStructure": {},
+            "contentTypeDataStructure": {},
+            "formErrors": {},
+            "initialData": {
+              "categories": "my_category",
+              "repeatable_repeatable_nested_component": [
+                {
+                  "__temp_key__": 0,
+                  "id": 1,
+                  "repeatable_simple": [
+                    {
+                      "__temp_key__": 0,
+                      "categories": [],
+                      "id": 17,
+                      "my_name": null,
+                    },
+                  ],
+                },
+              ],
+            },
+            "modifiedDZName": null,
+            "modifiedData": {
+              "categories": "my_category",
+              "repeatable_repeatable_nested_component": [
+                {
+                  "__temp_key__": 0,
+                  "id": 1,
+                  "repeatable_simple": [
+                    {
+                      "__temp_key__": 0,
+                      "categories": [],
+                      "id": 17,
+                      "my_name": null,
+                    },
+                  ],
+                },
+              ],
+            },
+            "publishConfirmation": {
+              "draftCount": 0,
+              "show": false,
+            },
+            "shouldCheckErrors": false,
+          }
+        `);
       });
 
       it('should create an array for a relational field inside a repeatable component which is inside a regular component', () => {
@@ -1462,43 +1501,6 @@ describe('CONTENT MANAGER | COMPONENTS | EditViewDataManagerProvider | reducer',
           shouldCheckErrors: true,
         };
 
-        const expected = {
-          ...initialState,
-          formErrors: {},
-          initialData: {
-            categories: 'my_category',
-            component: {
-              id: 2,
-              __temp_key__: 2,
-              repeatable_simple: [
-                {
-                  id: 18,
-                  my_name: null,
-                  categories: [],
-                  __temp_key__: 0,
-                },
-              ],
-            },
-          },
-          modifiedData: {
-            categories: 'my_category',
-            component: {
-              id: 2,
-              __temp_key__: 2,
-              repeatable_simple: [
-                {
-                  id: 18,
-                  my_name: null,
-                  categories: [],
-                  __temp_key__: 0,
-                },
-              ],
-            },
-          },
-          modifiedDZName: null,
-          shouldCheckErrors: false,
-        };
-
         const action = {
           type: 'INIT_FORM',
           initialValues,
@@ -1507,7 +1509,49 @@ describe('CONTENT MANAGER | COMPONENTS | EditViewDataManagerProvider | reducer',
           componentPaths: ['component'],
         };
 
-        expect(reducer(state, action)).toEqual(expected);
+        expect(reducer(state, action)).toMatchInlineSnapshot(`
+          {
+            "componentsDataStructure": {},
+            "contentTypeDataStructure": {},
+            "formErrors": {},
+            "initialData": {
+              "categories": "my_category",
+              "component": {
+                "__temp_key__": 2,
+                "id": 2,
+                "repeatable_simple": [
+                  {
+                    "__temp_key__": 0,
+                    "categories": [],
+                    "id": 18,
+                    "my_name": null,
+                  },
+                ],
+              },
+            },
+            "modifiedDZName": null,
+            "modifiedData": {
+              "categories": "my_category",
+              "component": {
+                "__temp_key__": 2,
+                "id": 2,
+                "repeatable_simple": [
+                  {
+                    "__temp_key__": 0,
+                    "categories": [],
+                    "id": 18,
+                    "my_name": null,
+                  },
+                ],
+              },
+            },
+            "publishConfirmation": {
+              "draftCount": 0,
+              "show": false,
+            },
+            "shouldCheckErrors": false,
+          }
+        `);
       });
     });
 
@@ -1520,37 +1564,6 @@ describe('CONTENT MANAGER | COMPONENTS | EditViewDataManagerProvider | reducer',
           modifiedData: {},
           modifiedDZName: true,
           shouldCheckErrors: true,
-        };
-
-        const expected = {
-          ...initialState,
-          formErrors: {},
-          initialData: {
-            ok: true,
-            dynamic_relations: [
-              {
-                __temp_key__: expect.any(Number),
-                __component: 'basic.simple',
-                id: 36,
-                my_name: null,
-                categories: [],
-              },
-            ],
-          },
-          modifiedData: {
-            ok: true,
-            dynamic_relations: [
-              {
-                __temp_key__: expect.any(Number),
-                __component: 'basic.simple',
-                id: 36,
-                my_name: null,
-                categories: [],
-              },
-            ],
-          },
-          modifiedDZName: null,
-          shouldCheckErrors: false,
         };
 
         const action = {
@@ -1572,7 +1585,43 @@ describe('CONTENT MANAGER | COMPONENTS | EditViewDataManagerProvider | reducer',
           dynamicZonePaths: ['dynamic_relations'],
         };
 
-        expect(reducer(state, action)).toEqual(expected);
+        expect(reducer(state, action)).toMatchInlineSnapshot(`
+          {
+            "componentsDataStructure": {},
+            "contentTypeDataStructure": {},
+            "formErrors": {},
+            "initialData": {
+              "dynamic_relations": [
+                {
+                  "__component": "basic.simple",
+                  "__temp_key__": 1,
+                  "categories": [],
+                  "id": 36,
+                  "my_name": null,
+                },
+              ],
+              "ok": true,
+            },
+            "modifiedDZName": null,
+            "modifiedData": {
+              "dynamic_relations": [
+                {
+                  "__component": "basic.simple",
+                  "__temp_key__": 1,
+                  "categories": [],
+                  "id": 36,
+                  "my_name": null,
+                },
+              ],
+              "ok": true,
+            },
+            "publishConfirmation": {
+              "draftCount": 0,
+              "show": false,
+            },
+            "shouldCheckErrors": false,
+          }
+        `);
       });
 
       it('should create an array for a relational field inside a nested component', () => {
@@ -1584,44 +1633,6 @@ describe('CONTENT MANAGER | COMPONENTS | EditViewDataManagerProvider | reducer',
           modifiedDZName: true,
           shouldCheckErrors: true,
         };
-
-        const expected = {
-          ...initialState,
-          formErrors: {},
-          initialData: {
-            ok: true,
-            dynamic_relations: [
-              {
-                __component: 'basic.nested-simple',
-                __temp_key__: expect.any(Number),
-                id: 7,
-                simple: {
-                  id: 47,
-                  my_name: null,
-                  categories: [],
-                },
-              },
-            ],
-          },
-          modifiedData: {
-            ok: true,
-            dynamic_relations: [
-              {
-                __component: 'basic.nested-simple',
-                __temp_key__: expect.any(Number),
-                id: 7,
-                simple: {
-                  id: 47,
-                  my_name: null,
-                  categories: [],
-                },
-              },
-            ],
-          },
-          modifiedDZName: null,
-          shouldCheckErrors: false,
-        };
-
         const action = {
           type: 'INIT_FORM',
           initialValues: {
@@ -1644,7 +1655,49 @@ describe('CONTENT MANAGER | COMPONENTS | EditViewDataManagerProvider | reducer',
           dynamicZonePaths: ['dynamic_relations'],
         };
 
-        expect(reducer(state, action)).toEqual(expected);
+        expect(reducer(state, action)).toMatchInlineSnapshot(`
+          {
+            "componentsDataStructure": {},
+            "contentTypeDataStructure": {},
+            "formErrors": {},
+            "initialData": {
+              "dynamic_relations": [
+                {
+                  "__component": "basic.nested-simple",
+                  "__temp_key__": 1,
+                  "id": 7,
+                  "simple": {
+                    "categories": [],
+                    "id": 47,
+                    "my_name": null,
+                  },
+                },
+              ],
+              "ok": true,
+            },
+            "modifiedDZName": null,
+            "modifiedData": {
+              "dynamic_relations": [
+                {
+                  "__component": "basic.nested-simple",
+                  "__temp_key__": 1,
+                  "id": 7,
+                  "simple": {
+                    "categories": [],
+                    "id": 47,
+                    "my_name": null,
+                  },
+                },
+              ],
+              "ok": true,
+            },
+            "publishConfirmation": {
+              "draftCount": 0,
+              "show": false,
+            },
+            "shouldCheckErrors": false,
+          }
+        `);
       });
 
       it('should create an array for a relational field inside a repeatable field', () => {
@@ -1657,61 +1710,6 @@ describe('CONTENT MANAGER | COMPONENTS | EditViewDataManagerProvider | reducer',
           shouldCheckErrors: true,
         };
 
-        const expected = {
-          ...initialState,
-          formErrors: {},
-          initialData: {
-            ok: true,
-            dynamic_relations: [
-              {
-                __component: 'basic.repeatable-repeatble-relation',
-                id: 5,
-                __temp_key__: 0,
-                repeatable_simple: [
-                  {
-                    id: 48,
-                    my_name: null,
-                    categories: [],
-                    __temp_key__: 0,
-                  },
-                  {
-                    id: 49,
-                    my_name: null,
-                    categories: [],
-                    __temp_key__: 1,
-                  },
-                ],
-              },
-            ],
-          },
-          modifiedData: {
-            ok: true,
-            dynamic_relations: [
-              {
-                __component: 'basic.repeatable-repeatble-relation',
-                id: 5,
-                __temp_key__: 0,
-                repeatable_simple: [
-                  {
-                    id: 48,
-                    my_name: null,
-                    categories: [],
-                    __temp_key__: 0,
-                  },
-                  {
-                    id: 49,
-                    my_name: null,
-                    categories: [],
-                    __temp_key__: 1,
-                  },
-                ],
-              },
-            ],
-          },
-          modifiedDZName: null,
-          shouldCheckErrors: false,
-        };
-
         const action = {
           type: 'INIT_FORM',
           initialValues: {
@@ -1746,7 +1744,67 @@ describe('CONTENT MANAGER | COMPONENTS | EditViewDataManagerProvider | reducer',
           dynamicZonePaths: ['dynamic_relations'],
         };
 
-        expect(reducer(state, action)).toEqual(expected);
+        expect(reducer(state, action)).toMatchInlineSnapshot(`
+          {
+            "componentsDataStructure": {},
+            "contentTypeDataStructure": {},
+            "formErrors": {},
+            "initialData": {
+              "dynamic_relations": [
+                {
+                  "__component": "basic.repeatable-repeatble-relation",
+                  "__temp_key__": 0,
+                  "id": 5,
+                  "repeatable_simple": [
+                    {
+                      "__temp_key__": 0,
+                      "categories": [],
+                      "id": 48,
+                      "my_name": null,
+                    },
+                    {
+                      "__temp_key__": 1,
+                      "categories": [],
+                      "id": 49,
+                      "my_name": null,
+                    },
+                  ],
+                },
+              ],
+              "ok": true,
+            },
+            "modifiedDZName": null,
+            "modifiedData": {
+              "dynamic_relations": [
+                {
+                  "__component": "basic.repeatable-repeatble-relation",
+                  "__temp_key__": 0,
+                  "id": 5,
+                  "repeatable_simple": [
+                    {
+                      "__temp_key__": 0,
+                      "categories": [],
+                      "id": 48,
+                      "my_name": null,
+                    },
+                    {
+                      "__temp_key__": 1,
+                      "categories": [],
+                      "id": 49,
+                      "my_name": null,
+                    },
+                  ],
+                },
+              ],
+              "ok": true,
+            },
+            "publishConfirmation": {
+              "draftCount": 0,
+              "show": false,
+            },
+            "shouldCheckErrors": false,
+          }
+        `);
       });
 
       it('should assign __temp_key__ to components when not in initialData', () => {
@@ -1758,54 +1816,6 @@ describe('CONTENT MANAGER | COMPONENTS | EditViewDataManagerProvider | reducer',
           modifiedDZName: true,
           shouldCheckErrors: true,
         };
-
-        const expected = {
-          ...initialState,
-          formErrors: {},
-          initialData: {
-            ok: true,
-            dynamic_relations: [
-              {
-                __component: 'basic.repeatable-repeatble-relation',
-                id: 5,
-                __temp_key__: expect.any(Number),
-                repeatable_simple: [
-                  {
-                    id: 48,
-                    my_name: null,
-                  },
-                  {
-                    id: 49,
-                    my_name: null,
-                  },
-                ],
-              },
-            ],
-          },
-          modifiedData: {
-            ok: true,
-            dynamic_relations: [
-              {
-                __component: 'basic.repeatable-repeatble-relation',
-                id: 5,
-                __temp_key__: expect.any(Number),
-                repeatable_simple: [
-                  {
-                    id: 48,
-                    my_name: null,
-                  },
-                  {
-                    id: 49,
-                    my_name: null,
-                  },
-                ],
-              },
-            ],
-          },
-          modifiedDZName: null,
-          shouldCheckErrors: false,
-        };
-
         const action = {
           type: 'INIT_FORM',
           initialValues: {
@@ -1831,7 +1841,63 @@ describe('CONTENT MANAGER | COMPONENTS | EditViewDataManagerProvider | reducer',
           dynamicZonePaths: ['dynamic_relations'],
         };
 
-        expect(reducer(state, action)).toEqual(expected);
+        expect(reducer(state, action)).toMatchInlineSnapshot(`
+          {
+            "componentsDataStructure": {},
+            "contentTypeDataStructure": {},
+            "formErrors": {},
+            "initialData": {
+              "dynamic_relations": [
+                {
+                  "__component": "basic.repeatable-repeatble-relation",
+                  "__temp_key__": 1,
+                  "id": 5,
+                  "repeatable_simple": [
+                    {
+                      "categories": [],
+                      "id": 48,
+                      "my_name": null,
+                    },
+                    {
+                      "categories": [],
+                      "id": 49,
+                      "my_name": null,
+                    },
+                  ],
+                },
+              ],
+              "ok": true,
+            },
+            "modifiedDZName": null,
+            "modifiedData": {
+              "dynamic_relations": [
+                {
+                  "__component": "basic.repeatable-repeatble-relation",
+                  "__temp_key__": 1,
+                  "id": 5,
+                  "repeatable_simple": [
+                    {
+                      "categories": [],
+                      "id": 48,
+                      "my_name": null,
+                    },
+                    {
+                      "categories": [],
+                      "id": 49,
+                      "my_name": null,
+                    },
+                  ],
+                },
+              ],
+              "ok": true,
+            },
+            "publishConfirmation": {
+              "draftCount": 0,
+              "show": false,
+            },
+            "shouldCheckErrors": false,
+          }
+        `);
       });
     });
 

--- a/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/utils/findLeafByPathAndReplace.js
+++ b/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/utils/findLeafByPathAndReplace.js
@@ -21,11 +21,9 @@ export const findLeafByPathAndReplace = (endpath, replaceWith) => {
 
     /**
      * If this is the last item in the array of paths
-     * and the current path is not undefined in the accumulator
      * then we assume it's a leaf and we can replace it.
      */
-
-    if (ind === currentArr.length - 1 && endpath === curr && acc[curr] !== undefined) {
+    if (ind === currentArr.length - 1 && endpath === curr) {
       set(acc, curr, replaceWith);
 
       return acc;

--- a/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/utils/tests/findLeafByPathAndReplace.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/utils/tests/findLeafByPathAndReplace.test.js
@@ -18,13 +18,15 @@ describe('findLeafByPathAndReplace', () => {
 
     path.reduce(findLeaf, obj);
 
-    expect(obj).toMatchObject({
-      a: {
-        b: {
-          c: [],
+    expect(obj).toMatchInlineSnapshot(`
+      {
+        "a": {
+          "b": {
+            "c": [],
+          },
         },
-      },
-    });
+      }
+    `);
   });
 
   it('should replace the value of the leaf by the provided one for all cases in the event of the leaf being a branch of an array', () => {
@@ -49,18 +51,20 @@ describe('findLeafByPathAndReplace', () => {
 
     path.reduce(findLeaf, obj);
 
-    expect(obj).toMatchObject({
-      a: {
-        b: [
-          {
-            c: [],
-          },
-          {
-            c: [],
-          },
-        ],
-      },
-    });
+    expect(obj).toMatchInlineSnapshot(`
+      {
+        "a": {
+          "b": [
+            {
+              "c": [],
+            },
+            {
+              "c": [],
+            },
+          ],
+        },
+      }
+    `);
   });
 
   it('should only replace the leaf declared no matter how many duplicate exist higher in the tree', () => {
@@ -97,30 +101,32 @@ describe('findLeafByPathAndReplace', () => {
 
     path.reduce(findLeaf, obj);
 
-    expect(obj).toMatchObject({
-      a: {
-        b: [
-          {
-            c: false,
-            d: {
-              e: [
-                {
-                  f: {
-                    c: [],
+    expect(obj).toMatchInlineSnapshot(`
+      {
+        "a": {
+          "b": [
+            {
+              "c": false,
+              "d": {
+                "e": [
+                  {
+                    "f": {
+                      "c": [],
+                    },
                   },
-                },
-                {
-                  f: {
-                    c: [],
+                  {
+                    "f": {
+                      "c": [],
+                    },
                   },
-                },
-              ],
+                ],
+              },
             },
-          },
-        ],
-        c: false,
-      },
-    });
+          ],
+          "c": false,
+        },
+      }
+    `);
   });
 
   it('should only replace the leaf if it is the last item in the array of paths', () => {
@@ -142,14 +148,16 @@ describe('findLeafByPathAndReplace', () => {
 
     path.reduce(findLeaf, obj);
 
-    expect(obj).toMatchObject({
-      a: {
-        a: [
-          {
-            a: [],
-          },
-        ],
-      },
-    });
+    expect(obj).toMatchInlineSnapshot(`
+      {
+        "a": {
+          "a": [
+            {
+              "a": [],
+            },
+          ],
+        },
+      }
+    `);
   });
 });


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* Convert tests to use `inlineSnapshot` (tests were converted first and then the code changes applied to ensure accidental breaking of test)
* Set even a relation to empty array even if it's undefined because `required` fields (components) will fail.

### Why is it needed?

* Jest struggles to compare an object with arrays inside efficiently so snapshot is better
* Solves issues with required components failing.

### How to test it?

* Unit testing

### Related issue(s)/PR(s)

* resolves #15680
* resolves CONTENT-1014
