### PR TITLE
feat(review-workflow): add permissions

### DIFF
--- a/packages/core/admin/ee/server/bootstrap.js
+++ b/packages/core/admin/ee/server/bootstrap.js
@@ -21,6 +21,7 @@ module.exports = async () => {
     const { bootstrap: rwBootstrap } = getService('review-workflows');
 
     await rwBootstrap();
+    await actionProvider.registerMany(actions.reviewWorkflows);
   }
 
   // TODO: check admin seats

--- a/packages/core/admin/ee/server/config/admin-actions.js
+++ b/packages/core/admin/ee/server/config/admin-actions.js
@@ -29,4 +29,14 @@ module.exports = {
       subCategory: 'options',
     },
   ],
+  reviewWorkflows: [
+    {
+      uid: 'review-workflows.read',
+      displayName: 'Read',
+      pluginName: 'admin',
+      section: 'settings',
+      category: 'review workflows',
+      subCategory: 'options',
+    },
+  ],
 };

--- a/packages/core/admin/ee/server/routes/index.js
+++ b/packages/core/admin/ee/server/routes/index.js
@@ -156,7 +156,15 @@ module.exports = [
     handler: 'workflows.find',
     config: {
       middlewares: [enableFeatureMiddleware('review-workflows')],
-      policies: ['admin::isAuthenticatedAdmin'],
+      policies: [
+        'admin::isAuthenticatedAdmin',
+        {
+          name: 'admin::hasPermissions',
+          config: {
+            actions: ['admin::review-workflows.read'],
+          },
+        },
+      ],
     },
   },
   {
@@ -165,7 +173,15 @@ module.exports = [
     handler: 'workflows.findById',
     config: {
       middlewares: [enableFeatureMiddleware('review-workflows')],
-      policies: ['admin::isAuthenticatedAdmin'],
+      policies: [
+        'admin::isAuthenticatedAdmin',
+        {
+          name: 'admin::hasPermissions',
+          config: {
+            actions: ['admin::review-workflows.read'],
+          },
+        },
+      ],
     },
   },
   {
@@ -174,7 +190,15 @@ module.exports = [
     handler: 'stages.find',
     config: {
       middlewares: [enableFeatureMiddleware('review-workflows')],
-      policies: ['admin::isAuthenticatedAdmin'],
+      policies: [
+        'admin::isAuthenticatedAdmin',
+        {
+          name: 'admin::hasPermissions',
+          config: {
+            actions: ['admin::review-workflows.read'],
+          },
+        },
+      ],
     },
   },
   {
@@ -183,7 +207,15 @@ module.exports = [
     handler: 'stages.replace',
     config: {
       middlewares: [enableFeatureMiddleware('review-workflows')],
-      policies: ['admin::isAuthenticatedAdmin'],
+      policies: [
+        'admin::isAuthenticatedAdmin',
+        {
+          name: 'admin::hasPermissions',
+          config: {
+            actions: ['admin::review-workflows.read'],
+          },
+        },
+      ],
     },
   },
   {
@@ -192,7 +224,15 @@ module.exports = [
     handler: 'stages.findById',
     config: {
       middlewares: [enableFeatureMiddleware('review-workflows')],
-      policies: ['admin::isAuthenticatedAdmin'],
+      policies: [
+        'admin::isAuthenticatedAdmin',
+        {
+          name: 'admin::hasPermissions',
+          config: {
+            actions: ['admin::review-workflows.read'],
+          },
+        },
+      ],
     },
   },
 ];


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Adding permissions to review workflow routes.
Now the user will need permission `admin::review-workflows.read` to access to the routes of the feature.

### Why is it needed?

To be able to activate/deactivate access to users on this feature.

### How to test it?

Try to request routes without appropriate permissions, you should end up with 403 errors.
