### PR TITLE
Settings: Protect review workflows page with read permissions

### DIFF
--- a/packages/core/admin/ee/admin/hooks/useSettingsMenu/utils/customGlobalLinks.js
+++ b/packages/core/admin/ee/admin/hooks/useSettingsMenu/utils/customGlobalLinks.js
@@ -18,7 +18,7 @@ if (window.strapi.features.isEnabled(window.strapi.features.REVIEW_WORKFLOWS)) {
     to: '/settings/review-workflows',
     id: 'review-workflows',
     isDisplayed: false,
-    permissions: adminPermissions.settings.reviewWorkflows.main,
+    permissions: adminPermissions.settings['review-workflows'].main,
   });
 }
 

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/ReviewWorkflows.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/ReviewWorkflows.js
@@ -3,7 +3,7 @@ import { FormikProvider, useFormik, Form } from 'formik';
 import { useIntl } from 'react-intl';
 import { useSelector, useDispatch } from 'react-redux';
 
-import { SettingsPageTitle } from '@strapi/helper-plugin';
+import { CheckPagePermissions, SettingsPageTitle } from '@strapi/helper-plugin';
 import { Button, ContentLayout, HeaderLayout, Layout, Loader, Main } from '@strapi/design-system';
 import { Check } from '@strapi/icons';
 
@@ -14,6 +14,7 @@ import { useInjectReducer } from '../../../../../../admin/src/hooks/useInjectRed
 import { useReviewWorkflows } from './hooks/useReviewWorkflows';
 import { setWorkflows } from './actions';
 import { getWorkflowValidationSchema } from './utils/getWorkflowValidationSchema';
+import adminPermissions from '../../../../../../admin/src/permissions';
 
 export function ReviewWorkflowsPage() {
   const { formatMessage } = useIntl();
@@ -44,57 +45,59 @@ export function ReviewWorkflowsPage() {
   }, [workflowsData.status, workflowsData.data, dispatch]);
 
   return (
-    <Layout>
-      <SettingsPageTitle
-        name={formatMessage({
-          id: 'Settings.review-workflows.page.title',
-          defaultMessage: 'Review Workflows',
-        })}
-      />
-      <Main tabIndex={-1}>
-        <FormikProvider value={formik}>
-          <Form onSubmit={formik.handleSubmit}>
-            <HeaderLayout
-              primaryAction={
-                <Button
-                  startIcon={<Check />}
-                  type="submit"
-                  size="M"
-                  disabled={!currentWorkflowIsDirty}
-                >
-                  {formatMessage({
-                    id: 'global.save',
-                    defaultMessage: 'Save',
-                  })}
-                </Button>
-              }
-              title={formatMessage({
-                id: 'Settings.review-workflows.page.title',
-                defaultMessage: 'Review Workflows',
-              })}
-              subtitle={formatMessage(
-                {
-                  id: 'Settings.review-workflows.page.subtitle',
-                  defaultMessage: '{count, plural, one {# stage} other {# stages}}',
-                },
-                { count: currentWorkflow?.stages?.length ?? 0 }
-              )}
-            />
-            <ContentLayout>
-              {status === 'loading' && (
-                <Loader>
-                  {formatMessage({
-                    id: 'Settings.review-workflows.page.isLoading',
-                    defaultMessage: 'Workflow is loading',
-                  })}
-                </Loader>
-              )}
+    <CheckPagePermissions permissions={adminPermissions.settings['review-workflows'].main}>
+      <Layout>
+        <SettingsPageTitle
+          name={formatMessage({
+            id: 'Settings.review-workflows.page.title',
+            defaultMessage: 'Review Workflows',
+          })}
+        />
+        <Main tabIndex={-1}>
+          <FormikProvider value={formik}>
+            <Form onSubmit={formik.handleSubmit}>
+              <HeaderLayout
+                primaryAction={
+                  <Button
+                    startIcon={<Check />}
+                    type="submit"
+                    size="M"
+                    disabled={!currentWorkflowIsDirty}
+                  >
+                    {formatMessage({
+                      id: 'global.save',
+                      defaultMessage: 'Save',
+                    })}
+                  </Button>
+                }
+                title={formatMessage({
+                  id: 'Settings.review-workflows.page.title',
+                  defaultMessage: 'Review Workflows',
+                })}
+                subtitle={formatMessage(
+                  {
+                    id: 'Settings.review-workflows.page.subtitle',
+                    defaultMessage: '{count, plural, one {# stage} other {# stages}}',
+                  },
+                  { count: currentWorkflow?.stages?.length ?? 0 }
+                )}
+              />
+              <ContentLayout>
+                {status === 'loading' && (
+                  <Loader>
+                    {formatMessage({
+                      id: 'Settings.review-workflows.page.isLoading',
+                      defaultMessage: 'Workflow is loading',
+                    })}
+                  </Loader>
+                )}
 
-              <Stages stages={formik.values?.stages} />
-            </ContentLayout>
-          </Form>
-        </FormikProvider>
-      </Main>
-    </Layout>
+                <Stages stages={formik.values?.stages} />
+              </ContentLayout>
+            </Form>
+          </FormikProvider>
+        </Main>
+      </Layout>
+    </CheckPagePermissions>
   );
 }

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/ReviewWorkflows.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/ReviewWorkflows.js
@@ -115,23 +115,23 @@ export function ReviewWorkflowsPage() {
                   </Loader>
                 )}
 
