### PR TITLE
[Data Transfer] Gracefully exit the transfer process

### DIFF
--- a/packages/core/data-transfer/src/strapi/providers/remote-destination/index.ts
+++ b/packages/core/data-transfer/src/strapi/providers/remote-destination/index.ts
@@ -41,10 +41,13 @@ class RemoteStrapiDestinationProvider implements IDestinationProvider {
 
   dispatcher: ReturnType<typeof createDispatcher> | null;
 
+  transferID: string | null;
+
   constructor(options: IRemoteStrapiDestinationProviderOptions) {
     this.options = options;
     this.ws = null;
     this.dispatcher = null;
+    this.transferID = null;
   }
 
   async initTransfer(): Promise<string> {
@@ -176,15 +179,23 @@ class RemoteStrapiDestinationProvider implements IDestinationProvider {
     this.ws = ws;
     this.dispatcher = createDispatcher(this.ws);
 
-    const transferID = await this.initTransfer();
+    this.transferID = await this.initTransfer();
 
-    this.dispatcher.setTransferProperties({ id: transferID, kind: 'push' });
+    this.dispatcher.setTransferProperties({ id: this.transferID, kind: 'push' });
 
     await this.dispatcher.dispatchTransferAction('bootstrap');
   }
 
   async close() {
-    await this.dispatcher?.dispatchTransferAction('close');
+    // Gracefully close the remote transfer process
+    if (this.transferID && this.dispatcher) {
+      await this.dispatcher.dispatchTransferAction('close');
+
+      await this.dispatcher.dispatchCommand({
+        command: 'end',
+        params: { transferID: this.transferID },
+      });
+    }
 
     await new Promise<void>((resolve) => {
       const { ws } = this;


### PR DESCRIPTION
### What does it do?

Send an "end" command upon closing the remote destination provider.

### Why is it needed?

The server's transfer runner was never stopping the transfer process.
