### PR TITLE
Github: Add admin bundle-size PR reporter

### DIFF
--- a/.github/workflows/adminBundleSize.yml
+++ b/.github/workflows/adminBundleSize.yml
@@ -1,0 +1,26 @@
+name: Admin bundle-size
+
+on:
+  pull_request:
+    paths:
+      - '**/admin/src/**.js'
+      - '**/helper-plugin/lib/src/**.js'
+      - '**/translations/**.json'
+      - 'yarn.lock'
+
+jobs:
+  admin_size:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: yarn
+
+      - uses: preactjs/compressed-size-action@v2
+        with:
+          pattern: '**/build/**/*.{js,css,html,svg}'
+          strip-hash: "\\.(?:(\\w{8})\\.chunk)|(?:\\.(\\w{8}))"


### PR DESCRIPTION
### What does it do?

Add a bundle-size action which runs on every PR that touches FE code.

### Why is it needed?

This was added previously twice:

1. https://github.com/strapi/strapi/pull/13785: we had to revert it, because at the time not all webpack chunk ids were stable.
2. https://github.com/strapi/strapi/pull/15770: even after the DS refactoring to Vite there were 4 duplicated chunks, which had their origins in the webpack.alias configuration. With https://github.com/strapi/strapi/pull/15830 these are now gone. 

Let's see 🤞🏼 

### How to test it?

It will run automatically when FE code was changed.

### Related issue(s)/PR(s)

- https://github.com/strapi/strapi/pull/13785
