### PR TITLE
[Private s3 bucket]: Fix show images when updating entity

### DIFF
--- a/packages/core/content-manager/server/services/entity-manager.js
+++ b/packages/core/content-manager/server/services/entity-manager.js
@@ -115,19 +115,21 @@ module.exports = ({ strapi }) => ({
     const counterPopulate = getDeepPopulate(uid, { countMany: true, countOne: true });
     const params = { populate: addCreatedByRolesPopulate(counterPopulate) };
 
-    const entity = await strapi.entityService.findOne(uid, id, params);
-    return this.mapEntity(entity, uid);
+    return strapi.entityService
+      .findOne(uid, id, params)
+      .then((entity) => this.mapEntity(entity, uid));
   },
 
   async findOne(id, uid) {
     const params = { populate: getDeepPopulate(uid) };
 
-    const entity = await strapi.entityService.findOne(uid, id, params);
-    return this.mapEntity(entity, uid);
+    return strapi.entityService
+      .findOne(uid, id, params)
+      .then((entity) => this.mapEntity(entity, uid));
   },
 
   async findOneWithCreatorRoles(id, uid) {
-    const entity = await this.findOne(id, uid);
+    const entity = await this.findOne(id, uid).then((entity) => this.mapEntity(entity, uid));
 
     if (!entity) {
       return entity;
@@ -152,7 +154,9 @@ module.exports = ({ strapi }) => ({
         : getDeepPopulate(uid, { countMany: true, countOne: true }),
     };
 
-    const entity = await strapi.entityService.create(uid, params);
+    const entity = await strapi.entityService
+      .create(uid, params)
+      .then((entity) => this.mapEntity(entity, uid));
 
     // If relations were populated, relations count will be returned instead of the array of relations.
     if (populateRelations) {
@@ -173,14 +177,16 @@ module.exports = ({ strapi }) => ({
         : getDeepPopulate(uid, { countMany: true, countOne: true }),
     };
 
-    const updatedEntity = await strapi.entityService.update(uid, entity.id, params);
+    const updatedEntity = await strapi.entityService
+      .update(uid, entity.id, params)
+      .then((entity) => this.mapEntity(entity, uid));
 
     // If relations were populated, relations count will be returned instead of the array of relations.
     if (populateRelations) {
       return getDeepRelationsCount(updatedEntity, uid);
     }
 
-    return this.mapEntity(updatedEntity, uid);
+    return updatedEntity;
   },
 
   async delete(entity, uid) {
@@ -236,12 +242,14 @@ module.exports = ({ strapi }) => ({
 
     await emitEvent(ENTRY_PUBLISH, entity, uid);
 
+    const mappedEntity = await this.mapEntity(updatedEntity, uid);
+
     // If relations were populated, relations count will be returned instead of the array of relations.
     if (isRelationsPopulateEnabled(uid)) {
-      return getDeepRelationsCount(updatedEntity, uid);
+      return getDeepRelationsCount(mappedEntity, uid);
     }
 
-    return this.mapEntity(updatedEntity, uid);
+    return mappedEntity;
   },
 
   async unpublish(entity, body = {}, uid) {
@@ -263,12 +271,14 @@ module.exports = ({ strapi }) => ({
 
     await emitEvent(ENTRY_UNPUBLISH, entity, uid);
 
+    const mappedEntity = await this.mapEntity(updatedEntity, uid);
+
     // If relations were populated, relations count will be returned instead of the array of relations.
     if (isRelationsPopulateEnabled(uid)) {
-      return getDeepRelationsCount(updatedEntity, uid);
+      return getDeepRelationsCount(mappedEntity, uid);
     }
 
-    return this.mapEntity(updatedEntity, uid);
+    return mappedEntity;
   },
 
   async getNumberOfDraftRelations(id, uid) {

--- a/packages/core/content-manager/server/services/entity-manager.js
+++ b/packages/core/content-manager/server/services/entity-manager.js
@@ -163,7 +163,7 @@ module.exports = ({ strapi }) => ({
       return getDeepRelationsCount(entity, uid);
     }
 
-    return this.mapEntity(entity, uid);
+    return entity;
   },
 
   async update(entity, body, uid) {


### PR DESCRIPTION
### What does it do?

We have to execute mapEntity before returning the relations count. (See code)

I changed the format a little bit for some methods of the entity manager, let me know what you think

### Why is it needed?

To see images when saving an entity.

