### PR TITLE
[Upload]: Add ability to upload via buffer

### DIFF
--- a/packages/core/upload/server/controllers/admin-upload.js
+++ b/packages/core/upload/server/controllers/admin-upload.js
@@ -91,7 +91,7 @@ module.exports = {
       request: { body, files: { files } = {} },
     } = ctx;
 
-    if (!body.file || body.file.length === 0 || _.isEmpty(files) || files.size === 0) {
+    if ((!body.file || body.file.length === 0) && (_.isEmpty(files) || files.size === 0)) {
       if (id) {
         return this.updateFileInfo(ctx);
       }

--- a/packages/core/upload/server/controllers/admin-upload.js
+++ b/packages/core/upload/server/controllers/admin-upload.js
@@ -48,7 +48,7 @@ module.exports = {
       throw new ApplicationError('Cannot replace a file with multiple ones');
     }
 
-    const data = await validateUploadBody(body);
+    const data = await validateUploadBody(body, { isBufferData: Buffer.isBuffer(files) });
     const replacedFiles = await uploadService.replace(id, { data, file: files }, { user });
 
     ctx.body = await pm.sanitizeOutput(replacedFiles, { action: ACTIONS.read });
@@ -71,7 +71,8 @@ module.exports = {
       return ctx.forbidden();
     }
 
-    const data = await validateUploadBody(body);
+    const data = await validateUploadBody(body, { isBufferData: Buffer.isBuffer(files) });
+
     const uploadedFiles = await uploadService.upload({ data, files }, { user });
 
     ctx.body = await pm.sanitizeOutput(uploadedFiles, { action: ACTIONS.read });

--- a/packages/core/upload/server/controllers/content-api.js
+++ b/packages/core/upload/server/controllers/content-api.js
@@ -78,7 +78,7 @@ module.exports = {
     }
 
     const replacedFiles = await getService('upload').replace(id, {
-      data: await validateUploadBody(body),
+      data: await validateUploadBody(body, { isBufferData: Buffer.isBuffer(files) }),
       file: files,
     });
 
@@ -90,7 +90,10 @@ module.exports = {
       request: { body, files: { files } = {} },
     } = ctx;
 
-    const data = await validateUploadBody(body, Array.isArray(files));
+    const data = await validateUploadBody(body, {
+      isMulti: Array.isArray(files),
+      isBufferData: Buffer.isBuffer(files),
+    });
 
     const apiUploadFolderService = getService('api-upload-folder');
 

--- a/packages/core/upload/server/controllers/validation/admin/upload.js
+++ b/packages/core/upload/server/controllers/validation/admin/upload.js
@@ -22,6 +22,33 @@ const fileInfoSchema = yup.object({
     }),
 });
 
+const bufferFileInfoSchema = yup.object({
+  name: yup.string().required(),
+  type: yup.string().required(),
+  alternativeText: yup.string().nullable(),
+  caption: yup.string().nullable(),
+  folder: yup
+    .strapiID()
+    .nullable()
+    .test('folder-exists', 'the folder does not exist', async (folderId) => {
+      if (isNil(folderId)) {
+        return true;
+      }
+
+      const exists = await getService('folder').exists({ id: folderId });
+
+      return exists;
+    }),
+});
+
+const bufferUploadSchema = yup.object({
+  fileInfo: bufferFileInfoSchema,
+});
+
+const multiBufferUploadSchema = yup.object({
+  fileInfo: yup.array().of(bufferFileInfoSchema),
+});
+
 const uploadSchema = yup.object({
   fileInfo: fileInfoSchema,
 });
@@ -30,8 +57,12 @@ const multiUploadSchema = yup.object({
   fileInfo: yup.array().of(fileInfoSchema),
 });
 
-const validateUploadBody = (data = {}, isMulti = false) => {
-  const schema = isMulti ? multiUploadSchema : uploadSchema;
+const validateUploadBody = (data = {}, { isMulti = false, isBufferData = false } = {}) => {
+  let schema = isMulti ? multiUploadSchema : uploadSchema;
+
+  if (isBufferData) {
+    schema = isMulti ? multiBufferUploadSchema : bufferUploadSchema;
+  }
 
   return validateYupSchema(schema, { strict: false })(data);
 };

--- a/packages/core/upload/server/controllers/validation/admin/upload.js
+++ b/packages/core/upload/server/controllers/validation/admin/upload.js
@@ -22,30 +22,34 @@ const fileInfoSchema = yup.object({
     }),
 });
 
