### PR TITLE
[Private s3 bucket]: Clean up s3 provider file

### DIFF
--- a/packages/core/upload/server/services/extensions/content-manager/entity-manager.js
+++ b/packages/core/upload/server/services/extensions/content-manager/entity-manager.js
@@ -58,11 +58,12 @@ const signEntityMedia = async (entity, uid) => {
   return signedEntity;
 };
 
-const addSignedFileUrlsToAdmin = () => {
+const addSignedFileUrlsToAdmin = async () => {
   const { provider } = strapi.plugins.upload;
+  const isPrivate = await provider.isPrivate();
 
   // We only need to sign the file urls if the provider is private
-  if (!provider.isPrivate()) {
+  if (!isPrivate) {
     return;
   }
 

--- a/packages/core/upload/server/services/file.js
+++ b/packages/core/upload/server/services/file.js
@@ -23,18 +23,13 @@ const deleteByIds = async (ids = []) => {
   return filesToDelete;
 };
 
-const signFileUrl = async (fileIdentifier) => {
-  const { provider } = strapi.plugins.upload;
-  const { url } = await provider.getSignedUrl(fileIdentifier);
-  return url;
-};
-
 const signFileUrls = async (file) => {
   const { provider } = strapi.plugins.upload;
   const { provider: providerConfig } = strapi.config.get('plugin.upload');
+  const isPrivate = await provider.isPrivate();
 
   // Check file provider and if provider is private
-  if (file.provider !== providerConfig || !provider.isPrivate()) {
+  if (file.provider !== providerConfig || !isPrivate) {
     return file;
   }
 
@@ -57,6 +52,5 @@ const signFileUrls = async (file) => {
 module.exports = {
   getFolderPath,
   deleteByIds,
-  signFileUrl,
   signFileUrls,
 };

--- a/packages/providers/upload-aws-s3/README.md
+++ b/packages/providers/upload-aws-s3/README.md
@@ -25,6 +25,10 @@ npm install @strapi/provider-upload-aws-s3 --save
 
 - `provider` defines the name of the provider
 - `providerOptions` is passed down during the construction of the provider. (ex: `new AWS.S3(config)`). [Complete list of options](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#constructor-property)
+- `providerOptions.params` is passed directly to the parameters to each method respectively.
+  - `ACL` is the access control list for the object. Defaults to `public-read`.
+  - `signedUrlExpires` is the number of seconds before a signed URL expires. (See [how signed URLs work](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-signed-urls.html)). Defaults to 7 days and URLs are only signed when ACL is set to `private`.
+  - `Bucket` is the name of the bucket to upload to.
 - `actionOptions` is passed directly to the parameters to each method respectively. You can find the complete list of [upload/ uploadStream options](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#upload-property) and [delete options](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#deleteObject-property)
 
 See the [documentation about using a provider](https://docs.strapi.io/developer-docs/latest/plugins/upload.html#using-a-provider) for information on installing and using a provider. To understand how environment variables are used in Strapi, please refer to the [documentation about environment variables](https://docs.strapi.io/developer-docs/latest/setup-deployment-guides/configurations/optional/environment.html#environment-variables).
@@ -44,6 +48,8 @@ module.exports = ({ env }) => ({
         secretAccessKey: env('AWS_ACCESS_SECRET'),
         region: env('AWS_REGION'),
         params: {
+          ACL: env('AWS_ACL', 'public-read'),
+          signedUrlExpires: env('AWS_SIGNED_URL_EXPIRES', 60 * 60 * 24 * 7),
           Bucket: env('AWS_BUCKET'),
         },
       },


### PR DESCRIPTION
### What does it do?

- Cleanup of s3 provider.
	- Added ability to set ACL
	- Added ability to configure signedURL expiration time
	- Added docs
- await `isProvider()`
	- This method was async (it's wrapped to be async in [here](https://github.com/strapi/strapi/blob/a663322c3312a5d387d48d0605e431d4e797b3e7/packages/core/upload/server/register.js#L70-L71)) and we were not awaiting it.


I think we are reaching a point where everything works, and we could share this with Derrick and rest of the team.

In the meantime we could be adding the tests :) 