### PR TITLE
Fix failing register unit test

### DIFF
--- a/packages/core/upload/server/__tests__/register.test.js
+++ b/packages/core/upload/server/__tests__/register.test.js
@@ -32,6 +32,13 @@ jest.mock('@strapi/provider-upload-local', () => ({
   },
 }));
 
+jest.mock('../utils', () => ({
+  ...jest.requireActual('../utils'),
+  getService: () => ({
+    contentManager: { entityManager: { addSignedFileUrlsToAdmin: jest.fn() } },
+  }),
+}));
+
 describe('Upload plugin register function', () => {
   test('The upload plugin registers the /upload route', async () => {
     const registerRoute = jest.fn();


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Mocks the new `getService('extensions')` call in the register unit tests

### Why is it needed?

To fix failing unit tests
