### PR TITLE
[Relations]: Introduce fractional indexing for better diffing

### DIFF
--- a/jest.base-config.front.js
+++ b/jest.base-config.front.js
@@ -75,7 +75,7 @@ module.exports = {
       '<rootDir>/fileTransformer.js',
   },
   transformIgnorePatterns: [
-    'node_modules/(?!(react-dnd|dnd-core|react-dnd-html5-backend|@strapi/design-system|@strapi/icons)/)',
+    'node_modules/(?!(react-dnd|dnd-core|react-dnd-html5-backend|@strapi/design-system|@strapi/icons|fractional-indexing)/)',
   ],
   testMatch: ['/**/tests/**/?(*.)+(spec|test).[jt]s?(x)'],
   testEnvironmentOptions: {

--- a/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/tests/reducer.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/tests/reducer.test.js
@@ -869,7 +869,7 @@ describe('CONTENT MANAGER | COMPONENTS | EditViewDataManagerProvider | reducer',
         componentsDataStructure: {},
         initialData: {},
         modifiedData: {
-          relation: [{ id: 1 }],
+          relation: [{ id: 1, __temp_key__: 'a0' }],
         },
       };
 
@@ -880,6 +880,74 @@ describe('CONTENT MANAGER | COMPONENTS | EditViewDataManagerProvider | reducer',
       };
 
       expect(reducer(state, action)).toEqual(expected);
+    });
+
+    it('should set a temp key every time a relation is connected', () => {
+      const state = {
+        ...initialState,
+
+        initialData: {
+          relation: [
+            { id: 1, __temp_key__: 'a0' },
+            { id: 2, __temp_key__: 'a1' },
+          ],
+        },
+        modifiedData: {
+          relation: [
+            { id: 1, __temp_key__: 'a0' },
+            { id: 2, __temp_key__: 'a1' },
+          ],
+        },
+      };
+
+      const nextState = reducer(state, {
+        type: 'CONNECT_RELATION',
+        keys: ['relation'],
+        value: { id: 3 },
+      });
+
+      expect(nextState).toStrictEqual({
+        ...initialState,
+        componentsDataStructure: {},
+        initialData: {
+          relation: [
+            { id: 1, __temp_key__: 'a0' },
+            { id: 2, __temp_key__: 'a1' },
+          ],
+        },
+        modifiedData: {
+          relation: [
+            { id: 1, __temp_key__: 'a0' },
+            { id: 2, __temp_key__: 'a1' },
+            { id: 3, __temp_key__: 'a2' },
+          ],
+        },
+      });
+
+      expect(
+        reducer(nextState, {
+          type: 'CONNECT_RELATION',
+          keys: ['relation'],
+          value: { id: 4 },
+        })
+      ).toStrictEqual({
+        ...initialState,
+        componentsDataStructure: {},
+        initialData: {
+          relation: [
+            { id: 1, __temp_key__: 'a0' },
+            { id: 2, __temp_key__: 'a1' },
+          ],
+        },
+        modifiedData: {
+          relation: [
+            { id: 1, __temp_key__: 'a0' },
+            { id: 2, __temp_key__: 'a1' },
+            { id: 3, __temp_key__: 'a2' },
+            { id: 4, __temp_key__: 'a3' },
+          ],
+        },
+      });
     });
 
     it('should overwrite existing data, when toOneRelation is set to true', () => {
@@ -953,10 +1021,10 @@ describe('CONTENT MANAGER | COMPONENTS | EditViewDataManagerProvider | reducer',
       expect(nextState).toStrictEqual({
         ...initialState,
         initialData: {
-          relation: [{ id: 1 }],
+          relation: [{ id: 1, __temp_key__: 'a0' }],
         },
         modifiedData: {
-          relation: [{ id: 1 }],
+          relation: [{ id: 1, __temp_key__: 'a0' }],
         },
       });
 
@@ -970,10 +1038,16 @@ describe('CONTENT MANAGER | COMPONENTS | EditViewDataManagerProvider | reducer',
       ).toStrictEqual({
         ...initialState,
         initialData: {
-          relation: [{ id: 2 }, { id: 1 }],
+          relation: [
+            { id: 2, __temp_key__: 'Zz' },
+            { id: 1, __temp_key__: 'a0' },
+          ],
         },
         modifiedData: {
-          relation: [{ id: 2 }, { id: 1 }],
+          relation: [
+            { id: 2, __temp_key__: 'Zz' },
+            { id: 1, __temp_key__: 'a0' },
+          ],
         },
       });
     });
@@ -1002,10 +1076,10 @@ describe('CONTENT MANAGER | COMPONENTS | EditViewDataManagerProvider | reducer',
       expect(nextState).toStrictEqual({
         ...initialState,
         initialData: {
-          relation: [{ id: 1 }],
+          relation: [{ id: 1, __temp_key__: 'a0' }],
         },
         modifiedData: {
-          relation: [{ id: 1 }],
+          relation: [{ id: 1, __temp_key__: 'a0' }],
         },
       });
 
@@ -1019,10 +1093,103 @@ describe('CONTENT MANAGER | COMPONENTS | EditViewDataManagerProvider | reducer',
       ).toStrictEqual({
         ...initialState,
         initialData: {
-          relation: [{ id: 1 }],
+          relation: [{ id: 1, __temp_key__: 'a0' }],
         },
         modifiedData: {
-          relation: [{ id: 1 }],
+          relation: [{ id: 1, __temp_key__: 'a0' }],
+        },
+      });
+    });
+
+    it('should add a temp key for all the relations added', () => {
+      const state = {
+        ...initialState,
+        initialData: {
+          relation: [],
+        },
+        modifiedData: {
+          relation: [],
+        },
+      };
+
+      const initialDataPath = ['initialData', 'relation'];
+      const modifiedDataPath = ['modifiedData', 'relation'];
+
+      let nextState = reducer(state, {
+        type: 'LOAD_RELATION',
+        initialDataPath,
+        modifiedDataPath,
+        value: [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }],
+      });
+
+      expect(nextState).toStrictEqual({
+        ...initialState,
+        initialData: {
+          relation: [
+            { id: 1, __temp_key__: 'a0' },
+            { id: 2, __temp_key__: 'a1' },
+            { id: 3, __temp_key__: 'a2' },
+            { id: 4, __temp_key__: 'a3' },
+            { id: 5, __temp_key__: 'a4' },
+          ],
+        },
+        modifiedData: {
+          relation: [
+            { id: 1, __temp_key__: 'a0' },
+            { id: 2, __temp_key__: 'a1' },
+            { id: 3, __temp_key__: 'a2' },
+            { id: 4, __temp_key__: 'a3' },
+            { id: 5, __temp_key__: 'a4' },
+          ],
+        },
+      });
+    });
+
+    it('should add a temp key working backwards on every new load because of how relations are shown in the UI', () => {
+      const state = {
+        ...initialState,
+        initialData: {
+          relation: [],
+        },
+        modifiedData: {
+          relation: [],
+        },
+      };
+
+      const initialDataPath = ['initialData', 'relation'];
+      const modifiedDataPath = ['modifiedData', 'relation'];
+
+      let nextState = reducer(state, {
+        type: 'LOAD_RELATION',
+        initialDataPath,
+        modifiedDataPath,
+        value: [{ id: 1 }, { id: 2 }],
+      });
+
+      expect(
+        reducer(nextState, {
+          type: 'LOAD_RELATION',
+          initialDataPath,
+          modifiedDataPath,
+          value: [{ id: 3 }, { id: 4 }],
+        })
+      ).toStrictEqual({
+        ...initialState,
+        initialData: {
+          relation: [
+            { id: 3, __temp_key__: 'Zy' },
+            { id: 4, __temp_key__: 'Zz' },
+            { id: 1, __temp_key__: 'a0' },
+            { id: 2, __temp_key__: 'a1' },
+          ],
+        },
+        modifiedData: {
+          relation: [
+            { id: 3, __temp_key__: 'Zy' },
+            { id: 4, __temp_key__: 'Zz' },
+            { id: 1, __temp_key__: 'a0' },
+            { id: 2, __temp_key__: 'a1' },
+          ],
         },
       });
     });
