### PR TITLE
Enhancement: Display real error messges thrown by the API

### DIFF
--- a/packages/core/admin/admin/src/content-manager/pages/App/useModels.js
+++ b/packages/core/admin/admin/src/content-manager/pages/App/useModels.js
@@ -3,12 +3,14 @@ import {
   useRBACProvider,
   useStrapiApp,
   useFetchClient,
+  useAPIErrorHandler,
 } from '@strapi/helper-plugin';
 import { useEffect, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { useNotifyAT } from '@strapi/design-system/LiveRegions';
+import { useNotifyAT } from '@strapi/design-system';
 import axios from 'axios';
 import { useIntl } from 'react-intl';
+
 import { MUTATE_COLLECTION_TYPES_LINKS, MUTATE_SINGLE_TYPES_LINKS } from '../../../exposedHooks';
 import { getRequestUrl, getTrad } from '../../utils';
 import { getData, resetProps, setContentTypeLinks } from './actions';
@@ -27,6 +29,7 @@ const useModels = () => {
   const { notifyStatus } = useNotifyAT();
   const { formatMessage } = useIntl();
   const { get } = useFetchClient();
+  const { formatAPIError } = useAPIErrorHandler();
 
   const fetchData = async () => {
     dispatch(getData());
@@ -75,9 +78,7 @@ const useModels = () => {
         return;
       }
 
-      console.error(err);
-
-      toggleNotification({ type: 'warning', message: { id: 'notification.error' } });
+      toggleNotification({ type: 'warning', message: formatAPIError(err) });
     }
   };
 

--- a/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/index.js
@@ -9,7 +9,13 @@ import flatMap from 'lodash/flatMap';
 import isEqual from 'lodash/isEqual';
 import get from 'lodash/get';
 import set from 'lodash/set';
-import { useNotification, useTracking, ConfirmDialog, Link } from '@strapi/helper-plugin';
+import {
+  useNotification,
+  useTracking,
+  useAPIErrorHandler,
+  ConfirmDialog,
+  Link,
+} from '@strapi/helper-plugin';
 import { useHistory } from 'react-router-dom';
 import { Main } from '@strapi/design-system/Main';
 import { HeaderLayout, ContentLayout } from '@strapi/design-system/Layout';
@@ -22,6 +28,7 @@ import { Stack } from '@strapi/design-system/Stack';
 import { Divider } from '@strapi/design-system/Divider';
 import ArrowLeft from '@strapi/icons/ArrowLeft';
 import Check from '@strapi/icons/Check';
+
 import { getTrad } from '../../utils';
 import reducer, { initialState } from './reducer';
 import init from './init';
@@ -43,6 +50,8 @@ const EditSettingsView = ({ mainLayout, components, isContentTypeView, slug, upd
   const [isConfirmDialogOpen, setIsConfirmDialogOpen] = useState(false);
   const { componentLayouts, initialData, modifiedData, metaToEdit, metaForm } = reducerState;
   const { formatMessage } = useIntl();
+  const { formatAPIError } = useAPIErrorHandler();
+
   const modelName = get(mainLayout, ['info', 'displayName'], '');
   const attributes = get(modifiedData, ['attributes'], {});
 
@@ -131,8 +140,8 @@ const EditSettingsView = ({ mainLayout, components, isContentTypeView, slug, upd
         toggleConfirmDialog();
         trackUsage('didEditEditSettings');
       },
-      onError() {
-        toggleNotification({ type: 'warning', message: { id: 'notification.error' } });
+      onError(error) {
+        toggleNotification({ type: 'warning', message: formatAPIError(error) });
       },
     }
   );

--- a/packages/core/admin/admin/src/content-manager/pages/ListSettingsView/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/ListSettingsView/index.js
@@ -7,7 +7,13 @@ import pick from 'lodash/pick';
 import get from 'lodash/get';
 import isEmpty from 'lodash/isEmpty';
 import { stringify } from 'qs';
-import { useNotification, useTracking, ConfirmDialog, Link } from '@strapi/helper-plugin';
+import {
+  useNotification,
+  useTracking,
+  useAPIErrorHandler,
+  ConfirmDialog,
+  Link,
+} from '@strapi/helper-plugin';
 import { useIntl } from 'react-intl';
 import { Box } from '@strapi/design-system/Box';
 import { Divider } from '@strapi/design-system/Divider';
@@ -33,6 +39,7 @@ const ListSettingsView = ({ layout, slug }) => {
   const pluginsQueryParams = usePluginsQueryParams();
   const toggleNotification = useNotification();
   const { refetchData } = useContext(ModelsContext);
+  const { formatAPIError } = useAPIErrorHandler();
 
   const [showWarningSubmit, setWarningSubmit] = useState(false);
   const toggleWarningSubmit = () => setWarningSubmit((prevState) => !prevState);
@@ -131,10 +138,10 @@ const ListSettingsView = ({ layout, slug }) => {
       trackUsage('didEditListSettings');
       refetchData();
     },
-    onError() {
+    onError(error) {
       toggleNotification({
         type: 'warning',
-        message: { id: 'notification.error' },
+        message: formatAPIError(error),
       });
     },
   });

--- a/packages/core/admin/admin/src/hooks/useFetchEnabledPlugins/index.js
+++ b/packages/core/admin/admin/src/hooks/useFetchEnabledPlugins/index.js
@@ -1,9 +1,10 @@
 import { useQuery } from 'react-query';
-import { useNotification } from '@strapi/helper-plugin';
+import { useNotification, useAPIErrorHandler } from '@strapi/helper-plugin';
 import { fetchEnabledPlugins } from './utils/api';
 
 const useFetchEnabledPlugins = (notifyLoad) => {
   const toggleNotification = useNotification();
+  const { formatAPIError } = useAPIErrorHandler();
 
   return useQuery('list-enabled-plugins', () => fetchEnabledPlugins(), {
     onSuccess() {
@@ -11,10 +12,10 @@ const useFetchEnabledPlugins = (notifyLoad) => {
         notifyLoad();
       }
     },
-    onError() {
+    onError(error) {
       toggleNotification({
         type: 'warning',
-        message: { id: 'notification.error', defaultMessage: 'An error occured' },
+        message: formatAPIError(error),
       });
     },
   });

--- a/packages/core/admin/admin/src/hooks/useFetchRole/index.js
+++ b/packages/core/admin/admin/src/hooks/useFetchRole/index.js
@@ -1,9 +1,10 @@
 import { useCallback, useReducer, useEffect } from 'react';
-import { request, useNotification } from '@strapi/helper-plugin';
+import { request, useNotification, useAPIErrorHandler } from '@strapi/helper-plugin';
 import reducer, { initialState } from './reducer';
 
 const useFetchRole = (id) => {
   const toggleNotification = useNotification();
+  const { formatAPIError } = useAPIErrorHandler();
   const [state, dispatch] = useReducer(reducer, initialState);
 
   useEffect(() => {
@@ -34,14 +35,12 @@ const useFetchRole = (id) => {
         permissions,
       });
     } catch (err) {
-      console.error(err);
-
       dispatch({
         type: 'GET_DATA_ERROR',
       });
       toggleNotification({
         type: 'warning',
-        message: { id: 'notification.error' },
+        message: formatAPIError(err),
       });
     }
   };

--- a/packages/core/admin/admin/src/hooks/useModels/index.js
+++ b/packages/core/admin/admin/src/hooks/useModels/index.js
@@ -1,9 +1,10 @@
 import { useReducer, useEffect } from 'react';
-import { request, useNotification } from '@strapi/helper-plugin';
+import { request, useNotification, useAPIErrorHandler } from '@strapi/helper-plugin';
 import reducer, { initialState } from './reducer';
 
 const useModels = () => {
   const toggleNotification = useNotification();
+  const { formatAPIError } = useAPIErrorHandler();
   const [state, dispatch] = useReducer(reducer, initialState);
 
   useEffect(() => {
@@ -34,7 +35,7 @@ const useModels = () => {
       });
       toggleNotification({
         type: 'warning',
-        message: { id: 'notification.error' },
+        message: formatAPIError(err),
       });
     }
   };

--- a/packages/core/admin/admin/src/hooks/useRegenerate/index.js
+++ b/packages/core/admin/admin/src/hooks/useRegenerate/index.js
@@ -1,11 +1,11 @@
 import { useState } from 'react';
-import { get } from 'lodash';
-import { useFetchClient, useNotification } from '@strapi/helper-plugin';
+import { useFetchClient, useNotification, useAPIErrorHandler } from '@strapi/helper-plugin';
 
 const useRegenerate = (id, onRegenerate) => {
   const [isLoadingConfirmation, setIsLoadingConfirmation] = useState(false);
   const toggleNotification = useNotification();
   const { post } = useFetchClient();
+  const { formatAPIError } = useAPIErrorHandler();
 
   const regenerateData = async () => {
     try {
@@ -20,7 +20,7 @@ const useRegenerate = (id, onRegenerate) => {
       setIsLoadingConfirmation(false);
       toggleNotification({
         type: 'warning',
-        message: get(error, 'response.data.message', 'notification.error'),
+        message: formatAPIError(error),
       });
     }
   };

--- a/packages/core/admin/admin/src/hooks/useRolesList/index.js
+++ b/packages/core/admin/admin/src/hooks/useRolesList/index.js
@@ -1,26 +1,18 @@
 import { useEffect, useReducer, useCallback } from 'react';
-import { getFetchClient, useNotification } from '@strapi/helper-plugin';
-import get from 'lodash/get';
+import { useFetchClient, useNotification, useAPIErrorHandler } from '@strapi/helper-plugin';
+
 import init from './init';
 import reducer, { initialState } from './reducer';
 
 const useRolesList = (shouldFetchData = true) => {
   const toggleNotification = useNotification();
+  const { formatAPIError } = useAPIErrorHandler();
   const [{ roles, isLoading }, dispatch] = useReducer(reducer, initialState, () =>
     init(initialState, shouldFetchData)
   );
-
-  useEffect(() => {
-    if (shouldFetchData) {
-      fetchRolesList();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [shouldFetchData]);
+  const { get } = useFetchClient();
 
   const fetchRolesList = useCallback(async () => {
-    // TODO: evaluate to replace it with a useFetchClient when we work on the useCallback to remove
-    const fetchClient = getFetchClient();
-
     try {
       dispatch({
         type: 'GET_DATA',
@@ -28,27 +20,29 @@ const useRolesList = (shouldFetchData = true) => {
 
       const {
         data: { data },
-      } = await fetchClient.get('/admin/roles');
+      } = await get('/admin/roles');
 
       dispatch({
         type: 'GET_DATA_SUCCEEDED',
         data,
       });
     } catch (err) {
-      const message = get(err, ['response', 'payload', 'message'], 'An error occured');
-
       dispatch({
         type: 'GET_DATA_ERROR',
       });
 
-      if (message !== 'Forbidden') {
-        toggleNotification({
-          type: 'warning',
-          message,
-        });
-      }
+      toggleNotification({
+        type: 'warning',
+        message: formatAPIError(err),
+      });
     }
-  }, [toggleNotification]);
+  }, [toggleNotification, formatAPIError, get]);
+
+  useEffect(() => {
+    if (shouldFetchData) {
+      fetchRolesList();
+    }
+  }, [fetchRolesList, shouldFetchData]);
 
   return { roles, isLoading, getData: fetchRolesList };
 };

--- a/packages/core/admin/admin/src/pages/AuthPage/components/Register/index.js
+++ b/packages/core/admin/admin/src/pages/AuthPage/components/Register/index.js
@@ -12,20 +12,25 @@ import {
   useQuery,
   useNotification,
   useTracking,
+  useAPIErrorHandler,
   getYupInnerErrors,
   Link,
 } from '@strapi/helper-plugin';
-import { Box } from '@strapi/design-system/Box';
-import { Stack } from '@strapi/design-system/Stack';
-import { Main } from '@strapi/design-system/Main';
-import { Flex } from '@strapi/design-system/Flex';
-import { Button } from '@strapi/design-system/Button';
-import { TextInput } from '@strapi/design-system/TextInput';
-import { Checkbox } from '@strapi/design-system/Checkbox';
-import { Grid, GridItem } from '@strapi/design-system/Grid';
-import { Typography } from '@strapi/design-system/Typography';
-import EyeStriked from '@strapi/icons/EyeStriked';
-import Eye from '@strapi/icons/Eye';
+
+import {
+  Box,
+  Button,
+  Checkbox,
+  Flex,
+  Grid,
+  GridItem,
+  Main,
+  Stack,
+  TextInput,
+  Typography,
+} from '@strapi/design-system';
+import { Eye, EyeStriked } from '@strapi/icons';
+
 import UnauthenticatedLayout, {
   Column,
   LayoutContent,
@@ -56,6 +61,7 @@ const Register = ({ authType, fieldsToDisable, noSignin, onSubmit, schema }) => 
   const [userInfo, setUserInfo] = useState({});
   const { trackUsage } = useTracking();
   const { formatMessage } = useIntl();
+  const { formatAPIError } = useAPIErrorHandler();
   const query = useQuery();
   const registrationToken = query.get('registrationToken');
 
@@ -77,7 +83,7 @@ const Register = ({ authType, fieldsToDisable, noSignin, onSubmit, schema }) => 
 
           toggleNotification({
             type: 'warning',
-            message: errorMessage,
+            message: formatAPIError(err),
           });
 
           // Redirect to the oops page in case of an invalid token
@@ -88,8 +94,7 @@ const Register = ({ authType, fieldsToDisable, noSignin, onSubmit, schema }) => 
 
       getData();
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [registrationToken]);
+  }, [registrationToken, formatAPIError, push, toggleNotification]);
 
   return (
     <UnauthenticatedLayout>

--- a/packages/core/admin/admin/src/pages/ProfilePage/index.js
+++ b/packages/core/admin/admin/src/pages/ProfilePage/index.js
@@ -10,6 +10,7 @@ import {
   useOverlayBlocker,
   auth,
   useTracking,
+  useAPIErrorHandler,
 } from '@strapi/helper-plugin';
 import { useIntl } from 'react-intl';
 import { Formik } from 'formik';
@@ -69,6 +70,7 @@ const ProfilePage = () => {
   const toggleNotification = useNotification();
   const { lockApp, unlockApp } = useOverlayBlocker();
   const { notifyStatus } = useNotifyAT();
+  const { formatAPIError } = useAPIErrorHandler();
   const { currentTheme, themes: allApplicationThemes, onChangeTheme } = useThemeToggle();
   useFocusWhenNavigate();
 
@@ -81,10 +83,10 @@ const ProfilePage = () => {
         })
       );
     },
-    onError() {
+    onError(error) {
       toggleNotification({
         type: 'warning',
-        message: { id: 'notification.error', defaultMessage: 'An error occured' },
+        message: formatAPIError(error),
       });
     },
   });
@@ -133,7 +135,7 @@ const ProfilePage = () => {
 
           return toggleNotification({
             type: 'warning',
-            message: { id: 'notification.error', defaultMessage: 'An error occured' },
+            message: formatAPIError(error),
           });
         },
       }

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/index.js
@@ -4,6 +4,7 @@ import {
   useNotification,
   useOverlayBlocker,
   useTracking,
+  useAPIErrorHandler,
   LoadingIndicatorPage,
   SettingsPageTitle,
   Link,
@@ -15,7 +16,6 @@ import { Main } from '@strapi/design-system/Main';
 import { Stack } from '@strapi/design-system/Stack';
 import { Formik } from 'formik';
 import ArrowLeft from '@strapi/icons/ArrowLeft';
-import get from 'lodash/get';
 import { useIntl } from 'react-intl';
 import { useRouteMatch } from 'react-router-dom';
 import { Permissions, RoleForm } from './components';
@@ -32,6 +32,7 @@ const EditPage = () => {
   const permissionsRef = useRef();
   const { lockApp, unlockApp } = useOverlayBlocker();
   const { trackUsage } = useTracking();
+  const { formatAPIError } = useAPIErrorHandler();
 
   const { isLoading: isLayoutLoading, data: permissionsLayout } = useFetchPermissionsLayout(id);
   const {
@@ -74,14 +75,9 @@ const EditPage = () => {
         message: { id: 'notification.success.saved' },
       });
     } catch (err) {
-      console.error(err.response);
-
-      const errorMessage = get(err, 'response.payload.message', 'An error occured');
-      const message = get(err, 'response.payload.data.permissions[0]', errorMessage);
-
       toggleNotification({
         type: 'warning',
-        message,
+        message: formatAPIError(err),
       });
     } finally {
       setIsSubmiting(false);

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Users/EditPage/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Users/EditPage/index.js
@@ -14,6 +14,7 @@ import {
   useFocusWhenNavigate,
   useNotification,
   useOverlayBlocker,
+  useAPIErrorHandler,
   LoadingIndicatorPage,
   Link,
 } from '@strapi/helper-plugin';
@@ -48,6 +49,7 @@ const EditPage = ({ canUpdate }) => {
   const toggleNotification = useNotification();
   const { lockApp, unlockApp } = useOverlayBlocker();
   useFocusWhenNavigate();
+  const { formatAPIError } = useAPIErrorHandler();
 
   const { status, data } = useQuery(['user', id], () => fetchUser(id), {
     retry: false,
@@ -106,7 +108,7 @@ const EditPage = ({ canUpdate }) => {
       actions.setErrors(fieldsErrors);
       toggleNotification({
         type: 'warning',
-        message: get(err, 'response.data.message', 'notification.error'),
+        message: formatAPIError(err),
       });
     }
 

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Users/ListPage/ModalForm/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Users/ListPage/ModalForm/index.js
@@ -21,6 +21,7 @@ import {
   useNotification,
   useOverlayBlocker,
   useFetchClient,
+  useAPIErrorHandler,
 } from '@strapi/helper-plugin';
 import { useQueryClient, useMutation } from 'react-query';
 import formDataModel from 'ee_else_ce/pages/SettingsPage/pages/Users/ListPage/ModalForm/utils/formDataModel';
@@ -40,6 +41,7 @@ const ModalForm = ({ queryName, onToggle }) => {
   const toggleNotification = useNotification();
   const { lockApp, unlockApp } = useOverlayBlocker();
   const { post } = useFetchClient();
+  const { formatAPIError } = useAPIErrorHandler();
   const postMutation = useMutation(
     (body) => {
       return post('/admin/users', body);
@@ -56,7 +58,7 @@ const ModalForm = ({ queryName, onToggle }) => {
 
         toggleNotification({
           type: 'warning',
-          message: { id: 'notification.error', defaultMessage: 'An error occured' },
+          message: formatAPIError(err),
         });
 
         throw err;

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Users/ListPage/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Users/ListPage/index.js
@@ -6,6 +6,7 @@ import {
   useRBAC,
   useNotification,
   useFocusWhenNavigate,
+  useAPIErrorHandler,
   NoPermissions,
 } from '@strapi/helper-plugin';
 import { ActionLayout, ContentLayout, HeaderLayout } from '@strapi/design-system/Layout';
@@ -36,6 +37,7 @@ const ListPage = () => {
   const { search } = useLocation();
   useFocusWhenNavigate();
   const { notifyStatus } = useNotifyAT();
+  const { formatAPIError } = useAPIErrorHandler();
   const queryName = ['users', search];
 
   const headers = tableHeaders.map((header) => ({
@@ -68,10 +70,10 @@ const ListPage = () => {
     keepPreviousData: true,
     retry: false,
     staleTime: 1000 * 20,
-    onError() {
+    onError(error) {
       toggleNotification({
         type: 'warning',
-        message: { id: 'notification.error', defaultMessage: 'An error occured' },
+        message: formatAPIError(error),
       });
     },
   });
@@ -84,15 +86,11 @@ const ListPage = () => {
     async onSuccess() {
       await queryClient.invalidateQueries(queryName);
     },
-    onError(err) {
-      if (err?.response?.data?.data) {
-        toggleNotification({ type: 'warning', message: err.response.data.data });
-      } else {
-        toggleNotification({
-          type: 'warning',
-          message: { id: 'notification.error', defaultMessage: 'An error occured' },
-        });
-      }
+    onError(error) {
+      toggleNotification({
+        type: 'warning',
+        message: formatAPIError(error),
+      });
     },
   });
 

--- a/packages/core/admin/ee/admin/hooks/useAuthProviders/index.js
+++ b/packages/core/admin/ee/admin/hooks/useAuthProviders/index.js
@@ -1,5 +1,5 @@
 import { useReducer, useEffect } from 'react';
-import { request, useNotification } from '@strapi/helper-plugin';
+import { request, useNotification, useAPIErrorHandler } from '@strapi/helper-plugin';
 
 import { getRequestUrl } from '../../../../admin/src/utils';
 import reducer, { initialState } from './reducer';
@@ -7,6 +7,7 @@ import reducer, { initialState } from './reducer';
 const useAuthProviders = ({ ssoEnabled }) => {
   const [state, dispatch] = useReducer(reducer, initialState);
   const toggleNotification = useNotification();
+  const { formatAPIError } = useAPIErrorHandler();
 
   useEffect(() => {
     fetchAuthProviders();
@@ -25,6 +26,7 @@ const useAuthProviders = ({ ssoEnabled }) => {
       }
 
       const requestUrl = getRequestUrl('providers');
+      // TODO: Replace with useFetchClient()
       const data = await request(requestUrl, { method: 'GET' });
 
       dispatch({
@@ -32,15 +34,13 @@ const useAuthProviders = ({ ssoEnabled }) => {
         data,
       });
     } catch (err) {
-      console.error(err);
-
       dispatch({
         type: 'GET_DATA_ERROR',
       });
 
       toggleNotification({
         type: 'warning',
-        message: { id: 'notification.error' },
+        message: formatAPIError(err),
       });
     }
   };

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/Roles/CreatePage/index.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/Roles/CreatePage/index.js
@@ -8,6 +8,7 @@ import {
   request,
   useNotification,
   useOverlayBlocker,
+  useAPIErrorHandler,
   useTracking,
   Link,
 } from '@strapi/helper-plugin';
@@ -51,6 +52,7 @@ const CreatePage = () => {
   const { replace } = useHistory();
   const permissionsRef = useRef();
   const { trackUsage } = useTracking();
+  const { formatAPIError } = useAPIErrorHandler();
   const params = useRouteMatch('/settings/roles/duplicate/:id');
   const id = get(params, 'params.id', null);
   const { isLoading: isLayoutLoading, data: permissionsLayout } = useFetchPermissionsLayout();
@@ -99,11 +101,10 @@ const CreatePage = () => {
         replace(`/settings/roles/${res.data.id}`);
       })
       .catch((err) => {
-        console.error(err);
         setIsSubmiting(false);
         toggleNotification({
           type: 'warning',
-          message: { id: 'notification.error' },
+          message: formatAPIError(err),
         });
       })
       .finally(() => {

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/Roles/ListPage/index.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/Roles/ListPage/index.js
@@ -9,6 +9,7 @@ import {
   useQueryParams,
   useRBAC,
   useFocusWhenNavigate,
+  useAPIErrorHandler,
 } from '@strapi/helper-plugin';
 import Plus from '@strapi/icons/Plus';
 import Trash from '@strapi/icons/Trash';
@@ -20,7 +21,6 @@ import { VisuallyHidden } from '@strapi/design-system/VisuallyHidden';
 import { Main } from '@strapi/design-system/Main';
 import { Table, Tbody, TFooter, Thead, Th, Tr } from '@strapi/design-system/Table';
 import { Typography } from '@strapi/design-system/Typography';
-import { get } from 'lodash';
 import matchSorter from 'match-sorter';
 import { useIntl } from 'react-intl';
 import { useHistory } from 'react-router-dom';
@@ -63,7 +63,7 @@ const useSortedRoles = () => {
 
 const useRoleActions = ({ getData, canCreate, canDelete, canUpdate }) => {
   const { formatMessage } = useIntl();
-
+  const { formatAPIError } = useAPIErrorHandler();
   const toggleNotification = useNotification();
   const [isWarningDeleteAllOpened, setIsWarningDeleteAllOpenend] = useState(false);
   const { push } = useHistory();
@@ -90,20 +90,10 @@ const useRoleActions = ({ getData, canCreate, canDelete, canUpdate }) => {
         type: 'RESET_DATA_TO_DELETE',
       });
     } catch (err) {
-      const errorIds = get(err, ['response', 'payload', 'data', 'ids'], null);
-
-      if (errorIds && Array.isArray(errorIds)) {
-        const errorsMsg = errorIds.join('\n');
-        toggleNotification({
-          type: 'warning',
-          message: errorsMsg,
-        });
-      } else {
-        toggleNotification({
-          type: 'warning',
-          message: { id: 'notification.error' },
-        });
-      }
+      toggleNotification({
+        type: 'warning',
+        message: formatAPIError(err),
+      });
     }
     handleToggleModal();
   };

--- a/packages/core/content-type-builder/admin/src/components/DataManagerProvider/index.js
+++ b/packages/core/content-type-builder/admin/src/components/DataManagerProvider/index.js
@@ -11,6 +11,7 @@ import {
   useRBACProvider,
   useGuidedTour,
   useFetchClient,
+  useAPIErrorHandler,
 } from '@strapi/helper-plugin';
 import { useIntl } from 'react-intl';
 import { useLocation, useRouteMatch, Redirect } from 'react-router-dom';
@@ -67,7 +68,7 @@ const DataManagerProvider = ({
   const toggleNotification = useNotification();
   const { lockAppWithAutoreload, unlockAppWithAutoreload } = useAutoReloadOverlayBlocker();
   const { setCurrentStep } = useGuidedTour();
-
+  const { formatAPIError } = useAPIErrorHandler();
   const { getPlugin } = useStrapiApp();
 
   const { apis } = getPlugin(pluginId);
@@ -125,10 +126,9 @@ const DataManagerProvider = ({
         reservedNames,
       });
     } catch (err) {
-      console.error({ err });
       toggleNotification({
         type: 'warning',
-        message: { id: 'notification.error' },
+        message: formatAPIError(err),
       });
     }
   };
@@ -278,10 +278,9 @@ const DataManagerProvider = ({
         await updatePermissions();
       }
     } catch (err) {
-      console.error({ err });
       toggleNotification({
         type: 'warning',
-        message: { id: 'notification.error' },
+        message: formatAPIError(err),
       });
     } finally {
       unlockAppWithAutoreload();
@@ -329,10 +328,9 @@ const DataManagerProvider = ({
         await updatePermissions();
       }
     } catch (err) {
-      console.error({ err });
       toggleNotification({
         type: 'warning',
-        message: { id: 'notification.error' },
+        message: formatAPIError(err),
       });
     } finally {
       unlockAppWithAutoreload();
@@ -360,10 +358,9 @@ const DataManagerProvider = ({
 
       await updatePermissions();
     } catch (err) {
-      console.error({ err });
       toggleNotification({
         type: 'warning',
-        message: { id: 'notification.error' },
+        message: formatAPIError(err),
       });
     } finally {
       unlockAppWithAutoreload();
@@ -547,10 +544,9 @@ const DataManagerProvider = ({
         trackUsage('didNotSaveComponent');
       }
 
-      console.error({ err: err.response });
       toggleNotification({
         type: 'warning',
-        message: { id: 'notification.error' },
+        message: formatAPIError(err),
       });
     } finally {
       unlockAppWithAutoreload();

--- a/packages/core/helper-plugin/lib/src/components/CheckPagePermissions/index.js
+++ b/packages/core/helper-plugin/lib/src/components/CheckPagePermissions/index.js
@@ -5,12 +5,14 @@ import useNotification from '../../hooks/useNotification';
 import useRBACProvider from '../../hooks/useRBACProvider';
 import hasPermissions from '../../utils/hasPermissions';
 import LoadingIndicatorPage from '../LoadingIndicatorPage';
+import { useAPIErrorHandler } from '../../hooks/useAPIErrorHandler';
 
 const CheckPagePermissions = ({ permissions, children }) => {
   const abortController = new AbortController();
   const { signal } = abortController;
   const { allPermissions } = useRBACProvider();
   const toggleNotification = useNotification();
+  const { formatAPIError } = useAPIErrorHandler();
 
   const [state, setState] = useState({ isLoading: true, canAccess: false });
   const isMounted = useRef(true);
@@ -27,11 +29,9 @@ const CheckPagePermissions = ({ permissions, children }) => {
         }
       } catch (err) {
         if (isMounted.current) {
-          console.error(err);
-
           toggleNotification({
             type: 'warning',
-            message: { id: 'notification.error' },
+            message: formatAPIError(err),
           });
 
           setState({ isLoading: false });

--- a/packages/core/helper-plugin/lib/src/components/CheckPermissions/index.js
+++ b/packages/core/helper-plugin/lib/src/components/CheckPermissions/index.js
@@ -4,6 +4,7 @@ import useNotification from '../../hooks/useNotification';
 
 import hasPermissions from '../../utils/hasPermissions';
 import useRBACProvider from '../../hooks/useRBACProvider';
+import { useAPIErrorHandler } from '../../hooks/useAPIErrorHandler';
 
 // NOTE: this component is very similar to the CheckPagePermissions
 // except that it does not handle redirections nor loading state
@@ -15,6 +16,7 @@ const CheckPermissions = ({ permissions, children }) => {
   const isMounted = useRef(true);
   const abortController = new AbortController();
   const { signal } = abortController;
+  const { formatAPIError } = useAPIErrorHandler();
 
   useEffect(() => {
     const checkPermission = async () => {
@@ -28,10 +30,9 @@ const CheckPermissions = ({ permissions, children }) => {
         }
       } catch (err) {
         if (isMounted.current) {
-          console.error(err);
           toggleNotification({
             type: 'warning',
-            message: { id: 'notification.error' },
+            message: formatAPIError(err),
           });
 
           setState({ isLoading: false });

--- a/packages/core/upload/admin/src/hooks/useAssets.js
+++ b/packages/core/upload/admin/src/hooks/useAssets.js
@@ -1,7 +1,7 @@
 import { stringify } from 'qs';
 import { useQuery } from 'react-query';
 import { useNotifyAT } from '@strapi/design-system/LiveRegions';
-import { useNotification, useFetchClient } from '@strapi/helper-plugin';
+import { useNotification, useFetchClient, useAPIErrorHandler } from '@strapi/helper-plugin';
 import { useIntl } from 'react-intl';
 
 import pluginId from '../pluginId';
@@ -12,6 +12,7 @@ export const useAssets = ({ skipWhen = false, query = {} } = {}) => {
   const toggleNotification = useNotification();
   const { notifyStatus } = useNotifyAT();
   const { get } = useFetchClient();
+  const { formatAPIError } = useAPIErrorHandler();
   const dataRequestURL = getRequestUrl('files');
   const { folder, _q, ...paramsExceptFolderAndQ } = query;
 
@@ -60,7 +61,7 @@ export const useAssets = ({ skipWhen = false, query = {} } = {}) => {
     } catch (err) {
       toggleNotification({
         type: 'warning',
-        message: { id: 'notification.error' },
+        message: formatAPIError(err),
       });
 
       throw err;

--- a/packages/core/upload/admin/src/hooks/useBulkRemove.js
+++ b/packages/core/upload/admin/src/hooks/useBulkRemove.js
@@ -1,5 +1,5 @@
 import { useMutation, useQueryClient } from 'react-query';
-import { useNotification, useFetchClient } from '@strapi/helper-plugin';
+import { useNotification, useFetchClient, useAPIErrorHandler } from '@strapi/helper-plugin';
 
 import pluginId from '../pluginId';
 import { getRequestUrl, getTrad } from '../utils';
@@ -7,6 +7,7 @@ import { getRequestUrl, getTrad } from '../utils';
 export const useBulkRemove = () => {
   const toggleNotification = useNotification();
   const queryClient = useQueryClient();
+  const { formatAPIError } = useAPIErrorHandler();
   const url = getRequestUrl('actions/bulk-delete');
   const { post } = useFetchClient();
 
@@ -51,7 +52,7 @@ export const useBulkRemove = () => {
       });
     },
     onError(error) {
-      toggleNotification({ type: 'warning', message: error.message });
+      toggleNotification({ type: 'warning', message: formatAPIError(error) });
     },
   });
 

--- a/packages/core/upload/admin/src/hooks/useConfig.js
+++ b/packages/core/upload/admin/src/hooks/useConfig.js
@@ -1,5 +1,10 @@
 import { useMutation, useQuery, useQueryClient } from 'react-query';
-import { useNotification, useTracking, useFetchClient } from '@strapi/helper-plugin';
+import {
+  useNotification,
+  useTracking,
+  useFetchClient,
+  useAPIErrorHandler,
+} from '@strapi/helper-plugin';
 
 import pluginId from '../pluginId';
 
@@ -11,6 +16,7 @@ export const useConfig = () => {
   const { trackUsage } = useTracking();
   const toggleNotification = useNotification();
   const { get, put } = useFetchClient();
+  const { formatAPIError } = useAPIErrorHandler();
 
   const config = useQuery(
     queryKey,
@@ -20,10 +26,10 @@ export const useConfig = () => {
       return res.data.data;
     },
     {
-      onError() {
+      onError(error) {
         return toggleNotification({
           type: 'warning',
-          message: { id: 'notification.error' },
+          message: formatAPIError(error),
         });
       },
     }
@@ -34,10 +40,10 @@ export const useConfig = () => {
       trackUsage('didEditMediaLibraryConfig');
       queryClient.refetchQueries(queryKey, { active: true });
     },
-    onError() {
+    onError(error) {
       return toggleNotification({
         type: 'warning',
-        message: { id: 'notification.error' },
+        message: formatAPIError(error),
       });
     },
   });

--- a/packages/core/upload/admin/src/hooks/useFolders.js
+++ b/packages/core/upload/admin/src/hooks/useFolders.js
@@ -1,7 +1,7 @@
 import { stringify } from 'qs';
 import { useQuery } from 'react-query';
 import { useNotifyAT } from '@strapi/design-system/LiveRegions';
-import { useNotification, useFetchClient } from '@strapi/helper-plugin';
+import { useNotification, useFetchClient, useAPIErrorHandler } from '@strapi/helper-plugin';
 import { useIntl } from 'react-intl';
 
 import pluginId from '../pluginId';
@@ -9,6 +9,7 @@ import { getRequestUrl } from '../utils';
 
 export const useFolders = ({ enabled = true, query = {} }) => {
   const { formatMessage } = useIntl();
+  const { formatAPIError } = useAPIErrorHandler();
   const toggleNotification = useNotification();
   const { notifyStatus } = useNotifyAT();
   const dataRequestURL = getRequestUrl('folders');
@@ -61,7 +62,7 @@ export const useFolders = ({ enabled = true, query = {} }) => {
     } catch (err) {
       toggleNotification({
         type: 'warning',
-        message: { id: 'notification.error' },
+        message: formatAPIError(err),
       });
 
       throw err;

--- a/packages/plugins/i18n/admin/src/hooks/useAddLocale/index.js
+++ b/packages/plugins/i18n/admin/src/hooks/useAddLocale/index.js
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { request, useNotification } from '@strapi/helper-plugin';
+import { request, useNotification, useAPIErrorHandler } from '@strapi/helper-plugin';
 import { useDispatch } from 'react-redux';
 import get from 'lodash/get';
 import { getTrad } from '../../utils';
@@ -27,6 +27,7 @@ const useAddLocale = () => {
   const [isLoading, setLoading] = useState(false);
   const dispatch = useDispatch();
   const toggleNotification = useNotification();
+  const { formatAPIError } = useAPIErrorHandler();
 
   const persistLocale = async (locale) => {
     setLoading(true);
@@ -45,7 +46,7 @@ const useAddLocale = () => {
       } else {
         toggleNotification({
           type: 'warning',
-          message: { id: 'notification.error' },
+          message: formatAPIError(e),
         });
       }
 

--- a/packages/plugins/i18n/admin/src/hooks/useDefaultLocales/index.js
+++ b/packages/plugins/i18n/admin/src/hooks/useDefaultLocales/index.js
@@ -1,30 +1,32 @@
 import { useQuery } from 'react-query';
-import { request, useNotification } from '@strapi/helper-plugin';
+import { request, useNotification, useAPIErrorHandler } from '@strapi/helper-plugin';
 import { useNotifyAT } from '@strapi/design-system/LiveRegions';
 import { useIntl } from 'react-intl';
 import { getTrad } from '../../utils';
 
-const fetchDefaultLocalesList = async (toggleNotification) => {
-  try {
-    const data = await request('/i18n/iso-locales', {
-      method: 'GET',
-    });
-
-    return data;
-  } catch (e) {
-    toggleNotification({
-      type: 'warning',
-      message: { id: 'notification.error' },
-    });
-
-    return [];
-  }
-};
-
 const useDefaultLocales = () => {
   const { formatMessage } = useIntl();
+  const { formatAPIError } = useAPIErrorHandler();
   const { notifyStatus } = useNotifyAT();
   const toggleNotification = useNotification();
+
+  const fetchDefaultLocalesList = async () => {
+    try {
+      const data = await request('/i18n/iso-locales', {
+        method: 'GET',
+      });
+
+      return data;
+    } catch (e) {
+      toggleNotification({
+        type: 'warning',
+        message: formatAPIError(e),
+      });
+
+      return [];
+    }
+  };
+
   const { isLoading, data } = useQuery('default-locales', () =>
     fetchDefaultLocalesList(toggleNotification).then((data) => {
       notifyStatus(

--- a/packages/plugins/i18n/admin/src/hooks/useEditLocale/index.js
+++ b/packages/plugins/i18n/admin/src/hooks/useEditLocale/index.js
@@ -1,41 +1,43 @@
 import { useState } from 'react';
-import { request, useNotification } from '@strapi/helper-plugin';
+import { request, useNotification, useAPIErrorHandler } from '@strapi/helper-plugin';
 import { useDispatch } from 'react-redux';
 import { getTrad } from '../../utils';
 import { UPDATE_LOCALE } from '../constants';
-
-const editLocale = async (id, payload, toggleNotification) => {
-  try {
-    const data = await request(`/i18n/locales/${id}`, {
-      method: 'PUT',
-      body: payload,
-    });
-
-    toggleNotification({
-      type: 'success',
-      message: { id: getTrad('Settings.locales.modal.edit.success') },
-    });
-
-    return data;
-  } catch {
-    toggleNotification({
-      type: 'warning',
-      message: { id: 'notification.error' },
-    });
-
-    return null;
-  }
-};
 
 const useEditLocale = () => {
   const [isLoading, setLoading] = useState(false);
   const dispatch = useDispatch();
   const toggleNotification = useNotification();
+  const { formatAPIError } = useAPIErrorHandler();
+
+  const editLocale = async (id, payload) => {
+    try {
+      // TODO: use useFetchClient instead
+      const data = await request(`/i18n/locales/${id}`, {
+        method: 'PUT',
+        body: payload,
+      });
+
+      toggleNotification({
+        type: 'success',
+        message: { id: getTrad('Settings.locales.modal.edit.success') },
+      });
+
+      return data;
+    } catch (error) {
+      toggleNotification({
+        type: 'warning',
+        message: formatAPIError(error),
+      });
+
+      return null;
+    }
+  };
 
   const modifyLocale = async (id, payload) => {
     setLoading(true);
 
-    const editedLocale = await editLocale(id, payload, toggleNotification);
+    const editedLocale = await editLocale(id, payload);
 
     dispatch({ type: UPDATE_LOCALE, editedLocale });
     setLoading(false);


### PR DESCRIPTION

### What does it do?

Refactors most generic "An error has been thrown" notifications to display the actual error messages that have been thrown by the API.

### Why is it needed?

Not being able to see the real errors which the API returns have been a pain point for a long time. This PR only refactors some obvious places.

### Related issue(s)/PR(s)

- Builds on top of https://github.com/strapi/strapi/pull/15321
