### PR TITLE
[Private S3]: Use traverse entity method for signing file

### DIFF
--- a/packages/core/upload/server/controllers/admin-upload.js
+++ b/packages/core/upload/server/controllers/admin-upload.js
@@ -51,7 +51,10 @@ module.exports = {
     const data = await validateUploadBody(body);
     const replacedFiles = await uploadService.replace(id, { data, file: files }, { user });
 
-    ctx.body = await pm.sanitizeOutput(replacedFiles, { action: ACTIONS.read });
+    // Sign file urls for private providers
+    const signedFiles = await getService('file').signFileUrls(replacedFiles);
+
+    ctx.body = await pm.sanitizeOutput(signedFiles, { action: ACTIONS.read });
   },
 
   async uploadFiles(ctx) {

--- a/packages/core/upload/server/services/extensions/content-manager/entity-manager.js
+++ b/packages/core/upload/server/services/extensions/content-manager/entity-manager.js
@@ -9,7 +9,7 @@ const { getService } = require('../../../utils');
  * @param {string} schema.key - The key of the attribute
  * @param {string} schema.value - The value of the attribute
  * @param {Object} schema.attribute - The attribute definition
- * @param {Object} entry - The context
+ * @param {Object} entry
  * @param {Function} entry.set - The set function to update the value
  */
 const signEntityMediaVisitor = async ({ key, value, attribute }, { set }) => {

--- a/packages/core/upload/server/services/extensions/content-manager/entity-manager.js
+++ b/packages/core/upload/server/services/extensions/content-manager/entity-manager.js
@@ -1,30 +1,23 @@
 'use strict';
 
-const { mapAsync } = require('@strapi/utils');
+const { traverseEntity } = require('@strapi/utils');
 const { getService } = require('../../../utils');
 
-const getSignedAttribute = (attributeName, entity, model) => {
+/**
+ * Visitor function to sign media URLs
+ * @param {Object} schema
+ * @param {string} schema.key - The key of the attribute
+ * @param {string} schema.value - The value of the attribute
+ * @param {Object} schema.attribute - The attribute definition
+ * @param {Object} entry - The context
+ * @param {Function} entry.set - The set function to update the value
+ */
+const signEntityMediaVisitor = async ({ key, value, attribute }, { set }) => {
   const { signFileUrls } = getService('file');
 
-  if (!entity) return entity;
-
-  const attribute = model.attributes[attributeName];
-
-  switch (attribute?.type) {
-    case 'media':
-      if (attribute.multiple) {
-        return mapAsync(entity, signFileUrls);
-      }
-      return signFileUrls(entity);
-    case 'component':
-      if (attribute.repeatable) {
-        return mapAsync(entity, (component) => signEntityMedia(component, attribute.component));
-      }
-      return signEntityMedia(entity, attribute.component);
-    case 'dynamiczone':
-      return mapAsync(entity, (component) => signEntityMedia(component, component.__component));
-    default:
-      return entity;
+  if (value && attribute.type === 'media') {
+    const signedFile = await signFileUrls(value);
+    set(key, signedFile);
   }
 };
 
@@ -34,27 +27,13 @@ const getSignedAttribute = (attributeName, entity, model) => {
  * Check which modelAttributes are media and pre sign the image URLs
  * if they are from the current upload provider
  *
- * TODO: Use traverse entity for strapi utils?
- *
  * @param {Object} entity
  * @param {Object} modelAttributes
  * @returns
  */
 const signEntityMedia = async (entity, uid) => {
   const model = strapi.getModel(uid);
-
-  const signedEntity = {};
-
-  // TODO: Use asyncReduce
-  for (const attributeName of Object.keys(entity)) {
-    signedEntity[attributeName] = await getSignedAttribute(
-      attributeName,
-      entity[attributeName],
-      model
-    );
-  }
-
-  return signedEntity;
+  return traverseEntity(signEntityMediaVisitor, { schema: model }, entity);
 };
 
 const addSignedFileUrlsToAdmin = async () => {


### PR DESCRIPTION
### What does it do?
Use the traverse entity util instead of reimplementing the logic to map through all the entity recursively.

### Why is it needed?

Simplify code.