@@ -2397,10 +2564,10 @@ describe('CONTENT MANAGER | COMPONENTS | EditViewDataManagerProvider | reducer',
           field1: {
             field2: {
               relation: [
-                { name: 'first' },
-                { name: 'second' },
-                { name: 'third' },
-                { name: 'fourth' },
+                { name: 'first', __temp_key__: 'a0' },
+                { name: 'second', __temp_key__: 'a1' },
+                { name: 'third', __temp_key__: 'a2' },
+                { name: 'fourth', __temp_key__: 'a3' },
               ],
             },
           },
@@ -2421,10 +2588,10 @@ describe('CONTENT MANAGER | COMPONENTS | EditViewDataManagerProvider | reducer',
           field1: {
             field2: {
               relation: [
-                { name: 'first' },
-                { name: 'fourth' },
-                { name: 'second' },
-                { name: 'third' },
+                { name: 'first', __temp_key__: 'a0' },
+                { name: 'fourth', __temp_key__: 'a0V' },
+                { name: 'second', __temp_key__: 'a1' },
+                { name: 'third', __temp_key__: 'a2' },
               ],
             },
           },
@@ -2432,6 +2599,89 @@ describe('CONTENT MANAGER | COMPONENTS | EditViewDataManagerProvider | reducer',
       };
 
       expect(reducer(state, action)).toEqual(expected);
+    });
+
+    it('should move many components many times and have the correct temp keys', () => {
+      const state = {
+        ...initialState,
+        modifiedData: {
+          relation: [
+            { name: 'first', __temp_key__: 'a0' },
+            { name: 'second', __temp_key__: 'a1' },
+            { name: 'third', __temp_key__: 'a2' },
+            { name: 'fourth', __temp_key__: 'a3' },
+          ],
+        },
+      };
+
+      const generateAction = (newIndex, oldIndex) => ({
+        type: 'REORDER_RELATION',
+        newIndex,
+        oldIndex,
+        keys: ['relation'],
+      });
+
+      const generateExpected = (relation = []) => ({
+        ...initialState,
+        modifiedData: {
+          relation,
+        },
+      });
+
+      const nextState1 = reducer(state, generateAction(1, 3));
+
+      expect(nextState1).toEqual(
+        generateExpected([
+          { name: 'first', __temp_key__: 'a0' },
+          { name: 'fourth', __temp_key__: 'a0V' },
+          { name: 'second', __temp_key__: 'a1' },
+          { name: 'third', __temp_key__: 'a2' },
+        ])
+      );
+
+      const nextState2 = reducer(nextState1, generateAction(1, 2));
+
+      expect(nextState2).toEqual(
+        generateExpected([
+          { name: 'first', __temp_key__: 'a0' },
+          { name: 'second', __temp_key__: 'a0G' },
+          { name: 'fourth', __temp_key__: 'a0V' },
+          { name: 'third', __temp_key__: 'a2' },
+        ])
+      );
+
+      const nextState3 = reducer(nextState2, generateAction(0, 3));
+
+      expect(nextState3).toEqual(
+        generateExpected([
+          { name: 'third', __temp_key__: 'Zz' },
+          { name: 'first', __temp_key__: 'a0' },
+          { name: 'second', __temp_key__: 'a0G' },
+          { name: 'fourth', __temp_key__: 'a0V' },
+        ])
+      );
+
+      const nextState4 = reducer(nextState3, generateAction(3, 1));
+
+      expect(nextState4).toEqual(
+        generateExpected([
+          { name: 'third', __temp_key__: 'Zz' },
+          { name: 'second', __temp_key__: 'a0G' },
+          { name: 'fourth', __temp_key__: 'a0V' },
+          { name: 'first', __temp_key__: 'a0O' },
+        ])
+      );
+
+      const nextState5 = reducer(nextState4, generateAction(1, 2));
+
+      expect(nextState5).toEqual(
+        generateExpected([
+          { name: 'third', __temp_key__: 'Zz' },
+          { name: 'fourth', __temp_key__: 'a0' },
+          { name: 'second', __temp_key__: 'a0G' },
+          { name: 'first', __temp_key__: 'a0O' },
+        ])
+      );
     });
   });
 

