### PR TITLE
[Data Transfer] allow ws to send error responses without uuid

### DIFF
--- a/packages/core/data-transfer/src/strapi/remote/handlers.ts
+++ b/packages/core/data-transfer/src/strapi/remote/handlers.ts
@@ -70,7 +70,7 @@ export const createTransferHandler = (options: IHandlerOptions) => {
          */
         const callback = <T = unknown>(e: Error | null = null, data?: T) => {
           return new Promise<void>((resolve, reject) => {
-            if (!uuid) {
+            if (!uuid && !e) {
               reject(new Error('Missing uuid for this message'));
               return;
             }


### PR DESCRIPTION
### What does it do?

Allows sending errors to client without a UUID

### Why is it needed?

To be able to send results back to user even if a uuid couldn't be retrieved from the original message

### How to test it?

Sending an invalid message should no longer throw an uncaught asnyc error on the server and instead should be returned to the websocket client as a message.
