### PR TITLE
Settings: Review Workflow: Confirm saving if a user has deleted stages

### DIFF
--- a/packages/core/admin/admin/src/translations/en.json
+++ b/packages/core/admin/admin/src/translations/en.json
@@ -227,6 +227,7 @@
   "Settings.review-workflows.page.title": "Review Workflows",
   "Settings.review-workflows.page.subtitle": "{count, plural, one {# stage} other {# stages}}",
   "Settings.review-workflows.page.isLoading": "Workflow is loading",
+  "Settings.review-workflows.page.delete.confirm.body": "All entries assigned to deleted stages will be moved to the first stage. Are you sure you want to save this?",
   "Settings.review-workflows.stage.name.label": "Stage name",
   "Settings.roles.create.description": "Define the rights given to the role",
   "Settings.roles.create.title": "Create a role",

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/index.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/index.js
@@ -47,8 +47,10 @@ export function reducer(state = initialState, action) {
           (stage) => (stage?.id ?? stage.__temp_key__) !== stageId
         );
 
-        draft.clientState.currentWorkflow.hasDeletedServerStages =
-          !!state.serverState.currentWorkflow.stages.find((stage) => stage.id === stageId);
+        if (!currentWorkflow.hasDeletedServerStages) {
+          draft.clientState.currentWorkflow.hasDeletedServerStages =
+            !!state.serverState.currentWorkflow.stages.find((stage) => stage.id === stageId);
+        }
 
         break;
       }

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/index.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/index.js
@@ -15,7 +15,7 @@ export const initialState = {
     workflows: [],
   },
   clientState: {
-    currentWorkflow: { data: null, isDirty: false },
+    currentWorkflow: { data: null, isDirty: false, hasDeletedServerStages: false },
   },
 };
 
@@ -43,12 +43,12 @@ export function reducer(state = initialState, action) {
         const { stageId } = payload;
         const { currentWorkflow } = state.clientState;
 
-        draft.clientState.currentWorkflow.data = {
-          ...currentWorkflow.data,
-          stages: currentWorkflow.data.stages.filter(
-            (stage) => (stage?.id ?? stage.__temp_key__) !== stageId
-          ),
-        };
+        draft.clientState.currentWorkflow.data.stages = currentWorkflow.data.stages.filter(
+          (stage) => (stage?.id ?? stage.__temp_key__) !== stageId
+        );
+
+        draft.clientState.currentWorkflow.hasDeletedServerStages =
+          !!state.serverState.currentWorkflow.stages.find((stage) => stage.id === stageId);
 
         break;
       }

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/tests/index.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/tests/index.test.js
@@ -44,16 +44,16 @@ describe('Admin | Settings | Review Workflows | reducer', () => {
     expect(reducer(state, action)).toStrictEqual(
       expect.objectContaining({
         status: 'loading-state',
-        serverState: {
+        serverState: expect.objectContaining({
           currentWorkflow: WORKFLOWS_FIXTURE[0],
           workflows: WORKFLOWS_FIXTURE,
-        },
-        clientState: {
-          currentWorkflow: {
+        }),
+        clientState: expect.objectContaining({
+          currentWorkflow: expect.objectContaining({
             data: WORKFLOWS_FIXTURE[0],
             isDirty: false,
-          },
-        },
+          }),
+        }),
       })
     );
   });
@@ -95,6 +95,69 @@ describe('Admin | Settings | Review Workflows | reducer', () => {
             data: expect.objectContaining({
               stages: expect.arrayContaining([WORKFLOWS_FIXTURE[0].stages[1]]),
             }),
+          }),
+        }),
+      })
+    );
+  });
+
+  test('ACTION_DELETE_STAGE - set hasDeletedServerStages to true if stageId exists on the server', () => {
+    const action = {
+      type: ACTION_DELETE_STAGE,
+      payload: { stageId: 1 },
+    };
+
+    state = {
+      status: expect.any(String),
+      serverState: {
+        currentWorkflow: WORKFLOWS_FIXTURE[0],
+      },
+      clientState: {
+        currentWorkflow: {
+          data: WORKFLOWS_FIXTURE[0],
+          isDirty: false,
+        },
+      },
+    };
+
+    expect(reducer(state, action)).toStrictEqual(
+      expect.objectContaining({
+        clientState: expect.objectContaining({
+          currentWorkflow: expect.objectContaining({
+            hasDeletedServerStages: true,
+          }),
+        }),
+      })
+    );
+  });
+
+  test('ACTION_DELETE_STAGE - set hasDeletedServerStages to false if stageId does not exist on the server', () => {
+    const action = {
+      type: ACTION_DELETE_STAGE,
+      payload: { stageId: 3 },
+    };
+
+    state = {
+      status: expect.any(String),
+      serverState: {
+        currentWorkflow: WORKFLOWS_FIXTURE[0],
+      },
+      clientState: {
+        currentWorkflow: {
+          data: {
+            ...WORKFLOWS_FIXTURE[0],
+            stages: [...WORKFLOWS_FIXTURE[0].stages, { __temp_key__: 3, name: 'something' }],
+          },
+          isDirty: false,
+        },
+      },
+    };
+
+    expect(reducer(state, action)).toStrictEqual(
+      expect.objectContaining({
+        clientState: expect.objectContaining({
+          currentWorkflow: expect.objectContaining({
+            hasDeletedServerStages: false,
           }),
         }),
       })

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/tests/index.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/tests/index.test.js
@@ -164,6 +164,44 @@ describe('Admin | Settings | Review Workflows | reducer', () => {
     );
   });
 
+  test('ACTION_DELETE_STAGE - keep hasDeletedServerStages true as soon as one server stage has been deleted', () => {
+    const actionDeleteServerStage = {
+      type: ACTION_DELETE_STAGE,
+      payload: { stageId: 1 },
+    };
+
+    const actionDeleteClientStage = {
+      type: ACTION_DELETE_STAGE,
+      payload: { stageId: 3 },
+    };
+
+    state = {
+      status: expect.any(String),
+      serverState: {
+        currentWorkflow: WORKFLOWS_FIXTURE[0],
+      },
+      clientState: {
+        currentWorkflow: {
+          data: WORKFLOWS_FIXTURE[0],
+          isDirty: false,
+        },
+      },
+    };
+
+    state = reducer(state, actionDeleteServerStage);
+    state = reducer(state, actionDeleteClientStage);
+
+    expect(state).toStrictEqual(
+      expect.objectContaining({
+        clientState: expect.objectContaining({
+          currentWorkflow: expect.objectContaining({
+            hasDeletedServerStages: true,
+          }),
+        }),
+      })
+    );
+  });
+
   test('ACTION_ADD_STAGE', () => {
     const action = {
       type: ACTION_ADD_STAGE,


### PR DESCRIPTION
### What does it do?

It adds a confirmation dialog that is displayed if: 1) the user saves the current workflow 2) stages that exist on the server have been deleted.

### Why is it needed?

This helps to prevent accidental data loss.

### How to test it?

1. Open the settings page http://localhost:4000/admin/settings/review-workflows
2. Delete a stage
3. Confirm the dialog is displayed

1. Open the settings page http://localhost:4000/admin/settings/review-workflows
2. Create a stage and delete it again
3. Confirm the dialog is NOT displayed

