### PR TITLE
Chore: Remove whatwg-fetch polyfill

### DIFF
--- a/jest.base-config.front.js
+++ b/jest.base-config.front.js
@@ -43,6 +43,7 @@ module.exports = {
   globalSetup: '<rootDir>/test/config/front/global-setup.js',
   setupFiles: [
     '<rootDir>/packages/admin-test-utils/lib/setup/test-bundler.js',
+    '<rootDir>/packages/admin-test-utils/lib/mocks/fetch.js',
     '<rootDir>/packages/admin-test-utils/lib/mocks/LocalStorageMock.js',
     '<rootDir>/packages/admin-test-utils/lib/mocks/IntersectionObserver.js',
     '<rootDir>/packages/admin-test-utils/lib/mocks/ResizeObserver.js',

--- a/packages/admin-test-utils/lib/mocks/fetch.js
+++ b/packages/admin-test-utils/lib/mocks/fetch.js
@@ -1,0 +1,4 @@
+'use strict';
+
+// Required as long as we are running tests on node@14 and node@16
+require('whatwg-fetch');

--- a/packages/admin-test-utils/package.json
+++ b/packages/admin-test-utils/package.json
@@ -24,7 +24,8 @@
     "react-dom": "^17.0.2",
     "react-is": "^17.0.2",
     "redux": "^4.2.1",
-    "styled-components": "5.3.3"
+    "styled-components": "5.3.3",
+    "whatwg-fetch": "3.6.2"
   },
   "peerDependencies": {
     "redux": "^4.2.1"

--- a/packages/core/admin/webpack.alias.js
+++ b/packages/core/admin/webpack.alias.js
@@ -32,7 +32,6 @@ const aliasExactMatch = [
   'redux',
   'reselect',
   'styled-components',
-  'whatwg-fetch',
   'yup',
 ];
 

--- a/packages/core/helper-plugin/lib/src/utils/request/index.js
+++ b/packages/core/helper-plugin/lib/src/utils/request/index.js
@@ -1,4 +1,3 @@
-import 'whatwg-fetch';
 import startsWith from 'lodash/startsWith';
 import auth from '../auth';
 

--- a/packages/core/helper-plugin/package.json
+++ b/packages/core/helper-plugin/package.json
@@ -51,8 +51,7 @@
     "qs": "6.11.0",
     "react-helmet": "^6.1.0",
     "react-intl": "6.2.8",
-    "react-select": "5.6.0",
-    "whatwg-fetch": "^3.6.2"
+    "react-select": "5.6.0"
   },
   "devDependencies": {
     "@storybook/addon-actions": "6.5.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -22579,11 +22579,6 @@ whatwg-encoding@^2.0.0:
   dependencies:
     iconv-lite "0.6.3"
 
-whatwg-fetch@^3.6.2:
-  version "3.6.2"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz#dced24f37f2624ed0281725d51d0e2e3fe677f8c"
-  integrity sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==
-
 whatwg-mimetype@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz#5fa1a7623867ff1af6ca3dc72ad6b8a4208beba7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -22579,6 +22579,11 @@ whatwg-encoding@^2.0.0:
   dependencies:
     iconv-lite "0.6.3"
 
+whatwg-fetch@3.6.2:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz#dced24f37f2624ed0281725d51d0e2e3fe677f8c"
+  integrity sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==
+
 whatwg-mimetype@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz#5fa1a7623867ff1af6ca3dc72ad6b8a4208beba7"


### PR DESCRIPTION
### What does it do?

Drops `whatwg-fetch` dependency.

### Why is it needed?

`fetch` is supported by all browsers we support according to our https://github.com/strapi/strapi/blob/main/packages/core/admin/.browserslistrc configuration.

https://caniuse.com/fetch

### Related issue(s)/PR(s)

- https://github.com/strapi/strapi/pull/15855
