### PR TITLE
Chore: Update msw to 1.0.0

### DIFF
--- a/packages/core/admin/package.json
+++ b/packages/core/admin/package.json
@@ -100,7 +100,6 @@
     "markdown-it-sup": "1.0.0",
     "match-sorter": "^4.0.2",
     "mini-css-extract-plugin": "2.7.2",
-    "msw": "0.49.1",
     "node-polyfill-webpack-plugin": "2.0.1",
     "node-schedule": "2.1.0",
     "p-map": "4.0.0",
@@ -145,6 +144,7 @@
     "@testing-library/user-event": "14.4.3",
     "duplicate-dependencies-webpack-plugin": "^1.0.2",
     "glob": "8.0.3",
+    "msw": "1.0.0",
     "react-test-renderer": "^17.0.2",
     "speed-measure-webpack-plugin": "1.5.0",
     "webpack-bundle-analyzer": "^4.7.0"

--- a/packages/core/upload/package.json
+++ b/packages/core/upload/package.json
@@ -49,7 +49,7 @@
     "@testing-library/react": "12.1.4",
     "@testing-library/react-hooks": "8.0.1",
     "@testing-library/user-event": "14.4.3",
-    "msw": "0.49.1",
+    "msw": "1.0.0",
     "react-test-renderer": "^17.0.2"
   },
   "engines": {

--- a/packages/plugins/documentation/package.json
+++ b/packages/plugins/documentation/package.json
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "@testing-library/react": "12.1.4",
-    "msw": "0.49.1"
+    "msw": "1.0.0"
   },
   "engines": {
     "node": ">=14.19.1 <=18.x.x",

--- a/packages/plugins/i18n/package.json
+++ b/packages/plugins/i18n/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@testing-library/react": "12.1.4",
-    "msw": "0.49.1"
+    "msw": "1.0.0"
   },
   "engines": {
     "node": ">=14.19.1 <=18.x.x",

--- a/packages/plugins/users-permissions/package.json
+++ b/packages/plugins/users-permissions/package.json
@@ -51,7 +51,7 @@
     "@testing-library/react": "12.1.4",
     "@testing-library/react-hooks": "8.0.1",
     "@testing-library/user-event": "14.4.3",
-    "msw": "0.49.1",
+    "msw": "1.0.0",
     "react-test-renderer": "^17.0.2"
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -16516,10 +16516,10 @@ ms@2.1.3, ms@^2.0.0, ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-msw@0.49.1:
-  version "0.49.1"
-  resolved "https://registry.yarnpkg.com/msw/-/msw-0.49.1.tgz#615e5c35736d8ec9924da6dce1f0c5c3528d4f26"
-  integrity sha512-JpIIq4P65ofj0HVmDMkJuRwgP9s5kcdutpZ15evMTb2k91/USB7IKWRLV9J1Mzc3OqTdwNj4RwtOWJ5y/FulQQ==
+msw@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/msw/-/msw-1.0.0.tgz#4f8e63aa23912561a63b99ff560a089da6969418"
+  integrity sha512-8QVa1RAN/Nzbn/tKmtimJ+b2M1QZOMdETQW7/1TmBOZ4w+wJojfxuh1Hj5J4FYdBgZWW/TK4CABUOlOM4OjTOA==
   dependencies:
     "@mswjs/cookies" "^0.2.2"
     "@mswjs/interceptors" "^0.17.5"
@@ -16537,7 +16537,7 @@ msw@0.49.1:
     node-fetch "^2.6.7"
     outvariant "^1.3.0"
     path-to-regexp "^6.2.0"
-    strict-event-emitter "^0.2.6"
+    strict-event-emitter "^0.4.3"
     type-fest "^2.19.0"
     yargs "^17.3.1"
 
@@ -17959,8 +17959,6 @@ path-case@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/path-case/-/path-case-2.1.1.tgz#94b8037c372d3fe2906e465bb45e25d226e8eea5"
   integrity sha1-lLgDfDctP+KQbkZbtF4l0ibo7qU=
-  dependencies:
-    no-case "^2.2.0"
 
 path-dirname@^1.0.0:
   version "1.0.2"
@@ -20776,12 +20774,17 @@ streamsearch@0.1.2:
   resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-0.1.2.tgz#808b9d0e56fc273d809ba57338e929919a1a9f1a"
   integrity sha512-jos8u++JKm0ARcSUTAZXOVC0mSox7Bhn6sBgty73P1f3JGf7yG2clTbBNHUdde/kdvP2FESam+vM6l8jBrNxHA==
 
-strict-event-emitter@^0.2.4, strict-event-emitter@^0.2.6:
+strict-event-emitter@^0.2.4:
   version "0.2.8"
   resolved "https://registry.yarnpkg.com/strict-event-emitter/-/strict-event-emitter-0.2.8.tgz#b4e768927c67273c14c13d20e19d5e6c934b47ca"
   integrity sha512-KDf/ujU8Zud3YaLtMCcTI4xkZlZVIYxTLr+XIULexP+77EEVWixeXroLUXQXiVtH4XH2W7jr/3PT1v3zBuvc3A==
   dependencies:
     events "^3.3.0"
+
+strict-event-emitter@^0.4.3:
+  version "0.4.6"
+  resolved "https://registry.yarnpkg.com/strict-event-emitter/-/strict-event-emitter-0.4.6.tgz#ff347c8162b3e931e3ff5f02cfce6772c3b07eb3"
+  integrity sha512-12KWeb+wixJohmnwNFerbyiBrAlq5qJLwIt38etRtKtmmHyDSoGlIqFE9wx+4IwG0aDjI7GV8tc8ZccjWZZtTg==
 
 string-argv@^0.3.1, string-argv@~0.3.1:
   version "0.3.1"


### PR DESCRIPTION
### What does it do?

- Updates `msw` to 1.0.0
- Move `msw` from dependencies to devDependencies

### Why is it needed?

Keep dependencies up-to-date.
