### PR TITLE
Move audit logs permissions to EE

### DIFF
--- a/packages/core/admin/admin/src/permissions/defaultPermissions.js
+++ b/packages/core/admin/admin/src/permissions/defaultPermissions.js
@@ -34,10 +34,6 @@ const permissions = {
     uninstall: [{ action: 'admin::marketplace.plugins.uninstall', subject: null }],
   },
   settings: {
-    auditLogs: {
-      main: [{ action: 'admin::audit-logs.read', subject: null }],
-      read: [{ action: 'admin::audit-logs.read', subject: null }],
-    },
     roles: {
       main: [
         { action: 'admin::roles.create', subject: null },

--- a/packages/core/admin/ee/admin/permissions/customPermissions.js
+++ b/packages/core/admin/ee/admin/permissions/customPermissions.js
@@ -1,5 +1,9 @@
 const customPermissions = {
   settings: {
+    auditLogs: {
+      main: [{ action: 'admin::audit-logs.read', subject: null }],
+      read: [{ action: 'admin::audit-logs.read', subject: null }],
+    },
     sso: {
       main: [{ action: 'admin::provider-login.read', subject: null }],
       read: [{ action: 'admin::provider-login.read', subject: null }],


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Moves the audit logs permissions code from CE to EE

### Why is it needed?

To make sure audit logs is entirely in the EE folder (well, except translations). It was spotted by @gu-stav on Slack.

### How to test it?

The behavior should stay the same as it was before. On the `/admin/settings/roles/1` page, you should see the audit logs section while using EE, not while using CE.

### Related issue(s)/PR(s)

Should have been part of #15568