### PR TITLE
chore: remove admin imports from tests

### DIFF
--- a/packages/core/content-type-builder/admin/src/components/ContentTypeBuilderNav/tests/index.test.js
+++ b/packages/core/content-type-builder/admin/src/components/ContentTypeBuilderNav/tests/index.test.js
@@ -4,15 +4,12 @@
  *
  */
 
-import { Layout, lightTheme, darkTheme } from '@strapi/design-system';
+import { Layout, lightTheme, ThemeProvider } from '@strapi/design-system';
+import { IntlProvider } from 'react-intl';
 import { render } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
 import React from 'react';
 import { Router } from 'react-router-dom';
-import LanguageProvider from '@strapi/admin/admin/src/components/LanguageProvider';
-import Theme from '@strapi/admin/admin/src/components/Theme';
-import ThemeToggleProvider from '@strapi/admin/admin/src/components/ThemeToggleProvider';
-import en from '@strapi/admin/admin/src/translations/en.json';
 import ContentTypeBuilderNav from '../index';
 import mockData from './mockData';
 
@@ -26,21 +23,17 @@ jest.mock('../useContentTypeBuilderMenu.js', () => {
 
 const makeApp = () => {
   const history = createMemoryHistory();
-  const messages = { en };
-  const localeNames = { en: 'English' };
 
   return (
-    <LanguageProvider messages={messages} localeNames={localeNames}>
-      <ThemeToggleProvider themes={{ light: lightTheme, dark: darkTheme }}>
-        <Theme>
-          <Router history={history}>
-            <Layout sideNav={<ContentTypeBuilderNav />}>
-              <div />
-            </Layout>
-          </Router>
-        </Theme>
-      </ThemeToggleProvider>
-    </LanguageProvider>
+    <IntlProvider messages={{}} defaultLocale="en" textComponent="span" locale="en">
+      <ThemeProvider theme={lightTheme}>
+        <Router history={history}>
+          <Layout sideNav={<ContentTypeBuilderNav />}>
+            <div />
+          </Layout>
+        </Router>
+      </ThemeProvider>
+    </IntlProvider>
   );
 };
 

--- a/packages/core/content-type-builder/admin/src/pages/ListView/tests/__snapshots__/index.test.js.snap
+++ b/packages/core/content-type-builder/admin/src/pages/ListView/tests/__snapshots__/index.test.js.snap
@@ -1208,7 +1208,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
             <span
               class="c9 c16"
             >
-              Add another field
+              content-type-builder.button.attributes.add.another
             </span>
           </button>
           <button
@@ -1287,7 +1287,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
               <span
                 class="c9 c16"
               >
-                Configure the view
+                content-type-builder.form.button.configure-view
               </span>
             </button>
           </div>
@@ -1373,7 +1373,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                     <span
                       class="c9 c35"
                     >
-                      Text
+                      string
                        
                     </span>
                   </td>
@@ -1629,7 +1629,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                     <span
                       class="c9 c35"
                     >
-                      Media
+                      media
                        
                     </span>
                   </td>
@@ -1756,7 +1756,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                     <span
                       class="c9 c35"
                     >
-                      Media
+                      media
                        
                     </span>
                   </td>
@@ -1881,7 +1881,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                     <span
                       class="c9 c35"
                     >
-                      Text
+                      string
                        
                     </span>
                   </td>
@@ -2008,7 +2008,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                     <span
                       class="c9 c35"
                     >
-                      JSON
+                      json
                        
                     </span>
                   </td>
@@ -2129,7 +2129,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                     <span
                       class="c9 c35"
                     >
-                      UID
+                      uid
                        
                     </span>
                   </td>
@@ -2260,7 +2260,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                     <span
                       class="c9 c35"
                     >
-                      Component
+                      component
                        
                     </span>
                   </td>
@@ -2418,7 +2418,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                 <span
                                   class="c9 c35"
                                 >
-                                  Text
+                                  string
                                    
                                 </span>
                               </td>
@@ -2562,7 +2562,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                 <span
                                   class="c9 c35"
                                 >
-                                  Text
+                                  string
                                    
                                 </span>
                               </td>
@@ -2706,7 +2706,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                 <span
                                   class="c9 c35"
                                 >
-                                  Text
+                                  string
                                    
                                 </span>
                               </td>
@@ -2816,7 +2816,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                             <span
                               class="c9 c48"
                             >
-                              Add another field to this component
+                              Add another field
                             </span>
                           </div>
                         </div>
@@ -2878,7 +2878,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                     <span
                       class="c9 c35"
                     >
-                      Component
+                      component
                        
                     </span>
                   </td>
@@ -3036,7 +3036,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                 <span
                                   class="c9 c35"
                                 >
-                                  Text
+                                  string
                                    
                                 </span>
                               </td>
@@ -3180,7 +3180,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                 <span
                                   class="c9 c35"
                                 >
-                                  Text
+                                  string
                                    
                                 </span>
                               </td>
@@ -3324,7 +3324,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                 <span
                                   class="c9 c35"
                                 >
-                                  Text
+                                  string
                                    
                                 </span>
                               </td>
@@ -3434,7 +3434,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                             <span
                               class="c9 c48"
                             >
-                              Add another field to this component
+                              Add another field
                             </span>
                           </div>
                         </div>
@@ -3490,7 +3490,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                     <span
                       class="c9 c35"
                     >
-                      Dynamic zone
+                      dynamiczone
                        
                     </span>
                   </td>
@@ -3601,7 +3601,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                             <span
                               class="c9 c56"
                             >
-                              Add a component
+                              content-type-builder.button.component.add
                             </span>
                           </div>
                         </button>
@@ -3865,7 +3865,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                             <span
                                               class="c9 c35"
                                             >
-                                              Text
+                                              string
                                                
                                             </span>
                                           </td>
@@ -4009,7 +4009,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                             <span
                                               class="c9 c35"
                                             >
-                                              Email
+                                              email
                                                
                                             </span>
                                           </td>
@@ -4126,7 +4126,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                             <span
                                               class="c9 c35"
                                             >
-                                              Number
+                                              integer
                                                
                                             </span>
                                           </td>
@@ -4236,7 +4236,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                         <span
                                           class="c9 c56"
                                         >
-                                          Add another field to this component
+                                          Add another field
                                         </span>
                                       </div>
                                     </div>
@@ -4334,7 +4334,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                             <span
                                               class="c9 c35"
                                             >
-                                              Text
+                                              string
                                                
                                             </span>
                                           </td>
@@ -4478,7 +4478,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                             <span
                                               class="c9 c35"
                                             >
-                                              Text
+                                              text
                                                
                                             </span>
                                           </td>
@@ -4595,7 +4595,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                             <span
                                               class="c9 c35"
                                             >
-                                              Number
+                                              float
                                                
                                             </span>
                                           </td>
@@ -4741,7 +4741,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                             <span
                                               class="c9 c35"
                                             >
-                                              Media
+                                              media
                                                
                                             </span>
                                           </td>
@@ -4858,7 +4858,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                             <span
                                               class="c9 c35"
                                             >
-                                              Rich text
+                                              richtext
                                                
                                             </span>
                                           </td>
@@ -5116,7 +5116,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                         <span
                                           class="c9 c56"
                                         >
-                                          Add another field to this component
+                                          Add another field
                                         </span>
                                       </div>
                                     </div>
@@ -5214,7 +5214,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                             <span
                                               class="c9 c35"
                                             >
-                                              Text
+                                              string
                                                
                                             </span>
                                           </td>
@@ -5358,7 +5358,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                             <span
                                               class="c9 c35"
                                             >
-                                              Text
+                                              string
                                                
                                             </span>
                                           </td>
@@ -5508,7 +5508,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                             <span
                                               class="c9 c35"
                                             >
-                                              Component
+                                              component
                                                
                                               (repeatable)
                                             </span>
@@ -5667,7 +5667,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                         <span
                                                           class="c9 c35"
                                                         >
-                                                          Text
+                                                          string
                                                            
                                                         </span>
                                                       </td>
@@ -5811,7 +5811,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                         <span
                                                           class="c9 c35"
                                                         >
-                                                          Text
+                                                          text
                                                            
                                                         </span>
                                                       </td>
@@ -5928,7 +5928,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                         <span
                                                           class="c9 c35"
                                                         >
-                                                          Number
+                                                          float
                                                            
                                                         </span>
                                                       </td>
@@ -6074,7 +6074,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                         <span
                                                           class="c9 c35"
                                                         >
-                                                          Media
+                                                          media
                                                            
                                                         </span>
                                                       </td>
@@ -6191,7 +6191,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                         <span
                                                           class="c9 c35"
                                                         >
-                                                          Rich text
+                                                          richtext
                                                            
                                                         </span>
                                                       </td>
@@ -6449,7 +6449,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                     <span
                                                       class="c9 c48"
                                                     >
-                                                      Add another field to this component
+                                                      Add another field
                                                     </span>
                                                   </div>
                                                 </div>
@@ -6490,7 +6490,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                         <span
                                           class="c9 c56"
                                         >
-                                          Add another field to this component
+                                          Add another field
                                         </span>
                                       </div>
                                     </div>
@@ -6588,7 +6588,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                             <span
                                               class="c9 c35"
                                             >
-                                              Text
+                                              string
                                                
                                             </span>
                                           </td>
@@ -6734,7 +6734,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                             <span
                                               class="c9 c35"
                                             >
-                                              Media
+                                              media
                                                
                                             </span>
                                           </td>
@@ -6878,7 +6878,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                             <span
                                               class="c9 c35"
                                             >
-                                              Boolean
+                                              boolean
                                                
                                             </span>
                                           </td>
@@ -6988,7 +6988,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                         <span
                                           class="c9 c56"
                                         >
-                                          Add another field to this component
+                                          Add another field
                                         </span>
                                       </div>
                                     </div>
@@ -7038,7 +7038,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                   <span
                     class="c9 c56"
                   >
-                    Add another field to this collection type
+                    Add another field
                   </span>
                 </div>
               </div>

--- a/packages/core/content-type-builder/admin/src/pages/ListView/tests/index.test.js
+++ b/packages/core/content-type-builder/admin/src/pages/ListView/tests/index.test.js
@@ -8,11 +8,8 @@ import { render } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
 import React from 'react';
 import { Router } from 'react-router-dom';
-import { lightTheme, darkTheme } from '@strapi/design-system';
-import LanguageProvider from '@strapi/admin/admin/src/components/LanguageProvider';
-import Theme from '@strapi/admin/admin/src/components/Theme';
-import ThemeToggleProvider from '@strapi/admin/admin/src/components/ThemeToggleProvider';
-import en from '@strapi/admin/admin/src/translations/en.json';
+import { ThemeProvider, lightTheme } from '@strapi/design-system';
+import { IntlProvider } from 'react-intl';
 import FormModalNavigationProvider from '../../../components/FormModalNavigationProvider';
 import pluginEn from '../../../translations/en.json';
 import getTrad from '../../../utils/getTrad';
@@ -41,30 +38,23 @@ jest.mock('@strapi/helper-plugin', () => ({
 const makeApp = () => {
   const history = createMemoryHistory();
   const messages = {
-    en: Object.keys(pluginEn).reduce(
-      (acc, current) => {
-        acc[getTrad(current)] = pluginEn[current];
+    en: Object.keys(pluginEn).reduce((acc, current) => {
+      acc[getTrad(current)] = pluginEn[current];
 
-        return acc;
-      },
-      { ...en }
-    ),
+      return acc;
+    }, {}),
   };
 
-  const localeNames = { en: 'English' };
-
   return (
-    <LanguageProvider messages={messages} localeNames={localeNames}>
-      <ThemeToggleProvider themes={{ light: lightTheme, dark: darkTheme }}>
-        <Theme>
-          <Router history={history}>
-            <FormModalNavigationProvider>
-              <ListView />
-            </FormModalNavigationProvider>
-          </Router>
-        </Theme>
-      </ThemeToggleProvider>
-    </LanguageProvider>
+    <IntlProvider messages={messages} defaultLocale="en" textComponent="span" locale="en">
+      <ThemeProvider theme={lightTheme}>
+        <Router history={history}>
+          <FormModalNavigationProvider>
+            <ListView />
+          </FormModalNavigationProvider>
+        </Router>
+      </ThemeProvider>
+    </IntlProvider>
   );
 };
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* removes admin imports from CTB tests

### Why is it needed?

* Technically it would mean `@strapi/admin` has to be installed in the CTB plugin – typically a weird thing to do at the moment and even weirder for tests

### How to test it?

* Automated tests were updated, note that the strings were changed because it didn't have the default admin translations anymore (doesn't matter too much imo)

### Related issue(s)/PR(s)

* relates to #15848 
* relates to #15855 
