### PR TITLE
Remove dead code for the install and uninstall plugin actions

### DIFF
--- a/packages/admin-test-utils/lib/fixtures/permissions/admin-permissions.js
+++ b/packages/admin-test-utils/lib/fixtures/permissions/admin-permissions.js
@@ -23,20 +23,6 @@ const adminPermissions = [
     conditions: [],
   },
   {
-    id: 172,
-    action: 'admin::marketplace.plugins.install',
-    subject: null,
-    properties: {},
-    conditions: [],
-  },
-  {
-    id: 173,
-    action: 'admin::marketplace.plugins.uninstall',
-    subject: null,
-    properties: {},
-    conditions: [],
-  },
-  {
     id: 174,
     action: 'admin::webhooks.create',
     subject: null,

--- a/packages/core/admin/admin/src/hooks/useMenu/utils/tests/getGeneralLinks.test.js
+++ b/packages/core/admin/admin/src/hooks/useMenu/utils/tests/getGeneralLinks.test.js
@@ -68,14 +68,6 @@ describe('getGeneralLinks', () => {
             action: 'admin::marketplace.read',
             subject: null,
           },
-          {
-            action: 'admin::marketplace.plugins.install',
-            subject: null,
-          },
-          {
-            action: 'admin::marketplace.plugins.uninstall',
-            subject: null,
-          },
         ],
         notificationsCount: 0,
       },
@@ -87,14 +79,6 @@ describe('getGeneralLinks', () => {
         permissions: [
           {
             action: 'admin::marketplace.read',
-            subject: null,
-          },
-          {
-            action: 'admin::marketplace.plugins.install',
-            subject: null,
-          },
-          {
-            action: 'admin::marketplace.plugins.uninstall',
             subject: null,
           },
         ],
@@ -121,14 +105,6 @@ describe('getGeneralLinks', () => {
             action: 'admin::marketplace.read',
             subject: null,
           },
-          {
-            action: 'admin::marketplace.plugins.install',
-            subject: null,
-          },
-          {
-            action: 'admin::marketplace.plugins.uninstall',
-            subject: null,
-          },
         ],
         notificationsCount: 0,
       },
@@ -140,14 +116,6 @@ describe('getGeneralLinks', () => {
         permissions: [
           {
             action: 'admin::marketplace.read',
-            subject: null,
-          },
-          {
-            action: 'admin::marketplace.plugins.install',
-            subject: null,
-          },
-          {
-            action: 'admin::marketplace.plugins.uninstall',
             subject: null,
           },
         ],

--- a/packages/core/admin/admin/src/pages/Admin/index.js
+++ b/packages/core/admin/admin/src/pages/Admin/index.js
@@ -78,8 +78,6 @@ const Admin = () => {
     return <LoadingIndicatorPage />;
   }
 
-  console.log({ generalSectionLinks, pluginsSectionLinks });
-
   return (
     <DndProvider backend={HTML5Backend}>
       <AppLayout

--- a/packages/core/admin/admin/src/pages/Admin/index.js
+++ b/packages/core/admin/admin/src/pages/Admin/index.js
@@ -78,6 +78,8 @@ const Admin = () => {
     return <LoadingIndicatorPage />;
   }
 
+  console.log({ generalSectionLinks, pluginsSectionLinks });
+
   return (
     <DndProvider backend={HTML5Backend}>
       <AppLayout

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/Permissions/utils/tests/data.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/Permissions/utils/tests/data.js
@@ -51,12 +51,6 @@ const permissionsLayout = {
         category: 'plugins and marketplace',
         subCategory: 'marketplace',
       },
-      {
-        displayName: 'Install (only for dev env)',
-        action: 'admin::marketplace.plugins.install',
-        category: 'plugins and marketplace',
-        subCategory: 'plugins',
-      },
     ],
   },
 };

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/Permissions/utils/tests/formatLayoutForSettingsAndPlugins.test.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/Permissions/utils/tests/formatLayoutForSettingsAndPlugins.test.js
@@ -131,18 +131,6 @@ describe('ADMIN | COMPONENTS | ROLE | PluginsAndSettings | formatLayoutForSetti
               },
             ],
           },
