### PR TITLE
Fix a tiny syntax error in `config/database.ts` of the template

### DIFF
--- a/packages/generators/app/lib/resources/templates/database-templates/ts/database.template
+++ b/packages/generators/app/lib/resources/templates/database-templates/ts/database.template
@@ -1,6 +1,6 @@
 import path from 'path';
 
-export default = ({ env }) => {
+export default ({ env }) => {
   const client = env('DATABASE_CLIENT', 'sqlite');
 
   const connections = {


### PR DESCRIPTION
### What does it do?

As the title says...

### Why is it needed?

`ＥＸＰＲＥＳＳＩＯＮ ＥＸＰＥＣＴＥＤ． ＴＳ（１１０９）`

### How to test it?

#### OK

```ts
export default () => {}
```

[Playground Link](https://www.typescriptlang.org/play?#code/KYDwDg9gTgLgBAE2AMwIYFcA28AUBKOAXgD44BvAXyA)

#### Oops...

```ts
export default = () => {}
```

[Playground Link](https://www.typescriptlang.org/play?#code/KYDwDg9gTgLgBAE2AMwIYFcA28C8cAUAlHDgHxwDeAvkA)

### Related issue(s)/PR(s)

None...