### PR TITLE
refactor(content-manager): entity manager support single types

### DIFF
--- a/packages/core/content-manager/server/services/entity-manager.js
+++ b/packages/core/content-manager/server/services/entity-manager.js
@@ -88,7 +88,13 @@ module.exports = ({ strapi }) => ({
 
     const entities = await strapi.entityService.findMany(uid, params);
 
-    const mappedResults = await mapAsync(entities.results, (entity) => this.mapEntity(entity, uid));
+    if (!entities) {
+      return entities;
+    }
+
+    const mappedResults = await mapAsync(entities.results || [entities], (entity) =>
+      this.mapEntity(entity, uid)
+    );
     return { ...entities, results: mappedResults };
   },
 
@@ -97,7 +103,13 @@ module.exports = ({ strapi }) => ({
 
     const entities = await strapi.entityService.findPage(uid, params);
 
-    const mappedResults = await mapAsync(entities.results, (entity) => this.mapEntity(entity, uid));
+    if (!entities) {
+      return entities;
+    }
+
+    const mappedResults = await mapAsync(entities.results || [entities], (entity) =>
+      this.mapEntity(entity, uid)
+    );
     return { ...entities, results: mappedResults };
   },
 
@@ -107,7 +119,13 @@ module.exports = ({ strapi }) => ({
 
     const entities = await strapi.entityService.findWithRelationCountsPage(uid, params);
 
-    const mappedResults = await mapAsync(entities.results, (entity) => this.mapEntity(entity, uid));
+    if (!entities) {
+      return entities;
+    }
+
+    const mappedResults = await mapAsync(entities.results || [entities], (entity) =>
+      this.mapEntity(entity, uid)
+    );
     return { ...entities, results: mappedResults };
   },
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Refactor some entity manager functions

### Why is it needed?

 - Entity manager functions may not always find entities, in which case we should return `undefined` as before this POC
 - entities.results is not always an array (in the case of single types) and therefore we should support this format too