-          {
-            subCategoryName: 'plugins',
-            subCategoryId: 'plugins',
-            actions: [
-              {
-                displayName: 'Install (only for dev env)',
-                action: 'admin::marketplace.plugins.install',
-                category: 'plugins and marketplace',
-                subCategory: 'plugins',
-              },
-            ],
-          },
         ],
       },
     ];

--- a/packages/core/admin/admin/src/permissions/defaultPermissions.js
+++ b/packages/core/admin/admin/src/permissions/defaultPermissions.js
@@ -21,17 +21,8 @@ const permissions = {
     ],
   },
   marketplace: {
-    main: [
-      { action: 'admin::marketplace.read', subject: null },
-      { action: 'admin::marketplace.plugins.install', subject: null },
-      { action: 'admin::marketplace.plugins.uninstall', subject: null },
-    ],
-    install: [{ action: 'admin::marketplace.plugins.install', subject: null }],
-    read: [
-      { action: 'admin::marketplace.read', subject: null },
-      { action: 'admin::marketplace.plugins.uninstall', subject: null },
-    ],
-    uninstall: [{ action: 'admin::marketplace.plugins.uninstall', subject: null }],
+    main: [{ action: 'admin::marketplace.read', subject: null }],
+    read: [{ action: 'admin::marketplace.read', subject: null }],
   },
   settings: {
     roles: {

--- a/packages/core/admin/server/config/admin-actions.js
+++ b/packages/core/admin/server/config/admin-actions.js
@@ -11,22 +11,6 @@ module.exports = {
       subCategory: 'marketplace',
     },
     {
-      uid: 'marketplace.plugins.install',
-      displayName: 'Install (only for dev env)',
-      pluginName: 'admin',
-      section: 'settings',
-      category: 'plugins and marketplace',
-      subCategory: 'plugins',
-    },
-    {
-      uid: 'marketplace.plugins.uninstall',
-      displayName: 'Uninstall (only for dev env)',
-      pluginName: 'admin',
-      section: 'settings',
-      category: 'plugins and marketplace',
-      subCategory: 'plugins',
-    },
-    {
       uid: 'webhooks.create',
       displayName: 'Create',
       pluginName: 'admin',

--- a/packages/core/admin/server/controllers/admin.js
+++ b/packages/core/admin/server/controllers/admin.js
@@ -3,11 +3,9 @@
 const path = require('path');
 
 const { map, values, sumBy, pipe, flatMap, propEq } = require('lodash/fp');
-const execa = require('execa');
 const _ = require('lodash');
 const { exists } = require('fs-extra');
 const { env } = require('@strapi/utils');
-const { ValidationError } = require('@strapi/utils').errors;
 const { isUsingTypeScript } = require('@strapi/typescript-utils');
 // eslint-disable-next-line node/no-extraneous-require
 const ee = require('@strapi/strapi/lib/utils/ee');
@@ -18,15 +16,6 @@ const {
   validateUpdateProjectSettingsImagesDimensions,
 } = require('../validation/project-settings');
 const { getService } = require('../utils');
-
-const PLUGIN_NAME_REGEX = /^[A-Za-z][A-Za-z0-9-_]+$/;
-
-/**
- * Validates a plugin name format
- */
-const isValidPluginName = (plugin) => {
-  return _.isString(plugin) && !_.isEmpty(plugin) && PLUGIN_NAME_REGEX.test(plugin);
-};
 
 /**
  * A set of functions called "actions" for `Admin`
@@ -146,28 +135,6 @@ module.exports = {
     };
   },
 
-  async installPlugin(ctx) {
-    try {
-      const { plugin } = ctx.request.body;
-
-      if (!isValidPluginName(plugin)) {
-        throw new ValidationError('Invalid plugin name');
-      }
-
-      strapi.reload.isWatching = false;
-
-      strapi.log.info(`Installing ${plugin}...`);
-      await execa('npm', ['run', 'strapi', '--', 'install', plugin]);
-
-      ctx.send({ ok: true });
-
-      strapi.reload();
-    } catch (err) {
-      strapi.reload.isWatching = true;
-      throw err;
-    }
-  },
-
   async plugins(ctx) {
     const enabledPlugins = strapi.config.get('enabledPlugins');
 
@@ -179,27 +146,5 @@ module.exports = {
     }));
 
     ctx.send({ plugins });
-  },
-
-  async uninstallPlugin(ctx) {
-    try {
-      const { plugin } = ctx.params;
-
-      if (!isValidPluginName(plugin)) {
-        throw new ValidationError('Invalid plugin name');
-      }
-
-      strapi.reload.isWatching = false;
-
-      strapi.log.info(`Uninstalling ${plugin}...`);
-      await execa('npm', ['run', 'strapi', '--', 'uninstall', plugin, '-d']);
-
-      ctx.send({ ok: true });
-
-      strapi.reload();
-    } catch (err) {
-      strapi.reload.isWatching = true;
-      throw err;
-    }
   },
 };

--- a/packages/core/admin/server/routes/admin.js
+++ b/packages/core/admin/server/routes/admin.js
@@ -68,32 +68,4 @@ module.exports = [
       ],
     },
   },
-  {
-    method: 'POST',
-    path: '/plugins/install',
-    handler: 'admin.installPlugin',
-    config: {
-      policies: [
-        'admin::isAuthenticatedAdmin',
-        {
-          name: 'admin::hasPermissions',
-          config: { actions: ['admin::marketplace.plugins.install'] },
-        },
-      ],
-    },
-  },
-  {
-    method: 'DELETE',
-    path: '/plugins/uninstall/:plugin',
-    handler: 'admin.uninstallPlugin',
-    config: {
-      policies: [
-        'admin::isAuthenticatedAdmin',
-        {
-          name: 'admin::hasPermissions',
-          config: { actions: ['admin::marketplace.plugins.uninstall'] },
-        },
-      ],
-    },
-  },
 ];

--- a/packages/core/admin/server/tests/admin-permission.test.api.js
+++ b/packages/core/admin/server/tests/admin-permission.test.api.js
@@ -336,18 +336,6 @@ describe('Role CRUD End to End', () => {
                 "subCategory": "general",
               },
               {
-                "action": "admin::marketplace.plugins.install",
-                "category": "plugins and marketplace",
-                "displayName": "Install (only for dev env)",
-                "subCategory": "plugins",
-              },
-              {
-                "action": "admin::marketplace.plugins.uninstall",
-                "category": "plugins and marketplace",
-                "displayName": "Uninstall (only for dev env)",
-                "subCategory": "plugins",
-              },
-              {
                 "action": "admin::marketplace.read",
                 "category": "plugins and marketplace",
                 "displayName": "Access the marketplace",
@@ -849,18 +837,6 @@ describe('Role CRUD End to End', () => {
                   "category": "audit logs",
                   "displayName": "Read",
                   "subCategory": "options",
-                },
-                {
-                  "action": "admin::marketplace.plugins.install",
-                  "category": "plugins and marketplace",
-                  "displayName": "Install (only for dev env)",
-                  "subCategory": "plugins",
-                },
-                {
-                  "action": "admin::marketplace.plugins.uninstall",
-                  "category": "plugins and marketplace",
-                  "displayName": "Uninstall (only for dev env)",
-                  "subCategory": "plugins",
                 },
                 {
                   "action": "admin::marketplace.read",
@@ -1365,18 +1341,6 @@ describe('Role CRUD End to End', () => {
                   "category": "api tokens",
                   "displayName": "Update",
                   "subCategory": "general",
-                },
-                {
-                  "action": "admin::marketplace.plugins.install",
-                  "category": "plugins and marketplace",
-                  "displayName": "Install (only for dev env)",
-                  "subCategory": "plugins",
-                },
-                {
-                  "action": "admin::marketplace.plugins.uninstall",
-                  "category": "plugins and marketplace",
-                  "displayName": "Uninstall (only for dev env)",
-                  "subCategory": "plugins",
                 },
                 {
                   "action": "admin::marketplace.read",

--- a/packages/core/helper-plugin/lib/src/utils/hasPermissions/tests/hasPermissions.test.js
+++ b/packages/core/helper-plugin/lib/src/utils/hasPermissions/tests/hasPermissions.test.js
@@ -23,19 +23,13 @@ describe('STRAPI-HELPER_PLUGIN | utils ', () => {
       const data = hasPermissionsTestData.userPermissions.user1;
       const dataToCheck = hasPermissionsTestData.permissionsToCheck.listPlugins;
 
-      expect(findMatchingPermissions(data, dataToCheck)).toHaveLength(2);
+      expect(findMatchingPermissions(data, dataToCheck)).toHaveLength(1);
       expect(findMatchingPermissions(data, dataToCheck)).toEqual([
         {
           action: 'admin::marketplace.read',
           subject: null,
           properties: {},
           conditions: [],
-        },
-        {
-          action: 'admin::marketplace.plugins.uninstall',
-          subject: null,
-          properties: {},
-          conditions: ['customCondition'],
         },
       ]);
     });
@@ -53,7 +47,7 @@ describe('STRAPI-HELPER_PLUGIN | utils ', () => {
           conditions: [],
         },
         {
-          action: 'admin::marketplace.plugins.uninstall',
+          action: 'admin::webhooks.delete',
           subject: null,
           properties: {},
           conditions: ['customCondition'],
@@ -64,7 +58,7 @@ describe('STRAPI-HELPER_PLUGIN | utils ', () => {
           action: 'admin::marketplace.read',
         },
         {
-          action: 'admin::marketplace.plugins.uninstall',
+          action: 'admin::webhooks.delete',
         },
       ];
 
@@ -130,13 +124,13 @@ describe('STRAPI-HELPER_PLUGIN | utils ', () => {
           conditions: [],
         },
         {
-          action: 'admin::marketplace.plugins.uninstall',
+          action: 'admin::webhooks.delete',
           subject: null,
           properties: {},
           conditions: ['customCondition'],
         },
         {
-          action: 'admin::marketplace.plugins.install',
+          action: 'admin::webhooks.create',
           subject: null,
           properties: {},
           conditions: null,
@@ -155,13 +149,13 @@ describe('STRAPI-HELPER_PLUGIN | utils ', () => {
           conditions: ['test'],
         },
         {
-          action: 'admin::marketplace.plugins.uninstall',
+          action: 'admin::webhooks.delete',
           subject: null,
           properties: {},
           conditions: ['customCondition'],
         },
         {
-          action: 'admin::marketplace.plugins.install',
+          action: 'admin::webhooks.create',
           subject: null,
           properties: {},
           conditions: ['test'],

--- a/packages/core/helper-plugin/lib/src/utils/hasPermissions/tests/hasPermissionsTestData.js
+++ b/packages/core/helper-plugin/lib/src/utils/hasPermissions/tests/hasPermissionsTestData.js
@@ -8,18 +8,6 @@ const hasPermissionsTestData = {
         properties: {},
         conditions: [],
       },
-      {
-        action: 'admin::marketplace.plugins.install',
-        subject: null,
-        properties: {},
-        conditions: [],
-      },
-      {
-        action: 'admin::marketplace.plugins.uninstall',
-        subject: null,
-        properties: {},
-        conditions: ['customCondition'],
-      },
 
       // Admin webhooks
       {
@@ -222,13 +210,6 @@ const hasPermissionsTestData = {
       },
     ],
     user2: [
-      {
-        action: 'admin::marketplace.plugins.install',
-        subject: null,
-        properties: {},
-        conditions: ['some condition'],
-      },
-
       // Admin webhooks
       {
         action: 'admin::webhooks.create',
@@ -411,14 +392,8 @@ const hasPermissionsTestData = {
     ],
   },
   permissionsToCheck: {
-    listPlugins: [
-      { action: 'admin::marketplace.read', subject: null },
-      { action: 'admin::marketplace.plugins.uninstall', subject: null },
-    ],
-    marketplace: [
-      { action: 'admin::marketplace.read', subject: null },
-      { action: 'admin::marketplace.plugins.install', subject: null },
-    ],
+    listPlugins: [{ action: 'admin::marketplace.read', subject: null }],
+    marketplace: [{ action: 'admin::marketplace.read', subject: null }],
     settings: [
       // webhooks
       { action: 'admin::webhook.create', subject: null },


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

- Removes the admin endpoints to install and uninstall a plugin
- Removes the actions/permissions about installing and uninstalling a plugin
- These actions were used as examples in some tests, so I replaced them by some webhook actions instead

### Why is it needed?

This code is from the v3 marketplace when the marketplace allowed installing and uninstalling plugins via the admin UI. This is something that was not ported to the v4 marketplace, and that we have no plans to implement. So I'm removing all this dead code as it is not used.

The permissions about adding/removing a plugin are also misleading, since to install or uninstall a plugin you need to have terminal/git access, it has nothing to do with your Strapi role.

### How to test it?

You shouldn't be able to see the install & uninstall plugin checkboxes in the edit role page.
