### PR TITLE
Fix JSON field for postgres when the value is a simple string

### DIFF
--- a/packages/core/database/lib/dialects/postgresql/index.js
+++ b/packages/core/database/lib/dialects/postgresql/index.js
@@ -16,11 +16,18 @@ class PostgresDialect extends Dialect {
   }
 
   async initialize() {
+    // Don't cast DATE string to Date()
     this.db.connection.client.driver.types.setTypeParser(
       this.db.connection.client.driver.types.builtins.DATE,
       'text',
       (v) => v
-    ); // Don't cast DATE string to Date()
+    );
+    // Don't parse JSONB automatically
+    this.db.connection.client.driver.types.setTypeParser(
+      this.db.connection.client.driver.types.builtins.JSONB,
+      'text',
+      (v) => v
+    );
     this.db.connection.client.driver.types.setTypeParser(
       this.db.connection.client.driver.types.builtins.NUMERIC,
       'text',


### PR DESCRIPTION
### What does it do?

Fix #15496

### Why is it needed?

On Postgres, when the JSON value was a simple string, the value was parsed twice instead of once.

### How to test it?

1. In the getStarted example, add a JSON field named "myjson"
2. Use this following bootstrap function
```js
async bootstrap({ strapi }) {
    await strapi.entityService.create('api::country.country', { data: { name: 'Imagine the people', myjson: "coucou" } });
  },
```
3. See no error

### Related issue(s)/PR(s)

* resolves #15496
* closes #15672
