### PR TITLE
Point CTB to the marketplace custom field category

### DIFF
--- a/packages/core/content-type-builder/admin/src/components/AttributeOptions/EmptyAttributes/index.js
+++ b/packages/core/content-type-builder/admin/src/components/AttributeOptions/EmptyAttributes/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { useIntl } from 'react-intl';
+import qs from 'qs';
 import { Box } from '@strapi/design-system/Box';
 import { Flex } from '@strapi/design-system/Flex';
 import { Typography } from '@strapi/design-system/Typography';
@@ -62,7 +63,11 @@ const EmptyAttributes = () => {
               </Box>
             </Box>
           </Box>
-          <LinkButton to="/marketplace" variant="secondary" startIcon={<Plus />}>
+          <LinkButton
+            to={`/marketplace?${qs.stringify({ categories: ['Custom fields'] })}`}
+            variant="secondary"
+            startIcon={<Plus />}
+          >
             {formatMessage({
               id: getTrad('modalForm.empty.button'),
               defaultMessage: 'Add custom fields',


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

From the CTB field type picker, if there was no custom field added, we had a link to the marketplace. Now we preselect the custom fields category in that link

### Why is it needed?

Avoids a few clicks for the users

### How to test it?

- go to the content type builder in a Strapi app that doesn't have a custom field installed
- click add new field, select the "custom" tab
- click on "add custom field"
- it should redirect you to the marketplace, with the custom fields category selected
