### PR TITLE
fix: always return an object if data is falsey

### DIFF
--- a/packages/core/upload/admin/src/hooks/tests/useConfig.test.js
+++ b/packages/core/upload/admin/src/hooks/tests/useConfig.test.js
@@ -81,13 +81,28 @@ describe('useConfig', () => {
   describe('query', () => {
     test('does call the get endpoint', async () => {
       const { get } = useFetchClient();
-      get.mockResolvedValue(mockGetResponse);
+      get.mockReturnValueOnce(mockGetResponse);
 
       const { waitFor, result } = await setup();
       expect(get).toHaveBeenCalledWith(`/${pluginId}/configuration`);
 
       await waitFor(() => !result.current.config.isLoading);
       expect(result.current.config.data).toEqual(mockGetResponse.data.data);
+    });
+
+    test('should still return an object even if the server returns a falsey value', async () => {
+      const { get } = useFetchClient();
+      get.mockReturnValueOnce({
+        data: {
+          data: null,
+        },
+      });
+
+      const { waitFor, result } = await setup();
+
+      await waitFor(() => !result.current.config.isLoading);
+
+      expect(result.current.config.data).toEqual({});
     });
 
     test('calls toggleNotification in case of error', async () => {

--- a/packages/core/upload/admin/src/hooks/useConfig.js
+++ b/packages/core/upload/admin/src/hooks/useConfig.js
@@ -26,6 +26,10 @@ export const useConfig = () => {
           message: { id: 'notification.error' },
         });
       },
+      /**
+       * We're cementing that we always expect an object to be returned.
+       */
+      select: (data) => (!data ? {} : data),
     }
   );
 


### PR DESCRIPTION

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* always returns an `object` for `data`

### Why is it needed?

* we assume we're always going to get an `object` so we don't do `?` checks

### How to test it?

* automated testing!

### Related issue(s)/PR(s)

* resolves #15751
* resolves CONTENT-1070
