### PR TITLE
Docs: Fix sidebar structure

### DIFF
--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -92,7 +92,7 @@ const sidebars = {
                 {
                   type: 'doc',
                   label: 'useAPIErrorHandler',
-                  id: 'core/hooks/use-api-error-handler',
+                  id: 'core/helper-plugin/hooks/use-api-error-handler',
                 },
               ],
             },


### PR DESCRIPTION
### What does it do?

Fixes the doc sidebar structure.

### Why is it needed?

I've made a mistake with the merge in https://github.com/strapi/strapi/pull/15321 and the docs don't build anymore.
