### PR TITLE
Set default locale when using Query Engine function createMany

### DIFF
--- a/packages/plugins/i18n/server/bootstrap.js
+++ b/packages/plugins/i18n/server/bootstrap.js
@@ -13,6 +13,9 @@ const registerModelsHooks = () => {
       async beforeCreate(event) {
         await getService('localizations').assignDefaultLocale(event.params.data);
       },
+      async beforeCreateMany(event) {
+        await getService('localizations').assignDefaultLocale(event.params.data);
+      },
     });
   }
 

--- a/packages/plugins/i18n/server/bootstrap.js
+++ b/packages/plugins/i18n/server/bootstrap.js
@@ -8,6 +8,9 @@ const registerModelsHooks = () => {
     .map((contentType) => contentType.uid);
 
   if (i18nModelUIDs.length > 0) {
+    // TODO V5 : to remove ?
+    // Should this code exist? It's putting business logic on the query engine
+    // whereas it should maybe stay on the entity service layer ?
     strapi.db.lifecycles.subscribe({
       models: i18nModelUIDs,
       async beforeCreate(event) {

--- a/packages/plugins/i18n/server/bootstrap.js
+++ b/packages/plugins/i18n/server/bootstrap.js
@@ -14,10 +14,10 @@ const registerModelsHooks = () => {
     strapi.db.lifecycles.subscribe({
       models: i18nModelUIDs,
       async beforeCreate(event) {
-        await getService('localizations').assignDefaultLocale(event.params.data);
+        await getService('localizations').assignDefaultLocaleToEntries(event.params.data);
       },
       async beforeCreateMany(event) {
-        await getService('localizations').assignDefaultLocale(event.params.data);
+        await getService('localizations').assignDefaultLocaleToEntries(event.params.data);
       },
     });
   }

--- a/packages/plugins/i18n/server/services/__tests__/localizations.test.js
+++ b/packages/plugins/i18n/server/services/__tests__/localizations.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { assignDefaultLocale, syncLocalizations, syncNonLocalizedAttributes } =
+const { assignDefaultLocaleToEntries, syncLocalizations, syncNonLocalizedAttributes } =
   require('../localizations')();
 
 const locales = require('../locales')();
@@ -69,16 +69,16 @@ const setGlobalStrapi = () => {
 };
 
 describe('localizations service', () => {
-  describe('assignDefaultLocale', () => {
-    test('Does not change the input if locale is already defined', async () => {
+  describe('assignDefaultLocaleToEntries', () => {
+    test('Does not change the input if locale is already defined (single entry)', async () => {
       setGlobalStrapi();
       const input = { locale: 'myLocale' };
-      await assignDefaultLocale(input);
+      await assignDefaultLocaleToEntries(input);
 
       expect(input).toStrictEqual({ locale: 'myLocale' });
     });
 
-    test('Use default locale to set the locale on the input data', async () => {
+    test('Use default locale to set the locale on the input data (single entry)', async () => {
       setGlobalStrapi();
 
       const getDefaultLocaleMock = jest.fn(() => 'defaultLocale');
@@ -86,9 +86,31 @@ describe('localizations service', () => {
       global.strapi.plugins.i18n.services.locales.getDefaultLocale = getDefaultLocaleMock;
 
       const input = {};
-      await assignDefaultLocale(input);
+      await assignDefaultLocaleToEntries(input);
 
       expect(input).toStrictEqual({ locale: 'defaultLocale' });
+      expect(getDefaultLocaleMock).toHaveBeenCalled();
+    });
+
+    test('Does not change the input if locale is already defined (multiple entries)', async () => {
+      setGlobalStrapi();
+      const input = [{ locale: 'myLocale' }, { locale: 'mylocalebis' }];
+      await assignDefaultLocaleToEntries(input);
+
+      expect(input).toStrictEqual([{ locale: 'myLocale' }, { locale: 'mylocalebis' }]);
+    });
+
+    test('Use default locale to set the locale on the entries missing it (multiple entries)', async () => {
+      setGlobalStrapi();
+
+      const getDefaultLocaleMock = jest.fn(() => 'defaultLocale');
+
+      global.strapi.plugins.i18n.services.locales.getDefaultLocale = getDefaultLocaleMock;
+
+      const input = [{ locale: 'mylocale' }, {}];
+      await assignDefaultLocaleToEntries(input);
+
+      expect(input).toStrictEqual([{ locale: 'mylocale' }, { locale: 'defaultLocale' }]);
       expect(getDefaultLocaleMock).toHaveBeenCalled();
     });
   });

--- a/packages/plugins/i18n/server/services/localizations.js
+++ b/packages/plugins/i18n/server/services/localizations.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { prop, isNil, isEmpty } = require('lodash/fp');
+const { prop, isNil, isEmpty, isArray } = require('lodash/fp');
 
 const { getService } = require('../utils');
 
@@ -11,7 +11,14 @@ const { getService } = require('../utils');
 const assignDefaultLocale = async (data) => {
   const { getDefaultLocale } = getService('locales');
 
-  if (isNil(data.locale)) {
+  if (isArray(data) && data.some((entry) => !entry.locale)) {
+    const defaultLocale = await getDefaultLocale();
+    data.forEach((entry) => {
+      if (isNil(entry.locale)) {
+        entry.locale = defaultLocale;
+      }
+    });
+  } else if (isNil(data.locale)) {
     data.locale = await getDefaultLocale();
   }
 };

--- a/packages/plugins/i18n/server/services/localizations.js
+++ b/packages/plugins/i18n/server/services/localizations.js
@@ -8,17 +8,15 @@ const { getService } = require('../utils');
  * Adds the default locale to an object if it isn't defined yet
  * @param {Object} data a data object before being persisted into db
  */
-const assignDefaultLocale = async (data) => {
+const assignDefaultLocaleToEntries = async (data) => {
   const { getDefaultLocale } = getService('locales');
 
   if (isArray(data) && data.some((entry) => !entry.locale)) {
     const defaultLocale = await getDefaultLocale();
     data.forEach((entry) => {
-      if (isNil(entry.locale)) {
-        entry.locale = defaultLocale;
-      }
+      entry.locale = entry.locale || defaultLocale;
     });
-  } else if (isNil(data.locale)) {
+  } else if (!isArray(data) && isNil(data.locale)) {
     data.locale = await getDefaultLocale();
   }
 };
@@ -72,7 +70,7 @@ const syncNonLocalizedAttributes = async (entry, { model }) => {
 };
 
 module.exports = () => ({
-  assignDefaultLocale,
+  assignDefaultLocaleToEntries,
   syncLocalizations,
   syncNonLocalizedAttributes,
 });


### PR DESCRIPTION
### What does it do?

Fix #13393

### Why is it needed?

So the function `create` and `createMany` have a consistent behavior of setting the default locale when it is undefined

### How to test it?

1. In the getStarted app, set the boostrap function as :
```js
  async bootstrap({ strapi }) {
    await strapi.db.query('api::country.country').createMany({ data: [{ name: 'I will have a locale' }] });
  },
```
2. See that the created country does have the default locale.
### Related issue(s)/PR(s)

#13393
