### PR TITLE
fix: duplicated component caused by missing component_type field in pivot table

### DIFF
--- a/packages/core/database/lib/entity-manager/index.js
+++ b/packages/core/database/lib/entity-manager/index.js
@@ -552,7 +552,7 @@ const createEntityManager = (db) => {
         if (attribute.joinTable) {
           // need to set the column on the target
 
-          const { joinTable } = attribute;
+          const { joinTable, component: component_type } = attribute;
           const { joinColumn, inverseJoinColumn, orderColumnName, inverseOrderColumnName } =
             joinTable;
 
@@ -576,6 +576,7 @@ const createEntityManager = (db) => {
               [inverseJoinColumn.name]: data.id,
               ...(joinTable.on || {}),
               ...(data.__pivot || {}),
+              ...(component_type ? { component_type } : {}),
             };
           });
 


### PR DESCRIPTION
### What does it do?

It sets the `component_type` field in the components pivot table when writing component relation through the entity service

### Why is it needed?

This is needed because if the component_type field is missing, for a repeatable component relation, when updating the component field in the entity via the REST API, repeating the existing component in the body causes the component to be duplicated with the component_type field populated. After this strange behaviors happen editing and deleting fields in the repeatable component field.

### How to test it?

This is the behaviour that this PR is fixing:

- Create a collection-type with any repeatable component field inside

```
// /src/api/foo/content-types/foo/schema.json
{
  "kind": "collectionType",
  "collectionName": "foos",
  "info": {
    "singularName": "foo",
    "pluralName": "foos",
    "displayName": "Foo",
    "description": "Foo"
  },
  "options": {
    "draftAndPublish": false
  },
  "pluginOptions": {},
  "attributes": {
    "foos": {
      "displayName": "Foos",
      "type": "component",
      "repeatable": true,
      "component": "foo.foo"
    }
  }
}

```

```
// /src/components/foo/foo.json
{
  {
  "collectionName": "components_foo_foo",
  "info": {
    "displayName": "Foo"
  },
  "options": {},
  "attributes": {
    "foo": {
      "type": "string"
    }
  }
}
```

- Insert a new component object with query engine.
```
const foo = await strapi.db.query('component.uid').create({
  data: { foo: bar }
})
```
- Create a new entity connecting the component with the newly created id
```
strapi.db.query('collection-type.uid').create({
  data: {
    foos: {
      connect: [ foo.id ]
    }
  }
})
```
- Update the entity via the rest api 
```
POST /api/foos

{
  "data": {
    "foos": [
      {
        "id": the-existing-foo-id,
        "foo": "bar"
      },
      {
        "foo": "baz"
      }
    ],
  }
}
```
- After the update the new component will be inserted and the existing component will be duplicated

```
{
  "data": {
    "foos": [
      {
        "id": the-existing-foo-id, // this one in the foos_foo_components table will not have the component_type field (first insert)
        "foo": "bar"
      },
      {
        "id": the-existing-foo-id, // this one in the foos_foo_components table will have the component_type field (duplicated)
        "foo": "bar"
      },
      {
        "id": the-newly-created-foo-id,
        "foo": "bar"
      }
    ],
  }
}
```


I don't know if this is the best way to solve the problem but it surely does without breaking anything else. This thing needs to be fixed so i'm happy to contribute.

