### PR TITLE
Fix data import on linux alpine

### DIFF
--- a/packages/core/data-transfer/src/strapi/providers/local-destination/index.ts
+++ b/packages/core/data-transfer/src/strapi/providers/local-destination/index.ts
@@ -156,7 +156,7 @@ class LocalStrapiDestinationProvider implements IDestinationProvider {
       `uploads_backup_${Date.now()}`
     );
 
-    await fse.rename(assetsDirectory, backupDirectory);
+    await fse.move(assetsDirectory, backupDirectory);
     await fse.mkdir(assetsDirectory);
     // Create a .gitkeep file to ensure the directory is not empty
     await fse.outputFile(path.join(assetsDirectory, '.gitkeep'), '');
@@ -177,7 +177,7 @@ class LocalStrapiDestinationProvider implements IDestinationProvider {
           .on('error', async (error: Error) => {
             try {
               await fse.rm(assetsDirectory, { recursive: true, force: true });
-              await fse.rename(backupDirectory, assetsDirectory);
+              await fse.move(backupDirectory, assetsDirectory);
               this.destroy(
                 new ProviderTransferError(
                   `There was an error during the transfer process. The original files have been restored to ${assetsDirectory}`


### PR DESCRIPTION
### What does it do?

Change fs-extra `rename` function (which is native `fs` function, see https://github.com/jprichardson/node-fs-extra/blob/master/lib/fs/index.js#L33) to fs-extra `move` method that works on multiple plaforms https://github.com/jprichardson/node-fs-extra/blob/master/docs/move.md

### Why is it needed?

This PR fixes bug: https://github.com/strapi/strapi/issues/15724

### How to test it?

Test `strapi import` on multiple platforms.

### Related issue(s)/PR(s)

[Let us know if this is related to any issue/pull request](https://github.com/strapi/strapi/issues/15724)
