### PR TITLE
Chore: Update koa-session to 6.4.0

### DIFF
--- a/packages/core/strapi/package.json
+++ b/packages/core/strapi/package.json
@@ -118,7 +118,7 @@
     "koa-favicon": "2.1.0",
     "koa-helmet": "6.1.0",
     "koa-ip": "^2.1.2",
-    "koa-session": "6.2.0",
+    "koa-session": "6.4.0",
     "koa-static": "5.0.0",
     "lodash": "4.17.21",
     "mime-types": "2.1.35",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9820,7 +9820,7 @@ cpy@^8.1.2:
     p-filter "^2.1.0"
     p-map "^3.0.0"
 
-crc@^3.4.4:
+crc@^3.8.0:
   version "3.8.0"
   resolved "https://registry.yarnpkg.com/crc/-/crc-3.8.0.tgz#ad60269c2c856f8c299e2c4cc0de4556914056c6"
   integrity sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==
@@ -14034,7 +14034,7 @@ is-text-path@^1.0.1:
   dependencies:
     text-extensions "^1.0.0"
 
-is-type-of@^1.0.0:
+is-type-of@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/is-type-of/-/is-type-of-1.2.1.tgz#e263ec3857aceb4f28c47130ec78db09a920f8c5"
   integrity sha512-uK0kyX9LZYhSDS7H2sVJQJop1UnWPWmo5RvR3q2kFH6AUHYs7sOrVg0b4nyBHw29kRRNFofYN/JbHZDlHiItTA==
@@ -15206,15 +15206,15 @@ koa-send@^5.0.0:
     http-errors "^1.7.3"
     resolve-path "^1.4.0"
 
-koa-session@6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/koa-session/-/koa-session-6.2.0.tgz#c0da2a808b520f62a25dac9f2914b580b2402078"
-  integrity sha512-l2ZC6D1BnRkIXhWkRgpewdqKn38/9/2WScmxyShuN408TxX+J/gUzdzGBIvGZaRwmezOU819sNpGmfFGLeDckg==
+koa-session@6.4.0:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/koa-session/-/koa-session-6.4.0.tgz#f17c6f1844b37114192aa23a0ccf4f58c3042e96"
+  integrity sha512-h/dxmSOvNEXpHQPRs4TV03TZVFyZIjmYQiTAW5JBFTYBOZ0VdpZ8QEE6Dud75g8z9JNGXi3m++VqRmqToB+c2A==
   dependencies:
-    crc "^3.4.4"
-    debug "^3.1.0"
-    is-type-of "^1.0.0"
-    uuid "^3.3.2"
+    crc "^3.8.0"
+    debug "^4.3.3"
+    is-type-of "^1.2.1"
+    uuid "^8.3.2"
 
 koa-static@5.0.0, koa-static@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
### What does it do?

Updates `koa-session` to v6.4.0.

### Why is it needed?

Currently users see a depreaction warning:

```
npm WARN deprecated uuid@3.4.0: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
```

The update didn't do much else than updating dependencies: https://github.com/koajs/session/commits/master so the warning during the installation goes away.

### Related issue(s)/PR(s)

- https://github.com/strapi/strapi/issues/14420
