### PR TITLE
Migrate helper plugin docs to contributor docs

### DIFF
--- a/docs/docs/core/helper-plugin/components/injection-zone.mdx
+++ b/docs/docs/core/helper-plugin/components/injection-zone.mdx
@@ -1,15 +1,19 @@
-import { Meta } from '@storybook/addon-docs';
-
-<Meta title="components/InjectionZone" />
-
-# InjectionZone
+---
+title: InjectionZone
+description: Define an injection zone that other plugins can use to add components in a dedicated area.
+tags:
+  - helper-plugin
+---
 
 This component is used in order to define an injection zone that other plugins can use to add components in a dedicated area.
 
 ## Usage
 
-```
-// Use the injection zone in a view
+### Creating an injection zone
+
+Use the injection zone in a view:
+
+```jsx
 import { InjectionZone } from '@strapi/helper-plugin';
 
 const HomePage = () => {
@@ -20,25 +24,31 @@ const HomePage = () => {
     <InjectionZone area="my-plugin.homePage.right" />
   );
 };
+```
 
+Define this injection zone:
 
-// Define this injection zone
+```js
 // path: 'my-plugin/admin/src/index.js
-
 export default {
   register() {
     app.registerPlugin({
       // ...
       injectionZones: {
         homepage: {
-          right: []
-        }
-      }
+          right: [],
+        },
+      },
     });
   },
-}
+};
+```
 
-// Inject from a plugin
+### Injecting a component
+
+From another plugin, inject a component in the injection zone:
+
+```js
 // path: 'my-other-plugin/admin/src/index.js'
 export default {
   register() {
@@ -49,6 +59,10 @@ export default {
       name: 'my-other-plugin-component',
       Component: () => 'This component is injected',
     });
-  }
+  },
 };
 ```
+
+## Examples
+
+The [Content Manager](/content-manager) creates injection zones that all plugins can use. [They are documented](https://docs.strapi.io/developer-docs/latest/developer-resources/plugin-api-reference/admin-panel.html#injection-zones-api) on the Strapi documentation website.

--- a/docs/docs/core/helper-plugin/components/storybook.mdx
+++ b/docs/docs/core/helper-plugin/components/storybook.mdx
@@ -1,0 +1,15 @@
+---
+title: Helper plugin components
+description: Explore the helper plugin React components using Storybook
+tags:
+  - helper-plugin
+hide_table_of_contents: true
+hide_title: true
+---
+
+<iframe
+  src="https://helper-plugin-storybook.vercel.app/"
+  width="100%"
+  height="650px"
+  seamless
+></iframe>

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -99,6 +99,11 @@ const sidebars = {
                   label: 'Storybook',
                   id: 'core/helper-plugin/components/storybook',
                 },
+                {
+                  type: 'doc',
+                  label: 'InjectionZone',
+                  id: 'core/helper-plugin/components/injection-zone',
+                },
               ],
             },
             {

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -92,6 +92,17 @@ const sidebars = {
           items: [
             {
               type: 'category',
+              label: 'Components',
+              items: [
+                {
+                  type: 'doc',
+                  label: 'Storybook',
+                  id: 'core/helper-plugin/components/storybook',
+                },
+              ],
+            },
+            {
+              type: 'category',
               label: 'Hooks',
               items: [
                 {
@@ -99,7 +110,6 @@ const sidebars = {
                   label: 'useFetchClient',
                   id: 'core/helper-plugin/hooks/use-fetch-client',
                 },
-
                 {
                   type: 'doc',
                   label: 'useAPIErrorHandler',


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

- [x] Embeds the helper plugin Storybook in the contributor docs
- [ ] Migrates all the helper plugin's non-react-component documentation to the contributor docs

### Why is it needed?

- We started having the helper plugin hooks documented in 2 places
- To have 1 central place for all contributor documentation
- To increase the helper plugin Storybook's discoverability

### How to test it?

Run contributor docs locally and open [localhost:3000/core/helper-plugin/components/storybook](http://localhost:3000/core/helper-plugin/components/storybook)
