### PR TITLE
fix: Can not update media folder

### DIFF
--- a/packages/core/upload/admin/src/hooks/useEditAsset.js
+++ b/packages/core/upload/admin/src/hooks/useEditAsset.js
@@ -21,7 +21,7 @@ const editAssetRequest = (asset, file, cancelToken, onProgress, post) => {
     JSON.stringify({
       alternativeText: asset.alternativeText,
       caption: asset.caption,
-      folder: asset.folder?.id,
+      folder: asset.folder,
       name: asset.name,
     })
   );


### PR DESCRIPTION
### What does it do?
Fixes changing the location of a media when editing the media attributes by passing in the correct `FormData folder property` using `asset.folder`.

### Why is it needed?
Currently we try to update `FormData folder property` using `asset.folder?.id` (wrong way).

### How to test it?
1. Go to Media Library
2. Click on any image you have uploaded
3. Attempt to change the directory of the image asset
4. Confirm that the location was changed successfully

### Related issue(s)/PR(s)
* Fixes https://github.com/strapi/strapi/issues/15722
* resolves CONTENT-1038

### Demo

https://user-images.githubusercontent.com/7220167/217487251-6480408b-4a9e-4bbc-bd0a-c708854cef85.mov