-const bufferFileInfoSchema = yup.object({
-  name: yup.string().required(),
-  type: yup.string().required(),
-  alternativeText: yup.string().nullable(),
-  caption: yup.string().nullable(),
-  folder: yup
-    .strapiID()
-    .nullable()
-    .test('folder-exists', 'the folder does not exist', async (folderId) => {
-      if (isNil(folderId)) {
-        return true;
-      }
+const bufferFileInfoSchema = yup
+  .object({
+    name: yup.string().required(),
+    type: yup.string().required(),
+    alternativeText: yup.string().nullable(),
+    caption: yup.string().nullable(),
+    folder: yup
+      .strapiID()
+      .nullable()
+      .test('folder-exists', 'the folder does not exist', async (folderId) => {
+        if (isNil(folderId)) {
+          return true;
+        }
 
-      const exists = await getService('folder').exists({ id: folderId });
+        const exists = await getService('folder').exists({ id: folderId });
 
-      return exists;
-    }),
-});
+        return exists;
+      }),
+  })
+  .required();
 
 const bufferUploadSchema = yup.object({
+  file: yup.mixed().required(),
   fileInfo: bufferFileInfoSchema,
 });
 
 const multiBufferUploadSchema = yup.object({
+  file: yup.array().of(yup.mixed().required()).required(),
   fileInfo: yup.array().of(bufferFileInfoSchema),
 });
 

--- a/packages/core/upload/server/controllers/validation/content-api/upload.js
+++ b/packages/core/upload/server/controllers/validation/content-api/upload.js
@@ -18,8 +18,27 @@ const multiUploadSchema = yup.object({
   fileInfo: yup.array().of(fileInfoSchema),
 });
 
