### PR TITLE
CM: Display current workflow stage in the edit-view

### DIFF
--- a/packages/core/admin/admin/src/content-manager/pages/EditView/Information/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/EditView/Information/index.js
@@ -1,5 +1,5 @@
 import React, { useRef } from 'react';
-import propTypes from 'prop-types';
+import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 import { useCMEditViewDataManager } from '@strapi/helper-plugin';
 import { Box, Divider, Flex, Stack, Typography } from '@strapi/design-system';
@@ -7,6 +7,25 @@ import { Box, Divider, Flex, Stack, Typography } from '@strapi/design-system';
 import { getTrad } from '../../../utils';
 import getUnits from './utils/getUnits';
 import { getFullName } from '../../../../utils';
+
+const Title = () => {
+  const { formatMessage } = useIntl();
+
+  return (
+    <Stack spacing={2}>
+      <Typography variant="sigma" textColor="neutral600" id="additional-information">
+        {formatMessage({
+          id: getTrad('containers.Edit.information'),
+          defaultMessage: 'Information',
+        })}
+      </Typography>
+
+      <Box>
+        <Divider />
+      </Box>
+    </Stack>
+  );
+};
 
 const KeyValuePair = ({ label, value }) => {
   return (
@@ -20,11 +39,11 @@ const KeyValuePair = ({ label, value }) => {
 };
 
 KeyValuePair.propTypes = {
-  label: propTypes.string.isRequired,
-  value: propTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
+  value: PropTypes.string.isRequired,
 };
 
-const Information = () => {
+const Body = () => {
   const { formatMessage, formatRelativeTime } = useIntl();
   const { initialData, isCreatingEntry } = useCMEditViewDataManager();
   const currentTime = useRef(Date.now());
@@ -49,57 +68,56 @@ const Information = () => {
   const created = getFieldInfo('createdAt', 'createdBy');
 
   return (
-    <Stack spacing={2}>
-      <Typography variant="sigma" textColor="neutral600" id="additional-information">
-        {formatMessage({
-          id: getTrad('containers.Edit.information'),
-          defaultMessage: 'Information',
-        })}
-      </Typography>
+    <Stack spacing={4}>
+      <Stack spacing={2} as="dl">
+        <KeyValuePair
+          label={formatMessage({
+            id: getTrad('containers.Edit.information.created'),
+            defaultMessage: 'Created',
+          })}
+          value={created.at}
+        />
 
-      <Box paddingBottom={4}>
-        <Divider />
-      </Box>
+        <KeyValuePair
+          label={formatMessage({
+            id: getTrad('containers.Edit.information.by'),
+            defaultMessage: 'By',
+          })}
+          value={created.by}
+        />
+      </Stack>
 
-      <Stack spacing={4}>
-        <Stack spacing={2} as="dl">
-          <KeyValuePair
-            label={formatMessage({
-              id: getTrad('containers.Edit.information.created'),
-              defaultMessage: 'Created',
-            })}
-            value={created.at}
-          />
+      <Stack spacing={2} as="dl">
+        <KeyValuePair
+          label={formatMessage({
+            id: getTrad('containers.Edit.information.lastUpdate'),
+            defaultMessage: 'Last update',
+          })}
+          value={updated.at}
+        />
 
-          <KeyValuePair
-            label={formatMessage({
-              id: getTrad('containers.Edit.information.by'),
-              defaultMessage: 'By',
-            })}
-            value={created.by}
-          />
-        </Stack>
-
-        <Stack spacing={2} as="dl">
-          <KeyValuePair
-            label={formatMessage({
-              id: getTrad('containers.Edit.information.lastUpdate'),
-              defaultMessage: 'Last update',
-            })}
-            value={updated.at}
-          />
-
-          <KeyValuePair
-            label={formatMessage({
-              id: getTrad('containers.Edit.information.by'),
-              defaultMessage: 'By',
-            })}
-            value={updated.by}
-          />
-        </Stack>
+        <KeyValuePair
+          label={formatMessage({
+            id: getTrad('containers.Edit.information.by'),
+            defaultMessage: 'By',
+          })}
+          value={updated.by}
+        />
       </Stack>
     </Stack>
   );
 };
 
-export default Information;
+const Root = ({ children }) => {
+  return <Stack spacing={6}>{children}</Stack>;
+};
+
+Root.propTypes = {
+  children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]).isRequired,
+};
+
+export default {
+  Root,
+  Title,
+  Body,
+};

--- a/packages/core/admin/admin/src/content-manager/pages/EditView/Information/tests/index.test.js
+++ b/packages/core/admin/admin/src/content-manager/pages/EditView/Information/tests/index.test.js
@@ -8,30 +8,30 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { IntlProvider } from 'react-intl';
 import { useCMEditViewDataManager } from '@strapi/helper-plugin';
-import { lightTheme, darkTheme } from '@strapi/design-system';
-import Theme from '../../../../../components/Theme';
-import ThemeToggleProvider from '../../../../../components/ThemeToggleProvider';
-import Information from '../index';
+import { ThemeProvider, lightTheme } from '@strapi/design-system';
+
+import Information from '..';
 
 jest.mock('@strapi/helper-plugin', () => ({
   ...jest.requireActual('@strapi/helper-plugin'),
   useCMEditViewDataManager: jest.fn(),
 }));
 
-const makeApp = () => {
+const ComponentFixture = () => {
   return (
-    <IntlProvider
-      locale="en"
-      defaultLocale="en"
-      messages={{ 'containers.Edit.information': 'Information' }}
-    >
-      <ThemeToggleProvider themes={{ light: lightTheme, dark: darkTheme }}>
-        <Theme>
-          <Information />
-        </Theme>
-      </ThemeToggleProvider>
+    <IntlProvider locale="en" messages={{}}>
+      <ThemeProvider theme={lightTheme}>
+        <Information.Root>
+          <Information.Title />
+          <Information.Body />
+        </Information.Root>
+      </ThemeProvider>
     </IntlProvider>
   );
+};
+
+const setup = (props) => {
+  return render(<ComponentFixture {...props} />);
 };
 
 describe('CONTENT MANAGER | EditView | Information', () => {
@@ -51,7 +51,7 @@ describe('CONTENT MANAGER | EditView | Information', () => {
       isCreatingEntry: true,
     }));
 
-    const { getByText, getAllByText } = render(makeApp());
+    const { getByText, getAllByText } = setup();
 
     expect(getByText('Created')).toBeInTheDocument();
     expect(getByText('Last update')).toBeInTheDocument();
@@ -78,7 +78,7 @@ describe('CONTENT MANAGER | EditView | Information', () => {
       isCreatingEntry: false,
     }));
 
-    const { getAllByText } = render(makeApp());
+    const { getAllByText } = setup();
 
     expect(getAllByText('8 months ago').length).toBe(2);
     expect(getAllByText('First name Last name').length).toBe(2);
@@ -104,7 +104,7 @@ describe('CONTENT MANAGER | EditView | Information', () => {
       isCreatingEntry: false,
     }));
 
-    const { queryByText, getAllByText } = render(makeApp());
+    const { queryByText, getAllByText } = setup();
 
     expect(getAllByText('user@strapi.io').length).toBe(2);
     expect(queryByText('First name')).toBeNull();

--- a/packages/core/admin/admin/src/content-manager/pages/EditView/InformationBox/InformationBoxCE.js
+++ b/packages/core/admin/admin/src/content-manager/pages/EditView/InformationBox/InformationBoxCE.js
@@ -1,0 +1,13 @@
+import React from 'react';
+
+import Information from '../Information';
+
+// This component is overwritten by the EE counterpart
+export function InformationBoxCE() {
+  return (
+    <Information.Root>
+      <Information.Title />
+      <Information.Body />
+    </Information.Root>
+  );
+}

--- a/packages/core/admin/admin/src/content-manager/pages/EditView/InformationBox/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/EditView/InformationBox/index.js
@@ -1,0 +1,3 @@
+import { InformationBoxCE } from './InformationBoxCE';
+
+export default InformationBoxCE;

--- a/packages/core/admin/admin/src/content-manager/pages/EditView/InformationBox/tests/InformationBoxCe.test.js
+++ b/packages/core/admin/admin/src/content-manager/pages/EditView/InformationBox/tests/InformationBoxCe.test.js
@@ -1,0 +1,56 @@
+/**
+ *
+ * Tests for Information
+ *
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
+import { useCMEditViewDataManager } from '@strapi/helper-plugin';
+import { ThemeProvider, lightTheme } from '@strapi/design-system';
+
+import { InformationBoxCE } from '../InformationBoxCE';
+
+jest.mock('@strapi/helper-plugin', () => ({
+  ...jest.requireActual('@strapi/helper-plugin'),
+  useCMEditViewDataManager: jest.fn(),
+}));
+
+const ComponentFixture = (props) => {
+  return (
+    <ThemeProvider theme={lightTheme}>
+      <IntlProvider locale="en" messages={{}}>
+        <InformationBoxCE {...props} />
+      </IntlProvider>
+    </ThemeProvider>
+  );
+};
+
+const setup = (props) => {
+  return render(<ComponentFixture {...props} />);
+};
+
+describe('CONTENT MANAGER | EditView | InformationBoxCE', () => {
+  const RealNow = Date.now;
+
+  beforeAll(() => {
+    global.Date.now = jest.fn(() => new Date('2022-09-20').getTime());
+  });
+
+  afterAll(() => {
+    global.Date.now = RealNow;
+  });
+
+  it('renders the title and body of the Information component', () => {
+    useCMEditViewDataManager.mockImplementationOnce(() => ({
+      initialData: {},
+      isCreatingEntry: true,
+    }));
+
+    const { getByText } = setup();
+
+    expect(getByText('Information')).toBeInTheDocument();
+    expect(getByText('Last update')).toBeInTheDocument();
+  });
+});

--- a/packages/core/admin/admin/src/content-manager/pages/EditView/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/EditView/index.js
@@ -8,24 +8,19 @@ import {
   LoadingIndicatorPage,
 } from '@strapi/helper-plugin';
 import { useIntl } from 'react-intl';
-import { ContentLayout } from '@strapi/design-system/Layout';
-import { Box } from '@strapi/design-system/Box';
-import { Grid, GridItem } from '@strapi/design-system/Grid';
-import { Main } from '@strapi/design-system/Main';
-import { Stack } from '@strapi/design-system/Stack';
-import Layer from '@strapi/icons/Layer';
-import Pencil from '@strapi/icons/Pencil';
+import { ContentLayout, Box, Grid, GridItem, Main, Stack } from '@strapi/design-system';
+
+import { Pencil, Layer } from '@strapi/icons';
+import InformationBox from 'ee_else_ce/content-manager/pages/EditView/InformationBox';
 import { InjectionZone } from '../../../shared/components';
 import permissions from '../../../permissions';
 import DynamicZone from '../../components/DynamicZone';
-
 import CollectionTypeFormWrapper from '../../components/CollectionTypeFormWrapper';
 import EditViewDataManagerProvider from '../../components/EditViewDataManagerProvider';
 import SingleTypeFormWrapper from '../../components/SingleTypeFormWrapper';
 import { getTrad } from '../../utils';
 import useLazyComponents from '../../hooks/useLazyComponents';
 import DraftAndPublishBadge from './DraftAndPublishBadge';
-import Information from './Information';
 import Header from './Header';
 import { getFieldsActionMatchingPermissions } from './utils';
 import DeleteLink from './DeleteLink';
@@ -185,7 +180,7 @@ const EditView = ({ allowedActions, isSingleType, goBack, slug, id, origin, user
                         paddingTop={6}
                         shadow="tableShadow"
                       >
-                        <Information />
+                        <InformationBox />
                         <InjectionZone area="contentManager.editView.informations" />
                       </Box>
                       <Box as="aside" aria-labelledby="links">

--- a/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/InformationBoxEE.js
+++ b/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/InformationBoxEE.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import { ReactSelect, useCMEditViewDataManager } from '@strapi/helper-plugin';
+
+import { useReviewWorkflows } from '../../../../pages/SettingsPage/pages/ReviewWorkflows/hooks/useReviewWorkflows';
+import Information from '../../../../../../admin/src/content-manager/pages/EditView/Information';
+
+const ATTRIBUTE_NAME = 'strapi_reviewWorkflows_stage';
+
+export function InformationBoxEE() {
+  const { initialData, isCreatingEntry } = useCMEditViewDataManager();
+  const activeWorkflowStage = initialData?.[ATTRIBUTE_NAME] ?? null;
+  const {
+    workflows: { data: workflow },
+  } = useReviewWorkflows(1);
+  // stages are empty while the workflow is loaded
+  const options = (workflow?.stages ?? []).map(({ id, name }) => ({ value: id, label: name }));
+
+  return (
+    <Information.Root>
+      <Information.Title />
+      {activeWorkflowStage && (
+        <ReactSelect
+          isDisabled={isCreatingEntry}
+          options={options}
+          name={ATTRIBUTE_NAME}
+          value={{ value: activeWorkflowStage?.id, label: activeWorkflowStage?.name }}
+          isSearchable={false}
+          isClearable={false}
+        />
+      )}
+      <Information.Body />
+    </Information.Root>
+  );
+}

--- a/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/index.js
+++ b/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/index.js
@@ -1,0 +1,3 @@
+import { InformationBoxEE } from './InformationBoxEE';
+
+export default InformationBoxEE;


### PR DESCRIPTION
### What does it do?

This PR allows EE mode to render a different information element in the CM edit view. In EE mode it will contain the current workflow stage, that is selected for an entity.

### Why is it needed?

Allows users to see (not to change yet) the current workflow stage of an entity.
