### PR TITLE
Chore: Remove usage of lodash chain from admin/src

### DIFF
--- a/packages/core/admin/admin/src/content-manager/pages/App/utils/generateModelsLinks.js
+++ b/packages/core/admin/admin/src/content-manager/pages/App/utils/generateModelsLinks.js
@@ -1,4 +1,5 @@
-import { chain, get } from 'lodash';
+import groupBy from 'lodash/groupBy';
+import sortBy from 'lodash/sortBy';
 import { stringify } from 'qs';
 
 const generateLinks = (links, type, configurations = []) => {
@@ -44,19 +45,19 @@ const generateLinks = (links, type, configurations = []) => {
 };
 
 const generateModelsLinks = (models, modelsConfigurations) => {
-  const [collectionTypes, singleTypes] = chain(models)
-    .groupBy('kind')
-    .map((value, key) => ({ name: key, links: value }))
-    .sortBy('name')
-    .value();
+  const groupedModels = Object.entries(groupBy(models, 'kind')).map(([key, value]) => ({
+    name: key,
+    links: value,
+  }));
+  const [collectionTypes, singleTypes] = sortBy(groupedModels, 'name');
 
   return {
     collectionTypesSectionLinks: generateLinks(
-      get(collectionTypes, 'links', []),
+      collectionTypes?.links || [],
       'collectionTypes',
       modelsConfigurations
     ),
-    singleTypesSectionLinks: generateLinks(get(singleTypes, 'links', []), 'singleTypes'),
+    singleTypesSectionLinks: generateLinks(singleTypes?.links ?? [], 'singleTypes'),
   };
 };
 

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/Permissions/utils/formatLayoutForSettingsAndPlugins.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/Permissions/utils/formatLayoutForSettingsAndPlugins.js
@@ -1,23 +1,19 @@
-import { chain } from 'lodash';
+import groupBy from 'lodash/groupBy';
 
 const replaceName = (name) => name.split(' ').join('-');
 
 const formatLayout = (layout, groupByKey) => {
-  return chain(layout)
-    .groupBy(groupByKey)
-    .map((item, itemName) => ({
-      category: itemName,
-      categoryId: replaceName(itemName),
-      childrenForm: chain(item)
-        .groupBy('subCategory')
-        .map((actions, subCategoryName) => ({
-          subCategoryName,
-          subCategoryId: replaceName(subCategoryName),
-          actions,
-        }))
-        .value(),
-    }))
-    .value();
+  return Object.entries(groupBy(layout, groupByKey)).map(([itemName, item]) => ({
+    category: itemName,
+    categoryId: replaceName(itemName),
+    childrenForm: Object.entries(groupBy(item, 'subCategory')).map(
+      ([subCategoryName, actions]) => ({
+        subCategoryName,
+        subCategoryId: replaceName(subCategoryName),
+        actions,
+      })
+    ),
+  }));
 };
 
 export default formatLayout;


### PR DESCRIPTION
### What does it do?

Remove the usage of lodash.chain from the admin FE app.

### Why is it needed?

It is not possible to correctly tree-shake `chain` and once we move all lodash imports to use the optimized deep-imports these two places are not as easy as the others. I didn't want to bury this refactoring in another (bigger) PR.

Luckily both methods have tests that were very helpful.
