### PR TITLE
[chore] en-KW & fr-MU i18n support

### DIFF
--- a/packages/plugins/i18n/server/constants/iso-locales.json
+++ b/packages/plugins/i18n/server/constants/iso-locales.json
@@ -345,7 +345,7 @@
   },
   {
     "code":"zh-Hans-HK",
-    "name":"Chinese (Simplified, Hong Kong SAR China) (zh-Hans-HK) "
+    "name":"Chinese (Simplified, Hong Kong SAR China) (zh-Hans-HK)"
   },
   {
     "code":"zh-Hans-MO",
@@ -630,6 +630,10 @@
   {
     "code":"en-KI",
     "name":"English (Kiribati) (en-KI)"
+  },
+  {
+    "code":"en-KW",
+    "name":"English (Kuwait) (en-KW)"
   },
   {
     "code":"en-LS",
@@ -1050,6 +1054,10 @@
   {
     "code":"fr-MF",
     "name":"French (Saint Martin) (fr-MF)"
+  },
+  {
+    "code":"fr-MU",
+    "name":"French (Mauritius) (fr-MU)"
   },
   {
     "code":"fr-SN",

--- a/packages/plugins/i18n/server/services/__tests__/__snapshots__/iso-locales.test.js.snap
+++ b/packages/plugins/i18n/server/services/__tests__/__snapshots__/iso-locales.test.js.snap
@@ -348,7 +348,7 @@ exports[`ISO locales getIsoLocales 1`] = `
   },
   {
     "code": "zh-Hans-HK",
-    "name": "Chinese (Simplified, Hong Kong SAR China) (zh-Hans-HK) ",
+    "name": "Chinese (Simplified, Hong Kong SAR China) (zh-Hans-HK)",
   },
   {
     "code": "zh-Hans-MO",
@@ -633,6 +633,10 @@ exports[`ISO locales getIsoLocales 1`] = `
   {
     "code": "en-KI",
     "name": "English (Kiribati) (en-KI)",
+  },
+  {
+    "code": "en-KW",
+    "name": "English (Kuwait) (en-KW)",
   },
   {
     "code": "en-LS",
@@ -1053,6 +1057,10 @@ exports[`ISO locales getIsoLocales 1`] = `
   {
     "code": "fr-MF",
     "name": "French (Saint Martin) (fr-MF)",
+  },
+  {
+    "code": "fr-MU",
+    "name": "French (Mauritius) (fr-MU)",
   },
   {
     "code": "fr-SN",


### PR DESCRIPTION
## What

Adding i18n missing support for:
- English (Kuwait) (en-KW)
- French (Mauritius) (fr-MU)

fixes #15531 