### PR TITLE
Chore: Bump swc jsc.target to es2020

### DIFF
--- a/jest.base-config.front.js
+++ b/jest.base-config.front.js
@@ -69,6 +69,8 @@ module.exports = {
             jsx: true,
             dynamicImport: true,
           },
+          // this should match the minimum supported node.js version
+          target: 'es2020',
         },
       },
     ],


### PR DESCRIPTION
### What does it do?

Updates the compile target for swc within jest to `es2020`.

### Why is it needed?

node@14 supports the full es2020 set and the less swc has to transform the smaller the output is and the faster the transpilation. This chops-off ~2min from the FE tests and will bring considerable performance boosts when running the tests locally.

### How to test it?

Trust jest.
