### PR TITLE
add ability to upload buffer

### DIFF
--- a/packages/core/upload/server/services/__tests__/upload/uploadImage.test.js
+++ b/packages/core/upload/server/services/__tests__/upload/uploadImage.test.js
@@ -78,6 +78,23 @@ describe('Upload image', () => {
     expect(upload).toHaveBeenCalledTimes(2);
   });
 
+  test('Upload file using buffer', async () => {
+    // create buffer from imageFilePath
+    const file = fs.readFileSync(imageFilePath);
+    const upload = jest.fn();
+    mockUploadProvider(upload);
+
+    uploadService.uploadBuffer({
+      file,
+      fileName: 'test',
+      mime: 'image/png',
+      ext: 'png',
+      alternativeText: 'test',
+    });
+    // 1 for the original image, 1 for thumbnail, 2 for the responsive formats
+    expect(upload).toHaveBeenCalledTimes(2);
+  });
+
   test('Upload with responsive formats', async () => {
     const fileData = getFileData(imageFilePath);
     const upload = jest.fn();

--- a/packages/core/upload/server/services/upload.js
+++ b/packages/core/upload/server/services/upload.js
@@ -181,6 +181,22 @@ module.exports = ({ strapi }) => ({
     return uploadedFiles;
   },
 
+  /**
+   * Asynchronously upload a buffer to the media library.
+   *
+   * @param {Object} params - The parameters for uploading the buffer.
+   * @param {Buffer} params.file - The buffer to be uploaded.
+   * @param {string} params.fileName - The name of the file to be uploaded.
+   * @param {string} [params.folder] - The folder to upload the file to.
+   * @param {string} params.mime - The MIME type of the file.
+   * @param {string} params.ext - The file extension.
+   * @param {string} [params.alternativeText] - The alternative text for the file.
+   * @param {string} [params.caption] - The caption for the file.
+   *
+   * @throws {ApplicationError} If `mime`, `ext`, `file`, or `fileName` is undefined.
+   *
+   * @returns {Promise<Object>} The uploaded file entity.
+   */
   async uploadBuffer({ file, fileName, folder, mime, ext, alternativeText, caption }) {
     if (!mime) {
       throw new ApplicationError('mime type is undefined');

--- a/packages/core/upload/server/services/upload.js
+++ b/packages/core/upload/server/services/upload.js
@@ -182,7 +182,6 @@ module.exports = ({ strapi }) => ({
   },
 
   async uploadBuffer({ file, fileName, folder, mime, ext, alternativeText, caption }) {
-    const bytesToKbytes = (bytes) => Math.round((bytes / 1000) * 100) / 100;
     if (!mime) {
       return strapi.log.error('mime type is undefined');
     }

--- a/packages/core/upload/server/services/upload.js
+++ b/packages/core/upload/server/services/upload.js
@@ -187,7 +187,7 @@ module.exports = ({ strapi }) => ({
    * @param {Object} params - The parameters for uploading the buffer.
    * @param {Buffer} params.file - The buffer to be uploaded.
    * @param {string} params.fileName - The name of the file to be uploaded.
-   * @param {string} [params.folder] - The folder to upload the file to.
+   * @param {number} [params.folder] - The folder to upload the file to.
    * @param {string} params.mime - The MIME type of the file.
    * @param {string} params.ext - The file extension.
    * @param {string} [params.alternativeText] - The alternative text for the file.

--- a/packages/core/upload/server/services/upload.js
+++ b/packages/core/upload/server/services/upload.js
@@ -183,16 +183,16 @@ module.exports = ({ strapi }) => ({
 
   async uploadBuffer({ file, fileName, folder, mime, ext, alternativeText, caption }) {
     if (!mime) {
-      return strapi.log.error('mime type is undefined');
+      throw new ApplicationError('mime type is undefined');
     }
     if (!ext) {
-      return strapi.log.error('ext is undefined');
+      throw new ApplicationError('ext is undefined');
     }
     if (!file) {
-      return strapi.log.error('file is undefined');
+      throw new ApplicationError('file is undefined');
     }
     if (!fileName) {
-      return strapi.log.error('fileName is undefined');
+      throw new ApplicationError('fileName is undefined');
     }
     const config = strapi.config.get('plugin.upload');
     const entity = {


### PR DESCRIPTION
### What does it do?

Ability to upload a nodejs file buffer. 

### Why is it needed?

Currently, the upload plugin wants a FormData object only available on the front end. this adds the ability to upload a node js buffer to the media library

### How to test it?

```js        
const file = fs.readFileSync('./test.png')
return strapi.plugin('upload').service('upload').uploadBuffer({file, fileName: crypto.randomUUID(), mime: 'image/png', ext: 'png', alternativeText: "test"})
```

