### PR TITLE
feat(review-workflow): add assert on workflow deletion

### DIFF
--- a/packages/core/admin/ee/server/tests/review-workflows.test.api.js
+++ b/packages/core/admin/ee/server/tests/review-workflows.test.api.js
@@ -242,5 +242,31 @@ describeOnCondition(edition === 'EE')('Review workflows', () => {
         expect(workflowRes.body.data).toBeUndefined();
       }
     });
+    test('It should throw an error if trying to delete all stages in a workflow', async () => {
+      const stagesRes = await requests.admin.put(
+        `/admin/review-workflows/workflows/${testWorkflow.id}/stages`,
+        { body: { data: [] } }
+      );
+      const workflowRes = await requests.admin.get(
+        `/admin/review-workflows/workflows/${testWorkflow.id}?populate=*`
+      );
+
+      if (hasRW) {
+        expect(stagesRes.status).toBe(400);
+        expect(stagesRes.body.error).toBeDefined();
+        expect(stagesRes.body.error.name).toEqual('ApplicationError');
+        expect(stagesRes.body.error.message).toBeDefined();
+        expect(workflowRes.status).toBe(200);
+        expect(workflowRes.body.data).toBeInstanceOf(Object);
+        expect(workflowRes.body.data.stages).toBeInstanceOf(Array);
+        expect(workflowRes.body.data.stages[0]).toMatchObject({ id: defaultStage.id });
+        expect(workflowRes.body.data.stages[1]).toMatchObject({ id: secondStage.id });
+      } else {
+        expect(stagesRes.status).toBe(404);
+        expect(stagesRes.body.data).toBeUndefined();
+        expect(workflowRes.status).toBe(404);
+        expect(workflowRes.body.data).toBeUndefined();
+      }
+    });
   });
 });

--- a/packages/core/admin/server/tests/admin-permission.test.api.js
+++ b/packages/core/admin/server/tests/admin-permission.test.api.js
@@ -893,6 +893,12 @@ describe('Role CRUD End to End', () => {
                   "subCategory": "options",
                 },
                 {
+                  "action": "admin::review-workflows.read",
+                  "category": "review workflows",
+                  "displayName": "Read",
+                  "subCategory": "options",
+                },
+                {
                   "action": "admin::roles.create",
                   "category": "users and roles",
                   "displayName": "Create",


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Add a check to throw an error if the user tries to delete all the stages from a workflow.

### Why is it needed?

We need to have at least one stage in a workflow.

### How to test it?

You can do the same as the integration test and tries to send a PUT request to `/admin/review-workflows/workflows/:workflow_id/stages` with an empty array `{ body: { data: [] } }`.
