### PR TITLE
Fix the relative path for sqlite database in the default database connection

### DIFF
--- a/packages/generators/app/lib/resources/templates/database-templates/ts/database.template
+++ b/packages/generators/app/lib/resources/templates/database-templates/ts/database.template
@@ -54,6 +54,7 @@ export default ({ env }) => {
         filename: path.join(
           __dirname,
           '..',
+          '..',
           env('DATABASE_FILENAME', 'data.db')
         ),
       },


### PR DESCRIPTION
### What does it do?

In typescript project, we need to go up two directories (relative path) in order to create the database file (otherwise it'll end up in the dist directory and will be deleted on every TS compilation)


### How to test it?

- Creates a typescript project
- Start the server and create a content type, wait for the server to restart
- Your data (entities, admin user) should still be there (the database file too)

### Related issue(s)/PR(s)
#15732