### PR TITLE
[Data Transfer] Show the progress of the transfer

### DIFF
--- a/packages/core/data-transfer/src/engine/index.ts
+++ b/packages/core/data-transfer/src/engine/index.ts
@@ -202,7 +202,7 @@ class TransferEngine<
     }
   ) {
     if (!this.progress.data[stage]) {
-      this.progress.data[stage] = { count: 0, bytes: 0 };
+      this.progress.data[stage] = { count: 0, bytes: 0, startTime: Date.now() };
     }
 
     const stageProgress = this.progress.data[stage];
@@ -251,7 +251,8 @@ class TransferEngine<
       transform: (data, _encoding, callback) => {
         this.#updateTransferProgress(stage, data, aggregate);
         this.#emitStageUpdate('progress', stage);
-        callback(null, data);
+        // callback(null, data);
+        setTimeout(() => callback(null, data), 150);
       },
     });
   }
@@ -437,6 +438,14 @@ class TransferEngine<
   }) {
     const { stage, source, destination, transform, tracker } = options;
 
+    const updateEndTime = () => {
+      const stageData = this.progress.data[stage];
+
+      if (stageData) {
+        stageData.endTime = Date.now();
+      }
+    };
+
     if (!source || !destination || this.shouldSkipStage(stage)) {
       // Wait until source and destination are closed
       const results = await Promise.allSettled(
@@ -480,11 +489,15 @@ class TransferEngine<
       stream
         .pipe(destination)
         .on('error', (e) => {
+          updateEndTime();
           this.#reportError(e, 'error');
           destination.destroy(e);
           reject(e);
         })
-        .on('close', resolve);
+        .on('close', () => {
+          updateEndTime();
+          resolve();
+        });
     });
 
     this.#emitStageUpdate('finish', stage);

--- a/packages/core/data-transfer/src/engine/index.ts
+++ b/packages/core/data-transfer/src/engine/index.ts
@@ -251,8 +251,7 @@ class TransferEngine<
       transform: (data, _encoding, callback) => {
         this.#updateTransferProgress(stage, data, aggregate);
         this.#emitStageUpdate('progress', stage);
-        // callback(null, data);
-        setTimeout(() => callback(null, data), 150);
+        callback(null, data);
       },
     });
   }

--- a/packages/core/data-transfer/src/strapi/providers/remote-destination/index.ts
+++ b/packages/core/data-transfer/src/strapi/providers/remote-destination/index.ts
@@ -54,22 +54,26 @@ class RemoteStrapiDestinationProvider implements IDestinationProvider {
     return new Promise<string>((resolve, reject) => {
       this.ws
         ?.once('open', async () => {
-          const query = this.dispatcher?.dispatchCommand({
-            command: 'init',
-            params: { options: { strategy, restore }, transfer: 'push' },
-          });
+          try {
+            const query = this.dispatcher?.dispatchCommand({
+              command: 'init',
+              params: { options: { strategy, restore }, transfer: 'push' },
+            });
 
-          const res = (await query) as server.Payload<server.InitMessage>;
+            const res = (await query) as server.Payload<server.InitMessage>;
 
-          if (!res?.transferID) {
-            return reject(
-              new ProviderTransferError('Init failed, invalid response from the server')
-            );
+            if (!res?.transferID) {
+              throw new ProviderTransferError('Init failed, invalid response from the server');
+            }
+
+            resolve(res.transferID);
+          } catch (e: unknown) {
+            reject(e);
           }
-
-          resolve(res.transferID);
         })
-        .once('error', reject);
+        .once('error', (message) => {
+          reject(message);
+        });
     });
   }
 

--- a/packages/core/data-transfer/src/strapi/providers/remote-destination/utils.ts
+++ b/packages/core/data-transfer/src/strapi/providers/remote-destination/utils.ts
@@ -56,7 +56,6 @@ const createDispatcher = (ws: WebSocket) => {
         }
       };
 
-      // TODO: What happens if the server sends another message (not a response to this message)
       ws.once('message', onResponse);
     });
   };

--- a/packages/core/data-transfer/src/strapi/remote/handlers.ts
+++ b/packages/core/data-transfer/src/strapi/remote/handlers.ts
@@ -13,7 +13,7 @@ import { ProviderTransferError, ProviderInitializationError } from '../../errors
 import { TRANSFER_METHODS } from './constants';
 import { createFlow, DEFAULT_TRANSFER_FLOW } from './flows';
 
