### PR TITLE
feat(review-workflows): add options in content type builder

### DIFF
--- a/packages/core/admin/ee/server/middlewares/review-workflows.js
+++ b/packages/core/admin/ee/server/middlewares/review-workflows.js
@@ -16,7 +16,7 @@ module.exports = {
  *
  * @param {object} strapi - The Strapi instance.
  */
-const contentTypeMiddleware = (strapi) => {
+function contentTypeMiddleware(strapi) {
   /**
    * A middleware function that moves the `reviewWorkflows` attribute from the top level of
    * the request body to the `options` object within the request body.
@@ -34,4 +34,4 @@ const contentTypeMiddleware = (strapi) => {
     }
     return next();
   });
-};
+}

--- a/packages/core/admin/ee/server/middlewares/review-workflows.js
+++ b/packages/core/admin/ee/server/middlewares/review-workflows.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const { set } = require('lodash/fp');
+
+module.exports = {
+  contentTypeMiddleware,
+};
+
+/**
+ * A Strapi middleware function that adds support for review workflows.
+ *
+ * Why is it needed ?
+ * For now, the admin panel cannot have anything but top-level attributes in the content-type for options.
+ * But we need the CE part to be agnostics from Review Workflow (which is an EE feature).
+ * CE handle the `options` object, that's why we move the reviewWorkflows boolean to the options object.
+ *
+ * @param {object} strapi - The Strapi instance.
+ */
+const contentTypeMiddleware = (strapi) => {
+  /**
+   * A middleware function that moves the `reviewWorkflows` attribute from the top level of
+   * the request body to the `options` object within the request body.
+   *
+   * @param {object} ctx - The Koa context object.
+   */
+  const moveReviewWorkflowOption = (ctx) => {
+    // Move reviewWorkflows to options.reviewWorkflows
+    const { reviewWorkflows, ...contentType } = ctx.request.body.contentType;
+    ctx.request.body.contentType = set('options.reviewWorkflows', reviewWorkflows, contentType);
+  };
+  strapi.server.router.use('/content-type-builder/content-types/:uid?', (ctx, next) => {
+    if (ctx.method === 'PUT' || ctx.method === 'POST') {
+      moveReviewWorkflowOption(ctx);
+    }
+    return next();
+  });
+};

--- a/packages/core/admin/ee/server/register.js
+++ b/packages/core/admin/ee/server/register.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { features } = require('@strapi/strapi/lib/utils/ee');
+const { set } = require('lodash/fp');
 const executeCERegister = require('../../server/register');
 const migrateAuditLogsTable = require('./migrations/audit-logs-table');
 const createAuditLogsService = require('./services/audit-logs');
@@ -12,6 +13,39 @@ module.exports = async ({ strapi }) => {
     strapi.container.register('audit-logs', auditLogsService);
     await auditLogsService.register();
   }
-
+  if (features.isEnabled('review-workflows')) {
+    addReviewWorkflowMiddleware(strapi);
+  }
   await executeCERegister({ strapi });
+};
+
+/**
+ * A Strapi middleware function that adds support for review workflows.
+ *
+ * @param {object} strapi - The Strapi instance.
+ */
+const addReviewWorkflowMiddleware = (strapi) => {
+  /**
+   * A middleware function that moves the `reviewWorkflows` attribute from the top level of
+   * the request body to the `options` object within the request body.
+   *
+   * @param {object} ctx - The Koa context object.
+   */
+  const moveReviewWorkflowOption = (ctx) => {
+    // Move reviewWorkflows to options.reviewWorkflows
+    const { reviewWorkflows, ...contentType } = ctx.request.body.contentType;
+    ctx.request.body.contentType = set('options.reviewWorkflows', reviewWorkflows, contentType);
+  };
+  strapi.server.router.use('/content-type-builder/content-types/:uid', (ctx, next) => {
+    if (ctx.method === 'PUT') {
+      moveReviewWorkflowOption(ctx);
+    }
+    return next();
+  });
+  strapi.server.router.use('/content-type-builder/content-types', (ctx, next) => {
+    if (ctx.method === 'POST') {
+      moveReviewWorkflowOption(ctx);
+    }
+    return next();
+  });
 };

--- a/packages/core/admin/ee/server/register.js
+++ b/packages/core/admin/ee/server/register.js
@@ -36,14 +36,8 @@ const addReviewWorkflowMiddleware = (strapi) => {
     const { reviewWorkflows, ...contentType } = ctx.request.body.contentType;
     ctx.request.body.contentType = set('options.reviewWorkflows', reviewWorkflows, contentType);
   };
-  strapi.server.router.use('/content-type-builder/content-types/:uid', (ctx, next) => {
-    if (ctx.method === 'PUT') {
-      moveReviewWorkflowOption(ctx);
-    }
-    return next();
-  });
-  strapi.server.router.use('/content-type-builder/content-types', (ctx, next) => {
-    if (ctx.method === 'POST') {
+  strapi.server.router.use('/content-type-builder/content-types/:uid?', (ctx, next) => {
+    if (ctx.method === 'PUT' || ctx.method === 'POST') {
       moveReviewWorkflowOption(ctx);
     }
     return next();

--- a/packages/core/content-type-builder/server/controllers/validation/content-type.js
+++ b/packages/core/content-type-builder/server/controllers/validation/content-type.js
@@ -72,7 +72,13 @@ const createContentTypeSchema = (data, { isEdition = false } = {}) => {
 
   return yup
     .object({
-      contentType: contentTypeSchema.required().noUnknown(),
+      // FIXME .noUnknown(false) will strip off the unwanted properties without throwing an error
+      // Why not having .noUnknown() ? Because we want to be able to add options relatable to EE features
+      // without having any reference to them in CE.
+      // Why not handle an "options" object in the content-type ? The admin panel needs lots of rework
+      // to be able to send this options object instead of top-level attributes.
+      // @nathan-pichon 20/02/2023
+      contentType: contentTypeSchema.required().noUnknown(false),
       components: nestedComponentSchema,
     })
     .noUnknown();

--- a/packages/core/content-type-builder/server/controllers/validation/model-schema.js
+++ b/packages/core/content-type-builder/server/controllers/validation/model-schema.js
@@ -13,6 +13,7 @@ const createSchema = (types, relations, { modelType } = {}) => {
   const shape = {
     description: yup.string(),
     draftAndPublish: yup.boolean(),
+    options: yup.object(),
     pluginOptions: yup.object(),
     collectionName: yup.string().nullable().test(isValidCollectionName),
     attributes: createAttributesValidator({ types, relations, modelType }),

--- a/packages/core/content-type-builder/server/services/content-types.js
+++ b/packages/core/content-type-builder/server/services/content-types.js
@@ -35,18 +35,18 @@ const getRestrictRelationsTo = (contentType = {}) => {
  * @param {Object} contentType
  */
 const formatContentType = (contentType) => {
-  const { uid, kind, modelName, plugin, collectionName, info, options } = contentType;
+  const { uid, kind, modelName, plugin, collectionName, info } = contentType;
 
   return {
     uid,
     plugin,
     apiID: modelName,
     schema: {
+      ...contentTypesUtils.getOptions(contentType),
       displayName: info.displayName,
       singularName: info.singularName,
       pluralName: info.pluralName,
       description: _.get(info, 'description', ''),
-      draftAndPublish: contentTypesUtils.hasDraftAndPublish({ options }),
       pluginOptions: contentType.pluginOptions,
       kind: kind || 'collectionType',
       collectionName,

--- a/packages/core/content-type-builder/server/services/schema-builder/content-type-builder.js
+++ b/packages/core/content-type-builder/server/services/schema-builder/content-type-builder.js
@@ -108,7 +108,10 @@ module.exports = function createComponentBuilder() {
           displayName: infos.displayName,
           description: infos.description,
         })
-        .set('options', { draftAndPublish: infos.draftAndPublish || false })
+        .set('options', {
+          ...(infos.options ?? {}),
+          draftAndPublish: infos.draftAndPublish || false,
+        })
         .set('pluginOptions', infos.pluginOptions)
         .set('config', infos.config)
         .setAttributes(this.convertAttributes(infos.attributes));
@@ -227,7 +230,10 @@ module.exports = function createComponentBuilder() {
         .set('kind', infos.kind || contentType.schema.kind)
         .set(['info', 'displayName'], infos.displayName)
         .set(['info', 'description'], infos.description)
-        .set(['options', 'draftAndPublish'], infos.draftAndPublish || false)
+        .set('options', {
+          ...(infos.options ?? {}),
+          draftAndPublish: infos.draftAndPublish || false,
+        })
         .set('pluginOptions', infos.pluginOptions)
         .setAttributes(this.convertAttributes(newAttributes));
 

--- a/packages/core/utils/lib/content-types.js
+++ b/packages/core/utils/lib/content-types.js
@@ -82,6 +82,7 @@ const isVisibleAttribute = (model, attributeName) => {
   return getVisibleAttributes(model).includes(attributeName);
 };
 
+const getOptions = (model) => _.assign({ draftAndPublish: false }, _.get(model, 'options', {}));
 const hasDraftAndPublish = (model) => _.get(model, 'options.draftAndPublish', false) === true;
 
 const isDraft = (data, model) =>
@@ -178,6 +179,7 @@ module.exports = {
   getTimestamps,
   isVisibleAttribute,
   hasDraftAndPublish,
+  getOptions,
   isDraft,
   isSingleType,
   isCollectionType,


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Previously, we were having an "options" object inside the content-type. Still, it was created on content-type creation or update by taking the draftAndPublish attribute (sent at the root level of content-type) and then moving to the options object.
As we do not want CE to be aware of EE features, I had to let the admin panel send top level options attributesthen in BE we move those in the options object. This way, FE avoid a massive refactorization and CE is agnostic from EE features options.

### Why is it needed?

We need to be able to put a new option in content-type called "reviewWorkflows" that is an EE feature, not really a plugin (that's why we didn't store this option under `pluginOptions` object in the content-type.

### How to test it?

Now you can use POST and PUT routes on content-type builder to store a `options` object in the targeted content-type.

E.g.: `PUT http://localhost:1337/content-type-builder/content-types/api::address.address`
```json
{
    "components": [],
    "contentType": {
        "displayName": "Address",
        "singularName": "address",
        "pluralName": "addresses",
        "description": "",
        "draftAndPublish": false,
        "reviewWorkflows": true,
        "pluginOptions": {},
        "kind": "collectionType",
        "collectionName": "addresses",
        "attributes": {
            "postal_code": {
                "type": "string",
                "pluginOptions": {},
                "maxLength": 2
            },
            "categories": {
                "type": "relation",
                "relation": "manyToMany",
                "target": "api::category.category",
                "inversedBy": "addresses",
                "targetAttribute": "addresses",
                "private": false
            },
            "cover": {
                "type": "media",
                "multiple": false,
                "required": false,
                "allowedTypes": [
                    "files",
                    "images",
                    "videos",
                    "audios"
                ],
                "pluginOptions": {}
            },
            "images": {
                "type": "media",
                "multiple": true,
                "required": false,
                "allowedTypes": [
                    "images"
                ],
                "pluginOptions": {}
            },
            "city": {
                "type": "string",
                "required": true,
                "maxLength": 200,
                "pluginOptions": {}
            },
            "json": {
                "type": "json",
                "pluginOptions": {}
            },
            "slug": {
                "type": "uid"
            },
            "notrepeat_req": {
                "type": "component",
                "repeatable": false,
                "pluginOptions": {},
                "component": "blog.test-como",
                "required": true
            },
            "repeat_req": {
                "type": "component",
                "repeatable": true,
                "pluginOptions": {},
                "component": "blog.test-como",
                "required": true
            },
            "repeat_req_min": {
                "type": "component",
                "repeatable": true,
                "pluginOptions": {},
                "component": "blog.test-como",
                "required": false,
                "min": 2
            }
        }
    }
}
```

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
