### PR TITLE
GH: Optimize GH bundle-size report setup

### DIFF
--- a/.github/workflows/adminBundleSize.yml
+++ b/.github/workflows/adminBundleSize.yml
@@ -4,13 +4,22 @@ on:
   pull_request:
     paths:
       - '**/admin/src/**.js'
+      - '**/ee/admin/**.js'
       - '**/helper-plugin/lib/src/**.js'
       - '**/translations/**.json'
+
+      # Might be too broad, but it runs the action even if a
+      # package.json wasn't changed, e.g. for non-pinned dependencies
       - 'yarn.lock'
 
 jobs:
   admin_size:
     runs-on: ubuntu-latest
+
+    # Allows the action to comment on PRs
+    permissions:
+      contents: read
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@v3
@@ -24,3 +33,8 @@ jobs:
         with:
           pattern: '**/build/**/*.{js,css,html,svg}'
           strip-hash: "\\.(?:(\\w{8})\\.chunk)|(?:\\.(\\w{8}))"
+          minimum-change-threshold: 10
+
+          # FIXME: exclude unnamed webpack chunks - remove once webpack
+          # does not create them anymore
+          exclude: '{**/build/**/+([0-9]{,4})*,**/node_modules/**}'


### PR DESCRIPTION
### What does it do?

Optimizes the GH bundle-size reporter:
  - Exclude unnamed chunks for now: we still have 4 chunks with unstable names that will be reported as removed + added on every run; we know where the problem comes from (webpack.alias.js), but not yet how to fix it. I'd like to keep the action because a little insight is better than no insight
  - Fixes comment permissions on PRs

### Why is it needed?

Makes the bundle-size action work properly.

### Related issue(s)/PR(s)

- https://github.com/strapi/strapi/pull/15832
