### PR TITLE
Add audit logs configuration and react to license changes

### DIFF
--- a/examples/getstarted/config/admin.js
+++ b/examples/getstarted/config/admin.js
@@ -6,4 +6,7 @@ module.exports = ({ env }) => ({
   apiToken: {
     salt: env('API_TOKEN_SALT', 'example-salt'),
   },
+  auditLogs: {
+    enabled: env.bool('AUDIT_LOGS_ENABLED', true),
+  },
 });

--- a/packages/core/admin/ee/server/register.js
+++ b/packages/core/admin/ee/server/register.js
@@ -6,7 +6,10 @@ const migrateAuditLogsTable = require('./migrations/audit-logs-table');
 const createAuditLogsService = require('./services/audit-logs');
 
 module.exports = async ({ strapi }) => {
-  if (features.isEnabled('audit-logs')) {
+  const auditLogsIsAllowed = features.isEnabled('audit-logs');
+  const auditLogsIsEnabled = strapi.config.get('server.auditLogs.enabled', true);
+
+  if (auditLogsIsAllowed && auditLogsIsEnabled) {
     strapi.hook('strapi::content-types.beforeSync').register(migrateAuditLogsTable);
     const auditLogsService = createAuditLogsService(strapi);
     strapi.container.register('audit-logs', auditLogsService);

--- a/packages/core/admin/ee/server/register.js
+++ b/packages/core/admin/ee/server/register.js
@@ -1,15 +1,13 @@
 'use strict';
 
-const { features } = require('@strapi/strapi/lib/utils/ee');
 const executeCERegister = require('../../server/register');
 const migrateAuditLogsTable = require('./migrations/audit-logs-table');
 const createAuditLogsService = require('./services/audit-logs');
 
 module.exports = async ({ strapi }) => {
-  const auditLogsIsAllowed = features.isEnabled('audit-logs');
-  const auditLogsIsEnabled = strapi.config.get('server.auditLogs.enabled', true);
+  const auditLogsIsEnabled = strapi.config.get('admin.auditLogs.enabled', true);
 
-  if (auditLogsIsAllowed && auditLogsIsEnabled) {
+  if (auditLogsIsEnabled) {
     strapi.hook('strapi::content-types.beforeSync').register(migrateAuditLogsTable);
     const auditLogsService = createAuditLogsService(strapi);
     strapi.container.register('audit-logs', auditLogsService);

--- a/packages/core/admin/ee/server/services/audit-logs.js
+++ b/packages/core/admin/ee/server/services/audit-logs.js
@@ -117,11 +117,9 @@ const createAuditLogsService = (strapi) => {
 
   return {
     async register() {
-      console.log('audit logs register');
       // Handle license being enabled
       if (!this._eeEnableUnsubscribe) {
         this._eeEnableUnsubscribe = strapi.eventHub.once('ee.enable', () => {
-          console.log('listened to ee.enable');
           // Recreate the service to use the new license info
           this.destroy();
           this.register();
@@ -130,7 +128,6 @@ const createAuditLogsService = (strapi) => {
 
       // Handle license being updated
       this._eeUpdateUnsubscribe = strapi.eventHub.on('ee.update', () => {
-        console.log('listened to ee.update');
         // Recreate the service to use the new license info
         this.destroy();
         this.register();
@@ -138,7 +135,6 @@ const createAuditLogsService = (strapi) => {
 
       // Handle license being disabled
       this._eeDisableUnsubscribe = strapi.eventHub.on('ee.disable', () => {
-        console.log('listened to ee.disable');
         // Turn off service when the license gets disabled
         // Only the ee.enable listener remains active to recreate the service
         this.destroy();
@@ -155,7 +151,6 @@ const createAuditLogsService = (strapi) => {
 
       // Manage audit logs auto deletion
       const retentionDays = getRetentionDays(strapi);
-      console.log('registering audit logs service', retentionDays);
       this._deleteExpiredJob = scheduleJob('0 0 * * *', () => {
         const expirationDate = new Date(Date.now() - retentionDays * 24 * 60 * 60 * 1000);
         this._provider.deleteExpiredEvents(expirationDate);
@@ -216,7 +211,6 @@ const createAuditLogsService = (strapi) => {
     },
 
     destroy() {
-      console.log('audit logs destroy');
       return this.unsubscribe();
     },
   };

--- a/packages/core/strapi/ee/index.js
+++ b/packages/core/strapi/ee/index.js
@@ -21,7 +21,6 @@ const disable = (message) => {
   // Only keep the license key for potential re-enabling during a later check
   ee.licenseInfo = pick('licenseKey', ee.licenseInfo);
 
-  // Prevent emitting ee.disable if it was already disabled
   ee.enabled = false;
 
   if (shouldEmitEvent) {
@@ -31,7 +30,7 @@ const disable = (message) => {
 };
 
 const enable = () => {
-  // Prevent emitting ee.disable if it was already disabled
+  // Prevent emitting ee.enable if it was already enabled
   const shouldEmitEvent = ee.enabled !== true;
 
   ee.enabled = true;
@@ -162,7 +161,6 @@ const validateInfo = () => {
     return disable('License expired.');
   }
 
-  // Prevent emitting ee.enable if it was already enabled
   enable();
 };
 
@@ -174,7 +172,6 @@ const checkLicense = async ({ strapi }) => {
 
   if (!shouldStayOffline) {
     await onlineUpdate({ strapi });
-
     strapi.cron.add({ [shiftCronExpression('0 0 */12 * * *')]: onlineUpdate });
   } else {
     if (!ee.licenseInfo.expireAt) {

--- a/packages/core/strapi/ee/index.js
+++ b/packages/core/strapi/ee/index.js
@@ -6,7 +6,7 @@ const { readLicense, verifyLicense, fetchLicense, LicenseCheckError } = require(
 const { eeStoreModel } = require('./ee-store');
 const { shiftCronExpression } = require('../lib/utils/cron');
 
-const ONE_MINUTE = 1 * 60;
+const ONE_MINUTE = 1000 * 60;
 
 const ee = {
   enabled: false,
@@ -22,7 +22,6 @@ const disable = (message) => {
   ee.licenseInfo = pick('licenseKey', ee.licenseInfo);
 
   // Prevent emitting ee.disable if it was already disabled
-  console.log('disabling EE');
   ee.enabled = false;
 
   if (shouldEmitEvent) {
@@ -78,7 +77,6 @@ const init = (licenseDir, logger) => {
  * Store the result in database to avoid unecessary requests, and will fallback to that in case of a network failure.
  */
 const onlineUpdate = async ({ strapi }) => {
-  console.log('onlineUpdate');
   const { get, commit, rollback } = await strapi.db.transaction();
   const transaction = get();
 
@@ -177,8 +175,7 @@ const checkLicense = async ({ strapi }) => {
   if (!shouldStayOffline) {
     await onlineUpdate({ strapi });
 
-    // strapi.cron.add({ [shiftCronExpression('0 0 */12 * * *')]: onlineUpdate });
-    strapi.cron.add({ [shiftCronExpression('*/10 * * * * *')]: onlineUpdate });
+    strapi.cron.add({ [shiftCronExpression('0 0 */12 * * *')]: onlineUpdate });
   } else {
     if (!ee.licenseInfo.expireAt) {
       return disable('Your license does not have offline support.');

--- a/packages/providers/audit-logs-local/lib/index.js
+++ b/packages/providers/audit-logs-local/lib/index.js
@@ -4,7 +4,10 @@ const auditLogContentType = require('./content-types/audit-log');
 
 const provider = {
   async register({ strapi }) {
-    strapi.container.get('content-types').add('admin::', { 'audit-log': auditLogContentType });
+    const contentTypes = strapi.container.get('content-types');
+    if (!contentTypes.keys().includes('admin::audit-log')) {
+      strapi.container.get('content-types').add('admin::', { 'audit-log': auditLogContentType });
+    }
 
     // Return the provider object
     return {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

- [x] Adds the ability to disable audit logs and set a custom retention duration via the config/
- [x] Makes audit logs react to license changes (enable, disable, update) at runtime, in order to accordingly enable, disable or reconfigure the feature. This is done by emitting events in the event hub so that other EE features can also apply similar logic.
- [ ] Write tests for the audit logs configuration

### Why is it needed?

The cloud will introduce new pricing plans. Currently when the audit logs service is registered, the license info we have access to is just the fallback used by the EE license [optimistic behavior](https://github.com/strapi/strapi/blob/50cd3813231c4b7068514223c6ce4d780ec3b591/packages/core/strapi/ee/index.js#L47-L49). This was fine as long as audit logs was only available in one plan, but now we need to be ready for the plans coming with the cloud.

### How to test it?

The easiest would be to undo [this commit](https://github.com/strapi/strapi/commit/50cd3813231c4b7068514223c6ce4d780ec3b591), so that you have access to a bunch a logs, and so that the license check happens every 10 seconds. Otherwise you can just perform admin actions and check if they produce a log to check if audit logs is enabled or not.

- Have access to the license registry (locally or in prod)
- Start the getstarted application
- Update the license in the registry (change the type, or the status of the assiociated subsription)
- The audit logs service should update accordingly
