### PR TITLE
Add debug command to CLI

### DIFF
--- a/packages/core/strapi/bin/strapi.js
+++ b/packages/core/strapi/bin/strapi.js
@@ -263,9 +263,9 @@ program
 program
   .command('debug')
   .description('Get system stats for debugging and submitting issues')
-  .option('--open', 'Create a new issue with the debug information')
-  .option('--uuid', 'Include Project UUID')
-  .option('--dependencies', 'Include Project Dependencies')
+  .option('-o, --open', 'Create a new issue with the debug information')
+  .option('-u, --uuid', 'Include Project UUID')
+  .option('-d, --dependencies', 'Include Project Dependencies')
   .option('--verbose', 'Include All Information')
   .action(getLocalScript('debug'));
 

--- a/packages/core/strapi/bin/strapi.js
+++ b/packages/core/strapi/bin/strapi.js
@@ -261,6 +261,15 @@ program
   .action(getLocalScript('opt-in-telemetry'));
 
 program
+  .command('debug')
+  .description('Get system stats for debugging and submitting issues')
+  .option('--open', 'Create a new issue with the debug information')
+  .option('--uuid', 'Include Project UUID')
+  .option('--dependencies', 'Include Project Dependencies')
+  .option('--verbose', 'Include All Information')
+  .action(getLocalScript('debug'));
+
+program
   .command('ts:generate-types')
   .description(`Generate TypeScript typings for your schemas`)
   .option(

--- a/packages/core/strapi/lib/commands/debug.js
+++ b/packages/core/strapi/lib/commands/debug.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const openURL = require('open');
+const fetch = require('node-fetch');
+const strapi = require('../index');
+
+module.exports = async function ({ open, uuid, dependencies, verbose }) {
+  if (verbose) {
+    // eslint-disable-next-line no-param-reassign
+    uuid = true;
+    // eslint-disable-next-line no-param-reassign
+    dependencies = true;
+  }
+  const appContext = await strapi.compile();
+  const app = await strapi(appContext).register();
+
+  let debugInfo = `
+Launched In: ${Date.now() - app.config.launchedAt} ms
+Environment: ${app.config.environment}
+OS: ${process.platform}-${process.arch}
+Strapi Version: ${app.config.info.strapi}
+Node/Yarn Version: ${process.env.npm_config_user_agent}
+Edition: ${app.EE ? 'Enterprise' : 'Community'}
+Database: ${app.config.database.connection.client}`;
+  if (uuid) {
+    debugInfo += `\nUUID: ${app.config.uuid}`;
+  }
+  if (dependencies) {
+    debugInfo += `\nDependencies: ${JSON.stringify(app.config.info.dependencies, null, 2)}`;
+  }
+  if (dependencies) {
+    debugInfo += `\nDev Dependencies: ${JSON.stringify(app.config.info.devDependencies, null, 2)}`;
+  }
+  debugInfo += '\n';
+  console.log(debugInfo);
+  if (!open) return app.destroy();
+
+  let githubIssueTemplate = await fetch(
+    'https://raw.githubusercontent.com/strapi/strapi/main/.github/ISSUE_TEMPLATE/BUG_REPORT.md'
+  ).then((res) => res.text());
+
+  githubIssueTemplate = githubIssueTemplate.replace(/---[\s\S]*?---/, '');
+
+  const template = githubIssueTemplate.replace(
+    /### Required System information[\s\S]*?### Describe the bug/g,
+    `### Required System information\n${debugInfo}\n### Describe the bug`
+  );
+  // url encode the template
+  const encodedTemplate = encodeURIComponent(template);
+  const url = `https://github.com/strapi/strapi/issues/new?assignees=&labels=&template=BUG_REPORT.md&body=${encodedTemplate}`;
+
+  openURL(url);
+
+  await app.destroy();
+};


### PR DESCRIPTION
### What does it do?

Add the debug command to the Strapi CLI `yarn strapi debug`

Flags:
```
-o, --open: will open a new GitHub issue with the data debug data already populated in the template
--verbose: logs all possible data
-u, --uuid: includes the project UUID
-d, --dependencies: Includes project dependencies
```

Example output
```
PS C:\Users\iamroot\cli-debug> yarn strapi debug -udo
yarn run v1.22.18
$ strapi debug -udo

Launched In: 725 ms
Environment: development
OS: win32-x64
Strapi Version: 4.6.1
Node/Yarn Version: yarn/1.22.18 npm/? node/v16.14.1 win32 x64
Edition: Community
Database: sqlite
UUID: e7dcf197-4c84-4633-ba92-746bf12fc701
Dependencies: {
  "@strapi/strapi": "4.6.1",
  "@strapi/plugin-users-permissions": "4.6.1",
  "@strapi/plugin-i18n": "4.6.1",
  "better-sqlite3": "8.0.1"
}
Dev Dependencies: {}
```
### Why is it needed?

Too many issues don't have the correct information. This will alow community members and Strapi engineers to easily debug. 

### How to test it?

`yarn strapi debug -udo`