-type TransferMethod = typeof TRANSFER_METHODS[number];
+type TransferMethod = (typeof TRANSFER_METHODS)[number];
 
 interface ITransferState {
   transfer?: {

--- a/packages/core/data-transfer/types/utils.d.ts
+++ b/packages/core/data-transfer/types/utils.d.ts
@@ -64,6 +64,8 @@ export type TransferProgress = {
   [key in TransferStage]?: {
     count: number;
     bytes: number;
+    startTime: number;
+    endTime?: number;
     aggregates?: {
       [key: string]: {
         count: number;

--- a/packages/core/strapi/lib/commands/__tests__/data-transfer/export.test.js
+++ b/packages/core/strapi/lib/commands/__tests__/data-transfer/export.test.js
@@ -56,6 +56,7 @@ describe('Export', () => {
 
   // mock utils
   const mockUtils = {
+    loadersFactory: jest.fn().mockReturnValue({ updateLoader: jest.fn() }),
     formatDiagnostic: jest.fn(),
     createStrapiInstance() {
       return {

--- a/packages/core/strapi/lib/commands/__tests__/data-transfer/import.test.js
+++ b/packages/core/strapi/lib/commands/__tests__/data-transfer/import.test.js
@@ -61,6 +61,7 @@ describe('Import', () => {
 
   // mock utils
   const mockUtils = {
+    loadersFactory: jest.fn().mockReturnValue({ updateLoader: jest.fn() }),
     formatDiagnostic: jest.fn(),
     createStrapiInstance: jest.fn().mockReturnValue({
       telemetry: {

--- a/packages/core/strapi/lib/commands/__tests__/data-transfer/transfer.test.js
+++ b/packages/core/strapi/lib/commands/__tests__/data-transfer/transfer.test.js
@@ -5,6 +5,7 @@ const { expectExit } = require('./shared/transfer.test.utils');
 describe('Transfer', () => {
   // mock utils
   const mockUtils = {
+    loadersFactory: jest.fn().mockReturnValue({ updateLoader: jest.fn() }),
     formatDiagnostic: jest.fn(),
     createStrapiInstance() {
       return {

--- a/packages/core/strapi/lib/commands/transfer/export.js
+++ b/packages/core/strapi/lib/commands/transfer/export.js
@@ -10,7 +10,6 @@ const { createTransferEngine } = require('@strapi/data-transfer/lib/engine');
 const { isObject, isString, isFinite, toNumber } = require('lodash/fp');
 const fs = require('fs-extra');
 const chalk = require('chalk');
-const ora = require('ora');
 
 const { TransferEngineTransferError } = require('@strapi/data-transfer/lib/engine/errors');
 const {
@@ -19,8 +18,9 @@ const {
   DEFAULT_IGNORED_CONTENT_TYPES,
   createStrapiInstance,
   formatDiagnostic,
+  loadersFactory,
 } = require('./utils');
-const { readableBytes, exitWith } = require('../utils/helpers');
+const { exitWith } = require('../utils/helpers');
 /**
  * @typedef ExportCommandOptions Options given to the CLI import command
  *
@@ -80,34 +80,14 @@ module.exports = async (opts) => {
 
   const progress = engine.progress.stream;
 
-  const loaders = {};
-
-  const updateLoader = (stage, data) => {
-    if (stage in loaders) {
-      const stageData = data[stage];
-
-      const amount = `amount: ${stageData?.count ?? 0}`;
-      const bytes = `size: ${readableBytes(stageData?.bytes ?? 0)}`;
-      const elapsed = `elapsed: ${stageData?.elapsed ?? 0} ms`;
-      const speed = `${
-        stageData?.endTime
-          ? readableBytes(((stageData?.bytes ?? 0) * 1000) / stageData.elapsed)
-          : '0 B'
-      }/s`;
-
-      loaders[stage].text = `${stage} (${amount}) (${bytes}) (${elapsed}) (${speed})`;
-    }
-  };
+  const { updateLoader } = loadersFactory();
 
   progress.on(`stage::start`, ({ stage, data }) => {
-    Object.assign(loaders, { [stage]: ora() });
-    updateLoader(stage, data);
-    loaders[stage].start();
+    updateLoader(stage, data).start();
   });
 
   progress.on('stage::finish', ({ stage, data }) => {
-    updateLoader(stage, data);
-    loaders[stage]?.succeed();
+    updateLoader(stage, data).succeed();
   });
 
   progress.on('stage::progress', ({ stage, data }) => {

--- a/packages/core/strapi/lib/commands/transfer/transfer.js
+++ b/packages/core/strapi/lib/commands/transfer/transfer.js
@@ -16,6 +16,7 @@ const {
   createStrapiInstance,
   DEFAULT_IGNORED_CONTENT_TYPES,
   formatDiagnostic,
+  loadersFactory,
 } = require('./utils');
 const { exitWith } = require('../utils/helpers');
 
@@ -115,6 +116,22 @@ module.exports = async (opts) => {
   });
 
   engine.diagnostics.onDiagnostic(formatDiagnostic('transfer'));
+
+  const progress = engine.progress.stream;
+
+  const { updateLoader } = loadersFactory();
+
+  progress.on(`stage::start`, ({ stage, data }) => {
+    updateLoader(stage, data).start();
+  });
+
+  progress.on('stage::finish', ({ stage, data }) => {
+    updateLoader(stage, data).succeed();
+  });
+
+  progress.on('stage::progress', ({ stage, data }) => {
+    updateLoader(stage, data);
+  });
 
   let results;
   try {


### PR DESCRIPTION
### What does it do?

It shows the progress of the transfer, import, and export commands to know at which stage and how advanced it is of the data transfer. 

### Why is it needed?
To be conscious of the stage of the data transfer.

### How to test it?
Run the following commands: 
`yarn strapi import -f <name-of-an-archive.tar>`
`yarn strapi transfer --to <strapi-url> --to-token <transfer-token>`
`yarn strapi export -f export --no-encrypt --no-compress`
And watch how the progress is being shown like in this loom video:
https://www.loom.com/share/0b5b451dde64462a97b595e1403e45fe
### Related issue(s)/PR(s)