-const validateUploadBody = (data = {}, isMulti = false) => {
-  const schema = isMulti ? multiUploadSchema : uploadSchema;
+const bufferFileInfoSchema = yup.object({
+  name: yup.string().required(),
+  type: yup.string().required(),
+  alternativeText: yup.string().nullable(),
+  caption: yup.string().nullable(),
+});
+
+const bufferUploadSchema = yup.object({
+  fileInfo: bufferFileInfoSchema,
+});
+
+const multiBufferUploadSchema = yup.object({
+  fileInfo: yup.array().of(bufferFileInfoSchema),
+});
+
+const validateUploadBody = (data = {}, { isMulti = false, isBufferData = false } = {}) => {
+  let schema = isMulti ? multiUploadSchema : uploadSchema;
+
+  if (isBufferData) {
+    schema = isMulti ? multiBufferUploadSchema : bufferUploadSchema;
+  }
 
   return validateYupSchema(schema, { strict: false })(data);
 };

--- a/packages/core/upload/server/services/__tests__/upload/uploadImage.test.js
+++ b/packages/core/upload/server/services/__tests__/upload/uploadImage.test.js
@@ -78,6 +78,23 @@ describe('Upload image', () => {
     expect(upload).toHaveBeenCalledTimes(2);
   });
 
+  test('Upload file using buffer', async () => {
+    // create buffer from imageFilePath
+    const file = fs.readFileSync(imageFilePath);
+    const upload = jest.fn();
+    mockUploadProvider(upload);
+
+    uploadService.uploadBuffer({
+      file,
+      fileName: 'test',
+      mime: 'image/png',
+      ext: 'png',
+      alternativeText: 'test',
+    });
+    // 1 for the original image, 1 for thumbnail, 2 for the responsive formats
+    expect(upload).toHaveBeenCalledTimes(2);
+  });
+
   test('Upload with responsive formats', async () => {
     const fileData = getFileData(imageFilePath);
     const upload = jest.fn();

--- a/packages/core/upload/server/services/__tests__/upload/uploadImage.test.js
+++ b/packages/core/upload/server/services/__tests__/upload/uploadImage.test.js
@@ -78,23 +78,6 @@ describe('Upload image', () => {
     expect(upload).toHaveBeenCalledTimes(2);
   });
 
-  test('Upload file using buffer', async () => {
-    // create buffer from imageFilePath
-    const file = fs.readFileSync(imageFilePath);
-    const upload = jest.fn();
-    mockUploadProvider(upload);
-
-    uploadService.uploadBuffer({
-      file,
-      fileName: 'test',
-      mime: 'image/png',
-      ext: 'png',
-      alternativeText: 'test',
-    });
-    // 1 for the original image, 1 for thumbnail, 2 for the responsive formats
-    expect(upload).toHaveBeenCalledTimes(2);
-  });
-
   test('Upload with responsive formats', async () => {
     const fileData = getFileData(imageFilePath);
     const upload = jest.fn();

--- a/packages/core/upload/server/services/upload.js
+++ b/packages/core/upload/server/services/upload.js
@@ -181,6 +181,22 @@ module.exports = ({ strapi }) => ({
     return uploadedFiles;
   },
 
+  /**
+   * Asynchronously upload a buffer to the media library.
+   *
+   * @param {Object} params - The parameters for uploading the buffer.
+   * @param {Buffer} params.file - The buffer to be uploaded.
+   * @param {string} params.fileName - The name of the file to be uploaded.
+   * @param {string} [params.folder] - The folder to upload the file to.
+   * @param {string} params.mime - The MIME type of the file.
+   * @param {string} params.ext - The file extension.
+   * @param {string} [params.alternativeText] - The alternative text for the file.
+   * @param {string} [params.caption] - The caption for the file.
+   *
+   * @throws {ApplicationError} If `mime`, `ext`, `file`, or `fileName` is undefined.
+   *
+   * @returns {Promise<Object>} The uploaded file entity.
+   */
   async uploadBuffer({ file, fileName, folder, mime, ext, alternativeText, caption }) {
     if (!mime) {
       throw new ApplicationError('mime type is undefined');

--- a/packages/core/upload/server/services/upload.js
+++ b/packages/core/upload/server/services/upload.js
@@ -182,7 +182,6 @@ module.exports = ({ strapi }) => ({
   },
 
   async uploadBuffer({ file, fileName, folder, mime, ext, alternativeText, caption }) {
-    const bytesToKbytes = (bytes) => Math.round((bytes / 1000) * 100) / 100;
     if (!mime) {
       return strapi.log.error('mime type is undefined');
     }

--- a/packages/core/upload/server/services/upload.js
+++ b/packages/core/upload/server/services/upload.js
@@ -187,7 +187,7 @@ module.exports = ({ strapi }) => ({
    * @param {Object} params - The parameters for uploading the buffer.
    * @param {Buffer} params.file - The buffer to be uploaded.
    * @param {string} params.fileName - The name of the file to be uploaded.
-   * @param {string} [params.folder] - The folder to upload the file to.
+   * @param {number} [params.folder] - The folder to upload the file to.
    * @param {string} params.mime - The MIME type of the file.
    * @param {string} params.ext - The file extension.
    * @param {string} [params.alternativeText] - The alternative text for the file.

--- a/packages/core/upload/server/services/upload.js
+++ b/packages/core/upload/server/services/upload.js
@@ -183,16 +183,16 @@ module.exports = ({ strapi }) => ({
 
   async uploadBuffer({ file, fileName, folder, mime, ext, alternativeText, caption }) {
     if (!mime) {
-      return strapi.log.error('mime type is undefined');
+      throw new ApplicationError('mime type is undefined');
     }
     if (!ext) {
-      return strapi.log.error('ext is undefined');
+      throw new ApplicationError('ext is undefined');
     }
     if (!file) {
-      return strapi.log.error('file is undefined');
+      throw new ApplicationError('file is undefined');
     }
     if (!fileName) {
-      return strapi.log.error('fileName is undefined');
+      throw new ApplicationError('fileName is undefined');
     }
     const config = strapi.config.get('plugin.upload');
     const entity = {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### Note

If this direction is objectively worse than the opposite PR we can continue working there 💪🏼 

### What does it do?

* builds upon #15755 
* Checks for buffers and handles appropriately in `doUpload`
* Adds function for `enhanceAndValidateBuffer` as the buffer alternative to `enhanceAndValidateFile`
* Updates the body validation incase it's `BufferData` because we need more information to create the file

### Why is it needed?

* Highly requested feature and I didn't want to mess with #15755 so I built on top of it for some validation before going further. My opinion is this route is better because instead of creating a new service that does XYZ we just check if it's `Buffer` and apply the necessary differences to the `fileData/entity` and pass it along our normal uploading flow.

### How to test it?

* I will need help to add tests if we're happy 😅 

### Related issue(s)/PR(s)

* resolves #5297
* closes #15755
