### PR TITLE
Refetch the ee license-dat, after a user has been invited or deleted

### DIFF
--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Users/ListPage/ModalForm/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Users/ListPage/ModalForm/index.js
@@ -49,7 +49,10 @@ const ModalForm = ({ queryName, onToggle }) => {
     {
       async onSuccess({ data }) {
         setRegistrationToken(data.data.registrationToken);
-        await queryClient.invalidateQueries(queryName);
+
+        await queryClient.refetchQueries(queryName);
+        await queryClient.refetchQueries(['ee', 'license-limit-info']);
+
         goNext();
         setIsSubmitting(false);
       },

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Users/ListPage/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Users/ListPage/index.js
@@ -92,6 +92,9 @@ const ListPage = () => {
   const deleteAllMutation = useMutation((ids) => deleteData(ids), {
     async onSuccess() {
       await queryClient.refetchQueries(queryName);
+
+      // Toggle enabled/ disabled state on the invite button
+      await queryClient.refetchQueries(['ee', 'license-limit-info']);
     },
     onError(error) {
       toggleNotification({

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Users/ListPage/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Users/ListPage/index.js
@@ -7,6 +7,7 @@ import {
   useNotification,
   useFocusWhenNavigate,
   NoPermissions,
+  useAPIErrorHandler,
 } from '@strapi/helper-plugin';
 import {
   ActionLayout,
@@ -30,6 +31,7 @@ import displayedFilters from './utils/displayedFilters';
 import tableHeaders from './utils/tableHeaders';
 
 const ListPage = () => {
+  const { formatAPIError } = useAPIErrorHandler();
   const [isModalOpened, setIsModalOpen] = useState(false);
   const {
     allowedActions: { canCreate, canDelete, canRead },
@@ -71,10 +73,14 @@ const ListPage = () => {
   const { status, data, isFetching } = useQuery(queryName, () => fetchData(search, notifyLoad), {
     enabled: canRead,
     retry: false,
-    onError() {
+    onError(error) {
       toggleNotification({
         type: 'warning',
-        message: { id: 'notification.error', defaultMessage: 'An error occured' },
+        message: {
+          id: 'notification.error',
+          message: formatAPIError(error),
+          defaultMessage: 'An error occured',
+        },
       });
     },
   });
@@ -85,17 +91,17 @@ const ListPage = () => {
 
   const deleteAllMutation = useMutation((ids) => deleteData(ids), {
     async onSuccess() {
-      await queryClient.invalidateQueries(queryName);
+      await queryClient.refetchQueries(queryName);
     },
-    onError(err) {
-      if (err?.response?.data?.data) {
-        toggleNotification({ type: 'warning', message: err.response.data.data });
-      } else {
-        toggleNotification({
-          type: 'warning',
-          message: { id: 'notification.error', defaultMessage: 'An error occured' },
-        });
-      }
+    onError(error) {
+      toggleNotification({
+        type: 'warning',
+        message: {
+          id: 'notification.error',
+          message: formatAPIError(error),
+          defaultMessage: 'An error occured',
+        },
+      });
     },
   });
 


### PR DESCRIPTION
### What does it do?

Refetches the ee license-data query, after a user has been invited or deleted.

### Why is it needed?

In case an invite and deletions leads to there being more users than permitted by the license (or less), the UI needs to reflect that state.

It is not ideal, but we can discuss how we want to handle it next week.

### How to test it?

1. Set yourself a seat-limit

```diff
diff --git a/packages/core/strapi/ee/index.js b/packages/core/strapi/ee/index.js
index d3e34b1291..f7b6e2f24c 100644
--- a/packages/core/strapi/ee/index.js
+++ b/packages/core/strapi/ee/index.js
@@ -129,6 +129,7 @@ const validateInfo = () => {
 };
 
 const checkLicense = async ({ strapi }) => {
+  return;
   const shouldStayOffline =
     ee.licenseInfo.type === 'gold' &&
     // This env variable support is temporarily used to ease the migration between online vs offline
@@ -165,7 +166,7 @@ module.exports = Object.freeze({
   },
 
   get seats() {
-    return ee.licenseInfo.seats;
+    return 3;
   },
 
   features: Object.freeze({
```

2. Try and invite more users than allowed (the invite button should be disabled)
3. Delete a user, after the limit has been reached (the invite button should be enabled again)

### Related issue(s)/PR(s)

- https://github.com/strapi/strapi/pull/15924