-              <Stages stages={formik.values?.stages} />
-            </ContentLayout>
-          </Form>
-        </FormikProvider>
+                <Stages stages={formik.values?.stages} />
+              </ContentLayout>
+            </Form>
+          </FormikProvider>
 
-        <ConfirmDialog
-          bodyText={{
-            id: 'Settings.review-workflows.page.delete.confirm.body',
-            defaultMessage:
-              'All entries assigned to deleted stages will be moved to the first stage. Are you sure you want to save this?',
-          }}
-          isOpen={isConfirmDeleteDialogOpen}
-          onToggleDialog={toggleConfirmDeleteDialog}
-          onConfirm={handleConfirmDeleteDialog}
-        />
-      </Main>
-    </Layout>
-  </CheckPagePermissions>
-);
+          <ConfirmDialog
+            bodyText={{
+              id: 'Settings.review-workflows.page.delete.confirm.body',
+              defaultMessage:
+                'All entries assigned to deleted stages will be moved to the first stage. Are you sure you want to save this?',
+            }}
+            isOpen={isConfirmDeleteDialogOpen}
+            onToggleDialog={toggleConfirmDeleteDialog}
+            onConfirm={handleConfirmDeleteDialog}
+          />
+        </Main>
+      </Layout>
+    </CheckPagePermissions>
+  );
 }

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/tests/ReviewWorkflows.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/tests/ReviewWorkflows.test.js
@@ -17,6 +17,12 @@ jest.mock('../hooks/useReviewWorkflows', () => ({
   useReviewWorkflows: jest.fn().mockReturnValue(),
 }));
 
+jest.mock('@strapi/helper-plugin', () => ({
+  ...jest.requireActual('@strapi/helper-plugin'),
+  // eslint-disable-next-line react/prop-types
+  CheckPagePermissions: ({ children }) => <>{children}</>,
+}));
+
 const client = new QueryClient({
   defaultOptions: {
     queries: {

--- a/packages/core/admin/ee/admin/permissions/customPermissions.js
+++ b/packages/core/admin/ee/admin/permissions/customPermissions.js
@@ -1,7 +1,7 @@
 const customPermissions = {
   settings: {
-    reviewWorkflows: {
-      main: [{ action: 'admin::roles.create', subject: null }],
+    'review-workflows': {
+      main: [{ action: 'admin::review-workflows.read', subject: null }],
     },
 
     sso: {


### PR DESCRIPTION
### What does it do?

Adds a read permission check for the review workflows settings page.

### Why is it needed?

Protects the page from being accessible if a user doesn't have the permissions.

### How to test it?

1. Validate the page is not visible in the menu
2. Validate it is not possible to access http://localhost:4000/admin/settings/review-workflows

