### PR TITLE
[Relations]: solve swapping entity ids without unmounting components

### DIFF
--- a/docs/docs/core/content-manager/relations.mdx
+++ b/docs/docs/core/content-manager/relations.mdx
@@ -147,7 +147,7 @@ The input field for relation fields consist of two components:
 
 ### `RelationInputDataManager`
 
-This container component handles data fetching and data normalization for the `RelationInput` component. This has been extracted from 
+This container component handles data fetching and data normalization for the `RelationInput` component. This has been extracted from
 the `RelationInput` so that Strapi is able to move the underlying component into the design-system if the community would need it
 (most other input components can be consumed from there).
 
@@ -163,7 +163,7 @@ would otherwise have a negative impact on the overall performance of the content
 This hook takes care of data-fetching and normalizes results relations aswell as search-results.
 
 ```ts
-const { relations: RelationResults, search: RelationResults, searchFor } = useRelation(reactQueryCacheKey: string, options: Options);
+const { relations: RelationResults, search: RelationResults, searchFor } = useRelation(reactQueryCacheKey: Array<string | object>, options: Options);
 ```
 
 ### `Options`
@@ -205,10 +205,10 @@ type RelationResults = RelationResult[];
 
 type RelationResult = {
   id: number;
-  href?: string;  // based on `shouldAddLink` and the `targetModel`
+  href?: string; // based on `shouldAddLink` and the `targetModel`
   publicationState: 'draft' | 'published';
-  mainField: string;  // will fallback to "id" if not set
-}
+  mainField: string; // will fallback to "id" if not set
+};
 ```
 
 #### `relations`

--- a/examples/getstarted/src/api/category/content-types/category/schema.json
+++ b/examples/getstarted/src/api/category/content-types/category/schema.json
@@ -53,6 +53,12 @@
         }
       },
       "type": "date"
+    },
+    "relation_locales": {
+      "type": "relation",
+      "relation": "manyToMany",
+      "target": "api::relation-locale.relation-locale",
+      "mappedBy": "categories"
     }
   }
 }

--- a/examples/getstarted/src/api/relation-locale/content-types/relation-locale/schema.json
+++ b/examples/getstarted/src/api/relation-locale/content-types/relation-locale/schema.json
@@ -40,7 +40,7 @@
       },
       "component": "basic.relation"
     },
-    "dyanmic_relations": {
+    "dynamic_relations": {
       "pluginOptions": {
         "i18n": {
           "localized": true

--- a/examples/getstarted/src/api/relation-locale/content-types/relation-locale/schema.json
+++ b/examples/getstarted/src/api/relation-locale/content-types/relation-locale/schema.json
@@ -1,0 +1,56 @@
+{
+  "kind": "collectionType",
+  "collectionName": "relation_locales",
+  "info": {
+    "singularName": "relation-locale",
+    "pluralName": "relation-locales",
+    "displayName": "relations",
+    "description": ""
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {
+    "i18n": {
+      "localized": true
+    }
+  },
+  "attributes": {
+    "categories": {
+      "type": "relation",
+      "relation": "manyToMany",
+      "target": "api::category.category",
+      "inversedBy": "relation_locales"
+    },
+    "title": {
+      "type": "string",
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
+    },
+    "repeatable_relations": {
+      "type": "component",
+      "repeatable": true,
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "component": "basic.relation"
+    },
+    "dyanmic_relations": {
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "type": "dynamiczone",
+      "components": [
+        "basic.relation",
+        "basic.simple"
+      ]
+    }
+  }
+}

--- a/examples/getstarted/src/api/relation-locale/content-types/relation-locale/schema.json
+++ b/examples/getstarted/src/api/relation-locale/content-types/relation-locale/schema.json
@@ -4,7 +4,7 @@
   "info": {
     "singularName": "relation-locale",
     "pluralName": "relation-locales",
-    "displayName": "relations",
+    "displayName": "Relations",
     "description": ""
   },
   "options": {

--- a/examples/getstarted/src/api/relation-locale/controllers/relation-locale.js
+++ b/examples/getstarted/src/api/relation-locale/controllers/relation-locale.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * relation-locale controller
+ */
+
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::relation-locale.relation-locale');

--- a/examples/getstarted/src/api/relation-locale/routes/relation-locale.js
+++ b/examples/getstarted/src/api/relation-locale/routes/relation-locale.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * relation-locale router
+ */
+
+const { createCoreRouter } = require('@strapi/strapi').factories;
+
+module.exports = createCoreRouter('api::relation-locale.relation-locale');

--- a/examples/getstarted/src/api/relation-locale/services/relation-locale.js
+++ b/examples/getstarted/src/api/relation-locale/services/relation-locale.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * relation-locale service
+ */
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::relation-locale.relation-locale');

--- a/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/reducer.js
+++ b/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/reducer.js
@@ -156,11 +156,13 @@ const reducer = (state, action) =>
         const initialDataRelations = get(state, initialDataPath);
         const modifiedDataRelations = get(state, modifiedDataPath);
 
-        const valuesToLoad = value.filter((relation) => {
-          return !initialDataRelations.some((initialDataRelation) => {
-            return initialDataRelation.id === relation.id;
-          });
-        });
+        const valuesToLoad = !initialDataRelations
+          ? value
+          : value.filter((relation) => {
+              return !initialDataRelations.some((initialDataRelation) => {
+                return initialDataRelation.id === relation.id;
+              });
+            });
 
         const keys = generateNKeysBetween(
           null,
@@ -282,9 +284,7 @@ const reducer = (state, action) =>
          * relationalFieldPaths won't be an array which is what we're expecting
          * Therefore we reset these bits of state to the correct data type
          * which is an array. Hence why we replace those fields.
-         *
          */
-
         const mergeDataWithPreparedRelations = relationalFieldPaths
           .map((path) => path.split('.'))
           .reduce((acc, currentPaths) => {
@@ -301,7 +301,14 @@ const reducer = (state, action) =>
               return result;
             }, existingComponents);
 
-            if (state.modifiedData && get(state.modifiedData, componentName)) {
+            if (
+              state.modifiedData &&
+              get(state.modifiedData, componentName) &&
+              /**
+               * Only replace the state if the entity ids are the same.
+               */
+              state.modifiedData?.id === initialValues?.id
+            ) {
               /**
                * this will be null on initial load, however subsequent calls
                * will have data in them correlating to the names of the relational fields.

--- a/packages/core/admin/admin/src/content-manager/components/RelationInput/RelationInput.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInput/RelationInput.js
@@ -107,8 +107,7 @@ const RelationInput = ({
     [totalNumberOfRelations, numberOfRelationsToDisplay]
   );
 
-  const shouldDisplayLoadMoreButton =
-    (!!labelLoadMore && paginatedRelations.hasNextPage) || paginatedRelations.isLoading;
+  const shouldDisplayLoadMoreButton = !!labelLoadMore && paginatedRelations.hasNextPage;
 
   const options = useMemo(
     () =>

--- a/packages/core/admin/admin/src/content-manager/components/RelationInput/tests/RelationInput.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInput/tests/RelationInput.test.js
@@ -295,23 +295,6 @@ describe('Content-Manager || RelationInput', () => {
       expect(screen.queryByText('Load more')).not.toBeInTheDocument();
     });
 
-    test('should display load more button loading if there is no next page but loading is true', () => {
-      setup({
-        relations: {
-          data: [],
-          isLoading: true,
-          isSuccess: true,
-          hasNextPage: false,
-          isFetchingNextPage: false,
-        },
-      });
-
-      expect(screen.getByRole('button', { name: 'Load more' })).toHaveAttribute(
-        'aria-disabled',
-        'true'
-      );
-    });
-
     test('should display error state', () => {
       setup({ error: 'This is an error' });
 

--- a/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/RelationInputDataManager.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/RelationInputDataManager.js
@@ -58,7 +58,7 @@ export const RelationInputDataManager = ({
   const currentLastPage = Math.ceil(get(initialData, name, []).length / RELATIONS_TO_DISPLAY);
 
   const { relations, search, searchFor } = useRelation(
-    [slug, initialDataPath.join('.'), modifiedData.id],
+    [slug, initialDataPath.join('.'), modifiedData.id, defaultParams],
     {
       relation: {
         enabled: !!endpoints.relation,

--- a/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/RelationInputDataManager.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/RelationInputDataManager.js
@@ -57,41 +57,47 @@ export const RelationInputDataManager = ({
 
   const currentLastPage = Math.ceil(get(initialData, name, []).length / RELATIONS_TO_DISPLAY);
 
-  const cacheKey = `${slug}-${initialDataPath.join('.')}`;
-  const { relations, search, searchFor } = useRelation(cacheKey, {
-    relation: {
-      enabled: !!endpoints.relation,
-      endpoint: endpoints.relation,
-      pageGoal: currentLastPage,
-      pageParams: {
-        ...defaultParams,
-        pageSize: RELATIONS_TO_DISPLAY,
+  const { relations, search, searchFor } = useRelation(
+    [slug, initialDataPath.join('.'), modifiedData.id],
+    {
+      relation: {
+        enabled: !!endpoints.relation,
+        endpoint: endpoints.relation,
+        pageGoal: currentLastPage,
+        pageParams: {
+          ...defaultParams,
+          pageSize: RELATIONS_TO_DISPLAY,
+        },
+        onLoad(value) {
+          relationLoad({
+            target: {
+              initialDataPath: ['initialData', ...initialDataPath],
+              modifiedDataPath: ['modifiedData', ...nameSplit],
+              value,
+            },
+          });
+        },
+        normalizeArguments: {
+          mainFieldName: mainField.name,
+          shouldAddLink: shouldDisplayRelationLink,
+          targetModel,
+        },
       },
-      onLoad(value) {
-        relationLoad({
-          target: {
-            initialDataPath: ['initialData', ...initialDataPath],
-            modifiedDataPath: ['modifiedData', ...nameSplit],
-            value,
-          },
-        });
+      search: {
+        endpoint: endpoints.search,
+        pageParams: {
+          ...defaultParams,
+          // eslint-disable-next-line no-nested-ternary
+          entityId: isCreatingEntry
+            ? undefined
+            : isComponentRelation
+            ? componentId
+            : initialData.id,
+          pageSize: SEARCH_RESULTS_TO_DISPLAY,
+        },
       },
-      normalizeArguments: {
-        mainFieldName: mainField.name,
-        shouldAddLink: shouldDisplayRelationLink,
-        targetModel,
-      },
-    },
-    search: {
-      endpoint: endpoints.search,
-      pageParams: {
-        ...defaultParams,
-        // eslint-disable-next-line no-nested-ternary
-        entityId: isCreatingEntry ? undefined : isComponentRelation ? componentId : initialData.id,
-        pageSize: SEARCH_RESULTS_TO_DISPLAY,
-      },
-    },
-  });
+    }
+  );
 
   const isMorph = useMemo(() => relationType.toLowerCase().includes('morph'), [relationType]);
   const toOneRelation = [

--- a/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/tests/RelationInputDataManger.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/tests/RelationInputDataManger.test.js
@@ -189,7 +189,7 @@ describe('RelationInputDataManager', () => {
     });
 
     expect(useRelation).toBeCalledWith(
-      expect.any(String),
+      expect.arrayContaining([expect.any(String)]),
       expect.objectContaining({
         search: expect.objectContaining({
           pageParams: expect.objectContaining({

--- a/packages/core/admin/admin/src/content-manager/hooks/useRelation/tests/useRelation.test.js
+++ b/packages/core/admin/admin/src/content-manager/hooks/useRelation/tests/useRelation.test.js
@@ -33,7 +33,7 @@ const ComponentFixture = ({ children }) => (
   <QueryClientProvider client={client}>{children}</QueryClientProvider>
 );
 
-const cacheKey = 'useRelation-cache-key';
+const cacheKey = ['useRelation-cache-key'];
 function setup(args) {
   return new Promise((resolve) => {
     act(() => {

--- a/packages/core/admin/admin/src/content-manager/hooks/useRelation/useRelation.js
+++ b/packages/core/admin/admin/src/content-manager/hooks/useRelation/useRelation.js
@@ -49,7 +49,7 @@ export const useRelation = (cacheKey, { relation, search }) => {
 
   const { onLoad: onLoadRelations, normalizeArguments = {} } = relation;
 
-  const relationsRes = useInfiniteQuery(['relation', cacheKey], fetchRelations, {
+  const relationsRes = useInfiniteQuery(['relation', ...cacheKey], fetchRelations, {
     cacheTime: 0,
     enabled: relation.enabled,
     /**
@@ -138,7 +138,7 @@ export const useRelation = (cacheKey, { relation, search }) => {
   }, [status, onLoadRelationsCallback, data]);
 
   const searchRes = useInfiniteQuery(
-    ['relation', cacheKey, 'search', JSON.stringify(searchParams)],
+    ['relation', ...cacheKey, 'search', JSON.stringify(searchParams)],
     fetchSearch,
     {
       enabled: Object.keys(searchParams).length > 0,


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* Merge the existing data with new data only if the entity ids are the same

### Why is it needed?

* relations are cached between locales which is typically undesired.

### How to test it?

* Create a localised content type
* Add a relation field
* Set the relation in one locale & save
* refresh the page
* see this relation correctly there
* swap locale
* the relation field should be empty

There's also an automated test.

### Related issue(s)/PR(s)

* resolves #15743
* resolves #15638
* resolves CONTENT-1032

### Thoughts

* ~Is there a way to pass this string to both places so we dont rely on spelling? 🤔  cc @gu-stav~
* ~Who's responsibility is this? It feels over eager for the content-manager to dismiss the cache when any part of the URL changes? But then if someone else creates a plugin _similar_ to how i18n works then they'll need to add this code too...~
