### PR TITLE
Call process.exit after successful build

### DIFF
--- a/packages/core/strapi/lib/commands/builders/admin.js
+++ b/packages/core/strapi/lib/commands/builders/admin.js
@@ -49,6 +49,7 @@ module.exports = async ({ buildDestDir, forceBuild = true, optimization, srcDir 
     })
     .then(() => {
       console.log('Admin UI built successfully');
+      process.exit(0);
     })
     .catch((err) => {
       console.error(err);


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* calls `process.exit` after a successful admin build

### Why is it needed?

* Users are experiencing node hanging after successful admin panel builds

### Related issue(s)/PR(s)

* resolves #13614
