### PR TITLE
[Private S3]: Call entity manager mapEntity

### DIFF
--- a/packages/core/upload/server/services/extensions/content-manager/entity-manager.js
+++ b/packages/core/upload/server/services/extensions/content-manager/entity-manager.js
@@ -64,7 +64,10 @@ const addSignedFileUrlsToAdmin = async () => {
        * @param {string} uid
        * @returns
        */
-      const mapEntity = (entity, uid) => signEntityMedia(entity, uid);
+      const mapEntity = async (entity, uid) => {
+        const signedEntity = await signEntityMedia(entity, uid);
+        return entityManager.mapEntity(signedEntity, uid);
+      };
 
       return { ...entityManager, mapEntity };
     });


### PR DESCRIPTION
### What does it do?
We were decorating the `mapEntity` method but we were not calling the method that was wrapped.

EntityManager mapEntity was not called before (we did not notice because it does not do anything). 
