### PR TITLE
EditAssetDialog: Only send the folderId when saving the cropped asset

### DIFF
--- a/packages/core/upload/admin/src/components/EditAssetDialog/PreviewBox/index.js
+++ b/packages/core/upload/admin/src/components/EditAssetDialog/PreviewBox/index.js
@@ -88,7 +88,7 @@ export const PreviewBox = ({
   }, [isCropImageReady, hasCropIntent, onCropStart, crop]);
 
   const handleCropping = async () => {
-    const nextAsset = { ...asset, width, height };
+    const nextAsset = { ...asset, width, height, folder: asset.folder?.id };
     const file = await produceFile(nextAsset.name, nextAsset.mime, nextAsset.updatedAt);
 
     // Making sure that when persisting the new asset, the URL changes with width and height


### PR DESCRIPTION
### What does it do?

Updates the usage of `useEditAsset` when cropping an asset to only send the folder id.

### Why is it needed?

In https://github.com/strapi/strapi/pull/15771 `useEditAsset` was updated to work with the folder-id instead of the whole folder object.

### How to test it?

1. Upload an image to the ML in a folder
2. Crop this image and save it as duplocate
3. Verify the cropped image has been placed in the same folder

Unfortunately, I don't see a good way to test this automatically.