--- a/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/utils/tests/cleanData.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/utils/tests/cleanData.test.js
@@ -407,10 +407,10 @@ describe('CM || components || EditViewDataManagerProvider || utils || cleanData'
       const result = cleanData(
         {
           browserState: {
-            relation: [{ id: 1, something: true }],
+            relation: [{ id: 1, __temp_key__: 'a1', something: true }],
           },
           serverState: {
-            relation: [{ id: 2, something: true }],
+            relation: [{ id: 2, __temp_key__: 'a0', something: true }],
           },
         },
         schema,
@@ -429,7 +429,7 @@ describe('CM || components || EditViewDataManagerProvider || utils || cleanData'
       const result = cleanData(
         {
           browserState: {
-            relation: [{ id: 1, something: true }],
+            relation: [{ id: 1, __temp_key__: 'a0', something: true }],
           },
           serverState: {
             relation: [],
@@ -454,7 +454,7 @@ describe('CM || components || EditViewDataManagerProvider || utils || cleanData'
             relation: [],
           },
           serverState: {
-            relation: [{ id: 1, something: true }],
+            relation: [{ id: 1, __temp_key__: 'a0', something: true }],
           },
         },
         schema,
@@ -477,13 +477,13 @@ describe('CM || components || EditViewDataManagerProvider || utils || cleanData'
               {
                 id: 1,
                 relation_component: {
-                  relation: [{ id: 1 }],
+                  relation: [{ id: 1, __temp_key__: 'a0' }],
                 },
               },
               {
                 id: 2,
                 relation_component: {
-                  relation: [{ id: 2 }],
+                  relation: [{ id: 2, __temp_key__: 'a0' }],
                 },
               },
             ],
@@ -541,7 +541,7 @@ describe('CM || components || EditViewDataManagerProvider || utils || cleanData'
               {
                 id: 2,
                 relation_component: {
-                  relation: [{ id: 2 }],
+                  relation: [{ id: 2, __temp_key__: 'a0' }],
                 },
               },
             ],
@@ -551,13 +551,13 @@ describe('CM || components || EditViewDataManagerProvider || utils || cleanData'
               {
                 id: 1,
                 relation_component: {
-                  relation: [{ id: 1 }],
+                  relation: [{ id: 1, __temp_key__: 'a0' }],
                 },
               },
               {
                 id: 2,
                 relation_component: {
-                  relation: [{ id: 2 }],
+                  relation: [{ id: 2, __temp_key__: 'a0' }],
                 },
               },
             ],
@@ -599,13 +599,13 @@ describe('CM || components || EditViewDataManagerProvider || utils || cleanData'
               {
                 __component: 'basic.relation',
                 id: 1,
-                relation: [{ id: 1 }],
+                relation: [{ id: 1, __temp_key__: 'a0' }],
               },
               {
                 __component: 'basic.nested-relation',
                 id: 2,
                 relation_component: {
-                  relation: [{ id: 2 }],
+                  relation: [{ id: 2, __temp_key__: 'a0' }],
                 },
               },
               {
@@ -615,7 +615,7 @@ describe('CM || components || EditViewDataManagerProvider || utils || cleanData'
                   {
                     __component: 'basic.relation',
                     id: 1,
-                    relation: [{ id: 3 }],
+                    relation: [{ id: 3, __temp_key__: 'a0' }],
                   },
                 ],
               },
@@ -715,7 +715,7 @@ describe('CM || components || EditViewDataManagerProvider || utils || cleanData'
                   {
                     __component: 'basic.relation',
                     id: 1,
-                    relation: [{ id: 3 }],
+                    relation: [{ id: 3, __temp_key__: 'a0' }],
                   },
                   {
                     __component: 'basic.relation',
@@ -731,13 +731,13 @@ describe('CM || components || EditViewDataManagerProvider || utils || cleanData'
               {
                 __component: 'basic.relation',
                 id: 1,
-                relation: [{ id: 1 }],
+                relation: [{ id: 1, __temp_key__: 'a0' }],
               },
               {
                 __component: 'basic.nested-relation',
                 id: 2,
                 relation_component: {
-                  relation: [{ id: 2 }],
+                  relation: [{ id: 2, __temp_key__: 'a0' }],
                 },
               },
               {
@@ -747,12 +747,12 @@ describe('CM || components || EditViewDataManagerProvider || utils || cleanData'
                   {
                     __component: 'basic.relation',
                     id: 1,
-                    relation: [{ id: 3 }],
+                    relation: [{ id: 3, __temp_key__: 'a0' }],
                   },
                   {
                     __component: 'basic.relation',
                     id: 2,
-                    relation: [{ id: 4 }],
+                    relation: [{ id: 4, __temp_key__: 'a0' }],
                   },
                 ],
               },
@@ -813,10 +813,16 @@ describe('CM || components || EditViewDataManagerProvider || utils || cleanData'
       const result = cleanData(
         {
           browserState: {
-            relation: [{ id: 1 }, { id: 2 }],
+            relation: [
+              { id: 1, __temp_key__: 'Zz' },
+              { id: 2, __temp_key__: 'a0' },
+            ],
           },
           serverState: {
-            relation: [{ id: 2 }, { id: 1 }],
+            relation: [
+              { id: 2, __temp_key__: 'a0' },
+              { id: 1, __temp_key__: 'a1' },
+            ],
           },
         },
         schema,
@@ -825,10 +831,7 @@ describe('CM || components || EditViewDataManagerProvider || utils || cleanData'
 
       expect(result).toStrictEqual({
         relation: {
-          connect: [
-            { id: 2, position: { end: true } },
-            { id: 1, position: { before: 2 } },
-          ],
+          connect: [{ id: 1, position: { before: 2 } }],
           disconnect: [],
         },
       });
@@ -838,10 +841,17 @@ describe('CM || components || EditViewDataManagerProvider || utils || cleanData'
       const result = cleanData(
         {
           browserState: {
-            relation: [{ id: 3 }, { id: 1 }, { id: 2 }],
+            relation: [
+              { id: 3, __temp_key__: 'Zz' },
+              { id: 1, __temp_key__: 'a0' },
+              { id: 2, __temp_key__: 'a1' },
+            ],
           },
           serverState: {
-            relation: [{ id: 1 }, { id: 2 }],
+            relation: [
+              { id: 1, __temp_key__: 'a0' },
+              { id: 2, __temp_key__: 'a1' },
+            ],
           },
         },
         schema,
@@ -851,8 +861,6 @@ describe('CM || components || EditViewDataManagerProvider || utils || cleanData'
       expect(result).toStrictEqual({
         relation: {
           connect: [
-            { id: 2, position: { end: true } },
-            { id: 1, position: { before: 2 } },
             {
               id: 3,
               position: { before: 1 },
@@ -867,10 +875,18 @@ describe('CM || components || EditViewDataManagerProvider || utils || cleanData'
       const result = cleanData(
         {
           browserState: {
-            relation: [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }],
+            relation: [
+              { id: 1, __temp_key__: 'a0' },
+              { id: 2, __temp_key__: 'a1' },
+              { id: 3, __temp_key__: 'a2' },
+              { id: 4, __temp_key__: 'a3' },
+            ],
           },
           serverState: {
-            relation: [{ id: 1 }, { id: 2 }],
+            relation: [
+              { id: 1, __temp_key__: 'a0' },
+              { id: 2, __temp_key__: 'a1' },
+            ],
           },
         },
         schema,
@@ -887,6 +903,256 @@ describe('CM || components || EditViewDataManagerProvider || utils || cleanData'
             {
               id: 3,
               position: { before: 4 },
+            },
+          ],
+          disconnect: [],
+        },
+      });
+    });
+
+    test('given a complicated list of reorderd relations it should only contain the items that moved', () => {
+      const result = cleanData(
+        {
+          browserState: {
+            relation: [
+              {
+                id: 3,
+                __temp_key__: 'Zw',
+              },
+              {
+                id: 2,
+                __temp_key__: 'Zx',
+              },
+              {
+                id: 4,
+                __temp_key__: 'Zwl',
+              },
+              {
+                id: 1,
+                __temp_key__: 'ZwV',
+              },
+              {
+                id: 5,
+                __temp_key__: 'Zy',
+              },
+              {
+                id: 7,
+                __temp_key__: 'Zz',
+              },
+              {
+                id: 10,
+                __temp_key__: 'ZzV',
+              },
+              {
+                id: 6,
+                __temp_key__: 'a0',
+              },
+              {
+                id: 9,
+                __temp_key__: 'a0G',
+              },
+              {
+                id: 8,
+                __temp_key__: 'a0V',
+              },
+            ],
+          },
+          serverState: {
+            relation: [
+              {
+                id: 1,
+                __temp_key__: 'Zv',
+              },
+              {
+                id: 3,
+                __temp_key__: 'Zw',
+              },
+              {
+                id: 2,
+                __temp_key__: 'Zx',
+              },
+              {
+                id: 5,
+                __temp_key__: 'Zy',
+              },
+              {
+                id: 4,
+                __temp_key__: 'Zz',
+              },
+              {
+                id: 6,
+                __temp_key__: 'a0',
+              },
+              {
+                id: 7,
+                __temp_key__: 'a1',
+              },
+              {
+                id: 8,
+                __temp_key__: 'a2',
+              },
+              {
+                id: 9,
+                __temp_key__: 'a3',
+              },
+              {
+                id: 10,
+                __temp_key__: 'a4',
+              },
+            ],
+          },
+        },
+        schema,
+        componentsSchema
+      );
+
+      expect(result).toStrictEqual({
+        relation: {
+          connect: [
+            {
+              id: 8,
+              position: {
+                end: true,
+              },
+            },
+            {
+              id: 9,
+              position: {
+                before: 8,
+              },
+            },
+            {
+              id: 10,
+              position: {
+                before: 6,
+              },
+            },
+            {
+              id: 7,
+              position: {
+                before: 10,
+              },
+            },
+            {
+              id: 1,
+              position: {
+                before: 5,
+              },
+            },
+            {
+              id: 4,
+              position: {
+                before: 1,
+              },
+            },
+          ],
+          disconnect: [],
+        },
+      });
+    });
+
+    test('given a long list of relations and i move the first to the last, only that item should be in the payload', () => {
+      const result = cleanData(
+        {
+          browserState: {
+            relation: [
+              {
+                id: 10,
+                __temp_key__: 'Zu',
+              },
+              {
+                id: 1,
+                __temp_key__: 'Zv',
+              },
+              {
+                id: 3,
+                __temp_key__: 'Zw',
+              },
+              {
+                id: 2,
+                __temp_key__: 'Zx',
+              },
+              {
+                id: 5,
+                __temp_key__: 'Zy',
+              },
+              {
+                id: 4,
+                __temp_key__: 'Zz',
+              },
+              {
+                id: 6,
+                __temp_key__: 'a0',
+              },
+              {
+                id: 7,
+                __temp_key__: 'a1',
+              },
+              {
+                id: 8,
+                __temp_key__: 'a2',
+              },
+              {
+                id: 9,
+                __temp_key__: 'a3',
+              },
+            ],
+          },
+          serverState: {
+            relation: [
+              {
+                id: 1,
+                __temp_key__: 'Zv',
+              },
+              {
+                id: 3,
+                __temp_key__: 'Zw',
+              },
+              {
+                id: 2,
+                __temp_key__: 'Zx',
+              },
+              {
+                id: 5,
+                __temp_key__: 'Zy',
+              },
+              {
+                id: 4,
+                __temp_key__: 'Zz',
+              },
+              {
+                id: 6,
+                __temp_key__: 'a0',
+              },
+              {
+                id: 7,
+                __temp_key__: 'a1',
+              },
+              {
+                id: 8,
+                __temp_key__: 'a2',
+              },
+              {
+                id: 9,
+                __temp_key__: 'a3',
+              },
+              {
+                id: 10,
+                __temp_key__: 'a4',
+              },
+            ],
+          },
+        },
+        schema,
+        componentsSchema
+      );
+
+      expect(result).toStrictEqual({
+        relation: {
+          connect: [
+            {
+              id: 10,
+              position: { before: 1 },
             },
           ],
           disconnect: [],

--- a/packages/core/admin/package.json
+++ b/packages/core/admin/package.json
@@ -73,6 +73,7 @@
     "find-root": "1.1.0",
     "fork-ts-checker-webpack-plugin": "7.2.1",
     "formik": "^2.2.6",
+    "fractional-indexing": "3.2.0",
     "fs-extra": "10.0.0",
     "highlight.js": "^10.4.1",
     "history": "^4.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12018,6 +12018,11 @@ forwarded@0.2.0:
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.2.0.tgz#2269936428aad4c15c7ebe9779a84bf0b2a81811"
   integrity sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==
 
+fractional-indexing@3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/fractional-indexing/-/fractional-indexing-3.2.0.tgz#1193e63d54ff4e0cbe0c79a9ed6cfbab25d91628"
+  integrity sha512-PcOxmqwYCW7O2ovKRU8OoQQj2yqTfEB/yeTYk4gPid6dN5ODRfU1hXd9tTVZzax/0NkO7AxpHykvZnT1aYp/BQ==
+
 fragment-cache@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/fragment-cache/-/fragment-cache-0.2.1.tgz#4290fad27f13e89be7f33799c6bc5a0abfff0d19"
@@ -17867,6 +17872,8 @@ path-case@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/path-case/-/path-case-2.1.1.tgz#94b8037c372d3fe2906e465bb45e25d226e8eea5"
   integrity sha1-lLgDfDctP+KQbkZbtF4l0ibo7qU=
+  dependencies:
+    no-case "^2.2.0"
 
 path-dirname@^1.0.0:
   version "1.0.2"


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* introduces the package `fractional-indexing` (you wouldn't want to write this // maintain it yourself)
* adds `__temp_key__` to relation items on load & on connect
* mutates the `__temp_key__` when relation items are reordered.
* Diffs to see if the `__temp_key__` has changed indicating the item moved and therefore should be in the `connect` array.

### Why is it needed?

* Makes the payload smaller – consider this extreme case: A user has 100 cities in their country, they move city at index 99 to index 0, _every_ relation will be sent in the API request because in the eyes of array indexing, they all moved. This is bad. Although, if we rethink how the CM works e.g. pushing PATCHES to the server instead of the whole entity, this would be redundant.

### How to test it?

* There are unit tests 👍🏼 

### Related issue(s)/PR(s)

* resolves CONTENT-1064
