### PR TITLE
Convert Stack components to Flex

### DIFF
--- a/.eslintrc.front.js
+++ b/.eslintrc.front.js
@@ -41,6 +41,14 @@ module.exports = {
     'no-restricted-imports': [
       'error',
       {
+        paths: [
+          {
+            name: '@strapi/design-system',
+            importNames: ['Stack'],
+            message:
+              "'Stack' has been deprecated. Please import 'Flex' from '@strapi/design-system' instead.",
+          },
+        ],
         patterns: [
           {
             group: [

--- a/packages/core/admin/admin/src/components/AutoReloadOverlayBlockerProvider/Blocker.js
+++ b/packages/core/admin/admin/src/components/AutoReloadOverlayBlockerProvider/Blocker.js
@@ -6,7 +6,7 @@ import styled, { keyframes } from 'styled-components';
 import { pxToRem } from '@strapi/helper-plugin';
 import { Clock, Refresh } from '@strapi/icons';
 import { Link } from '@strapi/design-system/v2';
-import { Box, Stack, Flex, Typography } from '@strapi/design-system';
+import { Box, Flex, Typography } from '@strapi/design-system';
 import { Content, IconBox, Overlay } from './Overlay';
 
 const overlayContainer = document.createElement('div');
@@ -40,8 +40,8 @@ const Blocker = ({ displayedIcon, description, title, isOpen }) => {
   if (isOpen) {
     return ReactDOM.createPortal(
       <Overlay>
-        <Content spacing={6}>
-          <Stack spacing={2}>
+        <Content direction="column" alignItems="stretch" gap={6}>
+          <Flex direction="column" alignItems="stretch" gap={2}>
             <Flex justifyContent="center">
               <Typography as="h1" variant="alpha">
                 {formatMessage(title)}
@@ -52,7 +52,7 @@ const Blocker = ({ displayedIcon, description, title, isOpen }) => {
                 {formatMessage(description)}
               </Typography>
             </Flex>
-          </Stack>
+          </Flex>
           <Flex justifyContent="center">
             {displayedIcon === 'reload' && (
               <IconBox padding={6} background="primary100" borderColor="primary200">

--- a/packages/core/admin/admin/src/components/AutoReloadOverlayBlockerProvider/Overlay.js
+++ b/packages/core/admin/admin/src/components/AutoReloadOverlayBlockerProvider/Overlay.js
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { Box, Stack } from '@strapi/design-system';
+import { Box, Flex } from '@strapi/design-system';
 import { pxToRem } from '@strapi/helper-plugin';
 
 const Overlay = styled(Box)`
@@ -21,7 +21,7 @@ const Overlay = styled(Box)`
   }
 `;
 
-const Content = styled(Stack)`
+const Content = styled(Flex)`
   position: fixed;
   top: 0;
   right: 0;

--- a/packages/core/admin/admin/src/components/GuidedTour/Homepage/index.js
+++ b/packages/core/admin/admin/src/components/GuidedTour/Homepage/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useGuidedTour, useTracking, LinkButton } from '@strapi/helper-plugin';
 import { useIntl } from 'react-intl';
-import { Stack, Flex, Box, Typography, Button } from '@strapi/design-system';
+import { Flex, Box, Typography, Button } from '@strapi/design-system';
 import { ArrowRight } from '@strapi/icons';
 import StepperHomepage from './components/Stepper';
 import layout from '../layout';
@@ -47,7 +47,7 @@ const GuidedTourHomepage = () => {
       paddingBottom={4}
       background="neutral0"
     >
-      <Stack spacing={6}>
+      <Flex direction="column" alignItems="stretch" gap={6}>
         <Typography variant="beta" as="h2">
           {formatMessage({
             id: 'app.components.GuidedTour.title',
@@ -55,7 +55,7 @@ const GuidedTourHomepage = () => {
           })}
         </Typography>
         <StepperHomepage sections={sections} currentSectionKey={activeSection} />
-      </Stack>
+      </Flex>
       <Flex justifyContent="flex-end">
         <Button variant="tertiary" onClick={handleSkip}>
           {formatMessage({ id: 'app.components.GuidedTour.skip', defaultMessage: 'Skip the tour' })}

--- a/packages/core/admin/admin/src/components/GuidedTour/Homepage/tests/index.test.js
+++ b/packages/core/admin/admin/src/components/GuidedTour/Homepage/tests/index.test.js
@@ -49,35 +49,35 @@ describe('GuidedTour Homepage', () => {
     } = render(App);
 
     expect(firstChild).toMatchInlineSnapshot(`
-      .c5 {
+      .c4 {
         font-weight: 600;
         font-size: 1.125rem;
         line-height: 1.22;
         color: #32324d;
       }
 
-      .c10 {
+      .c9 {
         font-size: 0.875rem;
         line-height: 1.43;
         font-weight: 500;
         color: #ffffff;
       }
 
-      .c11 {
+      .c10 {
         font-weight: 500;
         font-size: 1rem;
         line-height: 1.25;
         color: #32324d;
       }
 
-      .c23 {
+      .c22 {
         font-size: 0.875rem;
         line-height: 1.43;
         font-weight: 500;
         color: #666687;
       }
 
-      .c28 {
+      .c27 {
         font-size: 0.75rem;
         line-height: 1.33;
         font-weight: 600;
@@ -94,12 +94,12 @@ describe('GuidedTour Homepage', () => {
         box-shadow: 0px 1px 4px rgba(33,33,52,0.1);
       }
 
-      .c7 {
+      .c6 {
         margin-right: 20px;
         min-width: 1.875rem;
       }
 
-      .c8 {
+      .c7 {
         background: #4945ff;
         padding: 8px;
         border-radius: 50%;
@@ -107,14 +107,14 @@ describe('GuidedTour Homepage', () => {
         height: 1.875rem;
       }
 
-      .c13 {
+      .c12 {
         margin-right: 20px;
         margin-top: 12px;
         margin-bottom: 12px;
         min-width: 1.875rem;
       }
 
-      .c14 {
+      .c13 {
         background: #7b79ff;
         border-radius: 4px;
         width: 0.125rem;
@@ -122,11 +122,11 @@ describe('GuidedTour Homepage', () => {
         min-height: 5.3125rem;
       }
 
-      .c15 {
+      .c14 {
         margin-top: 8px;
       }
 
-      .c22 {
+      .c21 {
         padding: 8px;
         border-radius: 50%;
         border-style: solid;
@@ -136,7 +136,7 @@ describe('GuidedTour Homepage', () => {
         height: 1.875rem;
       }
 
-      .c24 {
+      .c23 {
         background: #c0c0cf;
         border-radius: 4px;
         width: 0.125rem;
@@ -156,9 +156,10 @@ describe('GuidedTour Homepage', () => {
         -webkit-flex-direction: column;
         -ms-flex-direction: column;
         flex-direction: column;
+        gap: 24px;
       }
 
-      .c6 {
+      .c5 {
         -webkit-align-items: center;
         -webkit-box-align: center;
         -ms-flex-align: center;
@@ -172,7 +173,7 @@ describe('GuidedTour Homepage', () => {
         flex-direction: row;
       }
 
-      .c9 {
+      .c8 {
         -webkit-align-items: center;
         -webkit-box-align: center;
         -ms-flex-align: center;
@@ -190,7 +191,7 @@ describe('GuidedTour Homepage', () => {
         justify-content: center;
       }
 
-      .c12 {
+      .c11 {
         -webkit-align-items: flex-start;
         -webkit-box-align: flex-start;
         -ms-flex-align: flex-start;
@@ -204,7 +205,7 @@ describe('GuidedTour Homepage', () => {
         flex-direction: row;
       }
 
-      .c25 {
+      .c24 {
         -webkit-align-items: center;
         -webkit-box-align: center;
         -ms-flex-align: center;
@@ -222,16 +223,7 @@ describe('GuidedTour Homepage', () => {
         justify-content: flex-end;
       }
 
-      .c3 > * {
-        margin-top: 0;
-        margin-bottom: 0;
-      }
-
-      .c3 > * + * {
-        margin-top: 24px;
-      }
-
-      .c26 {
+      .c25 {
         display: -webkit-box;
         display: -webkit-flex;
         display: -ms-flexbox;
@@ -245,21 +237,21 @@ describe('GuidedTour Homepage', () => {
         outline: none;
       }
 
-      .c26 svg {
+      .c25 svg {
         height: 12px;
         width: 12px;
       }
 
-      .c26 svg > g,
-      .c26 svg path {
+      .c25 svg > g,
+      .c25 svg path {
         fill: #ffffff;
       }
 
-      .c26[aria-disabled='true'] {
+      .c25[aria-disabled='true'] {
         pointer-events: none;
       }
 
-      .c26:after {
+      .c25:after {
         -webkit-transition-property: all;
         transition-property: all;
         -webkit-transition-duration: 0.2s;
@@ -274,11 +266,11 @@ describe('GuidedTour Homepage', () => {
         border: 2px solid transparent;
       }
 
-      .c26:focus-visible {
+      .c25:focus-visible {
         outline: none;
       }
 
-      .c26:focus-visible:after {
+      .c25:focus-visible:after {
         border-radius: 8px;
         content: '';
         position: absolute;
@@ -289,7 +281,7 @@ describe('GuidedTour Homepage', () => {
         border: 2px solid #4945ff;
       }
 
-      .c27 {
+      .c26 {
         -webkit-align-items: center;
         -webkit-box-align: center;
         -ms-flex-align: center;
@@ -303,7 +295,7 @@ describe('GuidedTour Homepage', () => {
         background: #ffffff;
       }
 
-      .c27 .c0 {
+      .c26 .c0 {
         display: -webkit-box;
         display: -webkit-flex;
         display: -ms-flexbox;
@@ -314,65 +306,65 @@ describe('GuidedTour Homepage', () => {
         align-items: center;
       }
 
-      .c27 .c4 {
+      .c26 .c3 {
         color: #ffffff;
       }
 
-      .c27[aria-disabled='true'] {
+      .c26[aria-disabled='true'] {
         border: 1px solid #dcdce4;
         background: #eaeaef;
       }
 
-      .c27[aria-disabled='true'] .c4 {
+      .c26[aria-disabled='true'] .c3 {
         color: #666687;
       }
 
-      .c27[aria-disabled='true'] svg > g,.c27[aria-disabled='true'] svg path {
+      .c26[aria-disabled='true'] svg > g,.c26[aria-disabled='true'] svg path {
         fill: #666687;
       }
 
-      .c27[aria-disabled='true']:active {
+      .c26[aria-disabled='true']:active {
         border: 1px solid #dcdce4;
         background: #eaeaef;
       }
 
-      .c27[aria-disabled='true']:active .c4 {
+      .c26[aria-disabled='true']:active .c3 {
         color: #666687;
       }
 
-      .c27[aria-disabled='true']:active svg > g,.c27[aria-disabled='true']:active svg path {
+      .c26[aria-disabled='true']:active svg > g,.c26[aria-disabled='true']:active svg path {
         fill: #666687;
       }
 
-      .c27:hover {
+      .c26:hover {
         background-color: #f6f6f9;
       }
 
-      .c27:active {
+      .c26:active {
         background-color: #eaeaef;
       }
 
-      .c27 .c4 {
+      .c26 .c3 {
         color: #32324d;
       }
 
-      .c27 svg > g,
-      .c27 svg path {
+      .c26 svg > g,
+      .c26 svg path {
         fill: #32324d;
       }
 
-      .c21 {
+      .c20 {
         padding-left: 8px;
       }
 
-      .c19 {
+      .c18 {
         font-size: 0.75rem;
         line-height: 1.33;
         font-weight: 600;
         color: #32324d;
       }
 
-      .c16 {
+      .c15 {
         display: -webkit-box;
         display: -webkit-flex;
         display: -ms-flexbox;
@@ -386,21 +378,21 @@ describe('GuidedTour Homepage', () => {
         outline: none;
       }
 
-      .c16 svg {
+      .c15 svg {
         height: 12px;
         width: 12px;
       }
 
-      .c16 svg > g,
-      .c16 svg path {
+      .c15 svg > g,
+      .c15 svg path {
         fill: #ffffff;
       }
 
-      .c16[aria-disabled='true'] {
+      .c15[aria-disabled='true'] {
         pointer-events: none;
       }
 
-      .c16:after {
+      .c15:after {
         -webkit-transition-property: all;
         transition-property: all;
         -webkit-transition-duration: 0.2s;
@@ -415,11 +407,11 @@ describe('GuidedTour Homepage', () => {
         border: 2px solid transparent;
       }
 
-      .c16:focus-visible {
+      .c15:focus-visible {
         outline: none;
       }
 
-      .c16:focus-visible:after {
+      .c15:focus-visible:after {
         border-radius: 8px;
         content: '';
         position: absolute;
@@ -430,7 +422,7 @@ describe('GuidedTour Homepage', () => {
         border: 2px solid #4945ff;
       }
 
-      .c17 {
+      .c16 {
         padding: 8px 16px;
         background: #4945ff;
         border: 1px solid #4945ff;
@@ -443,7 +435,7 @@ describe('GuidedTour Homepage', () => {
         text-decoration: none;
       }
 
-      .c17 .c20 {
+      .c16 .c19 {
         display: -webkit-box;
         display: -webkit-flex;
         display: -ms-flexbox;
@@ -454,48 +446,48 @@ describe('GuidedTour Homepage', () => {
         align-items: center;
       }
 
-      .c17 .c18 {
+      .c16 .c17 {
         color: #ffffff;
       }
 
-      .c17[aria-disabled='true'] {
+      .c16[aria-disabled='true'] {
         border: 1px solid #dcdce4;
         background: #eaeaef;
       }
 
-      .c17[aria-disabled='true'] .c18 {
+      .c16[aria-disabled='true'] .c17 {
         color: #666687;
       }
 
-      .c17[aria-disabled='true'] svg > g,.c17[aria-disabled='true'] svg path {
+      .c16[aria-disabled='true'] svg > g,.c16[aria-disabled='true'] svg path {
         fill: #666687;
       }
 
-      .c17[aria-disabled='true']:active {
+      .c16[aria-disabled='true']:active {
         border: 1px solid #dcdce4;
         background: #eaeaef;
       }
 
-      .c17[aria-disabled='true']:active .c18 {
+      .c16[aria-disabled='true']:active .c17 {
         color: #666687;
       }
 
-      .c17[aria-disabled='true']:active svg > g,.c17[aria-disabled='true']:active svg path {
+      .c16[aria-disabled='true']:active svg > g,.c16[aria-disabled='true']:active svg path {
         fill: #666687;
       }
 
-      .c17:hover {
+      .c16:hover {
         border: 1px solid #7b79ff;
         background: #7b79ff;
       }
 
-      .c17:active {
+      .c16:active {
         border: 1px solid #4945ff;
         background: #4945ff;
       }
 
-      .c17 svg > g,
-      .c17 svg path {
+      .c16 svg > g,
+      .c16 svg path {
         fill: #ffffff;
       }
 
@@ -503,10 +495,10 @@ describe('GuidedTour Homepage', () => {
         class="c0 c1"
       >
         <div
-          class="c0 c2 c3"
+          class="c0 c2"
         >
           <h2
-            class="c4 c5"
+            class="c3 c4"
           >
             3 steps to get started
           </h2>
@@ -517,54 +509,54 @@ describe('GuidedTour Homepage', () => {
               class="c0 "
             >
               <div
-                class="c0 c6"
+                class="c0 c5"
               >
                 <div
-                  class="c0 c7"
+                  class="c0 c6"
                 >
                   <div
-                    class="c0 c8 c9"
+                    class="c0 c7 c8"
                   >
                     <span
-                      class="c4 c10"
+                      class="c3 c9"
                     >
                       1
                     </span>
                   </div>
                 </div>
                 <h3
-                  class="c4 c11"
+                  class="c3 c10"
                 >
                   🧠 Build the content structure
                 </h3>
               </div>
               <div
-                class="c0 c12"
+                class="c0 c11"
               >
                 <div
-                  class="c0 c13 c9"
+                  class="c0 c12 c8"
                 >
                   <div
-                    class="c0 c14"
+                    class="c0 c13"
                   />
                 </div>
                 <div
-                  class="c0 c15"
+                  class="c0 c14"
                 >
                   <a
                     aria-disabled="false"
-                    class="c16 c17"
+                    class="c15 c16"
                     href="/plugins/content-type-builder"
                     variant="default"
                   >
                     <span
-                      class="c18 c19"
+                      class="c17 c18"
                     >
                       Go to the Content type Builder
                     </span>
                     <div
                       aria-hidden="true"
-                      class="c20 c21"
+                      class="c19 c20"
                     >
                       <svg
                         fill="none"
@@ -587,39 +579,39 @@ describe('GuidedTour Homepage', () => {
               class="c0 "
             >
               <div
-                class="c0 c6"
+                class="c0 c5"
               >
                 <div
-                  class="c0 c7"
+                  class="c0 c6"
                 >
                   <div
-                    class="c0 c22 c9"
+                    class="c0 c21 c8"
                   >
                     <span
-                      class="c4 c23"
+                      class="c3 c22"
                     >
                       2
                     </span>
                   </div>
                 </div>
                 <h3
-                  class="c4 c11"
+                  class="c3 c10"
                 >
                   ⚡️ What would you like to share with the world?
                 </h3>
               </div>
               <div
-                class="c0 c12"
+                class="c0 c11"
               >
                 <div
-                  class="c0 c13 c9"
+                  class="c0 c12 c8"
                 >
                   <div
-                    class="c0 c24"
+                    class="c0 c23"
                   />
                 </div>
                 <div
-                  class="c0 c15"
+                  class="c0 c14"
                 />
               </div>
             </div>
@@ -627,50 +619,50 @@ describe('GuidedTour Homepage', () => {
               class="c0 "
             >
               <div
-                class="c0 c6"
+                class="c0 c5"
               >
                 <div
-                  class="c0 c7"
+                  class="c0 c6"
                 >
                   <div
-                    class="c0 c22 c9"
+                    class="c0 c21 c8"
                   >
                     <span
-                      class="c4 c23"
+                      class="c3 c22"
                     >
                       3
                     </span>
                   </div>
                 </div>
                 <h3
-                  class="c4 c11"
+                  class="c3 c10"
                 >
                   🚀 See content in action
                 </h3>
               </div>
               <div
-                class="c0 c12"
+                class="c0 c11"
               >
                 <div
-                  class="c0 c13 c9"
+                  class="c0 c12 c8"
                 />
                 <div
-                  class="c0 c15"
+                  class="c0 c14"
                 />
               </div>
             </div>
           </div>
         </div>
         <div
-          class="c0 c25"
+          class="c0 c24"
         >
           <button
             aria-disabled="false"
-            class="c26 c27"
+            class="c25 c26"
             type="button"
           >
             <span
-              class="c4 c28"
+              class="c3 c27"
             >
               Skip the tour
             </span>

--- a/packages/core/admin/admin/src/components/GuidedTour/Modal/components/Content.js
+++ b/packages/core/admin/admin/src/components/GuidedTour/Modal/components/Content.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { Stack, Box, Typography } from '@strapi/design-system';
+import { Flex, Box, Typography } from '@strapi/design-system';
 import { useIntl } from 'react-intl';
 
 const LiStyled = styled.li`
@@ -15,35 +15,47 @@ const Content = ({ id, defaultMessage }) => {
   const { formatMessage } = useIntl();
 
   return (
-    <Stack spacing={4} paddingBottom={6}>
+    <Flex direction="column" alignItems="stretch" gap={4} paddingBottom={6}>
       {formatMessage(
         { id, defaultMessage },
         {
-          documentationLink: (children) => (
-            <Typography
-              as="a"
-              textColor="primary600"
-              target="_blank"
-              rel="noopener noreferrer"
-              href="https://docs.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/rest-api.html#api-parameters"
-            >
-              {children}
-            </Typography>
-          ),
-          b: (children) => <Typography fontWeight="semiBold">{children}</Typography>,
-          p: (children) => <Typography>{children}</Typography>,
-          light: (children) => <Typography textColor="neutral600">{children}</Typography>,
-          ul: (children) => (
-            <Box paddingLeft={6}>
-              <ul>{children}</ul>
-            </Box>
-          ),
-          li: (children) => <LiStyled>{children}</LiStyled>,
+          documentationLink: DocumentationLink,
+          b: Bold,
+          p: Paragraph,
+          light: Light,
+          ul: List,
+          li: ListItem,
         }
       )}
-    </Stack>
+    </Flex>
   );
 };
+
+const DocumentationLink = (children) => (
+  <Typography
+    as="a"
+    textColor="primary600"
+    target="_blank"
+    rel="noopener noreferrer"
+    href="https://docs.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/rest-api.html#api-parameters"
+  >
+    {children}
+  </Typography>
+);
+
+const Bold = (children) => <Typography fontWeight="semiBold">{children}</Typography>;
+
+const Paragraph = (children) => <Typography>{children}</Typography>;
+
+const Light = (children) => <Typography textColor="neutral600">{children}</Typography>;
+
+const List = (children) => (
+  <Box paddingLeft={6}>
+    <ul>{children}</ul>
+  </Box>
+);
+
+const ListItem = (children) => <LiStyled>{children}</LiStyled>;
 
 Content.propTypes = {
   id: PropTypes.string.isRequired,

--- a/packages/core/admin/admin/src/components/GuidedTour/Modal/components/Modal.js
+++ b/packages/core/admin/admin/src/components/GuidedTour/Modal/components/Modal.js
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 import { pxToRem } from '@strapi/helper-plugin';
-import { Portal, FocusTrap, Flex, Box, Stack, IconButton, Button } from '@strapi/design-system';
+import { Portal, FocusTrap, Flex, Box, IconButton, Button } from '@strapi/design-system';
 import { Cross } from '@strapi/icons';
 
 const ModalWrapper = styled(Flex)`
@@ -21,13 +21,15 @@ const Modal = ({ onClose, onSkip, children, hideSkip }) => {
     <Portal>
       <ModalWrapper onClick={onClose} padding={8} justifyContent="center">
         <FocusTrap onEscape={onClose}>
-          <Stack
+          <Flex
+            direction="column"
+            alignItems="stretch"
             background="neutral0"
             width={pxToRem(660)}
             shadow="popupShadow"
             hasRadius
             padding={4}
-            spacing={8}
+            gap={8}
             role="dialog"
             aria-modal
             onClick={(e) => e.stopPropagation()}
@@ -52,7 +54,7 @@ const Modal = ({ onClose, onSkip, children, hideSkip }) => {
                 </Button>
               </Flex>
             )}
-          </Stack>
+          </Flex>
         </FocusTrap>
       </ModalWrapper>
     </Portal>

--- a/packages/core/admin/admin/src/components/GuidedTour/Modal/tests/index.test.js
+++ b/packages/core/admin/admin/src/components/GuidedTour/Modal/tests/index.test.js
@@ -48,7 +48,7 @@ describe('<GuidedTourModal />', () => {
     expect(screen.getByText('🧠 Create a first Collection type')).toBeInTheDocument();
 
     expect(document.body).toMatchInlineSnapshot(`
-      .c16 {
+      .c15 {
         font-weight: 600;
         font-size: 0.6875rem;
         line-height: 1.45;
@@ -56,14 +56,14 @@ describe('<GuidedTourModal />', () => {
         color: #4945ff;
       }
 
-      .c20 {
+      .c19 {
         font-size: 0.875rem;
         line-height: 1.43;
         font-weight: 500;
         color: #ffffff;
       }
 
-      .c21 {
+      .c20 {
         font-weight: 600;
         font-size: 2rem;
         line-height: 1.25;
@@ -71,13 +71,13 @@ describe('<GuidedTourModal />', () => {
         color: #32324d;
       }
 
-      .c25 {
+      .c24 {
         font-size: 0.875rem;
         line-height: 1.43;
         color: #32324d;
       }
 
-      .c27 {
+      .c26 {
         font-size: 0.75rem;
         line-height: 1.33;
         font-weight: 600;
@@ -96,17 +96,17 @@ describe('<GuidedTourModal />', () => {
         width: 41.25rem;
       }
 
-      .c11 {
+      .c10 {
         padding-right: 32px;
         padding-left: 32px;
       }
 
-      .c13 {
+      .c12 {
         margin-right: 40px;
         min-width: 1.875rem;
       }
 
-      .c14 {
+      .c13 {
         background: #7b79ff;
         border-radius: 4px;
         width: 0.125rem;
@@ -114,12 +114,12 @@ describe('<GuidedTourModal />', () => {
         min-height: 1.5rem;
       }
 
-      .c18 {
+      .c17 {
         padding-top: 12px;
         padding-bottom: 12px;
       }
 
-      .c19 {
+      .c18 {
         background: #4945ff;
         padding: 8px;
         border-radius: 50%;
@@ -127,11 +127,11 @@ describe('<GuidedTourModal />', () => {
         height: 1.875rem;
       }
 
-      .c23 {
+      .c22 {
         padding-bottom: 24px;
       }
 
-      .c28 {
+      .c27 {
         padding-left: 8px;
       }
 
@@ -165,9 +165,10 @@ describe('<GuidedTourModal />', () => {
         -webkit-flex-direction: column;
         -ms-flex-direction: column;
         flex-direction: column;
+        gap: 40px;
       }
 
-      .c8 {
+      .c7 {
         -webkit-align-items: center;
         -webkit-box-align: center;
         -ms-flex-align: center;
@@ -185,7 +186,7 @@ describe('<GuidedTourModal />', () => {
         justify-content: flex-end;
       }
 
-      .c12 {
+      .c11 {
         -webkit-align-items: stretch;
         -webkit-box-align: stretch;
         -ms-flex-align: stretch;
@@ -199,7 +200,7 @@ describe('<GuidedTourModal />', () => {
         flex-direction: row;
       }
 
-      .c17 {
+      .c16 {
         -webkit-align-items: center;
         -webkit-box-align: center;
         -ms-flex-align: center;
@@ -213,7 +214,7 @@ describe('<GuidedTourModal />', () => {
         flex-direction: row;
       }
 
-      .c22 {
+      .c21 {
         -webkit-align-items: center;
         -webkit-box-align: center;
         -ms-flex-align: center;
@@ -231,25 +232,22 @@ describe('<GuidedTourModal />', () => {
         justify-content: center;
       }
 
-      .c7 > * {
-        margin-top: 0;
-        margin-bottom: 0;
+      .c23 {
+        -webkit-align-items: stretch;
+        -webkit-box-align: stretch;
+        -ms-flex-align: stretch;
+        align-items: stretch;
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+        -webkit-flex-direction: column;
+        -ms-flex-direction: column;
+        flex-direction: column;
+        gap: 16px;
       }
 
-      .c7 > * + * {
-        margin-top: 40px;
-      }
-
-      .c24 > * {
-        margin-top: 0;
-        margin-bottom: 0;
-      }
-
-      .c24 > * + * {
-        margin-top: 16px;
-      }
-
-      .c9 {
+      .c8 {
         display: -webkit-box;
         display: -webkit-flex;
         display: -ms-flexbox;
@@ -263,21 +261,21 @@ describe('<GuidedTourModal />', () => {
         outline: none;
       }
 
-      .c9 svg {
+      .c8 svg {
         height: 12px;
         width: 12px;
       }
 
-      .c9 svg > g,
-      .c9 svg path {
+      .c8 svg > g,
+      .c8 svg path {
         fill: #ffffff;
       }
 
-      .c9[aria-disabled='true'] {
+      .c8[aria-disabled='true'] {
         pointer-events: none;
       }
 
-      .c9:after {
+      .c8:after {
         -webkit-transition-property: all;
         transition-property: all;
         -webkit-transition-duration: 0.2s;
@@ -292,11 +290,11 @@ describe('<GuidedTourModal />', () => {
         border: 2px solid transparent;
       }
 
-      .c9:focus-visible {
+      .c8:focus-visible {
         outline: none;
       }
 
-      .c9:focus-visible:after {
+      .c8:focus-visible:after {
         border-radius: 8px;
         content: '';
         position: absolute;
@@ -319,7 +317,7 @@ describe('<GuidedTourModal />', () => {
         width: 1px;
       }
 
-      .c26 {
+      .c25 {
         -webkit-align-items: center;
         -webkit-box-align: center;
         -ms-flex-align: center;
@@ -331,7 +329,7 @@ describe('<GuidedTourModal />', () => {
         padding-right: 16px;
       }
 
-      .c26 .c1 {
+      .c25 .c1 {
         display: -webkit-box;
         display: -webkit-flex;
         display: -ms-flexbox;
@@ -342,52 +340,52 @@ describe('<GuidedTourModal />', () => {
         align-items: center;
       }
 
-      .c26 .c15 {
+      .c25 .c14 {
         color: #ffffff;
       }
 
-      .c26[aria-disabled='true'] {
+      .c25[aria-disabled='true'] {
         border: 1px solid #dcdce4;
         background: #eaeaef;
       }
 
-      .c26[aria-disabled='true'] .c15 {
+      .c25[aria-disabled='true'] .c14 {
         color: #666687;
       }
 
-      .c26[aria-disabled='true'] svg > g,.c26[aria-disabled='true'] svg path {
+      .c25[aria-disabled='true'] svg > g,.c25[aria-disabled='true'] svg path {
         fill: #666687;
       }
 
-      .c26[aria-disabled='true']:active {
+      .c25[aria-disabled='true']:active {
         border: 1px solid #dcdce4;
         background: #eaeaef;
       }
 
-      .c26[aria-disabled='true']:active .c15 {
+      .c25[aria-disabled='true']:active .c14 {
         color: #666687;
       }
 
-      .c26[aria-disabled='true']:active svg > g,.c26[aria-disabled='true']:active svg path {
+      .c25[aria-disabled='true']:active svg > g,.c25[aria-disabled='true']:active svg path {
         fill: #666687;
       }
 
-      .c26:hover {
+      .c25:hover {
         border: 1px solid #7b79ff;
         background: #7b79ff;
       }
 
-      .c26:active {
+      .c25:active {
         border: 1px solid #4945ff;
         background: #4945ff;
       }
 
-      .c26 svg > g,
-      .c26 svg path {
+      .c25 svg > g,
+      .c25 svg path {
         fill: #ffffff;
       }
 
-      .c29 {
+      .c28 {
         -webkit-align-items: center;
         -webkit-box-align: center;
         -ms-flex-align: center;
@@ -401,7 +399,7 @@ describe('<GuidedTourModal />', () => {
         background: #ffffff;
       }
 
-      .c29 .c1 {
+      .c28 .c1 {
         display: -webkit-box;
         display: -webkit-flex;
         display: -ms-flexbox;
@@ -412,54 +410,54 @@ describe('<GuidedTourModal />', () => {
         align-items: center;
       }
 
-      .c29 .c15 {
+      .c28 .c14 {
         color: #ffffff;
       }
 
-      .c29[aria-disabled='true'] {
+      .c28[aria-disabled='true'] {
         border: 1px solid #dcdce4;
         background: #eaeaef;
       }
 
-      .c29[aria-disabled='true'] .c15 {
+      .c28[aria-disabled='true'] .c14 {
         color: #666687;
       }
 
-      .c29[aria-disabled='true'] svg > g,.c29[aria-disabled='true'] svg path {
+      .c28[aria-disabled='true'] svg > g,.c28[aria-disabled='true'] svg path {
         fill: #666687;
       }
 
-      .c29[aria-disabled='true']:active {
+      .c28[aria-disabled='true']:active {
         border: 1px solid #dcdce4;
         background: #eaeaef;
       }
 
-      .c29[aria-disabled='true']:active .c15 {
+      .c28[aria-disabled='true']:active .c14 {
         color: #666687;
       }
 
-      .c29[aria-disabled='true']:active svg > g,.c29[aria-disabled='true']:active svg path {
+      .c28[aria-disabled='true']:active svg > g,.c28[aria-disabled='true']:active svg path {
         fill: #666687;
       }
 
-      .c29:hover {
+      .c28:hover {
         background-color: #f6f6f9;
       }
 
-      .c29:active {
+      .c28:active {
         background-color: #eaeaef;
       }
 
-      .c29 .c15 {
+      .c28 .c14 {
         color: #32324d;
       }
 
-      .c29 svg > g,
-      .c29 svg path {
+      .c28 svg > g,
+      .c28 svg path {
         fill: #32324d;
       }
 
-      .c10 {
+      .c9 {
         display: -webkit-box;
         display: -webkit-flex;
         display: -ms-flexbox;
@@ -476,26 +474,26 @@ describe('<GuidedTourModal />', () => {
         width: 2rem;
       }
 
-      .c10 svg > g,
-      .c10 svg path {
+      .c9 svg > g,
+      .c9 svg path {
         fill: #8e8ea9;
       }
 
-      .c10:hover svg > g,
-      .c10:hover svg path {
+      .c9:hover svg > g,
+      .c9:hover svg path {
         fill: #666687;
       }
 
-      .c10:active svg > g,
-      .c10:active svg path {
+      .c9:active svg > g,
+      .c9:active svg path {
         fill: #a5a5ba;
       }
 
-      .c10[aria-disabled='true'] {
+      .c9[aria-disabled='true'] {
         background-color: #eaeaef;
       }
 
-      .c10[aria-disabled='true'] svg path {
+      .c9[aria-disabled='true'] svg path {
         fill: #666687;
       }
 
@@ -540,15 +538,15 @@ describe('<GuidedTourModal />', () => {
             <div>
               <div
                 aria-modal="true"
-                class="c1 c5 c6 c7"
+                class="c1 c5 c6"
                 role="dialog"
               >
                 <div
-                  class="c1 c8"
+                  class="c1 c7"
                 >
                   <button
                     aria-disabled="false"
-                    class="c9 c10"
+                    class="c8 c9"
                     type="button"
                   >
                     <span
@@ -573,38 +571,38 @@ describe('<GuidedTourModal />', () => {
                   </button>
                 </div>
                 <div
-                  class="c1 c11"
+                  class="c1 c10"
                 >
                   <div
-                    class="c1 c12"
+                    class="c1 c11"
                   >
                     <div
-                      class="c1 c13 c3"
+                      class="c1 c12 c3"
                     >
                       <div
-                        class="c1 c14"
+                        class="c1 c13"
                       />
                     </div>
                     <span
-                      class="c15 c16"
+                      class="c14 c15"
                     >
                       3 steps to get started
                     </span>
                   </div>
                   <div
-                    class="c1 c17"
+                    class="c1 c16"
                   >
                     <div
-                      class="c1 c13 c17"
+                      class="c1 c12 c16"
                     >
                       <div
-                        class="c1 c18"
+                        class="c1 c17"
                       >
                         <div
-                          class="c1 c19 c3"
+                          class="c1 c18 c3"
                         >
                           <span
-                            class="c15 c20"
+                            class="c14 c19"
                           >
                             3
                           </span>
@@ -612,49 +610,49 @@ describe('<GuidedTourModal />', () => {
                       </div>
                     </div>
                     <h3
-                      class="c15 c21"
+                      class="c14 c20"
                       id="title"
                     >
                       🧠 Create a first Collection type
                     </h3>
                   </div>
                   <div
-                    class="c1 c12"
+                    class="c1 c11"
                   >
                     <div
-                      class="c1 c13 c22"
+                      class="c1 c12 c21"
                     />
                     <div
                       class="c1 "
                     >
                       <div
-                        class="c1 c23 c6 c24"
+                        class="c1 c22 c23"
                       >
                         <span
-                          class="c15 c25"
+                          class="c14 c24"
                         >
                           Collection types help you manage several entries, Single types are suitable to manage only one entry.
                         </span>
                          
                         <span
-                          class="c15 c25"
+                          class="c14 c24"
                         >
                           Ex: For a Blog website, Articles would be a Collection type whereas a Homepage would be a Single type.
                         </span>
                       </div>
                       <button
                         aria-disabled="false"
-                        class="c9 c26"
+                        class="c8 c25"
                         type="button"
                       >
                         <span
-                          class="c15 c27"
+                          class="c14 c26"
                         >
                           Build a Collection type
                         </span>
                         <div
                           aria-hidden="true"
-                          class="c1 c28"
+                          class="c1 c27"
                         >
                           <svg
                             fill="none"
@@ -674,15 +672,15 @@ describe('<GuidedTourModal />', () => {
                   </div>
                 </div>
                 <div
-                  class="c1 c8"
+                  class="c1 c7"
                 >
                   <button
                     aria-disabled="false"
-                    class="c9 c29"
+                    class="c8 c28"
                     type="button"
                   >
                     <span
-                      class="c15 c27"
+                      class="c14 c26"
                     >
                       Skip the tour
                     </span>

--- a/packages/core/admin/admin/src/components/LeftMenu/index.js
+++ b/packages/core/admin/admin/src/components/LeftMenu/index.js
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 import { NavLink as RouterNavLink, useLocation, useHistory } from 'react-router-dom';
-import { Divider, FocusTrap, Box, Typography, Stack } from '@strapi/design-system';
+import { Divider, FocusTrap, Box, Typography, Flex } from '@strapi/design-system';
 import {
   MainNav,
   NavBrand,
@@ -203,7 +203,7 @@ const LeftMenu = ({ generalSectionLinks, pluginsSectionLinks }) => {
             hasRadius
           >
             <FocusTrap onEscape={handleToggleUserLinks}>
-              <Stack spacing={0}>
+              <Flex direction="column" alignItems="stretch" gap={0}>
                 <LinkUser tabIndex={0} onClick={handleToggleUserLinks} to="/me">
                   <Typography>
                     {formatMessage({
@@ -221,7 +221,7 @@ const LeftMenu = ({ generalSectionLinks, pluginsSectionLinks }) => {
                   </Typography>
                   <Exit />
                 </LinkUser>
-              </Stack>
+              </Flex>
             </FocusTrap>
           </LinkUserWrapper>
         )}

--- a/packages/core/admin/admin/src/components/Notifications/index.js
+++ b/packages/core/admin/admin/src/components/Notifications/index.js
@@ -1,7 +1,7 @@
 import { NotificationsProvider } from '@strapi/helper-plugin';
 import React, { useReducer } from 'react';
 import PropTypes from 'prop-types';
-import { Stack } from '@strapi/design-system';
+import { Flex } from '@strapi/design-system';
 import Notification from './Notification';
 import reducer, { initialState } from './reducer';
 
@@ -17,11 +17,13 @@ const Notifications = ({ children }) => {
 
   return (
     <NotificationsProvider toggleNotification={displayNotification}>
-      <Stack
+      <Flex
         left="50%"
         marginLeft="-250px"
         position="fixed"
-        spacing={2}
+        direction="column"
+        alignItems="stretch"
+        gap={2}
         top={`${46 / 16}rem`}
         width={`${500 / 16}rem`}
         zIndex={10}
@@ -31,7 +33,7 @@ const Notifications = ({ children }) => {
             <Notification key={notification.id} dispatch={dispatch} notification={notification} />
           );
         })}
-      </Stack>
+      </Flex>
       {children}
     </NotificationsProvider>
   );

--- a/packages/core/admin/admin/src/components/Notifications/tests/index.test.js
+++ b/packages/core/admin/admin/src/components/Notifications/tests/index.test.js
@@ -54,19 +54,11 @@ describe('<Notifications />', () => {
         -webkit-flex-direction: column;
         -ms-flex-direction: column;
         flex-direction: column;
-      }
-
-      .c2 > * {
-        margin-top: 0;
-        margin-bottom: 0;
-      }
-
-      .c2 > * + * {
-        margin-top: 8px;
+        gap: 8px;
       }
 
       <div
-        class="c0 c1 c2"
+        class="c0 c1"
       />
     `);
   });

--- a/packages/core/admin/admin/src/components/UpgradePlanModal/index.js
+++ b/packages/core/admin/admin/src/components/UpgradePlanModal/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { useIntl } from 'react-intl';
-import { Portal, FocusTrap, IconButton, Box, Flex, Typography, Stack } from '@strapi/design-system';
+import { Portal, FocusTrap, IconButton, Box, Flex, Typography } from '@strapi/design-system';
 import { LinkButton } from '@strapi/design-system/v2';
 import { ExternalLink, Cross } from '@strapi/icons';
 import { setHexOpacity, useLockScroll } from '@strapi/helper-plugin';
@@ -41,8 +41,7 @@ const UpgradeContainer = styled(Flex)`
   }
 `;
 
-const StackFlexStart = styled(Stack)`
-  align-items: flex-start;
+const FlexStart = styled(Flex)`
   max-width: ${400 / 16}rem;
   z-index: 0;
 `;
@@ -75,14 +74,14 @@ const UpgradePlanModal = ({ onClose, isOpen }) => {
             <CloseButtonContainer>
               <IconButton onClick={onClose} aria-label="Close" icon={<Cross />} />
             </CloseButtonContainer>
-            <StackFlexStart spacing={6}>
+            <FlexStart direction="column" alignItems="flex-start" gap={6}>
               <Typography fontWeight="bold" textColor="primary600">
                 {formatMessage({
                   id: 'app.components.UpgradePlanModal.text-ce',
                   defaultMessage: 'COMMUNITY EDITION',
                 })}
               </Typography>
-              <Stack spacing={2}>
+              <Flex direction="column" alignItems="stretch" gap={2}>
                 <Typography variant="alpha" as="h2" id="upgrade-plan">
                   {formatMessage({
                     id: 'app.components.UpgradePlanModal.limit-reached',
@@ -96,7 +95,7 @@ const UpgradePlanModal = ({ onClose, isOpen }) => {
                       'Unlock the full power of Strapi by upgrading your plan to the Enterprise Edition',
                   })}
                 </Typography>
-              </Stack>
+              </Flex>
               <LinkButton
                 href="https://strapi.io/pricing-self-hosted"
                 isExternal
@@ -107,7 +106,7 @@ const UpgradePlanModal = ({ onClose, isOpen }) => {
                   defaultMessage: 'Learn more',
                 })}
               </LinkButton>
-            </StackFlexStart>
+            </FlexStart>
             <img src={BigArrow} alt="upgrade-arrow" />
           </UpgradeContainer>
         </FocusTrap>

--- a/packages/core/admin/admin/src/content-manager/components/ComponentInitializer/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/ComponentInitializer/index.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { useIntl } from 'react-intl';
 import { PlusCircle } from '@strapi/icons';
-import { Box, Stack, Flex, Typography } from '@strapi/design-system';
+import { Box, Flex, Typography } from '@strapi/design-system';
 import { pxToRem } from '@strapi/helper-plugin';
 import { getTrad } from '../../utils';
 
@@ -36,7 +36,7 @@ const ComponentInitializer = ({ error, isReadOnly, onClick }) => {
         paddingBottom={9}
         type="button"
       >
-        <Stack spacing={2}>
+        <Flex direction="column" alignItems="flex-start" gap={2}>
           <Flex justifyContent="center" style={{ cursor: isReadOnly ? 'not-allowed' : 'inherit' }}>
             <IconWrapper>
               <PlusCircle />
@@ -50,7 +50,7 @@ const ComponentInitializer = ({ error, isReadOnly, onClick }) => {
               })}
             </Typography>
           </Flex>
-        </Stack>
+        </Flex>
       </Box>
       {error?.id && (
         <Typography textColor="danger600" variant="pi">

--- a/packages/core/admin/admin/src/content-manager/components/DragLayer/RelationDragPreview.js
+++ b/packages/core/admin/admin/src/content-manager/components/DragLayer/RelationDragPreview.js
@@ -6,7 +6,7 @@ import { Drag, Cross } from '@strapi/icons';
 
 import { getTrad } from '../../utils';
 import { PUBLICATION_STATES } from '../RelationInputDataManager/constants';
-import { ChildrenWrapper, StackWrapper } from '../RelationInput/components/RelationItem';
+import { ChildrenWrapper, FlexWrapper } from '../RelationInput/components/RelationItem';
 import { LinkEllipsis, DisconnectButton } from '../RelationInput';
 
 export const RelationDragPreview = ({ status, displayedValue, width }) => {
@@ -39,7 +39,7 @@ export const RelationDragPreview = ({ status, displayedValue, width }) => {
         borderColor="neutral200"
         justifyContent="space-between"
       >
-        <StackWrapper spacing={1} horizontal>
+        <FlexWrapper gap={1}>
           <IconButton noBorder>
             <Drag />
           </IconButton>
@@ -59,7 +59,7 @@ export const RelationDragPreview = ({ status, displayedValue, width }) => {
               </Status>
             )}
           </ChildrenWrapper>
-        </StackWrapper>
+        </FlexWrapper>
         <Box paddingLeft={4}>
           <DisconnectButton type="button">
             <Icon width="12px" as={Cross} />

--- a/packages/core/admin/admin/src/content-manager/components/DynamicTable/ConfirmDialogDelete/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/DynamicTable/ConfirmDialogDelete/index.js
@@ -1,15 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
-import {
-  Dialog,
-  DialogBody,
-  DialogFooter,
-  Stack,
-  Flex,
-  Typography,
-  Button,
-} from '@strapi/design-system';
+import { Dialog, DialogBody, DialogFooter, Flex, Typography, Button } from '@strapi/design-system';
 import { ExclamationMarkCircle, Trash } from '@strapi/icons';
 import InjectionZoneList from '../../InjectionZoneList';
 
@@ -28,7 +20,7 @@ const ConfirmDialogDelete = ({ isConfirmButtonLoading, isOpen, onToggleDialog, o
       isOpen={isOpen}
     >
       <DialogBody icon={<ExclamationMarkCircle />}>
-        <Stack spacing={2}>
+        <Flex direction="column" alignItems="stretch" gap={2}>
           <Flex justifyContent="center">
             <Typography id="confirm-description">
               {formatMessage({
@@ -40,7 +32,7 @@ const ConfirmDialogDelete = ({ isConfirmButtonLoading, isOpen, onToggleDialog, o
           <Flex>
             <InjectionZoneList area="contentManager.listView.deleteModalAdditionalInfos" />
           </Flex>
-        </Stack>
+        </Flex>
       </DialogBody>
       <DialogFooter
         startAction={

--- a/packages/core/admin/admin/src/content-manager/components/DynamicTable/ConfirmDialogDeleteAll/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/DynamicTable/ConfirmDialogDeleteAll/index.js
@@ -1,15 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
-import {
-  Dialog,
-  DialogBody,
-  DialogFooter,
-  Stack,
-  Flex,
-  Typography,
-  Button,
-} from '@strapi/design-system';
+import { Dialog, DialogBody, DialogFooter, Flex, Typography, Button } from '@strapi/design-system';
 import { ExclamationMarkCircle, Trash } from '@strapi/icons';
 import InjectionZoneList from '../../InjectionZoneList';
 import { getTrad } from '../../../utils';
@@ -29,7 +21,7 @@ const ConfirmDialogDeleteAll = ({ isConfirmButtonLoading, isOpen, onToggleDialog
       isOpen={isOpen}
     >
       <DialogBody icon={<ExclamationMarkCircle />}>
-        <Stack spacing={2}>
+        <Flex direction="column" alignItems="stretch" gap={2}>
           <Flex justifyContent="center">
             <Typography id="confirm-description">
               {formatMessage({
@@ -41,7 +33,7 @@ const ConfirmDialogDeleteAll = ({ isConfirmButtonLoading, isOpen, onToggleDialog
           <Flex>
             <InjectionZoneList area="contentManager.listView.deleteModalAdditionalInfos" />
           </Flex>
-        </Stack>
+        </Flex>
       </DialogBody>
       <DialogFooter
         startAction={

--- a/packages/core/admin/admin/src/content-manager/components/DynamicZone/components/ComponentCard.js
+++ b/packages/core/admin/admin/src/content-manager/components/DynamicZone/components/ComponentCard.js
@@ -8,7 +8,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
-import { Box, Typography, Stack } from '@strapi/design-system';
+import { Box, Typography, Flex } from '@strapi/design-system';
 import { pxToRem } from '@strapi/helper-plugin';
 
 import { ComponentIcon } from '../../ComponentIcon';
@@ -32,7 +32,7 @@ const ComponentBox = styled(Box)`
       color: ${({ theme }) => theme.colors.primary600};
     }
 
-    /* > Stack > ComponentIcon */
+    /* > Flex > ComponentIcon */
     > div > div:first-child {
       background: ${({ theme }) => theme.colors.primary200};
       color: ${({ theme }) => theme.colors.primary600};
@@ -43,13 +43,13 @@ const ComponentBox = styled(Box)`
 export default function ComponentCard({ children, onClick }) {
   return (
     <ComponentBox as="button" type="button" onClick={onClick} hasRadius>
-      <Stack spacing={1} alignItems="center" justifyContent="center">
+      <Flex direction="column" gap={1} alignItems="center" justifyContent="center">
         <ComponentIcon />
 
         <Typography variant="pi" fontWeight="bold" textColor="neutral600">
           {children}
         </Typography>
-      </Stack>
+      </Flex>
     </ComponentBox>
   );
 }

--- a/packages/core/admin/admin/src/content-manager/components/DynamicZone/components/DynamicComponent.js
+++ b/packages/core/admin/admin/src/content-manager/components/DynamicZone/components/DynamicComponent.js
@@ -12,7 +12,6 @@ import {
   IconButton,
   Box,
   Flex,
-  Stack,
 } from '@strapi/design-system';
 import { useCMEditViewDataManager } from '@strapi/helper-plugin';
 import { Trash, Drag } from '@strapi/icons';
@@ -22,7 +21,7 @@ import { composeRefs, getTrad, ItemTypes } from '../../../utils';
 
 import FieldComponent from '../../FieldComponent';
 
-const ActionsStack = styled(Stack)`
+const ActionsFlex = styled(Flex)`
   /* 
     we need to remove the background from the button but we can't 
     wrap the element in styled because it breaks the forwardedAs which
@@ -149,7 +148,7 @@ const DynamicZoneComponent = ({
   const composedBoxRefs = composeRefs(boxRef, dropRef);
 
   const accordionActions = !isFieldAllowed ? null : (
-    <ActionsStack horizontal spacing={0} expanded={isOpen}>
+    <ActionsFlex gap={0} expanded={isOpen}>
       <IconButtonCustom
         noBorder
         label={formatMessage(
@@ -179,7 +178,7 @@ const DynamicZoneComponent = ({
       >
         <Drag />
       </IconButton>
-    </ActionsStack>
+    </ActionsFlex>
   );
 
   return (

--- a/packages/core/admin/admin/src/content-manager/components/DynamicZone/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/DynamicZone/index.js
@@ -2,7 +2,7 @@ import React, { memo, useMemo, useState } from 'react';
 import get from 'lodash/get';
 import isEqual from 'react-fast-compare';
 import PropTypes from 'prop-types';
-import { Box, Stack, VisuallyHidden } from '@strapi/design-system';
+import { Box, Flex, VisuallyHidden } from '@strapi/design-system';
 import { NotAllowedInput, useNotification } from '@strapi/helper-plugin';
 import { useIntl } from 'react-intl';
 
@@ -174,7 +174,7 @@ const DynamicZone = ({
   const ariaDescriptionId = `${name}-item-instructions`;
 
   return (
-    <Stack spacing={6}>
+    <Flex direction="column" alignItems="stretch" gap={6}>
       {dynamicDisplayedComponentsLength > 0 && (
         <Box>
           <DynamicZoneLabel
@@ -228,7 +228,7 @@ const DynamicZone = ({
         components={fieldSchema.components ?? []}
         onClickAddComponent={handleAddComponent}
       />
-    </Stack>
+    </Flex>
   );
 };
 

--- a/packages/core/admin/admin/src/content-manager/components/FieldComponent/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/FieldComponent/index.js
@@ -7,7 +7,7 @@ import { useIntl } from 'react-intl';
 
 import { NotAllowedInput } from '@strapi/helper-plugin';
 import { Trash } from '@strapi/icons';
-import { Box, IconButton, Flex, Stack } from '@strapi/design-system';
+import { Box, IconButton, Flex } from '@strapi/design-system';
 
 import connect from './utils/connect';
 import select from './utils/select';
@@ -92,7 +92,7 @@ const FieldComponent = ({
           />
         )}
       </Flex>
-      <Stack spacing={1}>
+      <Flex direction="column" alignItems="stretch" gap={1}>
         {!isRepeatable && !isInitialized && (
           <ComponentInitializer
             isReadOnly={isReadOnly}
@@ -118,7 +118,7 @@ const FieldComponent = ({
             name={name}
           />
         )}
-      </Stack>
+      </Flex>
     </Box>
   );
 };

--- a/packages/core/admin/admin/src/content-manager/components/NonRepeatableComponent/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/NonRepeatableComponent/index.js
@@ -3,7 +3,7 @@
 
 import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
-import { Box, Grid, GridItem, Stack } from '@strapi/design-system';
+import { Box, Grid, GridItem, Flex } from '@strapi/design-system';
 import { useContentTypeLayout } from '../../hooks';
 import FieldComponent from '../FieldComponent';
 import Inputs from '../Inputs';
@@ -29,7 +29,7 @@ const NonRepeatableComponent = ({ componentUid, isFromDynamicZone, isNested, nam
       hasRadius={isNested}
       borderColor={isNested ? 'neutral200' : ''}
     >
-      <Stack spacing={6}>
+      <Flex direction="column" alignItems="stretch" spacing={6}>
         {fields.map((fieldRow, key) => {
           return (
             <Grid gap={4} key={key}>
@@ -76,7 +76,7 @@ const NonRepeatableComponent = ({ componentUid, isFromDynamicZone, isNested, nam
             </Grid>
           );
         })}
-      </Stack>
+      </Flex>
     </Box>
   );
 };

--- a/packages/core/admin/admin/src/content-manager/components/RelationInput/components/Relation.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInput/components/Relation.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import { Stack, Flex } from '@strapi/design-system';
+import { Flex } from '@strapi/design-system';
 
 export const Relation = ({
   children,
@@ -20,9 +20,15 @@ export const Relation = ({
         alignItems="end"
         wrap="wrap"
       >
-        <Stack basis={size <= 6 ? '100%' : '70%'} spacing={1} {...props}>
+        <Flex
+          direction="column"
+          alignItems="stretch"
+          basis={size <= 6 ? '100%' : '70%'}
+          gap={1}
+          {...props}
+        >
           {search}
-        </Stack>
+        </Flex>
 
         {loadMore}
       </Flex>

--- a/packages/core/admin/admin/src/content-manager/components/RelationInput/components/RelationItem.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInput/components/RelationItem.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { getEmptyImage } from 'react-dnd-html5-backend';
 
-import { Box, Flex, Stack, IconButton } from '@strapi/design-system';
+import { Box, Flex, IconButton } from '@strapi/design-system';
 import { Drag } from '@strapi/icons';
 
 import { useDragAndDrop } from '../../../hooks/useDragAndDrop';
@@ -12,7 +12,7 @@ import { composeRefs, ItemTypes } from '../../../utils';
 
 import { RELATION_GUTTER } from '../constants';
 
-export const StackWrapper = styled(Stack)`
+export const FlexWrapper = styled(Flex)`
   width: 100%;
   /* Used to prevent endAction to be pushed out of container */
   min-width: 0;
@@ -94,7 +94,7 @@ export const RelationItem = ({
           data-handler-id={handlerId}
           {...props}
         >
-          <StackWrapper spacing={1} horizontal>
+          <FlexWrapper gap={1}>
             {canDrag ? (
               <IconButton
                 forwardedAs="div"
@@ -109,7 +109,7 @@ export const RelationItem = ({
               </IconButton>
             ) : null}
             <ChildrenWrapper justifyContent="space-between">{children}</ChildrenWrapper>
-          </StackWrapper>
+          </FlexWrapper>
           {endAction && <Box paddingLeft={4}>{endAction}</Box>}
         </Flex>
       )}

--- a/packages/core/admin/admin/src/content-manager/components/RelationInput/components/tests/__snapshots__/RelationItem.test.js.snap
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInput/components/tests/__snapshots__/RelationItem.test.js.snap
@@ -46,18 +46,10 @@ exports[`Content-Manager || RelationInput || RelationItem should render and matc
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
+  gap: 4px;
 }
 
-.c4 > * {
-  margin-left: 0;
-  margin-right: 0;
-}
-
-.c4 > * + * {
-  margin-left: 4px;
-}
-
-.c7 {
+.c6 {
   border: 0;
   -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
@@ -69,16 +61,16 @@ exports[`Content-Manager || RelationInput || RelationItem should render and matc
   width: 1px;
 }
 
-.c5 {
+.c4 {
   width: 100%;
   min-width: 0;
 }
 
-.c5 > div[role='button'] {
+.c4 > div[role='button'] {
   cursor: all-scroll;
 }
 
-.c6 {
+.c5 {
   width: 100%;
   min-width: 0;
 }
@@ -93,10 +85,10 @@ exports[`Content-Manager || RelationInput || RelationItem should render and matc
       data-handler-id="T0"
     >
       <div
-        class="c3 c4 c5"
+        class="c3 c4"
       >
         <div
-          class="c2 c6"
+          class="c2 c5"
         >
           First relation
         </div>
@@ -104,7 +96,7 @@ exports[`Content-Manager || RelationInput || RelationItem should render and matc
     </div>
   </li>
   <div
-    class="c7"
+    class="c6"
   >
     <p
       aria-live="polite"

--- a/packages/core/admin/admin/src/content-manager/components/RelationInput/components/tests/__snapshots__/RelationList.test.js.snap
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInput/components/tests/__snapshots__/RelationList.test.js.snap
@@ -46,18 +46,10 @@ exports[`Content-Manager || RelationInput || RelationList should render and matc
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
+  gap: 4px;
 }
 
-.c5 > * {
-  margin-left: 0;
-  margin-right: 0;
-}
-
-.c5 > * + * {
-  margin-left: 4px;
-}
-
-.c8 {
+.c7 {
   border: 0;
   -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
@@ -69,16 +61,16 @@ exports[`Content-Manager || RelationInput || RelationList should render and matc
   width: 1px;
 }
 
-.c6 {
+.c5 {
   width: 100%;
   min-width: 0;
 }
 
-.c6 > div[role='button'] {
+.c5 > div[role='button'] {
   cursor: all-scroll;
 }
 
-.c7 {
+.c6 {
   width: 100%;
   min-width: 0;
 }
@@ -128,10 +120,10 @@ exports[`Content-Manager || RelationInput || RelationList should render and matc
         data-handler-id="T0"
       >
         <div
-          class="c4 c5 c6"
+          class="c4 c5"
         >
           <div
-            class="c3 c7"
+            class="c3 c6"
           >
             First relation
           </div>
@@ -147,10 +139,10 @@ exports[`Content-Manager || RelationInput || RelationList should render and matc
         data-handler-id="T2"
       >
         <div
-          class="c4 c5 c6"
+          class="c4 c5"
         >
           <div
-            class="c3 c7"
+            class="c3 c6"
           >
             Second relation
           </div>
@@ -159,7 +151,7 @@ exports[`Content-Manager || RelationInput || RelationList should render and matc
     </li>
   </div>
   <div
-    class="c8"
+    class="c7"
   >
     <p
       aria-live="polite"

--- a/packages/core/admin/admin/src/content-manager/components/RelationInput/tests/__snapshots__/RelationInput.test.js.snap
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInput/tests/__snapshots__/RelationInput.test.js.snap
@@ -1,33 +1,33 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Content-Manager || RelationInput should render and match snapshot 1`] = `
-.c6 {
+.c5 {
   font-size: 0.75rem;
   line-height: 1.33;
   font-weight: 600;
   color: #32324d;
 }
 
-.c13 {
+.c12 {
   font-size: 0.75rem;
   line-height: 1.33;
   color: #4945ff;
 }
 
-.c27 {
+.c26 {
   font-size: 0.875rem;
   line-height: 1.43;
   color: #32324d;
 }
 
-.c30 {
+.c29 {
   font-size: 0.875rem;
   line-height: 1.43;
   font-weight: 600;
   color: #006096;
 }
 
-.c35 {
+.c34 {
   font-size: 0.875rem;
   line-height: 1.43;
   display: block;
@@ -37,14 +37,14 @@ exports[`Content-Manager || RelationInput should render and match snapshot 1`] =
   color: #4945ff;
 }
 
-.c38 {
+.c37 {
   font-size: 0.875rem;
   line-height: 1.43;
   font-weight: 600;
   color: #2f6846;
 }
 
-.c40 {
+.c39 {
   font-size: 0.75rem;
   line-height: 1.33;
   color: #666687;
@@ -60,19 +60,19 @@ exports[`Content-Manager || RelationInput should render and match snapshot 1`] =
   flex-basis: 70%;
 }
 
-.c8 {
+.c7 {
   padding-right: 12px;
 }
 
-.c12 {
+.c11 {
   padding-right: 8px;
 }
 
-.c16 {
+.c15 {
   cursor: all-scroll;
 }
 
-.c17 {
+.c16 {
   background: #ffffff;
   padding-top: 8px;
   padding-right: 16px;
@@ -83,14 +83,14 @@ exports[`Content-Manager || RelationInput should render and match snapshot 1`] =
   border: 1px solid #dcdce4;
 }
 
-.c24 {
+.c23 {
   padding-top: 4px;
   padding-right: 16px;
   padding-bottom: 4px;
   min-width: 0;
 }
 
-.c28 {
+.c27 {
   background: #eaf5ff;
   padding-top: 4px;
   padding-right: 8px;
@@ -101,16 +101,16 @@ exports[`Content-Manager || RelationInput should render and match snapshot 1`] =
   border: 1px solid #b8e1ff;
 }
 
-.c31 {
+.c30 {
   padding-left: 16px;
 }
 
-.c33 {
+.c32 {
   color: #666687;
   width: 12px;
 }
 
-.c36 {
+.c35 {
   background: #eafbe7;
   padding-top: 4px;
   padding-right: 8px;
@@ -121,7 +121,7 @@ exports[`Content-Manager || RelationInput should render and match snapshot 1`] =
   border: 1px solid #c6f0c2;
 }
 
-.c39 {
+.c38 {
   padding-top: 8px;
 }
 
@@ -159,9 +159,10 @@ exports[`Content-Manager || RelationInput should render and match snapshot 1`] =
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  gap: 4px;
 }
 
-.c7 {
+.c6 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -175,7 +176,7 @@ exports[`Content-Manager || RelationInput should render and match snapshot 1`] =
   flex-direction: row;
 }
 
-.c18 {
+.c17 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -193,22 +194,37 @@ exports[`Content-Manager || RelationInput should render and match snapshot 1`] =
   justify-content: space-between;
 }
 
-.c11 {
+.c18 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 4px;
+}
+
+.c10 {
   background: transparent;
   border: none;
   position: relative;
   outline: none;
 }
 
-.c11[aria-disabled='true'] {
+.c10[aria-disabled='true'] {
   pointer-events: none;
 }
 
-.c11[aria-disabled='true'] svg path {
+.c10[aria-disabled='true'] svg path {
   fill: #666687;
 }
 
-.c11 svg {
+.c10 svg {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -216,11 +232,11 @@ exports[`Content-Manager || RelationInput should render and match snapshot 1`] =
   font-size: 0.625rem;
 }
 
-.c11 svg path {
+.c10 svg path {
   fill: #4945ff;
 }
 
-.c11:after {
+.c10:after {
   -webkit-transition-property: all;
   transition-property: all;
   -webkit-transition-duration: 0.2s;
@@ -235,11 +251,11 @@ exports[`Content-Manager || RelationInput should render and match snapshot 1`] =
   border: 2px solid transparent;
 }
 
-.c11:focus-visible {
+.c10:focus-visible {
   outline: none;
 }
 
-.c11:focus-visible:after {
+.c10:focus-visible:after {
   border-radius: 8px;
   content: '';
   position: absolute;
@@ -250,29 +266,11 @@ exports[`Content-Manager || RelationInput should render and match snapshot 1`] =
   border: 2px solid #4945ff;
 }
 
-.c4 > * {
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
-.c4 > * + * {
-  margin-top: 4px;
-}
-
-.c19 > * {
-  margin-left: 0;
-  margin-right: 0;
-}
-
-.c19 > * + * {
-  margin-left: 4px;
-}
-
-.c34 path {
+.c33 path {
   fill: #666687;
 }
 
-.c21 {
+.c20 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -286,21 +284,21 @@ exports[`Content-Manager || RelationInput should render and match snapshot 1`] =
   outline: none;
 }
 
-.c21 svg {
+.c20 svg {
   height: 12px;
   width: 12px;
 }
 
-.c21 svg > g,
-.c21 svg path {
+.c20 svg > g,
+.c20 svg path {
   fill: #ffffff;
 }
 
-.c21[aria-disabled='true'] {
+.c20[aria-disabled='true'] {
   pointer-events: none;
 }
 
-.c21:after {
+.c20:after {
   -webkit-transition-property: all;
   transition-property: all;
   -webkit-transition-duration: 0.2s;
@@ -315,11 +313,11 @@ exports[`Content-Manager || RelationInput should render and match snapshot 1`] =
   border: 2px solid transparent;
 }
 
-.c21:focus-visible {
+.c20:focus-visible {
   outline: none;
 }
 
-.c21:focus-visible:after {
+.c20:focus-visible:after {
   border-radius: 8px;
   content: '';
   position: absolute;
@@ -330,7 +328,7 @@ exports[`Content-Manager || RelationInput should render and match snapshot 1`] =
   border: 2px solid #4945ff;
 }
 
-.c15 {
+.c14 {
   border: 0;
   -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
@@ -342,7 +340,7 @@ exports[`Content-Manager || RelationInput should render and match snapshot 1`] =
   width: 1px;
 }
 
-.c25 {
+.c24 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -358,31 +356,31 @@ exports[`Content-Manager || RelationInput should render and match snapshot 1`] =
   outline: none;
 }
 
-.c25 svg path {
+.c24 svg path {
   -webkit-transition: fill 150ms ease-out;
   transition: fill 150ms ease-out;
   fill: currentColor;
 }
 
-.c25 svg {
+.c24 svg {
   font-size: 0.625rem;
 }
 
-.c25 .c5 {
+.c24 .c4 {
   -webkit-transition: color 150ms ease-out;
   transition: color 150ms ease-out;
   color: currentColor;
 }
 
-.c25:hover {
+.c24:hover {
   color: #7b79ff;
 }
 
-.c25:active {
+.c24:active {
   color: #271fe0;
 }
 
-.c25:after {
+.c24:after {
   -webkit-transition-property: all;
   transition-property: all;
   -webkit-transition-duration: 0.2s;
@@ -397,11 +395,11 @@ exports[`Content-Manager || RelationInput should render and match snapshot 1`] =
   border: 2px solid transparent;
 }
 
-.c25:focus-visible {
+.c24:focus-visible {
   outline: none;
 }
 
-.c25:focus-visible:after {
+.c24:focus-visible:after {
   border-radius: 8px;
   content: '';
   position: absolute;
@@ -412,7 +410,7 @@ exports[`Content-Manager || RelationInput should render and match snapshot 1`] =
   border: 2px solid #4945ff;
 }
 
-.c22 {
+.c21 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -430,54 +428,54 @@ exports[`Content-Manager || RelationInput should render and match snapshot 1`] =
   border: none;
 }
 
-.c22 svg > g,
-.c22 svg path {
+.c21 svg > g,
+.c21 svg path {
   fill: #8e8ea9;
 }
 
-.c22:hover svg > g,
-.c22:hover svg path {
+.c21:hover svg > g,
+.c21:hover svg path {
   fill: #666687;
 }
 
-.c22:active svg > g,
-.c22:active svg path {
+.c21:active svg > g,
+.c21:active svg path {
   fill: #a5a5ba;
 }
 
-.c22[aria-disabled='true'] {
+.c21[aria-disabled='true'] {
   background-color: #eaeaef;
 }
 
-.c22[aria-disabled='true'] svg path {
+.c21[aria-disabled='true'] svg path {
   fill: #666687;
 }
 
-.c29 .c5 {
+.c28 .c4 {
   color: #0c75af;
 }
 
-.c37 .c5 {
+.c36 .c4 {
   color: #328048;
 }
 
-.c9 {
+.c8 {
   background: transparent;
   border: none;
   position: relative;
   z-index: 1;
 }
 
-.c9 svg {
+.c8 svg {
   height: 0.6875rem;
   width: 0.6875rem;
 }
 
-.c9 svg path {
+.c8 svg path {
   fill: #666687;
 }
 
-.c10 {
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -486,39 +484,39 @@ exports[`Content-Manager || RelationInput should render and match snapshot 1`] =
   border: none;
 }
 
-.c10 svg {
+.c9 svg {
   width: 0.5625rem;
 }
 
-.c20 {
+.c19 {
   width: 100%;
   min-width: 0;
 }
 
-.c20 > div[role='button'] {
+.c19 > div[role='button'] {
   cursor: all-scroll;
 }
 
-.c23 {
+.c22 {
   width: 100%;
   min-width: 0;
 }
 
-.c14 {
+.c13 {
   position: relative;
   overflow-x: hidden;
   overflow-y: auto;
 }
 
-.c14:before,
-.c14:after {
+.c13:before,
+.c13:after {
   position: absolute;
   width: 100%;
   height: 4px;
   z-index: 1;
 }
 
-.c14:before {
+.c13:before {
   content: '';
   background: linear-gradient(rgba(3,3,5,0.2) 0%,rgba(0,0,0,0) 100%);
   top: 0;
@@ -527,7 +525,7 @@ exports[`Content-Manager || RelationInput should render and match snapshot 1`] =
   transition: opacity 0.2s ease-in-out;
 }
 
-.c14:after {
+.c13:after {
   content: '';
   background: linear-gradient(0deg,rgba(3,3,5,0.2) 0%,rgba(0,0,0,0) 100%);
   bottom: 0;
@@ -536,23 +534,23 @@ exports[`Content-Manager || RelationInput should render and match snapshot 1`] =
   transition: opacity 0.2s ease-in-out;
 }
 
-.c26 {
+.c25 {
   display: block;
 }
 
-.c26 > span {
+.c25 > span {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
   display: block;
 }
 
-.c32 svg path {
+.c31 svg path {
   fill: #8e8ea9;
 }
 
-.c32:hover svg path,
-.c32:focus svg path {
+.c31:hover svg path,
+.c31:focus svg path {
   fill: #666687;
 }
 
@@ -563,14 +561,14 @@ exports[`Content-Manager || RelationInput should render and match snapshot 1`] =
       wrap="wrap"
     >
       <div
-        class="c2 c3 c4"
+        class="c2 c3"
       >
         <label
-          class="c5 c6"
+          class="c4 c5"
           for="1"
         >
           <div
-            class="c7"
+            class="c6"
           >
             Some Relation
           </div>
@@ -629,7 +627,7 @@ exports[`Content-Manager || RelationInput should render and match snapshot 1`] =
             >
               <div
                 aria-hidden="true"
-                class="c8 c9 c10"
+                class="c7 c8 c9"
               >
                 <svg
                   fill="none"
@@ -657,12 +655,12 @@ exports[`Content-Manager || RelationInput should render and match snapshot 1`] =
       </div>
       <button
         aria-disabled="false"
-        class="c7 c11"
+        class="c6 c10"
         type="button"
       >
         <span
           aria-hidden="true"
-          class="c12"
+          class="c11"
         >
           <svg
             fill="none"
@@ -680,24 +678,24 @@ exports[`Content-Manager || RelationInput should render and match snapshot 1`] =
           </svg>
         </span>
         <span
-          class="c5 c13"
+          class="c4 c12"
         >
           Load more
         </span>
       </button>
     </div>
     <div
-      class="c14"
+      class="c13"
     >
       <div
-        class="c15"
+        class="c14"
         id="some-relation-1-item-instructions"
       >
         Press spacebar to grab and re-order
       </div>
       <div
         aria-live="assertive"
-        class="c15"
+        class="c14"
       />
       <div
         style="position: relative; height: 162px; overflow: auto; will-change: transform; direction: ltr;"
@@ -707,26 +705,26 @@ exports[`Content-Manager || RelationInput should render and match snapshot 1`] =
         >
           <li
             aria-describedby="some-relation-1-item-instructions"
-            class="c16"
+            class="c15"
             style="position: absolute; left: 0px; top: 0px; height: 54px; width: 100%; bottom: 4px;"
           >
             <div
-              class="c17 c18"
+              class="c16 c17"
               data-handler-id="T0"
               draggable="true"
             >
               <div
-                class="c7 c19 c20"
+                class="c18 c19"
               >
                 <div
                   aria-disabled="false"
-                  class="c21 c22"
+                  class="c20 c21"
                   role="button"
                   tabindex="0"
                   type="button"
                 >
                   <span
-                    class="c15"
+                    class="c14"
                   >
                     Drag
                   </span>
@@ -770,21 +768,21 @@ exports[`Content-Manager || RelationInput should render and match snapshot 1`] =
                   </svg>
                 </div>
                 <div
-                  class="c18 c23"
+                  class="c17 c22"
                 >
                   <div
-                    class="c24"
+                    class="c23"
                   >
                     <span>
                       <a
                         aria-current="page"
                         aria-describedby="0"
-                        class="c25 c26 active"
+                        class="c24 c25 active"
                         href="/"
                         tabindex="0"
                       >
                         <span
-                          class="c5 c27"
+                          class="c4 c26"
                         >
                           Relation 1
                         </span>
@@ -792,10 +790,10 @@ exports[`Content-Manager || RelationInput should render and match snapshot 1`] =
                     </span>
                   </div>
                   <div
-                    class="c28 c29"
+                    class="c27 c28"
                   >
                     <span
-                      class="c5 c30"
+                      class="c4 c29"
                     >
                       Draft
                     </span>
@@ -803,16 +801,16 @@ exports[`Content-Manager || RelationInput should render and match snapshot 1`] =
                 </div>
               </div>
               <div
-                class="c31"
+                class="c30"
               >
                 <button
                   aria-label="Remove"
-                  class="c32"
+                  class="c31"
                   data-testid="remove-relation-1"
                   type="button"
                 >
                   <svg
-                    class="c33 c34"
+                    class="c32 c33"
                     fill="none"
                     height="1em"
                     viewBox="0 0 24 24"
@@ -830,26 +828,26 @@ exports[`Content-Manager || RelationInput should render and match snapshot 1`] =
           </li>
           <li
             aria-describedby="some-relation-1-item-instructions"
-            class="c16"
+            class="c15"
             style="position: absolute; left: 0px; top: 54px; height: 54px; width: 100%; bottom: 4px;"
           >
             <div
-              class="c17 c18"
+              class="c16 c17"
               data-handler-id="T2"
               draggable="true"
             >
               <div
-                class="c7 c19 c20"
+                class="c18 c19"
               >
                 <div
                   aria-disabled="false"
-                  class="c21 c22"
+                  class="c20 c21"
                   role="button"
                   tabindex="0"
                   type="button"
                 >
                   <span
-                    class="c15"
+                    class="c14"
                   >
                     Drag
                   </span>
@@ -893,15 +891,15 @@ exports[`Content-Manager || RelationInput should render and match snapshot 1`] =
                   </svg>
                 </div>
                 <div
-                  class="c18 c23"
+                  class="c17 c22"
                 >
                   <div
-                    class="c24"
+                    class="c23"
                   >
                     <span>
                       <span
                         aria-describedby="1"
-                        class="c5 c35"
+                        class="c4 c34"
                         tabindex="0"
                       >
                         Relation 2
@@ -909,10 +907,10 @@ exports[`Content-Manager || RelationInput should render and match snapshot 1`] =
                     </span>
                   </div>
                   <div
-                    class="c36 c37"
+                    class="c35 c36"
                   >
                     <span
-                      class="c5 c38"
+                      class="c4 c37"
                     >
                       Published
                     </span>
@@ -920,16 +918,16 @@ exports[`Content-Manager || RelationInput should render and match snapshot 1`] =
                 </div>
               </div>
               <div
-                class="c31"
+                class="c30"
               >
                 <button
                   aria-label="Remove"
-                  class="c32"
+                  class="c31"
                   data-testid="remove-relation-2"
                   type="button"
                 >
                   <svg
-                    class="c33 c34"
+                    class="c32 c33"
                     fill="none"
                     height="1em"
                     viewBox="0 0 24 24"
@@ -947,26 +945,26 @@ exports[`Content-Manager || RelationInput should render and match snapshot 1`] =
           </li>
           <li
             aria-describedby="some-relation-1-item-instructions"
-            class="c16"
+            class="c15"
             style="position: absolute; left: 0px; top: 108px; height: 54px; width: 100%; bottom: 4px;"
           >
             <div
-              class="c17 c18"
+              class="c16 c17"
               data-handler-id="T4"
               draggable="true"
             >
               <div
-                class="c7 c19 c20"
+                class="c18 c19"
               >
                 <div
                   aria-disabled="false"
-                  class="c21 c22"
+                  class="c20 c21"
                   role="button"
                   tabindex="0"
                   type="button"
                 >
                   <span
-                    class="c15"
+                    class="c14"
                   >
                     Drag
                   </span>
@@ -1010,15 +1008,15 @@ exports[`Content-Manager || RelationInput should render and match snapshot 1`] =
                   </svg>
                 </div>
                 <div
-                  class="c18 c23"
+                  class="c17 c22"
                 >
                   <div
-                    class="c24"
+                    class="c23"
                   >
                     <span>
                       <span
                         aria-describedby="2"
-                        class="c5 c35"
+                        class="c4 c34"
                         tabindex="0"
                       >
                         Relation 3
@@ -1028,16 +1026,16 @@ exports[`Content-Manager || RelationInput should render and match snapshot 1`] =
                 </div>
               </div>
               <div
-                class="c31"
+                class="c30"
               >
                 <button
                   aria-label="Remove"
-                  class="c32"
+                  class="c31"
                   data-testid="remove-relation-3"
                   type="button"
                 >
                   <svg
-                    class="c33 c34"
+                    class="c32 c33"
                     fill="none"
                     height="1em"
                     viewBox="0 0 24 24"
@@ -1057,10 +1055,10 @@ exports[`Content-Manager || RelationInput should render and match snapshot 1`] =
       </div>
     </div>
     <div
-      class="c39"
+      class="c38"
     >
       <p
-        class="c5 c40"
+        class="c4 c39"
         id="1-hint"
       >
         this is a description
@@ -1068,7 +1066,7 @@ exports[`Content-Manager || RelationInput should render and match snapshot 1`] =
     </div>
   </div>
   <div
-    class="c15"
+    class="c14"
   >
     <p
       aria-live="polite"

--- a/packages/core/admin/admin/src/content-manager/components/RepeatableComponent/components/Component.js
+++ b/packages/core/admin/admin/src/content-manager/components/RepeatableComponent/components/Component.js
@@ -14,7 +14,7 @@ import {
   AccordionContent,
   Grid,
   GridItem,
-  Stack,
+  Flex,
   Box,
   IconButton,
 } from '@strapi/design-system';
@@ -49,7 +49,7 @@ const CustomIconButton = styled(IconButton)`
   }
 `;
 
-const ActionsStack = styled(Stack)`
+const ActionsFlex = styled(Flex)`
   & .drag-handle {
     background: unset;
 
@@ -138,7 +138,7 @@ const DraggedItem = ({
           <AccordionToggle
             action={
               isReadOnly ? null : (
-                <ActionsStack horizontal spacing={0} expanded={isOpen}>
+                <ActionsFlex gap={0} expanded={isOpen}>
                   <CustomIconButton
                     expanded={isOpen}
                     noBorder
@@ -169,14 +169,20 @@ const DraggedItem = ({
                   >
                     <Drag />
                   </IconButton>
-                </ActionsStack>
+                </ActionsFlex>
               )
             }
             title={displayedValue}
             togglePosition="left"
           />
           <AccordionContent>
-            <Stack background="neutral100" padding={6} spacing={6}>
+            <Flex
+              direction="column"
+              alignItems="stretch"
+              background="neutral100"
+              padding={6}
+              gap={6}
+            >
               {fields.map((fieldRow, key) => {
                 return (
                   // eslint-disable-next-line react/no-array-index-key
@@ -224,7 +230,7 @@ const DraggedItem = ({
                   </Grid>
                 );
               })}
-            </Stack>
+            </Flex>
           </AccordionContent>
         </Accordion>
       )}

--- a/packages/core/admin/admin/src/content-manager/components/Wysiwyg/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/Wysiwyg/index.js
@@ -2,7 +2,7 @@ import React, { useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { useIntl } from 'react-intl';
-import { Typography, Box, Stack } from '@strapi/design-system';
+import { Typography, Box, Flex } from '@strapi/design-system';
 import { prefixFileUrlWithBackendUrl, useLibrary } from '@strapi/helper-plugin';
 import Editor from './Editor';
 import WysiwygNav from './WysiwygNav';
@@ -125,14 +125,14 @@ const Wysiwyg = ({
 
   return (
     <>
-      <Stack spacing={1}>
-        <Stack horizontal spacing={1}>
+      <Flex direction="column" alignItems="stretch" gap={1}>
+        <Flex gap={1}>
           <Typography variant="pi" fontWeight="bold" textColor="neutral800">
             {label}
             {required && <TypographyAsterisk textColor="danger600">*</TypographyAsterisk>}
           </Typography>
           {labelAction && <LabelAction paddingLeft={1}>{labelAction}</LabelAction>}
-        </Stack>
+        </Flex>
 
         <EditorLayout
           isExpandMode={isExpandMode}
@@ -166,7 +166,7 @@ const Wysiwyg = ({
           {!isExpandMode && <WysiwygFooter onToggleExpand={handleToggleExpand} />}
         </EditorLayout>
         <Hint hint={hint} name={name} error={error} />
-      </Stack>
+      </Flex>
 
       {error && (
         <Box paddingTop={1}>

--- a/packages/core/admin/admin/src/content-manager/components/Wysiwyg/tests/__snapshots__/index.test.js.snap
+++ b/packages/core/admin/admin/src/content-manager/components/Wysiwyg/tests/__snapshots__/index.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Wysiwyg render and actions buttons should render the Wysiwyg 1`] = `
-.c6 {
+.c4 {
   font-size: 0.75rem;
   line-height: 1.33;
   font-weight: 600;
@@ -24,14 +24,14 @@ exports[`Wysiwyg render and actions buttons should render the Wysiwyg 1`] = `
   color: #32324d;
 }
 
-.c7 {
+.c5 {
   border-radius: 4px;
   border-style: solid;
   border-width: 1px;
   border-color: #dcdce4;
 }
 
-.c8 {
+.c6 {
   background: #f6f6f9;
   padding: 8px;
 }
@@ -63,9 +63,10 @@ exports[`Wysiwyg render and actions buttons should render the Wysiwyg 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  gap: 4px;
 }
 
-.c3 {
+.c2 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -77,9 +78,10 @@ exports[`Wysiwyg render and actions buttons should render the Wysiwyg 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
+  gap: 4px;
 }
 
-.c9 {
+.c7 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -95,6 +97,34 @@ exports[`Wysiwyg render and actions buttons should render the Wysiwyg 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
+}
+
+.c8 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+}
+
+.c9 {
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
 }
 
 .c31 {
@@ -115,27 +145,9 @@ exports[`Wysiwyg render and actions buttons should render the Wysiwyg 1`] = `
   justify-content: flex-end;
 }
 
-.c2 > * {
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
-.c2 > * + * {
-  margin-top: 4px;
-}
-
 .c10 > * {
   margin-top: 0;
   margin-bottom: 0;
-}
-
-.c4 > * {
-  margin-left: 0;
-  margin-right: 0;
-}
-
-.c4 > * + * {
-  margin-left: 4px;
 }
 
 .c21 {
@@ -233,7 +245,7 @@ exports[`Wysiwyg render and actions buttons should render the Wysiwyg 1`] = `
   align-items: center;
 }
 
-.c27 .c5 {
+.c27 .c3 {
   color: #ffffff;
 }
 
@@ -242,7 +254,7 @@ exports[`Wysiwyg render and actions buttons should render the Wysiwyg 1`] = `
   background: #eaeaef;
 }
 
-.c27[aria-disabled='true'] .c5 {
+.c27[aria-disabled='true'] .c3 {
   color: #666687;
 }
 
@@ -255,7 +267,7 @@ exports[`Wysiwyg render and actions buttons should render the Wysiwyg 1`] = `
   background: #eaeaef;
 }
 
-.c27[aria-disabled='true']:active .c5 {
+.c27[aria-disabled='true']:active .c3 {
   color: #666687;
 }
 
@@ -271,7 +283,7 @@ exports[`Wysiwyg render and actions buttons should render the Wysiwyg 1`] = `
   background-color: #eaeaef;
 }
 
-.c27 .c5 {
+.c27 .c3 {
   color: #32324d;
 }
 
@@ -800,35 +812,35 @@ exports[`Wysiwyg render and actions buttons should render the Wysiwyg 1`] = `
 }
 
 <div
-  class="c0 c1 c2"
+  class="c0 c1"
 >
   <div
-    class="c0 c3 c4"
+    class="c0 c2"
   >
     <span
-      class="c5 c6"
+      class="c3 c4"
     >
       hello world
     </span>
   </div>
   <div
-    class="c0 c7"
+    class="c0 c5"
   >
     <div
-      class="c0 c8"
+      class="c0 c6"
     >
       <div
-        class="c0 c9"
+        class="c0 c7"
       >
         <div
-          class="c0 c3"
+          class="c0 c8"
         >
           <div>
             <div
-              class="c0 c1 c10"
+              class="c0 c9 c10"
             >
               <div
-                class="c0 c3 c11"
+                class="c0 c8 c11"
               >
                 <button
                   aria-disabled="false"
@@ -840,16 +852,16 @@ exports[`Wysiwyg render and actions buttons should render the Wysiwyg 1`] = `
                   type="button"
                 />
                 <div
-                  class="c0 c9 c13"
+                  class="c0 c7 c13"
                 >
                   <div
-                    class="c0 c3"
+                    class="c0 c8"
                   >
                     <div
                       class="c0 c14"
                     >
                       <span
-                        class="c5 c15"
+                        class="c3 c15"
                         id="selectTitle-content"
                       >
                         Add a title
@@ -857,7 +869,7 @@ exports[`Wysiwyg render and actions buttons should render the Wysiwyg 1`] = `
                     </div>
                   </div>
                   <div
-                    class="c0 c3"
+                    class="c0 c8"
                   >
                     <button
                       aria-hidden="true"
@@ -887,7 +899,7 @@ exports[`Wysiwyg render and actions buttons should render the Wysiwyg 1`] = `
             </div>
           </div>
           <div
-            class="c0 c3 c19 c20"
+            class="c0 c8 c19 c20"
           >
             <span>
               <button
@@ -1023,7 +1035,7 @@ exports[`Wysiwyg render and actions buttons should render the Wysiwyg 1`] = `
           type="button"
         >
           <span
-            class="c5 c6"
+            class="c3 c4"
           >
             Preview mode
           </span>
@@ -1144,7 +1156,7 @@ exports[`Wysiwyg render and actions buttons should render the Wysiwyg 1`] = `
           type="button"
         >
           <span
-            class="c5 c33"
+            class="c3 c33"
           >
             Expand
           </span>

--- a/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/components/DisplayedFields.js
+++ b/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/components/DisplayedFields.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
-import { Button, Box, Typography, Stack, Flex, SimpleMenu, MenuItem } from '@strapi/design-system';
+import { Button, Box, Typography, Flex, SimpleMenu, MenuItem } from '@strapi/design-system';
 import { Plus } from '@strapi/icons';
 import { getTrad } from '../../../utils';
 import RowsLayout from './RowsLayout';
@@ -11,7 +11,7 @@ const DisplayedFields = ({ editLayout, fields, onRemoveField, onAddField }) => {
   const { formatMessage } = useIntl();
 
   return (
-    <Stack spacing={4}>
+    <Flex direction="column" alignItems="stretch" gap={4}>
       <Flex justifyContent="space-between">
         <div>
           <Box>
@@ -34,7 +34,7 @@ const DisplayedFields = ({ editLayout, fields, onRemoveField, onAddField }) => {
         <LinkToCTB />
       </Flex>
       <Box padding={4} hasRadius borderStyle="dashed" borderWidth="1px" borderColor="neutral300">
-        <Stack spacing={2}>
+        <Flex direction="column" alignItems="stretch" gap={2}>
           {editLayout.map((row, index) => (
             <RowsLayout key={row.rowId} row={row} rowIndex={index} onRemoveField={onRemoveField} />
           ))}
@@ -58,9 +58,9 @@ const DisplayedFields = ({ editLayout, fields, onRemoveField, onAddField }) => {
               </MenuItem>
             ))}
           </SimpleMenu>
-        </Stack>
+        </Flex>
       </Box>
-    </Stack>
+    </Flex>
   );
 };
 

--- a/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/components/DynamicZoneList.js
+++ b/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/components/DynamicZoneList.js
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
-import { Box, Flex, Typography, Stack } from '@strapi/design-system';
+import { Box, Flex, Typography } from '@strapi/design-system';
 
 import { ComponentIcon } from '../../../components/ComponentIcon';
 import useLayoutDnd from '../../../hooks/useLayoutDnd';
@@ -33,7 +33,7 @@ const DynamicZoneList = ({ components }) => {
   const { componentLayouts } = useLayoutDnd();
 
   return (
-    <Stack spacing={2} horizontal overflow="scroll hidden" padding={3}>
+    <Flex gap={2} overflow="scroll hidden" padding={3}>
       {components.map((componentUid) => (
         <CustomLink
           hasRadius
@@ -58,7 +58,7 @@ const DynamicZoneList = ({ components }) => {
           </Box>
         </CustomLink>
       ))}
-    </Stack>
+    </Flex>
   );
 };
 

--- a/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/index.js
@@ -22,7 +22,7 @@ import {
   GridItem,
   Select,
   Option,
-  Stack,
+  Flex,
   Divider,
 } from '@strapi/design-system';
 import { ArrowLeft, Check } from '@strapi/icons';
@@ -264,7 +264,7 @@ const EditSettingsView = ({ mainLayout, components, isContentTypeView, slug, upd
               paddingLeft={7}
               paddingRight={7}
             >
-              <Stack spacing={4}>
+              <Flex direction="column" alignItems="stretch" gap={4}>
                 <Typography variant="delta" as="h2">
                   {formatMessage({
                     id: getTrad('containers.SettingPage.settings'),
@@ -328,7 +328,7 @@ const EditSettingsView = ({ mainLayout, components, isContentTypeView, slug, upd
                     });
                   }}
                 />
-              </Stack>
+              </Flex>
             </Box>
           </ContentLayout>
           <ConfirmDialog

--- a/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/tests/__snapshots__/index.test.js.snap
+++ b/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/tests/__snapshots__/index.test.js.snap
@@ -21,7 +21,7 @@ exports[`EditSettingsView renders and matches the snapshot 1`] = `
   color: #666687;
 }
 
-.c24 {
+.c23 {
   font-weight: 500;
   font-size: 1rem;
   line-height: 1.25;
@@ -182,6 +182,36 @@ exports[`EditSettingsView renders and matches the snapshot 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  gap: 16px;
+}
+
+.c26 {
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c45 {
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 8px;
 }
 
 .c49 {
@@ -198,15 +228,6 @@ exports[`EditSettingsView renders and matches the snapshot 1`] = `
   flex-direction: row;
 }
 
-.c23 > * {
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
-.c23 > * + * {
-  margin-top: 16px;
-}
-
 .c27 > * {
   margin-top: 0;
   margin-bottom: 0;
@@ -214,15 +235,6 @@ exports[`EditSettingsView renders and matches the snapshot 1`] = `
 
 .c27 > * + * {
   margin-top: 4px;
-}
-
-.c45 > * {
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
-.c45 > * + * {
-  margin-top: 8px;
 }
 
 .c14 {
@@ -540,12 +552,12 @@ exports[`EditSettingsView renders and matches the snapshot 1`] = `
   margin: 0;
 }
 
-.c25 {
+.c24 {
   display: grid;
   grid-template-columns: repeat(12,1fr);
 }
 
-.c26 {
+.c25 {
   grid-column: span 6;
   max-width: 100%;
 }
@@ -859,13 +871,13 @@ exports[`EditSettingsView renders and matches the snapshot 1`] = `
 }
 
 @media (max-width:68.75rem) {
-  .c26 {
+  .c25 {
     grid-column: span 12;
   }
 }
 
 @media (max-width:34.375rem) {
-  .c26 {
+  .c25 {
     grid-column: span;
   }
 }
@@ -985,25 +997,25 @@ exports[`EditSettingsView renders and matches the snapshot 1`] = `
           class="c1 c21"
         >
           <div
-            class="c1 c22 c23"
+            class="c1 c22"
           >
             <h2
-              class="c12 c24"
+              class="c12 c23"
             >
               Settings
             </h2>
             <div
-              class="c1 c25"
+              class="c1 c24"
             >
               <div
-                class="c26"
+                class="c25"
               >
                 <div
                   class="c1 "
                 >
                   <div>
                     <div
-                      class="c1 c22 c27"
+                      class="c1 c26 c27"
                     >
                       <label
                         class="c12 c18"
@@ -1092,12 +1104,12 @@ exports[`EditSettingsView renders and matches the snapshot 1`] = `
               />
             </div>
             <h3
-              class="c12 c24"
+              class="c12 c23"
             >
               View
             </h3>
             <div
-              class="c1 c22 c23"
+              class="c1 c22"
             >
               <div
                 class="c1 c10"
@@ -1160,10 +1172,10 @@ exports[`EditSettingsView renders and matches the snapshot 1`] = `
                 class="c1 c44"
               >
                 <div
-                  class="c1 c22 c45"
+                  class="c1 c45"
                 >
                   <div
-                    class="c1 c25"
+                    class="c1 c24"
                   >
                     <div
                       class="c46"
@@ -1534,7 +1546,7 @@ exports[`EditSettingsView should add field 1`] = `
   color: #666687;
 }
 
-.c24 {
+.c23 {
   font-weight: 500;
   font-size: 1rem;
   line-height: 1.25;
@@ -1695,6 +1707,36 @@ exports[`EditSettingsView should add field 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  gap: 16px;
+}
+
+.c26 {
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c45 {
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 8px;
 }
 
 .c49 {
@@ -1711,15 +1753,6 @@ exports[`EditSettingsView should add field 1`] = `
   flex-direction: row;
 }
 
-.c23 > * {
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
-.c23 > * + * {
-  margin-top: 16px;
-}
-
 .c27 > * {
   margin-top: 0;
   margin-bottom: 0;
@@ -1727,15 +1760,6 @@ exports[`EditSettingsView should add field 1`] = `
 
 .c27 > * + * {
   margin-top: 4px;
-}
-
-.c45 > * {
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
-.c45 > * + * {
-  margin-top: 8px;
 }
 
 .c14 {
@@ -2053,12 +2077,12 @@ exports[`EditSettingsView should add field 1`] = `
   margin: 0;
 }
 
-.c25 {
+.c24 {
   display: grid;
   grid-template-columns: repeat(12,1fr);
 }
 
-.c26 {
+.c25 {
   grid-column: span 6;
   max-width: 100%;
 }
@@ -2372,13 +2396,13 @@ exports[`EditSettingsView should add field 1`] = `
 }
 
 @media (max-width:68.75rem) {
-  .c26 {
+  .c25 {
     grid-column: span 12;
   }
 }
 
 @media (max-width:34.375rem) {
-  .c26 {
+  .c25 {
     grid-column: span;
   }
 }
@@ -2498,25 +2522,25 @@ exports[`EditSettingsView should add field 1`] = `
           class="c1 c21"
         >
           <div
-            class="c1 c22 c23"
+            class="c1 c22"
           >
             <h2
-              class="c12 c24"
+              class="c12 c23"
             >
               Settings
             </h2>
             <div
-              class="c1 c25"
+              class="c1 c24"
             >
               <div
-                class="c26"
+                class="c25"
               >
                 <div
                   class="c1 "
                 >
                   <div>
                     <div
-                      class="c1 c22 c27"
+                      class="c1 c26 c27"
                     >
                       <label
                         class="c12 c18"
@@ -2605,12 +2629,12 @@ exports[`EditSettingsView should add field 1`] = `
               />
             </div>
             <h3
-              class="c12 c24"
+              class="c12 c23"
             >
               View
             </h3>
             <div
-              class="c1 c22 c23"
+              class="c1 c22"
             >
               <div
                 class="c1 c10"
@@ -2673,10 +2697,10 @@ exports[`EditSettingsView should add field 1`] = `
                 class="c1 c44"
               >
                 <div
-                  class="c1 c22 c45"
+                  class="c1 c45"
                 >
                   <div
-                    class="c1 c25"
+                    class="c1 c24"
                   >
                     <div
                       class="c46"

--- a/packages/core/admin/admin/src/content-manager/pages/EditView/Header/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/EditView/Header/index.js
@@ -17,7 +17,6 @@ import {
   DialogFooter,
   Flex,
   Typography,
-  Stack,
 } from '@strapi/design-system';
 import styled from 'styled-components';
 import { getTrad } from '../../../utils';
@@ -70,7 +69,7 @@ const Header = ({
 
   if (isCreatingEntry && canCreate) {
     primaryAction = (
-      <Stack horizontal spacing={2}>
+      <Flex gap={2}>
         {hasDraftAndPublish && (
           <Button disabled startIcon={<Check />} variant="secondary">
             {formatMessage({ id: 'app.utils.publish', defaultMessage: 'Publish' })}
@@ -82,7 +81,7 @@ const Header = ({
             defaultMessage: 'Save',
           })}
         </Button>
-      </Stack>
+      </Flex>
     );
   }
 
@@ -168,7 +167,7 @@ const Header = ({
         isOpen={showWarningUnpublish}
       >
         <DialogBody icon={<ExclamationMarkCircle />}>
-          <Stack spacing={2}>
+          <Flex direction="column" alignItems="stretch" spacing={2}>
             <Flex justifyContent="center" style={{ textAlign: 'center' }}>
               <Typography id="confirm-description">
                 {formatMessage(
@@ -191,7 +190,7 @@ const Header = ({
                 })}
               </Typography>
             </Flex>
-          </Stack>
+          </Flex>
         </DialogBody>
         <DialogFooter
           startAction={
@@ -223,7 +222,7 @@ const Header = ({
         isOpen={showPublishConfirmation}
       >
         <DialogBody icon={<ExclamationMarkCircle />}>
-          <Stack spacing={2}>
+          <Flex direction="column" alignItems="stretch" gap={2}>
             <FlexTextAlign justifyContent="center">
               <Typography id="confirm-description">
                 {draftCount}
@@ -248,7 +247,7 @@ const Header = ({
                 })}
               </Typography>
             </FlexTextAlign>
-          </Stack>
+          </Flex>
         </DialogBody>
         <DialogFooter
           startAction={

--- a/packages/core/admin/admin/src/content-manager/pages/EditView/Header/tests/index.test.js
+++ b/packages/core/admin/admin/src/content-manager/pages/EditView/Header/tests/index.test.js
@@ -117,13 +117,19 @@ describe('CONTENT MANAGER | EditView | Header', () => {
         flex-direction: row;
       }
 
-      .c11 > * {
-        margin-left: 0;
-        margin-right: 0;
-      }
-
-      .c11 > * + * {
-        margin-left: 8px;
+      .c11 {
+        -webkit-align-items: center;
+        -webkit-box-align: center;
+        -ms-flex-align: center;
+        align-items: center;
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+        -webkit-flex-direction: row;
+        -ms-flex-direction: row;
+        flex-direction: row;
+        gap: 8px;
       }
 
       .c12 {
@@ -374,7 +380,7 @@ describe('CONTENT MANAGER | EditView | Header', () => {
               </h1>
             </div>
             <div
-              class="c0 c8 c11"
+              class="c0 c11"
             >
               <button
                 aria-disabled="true"

--- a/packages/core/admin/admin/src/content-manager/pages/EditView/Information/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/EditView/Information/index.js
@@ -2,7 +2,7 @@ import React, { useRef } from 'react';
 import propTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 import { useCMEditViewDataManager } from '@strapi/helper-plugin';
-import { Box, Divider, Flex, Stack, Typography } from '@strapi/design-system';
+import { Box, Divider, Flex, Typography } from '@strapi/design-system';
 
 import { getTrad } from '../../../utils';
 import getUnits from './utils/getUnits';
@@ -49,7 +49,7 @@ const Information = () => {
   const created = getFieldInfo('createdAt', 'createdBy');
 
   return (
-    <Stack spacing={2}>
+    <Flex direction="column" alignItems="stretch" gap={2}>
       <Typography variant="sigma" textColor="neutral600" id="additional-information">
         {formatMessage({
           id: getTrad('containers.Edit.information'),
@@ -61,8 +61,8 @@ const Information = () => {
         <Divider />
       </Box>
 
-      <Stack spacing={4}>
-        <Stack spacing={2} as="dl">
+      <Flex direction="column" alignItems="stretch" gap={4}>
+        <Flex direction="column" alignItems="stretch" gap={2} as="dl">
           <KeyValuePair
             label={formatMessage({
               id: getTrad('containers.Edit.information.created'),
@@ -78,9 +78,9 @@ const Information = () => {
             })}
             value={created.by}
           />
-        </Stack>
+        </Flex>
 
-        <Stack spacing={2} as="dl">
+        <Flex direction="column" alignItems="stretch" gap={2} as="dl">
           <KeyValuePair
             label={formatMessage({
               id: getTrad('containers.Edit.information.lastUpdate'),
@@ -96,9 +96,9 @@ const Information = () => {
             })}
             value={updated.by}
           />
-        </Stack>
-      </Stack>
-    </Stack>
+        </Flex>
+      </Flex>
+    </Flex>
   );
 };
 

--- a/packages/core/admin/admin/src/content-manager/pages/EditView/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/EditView/index.js
@@ -8,7 +8,7 @@ import {
   LoadingIndicatorPage,
 } from '@strapi/helper-plugin';
 import { useIntl } from 'react-intl';
-import { ContentLayout, Box, Grid, GridItem, Main, Stack } from '@strapi/design-system';
+import { ContentLayout, Box, Grid, GridItem, Main, Flex } from '@strapi/design-system';
 import { Pencil, Layer } from '@strapi/icons';
 import { InjectionZone } from '../../../shared/components';
 import permissions from '../../../permissions';
@@ -114,7 +114,7 @@ const EditView = ({ allowedActions, isSingleType, goBack, slug, id, origin, user
               <ContentLayout>
                 <Grid gap={4}>
                   <GridItem col={9} s={12}>
-                    <Stack spacing={6}>
+                    <Flex direction="column" alignItems="stretch" gap={6}>
                       {formattedContentTypeLayout.map((row, index) => {
                         if (isDynamicZone(row)) {
                           const {
@@ -151,7 +151,7 @@ const EditView = ({ allowedActions, isSingleType, goBack, slug, id, origin, user
                             paddingBottom={6}
                             borderColor="neutral150"
                           >
-                            <Stack spacing={6}>
+                            <Flex direction="column" alignItems="stretch" gap={6}>
                               {row.map((grid, gridRowIndex) => (
                                 <GridRow
                                   columns={grid}
@@ -159,14 +159,14 @@ const EditView = ({ allowedActions, isSingleType, goBack, slug, id, origin, user
                                   key={gridRowIndex}
                                 />
                               ))}
-                            </Stack>
+                            </Flex>
                           </Box>
                         );
                       })}
-                    </Stack>
+                    </Flex>
                   </GridItem>
                   <GridItem col={3} s={12}>
-                    <Stack spacing={2}>
+                    <Flex direction="column" alignItems="stretch" gap={2}>
                       <DraftAndPublishBadge />
                       <Box
                         as="aside"
@@ -184,7 +184,7 @@ const EditView = ({ allowedActions, isSingleType, goBack, slug, id, origin, user
                         <InjectionZone area="contentManager.editView.informations" />
                       </Box>
                       <Box as="aside" aria-labelledby="links">
-                        <Stack spacing={2}>
+                        <Flex direction="column" alignItems="stretch" gap={2}>
                           <InjectionZone area="contentManager.editView.right-links" slug={slug} />
                           {slug !== 'strapi::administrator' && (
                             <CheckPermissions permissions={ctbPermissions}>
@@ -228,9 +228,9 @@ const EditView = ({ allowedActions, isSingleType, goBack, slug, id, origin, user
                               onDeleteSucceeded={onDeleteSucceeded}
                             />
                           )}
-                        </Stack>
+                        </Flex>
                       </Box>
-                    </Stack>
+                    </Flex>
                   </GridItem>
                 </Grid>
               </ContentLayout>

--- a/packages/core/admin/admin/src/content-manager/pages/ListSettingsView/components/CardPreview.js
+++ b/packages/core/admin/admin/src/content-manager/pages/ListSettingsView/components/CardPreview.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { Flex, Typography, Stack } from '@strapi/design-system';
+import { Flex, Typography } from '@strapi/design-system';
 import { Pencil, Cross, Drag } from '@strapi/icons';
 import ellipsisCardTitle from '../utils/ellipsisCardTitle';
 
@@ -62,12 +62,12 @@ const CardPreview = ({ labelField, transparent, isSibling }) => {
       transparent={transparent}
       isSibling={isSibling}
     >
-      <Stack horizontal spacing={3}>
+      <Flex gap={3}>
         <DragButton alignItems="center">
           <Drag />
         </DragButton>
         <Typography fontWeight="bold">{cardEllipsisTitle}</Typography>
-      </Stack>
+      </Flex>
       <Flex paddingLeft={3}>
         <ActionBox alignItems="center">
           <Pencil />

--- a/packages/core/admin/admin/src/content-manager/pages/ListSettingsView/components/DraggableCard.js
+++ b/packages/core/admin/admin/src/content-manager/pages/ListSettingsView/components/DraggableCard.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { useDrag, useDrop } from 'react-dnd';
 import { getEmptyImage } from 'react-dnd-html5-backend';
 import { useIntl } from 'react-intl';
-import { Flex, Box, Typography, Stack } from '@strapi/design-system';
+import { Flex, Box, Typography } from '@strapi/design-system';
 import { Pencil, Cross, Drag } from '@strapi/icons';
 import CardPreview from './CardPreview';
 import ellipsisCardTitle from '../utils/ellipsisCardTitle';
@@ -188,7 +188,7 @@ const DraggableCard = ({
           onClick={handleClickEditRow}
           isDragging={isDragging}
         >
-          <Stack horizontal spacing={3}>
+          <Flex gap={3}>
             <DragButton
               as="span"
               aria-label={formatMessage(
@@ -205,7 +205,7 @@ const DraggableCard = ({
               <Drag />
             </DragButton>
             <Typography fontWeight="bold">{cardEllipsisTitle}</Typography>
-          </Stack>
+          </Flex>
           <Flex paddingLeft={3}>
             <ActionButton
               ref={editButtonRef}

--- a/packages/core/admin/admin/src/content-manager/pages/ListSettingsView/components/Settings.js
+++ b/packages/core/admin/admin/src/content-manager/pages/ListSettingsView/components/Settings.js
@@ -8,8 +8,8 @@ import {
   Select,
   Option,
   ToggleInput,
-  Stack,
   Typography,
+  Flex,
 } from '@strapi/design-system';
 import { getTrad } from '../../../utils';
 
@@ -18,7 +18,7 @@ const Settings = ({ modifiedData, onChange, sortOptions }) => {
   const { settings, metadatas } = modifiedData;
 
   return (
-    <Stack spacing={4}>
+    <Flex direction="column" alignItems="stretch" gap={4}>
       <Typography variant="delta" as="h2">
         {formatMessage({
           id: getTrad('containers.SettingPage.settings'),
@@ -26,7 +26,7 @@ const Settings = ({ modifiedData, onChange, sortOptions }) => {
         })}
       </Typography>
 
-      <Stack horizontal justifyContent="space-between" spacing={4}>
+      <Flex justifyContent="space-between" gap={4}>
         <Box width="100%">
           <ToggleInput
             label={formatMessage({
@@ -92,7 +92,7 @@ const Settings = ({ modifiedData, onChange, sortOptions }) => {
             checked={settings.bulkable}
           />
         </Box>
-      </Stack>
+      </Flex>
 
       <Grid gap={4}>
         <GridItem s={12} col={6}>
@@ -152,7 +152,7 @@ const Settings = ({ modifiedData, onChange, sortOptions }) => {
           </Select>
         </GridItem>
       </Grid>
-    </Stack>
+    </Flex>
   );
 };
 

--- a/packages/core/admin/admin/src/content-manager/pages/ListSettingsView/components/SortDisplayedFields.js
+++ b/packages/core/admin/admin/src/content-manager/pages/ListSettingsView/components/SortDisplayedFields.js
@@ -2,15 +2,7 @@ import React, { useState, useRef, useEffect } from 'react';
 import styled from 'styled-components';
 import { PropTypes } from 'prop-types';
 import { useIntl } from 'react-intl';
-import {
-  Box,
-  Flex,
-  Stack,
-  Typography,
-  SimpleMenu,
-  MenuItem,
-  IconButton,
-} from '@strapi/design-system';
+import { Box, Flex, Typography, SimpleMenu, MenuItem, IconButton } from '@strapi/design-system';
 import { Plus } from '@strapi/icons';
 import DraggableCard from './DraggableCard';
 import { getTrad } from '../../../utils';
@@ -78,7 +70,7 @@ const SortDisplayedFields = ({
         hasRadius
       >
         <ScrollableContainer size="1" paddingBottom={4} ref={scrollableContainerRef}>
-          <Stack horizontal spacing={3}>
+          <Flex gap={3}>
             {displayedFields.map((field, index) => (
               <DraggableCard
                 key={field}
@@ -92,7 +84,7 @@ const SortDisplayedFields = ({
                 setIsDraggingSibling={setIsDraggingSibling}
               />
             ))}
-          </Stack>
+          </Flex>
         </ScrollableContainer>
         <SelectContainer size="auto" paddingBottom={4}>
           <SimpleMenu

--- a/packages/core/admin/admin/src/content-manager/pages/ListSettingsView/tests/__snapshots__/index.test.js.snap
+++ b/packages/core/admin/admin/src/content-manager/pages/ListSettingsView/tests/__snapshots__/index.test.js.snap
@@ -21,7 +21,7 @@ exports[`ADMIN | CM | LV | Configure the view renders and matches the snapshot 1
   color: #666687;
 }
 
-.c25 {
+.c24 {
   font-weight: 500;
   font-size: 1rem;
   line-height: 1.25;
@@ -110,7 +110,7 @@ exports[`ADMIN | CM | LV | Configure the view renders and matches the snapshot 1
   box-shadow: 0px 1px 4px rgba(33,33,52,0.1);
 }
 
-.c27 {
+.c26 {
   width: 100%;
 }
 
@@ -216,6 +216,40 @@ exports[`ADMIN | CM | LV | Configure the view renders and matches the snapshot 1
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  gap: 16px;
+}
+
+.c25 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 16px;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c28 {
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
 }
 
 .c35 {
@@ -236,13 +270,19 @@ exports[`ADMIN | CM | LV | Configure the view renders and matches the snapshot 1
   justify-content: center;
 }
 
-.c24 > * {
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
-.c24 > * + * {
-  margin-top: 16px;
+.c61 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 12px;
 }
 
 .c29 > * {
@@ -252,24 +292,6 @@ exports[`ADMIN | CM | LV | Configure the view renders and matches the snapshot 1
 
 .c29 > * + * {
   margin-top: 4px;
-}
-
-.c26 > * {
-  margin-left: 0;
-  margin-right: 0;
-}
-
-.c26 > * + * {
-  margin-left: 16px;
-}
-
-.c61 > * {
-  margin-left: 0;
-  margin-right: 0;
-}
-
-.c61 > * + * {
-  margin-left: 12px;
 }
 
 .c15 {
@@ -632,7 +654,7 @@ exports[`ADMIN | CM | LV | Configure the view renders and matches the snapshot 1
   width: 100%;
 }
 
-.c28 {
+.c27 {
   max-width: 320px;
 }
 
@@ -923,24 +945,24 @@ exports[`ADMIN | CM | LV | Configure the view renders and matches the snapshot 1
               class="c0 c22"
             >
               <div
-                class="c0 c23 c24"
+                class="c0 c23"
               >
                 <h2
-                  class="c13 c25"
+                  class="c13 c24"
                 >
                   Settings
                 </h2>
                 <div
-                  class="c0 c11 c26"
+                  class="c0 c25"
                 >
                   <div
-                    class="c0 c27"
+                    class="c0 c26"
                   >
                     <div
-                      class="c28"
+                      class="c27"
                     >
                       <div
-                        class="c0 c23 c29"
+                        class="c0 c28 c29"
                       >
                         <div
                           class="c0 c12"
@@ -1003,13 +1025,13 @@ exports[`ADMIN | CM | LV | Configure the view renders and matches the snapshot 1
                     </div>
                   </div>
                   <div
-                    class="c0 c27"
+                    class="c0 c26"
                   >
                     <div
-                      class="c28"
+                      class="c27"
                     >
                       <div
-                        class="c0 c23 c29"
+                        class="c0 c28 c29"
                       >
                         <div
                           class="c0 c12"
@@ -1072,13 +1094,13 @@ exports[`ADMIN | CM | LV | Configure the view renders and matches the snapshot 1
                     </div>
                   </div>
                   <div
-                    class="c0 c27"
+                    class="c0 c26"
                   >
                     <div
-                      class="c28"
+                      class="c27"
                     >
                       <div
-                        class="c0 c23 c29"
+                        class="c0 c28 c29"
                       >
                         <div
                           class="c0 c12"
@@ -1151,7 +1173,7 @@ exports[`ADMIN | CM | LV | Configure the view renders and matches the snapshot 1
                     >
                       <div>
                         <div
-                          class="c0 c23 c29"
+                          class="c0 c28 c29"
                         >
                           <label
                             class="c13 c19"
@@ -1240,7 +1262,7 @@ exports[`ADMIN | CM | LV | Configure the view renders and matches the snapshot 1
                     >
                       <div>
                         <div
-                          class="c0 c23 c29"
+                          class="c0 c28 c29"
                         >
                           <label
                             class="c13 c19"
@@ -1322,7 +1344,7 @@ exports[`ADMIN | CM | LV | Configure the view renders and matches the snapshot 1
                     >
                       <div>
                         <div
-                          class="c0 c23 c29"
+                          class="c0 c28 c29"
                         >
                           <label
                             class="c13 c19"
@@ -1409,7 +1431,7 @@ exports[`ADMIN | CM | LV | Configure the view renders and matches the snapshot 1
                 class="c0 c57"
               >
                 <h2
-                  class="c13 c25"
+                  class="c13 c24"
                 >
                   View
                 </h2>
@@ -1422,7 +1444,7 @@ exports[`ADMIN | CM | LV | Configure the view renders and matches the snapshot 1
                   size="1"
                 >
                   <div
-                    class="c0 c12 c61"
+                    class="c0 c61"
                   >
                     <div
                       class="c0 c62"
@@ -1431,7 +1453,7 @@ exports[`ADMIN | CM | LV | Configure the view renders and matches the snapshot 1
                         class="c0 c63 c11 c64"
                       >
                         <div
-                          class="c0 c12 c61"
+                          class="c0 c61"
                         >
                           <span
                             aria-label="Move id"
@@ -1534,7 +1556,7 @@ exports[`ADMIN | CM | LV | Configure the view renders and matches the snapshot 1
                         class="c0 c63 c11 c64"
                       >
                         <div
-                          class="c0 c12 c61"
+                          class="c0 c61"
                         >
                           <span
                             aria-label="Move address"
@@ -1724,7 +1746,7 @@ exports[`ADMIN | CM | LV | Configure the view should add field 1`] = `
   color: #666687;
 }
 
-.c25 {
+.c24 {
   font-weight: 500;
   font-size: 1rem;
   line-height: 1.25;
@@ -1813,7 +1835,7 @@ exports[`ADMIN | CM | LV | Configure the view should add field 1`] = `
   box-shadow: 0px 1px 4px rgba(33,33,52,0.1);
 }
 
-.c27 {
+.c26 {
   width: 100%;
 }
 
@@ -1919,6 +1941,40 @@ exports[`ADMIN | CM | LV | Configure the view should add field 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  gap: 16px;
+}
+
+.c25 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 16px;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c28 {
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
 }
 
 .c35 {
@@ -1939,13 +1995,19 @@ exports[`ADMIN | CM | LV | Configure the view should add field 1`] = `
   justify-content: center;
 }
 
-.c24 > * {
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
-.c24 > * + * {
-  margin-top: 16px;
+.c61 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 12px;
 }
 
 .c29 > * {
@@ -1955,24 +2017,6 @@ exports[`ADMIN | CM | LV | Configure the view should add field 1`] = `
 
 .c29 > * + * {
   margin-top: 4px;
-}
-
-.c26 > * {
-  margin-left: 0;
-  margin-right: 0;
-}
-
-.c26 > * + * {
-  margin-left: 16px;
-}
-
-.c61 > * {
-  margin-left: 0;
-  margin-right: 0;
-}
-
-.c61 > * + * {
-  margin-left: 12px;
 }
 
 .c15 {
@@ -2335,7 +2379,7 @@ exports[`ADMIN | CM | LV | Configure the view should add field 1`] = `
   width: 100%;
 }
 
-.c28 {
+.c27 {
   max-width: 320px;
 }
 
@@ -2625,24 +2669,24 @@ exports[`ADMIN | CM | LV | Configure the view should add field 1`] = `
               class="c0 c22"
             >
               <div
-                class="c0 c23 c24"
+                class="c0 c23"
               >
                 <h2
-                  class="c13 c25"
+                  class="c13 c24"
                 >
                   Settings
                 </h2>
                 <div
-                  class="c0 c11 c26"
+                  class="c0 c25"
                 >
                   <div
-                    class="c0 c27"
+                    class="c0 c26"
                   >
                     <div
-                      class="c28"
+                      class="c27"
                     >
                       <div
-                        class="c0 c23 c29"
+                        class="c0 c28 c29"
                       >
                         <div
                           class="c0 c12"
@@ -2705,13 +2749,13 @@ exports[`ADMIN | CM | LV | Configure the view should add field 1`] = `
                     </div>
                   </div>
                   <div
-                    class="c0 c27"
+                    class="c0 c26"
                   >
                     <div
-                      class="c28"
+                      class="c27"
                     >
                       <div
-                        class="c0 c23 c29"
+                        class="c0 c28 c29"
                       >
                         <div
                           class="c0 c12"
@@ -2774,13 +2818,13 @@ exports[`ADMIN | CM | LV | Configure the view should add field 1`] = `
                     </div>
                   </div>
                   <div
-                    class="c0 c27"
+                    class="c0 c26"
                   >
                     <div
-                      class="c28"
+                      class="c27"
                     >
                       <div
-                        class="c0 c23 c29"
+                        class="c0 c28 c29"
                       >
                         <div
                           class="c0 c12"
@@ -2853,7 +2897,7 @@ exports[`ADMIN | CM | LV | Configure the view should add field 1`] = `
                     >
                       <div>
                         <div
-                          class="c0 c23 c29"
+                          class="c0 c28 c29"
                         >
                           <label
                             class="c13 c19"
@@ -2942,7 +2986,7 @@ exports[`ADMIN | CM | LV | Configure the view should add field 1`] = `
                     >
                       <div>
                         <div
-                          class="c0 c23 c29"
+                          class="c0 c28 c29"
                         >
                           <label
                             class="c13 c19"
@@ -3024,7 +3068,7 @@ exports[`ADMIN | CM | LV | Configure the view should add field 1`] = `
                     >
                       <div>
                         <div
-                          class="c0 c23 c29"
+                          class="c0 c28 c29"
                         >
                           <label
                             class="c13 c19"
@@ -3111,7 +3155,7 @@ exports[`ADMIN | CM | LV | Configure the view should add field 1`] = `
                 class="c0 c57"
               >
                 <h2
-                  class="c13 c25"
+                  class="c13 c24"
                 >
                   View
                 </h2>
@@ -3124,7 +3168,7 @@ exports[`ADMIN | CM | LV | Configure the view should add field 1`] = `
                   size="1"
                 >
                   <div
-                    class="c0 c12 c61"
+                    class="c0 c61"
                   >
                     <div
                       class="c0 c62"
@@ -3133,7 +3177,7 @@ exports[`ADMIN | CM | LV | Configure the view should add field 1`] = `
                         class="c0 c63 c11 c64"
                       >
                         <div
-                          class="c0 c12 c61"
+                          class="c0 c61"
                         >
                           <span
                             aria-label="Move id"
@@ -3236,7 +3280,7 @@ exports[`ADMIN | CM | LV | Configure the view should add field 1`] = `
                         class="c0 c63 c11 c64"
                       >
                         <div
-                          class="c0 c12 c61"
+                          class="c0 c61"
                         >
                           <span
                             aria-label="Move address"
@@ -3339,7 +3383,7 @@ exports[`ADMIN | CM | LV | Configure the view should add field 1`] = `
                         class="c0 c63 c11 c64"
                       >
                         <div
-                          class="c0 c12 c61"
+                          class="c0 c61"
                         >
                           <span
                             aria-label="Move Cover"

--- a/packages/core/admin/admin/src/pages/Admin/Onboarding/index.js
+++ b/packages/core/admin/admin/src/pages/Admin/Onboarding/index.js
@@ -11,7 +11,6 @@ import {
   Icon,
   Portal,
   PopoverPrimitives,
-  Stack,
   Typography,
   VisuallyHidden,
 } from '@strapi/design-system';
@@ -192,9 +191,16 @@ const Onboarding = () => {
                   </Flex>
                 </VideoLinkWrapper>
               ))}
-              <Stack spacing={2} paddingLeft={5} paddingTop={2} paddingBottom={5}>
+              <Flex
+                direction="column"
+                alignItems="stretch"
+                gap={2}
+                paddingLeft={5}
+                paddingTop={2}
+                paddingBottom={5}
+              >
                 {docLinks.map(({ label, href, icon }) => (
-                  <Stack horizontal spacing={3} key={href}>
+                  <Flex gap={3} key={href}>
                     <Icon as={icon} color="primary600" />
                     <TextLink
                       as="a"
@@ -206,9 +212,9 @@ const Onboarding = () => {
                     >
                       {formatMessage(label)}
                     </TextLink>
-                  </Stack>
+                  </Flex>
                 ))}
-              </Stack>
+              </Flex>
             </FocusTrap>
           </PopoverPrimitives.Content>
         </Portal>

--- a/packages/core/admin/admin/src/pages/AuthPage/components/ForgotPassword/index.js
+++ b/packages/core/admin/admin/src/pages/AuthPage/components/ForgotPassword/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { useIntl } from 'react-intl';
 import PropTypes from 'prop-types';
 import { Form, Link } from '@strapi/helper-plugin';
-import { Box, Stack, Main, Flex, Button, TextInput, Typography } from '@strapi/design-system';
+import { Box, Flex, Main, Button, TextInput, Typography } from '@strapi/design-system';
 import { Formik } from 'formik';
 import UnauthenticatedLayout, {
   Column,
@@ -53,7 +53,7 @@ const ForgotPassword = ({ onSubmit, schema }) => {
                   )}
                 </Column>
 
-                <Stack spacing={6}>
+                <Flex direction="column" alignItems="stretch" gap={6}>
                   <TextInput
                     error={
                       errors.email
@@ -79,7 +79,7 @@ const ForgotPassword = ({ onSubmit, schema }) => {
                       defaultMessage: 'Send Email',
                     })}
                   </Button>
-                </Stack>
+                </Flex>
               </Form>
             )}
           </Formik>

--- a/packages/core/admin/admin/src/pages/AuthPage/components/Login/BaseLogin.js
+++ b/packages/core/admin/admin/src/pages/AuthPage/components/Login/BaseLogin.js
@@ -1,16 +1,7 @@
 import React, { useState } from 'react';
 import { Form, Link } from '@strapi/helper-plugin';
 import { EyeStriked, Eye } from '@strapi/icons';
-import {
-  Box,
-  Stack,
-  Main,
-  Flex,
-  Button,
-  TextInput,
-  Checkbox,
-  Typography,
-} from '@strapi/design-system';
+import { Box, Main, Flex, Button, TextInput, Checkbox, Typography } from '@strapi/design-system';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 import styled from 'styled-components';
@@ -75,7 +66,7 @@ const Login = ({ onSubmit, schema, children }) => {
                 )}
               </Column>
 
-              <Stack spacing={6}>
+              <Flex direction="column" alignItems="stretch" gap={6}>
                 <TextInput
                   error={
                     errors.email
@@ -151,7 +142,7 @@ const Login = ({ onSubmit, schema, children }) => {
                 <Button fullWidth type="submit">
                   {formatMessage({ id: 'Auth.form.button.login', defaultMessage: 'Login' })}
                 </Button>
-              </Stack>
+              </Flex>
             </Form>
           )}
         </Formik>

--- a/packages/core/admin/admin/src/pages/AuthPage/components/Login/tests/BaseLogin.test.js
+++ b/packages/core/admin/admin/src/pages/AuthPage/components/Login/tests/BaseLogin.test.js
@@ -117,6 +117,21 @@ describe('ADMIN | PAGES | AUTH | BaseLogin', () => {
         -webkit-flex-direction: column;
         -ms-flex-direction: column;
         flex-direction: column;
+        gap: 24px;
+      }
+
+      .c13 {
+        -webkit-align-items: stretch;
+        -webkit-box-align: stretch;
+        -ms-flex-align: stretch;
+        align-items: stretch;
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+        -webkit-flex-direction: column;
+        -ms-flex-direction: column;
+        flex-direction: column;
       }
 
       .c18 {
@@ -153,15 +168,6 @@ describe('ADMIN | PAGES | AUTH | BaseLogin', () => {
         -webkit-justify-content: center;
         -ms-flex-pack: center;
         justify-content: center;
-      }
-
-      .c13 > * {
-        margin-top: 0;
-        margin-bottom: 0;
-      }
-
-      .c13 > * + * {
-        margin-top: 24px;
       }
 
       .c14 > * {
@@ -649,12 +655,12 @@ describe('ADMIN | PAGES | AUTH | BaseLogin', () => {
               </div>
             </div>
             <div
-              class="c1 c12 c13"
+              class="c1 c12"
             >
               <div>
                 <div>
                   <div
-                    class="c1 c12 c14"
+                    class="c1 c13 c14"
                   >
                     <label
                       class="c8 c15"
@@ -691,7 +697,7 @@ describe('ADMIN | PAGES | AUTH | BaseLogin', () => {
               <div>
                 <div>
                   <div
-                    class="c1 c12 c14"
+                    class="c1 c13 c14"
                   >
                     <label
                       class="c8 c15"
@@ -749,7 +755,7 @@ describe('ADMIN | PAGES | AUTH | BaseLogin', () => {
               </div>
               <div>
                 <div
-                  class="c1 c12 c14"
+                  class="c1 c13 c14"
                 >
                   <label
                     class="c8 c26 c27"

--- a/packages/core/admin/admin/src/pages/AuthPage/components/Register/index.js
+++ b/packages/core/admin/admin/src/pages/AuthPage/components/Register/index.js
@@ -17,7 +17,6 @@ import {
 } from '@strapi/helper-plugin';
 import {
   Box,
-  Stack,
   Main,
   Flex,
   Button,
@@ -159,7 +158,7 @@ const Register = ({ authType, fieldsToDisable, noSignin, onSubmit, schema }) => 
                       </Typography>
                     </CenteredBox>
                   </Column>
-                  <Stack spacing={6}>
+                  <Flex direction="column" alignItems="stretch" spacing={6}>
                     <Grid gap={4}>
                       <GridItem col={6}>
                         <TextInput
@@ -314,7 +313,7 @@ const Register = ({ authType, fieldsToDisable, noSignin, onSubmit, schema }) => 
                         defaultMessage: "Let's start",
                       })}
                     </Button>
-                  </Stack>
+                  </Flex>
                 </Main>
               </Form>
             );

--- a/packages/core/admin/admin/src/pages/AuthPage/components/Register/tests/index.test.js
+++ b/packages/core/admin/admin/src/pages/AuthPage/components/Register/tests/index.test.js
@@ -65,25 +65,25 @@ describe('ADMIN | PAGES | AUTH | Register', () => {
         color: #666687;
       }
 
-      .c26 {
+      .c25 {
         font-size: 0.875rem;
         line-height: 1.43;
         color: #d02b20;
       }
 
-      .c36 {
+      .c35 {
         font-size: 0.75rem;
         line-height: 1.33;
         color: #666687;
       }
 
-      .c37 {
+      .c36 {
         font-size: 0.875rem;
         line-height: 1.43;
         color: #32324d;
       }
 
-      .c42 {
+      .c41 {
         font-size: 0.875rem;
         line-height: 1.43;
         font-weight: 600;
@@ -123,7 +123,7 @@ describe('ADMIN | PAGES | AUTH | Register', () => {
         padding-bottom: 32px;
       }
 
-      .c33 {
+      .c32 {
         padding-right: 12px;
         padding-left: 8px;
       }
@@ -174,7 +174,7 @@ describe('ADMIN | PAGES | AUTH | Register', () => {
         flex-direction: column;
       }
 
-      .c28 {
+      .c27 {
         -webkit-align-items: center;
         -webkit-box-align: center;
         -ms-flex-align: center;
@@ -192,21 +192,12 @@ describe('ADMIN | PAGES | AUTH | Register', () => {
         justify-content: space-between;
       }
 
-      .c22 > * {
+      .c24 > * {
         margin-top: 0;
         margin-bottom: 0;
       }
 
-      .c22 > * + * {
-        margin-top: 24px;
-      }
-
-      .c25 > * {
-        margin-top: 0;
-        margin-bottom: 0;
-      }
-
-      .c25 > * + * {
+      .c24 > * + * {
         margin-top: 4px;
       }
 
@@ -268,7 +259,7 @@ describe('ADMIN | PAGES | AUTH | Register', () => {
         border: 2px solid #4945ff;
       }
 
-      .c39 {
+      .c38 {
         height: 18px;
         min-width: 18px;
         margin: 0;
@@ -279,12 +270,12 @@ describe('ADMIN | PAGES | AUTH | Register', () => {
         cursor: pointer;
       }
 
-      .c39:checked {
+      .c38:checked {
         background-color: #4945ff;
         border: 1px solid #4945ff;
       }
 
-      .c39:checked:after {
+      .c38:checked:after {
         content: '';
         display: block;
         position: relative;
@@ -298,21 +289,21 @@ describe('ADMIN | PAGES | AUTH | Register', () => {
         transform: translateX(-50%) translateY(-50%);
       }
 
-      .c39:checked:disabled:after {
+      .c38:checked:disabled:after {
         background: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTAiIGhlaWdodD0iOCIgdmlld0JveD0iMCAwIDEwIDgiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgPHBhdGgKICAgIGQ9Ik04LjU1MzIzIDAuMzk2OTczQzguNjMxMzUgMC4zMTYzNTUgOC43NjA1MSAwLjMxNTgxMSA4LjgzOTMxIDAuMzk1NzY4TDkuODYyNTYgMS40MzQwN0M5LjkzODkzIDEuNTExNTcgOS45MzkzNSAxLjYzNTkgOS44NjM0OSAxLjcxMzlMNC4wNjQwMSA3LjY3NzI0QzMuOTg1OSA3Ljc1NzU1IDMuODU3MDcgNy43NTgwNSAzLjc3ODM0IDcuNjc4MzRMMC4xMzg2NiAzLjk5MzMzQzAuMDYxNzc5OCAzLjkxNTQ5IDAuMDYxNzEwMiAzLjc5MDMyIDAuMTM4NTA0IDMuNzEyNEwxLjE2MjEzIDIuNjczNzJDMS4yNDAzOCAyLjU5NDMyIDEuMzY4NDMgMi41OTQyMiAxLjQ0NjggMi42NzM0OEwzLjkyMTc0IDUuMTc2NDdMOC41NTMyMyAwLjM5Njk3M1oiCiAgICBmaWxsPSIjOEU4RUE5IgogIC8+Cjwvc3ZnPg==) no-repeat no-repeat center center;
       }
 
-      .c39:disabled {
+      .c38:disabled {
         background-color: #dcdce4;
         border: 1px solid #c0c0cf;
       }
 
-      .c39:indeterminate {
+      .c38:indeterminate {
         background-color: #4945ff;
         border: 1px solid #4945ff;
       }
 
-      .c39:indeterminate:after {
+      .c38:indeterminate:after {
         content: '';
         display: block;
         position: relative;
@@ -327,12 +318,12 @@ describe('ADMIN | PAGES | AUTH | Register', () => {
         transform: translateX(-50%) translateY(-50%);
       }
 
-      .c39:indeterminate:disabled {
+      .c38:indeterminate:disabled {
         background-color: #dcdce4;
         border: 1px solid #c0c0cf;
       }
 
-      .c39:indeterminate:disabled:after {
+      .c38:indeterminate:disabled:after {
         background-color: #8e8ea9;
       }
 
@@ -409,7 +400,7 @@ describe('ADMIN | PAGES | AUTH | Register', () => {
         fill: #8e8ea9;
       }
 
-      .c41 {
+      .c40 {
         -webkit-align-items: center;
         -webkit-box-align: center;
         -ms-flex-align: center;
@@ -430,7 +421,7 @@ describe('ADMIN | PAGES | AUTH | Register', () => {
         width: 100%;
       }
 
-      .c41 .c0 {
+      .c40 .c0 {
         display: -webkit-box;
         display: -webkit-flex;
         display: -ms-flexbox;
@@ -441,53 +432,97 @@ describe('ADMIN | PAGES | AUTH | Register', () => {
         align-items: center;
       }
 
-      .c41 .c5 {
+      .c40 .c5 {
         color: #ffffff;
       }
 
-      .c41[aria-disabled='true'] {
+      .c40[aria-disabled='true'] {
         border: 1px solid #dcdce4;
         background: #eaeaef;
       }
 
-      .c41[aria-disabled='true'] .c5 {
+      .c40[aria-disabled='true'] .c5 {
         color: #666687;
       }
 
-      .c41[aria-disabled='true'] svg > g,.c41[aria-disabled='true'] svg path {
+      .c40[aria-disabled='true'] svg > g,.c40[aria-disabled='true'] svg path {
         fill: #666687;
       }
 
-      .c41[aria-disabled='true']:active {
+      .c40[aria-disabled='true']:active {
         border: 1px solid #dcdce4;
         background: #eaeaef;
       }
 
-      .c41[aria-disabled='true']:active .c5 {
+      .c40[aria-disabled='true']:active .c5 {
         color: #666687;
       }
 
-      .c41[aria-disabled='true']:active svg > g,.c41[aria-disabled='true']:active svg path {
+      .c40[aria-disabled='true']:active svg > g,.c40[aria-disabled='true']:active svg path {
         fill: #666687;
       }
 
-      .c41:hover {
+      .c40:hover {
         border: 1px solid #7b79ff;
         background: #7b79ff;
       }
 
-      .c41:active {
+      .c40:active {
         border: 1px solid #4945ff;
         background: #4945ff;
       }
 
-      .c41 svg > g,
-      .c41 svg path {
+      .c40 svg > g,
+      .c40 svg path {
         fill: #ffffff;
       }
 
-      .c27 {
+      .c26 {
         line-height: 0;
+      }
+
+      .c29 {
+        border: none;
+        border-radius: 4px;
+        padding-bottom: 0.65625rem;
+        padding-left: 16px;
+        padding-right: 16px;
+        padding-top: 0.65625rem;
+        color: #32324d;
+        font-weight: 400;
+        font-size: 0.875rem;
+        display: block;
+        width: 100%;
+        background: inherit;
+      }
+
+      .c29::-webkit-input-placeholder {
+        color: #8e8ea9;
+        opacity: 1;
+      }
+
+      .c29::-moz-placeholder {
+        color: #8e8ea9;
+        opacity: 1;
+      }
+
+      .c29:-ms-input-placeholder {
+        color: #8e8ea9;
+        opacity: 1;
+      }
+
+      .c29::placeholder {
+        color: #8e8ea9;
+        opacity: 1;
+      }
+
+      .c29[aria-disabled='true'] {
+        color: inherit;
+      }
+
+      .c29:focus {
+        outline: none;
+        box-shadow: none;
       }
 
       .c30 {
@@ -495,7 +530,7 @@ describe('ADMIN | PAGES | AUTH | Register', () => {
         border-radius: 4px;
         padding-bottom: 0.65625rem;
         padding-left: 16px;
-        padding-right: 16px;
+        padding-right: 0;
         padding-top: 0.65625rem;
         color: #32324d;
         font-weight: 400;
@@ -534,51 +569,7 @@ describe('ADMIN | PAGES | AUTH | Register', () => {
         box-shadow: none;
       }
 
-      .c31 {
-        border: none;
-        border-radius: 4px;
-        padding-bottom: 0.65625rem;
-        padding-left: 16px;
-        padding-right: 0;
-        padding-top: 0.65625rem;
-        color: #32324d;
-        font-weight: 400;
-        font-size: 0.875rem;
-        display: block;
-        width: 100%;
-        background: inherit;
-      }
-
-      .c31::-webkit-input-placeholder {
-        color: #8e8ea9;
-        opacity: 1;
-      }
-
-      .c31::-moz-placeholder {
-        color: #8e8ea9;
-        opacity: 1;
-      }
-
-      .c31:-ms-input-placeholder {
-        color: #8e8ea9;
-        opacity: 1;
-      }
-
-      .c31::placeholder {
-        color: #8e8ea9;
-        opacity: 1;
-      }
-
-      .c31[aria-disabled='true'] {
-        color: inherit;
-      }
-
-      .c31:focus {
-        outline: none;
-        box-shadow: none;
-      }
-
-      .c29 {
+      .c28 {
         border: 1px solid #dcdce4;
         border-radius: 4px;
         background: #ffffff;
@@ -590,12 +581,12 @@ describe('ADMIN | PAGES | AUTH | Register', () => {
         transition-duration: 0.2s;
       }
 
-      .c29:focus-within {
+      .c28:focus-within {
         border: 1px solid #4945ff;
         box-shadow: #4945ff 0px 0px 0px 2px;
       }
 
-      .c34 {
+      .c33 {
         border: none;
         background: transparent;
         font-size: 1.6rem;
@@ -611,7 +602,7 @@ describe('ADMIN | PAGES | AUTH | Register', () => {
         align-items: center;
       }
 
-      .c38 {
+      .c37 {
         display: -webkit-box;
         display: -webkit-flex;
         display: -ms-flexbox;
@@ -622,7 +613,7 @@ describe('ADMIN | PAGES | AUTH | Register', () => {
         align-items: flex-start;
       }
 
-      .c38 * {
+      .c37 * {
         cursor: pointer;
       }
 
@@ -642,13 +633,13 @@ describe('ADMIN | PAGES | AUTH | Register', () => {
         width: 6px;
       }
 
-      .c23 {
+      .c22 {
         display: grid;
         grid-template-columns: repeat(12,1fr);
         gap: 16px;
       }
 
-      .c24 {
+      .c23 {
         grid-column: span 6;
         max-width: 100%;
       }
@@ -672,12 +663,12 @@ describe('ADMIN | PAGES | AUTH | Register', () => {
         height: 4.5rem;
       }
 
-      .c35 svg {
+      .c34 svg {
         height: 1rem;
         width: 1rem;
       }
 
-      .c35 svg path {
+      .c34 svg path {
         fill: #666687;
       }
 
@@ -685,22 +676,22 @@ describe('ADMIN | PAGES | AUTH | Register', () => {
         text-align: center;
       }
 
-      .c40 {
+      .c39 {
         color: #4945ff;
       }
 
-      .c32::-ms-reveal {
+      .c31::-ms-reveal {
         display: none;
       }
 
       @media (max-width:68.75rem) {
-        .c24 {
+        .c23 {
           grid-column: span;
         }
       }
 
       @media (max-width:34.375rem) {
-        .c24 {
+        .c23 {
           grid-column: span;
         }
       }
@@ -800,13 +791,14 @@ describe('ADMIN | PAGES | AUTH | Register', () => {
                   </div>
                 </div>
                 <div
-                  class="c0 c21 c22"
+                  class="c0 c21"
+                  spacing="6"
                 >
                   <div
-                    class="c0 c23"
+                    class="c0 c22"
                   >
                     <div
-                      class="c24"
+                      class="c23"
                     >
                       <div
                         class="c0 "
@@ -814,7 +806,7 @@ describe('ADMIN | PAGES | AUTH | Register', () => {
                         <div>
                           <div>
                             <div
-                              class="c0 c21 c25"
+                              class="c0 c21 c24"
                             >
                               <label
                                 class="c5 c6"
@@ -825,20 +817,20 @@ describe('ADMIN | PAGES | AUTH | Register', () => {
                                 >
                                   Firstname
                                   <span
-                                    class="c5 c26 c27"
+                                    class="c5 c25 c26"
                                   >
                                     *
                                   </span>
                                 </div>
                               </label>
                               <div
-                                class="c0 c28 c29"
+                                class="c0 c27 c28"
                               >
                                 <input
                                   aria-disabled="false"
                                   aria-invalid="false"
                                   aria-required="true"
-                                  class="c30"
+                                  class="c29"
                                   id="2"
                                   name="firstname"
                                   value=""
@@ -850,7 +842,7 @@ describe('ADMIN | PAGES | AUTH | Register', () => {
                       </div>
                     </div>
                     <div
-                      class="c24"
+                      class="c23"
                     >
                       <div
                         class="c0 "
@@ -858,7 +850,7 @@ describe('ADMIN | PAGES | AUTH | Register', () => {
                         <div>
                           <div>
                             <div
-                              class="c0 c21 c25"
+                              class="c0 c21 c24"
                             >
                               <label
                                 class="c5 c6"
@@ -871,13 +863,13 @@ describe('ADMIN | PAGES | AUTH | Register', () => {
                                 </div>
                               </label>
                               <div
-                                class="c0 c28 c29"
+                                class="c0 c27 c28"
                               >
                                 <input
                                   aria-disabled="false"
                                   aria-invalid="false"
                                   aria-required="false"
-                                  class="c30"
+                                  class="c29"
                                   id="4"
                                   name="lastname"
                                   value=""
@@ -892,7 +884,7 @@ describe('ADMIN | PAGES | AUTH | Register', () => {
                   <div>
                     <div>
                       <div
-                        class="c0 c21 c25"
+                        class="c0 c21 c24"
                       >
                         <label
                           class="c5 c6"
@@ -903,20 +895,20 @@ describe('ADMIN | PAGES | AUTH | Register', () => {
                           >
                             Email
                             <span
-                              class="c5 c26 c27"
+                              class="c5 c25 c26"
                             >
                               *
                             </span>
                           </div>
                         </label>
                         <div
-                          class="c0 c28 c29"
+                          class="c0 c27 c28"
                         >
                           <input
                             aria-disabled="false"
                             aria-invalid="false"
                             aria-required="true"
-                            class="c30"
+                            class="c29"
                             id="6"
                             name="email"
                             type="email"
@@ -929,7 +921,7 @@ describe('ADMIN | PAGES | AUTH | Register', () => {
                   <div>
                     <div>
                       <div
-                        class="c0 c21 c25"
+                        class="c0 c21 c24"
                       >
                         <label
                           class="c5 c6"
@@ -940,32 +932,32 @@ describe('ADMIN | PAGES | AUTH | Register', () => {
                           >
                             Password
                             <span
-                              class="c5 c26 c27"
+                              class="c5 c25 c26"
                             >
                               *
                             </span>
                           </div>
                         </label>
                         <div
-                          class="c0 c28 c29"
+                          class="c0 c27 c28"
                         >
                           <input
                             aria-describedby="8-hint"
                             aria-disabled="false"
                             aria-invalid="false"
                             aria-required="true"
-                            class="c31 c32"
+                            class="c30 c31"
                             id="8"
                             name="password"
                             type="password"
                             value=""
                           />
                           <div
-                            class="c0 c33"
+                            class="c0 c32"
                           >
                             <button
                               aria-label="Hide password"
-                              class="c34 c35"
+                              class="c33 c34"
                               type="button"
                             >
                               <svg
@@ -984,7 +976,7 @@ describe('ADMIN | PAGES | AUTH | Register', () => {
                           </div>
                         </div>
                         <p
-                          class="c5 c36"
+                          class="c5 c35"
                           id="8-hint"
                         >
                           Must be at least 8 characters, 1 uppercase, 1 lowercase & 1 number
@@ -995,7 +987,7 @@ describe('ADMIN | PAGES | AUTH | Register', () => {
                   <div>
                     <div>
                       <div
-                        class="c0 c21 c25"
+                        class="c0 c21 c24"
                       >
                         <label
                           class="c5 c6"
@@ -1006,31 +998,31 @@ describe('ADMIN | PAGES | AUTH | Register', () => {
                           >
                             Confirm Password
                             <span
-                              class="c5 c26 c27"
+                              class="c5 c25 c26"
                             >
                               *
                             </span>
                           </div>
                         </label>
                         <div
-                          class="c0 c28 c29"
+                          class="c0 c27 c28"
                         >
                           <input
                             aria-disabled="false"
                             aria-invalid="false"
                             aria-required="true"
-                            class="c31 c32"
+                            class="c30 c31"
                             id="10"
                             name="confirmPassword"
                             type="password"
                             value=""
                           />
                           <div
-                            class="c0 c33"
+                            class="c0 c32"
                           >
                             <button
                               aria-label="Hide password"
-                              class="c34 c35"
+                              class="c33 c34"
                               type="button"
                             >
                               <svg
@@ -1053,17 +1045,17 @@ describe('ADMIN | PAGES | AUTH | Register', () => {
                   </div>
                   <div>
                     <div
-                      class="c0 c21 c25"
+                      class="c0 c21 c24"
                     >
                       <label
-                        class="c5 c37 c38"
+                        class="c5 c36 c37"
                       >
                         <div
                           class="c0 "
                         >
                           <input
                             aria-label="news"
-                            class="c39"
+                            class="c38"
                             id="12"
                             name="news"
                             type="checkbox"
@@ -1074,7 +1066,7 @@ describe('ADMIN | PAGES | AUTH | Register', () => {
                         >
                           Keep me updated about new features & upcoming improvements (by doing this you accept the 
                           <a
-                            class="c40"
+                            class="c39"
                             href="https://strapi.io/terms"
                             rel="noreferrer"
                             target="_blank"
@@ -1083,7 +1075,7 @@ describe('ADMIN | PAGES | AUTH | Register', () => {
                           </a>
                            and the 
                           <a
-                            class="c40"
+                            class="c39"
                             href="https://strapi.io/privacy"
                             rel="noreferrer"
                             target="_blank"
@@ -1097,11 +1089,11 @@ describe('ADMIN | PAGES | AUTH | Register', () => {
                   </div>
                   <button
                     aria-disabled="false"
-                    class="c3 c41"
+                    class="c3 c40"
                     type="submit"
                   >
                     <span
-                      class="c5 c42"
+                      class="c5 c41"
                     >
                       Let's start
                     </span>

--- a/packages/core/admin/admin/src/pages/AuthPage/components/ResetPassword/index.js
+++ b/packages/core/admin/admin/src/pages/AuthPage/components/ResetPassword/index.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { Formik } from 'formik';
 import { Form, Link } from '@strapi/helper-plugin';
-import { Box, Stack, Main, Flex, Button, TextInput, Typography } from '@strapi/design-system';
+import { Box, Main, Flex, Button, TextInput, Typography } from '@strapi/design-system';
 import { EyeStriked, Eye } from '@strapi/icons';
 import UnauthenticatedLayout, {
   Column,
@@ -65,7 +65,7 @@ const ForgotPassword = ({ onSubmit, schema }) => {
                   )}
                 </Column>
 
-                <Stack spacing={6}>
+                <Flex direction="column" alignItems="stretch" gap={6}>
                   <PasswordInput
                     name="password"
                     onChange={handleChange}
@@ -157,7 +157,7 @@ const ForgotPassword = ({ onSubmit, schema }) => {
                       defaultMessage: 'Change password',
                     })}
                   </Button>
-                </Stack>
+                </Flex>
               </Form>
             )}
           </Formik>

--- a/packages/core/admin/admin/src/pages/AuthPage/components/ResetPassword/tests/index.test.js
+++ b/packages/core/admin/admin/src/pages/AuthPage/components/ResetPassword/tests/index.test.js
@@ -144,6 +144,21 @@ describe('ADMIN | PAGES | AUTH | ResetPassword', () => {
         -webkit-flex-direction: column;
         -ms-flex-direction: column;
         flex-direction: column;
+        gap: 24px;
+      }
+
+      .c19 {
+        -webkit-align-items: stretch;
+        -webkit-box-align: stretch;
+        -ms-flex-align: stretch;
+        align-items: stretch;
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+        -webkit-flex-direction: column;
+        -ms-flex-direction: column;
+        flex-direction: column;
       }
 
       .c23 {
@@ -180,15 +195,6 @@ describe('ADMIN | PAGES | AUTH | ResetPassword', () => {
         -webkit-justify-content: center;
         -ms-flex-pack: center;
         justify-content: center;
-      }
-
-      .c19 > * {
-        margin-top: 0;
-        margin-bottom: 0;
-      }
-
-      .c19 > * + * {
-        margin-top: 24px;
       }
 
       .c20 > * {
@@ -673,12 +679,12 @@ describe('ADMIN | PAGES | AUTH | ResetPassword', () => {
                   </div>
                 </div>
                 <div
-                  class="c0 c18 c19"
+                  class="c0 c18"
                 >
                   <div>
                     <div>
                       <div
-                        class="c0 c18 c20"
+                        class="c0 c19 c20"
                       >
                         <label
                           class="c5 c6"
@@ -744,7 +750,7 @@ describe('ADMIN | PAGES | AUTH | ResetPassword', () => {
                   <div>
                     <div>
                       <div
-                        class="c0 c18 c20"
+                        class="c0 c19 c20"
                       >
                         <label
                           class="c5 c6"

--- a/packages/core/admin/admin/src/pages/HomePage/ContentBlocks.js
+++ b/packages/core/admin/admin/src/pages/HomePage/ContentBlocks.js
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import { useIntl } from 'react-intl';
 import { ContentBox, useTracking } from '@strapi/helper-plugin';
-import { Stack } from '@strapi/design-system';
+import { Flex } from '@strapi/design-system';
 import { InformationSquare, CodeSquare, PlaySquare, FeatherSquare } from '@strapi/icons';
 import CloudBox from './CloudBox';
 
@@ -19,7 +19,7 @@ const ContentBlocks = () => {
   };
 
   return (
-    <Stack spacing={5}>
+    <Flex direction="column" alignItems="stretch" gap={5}>
       <CloudBox />
       <BlockLink
         href="https://strapi.io/resource-center"
@@ -97,7 +97,7 @@ const ContentBlocks = () => {
           iconBackground="alternative100"
         />
       </BlockLink>
-    </Stack>
+    </Flex>
   );
 };
 

--- a/packages/core/admin/admin/src/pages/HomePage/HomeHeader.js
+++ b/packages/core/admin/admin/src/pages/HomePage/HomeHeader.js
@@ -2,16 +2,12 @@ import React from 'react';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
-import { Typography, Stack, Box, Button } from '@strapi/design-system';
+import { Typography, Box, Button, Flex } from '@strapi/design-system';
 import { Link } from '@strapi/design-system/v2';
 import { ArrowRight } from '@strapi/icons';
 
 const WordWrap = styled(Typography)`
   word-break: break-word;
-`;
-
-const StackCustom = styled(Stack)`
-  align-items: flex-start;
 `;
 
 const HomeHeader = ({ hasCreatedContentType, onCreateCT }) => {
@@ -20,7 +16,7 @@ const HomeHeader = ({ hasCreatedContentType, onCreateCT }) => {
   return (
     <div>
       <Box paddingLeft={6} paddingBottom={10}>
-        <StackCustom spacing={5}>
+        <Flex direction="column" alignItems="flex-start" gap={5}>
           <Typography as="h1" variant="alpha">
             {hasCreatedContentType
               ? formatMessage({
@@ -60,7 +56,7 @@ const HomeHeader = ({ hasCreatedContentType, onCreateCT }) => {
               })}
             </Button>
           )}
-        </StackCustom>
+        </Flex>
       </Box>
     </div>
   );

--- a/packages/core/admin/admin/src/pages/HomePage/SocialLinks.js
+++ b/packages/core/admin/admin/src/pages/HomePage/SocialLinks.js
@@ -7,7 +7,7 @@ import React from 'react';
 import styled from 'styled-components';
 import { useIntl } from 'react-intl';
 import { useAppInfos } from '@strapi/helper-plugin';
-import { Typography, Box, Stack, Grid, GridItem } from '@strapi/design-system';
+import { Typography, Box, Flex, Grid, GridItem } from '@strapi/design-system';
 import { Link, LinkButton } from '@strapi/design-system/v2';
 import { ExternalLink, Github, Discord, Reddit, Strapi, Twitter, Discourse } from '@strapi/icons';
 
@@ -160,8 +160,8 @@ const SocialLinks = () => {
       shadow="tableShadow"
     >
       <Box paddingBottom={7}>
-        <Stack spacing={5}>
-          <Stack spacing={3}>
+        <Flex direction="column" alignItems="stretch" gap={5}>
+          <Flex direction="column" alignItems="stretch" gap={3}>
             <Typography variant="delta" as="h2" id="join-the-community">
               {formatMessage({
                 id: 'app.components.HomePage.community',
@@ -175,14 +175,14 @@ const SocialLinks = () => {
                   'Discuss with team members, contributors and developers on different channels',
               })}
             </Typography>
-          </Stack>
+          </Flex>
           <Link href="https://feedback.strapi.io/" isExternal endIcon={<ExternalLink />}>
             {formatMessage({
               id: 'app.components.HomePage.roadmap',
               defaultMessage: 'See our road map',
             })}
           </Link>
-        </Stack>
+        </Flex>
       </Box>
       <GridGap>
         {socialLinksExtended.map(({ icon, link, name }) => {

--- a/packages/core/admin/admin/src/pages/MarketplacePage/components/NpmPackageCard/PackageStats.js
+++ b/packages/core/admin/admin/src/pages/MarketplacePage/components/NpmPackageCard/PackageStats.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { useIntl } from 'react-intl';
-import { Typography, Icon, Divider, Stack } from '@strapi/design-system';
+import { Typography, Icon, Divider, Flex } from '@strapi/design-system';
 import { Github, Download, Star } from '@strapi/icons';
 import { pxToRem } from '@strapi/helper-plugin';
 
@@ -15,7 +15,7 @@ const PackageStats = ({ githubStars, npmDownloads, npmPackageType }) => {
   const { formatMessage } = useIntl();
 
   return (
-    <Stack horizontal spacing={1}>
+    <Flex gap={1}>
       {!!githubStars && (
         <>
           <Icon as={Github} height={pxToRem(12)} width={pxToRem(12)} aria-hidden />
@@ -56,7 +56,7 @@ const PackageStats = ({ githubStars, npmDownloads, npmPackageType }) => {
           {npmDownloads}
         </Typography>
       </p>
-    </Stack>
+    </Flex>
   );
 };
 

--- a/packages/core/admin/admin/src/pages/MarketplacePage/components/NpmPackageCard/index.js
+++ b/packages/core/admin/admin/src/pages/MarketplacePage/components/NpmPackageCard/index.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 import styled from 'styled-components';
 import pluralize from 'pluralize';
-import { Box, Stack, Typography, Flex, Icon, Tooltip } from '@strapi/design-system';
+import { Box, Typography, Flex, Icon, Tooltip } from '@strapi/design-system';
 import { LinkButton } from '@strapi/design-system/v2';
 import { ExternalLink, CheckCircle } from '@strapi/icons';
 import { useTracking } from '@strapi/helper-plugin';
@@ -117,7 +117,7 @@ const NpmPackageCard = ({
         </Box>
       </Box>
 
-      <Stack horizontal spacing={2} style={{ alignSelf: 'flex-end' }} paddingTop={6}>
+      <Flex gap={2} style={{ alignSelf: 'flex-end' }} paddingTop={6}>
         <LinkButton
           size="S"
           href={npmPackageHref}
@@ -146,7 +146,7 @@ const NpmPackageCard = ({
           strapiPeerDepVersion={attributes.strapiVersion}
           pluginName={attributes.name}
         />
-      </Stack>
+      </Flex>
     </Flex>
   );
 };

--- a/packages/core/admin/admin/src/pages/MarketplacePage/components/NpmPackagesFilters/FiltersPopover.js
+++ b/packages/core/admin/admin/src/pages/MarketplacePage/components/NpmPackagesFilters/FiltersPopover.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Box, Popover, Stack, FocusTrap } from '@strapi/design-system';
+import { Box, Popover, Flex, FocusTrap } from '@strapi/design-system';
 import { useIntl } from 'react-intl';
 import FilterSelect from './FilterSelect';
 
@@ -19,7 +19,7 @@ const FiltersPopover = ({
   return (
     <Popover source={source} padding={3} spacing={4} onBlur={() => {}}>
       <FocusTrap onEscape={onToggle}>
-        <Stack spacing={1}>
+        <Flex direction="column" alignItems="stretch" gap={1}>
           <Box>
             <FilterSelect
               message={formatMessage({
@@ -73,7 +73,7 @@ const FiltersPopover = ({
               />
             </Box>
           )}
-        </Stack>
+        </Flex>
       </FocusTrap>
     </Popover>
   );

--- a/packages/core/admin/admin/src/pages/MarketplacePage/tests/__snapshots__/index.test.js.snap
+++ b/packages/core/admin/admin/src/pages/MarketplacePage/tests/__snapshots__/index.test.js.snap
@@ -66,14 +66,14 @@ exports[`Marketplace page - layout renders the online layout 1`] = `
   color: #666687;
 }
 
-.c83 {
+.c82 {
   font-size: 0.875rem;
   line-height: 1.43;
   font-weight: 600;
   color: #328048;
 }
 
-.c88 {
+.c87 {
   font-size: 0.75rem;
   line-height: 1.33;
   font-weight: 500;
@@ -174,46 +174,46 @@ exports[`Marketplace page - layout renders the online layout 1`] = `
   padding-top: 24px;
 }
 
-.c78 {
+.c77 {
   color: #328048;
   margin-left: 8px;
 }
 
-.c80 {
+.c79 {
   margin-left: 4px;
   width: 24px;
   height: auto;
 }
 
-.c81 {
+.c80 {
   padding-left: 16px;
 }
 
-.c82 {
+.c81 {
   color: #328048;
   margin-right: 8px;
   width: 12;
   height: 12;
 }
 
-.c84 {
+.c83 {
   padding-top: 32px;
 }
 
-.c85 {
+.c84 {
   background: #ffffff;
   padding: 24px;
   border-radius: 4px;
   box-shadow: 0px 1px 4px rgba(33,33,52,0.1);
 }
 
-.c86 {
+.c85 {
   background: #f6ecfc;
   padding: 12px;
   border-radius: 4px;
 }
 
-.c90 {
+.c89 {
   color: #666687;
   margin-left: 8px;
   width: 12px;
@@ -317,27 +317,24 @@ exports[`Marketplace page - layout renders the online layout 1`] = `
   justify-content: space-between;
 }
 
+.c60 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 4px;
+}
+
 .c39 > * {
   margin-top: 0;
   margin-bottom: 0;
-}
-
-.c60 > * {
-  margin-left: 0;
-  margin-right: 0;
-}
-
-.c60 > * + * {
-  margin-left: 4px;
-}
-
-.c75 > * {
-  margin-left: 0;
-  margin-right: 0;
-}
-
-.c75 > * + * {
-  margin-left: 8px;
 }
 
 .c62 path {
@@ -348,7 +345,7 @@ exports[`Marketplace page - layout renders the online layout 1`] = `
   fill: #f29d41;
 }
 
-.c79 path {
+.c78 path {
   fill: #328048;
 }
 
@@ -498,7 +495,7 @@ exports[`Marketplace page - layout renders the online layout 1`] = `
   fill: #32324d;
 }
 
-.c77 {
+.c76 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -512,7 +509,7 @@ exports[`Marketplace page - layout renders the online layout 1`] = `
   background: #f0f0ff;
 }
 
-.c77 .c0 {
+.c76 .c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -523,60 +520,60 @@ exports[`Marketplace page - layout renders the online layout 1`] = `
   align-items: center;
 }
 
-.c77 .c8 {
+.c76 .c8 {
   color: #ffffff;
 }
 
-.c77[aria-disabled='true'] {
+.c76[aria-disabled='true'] {
   border: 1px solid #dcdce4;
   background: #eaeaef;
 }
 
-.c77[aria-disabled='true'] .c8 {
+.c76[aria-disabled='true'] .c8 {
   color: #666687;
 }
 
-.c77[aria-disabled='true'] svg > g,.c77[aria-disabled='true'] svg path {
+.c76[aria-disabled='true'] svg > g,.c76[aria-disabled='true'] svg path {
   fill: #666687;
 }
 
-.c77[aria-disabled='true']:active {
+.c76[aria-disabled='true']:active {
   border: 1px solid #dcdce4;
   background: #eaeaef;
 }
 
-.c77[aria-disabled='true']:active .c8 {
+.c76[aria-disabled='true']:active .c8 {
   color: #666687;
 }
 
-.c77[aria-disabled='true']:active svg > g,.c77[aria-disabled='true']:active svg path {
+.c76[aria-disabled='true']:active svg > g,.c76[aria-disabled='true']:active svg path {
   fill: #666687;
 }
 
-.c77:hover {
+.c76:hover {
   background-color: #ffffff;
 }
 
-.c77:active {
+.c76:active {
   background-color: #ffffff;
   border: 1px solid #4945ff;
 }
 
-.c77:active .c8 {
+.c76:active .c8 {
   color: #4945ff;
 }
 
-.c77:active svg > g,
-.c77:active svg path {
+.c76:active svg > g,
+.c76:active svg path {
   fill: #4945ff;
 }
 
-.c77 .c8 {
+.c76 .c8 {
   color: #271fe0;
 }
 
-.c77 svg > g,
-.c77 svg path {
+.c76 svg > g,
+.c76 svg path {
   fill: #271fe0;
 }
 
@@ -790,16 +787,16 @@ exports[`Marketplace page - layout renders the online layout 1`] = `
   cursor: not-allowed;
 }
 
-.c87 {
+.c86 {
   margin-right: 24px;
 }
 
-.c87 svg {
+.c86 svg {
   width: 2rem;
   height: 2rem;
 }
 
-.c89 {
+.c88 {
   word-break: break-all;
 }
 
@@ -807,7 +804,7 @@ exports[`Marketplace page - layout renders the online layout 1`] = `
   padding-right: 8px;
 }
 
-.c76 {
+.c75 {
   padding-left: 8px;
 }
 
@@ -1321,7 +1318,7 @@ exports[`Marketplace page - layout renders the online layout 1`] = `
                             src="https://dl.airtable.com/.attachments/eb4cd59876565af77c9c3e5966b59f10/2111bfc8/vl_strapi-comments.png"
                           />
                           <div
-                            class="c0 c7 c60"
+                            class="c0 c60"
                           >
                             <svg
                               aria-hidden="true"
@@ -1414,7 +1411,7 @@ exports[`Marketplace page - layout renders the online layout 1`] = `
                         </div>
                       </div>
                       <div
-                        class="c0 c74 c7 c75"
+                        class="c0 c74 c36"
                         style="align-self: flex-end;"
                       >
                         <a
@@ -1432,7 +1429,7 @@ exports[`Marketplace page - layout renders the online layout 1`] = `
                           </span>
                           <div
                             aria-hidden="true"
-                            class="c13 c76"
+                            class="c13 c75"
                           >
                             <svg
                               fill="none"
@@ -1450,7 +1447,7 @@ exports[`Marketplace page - layout renders the online layout 1`] = `
                         </a>
                         <button
                           aria-disabled="false"
-                          class="c49 c77"
+                          class="c49 c76"
                           type="button"
                         >
                           <div
@@ -1507,7 +1504,7 @@ exports[`Marketplace page - layout renders the online layout 1`] = `
                             src="https://dl.airtable.com/.attachments/e23a7231d12cce89cb4b05cbfe759d45/96f5f496/Screenshot2021-12-09at22.15.37.png"
                           />
                           <div
-                            class="c0 c7 c60"
+                            class="c0 c60"
                           >
                             <svg
                               aria-hidden="true"
@@ -1553,7 +1550,7 @@ exports[`Marketplace page - layout renders the online layout 1`] = `
                                   tabindex="0"
                                 >
                                   <svg
-                                    class="c0 c78 c79"
+                                    class="c0 c77 c78"
                                     fill="none"
                                     height="1em"
                                     viewBox="0 0 24 24"
@@ -1583,7 +1580,7 @@ exports[`Marketplace page - layout renders the online layout 1`] = `
                         </div>
                       </div>
                       <div
-                        class="c0 c74 c7 c75"
+                        class="c0 c74 c36"
                         style="align-self: flex-end;"
                       >
                         <a
@@ -1601,7 +1598,7 @@ exports[`Marketplace page - layout renders the online layout 1`] = `
                           </span>
                           <div
                             aria-hidden="true"
-                            class="c13 c76"
+                            class="c13 c75"
                           >
                             <svg
                               fill="none"
@@ -1625,7 +1622,7 @@ exports[`Marketplace page - layout renders the online layout 1`] = `
                           >
                             <button
                               aria-disabled="false"
-                              class="c49 c77"
+                              class="c49 c76"
                               type="button"
                             >
                               <div
@@ -1684,7 +1681,7 @@ exports[`Marketplace page - layout renders the online layout 1`] = `
                             src="https://dl.airtable.com/.attachments/0b86f18e2606ed7f53bd54d536a1bea5/13a87f30/Artboard7copy.png"
                           />
                           <div
-                            class="c0 c7 c60"
+                            class="c0 c60"
                           >
                             <svg
                               aria-hidden="true"
@@ -1737,7 +1734,7 @@ exports[`Marketplace page - layout renders the online layout 1`] = `
                         </div>
                       </div>
                       <div
-                        class="c0 c74 c7 c75"
+                        class="c0 c74 c36"
                         style="align-self: flex-end;"
                       >
                         <a
@@ -1755,7 +1752,7 @@ exports[`Marketplace page - layout renders the online layout 1`] = `
                           </span>
                           <div
                             aria-hidden="true"
-                            class="c13 c76"
+                            class="c13 c75"
                           >
                             <svg
                               fill="none"
@@ -1779,7 +1776,7 @@ exports[`Marketplace page - layout renders the online layout 1`] = `
                           >
                             <button
                               aria-disabled="true"
-                              class="c49 c77"
+                              class="c49 c76"
                               disabled=""
                               type="button"
                             >
@@ -1839,7 +1836,7 @@ exports[`Marketplace page - layout renders the online layout 1`] = `
                             src="https://dl.airtable.com/.attachments/b6998ac52e8b0460b8a14ced8074b788/2a4d4a90/swagger.png"
                           />
                           <div
-                            class="c0 c7 c60"
+                            class="c0 c60"
                           >
                             <svg
                               aria-hidden="true"
@@ -1926,7 +1923,7 @@ exports[`Marketplace page - layout renders the online layout 1`] = `
                                 >
                                   <img
                                     alt="Made by Strapi"
-                                    class="c0 c80"
+                                    class="c0 c79"
                                     src="IMAGE_MOCK"
                                   />
                                 </div>
@@ -1945,7 +1942,7 @@ exports[`Marketplace page - layout renders the online layout 1`] = `
                         </div>
                       </div>
                       <div
-                        class="c0 c74 c7 c75"
+                        class="c0 c74 c36"
                         style="align-self: flex-end;"
                       >
                         <a
@@ -1963,7 +1960,7 @@ exports[`Marketplace page - layout renders the online layout 1`] = `
                           </span>
                           <div
                             aria-hidden="true"
-                            class="c13 c76"
+                            class="c13 c75"
                           >
                             <svg
                               fill="none"
@@ -1980,10 +1977,10 @@ exports[`Marketplace page - layout renders the online layout 1`] = `
                           </div>
                         </a>
                         <div
-                          class="c0 c81"
+                          class="c0 c80"
                         >
                           <svg
-                            class="c0 c82 c79"
+                            class="c0 c81 c78"
                             fill="none"
                             height="1em"
                             viewBox="0 0 24 24"
@@ -1996,7 +1993,7 @@ exports[`Marketplace page - layout renders the online layout 1`] = `
                             />
                           </svg>
                           <span
-                            class="c8 c83"
+                            class="c8 c82"
                           >
                             Installed
                           </span>
@@ -2028,7 +2025,7 @@ exports[`Marketplace page - layout renders the online layout 1`] = `
                             src="https://dl.airtable.com/.attachments/5ffd1782a2fabf423ccd6f56c562f31a/b8f8598f/transformer-logo.png"
                           />
                           <div
-                            class="c0 c7 c60"
+                            class="c0 c60"
                           >
                             <svg
                               aria-hidden="true"
@@ -2081,7 +2078,7 @@ exports[`Marketplace page - layout renders the online layout 1`] = `
                         </div>
                       </div>
                       <div
-                        class="c0 c74 c7 c75"
+                        class="c0 c74 c36"
                         style="align-self: flex-end;"
                       >
                         <a
@@ -2099,7 +2096,7 @@ exports[`Marketplace page - layout renders the online layout 1`] = `
                           </span>
                           <div
                             aria-hidden="true"
-                            class="c13 c76"
+                            class="c13 c75"
                           >
                             <svg
                               fill="none"
@@ -2123,7 +2120,7 @@ exports[`Marketplace page - layout renders the online layout 1`] = `
                           >
                             <button
                               aria-disabled="true"
-                              class="c49 c77"
+                              class="c49 c76"
                               disabled=""
                               type="button"
                             >
@@ -2165,7 +2162,7 @@ exports[`Marketplace page - layout renders the online layout 1`] = `
           </div>
         </div>
         <div
-          class="c0 c84"
+          class="c0 c83"
         >
           <a
             href="https://strapi.canny.io/plugin-requests"
@@ -2174,10 +2171,10 @@ exports[`Marketplace page - layout renders the online layout 1`] = `
             target="_blank"
           >
             <div
-              class="c0 c85 c7"
+              class="c0 c84 c7"
             >
               <div
-                class="c0 c86 c7 c87"
+                class="c0 c85 c7 c86"
               >
                 <svg
                   fill="none"
@@ -2199,18 +2196,18 @@ exports[`Marketplace page - layout renders the online layout 1`] = `
                 </svg>
               </div>
               <div
-                class="c0 c38 c39"
+                class="c0 c38"
               >
                 <div
                   class="c0 c7"
                 >
                   <span
-                    class="c8 c88 c89"
+                    class="c8 c87 c88"
                   >
                     Documentation
                   </span>
                   <svg
-                    class="c0 c90 c62"
+                    class="c0 c89 c62"
                     fill="none"
                     height="1em"
                     viewBox="0 0 24 24"

--- a/packages/core/admin/admin/src/pages/MarketplacePage/tests/__snapshots__/plugins.test.js.snap
+++ b/packages/core/admin/admin/src/pages/MarketplacePage/tests/__snapshots__/plugins.test.js.snap
@@ -66,14 +66,14 @@ exports[`Marketplace page - plugins tab renders and matches the plugin tab snaps
   color: #666687;
 }
 
-.c83 {
+.c82 {
   font-size: 0.875rem;
   line-height: 1.43;
   font-weight: 600;
   color: #328048;
 }
 
-.c88 {
+.c87 {
   font-size: 0.75rem;
   line-height: 1.33;
   font-weight: 500;
@@ -174,46 +174,46 @@ exports[`Marketplace page - plugins tab renders and matches the plugin tab snaps
   padding-top: 24px;
 }
 
-.c78 {
+.c77 {
   color: #328048;
   margin-left: 8px;
 }
 
-.c80 {
+.c79 {
   margin-left: 4px;
   width: 24px;
   height: auto;
 }
 
-.c81 {
+.c80 {
   padding-left: 16px;
 }
 
-.c82 {
+.c81 {
   color: #328048;
   margin-right: 8px;
   width: 12;
   height: 12;
 }
 
-.c84 {
+.c83 {
   padding-top: 32px;
 }
 
-.c85 {
+.c84 {
   background: #ffffff;
   padding: 24px;
   border-radius: 4px;
   box-shadow: 0px 1px 4px rgba(33,33,52,0.1);
 }
 
-.c86 {
+.c85 {
   background: #f6ecfc;
   padding: 12px;
   border-radius: 4px;
 }
 
-.c90 {
+.c89 {
   color: #666687;
   margin-left: 8px;
   width: 12px;
@@ -317,27 +317,24 @@ exports[`Marketplace page - plugins tab renders and matches the plugin tab snaps
   justify-content: space-between;
 }
 
+.c60 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 4px;
+}
+
 .c39 > * {
   margin-top: 0;
   margin-bottom: 0;
-}
-
-.c60 > * {
-  margin-left: 0;
-  margin-right: 0;
-}
-
-.c60 > * + * {
-  margin-left: 4px;
-}
-
-.c75 > * {
-  margin-left: 0;
-  margin-right: 0;
-}
-
-.c75 > * + * {
-  margin-left: 8px;
 }
 
 .c62 path {
@@ -348,7 +345,7 @@ exports[`Marketplace page - plugins tab renders and matches the plugin tab snaps
   fill: #f29d41;
 }
 
-.c79 path {
+.c78 path {
   fill: #328048;
 }
 
@@ -498,7 +495,7 @@ exports[`Marketplace page - plugins tab renders and matches the plugin tab snaps
   fill: #32324d;
 }
 
-.c77 {
+.c76 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -512,7 +509,7 @@ exports[`Marketplace page - plugins tab renders and matches the plugin tab snaps
   background: #f0f0ff;
 }
 
-.c77 .c0 {
+.c76 .c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -523,60 +520,60 @@ exports[`Marketplace page - plugins tab renders and matches the plugin tab snaps
   align-items: center;
 }
 
-.c77 .c8 {
+.c76 .c8 {
   color: #ffffff;
 }
 
-.c77[aria-disabled='true'] {
+.c76[aria-disabled='true'] {
   border: 1px solid #dcdce4;
   background: #eaeaef;
 }
 
-.c77[aria-disabled='true'] .c8 {
+.c76[aria-disabled='true'] .c8 {
   color: #666687;
 }
 
-.c77[aria-disabled='true'] svg > g,.c77[aria-disabled='true'] svg path {
+.c76[aria-disabled='true'] svg > g,.c76[aria-disabled='true'] svg path {
   fill: #666687;
 }
 
-.c77[aria-disabled='true']:active {
+.c76[aria-disabled='true']:active {
   border: 1px solid #dcdce4;
   background: #eaeaef;
 }
 
-.c77[aria-disabled='true']:active .c8 {
+.c76[aria-disabled='true']:active .c8 {
   color: #666687;
 }
 
-.c77[aria-disabled='true']:active svg > g,.c77[aria-disabled='true']:active svg path {
+.c76[aria-disabled='true']:active svg > g,.c76[aria-disabled='true']:active svg path {
   fill: #666687;
 }
 
-.c77:hover {
+.c76:hover {
   background-color: #ffffff;
 }
 
-.c77:active {
+.c76:active {
   background-color: #ffffff;
   border: 1px solid #4945ff;
 }
 
-.c77:active .c8 {
+.c76:active .c8 {
   color: #4945ff;
 }
 
-.c77:active svg > g,
-.c77:active svg path {
+.c76:active svg > g,
+.c76:active svg path {
   fill: #4945ff;
 }
 
-.c77 .c8 {
+.c76 .c8 {
   color: #271fe0;
 }
 
-.c77 svg > g,
-.c77 svg path {
+.c76 svg > g,
+.c76 svg path {
   fill: #271fe0;
 }
 
@@ -790,16 +787,16 @@ exports[`Marketplace page - plugins tab renders and matches the plugin tab snaps
   cursor: not-allowed;
 }
 
-.c87 {
+.c86 {
   margin-right: 24px;
 }
 
-.c87 svg {
+.c86 svg {
   width: 2rem;
   height: 2rem;
 }
 
-.c89 {
+.c88 {
   word-break: break-all;
 }
 
@@ -807,7 +804,7 @@ exports[`Marketplace page - plugins tab renders and matches the plugin tab snaps
   padding-right: 8px;
 }
 
-.c76 {
+.c75 {
   padding-left: 8px;
 }
 
@@ -1321,7 +1318,7 @@ exports[`Marketplace page - plugins tab renders and matches the plugin tab snaps
                             src="https://dl.airtable.com/.attachments/eb4cd59876565af77c9c3e5966b59f10/2111bfc8/vl_strapi-comments.png"
                           />
                           <div
-                            class="c0 c7 c60"
+                            class="c0 c60"
                           >
                             <svg
                               aria-hidden="true"
@@ -1414,7 +1411,7 @@ exports[`Marketplace page - plugins tab renders and matches the plugin tab snaps
                         </div>
                       </div>
                       <div
-                        class="c0 c74 c7 c75"
+                        class="c0 c74 c36"
                         style="align-self: flex-end;"
                       >
                         <a
@@ -1432,7 +1429,7 @@ exports[`Marketplace page - plugins tab renders and matches the plugin tab snaps
                           </span>
                           <div
                             aria-hidden="true"
-                            class="c13 c76"
+                            class="c13 c75"
                           >
                             <svg
                               fill="none"
@@ -1450,7 +1447,7 @@ exports[`Marketplace page - plugins tab renders and matches the plugin tab snaps
                         </a>
                         <button
                           aria-disabled="false"
-                          class="c49 c77"
+                          class="c49 c76"
                           type="button"
                         >
                           <div
@@ -1507,7 +1504,7 @@ exports[`Marketplace page - plugins tab renders and matches the plugin tab snaps
                             src="https://dl.airtable.com/.attachments/e23a7231d12cce89cb4b05cbfe759d45/96f5f496/Screenshot2021-12-09at22.15.37.png"
                           />
                           <div
-                            class="c0 c7 c60"
+                            class="c0 c60"
                           >
                             <svg
                               aria-hidden="true"
@@ -1553,7 +1550,7 @@ exports[`Marketplace page - plugins tab renders and matches the plugin tab snaps
                                   tabindex="0"
                                 >
                                   <svg
-                                    class="c0 c78 c79"
+                                    class="c0 c77 c78"
                                     fill="none"
                                     height="1em"
                                     viewBox="0 0 24 24"
@@ -1583,7 +1580,7 @@ exports[`Marketplace page - plugins tab renders and matches the plugin tab snaps
                         </div>
                       </div>
                       <div
-                        class="c0 c74 c7 c75"
+                        class="c0 c74 c36"
                         style="align-self: flex-end;"
                       >
                         <a
@@ -1601,7 +1598,7 @@ exports[`Marketplace page - plugins tab renders and matches the plugin tab snaps
                           </span>
                           <div
                             aria-hidden="true"
-                            class="c13 c76"
+                            class="c13 c75"
                           >
                             <svg
                               fill="none"
@@ -1619,7 +1616,7 @@ exports[`Marketplace page - plugins tab renders and matches the plugin tab snaps
                         </a>
                         <button
                           aria-disabled="false"
-                          class="c49 c77"
+                          class="c49 c76"
                           type="button"
                         >
                           <div
@@ -1676,7 +1673,7 @@ exports[`Marketplace page - plugins tab renders and matches the plugin tab snaps
                             src="https://dl.airtable.com/.attachments/0b86f18e2606ed7f53bd54d536a1bea5/13a87f30/Artboard7copy.png"
                           />
                           <div
-                            class="c0 c7 c60"
+                            class="c0 c60"
                           >
                             <svg
                               aria-hidden="true"
@@ -1729,7 +1726,7 @@ exports[`Marketplace page - plugins tab renders and matches the plugin tab snaps
                         </div>
                       </div>
                       <div
-                        class="c0 c74 c7 c75"
+                        class="c0 c74 c36"
                         style="align-self: flex-end;"
                       >
                         <a
@@ -1747,7 +1744,7 @@ exports[`Marketplace page - plugins tab renders and matches the plugin tab snaps
                           </span>
                           <div
                             aria-hidden="true"
-                            class="c13 c76"
+                            class="c13 c75"
                           >
                             <svg
                               fill="none"
@@ -1765,7 +1762,7 @@ exports[`Marketplace page - plugins tab renders and matches the plugin tab snaps
                         </a>
                         <button
                           aria-disabled="false"
-                          class="c49 c77"
+                          class="c49 c76"
                           type="button"
                         >
                           <div
@@ -1822,7 +1819,7 @@ exports[`Marketplace page - plugins tab renders and matches the plugin tab snaps
                             src="https://dl.airtable.com/.attachments/b6998ac52e8b0460b8a14ced8074b788/2a4d4a90/swagger.png"
                           />
                           <div
-                            class="c0 c7 c60"
+                            class="c0 c60"
                           >
                             <svg
                               aria-hidden="true"
@@ -1909,7 +1906,7 @@ exports[`Marketplace page - plugins tab renders and matches the plugin tab snaps
                                 >
                                   <img
                                     alt="Made by Strapi"
-                                    class="c0 c80"
+                                    class="c0 c79"
                                     src="IMAGE_MOCK"
                                   />
                                 </div>
@@ -1928,7 +1925,7 @@ exports[`Marketplace page - plugins tab renders and matches the plugin tab snaps
                         </div>
                       </div>
                       <div
-                        class="c0 c74 c7 c75"
+                        class="c0 c74 c36"
                         style="align-self: flex-end;"
                       >
                         <a
@@ -1946,7 +1943,7 @@ exports[`Marketplace page - plugins tab renders and matches the plugin tab snaps
                           </span>
                           <div
                             aria-hidden="true"
-                            class="c13 c76"
+                            class="c13 c75"
                           >
                             <svg
                               fill="none"
@@ -1963,10 +1960,10 @@ exports[`Marketplace page - plugins tab renders and matches the plugin tab snaps
                           </div>
                         </a>
                         <div
-                          class="c0 c81"
+                          class="c0 c80"
                         >
                           <svg
-                            class="c0 c82 c79"
+                            class="c0 c81 c78"
                             fill="none"
                             height="1em"
                             viewBox="0 0 24 24"
@@ -1979,7 +1976,7 @@ exports[`Marketplace page - plugins tab renders and matches the plugin tab snaps
                             />
                           </svg>
                           <span
-                            class="c8 c83"
+                            class="c8 c82"
                           >
                             Installed
                           </span>
@@ -2011,7 +2008,7 @@ exports[`Marketplace page - plugins tab renders and matches the plugin tab snaps
                             src="https://dl.airtable.com/.attachments/5ffd1782a2fabf423ccd6f56c562f31a/b8f8598f/transformer-logo.png"
                           />
                           <div
-                            class="c0 c7 c60"
+                            class="c0 c60"
                           >
                             <svg
                               aria-hidden="true"
@@ -2064,7 +2061,7 @@ exports[`Marketplace page - plugins tab renders and matches the plugin tab snaps
                         </div>
                       </div>
                       <div
-                        class="c0 c74 c7 c75"
+                        class="c0 c74 c36"
                         style="align-self: flex-end;"
                       >
                         <a
@@ -2082,7 +2079,7 @@ exports[`Marketplace page - plugins tab renders and matches the plugin tab snaps
                           </span>
                           <div
                             aria-hidden="true"
-                            class="c13 c76"
+                            class="c13 c75"
                           >
                             <svg
                               fill="none"
@@ -2100,7 +2097,7 @@ exports[`Marketplace page - plugins tab renders and matches the plugin tab snaps
                         </a>
                         <button
                           aria-disabled="false"
-                          class="c49 c77"
+                          class="c49 c76"
                           type="button"
                         >
                           <div
@@ -2139,7 +2136,7 @@ exports[`Marketplace page - plugins tab renders and matches the plugin tab snaps
           </div>
         </div>
         <div
-          class="c0 c84"
+          class="c0 c83"
         >
           <a
             href="https://strapi.canny.io/plugin-requests"
@@ -2148,10 +2145,10 @@ exports[`Marketplace page - plugins tab renders and matches the plugin tab snaps
             target="_blank"
           >
             <div
-              class="c0 c85 c7"
+              class="c0 c84 c7"
             >
               <div
-                class="c0 c86 c7 c87"
+                class="c0 c85 c7 c86"
               >
                 <svg
                   fill="none"
@@ -2173,18 +2170,18 @@ exports[`Marketplace page - plugins tab renders and matches the plugin tab snaps
                 </svg>
               </div>
               <div
-                class="c0 c38 c39"
+                class="c0 c38"
               >
                 <div
                   class="c0 c7"
                 >
                   <span
-                    class="c8 c88 c89"
+                    class="c8 c87 c88"
                   >
                     Documentation
                   </span>
                   <svg
-                    class="c0 c90 c62"
+                    class="c0 c89 c62"
                     fill="none"
                     height="1em"
                     viewBox="0 0 24 24"

--- a/packages/core/admin/admin/src/pages/MarketplacePage/tests/__snapshots__/providers.test.js.snap
+++ b/packages/core/admin/admin/src/pages/MarketplacePage/tests/__snapshots__/providers.test.js.snap
@@ -66,14 +66,14 @@ exports[`Marketplace page - providers tab renders and matches the providers tab 
   color: #666687;
 }
 
-.c82 {
+.c81 {
   font-size: 0.875rem;
   line-height: 1.43;
   font-weight: 600;
   color: #328048;
 }
 
-.c87 {
+.c86 {
   font-size: 0.75rem;
   line-height: 1.33;
   font-weight: 500;
@@ -154,11 +154,11 @@ exports[`Marketplace page - providers tab renders and matches the providers tab 
   color: #666687;
 }
 
-.c74 {
+.c73 {
   color: #f29d41;
 }
 
-.c76 {
+.c75 {
   background: #dcdce4;
 }
 
@@ -180,35 +180,35 @@ exports[`Marketplace page - providers tab renders and matches the providers tab 
   height: auto;
 }
 
-.c79 {
+.c78 {
   padding-left: 16px;
 }
 
-.c80 {
+.c79 {
   color: #328048;
   margin-right: 8px;
   width: 12;
   height: 12;
 }
 
-.c83 {
+.c82 {
   padding-top: 32px;
 }
 
-.c84 {
+.c83 {
   background: #ffffff;
   padding: 24px;
   border-radius: 4px;
   box-shadow: 0px 1px 4px rgba(33,33,52,0.1);
 }
 
-.c85 {
+.c84 {
   background: #f6ecfc;
   padding: 12px;
   border-radius: 4px;
 }
 
-.c89 {
+.c88 {
   color: #666687;
   margin-left: 8px;
   width: 12px;
@@ -312,38 +312,35 @@ exports[`Marketplace page - providers tab renders and matches the providers tab 
   justify-content: space-between;
 }
 
+.c60 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 4px;
+}
+
 .c39 > * {
   margin-top: 0;
   margin-bottom: 0;
-}
-
-.c60 > * {
-  margin-left: 0;
-  margin-right: 0;
-}
-
-.c60 > * + * {
-  margin-left: 4px;
-}
-
-.c71 > * {
-  margin-left: 0;
-  margin-right: 0;
-}
-
-.c71 > * + * {
-  margin-left: 8px;
 }
 
 .c62 path {
   fill: #666687;
 }
 
-.c75 path {
+.c74 path {
   fill: #f29d41;
 }
 
-.c81 path {
+.c80 path {
   fill: #328048;
 }
 
@@ -493,7 +490,7 @@ exports[`Marketplace page - providers tab renders and matches the providers tab 
   fill: #32324d;
 }
 
-.c73 {
+.c72 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -507,7 +504,7 @@ exports[`Marketplace page - providers tab renders and matches the providers tab 
   background: #f0f0ff;
 }
 
-.c73 .c0 {
+.c72 .c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -518,60 +515,60 @@ exports[`Marketplace page - providers tab renders and matches the providers tab 
   align-items: center;
 }
 
-.c73 .c8 {
+.c72 .c8 {
   color: #ffffff;
 }
 
-.c73[aria-disabled='true'] {
+.c72[aria-disabled='true'] {
   border: 1px solid #dcdce4;
   background: #eaeaef;
 }
 
-.c73[aria-disabled='true'] .c8 {
+.c72[aria-disabled='true'] .c8 {
   color: #666687;
 }
 
-.c73[aria-disabled='true'] svg > g,.c73[aria-disabled='true'] svg path {
+.c72[aria-disabled='true'] svg > g,.c72[aria-disabled='true'] svg path {
   fill: #666687;
 }
 
-.c73[aria-disabled='true']:active {
+.c72[aria-disabled='true']:active {
   border: 1px solid #dcdce4;
   background: #eaeaef;
 }
 
-.c73[aria-disabled='true']:active .c8 {
+.c72[aria-disabled='true']:active .c8 {
   color: #666687;
 }
 
-.c73[aria-disabled='true']:active svg > g,.c73[aria-disabled='true']:active svg path {
+.c72[aria-disabled='true']:active svg > g,.c72[aria-disabled='true']:active svg path {
   fill: #666687;
 }
 
-.c73:hover {
+.c72:hover {
   background-color: #ffffff;
 }
 
-.c73:active {
+.c72:active {
   background-color: #ffffff;
   border: 1px solid #4945ff;
 }
 
-.c73:active .c8 {
+.c72:active .c8 {
   color: #4945ff;
 }
 
-.c73:active svg > g,
-.c73:active svg path {
+.c72:active svg > g,
+.c72:active svg path {
   fill: #4945ff;
 }
 
-.c73 .c8 {
+.c72 .c8 {
   color: #271fe0;
 }
 
-.c73 svg > g,
-.c73 svg path {
+.c72 svg > g,
+.c72 svg path {
   fill: #271fe0;
 }
 
@@ -709,7 +706,7 @@ exports[`Marketplace page - providers tab renders and matches the providers tab 
   width: 100%;
 }
 
-.c77 {
+.c76 {
   height: 1px;
   border: none;
   -webkit-flex-shrink: 0;
@@ -785,16 +782,16 @@ exports[`Marketplace page - providers tab renders and matches the providers tab 
   cursor: not-allowed;
 }
 
-.c86 {
+.c85 {
   margin-right: 24px;
 }
 
-.c86 svg {
+.c85 svg {
   width: 2rem;
   height: 2rem;
 }
 
-.c88 {
+.c87 {
   word-break: break-all;
 }
 
@@ -802,7 +799,7 @@ exports[`Marketplace page - providers tab renders and matches the providers tab 
   padding-right: 8px;
 }
 
-.c72 {
+.c71 {
   padding-left: 8px;
 }
 
@@ -948,7 +945,7 @@ exports[`Marketplace page - providers tab renders and matches the providers tab 
   fill: #32324d;
 }
 
-.c78 {
+.c77 {
   -webkit-transform: rotate(90deg);
   -ms-transform: rotate(90deg);
   transform: rotate(90deg);
@@ -1316,7 +1313,7 @@ exports[`Marketplace page - providers tab renders and matches the providers tab 
                             src="https://dl.airtable.com/.attachments/04be9ade6077d029a9d4108cd2f47c8e/f5fe8d67/amazonSES.png?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=0561c26f91b25e21"
                           />
                           <div
-                            class="c0 c7 c60"
+                            class="c0 c60"
                           >
                             <svg
                               aria-hidden="true"
@@ -1382,7 +1379,7 @@ exports[`Marketplace page - providers tab renders and matches the providers tab 
                         </div>
                       </div>
                       <div
-                        class="c0 c70 c7 c71"
+                        class="c0 c70 c36"
                         style="align-self: flex-end;"
                       >
                         <a
@@ -1400,7 +1397,7 @@ exports[`Marketplace page - providers tab renders and matches the providers tab 
                           </span>
                           <div
                             aria-hidden="true"
-                            class="c13 c72"
+                            class="c13 c71"
                           >
                             <svg
                               fill="none"
@@ -1418,7 +1415,7 @@ exports[`Marketplace page - providers tab renders and matches the providers tab 
                         </a>
                         <button
                           aria-disabled="false"
-                          class="c49 c73"
+                          class="c49 c72"
                           type="button"
                         >
                           <div
@@ -1475,7 +1472,7 @@ exports[`Marketplace page - providers tab renders and matches the providers tab 
                             src="https://dl.airtable.com/.attachments/e24c0ef99b1e952cbf0c8cbeed8cc24f/da30ba27/Amazon-S3-Logo.png?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=953eaf833eba09a2"
                           />
                           <div
-                            class="c0 c7 c60"
+                            class="c0 c60"
                           >
                             <svg
                               aria-hidden="true"
@@ -1541,7 +1538,7 @@ exports[`Marketplace page - providers tab renders and matches the providers tab 
                         </div>
                       </div>
                       <div
-                        class="c0 c70 c7 c71"
+                        class="c0 c70 c36"
                         style="align-self: flex-end;"
                       >
                         <a
@@ -1559,7 +1556,7 @@ exports[`Marketplace page - providers tab renders and matches the providers tab 
                           </span>
                           <div
                             aria-hidden="true"
-                            class="c13 c72"
+                            class="c13 c71"
                           >
                             <svg
                               fill="none"
@@ -1577,7 +1574,7 @@ exports[`Marketplace page - providers tab renders and matches the providers tab 
                         </a>
                         <button
                           aria-disabled="false"
-                          class="c49 c73"
+                          class="c49 c72"
                           type="button"
                         >
                           <div
@@ -1634,7 +1631,7 @@ exports[`Marketplace page - providers tab renders and matches the providers tab 
                             src="https://dl.airtable.com/.attachments/74df39c3715a78589be1cbff69009dc2/14734e59/cloudinary.png?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=d82f74e2c1563864"
                           />
                           <div
-                            class="c0 c7 c60"
+                            class="c0 c60"
                           >
                             <svg
                               aria-hidden="true"
@@ -1652,7 +1649,7 @@ exports[`Marketplace page - providers tab renders and matches the providers tab 
                             </svg>
                             <svg
                               aria-hidden="true"
-                              class="c0 c74 c75"
+                              class="c0 c73 c74"
                               fill="none"
                               height="1em"
                               viewBox="0 0 24 24"
@@ -1674,7 +1671,7 @@ exports[`Marketplace page - providers tab renders and matches the providers tab 
                               </span>
                             </p>
                             <hr
-                              class="c0 c76 c77 c78"
+                              class="c0 c75 c76 c77"
                             />
                             <svg
                               aria-hidden="true"
@@ -1740,7 +1737,7 @@ exports[`Marketplace page - providers tab renders and matches the providers tab 
                         </div>
                       </div>
                       <div
-                        class="c0 c70 c7 c71"
+                        class="c0 c70 c36"
                         style="align-self: flex-end;"
                       >
                         <a
@@ -1758,7 +1755,7 @@ exports[`Marketplace page - providers tab renders and matches the providers tab 
                           </span>
                           <div
                             aria-hidden="true"
-                            class="c13 c72"
+                            class="c13 c71"
                           >
                             <svg
                               fill="none"
@@ -1775,10 +1772,10 @@ exports[`Marketplace page - providers tab renders and matches the providers tab 
                           </div>
                         </a>
                         <div
-                          class="c0 c79"
+                          class="c0 c78"
                         >
                           <svg
-                            class="c0 c80 c81"
+                            class="c0 c79 c80"
                             fill="none"
                             height="1em"
                             viewBox="0 0 24 24"
@@ -1791,7 +1788,7 @@ exports[`Marketplace page - providers tab renders and matches the providers tab 
                             />
                           </svg>
                           <span
-                            class="c8 c82"
+                            class="c8 c81"
                           >
                             Installed
                           </span>
@@ -1823,7 +1820,7 @@ exports[`Marketplace page - providers tab renders and matches the providers tab 
                             src="https://dl.airtable.com/.attachments/6707fcab8f5530214160bacf6f4369ec/9ed22aaf/typeplaceholderversion1.png?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=35d9e0bb75e4528a"
                           />
                           <div
-                            class="c0 c7 c60"
+                            class="c0 c60"
                           >
                             <svg
                               aria-hidden="true"
@@ -1841,7 +1838,7 @@ exports[`Marketplace page - providers tab renders and matches the providers tab 
                             </svg>
                             <svg
                               aria-hidden="true"
-                              class="c0 c74 c75"
+                              class="c0 c73 c74"
                               fill="none"
                               height="1em"
                               viewBox="0 0 24 24"
@@ -1863,7 +1860,7 @@ exports[`Marketplace page - providers tab renders and matches the providers tab 
                               </span>
                             </p>
                             <hr
-                              class="c0 c76 c77 c78"
+                              class="c0 c75 c76 c77"
                             />
                             <svg
                               aria-hidden="true"
@@ -1929,7 +1926,7 @@ exports[`Marketplace page - providers tab renders and matches the providers tab 
                         </div>
                       </div>
                       <div
-                        class="c0 c70 c7 c71"
+                        class="c0 c70 c36"
                         style="align-self: flex-end;"
                       >
                         <a
@@ -1947,7 +1944,7 @@ exports[`Marketplace page - providers tab renders and matches the providers tab 
                           </span>
                           <div
                             aria-hidden="true"
-                            class="c13 c72"
+                            class="c13 c71"
                           >
                             <svg
                               fill="none"
@@ -1965,7 +1962,7 @@ exports[`Marketplace page - providers tab renders and matches the providers tab 
                         </a>
                         <button
                           aria-disabled="false"
-                          class="c49 c73"
+                          class="c49 c72"
                           type="button"
                         >
                           <div
@@ -2022,7 +2019,7 @@ exports[`Marketplace page - providers tab renders and matches the providers tab 
                             src="https://dl.airtable.com/.attachments/73118ab0aea4d9eae66edc18a1db4982/808842ba/mailgun-logo-5388F66106-seeklogo_com.png?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=2e2e9ecb19e752ca"
                           />
                           <div
-                            class="c0 c7 c60"
+                            class="c0 c60"
                           >
                             <svg
                               aria-hidden="true"
@@ -2088,7 +2085,7 @@ exports[`Marketplace page - providers tab renders and matches the providers tab 
                         </div>
                       </div>
                       <div
-                        class="c0 c70 c7 c71"
+                        class="c0 c70 c36"
                         style="align-self: flex-end;"
                       >
                         <a
@@ -2106,7 +2103,7 @@ exports[`Marketplace page - providers tab renders and matches the providers tab 
                           </span>
                           <div
                             aria-hidden="true"
-                            class="c13 c72"
+                            class="c13 c71"
                           >
                             <svg
                               fill="none"
@@ -2124,7 +2121,7 @@ exports[`Marketplace page - providers tab renders and matches the providers tab 
                         </a>
                         <button
                           aria-disabled="false"
-                          class="c49 c73"
+                          class="c49 c72"
                           type="button"
                         >
                           <div
@@ -2181,7 +2178,7 @@ exports[`Marketplace page - providers tab renders and matches the providers tab 
                             src="https://dl.airtable.com/.attachments/73bea518f68fc312ec15a4a988da3bbc/4c024fea/Nodemailer.jpeg?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=a5dec98be44fa4e6"
                           />
                           <div
-                            class="c0 c7 c60"
+                            class="c0 c60"
                           >
                             <svg
                               aria-hidden="true"
@@ -2247,7 +2244,7 @@ exports[`Marketplace page - providers tab renders and matches the providers tab 
                         </div>
                       </div>
                       <div
-                        class="c0 c70 c7 c71"
+                        class="c0 c70 c36"
                         style="align-self: flex-end;"
                       >
                         <a
@@ -2265,7 +2262,7 @@ exports[`Marketplace page - providers tab renders and matches the providers tab 
                           </span>
                           <div
                             aria-hidden="true"
-                            class="c13 c72"
+                            class="c13 c71"
                           >
                             <svg
                               fill="none"
@@ -2283,7 +2280,7 @@ exports[`Marketplace page - providers tab renders and matches the providers tab 
                         </a>
                         <button
                           aria-disabled="false"
-                          class="c49 c73"
+                          class="c49 c72"
                           type="button"
                         >
                           <div
@@ -2340,7 +2337,7 @@ exports[`Marketplace page - providers tab renders and matches the providers tab 
                             src="https://dl.airtable.com/.attachments/f1e20497044cc6035f43b94f46bd5381/c78cbd9f/rackspace-logo.png?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=641682ec9adc2d1c"
                           />
                           <div
-                            class="c0 c7 c60"
+                            class="c0 c60"
                           >
                             <svg
                               aria-hidden="true"
@@ -2406,7 +2403,7 @@ exports[`Marketplace page - providers tab renders and matches the providers tab 
                         </div>
                       </div>
                       <div
-                        class="c0 c70 c7 c71"
+                        class="c0 c70 c36"
                         style="align-self: flex-end;"
                       >
                         <a
@@ -2424,7 +2421,7 @@ exports[`Marketplace page - providers tab renders and matches the providers tab 
                           </span>
                           <div
                             aria-hidden="true"
-                            class="c13 c72"
+                            class="c13 c71"
                           >
                             <svg
                               fill="none"
@@ -2442,7 +2439,7 @@ exports[`Marketplace page - providers tab renders and matches the providers tab 
                         </a>
                         <button
                           aria-disabled="false"
-                          class="c49 c73"
+                          class="c49 c72"
                           type="button"
                         >
                           <div
@@ -2499,7 +2496,7 @@ exports[`Marketplace page - providers tab renders and matches the providers tab 
                             src="https://dl.airtable.com/.attachments/c09bfc173321ee79a972a10735ed6cf7/4e0a5321/sendgrid-logo-7574E52082-seeklogo_com.png?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=1ff0a128488e143f"
                           />
                           <div
-                            class="c0 c7 c60"
+                            class="c0 c60"
                           >
                             <svg
                               aria-hidden="true"
@@ -2565,7 +2562,7 @@ exports[`Marketplace page - providers tab renders and matches the providers tab 
                         </div>
                       </div>
                       <div
-                        class="c0 c70 c7 c71"
+                        class="c0 c70 c36"
                         style="align-self: flex-end;"
                       >
                         <a
@@ -2583,7 +2580,7 @@ exports[`Marketplace page - providers tab renders and matches the providers tab 
                           </span>
                           <div
                             aria-hidden="true"
-                            class="c13 c72"
+                            class="c13 c71"
                           >
                             <svg
                               fill="none"
@@ -2601,7 +2598,7 @@ exports[`Marketplace page - providers tab renders and matches the providers tab 
                         </a>
                         <button
                           aria-disabled="false"
-                          class="c49 c73"
+                          class="c49 c72"
                           type="button"
                         >
                           <div
@@ -2658,7 +2655,7 @@ exports[`Marketplace page - providers tab renders and matches the providers tab 
                             src="https://dl.airtable.com/.attachments/0f14c78742105dffd36d6e253612f992/2f0e8605/sendmail-logo-png-transparent.png?ts=1654603863&userId=usrUa8HWbsGCCzcQm&cs=65d4bd3786c6b0a2"
                           />
                           <div
-                            class="c0 c7 c60"
+                            class="c0 c60"
                           >
                             <svg
                               aria-hidden="true"
@@ -2724,7 +2721,7 @@ exports[`Marketplace page - providers tab renders and matches the providers tab 
                         </div>
                       </div>
                       <div
-                        class="c0 c70 c7 c71"
+                        class="c0 c70 c36"
                         style="align-self: flex-end;"
                       >
                         <a
@@ -2742,7 +2739,7 @@ exports[`Marketplace page - providers tab renders and matches the providers tab 
                           </span>
                           <div
                             aria-hidden="true"
-                            class="c13 c72"
+                            class="c13 c71"
                           >
                             <svg
                               fill="none"
@@ -2760,7 +2757,7 @@ exports[`Marketplace page - providers tab renders and matches the providers tab 
                         </a>
                         <button
                           aria-disabled="false"
-                          class="c49 c73"
+                          class="c49 c72"
                           type="button"
                         >
                           <div
@@ -2799,7 +2796,7 @@ exports[`Marketplace page - providers tab renders and matches the providers tab 
           </div>
         </div>
         <div
-          class="c0 c83"
+          class="c0 c82"
         >
           <a
             href="https://strapi.canny.io/plugin-requests"
@@ -2808,10 +2805,10 @@ exports[`Marketplace page - providers tab renders and matches the providers tab 
             target="_blank"
           >
             <div
-              class="c0 c84 c7"
+              class="c0 c83 c7"
             >
               <div
-                class="c0 c85 c7 c86"
+                class="c0 c84 c7 c85"
               >
                 <svg
                   fill="none"
@@ -2833,18 +2830,18 @@ exports[`Marketplace page - providers tab renders and matches the providers tab 
                 </svg>
               </div>
               <div
-                class="c0 c38 c39"
+                class="c0 c38"
               >
                 <div
                   class="c0 c7"
                 >
                   <span
-                    class="c8 c87 c88"
+                    class="c8 c86 c87"
                   >
                     Documentation
                   </span>
                   <svg
-                    class="c0 c89 c62"
+                    class="c0 c88 c62"
                     fill="none"
                     height="1em"
                     viewBox="0 0 24 24"

--- a/packages/core/admin/admin/src/pages/ProfilePage/index.js
+++ b/packages/core/admin/admin/src/pages/ProfilePage/index.js
@@ -26,7 +26,7 @@ import {
   Button,
   Grid,
   GridItem,
-  Stack,
+  Flex,
   useNotifyAT,
   Select,
   Option,
@@ -208,7 +208,7 @@ const ProfilePage = () => {
               />
               <Box paddingBottom={10}>
                 <ContentLayout>
-                  <Stack spacing={6}>
+                  <Flex direction="column" alignItems="stretch" gap={6}>
                     <Box
                       background="neutral0"
                       hasRadius
@@ -218,7 +218,7 @@ const ProfilePage = () => {
                       paddingLeft={7}
                       paddingRight={7}
                     >
-                      <Stack spacing={4}>
+                      <Flex direction="column" alignItems="stretch" gap={4}>
                         <Typography variant="delta" as="h2">
                           {formatMessage({
                             id: 'global.profile',
@@ -278,7 +278,7 @@ const ProfilePage = () => {
                             />
                           </GridItem>
                         </Grid>
-                      </Stack>
+                      </Flex>
                     </Box>
                     <Box
                       background="neutral0"
@@ -289,7 +289,7 @@ const ProfilePage = () => {
                       paddingLeft={7}
                       paddingRight={7}
                     >
-                      <Stack spacing={4}>
+                      <Flex direction="column" alignItems="stretch" gap={4}>
                         <Typography variant="delta" as="h2">
                           {formatMessage({
                             id: 'global.change-password',
@@ -427,7 +427,7 @@ const ProfilePage = () => {
                             />
                           </GridItem>
                         </Grid>
-                      </Stack>
+                      </Flex>
                     </Box>
                     <Box
                       background="neutral0"
@@ -438,8 +438,8 @@ const ProfilePage = () => {
                       paddingLeft={7}
                       paddingRight={7}
                     >
-                      <Stack spacing={4}>
-                        <Stack spacing={1}>
+                      <Flex direction="column" alignItems="stretch" gap={4}>
+                        <Flex direction="column" alignItems="stretch" gap={1}>
                           <Typography variant="delta" as="h2">
                             {formatMessage({
                               id: 'Settings.profile.form.section.experience.title',
@@ -469,7 +469,7 @@ const ProfilePage = () => {
                               }
                             )}
                           </Typography>
-                        </Stack>
+                        </Flex>
                         <Grid gap={5}>
                           <GridItem s={12} col={6}>
                             <Select
@@ -553,9 +553,9 @@ const ProfilePage = () => {
                             </Select>
                           </GridItem>
                         </Grid>
-                      </Stack>
+                      </Flex>
                     </Box>
-                  </Stack>
+                  </Flex>
                 </ContentLayout>
               </Box>
             </Form>

--- a/packages/core/admin/admin/src/pages/ProfilePage/tests/__snapshots__/index.test.js.snap
+++ b/packages/core/admin/admin/src/pages/ProfilePage/tests/__snapshots__/index.test.js.snap
@@ -15,7 +15,7 @@ exports[`ADMIN | Pages | Profile page renders and matches the snapshot 1`] = `
   color: #32324d;
 }
 
-.c18 {
+.c17 {
   font-weight: 500;
   font-size: 1rem;
   line-height: 1.25;
@@ -28,13 +28,13 @@ exports[`ADMIN | Pages | Profile page renders and matches the snapshot 1`] = `
   color: #d02b20;
 }
 
-.c31 {
+.c32 {
   font-size: 0.875rem;
   line-height: 1.43;
   color: #32324d;
 }
 
-.c37 {
+.c38 {
   font-size: 0.875rem;
   line-height: 1.43;
   display: block;
@@ -44,7 +44,7 @@ exports[`ADMIN | Pages | Profile page renders and matches the snapshot 1`] = `
   color: #32324d;
 }
 
-.c41 {
+.c42 {
   font-size: 0.75rem;
   line-height: 1.33;
   color: #666687;
@@ -71,7 +71,7 @@ exports[`ADMIN | Pages | Profile page renders and matches the snapshot 1`] = `
   padding-bottom: 56px;
 }
 
-.c16 {
+.c15 {
   background: #ffffff;
   padding-top: 24px;
   padding-right: 32px;
@@ -86,12 +86,12 @@ exports[`ADMIN | Pages | Profile page renders and matches the snapshot 1`] = `
   padding-left: 8px;
 }
 
-.c36 {
+.c37 {
   padding-right: 16px;
   padding-left: 16px;
 }
 
-.c39 {
+.c40 {
   padding-left: 12px;
 }
 
@@ -139,24 +139,51 @@ exports[`ADMIN | Pages | Profile page renders and matches the snapshot 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  gap: 24px;
 }
 
-.c15 > * {
-  margin-top: 0;
-  margin-bottom: 0;
+.c16 {
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 16px;
 }
 
-.c15 > * + * {
-  margin-top: 24px;
+.c20 {
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
 }
 
-.c17 > * {
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
-.c17 > * + * {
-  margin-top: 16px;
+.c31 {
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 4px;
 }
 
 .c21 > * {
@@ -423,7 +450,7 @@ exports[`ADMIN | Pages | Profile page renders and matches the snapshot 1`] = `
   align-items: center;
 }
 
-.c33 {
+.c34 {
   position: relative;
   border: 1px solid #dcdce4;
   padding-right: 12px;
@@ -439,28 +466,28 @@ exports[`ADMIN | Pages | Profile page renders and matches the snapshot 1`] = `
   transition-duration: 0.2s;
 }
 
-.c33:focus-within {
+.c34:focus-within {
   border: 1px solid #4945ff;
   box-shadow: #4945ff 0px 0px 0px 2px;
 }
 
-.c38 {
+.c39 {
   background: transparent;
   border: none;
   position: relative;
   z-index: 1;
 }
 
-.c38 svg {
+.c39 svg {
   height: 0.6875rem;
   width: 0.6875rem;
 }
 
-.c38 svg path {
+.c39 svg path {
   fill: #666687;
 }
 
-.c40 {
+.c41 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -469,11 +496,11 @@ exports[`ADMIN | Pages | Profile page renders and matches the snapshot 1`] = `
   border: none;
 }
 
-.c40 svg {
+.c41 svg {
   width: 0.375rem;
 }
 
-.c34 {
+.c35 {
   position: absolute;
   left: 0;
   right: 0;
@@ -484,25 +511,25 @@ exports[`ADMIN | Pages | Profile page renders and matches the snapshot 1`] = `
   border: none;
 }
 
-.c34:focus {
+.c35:focus {
   outline: none;
 }
 
-.c34[aria-disabled='true'] {
+.c35[aria-disabled='true'] {
   cursor: not-allowed;
 }
 
-.c35 {
+.c36 {
   width: 100%;
 }
 
-.c19 {
+.c18 {
   display: grid;
   grid-template-columns: repeat(12,1fr);
   gap: 20px;
 }
 
-.c20 {
+.c19 {
   grid-column: span 6;
   max-width: 100%;
 }
@@ -511,7 +538,7 @@ exports[`ADMIN | Pages | Profile page renders and matches the snapshot 1`] = `
   outline: none;
 }
 
-.c32 {
+.c33 {
   color: #4945ff;
 }
 
@@ -529,13 +556,13 @@ exports[`ADMIN | Pages | Profile page renders and matches the snapshot 1`] = `
 }
 
 @media (max-width:68.75rem) {
-  .c20 {
+  .c19 {
     grid-column: span 12;
   }
 }
 
 @media (max-width:34.375rem) {
-  .c20 {
+  .c19 {
     grid-column: span;
   }
 }
@@ -608,24 +635,24 @@ exports[`ADMIN | Pages | Profile page renders and matches the snapshot 1`] = `
         class="c1 c13"
       >
         <div
-          class="c1 c14 c15"
+          class="c1 c14"
         >
           <div
-            class="c1 c16"
+            class="c1 c15"
           >
             <div
-              class="c1 c14 c17"
+              class="c1 c16"
             >
               <h2
-                class="c5 c18"
+                class="c5 c17"
               >
                 Profile
               </h2>
               <div
-                class="c1 c19"
+                class="c1 c18"
               >
                 <div
-                  class="c20"
+                  class="c19"
                 >
                   <div
                     class="c1 "
@@ -633,7 +660,7 @@ exports[`ADMIN | Pages | Profile page renders and matches the snapshot 1`] = `
                     <div>
                       <div>
                         <div
-                          class="c1 c14 c21"
+                          class="c1 c20 c21"
                         >
                           <label
                             class="c5 c11"
@@ -671,7 +698,7 @@ exports[`ADMIN | Pages | Profile page renders and matches the snapshot 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c20"
+                  class="c19"
                 >
                   <div
                     class="c1 "
@@ -679,7 +706,7 @@ exports[`ADMIN | Pages | Profile page renders and matches the snapshot 1`] = `
                     <div>
                       <div>
                         <div
-                          class="c1 c14 c21"
+                          class="c1 c20 c21"
                         >
                           <label
                             class="c5 c11"
@@ -712,7 +739,7 @@ exports[`ADMIN | Pages | Profile page renders and matches the snapshot 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c20"
+                  class="c19"
                 >
                   <div
                     class="c1 "
@@ -720,7 +747,7 @@ exports[`ADMIN | Pages | Profile page renders and matches the snapshot 1`] = `
                     <div>
                       <div>
                         <div
-                          class="c1 c14 c21"
+                          class="c1 c20 c21"
                         >
                           <label
                             class="c5 c11"
@@ -758,7 +785,7 @@ exports[`ADMIN | Pages | Profile page renders and matches the snapshot 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c20"
+                  class="c19"
                 >
                   <div
                     class="c1 "
@@ -766,7 +793,7 @@ exports[`ADMIN | Pages | Profile page renders and matches the snapshot 1`] = `
                     <div>
                       <div>
                         <div
-                          class="c1 c14 c21"
+                          class="c1 c20 c21"
                         >
                           <label
                             class="c5 c11"
@@ -802,21 +829,21 @@ exports[`ADMIN | Pages | Profile page renders and matches the snapshot 1`] = `
             </div>
           </div>
           <div
-            class="c1 c16"
+            class="c1 c15"
           >
             <div
-              class="c1 c14 c17"
+              class="c1 c16"
             >
               <h2
-                class="c5 c18"
+                class="c5 c17"
               >
                 Change password
               </h2>
               <div
-                class="c1 c19"
+                class="c1 c18"
               >
                 <div
-                  class="c20"
+                  class="c19"
                 >
                   <div
                     class="c1 "
@@ -824,7 +851,7 @@ exports[`ADMIN | Pages | Profile page renders and matches the snapshot 1`] = `
                     <div>
                       <div>
                         <div
-                          class="c1 c14 c21"
+                          class="c1 c20 c21"
                         >
                           <label
                             class="c5 c11"
@@ -879,10 +906,10 @@ exports[`ADMIN | Pages | Profile page renders and matches the snapshot 1`] = `
                 </div>
               </div>
               <div
-                class="c1 c19"
+                class="c1 c18"
               >
                 <div
-                  class="c20"
+                  class="c19"
                 >
                   <div
                     class="c1 "
@@ -890,7 +917,7 @@ exports[`ADMIN | Pages | Profile page renders and matches the snapshot 1`] = `
                     <div>
                       <div>
                         <div
-                          class="c1 c14 c21"
+                          class="c1 c20 c21"
                         >
                           <label
                             class="c5 c11"
@@ -945,7 +972,7 @@ exports[`ADMIN | Pages | Profile page renders and matches the snapshot 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c20"
+                  class="c19"
                 >
                   <div
                     class="c1 "
@@ -953,7 +980,7 @@ exports[`ADMIN | Pages | Profile page renders and matches the snapshot 1`] = `
                     <div>
                       <div>
                         <div
-                          class="c1 c14 c21"
+                          class="c1 c20 c21"
                         >
                           <label
                             class="c5 c11"
@@ -1011,25 +1038,25 @@ exports[`ADMIN | Pages | Profile page renders and matches the snapshot 1`] = `
             </div>
           </div>
           <div
-            class="c1 c16"
+            class="c1 c15"
           >
             <div
-              class="c1 c14 c17"
+              class="c1 c16"
             >
               <div
-                class="c1 c14 c21"
+                class="c1 c31"
               >
                 <h2
-                  class="c5 c18"
+                  class="c5 c17"
                 >
                   Experience
                 </h2>
                 <span
-                  class="c5 c31"
+                  class="c5 c32"
                 >
                   Preference changes will apply only to you. More information is available 
                   <a
-                    class="c32"
+                    class="c33"
                     href="https://docs.strapi.io/developer-docs/latest/development/admin-customization.html#locales"
                     rel="noopener noreferrer"
                     target="_blank"
@@ -1040,17 +1067,17 @@ exports[`ADMIN | Pages | Profile page renders and matches the snapshot 1`] = `
                 </span>
               </div>
               <div
-                class="c1 c19"
+                class="c1 c18"
               >
                 <div
-                  class="c20"
+                  class="c19"
                 >
                   <div
                     class="c1 "
                   >
                     <div>
                       <div
-                        class="c1 c14 c21"
+                        class="c1 c20 c21"
                       >
                         <label
                           class="c5 c11"
@@ -1063,7 +1090,7 @@ exports[`ADMIN | Pages | Profile page renders and matches the snapshot 1`] = `
                           </div>
                         </label>
                         <div
-                          class="c1 c4 c33"
+                          class="c1 c4 c34"
                         >
                           <button
                             aria-describedby="7-hint"
@@ -1071,21 +1098,21 @@ exports[`ADMIN | Pages | Profile page renders and matches the snapshot 1`] = `
                             aria-expanded="false"
                             aria-haspopup="listbox"
                             aria-labelledby="7 7-label 7-content"
-                            class="c34"
+                            class="c35"
                             id="7"
                             type="button"
                           />
                           <div
-                            class="c1 c3 c35"
+                            class="c1 c3 c36"
                           >
                             <div
                               class="c1 c4"
                             >
                               <div
-                                class="c1 c36"
+                                class="c1 c37"
                               >
                                 <span
-                                  class="c5 c37"
+                                  class="c5 c38"
                                   id="7-content"
                                 >
                                   Select
@@ -1098,7 +1125,7 @@ exports[`ADMIN | Pages | Profile page renders and matches the snapshot 1`] = `
                               <button
                                 aria-disabled="false"
                                 aria-label="Clear the interface language selected"
-                                class="c1 c38"
+                                class="c1 c39"
                                 title="Clear the interface language selected"
                                 type="button"
                               >
@@ -1117,7 +1144,7 @@ exports[`ADMIN | Pages | Profile page renders and matches the snapshot 1`] = `
                               </button>
                               <button
                                 aria-hidden="true"
-                                class="c1 c39 c38 c40"
+                                class="c1 c40 c39 c41"
                                 tabindex="-1"
                                 title="Carret Down Button"
                                 type="button"
@@ -1141,7 +1168,7 @@ exports[`ADMIN | Pages | Profile page renders and matches the snapshot 1`] = `
                           </div>
                         </div>
                         <p
-                          class="c5 c41"
+                          class="c5 c42"
                           id="7-hint"
                         >
                           This will only display your own interface in the chosen language.
@@ -1151,14 +1178,14 @@ exports[`ADMIN | Pages | Profile page renders and matches the snapshot 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c20"
+                  class="c19"
                 >
                   <div
                     class="c1 "
                   >
                     <div>
                       <div
-                        class="c1 c14 c21"
+                        class="c1 c20 c21"
                       >
                         <label
                           class="c5 c11"
@@ -1171,7 +1198,7 @@ exports[`ADMIN | Pages | Profile page renders and matches the snapshot 1`] = `
                           </div>
                         </label>
                         <div
-                          class="c1 c4 c33"
+                          class="c1 c4 c34"
                         >
                           <button
                             aria-describedby="9-hint"
@@ -1179,21 +1206,21 @@ exports[`ADMIN | Pages | Profile page renders and matches the snapshot 1`] = `
                             aria-expanded="false"
                             aria-haspopup="listbox"
                             aria-labelledby="9 9-label 9-content"
-                            class="c34"
+                            class="c35"
                             id="9"
                             type="button"
                           />
                           <div
-                            class="c1 c3 c35"
+                            class="c1 c3 c36"
                           >
                             <div
                               class="c1 c4"
                             >
                               <div
-                                class="c1 c36"
+                                class="c1 c37"
                               >
                                 <span
-                                  class="c5 c37"
+                                  class="c5 c38"
                                   id="9-content"
                                 >
                                   Light mode
@@ -1205,7 +1232,7 @@ exports[`ADMIN | Pages | Profile page renders and matches the snapshot 1`] = `
                             >
                               <button
                                 aria-hidden="true"
-                                class="c1 c39 c38 c40"
+                                class="c1 c40 c39 c41"
                                 tabindex="-1"
                                 title="Carret Down Button"
                                 type="button"
@@ -1229,7 +1256,7 @@ exports[`ADMIN | Pages | Profile page renders and matches the snapshot 1`] = `
                           </div>
                         </div>
                         <p
-                          class="c5 c41"
+                          class="c5 c42"
                           id="9-hint"
                         >
                           Displays your interface in the chosen mode.

--- a/packages/core/admin/admin/src/pages/SettingsPage/components/Tokens/FormHead/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/components/Tokens/FormHead/index.js
@@ -3,7 +3,7 @@ import { useIntl } from 'react-intl';
 import PropTypes from 'prop-types';
 import { Link } from '@strapi/helper-plugin';
 import { ArrowLeft, Check } from '@strapi/icons';
-import { Button, HeaderLayout, Stack } from '@strapi/design-system';
+import { Button, HeaderLayout, Flex } from '@strapi/design-system';
 import Regenerate from '../Regenerate';
 
 const FormHead = ({
@@ -29,7 +29,7 @@ const FormHead = ({
       title={token?.name || formatMessage(title)}
       primaryAction={
         canEditInputs ? (
-          <Stack horizontal spacing={2}>
+          <Flex gap={2}>
             {canRegenerate && token?.id && (
               <Regenerate
                 backUrl={regenerateUrl}
@@ -49,7 +49,7 @@ const FormHead = ({
                 defaultMessage: 'Save',
               })}
             </Button>
-          </Stack>
+          </Flex>
         ) : (
           canRegenerate &&
           token?.id && (

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/ApiTokens/EditView/components/ActionBoundRoutes/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/ApiTokens/EditView/components/ActionBoundRoutes/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useIntl } from 'react-intl';
-import { Typography, Stack, GridItem } from '@strapi/design-system';
+import { Typography, Flex, GridItem } from '@strapi/design-system';
 import BoundRoute from '../BoundRoute';
 import { useApiTokenPermissionsContext } from '../../../../../../../contexts/ApiTokenPermissions';
 
@@ -22,16 +22,16 @@ const ActionBoundRoutes = () => {
       style={{ minHeight: '100%' }}
     >
       {selectedAction ? (
-        <Stack spacing={2}>
+        <Flex direction="column" alignItems="stretch" gap={2}>
           {routes[actionSection]?.map((route) => {
             return route.config.auth?.scope?.includes(selectedAction) ||
               route.handler === selectedAction ? (
               <BoundRoute key={route.handler} route={route} />
             ) : null;
           })}
-        </Stack>
+        </Flex>
       ) : (
-        <Stack spacing={2}>
+        <Flex direction="column" alignItems="stretch" gap={2}>
           <Typography variant="delta" as="h3">
             {formatMessage({
               id: 'Settings.apiTokens.createPage.permissions.header.title',
@@ -45,7 +45,7 @@ const ActionBoundRoutes = () => {
                 "Select the application's actions or the plugin's actions and click on the cog icon to display the bound route",
             })}
           </Typography>
-        </Stack>
+        </Flex>
       )}
     </GridItem>
   );

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/ApiTokens/EditView/components/BoundRoute/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/ApiTokens/EditView/components/BoundRoute/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-import { Stack, Box, Typography } from '@strapi/design-system';
+import { Flex, Box, Typography } from '@strapi/design-system';
 import map from 'lodash/map';
 import tail from 'lodash/tail';
 import { useIntl } from 'react-intl';
@@ -21,7 +21,7 @@ function BoundRoute({ route }) {
   const colors = getMethodColor(route.method);
 
   return (
-    <Stack spacing={2}>
+    <Flex direction="column" alignItems="stretch" gap={2}>
       <Typography variant="delta" as="h3">
         {formatMessage({
           id: 'Settings.apiTokens.createPage.BoundRoute.title',
@@ -33,7 +33,7 @@ function BoundRoute({ route }) {
           .{action}
         </Typography>
       </Typography>
-      <Stack horizontal hasRadius background="neutral0" borderColor="neutral200" spacing={0}>
+      <Flex hasRadius background="neutral0" borderColor="neutral200" gap={0}>
         <MethodBox background={colors.background} borderColor={colors.border} padding={2}>
           <Typography fontWeight="bold" textColor={colors.text}>
             {method}
@@ -46,8 +46,8 @@ function BoundRoute({ route }) {
             </Typography>
           ))}
         </Box>
-      </Stack>
-    </Stack>
+      </Flex>
+    </Flex>
   );
 }
 

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/ApiTokens/EditView/components/FormApiTokenContainer/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/ApiTokens/EditView/components/FormApiTokenContainer/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useIntl } from 'react-intl';
 import PropTypes from 'prop-types';
-import { Box, Grid, GridItem, Stack, Typography } from '@strapi/design-system';
+import { Box, Grid, GridItem, Flex, Typography } from '@strapi/design-system';
 import LifeSpanInput from '../../../../../components/Tokens/LifeSpanInput';
 import TokenName from '../../../../../components/Tokens/TokenName';
 import TokenDescription from '../../../../../components/Tokens/TokenDescription';
@@ -68,7 +68,7 @@ const FormApiTokenContainer = ({
       paddingLeft={7}
       paddingRight={7}
     >
-      <Stack spacing={4}>
+      <Flex direction="column" alignItems="stretch" gap={4}>
         <Typography variant="delta" as="h2">
           {formatMessage({
             id: 'global.details',
@@ -119,7 +119,7 @@ const FormApiTokenContainer = ({
             />
           </GridItem>
         </Grid>
-      </Stack>
+      </Flex>
     </Box>
   );
 };

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/ApiTokens/EditView/components/Permissions/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/ApiTokens/EditView/components/Permissions/index.js
@@ -1,6 +1,6 @@
 import React, { memo } from 'react';
 import { useIntl } from 'react-intl';
-import { Typography, Stack, Grid, GridItem } from '@strapi/design-system';
+import { Typography, Flex, Grid, GridItem } from '@strapi/design-system';
 import ContentTypesSection from '../ContenTypesSection';
 import ActionBoundRoutes from '../ActionBoundRoutes';
 import { useApiTokenPermissionsContext } from '../../../../../../../contexts/ApiTokenPermissions';
@@ -14,7 +14,7 @@ const Permissions = ({ ...props }) => {
   return (
     <Grid gap={0} shadow="filterShadow" hasRadius background="neutral0">
       <GridItem col={7} paddingTop={6} paddingBottom={6} paddingLeft={7} paddingRight={7}>
-        <Stack spacing={2}>
+        <Flex direction="column" alignItems="stretch" gap={2}>
           <Typography variant="delta" as="h2">
             {formatMessage({
               id: 'Settings.apiTokens.createPage.permissions.title',
@@ -27,7 +27,7 @@ const Permissions = ({ ...props }) => {
               defaultMessage: 'Only actions bound by a route are listed below.',
             })}
           </Typography>
-        </Stack>
+        </Flex>
         {data?.permissions && <ContentTypesSection section={data?.permissions} {...props} />}
       </GridItem>
       <ActionBoundRoutes />

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/ApiTokens/EditView/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/ApiTokens/EditView/index.js
@@ -11,7 +11,7 @@ import {
   useRBAC,
   useFetchClient,
 } from '@strapi/helper-plugin';
-import { Main, ContentLayout, Stack } from '@strapi/design-system';
+import { Main, ContentLayout, Flex } from '@strapi/design-system';
 import { Formik } from 'formik';
 import { useRouteMatch, useHistory } from 'react-router-dom';
 import { useQuery } from 'react-query';
@@ -302,7 +302,7 @@ const ApiTokenCreateView = () => {
                 />
 
                 <ContentLayout>
-                  <Stack spacing={6}>
+                  <Flex direction="column" alignItems="stretch" gap={6}>
                     {Boolean(apiToken?.name) && (
                       <TokenBox token={apiToken?.accessKey} tokenType={API_TOKEN_TYPE} />
                     )}
@@ -323,7 +323,7 @@ const ApiTokenCreateView = () => {
                         values?.type === 'full-access'
                       }
                     />
-                  </Stack>
+                  </Flex>
                 </ContentLayout>
               </Form>
             );

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/ApiTokens/EditView/tests/__snapshots__/index.test.js.snap
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/ApiTokens/EditView/tests/__snapshots__/index.test.js.snap
@@ -15,7 +15,7 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
   color: #32324d;
 }
 
-.c24 {
+.c23 {
   font-weight: 500;
   font-size: 1rem;
   line-height: 1.25;
@@ -88,7 +88,7 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
   padding-left: 56px;
 }
 
-.c22 {
+.c21 {
   background: #ffffff;
   padding-top: 24px;
   padding-right: 32px;
@@ -215,6 +215,21 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
   flex-direction: row;
 }
 
+.c13 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 8px;
+}
+
 .c20 {
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -227,6 +242,51 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  gap: 24px;
+}
+
+.c22 {
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.c26 {
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c48 {
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 8px;
 }
 
 .c63 {
@@ -347,24 +407,6 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
   border: 2px solid #4945ff;
 }
 
-.c21 > * {
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
-.c21 > * + * {
-  margin-top: 24px;
-}
-
-.c23 > * {
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
-.c23 > * + * {
-  margin-top: 16px;
-}
-
 .c27 > * {
   margin-top: 0;
   margin-bottom: 0;
@@ -372,24 +414,6 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
 
 .c27 > * + * {
   margin-top: 4px;
-}
-
-.c48 > * {
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
-.c48 > * + * {
-  margin-top: 8px;
-}
-
-.c13 > * {
-  margin-left: 0;
-  margin-right: 0;
-}
-
-.c13 > * + * {
-  margin-left: 8px;
 }
 
 .c56 > * {
@@ -711,7 +735,7 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
   width: 100%;
 }
 
-.c25 {
+.c24 {
   display: grid;
   grid-template-columns: repeat(12,1fr);
   gap: 20px;
@@ -722,7 +746,7 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
   grid-template-columns: repeat(12,1fr);
 }
 
-.c26 {
+.c25 {
   grid-column: span 6;
   max-width: 100%;
 }
@@ -905,13 +929,13 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
 }
 
 @media (max-width:68.75rem) {
-  .c26 {
+  .c25 {
     grid-column: span;
   }
 }
 
 @media (max-width:34.375rem) {
-  .c26 {
+  .c25 {
     grid-column: span 12;
   }
 }
@@ -1003,7 +1027,7 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
               </h1>
             </div>
             <div
-              class="c1 c8 c10 c13"
+              class="c1 c8 c13"
             >
               <button
                 aria-disabled="false"
@@ -1041,24 +1065,24 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
         class="c1 c19"
       >
         <div
-          class="c1 c8 c20 c21"
+          class="c1 c8 c20"
         >
           <div
-            class="c1 c22"
+            class="c1 c21"
           >
             <div
-              class="c1 c8 c20 c23"
+              class="c1 c8 c22"
             >
               <h2
-                class="c11 c24"
+                class="c11 c23"
               >
                 Details
               </h2>
               <div
-                class="c1 c25"
+                class="c1 c24"
               >
                 <div
-                  class="c26"
+                  class="c25"
                 >
                   <div
                     class="c1 "
@@ -1066,7 +1090,7 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
                     <div>
                       <div>
                         <div
-                          class="c1 c8 c20 c27"
+                          class="c1 c8 c26 c27"
                         >
                           <label
                             class="c11 c18"
@@ -1102,7 +1126,7 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
                   </div>
                 </div>
                 <div
-                  class="c26"
+                  class="c25"
                 >
                   <div
                     class="c1 "
@@ -1112,7 +1136,7 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
                     >
                       <div>
                         <div
-                          class="c1 c8 c20 c27"
+                          class="c1 c8 c26 c27"
                         >
                           <div
                             class="c1 c8 c10"
@@ -1145,14 +1169,14 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
                   </div>
                 </div>
                 <div
-                  class="c26"
+                  class="c25"
                 >
                   <div
                     class="c1 "
                   >
                     <div>
                       <div
-                        class="c1 c8 c20 c27"
+                        class="c1 c8 c26 c27"
                       >
                         <label
                           class="c11 c18"
@@ -1235,14 +1259,14 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
                   </div>
                 </div>
                 <div
-                  class="c26"
+                  class="c25"
                 >
                   <div
                     class="c1 "
                   >
                     <div>
                       <div
-                        class="c1 c8 c20 c27"
+                        class="c1 c8 c26 c27"
                       >
                         <label
                           class="c11 c18"
@@ -1334,10 +1358,10 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
                 class="c1 c47"
               >
                 <div
-                  class="c1 c8 c20 c48"
+                  class="c1 c8 c48"
                 >
                   <h2
-                    class="c11 c24"
+                    class="c11 c23"
                   >
                     Permissions
                   </h2>
@@ -1479,10 +1503,10 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
                 style="min-height: 100%;"
               >
                 <div
-                  class="c1 c8 c20 c48"
+                  class="c1 c8 c48"
                 >
                   <h3
-                    class="c11 c24"
+                    class="c11 c23"
                   >
                     Advanced settings
                   </h3>
@@ -1539,33 +1563,33 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
   color: #32324d;
 }
 
-.c27 {
+.c26 {
   font-size: 0.75rem;
   line-height: 1.33;
   font-weight: 500;
   color: #32324d;
 }
 
-.c29 {
+.c28 {
   font-size: 0.875rem;
   line-height: 1.43;
   color: #666687;
 }
 
-.c32 {
+.c31 {
   font-weight: 500;
   font-size: 1rem;
   line-height: 1.25;
   color: #32324d;
 }
 
-.c35 {
+.c36 {
   font-size: 0.875rem;
   line-height: 1.43;
   color: #d02b20;
 }
 
-.c46 {
+.c47 {
   font-size: 0.875rem;
   line-height: 1.43;
   display: block;
@@ -1575,13 +1599,13 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
   color: #666687;
 }
 
-.c50 {
+.c51 {
   font-size: 0.75rem;
   line-height: 1.33;
   color: #666687;
 }
 
-.c52 {
+.c53 {
   font-size: 0.875rem;
   line-height: 1.43;
   display: block;
@@ -1591,13 +1615,13 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
   color: #32324d;
 }
 
-.c69 {
+.c70 {
   font-size: 0.75rem;
   line-height: 1.33;
   color: #4945ff;
 }
 
-.c70 {
+.c71 {
   font-weight: 500;
   font-size: 1rem;
   line-height: 1.25;
@@ -1629,20 +1653,20 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
   padding-bottom: 8px;
 }
 
-.c23 {
+.c22 {
   background: #ffffff;
   padding: 24px;
   border-radius: 4px;
   box-shadow: 0px 1px 4px rgba(33,33,52,0.1);
 }
 
-.c24 {
+.c23 {
   background: #f6f6f9;
   padding: 12px;
   border-radius: 4px;
 }
 
-.c30 {
+.c29 {
   background: #ffffff;
   padding-top: 24px;
   padding-right: 32px;
@@ -1652,35 +1676,22 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
   box-shadow: 0px 1px 4px rgba(33,33,52,0.1);
 }
 
-.c45 {
+.c46 {
   padding-right: 16px;
   padding-left: 16px;
 }
 
-.c47 {
+.c48 {
   padding-left: 12px;
 }
 
-.c54 {
+.c55 {
   background: #ffffff;
   border-radius: 4px;
   box-shadow: 0px 1px 4px rgba(33,33,52,0.1);
 }
 
-.c57 {
-  padding-top: 24px;
-  padding-right: 32px;
-  padding-bottom: 24px;
-  padding-left: 32px;
-}
-
-.c59 {
-  background: #ffffff;
-  padding: 16px;
-}
-
-.c78 {
-  background: #eaeaef;
+.c58 {
   padding-top: 24px;
   padding-right: 32px;
   padding-bottom: 24px;
@@ -1688,10 +1699,23 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
 }
 
 .c60 {
+  background: #ffffff;
+  padding: 16px;
+}
+
+.c79 {
+  background: #eaeaef;
+  padding-top: 24px;
+  padding-right: 32px;
+  padding-bottom: 24px;
+  padding-left: 32px;
+}
+
+.c61 {
   border-radius: 4px;
 }
 
-.c62 {
+.c63 {
   background: #f6f6f9;
   padding-top: 24px;
   padding-right: 24px;
@@ -1699,21 +1723,21 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
   padding-left: 24px;
 }
 
-.c64 {
+.c65 {
   max-width: 100%;
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
 }
 
-.c66 {
+.c67 {
   min-width: 0;
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
 }
 
-.c71 {
+.c72 {
   background: #dcdce4;
   border-radius: 50%;
   width: 2rem;
@@ -1724,12 +1748,12 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
   cursor: pointer;
 }
 
-.c73 {
+.c74 {
   color: #666687;
   width: 0.6875rem;
 }
 
-.c76 {
+.c77 {
   background: #ffffff;
   padding-top: 24px;
   padding-right: 24px;
@@ -1769,7 +1793,67 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
   flex-direction: row;
 }
 
+.c13 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 8px;
+}
+
 .c21 {
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.c25 {
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.c30 {
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.c34 {
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -1783,7 +1867,22 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
   flex-direction: column;
 }
 
-.c72 {
+.c59 {
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.c73 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1804,62 +1903,62 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
   justify-content: center;
 }
 
-.c61 {
+.c62 {
   border: 1px solid #f6f6f9;
 }
 
-.c61:hover:not([aria-disabled='true']) {
+.c62:hover:not([aria-disabled='true']) {
   border: 1px solid #4945ff;
 }
 
-.c61:hover:not([aria-disabled='true']) .c11 {
+.c62:hover:not([aria-disabled='true']) .c11 {
   color: #4945ff;
 }
 
-.c61:hover:not([aria-disabled='true']) > .c8 {
+.c62:hover:not([aria-disabled='true']) > .c8 {
   background: #f0f0ff;
 }
 
-.c61:hover:not([aria-disabled='true']) [data-strapi-dropdown='true'] {
+.c62:hover:not([aria-disabled='true']) [data-strapi-dropdown='true'] {
   background: #d9d8ff;
 }
 
-.c75 {
+.c76 {
   border: 1px solid #ffffff;
 }
 
-.c75:hover:not([aria-disabled='true']) {
+.c76:hover:not([aria-disabled='true']) {
   border: 1px solid #4945ff;
 }
 
-.c75:hover:not([aria-disabled='true']) .c11 {
+.c76:hover:not([aria-disabled='true']) .c11 {
   color: #4945ff;
 }
 
-.c75:hover:not([aria-disabled='true']) > .c8 {
+.c76:hover:not([aria-disabled='true']) > .c8 {
   background: #f0f0ff;
 }
 
-.c75:hover:not([aria-disabled='true']) [data-strapi-dropdown='true'] {
+.c76:hover:not([aria-disabled='true']) [data-strapi-dropdown='true'] {
   background: #d9d8ff;
 }
 
-.c67 {
+.c68 {
   background: transparent;
   border: none;
   position: relative;
   outline: none;
 }
 
-.c67[aria-disabled='true'] {
+.c68[aria-disabled='true'] {
   pointer-events: none;
 }
 
-.c67[aria-disabled='true'] svg path {
+.c68[aria-disabled='true'] svg path {
   fill: #666687;
 }
 
-.c67 svg {
+.c68 svg {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1867,11 +1966,11 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
   font-size: 0.625rem;
 }
 
-.c67 svg path {
+.c68 svg path {
   fill: #4945ff;
 }
 
-.c67:after {
+.c68:after {
   -webkit-transition-property: all;
   transition-property: all;
   -webkit-transition-duration: 0.2s;
@@ -1886,11 +1985,11 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
   border: 2px solid transparent;
 }
 
-.c67:focus-visible {
+.c68:focus-visible {
   outline: none;
 }
 
-.c67:focus-visible:after {
+.c68:focus-visible:after {
   border-radius: 8px;
   content: '';
   position: absolute;
@@ -1901,87 +2000,51 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
   border: 2px solid #4945ff;
 }
 
-.c22 > * {
+.c35 > * {
   margin-top: 0;
   margin-bottom: 0;
 }
 
-.c22 > * + * {
-  margin-top: 24px;
-}
-
-.c26 > * {
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
-.c26 > * + * {
+.c35 > * + * {
   margin-top: 4px;
 }
 
-.c31 > * {
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
-.c31 > * + * {
-  margin-top: 16px;
-}
-
-.c58 > * {
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
-.c58 > * + * {
-  margin-top: 8px;
-}
-
-.c13 > * {
+.c66 > * {
   margin-left: 0;
   margin-right: 0;
 }
 
-.c13 > * + * {
-  margin-left: 8px;
-}
-
-.c65 > * {
-  margin-left: 0;
-  margin-right: 0;
-}
-
-.c65 > * + * {
+.c66 > * + * {
   margin-left: 12px;
 }
 
-.c74 path {
+.c75 path {
   fill: #666687;
 }
 
-.c68 {
+.c69 {
   text-align: left;
 }
 
-.c68 > span {
+.c69 > span {
   max-width: 100%;
 }
 
-.c68 svg {
+.c69 svg {
   width: 0.875rem;
   height: 0.875rem;
 }
 
-.c68 svg path {
+.c69 svg path {
   fill: #8e8ea9;
 }
 
-.c63 {
+.c64 {
   min-height: 5.5rem;
   border-radius: 4px;
 }
 
-.c63:hover svg path {
+.c64:hover svg path {
   fill: #4945ff;
 }
 
@@ -2043,7 +2106,7 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
   border: 2px solid #4945ff;
 }
 
-.c79 {
+.c80 {
   border: 0;
   -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
@@ -2059,7 +2122,7 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
   height: 100%;
 }
 
-.c80 .c1 {
+.c81 .c1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2070,15 +2133,15 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
   align-items: center;
 }
 
-.c80 .c11 {
+.c81 .c11 {
   color: #ffffff;
 }
 
-.c80[aria-disabled='true'] .c11 {
+.c81[aria-disabled='true'] .c11 {
   color: #666687;
 }
 
-.c80[aria-disabled='true']:active .c11 {
+.c81[aria-disabled='true']:active .c11 {
   color: #666687;
 }
 
@@ -2222,11 +2285,11 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
   fill: #ffffff;
 }
 
-.c36 {
+.c37 {
   line-height: 0;
 }
 
-.c38 {
+.c39 {
   border: none;
   border-radius: 4px;
   padding-bottom: 0.65625rem;
@@ -2241,36 +2304,36 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
   background: inherit;
 }
 
-.c38::-webkit-input-placeholder {
+.c39::-webkit-input-placeholder {
   color: #8e8ea9;
   opacity: 1;
 }
 
-.c38::-moz-placeholder {
+.c39::-moz-placeholder {
   color: #8e8ea9;
   opacity: 1;
 }
 
-.c38:-ms-input-placeholder {
+.c39:-ms-input-placeholder {
   color: #8e8ea9;
   opacity: 1;
 }
 
-.c38::placeholder {
+.c39::placeholder {
   color: #8e8ea9;
   opacity: 1;
 }
 
-.c38[aria-disabled='true'] {
+.c39[aria-disabled='true'] {
   color: inherit;
 }
 
-.c38:focus {
+.c39:focus {
   outline: none;
   box-shadow: none;
 }
 
-.c37 {
+.c38 {
   border: 1px solid #dcdce4;
   border-radius: 4px;
   background: #ffffff;
@@ -2282,12 +2345,12 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
   transition-duration: 0.2s;
 }
 
-.c37:focus-within {
+.c38:focus-within {
   border: 1px solid #4945ff;
   box-shadow: #4945ff 0px 0px 0px 2px;
 }
 
-.c42 {
+.c43 {
   position: relative;
   border: 1px solid #dcdce4;
   padding-right: 12px;
@@ -2305,12 +2368,12 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
   transition-duration: 0.2s;
 }
 
-.c42:focus-within {
+.c43:focus-within {
   border: 1px solid #4945ff;
   box-shadow: #4945ff 0px 0px 0px 2px;
 }
 
-.c51 {
+.c52 {
   position: relative;
   border: 1px solid #dcdce4;
   padding-right: 12px;
@@ -2326,28 +2389,28 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
   transition-duration: 0.2s;
 }
 
-.c51:focus-within {
+.c52:focus-within {
   border: 1px solid #4945ff;
   box-shadow: #4945ff 0px 0px 0px 2px;
 }
 
-.c48 {
+.c49 {
   background: transparent;
   border: none;
   position: relative;
   z-index: 1;
 }
 
-.c48 svg {
+.c49 svg {
   height: 0.6875rem;
   width: 0.6875rem;
 }
 
-.c48 svg path {
+.c49 svg path {
   fill: #666687;
 }
 
-.c49 {
+.c50 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2357,11 +2420,11 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
   cursor: not-allowed;
 }
 
-.c49 svg {
+.c50 svg {
   width: 0.375rem;
 }
 
-.c53 {
+.c54 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2370,11 +2433,11 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
   border: none;
 }
 
-.c53 svg {
+.c54 svg {
   width: 0.375rem;
 }
 
-.c43 {
+.c44 {
   position: absolute;
   left: 0;
   right: 0;
@@ -2385,40 +2448,40 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
   border: none;
 }
 
-.c43:focus {
+.c44:focus {
   outline: none;
 }
 
-.c43[aria-disabled='true'] {
+.c44[aria-disabled='true'] {
   cursor: not-allowed;
 }
 
-.c44 {
+.c45 {
   width: 100%;
 }
 
-.c33 {
+.c32 {
   display: grid;
   grid-template-columns: repeat(12,1fr);
   gap: 20px;
 }
 
-.c55 {
+.c56 {
   display: grid;
   grid-template-columns: repeat(12,1fr);
 }
 
-.c34 {
+.c33 {
   grid-column: span 6;
   max-width: 100%;
 }
 
-.c56 {
+.c57 {
   grid-column: span 7;
   max-width: 100%;
 }
 
-.c77 {
+.c78 {
   grid-column: span 5;
   max-width: 100%;
 }
@@ -2427,7 +2490,7 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
   outline: none;
 }
 
-.c40 {
+.c41 {
   border: 1px solid #dcdce4;
   border-radius: 4px;
   padding-left: 16px;
@@ -2443,12 +2506,12 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
   transition-duration: 0.2s;
 }
 
-.c40:focus-within {
+.c41:focus-within {
   border: 1px solid #4945ff;
   box-shadow: #4945ff 0px 0px 0px 2px;
 }
 
-.c41 {
+.c42 {
   display: block;
   width: 100%;
   font-weight: 400;
@@ -2459,36 +2522,36 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
   background: inherit;
 }
 
-.c41::-webkit-input-placeholder {
+.c42::-webkit-input-placeholder {
   color: #8e8ea9;
   opacity: 1;
 }
 
-.c41::-moz-placeholder {
+.c42::-moz-placeholder {
   color: #8e8ea9;
   opacity: 1;
 }
 
-.c41:-ms-input-placeholder {
+.c42:-ms-input-placeholder {
   color: #8e8ea9;
   opacity: 1;
 }
 
-.c41::placeholder {
+.c42::placeholder {
   color: #8e8ea9;
   opacity: 1;
 }
 
-.c41:focus-within {
+.c42:focus-within {
   outline: none;
 }
 
-.c39 textarea {
+.c40 textarea {
   height: 5rem;
   line-height: 1.25rem;
 }
 
-.c39 textarea::-webkit-input-placeholder {
+.c40 textarea::-webkit-input-placeholder {
   font-weight: 400;
   font-size: 0.875rem;
   line-height: 1.43;
@@ -2496,7 +2559,7 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
   opacity: 1;
 }
 
-.c39 textarea::-moz-placeholder {
+.c40 textarea::-moz-placeholder {
   font-weight: 400;
   font-size: 0.875rem;
   line-height: 1.43;
@@ -2504,7 +2567,7 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
   opacity: 1;
 }
 
-.c39 textarea:-ms-input-placeholder {
+.c40 textarea:-ms-input-placeholder {
   font-weight: 400;
   font-size: 0.875rem;
   line-height: 1.43;
@@ -2512,7 +2575,7 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
   opacity: 1;
 }
 
-.c39 textarea::placeholder {
+.c40 textarea::placeholder {
   font-weight: 400;
   font-size: 0.875rem;
   line-height: 1.43;
@@ -2520,16 +2583,16 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
   opacity: 1;
 }
 
-.c25 {
+.c24 {
   margin-right: 24px;
 }
 
-.c25 svg {
+.c24 svg {
   width: 2rem;
   height: 2rem;
 }
 
-.c28 {
+.c27 {
   word-break: break-all;
 }
 
@@ -2604,37 +2667,37 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
 }
 
 @media (max-width:68.75rem) {
-  .c34 {
+  .c33 {
     grid-column: span;
   }
 }
 
 @media (max-width:34.375rem) {
-  .c34 {
+  .c33 {
     grid-column: span 12;
   }
 }
 
 @media (max-width:68.75rem) {
-  .c56 {
+  .c57 {
     grid-column: span;
   }
 }
 
 @media (max-width:34.375rem) {
-  .c56 {
+  .c57 {
     grid-column: span;
   }
 }
 
 @media (max-width:68.75rem) {
-  .c77 {
+  .c78 {
     grid-column: span;
   }
 }
 
 @media (max-width:34.375rem) {
-  .c77 {
+  .c78 {
     grid-column: span;
   }
 }
@@ -2702,7 +2765,7 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
               </h1>
             </div>
             <div
-              class="c1 c8 c10 c13"
+              class="c1 c8 c13"
             >
               <button
                 aria-disabled="false"
@@ -2771,13 +2834,13 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
         class="c1 c20"
       >
         <div
-          class="c1 c8 c21 c22"
+          class="c1 c8 c21"
         >
           <div
-            class="c1 c8 c23 c10"
+            class="c1 c8 c22 c10"
           >
             <div
-              class="c1 c8 c24 c10 c25"
+              class="c1 c8 c23 c10 c24"
             >
               <svg
                 fill="none"
@@ -2793,40 +2856,40 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
               </svg>
             </div>
             <div
-              class="c1 c8 c21 c26"
+              class="c1 c8 c25"
             >
               <div
                 class="c1 c8 c10"
               >
                 <span
-                  class="c11 c27 c28"
+                  class="c11 c26 c27"
                 >
                   This token isn’t accessible anymore.
                 </span>
               </div>
               <span
-                class="c11 c29"
+                class="c11 c28"
               >
                 For security reasons, you can only see your token once.
               </span>
             </div>
           </div>
           <div
-            class="c1 c30"
+            class="c1 c29"
           >
             <div
-              class="c1 c8 c21 c31"
+              class="c1 c8 c30"
             >
               <h2
-                class="c11 c32"
+                class="c11 c31"
               >
                 Details
               </h2>
               <div
-                class="c1 c33"
+                class="c1 c32"
               >
                 <div
-                  class="c34"
+                  class="c33"
                 >
                   <div
                     class="c1 "
@@ -2834,7 +2897,7 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
                     <div>
                       <div>
                         <div
-                          class="c1 c8 c21 c26"
+                          class="c1 c8 c34 c35"
                         >
                           <label
                             class="c11 c18"
@@ -2845,20 +2908,20 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
                             >
                               Name
                               <span
-                                class="c11 c35 c36"
+                                class="c11 c36 c37"
                               >
                                 *
                               </span>
                             </div>
                           </label>
                           <div
-                            class="c1 c8 c9 c37"
+                            class="c1 c8 c9 c38"
                           >
                             <input
                               aria-disabled="false"
                               aria-invalid="false"
                               aria-required="true"
-                              class="c38"
+                              class="c39"
                               id="12"
                               name="name"
                               value="My super token"
@@ -2870,17 +2933,17 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
                   </div>
                 </div>
                 <div
-                  class="c34"
+                  class="c33"
                 >
                   <div
                     class="c1 "
                   >
                     <div
-                      class="c39"
+                      class="c40"
                     >
                       <div>
                         <div
-                          class="c1 c8 c21 c26"
+                          class="c1 c8 c34 c35"
                         >
                           <div
                             class="c1 c8 c10"
@@ -2897,12 +2960,12 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
                             </label>
                           </div>
                           <div
-                            class="c40"
+                            class="c41"
                           >
                             <textarea
                               aria-invalid="false"
                               aria-required="false"
-                              class="c41"
+                              class="c42"
                               id="14"
                               name="description"
                             >
@@ -2915,14 +2978,14 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
                   </div>
                 </div>
                 <div
-                  class="c34"
+                  class="c33"
                 >
                   <div
                     class="c1 "
                   >
                     <div>
                       <div
-                        class="c1 c8 c21 c26"
+                        class="c1 c8 c34 c35"
                       >
                         <label
                           class="c11 c18"
@@ -2933,14 +2996,14 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
                           >
                             Token duration
                             <span
-                              class="c11 c35 c36"
+                              class="c11 c36 c37"
                             >
                               *
                             </span>
                           </div>
                         </label>
                         <div
-                          class="c1 c8 c10 c42"
+                          class="c1 c8 c10 c43"
                           disabled=""
                         >
                           <button
@@ -2948,22 +3011,22 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
                             aria-expanded="false"
                             aria-haspopup="listbox"
                             aria-labelledby="16 16-label 16-content"
-                            class="c43"
+                            class="c44"
                             id="16"
                             name="lifespan"
                             type="button"
                           />
                           <div
-                            class="c1 c8 c9 c44"
+                            class="c1 c8 c9 c45"
                           >
                             <div
                               class="c1 c8 c10"
                             >
                               <div
-                                class="c1 c45"
+                                class="c1 c46"
                               >
                                 <span
-                                  class="c11 c46"
+                                  class="c11 c47"
                                   id="16-content"
                                 >
                                   Select
@@ -2975,7 +3038,7 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
                             >
                               <button
                                 aria-hidden="true"
-                                class="c1 c47 c48 c49"
+                                class="c1 c48 c49 c50"
                                 disabled=""
                                 tabindex="-1"
                                 title="Carret Down Button"
@@ -3002,21 +3065,21 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
                       </div>
                     </div>
                     <span
-                      class="c11 c50"
+                      class="c11 c51"
                     >
                       Expiration date: Unlimited
                     </span>
                   </div>
                 </div>
                 <div
-                  class="c34"
+                  class="c33"
                 >
                   <div
                     class="c1 "
                   >
                     <div>
                       <div
-                        class="c1 c8 c21 c26"
+                        class="c1 c8 c34 c35"
                       >
                         <label
                           class="c11 c18"
@@ -3027,36 +3090,36 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
                           >
                             Token type
                             <span
-                              class="c11 c35 c36"
+                              class="c11 c36 c37"
                             >
                               *
                             </span>
                           </div>
                         </label>
                         <div
-                          class="c1 c8 c10 c51"
+                          class="c1 c8 c10 c52"
                         >
                           <button
                             aria-disabled="false"
                             aria-expanded="false"
                             aria-haspopup="listbox"
                             aria-labelledby="18 18-label 18-content"
-                            class="c43"
+                            class="c44"
                             id="18"
                             name="type"
                             type="button"
                           />
                           <div
-                            class="c1 c8 c9 c44"
+                            class="c1 c8 c9 c45"
                           >
                             <div
                               class="c1 c8 c10"
                             >
                               <div
-                                class="c1 c45"
+                                class="c1 c46"
                               >
                                 <span
-                                  class="c11 c52"
+                                  class="c11 c53"
                                   id="18-content"
                                 >
                                   Read-only
@@ -3068,7 +3131,7 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
                             >
                               <button
                                 aria-hidden="true"
-                                class="c1 c47 c48 c53"
+                                class="c1 c48 c49 c54"
                                 tabindex="-1"
                                 title="Carret Down Button"
                                 type="button"
@@ -3099,56 +3162,56 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
             </div>
           </div>
           <div
-            class="c1 c54 c55"
+            class="c1 c55 c56"
           >
             <div
-              class="c56"
+              class="c57"
             >
               <div
-                class="c1 c57"
+                class="c1 c58"
               >
                 <div
-                  class="c1 c8 c21 c58"
+                  class="c1 c8 c59"
                 >
                   <h2
-                    class="c11 c32"
+                    class="c11 c31"
                   >
                     Permissions
                   </h2>
                   <p
-                    class="c11 c29"
+                    class="c11 c28"
                   >
                     Only actions bound by a route are listed below.
                   </p>
                 </div>
                 <div
-                  class="c1 c59"
+                  class="c1 c60"
                 >
                   <div
                     aria-disabled="false"
-                    class="c1 c60 c61"
+                    class="c1 c61 c62"
                     data-strapi-expanded="false"
                   >
                     <div
-                      class="c1 c8 c62 c9 c63"
+                      class="c1 c8 c63 c9 c64"
                     >
                       <div
-                        class="c1 c8 c64 c10 c65"
+                        class="c1 c8 c65 c10 c66"
                       >
                         <button
                           aria-controls="accordion-content-19"
                           aria-disabled="false"
                           aria-expanded="false"
                           aria-labelledby="accordion-label-19"
-                          class="c1 c8 c66 c10 c67 c68"
+                          class="c1 c8 c67 c10 c68 c69"
                           data-strapi-accordion-toggle="true"
                           type="button"
                         >
                           <span
-                            class="c11 c69"
+                            class="c11 c70"
                           >
                             <span
-                              class="c11 c70"
+                              class="c11 c71"
                               id="accordion-label-19"
                             >
                               Address
@@ -3156,15 +3219,15 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
                           </span>
                         </button>
                         <div
-                          class="c1 c8 c10 c65"
+                          class="c1 c8 c10 c66"
                         >
                           <span
                             aria-hidden="true"
-                            class="c1 c8 c71 c72"
+                            class="c1 c8 c72 c73"
                             data-strapi-dropdown="true"
                           >
                             <svg
-                              class="c1 c73 c74"
+                              class="c1 c74 c75"
                               fill="none"
                               height="1em"
                               viewBox="0 0 14 8"
@@ -3185,29 +3248,29 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
                   </div>
                   <div
                     aria-disabled="false"
-                    class="c1 c60 c75"
+                    class="c1 c61 c76"
                     data-strapi-expanded="false"
                   >
                     <div
-                      class="c1 c8 c76 c9 c63"
+                      class="c1 c8 c77 c9 c64"
                     >
                       <div
-                        class="c1 c8 c64 c10 c65"
+                        class="c1 c8 c65 c10 c66"
                       >
                         <button
                           aria-controls="accordion-content-20"
                           aria-disabled="false"
                           aria-expanded="false"
                           aria-labelledby="accordion-label-20"
-                          class="c1 c8 c66 c10 c67 c68"
+                          class="c1 c8 c67 c10 c68 c69"
                           data-strapi-accordion-toggle="true"
                           type="button"
                         >
                           <span
-                            class="c11 c69"
+                            class="c11 c70"
                           >
                             <span
-                              class="c11 c70"
+                              class="c11 c71"
                               id="accordion-label-20"
                             >
                               Category
@@ -3215,15 +3278,15 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
                           </span>
                         </button>
                         <div
-                          class="c1 c8 c10 c65"
+                          class="c1 c8 c10 c66"
                         >
                           <span
                             aria-hidden="true"
-                            class="c1 c8 c71 c72"
+                            class="c1 c8 c72 c73"
                             data-strapi-dropdown="true"
                           >
                             <svg
-                              class="c1 c73 c74"
+                              class="c1 c74 c75"
                               fill="none"
                               height="1em"
                               viewBox="0 0 14 8"
@@ -3246,22 +3309,22 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
               </div>
             </div>
             <div
-              class="c77"
+              class="c78"
             >
               <div
-                class="c1 c78"
+                class="c1 c79"
                 style="min-height: 100%;"
               >
                 <div
-                  class="c1 c8 c21 c58"
+                  class="c1 c8 c59"
                 >
                   <h3
-                    class="c11 c32"
+                    class="c11 c31"
                   >
                     Advanced settings
                   </h3>
                   <p
-                    class="c11 c29"
+                    class="c11 c28"
                   >
                     Select the application's actions or the plugin's actions and click on the cog icon to display the bound route
                   </p>
@@ -3274,7 +3337,7 @@ exports[`ADMIN | Pages | API TOKENS | EditView renders and matches the snapshot 
     </form>
   </main>
   <div
-    class="c79"
+    class="c80"
   >
     <p
       aria-live="polite"

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/ApplicationInfosPage/components/LogoInput/tests/__snapshots__/index.test.js.snap
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/ApplicationInfosPage/components/LogoInput/tests/__snapshots__/index.test.js.snap
@@ -239,6 +239,21 @@ exports[`ApplicationsInfosPage || LogoInput from computer should render upload m
   justify-content: space-between;
 }
 
+.c43 {
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 8px;
+}
+
 .c45 {
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -264,15 +279,6 @@ exports[`ApplicationsInfosPage || LogoInput from computer should render upload m
 
 .c2 > * + * {
   margin-top: 4px;
-}
-
-.c43 > * {
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
-.c43 > * + * {
-  margin-top: 8px;
 }
 
 .c16 > * {
@@ -891,7 +897,7 @@ exports[`ApplicationsInfosPage || LogoInput from computer should render upload m
                           for="logo-upload"
                         >
                           <div
-                            class="c0 c1 c43"
+                            class="c0 c43"
                           >
                             <div
                               class="c0 c44 c45"

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/ApplicationInfosPage/components/LogoModalStepper/FromComputerForm.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/ApplicationInfosPage/components/LogoModalStepper/FromComputerForm.js
@@ -4,7 +4,6 @@ import { useIntl } from 'react-intl';
 import styled from 'styled-components';
 import {
   Box,
-  Stack,
   Flex,
   Icon,
   Typography,
@@ -81,7 +80,7 @@ const FromComputerForm = ({ setLocalImage, goTo, next, onClose }) => {
         <Box paddingLeft={8} paddingRight={8} paddingTop={6} paddingBottom={6}>
           <Field name="logo-upload" error={fileError}>
             <label htmlFor="logo-upload">
-              <Stack spacing={2}>
+              <Flex direction="column" alignItems="stretch" gap={2}>
                 <Flex
                   paddingTop={9}
                   paddingBottom={7}
@@ -147,7 +146,7 @@ const FromComputerForm = ({ setLocalImage, goTo, next, onClose }) => {
                   </Box>
                 </Flex>
                 <FieldError />
-              </Stack>
+              </Flex>
             </label>
           </Field>
         </Box>

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/ApplicationInfosPage/components/LogoModalStepper/tests/__snapshots__/AddLogoDialog.test.js.snap
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/ApplicationInfosPage/components/LogoModalStepper/tests/__snapshots__/AddLogoDialog.test.js.snap
@@ -17,21 +17,21 @@ exports[`ApplicationInfosPage | AddLogoDialog shoud render from computer tab and
   color: #666687;
 }
 
-.c19 {
+.c18 {
   font-weight: 500;
   font-size: 1rem;
   line-height: 1.25;
   color: #32324d;
 }
 
-.c23 {
+.c22 {
   font-size: 0.75rem;
   line-height: 1.33;
   font-weight: 600;
   color: #32324d;
 }
 
-.c25 {
+.c24 {
   font-size: 0.75rem;
   line-height: 1.33;
   color: #666687;
@@ -57,7 +57,7 @@ exports[`ApplicationInfosPage | AddLogoDialog shoud render from computer tab and
   padding-left: 40px;
 }
 
-.c14 {
+.c13 {
   background: #f6f6f9;
   padding-top: 48px;
   padding-bottom: 32px;
@@ -68,22 +68,22 @@ exports[`ApplicationInfosPage | AddLogoDialog shoud render from computer tab and
   position: relative;
 }
 
-.c16 {
+.c15 {
   color: #4945ff;
   width: 3.75rem;
   height: 3.75rem;
 }
 
-.c18 {
+.c17 {
   padding-top: 12px;
   padding-bottom: 20px;
 }
 
-.c24 {
+.c23 {
   padding-top: 24px;
 }
 
-.c26 {
+.c25 {
   background: #f6f6f9;
   padding-top: 16px;
   padding-right: 20px;
@@ -103,9 +103,10 @@ exports[`ApplicationInfosPage | AddLogoDialog shoud render from computer tab and
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  gap: 8px;
 }
 
-.c15 {
+.c14 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -123,7 +124,7 @@ exports[`ApplicationInfosPage | AddLogoDialog shoud render from computer tab and
   justify-content: center;
 }
 
-.c28 {
+.c27 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -141,7 +142,7 @@ exports[`ApplicationInfosPage | AddLogoDialog shoud render from computer tab and
   justify-content: space-between;
 }
 
-.c29 {
+.c28 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -155,20 +156,11 @@ exports[`ApplicationInfosPage | AddLogoDialog shoud render from computer tab and
   flex-direction: row;
 }
 
-.c13 > * {
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
-.c13 > * + * {
-  margin-top: 8px;
-}
-
-.c17 path {
+.c16 path {
   fill: #4945ff;
 }
 
-.c21 {
+.c20 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -182,21 +174,21 @@ exports[`ApplicationInfosPage | AddLogoDialog shoud render from computer tab and
   outline: none;
 }
 
-.c21 svg {
+.c20 svg {
   height: 12px;
   width: 12px;
 }
 
-.c21 svg > g,
-.c21 svg path {
+.c20 svg > g,
+.c20 svg path {
   fill: #ffffff;
 }
 
-.c21[aria-disabled='true'] {
+.c20[aria-disabled='true'] {
   pointer-events: none;
 }
 
-.c21:after {
+.c20:after {
   -webkit-transition-property: all;
   transition-property: all;
   -webkit-transition-duration: 0.2s;
@@ -211,11 +203,11 @@ exports[`ApplicationInfosPage | AddLogoDialog shoud render from computer tab and
   border: 2px solid transparent;
 }
 
-.c21:focus-visible {
+.c20:focus-visible {
   outline: none;
 }
 
-.c21:focus-visible:after {
+.c20:focus-visible:after {
   border-radius: 8px;
   content: '';
   position: absolute;
@@ -226,7 +218,7 @@ exports[`ApplicationInfosPage | AddLogoDialog shoud render from computer tab and
   border: 2px solid #4945ff;
 }
 
-.c32 {
+.c31 {
   border: 0;
   -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
@@ -238,7 +230,7 @@ exports[`ApplicationInfosPage | AddLogoDialog shoud render from computer tab and
   width: 1px;
 }
 
-.c22 {
+.c21 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -250,7 +242,7 @@ exports[`ApplicationInfosPage | AddLogoDialog shoud render from computer tab and
   padding-right: 16px;
 }
 
-.c22 .c0 {
+.c21 .c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -261,52 +253,52 @@ exports[`ApplicationInfosPage | AddLogoDialog shoud render from computer tab and
   align-items: center;
 }
 
-.c22 .c5 {
+.c21 .c5 {
   color: #ffffff;
 }
 
-.c22[aria-disabled='true'] {
+.c21[aria-disabled='true'] {
   border: 1px solid #dcdce4;
   background: #eaeaef;
 }
 
-.c22[aria-disabled='true'] .c5 {
+.c21[aria-disabled='true'] .c5 {
   color: #666687;
 }
 
-.c22[aria-disabled='true'] svg > g,.c22[aria-disabled='true'] svg path {
+.c21[aria-disabled='true'] svg > g,.c21[aria-disabled='true'] svg path {
   fill: #666687;
 }
 
-.c22[aria-disabled='true']:active {
+.c21[aria-disabled='true']:active {
   border: 1px solid #dcdce4;
   background: #eaeaef;
 }
 
-.c22[aria-disabled='true']:active .c5 {
+.c21[aria-disabled='true']:active .c5 {
   color: #666687;
 }
 
-.c22[aria-disabled='true']:active svg > g,.c22[aria-disabled='true']:active svg path {
+.c21[aria-disabled='true']:active svg > g,.c21[aria-disabled='true']:active svg path {
   fill: #666687;
 }
 
-.c22:hover {
+.c21:hover {
   border: 1px solid #7b79ff;
   background: #7b79ff;
 }
 
-.c22:active {
+.c21:active {
   border: 1px solid #4945ff;
   background: #4945ff;
 }
 
-.c22 svg > g,
-.c22 svg path {
+.c21 svg > g,
+.c21 svg path {
   fill: #ffffff;
 }
 
-.c31 {
+.c30 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -320,7 +312,7 @@ exports[`ApplicationInfosPage | AddLogoDialog shoud render from computer tab and
   background: #ffffff;
 }
 
-.c31 .c0 {
+.c30 .c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -331,50 +323,50 @@ exports[`ApplicationInfosPage | AddLogoDialog shoud render from computer tab and
   align-items: center;
 }
 
-.c31 .c5 {
+.c30 .c5 {
   color: #ffffff;
 }
 
-.c31[aria-disabled='true'] {
+.c30[aria-disabled='true'] {
   border: 1px solid #dcdce4;
   background: #eaeaef;
 }
 
-.c31[aria-disabled='true'] .c5 {
+.c30[aria-disabled='true'] .c5 {
   color: #666687;
 }
 
-.c31[aria-disabled='true'] svg > g,.c31[aria-disabled='true'] svg path {
+.c30[aria-disabled='true'] svg > g,.c30[aria-disabled='true'] svg path {
   fill: #666687;
 }
 
-.c31[aria-disabled='true']:active {
+.c30[aria-disabled='true']:active {
   border: 1px solid #dcdce4;
   background: #eaeaef;
 }
 
-.c31[aria-disabled='true']:active .c5 {
+.c30[aria-disabled='true']:active .c5 {
   color: #666687;
 }
 
-.c31[aria-disabled='true']:active svg > g,.c31[aria-disabled='true']:active svg path {
+.c30[aria-disabled='true']:active svg > g,.c30[aria-disabled='true']:active svg path {
   fill: #666687;
 }
 
-.c31:hover {
+.c30:hover {
   background-color: #f6f6f9;
 }
 
-.c31:active {
+.c30:active {
   background-color: #eaeaef;
 }
 
-.c31 .c5 {
+.c30 .c5 {
   color: #32324d;
 }
 
-.c31 svg > g,
-.c31 svg path {
+.c30 svg > g,
+.c30 svg path {
   fill: #32324d;
 }
 
@@ -387,12 +379,12 @@ exports[`ApplicationInfosPage | AddLogoDialog shoud render from computer tab and
   margin: 0;
 }
 
-.c27 {
+.c26 {
   border-radius: 0 0 4px 4px;
   border-top: 1px solid #eaeaef;
 }
 
-.c30 > * + * {
+.c29 > * + * {
   margin-left: 8px;
 }
 
@@ -408,7 +400,7 @@ exports[`ApplicationInfosPage | AddLogoDialog shoud render from computer tab and
   cursor: not-allowed;
 }
 
-.c20 {
+.c19 {
   opacity: 0;
   position: absolute;
   top: 0;
@@ -487,14 +479,14 @@ exports[`ApplicationInfosPage | AddLogoDialog shoud render from computer tab and
                 for="logo-upload"
               >
                 <div
-                  class="c0 c12 c13"
+                  class="c0 c12"
                 >
                   <div
-                    class="c0 c14 c15"
+                    class="c0 c13 c14"
                   >
                     <svg
                       aria-hidden="true"
-                      class="c0 c16 c17"
+                      class="c0 c15 c16"
                       fill="none"
                       height="1em"
                       viewBox="0 0 24 20"
@@ -511,17 +503,17 @@ exports[`ApplicationInfosPage | AddLogoDialog shoud render from computer tab and
                       />
                     </svg>
                     <div
-                      class="c0 c18"
+                      class="c0 c17"
                     >
                       <span
-                        class="c5 c19"
+                        class="c5 c18"
                       >
                         Drag and Drop here or
                       </span>
                     </div>
                     <input
                       accept="image/jpeg,image/png,image/svg+xml"
-                      class="c20"
+                      class="c19"
                       cursor="pointer"
                       id="logo-upload"
                       name="files"
@@ -530,20 +522,20 @@ exports[`ApplicationInfosPage | AddLogoDialog shoud render from computer tab and
                     />
                     <button
                       aria-disabled="false"
-                      class="c21 c22"
+                      class="c20 c21"
                       type="button"
                     >
                       <span
-                        class="c5 c23"
+                        class="c5 c22"
                       >
                         Browse files
                       </span>
                     </button>
                     <div
-                      class="c0 c24"
+                      class="c0 c23"
                     >
                       <span
-                        class="c5 c25"
+                        class="c5 c24"
                       >
                         Max dimension: 750x750, Max size: 100KB
                       </span>
@@ -555,28 +547,28 @@ exports[`ApplicationInfosPage | AddLogoDialog shoud render from computer tab and
           </div>
         </form>
         <div
-          class="c0 c26 c27"
+          class="c0 c25 c26"
         >
           <div
-            class="c0 c28"
+            class="c0 c27"
           >
             <div
-              class="c0 c29 c30"
+              class="c0 c28 c29"
             >
               <button
                 aria-disabled="false"
-                class="c21 c31"
+                class="c20 c30"
                 type="button"
               >
                 <span
-                  class="c5 c23"
+                  class="c5 c22"
                 >
                   Cancel
                 </span>
               </button>
             </div>
             <div
-              class="c0 c29 c30"
+              class="c0 c28 c29"
             />
           </div>
         </div>
@@ -584,7 +576,7 @@ exports[`ApplicationInfosPage | AddLogoDialog shoud render from computer tab and
     </div>
   </div>
   <div
-    class="c32"
+    class="c31"
   >
     <p
       aria-live="polite"
@@ -660,20 +652,6 @@ exports[`ApplicationInfosPage | AddLogoDialog shoud render from url tab and matc
   padding-left: 20px;
 }
 
-.c12 {
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
-  align-items: stretch;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
 .c16 {
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -704,6 +682,20 @@ exports[`ApplicationInfosPage | AddLogoDialog shoud render from url tab and matc
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
+}
+
+.c12 {
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
 }
 
 .c13 > * {

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/ApplicationInfosPage/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/ApplicationInfosPage/index.js
@@ -19,7 +19,6 @@ import {
   Layout,
   Link,
   Main,
-  Stack,
   Typography,
 } from '@strapi/design-system';
 import { ExternalLink, Check } from '@strapi/icons';
@@ -114,9 +113,11 @@ const ApplicationInfosPage = () => {
             }
           />
           <ContentLayout>
-            <Stack spacing={6}>
-              <Stack
-                spacing={4}
+            <Flex direction="column" alignItems="stretch" gap={6}>
+              <Flex
+                direction="column"
+                alignItems="stretch"
+                gap={4}
                 hasRadius
                 background="neutral0"
                 shadow="tableShadow"
@@ -198,7 +199,7 @@ const ApplicationInfosPage = () => {
                   </GridItem>
                   <AdminSeatInfo />
                 </Grid>
-              </Stack>
+              </Flex>
               {canRead && data && (
                 <CustomizationInfos
                   canUpdate={canUpdate}
@@ -206,7 +207,7 @@ const ApplicationInfosPage = () => {
                   projectSettingsStored={data}
                 />
               )}
-            </Stack>
+            </Flex>
           </ContentLayout>
         </form>
       </Main>

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/GlobalActions/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/GlobalActions/index.js
@@ -1,6 +1,6 @@
 import React, { memo, useMemo } from 'react';
 import PropTypes from 'prop-types';
-import { BaseCheckbox, Box, Stack, Typography } from '@strapi/design-system';
+import { BaseCheckbox, Box, Flex, Typography } from '@strapi/design-system';
 import styled from 'styled-components';
 import get from 'lodash/get';
 import IS_DISABLED from 'ee_else_ce/pages/SettingsPage/pages/Roles/EditPage/components/GlobalActions/utils/constants';
@@ -9,9 +9,7 @@ import { usePermissionsDataManager } from '../../../../../../../hooks';
 import { cellWidth, firstRowWidth } from '../Permissions/utils/constants';
 import { findDisplayedActions, getCheckboxesState } from './utils';
 
-const CenteredStack = styled(Stack)`
-  align-items: center;
-  justify-content: center;
+const CenteredStack = styled(Flex)`
   width: ${cellWidth};
   flex-shrink: 0;
 `;
@@ -30,7 +28,7 @@ const GlobalActions = ({ actions, isFormDisabled, kind }) => {
 
   return (
     <Box paddingBottom={4} paddingTop={6} style={{ paddingLeft: firstRowWidth }}>
-      <Stack horizontal spacing={0}>
+      <Flex alignItems="center" justifyContent="center" gap={0}>
         {displayedActions.map(({ label, actionId }) => {
           return (
             <CenteredStack key={actionId} spacing={3}>
@@ -64,7 +62,7 @@ const GlobalActions = ({ actions, isFormDisabled, kind }) => {
             </CenteredStack>
           );
         })}
-      </Stack>
+      </Flex>
     </Box>
   );
 };

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/RoleForm/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/RoleForm/index.js
@@ -4,7 +4,6 @@ import {
   Grid,
   GridItem,
   Flex,
-  Stack,
   Typography,
   Textarea,
   TextInput,
@@ -18,7 +17,7 @@ const RoleForm = ({ disabled, role, values, errors, onChange, onBlur }) => {
 
   return (
     <Box background="neutral0" padding={6} shadow="filterShadow" hasRadius>
-      <Stack spacing={4}>
+      <Flex direction="column" alignItems="stretch" gap={4}>
         <Flex justifyContent="space-between">
           <Box>
             <Box>
@@ -84,7 +83,7 @@ const RoleForm = ({ disabled, role, values, errors, onChange, onBlur }) => {
             </Textarea>
           </GridItem>
         </Grid>
-      </Stack>
+      </Flex>
     </Box>
   );
 };

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/index.js
@@ -8,7 +8,7 @@ import {
   SettingsPageTitle,
   Link,
 } from '@strapi/helper-plugin';
-import { Box, Button, ContentLayout, HeaderLayout, Main, Stack } from '@strapi/design-system';
+import { Box, Button, ContentLayout, HeaderLayout, Main, Flex } from '@strapi/design-system';
 import { Formik } from 'formik';
 import { ArrowLeft } from '@strapi/icons';
 import get from 'lodash/get';
@@ -104,7 +104,7 @@ const EditPage = () => {
           <form onSubmit={handleSubmit}>
             <HeaderLayout
               primaryAction={
-                <Stack horizontal spacing={2}>
+                <Flex gap={2}>
                   <Button
                     disabled={role.code === 'strapi-super-admin'}
                     onClick={handleSubmit}
@@ -116,7 +116,7 @@ const EditPage = () => {
                       defaultMessage: 'Save',
                     })}
                   </Button>
-                </Stack>
+                </Flex>
               }
               title={formatMessage({
                 id: 'Settings.roles.edit.title',
@@ -136,7 +136,7 @@ const EditPage = () => {
               }
             />
             <ContentLayout>
-              <Stack spacing={6}>
+              <Flex direction="column" alignItems="stretch" gap={6}>
                 <RoleForm
                   isLoading={isRoleLoading}
                   disabled={isFormDisabled}
@@ -160,7 +160,7 @@ const EditPage = () => {
                     <LoadingIndicatorPage />
                   </Box>
                 )}
-              </Stack>
+              </Flex>
             </ContentLayout>
           </form>
         )}

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/tests/__snapshots__/index.test.js.snap
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/tests/__snapshots__/index.test.js.snap
@@ -21,13 +21,13 @@ exports[`<EditPage /> renders and matches the snapshot 1`] = `
   color: #666687;
 }
 
-.c22 {
+.c21 {
   font-size: 0.75rem;
   line-height: 1.33;
   color: #8e8ea9;
 }
 
-.c24 {
+.c23 {
   font-size: 0.75rem;
   line-height: 1.33;
   font-weight: 600;
@@ -51,7 +51,7 @@ exports[`<EditPage /> renders and matches the snapshot 1`] = `
   padding-left: 56px;
 }
 
-.c20 {
+.c19 {
   background: #ffffff;
   padding: 24px;
   border-radius: 4px;
@@ -90,7 +90,52 @@ exports[`<EditPage /> renders and matches the snapshot 1`] = `
   flex-direction: row;
 }
 
+.c12 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 8px;
+}
+
 .c18 {
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.c20 {
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.c26 {
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -122,24 +167,6 @@ exports[`<EditPage /> renders and matches the snapshot 1`] = `
   justify-content: space-around;
 }
 
-.c19 > * {
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
-.c19 > * + * {
-  margin-top: 24px;
-}
-
-.c21 > * {
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
-.c21 > * + * {
-  margin-top: 16px;
-}
-
 .c27 > * {
   margin-top: 0;
   margin-bottom: 0;
@@ -147,15 +174,6 @@ exports[`<EditPage /> renders and matches the snapshot 1`] = `
 
 .c27 > * + * {
   margin-top: 4px;
-}
-
-.c12 > * {
-  margin-left: 0;
-  margin-right: 0;
-}
-
-.c12 > * + * {
-  margin-left: 8px;
 }
 
 .c13 {
@@ -296,7 +314,7 @@ exports[`<EditPage /> renders and matches the snapshot 1`] = `
   fill: #ffffff;
 }
 
-.c23 {
+.c22 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -310,7 +328,7 @@ exports[`<EditPage /> renders and matches the snapshot 1`] = `
   background: #f0f0ff;
 }
 
-.c23 .c1 {
+.c22 .c1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -321,60 +339,60 @@ exports[`<EditPage /> renders and matches the snapshot 1`] = `
   align-items: center;
 }
 
-.c23 .c10 {
+.c22 .c10 {
   color: #ffffff;
 }
 
-.c23[aria-disabled='true'] {
+.c22[aria-disabled='true'] {
   border: 1px solid #dcdce4;
   background: #eaeaef;
 }
 
-.c23[aria-disabled='true'] .c10 {
+.c22[aria-disabled='true'] .c10 {
   color: #666687;
 }
 
-.c23[aria-disabled='true'] svg > g,.c23[aria-disabled='true'] svg path {
+.c22[aria-disabled='true'] svg > g,.c22[aria-disabled='true'] svg path {
   fill: #666687;
 }
 
-.c23[aria-disabled='true']:active {
+.c22[aria-disabled='true']:active {
   border: 1px solid #dcdce4;
   background: #eaeaef;
 }
 
-.c23[aria-disabled='true']:active .c10 {
+.c22[aria-disabled='true']:active .c10 {
   color: #666687;
 }
 
-.c23[aria-disabled='true']:active svg > g,.c23[aria-disabled='true']:active svg path {
+.c22[aria-disabled='true']:active svg > g,.c22[aria-disabled='true']:active svg path {
   fill: #666687;
 }
 
-.c23:hover {
+.c22:hover {
   background-color: #ffffff;
 }
 
-.c23:active {
+.c22:active {
   background-color: #ffffff;
   border: 1px solid #4945ff;
 }
 
-.c23:active .c10 {
+.c22:active .c10 {
   color: #4945ff;
 }
 
-.c23:active svg > g,
-.c23:active svg path {
+.c22:active svg > g,
+.c22:active svg path {
   fill: #4945ff;
 }
 
-.c23 .c10 {
+.c22 .c10 {
   color: #271fe0;
 }
 
-.c23 svg > g,
-.c23 svg path {
+.c22 svg > g,
+.c22 svg path {
   fill: #271fe0;
 }
 
@@ -445,13 +463,13 @@ exports[`<EditPage /> renders and matches the snapshot 1`] = `
   will-change: transform;
 }
 
-.c25 {
+.c24 {
   display: grid;
   grid-template-columns: repeat(12,1fr);
   gap: 16px;
 }
 
-.c26 {
+.c25 {
   grid-column: span 6;
   max-width: 100%;
 }
@@ -628,13 +646,13 @@ exports[`<EditPage /> renders and matches the snapshot 1`] = `
 }
 
 @media (max-width:68.75rem) {
-  .c26 {
+  .c25 {
     grid-column: span;
   }
 }
 
 @media (max-width:34.375rem) {
-  .c26 {
+  .c25 {
     grid-column: span;
   }
 }
@@ -699,7 +717,7 @@ exports[`<EditPage /> renders and matches the snapshot 1`] = `
               </h1>
             </div>
             <div
-              class="c1 c9 c12"
+              class="c1 c12"
             >
               <button
                 aria-disabled="false"
@@ -725,13 +743,13 @@ exports[`<EditPage /> renders and matches the snapshot 1`] = `
         class="c1 c17"
       >
         <div
-          class="c1 c18 c19"
+          class="c1 c18"
         >
           <div
-            class="c1 c20"
+            class="c1 c19"
           >
             <div
-              class="c1 c18 c21"
+              class="c1 c20"
             >
               <div
                 class="c1 c8"
@@ -750,28 +768,28 @@ exports[`<EditPage /> renders and matches the snapshot 1`] = `
                     class="c1 "
                   >
                     <span
-                      class="c10 c22"
+                      class="c10 c21"
                     />
                   </div>
                 </div>
                 <button
                   aria-disabled="true"
-                  class="c13 c23"
+                  class="c13 c22"
                   disabled=""
                   type="button"
                 >
                   <span
-                    class="c10 c24"
+                    class="c10 c23"
                   >
                     NaN users with this role
                   </span>
                 </button>
               </div>
               <div
-                class="c1 c25"
+                class="c1 c24"
               >
                 <div
-                  class="c26"
+                  class="c25"
                 >
                   <div
                     class="c1 "
@@ -779,10 +797,10 @@ exports[`<EditPage /> renders and matches the snapshot 1`] = `
                     <div>
                       <div>
                         <div
-                          class="c1 c18 c27"
+                          class="c1 c26 c27"
                         >
                           <label
-                            class="c10 c24"
+                            class="c10 c23"
                             for="1"
                           >
                             <div
@@ -810,7 +828,7 @@ exports[`<EditPage /> renders and matches the snapshot 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c26"
+                  class="c25"
                 >
                   <div
                     class="c1 "
@@ -820,13 +838,13 @@ exports[`<EditPage /> renders and matches the snapshot 1`] = `
                     >
                       <div>
                         <div
-                          class="c1 c18 c27"
+                          class="c1 c26 c27"
                         >
                           <div
                             class="c1 c9"
                           >
                             <label
-                              class="c10 c24"
+                              class="c10 c23"
                               for="3"
                             >
                               <div
@@ -856,7 +874,7 @@ exports[`<EditPage /> renders and matches the snapshot 1`] = `
             </div>
           </div>
           <div
-            class="c1 c20"
+            class="c1 c19"
           >
             <div
               class="c1 c33 c34"

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/TransferTokens/EditView/components/FormTransferTokenContainer/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/TransferTokens/EditView/components/FormTransferTokenContainer/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useIntl } from 'react-intl';
 import PropTypes from 'prop-types';
-import { Box, Grid, GridItem, Stack, Typography } from '@strapi/design-system';
+import { Box, Grid, GridItem, Flex, Typography } from '@strapi/design-system';
 import LifeSpanInput from '../../../../../components/Tokens/LifeSpanInput';
 import TokenName from '../../../../../components/Tokens/TokenName';
 import TokenDescription from '../../../../../components/Tokens/TokenDescription';
@@ -26,7 +26,7 @@ const FormTransferTokenContainer = ({
       paddingLeft={7}
       paddingRight={7}
     >
-      <Stack spacing={4}>
+      <Flex direction="column" alignItems="stretch" gap={4}>
         <Typography variant="delta" as="h2">
           {formatMessage({
             id: 'global.details',
@@ -60,7 +60,7 @@ const FormTransferTokenContainer = ({
             />
           </GridItem>
         </Grid>
-      </Stack>
+      </Flex>
     </Box>
   );
 };

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/TransferTokens/EditView/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/TransferTokens/EditView/index.js
@@ -14,7 +14,7 @@ import {
   useRBAC,
   useFetchClient,
 } from '@strapi/helper-plugin';
-import { ContentLayout, Main, Stack } from '@strapi/design-system';
+import { ContentLayout, Main, Flex } from '@strapi/design-system';
 import { formatAPIErrors } from '../../../../../utils';
 import { schema } from './utils';
 import LoadingView from './components/LoadingView';
@@ -194,7 +194,7 @@ const TransferTokenCreateView = () => {
                 regenerateUrl="/admin/transfer/tokens/"
               />
               <ContentLayout>
-                <Stack spacing={6}>
+                <Flex direction="column" alignItems="stretch" gap={6}>
                   {Boolean(transferToken?.name) && (
                     <TokenBox token={transferToken?.accessKey} tokenType={TRANSFER_TOKEN_TYPE} />
                   )}
@@ -206,7 +206,7 @@ const TransferTokenCreateView = () => {
                     values={values}
                     transferToken={transferToken}
                   />
-                </Stack>
+                </Flex>
               </ContentLayout>
             </Form>
           );

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/TransferTokens/EditView/tests/__snapshots__/index.test.js.snap
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/TransferTokens/EditView/tests/__snapshots__/index.test.js.snap
@@ -15,7 +15,7 @@ exports[`ADMIN | Pages | TRANSFER TOKENS | EditView renders and matches the snap
   color: #32324d;
 }
 
-.c23 {
+.c22 {
   font-weight: 500;
   font-size: 1rem;
   line-height: 1.25;
@@ -65,7 +65,7 @@ exports[`ADMIN | Pages | TRANSFER TOKENS | EditView renders and matches the snap
   padding-left: 56px;
 }
 
-.c21 {
+.c20 {
   background: #ffffff;
   padding-top: 24px;
   padding-right: 32px;
@@ -116,7 +116,52 @@ exports[`ADMIN | Pages | TRANSFER TOKENS | EditView renders and matches the snap
   flex-direction: row;
 }
 
+.c12 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 8px;
+}
+
 .c19 {
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.c21 {
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.c25 {
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -130,24 +175,6 @@ exports[`ADMIN | Pages | TRANSFER TOKENS | EditView renders and matches the snap
   flex-direction: column;
 }
 
-.c20 > * {
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
-.c20 > * + * {
-  margin-top: 24px;
-}
-
-.c22 > * {
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
-.c22 > * + * {
-  margin-top: 16px;
-}
-
 .c26 > * {
   margin-top: 0;
   margin-bottom: 0;
@@ -155,15 +182,6 @@ exports[`ADMIN | Pages | TRANSFER TOKENS | EditView renders and matches the snap
 
 .c26 > * + * {
   margin-top: 4px;
-}
-
-.c12 > * {
-  margin-left: 0;
-  margin-right: 0;
-}
-
-.c12 > * + * {
-  margin-left: 8px;
 }
 
 .c13 {
@@ -446,13 +464,13 @@ exports[`ADMIN | Pages | TRANSFER TOKENS | EditView renders and matches the snap
   width: 100%;
 }
 
-.c24 {
+.c23 {
   display: grid;
   grid-template-columns: repeat(12,1fr);
   gap: 20px;
 }
 
-.c25 {
+.c24 {
   grid-column: span 6;
   max-width: 100%;
 }
@@ -625,13 +643,13 @@ exports[`ADMIN | Pages | TRANSFER TOKENS | EditView renders and matches the snap
 }
 
 @media (max-width:68.75rem) {
-  .c25 {
+  .c24 {
     grid-column: span;
   }
 }
 
 @media (max-width:34.375rem) {
-  .c25 {
+  .c24 {
     grid-column: span 12;
   }
 }
@@ -699,7 +717,7 @@ exports[`ADMIN | Pages | TRANSFER TOKENS | EditView renders and matches the snap
               </h1>
             </div>
             <div
-              class="c1 c9 c12"
+              class="c1 c12"
             >
               <button
                 aria-disabled="false"
@@ -737,24 +755,24 @@ exports[`ADMIN | Pages | TRANSFER TOKENS | EditView renders and matches the snap
         class="c1 c18"
       >
         <div
-          class="c1 c19 c20"
+          class="c1 c19"
         >
           <div
-            class="c1 c21"
+            class="c1 c20"
           >
             <div
-              class="c1 c19 c22"
+              class="c1 c21"
             >
               <h2
-                class="c10 c23"
+                class="c10 c22"
               >
                 Details
               </h2>
               <div
-                class="c1 c24"
+                class="c1 c23"
               >
                 <div
-                  class="c25"
+                  class="c24"
                 >
                   <div
                     class="c1 "
@@ -762,7 +780,7 @@ exports[`ADMIN | Pages | TRANSFER TOKENS | EditView renders and matches the snap
                     <div>
                       <div>
                         <div
-                          class="c1 c19 c26"
+                          class="c1 c25 c26"
                         >
                           <label
                             class="c10 c17"
@@ -798,7 +816,7 @@ exports[`ADMIN | Pages | TRANSFER TOKENS | EditView renders and matches the snap
                   </div>
                 </div>
                 <div
-                  class="c25"
+                  class="c24"
                 >
                   <div
                     class="c1 "
@@ -808,7 +826,7 @@ exports[`ADMIN | Pages | TRANSFER TOKENS | EditView renders and matches the snap
                     >
                       <div>
                         <div
-                          class="c1 c19 c26"
+                          class="c1 c25 c26"
                         >
                           <div
                             class="c1 c9"
@@ -841,14 +859,14 @@ exports[`ADMIN | Pages | TRANSFER TOKENS | EditView renders and matches the snap
                   </div>
                 </div>
                 <div
-                  class="c25"
+                  class="c24"
                 >
                   <div
                     class="c1 "
                   >
                     <div>
                       <div
-                        class="c1 c19 c26"
+                        class="c1 c25 c26"
                       >
                         <label
                           class="c10 c17"
@@ -977,33 +995,33 @@ exports[`ADMIN | Pages | TRANSFER TOKENS | EditView renders and matches the snap
   color: #32324d;
 }
 
-.c26 {
+.c25 {
   font-size: 0.75rem;
   line-height: 1.33;
   font-weight: 500;
   color: #32324d;
 }
 
-.c28 {
+.c27 {
   font-size: 0.875rem;
   line-height: 1.43;
   color: #666687;
 }
 
-.c31 {
+.c30 {
   font-weight: 500;
   font-size: 1rem;
   line-height: 1.25;
   color: #32324d;
 }
 
-.c34 {
+.c35 {
   font-size: 0.875rem;
   line-height: 1.43;
   color: #d02b20;
 }
 
-.c45 {
+.c46 {
   font-size: 0.875rem;
   line-height: 1.43;
   display: block;
@@ -1013,7 +1031,7 @@ exports[`ADMIN | Pages | TRANSFER TOKENS | EditView renders and matches the snap
   color: #666687;
 }
 
-.c49 {
+.c50 {
   font-size: 0.75rem;
   line-height: 1.33;
   color: #666687;
@@ -1040,20 +1058,20 @@ exports[`ADMIN | Pages | TRANSFER TOKENS | EditView renders and matches the snap
   padding-bottom: 8px;
 }
 
-.c22 {
+.c21 {
   background: #ffffff;
   padding: 24px;
   border-radius: 4px;
   box-shadow: 0px 1px 4px rgba(33,33,52,0.1);
 }
 
-.c23 {
+.c22 {
   background: #f6f6f9;
   padding: 12px;
   border-radius: 4px;
 }
 
-.c29 {
+.c28 {
   background: #ffffff;
   padding-top: 24px;
   padding-right: 32px;
@@ -1063,12 +1081,12 @@ exports[`ADMIN | Pages | TRANSFER TOKENS | EditView renders and matches the snap
   box-shadow: 0px 1px 4px rgba(33,33,52,0.1);
 }
 
-.c44 {
+.c45 {
   padding-right: 16px;
   padding-left: 16px;
 }
 
-.c46 {
+.c47 {
   padding-left: 12px;
 }
 
@@ -1104,7 +1122,67 @@ exports[`ADMIN | Pages | TRANSFER TOKENS | EditView renders and matches the snap
   flex-direction: row;
 }
 
+.c12 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 8px;
+}
+
 .c20 {
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.c24 {
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.c29 {
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.c33 {
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -1118,40 +1196,13 @@ exports[`ADMIN | Pages | TRANSFER TOKENS | EditView renders and matches the snap
   flex-direction: column;
 }
 
-.c21 > * {
+.c34 > * {
   margin-top: 0;
   margin-bottom: 0;
 }
 
-.c21 > * + * {
-  margin-top: 24px;
-}
-
-.c25 > * {
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
-.c25 > * + * {
+.c34 > * + * {
   margin-top: 4px;
-}
-
-.c30 > * {
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
-.c30 > * + * {
-  margin-top: 16px;
-}
-
-.c12 > * {
-  margin-left: 0;
-  margin-right: 0;
-}
-
-.c12 > * + * {
-  margin-left: 8px;
 }
 
 .c13 {
@@ -1212,7 +1263,7 @@ exports[`ADMIN | Pages | TRANSFER TOKENS | EditView renders and matches the snap
   border: 2px solid #4945ff;
 }
 
-.c50 {
+.c51 {
   border: 0;
   -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
@@ -1228,7 +1279,7 @@ exports[`ADMIN | Pages | TRANSFER TOKENS | EditView renders and matches the snap
   height: 100%;
 }
 
-.c51 .c1 {
+.c52 .c1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1239,15 +1290,15 @@ exports[`ADMIN | Pages | TRANSFER TOKENS | EditView renders and matches the snap
   align-items: center;
 }
 
-.c51 .c10 {
+.c52 .c10 {
   color: #ffffff;
 }
 
-.c51[aria-disabled='true'] .c10 {
+.c52[aria-disabled='true'] .c10 {
   color: #666687;
 }
 
-.c51[aria-disabled='true']:active .c10 {
+.c52[aria-disabled='true']:active .c10 {
   color: #666687;
 }
 
@@ -1391,11 +1442,11 @@ exports[`ADMIN | Pages | TRANSFER TOKENS | EditView renders and matches the snap
   fill: #ffffff;
 }
 
-.c35 {
+.c36 {
   line-height: 0;
 }
 
-.c37 {
+.c38 {
   border: none;
   border-radius: 4px;
   padding-bottom: 0.65625rem;
@@ -1410,36 +1461,36 @@ exports[`ADMIN | Pages | TRANSFER TOKENS | EditView renders and matches the snap
   background: inherit;
 }
 
-.c37::-webkit-input-placeholder {
+.c38::-webkit-input-placeholder {
   color: #8e8ea9;
   opacity: 1;
 }
 
-.c37::-moz-placeholder {
+.c38::-moz-placeholder {
   color: #8e8ea9;
   opacity: 1;
 }
 
-.c37:-ms-input-placeholder {
+.c38:-ms-input-placeholder {
   color: #8e8ea9;
   opacity: 1;
 }
 
-.c37::placeholder {
+.c38::placeholder {
   color: #8e8ea9;
   opacity: 1;
 }
 
-.c37[aria-disabled='true'] {
+.c38[aria-disabled='true'] {
   color: inherit;
 }
 
-.c37:focus {
+.c38:focus {
   outline: none;
   box-shadow: none;
 }
 
-.c36 {
+.c37 {
   border: 1px solid #dcdce4;
   border-radius: 4px;
   background: #ffffff;
@@ -1451,12 +1502,12 @@ exports[`ADMIN | Pages | TRANSFER TOKENS | EditView renders and matches the snap
   transition-duration: 0.2s;
 }
 
-.c36:focus-within {
+.c37:focus-within {
   border: 1px solid #4945ff;
   box-shadow: #4945ff 0px 0px 0px 2px;
 }
 
-.c41 {
+.c42 {
   position: relative;
   border: 1px solid #dcdce4;
   padding-right: 12px;
@@ -1474,28 +1525,28 @@ exports[`ADMIN | Pages | TRANSFER TOKENS | EditView renders and matches the snap
   transition-duration: 0.2s;
 }
 
-.c41:focus-within {
+.c42:focus-within {
   border: 1px solid #4945ff;
   box-shadow: #4945ff 0px 0px 0px 2px;
 }
 
-.c47 {
+.c48 {
   background: transparent;
   border: none;
   position: relative;
   z-index: 1;
 }
 
-.c47 svg {
+.c48 svg {
   height: 0.6875rem;
   width: 0.6875rem;
 }
 
-.c47 svg path {
+.c48 svg path {
   fill: #666687;
 }
 
-.c48 {
+.c49 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1505,11 +1556,11 @@ exports[`ADMIN | Pages | TRANSFER TOKENS | EditView renders and matches the snap
   cursor: not-allowed;
 }
 
-.c48 svg {
+.c49 svg {
   width: 0.375rem;
 }
 
-.c42 {
+.c43 {
   position: absolute;
   left: 0;
   right: 0;
@@ -1520,25 +1571,25 @@ exports[`ADMIN | Pages | TRANSFER TOKENS | EditView renders and matches the snap
   border: none;
 }
 
-.c42:focus {
+.c43:focus {
   outline: none;
 }
 
-.c42[aria-disabled='true'] {
+.c43[aria-disabled='true'] {
   cursor: not-allowed;
 }
 
-.c43 {
+.c44 {
   width: 100%;
 }
 
-.c32 {
+.c31 {
   display: grid;
   grid-template-columns: repeat(12,1fr);
   gap: 20px;
 }
 
-.c33 {
+.c32 {
   grid-column: span 6;
   max-width: 100%;
 }
@@ -1547,7 +1598,7 @@ exports[`ADMIN | Pages | TRANSFER TOKENS | EditView renders and matches the snap
   outline: none;
 }
 
-.c39 {
+.c40 {
   border: 1px solid #dcdce4;
   border-radius: 4px;
   padding-left: 16px;
@@ -1563,12 +1614,12 @@ exports[`ADMIN | Pages | TRANSFER TOKENS | EditView renders and matches the snap
   transition-duration: 0.2s;
 }
 
-.c39:focus-within {
+.c40:focus-within {
   border: 1px solid #4945ff;
   box-shadow: #4945ff 0px 0px 0px 2px;
 }
 
-.c40 {
+.c41 {
   display: block;
   width: 100%;
   font-weight: 400;
@@ -1579,36 +1630,36 @@ exports[`ADMIN | Pages | TRANSFER TOKENS | EditView renders and matches the snap
   background: inherit;
 }
 
-.c40::-webkit-input-placeholder {
+.c41::-webkit-input-placeholder {
   color: #8e8ea9;
   opacity: 1;
 }
 
-.c40::-moz-placeholder {
+.c41::-moz-placeholder {
   color: #8e8ea9;
   opacity: 1;
 }
 
-.c40:-ms-input-placeholder {
+.c41:-ms-input-placeholder {
   color: #8e8ea9;
   opacity: 1;
 }
 
-.c40::placeholder {
+.c41::placeholder {
   color: #8e8ea9;
   opacity: 1;
 }
 
-.c40:focus-within {
+.c41:focus-within {
   outline: none;
 }
 
-.c38 textarea {
+.c39 textarea {
   height: 5rem;
   line-height: 1.25rem;
 }
 
-.c38 textarea::-webkit-input-placeholder {
+.c39 textarea::-webkit-input-placeholder {
   font-weight: 400;
   font-size: 0.875rem;
   line-height: 1.43;
@@ -1616,7 +1667,7 @@ exports[`ADMIN | Pages | TRANSFER TOKENS | EditView renders and matches the snap
   opacity: 1;
 }
 
-.c38 textarea::-moz-placeholder {
+.c39 textarea::-moz-placeholder {
   font-weight: 400;
   font-size: 0.875rem;
   line-height: 1.43;
@@ -1624,7 +1675,7 @@ exports[`ADMIN | Pages | TRANSFER TOKENS | EditView renders and matches the snap
   opacity: 1;
 }
 
-.c38 textarea:-ms-input-placeholder {
+.c39 textarea:-ms-input-placeholder {
   font-weight: 400;
   font-size: 0.875rem;
   line-height: 1.43;
@@ -1632,7 +1683,7 @@ exports[`ADMIN | Pages | TRANSFER TOKENS | EditView renders and matches the snap
   opacity: 1;
 }
 
-.c38 textarea::placeholder {
+.c39 textarea::placeholder {
   font-weight: 400;
   font-size: 0.875rem;
   line-height: 1.43;
@@ -1640,16 +1691,16 @@ exports[`ADMIN | Pages | TRANSFER TOKENS | EditView renders and matches the snap
   opacity: 1;
 }
 
-.c24 {
+.c23 {
   margin-right: 24px;
 }
 
-.c24 svg {
+.c23 svg {
   width: 2rem;
   height: 2rem;
 }
 
-.c27 {
+.c26 {
   word-break: break-all;
 }
 
@@ -1724,13 +1775,13 @@ exports[`ADMIN | Pages | TRANSFER TOKENS | EditView renders and matches the snap
 }
 
 @media (max-width:68.75rem) {
-  .c33 {
+  .c32 {
     grid-column: span;
   }
 }
 
 @media (max-width:34.375rem) {
-  .c33 {
+  .c32 {
     grid-column: span 12;
   }
 }
@@ -1798,7 +1849,7 @@ exports[`ADMIN | Pages | TRANSFER TOKENS | EditView renders and matches the snap
               </h1>
             </div>
             <div
-              class="c1 c9 c12"
+              class="c1 c12"
             >
               <button
                 aria-disabled="false"
@@ -1867,13 +1918,13 @@ exports[`ADMIN | Pages | TRANSFER TOKENS | EditView renders and matches the snap
         class="c1 c19"
       >
         <div
-          class="c1 c20 c21"
+          class="c1 c20"
         >
           <div
-            class="c1 c22 c9"
+            class="c1 c21 c9"
           >
             <div
-              class="c1 c23 c9 c24"
+              class="c1 c22 c9 c23"
             >
               <svg
                 fill="none"
@@ -1889,40 +1940,40 @@ exports[`ADMIN | Pages | TRANSFER TOKENS | EditView renders and matches the snap
               </svg>
             </div>
             <div
-              class="c1 c20 c25"
+              class="c1 c24"
             >
               <div
                 class="c1 c9"
               >
                 <span
-                  class="c10 c26 c27"
+                  class="c10 c25 c26"
                 >
                   This token isn’t accessible anymore.
                 </span>
               </div>
               <span
-                class="c10 c28"
+                class="c10 c27"
               >
                 For security reasons, you can only see your token once.
               </span>
             </div>
           </div>
           <div
-            class="c1 c29"
+            class="c1 c28"
           >
             <div
-              class="c1 c20 c30"
+              class="c1 c29"
             >
               <h2
-                class="c10 c31"
+                class="c10 c30"
               >
                 Details
               </h2>
               <div
-                class="c1 c32"
+                class="c1 c31"
               >
                 <div
-                  class="c33"
+                  class="c32"
                 >
                   <div
                     class="c1 "
@@ -1930,7 +1981,7 @@ exports[`ADMIN | Pages | TRANSFER TOKENS | EditView renders and matches the snap
                     <div>
                       <div>
                         <div
-                          class="c1 c20 c25"
+                          class="c1 c33 c34"
                         >
                           <label
                             class="c10 c17"
@@ -1941,20 +1992,20 @@ exports[`ADMIN | Pages | TRANSFER TOKENS | EditView renders and matches the snap
                             >
                               Name
                               <span
-                                class="c10 c34 c35"
+                                class="c10 c35 c36"
                               >
                                 *
                               </span>
                             </div>
                           </label>
                           <div
-                            class="c1 c8 c36"
+                            class="c1 c8 c37"
                           >
                             <input
                               aria-disabled="false"
                               aria-invalid="false"
                               aria-required="true"
-                              class="c37"
+                              class="c38"
                               id="8"
                               name="name"
                               value="My super token"
@@ -1966,17 +2017,17 @@ exports[`ADMIN | Pages | TRANSFER TOKENS | EditView renders and matches the snap
                   </div>
                 </div>
                 <div
-                  class="c33"
+                  class="c32"
                 >
                   <div
                     class="c1 "
                   >
                     <div
-                      class="c38"
+                      class="c39"
                     >
                       <div>
                         <div
-                          class="c1 c20 c25"
+                          class="c1 c33 c34"
                         >
                           <div
                             class="c1 c9"
@@ -1993,12 +2044,12 @@ exports[`ADMIN | Pages | TRANSFER TOKENS | EditView renders and matches the snap
                             </label>
                           </div>
                           <div
-                            class="c39"
+                            class="c40"
                           >
                             <textarea
                               aria-invalid="false"
                               aria-required="false"
-                              class="c40"
+                              class="c41"
                               id="10"
                               name="description"
                             >
@@ -2011,14 +2062,14 @@ exports[`ADMIN | Pages | TRANSFER TOKENS | EditView renders and matches the snap
                   </div>
                 </div>
                 <div
-                  class="c33"
+                  class="c32"
                 >
                   <div
                     class="c1 "
                   >
                     <div>
                       <div
-                        class="c1 c20 c25"
+                        class="c1 c33 c34"
                       >
                         <label
                           class="c10 c17"
@@ -2029,14 +2080,14 @@ exports[`ADMIN | Pages | TRANSFER TOKENS | EditView renders and matches the snap
                           >
                             Token duration
                             <span
-                              class="c10 c34 c35"
+                              class="c10 c35 c36"
                             >
                               *
                             </span>
                           </div>
                         </label>
                         <div
-                          class="c1 c9 c41"
+                          class="c1 c9 c42"
                           disabled=""
                         >
                           <button
@@ -2044,22 +2095,22 @@ exports[`ADMIN | Pages | TRANSFER TOKENS | EditView renders and matches the snap
                             aria-expanded="false"
                             aria-haspopup="listbox"
                             aria-labelledby="12 12-label 12-content"
-                            class="c42"
+                            class="c43"
                             id="12"
                             name="lifespan"
                             type="button"
                           />
                           <div
-                            class="c1 c8 c43"
+                            class="c1 c8 c44"
                           >
                             <div
                               class="c1 c9"
                             >
                               <div
-                                class="c1 c44"
+                                class="c1 c45"
                               >
                                 <span
-                                  class="c10 c45"
+                                  class="c10 c46"
                                   id="12-content"
                                 >
                                   Select
@@ -2071,7 +2122,7 @@ exports[`ADMIN | Pages | TRANSFER TOKENS | EditView renders and matches the snap
                             >
                               <button
                                 aria-hidden="true"
-                                class="c1 c46 c47 c48"
+                                class="c1 c47 c48 c49"
                                 disabled=""
                                 tabindex="-1"
                                 title="Carret Down Button"
@@ -2098,7 +2149,7 @@ exports[`ADMIN | Pages | TRANSFER TOKENS | EditView renders and matches the snap
                       </div>
                     </div>
                     <span
-                      class="c10 c49"
+                      class="c10 c50"
                     >
                       Expiration date: Unlimited
                     </span>
@@ -2112,7 +2163,7 @@ exports[`ADMIN | Pages | TRANSFER TOKENS | EditView renders and matches the snap
     </form>
   </main>
   <div
-    class="c50"
+    class="c51"
   >
     <p
       aria-live="polite"

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Users/EditPage/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Users/EditPage/index.js
@@ -28,7 +28,7 @@ import {
   ContentLayout,
   Typography,
   Main,
-  Stack,
+  Flex,
 } from '@strapi/design-system';
 import { ArrowLeft, Check } from '@strapi/icons';
 import MagicLink from 'ee_else_ce/pages/SettingsPage/pages/Users/components/MagicLink';
@@ -205,7 +205,7 @@ const EditPage = ({ canUpdate }) => {
                     <MagicLink registrationToken={data.registrationToken} />
                   </Box>
                 )}
-                <Stack spacing={7}>
+                <Flex direction="column" alignItems="stretch" gap={7}>
                   <Box
                     background="neutral0"
                     hasRadius
@@ -215,7 +215,7 @@ const EditPage = ({ canUpdate }) => {
                     paddingLeft={7}
                     paddingRight={7}
                   >
-                    <Stack spacing={4}>
+                    <Flex direction="column" alignItems="stretch" gap={4}>
                       <Typography variant="delta" as="h2">
                         {formatMessage({
                           id: 'app.components.Users.ModalCreateBody.block-title.details',
@@ -239,7 +239,7 @@ const EditPage = ({ canUpdate }) => {
                           });
                         })}
                       </Grid>
-                    </Stack>
+                    </Flex>
                   </Box>
                   <Box
                     background="neutral0"
@@ -250,7 +250,7 @@ const EditPage = ({ canUpdate }) => {
                     paddingLeft={7}
                     paddingRight={7}
                   >
-                    <Stack spacing={4}>
+                    <Flex direction="column" alignItems="stretch" gap={4}>
                       <Typography variant="delta" as="h2">
                         {formatMessage({
                           id: 'global.roles',
@@ -267,9 +267,9 @@ const EditPage = ({ canUpdate }) => {
                           />
                         </GridItem>
                       </Grid>
-                    </Stack>
+                    </Flex>
                   </Box>
-                </Stack>
+                </Flex>
               </ContentLayout>
             </Form>
           );

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Users/ListPage/ModalForm/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Users/ListPage/ModalForm/index.js
@@ -12,7 +12,7 @@ import {
   Crumb,
   Box,
   Button,
-  Stack,
+  Flex,
   Typography,
 } from '@strapi/design-system';
 
@@ -128,7 +128,7 @@ const ModalForm = ({ queryName, onToggle }) => {
           return (
             <Form>
               <ModalBody>
-                <Stack spacing={6}>
+                <Flex direction="column" alignItems="stretch" gap={6}>
                   {currentStep !== 'create' && <MagicLink registrationToken={registrationToken} />}
                   <Box>
                     <Typography variant="beta" as="h2">
@@ -138,7 +138,7 @@ const ModalForm = ({ queryName, onToggle }) => {
                       })}
                     </Typography>
                     <Box paddingTop={4}>
-                      <Stack spacing={1}>
+                      <Flex direction="column" alignItems="stretch" gap={1}>
                         <Grid gap={5}>
                           {layout.map((row) => {
                             return row.map((input) => {
@@ -156,7 +156,7 @@ const ModalForm = ({ queryName, onToggle }) => {
                             });
                           })}
                         </Grid>
-                      </Stack>
+                      </Flex>
                     </Box>
                   </Box>
                   <Box>
@@ -193,7 +193,7 @@ const ModalForm = ({ queryName, onToggle }) => {
                       </Grid>
                     </Box>
                   </Box>
-                </Stack>
+                </Flex>
               </ModalBody>
               <ModalFooter
                 startActions={

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Webhooks/EditView/components/EventInput/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Webhooks/EditView/components/EventInput/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FieldLabel, Stack, Typography } from '@strapi/design-system';
+import { FieldLabel, Flex, Typography } from '@strapi/design-system';
 import { useFormikContext } from 'formik';
 import { useIntl } from 'react-intl';
 import styled from 'styled-components';
@@ -97,7 +97,7 @@ const EventInput = ({ isDraftAndPublish }) => {
   };
 
   return (
-    <Stack spacing={1}>
+    <Flex direction="column" alignItems="stretch" gap={1}>
       <FieldLabel>
         {formatMessage({
           id: 'Settings.webhooks.form.events',
@@ -152,7 +152,7 @@ const EventInput = ({ isDraftAndPublish }) => {
           })}
         </tbody>
       </StyledTable>
-    </Stack>
+    </Flex>
   );
 };
 

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Webhooks/EditView/components/HeadersInput/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Webhooks/EditView/components/HeadersInput/index.js
@@ -7,7 +7,6 @@ import {
   Grid,
   GridItem,
   Flex,
-  Stack,
   TextInput,
   TextButton,
 } from '@strapi/design-system';
@@ -20,7 +19,7 @@ const HeadersInput = () => {
   const { values, errors } = useFormikContext();
 
   return (
-    <Stack spacing={1}>
+    <Flex direction="column" alignItems="stretch" gap={1}>
       <FieldLabel>
         {formatMessage({
           id: 'Settings.webhooks.form.headers',
@@ -112,7 +111,7 @@ const HeadersInput = () => {
           )}
         />
       </Box>
-    </Stack>
+    </Flex>
   );
 };
 

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Webhooks/EditView/components/TriggerContainer/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Webhooks/EditView/components/TriggerContainer/index.js
@@ -4,7 +4,7 @@ import { useIntl } from 'react-intl';
 import styled from 'styled-components';
 import { pxToRem } from '@strapi/helper-plugin';
 import { Check, Cross, Loader } from '@strapi/icons';
-import { Box, Flex, Typography, Stack, Grid, GridItem } from '@strapi/design-system';
+import { Box, Flex, Typography, Grid, GridItem } from '@strapi/design-system';
 
 // Being discussed in Notion: create a <Icon /> component in Parts
 const Icon = styled.svg(
@@ -23,34 +23,34 @@ const Status = ({ isPending, statusCode }) => {
 
   if (isPending) {
     return (
-      <Stack horizontal spacing={2} style={{ alignItems: 'center' }}>
+      <Flex gap={2} alignItems="center">
         <Icon as={Loader} />
         <Typography>
           {formatMessage({ id: 'Settings.webhooks.trigger.pending', defaultMessage: 'pending' })}
         </Typography>
-      </Stack>
+      </Flex>
     );
   }
 
   if (statusCode >= 200 && statusCode < 300) {
     return (
-      <Stack horizontal spacing={2} style={{ alignItems: 'center' }}>
+      <Flex gap={2} alignItems="center">
         <Icon as={Check} color="success700" />
         <Typography>
           {formatMessage({ id: 'Settings.webhooks.trigger.success', defaultMessage: 'success' })}
         </Typography>
-      </Stack>
+      </Flex>
     );
   }
 
   if (statusCode >= 300) {
     return (
-      <Stack horizontal spacing={2} style={{ alignItems: 'center' }}>
+      <Flex gap={2} alignItems="center">
         <Icon as={Cross} color="danger700" />
         <Typography>
           {formatMessage({ id: 'Settings.error', defaultMessage: 'error' })} {statusCode}
         </Typography>
-      </Stack>
+      </Flex>
     );
   }
 
@@ -109,12 +109,12 @@ const CancelButton = ({ onCancel }) => {
   return (
     <Flex justifyContent="flex-end">
       <button onClick={onCancel} type="button">
-        <Stack horizontal spacing={2} style={{ alignItems: 'center' }}>
+        <Flex gap={2} alignItems="center">
           <Typography textColor="neutral400">
             {formatMessage({ id: 'Settings.webhooks.trigger.cancel', defaultMessage: 'cancel' })}
           </Typography>
           <Icon as={Cross} color="neutral400" />
-        </Stack>
+        </Flex>
       </button>
     </Flex>
   );

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Webhooks/EditView/components/WebhookForm/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Webhooks/EditView/components/WebhookForm/index.js
@@ -7,7 +7,7 @@ import {
   HeaderLayout,
   Box,
   Button,
-  Stack,
+  Flex,
   TextInput,
   Grid,
   GridItem,
@@ -51,7 +51,7 @@ const WebhookForm = ({
         <Form noValidate>
           <HeaderLayout
             primaryAction={
-              <Stack horizontal spacing={2}>
+              <Flex gap={2}>
                 <Button
                   onClick={() => {
                     triggerWebhook();
@@ -73,7 +73,7 @@ const WebhookForm = ({
                     defaultMessage: 'Save',
                   })}
                 </Button>
-              </Stack>
+              </Flex>
             }
             title={
               isCreating
@@ -93,7 +93,7 @@ const WebhookForm = ({
             }
           />
           <ContentLayout>
-            <Stack spacing={4}>
+            <Flex direction="column" alignItems="stretch" gap={4}>
               {showTriggerResponse && (
                 <div className="trigger-wrapper">
                   <TriggerContainer
@@ -104,7 +104,7 @@ const WebhookForm = ({
                 </div>
               )}
               <Box background="neutral0" padding={8} shadow="filterShadow" hasRadius>
-                <Stack spacing={6}>
+                <Flex direction="column" alignItems="stretch" gap={6}>
                   <Grid gap={6}>
                     <GridItem col={6}>
                       <Field
@@ -133,9 +133,9 @@ const WebhookForm = ({
                   </Grid>
                   <HeadersInput />
                   <EventInput isDraftAndPublish={isDraftAndPublishEvents} />
-                </Stack>
+                </Flex>
               </Box>
-            </Stack>
+            </Flex>
           </ContentLayout>
         </Form>
       )}

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Webhooks/ListView/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Webhooks/ListView/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-nested-ternary */
 /**
  *
  * ListView
@@ -26,7 +27,6 @@ import {
   ActionLayout,
   EmptyStateLayout,
   Flex,
-  Stack,
   IconButton,
   BaseCheckbox,
   Table,
@@ -303,178 +303,171 @@ const ListView = () => {
             <Box background="neutral0" padding={6} shadow="filterShadow" hasRadius>
               <LoadingIndicatorPage />
             </Box>
-          ) : (
-            <>
-              {rowsCount > 0 ? (
-                <Table
-                  colCount={5}
-                  rowCount={rowsCount + 1}
-                  footer={
-                    <TFooter
-                      onClick={() => (canCreate ? handleGoTo('create') : {})}
-                      icon={<Plus />}
-                    >
-                      {formatMessage({
-                        id: 'Settings.webhooks.list.button.add',
-                        defaultMessage: 'Create new webhook',
+          ) : rowsCount > 0 ? (
+            <Table
+              colCount={5}
+              rowCount={rowsCount + 1}
+              footer={
+                <TFooter onClick={() => (canCreate ? handleGoTo('create') : {})} icon={<Plus />}>
+                  {formatMessage({
+                    id: 'Settings.webhooks.list.button.add',
+                    defaultMessage: 'Create new webhook',
+                  })}
+                </TFooter>
+              }
+            >
+              <Thead>
+                <Tr>
+                  <Th>
+                    <BaseCheckbox
+                      aria-label={formatMessage({
+                        id: 'global.select-all-entries',
+                        defaultMessage: 'Select all entries',
                       })}
-                    </TFooter>
-                  }
-                >
-                  <Thead>
-                    <Tr>
-                      <Th>
-                        <BaseCheckbox
-                          aria-label={formatMessage({
-                            id: 'global.select-all-entries',
-                            defaultMessage: 'Select all entries',
+                      indeterminate={
+                        webhooksToDeleteLength > 0 && webhooksToDeleteLength < rowsCount
+                      }
+                      value={webhooksToDeleteLength === rowsCount}
+                      onValueChange={handleSelectAllCheckbox}
+                    />
+                  </Th>
+                  <Th width="20%">
+                    <Typography variant="sigma" textColor="neutral600">
+                      {formatMessage({
+                        id: 'global.name',
+                        defaultMessage: 'Name',
+                      })}
+                    </Typography>
+                  </Th>
+                  <Th width="60%">
+                    <Typography variant="sigma" textColor="neutral600">
+                      {formatMessage({
+                        id: 'Settings.webhooks.form.url',
+                        defaultMessage: 'URL',
+                      })}
+                    </Typography>
+                  </Th>
+                  <Th width="20%">
+                    <Typography variant="sigma" textColor="neutral600">
+                      {formatMessage({
+                        id: 'Settings.webhooks.list.th.status',
+                        defaultMessage: 'Status',
+                      })}
+                    </Typography>
+                  </Th>
+                  <Th>
+                    <VisuallyHidden>
+                      {formatMessage({
+                        id: 'Settings.webhooks.list.th.actions',
+                        defaultMessage: 'Actions',
+                      })}
+                    </VisuallyHidden>
+                  </Th>
+                </Tr>
+              </Thead>
+              <Tbody>
+                {webhooks.map((webhook) => (
+                  <Tr
+                    key={webhook.id}
+                    {...onRowClick({
+                      fn: () => handleGoTo(webhook.id),
+                      condition: canUpdate,
+                    })}
+                  >
+                    <Td {...stopPropagation}>
+                      <BaseCheckbox
+                        aria-label={`${formatMessage({
+                          id: 'global.select',
+                          defaultMessage: 'Select',
+                        })} ${webhook.name}`}
+                        value={webhooksToDelete?.includes(webhook.id)}
+                        onValueChange={(value) => handleSelectOneCheckbox(value, webhook.id)}
+                        id="select"
+                        name="select"
+                      />
+                    </Td>
+                    <Td>
+                      <Typography fontWeight="semiBold" textColor="neutral800">
+                        {webhook.name}
+                      </Typography>
+                    </Td>
+                    <Td>
+                      <Typography textColor="neutral800">{webhook.url}</Typography>
+                    </Td>
+                    <Td>
+                      <Flex {...stopPropagation}>
+                        <Switch
+                          onLabel={formatMessage({
+                            id: 'global.enabled',
+                            defaultMessage: 'Enabled',
                           })}
-                          indeterminate={
-                            webhooksToDeleteLength > 0 && webhooksToDeleteLength < rowsCount
-                          }
-                          value={webhooksToDeleteLength === rowsCount}
-                          onValueChange={handleSelectAllCheckbox}
-                        />
-                      </Th>
-                      <Th width="20%">
-                        <Typography variant="sigma" textColor="neutral600">
-                          {formatMessage({
-                            id: 'global.name',
-                            defaultMessage: 'Name',
+                          offLabel={formatMessage({
+                            id: 'global.disabled',
+                            defaultMessage: 'Disabled',
                           })}
-                        </Typography>
-                      </Th>
-                      <Th width="60%">
-                        <Typography variant="sigma" textColor="neutral600">
-                          {formatMessage({
-                            id: 'Settings.webhooks.form.url',
-                            defaultMessage: 'URL',
-                          })}
-                        </Typography>
-                      </Th>
-                      <Th width="20%">
-                        <Typography variant="sigma" textColor="neutral600">
-                          {formatMessage({
+                          label={`${webhook.name} ${formatMessage({
                             id: 'Settings.webhooks.list.th.status',
                             defaultMessage: 'Status',
-                          })}
-                        </Typography>
-                      </Th>
-                      <Th>
-                        <VisuallyHidden>
-                          {formatMessage({
-                            id: 'Settings.webhooks.list.th.actions',
-                            defaultMessage: 'Actions',
-                          })}
-                        </VisuallyHidden>
-                      </Th>
-                    </Tr>
-                  </Thead>
-                  <Tbody>
-                    {webhooks.map((webhook) => (
-                      <Tr
-                        key={webhook.id}
-                        {...onRowClick({
-                          fn: () => handleGoTo(webhook.id),
-                          condition: canUpdate,
-                        })}
-                      >
-                        <Td {...stopPropagation}>
-                          <BaseCheckbox
-                            aria-label={`${formatMessage({
-                              id: 'global.select',
-                              defaultMessage: 'Select',
-                            })} ${webhook.name}`}
-                            value={webhooksToDelete?.includes(webhook.id)}
-                            onValueChange={(value) => handleSelectOneCheckbox(value, webhook.id)}
-                            id="select"
-                            name="select"
+                          })}`}
+                          selected={webhook.isEnabled}
+                          onChange={() => handleEnabledChange(!webhook.isEnabled, webhook.id)}
+                          visibleLabels
+                        />
+                      </Flex>
+                    </Td>
+                    <Td>
+                      <Flex gap={1} {...stopPropagation}>
+                        {canUpdate && (
+                          <IconButton
+                            onClick={() => {
+                              handleGoTo(webhook.id);
+                            }}
+                            label={formatMessage({
+                              id: 'Settings.webhooks.events.update',
+                              defaultMessage: 'Update',
+                            })}
+                            icon={<Pencil />}
+                            noBorder
                           />
-                        </Td>
-                        <Td>
-                          <Typography fontWeight="semiBold" textColor="neutral800">
-                            {webhook.name}
-                          </Typography>
-                        </Td>
-                        <Td>
-                          <Typography textColor="neutral800">{webhook.url}</Typography>
-                        </Td>
-                        <Td>
-                          <Flex {...stopPropagation}>
-                            <Switch
-                              onLabel={formatMessage({
-                                id: 'global.enabled',
-                                defaultMessage: 'Enabled',
-                              })}
-                              offLabel={formatMessage({
-                                id: 'global.disabled',
-                                defaultMessage: 'Disabled',
-                              })}
-                              label={`${webhook.name} ${formatMessage({
-                                id: 'Settings.webhooks.list.th.status',
-                                defaultMessage: 'Status',
-                              })}`}
-                              selected={webhook.isEnabled}
-                              onChange={() => handleEnabledChange(!webhook.isEnabled, webhook.id)}
-                              visibleLabels
-                            />
-                          </Flex>
-                        </Td>
-                        <Td>
-                          <Stack horizontal spacing={1} {...stopPropagation}>
-                            {canUpdate && (
-                              <IconButton
-                                onClick={() => {
-                                  handleGoTo(webhook.id);
-                                }}
-                                label={formatMessage({
-                                  id: 'Settings.webhooks.events.update',
-                                  defaultMessage: 'Update',
-                                })}
-                                icon={<Pencil />}
-                                noBorder
-                              />
-                            )}
-                            {canDelete && (
-                              <IconButton
-                                onClick={() => handleDeleteClick(webhook.id)}
-                                label={formatMessage({
-                                  id: 'global.delete',
-                                  defaultMessage: 'Delete',
-                                })}
-                                icon={<Trash />}
-                                noBorder
-                                id={`delete-${webhook.id}`}
-                              />
-                            )}
-                          </Stack>
-                        </Td>
-                      </Tr>
-                    ))}
-                  </Tbody>
-                </Table>
-              ) : (
-                <EmptyStateLayout
-                  icon={<EmptyDocuments width="160px" />}
-                  content={formatMessage({
-                    id: 'Settings.webhooks.list.empty.description',
-                    defaultMessage: 'No webhooks found',
+                        )}
+                        {canDelete && (
+                          <IconButton
+                            onClick={() => handleDeleteClick(webhook.id)}
+                            label={formatMessage({
+                              id: 'global.delete',
+                              defaultMessage: 'Delete',
+                            })}
+                            icon={<Trash />}
+                            noBorder
+                            id={`delete-${webhook.id}`}
+                          />
+                        )}
+                      </Flex>
+                    </Td>
+                  </Tr>
+                ))}
+              </Tbody>
+            </Table>
+          ) : (
+            <EmptyStateLayout
+              icon={<EmptyDocuments width="160px" />}
+              content={formatMessage({
+                id: 'Settings.webhooks.list.empty.description',
+                defaultMessage: 'No webhooks found',
+              })}
+              action={
+                <Button
+                  variant="secondary"
+                  startIcon={<Plus />}
+                  onClick={() => (canCreate ? handleGoTo('create') : {})}
+                >
+                  {formatMessage({
+                    id: 'Settings.webhooks.list.button.add',
+                    defaultMessage: 'Create new webhook',
                   })}
-                  action={
-                    <Button
-                      variant="secondary"
-                      startIcon={<Plus />}
-                      onClick={() => (canCreate ? handleGoTo('create') : {})}
-                    >
-                      {formatMessage({
-                        id: 'Settings.webhooks.list.button.add',
-                        defaultMessage: 'Create new webhook',
-                      })}
-                    </Button>
-                  }
-                />
-              )}
-            </>
+                </Button>
+              }
+            />
           )}
         </ContentLayout>
       </Main>

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Webhooks/ListView/tests/index.test.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Webhooks/ListView/tests/index.test.js
@@ -193,13 +193,19 @@ describe('Admin | containers | ListView', () => {
         flex-direction: row;
       }
 
-      .c39 > * {
-        margin-left: 0;
-        margin-right: 0;
-      }
-
-      .c39 > * + * {
-        margin-left: 4px;
+      .c39 {
+        -webkit-align-items: center;
+        -webkit-box-align: center;
+        -ms-flex-align: center;
+        align-items: center;
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+        -webkit-flex-direction: row;
+        -ms-flex-direction: row;
+        flex-direction: row;
+        gap: 4px;
       }
 
       .c40 {
@@ -996,7 +1002,7 @@ describe('Admin | containers | ListView', () => {
                           >
                             <div
                               aria-hidden="true"
-                              class="c6 c39"
+                              class="c39"
                               role="button"
                             >
                               <span>
@@ -1159,7 +1165,7 @@ describe('Admin | containers | ListView', () => {
                           >
                             <div
                               aria-hidden="true"
-                              class="c6 c39"
+                              class="c39"
                               role="button"
                             >
                               <span>

--- a/packages/core/admin/admin/src/pages/UseCasePage/index.js
+++ b/packages/core/admin/admin/src/pages/UseCasePage/index.js
@@ -9,7 +9,6 @@ import {
   Main,
   Flex,
   Box,
-  Stack,
   Typography,
   Select,
   Option,
@@ -124,7 +123,7 @@ const UseCasePage = () => {
                 </TypographyCenter>
               </Box>
             </Flex>
-            <Stack spacing={6}>
+            <Flex direction="column" alignItems="stretch" gap={6}>
               <Select
                 id="usecase"
                 data-testid="usecase"
@@ -155,7 +154,7 @@ const UseCasePage = () => {
               <Button type="submit" size="L" fullWidth disabled={!role}>
                 {formatMessage({ id: 'global.finish', defaultMessage: 'Finish' })}
               </Button>
-            </Stack>
+            </Flex>
           </form>
         </LayoutContent>
         <Flex justifyContent="center">

--- a/packages/core/admin/admin/src/pages/UseCasePage/tests/index.test.js
+++ b/packages/core/admin/admin/src/pages/UseCasePage/tests/index.test.js
@@ -173,6 +173,21 @@ describe('Admin | UseCasePage', () => {
         -webkit-flex-direction: column;
         -ms-flex-direction: column;
         flex-direction: column;
+        gap: 24px;
+      }
+
+      .c20 {
+        -webkit-align-items: stretch;
+        -webkit-box-align: stretch;
+        -ms-flex-align: stretch;
+        align-items: stretch;
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+        -webkit-flex-direction: column;
+        -ms-flex-direction: column;
+        flex-direction: column;
       }
 
       .c22 {
@@ -280,15 +295,6 @@ describe('Admin | UseCasePage', () => {
         left: -5px;
         right: -5px;
         border: 2px solid #4945ff;
-      }
-
-      .c20 > * {
-        margin-top: 0;
-        margin-bottom: 0;
-      }
-
-      .c20 > * + * {
-        margin-top: 24px;
       }
 
       .c21 > * {
@@ -711,11 +717,11 @@ describe('Admin | UseCasePage', () => {
                     </div>
                   </div>
                   <div
-                    class="c0 c19 c20"
+                    class="c0 c19"
                   >
                     <div>
                       <div
-                        class="c0 c19 c21"
+                        class="c0 c20 c21"
                       >
                         <label
                           class="c5 c6"

--- a/packages/core/admin/admin/src/tests/__snapshots__/StrapiApp.test.js.snap
+++ b/packages/core/admin/admin/src/tests/__snapshots__/StrapiApp.test.js.snap
@@ -22,18 +22,10 @@ exports[`ADMIN | StrapiApp should render the app without plugins 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-}
-
-.c2 > * {
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
-.c2 > * + * {
-  margin-top: 8px;
+  gap: 8px;
 }
 
 <div
-  class="c0 c1 c2"
+  class="c0 c1"
 />
 `;

--- a/packages/core/admin/ee/admin/pages/AuthPage/components/Login/index.js
+++ b/packages/core/admin/ee/admin/pages/AuthPage/components/Login/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { Box, Flex, Divider, Stack, Typography } from '@strapi/design-system';
+import { Box, Flex, Divider, Typography } from '@strapi/design-system';
 import { useIntl } from 'react-intl';
 import BaseLogin from '../../../../../../admin/src/pages/AuthPage/components/Login/BaseLogin';
 import { useAuthProviders } from '../../../../hooks';
@@ -29,7 +29,7 @@ const Login = (loginProps) => {
     <UnauthenticatedLayout>
       <BaseLogin {...loginProps}>
         <Box paddingTop={7}>
-          <Stack spacing={7}>
+          <Flex direction="column" alignItems="stretch" gap={7}>
             <Flex>
               <DividerFull />
               <Box paddingLeft={3} paddingRight={3}>
@@ -40,7 +40,7 @@ const Login = (loginProps) => {
               <DividerFull />
             </Flex>
             <SSOProviders providers={providers} displayAllProviders={false} />
-          </Stack>
+          </Flex>
         </Box>
       </BaseLogin>
     </UnauthenticatedLayout>

--- a/packages/core/admin/ee/admin/pages/AuthPage/components/Providers/index.js
+++ b/packages/core/admin/ee/admin/pages/AuthPage/components/Providers/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { Redirect, useHistory } from 'react-router-dom';
 import styled from 'styled-components';
 import { Link } from '@strapi/helper-plugin';
-import { Divider, Stack, Flex, Box, Button, Loader, Typography, Main } from '@strapi/design-system';
+import { Divider, Flex, Box, Button, Loader, Typography, Main } from '@strapi/design-system';
 import { useIntl } from 'react-intl';
 import { useAuthProviders } from '../../../../hooks';
 import UnauthenticatedLayout, {
@@ -48,7 +48,7 @@ const Providers = () => {
               </Typography>
             </Box>
           </Column>
-          <Stack spacing={7}>
+          <Flex direction="column" alignItems="stretch" gap={7}>
             {isLoading ? (
               <Flex justifyContent="center">
                 <Loader>{formatMessage({ id: 'Auth.login.sso.loading' })}</Loader>
@@ -68,7 +68,7 @@ const Providers = () => {
             <Button fullWidth size="L" onClick={handleClick}>
               {formatMessage({ id: 'Auth.form.button.login.strapi' })}
             </Button>
-          </Stack>
+          </Flex>
         </LayoutContent>
         <Flex justifyContent="center">
           <Box paddingTop={4}>

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ApplicationInfosPage/components/AdminSeatInfo/index.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ApplicationInfosPage/components/AdminSeatInfo/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useIntl } from 'react-intl';
-import { Flex, Tooltip, Icon, GridItem, Typography, Stack } from '@strapi/design-system';
+import { Flex, Tooltip, Icon, GridItem, Typography } from '@strapi/design-system';
 import { Link } from '@strapi/design-system/v2';
 import { ExternalLink, ExclamationMarkCircle } from '@strapi/icons';
 import { pxToRem } from '@strapi/helper-plugin';
@@ -27,7 +27,7 @@ const AdminSeatInfo = () => {
           defaultMessage: 'Admin seats',
         })}
       </Typography>
-      <Stack spacing={2} horizontal>
+      <Flex gap={2}>
         <Flex>
           <Typography as="p">
             {formatMessage(
@@ -66,7 +66,7 @@ const AdminSeatInfo = () => {
             />
           </Tooltip>
         )}
-      </Stack>
+      </Flex>
       <Link
         href={isHostedOnStrapiCloud ? BILLING_STRAPI_CLOUD_URL : BILLING_SELF_HOSTED_URL}
         isExternal

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/Roles/CreatePage/index.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/Roles/CreatePage/index.js
@@ -20,7 +20,6 @@ import {
   GridItem,
   Main,
   Flex,
-  Stack,
   Typography,
   TextInput,
   Textarea,
@@ -134,7 +133,7 @@ const CreatePage = () => {
             <>
               <HeaderLayout
                 primaryAction={
-                  <Stack horizontal spacing={2}>
+                  <Flex gap={2}>
                     <Button
                       variant="secondary"
                       onClick={() => {
@@ -154,7 +153,7 @@ const CreatePage = () => {
                         defaultMessage: 'Save',
                       })}
                     </Button>
-                  </Stack>
+                  </Flex>
                 }
                 title={formatMessage({
                   id: 'Settings.roles.create.title',
@@ -174,9 +173,9 @@ const CreatePage = () => {
                 }
               />
               <ContentLayout>
-                <Stack spacing={6}>
+                <Flex direction="column" alignItems="stretch" gap={6}>
                   <Box background="neutral0" padding={6} shadow="filterShadow" hasRadius>
-                    <Stack spacing={4}>
+                    <Flex direction="column" alignItems="stretch" gap={4}>
                       <Flex justifyContent="space-between">
                         <Box>
                           <Box>
@@ -234,7 +233,7 @@ const CreatePage = () => {
                           </Textarea>
                         </GridItem>
                       </Grid>
-                    </Stack>
+                    </Flex>
                   </Box>
                   {!isLayoutLoading && !isRoleLoading ? (
                     <Box shadow="filterShadow" hasRadius>
@@ -250,7 +249,7 @@ const CreatePage = () => {
                       <LoadingIndicatorPage />
                     </Box>
                   )}
-                </Stack>
+                </Flex>
               </ContentLayout>
             </>
           </Form>

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/Roles/CreatePage/tests/__snapshots__/index.test.js.snap
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/Roles/CreatePage/tests/__snapshots__/index.test.js.snap
@@ -21,7 +21,7 @@ exports[`<CreatePage /> renders and matches the snapshot 1`] = `
   color: #666687;
 }
 
-.c23 {
+.c22 {
   font-size: 0.75rem;
   line-height: 1.33;
   color: #666687;
@@ -51,7 +51,7 @@ exports[`<CreatePage /> renders and matches the snapshot 1`] = `
   padding-left: 56px;
 }
 
-.c21 {
+.c20 {
   background: #ffffff;
   padding: 24px;
   border-radius: 4px;
@@ -90,7 +90,52 @@ exports[`<CreatePage /> renders and matches the snapshot 1`] = `
   flex-direction: row;
 }
 
+.c12 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 8px;
+}
+
 .c19 {
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.c21 {
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.c26 {
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -122,24 +167,6 @@ exports[`<CreatePage /> renders and matches the snapshot 1`] = `
   justify-content: space-around;
 }
 
-.c20 > * {
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
-.c20 > * + * {
-  margin-top: 24px;
-}
-
-.c22 > * {
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
-.c22 > * + * {
-  margin-top: 16px;
-}
-
 .c27 > * {
   margin-top: 0;
   margin-bottom: 0;
@@ -147,15 +174,6 @@ exports[`<CreatePage /> renders and matches the snapshot 1`] = `
 
 .c27 > * + * {
   margin-top: 4px;
-}
-
-.c12 > * {
-  margin-left: 0;
-  margin-right: 0;
-}
-
-.c12 > * + * {
-  margin-left: 8px;
 }
 
 .c13 {
@@ -445,13 +463,13 @@ exports[`<CreatePage /> renders and matches the snapshot 1`] = `
   will-change: transform;
 }
 
-.c25 {
+.c24 {
   display: grid;
   grid-template-columns: repeat(12,1fr);
   gap: 16px;
 }
 
-.c26 {
+.c25 {
   grid-column: span 6;
   max-width: 100%;
 }
@@ -627,7 +645,7 @@ exports[`<CreatePage /> renders and matches the snapshot 1`] = `
   display: flex;
 }
 
-.c24 {
+.c23 {
   border: 1px solid #d9d8ff;
   background: #f0f0ff;
   padding: 8px 16px;
@@ -638,13 +656,13 @@ exports[`<CreatePage /> renders and matches the snapshot 1`] = `
 }
 
 @media (max-width:68.75rem) {
-  .c26 {
+  .c25 {
     grid-column: span;
   }
 }
 
 @media (max-width:34.375rem) {
-  .c26 {
+  .c25 {
     grid-column: span;
   }
 }
@@ -712,7 +730,7 @@ exports[`<CreatePage /> renders and matches the snapshot 1`] = `
               </h1>
             </div>
             <div
-              class="c1 c9 c12"
+              class="c1 c12"
             >
               <button
                 aria-disabled="false"
@@ -749,13 +767,13 @@ exports[`<CreatePage /> renders and matches the snapshot 1`] = `
         class="c1 c18"
       >
         <div
-          class="c1 c19 c20"
+          class="c1 c19"
         >
           <div
-            class="c1 c21"
+            class="c1 c20"
           >
             <div
-              class="c1 c19 c22"
+              class="c1 c21"
             >
               <div
                 class="c1 c8"
@@ -776,23 +794,23 @@ exports[`<CreatePage /> renders and matches the snapshot 1`] = `
                     class="c1 "
                   >
                     <span
-                      class="c10 c23"
+                      class="c10 c22"
                     >
                       Name and description of the role
                     </span>
                   </div>
                 </div>
                 <div
-                  class="c24"
+                  class="c23"
                 >
                   0 users with this role
                 </div>
               </div>
               <div
-                class="c1 c25"
+                class="c1 c24"
               >
                 <div
-                  class="c26"
+                  class="c25"
                 >
                   <div
                     class="c1 "
@@ -800,7 +818,7 @@ exports[`<CreatePage /> renders and matches the snapshot 1`] = `
                     <div>
                       <div>
                         <div
-                          class="c1 c19 c27"
+                          class="c1 c26 c27"
                         >
                           <label
                             class="c10 c28"
@@ -831,7 +849,7 @@ exports[`<CreatePage /> renders and matches the snapshot 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c26"
+                  class="c25"
                 >
                   <div
                     class="c1 "
@@ -841,7 +859,7 @@ exports[`<CreatePage /> renders and matches the snapshot 1`] = `
                     >
                       <div>
                         <div
-                          class="c1 c19 c27"
+                          class="c1 c26 c27"
                         >
                           <div
                             class="c1 c9"
@@ -879,7 +897,7 @@ exports[`<CreatePage /> renders and matches the snapshot 1`] = `
             </div>
           </div>
           <div
-            class="c1 c21"
+            class="c1 c20"
           >
             <div
               class="c1 c34 c35"

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/SingleSignOn/index.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/SingleSignOn/index.js
@@ -13,13 +13,13 @@ import {
   Layout,
   Button,
   Main,
-  Stack,
   Typography,
   ToggleInput,
   Select,
   Option,
   Grid,
   GridItem,
+  Flex,
 } from '@strapi/design-system';
 import { useIntl } from 'react-intl';
 import isEqual from 'lodash/isEqual';
@@ -106,7 +106,15 @@ export const SingleSignOn = () => {
             {showLoader ? (
               <LoadingIndicatorPage />
             ) : (
-              <Stack spacing={4} background="neutral0" padding={6} shadow="filterShadow" hasRadius>
+              <Flex
+                direction="column"
+                alignItems="stretch"
+                gap={4}
+                background="neutral0"
+                padding={6}
+                shadow="filterShadow"
+                hasRadius
+              >
                 <Typography variant="delta" as="h2">
                   {formatMessage({
                     id: 'global.settings',
@@ -182,7 +190,7 @@ export const SingleSignOn = () => {
                     </Select>
                   </GridItem>
                 </Grid>
-              </Stack>
+              </Flex>
             )}
           </ContentLayout>
         </form>

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/SingleSignOn/tests/__snapshots__/index.test.js.snap
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/SingleSignOn/tests/__snapshots__/index.test.js.snap
@@ -21,7 +21,7 @@ exports[`Admin | ee | SettingsPage | SSO renders and matches the snapshot 1`] = 
   color: #666687;
 }
 
-.c20 {
+.c19 {
   font-weight: 500;
   font-size: 1rem;
   line-height: 1.25;
@@ -167,6 +167,21 @@ exports[`Admin | ee | SettingsPage | SSO renders and matches the snapshot 1`] = 
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  gap: 16px;
+}
+
+.c23 {
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
 }
 
 .c31 {
@@ -185,15 +200,6 @@ exports[`Admin | ee | SettingsPage | SSO renders and matches the snapshot 1`] = 
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-}
-
-.c19 > * {
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
-.c19 > * + * {
-  margin-top: 16px;
 }
 
 .c24 > * {
@@ -420,13 +426,13 @@ exports[`Admin | ee | SettingsPage | SSO renders and matches the snapshot 1`] = 
   width: 100%;
 }
 
-.c21 {
+.c20 {
   display: grid;
   grid-template-columns: repeat(12,1fr);
   gap: 16px;
 }
 
-.c22 {
+.c21 {
   grid-column: span 6;
   max-width: 100%;
 }
@@ -511,18 +517,18 @@ exports[`Admin | ee | SettingsPage | SSO renders and matches the snapshot 1`] = 
   width: 100%;
 }
 
-.c23 {
+.c22 {
   max-width: 320px;
 }
 
 @media (max-width:68.75rem) {
-  .c22 {
+  .c21 {
     grid-column: span 12;
   }
 }
 
 @media (max-width:34.375rem) {
-  .c22 {
+  .c21 {
     grid-column: span;
   }
 }
@@ -601,27 +607,27 @@ exports[`Admin | ee | SettingsPage | SSO renders and matches the snapshot 1`] = 
           class="c0 c16"
         >
           <div
-            class="c0 c17 c18 c19"
+            class="c0 c17 c18"
           >
             <h2
-              class="c8 c20"
+              class="c8 c19"
             >
               Settings
             </h2>
             <div
-              class="c0 c21"
+              class="c0 c20"
             >
               <div
-                class="c22"
+                class="c21"
               >
                 <div
                   class="c0 "
                 >
                   <div
-                    class="c23"
+                    class="c22"
                   >
                     <div
-                      class="c0 c18 c24"
+                      class="c0 c23 c24"
                     >
                       <div
                         class="c0 c7"
@@ -694,14 +700,14 @@ exports[`Admin | ee | SettingsPage | SSO renders and matches the snapshot 1`] = 
                 </div>
               </div>
               <div
-                class="c22"
+                class="c21"
               >
                 <div
                   class="c0 "
                 >
                   <div>
                     <div
-                      class="c0 c18 c24"
+                      class="c0 c23 c24"
                     >
                       <label
                         class="c8 c25"

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/Users/ListPage/CreateAction/index.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/Users/ListPage/CreateAction/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useIntl } from 'react-intl';
 import PropTypes from 'prop-types';
-import { Stack, Button, Tooltip, Icon } from '@strapi/design-system';
+import { Flex, Button, Tooltip, Icon } from '@strapi/design-system';
 import { Envelop, ExclamationMarkCircle } from '@strapi/icons';
 import { useLicenseLimits } from '../../../../../../hooks';
 
@@ -11,7 +11,7 @@ const CreateAction = ({ onClick }) => {
   const { permittedSeats, shouldStopCreate } = license?.data ?? {};
 
   return (
-    <Stack spacing={2} horizontal>
+    <Flex gap={2}>
       {permittedSeats && shouldStopCreate && (
         <Tooltip
           description={formatMessage({
@@ -40,7 +40,7 @@ const CreateAction = ({ onClick }) => {
           defaultMessage: 'Invite new user',
         })}
       </Button>
-    </Stack>
+    </Flex>
   );
 };
 

--- a/packages/core/content-type-builder/admin/src/components/AttributeOptions/AttributeList/index.js
+++ b/packages/core/content-type-builder/admin/src/components/AttributeOptions/AttributeList/index.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Box, Grid, GridItem, KeyboardNavigable, Stack } from '@strapi/design-system';
+import { Box, Grid, GridItem, KeyboardNavigable, Flex } from '@strapi/design-system';
 import AttributeOption from '../AttributeOption';
 import getPadding from '../utils/getPadding';
 
 const AttributeList = ({ attributes }) => (
   <KeyboardNavigable tagName="button">
-    <Stack spacing={8}>
+    <Flex direction="column" alignItems="stretch" gap={8}>
       {attributes.map((attributeRow, index) => {
         return (
           // eslint-disable-next-line react/no-array-index-key
@@ -30,7 +30,7 @@ const AttributeList = ({ attributes }) => (
           </Grid>
         );
       })}
-    </Stack>
+    </Flex>
   </KeyboardNavigable>
 );
 

--- a/packages/core/content-type-builder/admin/src/components/AttributeOptions/CustomFieldsList/index.js
+++ b/packages/core/content-type-builder/admin/src/components/AttributeOptions/CustomFieldsList/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useCustomFields } from '@strapi/helper-plugin';
-import { Box, Grid, GridItem, KeyboardNavigable, Stack, Link } from '@strapi/design-system';
+import { Box, Grid, GridItem, KeyboardNavigable, Flex, Link } from '@strapi/design-system';
 import { useIntl } from 'react-intl';
 import EmptyAttributes from '../EmptyAttributes';
 import CustomFieldOption from '../CustomFieldOption';
@@ -23,7 +23,7 @@ const CustomFieldsList = () => {
 
   return (
     <KeyboardNavigable tagName="button">
-      <Stack spacing={3}>
+      <Flex direction="column" alignItems="stretch" gap={3}>
         <Grid gap={0}>
           {sortedCustomFields.map(([uid, customField], index) => {
             const { paddingLeft, paddingRight } = getPadding(index);
@@ -51,7 +51,7 @@ const CustomFieldsList = () => {
             defaultMessage: 'How to add custom fields',
           })}
         </Link>
-      </Stack>
+      </Flex>
     </KeyboardNavigable>
   );
 };

--- a/packages/core/content-type-builder/admin/src/components/AttributeOptions/tests/__snapshots__/index.test.js.snap
+++ b/packages/core/content-type-builder/admin/src/components/AttributeOptions/tests/__snapshots__/index.test.js.snap
@@ -24,14 +24,14 @@ exports[`<AttributeOptions /> renders and matches the snapshot 1`] = `
   color: #666687;
 }
 
-.c24 {
+.c23 {
   font-size: 0.875rem;
   line-height: 1.43;
   font-weight: 600;
   color: #32324d;
 }
 
-.c25 {
+.c24 {
   font-size: 0.75rem;
   line-height: 1.33;
   color: #666687;
@@ -53,17 +53,17 @@ exports[`<AttributeOptions /> renders and matches the snapshot 1`] = `
   background: #eaeaef;
 }
 
-.c17 {
+.c16 {
   padding-right: 8px;
   padding-bottom: 4px;
 }
 
-.c18 {
+.c17 {
   padding: 16px;
   border-radius: 4px;
 }
 
-.c21 {
+.c20 {
   width: 2rem;
   height: 1.5rem;
   -webkit-flex-shrink: 0;
@@ -71,11 +71,11 @@ exports[`<AttributeOptions /> renders and matches the snapshot 1`] = `
   flex-shrink: 0;
 }
 
-.c23 {
+.c22 {
   padding-left: 16px;
 }
 
-.c26 {
+.c25 {
   padding-bottom: 4px;
   padding-left: 8px;
 }
@@ -110,9 +110,10 @@ exports[`<AttributeOptions /> renders and matches the snapshot 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  gap: 40px;
 }
 
-.c20 {
+.c19 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -126,16 +127,7 @@ exports[`<AttributeOptions /> renders and matches the snapshot 1`] = `
   flex-direction: row;
 }
 
-.c14 > * {
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
-.c14 > * + * {
-  margin-top: 40px;
-}
-
-.c27 {
+.c26 {
   border: 0;
   -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
@@ -156,12 +148,12 @@ exports[`<AttributeOptions /> renders and matches the snapshot 1`] = `
   margin: 0;
 }
 
-.c15 {
+.c14 {
   display: grid;
   grid-template-columns: repeat(12,1fr);
 }
 
-.c16 {
+.c15 {
   grid-column: span 6;
   max-width: 100%;
 }
@@ -183,31 +175,31 @@ exports[`<AttributeOptions /> renders and matches the snapshot 1`] = `
   cursor: not-allowed;
 }
 
-.c22 svg {
+.c21 svg {
   height: 100%;
   width: 100%;
 }
 
-.c19 {
+.c18 {
   width: 100%;
   height: 100%;
   border: 1px solid #dcdce4;
   text-align: left;
 }
 
-.c19:hover {
+.c18:hover {
   background: #f0f0ff;
   border: 1px solid #d9d8ff;
 }
 
 @media (max-width:68.75rem) {
-  .c16 {
+  .c15 {
     grid-column: span;
   }
 }
 
 @media (max-width:34.375rem) {
-  .c16 {
+  .c15 {
     grid-column: span;
   }
 }
@@ -288,32 +280,32 @@ exports[`<AttributeOptions /> renders and matches the snapshot 1`] = `
             class=""
           >
             <div
-              class="c13 c14"
+              class="c13"
             >
               <div
-                class="c15"
+                class="c14"
               >
                 <div
-                  class="c16"
+                  class="c15"
                 >
                   <div
                     class=""
                     style="height: 100%;"
                   >
                     <div
-                      class="c17"
+                      class="c16"
                       style="height: 100%;"
                     >
                       <button
-                        class="c18 c19"
+                        class="c17 c18"
                         type="button"
                       >
                         <div
-                          class="c20"
+                          class="c19"
                         >
                           <div
                             aria-hidden="true"
-                            class="c21 c22"
+                            class="c20 c21"
                           >
                             <svg
                               class=""
@@ -339,22 +331,22 @@ exports[`<AttributeOptions /> renders and matches the snapshot 1`] = `
                             </svg>
                           </div>
                           <div
-                            class="c23"
+                            class="c22"
                           >
                             <div
-                              class="c20"
+                              class="c19"
                             >
                               <span
-                                class="c24"
+                                class="c23"
                               >
                                 text
                               </span>
                             </div>
                             <div
-                              class="c20"
+                              class="c19"
                             >
                               <span
-                                class="c25"
+                                class="c24"
                               >
                                 A type for modeling data
                               </span>
@@ -366,26 +358,26 @@ exports[`<AttributeOptions /> renders and matches the snapshot 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c16"
+                  class="c15"
                 >
                   <div
                     class=""
                     style="height: 100%;"
                   >
                     <div
-                      class="c26"
+                      class="c25"
                       style="height: 100%;"
                     >
                       <button
-                        class="c18 c19"
+                        class="c17 c18"
                         type="button"
                       >
                         <div
-                          class="c20"
+                          class="c19"
                         >
                           <div
                             aria-hidden="true"
-                            class="c21 c22"
+                            class="c20 c21"
                           >
                             <svg
                               class=""
@@ -411,22 +403,22 @@ exports[`<AttributeOptions /> renders and matches the snapshot 1`] = `
                             </svg>
                           </div>
                           <div
-                            class="c23"
+                            class="c22"
                           >
                             <div
-                              class="c20"
+                              class="c19"
                             >
                               <span
-                                class="c24"
+                                class="c23"
                               >
                                 email
                               </span>
                             </div>
                             <div
-                              class="c20"
+                              class="c19"
                             >
                               <span
-                                class="c25"
+                                class="c24"
                               >
                                 A type for modeling data
                               </span>
@@ -438,26 +430,26 @@ exports[`<AttributeOptions /> renders and matches the snapshot 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c16"
+                  class="c15"
                 >
                   <div
                     class=""
                     style="height: 100%;"
                   >
                     <div
-                      class="c17"
+                      class="c16"
                       style="height: 100%;"
                     >
                       <button
-                        class="c18 c19"
+                        class="c17 c18"
                         type="button"
                       >
                         <div
-                          class="c20"
+                          class="c19"
                         >
                           <div
                             aria-hidden="true"
-                            class="c21 c22"
+                            class="c20 c21"
                           >
                             <svg
                               class=""
@@ -485,22 +477,22 @@ exports[`<AttributeOptions /> renders and matches the snapshot 1`] = `
                             </svg>
                           </div>
                           <div
-                            class="c23"
+                            class="c22"
                           >
                             <div
-                              class="c20"
+                              class="c19"
                             >
                               <span
-                                class="c24"
+                                class="c23"
                               >
                                 richtext
                               </span>
                             </div>
                             <div
-                              class="c20"
+                              class="c19"
                             >
                               <span
-                                class="c25"
+                                class="c24"
                               >
                                 A type for modeling data
                               </span>
@@ -512,26 +504,26 @@ exports[`<AttributeOptions /> renders and matches the snapshot 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c16"
+                  class="c15"
                 >
                   <div
                     class=""
                     style="height: 100%;"
                   >
                     <div
-                      class="c26"
+                      class="c25"
                       style="height: 100%;"
                     >
                       <button
-                        class="c18 c19"
+                        class="c17 c18"
                         type="button"
                       >
                         <div
-                          class="c20"
+                          class="c19"
                         >
                           <div
                             aria-hidden="true"
-                            class="c21 c22"
+                            class="c20 c21"
                           >
                             <svg
                               class=""
@@ -553,22 +545,22 @@ exports[`<AttributeOptions /> renders and matches the snapshot 1`] = `
                             </svg>
                           </div>
                           <div
-                            class="c23"
+                            class="c22"
                           >
                             <div
-                              class="c20"
+                              class="c19"
                             >
                               <span
-                                class="c24"
+                                class="c23"
                               >
                                 password
                               </span>
                             </div>
                             <div
-                              class="c20"
+                              class="c19"
                             >
                               <span
-                                class="c25"
+                                class="c24"
                               >
                                 A type for modeling data
                               </span>
@@ -580,26 +572,26 @@ exports[`<AttributeOptions /> renders and matches the snapshot 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c16"
+                  class="c15"
                 >
                   <div
                     class=""
                     style="height: 100%;"
                   >
                     <div
-                      class="c17"
+                      class="c16"
                       style="height: 100%;"
                     >
                       <button
-                        class="c18 c19"
+                        class="c17 c18"
                         type="button"
                       >
                         <div
-                          class="c20"
+                          class="c19"
                         >
                           <div
                             aria-hidden="true"
-                            class="c21 c22"
+                            class="c20 c21"
                           >
                             <svg
                               class=""
@@ -625,22 +617,22 @@ exports[`<AttributeOptions /> renders and matches the snapshot 1`] = `
                             </svg>
                           </div>
                           <div
-                            class="c23"
+                            class="c22"
                           >
                             <div
-                              class="c20"
+                              class="c19"
                             >
                               <span
-                                class="c24"
+                                class="c23"
                               >
                                 number
                               </span>
                             </div>
                             <div
-                              class="c20"
+                              class="c19"
                             >
                               <span
-                                class="c25"
+                                class="c24"
                               >
                                 A type for modeling data
                               </span>
@@ -652,26 +644,26 @@ exports[`<AttributeOptions /> renders and matches the snapshot 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c16"
+                  class="c15"
                 >
                   <div
                     class=""
                     style="height: 100%;"
                   >
                     <div
-                      class="c26"
+                      class="c25"
                       style="height: 100%;"
                     >
                       <button
-                        class="c18 c19"
+                        class="c17 c18"
                         type="button"
                       >
                         <div
-                          class="c20"
+                          class="c19"
                         >
                           <div
                             aria-hidden="true"
-                            class="c21 c22"
+                            class="c20 c21"
                           >
                             <svg
                               class=""
@@ -699,22 +691,22 @@ exports[`<AttributeOptions /> renders and matches the snapshot 1`] = `
                             </svg>
                           </div>
                           <div
-                            class="c23"
+                            class="c22"
                           >
                             <div
-                              class="c20"
+                              class="c19"
                             >
                               <span
-                                class="c24"
+                                class="c23"
                               >
                                 enumeration
                               </span>
                             </div>
                             <div
-                              class="c20"
+                              class="c19"
                             >
                               <span
-                                class="c25"
+                                class="c24"
                               >
                                 A type for modeling data
                               </span>
@@ -726,26 +718,26 @@ exports[`<AttributeOptions /> renders and matches the snapshot 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c16"
+                  class="c15"
                 >
                   <div
                     class=""
                     style="height: 100%;"
                   >
                     <div
-                      class="c17"
+                      class="c16"
                       style="height: 100%;"
                     >
                       <button
-                        class="c18 c19"
+                        class="c17 c18"
                         type="button"
                       >
                         <div
-                          class="c20"
+                          class="c19"
                         >
                           <div
                             aria-hidden="true"
-                            class="c21 c22"
+                            class="c20 c21"
                           >
                             <svg
                               class=""
@@ -769,22 +761,22 @@ exports[`<AttributeOptions /> renders and matches the snapshot 1`] = `
                             </svg>
                           </div>
                           <div
-                            class="c23"
+                            class="c22"
                           >
                             <div
-                              class="c20"
+                              class="c19"
                             >
                               <span
-                                class="c24"
+                                class="c23"
                               >
                                 date
                               </span>
                             </div>
                             <div
-                              class="c20"
+                              class="c19"
                             >
                               <span
-                                class="c25"
+                                class="c24"
                               >
                                 A type for modeling data
                               </span>
@@ -796,26 +788,26 @@ exports[`<AttributeOptions /> renders and matches the snapshot 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c16"
+                  class="c15"
                 >
                   <div
                     class=""
                     style="height: 100%;"
                   >
                     <div
-                      class="c26"
+                      class="c25"
                       style="height: 100%;"
                     >
                       <button
-                        class="c18 c19"
+                        class="c17 c18"
                         type="button"
                       >
                         <div
-                          class="c20"
+                          class="c19"
                         >
                           <div
                             aria-hidden="true"
-                            class="c21 c22"
+                            class="c20 c21"
                           >
                             <svg
                               class=""
@@ -843,22 +835,22 @@ exports[`<AttributeOptions /> renders and matches the snapshot 1`] = `
                             </svg>
                           </div>
                           <div
-                            class="c23"
+                            class="c22"
                           >
                             <div
-                              class="c20"
+                              class="c19"
                             >
                               <span
-                                class="c24"
+                                class="c23"
                               >
                                 media
                               </span>
                             </div>
                             <div
-                              class="c20"
+                              class="c19"
                             >
                               <span
-                                class="c25"
+                                class="c24"
                               >
                                 A type for modeling data
                               </span>
@@ -870,26 +862,26 @@ exports[`<AttributeOptions /> renders and matches the snapshot 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c16"
+                  class="c15"
                 >
                   <div
                     class=""
                     style="height: 100%;"
                   >
                     <div
-                      class="c17"
+                      class="c16"
                       style="height: 100%;"
                     >
                       <button
-                        class="c18 c19"
+                        class="c17 c18"
                         type="button"
                       >
                         <div
-                          class="c20"
+                          class="c19"
                         >
                           <div
                             aria-hidden="true"
-                            class="c21 c22"
+                            class="c20 c21"
                           >
                             <svg
                               class=""
@@ -915,22 +907,22 @@ exports[`<AttributeOptions /> renders and matches the snapshot 1`] = `
                             </svg>
                           </div>
                           <div
-                            class="c23"
+                            class="c22"
                           >
                             <div
-                              class="c20"
+                              class="c19"
                             >
                               <span
-                                class="c24"
+                                class="c23"
                               >
                                 boolean
                               </span>
                             </div>
                             <div
-                              class="c20"
+                              class="c19"
                             >
                               <span
-                                class="c25"
+                                class="c24"
                               >
                                 A type for modeling data
                               </span>
@@ -942,26 +934,26 @@ exports[`<AttributeOptions /> renders and matches the snapshot 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c16"
+                  class="c15"
                 >
                   <div
                     class=""
                     style="height: 100%;"
                   >
                     <div
-                      class="c26"
+                      class="c25"
                       style="height: 100%;"
                     >
                       <button
-                        class="c18 c19"
+                        class="c17 c18"
                         type="button"
                       >
                         <div
-                          class="c20"
+                          class="c19"
                         >
                           <div
                             aria-hidden="true"
-                            class="c21 c22"
+                            class="c20 c21"
                           >
                             <svg
                               class=""
@@ -989,22 +981,22 @@ exports[`<AttributeOptions /> renders and matches the snapshot 1`] = `
                             </svg>
                           </div>
                           <div
-                            class="c23"
+                            class="c22"
                           >
                             <div
-                              class="c20"
+                              class="c19"
                             >
                               <span
-                                class="c24"
+                                class="c23"
                               >
                                 json
                               </span>
                             </div>
                             <div
-                              class="c20"
+                              class="c19"
                             >
                               <span
-                                class="c25"
+                                class="c24"
                               >
                                 A type for modeling data
                               </span>
@@ -1016,26 +1008,26 @@ exports[`<AttributeOptions /> renders and matches the snapshot 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c16"
+                  class="c15"
                 >
                   <div
                     class=""
                     style="height: 100%;"
                   >
                     <div
-                      class="c17"
+                      class="c16"
                       style="height: 100%;"
                     >
                       <button
-                        class="c18 c19"
+                        class="c17 c18"
                         type="button"
                       >
                         <div
-                          class="c20"
+                          class="c19"
                         >
                           <div
                             aria-hidden="true"
-                            class="c21 c22"
+                            class="c20 c21"
                           >
                             <svg
                               class=""
@@ -1059,22 +1051,22 @@ exports[`<AttributeOptions /> renders and matches the snapshot 1`] = `
                             </svg>
                           </div>
                           <div
-                            class="c23"
+                            class="c22"
                           >
                             <div
-                              class="c20"
+                              class="c19"
                             >
                               <span
-                                class="c24"
+                                class="c23"
                               >
                                 relation
                               </span>
                             </div>
                             <div
-                              class="c20"
+                              class="c19"
                             >
                               <span
-                                class="c25"
+                                class="c24"
                               >
                                 A type for modeling data
                               </span>
@@ -1086,26 +1078,26 @@ exports[`<AttributeOptions /> renders and matches the snapshot 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c16"
+                  class="c15"
                 >
                   <div
                     class=""
                     style="height: 100%;"
                   >
                     <div
-                      class="c26"
+                      class="c25"
                       style="height: 100%;"
                     >
                       <button
-                        class="c18 c19"
+                        class="c17 c18"
                         type="button"
                       >
                         <div
-                          class="c20"
+                          class="c19"
                         >
                           <div
                             aria-hidden="true"
-                            class="c21 c22"
+                            class="c20 c21"
                           >
                             <svg
                               class=""
@@ -1127,22 +1119,22 @@ exports[`<AttributeOptions /> renders and matches the snapshot 1`] = `
                             </svg>
                           </div>
                           <div
-                            class="c23"
+                            class="c22"
                           >
                             <div
-                              class="c20"
+                              class="c19"
                             >
                               <span
-                                class="c24"
+                                class="c23"
                               >
                                 uid
                               </span>
                             </div>
                             <div
-                              class="c20"
+                              class="c19"
                             >
                               <span
-                                class="c25"
+                                class="c24"
                               >
                                 A type for modeling data
                               </span>
@@ -1155,29 +1147,29 @@ exports[`<AttributeOptions /> renders and matches the snapshot 1`] = `
                 </div>
               </div>
               <div
-                class="c15"
+                class="c14"
               >
                 <div
-                  class="c16"
+                  class="c15"
                 >
                   <div
                     class=""
                     style="height: 100%;"
                   >
                     <div
-                      class="c17"
+                      class="c16"
                       style="height: 100%;"
                     >
                       <button
-                        class="c18 c19"
+                        class="c17 c18"
                         type="button"
                       >
                         <div
-                          class="c20"
+                          class="c19"
                         >
                           <div
                             aria-hidden="true"
-                            class="c21 c22"
+                            class="c20 c21"
                           >
                             <svg
                               class=""
@@ -1209,22 +1201,22 @@ exports[`<AttributeOptions /> renders and matches the snapshot 1`] = `
                             </svg>
                           </div>
                           <div
-                            class="c23"
+                            class="c22"
                           >
                             <div
-                              class="c20"
+                              class="c19"
                             >
                               <span
-                                class="c24"
+                                class="c23"
                               >
                                 component
                               </span>
                             </div>
                             <div
-                              class="c20"
+                              class="c19"
                             >
                               <span
-                                class="c25"
+                                class="c24"
                               >
                                 A type for modeling data
                               </span>
@@ -1236,26 +1228,26 @@ exports[`<AttributeOptions /> renders and matches the snapshot 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c16"
+                  class="c15"
                 >
                   <div
                     class=""
                     style="height: 100%;"
                   >
                     <div
-                      class="c26"
+                      class="c25"
                       style="height: 100%;"
                     >
                       <button
-                        class="c18 c19"
+                        class="c17 c18"
                         type="button"
                       >
                         <div
-                          class="c20"
+                          class="c19"
                         >
                           <div
                             aria-hidden="true"
-                            class="c21 c22"
+                            class="c20 c21"
                           >
                             <svg
                               class=""
@@ -1281,22 +1273,22 @@ exports[`<AttributeOptions /> renders and matches the snapshot 1`] = `
                             </svg>
                           </div>
                           <div
-                            class="c23"
+                            class="c22"
                           >
                             <div
-                              class="c20"
+                              class="c19"
                             >
                               <span
-                                class="c24"
+                                class="c23"
                               >
                                 dynamiczone
                               </span>
                             </div>
                             <div
-                              class="c20"
+                              class="c19"
                             >
                               <span
-                                class="c25"
+                                class="c24"
                               >
                                 A type for modeling data
                               </span>
@@ -1315,7 +1307,7 @@ exports[`<AttributeOptions /> renders and matches the snapshot 1`] = `
     </div>
   </div>
   <div
-    class="c27"
+    class="c26"
   >
     <p
       aria-live="polite"

--- a/packages/core/content-type-builder/admin/src/components/CheckboxWithNumberField/index.js
+++ b/packages/core/content-type-builder/admin/src/components/CheckboxWithNumberField/index.js
@@ -7,7 +7,7 @@
 import React, { useState } from 'react';
 import { useIntl } from 'react-intl';
 import PropTypes from 'prop-types';
-import { Box, Checkbox, Stack, NumberInput, TextInput } from '@strapi/design-system';
+import { Box, Checkbox, Flex, NumberInput, TextInput } from '@strapi/design-system';
 
 const CheckboxWithNumberField = ({ error, intlLabel, modifiedData, name, onChange, value }) => {
   const { formatMessage } = useIntl();
@@ -25,7 +25,7 @@ const CheckboxWithNumberField = ({ error, intlLabel, modifiedData, name, onChang
   const errorMessage = error ? formatMessage({ id: error, defaultMessage: error }) : '';
 
   return (
-    <Stack spacing={2}>
+    <Flex direction="column" alignItems="stretch" gap={2}>
       <Checkbox
         id={name}
         name={name}
@@ -67,7 +67,7 @@ const CheckboxWithNumberField = ({ error, intlLabel, modifiedData, name, onChang
           )}
         </Box>
       )}
-    </Stack>
+    </Flex>
   );
 };
 

--- a/packages/core/content-type-builder/admin/src/components/CustomRadioGroup/components.js
+++ b/packages/core/content-type-builder/admin/src/components/CustomRadioGroup/components.js
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
-import { Stack, Typography, inputFocusStyle } from '@strapi/design-system';
+import { Flex, Typography, inputFocusStyle } from '@strapi/design-system';
 
-const Wrapper = styled(Stack)`
+const Wrapper = styled(Flex)`
   position: relative;
   align-items: stretch;
 

--- a/packages/core/content-type-builder/admin/src/components/CustomRadioGroup/index.js
+++ b/packages/core/content-type-builder/admin/src/components/CustomRadioGroup/index.js
@@ -1,18 +1,18 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
-import { Typography, Box, Flex, Stack } from '@strapi/design-system';
+import { Typography, Box, Flex } from '@strapi/design-system';
 import { Wrapper } from './components';
 
 const CustomRadioGroup = ({ intlLabel, name, onChange, radios, value }) => {
   const { formatMessage } = useIntl();
 
   return (
-    <Stack spacing={2}>
+    <Flex direction="column" alignItems="stretch" gap={2}>
       <Typography variant="pi" fontWeight="bold" textColor="neutral800" htmlFor={name} as="label">
         {formatMessage(intlLabel)}
       </Typography>
-      <Wrapper horizontal spacing={4} style={{ alignItems: 'stretch' }}>
+      <Wrapper gap={4} alignItems="stretch">
         {radios.map((radio) => {
           return (
             <label htmlFor={radio.value.toString()} key={radio.value} className="container">
@@ -31,19 +31,19 @@ const CustomRadioGroup = ({ intlLabel, name, onChange, radios, value }) => {
                   <Box paddingRight={4}>
                     <span className="checkmark" />
                   </Box>
-                  <Stack spacing={2}>
+                  <Flex direction="column" alignItems="stretch" gap={2}>
                     <Typography fontWeight="bold">{formatMessage(radio.title)}</Typography>
                     <Typography variant="pi" textColor="neutral600">
                       {formatMessage(radio.description)}
                     </Typography>
-                  </Stack>
+                  </Flex>
                 </Flex>
               </Box>
             </label>
           );
         })}
       </Wrapper>
-    </Stack>
+    </Flex>
   );
 };
 

--- a/packages/core/content-type-builder/admin/src/components/DynamicZoneList/index.js
+++ b/packages/core/content-type-builder/admin/src/components/DynamicZoneList/index.js
@@ -9,7 +9,7 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { pxToRem } from '@strapi/helper-plugin';
 import { Plus } from '@strapi/icons';
-import { Box, Stack, Typography } from '@strapi/design-system';
+import { Box, Flex, Typography } from '@strapi/design-system';
 import { useIntl } from 'react-intl';
 import styled from 'styled-components';
 import useDataManager from '../../hooks/useDataManager';
@@ -37,7 +37,7 @@ const FixedBox = styled(Box)`
   left: 0;
 `;
 
-const ScrollableStack = styled(Stack)`
+const ScrollableStack = styled(Flex)`
   width: 100%;
   overflow-x: auto;
 `;
@@ -46,7 +46,7 @@ const ComponentContentBox = styled(Box)`
   padding-top: ${pxToRem(90)};
 `;
 
-const ComponentStack = styled(Stack)`
+const ComponentStack = styled(Flex)`
   flex-shrink: 0;
   width: ${pxToRem(140)};
   height: ${pxToRem(80)};
@@ -73,10 +73,10 @@ function DynamicZoneList({ customRowComponent, components, addComponent, name, t
     <Tr className="dynamiczone-row" isFromDynamicZone>
       <td colSpan={12}>
         <FixedBox paddingLeft={8}>
-          <ScrollableStack horizontal spacing={2}>
+          <ScrollableStack gap={2}>
             {isInDevelopmentMode && (
               <button type="button" onClick={handleClickAdd}>
-                <ComponentStack spacing={1}>
+                <ComponentStack direction="column" alignItems="stretch" gap={1}>
                   <StyledAddIcon />
                   <Typography variant="pi" fontWeight="bold" textColor="primary600">
                     {formatMessage({

--- a/packages/core/content-type-builder/admin/src/components/FormModal/index.js
+++ b/packages/core/content-type-builder/admin/src/components/FormModal/index.js
@@ -26,7 +26,6 @@ import {
   TabPanels,
   TabPanel,
   Flex,
-  Stack,
 } from '@strapi/design-system';
 import { isEqual } from 'lodash';
 import pluginId from '../../pluginId';
@@ -1050,7 +1049,7 @@ const FormModal = () => {
               <Box paddingTop={6}>
                 <TabPanels>
                   <TabPanel>
-                    <Stack spacing={6}>
+                    <Flex direction="column" alignItems="stretch" gap={6}>
                       <TabForm
                         form={baseForm}
                         formErrors={formErrors}
@@ -1058,10 +1057,10 @@ const FormModal = () => {
                         modifiedData={modifiedData}
                         onChange={handleChange}
                       />
-                    </Stack>
+                    </Flex>
                   </TabPanel>
                   <TabPanel>
-                    <Stack spacing={6}>
+                    <Flex direction="column" alignItems="stretch" gap={6}>
                       <TabForm
                         form={advancedForm}
                         formErrors={formErrors}
@@ -1069,7 +1068,7 @@ const FormModal = () => {
                         modifiedData={modifiedData}
                         onChange={handleChange}
                       />
-                    </Stack>
+                    </Flex>
                   </TabPanel>
                 </TabPanels>
               </Box>

--- a/packages/core/content-type-builder/admin/src/components/FormModalHeader/index.js
+++ b/packages/core/content-type-builder/admin/src/components/FormModalHeader/index.js
@@ -8,15 +8,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 import upperFirst from 'lodash/upperFirst';
-import {
-  Breadcrumbs,
-  Crumb,
-  ModalHeader,
-  Box,
-  Flex,
-  Stack,
-  Typography,
-} from '@strapi/design-system';
+import { Breadcrumbs, Crumb, ModalHeader, Box, Flex, Typography } from '@strapi/design-system';
 import useDataManager from '../../hooks/useDataManager';
 import getTrad from '../../utils/getTrad';
 import AttributeIcon from '../AttributeIcon';
@@ -113,7 +105,7 @@ const FormModalHeader = ({
 
   return (
     <ModalHeader>
-      <Stack horizontal spacing={3}>
+      <Flex gap={3}>
         <AttributeIcon type={icon} customField={customFieldUid} />
 
         <Breadcrumbs label={breadcrumbsLabel}>
@@ -137,7 +129,7 @@ const FormModalHeader = ({
             return <Crumb key={key}>{label}</Crumb>;
           })}
         </Breadcrumbs>
-      </Stack>
+      </Flex>
     </ModalHeader>
   );
 };

--- a/packages/core/content-type-builder/admin/src/components/FormModalSubHeader/index.js
+++ b/packages/core/content-type-builder/admin/src/components/FormModalSubHeader/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 import upperFirst from 'lodash/upperFirst';
-import { Stack, Typography } from '@strapi/design-system';
+import { Flex, Typography } from '@strapi/design-system';
 
 import { getTrad } from '../../utils';
 
@@ -25,7 +25,7 @@ const FormModalSubHeader = ({
       : { id: getTrad(`attribute.${attributeType}`) };
 
   return (
-    <Stack direction="column" alignItems="flex-start" paddingBottom={2} gap={1}>
+    <Flex direction="column" alignItems="flex-start" paddingBottom={2} gap={1}>
       <Typography as="h2" variant="beta">
         {formatMessage(
           {
@@ -51,7 +51,7 @@ const FormModalSubHeader = ({
           defaultMessage: 'A type for modeling data',
         })}
       </Typography>
-    </Stack>
+    </Flex>
   );
 };
 

--- a/packages/core/content-type-builder/admin/src/components/ListRow/index.js
+++ b/packages/core/content-type-builder/admin/src/components/ListRow/index.js
@@ -2,7 +2,7 @@ import React, { memo } from 'react';
 import PropTypes from 'prop-types';
 import get from 'lodash/get';
 import { useIntl } from 'react-intl';
-import { IconButton, Flex, Stack, Typography, Box } from '@strapi/design-system';
+import { IconButton, Flex, Typography, Box } from '@strapi/design-system';
 import { Lock, Pencil, Trash } from '@strapi/icons';
 import { stopPropagation, onRowClick, pxToRem } from '@strapi/helper-plugin';
 import useDataManager from '../../hooks/useDataManager';
@@ -81,10 +81,10 @@ function ListRow({
     >
       <td style={{ position: 'relative' }}>
         {loopNumber !== 0 && <Curve color={isFromDynamicZone ? 'primary200' : 'neutral150'} />}
-        <Stack paddingLeft={2} spacing={4} horizontal>
+        <Flex paddingLeft={2} gap={4}>
           <AttributeIcon type={src} customField={customField} />
           <Typography fontWeight="bold">{name}</Typography>
-        </Stack>
+        </Flex>
       </td>
       <td>
         {target ? (
@@ -114,7 +114,7 @@ function ListRow({
         {isInDevelopmentMode ? (
           <Flex justifyContent="flex-end" {...stopPropagation}>
             {configurable ? (
-              <Stack horizontal spacing={1}>
+              <Flex gap={1}>
                 {!isMorph && (
                   <IconButton
                     onClick={handleClick}
@@ -142,7 +142,7 @@ function ListRow({
                   noBorder
                   icon={<Trash />}
                 />
-              </Stack>
+              </Flex>
             ) : (
               <Lock />
             )}

--- a/packages/core/content-type-builder/admin/src/components/Relation/RelationNaturePicker/index.js
+++ b/packages/core/content-type-builder/admin/src/components/Relation/RelationNaturePicker/index.js
@@ -13,7 +13,7 @@ import {
   ManyToOne,
   ManyToMany,
 } from '@strapi/icons';
-import { Flex, Typography, KeyboardNavigable, Stack } from '@strapi/design-system';
+import { Flex, Typography, KeyboardNavigable } from '@strapi/design-system';
 import useDataManager from '../../../hooks/useDataManager';
 import { ON_CHANGE_RELATION_TYPE } from '../../FormModal/constants';
 import getTrad from '../../../utils/getTrad';
@@ -71,7 +71,7 @@ const RelationNaturePicker = ({
       <Wrapper>
         <Flex paddingLeft={9} paddingRight={9} paddingTop={1} justifyContent="center">
           <KeyboardNavigable tagName="button">
-            <Stack spacing={3} horizontal>
+            <Flex gap={3}>
               {relationsType.map((relation) => {
                 const Asset = relations[relation];
                 const isEnabled =
@@ -102,7 +102,7 @@ const RelationNaturePicker = ({
                   </IconWrapper>
                 );
               })}
-            </Stack>
+            </Flex>
           </KeyboardNavigable>
         </Flex>
       </Wrapper>

--- a/packages/core/content-type-builder/admin/src/pages/ListView/index.js
+++ b/packages/core/content-type-builder/admin/src/pages/ListView/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useTracking, Link } from '@strapi/helper-plugin';
 import { Plus, ArrowLeft, Check, Pencil } from '@strapi/icons';
-import { Button, Flex, Stack, Box, ContentLayout, HeaderLayout } from '@strapi/design-system';
+import { Button, Flex, Box, ContentLayout, HeaderLayout } from '@strapi/design-system';
 import get from 'lodash/get';
 import has from 'lodash/has';
 import isEqual from 'lodash/isEqual';
@@ -113,7 +113,7 @@ const ListView = () => {
         id="title"
         primaryAction={
           isInDevelopmentMode && (
-            <Stack horizontal spacing={2}>
+            <Flex gap={2}>
               {/* DON'T display the add field button when the content type has not been created */}
               {!isCreatingFirstContentType && (
                 <Button
@@ -137,7 +137,7 @@ const ListView = () => {
                   defaultMessage: 'Save',
                 })}
               </Button>
-            </Stack>
+            </Flex>
           )
         }
         secondaryAction={
@@ -167,9 +167,9 @@ const ListView = () => {
         }
       />
       <ContentLayout>
-        <Stack spacing={4}>
+        <Flex direction="column" alignItems="stretch" gap={4}>
           <Flex justifyContent="flex-end">
-            <Stack horizontal spacing={2}>
+            <Flex gap={2}>
               <LinkToCMSettingsView
                 key="link-to-cm-settings-view"
                 targetUid={targetUid}
@@ -178,7 +178,7 @@ const ListView = () => {
                 contentTypeKind={contentTypeKind}
                 disabled={isCreatingFirstContentType}
               />
-            </Stack>
+            </Flex>
           </Flex>
           <Box background="neutral0" shadow="filterShadow" hasRadius>
             <List
@@ -190,7 +190,7 @@ const ListView = () => {
               isMain
             />
           </Box>
-        </Stack>
+        </Flex>
       </ContentLayout>
     </>
   );

--- a/packages/core/content-type-builder/admin/src/pages/ListView/tests/__snapshots__/index.test.js.snap
+++ b/packages/core/content-type-builder/admin/src/pages/ListView/tests/__snapshots__/index.test.js.snap
@@ -21,7 +21,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
   color: #666687;
 }
 
-.c28 {
+.c27 {
   font-weight: 600;
   font-size: 0.6875rem;
   line-height: 1.45;
@@ -29,34 +29,34 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
   color: #666687;
 }
 
-.c34 {
+.c33 {
   font-size: 0.875rem;
   line-height: 1.43;
   font-weight: 600;
   color: #32324d;
 }
 
-.c35 {
+.c34 {
   font-size: 0.875rem;
   line-height: 1.43;
   color: #32324d;
 }
 
-.c48 {
+.c47 {
   font-size: 0.75rem;
   line-height: 1.33;
   font-weight: 600;
   color: #666687;
 }
 
-.c56 {
+.c55 {
   font-size: 0.75rem;
   line-height: 1.33;
   font-weight: 600;
   color: #4945ff;
 }
 
-.c64 {
+.c63 {
   font-size: 0.75rem;
   line-height: 1.33;
   display: block;
@@ -92,22 +92,22 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
   padding-left: 56px;
 }
 
-.c25 {
+.c24 {
   background: #ffffff;
   border-radius: 4px;
   box-shadow: 0px 1px 4px rgba(33,33,52,0.1);
 }
 
-.c27 {
+.c26 {
   padding-right: 24px;
   padding-left: 24px;
 }
 
-.c30 {
+.c29 {
   padding-left: 8px;
 }
 
-.c32 {
+.c31 {
   width: 2rem;
   height: 1.5rem;
   -webkit-flex-shrink: 0;
@@ -115,28 +115,28 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
   flex-shrink: 0;
 }
 
-.c40 {
+.c39 {
   padding-left: 24px;
 }
 
-.c43 {
+.c42 {
   padding-top: 16px;
   padding-bottom: 16px;
 }
 
-.c45 {
+.c44 {
   background: #dcdce4;
 }
 
-.c47 {
+.c46 {
   padding-left: 12px;
 }
 
-.c50 {
+.c49 {
   padding-left: 40px;
 }
 
-.c57 {
+.c56 {
   padding-right: 16px;
   padding-left: 16px;
   border-radius: borderRadius;
@@ -145,20 +145,20 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
   flex-shrink: 0;
 }
 
-.c60 {
+.c59 {
   background: #d9d8ff;
 }
 
-.c63 {
+.c62 {
   margin-top: 4px;
   max-width: 100%;
 }
 
-.c71 {
+.c70 {
   background: #eaeaef;
 }
 
-.c73 {
+.c72 {
   background: #f0f0ff;
   padding: 20px;
 }
@@ -195,6 +195,21 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
   flex-direction: row;
 }
 
+.c17 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 8px;
+}
+
 .c22 {
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -207,9 +222,10 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  gap: 16px;
 }
 
-.c24 {
+.c23 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -227,7 +243,52 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
   justify-content: flex-end;
 }
 
-.c58 {
+.c30 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 16px;
+}
+
+.c35 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 4px;
+}
+
+.c52 {
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.c57 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -248,7 +309,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
   justify-content: center;
 }
 
-.c61 {
+.c60 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -264,51 +325,6 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-}
-
-.c23 > * {
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
-.c23 > * + * {
-  margin-top: 16px;
-}
-
-.c53 > * {
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
-.c53 > * + * {
-  margin-top: 4px;
-}
-
-.c17 > * {
-  margin-left: 0;
-  margin-right: 0;
-}
-
-.c17 > * + * {
-  margin-left: 8px;
-}
-
-.c31 > * {
-  margin-left: 0;
-  margin-right: 0;
-}
-
-.c31 > * + * {
-  margin-left: 16px;
-}
-
-.c36 > * {
-  margin-left: 0;
-  margin-right: 0;
-}
-
-.c36 > * + * {
-  margin-left: 4px;
 }
 
 .c12 {
@@ -369,7 +385,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
   border: 2px solid #4945ff;
 }
 
-.c38 {
+.c37 {
   border: 0;
   -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
@@ -607,7 +623,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
   fill: #ffffff;
 }
 
-.c72 {
+.c71 {
   height: 1px;
   border: none;
   -webkit-flex-shrink: 0;
@@ -616,7 +632,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
   margin: 0;
 }
 
-.c37 {
+.c36 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -634,30 +650,30 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
   border: none;
 }
 
-.c37 svg > g,
-.c37 svg path {
+.c36 svg > g,
+.c36 svg path {
   fill: #8e8ea9;
 }
 
-.c37:hover svg > g,
-.c37:hover svg path {
+.c36:hover svg > g,
+.c36:hover svg path {
   fill: #666687;
 }
 
-.c37:active svg > g,
-.c37:active svg path {
+.c36:active svg > g,
+.c36:active svg path {
   fill: #a5a5ba;
 }
 
-.c37[aria-disabled='true'] {
+.c36[aria-disabled='true'] {
   background-color: #eaeaef;
 }
 
-.c37[aria-disabled='true'] svg path {
+.c36[aria-disabled='true'] svg path {
   fill: #666687;
 }
 
-.c75 {
+.c74 {
   height: 1.5rem;
   width: 1.5rem;
   border-radius: 50%;
@@ -675,16 +691,16 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
   align-items: center;
 }
 
-.c75 svg {
+.c74 svg {
   height: 0.625rem;
   width: 0.625rem;
 }
 
-.c75 svg path {
+.c74 svg path {
   fill: #4945ff;
 }
 
-.c74 {
+.c73 {
   border-radius: 0 0 4px 4px;
   display: block;
   width: 100%;
@@ -761,47 +777,47 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
   display: flex;
 }
 
-.c62 {
+.c61 {
   border-radius: 50%;
   color: #4945ff;
   height: 40px;
   width: 40px;
 }
 
-.c62 svg {
+.c61 svg {
   height: 20px;
   width: 20px;
 }
 
-.c67 {
+.c66 {
   border-radius: 50%;
   color: #666687;
   height: 40px;
   width: 40px;
 }
 
-.c67 svg {
+.c66 svg {
   height: 20px;
   width: 20px;
 }
 
-.c66 {
+.c65 {
   position: absolute;
   display: none;
   top: 5px;
   right: 0.5rem;
 }
 
-.c66 svg {
+.c65 svg {
   width: 0.625rem;
   height: 0.625rem;
 }
 
-.c66 svg path {
+.c65 svg path {
   fill: #4945ff;
 }
 
-.c59 {
+.c58 {
   width: 8.75rem;
   height: 5rem;
   position: relative;
@@ -811,51 +827,51 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
   max-width: 100%;
 }
 
-.c59.active,
-.c59:focus,
-.c59:hover {
+.c58.active,
+.c58:focus,
+.c58:hover {
   border: 1px solid #d9d8ff;
   background: #f0f0ff;
 }
 
-.c59.active .c65,
-.c59:focus .c65,
-.c59:hover .c65 {
+.c58.active .c64,
+.c58:focus .c64,
+.c58:hover .c64 {
   display: block;
 }
 
-.c59.active .c9,
-.c59:focus .c9,
-.c59:hover .c9 {
+.c58.active .c9,
+.c58:focus .c9,
+.c58:hover .c9 {
   color: #4945ff;
 }
 
-.c59.active > div:first-child,
-.c59:focus > div:first-child,
-.c59:hover > div:first-child {
+.c58.active > div:first-child,
+.c58:focus > div:first-child,
+.c58:hover > div:first-child {
   background: #d9d8ff;
   color: #4945ff;
 }
 
-.c39.component-row,
-.c39.dynamiczone-row {
+.c38.component-row,
+.c38.dynamiczone-row {
   position: relative;
   border-top: none !important;
 }
 
-.c39.component-row table tr:first-child,
-.c39.dynamiczone-row table tr:first-child {
+.c38.component-row table tr:first-child,
+.c38.dynamiczone-row table tr:first-child {
   border-top: none;
 }
 
-.c39.component-row > td:first-of-type,
-.c39.dynamiczone-row > td:first-of-type {
+.c38.component-row > td:first-of-type,
+.c38.dynamiczone-row > td:first-of-type {
   padding: 0 0 0 1.25rem;
   position: relative;
 }
 
-.c39.component-row > td:first-of-type::before,
-.c39.dynamiczone-row > td:first-of-type::before {
+.c38.component-row > td:first-of-type::before,
+.c38.dynamiczone-row > td:first-of-type::before {
   content: '';
   width: 0.25rem;
   height: calc(100% - 40px);
@@ -866,29 +882,29 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
   background: #eaeaef;
 }
 
-.c39.dynamiczone-row > td:first-of-type {
+.c38.dynamiczone-row > td:first-of-type {
   padding: 0;
 }
 
-.c49.component-row,
-.c49.dynamiczone-row {
+.c48.component-row,
+.c48.dynamiczone-row {
   position: relative;
   border-top: none !important;
 }
 
-.c49.component-row table tr:first-child,
-.c49.dynamiczone-row table tr:first-child {
+.c48.component-row table tr:first-child,
+.c48.dynamiczone-row table tr:first-child {
   border-top: none;
 }
 
-.c49.component-row > td:first-of-type,
-.c49.dynamiczone-row > td:first-of-type {
+.c48.component-row > td:first-of-type,
+.c48.dynamiczone-row > td:first-of-type {
   padding: 0 0 0 1.25rem;
   position: relative;
 }
 
-.c49.component-row > td:first-of-type::before,
-.c49.dynamiczone-row > td:first-of-type::before {
+.c48.component-row > td:first-of-type::before,
+.c48.dynamiczone-row > td:first-of-type::before {
   content: '';
   width: 0.25rem;
   height: calc(100% - 40px);
@@ -899,11 +915,11 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
   background-color: #d9d8ff;
 }
 
-.c49.dynamiczone-row > td:first-of-type {
+.c48.dynamiczone-row > td:first-of-type {
   padding: 0;
 }
 
-.c55 {
+.c54 {
   width: 2rem;
   height: 2rem;
   padding: 0.5625rem;
@@ -911,11 +927,11 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
   background: #f0f0ff;
 }
 
-.c55 path {
+.c54 path {
   fill: #4945ff;
 }
 
-.c51 {
+.c50 {
   height: 5.625rem;
   position: absolute;
   width: 100%;
@@ -923,16 +939,16 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
   left: 0;
 }
 
-.c52 {
+.c51 {
   width: 100%;
   overflow-x: auto;
 }
 
-.c68 {
+.c67 {
   padding-top: 5.625rem;
 }
 
-.c54 {
+.c53 {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -948,42 +964,42 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
   align-items: center;
 }
 
-.c26 table {
+.c25 table {
   width: 100%;
   white-space: nowrap;
 }
 
-.c26 thead {
+.c25 thead {
   border-bottom: 1px solid #eaeaef;
 }
 
-.c26 thead tr {
+.c25 thead tr {
   border-top: 0;
 }
 
-.c26 tr {
+.c25 tr {
   border-top: 1px solid #eaeaef;
 }
 
-.c26 tr td,
-.c26 tr th {
+.c25 tr td,
+.c25 tr th {
   padding: 16px;
 }
 
-.c26 tr td:first-of-type,
-.c26 tr th:first-of-type {
+.c25 tr td:first-of-type,
+.c25 tr th:first-of-type {
   padding: 0 4px;
 }
 
-.c26 th,
-.c26 td {
+.c25 th,
+.c25 td {
   vertical-align: middle;
   text-align: left;
   color: #666687;
   outline-offset: -4px;
 }
 
-.c46 {
+.c45 {
   height: 1.5rem;
   width: 1.5rem;
   border-radius: 50%;
@@ -1001,16 +1017,16 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
   align-items: center;
 }
 
-.c46 svg {
+.c45 svg {
   height: 0.625rem;
   width: 0.625rem;
 }
 
-.c46 svg path {
+.c45 svg path {
   fill: #666687;
 }
 
-.c70 {
+.c69 {
   height: 1.5rem;
   width: 1.5rem;
   border-radius: 50%;
@@ -1028,16 +1044,16 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
   align-items: center;
 }
 
-.c70 svg {
+.c69 svg {
   height: 0.625rem;
   width: 0.625rem;
 }
 
-.c70 svg path {
+.c69 svg path {
   fill: #4945ff;
 }
 
-.c44 {
+.c43 {
   border-radius: 0 0 4px 4px;
   display: block;
   width: 100%;
@@ -1046,20 +1062,20 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
   left: -0.25rem;
 }
 
-.c41 {
+.c40 {
   position: absolute;
   left: -1.125rem;
   top: 0px;
 }
 
-.c41:before {
+.c40:before {
   content: '';
   width: 0.25rem;
   height: 0.75rem;
   display: block;
 }
 
-.c42 {
+.c41 {
   position: relative;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
@@ -1069,11 +1085,11 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
   transform: translate(-0.5px,-1px);
 }
 
-.c42 * {
+.c41 * {
   fill: #eaeaef;
 }
 
-.c69 {
+.c68 {
   position: relative;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
@@ -1083,15 +1099,15 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
   transform: translate(-0.5px,-1px);
 }
 
-.c69 * {
+.c68 * {
   fill: #d9d8ff;
 }
 
-.c29 {
+.c28 {
   position: relative;
 }
 
-.c33 svg {
+.c32 svg {
   height: 100%;
   width: 100%;
 }
@@ -1181,7 +1197,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
           </div>
         </div>
         <div
-          class="c0 c8 c17"
+          class="c0 c17"
         >
           <button
             aria-disabled="false"
@@ -1253,13 +1269,13 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
     class="c0 c21"
   >
     <div
-      class="c0 c22 c23"
+      class="c0 c22"
     >
       <div
-        class="c0 c24"
+        class="c0 c23"
       >
         <div
-          class="c0 c8 c17"
+          class="c0 c17"
         >
           <div>
             <button
@@ -1294,13 +1310,13 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
         </div>
       </div>
       <div
-        class="c0 c25"
+        class="c0 c24"
       >
         <div
-          class="c0 c26"
+          class="c0 c25"
         >
           <div
-            class="c0 c27"
+            class="c0 c26"
             style="overflow-x: auto;"
           >
             <table>
@@ -1308,7 +1324,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                 <tr>
                   <th>
                     <span
-                      class="c9 c28"
+                      class="c9 c27"
                     >
                       Name
                     </span>
@@ -1317,7 +1333,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                     colspan="2"
                   >
                     <span
-                      class="c9 c28"
+                      class="c9 c27"
                     >
                       Type
                     </span>
@@ -1326,18 +1342,18 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
               </thead>
               <tbody>
                 <tr
-                  class="c0 c29"
+                  class="c0 c28"
                   style="cursor: pointer;"
                 >
                   <td
                     style="position: relative;"
                   >
                     <div
-                      class="c0 c30 c8 c31"
+                      class="c0 c29 c30"
                     >
                       <div
                         aria-hidden="true"
-                        class="c0 c32 c33"
+                        class="c0 c31 c32"
                       >
                         <svg
                           class="c0 "
@@ -1363,7 +1379,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                         </svg>
                       </div>
                       <span
-                        class="c9 c34"
+                        class="c9 c33"
                       >
                         postal_code
                       </span>
@@ -1371,7 +1387,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                   </td>
                   <td>
                     <span
-                      class="c9 c35"
+                      class="c9 c34"
                     >
                       string
                        
@@ -1380,22 +1396,22 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                   <td>
                     <div
                       aria-hidden="true"
-                      class="c0 c24"
+                      class="c0 c23"
                       role="button"
                     >
                       <div
-                        class="c0 c8 c36"
+                        class="c0 c35"
                       >
                         <span>
                           <button
                             aria-disabled="false"
                             aria-labelledby="0"
-                            class="c12 c37"
+                            class="c12 c36"
                             tabindex="0"
                             type="button"
                           >
                             <span
-                              class="c38"
+                              class="c37"
                             >
                               Edit postal_code
                             </span>
@@ -1421,12 +1437,12 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                           <button
                             aria-disabled="false"
                             aria-labelledby="1"
-                            class="c12 c37"
+                            class="c12 c36"
                             tabindex="0"
                             type="button"
                           >
                             <span
-                              class="c38"
+                              class="c37"
                             >
                               Delete postal_code
                             </span>
@@ -1451,18 +1467,18 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                   </td>
                 </tr>
                 <tr
-                  class="c0 c29"
+                  class="c0 c28"
                   style="cursor: pointer;"
                 >
                   <td
                     style="position: relative;"
                   >
                     <div
-                      class="c0 c30 c8 c31"
+                      class="c0 c29 c30"
                     >
                       <div
                         aria-hidden="true"
-                        class="c0 c32 c33"
+                        class="c0 c31 c32"
                       >
                         <svg
                           class="c0 "
@@ -1486,7 +1502,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                         </svg>
                       </div>
                       <span
-                        class="c9 c34"
+                        class="c9 c33"
                       >
                         categories
                       </span>
@@ -1494,7 +1510,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                   </td>
                   <td>
                     <span
-                      class="c9 c35"
+                      class="c9 c34"
                     >
                       Relation with
                        
@@ -1509,22 +1525,22 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                   <td>
                     <div
                       aria-hidden="true"
-                      class="c0 c24"
+                      class="c0 c23"
                       role="button"
                     >
                       <div
-                        class="c0 c8 c36"
+                        class="c0 c35"
                       >
                         <span>
                           <button
                             aria-disabled="false"
                             aria-labelledby="2"
-                            class="c12 c37"
+                            class="c12 c36"
                             tabindex="0"
                             type="button"
                           >
                             <span
-                              class="c38"
+                              class="c37"
                             >
                               Edit categories
                             </span>
@@ -1550,12 +1566,12 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                           <button
                             aria-disabled="false"
                             aria-labelledby="3"
-                            class="c12 c37"
+                            class="c12 c36"
                             tabindex="0"
                             type="button"
                           >
                             <span
-                              class="c38"
+                              class="c37"
                             >
                               Delete categories
                             </span>
@@ -1580,18 +1596,18 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                   </td>
                 </tr>
                 <tr
-                  class="c0 c29"
+                  class="c0 c28"
                   style="cursor: pointer;"
                 >
                   <td
                     style="position: relative;"
                   >
                     <div
-                      class="c0 c30 c8 c31"
+                      class="c0 c29 c30"
                     >
                       <div
                         aria-hidden="true"
-                        class="c0 c32 c33"
+                        class="c0 c31 c32"
                       >
                         <svg
                           class="c0 "
@@ -1619,7 +1635,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                         </svg>
                       </div>
                       <span
-                        class="c9 c34"
+                        class="c9 c33"
                       >
                         cover
                       </span>
@@ -1627,7 +1643,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                   </td>
                   <td>
                     <span
-                      class="c9 c35"
+                      class="c9 c34"
                     >
                       media
                        
@@ -1636,22 +1652,22 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                   <td>
                     <div
                       aria-hidden="true"
-                      class="c0 c24"
+                      class="c0 c23"
                       role="button"
                     >
                       <div
-                        class="c0 c8 c36"
+                        class="c0 c35"
                       >
                         <span>
                           <button
                             aria-disabled="false"
                             aria-labelledby="4"
-                            class="c12 c37"
+                            class="c12 c36"
                             tabindex="0"
                             type="button"
                           >
                             <span
-                              class="c38"
+                              class="c37"
                             >
                               Edit cover
                             </span>
@@ -1677,12 +1693,12 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                           <button
                             aria-disabled="false"
                             aria-labelledby="5"
-                            class="c12 c37"
+                            class="c12 c36"
                             tabindex="0"
                             type="button"
                           >
                             <span
-                              class="c38"
+                              class="c37"
                             >
                               Delete cover
                             </span>
@@ -1707,18 +1723,18 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                   </td>
                 </tr>
                 <tr
-                  class="c0 c29"
+                  class="c0 c28"
                   style="cursor: pointer;"
                 >
                   <td
                     style="position: relative;"
                   >
                     <div
-                      class="c0 c30 c8 c31"
+                      class="c0 c29 c30"
                     >
                       <div
                         aria-hidden="true"
-                        class="c0 c32 c33"
+                        class="c0 c31 c32"
                       >
                         <svg
                           class="c0 "
@@ -1746,7 +1762,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                         </svg>
                       </div>
                       <span
-                        class="c9 c34"
+                        class="c9 c33"
                       >
                         images
                       </span>
@@ -1754,7 +1770,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                   </td>
                   <td>
                     <span
-                      class="c9 c35"
+                      class="c9 c34"
                     >
                       media
                        
@@ -1763,22 +1779,22 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                   <td>
                     <div
                       aria-hidden="true"
-                      class="c0 c24"
+                      class="c0 c23"
                       role="button"
                     >
                       <div
-                        class="c0 c8 c36"
+                        class="c0 c35"
                       >
                         <span>
                           <button
                             aria-disabled="false"
                             aria-labelledby="6"
-                            class="c12 c37"
+                            class="c12 c36"
                             tabindex="0"
                             type="button"
                           >
                             <span
-                              class="c38"
+                              class="c37"
                             >
                               Edit images
                             </span>
@@ -1804,12 +1820,12 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                           <button
                             aria-disabled="false"
                             aria-labelledby="7"
-                            class="c12 c37"
+                            class="c12 c36"
                             tabindex="0"
                             type="button"
                           >
                             <span
-                              class="c38"
+                              class="c37"
                             >
                               Delete images
                             </span>
@@ -1834,18 +1850,18 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                   </td>
                 </tr>
                 <tr
-                  class="c0 c29"
+                  class="c0 c28"
                   style="cursor: pointer;"
                 >
                   <td
                     style="position: relative;"
                   >
                     <div
-                      class="c0 c30 c8 c31"
+                      class="c0 c29 c30"
                     >
                       <div
                         aria-hidden="true"
-                        class="c0 c32 c33"
+                        class="c0 c31 c32"
                       >
                         <svg
                           class="c0 "
@@ -1871,7 +1887,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                         </svg>
                       </div>
                       <span
-                        class="c9 c34"
+                        class="c9 c33"
                       >
                         city
                       </span>
@@ -1879,7 +1895,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                   </td>
                   <td>
                     <span
-                      class="c9 c35"
+                      class="c9 c34"
                     >
                       string
                        
@@ -1888,22 +1904,22 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                   <td>
                     <div
                       aria-hidden="true"
-                      class="c0 c24"
+                      class="c0 c23"
                       role="button"
                     >
                       <div
-                        class="c0 c8 c36"
+                        class="c0 c35"
                       >
                         <span>
                           <button
                             aria-disabled="false"
                             aria-labelledby="8"
-                            class="c12 c37"
+                            class="c12 c36"
                             tabindex="0"
                             type="button"
                           >
                             <span
-                              class="c38"
+                              class="c37"
                             >
                               Edit city
                             </span>
@@ -1929,12 +1945,12 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                           <button
                             aria-disabled="false"
                             aria-labelledby="9"
-                            class="c12 c37"
+                            class="c12 c36"
                             tabindex="0"
                             type="button"
                           >
                             <span
-                              class="c38"
+                              class="c37"
                             >
                               Delete city
                             </span>
@@ -1959,18 +1975,18 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                   </td>
                 </tr>
                 <tr
-                  class="c0 c29"
+                  class="c0 c28"
                   style="cursor: pointer;"
                 >
                   <td
                     style="position: relative;"
                   >
                     <div
-                      class="c0 c30 c8 c31"
+                      class="c0 c29 c30"
                     >
                       <div
                         aria-hidden="true"
-                        class="c0 c32 c33"
+                        class="c0 c31 c32"
                       >
                         <svg
                           class="c0 "
@@ -1998,7 +2014,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                         </svg>
                       </div>
                       <span
-                        class="c9 c34"
+                        class="c9 c33"
                       >
                         json
                       </span>
@@ -2006,7 +2022,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                   </td>
                   <td>
                     <span
-                      class="c9 c35"
+                      class="c9 c34"
                     >
                       json
                        
@@ -2015,22 +2031,22 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                   <td>
                     <div
                       aria-hidden="true"
-                      class="c0 c24"
+                      class="c0 c23"
                       role="button"
                     >
                       <div
-                        class="c0 c8 c36"
+                        class="c0 c35"
                       >
                         <span>
                           <button
                             aria-disabled="false"
                             aria-labelledby="10"
-                            class="c12 c37"
+                            class="c12 c36"
                             tabindex="0"
                             type="button"
                           >
                             <span
-                              class="c38"
+                              class="c37"
                             >
                               Edit json
                             </span>
@@ -2056,12 +2072,12 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                           <button
                             aria-disabled="false"
                             aria-labelledby="11"
-                            class="c12 c37"
+                            class="c12 c36"
                             tabindex="0"
                             type="button"
                           >
                             <span
-                              class="c38"
+                              class="c37"
                             >
                               Delete json
                             </span>
@@ -2086,18 +2102,18 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                   </td>
                 </tr>
                 <tr
-                  class="c0 c29"
+                  class="c0 c28"
                   style="cursor: pointer;"
                 >
                   <td
                     style="position: relative;"
                   >
                     <div
-                      class="c0 c30 c8 c31"
+                      class="c0 c29 c30"
                     >
                       <div
                         aria-hidden="true"
-                        class="c0 c32 c33"
+                        class="c0 c31 c32"
                       >
                         <svg
                           class="c0 "
@@ -2119,7 +2135,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                         </svg>
                       </div>
                       <span
-                        class="c9 c34"
+                        class="c9 c33"
                       >
                         slug
                       </span>
@@ -2127,7 +2143,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                   </td>
                   <td>
                     <span
-                      class="c9 c35"
+                      class="c9 c34"
                     >
                       uid
                        
@@ -2136,22 +2152,22 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                   <td>
                     <div
                       aria-hidden="true"
-                      class="c0 c24"
+                      class="c0 c23"
                       role="button"
                     >
                       <div
-                        class="c0 c8 c36"
+                        class="c0 c35"
                       >
                         <span>
                           <button
                             aria-disabled="false"
                             aria-labelledby="12"
-                            class="c12 c37"
+                            class="c12 c36"
                             tabindex="0"
                             type="button"
                           >
                             <span
-                              class="c38"
+                              class="c37"
                             >
                               Edit slug
                             </span>
@@ -2177,12 +2193,12 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                           <button
                             aria-disabled="false"
                             aria-labelledby="13"
-                            class="c12 c37"
+                            class="c12 c36"
                             tabindex="0"
                             type="button"
                           >
                             <span
-                              class="c38"
+                              class="c37"
                             >
                               Delete slug
                             </span>
@@ -2207,18 +2223,18 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                   </td>
                 </tr>
                 <tr
-                  class="c0 c29"
+                  class="c0 c28"
                   style="cursor: pointer;"
                 >
                   <td
                     style="position: relative;"
                   >
                     <div
-                      class="c0 c30 c8 c31"
+                      class="c0 c29 c30"
                     >
                       <div
                         aria-hidden="true"
-                        class="c0 c32 c33"
+                        class="c0 c31 c32"
                       >
                         <svg
                           class="c0 "
@@ -2250,7 +2266,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                         </svg>
                       </div>
                       <span
-                        class="c9 c34"
+                        class="c9 c33"
                       >
                         notrepeat_req
                       </span>
@@ -2258,7 +2274,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                   </td>
                   <td>
                     <span
-                      class="c9 c35"
+                      class="c9 c34"
                     >
                       component
                        
@@ -2267,22 +2283,22 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                   <td>
                     <div
                       aria-hidden="true"
-                      class="c0 c24"
+                      class="c0 c23"
                       role="button"
                     >
                       <div
-                        class="c0 c8 c36"
+                        class="c0 c35"
                       >
                         <span>
                           <button
                             aria-disabled="false"
                             aria-labelledby="14"
-                            class="c12 c37"
+                            class="c12 c36"
                             tabindex="0"
                             type="button"
                           >
                             <span
-                              class="c38"
+                              class="c37"
                             >
                               Edit notrepeat_req
                             </span>
@@ -2308,12 +2324,12 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                           <button
                             aria-disabled="false"
                             aria-labelledby="15"
-                            class="c12 c37"
+                            class="c12 c36"
                             tabindex="0"
                             type="button"
                           >
                             <span
-                              class="c38"
+                              class="c37"
                             >
                               Delete notrepeat_req
                             </span>
@@ -2338,31 +2354,31 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                   </td>
                 </tr>
                 <tr
-                  class="c39 component-row"
+                  class="c38 component-row"
                 >
                   <td
                     colspan="12"
                   >
                     <div
-                      class="c0 c26"
+                      class="c0 c25"
                     >
                       <div
-                        class="c0 c40"
+                        class="c0 c39"
                       >
                         <table>
                           <tbody>
                             <tr
-                              class="c0 c29"
+                              class="c0 c28"
                               style="cursor: pointer;"
                             >
                               <td
                                 style="position: relative;"
                               >
                                 <div
-                                  class="c0 c41"
+                                  class="c0 c40"
                                 >
                                   <svg
-                                    class="c42"
+                                    class="c41"
                                     color="neutral150"
                                     fill="none"
                                     height="23"
@@ -2378,11 +2394,11 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                   </svg>
                                 </div>
                                 <div
-                                  class="c0 c30 c8 c31"
+                                  class="c0 c29 c30"
                                 >
                                   <div
                                     aria-hidden="true"
-                                    class="c0 c32 c33"
+                                    class="c0 c31 c32"
                                   >
                                     <svg
                                       class="c0 "
@@ -2408,7 +2424,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                     </svg>
                                   </div>
                                   <span
-                                    class="c9 c34"
+                                    class="c9 c33"
                                   >
                                     name
                                   </span>
@@ -2416,7 +2432,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                               </td>
                               <td>
                                 <span
-                                  class="c9 c35"
+                                  class="c9 c34"
                                 >
                                   string
                                    
@@ -2425,22 +2441,22 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                               <td>
                                 <div
                                   aria-hidden="true"
-                                  class="c0 c24"
+                                  class="c0 c23"
                                   role="button"
                                 >
                                   <div
-                                    class="c0 c8 c36"
+                                    class="c0 c35"
                                   >
                                     <span>
                                       <button
                                         aria-disabled="false"
                                         aria-labelledby="16"
-                                        class="c12 c37"
+                                        class="c12 c36"
                                         tabindex="0"
                                         type="button"
                                       >
                                         <span
-                                          class="c38"
+                                          class="c37"
                                         >
                                           Edit name
                                         </span>
@@ -2466,12 +2482,12 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                       <button
                                         aria-disabled="false"
                                         aria-labelledby="17"
-                                        class="c12 c37"
+                                        class="c12 c36"
                                         tabindex="0"
                                         type="button"
                                       >
                                         <span
-                                          class="c38"
+                                          class="c37"
                                         >
                                           Delete name
                                         </span>
@@ -2496,17 +2512,17 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                               </td>
                             </tr>
                             <tr
-                              class="c0 c29"
+                              class="c0 c28"
                               style="cursor: pointer;"
                             >
                               <td
                                 style="position: relative;"
                               >
                                 <div
-                                  class="c0 c41"
+                                  class="c0 c40"
                                 >
                                   <svg
-                                    class="c42"
+                                    class="c41"
                                     color="neutral150"
                                     fill="none"
                                     height="23"
@@ -2522,11 +2538,11 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                   </svg>
                                 </div>
                                 <div
-                                  class="c0 c30 c8 c31"
+                                  class="c0 c29 c30"
                                 >
                                   <div
                                     aria-hidden="true"
-                                    class="c0 c32 c33"
+                                    class="c0 c31 c32"
                                   >
                                     <svg
                                       class="c0 "
@@ -2552,7 +2568,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                     </svg>
                                   </div>
                                   <span
-                                    class="c9 c34"
+                                    class="c9 c33"
                                   >
                                     popo
                                   </span>
@@ -2560,7 +2576,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                               </td>
                               <td>
                                 <span
-                                  class="c9 c35"
+                                  class="c9 c34"
                                 >
                                   string
                                    
@@ -2569,22 +2585,22 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                               <td>
                                 <div
                                   aria-hidden="true"
-                                  class="c0 c24"
+                                  class="c0 c23"
                                   role="button"
                                 >
                                   <div
-                                    class="c0 c8 c36"
+                                    class="c0 c35"
                                   >
                                     <span>
                                       <button
                                         aria-disabled="false"
                                         aria-labelledby="18"
-                                        class="c12 c37"
+                                        class="c12 c36"
                                         tabindex="0"
                                         type="button"
                                       >
                                         <span
-                                          class="c38"
+                                          class="c37"
                                         >
                                           Edit popo
                                         </span>
@@ -2610,12 +2626,12 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                       <button
                                         aria-disabled="false"
                                         aria-labelledby="19"
-                                        class="c12 c37"
+                                        class="c12 c36"
                                         tabindex="0"
                                         type="button"
                                       >
                                         <span
-                                          class="c38"
+                                          class="c37"
                                         >
                                           Delete popo
                                         </span>
@@ -2640,17 +2656,17 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                               </td>
                             </tr>
                             <tr
-                              class="c0 c29"
+                              class="c0 c28"
                               style="cursor: pointer;"
                             >
                               <td
                                 style="position: relative;"
                               >
                                 <div
-                                  class="c0 c41"
+                                  class="c0 c40"
                                 >
                                   <svg
-                                    class="c42"
+                                    class="c41"
                                     color="neutral150"
                                     fill="none"
                                     height="23"
@@ -2666,11 +2682,11 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                   </svg>
                                 </div>
                                 <div
-                                  class="c0 c30 c8 c31"
+                                  class="c0 c29 c30"
                                 >
                                   <div
                                     aria-hidden="true"
-                                    class="c0 c32 c33"
+                                    class="c0 c31 c32"
                                   >
                                     <svg
                                       class="c0 "
@@ -2696,7 +2712,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                     </svg>
                                   </div>
                                   <span
-                                    class="c9 c34"
+                                    class="c9 c33"
                                   >
                                     poq
                                   </span>
@@ -2704,7 +2720,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                               </td>
                               <td>
                                 <span
-                                  class="c9 c35"
+                                  class="c9 c34"
                                 >
                                   string
                                    
@@ -2713,22 +2729,22 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                               <td>
                                 <div
                                   aria-hidden="true"
-                                  class="c0 c24"
+                                  class="c0 c23"
                                   role="button"
                                 >
                                   <div
-                                    class="c0 c8 c36"
+                                    class="c0 c35"
                                   >
                                     <span>
                                       <button
                                         aria-disabled="false"
                                         aria-labelledby="20"
-                                        class="c12 c37"
+                                        class="c12 c36"
                                         tabindex="0"
                                         type="button"
                                       >
                                         <span
-                                          class="c38"
+                                          class="c37"
                                         >
                                           Edit poq
                                         </span>
@@ -2754,12 +2770,12 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                       <button
                                         aria-disabled="false"
                                         aria-labelledby="21"
-                                        class="c12 c37"
+                                        class="c12 c36"
                                         tabindex="0"
                                         type="button"
                                       >
                                         <span
-                                          class="c38"
+                                          class="c37"
                                         >
                                           Delete poq
                                         </span>
@@ -2787,7 +2803,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                         </table>
                       </div>
                       <button
-                        class="c0 c43 c44"
+                        class="c0 c42 c43"
                         type="button"
                       >
                         <div
@@ -2795,7 +2811,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                         >
                           <div
                             aria-hidden="true"
-                            class="c0 c45 c46"
+                            class="c0 c44 c45"
                           >
                             <svg
                               fill="none"
@@ -2811,10 +2827,10 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                             </svg>
                           </div>
                           <div
-                            class="c0 c47"
+                            class="c0 c46"
                           >
                             <span
-                              class="c9 c48"
+                              class="c9 c47"
                             >
                               Add another field
                             </span>
@@ -2825,18 +2841,18 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                   </td>
                 </tr>
                 <tr
-                  class="c0 c29"
+                  class="c0 c28"
                   style="cursor: pointer;"
                 >
                   <td
                     style="position: relative;"
                   >
                     <div
-                      class="c0 c30 c8 c31"
+                      class="c0 c29 c30"
                     >
                       <div
                         aria-hidden="true"
-                        class="c0 c32 c33"
+                        class="c0 c31 c32"
                       >
                         <svg
                           class="c0 "
@@ -2868,7 +2884,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                         </svg>
                       </div>
                       <span
-                        class="c9 c34"
+                        class="c9 c33"
                       >
                         Compopo
                       </span>
@@ -2876,7 +2892,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                   </td>
                   <td>
                     <span
-                      class="c9 c35"
+                      class="c9 c34"
                     >
                       component
                        
@@ -2885,22 +2901,22 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                   <td>
                     <div
                       aria-hidden="true"
-                      class="c0 c24"
+                      class="c0 c23"
                       role="button"
                     >
                       <div
-                        class="c0 c8 c36"
+                        class="c0 c35"
                       >
                         <span>
                           <button
                             aria-disabled="false"
                             aria-labelledby="22"
-                            class="c12 c37"
+                            class="c12 c36"
                             tabindex="0"
                             type="button"
                           >
                             <span
-                              class="c38"
+                              class="c37"
                             >
                               Edit Compopo
                             </span>
@@ -2926,12 +2942,12 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                           <button
                             aria-disabled="false"
                             aria-labelledby="23"
-                            class="c12 c37"
+                            class="c12 c36"
                             tabindex="0"
                             type="button"
                           >
                             <span
-                              class="c38"
+                              class="c37"
                             >
                               Delete Compopo
                             </span>
@@ -2956,31 +2972,31 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                   </td>
                 </tr>
                 <tr
-                  class="c39 component-row"
+                  class="c38 component-row"
                 >
                   <td
                     colspan="12"
                   >
                     <div
-                      class="c0 c26"
+                      class="c0 c25"
                     >
                       <div
-                        class="c0 c40"
+                        class="c0 c39"
                       >
                         <table>
                           <tbody>
                             <tr
-                              class="c0 c29"
+                              class="c0 c28"
                               style="cursor: pointer;"
                             >
                               <td
                                 style="position: relative;"
                               >
                                 <div
-                                  class="c0 c41"
+                                  class="c0 c40"
                                 >
                                   <svg
-                                    class="c42"
+                                    class="c41"
                                     color="neutral150"
                                     fill="none"
                                     height="23"
@@ -2996,11 +3012,11 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                   </svg>
                                 </div>
                                 <div
-                                  class="c0 c30 c8 c31"
+                                  class="c0 c29 c30"
                                 >
                                   <div
                                     aria-hidden="true"
-                                    class="c0 c32 c33"
+                                    class="c0 c31 c32"
                                   >
                                     <svg
                                       class="c0 "
@@ -3026,7 +3042,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                     </svg>
                                   </div>
                                   <span
-                                    class="c9 c34"
+                                    class="c9 c33"
                                   >
                                     dede
                                   </span>
@@ -3034,7 +3050,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                               </td>
                               <td>
                                 <span
-                                  class="c9 c35"
+                                  class="c9 c34"
                                 >
                                   string
                                    
@@ -3043,22 +3059,22 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                               <td>
                                 <div
                                   aria-hidden="true"
-                                  class="c0 c24"
+                                  class="c0 c23"
                                   role="button"
                                 >
                                   <div
-                                    class="c0 c8 c36"
+                                    class="c0 c35"
                                   >
                                     <span>
                                       <button
                                         aria-disabled="false"
                                         aria-labelledby="24"
-                                        class="c12 c37"
+                                        class="c12 c36"
                                         tabindex="0"
                                         type="button"
                                       >
                                         <span
-                                          class="c38"
+                                          class="c37"
                                         >
                                           Edit dede
                                         </span>
@@ -3084,12 +3100,12 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                       <button
                                         aria-disabled="false"
                                         aria-labelledby="25"
-                                        class="c12 c37"
+                                        class="c12 c36"
                                         tabindex="0"
                                         type="button"
                                       >
                                         <span
-                                          class="c38"
+                                          class="c37"
                                         >
                                           Delete dede
                                         </span>
@@ -3114,17 +3130,17 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                               </td>
                             </tr>
                             <tr
-                              class="c0 c29"
+                              class="c0 c28"
                               style="cursor: pointer;"
                             >
                               <td
                                 style="position: relative;"
                               >
                                 <div
-                                  class="c0 c41"
+                                  class="c0 c40"
                                 >
                                   <svg
-                                    class="c42"
+                                    class="c41"
                                     color="neutral150"
                                     fill="none"
                                     height="23"
@@ -3140,11 +3156,11 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                   </svg>
                                 </div>
                                 <div
-                                  class="c0 c30 c8 c31"
+                                  class="c0 c29 c30"
                                 >
                                   <div
                                     aria-hidden="true"
-                                    class="c0 c32 c33"
+                                    class="c0 c31 c32"
                                   >
                                     <svg
                                       class="c0 "
@@ -3170,7 +3186,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                     </svg>
                                   </div>
                                   <span
-                                    class="c9 c34"
+                                    class="c9 c33"
                                   >
                                     dada
                                   </span>
@@ -3178,7 +3194,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                               </td>
                               <td>
                                 <span
-                                  class="c9 c35"
+                                  class="c9 c34"
                                 >
                                   string
                                    
@@ -3187,22 +3203,22 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                               <td>
                                 <div
                                   aria-hidden="true"
-                                  class="c0 c24"
+                                  class="c0 c23"
                                   role="button"
                                 >
                                   <div
-                                    class="c0 c8 c36"
+                                    class="c0 c35"
                                   >
                                     <span>
                                       <button
                                         aria-disabled="false"
                                         aria-labelledby="26"
-                                        class="c12 c37"
+                                        class="c12 c36"
                                         tabindex="0"
                                         type="button"
                                       >
                                         <span
-                                          class="c38"
+                                          class="c37"
                                         >
                                           Edit dada
                                         </span>
@@ -3228,12 +3244,12 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                       <button
                                         aria-disabled="false"
                                         aria-labelledby="27"
-                                        class="c12 c37"
+                                        class="c12 c36"
                                         tabindex="0"
                                         type="button"
                                       >
                                         <span
-                                          class="c38"
+                                          class="c37"
                                         >
                                           Delete dada
                                         </span>
@@ -3258,17 +3274,17 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                               </td>
                             </tr>
                             <tr
-                              class="c0 c29"
+                              class="c0 c28"
                               style="cursor: pointer;"
                             >
                               <td
                                 style="position: relative;"
                               >
                                 <div
-                                  class="c0 c41"
+                                  class="c0 c40"
                                 >
                                   <svg
-                                    class="c42"
+                                    class="c41"
                                     color="neutral150"
                                     fill="none"
                                     height="23"
@@ -3284,11 +3300,11 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                   </svg>
                                 </div>
                                 <div
-                                  class="c0 c30 c8 c31"
+                                  class="c0 c29 c30"
                                 >
                                   <div
                                     aria-hidden="true"
-                                    class="c0 c32 c33"
+                                    class="c0 c31 c32"
                                   >
                                     <svg
                                       class="c0 "
@@ -3314,7 +3330,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                     </svg>
                                   </div>
                                   <span
-                                    class="c9 c34"
+                                    class="c9 c33"
                                   >
                                     papi
                                   </span>
@@ -3322,7 +3338,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                               </td>
                               <td>
                                 <span
-                                  class="c9 c35"
+                                  class="c9 c34"
                                 >
                                   string
                                    
@@ -3331,22 +3347,22 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                               <td>
                                 <div
                                   aria-hidden="true"
-                                  class="c0 c24"
+                                  class="c0 c23"
                                   role="button"
                                 >
                                   <div
-                                    class="c0 c8 c36"
+                                    class="c0 c35"
                                   >
                                     <span>
                                       <button
                                         aria-disabled="false"
                                         aria-labelledby="28"
-                                        class="c12 c37"
+                                        class="c12 c36"
                                         tabindex="0"
                                         type="button"
                                       >
                                         <span
-                                          class="c38"
+                                          class="c37"
                                         >
                                           Edit papi
                                         </span>
@@ -3372,12 +3388,12 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                       <button
                                         aria-disabled="false"
                                         aria-labelledby="29"
-                                        class="c12 c37"
+                                        class="c12 c36"
                                         tabindex="0"
                                         type="button"
                                       >
                                         <span
-                                          class="c38"
+                                          class="c37"
                                         >
                                           Delete papi
                                         </span>
@@ -3405,7 +3421,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                         </table>
                       </div>
                       <button
-                        class="c0 c43 c44"
+                        class="c0 c42 c43"
                         type="button"
                       >
                         <div
@@ -3413,7 +3429,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                         >
                           <div
                             aria-hidden="true"
-                            class="c0 c45 c46"
+                            class="c0 c44 c45"
                           >
                             <svg
                               fill="none"
@@ -3429,10 +3445,10 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                             </svg>
                           </div>
                           <div
-                            class="c0 c47"
+                            class="c0 c46"
                           >
                             <span
-                              class="c9 c48"
+                              class="c9 c47"
                             >
                               Add another field
                             </span>
@@ -3443,18 +3459,18 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                   </td>
                 </tr>
                 <tr
-                  class="c0 c29"
+                  class="c0 c28"
                   style="cursor: pointer;"
                 >
                   <td
                     style="position: relative;"
                   >
                     <div
-                      class="c0 c30 c8 c31"
+                      class="c0 c29 c30"
                     >
                       <div
                         aria-hidden="true"
-                        class="c0 c32 c33"
+                        class="c0 c31 c32"
                       >
                         <svg
                           class="c0 "
@@ -3480,7 +3496,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                         </svg>
                       </div>
                       <span
-                        class="c9 c34"
+                        class="c9 c33"
                       >
                         DynamicZone
                       </span>
@@ -3488,7 +3504,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                   </td>
                   <td>
                     <span
-                      class="c9 c35"
+                      class="c9 c34"
                     >
                       dynamiczone
                        
@@ -3497,22 +3513,22 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                   <td>
                     <div
                       aria-hidden="true"
-                      class="c0 c24"
+                      class="c0 c23"
                       role="button"
                     >
                       <div
-                        class="c0 c8 c36"
+                        class="c0 c35"
                       >
                         <span>
                           <button
                             aria-disabled="false"
                             aria-labelledby="30"
-                            class="c12 c37"
+                            class="c12 c36"
                             tabindex="0"
                             type="button"
                           >
                             <span
-                              class="c38"
+                              class="c37"
                             >
                               Edit DynamicZone
                             </span>
@@ -3538,12 +3554,12 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                           <button
                             aria-disabled="false"
                             aria-labelledby="31"
-                            class="c12 c37"
+                            class="c12 c36"
                             tabindex="0"
                             type="button"
                           >
                             <span
-                              class="c38"
+                              class="c37"
                             >
                               Delete DynamicZone
                             </span>
@@ -3568,25 +3584,25 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                   </td>
                 </tr>
                 <tr
-                  class="c49 dynamiczone-row"
+                  class="c48 dynamiczone-row"
                 >
                   <td
                     colspan="12"
                   >
                     <div
-                      class="c0 c50 c51"
+                      class="c0 c49 c50"
                     >
                       <div
-                        class="c0 c8 c17 c52"
+                        class="c0 c17 c51"
                       >
                         <button
                           type="button"
                         >
                           <div
-                            class="c0 c22 c53 c54"
+                            class="c0 c52 c53"
                           >
                             <svg
-                              class="c55"
+                              class="c54"
                               fill="none"
                               height="1em"
                               viewBox="0 0 24 24"
@@ -3599,18 +3615,18 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                               />
                             </svg>
                             <span
-                              class="c9 c56"
+                              class="c9 c55"
                             >
                               content-type-builder.button.component.add
                             </span>
                           </div>
                         </button>
                         <button
-                          class="c0 c57 c58 c59 active"
+                          class="c0 c56 c57 c58 active"
                           type="button"
                         >
                           <div
-                            class="c0 c60 c61 c62"
+                            class="c0 c59 c60 c61"
                           >
                             <svg
                               viewBox="0 0 448 512"
@@ -3623,14 +3639,14 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                             </svg>
                           </div>
                           <div
-                            class="c0 c63"
+                            class="c0 c62"
                           >
                             <span
-                              class="c9 c64"
+                              class="c9 c63"
                             />
                           </div>
                           <button
-                            class="c0 c65 c66"
+                            class="c0 c64 c65"
                             type="button"
                           >
                             <svg
@@ -3648,11 +3664,11 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                           </button>
                         </button>
                         <button
-                          class="c0 c57 c58 c59"
+                          class="c0 c56 c57 c58"
                           type="button"
                         >
                           <div
-                            class="c0 c45 c61 c67"
+                            class="c0 c44 c60 c66"
                           >
                             <svg
                               viewBox="0 0 448 512"
@@ -3665,14 +3681,14 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                             </svg>
                           </div>
                           <div
-                            class="c0 c63"
+                            class="c0 c62"
                           >
                             <span
-                              class="c9 c64"
+                              class="c9 c63"
                             />
                           </div>
                           <button
-                            class="c0 c65 c66"
+                            class="c0 c64 c65"
                             type="button"
                           >
                             <svg
@@ -3690,11 +3706,11 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                           </button>
                         </button>
                         <button
-                          class="c0 c57 c58 c59"
+                          class="c0 c56 c57 c58"
                           type="button"
                         >
                           <div
-                            class="c0 c45 c61 c67"
+                            class="c0 c44 c60 c66"
                           >
                             <svg
                               viewBox="0 0 448 512"
@@ -3707,14 +3723,14 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                             </svg>
                           </div>
                           <div
-                            class="c0 c63"
+                            class="c0 c62"
                           >
                             <span
-                              class="c9 c64"
+                              class="c9 c63"
                             />
                           </div>
                           <button
-                            class="c0 c65 c66"
+                            class="c0 c64 c65"
                             type="button"
                           >
                             <svg
@@ -3732,11 +3748,11 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                           </button>
                         </button>
                         <button
-                          class="c0 c57 c58 c59"
+                          class="c0 c56 c57 c58"
                           type="button"
                         >
                           <div
-                            class="c0 c45 c61 c67"
+                            class="c0 c44 c60 c66"
                           >
                             <svg
                               viewBox="0 0 448 512"
@@ -3749,14 +3765,14 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                             </svg>
                           </div>
                           <div
-                            class="c0 c63"
+                            class="c0 c62"
                           >
                             <span
-                              class="c9 c64"
+                              class="c9 c63"
                             />
                           </div>
                           <button
-                            class="c0 c65 c66"
+                            class="c0 c64 c65"
                             type="button"
                           >
                             <svg
@@ -3776,7 +3792,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                       </div>
                     </div>
                     <div
-                      class="c0 c68"
+                      class="c0 c67"
                     >
                       <div
                         class="c0 "
@@ -3785,31 +3801,31 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                         <table>
                           <tbody>
                             <tr
-                              class="c49 component-row"
+                              class="c48 component-row"
                             >
                               <td
                                 colspan="12"
                               >
                                 <div
-                                  class="c0 c26"
+                                  class="c0 c25"
                                 >
                                   <div
-                                    class="c0 c40"
+                                    class="c0 c39"
                                   >
                                     <table>
                                       <tbody>
                                         <tr
-                                          class="c0 c29"
+                                          class="c0 c28"
                                           style="cursor: pointer;"
                                         >
                                           <td
                                             style="position: relative;"
                                           >
                                             <div
-                                              class="c0 c41"
+                                              class="c0 c40"
                                             >
                                               <svg
-                                                class="c69"
+                                                class="c68"
                                                 color="primary200"
                                                 fill="none"
                                                 height="23"
@@ -3825,11 +3841,11 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                               </svg>
                                             </div>
                                             <div
-                                              class="c0 c30 c8 c31"
+                                              class="c0 c29 c30"
                                             >
                                               <div
                                                 aria-hidden="true"
-                                                class="c0 c32 c33"
+                                                class="c0 c31 c32"
                                               >
                                                 <svg
                                                   class="c0 "
@@ -3855,7 +3871,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                 </svg>
                                               </div>
                                               <span
-                                                class="c9 c34"
+                                                class="c9 c33"
                                               >
                                                 name
                                               </span>
@@ -3863,7 +3879,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                           </td>
                                           <td>
                                             <span
-                                              class="c9 c35"
+                                              class="c9 c34"
                                             >
                                               string
                                                
@@ -3872,22 +3888,22 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                           <td>
                                             <div
                                               aria-hidden="true"
-                                              class="c0 c24"
+                                              class="c0 c23"
                                               role="button"
                                             >
                                               <div
-                                                class="c0 c8 c36"
+                                                class="c0 c35"
                                               >
                                                 <span>
                                                   <button
                                                     aria-disabled="false"
                                                     aria-labelledby="32"
-                                                    class="c12 c37"
+                                                    class="c12 c36"
                                                     tabindex="0"
                                                     type="button"
                                                   >
                                                     <span
-                                                      class="c38"
+                                                      class="c37"
                                                     >
                                                       Edit name
                                                     </span>
@@ -3913,12 +3929,12 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                   <button
                                                     aria-disabled="false"
                                                     aria-labelledby="33"
-                                                    class="c12 c37"
+                                                    class="c12 c36"
                                                     tabindex="0"
                                                     type="button"
                                                   >
                                                     <span
-                                                      class="c38"
+                                                      class="c37"
                                                     >
                                                       Delete name
                                                     </span>
@@ -3943,17 +3959,17 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                           </td>
                                         </tr>
                                         <tr
-                                          class="c0 c29"
+                                          class="c0 c28"
                                           style="cursor: pointer;"
                                         >
                                           <td
                                             style="position: relative;"
                                           >
                                             <div
-                                              class="c0 c41"
+                                              class="c0 c40"
                                             >
                                               <svg
-                                                class="c69"
+                                                class="c68"
                                                 color="primary200"
                                                 fill="none"
                                                 height="23"
@@ -3969,11 +3985,11 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                               </svg>
                                             </div>
                                             <div
-                                              class="c0 c30 c8 c31"
+                                              class="c0 c29 c30"
                                             >
                                               <div
                                                 aria-hidden="true"
-                                                class="c0 c32 c33"
+                                                class="c0 c31 c32"
                                               >
                                                 <svg
                                                   class="c0 "
@@ -3999,7 +4015,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                 </svg>
                                               </div>
                                               <span
-                                                class="c9 c34"
+                                                class="c9 c33"
                                               >
                                                 mail
                                               </span>
@@ -4007,7 +4023,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                           </td>
                                           <td>
                                             <span
-                                              class="c9 c35"
+                                              class="c9 c34"
                                             >
                                               email
                                                
@@ -4016,22 +4032,22 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                           <td>
                                             <div
                                               aria-hidden="true"
-                                              class="c0 c24"
+                                              class="c0 c23"
                                               role="button"
                                             >
                                               <div
-                                                class="c0 c8 c36"
+                                                class="c0 c35"
                                               >
                                                 <span>
                                                   <button
                                                     aria-disabled="false"
                                                     aria-labelledby="34"
-                                                    class="c12 c37"
+                                                    class="c12 c36"
                                                     tabindex="0"
                                                     type="button"
                                                   >
                                                     <span
-                                                      class="c38"
+                                                      class="c37"
                                                     >
                                                       Edit mail
                                                     </span>
@@ -4057,12 +4073,12 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                   <button
                                                     aria-disabled="false"
                                                     aria-labelledby="35"
-                                                    class="c12 c37"
+                                                    class="c12 c36"
                                                     tabindex="0"
                                                     type="button"
                                                   >
                                                     <span
-                                                      class="c38"
+                                                      class="c37"
                                                     >
                                                       Delete mail
                                                     </span>
@@ -4087,17 +4103,17 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                           </td>
                                         </tr>
                                         <tr
-                                          class="c0 c29"
+                                          class="c0 c28"
                                           style="cursor: pointer;"
                                         >
                                           <td
                                             style="position: relative;"
                                           >
                                             <div
-                                              class="c0 c41"
+                                              class="c0 c40"
                                             >
                                               <svg
-                                                class="c69"
+                                                class="c68"
                                                 color="primary200"
                                                 fill="none"
                                                 height="23"
@@ -4113,11 +4129,11 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                               </svg>
                                             </div>
                                             <div
-                                              class="c0 c30 c8 c31"
+                                              class="c0 c29 c30"
                                             >
                                               <div
                                                 aria-hidden="true"
-                                                class="c0 c32 c33"
+                                                class="c0 c31 c32"
                                               >
                                                 <svg
                                                   class="c0 "
@@ -4143,7 +4159,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                 </svg>
                                               </div>
                                               <span
-                                                class="c9 c34"
+                                                class="c9 c33"
                                               >
                                                 phone
                                               </span>
@@ -4151,7 +4167,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                           </td>
                                           <td>
                                             <span
-                                              class="c9 c35"
+                                              class="c9 c34"
                                             >
                                               integer
                                                
@@ -4160,22 +4176,22 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                           <td>
                                             <div
                                               aria-hidden="true"
-                                              class="c0 c24"
+                                              class="c0 c23"
                                               role="button"
                                             >
                                               <div
-                                                class="c0 c8 c36"
+                                                class="c0 c35"
                                               >
                                                 <span>
                                                   <button
                                                     aria-disabled="false"
                                                     aria-labelledby="36"
-                                                    class="c12 c37"
+                                                    class="c12 c36"
                                                     tabindex="0"
                                                     type="button"
                                                   >
                                                     <span
-                                                      class="c38"
+                                                      class="c37"
                                                     >
                                                       Edit phone
                                                     </span>
@@ -4201,12 +4217,12 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                   <button
                                                     aria-disabled="false"
                                                     aria-labelledby="37"
-                                                    class="c12 c37"
+                                                    class="c12 c36"
                                                     tabindex="0"
                                                     type="button"
                                                   >
                                                     <span
-                                                      class="c38"
+                                                      class="c37"
                                                     >
                                                       Delete phone
                                                     </span>
@@ -4234,7 +4250,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                     </table>
                                   </div>
                                   <button
-                                    class="c0 c43 c44"
+                                    class="c0 c42 c43"
                                     type="button"
                                   >
                                     <div
@@ -4242,7 +4258,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                     >
                                       <div
                                         aria-hidden="true"
-                                        class="c0 c60 c70"
+                                        class="c0 c59 c69"
                                       >
                                         <svg
                                           fill="none"
@@ -4258,10 +4274,10 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                         </svg>
                                       </div>
                                       <div
-                                        class="c0 c47"
+                                        class="c0 c46"
                                       >
                                         <span
-                                          class="c9 c56"
+                                          class="c9 c55"
                                         >
                                           Add another field
                                         </span>
@@ -4281,31 +4297,31 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                         <table>
                           <tbody>
                             <tr
-                              class="c49 component-row"
+                              class="c48 component-row"
                             >
                               <td
                                 colspan="12"
                               >
                                 <div
-                                  class="c0 c26"
+                                  class="c0 c25"
                                 >
                                   <div
-                                    class="c0 c40"
+                                    class="c0 c39"
                                   >
                                     <table>
                                       <tbody>
                                         <tr
-                                          class="c0 c29"
+                                          class="c0 c28"
                                           style="cursor: pointer;"
                                         >
                                           <td
                                             style="position: relative;"
                                           >
                                             <div
-                                              class="c0 c41"
+                                              class="c0 c40"
                                             >
                                               <svg
-                                                class="c69"
+                                                class="c68"
                                                 color="primary200"
                                                 fill="none"
                                                 height="23"
@@ -4321,11 +4337,11 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                               </svg>
                                             </div>
                                             <div
-                                              class="c0 c30 c8 c31"
+                                              class="c0 c29 c30"
                                             >
                                               <div
                                                 aria-hidden="true"
-                                                class="c0 c32 c33"
+                                                class="c0 c31 c32"
                                               >
                                                 <svg
                                                   class="c0 "
@@ -4351,7 +4367,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                 </svg>
                                               </div>
                                               <span
-                                                class="c9 c34"
+                                                class="c9 c33"
                                               >
                                                 name
                                               </span>
@@ -4359,7 +4375,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                           </td>
                                           <td>
                                             <span
-                                              class="c9 c35"
+                                              class="c9 c34"
                                             >
                                               string
                                                
@@ -4368,22 +4384,22 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                           <td>
                                             <div
                                               aria-hidden="true"
-                                              class="c0 c24"
+                                              class="c0 c23"
                                               role="button"
                                             >
                                               <div
-                                                class="c0 c8 c36"
+                                                class="c0 c35"
                                               >
                                                 <span>
                                                   <button
                                                     aria-disabled="false"
                                                     aria-labelledby="38"
-                                                    class="c12 c37"
+                                                    class="c12 c36"
                                                     tabindex="0"
                                                     type="button"
                                                   >
                                                     <span
-                                                      class="c38"
+                                                      class="c37"
                                                     >
                                                       Edit name
                                                     </span>
@@ -4409,12 +4425,12 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                   <button
                                                     aria-disabled="false"
                                                     aria-labelledby="39"
-                                                    class="c12 c37"
+                                                    class="c12 c36"
                                                     tabindex="0"
                                                     type="button"
                                                   >
                                                     <span
-                                                      class="c38"
+                                                      class="c37"
                                                     >
                                                       Delete name
                                                     </span>
@@ -4439,17 +4455,17 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                           </td>
                                         </tr>
                                         <tr
-                                          class="c0 c29"
+                                          class="c0 c28"
                                           style="cursor: pointer;"
                                         >
                                           <td
                                             style="position: relative;"
                                           >
                                             <div
-                                              class="c0 c41"
+                                              class="c0 c40"
                                             >
                                               <svg
-                                                class="c69"
+                                                class="c68"
                                                 color="primary200"
                                                 fill="none"
                                                 height="23"
@@ -4465,11 +4481,11 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                               </svg>
                                             </div>
                                             <div
-                                              class="c0 c30 c8 c31"
+                                              class="c0 c29 c30"
                                             >
                                               <div
                                                 aria-hidden="true"
-                                                class="c0 c32 c33"
+                                                class="c0 c31 c32"
                                               >
                                                 <svg
                                                   class="c0 "
@@ -4495,7 +4511,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                 </svg>
                                               </div>
                                               <span
-                                                class="c9 c34"
+                                                class="c9 c33"
                                               >
                                                 description
                                               </span>
@@ -4503,7 +4519,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                           </td>
                                           <td>
                                             <span
-                                              class="c9 c35"
+                                              class="c9 c34"
                                             >
                                               text
                                                
@@ -4512,22 +4528,22 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                           <td>
                                             <div
                                               aria-hidden="true"
-                                              class="c0 c24"
+                                              class="c0 c23"
                                               role="button"
                                             >
                                               <div
-                                                class="c0 c8 c36"
+                                                class="c0 c35"
                                               >
                                                 <span>
                                                   <button
                                                     aria-disabled="false"
                                                     aria-labelledby="40"
-                                                    class="c12 c37"
+                                                    class="c12 c36"
                                                     tabindex="0"
                                                     type="button"
                                                   >
                                                     <span
-                                                      class="c38"
+                                                      class="c37"
                                                     >
                                                       Edit description
                                                     </span>
@@ -4553,12 +4569,12 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                   <button
                                                     aria-disabled="false"
                                                     aria-labelledby="41"
-                                                    class="c12 c37"
+                                                    class="c12 c36"
                                                     tabindex="0"
                                                     type="button"
                                                   >
                                                     <span
-                                                      class="c38"
+                                                      class="c37"
                                                     >
                                                       Delete description
                                                     </span>
@@ -4583,17 +4599,17 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                           </td>
                                         </tr>
                                         <tr
-                                          class="c0 c29"
+                                          class="c0 c28"
                                           style="cursor: pointer;"
                                         >
                                           <td
                                             style="position: relative;"
                                           >
                                             <div
-                                              class="c0 c41"
+                                              class="c0 c40"
                                             >
                                               <svg
-                                                class="c69"
+                                                class="c68"
                                                 color="primary200"
                                                 fill="none"
                                                 height="23"
@@ -4609,11 +4625,11 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                               </svg>
                                             </div>
                                             <div
-                                              class="c0 c30 c8 c31"
+                                              class="c0 c29 c30"
                                             >
                                               <div
                                                 aria-hidden="true"
-                                                class="c0 c32 c33"
+                                                class="c0 c31 c32"
                                               >
                                                 <svg
                                                   class="c0 "
@@ -4639,7 +4655,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                 </svg>
                                               </div>
                                               <span
-                                                class="c9 c34"
+                                                class="c9 c33"
                                               >
                                                 price
                                               </span>
@@ -4647,7 +4663,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                           </td>
                                           <td>
                                             <span
-                                              class="c9 c35"
+                                              class="c9 c34"
                                             >
                                               float
                                                
@@ -4656,22 +4672,22 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                           <td>
                                             <div
                                               aria-hidden="true"
-                                              class="c0 c24"
+                                              class="c0 c23"
                                               role="button"
                                             >
                                               <div
-                                                class="c0 c8 c36"
+                                                class="c0 c35"
                                               >
                                                 <span>
                                                   <button
                                                     aria-disabled="false"
                                                     aria-labelledby="42"
-                                                    class="c12 c37"
+                                                    class="c12 c36"
                                                     tabindex="0"
                                                     type="button"
                                                   >
                                                     <span
-                                                      class="c38"
+                                                      class="c37"
                                                     >
                                                       Edit price
                                                     </span>
@@ -4697,12 +4713,12 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                   <button
                                                     aria-disabled="false"
                                                     aria-labelledby="43"
-                                                    class="c12 c37"
+                                                    class="c12 c36"
                                                     tabindex="0"
                                                     type="button"
                                                   >
                                                     <span
-                                                      class="c38"
+                                                      class="c37"
                                                     >
                                                       Delete price
                                                     </span>
@@ -4727,17 +4743,17 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                           </td>
                                         </tr>
                                         <tr
-                                          class="c0 c29"
+                                          class="c0 c28"
                                           style="cursor: pointer;"
                                         >
                                           <td
                                             style="position: relative;"
                                           >
                                             <div
-                                              class="c0 c41"
+                                              class="c0 c40"
                                             >
                                               <svg
-                                                class="c69"
+                                                class="c68"
                                                 color="primary200"
                                                 fill="none"
                                                 height="23"
@@ -4753,11 +4769,11 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                               </svg>
                                             </div>
                                             <div
-                                              class="c0 c30 c8 c31"
+                                              class="c0 c29 c30"
                                             >
                                               <div
                                                 aria-hidden="true"
-                                                class="c0 c32 c33"
+                                                class="c0 c31 c32"
                                               >
                                                 <svg
                                                   class="c0 "
@@ -4785,7 +4801,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                 </svg>
                                               </div>
                                               <span
-                                                class="c9 c34"
+                                                class="c9 c33"
                                               >
                                                 picture
                                               </span>
@@ -4793,7 +4809,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                           </td>
                                           <td>
                                             <span
-                                              class="c9 c35"
+                                              class="c9 c34"
                                             >
                                               media
                                                
@@ -4802,22 +4818,22 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                           <td>
                                             <div
                                               aria-hidden="true"
-                                              class="c0 c24"
+                                              class="c0 c23"
                                               role="button"
                                             >
                                               <div
-                                                class="c0 c8 c36"
+                                                class="c0 c35"
                                               >
                                                 <span>
                                                   <button
                                                     aria-disabled="false"
                                                     aria-labelledby="44"
-                                                    class="c12 c37"
+                                                    class="c12 c36"
                                                     tabindex="0"
                                                     type="button"
                                                   >
                                                     <span
-                                                      class="c38"
+                                                      class="c37"
                                                     >
                                                       Edit picture
                                                     </span>
@@ -4843,12 +4859,12 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                   <button
                                                     aria-disabled="false"
                                                     aria-labelledby="45"
-                                                    class="c12 c37"
+                                                    class="c12 c36"
                                                     tabindex="0"
                                                     type="button"
                                                   >
                                                     <span
-                                                      class="c38"
+                                                      class="c37"
                                                     >
                                                       Delete picture
                                                     </span>
@@ -4873,17 +4889,17 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                           </td>
                                         </tr>
                                         <tr
-                                          class="c0 c29"
+                                          class="c0 c28"
                                           style="cursor: pointer;"
                                         >
                                           <td
                                             style="position: relative;"
                                           >
                                             <div
-                                              class="c0 c41"
+                                              class="c0 c40"
                                             >
                                               <svg
-                                                class="c69"
+                                                class="c68"
                                                 color="primary200"
                                                 fill="none"
                                                 height="23"
@@ -4899,11 +4915,11 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                               </svg>
                                             </div>
                                             <div
-                                              class="c0 c30 c8 c31"
+                                              class="c0 c29 c30"
                                             >
                                               <div
                                                 aria-hidden="true"
-                                                class="c0 c32 c33"
+                                                class="c0 c31 c32"
                                               >
                                                 <svg
                                                   class="c0 "
@@ -4931,7 +4947,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                 </svg>
                                               </div>
                                               <span
-                                                class="c9 c34"
+                                                class="c9 c33"
                                               >
                                                 very_long_description
                                               </span>
@@ -4939,7 +4955,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                           </td>
                                           <td>
                                             <span
-                                              class="c9 c35"
+                                              class="c9 c34"
                                             >
                                               richtext
                                                
@@ -4948,22 +4964,22 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                           <td>
                                             <div
                                               aria-hidden="true"
-                                              class="c0 c24"
+                                              class="c0 c23"
                                               role="button"
                                             >
                                               <div
-                                                class="c0 c8 c36"
+                                                class="c0 c35"
                                               >
                                                 <span>
                                                   <button
                                                     aria-disabled="false"
                                                     aria-labelledby="46"
-                                                    class="c12 c37"
+                                                    class="c12 c36"
                                                     tabindex="0"
                                                     type="button"
                                                   >
                                                     <span
-                                                      class="c38"
+                                                      class="c37"
                                                     >
                                                       Edit very_long_description
                                                     </span>
@@ -4989,12 +5005,12 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                   <button
                                                     aria-disabled="false"
                                                     aria-labelledby="47"
-                                                    class="c12 c37"
+                                                    class="c12 c36"
                                                     tabindex="0"
                                                     type="button"
                                                   >
                                                     <span
-                                                      class="c38"
+                                                      class="c37"
                                                     >
                                                       Delete very_long_description
                                                     </span>
@@ -5019,17 +5035,17 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                           </td>
                                         </tr>
                                         <tr
-                                          class="c0 c29"
+                                          class="c0 c28"
                                           style="cursor: pointer;"
                                         >
                                           <td
                                             style="position: relative;"
                                           >
                                             <div
-                                              class="c0 c41"
+                                              class="c0 c40"
                                             >
                                               <svg
-                                                class="c69"
+                                                class="c68"
                                                 color="primary200"
                                                 fill="none"
                                                 height="23"
@@ -5045,11 +5061,11 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                               </svg>
                                             </div>
                                             <div
-                                              class="c0 c30 c8 c31"
+                                              class="c0 c29 c30"
                                             >
                                               <div
                                                 aria-hidden="true"
-                                                class="c0 c32 c33"
+                                                class="c0 c31 c32"
                                               >
                                                 <svg
                                                   class="c0 "
@@ -5073,7 +5089,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                 </svg>
                                               </div>
                                               <span
-                                                class="c9 c34"
+                                                class="c9 c33"
                                               >
                                                 categories
                                               </span>
@@ -5081,7 +5097,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                           </td>
                                           <td>
                                             <span
-                                              class="c9 c35"
+                                              class="c9 c34"
                                             >
                                               Relation with
                                                
@@ -5096,22 +5112,22 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                           <td>
                                             <div
                                               aria-hidden="true"
-                                              class="c0 c24"
+                                              class="c0 c23"
                                               role="button"
                                             >
                                               <div
-                                                class="c0 c8 c36"
+                                                class="c0 c35"
                                               >
                                                 <span>
                                                   <button
                                                     aria-disabled="false"
                                                     aria-labelledby="48"
-                                                    class="c12 c37"
+                                                    class="c12 c36"
                                                     tabindex="0"
                                                     type="button"
                                                   >
                                                     <span
-                                                      class="c38"
+                                                      class="c37"
                                                     >
                                                       Edit categories
                                                     </span>
@@ -5137,12 +5153,12 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                   <button
                                                     aria-disabled="false"
                                                     aria-labelledby="49"
-                                                    class="c12 c37"
+                                                    class="c12 c36"
                                                     tabindex="0"
                                                     type="button"
                                                   >
                                                     <span
-                                                      class="c38"
+                                                      class="c37"
                                                     >
                                                       Delete categories
                                                     </span>
@@ -5170,7 +5186,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                     </table>
                                   </div>
                                   <button
-                                    class="c0 c43 c44"
+                                    class="c0 c42 c43"
                                     type="button"
                                   >
                                     <div
@@ -5178,7 +5194,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                     >
                                       <div
                                         aria-hidden="true"
-                                        class="c0 c60 c70"
+                                        class="c0 c59 c69"
                                       >
                                         <svg
                                           fill="none"
@@ -5194,10 +5210,10 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                         </svg>
                                       </div>
                                       <div
-                                        class="c0 c47"
+                                        class="c0 c46"
                                       >
                                         <span
-                                          class="c9 c56"
+                                          class="c9 c55"
                                         >
                                           Add another field
                                         </span>
@@ -5217,31 +5233,31 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                         <table>
                           <tbody>
                             <tr
-                              class="c49 component-row"
+                              class="c48 component-row"
                             >
                               <td
                                 colspan="12"
                               >
                                 <div
-                                  class="c0 c26"
+                                  class="c0 c25"
                                 >
                                   <div
-                                    class="c0 c40"
+                                    class="c0 c39"
                                   >
                                     <table>
                                       <tbody>
                                         <tr
-                                          class="c0 c29"
+                                          class="c0 c28"
                                           style="cursor: pointer;"
                                         >
                                           <td
                                             style="position: relative;"
                                           >
                                             <div
-                                              class="c0 c41"
+                                              class="c0 c40"
                                             >
                                               <svg
-                                                class="c69"
+                                                class="c68"
                                                 color="primary200"
                                                 fill="none"
                                                 height="23"
@@ -5257,11 +5273,11 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                               </svg>
                                             </div>
                                             <div
-                                              class="c0 c30 c8 c31"
+                                              class="c0 c29 c30"
                                             >
                                               <div
                                                 aria-hidden="true"
-                                                class="c0 c32 c33"
+                                                class="c0 c31 c32"
                                               >
                                                 <svg
                                                   class="c0 "
@@ -5287,7 +5303,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                 </svg>
                                               </div>
                                               <span
-                                                class="c9 c34"
+                                                class="c9 c33"
                                               >
                                                 label
                                               </span>
@@ -5295,7 +5311,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                           </td>
                                           <td>
                                             <span
-                                              class="c9 c35"
+                                              class="c9 c34"
                                             >
                                               string
                                                
@@ -5304,22 +5320,22 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                           <td>
                                             <div
                                               aria-hidden="true"
-                                              class="c0 c24"
+                                              class="c0 c23"
                                               role="button"
                                             >
                                               <div
-                                                class="c0 c8 c36"
+                                                class="c0 c35"
                                               >
                                                 <span>
                                                   <button
                                                     aria-disabled="false"
                                                     aria-labelledby="50"
-                                                    class="c12 c37"
+                                                    class="c12 c36"
                                                     tabindex="0"
                                                     type="button"
                                                   >
                                                     <span
-                                                      class="c38"
+                                                      class="c37"
                                                     >
                                                       Edit label
                                                     </span>
@@ -5345,12 +5361,12 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                   <button
                                                     aria-disabled="false"
                                                     aria-labelledby="51"
-                                                    class="c12 c37"
+                                                    class="c12 c36"
                                                     tabindex="0"
                                                     type="button"
                                                   >
                                                     <span
-                                                      class="c38"
+                                                      class="c37"
                                                     >
                                                       Delete label
                                                     </span>
@@ -5375,17 +5391,17 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                           </td>
                                         </tr>
                                         <tr
-                                          class="c0 c29"
+                                          class="c0 c28"
                                           style="cursor: pointer;"
                                         >
                                           <td
                                             style="position: relative;"
                                           >
                                             <div
-                                              class="c0 c41"
+                                              class="c0 c40"
                                             >
                                               <svg
-                                                class="c69"
+                                                class="c68"
                                                 color="primary200"
                                                 fill="none"
                                                 height="23"
@@ -5401,11 +5417,11 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                               </svg>
                                             </div>
                                             <div
-                                              class="c0 c30 c8 c31"
+                                              class="c0 c29 c30"
                                             >
                                               <div
                                                 aria-hidden="true"
-                                                class="c0 c32 c33"
+                                                class="c0 c31 c32"
                                               >
                                                 <svg
                                                   class="c0 "
@@ -5431,7 +5447,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                 </svg>
                                               </div>
                                               <span
-                                                class="c9 c34"
+                                                class="c9 c33"
                                               >
                                                 time
                                               </span>
@@ -5439,7 +5455,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                           </td>
                                           <td>
                                             <span
-                                              class="c9 c35"
+                                              class="c9 c34"
                                             >
                                               string
                                                
@@ -5448,22 +5464,22 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                           <td>
                                             <div
                                               aria-hidden="true"
-                                              class="c0 c24"
+                                              class="c0 c23"
                                               role="button"
                                             >
                                               <div
-                                                class="c0 c8 c36"
+                                                class="c0 c35"
                                               >
                                                 <span>
                                                   <button
                                                     aria-disabled="false"
                                                     aria-labelledby="52"
-                                                    class="c12 c37"
+                                                    class="c12 c36"
                                                     tabindex="0"
                                                     type="button"
                                                   >
                                                     <span
-                                                      class="c38"
+                                                      class="c37"
                                                     >
                                                       Edit time
                                                     </span>
@@ -5489,12 +5505,12 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                   <button
                                                     aria-disabled="false"
                                                     aria-labelledby="53"
-                                                    class="c12 c37"
+                                                    class="c12 c36"
                                                     tabindex="0"
                                                     type="button"
                                                   >
                                                     <span
-                                                      class="c38"
+                                                      class="c37"
                                                     >
                                                       Delete time
                                                     </span>
@@ -5519,17 +5535,17 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                           </td>
                                         </tr>
                                         <tr
-                                          class="c0 c29"
+                                          class="c0 c28"
                                           style="cursor: pointer;"
                                         >
                                           <td
                                             style="position: relative;"
                                           >
                                             <div
-                                              class="c0 c41"
+                                              class="c0 c40"
                                             >
                                               <svg
-                                                class="c69"
+                                                class="c68"
                                                 color="primary200"
                                                 fill="none"
                                                 height="23"
@@ -5545,11 +5561,11 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                               </svg>
                                             </div>
                                             <div
-                                              class="c0 c30 c8 c31"
+                                              class="c0 c29 c30"
                                             >
                                               <div
                                                 aria-hidden="true"
-                                                class="c0 c32 c33"
+                                                class="c0 c31 c32"
                                               >
                                                 <svg
                                                   class="c0 "
@@ -5581,7 +5597,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                 </svg>
                                               </div>
                                               <span
-                                                class="c9 c34"
+                                                class="c9 c33"
                                               >
                                                 dishrep
                                               </span>
@@ -5589,7 +5605,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                           </td>
                                           <td>
                                             <span
-                                              class="c9 c35"
+                                              class="c9 c34"
                                             >
                                               component
                                                
@@ -5599,22 +5615,22 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                           <td>
                                             <div
                                               aria-hidden="true"
-                                              class="c0 c24"
+                                              class="c0 c23"
                                               role="button"
                                             >
                                               <div
-                                                class="c0 c8 c36"
+                                                class="c0 c35"
                                               >
                                                 <span>
                                                   <button
                                                     aria-disabled="false"
                                                     aria-labelledby="54"
-                                                    class="c12 c37"
+                                                    class="c12 c36"
                                                     tabindex="0"
                                                     type="button"
                                                   >
                                                     <span
-                                                      class="c38"
+                                                      class="c37"
                                                     >
                                                       Edit dishrep
                                                     </span>
@@ -5640,12 +5656,12 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                   <button
                                                     aria-disabled="false"
                                                     aria-labelledby="55"
-                                                    class="c12 c37"
+                                                    class="c12 c36"
                                                     tabindex="0"
                                                     type="button"
                                                   >
                                                     <span
-                                                      class="c38"
+                                                      class="c37"
                                                     >
                                                       Delete dishrep
                                                     </span>
@@ -5670,31 +5686,31 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                           </td>
                                         </tr>
                                         <tr
-                                          class="c39 component-row"
+                                          class="c38 component-row"
                                         >
                                           <td
                                             colspan="12"
                                           >
                                             <div
-                                              class="c0 c26"
+                                              class="c0 c25"
                                             >
                                               <div
-                                                class="c0 c40"
+                                                class="c0 c39"
                                               >
                                                 <table>
                                                   <tbody>
                                                     <tr
-                                                      class="c0 c29"
+                                                      class="c0 c28"
                                                       style="cursor: pointer;"
                                                     >
                                                       <td
                                                         style="position: relative;"
                                                       >
                                                         <div
-                                                          class="c0 c41"
+                                                          class="c0 c40"
                                                         >
                                                           <svg
-                                                            class="c42"
+                                                            class="c41"
                                                             color="neutral150"
                                                             fill="none"
                                                             height="23"
@@ -5710,11 +5726,11 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                           </svg>
                                                         </div>
                                                         <div
-                                                          class="c0 c30 c8 c31"
+                                                          class="c0 c29 c30"
                                                         >
                                                           <div
                                                             aria-hidden="true"
-                                                            class="c0 c32 c33"
+                                                            class="c0 c31 c32"
                                                           >
                                                             <svg
                                                               class="c0 "
@@ -5740,7 +5756,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                             </svg>
                                                           </div>
                                                           <span
-                                                            class="c9 c34"
+                                                            class="c9 c33"
                                                           >
                                                             name
                                                           </span>
@@ -5748,7 +5764,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                       </td>
                                                       <td>
                                                         <span
-                                                          class="c9 c35"
+                                                          class="c9 c34"
                                                         >
                                                           string
                                                            
@@ -5757,22 +5773,22 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                       <td>
                                                         <div
                                                           aria-hidden="true"
-                                                          class="c0 c24"
+                                                          class="c0 c23"
                                                           role="button"
                                                         >
                                                           <div
-                                                            class="c0 c8 c36"
+                                                            class="c0 c35"
                                                           >
                                                             <span>
                                                               <button
                                                                 aria-disabled="false"
                                                                 aria-labelledby="56"
-                                                                class="c12 c37"
+                                                                class="c12 c36"
                                                                 tabindex="0"
                                                                 type="button"
                                                               >
                                                                 <span
-                                                                  class="c38"
+                                                                  class="c37"
                                                                 >
                                                                   Edit name
                                                                 </span>
@@ -5798,12 +5814,12 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                               <button
                                                                 aria-disabled="false"
                                                                 aria-labelledby="57"
-                                                                class="c12 c37"
+                                                                class="c12 c36"
                                                                 tabindex="0"
                                                                 type="button"
                                                               >
                                                                 <span
-                                                                  class="c38"
+                                                                  class="c37"
                                                                 >
                                                                   Delete name
                                                                 </span>
@@ -5828,17 +5844,17 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                       </td>
                                                     </tr>
                                                     <tr
-                                                      class="c0 c29"
+                                                      class="c0 c28"
                                                       style="cursor: pointer;"
                                                     >
                                                       <td
                                                         style="position: relative;"
                                                       >
                                                         <div
-                                                          class="c0 c41"
+                                                          class="c0 c40"
                                                         >
                                                           <svg
-                                                            class="c42"
+                                                            class="c41"
                                                             color="neutral150"
                                                             fill="none"
                                                             height="23"
@@ -5854,11 +5870,11 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                           </svg>
                                                         </div>
                                                         <div
-                                                          class="c0 c30 c8 c31"
+                                                          class="c0 c29 c30"
                                                         >
                                                           <div
                                                             aria-hidden="true"
-                                                            class="c0 c32 c33"
+                                                            class="c0 c31 c32"
                                                           >
                                                             <svg
                                                               class="c0 "
@@ -5884,7 +5900,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                             </svg>
                                                           </div>
                                                           <span
-                                                            class="c9 c34"
+                                                            class="c9 c33"
                                                           >
                                                             description
                                                           </span>
@@ -5892,7 +5908,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                       </td>
                                                       <td>
                                                         <span
-                                                          class="c9 c35"
+                                                          class="c9 c34"
                                                         >
                                                           text
                                                            
@@ -5901,22 +5917,22 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                       <td>
                                                         <div
                                                           aria-hidden="true"
-                                                          class="c0 c24"
+                                                          class="c0 c23"
                                                           role="button"
                                                         >
                                                           <div
-                                                            class="c0 c8 c36"
+                                                            class="c0 c35"
                                                           >
                                                             <span>
                                                               <button
                                                                 aria-disabled="false"
                                                                 aria-labelledby="58"
-                                                                class="c12 c37"
+                                                                class="c12 c36"
                                                                 tabindex="0"
                                                                 type="button"
                                                               >
                                                                 <span
-                                                                  class="c38"
+                                                                  class="c37"
                                                                 >
                                                                   Edit description
                                                                 </span>
@@ -5942,12 +5958,12 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                               <button
                                                                 aria-disabled="false"
                                                                 aria-labelledby="59"
-                                                                class="c12 c37"
+                                                                class="c12 c36"
                                                                 tabindex="0"
                                                                 type="button"
                                                               >
                                                                 <span
-                                                                  class="c38"
+                                                                  class="c37"
                                                                 >
                                                                   Delete description
                                                                 </span>
@@ -5972,17 +5988,17 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                       </td>
                                                     </tr>
                                                     <tr
-                                                      class="c0 c29"
+                                                      class="c0 c28"
                                                       style="cursor: pointer;"
                                                     >
                                                       <td
                                                         style="position: relative;"
                                                       >
                                                         <div
-                                                          class="c0 c41"
+                                                          class="c0 c40"
                                                         >
                                                           <svg
-                                                            class="c42"
+                                                            class="c41"
                                                             color="neutral150"
                                                             fill="none"
                                                             height="23"
@@ -5998,11 +6014,11 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                           </svg>
                                                         </div>
                                                         <div
-                                                          class="c0 c30 c8 c31"
+                                                          class="c0 c29 c30"
                                                         >
                                                           <div
                                                             aria-hidden="true"
-                                                            class="c0 c32 c33"
+                                                            class="c0 c31 c32"
                                                           >
                                                             <svg
                                                               class="c0 "
@@ -6028,7 +6044,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                             </svg>
                                                           </div>
                                                           <span
-                                                            class="c9 c34"
+                                                            class="c9 c33"
                                                           >
                                                             price
                                                           </span>
@@ -6036,7 +6052,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                       </td>
                                                       <td>
                                                         <span
-                                                          class="c9 c35"
+                                                          class="c9 c34"
                                                         >
                                                           float
                                                            
@@ -6045,22 +6061,22 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                       <td>
                                                         <div
                                                           aria-hidden="true"
-                                                          class="c0 c24"
+                                                          class="c0 c23"
                                                           role="button"
                                                         >
                                                           <div
-                                                            class="c0 c8 c36"
+                                                            class="c0 c35"
                                                           >
                                                             <span>
                                                               <button
                                                                 aria-disabled="false"
                                                                 aria-labelledby="60"
-                                                                class="c12 c37"
+                                                                class="c12 c36"
                                                                 tabindex="0"
                                                                 type="button"
                                                               >
                                                                 <span
-                                                                  class="c38"
+                                                                  class="c37"
                                                                 >
                                                                   Edit price
                                                                 </span>
@@ -6086,12 +6102,12 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                               <button
                                                                 aria-disabled="false"
                                                                 aria-labelledby="61"
-                                                                class="c12 c37"
+                                                                class="c12 c36"
                                                                 tabindex="0"
                                                                 type="button"
                                                               >
                                                                 <span
-                                                                  class="c38"
+                                                                  class="c37"
                                                                 >
                                                                   Delete price
                                                                 </span>
@@ -6116,17 +6132,17 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                       </td>
                                                     </tr>
                                                     <tr
-                                                      class="c0 c29"
+                                                      class="c0 c28"
                                                       style="cursor: pointer;"
                                                     >
                                                       <td
                                                         style="position: relative;"
                                                       >
                                                         <div
-                                                          class="c0 c41"
+                                                          class="c0 c40"
                                                         >
                                                           <svg
-                                                            class="c42"
+                                                            class="c41"
                                                             color="neutral150"
                                                             fill="none"
                                                             height="23"
@@ -6142,11 +6158,11 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                           </svg>
                                                         </div>
                                                         <div
-                                                          class="c0 c30 c8 c31"
+                                                          class="c0 c29 c30"
                                                         >
                                                           <div
                                                             aria-hidden="true"
-                                                            class="c0 c32 c33"
+                                                            class="c0 c31 c32"
                                                           >
                                                             <svg
                                                               class="c0 "
@@ -6174,7 +6190,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                             </svg>
                                                           </div>
                                                           <span
-                                                            class="c9 c34"
+                                                            class="c9 c33"
                                                           >
                                                             picture
                                                           </span>
@@ -6182,7 +6198,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                       </td>
                                                       <td>
                                                         <span
-                                                          class="c9 c35"
+                                                          class="c9 c34"
                                                         >
                                                           media
                                                            
@@ -6191,22 +6207,22 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                       <td>
                                                         <div
                                                           aria-hidden="true"
-                                                          class="c0 c24"
+                                                          class="c0 c23"
                                                           role="button"
                                                         >
                                                           <div
-                                                            class="c0 c8 c36"
+                                                            class="c0 c35"
                                                           >
                                                             <span>
                                                               <button
                                                                 aria-disabled="false"
                                                                 aria-labelledby="62"
-                                                                class="c12 c37"
+                                                                class="c12 c36"
                                                                 tabindex="0"
                                                                 type="button"
                                                               >
                                                                 <span
-                                                                  class="c38"
+                                                                  class="c37"
                                                                 >
                                                                   Edit picture
                                                                 </span>
@@ -6232,12 +6248,12 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                               <button
                                                                 aria-disabled="false"
                                                                 aria-labelledby="63"
-                                                                class="c12 c37"
+                                                                class="c12 c36"
                                                                 tabindex="0"
                                                                 type="button"
                                                               >
                                                                 <span
-                                                                  class="c38"
+                                                                  class="c37"
                                                                 >
                                                                   Delete picture
                                                                 </span>
@@ -6262,17 +6278,17 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                       </td>
                                                     </tr>
                                                     <tr
-                                                      class="c0 c29"
+                                                      class="c0 c28"
                                                       style="cursor: pointer;"
                                                     >
                                                       <td
                                                         style="position: relative;"
                                                       >
                                                         <div
-                                                          class="c0 c41"
+                                                          class="c0 c40"
                                                         >
                                                           <svg
-                                                            class="c42"
+                                                            class="c41"
                                                             color="neutral150"
                                                             fill="none"
                                                             height="23"
@@ -6288,11 +6304,11 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                           </svg>
                                                         </div>
                                                         <div
-                                                          class="c0 c30 c8 c31"
+                                                          class="c0 c29 c30"
                                                         >
                                                           <div
                                                             aria-hidden="true"
-                                                            class="c0 c32 c33"
+                                                            class="c0 c31 c32"
                                                           >
                                                             <svg
                                                               class="c0 "
@@ -6320,7 +6336,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                             </svg>
                                                           </div>
                                                           <span
-                                                            class="c9 c34"
+                                                            class="c9 c33"
                                                           >
                                                             very_long_description
                                                           </span>
@@ -6328,7 +6344,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                       </td>
                                                       <td>
                                                         <span
-                                                          class="c9 c35"
+                                                          class="c9 c34"
                                                         >
                                                           richtext
                                                            
@@ -6337,22 +6353,22 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                       <td>
                                                         <div
                                                           aria-hidden="true"
-                                                          class="c0 c24"
+                                                          class="c0 c23"
                                                           role="button"
                                                         >
                                                           <div
-                                                            class="c0 c8 c36"
+                                                            class="c0 c35"
                                                           >
                                                             <span>
                                                               <button
                                                                 aria-disabled="false"
                                                                 aria-labelledby="64"
-                                                                class="c12 c37"
+                                                                class="c12 c36"
                                                                 tabindex="0"
                                                                 type="button"
                                                               >
                                                                 <span
-                                                                  class="c38"
+                                                                  class="c37"
                                                                 >
                                                                   Edit very_long_description
                                                                 </span>
@@ -6378,12 +6394,12 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                               <button
                                                                 aria-disabled="false"
                                                                 aria-labelledby="65"
-                                                                class="c12 c37"
+                                                                class="c12 c36"
                                                                 tabindex="0"
                                                                 type="button"
                                                               >
                                                                 <span
-                                                                  class="c38"
+                                                                  class="c37"
                                                                 >
                                                                   Delete very_long_description
                                                                 </span>
@@ -6408,17 +6424,17 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                       </td>
                                                     </tr>
                                                     <tr
-                                                      class="c0 c29"
+                                                      class="c0 c28"
                                                       style="cursor: pointer;"
                                                     >
                                                       <td
                                                         style="position: relative;"
                                                       >
                                                         <div
-                                                          class="c0 c41"
+                                                          class="c0 c40"
                                                         >
                                                           <svg
-                                                            class="c42"
+                                                            class="c41"
                                                             color="neutral150"
                                                             fill="none"
                                                             height="23"
@@ -6434,11 +6450,11 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                           </svg>
                                                         </div>
                                                         <div
-                                                          class="c0 c30 c8 c31"
+                                                          class="c0 c29 c30"
                                                         >
                                                           <div
                                                             aria-hidden="true"
-                                                            class="c0 c32 c33"
+                                                            class="c0 c31 c32"
                                                           >
                                                             <svg
                                                               class="c0 "
@@ -6462,7 +6478,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                             </svg>
                                                           </div>
                                                           <span
-                                                            class="c9 c34"
+                                                            class="c9 c33"
                                                           >
                                                             categories
                                                           </span>
@@ -6470,7 +6486,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                       </td>
                                                       <td>
                                                         <span
-                                                          class="c9 c35"
+                                                          class="c9 c34"
                                                         >
                                                           Relation with
                                                            
@@ -6485,22 +6501,22 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                       <td>
                                                         <div
                                                           aria-hidden="true"
-                                                          class="c0 c24"
+                                                          class="c0 c23"
                                                           role="button"
                                                         >
                                                           <div
-                                                            class="c0 c8 c36"
+                                                            class="c0 c35"
                                                           >
                                                             <span>
                                                               <button
                                                                 aria-disabled="false"
                                                                 aria-labelledby="66"
-                                                                class="c12 c37"
+                                                                class="c12 c36"
                                                                 tabindex="0"
                                                                 type="button"
                                                               >
                                                                 <span
-                                                                  class="c38"
+                                                                  class="c37"
                                                                 >
                                                                   Edit categories
                                                                 </span>
@@ -6526,12 +6542,12 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                               <button
                                                                 aria-disabled="false"
                                                                 aria-labelledby="67"
-                                                                class="c12 c37"
+                                                                class="c12 c36"
                                                                 tabindex="0"
                                                                 type="button"
                                                               >
                                                                 <span
-                                                                  class="c38"
+                                                                  class="c37"
                                                                 >
                                                                   Delete categories
                                                                 </span>
@@ -6559,7 +6575,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                 </table>
                                               </div>
                                               <button
-                                                class="c0 c43 c44"
+                                                class="c0 c42 c43"
                                                 type="button"
                                               >
                                                 <div
@@ -6567,7 +6583,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                 >
                                                   <div
                                                     aria-hidden="true"
-                                                    class="c0 c45 c46"
+                                                    class="c0 c44 c45"
                                                   >
                                                     <svg
                                                       fill="none"
@@ -6583,10 +6599,10 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                     </svg>
                                                   </div>
                                                   <div
-                                                    class="c0 c47"
+                                                    class="c0 c46"
                                                   >
                                                     <span
-                                                      class="c9 c48"
+                                                      class="c9 c47"
                                                     >
                                                       Add another field
                                                     </span>
@@ -6600,7 +6616,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                     </table>
                                   </div>
                                   <button
-                                    class="c0 c43 c44"
+                                    class="c0 c42 c43"
                                     type="button"
                                   >
                                     <div
@@ -6608,7 +6624,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                     >
                                       <div
                                         aria-hidden="true"
-                                        class="c0 c60 c70"
+                                        class="c0 c59 c69"
                                       >
                                         <svg
                                           fill="none"
@@ -6624,10 +6640,10 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                         </svg>
                                       </div>
                                       <div
-                                        class="c0 c47"
+                                        class="c0 c46"
                                       >
                                         <span
-                                          class="c9 c56"
+                                          class="c9 c55"
                                         >
                                           Add another field
                                         </span>
@@ -6647,31 +6663,31 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                         <table>
                           <tbody>
                             <tr
-                              class="c49 component-row"
+                              class="c48 component-row"
                             >
                               <td
                                 colspan="12"
                               >
                                 <div
-                                  class="c0 c26"
+                                  class="c0 c25"
                                 >
                                   <div
-                                    class="c0 c40"
+                                    class="c0 c39"
                                   >
                                     <table>
                                       <tbody>
                                         <tr
-                                          class="c0 c29"
+                                          class="c0 c28"
                                           style="cursor: pointer;"
                                         >
                                           <td
                                             style="position: relative;"
                                           >
                                             <div
-                                              class="c0 c41"
+                                              class="c0 c40"
                                             >
                                               <svg
-                                                class="c69"
+                                                class="c68"
                                                 color="primary200"
                                                 fill="none"
                                                 height="23"
@@ -6687,11 +6703,11 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                               </svg>
                                             </div>
                                             <div
-                                              class="c0 c30 c8 c31"
+                                              class="c0 c29 c30"
                                             >
                                               <div
                                                 aria-hidden="true"
-                                                class="c0 c32 c33"
+                                                class="c0 c31 c32"
                                               >
                                                 <svg
                                                   class="c0 "
@@ -6717,7 +6733,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                 </svg>
                                               </div>
                                               <span
-                                                class="c9 c34"
+                                                class="c9 c33"
                                               >
                                                 name
                                               </span>
@@ -6725,7 +6741,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                           </td>
                                           <td>
                                             <span
-                                              class="c9 c35"
+                                              class="c9 c34"
                                             >
                                               string
                                                
@@ -6734,22 +6750,22 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                           <td>
                                             <div
                                               aria-hidden="true"
-                                              class="c0 c24"
+                                              class="c0 c23"
                                               role="button"
                                             >
                                               <div
-                                                class="c0 c8 c36"
+                                                class="c0 c35"
                                               >
                                                 <span>
                                                   <button
                                                     aria-disabled="false"
                                                     aria-labelledby="68"
-                                                    class="c12 c37"
+                                                    class="c12 c36"
                                                     tabindex="0"
                                                     type="button"
                                                   >
                                                     <span
-                                                      class="c38"
+                                                      class="c37"
                                                     >
                                                       Edit name
                                                     </span>
@@ -6775,12 +6791,12 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                   <button
                                                     aria-disabled="false"
                                                     aria-labelledby="69"
-                                                    class="c12 c37"
+                                                    class="c12 c36"
                                                     tabindex="0"
                                                     type="button"
                                                   >
                                                     <span
-                                                      class="c38"
+                                                      class="c37"
                                                     >
                                                       Delete name
                                                     </span>
@@ -6805,17 +6821,17 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                           </td>
                                         </tr>
                                         <tr
-                                          class="c0 c29"
+                                          class="c0 c28"
                                           style="cursor: pointer;"
                                         >
                                           <td
                                             style="position: relative;"
                                           >
                                             <div
-                                              class="c0 c41"
+                                              class="c0 c40"
                                             >
                                               <svg
-                                                class="c69"
+                                                class="c68"
                                                 color="primary200"
                                                 fill="none"
                                                 height="23"
@@ -6831,11 +6847,11 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                               </svg>
                                             </div>
                                             <div
-                                              class="c0 c30 c8 c31"
+                                              class="c0 c29 c30"
                                             >
                                               <div
                                                 aria-hidden="true"
-                                                class="c0 c32 c33"
+                                                class="c0 c31 c32"
                                               >
                                                 <svg
                                                   class="c0 "
@@ -6863,7 +6879,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                 </svg>
                                               </div>
                                               <span
-                                                class="c9 c34"
+                                                class="c9 c33"
                                               >
                                                 media
                                               </span>
@@ -6871,7 +6887,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                           </td>
                                           <td>
                                             <span
-                                              class="c9 c35"
+                                              class="c9 c34"
                                             >
                                               media
                                                
@@ -6880,22 +6896,22 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                           <td>
                                             <div
                                               aria-hidden="true"
-                                              class="c0 c24"
+                                              class="c0 c23"
                                               role="button"
                                             >
                                               <div
-                                                class="c0 c8 c36"
+                                                class="c0 c35"
                                               >
                                                 <span>
                                                   <button
                                                     aria-disabled="false"
                                                     aria-labelledby="70"
-                                                    class="c12 c37"
+                                                    class="c12 c36"
                                                     tabindex="0"
                                                     type="button"
                                                   >
                                                     <span
-                                                      class="c38"
+                                                      class="c37"
                                                     >
                                                       Edit media
                                                     </span>
@@ -6921,12 +6937,12 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                   <button
                                                     aria-disabled="false"
                                                     aria-labelledby="71"
-                                                    class="c12 c37"
+                                                    class="c12 c36"
                                                     tabindex="0"
                                                     type="button"
                                                   >
                                                     <span
-                                                      class="c38"
+                                                      class="c37"
                                                     >
                                                       Delete media
                                                     </span>
@@ -6951,17 +6967,17 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                           </td>
                                         </tr>
                                         <tr
-                                          class="c0 c29"
+                                          class="c0 c28"
                                           style="cursor: pointer;"
                                         >
                                           <td
                                             style="position: relative;"
                                           >
                                             <div
-                                              class="c0 c41"
+                                              class="c0 c40"
                                             >
                                               <svg
-                                                class="c69"
+                                                class="c68"
                                                 color="primary200"
                                                 fill="none"
                                                 height="23"
@@ -6977,11 +6993,11 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                               </svg>
                                             </div>
                                             <div
-                                              class="c0 c30 c8 c31"
+                                              class="c0 c29 c30"
                                             >
                                               <div
                                                 aria-hidden="true"
-                                                class="c0 c32 c33"
+                                                class="c0 c31 c32"
                                               >
                                                 <svg
                                                   class="c0 "
@@ -7007,7 +7023,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                 </svg>
                                               </div>
                                               <span
-                                                class="c9 c34"
+                                                class="c9 c33"
                                               >
                                                 is_available
                                               </span>
@@ -7015,7 +7031,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                           </td>
                                           <td>
                                             <span
-                                              class="c9 c35"
+                                              class="c9 c34"
                                             >
                                               boolean
                                                
@@ -7024,22 +7040,22 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                           <td>
                                             <div
                                               aria-hidden="true"
-                                              class="c0 c24"
+                                              class="c0 c23"
                                               role="button"
                                             >
                                               <div
-                                                class="c0 c8 c36"
+                                                class="c0 c35"
                                               >
                                                 <span>
                                                   <button
                                                     aria-disabled="false"
                                                     aria-labelledby="72"
-                                                    class="c12 c37"
+                                                    class="c12 c36"
                                                     tabindex="0"
                                                     type="button"
                                                   >
                                                     <span
-                                                      class="c38"
+                                                      class="c37"
                                                     >
                                                       Edit is_available
                                                     </span>
@@ -7065,12 +7081,12 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                   <button
                                                     aria-disabled="false"
                                                     aria-labelledby="73"
-                                                    class="c12 c37"
+                                                    class="c12 c36"
                                                     tabindex="0"
                                                     type="button"
                                                   >
                                                     <span
-                                                      class="c38"
+                                                      class="c37"
                                                     >
                                                       Delete is_available
                                                     </span>
@@ -7098,7 +7114,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                     </table>
                                   </div>
                                   <button
-                                    class="c0 c43 c44"
+                                    class="c0 c42 c43"
                                     type="button"
                                   >
                                     <div
@@ -7106,7 +7122,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                     >
                                       <div
                                         aria-hidden="true"
-                                        class="c0 c60 c70"
+                                        class="c0 c59 c69"
                                       >
                                         <svg
                                           fill="none"
@@ -7122,10 +7138,10 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                         </svg>
                                       </div>
                                       <div
-                                        class="c0 c47"
+                                        class="c0 c46"
                                       >
                                         <span
-                                          class="c9 c56"
+                                          class="c9 c55"
                                         >
                                           Add another field
                                         </span>
@@ -7146,17 +7162,17 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
           </div>
           <div>
             <hr
-              class="c0 c71 c72"
+              class="c0 c70 c71"
             />
             <button
-              class="c0 c73 c74"
+              class="c0 c72 c73"
             >
               <div
                 class="c0 c8"
               >
                 <div
                   aria-hidden="true"
-                  class="c0 c60 c75"
+                  class="c0 c59 c74"
                 >
                   <svg
                     fill="none"
@@ -7172,10 +7188,10 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                   </svg>
                 </div>
                 <div
-                  class="c0 c47"
+                  class="c0 c46"
                 >
                   <span
-                    class="c9 c56"
+                    class="c9 c55"
                   >
                     Add another field
                   </span>
@@ -7188,7 +7204,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
     </div>
   </div>
   <div
-    class="c38"
+    class="c37"
   >
     <p
       aria-live="polite"

--- a/packages/core/email/admin/src/pages/Settings/components/Configuration.js
+++ b/packages/core/email/admin/src/pages/Settings/components/Configuration.js
@@ -4,15 +4,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { useIntl } from 'react-intl';
-import {
-  Stack,
-  Grid,
-  GridItem,
-  Typography,
-  TextInput,
-  Select,
-  Option,
-} from '@strapi/design-system';
+import { Flex, Grid, GridItem, Typography, TextInput, Select, Option } from '@strapi/design-system';
 import getTrad from '../../../utils/getTrad';
 
 const DocumentationLink = styled.a`
@@ -23,8 +15,8 @@ const Configuration = ({ config }) => {
   const { formatMessage } = useIntl();
 
   return (
-    <Stack spacing={4}>
-      <Stack spacing={1}>
+    <Flex direction="column" alignItems="stretch" gap={4}>
+      <Flex direction="column" alignItems="stretch" gap={1}>
         <Typography variant="delta" as="h2">
           {formatMessage({
             id: getTrad('Settings.email.plugin.title.config'),
@@ -55,7 +47,7 @@ const Configuration = ({ config }) => {
             }
           )}
         </Typography>
-      </Stack>
+      </Flex>
       <Grid gap={5}>
         <GridItem col={6} s={12}>
           <TextInput
@@ -104,7 +96,7 @@ const Configuration = ({ config }) => {
           </Select>
         </GridItem>
       </Grid>
-    </Stack>
+    </Flex>
   );
 };
 

--- a/packages/core/email/admin/src/pages/Settings/index.js
+++ b/packages/core/email/admin/src/pages/Settings/index.js
@@ -11,13 +11,13 @@ import {
 import {
   Main,
   ContentLayout,
-  Stack,
   Box,
   Grid,
   GridItem,
   Typography,
   TextInput,
   Button,
+  Flex,
   useNotifyAT,
 } from '@strapi/design-system';
 import { Envelop } from '@strapi/icons';
@@ -160,7 +160,7 @@ const SettingsPage = () => {
       <EmailHeader />
       <ContentLayout>
         <form onSubmit={handleSubmit}>
-          <Stack spacing={7}>
+          <Flex direction="column" alignItems="stretch" gap={7}>
             <Box
               background="neutral0"
               hasRadius
@@ -181,7 +181,7 @@ const SettingsPage = () => {
               paddingLeft={7}
               paddingRight={7}
             >
-              <Stack spacing={4}>
+              <Flex direction="column" alignItems="stretch" gap={4}>
                 <Typography variant="delta" as="h2">
                   {formatMessage({
                     id: getTrad('Settings.email.plugin.title.test'),
@@ -226,9 +226,9 @@ const SettingsPage = () => {
                     </Button>
                   </GridItem>
                 </Grid>
-              </Stack>
+              </Flex>
             </Box>
-          </Stack>
+          </Flex>
         </form>
       </ContentLayout>
     </Main>

--- a/packages/core/email/admin/src/pages/Settings/tests/index.test.js
+++ b/packages/core/email/admin/src/pages/Settings/tests/index.test.js
@@ -59,27 +59,27 @@ describe('Email | Pages | Settings', () => {
         color: #666687;
       }
 
-      .c14 {
+      .c13 {
         font-weight: 500;
         font-size: 1rem;
         line-height: 1.25;
         color: #32324d;
       }
 
-      .c15 {
+      .c14 {
         font-size: 0.875rem;
         line-height: 1.43;
         color: #32324d;
       }
 
-      .c19 {
+      .c20 {
         font-size: 0.75rem;
         line-height: 1.33;
         font-weight: 600;
         color: #32324d;
       }
 
-      .c26 {
+      .c27 {
         font-size: 0.875rem;
         line-height: 1.43;
         display: block;
@@ -102,7 +102,7 @@ describe('Email | Pages | Settings', () => {
         padding-left: 56px;
       }
 
-      .c11 {
+      .c10 {
         background: #ffffff;
         padding-top: 24px;
         padding-right: 32px;
@@ -112,16 +112,16 @@ describe('Email | Pages | Settings', () => {
         box-shadow: 0px 1px 4px rgba(33,33,52,0.1);
       }
 
-      .c25 {
+      .c26 {
         padding-right: 16px;
         padding-left: 16px;
       }
 
-      .c27 {
+      .c28 {
         padding-left: 12px;
       }
 
-      .c35 {
+      .c36 {
         padding-right: 8px;
       }
 
@@ -169,36 +169,63 @@ describe('Email | Pages | Settings', () => {
         -webkit-flex-direction: column;
         -ms-flex-direction: column;
         flex-direction: column;
+        gap: 32px;
       }
 
-      .c10 > * {
+      .c11 {
+        -webkit-align-items: stretch;
+        -webkit-box-align: stretch;
+        -ms-flex-align: stretch;
+        align-items: stretch;
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+        -webkit-flex-direction: column;
+        -ms-flex-direction: column;
+        flex-direction: column;
+        gap: 16px;
+      }
+
+      .c12 {
+        -webkit-align-items: stretch;
+        -webkit-box-align: stretch;
+        -ms-flex-align: stretch;
+        align-items: stretch;
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+        -webkit-flex-direction: column;
+        -ms-flex-direction: column;
+        flex-direction: column;
+        gap: 4px;
+      }
+
+      .c18 {
+        -webkit-align-items: stretch;
+        -webkit-box-align: stretch;
+        -ms-flex-align: stretch;
+        align-items: stretch;
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+        -webkit-flex-direction: column;
+        -ms-flex-direction: column;
+        flex-direction: column;
+      }
+
+      .c19 > * {
         margin-top: 0;
         margin-bottom: 0;
       }
 
-      .c10 > * + * {
-        margin-top: 32px;
-      }
-
-      .c12 > * {
-        margin-top: 0;
-        margin-bottom: 0;
-      }
-
-      .c12 > * + * {
-        margin-top: 16px;
-      }
-
-      .c13 > * {
-        margin-top: 0;
-        margin-bottom: 0;
-      }
-
-      .c13 > * + * {
+      .c19 > * + * {
         margin-top: 4px;
       }
 
-      .c33 {
+      .c34 {
         display: -webkit-box;
         display: -webkit-flex;
         display: -ms-flexbox;
@@ -212,21 +239,21 @@ describe('Email | Pages | Settings', () => {
         outline: none;
       }
 
-      .c33 svg {
+      .c34 svg {
         height: 12px;
         width: 12px;
       }
 
-      .c33 svg > g,
-      .c33 svg path {
+      .c34 svg > g,
+      .c34 svg path {
         fill: #ffffff;
       }
 
-      .c33[aria-disabled='true'] {
+      .c34[aria-disabled='true'] {
         pointer-events: none;
       }
 
-      .c33:after {
+      .c34:after {
         -webkit-transition-property: all;
         transition-property: all;
         -webkit-transition-duration: 0.2s;
@@ -241,11 +268,11 @@ describe('Email | Pages | Settings', () => {
         border: 2px solid transparent;
       }
 
-      .c33:focus-visible {
+      .c34:focus-visible {
         outline: none;
       }
 
-      .c33:focus-visible:after {
+      .c34:focus-visible:after {
         border-radius: 8px;
         content: '';
         position: absolute;
@@ -256,11 +283,11 @@ describe('Email | Pages | Settings', () => {
         border: 2px solid #4945ff;
       }
 
-      .c36 {
+      .c37 {
         height: 100%;
       }
 
-      .c34 {
+      .c35 {
         -webkit-align-items: center;
         -webkit-box-align: center;
         -ms-flex-align: center;
@@ -272,7 +299,7 @@ describe('Email | Pages | Settings', () => {
         padding-right: 16px;
       }
 
-      .c34 .c1 {
+      .c35 .c1 {
         display: -webkit-box;
         display: -webkit-flex;
         display: -ms-flexbox;
@@ -283,52 +310,52 @@ describe('Email | Pages | Settings', () => {
         align-items: center;
       }
 
-      .c34 .c5 {
+      .c35 .c5 {
         color: #ffffff;
       }
 
-      .c34[aria-disabled='true'] {
+      .c35[aria-disabled='true'] {
         border: 1px solid #dcdce4;
         background: #eaeaef;
       }
 
-      .c34[aria-disabled='true'] .c5 {
+      .c35[aria-disabled='true'] .c5 {
         color: #666687;
       }
 
-      .c34[aria-disabled='true'] svg > g,.c34[aria-disabled='true'] svg path {
+      .c35[aria-disabled='true'] svg > g,.c35[aria-disabled='true'] svg path {
         fill: #666687;
       }
 
-      .c34[aria-disabled='true']:active {
+      .c35[aria-disabled='true']:active {
         border: 1px solid #dcdce4;
         background: #eaeaef;
       }
 
-      .c34[aria-disabled='true']:active .c5 {
+      .c35[aria-disabled='true']:active .c5 {
         color: #666687;
       }
 
-      .c34[aria-disabled='true']:active svg > g,.c34[aria-disabled='true']:active svg path {
+      .c35[aria-disabled='true']:active svg > g,.c35[aria-disabled='true']:active svg path {
         fill: #666687;
       }
 
-      .c34:hover {
+      .c35:hover {
         border: 1px solid #7b79ff;
         background: #7b79ff;
       }
 
-      .c34:active {
+      .c35:active {
         border: 1px solid #4945ff;
         background: #4945ff;
       }
 
-      .c34 svg > g,
-      .c34 svg path {
+      .c35 svg > g,
+      .c35 svg path {
         fill: #ffffff;
       }
 
-      .c21 {
+      .c22 {
         border: none;
         border-radius: 4px;
         padding-bottom: 0.65625rem;
@@ -344,36 +371,36 @@ describe('Email | Pages | Settings', () => {
         background: inherit;
       }
 
-      .c21::-webkit-input-placeholder {
+      .c22::-webkit-input-placeholder {
         color: #8e8ea9;
         opacity: 1;
       }
 
-      .c21::-moz-placeholder {
+      .c22::-moz-placeholder {
         color: #8e8ea9;
         opacity: 1;
       }
 
-      .c21:-ms-input-placeholder {
+      .c22:-ms-input-placeholder {
         color: #8e8ea9;
         opacity: 1;
       }
 
-      .c21::placeholder {
+      .c22::placeholder {
         color: #8e8ea9;
         opacity: 1;
       }
 
-      .c21[aria-disabled='true'] {
+      .c22[aria-disabled='true'] {
         color: inherit;
       }
 
-      .c21:focus {
+      .c22:focus {
         outline: none;
         box-shadow: none;
       }
 
-      .c31 {
+      .c32 {
         border: none;
         border-radius: 4px;
         padding-bottom: 0.65625rem;
@@ -388,36 +415,36 @@ describe('Email | Pages | Settings', () => {
         background: inherit;
       }
 
-      .c31::-webkit-input-placeholder {
+      .c32::-webkit-input-placeholder {
         color: #8e8ea9;
         opacity: 1;
       }
 
-      .c31::-moz-placeholder {
+      .c32::-moz-placeholder {
         color: #8e8ea9;
         opacity: 1;
       }
 
-      .c31:-ms-input-placeholder {
+      .c32:-ms-input-placeholder {
         color: #8e8ea9;
         opacity: 1;
       }
 
-      .c31::placeholder {
+      .c32::placeholder {
         color: #8e8ea9;
         opacity: 1;
       }
 
-      .c31[aria-disabled='true'] {
+      .c32[aria-disabled='true'] {
         color: inherit;
       }
 
-      .c31:focus {
+      .c32:focus {
         outline: none;
         box-shadow: none;
       }
 
-      .c20 {
+      .c21 {
         border: 1px solid #dcdce4;
         border-radius: 4px;
         background: #ffffff;
@@ -431,12 +458,12 @@ describe('Email | Pages | Settings', () => {
         background: #eaeaef;
       }
 
-      .c20:focus-within {
+      .c21:focus-within {
         border: 1px solid #4945ff;
         box-shadow: #4945ff 0px 0px 0px 2px;
       }
 
-      .c30 {
+      .c31 {
         border: 1px solid #dcdce4;
         border-radius: 4px;
         background: #ffffff;
@@ -448,12 +475,12 @@ describe('Email | Pages | Settings', () => {
         transition-duration: 0.2s;
       }
 
-      .c30:focus-within {
+      .c31:focus-within {
         border: 1px solid #4945ff;
         box-shadow: #4945ff 0px 0px 0px 2px;
       }
 
-      .c22 {
+      .c23 {
         position: relative;
         border: 1px solid #dcdce4;
         padding-right: 12px;
@@ -471,28 +498,28 @@ describe('Email | Pages | Settings', () => {
         transition-duration: 0.2s;
       }
 
-      .c22:focus-within {
+      .c23:focus-within {
         border: 1px solid #4945ff;
         box-shadow: #4945ff 0px 0px 0px 2px;
       }
 
-      .c28 {
+      .c29 {
         background: transparent;
         border: none;
         position: relative;
         z-index: 1;
       }
 
-      .c28 svg {
+      .c29 svg {
         height: 0.6875rem;
         width: 0.6875rem;
       }
 
-      .c28 svg path {
+      .c29 svg path {
         fill: #666687;
       }
 
-      .c29 {
+      .c30 {
         display: -webkit-box;
         display: -webkit-flex;
         display: -ms-flexbox;
@@ -502,11 +529,11 @@ describe('Email | Pages | Settings', () => {
         cursor: not-allowed;
       }
 
-      .c29 svg {
+      .c30 svg {
         width: 0.375rem;
       }
 
-      .c23 {
+      .c24 {
         position: absolute;
         left: 0;
         right: 0;
@@ -517,30 +544,30 @@ describe('Email | Pages | Settings', () => {
         border: none;
       }
 
-      .c23:focus {
+      .c24:focus {
         outline: none;
       }
 
-      .c23[aria-disabled='true'] {
+      .c24[aria-disabled='true'] {
         cursor: not-allowed;
       }
 
-      .c24 {
+      .c25 {
         width: 100%;
       }
 
-      .c17 {
+      .c16 {
         display: grid;
         grid-template-columns: repeat(12,1fr);
         gap: 20px;
       }
 
-      .c18 {
+      .c17 {
         grid-column: span 6;
         max-width: 100%;
       }
 
-      .c32 {
+      .c33 {
         grid-column: span 7;
         max-width: 100%;
       }
@@ -549,30 +576,30 @@ describe('Email | Pages | Settings', () => {
         outline: none;
       }
 
-      .c16 {
+      .c15 {
         color: #4945ff;
       }
 
       @media (max-width:68.75rem) {
-        .c18 {
+        .c17 {
           grid-column: span 12;
         }
       }
 
       @media (max-width:34.375rem) {
-        .c18 {
+        .c17 {
           grid-column: span;
         }
       }
 
       @media (max-width:68.75rem) {
-        .c32 {
+        .c33 {
           grid-column: span 12;
         }
       }
 
       @media (max-width:34.375rem) {
-        .c32 {
+        .c33 {
           grid-column: span;
         }
       }
@@ -617,28 +644,28 @@ describe('Email | Pages | Settings', () => {
         >
           <form>
             <div
-              class="c1 c9 c10"
+              class="c1 c9"
             >
               <div
-                class="c1 c11"
+                class="c1 c10"
               >
                 <div
-                  class="c1 c9 c12"
+                  class="c1 c11"
                 >
                   <div
-                    class="c1 c9 c13"
+                    class="c1 c12"
                   >
                     <h2
-                      class="c5 c14"
+                      class="c5 c13"
                     >
                       Configuration
                     </h2>
                     <span
-                      class="c5 c15"
+                      class="c5 c14"
                     >
                       The plugin is configured through the ./config/plugins.js file, checkout this 
                       <a
-                        class="c16"
+                        class="c15"
                         href="https://docs.strapi.io/developer-docs/latest/plugins/email.html"
                         rel="noopener noreferrer"
                         target="_blank"
@@ -649,10 +676,10 @@ describe('Email | Pages | Settings', () => {
                     </span>
                   </div>
                   <div
-                    class="c1 c17"
+                    class="c1 c16"
                   >
                     <div
-                      class="c18"
+                      class="c17"
                     >
                       <div
                         class="c1 "
@@ -660,10 +687,10 @@ describe('Email | Pages | Settings', () => {
                         <div>
                           <div>
                             <div
-                              class="c1 c9 c13"
+                              class="c1 c18 c19"
                             >
                               <label
-                                class="c5 c19"
+                                class="c5 c20"
                                 for="7"
                               >
                                 <div
@@ -673,14 +700,14 @@ describe('Email | Pages | Settings', () => {
                                 </div>
                               </label>
                               <div
-                                class="c1 c3 c20"
+                                class="c1 c3 c21"
                                 disabled=""
                               >
                                 <input
                                   aria-disabled="true"
                                   aria-invalid="false"
                                   aria-required="false"
-                                  class="c21"
+                                  class="c22"
                                   id="7"
                                   name="shipper-email"
                                   placeholder="ex: Strapi No-Reply <no-reply@strapi.io>"
@@ -693,7 +720,7 @@ describe('Email | Pages | Settings', () => {
                       </div>
                     </div>
                     <div
-                      class="c18"
+                      class="c17"
                     >
                       <div
                         class="c1 "
@@ -701,10 +728,10 @@ describe('Email | Pages | Settings', () => {
                         <div>
                           <div>
                             <div
-                              class="c1 c9 c13"
+                              class="c1 c18 c19"
                             >
                               <label
-                                class="c5 c19"
+                                class="c5 c20"
                                 for="9"
                               >
                                 <div
@@ -714,14 +741,14 @@ describe('Email | Pages | Settings', () => {
                                 </div>
                               </label>
                               <div
-                                class="c1 c3 c20"
+                                class="c1 c3 c21"
                                 disabled=""
                               >
                                 <input
                                   aria-disabled="true"
                                   aria-invalid="false"
                                   aria-required="false"
-                                  class="c21"
+                                  class="c22"
                                   id="9"
                                   name="response-email"
                                   placeholder="ex: Strapi <example@strapi.io>"
@@ -734,17 +761,17 @@ describe('Email | Pages | Settings', () => {
                       </div>
                     </div>
                     <div
-                      class="c18"
+                      class="c17"
                     >
                       <div
                         class="c1 "
                       >
                         <div>
                           <div
-                            class="c1 c9 c13"
+                            class="c1 c18 c19"
                           >
                             <label
-                              class="c5 c19"
+                              class="c5 c20"
                               for="11"
                             >
                               <div
@@ -754,7 +781,7 @@ describe('Email | Pages | Settings', () => {
                               </div>
                             </label>
                             <div
-                              class="c1 c4 c22"
+                              class="c1 c4 c23"
                               disabled=""
                             >
                               <button
@@ -762,22 +789,22 @@ describe('Email | Pages | Settings', () => {
                                 aria-expanded="false"
                                 aria-haspopup="listbox"
                                 aria-labelledby="11 11-label 11-content"
-                                class="c23"
+                                class="c24"
                                 id="11"
                                 name="email-provider"
                                 type="button"
                               />
                               <div
-                                class="c1 c3 c24"
+                                class="c1 c3 c25"
                               >
                                 <div
                                   class="c1 c4"
                                 >
                                   <div
-                                    class="c1 c25"
+                                    class="c1 c26"
                                   >
                                     <span
-                                      class="c5 c26"
+                                      class="c5 c27"
                                       id="11-content"
                                     >
                                       Select...
@@ -790,7 +817,7 @@ describe('Email | Pages | Settings', () => {
                                   
                                   <button
                                     aria-hidden="true"
-                                    class="c1 c27 c28 c29"
+                                    class="c1 c28 c29 c30"
                                     disabled=""
                                     tabindex="-1"
                                     title="Carret Down Button"
@@ -822,21 +849,21 @@ describe('Email | Pages | Settings', () => {
                 </div>
               </div>
               <div
-                class="c1 c11"
+                class="c1 c10"
               >
                 <div
-                  class="c1 c9 c12"
+                  class="c1 c11"
                 >
                   <h2
-                    class="c5 c14"
+                    class="c5 c13"
                   >
                     Test email delivery
                   </h2>
                   <div
-                    class="c1 c17"
+                    class="c1 c16"
                   >
                     <div
-                      class="c18"
+                      class="c17"
                     >
                       <div
                         class="c1 "
@@ -844,10 +871,10 @@ describe('Email | Pages | Settings', () => {
                         <div>
                           <div>
                             <div
-                              class="c1 c9 c13"
+                              class="c1 c18 c19"
                             >
                               <label
-                                class="c5 c19"
+                                class="c5 c20"
                                 for="test-address-input"
                               >
                                 <div
@@ -857,13 +884,13 @@ describe('Email | Pages | Settings', () => {
                                 </div>
                               </label>
                               <div
-                                class="c1 c3 c30"
+                                class="c1 c3 c31"
                               >
                                 <input
                                   aria-disabled="false"
                                   aria-invalid="false"
                                   aria-required="false"
-                                  class="c31"
+                                  class="c32"
                                   id="test-address-input"
                                   name="test-address"
                                   placeholder="ex: developer@example.com"
@@ -876,20 +903,20 @@ describe('Email | Pages | Settings', () => {
                       </div>
                     </div>
                     <div
-                      class="c32"
+                      class="c33"
                     >
                       <div
                         class="c1 "
                       >
                         <button
                           aria-disabled="true"
-                          class="c33 c34"
+                          class="c34 c35"
                           disabled=""
                           type="submit"
                         >
                           <div
                             aria-hidden="true"
-                            class="c1 c35 c36"
+                            class="c1 c36 c37"
                           >
                             <svg
                               fill="none"
@@ -913,7 +940,7 @@ describe('Email | Pages | Settings', () => {
                             </svg>
                           </div>
                           <span
-                            class="c5 c19"
+                            class="c5 c20"
                           >
                             Send test email
                           </span>

--- a/packages/core/helper-plugin/lib/src/components/ConfirmDialog/index.js
+++ b/packages/core/helper-plugin/lib/src/components/ConfirmDialog/index.js
@@ -1,15 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
-import {
-  Dialog,
-  DialogBody,
-  DialogFooter,
-  Stack,
-  Flex,
-  Typography,
-  Button,
-} from '@strapi/design-system';
+import { Dialog, DialogBody, DialogFooter, Flex, Typography, Button } from '@strapi/design-system';
 import { ExclamationMarkCircle, Trash } from '@strapi/icons';
 
 const ConfirmDialog = ({
@@ -39,7 +31,7 @@ const ConfirmDialog = ({
       {...props}
     >
       <DialogBody icon={iconBody}>
-        <Stack spacing={2}>
+        <Flex direction="column" alignItems="stretch" gap={2}>
           <Flex justifyContent="center">
             <Typography variant="omega" id="confirm-description">
               {formatMessage({
@@ -48,7 +40,7 @@ const ConfirmDialog = ({
               })}
             </Typography>
           </Flex>
-        </Stack>
+        </Flex>
       </DialogBody>
       <DialogFooter
         startAction={

--- a/packages/core/helper-plugin/lib/src/components/ContentBox/ContentBox.stories.mdx
+++ b/packages/core/helper-plugin/lib/src/components/ContentBox/ContentBox.stories.mdx
@@ -3,8 +3,7 @@
 import { useState } from 'react';
 import { ArgsTable, Meta, Canvas, Story } from '@storybook/addon-docs';
 import ContentBox from './index';
-import { Stack } from '@strapi/design-system';
-import { IconButton } from '@strapi/design-system';
+import { IconButton, Flex } from '@strapi/design-system';
 import { InformationSquare, CodeSquare, PlaySquare, FeatherSquare, Duplicate } from '@strapi/icons';
 
 <Meta title="components/ContentBox" />
@@ -17,7 +16,7 @@ TODO
 
 <Canvas>
   <Story name="base">
-    <Stack spacing={4}>
+    <Flex direction="column" alignItems="stretch" gap={4}>
       <ContentBox
         title="Read the documentation"
         subtitle="Discover the concepts, reference, guides and PlaySquares"
@@ -65,7 +64,7 @@ TODO
         }
         iconBackground="neutral100"
       />
-    </Stack>
+    </Flex>
   </Story>
 </Canvas>
 

--- a/packages/core/helper-plugin/lib/src/components/ContentBox/index.js
+++ b/packages/core/helper-plugin/lib/src/components/ContentBox/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { Flex, Stack, Typography } from '@strapi/design-system';
+import { Flex, Typography } from '@strapi/design-system';
 
 const IconWrapper = styled(Flex)`
   margin-right: ${({ theme }) => theme.spaces[6]};
@@ -26,7 +26,7 @@ const ContentBox = ({ title, subtitle, icon, iconBackground, endAction, titleEll
       <IconWrapper background={iconBackground} hasRadius padding={3}>
         {icon}
       </IconWrapper>
-      <Stack spacing={endAction ? 0 : 1}>
+      <Flex direction="column" alignItems="stretch" gap={endAction ? 0 : 1}>
         <Flex>
           <TypographyWordBreak fontWeight="semiBold" variant="pi">
             {title}
@@ -34,7 +34,7 @@ const ContentBox = ({ title, subtitle, icon, iconBackground, endAction, titleEll
           {endAction}
         </Flex>
         <Typography textColor="neutral600">{subtitle}</Typography>
-      </Stack>
+      </Flex>
     </Flex>
   );
 };

--- a/packages/core/helper-plugin/lib/src/components/ContentBox/tests/index.test.js
+++ b/packages/core/helper-plugin/lib/src/components/ContentBox/tests/index.test.js
@@ -22,14 +22,14 @@ describe('ContentBox', () => {
     } = render(App);
 
     expect(firstChild).toMatchInlineSnapshot(`
-      .c6 {
+      .c5 {
         font-size: 0.75rem;
         line-height: 1.33;
         font-weight: 500;
         color: #32324d;
       }
 
-      .c8 {
+      .c7 {
         font-size: 0.875rem;
         line-height: 1.43;
         color: #666687;
@@ -73,15 +73,7 @@ describe('ContentBox', () => {
         -webkit-flex-direction: column;
         -ms-flex-direction: column;
         flex-direction: column;
-      }
-
-      .c5 > * {
-        margin-top: 0;
-        margin-bottom: 0;
-      }
-
-      .c5 > * + * {
-        margin-top: 4px;
+        gap: 4px;
       }
 
       .c3 {
@@ -93,7 +85,7 @@ describe('ContentBox', () => {
         height: 2rem;
       }
 
-      .c7 {
+      .c6 {
         word-break: break-all;
       }
 
@@ -104,19 +96,19 @@ describe('ContentBox', () => {
           class="c2 c1 c3"
         />
         <div
-          class="c4 c5"
+          class="c4"
         >
           <div
             class="c1"
           >
             <span
-              class="c6 c7"
+              class="c5 c6"
             >
               Code example
             </span>
           </div>
           <span
-            class="c8"
+            class="c7"
           >
             Learn by testing real project developed by the community
           </span>

--- a/packages/core/helper-plugin/lib/src/components/DynamicTable/DynamicTable.stories.mdx
+++ b/packages/core/helper-plugin/lib/src/components/DynamicTable/DynamicTable.stories.mdx
@@ -2,15 +2,22 @@
 
 import { useEffect } from 'react';
 import { Meta, ArgsTable, Canvas, Story } from '@storybook/addon-docs';
-import { Main } from '@strapi/design-system';
-import { Button } from '@strapi/design-system';
-import { Box } from '@strapi/design-system';
-import { Flex } from '@strapi/design-system';
-import { BaseCheckbox } from '@strapi/design-system';
-import { Dialog, DialogBody, DialogFooter } from '@strapi/design-system';
-import { Tbody, Td, Tr, TFooter } from '@strapi/design-system';
-import { Typography } from '@strapi/design-system';
-import { IconButton } from '@strapi/design-system';
+import {
+  Main,
+  Button,
+  Box,
+  Flex,
+  BaseCheckbox,
+  Dialog,
+  DialogBody,
+  DialogFooter,
+  Tbody,
+  Td,
+  Tr,
+  TFooter,
+  Typography,
+  IconButton,
+} from '@strapi/design-system';
 import { Plus, Pencil, Trash } from '@strapi/icons';
 import useQueryParams from '../../hooks/useQueryParams';
 import DynamicTable from './index';

--- a/packages/core/helper-plugin/lib/src/components/FilterListURLQuery/FilterListURLQuery.stories.mdx
+++ b/packages/core/helper-plugin/lib/src/components/FilterListURLQuery/FilterListURLQuery.stories.mdx
@@ -2,11 +2,7 @@
 
 import { useEffect } from 'react';
 import { Meta, ArgsTable, Canvas, Story } from '@storybook/addon-docs';
-import { Button } from '@strapi/design-system';
-import { Box } from '@strapi/design-system';
-import { Main } from '@strapi/design-system';
-import { Flex } from '@strapi/design-system';
-import { Stack } from '@strapi/design-system';
+import { Button, Box, Main, Flex } from '@strapi/design-system';
 import useQueryParams from '../../hooks/useQueryParams';
 import FilterListURLQuery from './index';
 
@@ -37,7 +33,7 @@ import { FilterListURLQuery } from '@strapi/helper-plugin';
       const handleResetFilters = () => setQuery({ filters });
       return (
         <Main>
-          <Stack spacing={6}>
+          <Flex direction="column" alignItems="stretch" gap={6}>
             <Flex paddingTop={6}>
               <FilterListURLQuery
                 filtersSchema={[
@@ -62,7 +58,7 @@ import { FilterListURLQuery } from '@strapi/helper-plugin';
             <Box>
               <Button onClick={handleResetFilters}>Reset filters</Button>
             </Box>
-          </Stack>
+          </Flex>
         </Main>
       );
     }}

--- a/packages/core/helper-plugin/lib/src/components/FilterPopoverURLQuery/FilterPopoverURLQuery.stories.mdx
+++ b/packages/core/helper-plugin/lib/src/components/FilterPopoverURLQuery/FilterPopoverURLQuery.stories.mdx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState, useRef } from 'react';
 import { Meta, ArgsTable, Canvas, Story } from '@storybook/addon-docs';
-import { Button, Box, Main, Flex, Stack } from '@strapi/design-system';
+import { Button, Box, Main, Flex } from '@strapi/design-system';
 import useQueryParams from '../../hooks/useQueryParams';
 import FilterListURLQuery from '../FilterListURLQuery';
 import FilterPopoverURLQuery from './index';
@@ -28,7 +28,7 @@ import { FilterListURLQuery } from '@strapi/helper-plugin';
       const [isVisible, setIsVisible] = useState(false);
       const buttonRef = useRef();
       const handleToggle = () => {
-        setIsVisible(prev => !prev);
+        setIsVisible((prev) => !prev);
       };
       const [{ query }, setQuery] = useQueryParams();
       const filters = {
@@ -53,7 +53,7 @@ import { FilterListURLQuery } from '@strapi/helper-plugin';
       ];
       return (
         <Main>
-          <Stack spacing={6}>
+          <Flex direction="column" alignItems="stretch" gap={6}>
             <Flex paddingTop={6}>
               <Button variant="tertiary" onClick={handleToggle} size="S" ref={buttonRef}>
                 Filters
@@ -66,7 +66,7 @@ import { FilterListURLQuery } from '@strapi/helper-plugin';
               />
               <FilterListURLQuery filtersSchema={filtersSchema} />
             </Flex>
-          </Stack>
+          </Flex>
         </Main>
       );
     }}

--- a/packages/core/helper-plugin/lib/src/components/FilterPopoverURLQuery/index.js
+++ b/packages/core/helper-plugin/lib/src/components/FilterPopoverURLQuery/index.js
@@ -6,7 +6,7 @@
 
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { Button, Box, Popover, Stack, FocusTrap, Select, Option } from '@strapi/design-system';
+import { Button, Flex, Box, Popover, FocusTrap, Select, Option } from '@strapi/design-system';
 import { Plus } from '@strapi/icons';
 import { useIntl } from 'react-intl';
 import useQueryParams from '../../hooks/useQueryParams';
@@ -115,7 +115,7 @@ const FilterPopoverURLQuery = ({ displayedFilters, isVisible, onBlur, onToggle, 
     <Popover source={source} padding={3} spacing={4} onBlur={onBlur}>
       <FocusTrap onEscape={onToggle}>
         <form onSubmit={handleSubmit}>
-          <Stack spacing={1} style={{ minWidth: 184 }}>
+          <Flex direction="column" alignItems="stretch" gap={1} style={{ minWidth: 184 }}>
             <Box>
               <Select
                 aria-label={formatMessage({
@@ -171,7 +171,7 @@ const FilterPopoverURLQuery = ({ displayedFilters, isVisible, onBlur, onToggle, 
                 {formatMessage({ id: 'app.utils.add-filter', defaultMessage: 'Add filter' })}
               </Button>
             </Box>
-          </Stack>
+          </Flex>
         </form>
       </FocusTrap>
     </Popover>

--- a/packages/core/helper-plugin/lib/src/components/GenericInput/GenericInput.stories.mdx
+++ b/packages/core/helper-plugin/lib/src/components/GenericInput/GenericInput.stories.mdx
@@ -5,7 +5,7 @@ import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
 import { Grid, GridItem } from '@strapi/design-system';
 import { HeaderLayout, ContentLayout } from '@strapi/design-system';
 import { Main } from '@strapi/design-system';
-import { Stack } from '@strapi/design-system';
+import { Flex } from '@strapi/design-system';
 import { Box } from '@strapi/design-system';
 import set from 'lodash/set';
 import GenericInput from './index';
@@ -34,7 +34,7 @@ Description...
       });
       return (
         <ContentLayout>
-          <Stack spacing={4}>
+          <Flex direction="column" alignItems="stretch" gap={4}>
             {layout.map((row, rowIndex) => {
               return (
                 <Box key={rowIndex}>
@@ -58,7 +58,7 @@ Description...
                 </Box>
               );
             })}
-          </Stack>
+          </Flex>
         </ContentLayout>
       );
     }}

--- a/packages/core/helper-plugin/lib/src/components/SearchURLQuery/SearchURLQuery.stories.mdx
+++ b/packages/core/helper-plugin/lib/src/components/SearchURLQuery/SearchURLQuery.stories.mdx
@@ -1,7 +1,7 @@
 <!--- Search.stories.mdx --->
 
 import { ArgsTable, Meta, Canvas, Story } from '@storybook/addon-docs';
-import { Stack } from '@strapi/design-system';
+import { Flex } from '@strapi/design-system';
 import matchSorter from 'match-sorter';
 import useQueryParams from '../../hooks/useQueryParams';
 import SearchURLQuery from './index';
@@ -68,7 +68,7 @@ const HomePage = () => {
       const sortedList = matchSorter(items, _q, { keys: ['name', 'instrument'] });
       const itemsList = sortedList?.length ? sortedList : items;
       return (
-        <Stack paddingTop={6} spacing={4}>
+        <Flex direction="column" alignItems="stretch" paddingTop={6} gap={4}>
           <SearchURLQuery label="Label" />
           {itemsList.map((item, i) => (
             <div key={i}>
@@ -76,7 +76,7 @@ const HomePage = () => {
               <p>{item.instrument}</p>
             </div>
           ))}
-        </Stack>
+        </Flex>
       );
     }}
   </Story>

--- a/packages/core/upload/admin/src/components/AssetCard/UploadingAssetCard.js
+++ b/packages/core/upload/admin/src/components/AssetCard/UploadingAssetCard.js
@@ -12,7 +12,6 @@ import {
   CardSubtitle,
   CardBadge,
   Typography,
-  Stack,
   Box,
   Flex,
 } from '@strapi/design-system';
@@ -86,7 +85,7 @@ export const UploadingAssetCard = ({
   };
 
   return (
-    <Stack spacing={1}>
+    <Flex direction="column" alignItems="stretch" gap={1}>
       <Card borderColor={error ? 'danger600' : 'neutral150'}>
         <CardHeader>
           <UploadProgressWrapper>
@@ -126,7 +125,7 @@ export const UploadingAssetCard = ({
           )}
         </Typography>
       ) : undefined}
-    </Stack>
+    </Flex>
   );
 };
 

--- a/packages/core/upload/admin/src/components/AssetDialog/BrowseStep/tests/__snapshots__/index.test.js.snap
+++ b/packages/core/upload/admin/src/components/AssetDialog/BrowseStep/tests/__snapshots__/index.test.js.snap
@@ -37,7 +37,7 @@ exports[`BrowseStep renders and match snapshot 1`] = `
   color: #666687;
 }
 
-.c62 {
+.c63 {
   font-size: 0.875rem;
   line-height: 1.43;
   display: block;
@@ -47,7 +47,7 @@ exports[`BrowseStep renders and match snapshot 1`] = `
   color: #32324d;
 }
 
-.c66 {
+.c67 {
   font-size: 0.875rem;
   line-height: 1.43;
   color: #666687;
@@ -122,16 +122,16 @@ exports[`BrowseStep renders and match snapshot 1`] = `
   right: 16px;
 }
 
-.c54 {
+.c55 {
   padding-top: 16px;
 }
 
-.c61 {
+.c62 {
   padding-right: 16px;
   padding-left: 16px;
 }
 
-.c63 {
+.c64 {
   padding-left: 12px;
 }
 
@@ -184,6 +184,21 @@ exports[`BrowseStep renders and match snapshot 1`] = `
   flex-direction: row;
 }
 
+.c37 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 8px;
+}
+
 .c41 {
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
@@ -212,7 +227,7 @@ exports[`BrowseStep renders and match snapshot 1`] = `
   flex-direction: column;
 }
 
-.c55 {
+.c56 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -230,7 +245,7 @@ exports[`BrowseStep renders and match snapshot 1`] = `
   justify-content: space-between;
 }
 
-.c56 {
+.c57 {
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -244,17 +259,17 @@ exports[`BrowseStep renders and match snapshot 1`] = `
   flex-direction: column;
 }
 
-.c57 > * {
+.c58 > * {
   margin-top: 0;
   margin-bottom: 0;
 }
 
-.c37 > * {
+.c53 > * {
   margin-left: 0;
   margin-right: 0;
 }
 
-.c37 > * + * {
+.c53 > * + * {
   margin-left: 8px;
 }
 
@@ -404,12 +419,12 @@ exports[`BrowseStep renders and match snapshot 1`] = `
   fill: #32324d;
 }
 
-.c53 {
+.c54 {
   position: absolute;
   top: 12px;
 }
 
-.c58 {
+.c59 {
   position: relative;
   border: 1px solid #dcdce4;
   padding-right: 12px;
@@ -425,28 +440,28 @@ exports[`BrowseStep renders and match snapshot 1`] = `
   transition-duration: 0.2s;
 }
 
-.c58:focus-within {
+.c59:focus-within {
   border: 1px solid #4945ff;
   box-shadow: #4945ff 0px 0px 0px 2px;
 }
 
-.c64 {
+.c65 {
   background: transparent;
   border: none;
   position: relative;
   z-index: 1;
 }
 
-.c64 svg {
+.c65 svg {
   height: 0.6875rem;
   width: 0.6875rem;
 }
 
-.c64 svg path {
+.c65 svg path {
   fill: #666687;
 }
 
-.c65 {
+.c66 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -455,7 +470,7 @@ exports[`BrowseStep renders and match snapshot 1`] = `
   border: none;
 }
 
-.c65 svg {
+.c66 svg {
   width: 0.375rem;
 }
 
@@ -475,7 +490,7 @@ exports[`BrowseStep renders and match snapshot 1`] = `
   width: 6px;
 }
 
-.c59 {
+.c60 {
   position: absolute;
   left: 0;
   right: 0;
@@ -486,15 +501,15 @@ exports[`BrowseStep renders and match snapshot 1`] = `
   border: none;
 }
 
-.c59:focus {
+.c60:focus {
   outline: none;
 }
 
-.c59[aria-disabled='true'] {
+.c60[aria-disabled='true'] {
   cursor: not-allowed;
 }
 
-.c60 {
+.c61 {
   width: 100%;
 }
 
@@ -661,15 +676,15 @@ exports[`BrowseStep renders and match snapshot 1`] = `
   outline-offset: -2px;
 }
 
-.c67 > * + * {
+.c68 > * + * {
   margin-left: 4px;
 }
 
-.c72 {
+.c73 {
   line-height: revert;
 }
 
-.c68 {
+.c69 {
   padding: 12px;
   border-radius: 4px;
   -webkit-text-decoration: none;
@@ -682,7 +697,7 @@ exports[`BrowseStep renders and match snapshot 1`] = `
   outline: none;
 }
 
-.c68:after {
+.c69:after {
   -webkit-transition-property: all;
   transition-property: all;
   -webkit-transition-duration: 0.2s;
@@ -697,55 +712,11 @@ exports[`BrowseStep renders and match snapshot 1`] = `
   border: 2px solid transparent;
 }
 
-.c68:focus-visible {
+.c69:focus-visible {
   outline: none;
 }
 
-.c68:focus-visible:after {
-  border-radius: 8px;
-  content: '';
-  position: absolute;
-  top: -5px;
-  bottom: -5px;
-  left: -5px;
-  right: -5px;
-  border: 2px solid #4945ff;
-}
-
-.c70 {
-  padding: 12px;
-  border-radius: 4px;
-  box-shadow: 0px 1px 4px rgba(33,33,52,0.1);
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  position: relative;
-  outline: none;
-}
-
-.c70:after {
-  -webkit-transition-property: all;
-  transition-property: all;
-  -webkit-transition-duration: 0.2s;
-  transition-duration: 0.2s;
-  border-radius: 8px;
-  content: '';
-  position: absolute;
-  top: -4px;
-  bottom: -4px;
-  left: -4px;
-  right: -4px;
-  border: 2px solid transparent;
-}
-
-.c70:focus-visible {
-  outline: none;
-}
-
-.c70:focus-visible:after {
+.c69:focus-visible:after {
   border-radius: 8px;
   content: '';
   position: absolute;
@@ -757,25 +728,69 @@ exports[`BrowseStep renders and match snapshot 1`] = `
 }
 
 .c71 {
+  padding: 12px;
+  border-radius: 4px;
+  box-shadow: 0px 1px 4px rgba(33,33,52,0.1);
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  outline: none;
+}
+
+.c71:after {
+  -webkit-transition-property: all;
+  transition-property: all;
+  -webkit-transition-duration: 0.2s;
+  transition-duration: 0.2s;
+  border-radius: 8px;
+  content: '';
+  position: absolute;
+  top: -4px;
+  bottom: -4px;
+  left: -4px;
+  right: -4px;
+  border: 2px solid transparent;
+}
+
+.c71:focus-visible {
+  outline: none;
+}
+
+.c71:focus-visible:after {
+  border-radius: 8px;
+  content: '';
+  position: absolute;
+  top: -5px;
+  bottom: -5px;
+  left: -5px;
+  right: -5px;
+  border: 2px solid #4945ff;
+}
+
+.c72 {
   color: #271fe0;
   background: #ffffff;
 }
 
-.c71:hover {
+.c72:hover {
   box-shadow: 0px 1px 4px rgba(33,33,52,0.1);
 }
 
-.c69 {
+.c70 {
   font-size: 0.7rem;
   pointer-events: none;
 }
 
-.c69 svg path {
+.c70 svg path {
   fill: #c0c0cf;
 }
 
-.c69:focus svg path,
-.c69:hover svg path {
+.c70:focus svg path,
+.c70:hover svg path {
   fill: #c0c0cf;
 }
 
@@ -1073,7 +1088,7 @@ exports[`BrowseStep renders and match snapshot 1`] = `
                 type="button"
               />
               <div
-                class="c0 c36 c13 c37"
+                class="c0 c36 c37"
               >
                 <div
                   class="c0 c38"
@@ -1126,7 +1141,7 @@ exports[`BrowseStep renders and match snapshot 1`] = `
                   class="c0 c50 c51"
                 >
                   <div
-                    class="c0 c52 c13 c37 c53"
+                    class="c0 c52 c13 c53 c54"
                   >
                     <button
                       aria-disabled="false"
@@ -1164,17 +1179,17 @@ exports[`BrowseStep renders and match snapshot 1`] = `
       </div>
     </div>
     <div
-      class="c0 c54 c55"
+      class="c0 c55 c56"
     >
       <div
         class="c0 c13"
       >
         <div>
           <div
-            class="c0 c56 c57"
+            class="c0 c57 c58"
           >
             <div
-              class="c0 c13 c58"
+              class="c0 c13 c59"
             >
               <button
                 aria-disabled="false"
@@ -1182,21 +1197,21 @@ exports[`BrowseStep renders and match snapshot 1`] = `
                 aria-haspopup="listbox"
                 aria-label="Entries per page"
                 aria-labelledby="4 4-label 4-content"
-                class="c59"
+                class="c60"
                 id="4"
                 type="button"
               />
               <div
-                class="c0 c55 c60"
+                class="c0 c56 c61"
               >
                 <div
                   class="c0 c13"
                 >
                   <div
-                    class="c0 c61"
+                    class="c0 c62"
                   >
                     <span
-                      class="c7 c62"
+                      class="c7 c63"
                       id="4-content"
                     >
                       10
@@ -1208,7 +1223,7 @@ exports[`BrowseStep renders and match snapshot 1`] = `
                 >
                   <button
                     aria-hidden="true"
-                    class="c0 c63 c64 c65"
+                    class="c0 c64 c65 c66"
                     tabindex="-1"
                     title="Carret Down Button"
                     type="button"
@@ -1237,7 +1252,7 @@ exports[`BrowseStep renders and match snapshot 1`] = `
           class="c0 c9"
         >
           <label
-            class="c7 c66"
+            class="c7 c67"
             for="page-size"
           >
             Entries per page
@@ -1249,12 +1264,12 @@ exports[`BrowseStep renders and match snapshot 1`] = `
         class=""
       >
         <ul
-          class="c0 c13 c67"
+          class="c0 c13 c68"
         >
           <li>
             <button
               aria-disabled="true"
-              class="c68 c69"
+              class="c69 c70"
               tabindex="-1"
               type="button"
             >
@@ -1280,7 +1295,7 @@ exports[`BrowseStep renders and match snapshot 1`] = `
           </li>
           <li>
             <button
-              class="c70 c71"
+              class="c71 c72"
               type="button"
             >
               <div
@@ -1290,7 +1305,7 @@ exports[`BrowseStep renders and match snapshot 1`] = `
               </div>
               <span
                 aria-hidden="true"
-                class="c7 c8 c72"
+                class="c7 c8 c73"
               >
                 1
               </span>
@@ -1299,7 +1314,7 @@ exports[`BrowseStep renders and match snapshot 1`] = `
           <li>
             <button
               aria-disabled="true"
-              class="c68 c69"
+              class="c69 c70"
               tabindex="-1"
               type="button"
             >

--- a/packages/core/upload/admin/src/components/AssetDialog/SelectedStep/index.js
+++ b/packages/core/upload/admin/src/components/AssetDialog/SelectedStep/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useIntl } from 'react-intl';
 import PropTypes from 'prop-types';
-import { Stack, Typography } from '@strapi/design-system';
+import { Flex, Typography } from '@strapi/design-system';
 import { AssetGridList } from '../../AssetGridList';
 import getTrad from '../../../utils/getTrad';
 
@@ -9,8 +9,8 @@ export const SelectedStep = ({ selectedAssets, onSelectAsset, onReorderAsset }) 
   const { formatMessage } = useIntl();
 
   return (
-    <Stack spacing={4}>
-      <Stack spacing={0}>
+    <Flex direction="column" alignItems="stretch" gap={4}>
+      <Flex gap={0}>
         <Typography variant="pi" fontWeight="bold" textColor="neutral800">
           {formatMessage(
             {
@@ -27,7 +27,7 @@ export const SelectedStep = ({ selectedAssets, onSelectAsset, onReorderAsset }) 
             defaultMessage: 'Manage the assets before adding them to the Media Library',
           })}
         </Typography>
-      </Stack>
+      </Flex>
 
       <AssetGridList
         size="S"
@@ -36,7 +36,7 @@ export const SelectedStep = ({ selectedAssets, onSelectAsset, onReorderAsset }) 
         selectedAssets={selectedAssets}
         onReorderAsset={onReorderAsset}
       />
-    </Stack>
+    </Flex>
   );
 };
 

--- a/packages/core/upload/admin/src/components/AssetDialog/index.js
+++ b/packages/core/upload/admin/src/components/AssetDialog/index.js
@@ -17,7 +17,6 @@ import {
   TabPanel,
   Badge,
   Loader,
-  Stack,
 } from '@strapi/design-system';
 import { NoPermissions, AnErrorOccurred, useSelectionState, pxToRem } from '@strapi/helper-plugin';
 import { getTrad, containsAssetFilter } from '../../utils';
@@ -250,7 +249,7 @@ export const AssetDialog = ({
               <Badge marginLeft={2}>{selectedAssets.length}</Badge>
             </Tab>
           </Tabs>
-          <Stack horizontal spacing={2}>
+          <Flex gap={2}>
             <Button
               variant="secondary"
               onClick={() => onAddFolder({ folderId: queryObject?.folder })}
@@ -266,7 +265,7 @@ export const AssetDialog = ({
                 defaultMessage: 'Add more assets',
               })}
             </Button>
-          </Stack>
+          </Flex>
         </Flex>
         <Divider />
         <TabPanels>

--- a/packages/core/upload/admin/src/components/BulkMoveDialog/BulkMoveDialog.js
+++ b/packages/core/upload/admin/src/components/BulkMoveDialog/BulkMoveDialog.js
@@ -14,7 +14,6 @@ import {
   ModalBody,
   ModalFooter,
   FieldLabel,
-  Stack,
   Typography,
 } from '@strapi/design-system';
 import { Form, normalizeAPIError } from '@strapi/helper-plugin';
@@ -98,7 +97,7 @@ export const BulkMoveDialog = ({ onClose, selected, currentFolder }) => {
             <ModalBody>
               <Grid gap={4}>
                 <GridItem xs={12} col={12}>
-                  <Stack spacing={1}>
+                  <Flex direction="column" alignItems="stretch" gap={1}>
                     <FieldLabel htmlFor="folder-destination">
                       {formatMessage({
                         id: getTrad('form.input.label.folder-location'),
@@ -129,7 +128,7 @@ export const BulkMoveDialog = ({ onClose, selected, currentFolder }) => {
                         {errors.destination}
                       </Typography>
                     )}
-                  </Stack>
+                  </Flex>
                 </GridItem>
               </Grid>
             </ModalBody>

--- a/packages/core/upload/admin/src/components/BulkMoveDialog/tests/__snapshots__/BulkMoveDialog.test.js.snap
+++ b/packages/core/upload/admin/src/components/BulkMoveDialog/tests/__snapshots__/BulkMoveDialog.test.js.snap
@@ -8,7 +8,7 @@ exports[`BulkMoveDialog renders and matches the snapshot 1`] = `
   color: #32324d;
 }
 
-.c20 {
+.c19 {
   font-size: 0.75rem;
   line-height: 1.33;
   font-weight: 600;
@@ -40,7 +40,7 @@ exports[`BulkMoveDialog renders and matches the snapshot 1`] = `
   padding: 32px;
 }
 
-.c22 {
+.c21 {
   padding-right: 12px;
 }
 
@@ -92,9 +92,10 @@ exports[`BulkMoveDialog renders and matches the snapshot 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  gap: 4px;
 }
 
-.c21 {
+.c20 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -106,15 +107,6 @@ exports[`BulkMoveDialog renders and matches the snapshot 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-}
-
-.c19 > * {
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
-.c19 > * + * {
-  margin-top: 4px;
 }
 
 .c12 {
@@ -187,7 +179,7 @@ exports[`BulkMoveDialog renders and matches the snapshot 1`] = `
   width: 1px;
 }
 
-.c27 {
+.c26 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -199,6 +191,76 @@ exports[`BulkMoveDialog renders and matches the snapshot 1`] = `
   padding-right: 16px;
   border: 1px solid #dcdce4;
   background: #ffffff;
+}
+
+.c26 .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c26 .c10 {
+  color: #ffffff;
+}
+
+.c26[aria-disabled='true'] {
+  border: 1px solid #dcdce4;
+  background: #eaeaef;
+}
+
+.c26[aria-disabled='true'] .c10 {
+  color: #666687;
+}
+
+.c26[aria-disabled='true'] svg > g,.c26[aria-disabled='true'] svg path {
+  fill: #666687;
+}
+
+.c26[aria-disabled='true']:active {
+  border: 1px solid #dcdce4;
+  background: #eaeaef;
+}
+
+.c26[aria-disabled='true']:active .c10 {
+  color: #666687;
+}
+
+.c26[aria-disabled='true']:active svg > g,.c26[aria-disabled='true']:active svg path {
+  fill: #666687;
+}
+
+.c26:hover {
+  background-color: #f6f6f9;
+}
+
+.c26:active {
+  background-color: #eaeaef;
+}
+
+.c26 .c10 {
+  color: #32324d;
+}
+
+.c26 svg > g,
+.c26 svg path {
+  fill: #32324d;
+}
+
+.c27 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background-color: #4945ff;
+  border: 1px solid #4945ff;
+  height: 2rem;
+  padding-left: 16px;
+  padding-right: 16px;
 }
 
 .c27 .c1 {
@@ -243,87 +305,17 @@ exports[`BulkMoveDialog renders and matches the snapshot 1`] = `
 }
 
 .c27:hover {
-  background-color: #f6f6f9;
-}
-
-.c27:active {
-  background-color: #eaeaef;
-}
-
-.c27 .c10 {
-  color: #32324d;
-}
-
-.c27 svg > g,
-.c27 svg path {
-  fill: #32324d;
-}
-
-.c28 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  background-color: #4945ff;
-  border: 1px solid #4945ff;
-  height: 2rem;
-  padding-left: 16px;
-  padding-right: 16px;
-}
-
-.c28 .c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c28 .c10 {
-  color: #ffffff;
-}
-
-.c28[aria-disabled='true'] {
-  border: 1px solid #dcdce4;
-  background: #eaeaef;
-}
-
-.c28[aria-disabled='true'] .c10 {
-  color: #666687;
-}
-
-.c28[aria-disabled='true'] svg > g,.c28[aria-disabled='true'] svg path {
-  fill: #666687;
-}
-
-.c28[aria-disabled='true']:active {
-  border: 1px solid #dcdce4;
-  background: #eaeaef;
-}
-
-.c28[aria-disabled='true']:active .c10 {
-  color: #666687;
-}
-
-.c28[aria-disabled='true']:active svg > g,.c28[aria-disabled='true']:active svg path {
-  fill: #666687;
-}
-
-.c28:hover {
   border: 1px solid #7b79ff;
   background: #7b79ff;
 }
 
-.c28:active {
+.c27:active {
   border: 1px solid #4945ff;
   background: #4945ff;
 }
 
-.c28 svg > g,
-.c28 svg path {
+.c27 svg > g,
+.c27 svg path {
   fill: #ffffff;
 }
 
@@ -392,12 +384,12 @@ exports[`BulkMoveDialog renders and matches the snapshot 1`] = `
   border-bottom: 1px solid #eaeaef;
 }
 
-.c25 {
+.c24 {
   border-radius: 0 0 4px 4px;
   border-top: 1px solid #eaeaef;
 }
 
-.c26 > * + * {
+.c25 > * + * {
   margin-left: 8px;
 }
 
@@ -406,23 +398,23 @@ exports[`BulkMoveDialog renders and matches the snapshot 1`] = `
   max-height: 60vh;
 }
 
-.c23 {
+.c22 {
   background: transparent;
   border: none;
   position: relative;
   z-index: 1;
 }
 
-.c23 svg {
+.c22 svg {
   height: 0.6875rem;
   width: 0.6875rem;
 }
 
-.c23 svg path {
+.c22 svg path {
   fill: #666687;
 }
 
-.c24 {
+.c23 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -431,7 +423,7 @@ exports[`BulkMoveDialog renders and matches the snapshot 1`] = `
   border: none;
 }
 
-.c24 svg {
+.c23 svg {
   width: 0.5625rem;
 }
 
@@ -544,14 +536,14 @@ exports[`BulkMoveDialog renders and matches the snapshot 1`] = `
                       class="c1 "
                     >
                       <div
-                        class="c1 c18 c19"
+                        class="c1 c18"
                       >
                         <label
-                          class="c10 c20"
+                          class="c10 c19"
                           for="folder-destination"
                         >
                           <div
-                            class="c1 c21"
+                            class="c1 c20"
                           >
                             Location
                           </div>
@@ -599,7 +591,7 @@ exports[`BulkMoveDialog renders and matches the snapshot 1`] = `
                             >
                               <div
                                 aria-hidden="true"
-                                class="c1 c22 c23 c24"
+                                class="c1 c21 c22 c23"
                               >
                                 <svg
                                   fill="none"
@@ -630,37 +622,37 @@ exports[`BulkMoveDialog renders and matches the snapshot 1`] = `
                 </div>
               </div>
               <div
-                class="c1 c7 c25"
+                class="c1 c7 c24"
               >
                 <div
                   class="c1 c9"
                 >
                   <div
-                    class="c1 c21 c26"
+                    class="c1 c20 c25"
                   >
                     <button
                       aria-disabled="false"
-                      class="c12 c27"
+                      class="c12 c26"
                       name="cancel"
                       type="button"
                     >
                       <span
-                        class="c10 c20"
+                        class="c10 c19"
                       >
                         Cancel
                       </span>
                     </button>
                   </div>
                   <div
-                    class="c1 c21 c26"
+                    class="c1 c20 c25"
                   >
                     <button
                       aria-disabled="false"
-                      class="c12 c28"
+                      class="c12 c27"
                       type="submit"
                     >
                       <span
-                        class="c10 c20"
+                        class="c10 c19"
                       >
                         Move
                       </span>

--- a/packages/core/upload/admin/src/components/ContextInfo/ContextInfo.js
+++ b/packages/core/upload/admin/src/components/ContextInfo/ContextInfo.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Box, Stack, Grid, GridItem, Typography } from '@strapi/design-system';
+import { Box, Flex, Grid, GridItem, Typography } from '@strapi/design-system';
 
 export const ContextInfo = ({ blocks }) => {
   return (
@@ -15,14 +15,14 @@ export const ContextInfo = ({ blocks }) => {
       <Grid gap={4}>
         {blocks.map(({ label, value }) => (
           <GridItem col={6} xs={12} key={label}>
-            <Stack spacing={1}>
+            <Flex direction="column" alignItems="stretch" gap={1}>
               <Typography variant="sigma" textColor="neutral600">
                 {label}
               </Typography>
               <Typography variant="pi" textColor="neutral700">
                 {value}
               </Typography>
-            </Stack>
+            </Flex>
           </GridItem>
         ))}
       </Grid>

--- a/packages/core/upload/admin/src/components/ContextInfo/tests/__snapshots__/ContextInfo.test.js.snap
+++ b/packages/core/upload/admin/src/components/ContextInfo/tests/__snapshots__/ContextInfo.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ContextInfo renders 1`] = `
-.c5 {
+.c4 {
   font-weight: 600;
   font-size: 0.6875rem;
   line-height: 1.45;
@@ -9,7 +9,7 @@ exports[`ContextInfo renders 1`] = `
   color: #666687;
 }
 
-.c6 {
+.c5 {
   font-size: 0.75rem;
   line-height: 1.33;
   color: #4a4a6a;
@@ -36,18 +36,10 @@ exports[`ContextInfo renders 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  gap: 4px;
 }
 
-.c4 > * {
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
-.c4 > * + * {
-  margin-top: 4px;
-}
-
-.c7 {
+.c6 {
   border: 0;
   -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
@@ -96,15 +88,15 @@ exports[`ContextInfo renders 1`] = `
           class=""
         >
           <div
-            class="c3 c4"
+            class="c3"
           >
             <span
-              class="c5"
+              class="c4"
             >
               Label 1
             </span>
             <span
-              class="c6"
+              class="c5"
             >
               value1
             </span>
@@ -118,15 +110,15 @@ exports[`ContextInfo renders 1`] = `
           class=""
         >
           <div
-            class="c3 c4"
+            class="c3"
           >
             <span
-              class="c5"
+              class="c4"
             >
               Label 2
             </span>
             <span
-              class="c6"
+              class="c5"
             >
               value2
             </span>
@@ -140,15 +132,15 @@ exports[`ContextInfo renders 1`] = `
           class=""
         >
           <div
-            class="c3 c4"
+            class="c3"
           >
             <span
-              class="c5"
+              class="c4"
             >
               Label 3
             </span>
             <span
-              class="c6"
+              class="c5"
             >
               value3
             </span>
@@ -158,7 +150,7 @@ exports[`ContextInfo renders 1`] = `
     </div>
   </div>
   <div
-    class="c7"
+    class="c6"
   >
     <p
       aria-live="polite"

--- a/packages/core/upload/admin/src/components/EditAssetDialog/PreviewBox/CroppingActions.js
+++ b/packages/core/upload/admin/src/components/EditAssetDialog/PreviewBox/CroppingActions.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { IconButton, FocusTrap, SimpleMenu, MenuItem, Stack } from '@strapi/design-system';
+import { IconButton, FocusTrap, SimpleMenu, MenuItem, Flex } from '@strapi/design-system';
 import { Cross, Check } from '@strapi/icons';
 import { useIntl } from 'react-intl';
 import getTrad from '../../../utils/getTrad';
@@ -12,7 +12,7 @@ export const CroppingActions = ({ onCancel, onValidate, onDuplicate }) => {
   return (
     <FocusTrap onEscape={onCancel}>
       <CroppingActionRow justifyContent="flex-end" paddingLeft={3} paddingRight={3}>
-        <Stack spacing={1} horizontal>
+        <Flex gap={1}>
           <IconButton
             label={formatMessage({
               id: getTrad('control-card.stop-crop'),
@@ -46,7 +46,7 @@ export const CroppingActions = ({ onCancel, onValidate, onDuplicate }) => {
               </MenuItem>
             )}
           </SimpleMenu>
-        </Stack>
+        </Flex>
       </CroppingActionRow>
     </FocusTrap>
   );

--- a/packages/core/upload/admin/src/components/EditAssetDialog/PreviewBox/index.js
+++ b/packages/core/upload/admin/src/components/EditAssetDialog/PreviewBox/index.js
@@ -1,7 +1,7 @@
 import React, { useState, useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
-import { Stack, IconButton } from '@strapi/design-system';
+import { Flex, IconButton } from '@strapi/design-system';
 import { Trash, Download as DownloadIcon, Crop as Resize } from '@strapi/icons';
 import { useTracking } from '@strapi/helper-plugin';
 import getTrad from '../../../utils/getTrad';
@@ -150,7 +150,7 @@ export const PreviewBox = ({
         )}
 
         <ActionRow paddingLeft={3} paddingRight={3} justifyContent="flex-end">
-          <Stack spacing={1} horizontal>
+          <Flex gap={1}>
             {canUpdate && !asset.isLocal && (
               <IconButton
                 label={formatMessage({
@@ -182,7 +182,7 @@ export const PreviewBox = ({
                 onClick={handleCropStart}
               />
             )}
-          </Stack>
+          </Flex>
         </ActionRow>
 
         <Wrapper>

--- a/packages/core/upload/admin/src/components/EditAssetDialog/index.js
+++ b/packages/core/upload/admin/src/components/EditAssetDialog/index.js
@@ -13,7 +13,6 @@ import {
   ModalLayout,
   ModalBody,
   ModalFooter,
-  Stack,
   Flex,
   Loader,
   Grid,
@@ -195,7 +194,7 @@ export const EditAssetDialog = ({
               </GridItem>
               <GridItem xs={12} col={6}>
                 <Form noValidate>
-                  <Stack spacing={3}>
+                  <Flex direction="column" alignItems="stretch" gap={3}>
                     <ContextInfo
                       blocks={[
                         {
@@ -281,7 +280,7 @@ export const EditAssetDialog = ({
                       disabled={formDisabled}
                     />
 
-                    <Stack spacing={1}>
+                    <Flex direction="column" alignItems="stretch" gap={1}>
                       <FieldLabel htmlFor="asset-folder">
                         {formatMessage({
                           id: getTrad('form.input.label.file-location'),
@@ -302,8 +301,8 @@ export const EditAssetDialog = ({
                         error={errors?.parent}
                         ariaErrorMessage="folder-parent-error"
                       />
-                    </Stack>
-                  </Stack>
+                    </Flex>
+                  </Flex>
 
                   <VisuallyHidden>
                     <button

--- a/packages/core/upload/admin/src/components/EditAssetDialog/tests/__snapshots__/EditAssetDialog.test.js.snap
+++ b/packages/core/upload/admin/src/components/EditAssetDialog/tests/__snapshots__/EditAssetDialog.test.js.snap
@@ -8,7 +8,7 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
   color: #32324d;
 }
 
-.c31 {
+.c29 {
   font-weight: 600;
   font-size: 0.6875rem;
   line-height: 1.45;
@@ -16,7 +16,7 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
   color: #666687;
 }
 
-.c32 {
+.c30 {
   font-size: 0.75rem;
   line-height: 1.33;
   color: #4a4a6a;
@@ -29,13 +29,13 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
   color: #32324d;
 }
 
-.c36 {
+.c37 {
   font-size: 0.75rem;
   line-height: 1.33;
   color: #666687;
 }
 
-.c47 {
+.c48 {
   font-size: 0.75rem;
   line-height: 1.33;
   font-weight: 600;
@@ -79,12 +79,12 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
   padding-left: 12px;
 }
 
-.c26 {
+.c25 {
   padding-right: 8px;
   padding-left: 8px;
 }
 
-.c29 {
+.c27 {
   background: #f6f6f9;
   padding-top: 16px;
   padding-right: 24px;
@@ -93,11 +93,11 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
   border-radius: 4px;
 }
 
-.c37 {
+.c38 {
   padding-right: 12px;
 }
 
-.c45 {
+.c46 {
   background: #212134;
   padding: 8px;
   border-radius: 4px;
@@ -170,9 +170,40 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
+  gap: 4px;
 }
 
-.c27 {
+.c26 {
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.c28 {
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.c31 {
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -186,31 +217,27 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
   flex-direction: column;
 }
 
-.c28 > * {
+.c34 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+}
+
+.c32 > * {
   margin-top: 0;
   margin-bottom: 0;
 }
 
-.c28 > * + * {
-  margin-top: 12px;
-}
-
-.c30 > * {
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
-.c30 > * + * {
+.c32 > * + * {
   margin-top: 4px;
-}
-
-.c24 > * {
-  margin-left: 0;
-  margin-right: 0;
-}
-
-.c24 > * + * {
-  margin-left: 4px;
 }
 
 .c12 {
@@ -283,7 +310,7 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
   width: 1px;
 }
 
-.c42 {
+.c43 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -295,78 +322,6 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
   padding-right: 16px;
   border: 1px solid #dcdce4;
   background: #ffffff;
-}
-
-.c42 .c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c42 .c10 {
-  color: #ffffff;
-}
-
-.c42[aria-disabled='true'] {
-  border: 1px solid #dcdce4;
-  background: #eaeaef;
-}
-
-.c42[aria-disabled='true'] .c10 {
-  color: #666687;
-}
-
-.c42[aria-disabled='true'] svg > g,.c42[aria-disabled='true'] svg path {
-  fill: #666687;
-}
-
-.c42[aria-disabled='true']:active {
-  border: 1px solid #dcdce4;
-  background: #eaeaef;
-}
-
-.c42[aria-disabled='true']:active .c10 {
-  color: #666687;
-}
-
-.c42[aria-disabled='true']:active svg > g,.c42[aria-disabled='true']:active svg path {
-  fill: #666687;
-}
-
-.c42:hover {
-  background-color: #f6f6f9;
-}
-
-.c42:active {
-  background-color: #eaeaef;
-}
-
-.c42 .c10 {
-  color: #32324d;
-}
-
-.c42 svg > g,
-.c42 svg path {
-  fill: #32324d;
-}
-
-.c43 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  background-color: #4945ff;
-  border: 1px solid #4945ff;
-  height: 2rem;
-  padding-left: 16px;
-  padding-right: 16px;
-  border: 1px solid #d9d8ff;
-  background: #f0f0ff;
 }
 
 .c43 .c1 {
@@ -411,30 +366,20 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
 }
 
 .c43:hover {
-  background-color: #ffffff;
+  background-color: #f6f6f9;
 }
 
 .c43:active {
-  background-color: #ffffff;
-  border: 1px solid #4945ff;
-}
-
-.c43:active .c10 {
-  color: #4945ff;
-}
-
-.c43:active svg > g,
-.c43:active svg path {
-  fill: #4945ff;
+  background-color: #eaeaef;
 }
 
 .c43 .c10 {
-  color: #271fe0;
+  color: #32324d;
 }
 
 .c43 svg > g,
 .c43 svg path {
-  fill: #271fe0;
+  fill: #32324d;
 }
 
 .c44 {
@@ -447,6 +392,8 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
   height: 2rem;
   padding-left: 16px;
   padding-right: 16px;
+  border: 1px solid #d9d8ff;
+  background: #f0f0ff;
 }
 
 .c44 .c1 {
@@ -491,26 +438,106 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
 }
 
 .c44:hover {
-  border: 1px solid #7b79ff;
-  background: #7b79ff;
+  background-color: #ffffff;
 }
 
 .c44:active {
+  background-color: #ffffff;
   border: 1px solid #4945ff;
-  background: #4945ff;
+}
+
+.c44:active .c10 {
+  color: #4945ff;
+}
+
+.c44:active svg > g,
+.c44:active svg path {
+  fill: #4945ff;
+}
+
+.c44 .c10 {
+  color: #271fe0;
 }
 
 .c44 svg > g,
 .c44 svg path {
+  fill: #271fe0;
+}
+
+.c45 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background-color: #4945ff;
+  border: 1px solid #4945ff;
+  height: 2rem;
+  padding-left: 16px;
+  padding-right: 16px;
+}
+
+.c45 .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c45 .c10 {
+  color: #ffffff;
+}
+
+.c45[aria-disabled='true'] {
+  border: 1px solid #dcdce4;
+  background: #eaeaef;
+}
+
+.c45[aria-disabled='true'] .c10 {
+  color: #666687;
+}
+
+.c45[aria-disabled='true'] svg > g,.c45[aria-disabled='true'] svg path {
+  fill: #666687;
+}
+
+.c45[aria-disabled='true']:active {
+  border: 1px solid #dcdce4;
+  background: #eaeaef;
+}
+
+.c45[aria-disabled='true']:active .c10 {
+  color: #666687;
+}
+
+.c45[aria-disabled='true']:active svg > g,.c45[aria-disabled='true']:active svg path {
+  fill: #666687;
+}
+
+.c45:hover {
+  border: 1px solid #7b79ff;
+  background: #7b79ff;
+}
+
+.c45:active {
+  border: 1px solid #4945ff;
+  background: #4945ff;
+}
+
+.c45 svg > g,
+.c45 svg path {
   fill: #ffffff;
 }
 
-.c46 {
+.c47 {
   z-index: 4;
   display: none;
 }
 
-.c35 {
+.c36 {
   border: none;
   border-radius: 4px;
   padding-bottom: 0.65625rem;
@@ -525,36 +552,36 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
   background: inherit;
 }
 
-.c35::-webkit-input-placeholder {
+.c36::-webkit-input-placeholder {
   color: #8e8ea9;
   opacity: 1;
 }
 
-.c35::-moz-placeholder {
+.c36::-moz-placeholder {
   color: #8e8ea9;
   opacity: 1;
 }
 
-.c35:-ms-input-placeholder {
+.c36:-ms-input-placeholder {
   color: #8e8ea9;
   opacity: 1;
 }
 
-.c35::placeholder {
+.c36::placeholder {
   color: #8e8ea9;
   opacity: 1;
 }
 
-.c35[aria-disabled='true'] {
+.c36[aria-disabled='true'] {
   color: inherit;
 }
 
-.c35:focus {
+.c36:focus {
   outline: none;
   box-shadow: none;
 }
 
-.c34 {
+.c35 {
   border: 1px solid #dcdce4;
   border-radius: 4px;
   background: #ffffff;
@@ -566,7 +593,7 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
   transition-duration: 0.2s;
 }
 
-.c34:focus-within {
+.c35:focus-within {
   border: 1px solid #4945ff;
   box-shadow: #4945ff 0px 0px 0px 2px;
 }
@@ -636,12 +663,12 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
   border-bottom: 1px solid #eaeaef;
 }
 
-.c40 {
+.c41 {
   border-radius: 0 0 4px 4px;
   border-top: 1px solid #eaeaef;
 }
 
-.c41 > * + * {
+.c42 > * + * {
   margin-left: 8px;
 }
 
@@ -650,23 +677,23 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
   max-height: 60vh;
 }
 
-.c38 {
+.c39 {
   background: transparent;
   border: none;
   position: relative;
   z-index: 1;
 }
 
-.c38 svg {
+.c39 svg {
   height: 0.6875rem;
   width: 0.6875rem;
 }
 
-.c38 svg path {
+.c39 svg path {
   fill: #666687;
 }
 
-.c39 {
+.c40 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -675,7 +702,7 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
   border: none;
 }
 
-.c39 svg {
+.c40 svg {
   width: 0.5625rem;
 }
 
@@ -683,19 +710,19 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
   position: relative;
 }
 
-.c25 {
+.c24 {
   position: relative;
   text-align: center;
   background: repeating-conic-gradient( #f6f6f9 0% 25%, transparent 0% 50% ) 50% / 20px 20px;
 }
 
-.c25 svg {
+.c24 svg {
   font-size: 3rem;
   height: 16.5rem;
 }
 
-.c25 img,
-.c25 video {
+.c24 img,
+.c24 video {
   margin: 0;
   padding: 0;
   max-height: 16.5rem;
@@ -817,7 +844,7 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
                         class="c1 c20 c21 c22"
                       >
                         <div
-                          class="c1 c23 c24"
+                          class="c1 c23"
                         >
                           <span>
                             <button
@@ -944,7 +971,7 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
                         </div>
                       </div>
                       <div
-                        class="c25"
+                        class="c24"
                       >
                         <img
                           alt="Screenshot 2.png"
@@ -952,7 +979,7 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
                         />
                       </div>
                       <div
-                        class="c1 c26 c21 c22"
+                        class="c1 c25 c21 c22"
                       />
                     </div>
                   </div>
@@ -968,10 +995,10 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
                       novalidate=""
                     >
                       <div
-                        class="c1 c27 c28"
+                        class="c1 c26"
                       >
                         <div
-                          class="c1 c29"
+                          class="c1 c27"
                         >
                           <div
                             class="c1 c16"
@@ -983,15 +1010,15 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
                                 class="c1 "
                               >
                                 <div
-                                  class="c1 c27 c30"
+                                  class="c1 c28"
                                 >
                                   <span
-                                    class="c10 c31"
+                                    class="c10 c29"
                                   >
                                     Size
                                   </span>
                                   <span
-                                    class="c10 c32"
+                                    class="c10 c30"
                                   >
                                     102KB
                                   </span>
@@ -1005,15 +1032,15 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
                                 class="c1 "
                               >
                                 <div
-                                  class="c1 c27 c30"
+                                  class="c1 c28"
                                 >
                                   <span
-                                    class="c10 c31"
+                                    class="c10 c29"
                                   >
                                     Dimensions
                                   </span>
                                   <span
-                                    class="c10 c32"
+                                    class="c10 c30"
                                   >
                                     1476✕780
                                   </span>
@@ -1027,15 +1054,15 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
                                 class="c1 "
                               >
                                 <div
-                                  class="c1 c27 c30"
+                                  class="c1 c28"
                                 >
                                   <span
-                                    class="c10 c31"
+                                    class="c10 c29"
                                   >
                                     Date
                                   </span>
                                   <span
-                                    class="c10 c32"
+                                    class="c10 c30"
                                   >
                                     10/4/2021
                                   </span>
@@ -1049,15 +1076,15 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
                                 class="c1 "
                               >
                                 <div
-                                  class="c1 c27 c30"
+                                  class="c1 c28"
                                 >
                                   <span
-                                    class="c10 c31"
+                                    class="c10 c29"
                                   >
                                     Extension
                                   </span>
                                   <span
-                                    class="c10 c32"
+                                    class="c10 c30"
                                   >
                                     png
                                   </span>
@@ -1071,15 +1098,15 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
                                 class="c1 "
                               >
                                 <div
-                                  class="c1 c27 c30"
+                                  class="c1 c28"
                                 >
                                   <span
-                                    class="c10 c31"
+                                    class="c10 c29"
                                   >
                                     Asset ID
                                   </span>
                                   <span
-                                    class="c10 c32"
+                                    class="c10 c30"
                                   >
                                     8
                                   </span>
@@ -1091,26 +1118,26 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
                         <div>
                           <div>
                             <div
-                              class="c1 c27 c30"
+                              class="c1 c31 c32"
                             >
                               <label
                                 class="c10 c33"
                                 for="5"
                               >
                                 <div
-                                  class="c1 c23"
+                                  class="c1 c34"
                                 >
                                   File name
                                 </div>
                               </label>
                               <div
-                                class="c1 c9 c34"
+                                class="c1 c9 c35"
                               >
                                 <input
                                   aria-disabled="false"
                                   aria-invalid="false"
                                   aria-required="false"
-                                  class="c35"
+                                  class="c36"
                                   id="5"
                                   name="name"
                                   value="Screenshot 2.png"
@@ -1122,34 +1149,34 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
                         <div>
                           <div>
                             <div
-                              class="c1 c27 c30"
+                              class="c1 c31 c32"
                             >
                               <label
                                 class="c10 c33"
                                 for="7"
                               >
                                 <div
-                                  class="c1 c23"
+                                  class="c1 c34"
                                 >
                                   Alternative text
                                 </div>
                               </label>
                               <div
-                                class="c1 c9 c34"
+                                class="c1 c9 c35"
                               >
                                 <input
                                   aria-describedby="7-hint"
                                   aria-disabled="false"
                                   aria-invalid="false"
                                   aria-required="false"
-                                  class="c35"
+                                  class="c36"
                                   id="7"
                                   name="alternativeText"
                                   value=""
                                 />
                               </div>
                               <p
-                                class="c10 c36"
+                                class="c10 c37"
                                 id="7-hint"
                               >
                                 This text will be displayed if the asset can’t be shown.
@@ -1160,26 +1187,26 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
                         <div>
                           <div>
                             <div
-                              class="c1 c27 c30"
+                              class="c1 c31 c32"
                             >
                               <label
                                 class="c10 c33"
                                 for="9"
                               >
                                 <div
-                                  class="c1 c23"
+                                  class="c1 c34"
                                 >
                                   Caption
                                 </div>
                               </label>
                               <div
-                                class="c1 c9 c34"
+                                class="c1 c9 c35"
                               >
                                 <input
                                   aria-disabled="false"
                                   aria-invalid="false"
                                   aria-required="false"
-                                  class="c35"
+                                  class="c36"
                                   id="9"
                                   name="caption"
                                   value=""
@@ -1189,14 +1216,14 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
                           </div>
                         </div>
                         <div
-                          class="c1 c27 c30"
+                          class="c1 c28"
                         >
                           <label
                             class="c10 c33"
                             for="asset-folder"
                           >
                             <div
-                              class="c1 c23"
+                              class="c1 c34"
                             >
                               Location
                             </div>
@@ -1244,7 +1271,7 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
                               >
                                 <div
                                   aria-hidden="true"
-                                  class="c1 c37 c38 c39"
+                                  class="c1 c38 c39 c40"
                                 >
                                   <svg
                                     fill="none"
@@ -1287,17 +1314,17 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
               </div>
             </div>
             <div
-              class="c1 c7 c40"
+              class="c1 c7 c41"
             >
               <div
                 class="c1 c9"
               >
                 <div
-                  class="c1 c23 c41"
+                  class="c1 c34 c42"
                 >
                   <button
                     aria-disabled="false"
-                    class="c12 c42"
+                    class="c12 c43"
                     type="button"
                   >
                     <span
@@ -1308,11 +1335,11 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
                   </button>
                 </div>
                 <div
-                  class="c1 c23 c41"
+                  class="c1 c34 c42"
                 >
                   <button
                     aria-disabled="false"
-                    class="c12 c43"
+                    class="c12 c44"
                     type="button"
                   >
                     <span
@@ -1334,7 +1361,7 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
                   </div>
                   <button
                     aria-disabled="false"
-                    class="c12 c44"
+                    class="c12 c45"
                     type="button"
                   >
                     <span
@@ -1355,12 +1382,12 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
     data-react-portal="true"
   >
     <div
-      class="c1 c45 c46"
+      class="c1 c46 c47"
       id="0"
       role="tooltip"
     >
       <p
-        class="c10 c47"
+        class="c10 c48"
       >
         Delete
       </p>
@@ -1370,12 +1397,12 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
     data-react-portal="true"
   >
     <div
-      class="c1 c45 c46"
+      class="c1 c46 c47"
       id="1"
       role="tooltip"
     >
       <p
-        class="c10 c47"
+        class="c10 c48"
       >
         Download
       </p>
@@ -1385,12 +1412,12 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
     data-react-portal="true"
   >
     <div
-      class="c1 c45 c46"
+      class="c1 c46 c47"
       id="2"
       role="tooltip"
     >
       <p
-        class="c10 c47"
+        class="c10 c48"
       >
         Copy link
       </p>
@@ -1400,12 +1427,12 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
     data-react-portal="true"
   >
     <div
-      class="c1 c45 c46"
+      class="c1 c46 c47"
       id="3"
       role="tooltip"
     >
       <p
-        class="c10 c47"
+        class="c10 c48"
       >
         Crop
       </p>

--- a/packages/core/upload/admin/src/components/EditAssetDialog/tests/__snapshots__/RemoveAssetDialog.test.js.snap
+++ b/packages/core/upload/admin/src/components/EditAssetDialog/tests/__snapshots__/RemoveAssetDialog.test.js.snap
@@ -8,13 +8,13 @@ exports[`RemoveAssetDialog snapshots the component 1`] = `
   color: #32324d;
 }
 
-.c16 {
+.c15 {
   font-size: 0.875rem;
   line-height: 1.43;
   color: #32324d;
 }
 
-.c23 {
+.c22 {
   font-size: 0.75rem;
   line-height: 1.33;
   font-weight: 600;
@@ -48,11 +48,11 @@ exports[`RemoveAssetDialog snapshots the component 1`] = `
   padding-bottom: 8px;
 }
 
-.c17 {
+.c16 {
   padding: 16px;
 }
 
-.c25 {
+.c24 {
   padding-right: 8px;
 }
 
@@ -86,9 +86,10 @@ exports[`RemoveAssetDialog snapshots the component 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  gap: 8px;
 }
 
-.c19 {
+.c18 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -102,25 +103,16 @@ exports[`RemoveAssetDialog snapshots the component 1`] = `
   flex-direction: row;
 }
 
-.c15 > * {
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
-.c15 > * + * {
-  margin-top: 8px;
-}
-
-.c20 > * {
+.c19 > * {
   margin-left: 0;
   margin-right: 0;
 }
 
-.c20 > * + * {
+.c19 > * + * {
   margin-left: 8px;
 }
 
-.c21 {
+.c20 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -134,21 +126,21 @@ exports[`RemoveAssetDialog snapshots the component 1`] = `
   outline: none;
 }
 
-.c21 svg {
+.c20 svg {
   height: 12px;
   width: 12px;
 }
 
-.c21 svg > g,
-.c21 svg path {
+.c20 svg > g,
+.c20 svg path {
   fill: #ffffff;
 }
 
-.c21[aria-disabled='true'] {
+.c20[aria-disabled='true'] {
   pointer-events: none;
 }
 
-.c21:after {
+.c20:after {
   -webkit-transition-property: all;
   transition-property: all;
   -webkit-transition-duration: 0.2s;
@@ -163,11 +155,11 @@ exports[`RemoveAssetDialog snapshots the component 1`] = `
   border: 2px solid transparent;
 }
 
-.c21:focus-visible {
+.c20:focus-visible {
   outline: none;
 }
 
-.c21:focus-visible:after {
+.c20:focus-visible:after {
   border-radius: 8px;
   content: '';
   position: absolute;
@@ -190,11 +182,11 @@ exports[`RemoveAssetDialog snapshots the component 1`] = `
   width: 1px;
 }
 
-.c26 {
+.c25 {
   height: 100%;
 }
 
-.c22 {
+.c21 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -208,7 +200,7 @@ exports[`RemoveAssetDialog snapshots the component 1`] = `
   background: #ffffff;
 }
 
-.c22 .c1 {
+.c21 .c1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -219,54 +211,54 @@ exports[`RemoveAssetDialog snapshots the component 1`] = `
   align-items: center;
 }
 
-.c22 .c9 {
+.c21 .c9 {
   color: #ffffff;
 }
 
-.c22[aria-disabled='true'] {
+.c21[aria-disabled='true'] {
   border: 1px solid #dcdce4;
   background: #eaeaef;
 }
 
-.c22[aria-disabled='true'] .c9 {
+.c21[aria-disabled='true'] .c9 {
   color: #666687;
 }
 
-.c22[aria-disabled='true'] svg > g,.c22[aria-disabled='true'] svg path {
+.c21[aria-disabled='true'] svg > g,.c21[aria-disabled='true'] svg path {
   fill: #666687;
 }
 
-.c22[aria-disabled='true']:active {
+.c21[aria-disabled='true']:active {
   border: 1px solid #dcdce4;
   background: #eaeaef;
 }
 
-.c22[aria-disabled='true']:active .c9 {
+.c21[aria-disabled='true']:active .c9 {
   color: #666687;
 }
 
-.c22[aria-disabled='true']:active svg > g,.c22[aria-disabled='true']:active svg path {
+.c21[aria-disabled='true']:active svg > g,.c21[aria-disabled='true']:active svg path {
   fill: #666687;
 }
 
-.c22:hover {
+.c21:hover {
   background-color: #f6f6f9;
 }
 
-.c22:active {
+.c21:active {
   background-color: #eaeaef;
 }
 
-.c22 .c9 {
+.c21 .c9 {
   color: #32324d;
 }
 
-.c22 svg > g,
-.c22 svg path {
+.c21 svg > g,
+.c21 svg path {
   fill: #32324d;
 }
 
-.c24 {
+.c23 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -280,7 +272,7 @@ exports[`RemoveAssetDialog snapshots the component 1`] = `
   background: #fcecea;
 }
 
-.c24 .c1 {
+.c23 .c1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -291,60 +283,60 @@ exports[`RemoveAssetDialog snapshots the component 1`] = `
   align-items: center;
 }
 
-.c24 .c9 {
+.c23 .c9 {
   color: #ffffff;
 }
 
-.c24[aria-disabled='true'] {
+.c23[aria-disabled='true'] {
   border: 1px solid #dcdce4;
   background: #eaeaef;
 }
 
-.c24[aria-disabled='true'] .c9 {
+.c23[aria-disabled='true'] .c9 {
   color: #666687;
 }
 
-.c24[aria-disabled='true'] svg > g,.c24[aria-disabled='true'] svg path {
+.c23[aria-disabled='true'] svg > g,.c23[aria-disabled='true'] svg path {
   fill: #666687;
 }
 
-.c24[aria-disabled='true']:active {
+.c23[aria-disabled='true']:active {
   border: 1px solid #dcdce4;
   background: #eaeaef;
 }
 
-.c24[aria-disabled='true']:active .c9 {
+.c23[aria-disabled='true']:active .c9 {
   color: #666687;
 }
 
-.c24[aria-disabled='true']:active svg > g,.c24[aria-disabled='true']:active svg path {
+.c23[aria-disabled='true']:active svg > g,.c23[aria-disabled='true']:active svg path {
   fill: #666687;
 }
 
-.c24:hover {
+.c23:hover {
   background-color: #ffffff;
 }
 
-.c24:active {
+.c23:active {
   background-color: #ffffff;
   border: 1px solid #d02b20;
 }
 
-.c24:active .c9 {
+.c23:active .c9 {
   color: #d02b20;
 }
 
-.c24:active svg > g,
-.c24:active svg path {
+.c23:active svg > g,
+.c23:active svg path {
   fill: #d02b20;
 }
 
-.c24 .c9 {
+.c23 .c9 {
   color: #b72b1a;
 }
 
-.c24 svg > g,
-.c24 svg path {
+.c23 svg > g,
+.c23 svg path {
   fill: #b72b1a;
 }
 
@@ -373,11 +365,11 @@ exports[`RemoveAssetDialog snapshots the component 1`] = `
   fill: #d02b20;
 }
 
-.c18 {
+.c17 {
   border-top: 1px solid #eaeaef;
 }
 
-.c18 button {
+.c17 button {
   width: 100%;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -467,13 +459,13 @@ exports[`RemoveAssetDialog snapshots the component 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c1 c14 c15"
+                  class="c1 c14"
                 >
                   <div
                     class="c1 c7"
                   >
                     <span
-                      class="c9 c16"
+                      class="c9 c15"
                       id="confirm-description"
                     >
                       Are you sure you want to delete this?
@@ -482,31 +474,31 @@ exports[`RemoveAssetDialog snapshots the component 1`] = `
                 </div>
               </div>
               <div
-                class="c1 c17 c18"
+                class="c1 c16 c17"
               >
                 <div
-                  class="c1 c19 c20"
+                  class="c1 c18 c19"
                 >
                   <button
                     aria-disabled="false"
-                    class="c21 c22"
+                    class="c20 c21"
                     type="button"
                   >
                     <span
-                      class="c9 c23"
+                      class="c9 c22"
                     >
                       Cancel
                     </span>
                   </button>
                   <button
                     aria-disabled="false"
-                    class="c21 c24"
+                    class="c20 c23"
                     id="confirm-delete"
                     type="button"
                   >
                     <div
                       aria-hidden="true"
-                      class="c1 c25 c26"
+                      class="c1 c24 c25"
                     >
                       <svg
                         fill="none"
@@ -522,7 +514,7 @@ exports[`RemoveAssetDialog snapshots the component 1`] = `
                       </svg>
                     </div>
                     <span
-                      class="c9 c23"
+                      class="c9 c22"
                     >
                       Confirm
                     </span>

--- a/packages/core/upload/admin/src/components/EditAssetDialog/tests/__snapshots__/index.test.js.snap
+++ b/packages/core/upload/admin/src/components/EditAssetDialog/tests/__snapshots__/index.test.js.snap
@@ -8,7 +8,7 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
   color: #32324d;
 }
 
-.c31 {
+.c29 {
   font-weight: 600;
   font-size: 0.6875rem;
   line-height: 1.45;
@@ -16,7 +16,7 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
   color: #666687;
 }
 
-.c32 {
+.c30 {
   font-size: 0.75rem;
   line-height: 1.33;
   color: #4a4a6a;
@@ -29,13 +29,13 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
   color: #32324d;
 }
 
-.c36 {
+.c37 {
   font-size: 0.75rem;
   line-height: 1.33;
   color: #666687;
 }
 
-.c47 {
+.c48 {
   font-size: 0.75rem;
   line-height: 1.33;
   font-weight: 600;
@@ -79,12 +79,12 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
   padding-left: 12px;
 }
 
-.c26 {
+.c25 {
   padding-right: 8px;
   padding-left: 8px;
 }
 
-.c29 {
+.c27 {
   background: #f6f6f9;
   padding-top: 16px;
   padding-right: 24px;
@@ -93,11 +93,11 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
   border-radius: 4px;
 }
 
-.c37 {
+.c38 {
   padding-right: 12px;
 }
 
-.c45 {
+.c46 {
   background: #212134;
   padding: 8px;
   border-radius: 4px;
@@ -170,9 +170,40 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
+  gap: 4px;
 }
 
-.c27 {
+.c26 {
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.c28 {
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.c31 {
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -186,31 +217,27 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
   flex-direction: column;
 }
 
-.c28 > * {
+.c34 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+}
+
+.c32 > * {
   margin-top: 0;
   margin-bottom: 0;
 }
 
-.c28 > * + * {
-  margin-top: 12px;
-}
-
-.c30 > * {
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
-.c30 > * + * {
+.c32 > * + * {
   margin-top: 4px;
-}
-
-.c24 > * {
-  margin-left: 0;
-  margin-right: 0;
-}
-
-.c24 > * + * {
-  margin-left: 4px;
 }
 
 .c12 {
@@ -283,7 +310,7 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
   width: 1px;
 }
 
-.c42 {
+.c43 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -295,78 +322,6 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
   padding-right: 16px;
   border: 1px solid #dcdce4;
   background: #ffffff;
-}
-
-.c42 .c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c42 .c10 {
-  color: #ffffff;
-}
-
-.c42[aria-disabled='true'] {
-  border: 1px solid #dcdce4;
-  background: #eaeaef;
-}
-
-.c42[aria-disabled='true'] .c10 {
-  color: #666687;
-}
-
-.c42[aria-disabled='true'] svg > g,.c42[aria-disabled='true'] svg path {
-  fill: #666687;
-}
-
-.c42[aria-disabled='true']:active {
-  border: 1px solid #dcdce4;
-  background: #eaeaef;
-}
-
-.c42[aria-disabled='true']:active .c10 {
-  color: #666687;
-}
-
-.c42[aria-disabled='true']:active svg > g,.c42[aria-disabled='true']:active svg path {
-  fill: #666687;
-}
-
-.c42:hover {
-  background-color: #f6f6f9;
-}
-
-.c42:active {
-  background-color: #eaeaef;
-}
-
-.c42 .c10 {
-  color: #32324d;
-}
-
-.c42 svg > g,
-.c42 svg path {
-  fill: #32324d;
-}
-
-.c43 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  background-color: #4945ff;
-  border: 1px solid #4945ff;
-  height: 2rem;
-  padding-left: 16px;
-  padding-right: 16px;
-  border: 1px solid #d9d8ff;
-  background: #f0f0ff;
 }
 
 .c43 .c1 {
@@ -411,30 +366,20 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
 }
 
 .c43:hover {
-  background-color: #ffffff;
+  background-color: #f6f6f9;
 }
 
 .c43:active {
-  background-color: #ffffff;
-  border: 1px solid #4945ff;
-}
-
-.c43:active .c10 {
-  color: #4945ff;
-}
-
-.c43:active svg > g,
-.c43:active svg path {
-  fill: #4945ff;
+  background-color: #eaeaef;
 }
 
 .c43 .c10 {
-  color: #271fe0;
+  color: #32324d;
 }
 
 .c43 svg > g,
 .c43 svg path {
-  fill: #271fe0;
+  fill: #32324d;
 }
 
 .c44 {
@@ -447,6 +392,8 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
   height: 2rem;
   padding-left: 16px;
   padding-right: 16px;
+  border: 1px solid #d9d8ff;
+  background: #f0f0ff;
 }
 
 .c44 .c1 {
@@ -491,26 +438,106 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
 }
 
 .c44:hover {
-  border: 1px solid #7b79ff;
-  background: #7b79ff;
+  background-color: #ffffff;
 }
 
 .c44:active {
+  background-color: #ffffff;
   border: 1px solid #4945ff;
-  background: #4945ff;
+}
+
+.c44:active .c10 {
+  color: #4945ff;
+}
+
+.c44:active svg > g,
+.c44:active svg path {
+  fill: #4945ff;
+}
+
+.c44 .c10 {
+  color: #271fe0;
 }
 
 .c44 svg > g,
 .c44 svg path {
+  fill: #271fe0;
+}
+
+.c45 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background-color: #4945ff;
+  border: 1px solid #4945ff;
+  height: 2rem;
+  padding-left: 16px;
+  padding-right: 16px;
+}
+
+.c45 .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c45 .c10 {
+  color: #ffffff;
+}
+
+.c45[aria-disabled='true'] {
+  border: 1px solid #dcdce4;
+  background: #eaeaef;
+}
+
+.c45[aria-disabled='true'] .c10 {
+  color: #666687;
+}
+
+.c45[aria-disabled='true'] svg > g,.c45[aria-disabled='true'] svg path {
+  fill: #666687;
+}
+
+.c45[aria-disabled='true']:active {
+  border: 1px solid #dcdce4;
+  background: #eaeaef;
+}
+
+.c45[aria-disabled='true']:active .c10 {
+  color: #666687;
+}
+
+.c45[aria-disabled='true']:active svg > g,.c45[aria-disabled='true']:active svg path {
+  fill: #666687;
+}
+
+.c45:hover {
+  border: 1px solid #7b79ff;
+  background: #7b79ff;
+}
+
+.c45:active {
+  border: 1px solid #4945ff;
+  background: #4945ff;
+}
+
+.c45 svg > g,
+.c45 svg path {
   fill: #ffffff;
 }
 
-.c46 {
+.c47 {
   z-index: 4;
   display: none;
 }
 
-.c35 {
+.c36 {
   border: none;
   border-radius: 4px;
   padding-bottom: 0.65625rem;
@@ -525,36 +552,36 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
   background: inherit;
 }
 
-.c35::-webkit-input-placeholder {
+.c36::-webkit-input-placeholder {
   color: #8e8ea9;
   opacity: 1;
 }
 
-.c35::-moz-placeholder {
+.c36::-moz-placeholder {
   color: #8e8ea9;
   opacity: 1;
 }
 
-.c35:-ms-input-placeholder {
+.c36:-ms-input-placeholder {
   color: #8e8ea9;
   opacity: 1;
 }
 
-.c35::placeholder {
+.c36::placeholder {
   color: #8e8ea9;
   opacity: 1;
 }
 
-.c35[aria-disabled='true'] {
+.c36[aria-disabled='true'] {
   color: inherit;
 }
 
-.c35:focus {
+.c36:focus {
   outline: none;
   box-shadow: none;
 }
 
-.c34 {
+.c35 {
   border: 1px solid #dcdce4;
   border-radius: 4px;
   background: #ffffff;
@@ -566,7 +593,7 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
   transition-duration: 0.2s;
 }
 
-.c34:focus-within {
+.c35:focus-within {
   border: 1px solid #4945ff;
   box-shadow: #4945ff 0px 0px 0px 2px;
 }
@@ -636,12 +663,12 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
   border-bottom: 1px solid #eaeaef;
 }
 
-.c40 {
+.c41 {
   border-radius: 0 0 4px 4px;
   border-top: 1px solid #eaeaef;
 }
 
-.c41 > * + * {
+.c42 > * + * {
   margin-left: 8px;
 }
 
@@ -650,23 +677,23 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
   max-height: 60vh;
 }
 
-.c38 {
+.c39 {
   background: transparent;
   border: none;
   position: relative;
   z-index: 1;
 }
 
-.c38 svg {
+.c39 svg {
   height: 0.6875rem;
   width: 0.6875rem;
 }
 
-.c38 svg path {
+.c39 svg path {
   fill: #666687;
 }
 
-.c39 {
+.c40 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -675,7 +702,7 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
   border: none;
 }
 
-.c39 svg {
+.c40 svg {
   width: 0.5625rem;
 }
 
@@ -683,19 +710,19 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
   position: relative;
 }
 
-.c25 {
+.c24 {
   position: relative;
   text-align: center;
   background: repeating-conic-gradient( #f6f6f9 0% 25%, transparent 0% 50% ) 50% / 20px 20px;
 }
 
-.c25 svg {
+.c24 svg {
   font-size: 3rem;
   height: 16.5rem;
 }
 
-.c25 img,
-.c25 video {
+.c24 img,
+.c24 video {
   margin: 0;
   padding: 0;
   max-height: 16.5rem;
@@ -817,7 +844,7 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
                         class="c1 c20 c21 c22"
                       >
                         <div
-                          class="c1 c23 c24"
+                          class="c1 c23"
                         >
                           <span>
                             <button
@@ -944,7 +971,7 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
                         </div>
                       </div>
                       <div
-                        class="c25"
+                        class="c24"
                       >
                         <img
                           alt="Screenshot 2.png"
@@ -952,7 +979,7 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
                         />
                       </div>
                       <div
-                        class="c1 c26 c21 c22"
+                        class="c1 c25 c21 c22"
                       />
                     </div>
                   </div>
@@ -968,10 +995,10 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
                       novalidate=""
                     >
                       <div
-                        class="c1 c27 c28"
+                        class="c1 c26"
                       >
                         <div
-                          class="c1 c29"
+                          class="c1 c27"
                         >
                           <div
                             class="c1 c16"
@@ -983,15 +1010,15 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
                                 class="c1 "
                               >
                                 <div
-                                  class="c1 c27 c30"
+                                  class="c1 c28"
                                 >
                                   <span
-                                    class="c10 c31"
+                                    class="c10 c29"
                                   >
                                     Size
                                   </span>
                                   <span
-                                    class="c10 c32"
+                                    class="c10 c30"
                                   >
                                     102KB
                                   </span>
@@ -1005,15 +1032,15 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
                                 class="c1 "
                               >
                                 <div
-                                  class="c1 c27 c30"
+                                  class="c1 c28"
                                 >
                                   <span
-                                    class="c10 c31"
+                                    class="c10 c29"
                                   >
                                     Dimensions
                                   </span>
                                   <span
-                                    class="c10 c32"
+                                    class="c10 c30"
                                   >
                                     1476✕780
                                   </span>
@@ -1027,15 +1054,15 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
                                 class="c1 "
                               >
                                 <div
-                                  class="c1 c27 c30"
+                                  class="c1 c28"
                                 >
                                   <span
-                                    class="c10 c31"
+                                    class="c10 c29"
                                   >
                                     Date
                                   </span>
                                   <span
-                                    class="c10 c32"
+                                    class="c10 c30"
                                   >
                                     10/4/2021
                                   </span>
@@ -1049,15 +1076,15 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
                                 class="c1 "
                               >
                                 <div
-                                  class="c1 c27 c30"
+                                  class="c1 c28"
                                 >
                                   <span
-                                    class="c10 c31"
+                                    class="c10 c29"
                                   >
                                     Extension
                                   </span>
                                   <span
-                                    class="c10 c32"
+                                    class="c10 c30"
                                   >
                                     png
                                   </span>
@@ -1071,15 +1098,15 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
                                 class="c1 "
                               >
                                 <div
-                                  class="c1 c27 c30"
+                                  class="c1 c28"
                                 >
                                   <span
-                                    class="c10 c31"
+                                    class="c10 c29"
                                   >
                                     Asset ID
                                   </span>
                                   <span
-                                    class="c10 c32"
+                                    class="c10 c30"
                                   >
                                     8
                                   </span>
@@ -1091,26 +1118,26 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
                         <div>
                           <div>
                             <div
-                              class="c1 c27 c30"
+                              class="c1 c31 c32"
                             >
                               <label
                                 class="c10 c33"
                                 for="5"
                               >
                                 <div
-                                  class="c1 c23"
+                                  class="c1 c34"
                                 >
                                   File name
                                 </div>
                               </label>
                               <div
-                                class="c1 c9 c34"
+                                class="c1 c9 c35"
                               >
                                 <input
                                   aria-disabled="false"
                                   aria-invalid="false"
                                   aria-required="false"
-                                  class="c35"
+                                  class="c36"
                                   id="5"
                                   name="name"
                                   value="Screenshot 2.png"
@@ -1122,34 +1149,34 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
                         <div>
                           <div>
                             <div
-                              class="c1 c27 c30"
+                              class="c1 c31 c32"
                             >
                               <label
                                 class="c10 c33"
                                 for="7"
                               >
                                 <div
-                                  class="c1 c23"
+                                  class="c1 c34"
                                 >
                                   Alternative text
                                 </div>
                               </label>
                               <div
-                                class="c1 c9 c34"
+                                class="c1 c9 c35"
                               >
                                 <input
                                   aria-describedby="7-hint"
                                   aria-disabled="false"
                                   aria-invalid="false"
                                   aria-required="false"
-                                  class="c35"
+                                  class="c36"
                                   id="7"
                                   name="alternativeText"
                                   value=""
                                 />
                               </div>
                               <p
-                                class="c10 c36"
+                                class="c10 c37"
                                 id="7-hint"
                               >
                                 This text will be displayed if the asset can’t be shown.
@@ -1160,26 +1187,26 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
                         <div>
                           <div>
                             <div
-                              class="c1 c27 c30"
+                              class="c1 c31 c32"
                             >
                               <label
                                 class="c10 c33"
                                 for="9"
                               >
                                 <div
-                                  class="c1 c23"
+                                  class="c1 c34"
                                 >
                                   Caption
                                 </div>
                               </label>
                               <div
-                                class="c1 c9 c34"
+                                class="c1 c9 c35"
                               >
                                 <input
                                   aria-disabled="false"
                                   aria-invalid="false"
                                   aria-required="false"
-                                  class="c35"
+                                  class="c36"
                                   id="9"
                                   name="caption"
                                   value=""
@@ -1189,14 +1216,14 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
                           </div>
                         </div>
                         <div
-                          class="c1 c27 c30"
+                          class="c1 c28"
                         >
                           <label
                             class="c10 c33"
                             for="asset-folder"
                           >
                             <div
-                              class="c1 c23"
+                              class="c1 c34"
                             >
                               Location
                             </div>
@@ -1244,7 +1271,7 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
                               >
                                 <div
                                   aria-hidden="true"
-                                  class="c1 c37 c38 c39"
+                                  class="c1 c38 c39 c40"
                                 >
                                   <svg
                                     fill="none"
@@ -1287,17 +1314,17 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
               </div>
             </div>
             <div
-              class="c1 c7 c40"
+              class="c1 c7 c41"
             >
               <div
                 class="c1 c9"
               >
                 <div
-                  class="c1 c23 c41"
+                  class="c1 c34 c42"
                 >
                   <button
                     aria-disabled="false"
-                    class="c12 c42"
+                    class="c12 c43"
                     type="button"
                   >
                     <span
@@ -1308,11 +1335,11 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
                   </button>
                 </div>
                 <div
-                  class="c1 c23 c41"
+                  class="c1 c34 c42"
                 >
                   <button
                     aria-disabled="false"
-                    class="c12 c43"
+                    class="c12 c44"
                     type="button"
                   >
                     <span
@@ -1334,7 +1361,7 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
                   </div>
                   <button
                     aria-disabled="false"
-                    class="c12 c44"
+                    class="c12 c45"
                     type="button"
                   >
                     <span
@@ -1355,12 +1382,12 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
     data-react-portal="true"
   >
     <div
-      class="c1 c45 c46"
+      class="c1 c46 c47"
       id="0"
       role="tooltip"
     >
       <p
-        class="c10 c47"
+        class="c10 c48"
       >
         Delete
       </p>
@@ -1370,12 +1397,12 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
     data-react-portal="true"
   >
     <div
-      class="c1 c45 c46"
+      class="c1 c46 c47"
       id="1"
       role="tooltip"
     >
       <p
-        class="c10 c47"
+        class="c10 c48"
       >
         Download
       </p>
@@ -1385,12 +1412,12 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
     data-react-portal="true"
   >
     <div
-      class="c1 c45 c46"
+      class="c1 c46 c47"
       id="2"
       role="tooltip"
     >
       <p
-        class="c10 c47"
+        class="c10 c48"
       >
         Copy link
       </p>
@@ -1400,12 +1427,12 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
     data-react-portal="true"
   >
     <div
-      class="c1 c45 c46"
+      class="c1 c46 c47"
       id="3"
       role="tooltip"
     >
       <p
-        class="c10 c47"
+        class="c10 c48"
       >
         Crop
       </p>

--- a/packages/core/upload/admin/src/components/EditFolderDialog/EditFolderDialog.js
+++ b/packages/core/upload/admin/src/components/EditFolderDialog/EditFolderDialog.js
@@ -14,7 +14,6 @@ import {
   FieldLabel,
   Flex,
   Loader,
-  Stack,
   TextInput,
   Typography,
 } from '@strapi/design-system';
@@ -208,7 +207,7 @@ export const EditFolderDialog = ({ onClose, folder, location, parentFolderId }) 
                   </GridItem>
 
                   <GridItem xs={12} col={6}>
-                    <Stack spacing={1}>
+                    <Flex direction="column" alignItems="stretch" gap={1}>
                       <FieldLabel htmlFor="folder-parent">
                         {formatMessage({
                           id: getTrad('form.input.label.folder-location'),
@@ -241,7 +240,7 @@ export const EditFolderDialog = ({ onClose, folder, location, parentFolderId }) 
                           {errors.parent}
                         </Typography>
                       )}
-                    </Stack>
+                    </Flex>
                   </GridItem>
                 </Grid>
               </ModalBody>
@@ -253,7 +252,7 @@ export const EditFolderDialog = ({ onClose, folder, location, parentFolderId }) 
                   </Button>
                 }
                 endActions={
-                  <Stack horizontal spacing={2}>
+                  <Flex gap={2}>
                     {isEditing && canUpdate && (
                       <Button
                         type="button"
@@ -281,7 +280,7 @@ export const EditFolderDialog = ({ onClose, folder, location, parentFolderId }) 
                           : { id: getTrad('modal.folder.create.submit'), defaultMessage: 'Create' }
                       )}
                     </Button>
-                  </Stack>
+                  </Flex>
                 }
               />
             </Form>

--- a/packages/core/upload/admin/src/components/EditFolderDialog/tests/__snapshots__/EditFolderDialog.test.js.snap
+++ b/packages/core/upload/admin/src/components/EditFolderDialog/tests/__snapshots__/EditFolderDialog.test.js.snap
@@ -40,7 +40,7 @@ exports[`EditFolderDialog renders and matches the snapshot 1`] = `
   padding: 32px;
 }
 
-.c24 {
+.c25 {
   padding-right: 12px;
 }
 
@@ -108,6 +108,36 @@ exports[`EditFolderDialog renders and matches the snapshot 1`] = `
   flex-direction: row;
 }
 
+.c24 {
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.c31 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 8px;
+}
+
 .c19 > * {
   margin-top: 0;
   margin-bottom: 0;
@@ -115,15 +145,6 @@ exports[`EditFolderDialog renders and matches the snapshot 1`] = `
 
 .c19 > * + * {
   margin-top: 4px;
-}
-
-.c30 > * {
-  margin-left: 0;
-  margin-right: 0;
-}
-
-.c30 > * + * {
-  margin-left: 8px;
 }
 
 .c12 {
@@ -196,7 +217,7 @@ exports[`EditFolderDialog renders and matches the snapshot 1`] = `
   width: 1px;
 }
 
-.c29 {
+.c30 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -210,7 +231,7 @@ exports[`EditFolderDialog renders and matches the snapshot 1`] = `
   background: #ffffff;
 }
 
-.c29 .c1 {
+.c30 .c1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -221,54 +242,54 @@ exports[`EditFolderDialog renders and matches the snapshot 1`] = `
   align-items: center;
 }
 
-.c29 .c10 {
+.c30 .c10 {
   color: #ffffff;
 }
 
-.c29[aria-disabled='true'] {
+.c30[aria-disabled='true'] {
   border: 1px solid #dcdce4;
   background: #eaeaef;
 }
 
-.c29[aria-disabled='true'] .c10 {
+.c30[aria-disabled='true'] .c10 {
   color: #666687;
 }
 
-.c29[aria-disabled='true'] svg > g,.c29[aria-disabled='true'] svg path {
+.c30[aria-disabled='true'] svg > g,.c30[aria-disabled='true'] svg path {
   fill: #666687;
 }
 
-.c29[aria-disabled='true']:active {
+.c30[aria-disabled='true']:active {
   border: 1px solid #dcdce4;
   background: #eaeaef;
 }
 
-.c29[aria-disabled='true']:active .c10 {
+.c30[aria-disabled='true']:active .c10 {
   color: #666687;
 }
 
-.c29[aria-disabled='true']:active svg > g,.c29[aria-disabled='true']:active svg path {
+.c30[aria-disabled='true']:active svg > g,.c30[aria-disabled='true']:active svg path {
   fill: #666687;
 }
 
-.c29:hover {
+.c30:hover {
   background-color: #f6f6f9;
 }
 
-.c29:active {
+.c30:active {
   background-color: #eaeaef;
 }
 
-.c29 .c10 {
+.c30 .c10 {
   color: #32324d;
 }
 
-.c29 svg > g,
-.c29 svg path {
+.c30 svg > g,
+.c30 svg path {
   fill: #32324d;
 }
 
-.c31 {
+.c32 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -280,7 +301,7 @@ exports[`EditFolderDialog renders and matches the snapshot 1`] = `
   padding-right: 16px;
 }
 
-.c31 .c1 {
+.c32 .c1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -291,48 +312,48 @@ exports[`EditFolderDialog renders and matches the snapshot 1`] = `
   align-items: center;
 }
 
-.c31 .c10 {
+.c32 .c10 {
   color: #ffffff;
 }
 
-.c31[aria-disabled='true'] {
+.c32[aria-disabled='true'] {
   border: 1px solid #dcdce4;
   background: #eaeaef;
 }
 
-.c31[aria-disabled='true'] .c10 {
+.c32[aria-disabled='true'] .c10 {
   color: #666687;
 }
 
-.c31[aria-disabled='true'] svg > g,.c31[aria-disabled='true'] svg path {
+.c32[aria-disabled='true'] svg > g,.c32[aria-disabled='true'] svg path {
   fill: #666687;
 }
 
-.c31[aria-disabled='true']:active {
+.c32[aria-disabled='true']:active {
   border: 1px solid #dcdce4;
   background: #eaeaef;
 }
 
-.c31[aria-disabled='true']:active .c10 {
+.c32[aria-disabled='true']:active .c10 {
   color: #666687;
 }
 
-.c31[aria-disabled='true']:active svg > g,.c31[aria-disabled='true']:active svg path {
+.c32[aria-disabled='true']:active svg > g,.c32[aria-disabled='true']:active svg path {
   fill: #666687;
 }
 
-.c31:hover {
+.c32:hover {
   border: 1px solid #7b79ff;
   background: #7b79ff;
 }
 
-.c31:active {
+.c32:active {
   border: 1px solid #4945ff;
   background: #4945ff;
 }
 
-.c31 svg > g,
-.c31 svg path {
+.c32 svg > g,
+.c32 svg path {
   fill: #ffffff;
 }
 
@@ -462,12 +483,12 @@ exports[`EditFolderDialog renders and matches the snapshot 1`] = `
   border-bottom: 1px solid #eaeaef;
 }
 
-.c27 {
+.c28 {
   border-radius: 0 0 4px 4px;
   border-top: 1px solid #eaeaef;
 }
 
-.c28 > * + * {
+.c29 > * + * {
   margin-left: 8px;
 }
 
@@ -476,23 +497,23 @@ exports[`EditFolderDialog renders and matches the snapshot 1`] = `
   max-height: 60vh;
 }
 
-.c25 {
+.c26 {
   background: transparent;
   border: none;
   position: relative;
   z-index: 1;
 }
 
-.c25 svg {
+.c26 svg {
   height: 0.6875rem;
   width: 0.6875rem;
 }
 
-.c25 svg path {
+.c26 svg path {
   fill: #666687;
 }
 
-.c26 {
+.c27 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -501,7 +522,7 @@ exports[`EditFolderDialog renders and matches the snapshot 1`] = `
   border: none;
 }
 
-.c26 svg {
+.c27 svg {
   width: 0.5625rem;
 }
 
@@ -653,7 +674,7 @@ exports[`EditFolderDialog renders and matches the snapshot 1`] = `
                       class="c1 "
                     >
                       <div
-                        class="c1 c18 c19"
+                        class="c1 c24"
                       >
                         <label
                           class="c10 c20"
@@ -708,7 +729,7 @@ exports[`EditFolderDialog renders and matches the snapshot 1`] = `
                             >
                               <div
                                 aria-hidden="true"
-                                class="c1 c24 c25 c26"
+                                class="c1 c25 c26 c27"
                               >
                                 <svg
                                   fill="none"
@@ -739,17 +760,17 @@ exports[`EditFolderDialog renders and matches the snapshot 1`] = `
                 </div>
               </div>
               <div
-                class="c1 c7 c27"
+                class="c1 c7 c28"
               >
                 <div
                   class="c1 c9"
                 >
                   <div
-                    class="c1 c21 c28"
+                    class="c1 c21 c29"
                   >
                     <button
                       aria-disabled="false"
-                      class="c12 c29"
+                      class="c12 c30"
                       name="cancel"
                       type="button"
                     >
@@ -761,14 +782,14 @@ exports[`EditFolderDialog renders and matches the snapshot 1`] = `
                     </button>
                   </div>
                   <div
-                    class="c1 c21 c28"
+                    class="c1 c21 c29"
                   >
                     <div
-                      class="c1 c21 c30"
+                      class="c1 c31"
                     >
                       <button
                         aria-disabled="false"
-                        class="c12 c31"
+                        class="c12 c32"
                         name="submit"
                         type="submit"
                       >

--- a/packages/core/upload/admin/src/components/EmptyAssets/index.js
+++ b/packages/core/upload/admin/src/components/EmptyAssets/index.js
@@ -1,13 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import styled from 'styled-components';
-import { Typography, Stack, Box, Icon } from '@strapi/design-system';
+import { Typography, Flex, Box, Icon } from '@strapi/design-system';
 import { EmptyStateDocuments } from '@strapi/icons';
 import { EmptyAssetGrid } from './EmptyAssetGrid';
-
-const EnhancedStack = styled(Stack)`
-  align-items: center;
-`;
 
 export const EmptyAssets = ({ icon, content, action, size, count }) => {
   return (
@@ -15,17 +10,17 @@ export const EmptyAssets = ({ icon, content, action, size, count }) => {
       <EmptyAssetGrid size={size} count={count} />
 
       <Box position="absolute" top={11} width="100%">
-        <EnhancedStack spacing={4} textAlign="center">
-          <EnhancedStack spacing={6}>
+        <Flex direction="column" alignItems="center" gap={4} textAlign="center">
+          <Flex direction="column" alignItems="center" gap={6}>
             <Icon as={icon || EmptyStateDocuments} color="" width="160px" height="88px" />
 
             <Typography variant="delta" as="p" textColor="neutral600">
               {content}
             </Typography>
-          </EnhancedStack>
+          </Flex>
 
           {action}
-        </EnhancedStack>
+        </Flex>
       </Box>
     </Box>
   );

--- a/packages/core/upload/admin/src/components/FilterPopover/index.js
+++ b/packages/core/upload/admin/src/components/FilterPopover/index.js
@@ -7,7 +7,7 @@
 import React, { useState } from 'react';
 import { useIntl } from 'react-intl';
 import PropTypes from 'prop-types';
-import { Button, Box, Popover, Stack, FocusTrap, Select, Option } from '@strapi/design-system';
+import { Button, Box, Popover, Flex, FocusTrap, Select, Option } from '@strapi/design-system';
 import { Plus } from '@strapi/icons';
 import FilterValueInput from './FilterValueInput';
 import getFilterList from './utils/getFilterList';
@@ -190,7 +190,7 @@ const FilterPopover = ({ displayedFilters, filters, onSubmit, onToggle, source }
     <Popover source={source} padding={3} spacing={4}>
       <FocusTrap onEscape={onToggle}>
         <form onSubmit={handleSubmit}>
-          <Stack spacing={1} style={{ minWidth: 184 }}>
+          <Flex direction="column" alignItems="stretch" gap={1} style={{ minWidth: 184 }}>
             <Box>
               <Select
                 aria-label={formatMessage({
@@ -244,7 +244,7 @@ const FilterPopover = ({ displayedFilters, filters, onSubmit, onToggle, source }
                 {formatMessage({ id: 'app.utils.add-filter', defaultMessage: 'Add filter' })}
               </Button>
             </Box>
-          </Stack>
+          </Flex>
         </form>
       </FocusTrap>
     </Popover>

--- a/packages/core/upload/admin/src/components/FolderCard/FolderCard/FolderCard.js
+++ b/packages/core/upload/admin/src/components/FolderCard/FolderCard/FolderCard.js
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import { NavLink } from 'react-router-dom';
 
 import { pxToRem } from '@strapi/helper-plugin';
-import { Box, CardAction, Stack } from '@strapi/design-system';
+import { Box, CardAction, Flex } from '@strapi/design-system';
 import { Folder } from '@strapi/icons';
 
 import { FolderCardContext } from '../contexts/FolderCard';
@@ -61,7 +61,7 @@ export const FolderCard = forwardRef(
             aria-hidden
           />
 
-          <Stack
+          <Flex
             hasRadius
             borderStyle="solid"
             borderWidth="1px"
@@ -69,8 +69,7 @@ export const FolderCard = forwardRef(
             background="neutral0"
             shadow="tableShadow"
             padding={3}
-            spacing={2}
-            horizontal
+            gap={2}
             cursor="pointer"
           >
             {startAction}
@@ -92,7 +91,7 @@ export const FolderCard = forwardRef(
             <CardActionDisplay>
               <CardAction right={4}>{cardActions}</CardAction>
             </CardActionDisplay>
-          </Stack>
+          </Flex>
         </Card>
       </FolderCardContext.Provider>
     );

--- a/packages/core/upload/admin/src/components/FolderCard/tests/__snapshots__/FolderCard.test.js.snap
+++ b/packages/core/upload/admin/src/components/FolderCard/tests/__snapshots__/FolderCard.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`FolderCard has all required ids set when rendering a start action 1`] = `
-.c14 {
+.c13 {
   font-size: 0.875rem;
   line-height: 1.43;
   font-weight: 500;
@@ -23,12 +23,12 @@ exports[`FolderCard has all required ids set when rendering a start action 1`] =
   cursor: pointer;
 }
 
-.c5 {
+.c4 {
   position: relative;
   z-index: 2;
 }
 
-.c7 {
+.c6 {
   background: #eaf5ff;
   color: #66b7f1;
   padding-top: 8px;
@@ -38,18 +38,18 @@ exports[`FolderCard has all required ids set when rendering a start action 1`] =
   border-radius: 4px;
 }
 
-.c9 {
+.c8 {
   position: relative;
   overflow: hidden;
   max-width: 100%;
 }
 
-.c12 {
+.c11 {
   padding: 4px;
   max-width: 100%;
 }
 
-.c16 {
+.c15 {
   right: 16px;
 }
 
@@ -65,9 +65,10 @@ exports[`FolderCard has all required ids set when rendering a start action 1`] =
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
+  gap: 8px;
 }
 
-.c10 {
+.c9 {
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -81,16 +82,30 @@ exports[`FolderCard has all required ids set when rendering a start action 1`] =
   flex-direction: column;
 }
 
-.c4 > * {
+.c16 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+}
+
+.c17 > * {
   margin-left: 0;
   margin-right: 0;
 }
 
-.c4 > * + * {
+.c17 > * + * {
   margin-left: 8px;
 }
 
-.c6 {
+.c5 {
   height: 18px;
   min-width: 18px;
   margin: 0;
@@ -101,12 +116,12 @@ exports[`FolderCard has all required ids set when rendering a start action 1`] =
   cursor: pointer;
 }
 
-.c6:checked {
+.c5:checked {
   background-color: #4945ff;
   border: 1px solid #4945ff;
 }
 
-.c6:checked:after {
+.c5:checked:after {
   content: '';
   display: block;
   position: relative;
@@ -120,21 +135,21 @@ exports[`FolderCard has all required ids set when rendering a start action 1`] =
   transform: translateX(-50%) translateY(-50%);
 }
 
-.c6:checked:disabled:after {
+.c5:checked:disabled:after {
   background: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTAiIGhlaWdodD0iOCIgdmlld0JveD0iMCAwIDEwIDgiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgPHBhdGgKICAgIGQ9Ik04LjU1MzIzIDAuMzk2OTczQzguNjMxMzUgMC4zMTYzNTUgOC43NjA1MSAwLjMxNTgxMSA4LjgzOTMxIDAuMzk1NzY4TDkuODYyNTYgMS40MzQwN0M5LjkzODkzIDEuNTExNTcgOS45MzkzNSAxLjYzNTkgOS44NjM0OSAxLjcxMzlMNC4wNjQwMSA3LjY3NzI0QzMuOTg1OSA3Ljc1NzU1IDMuODU3MDcgNy43NTgwNSAzLjc3ODM0IDcuNjc4MzRMMC4xMzg2NiAzLjk5MzMzQzAuMDYxNzc5OCAzLjkxNTQ5IDAuMDYxNzEwMiAzLjc5MDMyIDAuMTM4NTA0IDMuNzEyNEwxLjE2MjEzIDIuNjczNzJDMS4yNDAzOCAyLjU5NDMyIDEuMzY4NDMgMi41OTQyMiAxLjQ0NjggMi42NzM0OEwzLjkyMTc0IDUuMTc2NDdMOC41NTMyMyAwLjM5Njk3M1oiCiAgICBmaWxsPSIjOEU4RUE5IgogIC8+Cjwvc3ZnPg==) no-repeat no-repeat center center;
 }
 
-.c6:disabled {
+.c5:disabled {
   background-color: #dcdce4;
   border: 1px solid #c0c0cf;
 }
 
-.c6:indeterminate {
+.c5:indeterminate {
   background-color: #4945ff;
   border: 1px solid #4945ff;
 }
 
-.c6:indeterminate:after {
+.c5:indeterminate:after {
   content: '';
   display: block;
   position: relative;
@@ -149,16 +164,16 @@ exports[`FolderCard has all required ids set when rendering a start action 1`] =
   transform: translateX(-50%) translateY(-50%);
 }
 
-.c6:indeterminate:disabled {
+.c5:indeterminate:disabled {
   background-color: #dcdce4;
   border: 1px solid #c0c0cf;
 }
 
-.c6:indeterminate:disabled:after {
+.c5:indeterminate:disabled:after {
   background-color: #8e8ea9;
 }
 
-.c18 {
+.c19 {
   border: 0;
   -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
@@ -170,7 +185,7 @@ exports[`FolderCard has all required ids set when rendering a start action 1`] =
   width: 1px;
 }
 
-.c17 {
+.c18 {
   position: absolute;
   top: 12px;
 }
@@ -190,22 +205,22 @@ exports[`FolderCard has all required ids set when rendering a start action 1`] =
   text-decoration: none;
 }
 
-.c8 path {
+.c7 path {
   fill: currentColor;
 }
 
-.c15 {
+.c14 {
   display: none;
 }
 
-.c11 {
+.c10 {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
 }
 
-.c13:focus {
+.c12:focus {
   outline: 2px solid #4945ff;
   outline-offset: -2px;
 }
@@ -223,26 +238,26 @@ exports[`FolderCard has all required ids set when rendering a start action 1`] =
       type="button"
     />
     <div
-      class="c2 c3 c4"
+      class="c2 c3"
     >
       <div
-        class="c5"
+        class="c4"
       >
         <div
           class=""
         >
           <input
             aria-labelledby="folder-3-title"
-            class="c6"
+            class="c5"
             type="checkbox"
           />
         </div>
       </div>
       <div
-        class="c7"
+        class="c6"
       >
         <svg
-          class="c8"
+          class="c7"
           fill="none"
           height="1.5rem"
           viewBox="0 0 24 24"
@@ -256,19 +271,19 @@ exports[`FolderCard has all required ids set when rendering a start action 1`] =
         </svg>
       </div>
       <h2
-        class="c9 c10 c11"
+        class="c8 c9 c10"
         id="folder-3-title"
         overflow="hidden"
       >
         <button
-          class="c12 c13"
+          class="c11 c12"
           type="button"
         >
           <div
-            class="c10"
+            class="c9"
           >
             <span
-              class="c14"
+              class="c13"
             >
               Pictures
             </span>
@@ -276,16 +291,16 @@ exports[`FolderCard has all required ids set when rendering a start action 1`] =
         </button>
       </h2>
       <div
-        class="c15"
+        class="c14"
       >
         <div
-          class="c16 c3 c4 c17"
+          class="c15 c16 c17 c18"
         />
       </div>
     </div>
   </div>
   <div
-    class="c18"
+    class="c19"
   >
     <p
       aria-live="polite"
@@ -310,7 +325,7 @@ exports[`FolderCard has all required ids set when rendering a start action 1`] =
 `;
 
 exports[`FolderCard renders and matches the snapshot 1`] = `
-.c12 {
+.c11 {
   font-size: 0.875rem;
   line-height: 1.43;
   font-weight: 500;
@@ -332,7 +347,7 @@ exports[`FolderCard renders and matches the snapshot 1`] = `
   cursor: pointer;
 }
 
-.c5 {
+.c4 {
   background: #eaf5ff;
   color: #66b7f1;
   padding-top: 8px;
@@ -342,18 +357,18 @@ exports[`FolderCard renders and matches the snapshot 1`] = `
   border-radius: 4px;
 }
 
-.c7 {
+.c6 {
   position: relative;
   overflow: hidden;
   max-width: 100%;
 }
 
-.c10 {
+.c9 {
   padding: 4px;
   max-width: 100%;
 }
 
-.c14 {
+.c13 {
   right: 16px;
 }
 
@@ -369,9 +384,10 @@ exports[`FolderCard renders and matches the snapshot 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
+  gap: 8px;
 }
 
-.c8 {
+.c7 {
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -385,16 +401,30 @@ exports[`FolderCard renders and matches the snapshot 1`] = `
   flex-direction: column;
 }
 
-.c4 > * {
+.c14 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+}
+
+.c15 > * {
   margin-left: 0;
   margin-right: 0;
 }
 
-.c4 > * + * {
+.c15 > * + * {
   margin-left: 8px;
 }
 
-.c16 {
+.c17 {
   border: 0;
   -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
@@ -406,7 +436,7 @@ exports[`FolderCard renders and matches the snapshot 1`] = `
   width: 1px;
 }
 
-.c15 {
+.c16 {
   position: absolute;
   top: 12px;
 }
@@ -426,22 +456,22 @@ exports[`FolderCard renders and matches the snapshot 1`] = `
   text-decoration: none;
 }
 
-.c6 path {
+.c5 path {
   fill: currentColor;
 }
 
-.c13 {
+.c12 {
   display: none;
 }
 
-.c9 {
+.c8 {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
 }
 
-.c11:focus {
+.c10:focus {
   outline: 2px solid #4945ff;
   outline-offset: -2px;
 }
@@ -459,13 +489,13 @@ exports[`FolderCard renders and matches the snapshot 1`] = `
       type="button"
     />
     <div
-      class="c2 c3 c4"
+      class="c2 c3"
     >
       <div
-        class="c5"
+        class="c4"
       >
         <svg
-          class="c6"
+          class="c5"
           fill="none"
           height="1.5rem"
           viewBox="0 0 24 24"
@@ -479,19 +509,19 @@ exports[`FolderCard renders and matches the snapshot 1`] = `
         </svg>
       </div>
       <h2
-        class="c7 c8 c9"
+        class="c6 c7 c8"
         id="folder-1-title"
         overflow="hidden"
       >
         <button
-          class="c10 c11"
+          class="c9 c10"
           type="button"
         >
           <div
-            class="c8"
+            class="c7"
           >
             <span
-              class="c12"
+              class="c11"
             >
               Pictures
             </span>
@@ -499,16 +529,16 @@ exports[`FolderCard renders and matches the snapshot 1`] = `
         </button>
       </h2>
       <div
-        class="c13"
+        class="c12"
       >
         <div
-          class="c14 c3 c4 c15"
+          class="c13 c14 c15 c16"
         />
       </div>
     </div>
   </div>
   <div
-    class="c16"
+    class="c17"
   >
     <p
       aria-live="polite"

--- a/packages/core/upload/admin/src/components/UploadAssetDialog/PendingAssetStep/PendingAssetStep.js
+++ b/packages/core/upload/admin/src/components/UploadAssetDialog/PendingAssetStep/PendingAssetStep.js
@@ -8,7 +8,6 @@ import {
   Typography,
   Button,
   Flex,
-  Stack,
   Grid,
   GridItem,
   KeyboardNavigable,
@@ -98,9 +97,9 @@ export const PendingAssetStep = ({
       </ModalHeader>
 
       <ModalBody>
-        <Stack spacing={7}>
+        <Flex direction="column" alignItems="stretch" gap={7}>
           <Flex justifyContent="space-between">
-            <Stack spacing={0}>
+            <Flex direction="column" alignItems="stretch" gap={0}>
               <Typography variant="pi" fontWeight="bold" textColor="neutral800">
                 {formatMessage(
                   {
@@ -117,7 +116,7 @@ export const PendingAssetStep = ({
                   defaultMessage: 'Manage the assets before adding them to the Media Library',
                 })}
               </Typography>
-            </Stack>
+            </Flex>
             <Button size="S" onClick={onClickAddAsset}>
               {formatMessage({
                 id: getTrad('header.actions.add-assets'),
@@ -163,7 +162,7 @@ export const PendingAssetStep = ({
               })}
             </Grid>
           </KeyboardNavigable>
-        </Stack>
+        </Flex>
       </ModalBody>
 
       <ModalFooter

--- a/packages/core/upload/admin/src/components/UploadAssetDialog/PendingAssetStep/tests/__snapshots__/PendingAssetStep.test.js.snap
+++ b/packages/core/upload/admin/src/components/UploadAssetDialog/PendingAssetStep/tests/__snapshots__/PendingAssetStep.test.js.snap
@@ -8,20 +8,20 @@ exports[`PendingAssetStep snapshots the component with valid cards 1`] = `
   color: #32324d;
 }
 
-.c14 {
+.c13 {
   font-size: 0.75rem;
   line-height: 1.33;
   font-weight: 600;
   color: #32324d;
 }
 
-.c15 {
+.c14 {
   font-size: 0.75rem;
   line-height: 1.33;
   color: #666687;
 }
 
-.c46 {
+.c45 {
   font-weight: 600;
   font-size: 0.6875rem;
   line-height: 1.45;
@@ -29,7 +29,7 @@ exports[`PendingAssetStep snapshots the component with valid cards 1`] = `
   color: #666687;
 }
 
-.c52 {
+.c51 {
   font-size: 0.75rem;
   line-height: 1.33;
   color: #ffffff;
@@ -47,7 +47,7 @@ exports[`PendingAssetStep snapshots the component with valid cards 1`] = `
   padding: 32px;
 }
 
-.c19 {
+.c18 {
   background: #ffffff;
   border-radius: 4px;
   border-style: solid;
@@ -57,30 +57,30 @@ exports[`PendingAssetStep snapshots the component with valid cards 1`] = `
   height: 100%;
 }
 
-.c21 {
+.c20 {
   position: relative;
 }
 
-.c24 {
+.c23 {
   position: start;
 }
 
-.c29 {
+.c28 {
   position: end;
 }
 
-.c35 {
+.c34 {
   padding-top: 8px;
   padding-right: 12px;
   padding-bottom: 8px;
   padding-left: 12px;
 }
 
-.c38 {
+.c37 {
   padding-top: 4px;
 }
 
-.c40 {
+.c39 {
   padding-top: 4px;
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
@@ -88,19 +88,19 @@ exports[`PendingAssetStep snapshots the component with valid cards 1`] = `
   flex-grow: 1;
 }
 
-.c42 {
+.c41 {
   background: #eaeaef;
   padding-right: 8px;
   padding-left: 8px;
   min-width: 20px;
 }
 
-.c47 {
+.c46 {
   width: 100%;
   height: 5.5rem;
 }
 
-.c51 {
+.c50 {
   background: #32324d;
   color: #ffffff;
   padding: 4px;
@@ -140,9 +140,24 @@ exports[`PendingAssetStep snapshots the component with valid cards 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  gap: 32px;
 }
 
-.c22 {
+.c12 {
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c21 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -160,7 +175,7 @@ exports[`PendingAssetStep snapshots the component with valid cards 1`] = `
   justify-content: center;
 }
 
-.c25 {
+.c24 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -174,7 +189,7 @@ exports[`PendingAssetStep snapshots the component with valid cards 1`] = `
   flex-direction: row;
 }
 
-.c36 {
+.c35 {
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -188,7 +203,7 @@ exports[`PendingAssetStep snapshots the component with valid cards 1`] = `
   flex-direction: row;
 }
 
-.c43 {
+.c42 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -206,30 +221,16 @@ exports[`PendingAssetStep snapshots the component with valid cards 1`] = `
   justify-content: center;
 }
 
-.c12 > * {
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
-.c12 > * + * {
-  margin-top: 32px;
-}
-
-.c13 > * {
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
-.c26 > * {
+.c25 > * {
   margin-left: 0;
   margin-right: 0;
 }
 
-.c26 > * + * {
+.c25 > * + * {
   margin-left: 8px;
 }
 
-.c44 {
+.c43 {
   border-radius: 4px;
   height: 1.5rem;
 }
@@ -292,7 +293,7 @@ exports[`PendingAssetStep snapshots the component with valid cards 1`] = `
   border: 2px solid #4945ff;
 }
 
-.c28 {
+.c27 {
   height: 18px;
   min-width: 18px;
   margin: 0;
@@ -303,12 +304,12 @@ exports[`PendingAssetStep snapshots the component with valid cards 1`] = `
   cursor: pointer;
 }
 
-.c28:checked {
+.c27:checked {
   background-color: #4945ff;
   border: 1px solid #4945ff;
 }
 
-.c28:checked:after {
+.c27:checked:after {
   content: '';
   display: block;
   position: relative;
@@ -322,21 +323,21 @@ exports[`PendingAssetStep snapshots the component with valid cards 1`] = `
   transform: translateX(-50%) translateY(-50%);
 }
 
-.c28:checked:disabled:after {
+.c27:checked:disabled:after {
   background: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTAiIGhlaWdodD0iOCIgdmlld0JveD0iMCAwIDEwIDgiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgPHBhdGgKICAgIGQ9Ik04LjU1MzIzIDAuMzk2OTczQzguNjMxMzUgMC4zMTYzNTUgOC43NjA1MSAwLjMxNTgxMSA4LjgzOTMxIDAuMzk1NzY4TDkuODYyNTYgMS40MzQwN0M5LjkzODkzIDEuNTExNTcgOS45MzkzNSAxLjYzNTkgOS44NjM0OSAxLjcxMzlMNC4wNjQwMSA3LjY3NzI0QzMuOTg1OSA3Ljc1NzU1IDMuODU3MDcgNy43NTgwNSAzLjc3ODM0IDcuNjc4MzRMMC4xMzg2NiAzLjk5MzMzQzAuMDYxNzc5OCAzLjkxNTQ5IDAuMDYxNzEwMiAzLjc5MDMyIDAuMTM4NTA0IDMuNzEyNEwxLjE2MjEzIDIuNjczNzJDMS4yNDAzOCAyLjU5NDMyIDEuMzY4NDMgMi41OTQyMiAxLjQ0NjggMi42NzM0OEwzLjkyMTc0IDUuMTc2NDdMOC41NTMyMyAwLjM5Njk3M1oiCiAgICBmaWxsPSIjOEU4RUE5IgogIC8+Cjwvc3ZnPg==) no-repeat no-repeat center center;
 }
 
-.c28:disabled {
+.c27:disabled {
   background-color: #dcdce4;
   border: 1px solid #c0c0cf;
 }
 
-.c28:indeterminate {
+.c27:indeterminate {
   background-color: #4945ff;
   border: 1px solid #4945ff;
 }
 
-.c28:indeterminate:after {
+.c27:indeterminate:after {
   content: '';
   display: block;
   position: relative;
@@ -351,12 +352,12 @@ exports[`PendingAssetStep snapshots the component with valid cards 1`] = `
   transform: translateX(-50%) translateY(-50%);
 }
 
-.c28:indeterminate:disabled {
+.c27:indeterminate:disabled {
   background-color: #dcdce4;
   border: 1px solid #c0c0cf;
 }
 
-.c28:indeterminate:disabled:after {
+.c27:indeterminate:disabled:after {
   background-color: #8e8ea9;
 }
 
@@ -372,7 +373,7 @@ exports[`PendingAssetStep snapshots the component with valid cards 1`] = `
   width: 1px;
 }
 
-.c16 {
+.c15 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -384,7 +385,7 @@ exports[`PendingAssetStep snapshots the component with valid cards 1`] = `
   padding-right: 16px;
 }
 
-.c16 .c0 {
+.c15 .c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -395,52 +396,52 @@ exports[`PendingAssetStep snapshots the component with valid cards 1`] = `
   align-items: center;
 }
 
-.c16 .c4 {
+.c15 .c4 {
   color: #ffffff;
 }
 
-.c16[aria-disabled='true'] {
+.c15[aria-disabled='true'] {
   border: 1px solid #dcdce4;
   background: #eaeaef;
 }
 
-.c16[aria-disabled='true'] .c4 {
+.c15[aria-disabled='true'] .c4 {
   color: #666687;
 }
 
-.c16[aria-disabled='true'] svg > g,.c16[aria-disabled='true'] svg path {
+.c15[aria-disabled='true'] svg > g,.c15[aria-disabled='true'] svg path {
   fill: #666687;
 }
 
-.c16[aria-disabled='true']:active {
+.c15[aria-disabled='true']:active {
   border: 1px solid #dcdce4;
   background: #eaeaef;
 }
 
-.c16[aria-disabled='true']:active .c4 {
+.c15[aria-disabled='true']:active .c4 {
   color: #666687;
 }
 
-.c16[aria-disabled='true']:active svg > g,.c16[aria-disabled='true']:active svg path {
+.c15[aria-disabled='true']:active svg > g,.c15[aria-disabled='true']:active svg path {
   fill: #666687;
 }
 
-.c16:hover {
+.c15:hover {
   border: 1px solid #7b79ff;
   background: #7b79ff;
 }
 
-.c16:active {
+.c15:active {
   border: 1px solid #4945ff;
   background: #4945ff;
 }
 
-.c16 svg > g,
-.c16 svg path {
+.c15 svg > g,
+.c15 svg path {
   fill: #ffffff;
 }
 
-.c55 {
+.c54 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -454,7 +455,7 @@ exports[`PendingAssetStep snapshots the component with valid cards 1`] = `
   background: #ffffff;
 }
 
-.c55 .c0 {
+.c54 .c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -465,66 +466,66 @@ exports[`PendingAssetStep snapshots the component with valid cards 1`] = `
   align-items: center;
 }
 
-.c55 .c4 {
+.c54 .c4 {
   color: #ffffff;
 }
 
-.c55[aria-disabled='true'] {
+.c54[aria-disabled='true'] {
   border: 1px solid #dcdce4;
   background: #eaeaef;
 }
 
-.c55[aria-disabled='true'] .c4 {
+.c54[aria-disabled='true'] .c4 {
   color: #666687;
 }
 
-.c55[aria-disabled='true'] svg > g,.c55[aria-disabled='true'] svg path {
+.c54[aria-disabled='true'] svg > g,.c54[aria-disabled='true'] svg path {
   fill: #666687;
 }
 
-.c55[aria-disabled='true']:active {
+.c54[aria-disabled='true']:active {
   border: 1px solid #dcdce4;
   background: #eaeaef;
 }
 
-.c55[aria-disabled='true']:active .c4 {
+.c54[aria-disabled='true']:active .c4 {
   color: #666687;
 }
 
-.c55[aria-disabled='true']:active svg > g,.c55[aria-disabled='true']:active svg path {
+.c54[aria-disabled='true']:active svg > g,.c54[aria-disabled='true']:active svg path {
   fill: #666687;
 }
 
-.c55:hover {
+.c54:hover {
   background-color: #f6f6f9;
 }
 
-.c55:active {
+.c54:active {
   background-color: #eaeaef;
 }
 
-.c55 .c4 {
+.c54 .c4 {
   color: #32324d;
 }
 
-.c55 svg > g,
-.c55 svg path {
+.c54 svg > g,
+.c54 svg path {
   fill: #32324d;
 }
 
-.c27 {
+.c26 {
   position: absolute;
   top: 12px;
   left: 12px;
 }
 
-.c31 {
+.c30 {
   position: absolute;
   top: 12px;
   right: 12px;
 }
 
-.c34 {
+.c33 {
   margin: 0;
   padding: 0;
   max-height: 100%;
@@ -532,7 +533,7 @@ exports[`PendingAssetStep snapshots the component with valid cards 1`] = `
   object-fit: contain;
 }
 
-.c33 {
+.c32 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -548,32 +549,32 @@ exports[`PendingAssetStep snapshots the component with valid cards 1`] = `
   border-top-right-radius: 4px;
 }
 
-.c41 {
+.c40 {
   margin-left: auto;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.c45 {
+.c44 {
   margin-left: 4px;
 }
 
-.c37 {
+.c36 {
   word-break: break-all;
 }
 
-.c23 {
+.c22 {
   border-bottom: 1px solid #eaeaef;
 }
 
-.c17 {
+.c16 {
   display: grid;
   grid-template-columns: repeat(12,1fr);
   gap: 16px;
 }
 
-.c18 {
+.c17 {
   grid-column: span 4;
   max-width: 100%;
 }
@@ -623,12 +624,12 @@ exports[`PendingAssetStep snapshots the component with valid cards 1`] = `
   border-bottom: 1px solid #eaeaef;
 }
 
-.c53 {
+.c52 {
   border-radius: 0 0 4px 4px;
   border-top: 1px solid #eaeaef;
 }
 
-.c54 > * + * {
+.c53 > * + * {
   margin-left: 8px;
 }
 
@@ -637,51 +638,51 @@ exports[`PendingAssetStep snapshots the component with valid cards 1`] = `
   max-height: 60vh;
 }
 
-.c39 {
+.c38 {
   text-transform: uppercase;
 }
 
-.c32 {
+.c31 {
   opacity: 0;
 }
 
-.c32:focus-within {
+.c31:focus-within {
   opacity: 1;
 }
 
-.c20 {
+.c19 {
   cursor: pointer;
 }
 
-.c20:hover .c30 {
+.c19:hover .c29 {
   opacity: 1;
 }
 
-.c50 canvas,
-.c50 video {
+.c49 canvas,
+.c49 video {
   display: block;
   pointer-events: none;
   max-width: 100%;
   max-height: 5.5rem;
 }
 
-.c49 svg {
+.c48 svg {
   font-size: 3rem;
 }
 
-.c48 {
+.c47 {
   border-radius: 4px 4px 0 0;
   background: linear-gradient(180deg,#ffffff 0%,#f6f6f9 121.48%);
 }
 
 @media (max-width:68.75rem) {
-  .c18 {
+  .c17 {
     grid-column: span;
   }
 }
 
 @media (max-width:34.375rem) {
-  .c18 {
+  .c17 {
     grid-column: span;
   }
 }
@@ -731,32 +732,32 @@ exports[`PendingAssetStep snapshots the component with valid cards 1`] = `
       class="c0 c9 c10"
     >
       <div
-        class="c0 c11 c12"
+        class="c0 c11"
       >
         <div
           class="c0 c3"
         >
           <div
-            class="c0 c11 c13"
+            class="c0 c12"
           >
             <span
-              class="c4 c14"
+              class="c4 c13"
             >
               3 assets ready to upload
             </span>
             <span
-              class="c4 c15"
+              class="c4 c14"
             >
               Manage the assets before adding them to the Media Library
             </span>
           </div>
           <button
             aria-disabled="false"
-            class="c6 c16"
+            class="c6 c15"
             type="button"
           >
             <span
-              class="c4 c14"
+              class="c4 c13"
             >
               Add new assets
             </span>
@@ -766,40 +767,40 @@ exports[`PendingAssetStep snapshots the component with valid cards 1`] = `
           class="c0 "
         >
           <div
-            class="c0 c17"
+            class="c0 c16"
           >
             <div
-              class="c18"
+              class="c17"
             >
               <div
                 class="c0 "
               >
                 <article
                   aria-labelledby="2-title"
-                  class="c0 c19 c20"
+                  class="c0 c18 c19"
                   role="button"
                   tabindex="-1"
                 >
                   <div
-                    class="c0 c21 c22 c23"
+                    class="c0 c20 c21 c22"
                   >
                     <div>
                       <div
-                        class="c0 c24 c25 c26 c27"
+                        class="c0 c23 c24 c25 c26"
                       >
                         <div
                           class="c0 "
                         >
                           <input
                             aria-labelledby="2-title"
-                            class="c28"
+                            class="c27"
                             type="checkbox"
                           />
                         </div>
                       </div>
                     </div>
                     <div
-                      class="c0 c29 c25 c26 c30 c31 c32"
+                      class="c0 c28 c24 c25 c29 c30 c31"
                     >
                       <span>
                         <button
@@ -863,40 +864,40 @@ exports[`PendingAssetStep snapshots the component with valid cards 1`] = `
                       </span>
                     </div>
                     <div
-                      class="c33"
+                      class="c32"
                     >
                       <img
                         alt="something.jpg"
                         aria-hidden="true"
-                        class="c34"
+                        class="c33"
                         src="http://localhost:5000/CPAM.jpg"
                       />
                     </div>
                   </div>
                   <div
-                    class="c0 c35"
+                    class="c0 c34"
                   >
                     <div
-                      class="c0 c36"
+                      class="c0 c35"
                     >
                       <div
-                        class="c0 c37"
+                        class="c0 c36"
                       >
                         <div
-                          class="c0 c38"
+                          class="c0 c37"
                         >
                           <h2
-                            class="c4 c14"
+                            class="c4 c13"
                             id="2-title"
                           >
                             something.jpg
                           </h2>
                         </div>
                         <div
-                          class="c4 c15"
+                          class="c4 c14"
                         >
                           <span
-                            class="c39"
+                            class="c38"
                           >
                             jpg
                           </span>
@@ -904,16 +905,16 @@ exports[`PendingAssetStep snapshots the component with valid cards 1`] = `
                         </div>
                       </div>
                       <div
-                        class="c0 c40 c25"
+                        class="c0 c39 c24"
                       >
                         <div
-                          class="c41"
+                          class="c40"
                         >
                           <div
-                            class="c0 c42 c43 c44 c45"
+                            class="c0 c41 c42 c43 c44"
                           >
                             <span
-                              class="c4 c46"
+                              class="c4 c45"
                             >
                               Image
                             </span>
@@ -926,37 +927,37 @@ exports[`PendingAssetStep snapshots the component with valid cards 1`] = `
               </div>
             </div>
             <div
-              class="c18"
+              class="c17"
             >
               <div
                 class="c0 "
               >
                 <article
                   aria-labelledby="5-title"
-                  class="c0 c19 c20"
+                  class="c0 c18 c19"
                   role="button"
                   tabindex="-1"
                 >
                   <div
-                    class="c0 c21 c22 c23"
+                    class="c0 c20 c21 c22"
                   >
                     <div>
                       <div
-                        class="c0 c24 c25 c26 c27"
+                        class="c0 c23 c24 c25 c26"
                       >
                         <div
                           class="c0 "
                         >
                           <input
                             aria-labelledby="5-title"
-                            class="c28"
+                            class="c27"
                             type="checkbox"
                           />
                         </div>
                       </div>
                     </div>
                     <div
-                      class="c0 c29 c25 c26 c30 c31 c32"
+                      class="c0 c28 c24 c25 c29 c30 c31"
                     >
                       <span>
                         <button
@@ -1020,10 +1021,10 @@ exports[`PendingAssetStep snapshots the component with valid cards 1`] = `
                       </span>
                     </div>
                     <div
-                      class="c0 c47 c22 c48"
+                      class="c0 c46 c21 c47"
                     >
                       <span
-                        class="c49"
+                        class="c48"
                       >
                         <svg
                           aria-label="something.pdf"
@@ -1048,29 +1049,29 @@ exports[`PendingAssetStep snapshots the component with valid cards 1`] = `
                     </div>
                   </div>
                   <div
-                    class="c0 c35"
+                    class="c0 c34"
                   >
                     <div
-                      class="c0 c36"
+                      class="c0 c35"
                     >
                       <div
-                        class="c0 c37"
+                        class="c0 c36"
                       >
                         <div
-                          class="c0 c38"
+                          class="c0 c37"
                         >
                           <h2
-                            class="c4 c14"
+                            class="c4 c13"
                             id="5-title"
                           >
                             something.pdf
                           </h2>
                         </div>
                         <div
-                          class="c4 c15"
+                          class="c4 c14"
                         >
                           <span
-                            class="c39"
+                            class="c38"
                           >
                             pdf
                           </span>
@@ -1078,16 +1079,16 @@ exports[`PendingAssetStep snapshots the component with valid cards 1`] = `
                         </div>
                       </div>
                       <div
-                        class="c0 c40 c25"
+                        class="c0 c39 c24"
                       >
                         <div
-                          class="c41"
+                          class="c40"
                         >
                           <div
-                            class="c0 c42 c43 c44 c45"
+                            class="c0 c41 c42 c43 c44"
                           >
                             <span
-                              class="c4 c46"
+                              class="c4 c45"
                             >
                               Doc
                             </span>
@@ -1100,37 +1101,37 @@ exports[`PendingAssetStep snapshots the component with valid cards 1`] = `
               </div>
             </div>
             <div
-              class="c18"
+              class="c17"
             >
               <div
                 class="c0 "
               >
                 <article
                   aria-labelledby="8-title"
-                  class="c0 c19 c20"
+                  class="c0 c18 c19"
                   role="button"
                   tabindex="-1"
                 >
                   <div
-                    class="c0 c21 c22 c23"
+                    class="c0 c20 c21 c22"
                   >
                     <div>
                       <div
-                        class="c0 c24 c25 c26 c27"
+                        class="c0 c23 c24 c25 c26"
                       >
                         <div
                           class="c0 "
                         >
                           <input
                             aria-labelledby="8-title"
-                            class="c28"
+                            class="c27"
                             type="checkbox"
                           />
                         </div>
                       </div>
                     </div>
                     <div
-                      class="c0 c29 c25 c26 c30 c31 c32"
+                      class="c0 c28 c24 c25 c29 c30 c31"
                     >
                       <span>
                         <button
@@ -1194,13 +1195,13 @@ exports[`PendingAssetStep snapshots the component with valid cards 1`] = `
                       </span>
                     </div>
                     <div
-                      class="c33"
+                      class="c32"
                     >
                       <div
-                        class="c0 c25"
+                        class="c0 c24"
                       >
                         <div
-                          class="c0 c50"
+                          class="c0 c49"
                         >
                           <figure
                             class="c0 "
@@ -1223,39 +1224,39 @@ exports[`PendingAssetStep snapshots the component with valid cards 1`] = `
                       </div>
                     </div>
                     <time
-                      class="c0 c51"
+                      class="c0 c50"
                     >
                       <span
-                        class="c4 c52"
+                        class="c4 c51"
                       >
                         ...
                       </span>
                     </time>
                   </div>
                   <div
-                    class="c0 c35"
+                    class="c0 c34"
                   >
                     <div
-                      class="c0 c36"
+                      class="c0 c35"
                     >
                       <div
-                        class="c0 c37"
+                        class="c0 c36"
                       >
                         <div
-                          class="c0 c38"
+                          class="c0 c37"
                         >
                           <h2
-                            class="c4 c14"
+                            class="c4 c13"
                             id="8-title"
                           >
                             something.mp4
                           </h2>
                         </div>
                         <div
-                          class="c4 c15"
+                          class="c4 c14"
                         >
                           <span
-                            class="c39"
+                            class="c38"
                           >
                             mp4
                           </span>
@@ -1263,16 +1264,16 @@ exports[`PendingAssetStep snapshots the component with valid cards 1`] = `
                         </div>
                       </div>
                       <div
-                        class="c0 c40 c25"
+                        class="c0 c39 c24"
                       >
                         <div
-                          class="c41"
+                          class="c40"
                         >
                           <div
-                            class="c0 c42 c43 c44 c45"
+                            class="c0 c41 c42 c43 c44"
                           >
                             <span
-                              class="c4 c46"
+                              class="c4 c45"
                             >
                               Video
                             </span>
@@ -1289,36 +1290,36 @@ exports[`PendingAssetStep snapshots the component with valid cards 1`] = `
       </div>
     </div>
     <div
-      class="c0 c1 c53"
+      class="c0 c1 c52"
     >
       <div
         class="c0 c3"
       >
         <div
-          class="c0 c25 c54"
+          class="c0 c24 c53"
         >
           <button
             aria-disabled="false"
-            class="c6 c55"
+            class="c6 c54"
             type="button"
           >
             <span
-              class="c4 c14"
+              class="c4 c13"
             >
               cancel
             </span>
           </button>
         </div>
         <div
-          class="c0 c25 c54"
+          class="c0 c24 c53"
         >
           <button
             aria-disabled="false"
-            class="c6 c16"
+            class="c6 c15"
             type="submit"
           >
             <span
-              class="c4 c14"
+              class="c4 c13"
             >
               Upload 3 assets to the library
             </span>

--- a/packages/core/upload/admin/src/components/UploadProgress/index.js
+++ b/packages/core/upload/admin/src/components/UploadProgress/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { Cross } from '@strapi/icons';
-import { Typography, Flex, Stack, ProgressBar } from '@strapi/design-system';
+import { Typography, Flex, ProgressBar } from '@strapi/design-system';
 import { useIntl } from 'react-intl';
 
 const BoxWrapper = styled(Flex)`
@@ -46,11 +46,11 @@ export const UploadProgress = ({ onCancel, progress, error }) => {
       {error ? (
         <Cross aria-label={error?.message} />
       ) : (
-        <Stack alignItems="center" spacing={2} width="100%">
+        <Flex direction="column" alignItems="center" gap={2} width="100%">
           <ProgressBar value={progress}>{`${progress}/100%`}</ProgressBar>
 
           <CancelButton type="button" onClick={onCancel}>
-            <Stack horizontal spacing={2}>
+            <Flex gap={2}>
               <Typography variant="pi" as="span" textColor="inherit">
                 {formatMessage({
                   id: 'app.components.Button.cancel',
@@ -59,9 +59,9 @@ export const UploadProgress = ({ onCancel, progress, error }) => {
               </Typography>
 
               <Cross aria-hidden />
-            </Stack>
+            </Flex>
           </CancelButton>
-        </Stack>
+        </Flex>
       )}
     </BoxWrapper>
   );

--- a/packages/core/upload/admin/src/components/UploadProgress/tests/index.test.js
+++ b/packages/core/upload/admin/src/components/UploadProgress/tests/index.test.js
@@ -49,7 +49,7 @@ describe('<UploadProgress />', () => {
     } = renderCompo();
 
     expect(firstChild).toMatchInlineSnapshot(`
-      .c10 {
+      .c9 {
         font-size: 0.75rem;
         line-height: 1.33;
       }
@@ -62,7 +62,7 @@ describe('<UploadProgress />', () => {
         width: 100%;
       }
 
-      .c6 {
+      .c5 {
         background: #666687;
         border-radius: 4px;
         position: relative;
@@ -96,27 +96,25 @@ describe('<UploadProgress />', () => {
         -webkit-flex-direction: column;
         -ms-flex-direction: column;
         flex-direction: column;
+        gap: 8px;
       }
 
-      .c5 > * {
-        margin-top: 0;
-        margin-bottom: 0;
+      .c8 {
+        -webkit-align-items: center;
+        -webkit-box-align: center;
+        -ms-flex-align: center;
+        align-items: center;
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+        -webkit-flex-direction: row;
+        -ms-flex-direction: row;
+        flex-direction: row;
+        gap: 8px;
       }
 
-      .c5 > * + * {
-        margin-top: 8px;
-      }
-
-      .c9 > * {
-        margin-left: 0;
-        margin-right: 0;
-      }
-
-      .c9 > * + * {
-        margin-left: 8px;
-      }
-
-      .c7:before {
+      .c6:before {
         background-color: #ffffff;
         border-radius: 4px;
         bottom: 0;
@@ -132,7 +130,7 @@ describe('<UploadProgress />', () => {
         height: 100%;
       }
 
-      .c8 {
+      .c7 {
         border: none;
         background: none;
         width: -webkit-min-content;
@@ -141,17 +139,17 @@ describe('<UploadProgress />', () => {
         color: #666687;
       }
 
-      .c8:hover,
-      .c8:focus {
+      .c7:hover,
+      .c7:focus {
         color: #4a4a6a;
       }
 
-      .c8 svg {
+      .c7 svg {
         height: 10px;
         width: 10px;
       }
 
-      .c8 svg path {
+      .c7 svg path {
         fill: currentColor;
       }
 
@@ -159,26 +157,26 @@ describe('<UploadProgress />', () => {
         class="c0 c1 c2"
       >
         <div
-          class="c3 c4 c5"
+          class="c3 c4"
         >
           <div
             aria-label="0/100%"
             aria-valuemax="100"
             aria-valuemin="0"
             aria-valuenow="0"
-            class="c6 c7"
+            class="c5 c6"
             role="progressbar"
             value="0"
           />
           <button
-            class="c8"
+            class="c7"
             type="button"
           >
             <div
-              class="c1 c9"
+              class="c8"
             >
               <span
-                class="c10"
+                class="c9"
               >
                 Cancel
               </span>

--- a/packages/core/upload/admin/src/pages/App/MediaLibrary/components/BulkActions.js
+++ b/packages/core/upload/admin/src/pages/App/MediaLibrary/components/BulkActions.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
-import { Stack, Typography } from '@strapi/design-system';
+import { Flex, Typography } from '@strapi/design-system';
 
 import { AssetDefinition, FolderDefinition } from '../../../../constants';
 import getTrad from '../../../../utils/getTrad';
@@ -12,7 +12,7 @@ export const BulkActions = ({ selected, onSuccess, currentFolder }) => {
   const { formatMessage } = useIntl();
 
   return (
-    <Stack horizontal spacing={2} paddingBottom={5}>
+    <Flex gap={2} paddingBottom={5}>
       <Typography variant="epsilon" textColor="neutral600">
         {formatMessage(
           {
@@ -29,7 +29,7 @@ export const BulkActions = ({ selected, onSuccess, currentFolder }) => {
 
       <BulkDeleteButton selected={selected} onSuccess={onSuccess} />
       <BulkMoveButton currentFolder={currentFolder} selected={selected} onSuccess={onSuccess} />
-    </Stack>
+    </Flex>
   );
 };
 

--- a/packages/core/upload/admin/src/pages/App/MediaLibrary/components/Header.js
+++ b/packages/core/upload/admin/src/pages/App/MediaLibrary/components/Header.js
@@ -4,7 +4,7 @@ import { useIntl } from 'react-intl';
 import { stringify } from 'qs';
 import { useLocation } from 'react-router-dom';
 import { useQueryParams } from '@strapi/helper-plugin';
-import { HeaderLayout, Button, Stack, Link } from '@strapi/design-system';
+import { HeaderLayout, Button, Flex, Link } from '@strapi/design-system';
 import { ArrowLeft, Plus } from '@strapi/icons';
 import { getTrad } from '../../../../utils';
 import { FolderDefinition, BreadcrumbsDefinition } from '../../../../constants';
@@ -60,7 +60,7 @@ export const Header = ({
       }
       primaryAction={
         canCreate && (
-          <Stack horizontal spacing={2}>
+          <Flex gap={2}>
             <Button startIcon={<Plus />} variant="secondary" onClick={onToggleEditFolderDialog}>
               {formatMessage({
                 id: getTrad('header.actions.add-folder'),
@@ -74,7 +74,7 @@ export const Header = ({
                 defaultMessage: 'Add new assets',
               })}
             </Button>
-          </Stack>
+          </Flex>
         )
       }
     />

--- a/packages/core/upload/admin/src/pages/App/MediaLibrary/components/tests/__snapshots__/BulkActions.test.js.snap
+++ b/packages/core/upload/admin/src/pages/App/MediaLibrary/components/tests/__snapshots__/BulkActions.test.js.snap
@@ -1,13 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`BulkActions renders 1`] = `
-.c5 {
+.c4 {
   font-size: 1rem;
   line-height: 1.5;
   color: #666687;
 }
 
-.c10 {
+.c9 {
   font-size: 0.75rem;
   line-height: 1.33;
   font-weight: 600;
@@ -18,7 +18,7 @@ exports[`BulkActions renders 1`] = `
   padding-bottom: 20px;
 }
 
-.c8 {
+.c7 {
   padding-right: 8px;
 }
 
@@ -34,18 +34,10 @@ exports[`BulkActions renders 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
+  gap: 8px;
 }
 
-.c3 > * {
-  margin-left: 0;
-  margin-right: 0;
-}
-
-.c3 > * + * {
-  margin-left: 8px;
-}
-
-.c6 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -59,21 +51,21 @@ exports[`BulkActions renders 1`] = `
   outline: none;
 }
 
-.c6 svg {
+.c5 svg {
   height: 12px;
   width: 12px;
 }
 
-.c6 svg > g,
-.c6 svg path {
+.c5 svg > g,
+.c5 svg path {
   fill: #ffffff;
 }
 
-.c6[aria-disabled='true'] {
+.c5[aria-disabled='true'] {
   pointer-events: none;
 }
 
-.c6:after {
+.c5:after {
   -webkit-transition-property: all;
   transition-property: all;
   -webkit-transition-duration: 0.2s;
@@ -88,11 +80,11 @@ exports[`BulkActions renders 1`] = `
   border: 2px solid transparent;
 }
 
-.c6:focus-visible {
+.c5:focus-visible {
   outline: none;
 }
 
-.c6:focus-visible:after {
+.c5:focus-visible:after {
   border-radius: 8px;
   content: '';
   position: absolute;
@@ -103,7 +95,7 @@ exports[`BulkActions renders 1`] = `
   border: 2px solid #4945ff;
 }
 
-.c12 {
+.c11 {
   border: 0;
   -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
@@ -115,11 +107,11 @@ exports[`BulkActions renders 1`] = `
   width: 1px;
 }
 
-.c9 {
+.c8 {
   height: 100%;
 }
 
-.c7 {
+.c6 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -133,7 +125,7 @@ exports[`BulkActions renders 1`] = `
   background: #fcecea;
 }
 
-.c7 .c0 {
+.c6 .c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -144,64 +136,64 @@ exports[`BulkActions renders 1`] = `
   align-items: center;
 }
 
-.c7 .c4 {
+.c6 .c3 {
   color: #ffffff;
 }
 
-.c7[aria-disabled='true'] {
+.c6[aria-disabled='true'] {
   border: 1px solid #dcdce4;
   background: #eaeaef;
 }
 
-.c7[aria-disabled='true'] .c4 {
+.c6[aria-disabled='true'] .c3 {
   color: #666687;
 }
 
-.c7[aria-disabled='true'] svg > g,.c7[aria-disabled='true'] svg path {
+.c6[aria-disabled='true'] svg > g,.c6[aria-disabled='true'] svg path {
   fill: #666687;
 }
 
-.c7[aria-disabled='true']:active {
+.c6[aria-disabled='true']:active {
   border: 1px solid #dcdce4;
   background: #eaeaef;
 }
 
-.c7[aria-disabled='true']:active .c4 {
+.c6[aria-disabled='true']:active .c3 {
   color: #666687;
 }
 
-.c7[aria-disabled='true']:active svg > g,.c7[aria-disabled='true']:active svg path {
+.c6[aria-disabled='true']:active svg > g,.c6[aria-disabled='true']:active svg path {
   fill: #666687;
 }
 
-.c7:hover {
+.c6:hover {
   background-color: #ffffff;
 }
 
-.c7:active {
+.c6:active {
   background-color: #ffffff;
   border: 1px solid #d02b20;
 }
 
-.c7:active .c4 {
+.c6:active .c3 {
   color: #d02b20;
 }
 
-.c7:active svg > g,
-.c7:active svg path {
+.c6:active svg > g,
+.c6:active svg path {
   fill: #d02b20;
 }
 
-.c7 .c4 {
+.c6 .c3 {
   color: #b72b1a;
 }
 
-.c7 svg > g,
-.c7 svg path {
+.c6 svg > g,
+.c6 svg path {
   fill: #b72b1a;
 }
 
-.c11 {
+.c10 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -215,7 +207,7 @@ exports[`BulkActions renders 1`] = `
   background: #f0f0ff;
 }
 
-.c11 .c0 {
+.c10 .c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -226,80 +218,80 @@ exports[`BulkActions renders 1`] = `
   align-items: center;
 }
 
-.c11 .c4 {
+.c10 .c3 {
   color: #ffffff;
 }
 
-.c11[aria-disabled='true'] {
+.c10[aria-disabled='true'] {
   border: 1px solid #dcdce4;
   background: #eaeaef;
 }
 
-.c11[aria-disabled='true'] .c4 {
+.c10[aria-disabled='true'] .c3 {
   color: #666687;
 }
 
-.c11[aria-disabled='true'] svg > g,.c11[aria-disabled='true'] svg path {
+.c10[aria-disabled='true'] svg > g,.c10[aria-disabled='true'] svg path {
   fill: #666687;
 }
 
-.c11[aria-disabled='true']:active {
+.c10[aria-disabled='true']:active {
   border: 1px solid #dcdce4;
   background: #eaeaef;
 }
 
-.c11[aria-disabled='true']:active .c4 {
+.c10[aria-disabled='true']:active .c3 {
   color: #666687;
 }
 
-.c11[aria-disabled='true']:active svg > g,.c11[aria-disabled='true']:active svg path {
+.c10[aria-disabled='true']:active svg > g,.c10[aria-disabled='true']:active svg path {
   fill: #666687;
 }
 
-.c11:hover {
+.c10:hover {
   background-color: #ffffff;
 }
 
-.c11:active {
+.c10:active {
   background-color: #ffffff;
   border: 1px solid #4945ff;
 }
 
-.c11:active .c4 {
+.c10:active .c3 {
   color: #4945ff;
 }
 
-.c11:active svg > g,
-.c11:active svg path {
+.c10:active svg > g,
+.c10:active svg path {
   fill: #4945ff;
 }
 
-.c11 .c4 {
+.c10 .c3 {
   color: #271fe0;
 }
 
-.c11 svg > g,
-.c11 svg path {
+.c10 svg > g,
+.c10 svg path {
   fill: #271fe0;
 }
 
 <div>
   <div
-    class="c0 c1 c2 c3"
+    class="c0 c1 c2"
   >
     <span
-      class="c4 c5"
+      class="c3 c4"
     >
       0 folders - 0 assets selected
     </span>
     <button
       aria-disabled="false"
-      class="c6 c7"
+      class="c5 c6"
       type="button"
     >
       <div
         aria-hidden="true"
-        class="c0 c8 c9"
+        class="c0 c7 c8"
       >
         <svg
           fill="none"
@@ -315,19 +307,19 @@ exports[`BulkActions renders 1`] = `
         </svg>
       </div>
       <span
-        class="c4 c10"
+        class="c3 c9"
       >
         Delete
       </span>
     </button>
     <button
       aria-disabled="false"
-      class="c6 c11"
+      class="c5 c10"
       type="button"
     >
       <div
         aria-hidden="true"
-        class="c0 c8 c9"
+        class="c0 c7 c8"
       >
         <svg
           fill="none"
@@ -343,14 +335,14 @@ exports[`BulkActions renders 1`] = `
         </svg>
       </div>
       <span
-        class="c4 c10"
+        class="c3 c9"
       >
         Move
       </span>
     </button>
   </div>
   <div
-    class="c12"
+    class="c11"
   >
     <p
       aria-live="polite"

--- a/packages/core/upload/admin/src/pages/App/MediaLibrary/components/tests/__snapshots__/Header.test.js.snap
+++ b/packages/core/upload/admin/src/pages/App/MediaLibrary/components/tests/__snapshots__/Header.test.js.snap
@@ -69,13 +69,19 @@ exports[`Header renders 1`] = `
   flex-direction: row;
 }
 
-.c11 > * {
-  margin-left: 0;
-  margin-right: 0;
-}
-
-.c11 > * + * {
-  margin-left: 8px;
+.c11 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 8px;
 }
 
 .c12 {
@@ -432,7 +438,7 @@ exports[`Header renders 1`] = `
           </h1>
         </div>
         <div
-          class="c0 c9 c11"
+          class="c0 c11"
         >
           <button
             aria-disabled="false"

--- a/packages/core/upload/admin/src/pages/App/components/BulkActions.js
+++ b/packages/core/upload/admin/src/pages/App/components/BulkActions.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
-import { Stack, Typography } from '@strapi/design-system';
+import { Flex, Typography } from '@strapi/design-system';
 
 import { AssetDefinition, FolderDefinition } from '../../../constants';
 import getTrad from '../../../utils/getTrad';
@@ -12,7 +12,7 @@ export const BulkActions = ({ selected, onSuccess, currentFolder }) => {
   const { formatMessage } = useIntl();
 
   return (
-    <Stack horizontal spacing={2} paddingBottom={5}>
+    <Flex gap={2} paddingBottom={5}>
       <Typography variant="epsilon" textColor="neutral600">
         {formatMessage(
           {
@@ -29,7 +29,7 @@ export const BulkActions = ({ selected, onSuccess, currentFolder }) => {
 
       <BulkDeleteButton selected={selected} onSuccess={onSuccess} />
       <BulkMoveButton currentFolder={currentFolder} selected={selected} onSuccess={onSuccess} />
-    </Stack>
+    </Flex>
   );
 };
 

--- a/packages/core/upload/admin/src/pages/App/components/Header.js
+++ b/packages/core/upload/admin/src/pages/App/components/Header.js
@@ -4,7 +4,7 @@ import { useIntl } from 'react-intl';
 import { stringify } from 'qs';
 import { useLocation } from 'react-router-dom';
 import { useQueryParams } from '@strapi/helper-plugin';
-import { HeaderLayout, Button, Stack, Link } from '@strapi/design-system';
+import { HeaderLayout, Button, Flex, Link } from '@strapi/design-system';
 import { ArrowLeft, Plus } from '@strapi/icons';
 import { getTrad } from '../../../utils';
 import { FolderDefinition, BreadcrumbsDefinition } from '../../../constants';
@@ -60,7 +60,7 @@ export const Header = ({
       }
       primaryAction={
         canCreate && (
-          <Stack horizontal spacing={2}>
+          <Flex gap={2}>
             <Button startIcon={<Plus />} variant="secondary" onClick={onToggleEditFolderDialog}>
               {formatMessage({
                 id: getTrad('header.actions.add-folder'),
@@ -74,7 +74,7 @@ export const Header = ({
                 defaultMessage: 'Add new assets',
               })}
             </Button>
-          </Stack>
+          </Flex>
         )
       }
     />

--- a/packages/core/upload/admin/src/pages/SettingsPage/index.js
+++ b/packages/core/upload/admin/src/pages/SettingsPage/index.js
@@ -17,7 +17,6 @@ import {
   Typography,
   Button,
   Main,
-  Stack,
   Grid,
   GridItem,
   ContentLayout,
@@ -158,9 +157,9 @@ export const SettingsPage = () => {
             <LoadingIndicatorPage />
           ) : (
             <Layout>
-              <Stack spacing={12}>
+              <Flex direction="column" alignItems="stretch" gap={12}>
                 <Box background="neutral0" padding={6} shadow="filterShadow" hasRadius>
-                  <Stack spacing={4}>
+                  <Flex direction="column" alignItems="stretch" gap={4}>
                     <Flex>
                       <Typography variant="delta" as="h2">
                         {formatMessage({
@@ -261,9 +260,9 @@ export const SettingsPage = () => {
                         />
                       </GridItem>
                     </Grid>
-                  </Stack>
+                  </Flex>
                 </Box>
-              </Stack>
+              </Flex>
             </Layout>
           )}
         </ContentLayout>

--- a/packages/core/upload/admin/src/pages/SettingsPage/tests/index.test.js
+++ b/packages/core/upload/admin/src/pages/SettingsPage/tests/index.test.js
@@ -69,7 +69,7 @@ describe('Upload | SettingsPage', () => {
         color: #666687;
       }
 
-      .c21 {
+      .c20 {
         font-weight: 500;
         font-size: 1rem;
         line-height: 1.25;
@@ -127,7 +127,7 @@ describe('Upload | SettingsPage', () => {
         padding-bottom: 56px;
       }
 
-      .c19 {
+      .c18 {
         background: #ffffff;
         padding: 24px;
         border-radius: 4px;
@@ -197,6 +197,36 @@ describe('Upload | SettingsPage', () => {
         -webkit-flex-direction: column;
         -ms-flex-direction: column;
         flex-direction: column;
+        gap: 12;
+      }
+
+      .c19 {
+        -webkit-align-items: stretch;
+        -webkit-box-align: stretch;
+        -ms-flex-align: stretch;
+        align-items: stretch;
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+        -webkit-flex-direction: column;
+        -ms-flex-direction: column;
+        flex-direction: column;
+        gap: 16px;
+      }
+
+      .c24 {
+        -webkit-align-items: stretch;
+        -webkit-box-align: stretch;
+        -ms-flex-align: stretch;
+        align-items: stretch;
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+        -webkit-flex-direction: column;
+        -ms-flex-direction: column;
+        flex-direction: column;
       }
 
       .c31 {
@@ -215,20 +245,6 @@ describe('Upload | SettingsPage', () => {
         -webkit-justify-content: center;
         -ms-flex-pack: center;
         justify-content: center;
-      }
-
-      .c18 > * {
-        margin-top: 0;
-        margin-bottom: 0;
-      }
-
-      .c20 > * {
-        margin-top: 0;
-        margin-bottom: 0;
-      }
-
-      .c20 > * + * {
-        margin-top: 16px;
       }
 
       .c25 > * {
@@ -382,13 +398,13 @@ describe('Upload | SettingsPage', () => {
         fill: #ffffff;
       }
 
-      .c22 {
+      .c21 {
         display: grid;
         grid-template-columns: repeat(12,1fr);
         gap: 24px;
       }
 
-      .c23 {
+      .c22 {
         grid-column: span 6;
         max-width: 100%;
       }
@@ -473,18 +489,18 @@ describe('Upload | SettingsPage', () => {
         width: 100%;
       }
 
-      .c24 {
+      .c23 {
         max-width: 320px;
       }
 
       @media (max-width:68.75rem) {
-        .c23 {
+        .c22 {
           grid-column: span 12;
         }
       }
 
       @media (max-width:34.375rem) {
-        .c23 {
+        .c22 {
           grid-column: span;
         }
       }
@@ -564,37 +580,37 @@ describe('Upload | SettingsPage', () => {
                   class="c1 c15 c16"
                 >
                   <div
-                    class="c1 c17 c18"
+                    class="c1 c17"
                   >
                     <div
-                      class="c1 c19"
+                      class="c1 c18"
                     >
                       <div
-                        class="c1 c17 c20"
+                        class="c1 c19"
                       >
                         <div
                           class="c1 c4"
                         >
                           <h2
-                            class="c5 c21"
+                            class="c5 c20"
                           >
                             Asset management
                           </h2>
                         </div>
                         <div
-                          class="c1 c22"
+                          class="c1 c21"
                         >
                           <div
-                            class="c23"
+                            class="c22"
                           >
                             <div
                               class="c1 "
                             >
                               <div
-                                class="c24"
+                                class="c23"
                               >
                                 <div
-                                  class="c1 c17 c25"
+                                  class="c1 c24 c25"
                                 >
                                   <div
                                     class="c1 c4"
@@ -667,16 +683,16 @@ describe('Upload | SettingsPage', () => {
                             </div>
                           </div>
                           <div
-                            class="c23"
+                            class="c22"
                           >
                             <div
                               class="c1 "
                             >
                               <div
-                                class="c24"
+                                class="c23"
                               >
                                 <div
-                                  class="c1 c17 c25"
+                                  class="c1 c24 c25"
                                 >
                                   <div
                                     class="c1 c4"
@@ -748,16 +764,16 @@ describe('Upload | SettingsPage', () => {
                             </div>
                           </div>
                           <div
-                            class="c23"
+                            class="c22"
                           >
                             <div
                               class="c1 "
                             >
                               <div
-                                class="c24"
+                                class="c23"
                               >
                                 <div
-                                  class="c1 c17 c25"
+                                  class="c1 c24 c25"
                                 >
                                   <div
                                     class="c1 c4"

--- a/packages/plugins/color-picker/admin/src/components/ColorPicker/ColorPickerInput/index.js
+++ b/packages/plugins/color-picker/admin/src/components/ColorPicker/ColorPickerInput/index.js
@@ -2,7 +2,6 @@ import React, { useState, useRef } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import {
-  Stack,
   Typography,
   Flex,
   Box,
@@ -109,7 +108,7 @@ const ColorPickerInput = ({
       hint={description && formatMessage(description)}
       required={required}
     >
-      <Stack spacing={1}>
+      <Flex direction="column" alignItems="stretch" gap={1}>
         <FieldLabel action={labelAction}>{formatMessage(intlLabel)}</FieldLabel>
         <ColorPickerToggle
           ref={colorPickerButtonRef}
@@ -176,7 +175,7 @@ const ColorPickerInput = ({
         )}
         <FieldHint />
         <FieldError />
-      </Stack>
+      </Flex>
     </Field>
   );
 };

--- a/packages/plugins/color-picker/admin/src/components/tests/__snapshots__/color-picker-input.test.js.snap
+++ b/packages/plugins/color-picker/admin/src/components/tests/__snapshots__/color-picker-input.test.js.snap
@@ -1,14 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<ColorPickerInput /> renders and matches the snapshot 1`] = `
-.c2 {
+.c1 {
   font-size: 0.75rem;
   line-height: 1.33;
   font-weight: 600;
   color: #32324d;
 }
 
-.c7 {
+.c6 {
   font-size: 0.875rem;
   line-height: 1.43;
   color: #666687;
@@ -26,9 +26,10 @@ exports[`<ColorPickerInput /> renders and matches the snapshot 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  gap: 4px;
 }
 
-.c3 {
+.c2 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -42,16 +43,7 @@ exports[`<ColorPickerInput /> renders and matches the snapshot 1`] = `
   flex-direction: row;
 }
 
-.c1 > * {
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
-.c1 > * + * {
-  margin-top: 4px;
-}
-
-.c4 {
+.c3 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -65,21 +57,21 @@ exports[`<ColorPickerInput /> renders and matches the snapshot 1`] = `
   outline: none;
 }
 
-.c4 svg {
+.c3 svg {
   height: 12px;
   width: 12px;
 }
 
-.c4 svg > g,
-.c4 svg path {
+.c3 svg > g,
+.c3 svg path {
   fill: #ffffff;
 }
 
-.c4[aria-disabled='true'] {
+.c3[aria-disabled='true'] {
   pointer-events: none;
 }
 
-.c4:after {
+.c3:after {
   -webkit-transition-property: all;
   transition-property: all;
   -webkit-transition-duration: 0.2s;
@@ -94,11 +86,11 @@ exports[`<ColorPickerInput /> renders and matches the snapshot 1`] = `
   border: 2px solid transparent;
 }
 
-.c4:focus-visible {
+.c3:focus-visible {
   outline: none;
 }
 
-.c4:focus-visible:after {
+.c3:focus-visible:after {
   border-radius: 8px;
   content: '';
   position: absolute;
@@ -109,7 +101,7 @@ exports[`<ColorPickerInput /> renders and matches the snapshot 1`] = `
   border: 2px solid #4945ff;
 }
 
-.c8 {
+.c7 {
   border: 0;
   -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
@@ -121,7 +113,7 @@ exports[`<ColorPickerInput /> renders and matches the snapshot 1`] = `
   width: 1px;
 }
 
-.c6 {
+.c5 {
   border-radius: 50%;
   width: 20px;
   height: 20px;
@@ -130,7 +122,7 @@ exports[`<ColorPickerInput /> renders and matches the snapshot 1`] = `
   border: 1px solid rgba(0,0,0,0.1);
 }
 
-.c5 {
+.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -145,12 +137,12 @@ exports[`<ColorPickerInput /> renders and matches the snapshot 1`] = `
   align-items: center;
 }
 
-.c5 svg {
+.c4 svg {
   width: 8px;
   height: 8px;
 }
 
-.c5 svg > path {
+.c4 svg > path {
   fill: #8e8ea9;
   justify-self: flex-end;
 }
@@ -158,14 +150,14 @@ exports[`<ColorPickerInput /> renders and matches the snapshot 1`] = `
 <div>
   <div>
     <div
-      class="c0 c1"
+      class="c0"
     >
       <label
-        class="c2"
+        class="c1"
         for="color"
       >
         <div
-          class="c3"
+          class="c2"
         >
           color-picker
         </div>
@@ -176,18 +168,18 @@ exports[`<ColorPickerInput /> renders and matches the snapshot 1`] = `
         aria-expanded="false"
         aria-haspopup="dialog"
         aria-label="Color picker toggle"
-        class="c4 c5"
+        class="c3 c4"
         type="button"
       >
         <div
-          class="c3"
+          class="c2"
         >
           <div
-            class="c6"
+            class="c5"
             color="#000000"
           />
           <span
-            class="c7"
+            class="c6"
             style="text-transform: uppercase;"
           >
             #000000
@@ -212,7 +204,7 @@ exports[`<ColorPickerInput /> renders and matches the snapshot 1`] = `
     </div>
   </div>
   <div
-    class="c8"
+    class="c7"
   >
     <p
       aria-live="polite"

--- a/packages/plugins/documentation/admin/src/pages/SettingsPage/index.js
+++ b/packages/plugins/documentation/admin/src/pages/SettingsPage/index.js
@@ -15,7 +15,7 @@ import {
   Main,
   Button,
   Box,
-  Stack,
+  Flex,
   Typography,
   ToggleInput,
   TextInput,
@@ -91,7 +91,7 @@ const SettingsPage = () => {
                     paddingLeft={7}
                     paddingRight={7}
                   >
-                    <Stack spacing={4}>
+                    <Flex direction="column" alignItems="stretch" gap={4}>
                       <Typography variant="delta" as="h2">
                         {formatMessage({
                           id: 'global.settings',
@@ -168,7 +168,7 @@ const SettingsPage = () => {
                           </GridItem>
                         )}
                       </Grid>
-                    </Stack>
+                    </Flex>
                   </Box>
                 </ContentLayout>
               </Form>

--- a/packages/plugins/i18n/admin/src/components/CMEditViewInjectedComponents/CMEditViewCopyLocale/index.js
+++ b/packages/plugins/i18n/admin/src/components/CMEditViewInjectedComponents/CMEditViewCopyLocale/index.js
@@ -13,7 +13,6 @@ import {
   Box,
   Typography,
   Flex,
-  Stack,
 } from '@strapi/design-system';
 import { ExclamationMarkCircle, Duplicate } from '@strapi/icons';
 import { useCMEditViewDataManager, useNotification, useFetchClient } from '@strapi/helper-plugin';
@@ -131,7 +130,7 @@ const Content = ({ appLocales, currentLocale, localizations, readPermissions }) 
       {isOpen && (
         <Dialog onClose={handleToggle} title="Confirmation" isOpen={isOpen}>
           <DialogBody icon={<ExclamationMarkCircle />}>
-            <Stack spacing={2}>
+            <Flex direction="column" alignItems="stretch" gap={2}>
               <Flex justifyContent="center">
                 <CenteredTypography id="confirm-description">
                   {formatMessage({
@@ -158,7 +157,7 @@ const Content = ({ appLocales, currentLocale, localizations, readPermissions }) 
                   })}
                 </Select>
               </Box>
-            </Stack>
+            </Flex>
           </DialogBody>
           <DialogFooter
             startAction={

--- a/packages/plugins/i18n/admin/src/components/CMEditViewInjectedComponents/CMEditViewLocalePicker/index.js
+++ b/packages/plugins/i18n/admin/src/components/CMEditViewInjectedComponents/CMEditViewLocalePicker/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import get from 'lodash/get';
-import { Box, Divider, Select, Option, Typography, Stack } from '@strapi/design-system';
+import { Box, Divider, Select, Option, Typography, Flex } from '@strapi/design-system';
 import { useIntl } from 'react-intl';
 import { useHistory } from 'react-router-dom';
 import { stringify } from 'qs';
@@ -101,7 +101,7 @@ const CMEditViewLocalePicker = ({
       <Box paddingTop={2} paddingBottom={6}>
         <Divider />
       </Box>
-      <Stack spacing={2}>
+      <Flex direction="column" alignItems="stretch" gaps={2}>
         <Box>
           <Select
             label={formatMessage({
@@ -138,7 +138,7 @@ const CMEditViewLocalePicker = ({
             readPermissions={readPermissions}
           />
         </Box>
-      </Stack>
+      </Flex>
     </Box>
   );
 };

--- a/packages/plugins/i18n/admin/src/components/CheckboxConfirmation/index.js
+++ b/packages/plugins/i18n/admin/src/components/CheckboxConfirmation/index.js
@@ -9,7 +9,6 @@ import {
   DialogFooter,
   Typography,
   Flex,
-  Stack,
   Button,
 } from '@strapi/design-system';
 import { ExclamationMarkCircle } from '@strapi/icons';
@@ -71,7 +70,7 @@ const CheckboxConfirmation = ({ description, isCreating, intlLabel, name, onChan
       {isOpen && (
         <Dialog onClose={handleToggle} title="Confirmation" isOpen={isOpen}>
           <DialogBody icon={<ExclamationMarkCircle />}>
-            <Stack spacing={2}>
+            <Flex direction="column" alignItems="stretch" gap={2}>
               <Flex justifyContent="center">
                 <TextAlignTypography id="confirm-description">
                   {formatMessage({
@@ -89,7 +88,7 @@ const CheckboxConfirmation = ({ description, isCreating, intlLabel, name, onChan
                   })}
                 </Typography>
               </Flex>
-            </Stack>
+            </Flex>
           </DialogBody>
           <DialogFooter
             startAction={

--- a/packages/plugins/i18n/admin/src/components/LocaleList/LocaleTable.js
+++ b/packages/plugins/i18n/admin/src/components/LocaleList/LocaleTable.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import {
   Typography,
   IconButton,
-  Stack,
+  Flex,
   Table,
   Thead,
   Tr,
@@ -68,12 +68,7 @@ const LocaleTable = ({ locales, onDeleteLocale, onEditLocale }) => {
               </Typography>
             </Td>
             <Td>
-              <Stack
-                horizontal
-                spacing={1}
-                style={{ justifyContent: 'flex-end' }}
-                {...stopPropagation}
-              >
+              <Flex gap={1} justifyContent="flex-end" {...stopPropagation}>
                 {onEditLocale && (
                   <IconButton
                     onClick={() => onEditLocale(locale)}
@@ -90,7 +85,7 @@ const LocaleTable = ({ locales, onDeleteLocale, onEditLocale }) => {
                     noBorder
                   />
                 )}
-              </Stack>
+              </Flex>
             </Td>
           </Tr>
         ))}

--- a/packages/plugins/users-permissions/admin/src/components/BoundRoute/index.js
+++ b/packages/plugins/users-permissions/admin/src/components/BoundRoute/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-import { Stack, Box, Typography } from '@strapi/design-system';
+import { Flex, Box, Typography } from '@strapi/design-system';
 import map from 'lodash/map';
 import tail from 'lodash/tail';
 import { useIntl } from 'react-intl';
@@ -21,7 +21,7 @@ function BoundRoute({ route }) {
   const colors = getMethodColor(route.method);
 
   return (
-    <Stack spacing={2}>
+    <Flex direction="column" alignItems="stretch" gap={2}>
       <Typography variant="delta" as="h3">
         {formatMessage({
           id: 'users-permissions.BoundRoute.title',
@@ -33,7 +33,7 @@ function BoundRoute({ route }) {
           .{action}
         </Typography>
       </Typography>
-      <Stack horizontal hasRadius background="neutral0" borderColor="neutral200" spacing={0}>
+      <Flex hasRadius background="neutral0" borderColor="neutral200" gap={0}>
         <MethodBox background={colors.background} borderColor={colors.border} padding={2}>
           <Typography fontWeight="bold" textColor={colors.text}>
             {method}
@@ -46,8 +46,8 @@ function BoundRoute({ route }) {
             </Typography>
           ))}
         </Box>
-      </Stack>
-    </Stack>
+      </Flex>
+    </Flex>
   );
 }
 

--- a/packages/plugins/users-permissions/admin/src/components/FormModal/index.js
+++ b/packages/plugins/users-permissions/admin/src/components/FormModal/index.js
@@ -8,7 +8,7 @@ import React from 'react';
 import { useIntl } from 'react-intl';
 import {
   Button,
-  Stack,
+  Flex,
   Breadcrumbs,
   Crumb,
   Grid,
@@ -58,7 +58,7 @@ const FormModal = ({
           return (
             <Form>
               <ModalBody>
-                <Stack spacing={1}>
+                <Flex direction="column" alignItems="stretch" gap={1}>
                   <Grid gap={5}>
                     {layout.form.map((row) => {
                       return row.map((input) => {
@@ -76,7 +76,7 @@ const FormModal = ({
                       });
                     })}
                   </Grid>
-                </Stack>
+                </Flex>
               </ModalBody>
               <ModalFooter
                 startActions={

--- a/packages/plugins/users-permissions/admin/src/components/Permissions/index.js
+++ b/packages/plugins/users-permissions/admin/src/components/Permissions/index.js
@@ -1,5 +1,5 @@
 import React, { useReducer } from 'react';
-import { Accordion, AccordionToggle, AccordionContent, Box, Stack } from '@strapi/design-system';
+import { Accordion, AccordionToggle, AccordionContent, Box, Flex } from '@strapi/design-system';
 import { useIntl } from 'react-intl';
 import { useUsersPermissions } from '../../contexts/UsersPermissionsContext';
 import formatPluginName from '../../utils/formatPluginName';
@@ -21,7 +21,7 @@ const Permissions = () => {
     });
 
   return (
-    <Stack spacing={1}>
+    <Flex direction="column" alignItems="stretch" gap={1}>
       {collapses.map((collapse, index) => (
         <Accordion
           expanded={collapse.isOpen}
@@ -47,7 +47,7 @@ const Permissions = () => {
           </AccordionContent>
         </Accordion>
       ))}
-    </Stack>
+    </Flex>
   );
 };
 

--- a/packages/plugins/users-permissions/admin/src/components/Policies/index.js
+++ b/packages/plugins/users-permissions/admin/src/components/Policies/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useIntl } from 'react-intl';
-import { Typography, Stack, GridItem } from '@strapi/design-system';
+import { Typography, Flex, GridItem } from '@strapi/design-system';
 import { get, isEmpty, without } from 'lodash';
 import { useUsersPermissions } from '../../contexts/UsersPermissionsContext';
 import BoundRoute from '../BoundRoute';
@@ -28,14 +28,14 @@ const Policies = () => {
       style={{ minHeight: '100%' }}
     >
       {selectedAction ? (
-        <Stack spacing={2}>
+        <Flex direction="column" alignItems="stretch" gap={2}>
           {displayedRoutes.map((route, key) => (
             // eslint-disable-next-line react/no-array-index-key
             <BoundRoute key={key} route={route} />
           ))}
-        </Stack>
+        </Flex>
       ) : (
-        <Stack spacing={2}>
+        <Flex direction="column" alignItems="stretch" gap={2}>
           <Typography variant="delta" as="h3">
             {formatMessage({
               id: 'users-permissions.Policies.header.title',
@@ -49,7 +49,7 @@ const Policies = () => {
                 "Select the application's actions or the plugin's actions and click on the cog icon to display the bound route",
             })}
           </Typography>
-        </Stack>
+        </Flex>
       )}
     </GridItem>
   );

--- a/packages/plugins/users-permissions/admin/src/components/UsersPermissions/index.js
+++ b/packages/plugins/users-permissions/admin/src/components/UsersPermissions/index.js
@@ -1,6 +1,6 @@
 import React, { memo, useReducer, forwardRef, useImperativeHandle } from 'react';
 import PropTypes from 'prop-types';
-import { Typography, Stack, Grid, GridItem } from '@strapi/design-system';
+import { Typography, Flex, Grid, GridItem } from '@strapi/design-system';
 import { useIntl } from 'react-intl';
 import getTrad from '../../utils/getTrad';
 import Policies from '../Policies';
@@ -60,8 +60,8 @@ const UsersPermissions = forwardRef(({ permissions, routes }, ref) => {
     <UsersPermissionsProvider value={providerValue}>
       <Grid gap={0} shadow="filterShadow" hasRadius background="neutral0">
         <GridItem col={7} paddingTop={6} paddingBottom={6} paddingLeft={7} paddingRight={7}>
-          <Stack spacing={6}>
-            <Stack spacing={2}>
+          <Flex direction="column" alignItems="stretch" gap={6}>
+            <Flex direction="column" alignItems="stretch" gap={2}>
               <Typography variant="delta" as="h2">
                 {formatMessage({
                   id: getTrad('Plugins.header.title'),
@@ -74,9 +74,9 @@ const UsersPermissions = forwardRef(({ permissions, routes }, ref) => {
                   defaultMessage: 'Only actions bound by a route are listed below.',
                 })}
               </Typography>
-            </Stack>
+            </Flex>
             <Permissions />
-          </Stack>
+          </Flex>
         </GridItem>
         <Policies />
       </Grid>

--- a/packages/plugins/users-permissions/admin/src/pages/AdvancedSettings/index.js
+++ b/packages/plugins/users-permissions/admin/src/pages/AdvancedSettings/index.js
@@ -20,7 +20,7 @@ import {
   ContentLayout,
   Button,
   Box,
-  Stack,
+  Flex,
   Select,
   Option,
   Typography,
@@ -173,7 +173,7 @@ const AdvancedSettingsPage = () => {
                   paddingLeft={7}
                   paddingRight={7}
                 >
-                  <Stack spacing={4}>
+                  <Flex direction="column" alignItems="stretch" gap={4}>
                     <Typography variant="delta" as="h2">
                       {formatMessage({
                         id: 'global.settings',
@@ -229,7 +229,7 @@ const AdvancedSettingsPage = () => {
                         );
                       })}
                     </Grid>
-                  </Stack>
+                  </Flex>
                 </Box>
               </ContentLayout>
             </Form>

--- a/packages/plugins/users-permissions/admin/src/pages/AdvancedSettings/tests/index.test.js
+++ b/packages/plugins/users-permissions/admin/src/pages/AdvancedSettings/tests/index.test.js
@@ -76,7 +76,7 @@ describe('ADMIN | Pages | Settings | Advanced Settings', () => {
         color: #32324d;
       }
 
-      .c16 {
+      .c15 {
         font-weight: 500;
         font-size: 1rem;
         line-height: 1.25;
@@ -214,6 +214,21 @@ describe('ADMIN | Pages | Settings | Advanced Settings', () => {
         -webkit-flex-direction: column;
         -ms-flex-direction: column;
         flex-direction: column;
+        gap: 16px;
+      }
+
+      .c18 {
+        -webkit-align-items: stretch;
+        -webkit-box-align: stretch;
+        -ms-flex-align: stretch;
+        align-items: stretch;
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+        -webkit-flex-direction: column;
+        -ms-flex-direction: column;
+        flex-direction: column;
       }
 
       .c36 {
@@ -232,15 +247,6 @@ describe('ADMIN | Pages | Settings | Advanced Settings', () => {
         -webkit-justify-content: center;
         -ms-flex-pack: center;
         justify-content: center;
-      }
-
-      .c15 > * {
-        margin-top: 0;
-        margin-bottom: 0;
-      }
-
-      .c15 > * + * {
-        margin-top: 16px;
       }
 
       .c19 > * {
@@ -592,13 +598,13 @@ describe('ADMIN | Pages | Settings | Advanced Settings', () => {
         width: 100%;
       }
 
-      .c17 {
+      .c16 {
         display: grid;
         grid-template-columns: repeat(12,1fr);
         gap: 24px;
       }
 
-      .c18 {
+      .c17 {
         grid-column: span 6;
         max-width: 100%;
       }
@@ -689,13 +695,13 @@ describe('ADMIN | Pages | Settings | Advanced Settings', () => {
       }
 
       @media (max-width:68.75rem) {
-        .c18 {
+        .c17 {
           grid-column: span 12;
         }
       }
 
       @media (max-width:34.375rem) {
-        .c18 {
+        .c17 {
           grid-column: span;
         }
       }
@@ -792,25 +798,25 @@ describe('ADMIN | Pages | Settings | Advanced Settings', () => {
               class="c1 c13"
             >
               <div
-                class="c1 c14 c15"
+                class="c1 c14"
               >
                 <h2
-                  class="c5 c16"
+                  class="c5 c15"
                 >
                   Settings
                 </h2>
                 <div
-                  class="c1 c17"
+                  class="c1 c16"
                 >
                   <div
-                    class="c18"
+                    class="c17"
                   >
                     <div
                       class="c1 "
                     >
                       <div>
                         <div
-                          class="c1 c14 c19"
+                          class="c1 c18 c19"
                         >
                           <label
                             class="c5 c11"
@@ -900,7 +906,7 @@ describe('ADMIN | Pages | Settings | Advanced Settings', () => {
                         class="c30"
                       >
                         <div
-                          class="c1 c14 c19"
+                          class="c1 c18 c19"
                         >
                           <div
                             class="c1 c4"
@@ -979,7 +985,7 @@ describe('ADMIN | Pages | Settings | Advanced Settings', () => {
                         class="c30"
                       >
                         <div
-                          class="c1 c14 c19"
+                          class="c1 c18 c19"
                         >
                           <div
                             class="c1 c4"
@@ -1057,7 +1063,7 @@ describe('ADMIN | Pages | Settings | Advanced Settings', () => {
                       <div>
                         <div>
                           <div
-                            class="c1 c14 c19"
+                            class="c1 c18 c19"
                           >
                             <label
                               class="c5 c11"
@@ -1106,7 +1112,7 @@ describe('ADMIN | Pages | Settings | Advanced Settings', () => {
                         class="c30"
                       >
                         <div
-                          class="c1 c14 c19"
+                          class="c1 c18 c19"
                         >
                           <div
                             class="c1 c4"
@@ -1184,7 +1190,7 @@ describe('ADMIN | Pages | Settings | Advanced Settings', () => {
                       <div>
                         <div>
                           <div
-                            class="c1 c14 c19"
+                            class="c1 c18 c19"
                           >
                             <label
                               class="c5 c11"

--- a/packages/plugins/users-permissions/admin/src/pages/Roles/CreatePage/index.js
+++ b/packages/plugins/users-permissions/admin/src/pages/Roles/CreatePage/index.js
@@ -5,7 +5,7 @@ import {
   HeaderLayout,
   Main,
   Button,
-  Stack,
+  Flex,
   Box,
   TextInput,
   Textarea,
@@ -107,7 +107,7 @@ const EditPage = () => {
               })}
             />
             <ContentLayout>
-              <Stack spacing={7}>
+              <Flex direction="column" alignItems="stretch" gap={7}>
                 <Box
                   background="neutral0"
                   hasRadius
@@ -117,7 +117,7 @@ const EditPage = () => {
                   paddingLeft={7}
                   paddingRight={7}
                 >
-                  <Stack spacing={4}>
+                  <Flex direction="column" alignItems="stretch" gap={4}>
                     <Typography variant="delta" as="h2">
                       {formatMessage({
                         id: getTrad('EditPage.form.roles'),
@@ -161,7 +161,7 @@ const EditPage = () => {
                         />
                       </GridItem>
                     </Grid>
-                  </Stack>
+                  </Flex>
                 </Box>
                 {!isLoadingPlugins && (
                   <UsersPermissions
@@ -170,7 +170,7 @@ const EditPage = () => {
                     routes={routes}
                   />
                 )}
-              </Stack>
+              </Flex>
             </ContentLayout>
           </Form>
         )}

--- a/packages/plugins/users-permissions/admin/src/pages/Roles/CreatePage/tests/index.test.js
+++ b/packages/plugins/users-permissions/admin/src/pages/Roles/CreatePage/tests/index.test.js
@@ -76,7 +76,7 @@ describe('Admin | containers | RoleCreatePage', () => {
         color: #666687;
       }
 
-      .c19 {
+      .c18 {
         font-weight: 500;
         font-size: 1rem;
         line-height: 1.25;
@@ -96,13 +96,13 @@ describe('Admin | containers | RoleCreatePage', () => {
         color: #666687;
       }
 
-      .c44 {
+      .c45 {
         font-size: 0.75rem;
         line-height: 1.33;
         color: #4945ff;
       }
 
-      .c45 {
+      .c46 {
         font-weight: 500;
         font-size: 1rem;
         line-height: 1.25;
@@ -126,7 +126,7 @@ describe('Admin | containers | RoleCreatePage', () => {
         padding-left: 56px;
       }
 
-      .c17 {
+      .c16 {
         background: #ffffff;
         padding-top: 24px;
         padding-right: 32px;
@@ -153,11 +153,11 @@ describe('Admin | containers | RoleCreatePage', () => {
         padding-left: 32px;
       }
 
-      .c35 {
+      .c36 {
         border-radius: 4px;
       }
 
-      .c37 {
+      .c38 {
         background: #f6f6f9;
         padding-top: 24px;
         padding-right: 24px;
@@ -165,21 +165,21 @@ describe('Admin | containers | RoleCreatePage', () => {
         padding-left: 24px;
       }
 
-      .c39 {
+      .c40 {
         max-width: 100%;
         -webkit-flex: 1;
         -ms-flex: 1;
         flex: 1;
       }
 
-      .c41 {
+      .c42 {
         min-width: 0;
         -webkit-flex: 1;
         -ms-flex: 1;
         flex: 1;
       }
 
-      .c46 {
+      .c47 {
         background: #dcdce4;
         border-radius: 50%;
         width: 2rem;
@@ -190,12 +190,12 @@ describe('Admin | containers | RoleCreatePage', () => {
         cursor: pointer;
       }
 
-      .c48 {
+      .c49 {
         color: #666687;
         width: 0.6875rem;
       }
 
-      .c51 {
+      .c52 {
         background: #eaeaef;
         padding-top: 24px;
         padding-right: 32px;
@@ -247,9 +247,84 @@ describe('Admin | containers | RoleCreatePage', () => {
         -webkit-flex-direction: column;
         -ms-flex-direction: column;
         flex-direction: column;
+        gap: 32px;
       }
 
-      .c47 {
+      .c17 {
+        -webkit-align-items: stretch;
+        -webkit-box-align: stretch;
+        -ms-flex-align: stretch;
+        align-items: stretch;
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+        -webkit-flex-direction: column;
+        -ms-flex-direction: column;
+        flex-direction: column;
+        gap: 16px;
+      }
+
+      .c21 {
+        -webkit-align-items: stretch;
+        -webkit-box-align: stretch;
+        -ms-flex-align: stretch;
+        align-items: stretch;
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+        -webkit-flex-direction: column;
+        -ms-flex-direction: column;
+        flex-direction: column;
+      }
+
+      .c32 {
+        -webkit-align-items: stretch;
+        -webkit-box-align: stretch;
+        -ms-flex-align: stretch;
+        align-items: stretch;
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+        -webkit-flex-direction: column;
+        -ms-flex-direction: column;
+        flex-direction: column;
+        gap: 24px;
+      }
+
+      .c33 {
+        -webkit-align-items: stretch;
+        -webkit-box-align: stretch;
+        -ms-flex-align: stretch;
+        align-items: stretch;
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+        -webkit-flex-direction: column;
+        -ms-flex-direction: column;
+        flex-direction: column;
+        gap: 8px;
+      }
+
+      .c35 {
+        -webkit-align-items: stretch;
+        -webkit-box-align: stretch;
+        -ms-flex-align: stretch;
+        align-items: stretch;
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+        -webkit-flex-direction: column;
+        -ms-flex-direction: column;
+        flex-direction: column;
+        gap: 4px;
+      }
+
+      .c48 {
         -webkit-align-items: center;
         -webkit-box-align: center;
         -ms-flex-align: center;
@@ -270,42 +345,42 @@ describe('Admin | containers | RoleCreatePage', () => {
         justify-content: center;
       }
 
-      .c36 {
+      .c37 {
         border: 1px solid #f6f6f9;
       }
 
-      .c36:hover:not([aria-disabled='true']) {
+      .c37:hover:not([aria-disabled='true']) {
         border: 1px solid #4945ff;
       }
 
-      .c36:hover:not([aria-disabled='true']) .c6 {
+      .c37:hover:not([aria-disabled='true']) .c6 {
         color: #4945ff;
       }
 
-      .c36:hover:not([aria-disabled='true']) > .c3 {
+      .c37:hover:not([aria-disabled='true']) > .c3 {
         background: #f0f0ff;
       }
 
-      .c36:hover:not([aria-disabled='true']) [data-strapi-dropdown='true'] {
+      .c37:hover:not([aria-disabled='true']) [data-strapi-dropdown='true'] {
         background: #d9d8ff;
       }
 
-      .c42 {
+      .c43 {
         background: transparent;
         border: none;
         position: relative;
         outline: none;
       }
 
-      .c42[aria-disabled='true'] {
+      .c43[aria-disabled='true'] {
         pointer-events: none;
       }
 
-      .c42[aria-disabled='true'] svg path {
+      .c43[aria-disabled='true'] svg path {
         fill: #666687;
       }
 
-      .c42 svg {
+      .c43 svg {
         display: -webkit-box;
         display: -webkit-flex;
         display: -ms-flexbox;
@@ -313,11 +388,11 @@ describe('Admin | containers | RoleCreatePage', () => {
         font-size: 0.625rem;
       }
 
-      .c42 svg path {
+      .c43 svg path {
         fill: #4945ff;
       }
 
-      .c42:after {
+      .c43:after {
         -webkit-transition-property: all;
         transition-property: all;
         -webkit-transition-duration: 0.2s;
@@ -332,11 +407,11 @@ describe('Admin | containers | RoleCreatePage', () => {
         border: 2px solid transparent;
       }
 
-      .c42:focus-visible {
+      .c43:focus-visible {
         outline: none;
       }
 
-      .c42:focus-visible:after {
+      .c43:focus-visible:after {
         border-radius: 8px;
         content: '';
         position: absolute;
@@ -345,24 +420,6 @@ describe('Admin | containers | RoleCreatePage', () => {
         left: -5px;
         right: -5px;
         border: 2px solid #4945ff;
-      }
-
-      .c16 > * {
-        margin-top: 0;
-        margin-bottom: 0;
-      }
-
-      .c16 > * + * {
-        margin-top: 32px;
-      }
-
-      .c18 > * {
-        margin-top: 0;
-        margin-bottom: 0;
-      }
-
-      .c18 > * + * {
-        margin-top: 16px;
       }
 
       .c22 > * {
@@ -374,60 +431,42 @@ describe('Admin | containers | RoleCreatePage', () => {
         margin-top: 4px;
       }
 
-      .c32 > * {
-        margin-top: 0;
-        margin-bottom: 0;
-      }
-
-      .c32 > * + * {
-        margin-top: 24px;
-      }
-
-      .c33 > * {
-        margin-top: 0;
-        margin-bottom: 0;
-      }
-
-      .c33 > * + * {
-        margin-top: 8px;
-      }
-
-      .c40 > * {
+      .c41 > * {
         margin-left: 0;
         margin-right: 0;
       }
 
-      .c40 > * + * {
+      .c41 > * + * {
         margin-left: 12px;
       }
 
-      .c49 path {
+      .c50 path {
         fill: #666687;
       }
 
-      .c43 {
+      .c44 {
         text-align: left;
       }
 
-      .c43 > span {
+      .c44 > span {
         max-width: 100%;
       }
 
-      .c43 svg {
+      .c44 svg {
         width: 0.875rem;
         height: 0.875rem;
       }
 
-      .c43 svg path {
+      .c44 svg path {
         fill: #8e8ea9;
       }
 
-      .c38 {
+      .c39 {
         min-height: 5.5rem;
         border-radius: 4px;
       }
 
-      .c38:hover svg path {
+      .c39:hover svg path {
         fill: #4945ff;
       }
 
@@ -622,7 +661,7 @@ describe('Admin | containers | RoleCreatePage', () => {
         box-shadow: #4945ff 0px 0px 0px 2px;
       }
 
-      .c20 {
+      .c19 {
         display: grid;
         grid-template-columns: repeat(12,1fr);
         gap: 16px;
@@ -633,7 +672,7 @@ describe('Admin | containers | RoleCreatePage', () => {
         grid-template-columns: repeat(12,1fr);
       }
 
-      .c21 {
+      .c20 {
         grid-column: span 6;
         max-width: 100%;
       }
@@ -643,7 +682,7 @@ describe('Admin | containers | RoleCreatePage', () => {
         max-width: 100%;
       }
 
-      .c50 {
+      .c51 {
         grid-column: span 5;
         max-width: 100%;
       }
@@ -746,13 +785,13 @@ describe('Admin | containers | RoleCreatePage', () => {
       }
 
       @media (max-width:68.75rem) {
-        .c21 {
+        .c20 {
           grid-column: span;
         }
       }
 
       @media (max-width:34.375rem) {
-        .c21 {
+        .c20 {
           grid-column: span;
         }
       }
@@ -770,13 +809,13 @@ describe('Admin | containers | RoleCreatePage', () => {
       }
 
       @media (max-width:68.75rem) {
-        .c50 {
+        .c51 {
           grid-column: span;
         }
       }
 
       @media (max-width:34.375rem) {
-        .c50 {
+        .c51 {
           grid-column: span;
         }
       }
@@ -850,24 +889,24 @@ describe('Admin | containers | RoleCreatePage', () => {
             class="c1 c14"
           >
             <div
-              class="c1 c3 c15 c16"
+              class="c1 c3 c15"
             >
               <div
-                class="c1 c17"
+                class="c1 c16"
               >
                 <div
-                  class="c1 c3 c15 c18"
+                  class="c1 c3 c17"
                 >
                   <h2
-                    class="c6 c19"
+                    class="c6 c18"
                   >
                     Role details
                   </h2>
                   <div
-                    class="c1 c20"
+                    class="c1 c19"
                   >
                     <div
-                      class="c21"
+                      class="c20"
                     >
                       <div
                         class="c1 "
@@ -875,7 +914,7 @@ describe('Admin | containers | RoleCreatePage', () => {
                         <div>
                           <div>
                             <div
-                              class="c1 c3 c15 c22"
+                              class="c1 c3 c21 c22"
                             >
                               <label
                                 class="c6 c12"
@@ -906,7 +945,7 @@ describe('Admin | containers | RoleCreatePage', () => {
                       </div>
                     </div>
                     <div
-                      class="c21"
+                      class="c20"
                     >
                       <div
                         class="c1 "
@@ -916,7 +955,7 @@ describe('Admin | containers | RoleCreatePage', () => {
                         >
                           <div>
                             <div
-                              class="c1 c3 c15 c22"
+                              class="c1 c3 c21 c22"
                             >
                               <div
                                 class="c1 c3 c5"
@@ -961,13 +1000,13 @@ describe('Admin | containers | RoleCreatePage', () => {
                     class="c1 c31"
                   >
                     <div
-                      class="c1 c3 c15 c32"
+                      class="c1 c3 c32"
                     >
                       <div
-                        class="c1 c3 c15 c33"
+                        class="c1 c3 c33"
                       >
                         <h2
-                          class="c6 c19"
+                          class="c6 c18"
                         >
                           Permissions
                         </h2>
@@ -978,33 +1017,33 @@ describe('Admin | containers | RoleCreatePage', () => {
                         </p>
                       </div>
                       <div
-                        class="c1 c3 c15 c22"
+                        class="c1 c3 c35"
                       >
                         <div
                           aria-disabled="false"
-                          class="c1 c35 c36"
+                          class="c1 c36 c37"
                           data-strapi-expanded="false"
                         >
                           <div
-                            class="c1 c3 c37 c4 c38"
+                            class="c1 c3 c38 c4 c39"
                           >
                             <div
-                              class="c1 c3 c39 c5 c40"
+                              class="c1 c3 c40 c5 c41"
                             >
                               <button
                                 aria-controls="accordion-content-4"
                                 aria-disabled="false"
                                 aria-expanded="false"
                                 aria-labelledby="accordion-label-4"
-                                class="c1 c3 c41 c5 c42 c43"
+                                class="c1 c3 c42 c5 c43 c44"
                                 data-strapi-accordion-toggle="true"
                                 type="button"
                               >
                                 <span
-                                  class="c6 c44"
+                                  class="c6 c45"
                                 >
                                   <span
-                                    class="c6 c45"
+                                    class="c6 c46"
                                     id="accordion-label-4"
                                   >
                                     Address
@@ -1018,15 +1057,15 @@ describe('Admin | containers | RoleCreatePage', () => {
                                 </span>
                               </button>
                               <div
-                                class="c1 c3 c5 c40"
+                                class="c1 c3 c5 c41"
                               >
                                 <span
                                   aria-hidden="true"
-                                  class="c1 c3 c46 c47"
+                                  class="c1 c3 c47 c48"
                                   data-strapi-dropdown="true"
                                 >
                                   <svg
-                                    class="c1 c48 c49"
+                                    class="c1 c49 c50"
                                     fill="none"
                                     height="1em"
                                     viewBox="0 0 14 8"
@@ -1050,17 +1089,17 @@ describe('Admin | containers | RoleCreatePage', () => {
                   </div>
                 </div>
                 <div
-                  class="c50"
+                  class="c51"
                 >
                   <div
-                    class="c1 c51"
+                    class="c1 c52"
                     style="min-height: 100%;"
                   >
                     <div
-                      class="c1 c3 c15 c33"
+                      class="c1 c3 c33"
                     >
                       <h3
-                        class="c6 c19"
+                        class="c6 c18"
                       >
                         Advanced settings
                       </h3>

--- a/packages/plugins/users-permissions/admin/src/pages/Roles/EditPage/index.js
+++ b/packages/plugins/users-permissions/admin/src/pages/Roles/EditPage/index.js
@@ -16,7 +16,7 @@ import {
   HeaderLayout,
   Main,
   Button,
-  Stack,
+  Flex,
   Box,
   TextInput,
   Textarea,
@@ -119,7 +119,7 @@ const EditPage = () => {
               }
             />
             <ContentLayout>
-              <Stack spacing={7}>
+              <Flex direction="column" alignItems="stretch" gap={7}>
                 <Box
                   background="neutral0"
                   hasRadius
@@ -129,7 +129,7 @@ const EditPage = () => {
                   paddingLeft={7}
                   paddingRight={7}
                 >
-                  <Stack spacing={4}>
+                  <Flex direction="column" alignItems="stretch" gap={4}>
                     <Typography variant="delta" as="h2">
                       {formatMessage({
                         id: getTrad('EditPage.form.roles'),
@@ -173,7 +173,7 @@ const EditPage = () => {
                         />
                       </GridItem>
                     </Grid>
-                  </Stack>
+                  </Flex>
                 </Box>
                 {!isLoadingPlugins && (
                   <UsersPermissions
@@ -182,7 +182,7 @@ const EditPage = () => {
                     routes={routes}
                   />
                 )}
-              </Stack>
+              </Flex>
             </ContentLayout>
           </Form>
         )}

--- a/packages/plugins/users-permissions/admin/src/pages/Roles/EditPage/tests/index.test.js
+++ b/packages/plugins/users-permissions/admin/src/pages/Roles/EditPage/tests/index.test.js
@@ -77,7 +77,7 @@ describe('Admin | containers | RoleEditPage', () => {
         color: #666687;
       }
 
-      .c24 {
+      .c23 {
         font-weight: 500;
         font-size: 1rem;
         line-height: 1.25;
@@ -90,13 +90,13 @@ describe('Admin | containers | RoleEditPage', () => {
         color: #666687;
       }
 
-      .c49 {
+      .c50 {
         font-size: 0.75rem;
         line-height: 1.33;
         color: #4945ff;
       }
 
-      .c50 {
+      .c51 {
         font-weight: 500;
         font-size: 1rem;
         line-height: 1.25;
@@ -128,7 +128,7 @@ describe('Admin | containers | RoleEditPage', () => {
         padding-left: 56px;
       }
 
-      .c22 {
+      .c21 {
         background: #ffffff;
         padding-top: 24px;
         padding-right: 32px;
@@ -151,11 +151,11 @@ describe('Admin | containers | RoleEditPage', () => {
         padding-left: 32px;
       }
 
-      .c40 {
+      .c41 {
         border-radius: 4px;
       }
 
-      .c42 {
+      .c43 {
         background: #f6f6f9;
         padding-top: 24px;
         padding-right: 24px;
@@ -163,21 +163,21 @@ describe('Admin | containers | RoleEditPage', () => {
         padding-left: 24px;
       }
 
-      .c44 {
+      .c45 {
         max-width: 100%;
         -webkit-flex: 1;
         -ms-flex: 1;
         flex: 1;
       }
 
-      .c46 {
+      .c47 {
         min-width: 0;
         -webkit-flex: 1;
         -ms-flex: 1;
         flex: 1;
       }
 
-      .c51 {
+      .c52 {
         background: #dcdce4;
         border-radius: 50%;
         width: 2rem;
@@ -188,12 +188,12 @@ describe('Admin | containers | RoleEditPage', () => {
         cursor: pointer;
       }
 
-      .c53 {
+      .c54 {
         color: #666687;
         width: 0.6875rem;
       }
 
-      .c56 {
+      .c57 {
         background: #eaeaef;
         padding-top: 24px;
         padding-right: 32px;
@@ -245,9 +245,84 @@ describe('Admin | containers | RoleEditPage', () => {
         -webkit-flex-direction: column;
         -ms-flex-direction: column;
         flex-direction: column;
+        gap: 32px;
       }
 
-      .c52 {
+      .c22 {
+        -webkit-align-items: stretch;
+        -webkit-box-align: stretch;
+        -ms-flex-align: stretch;
+        align-items: stretch;
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+        -webkit-flex-direction: column;
+        -ms-flex-direction: column;
+        flex-direction: column;
+        gap: 16px;
+      }
+
+      .c26 {
+        -webkit-align-items: stretch;
+        -webkit-box-align: stretch;
+        -ms-flex-align: stretch;
+        align-items: stretch;
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+        -webkit-flex-direction: column;
+        -ms-flex-direction: column;
+        flex-direction: column;
+      }
+
+      .c37 {
+        -webkit-align-items: stretch;
+        -webkit-box-align: stretch;
+        -ms-flex-align: stretch;
+        align-items: stretch;
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+        -webkit-flex-direction: column;
+        -ms-flex-direction: column;
+        flex-direction: column;
+        gap: 24px;
+      }
+
+      .c38 {
+        -webkit-align-items: stretch;
+        -webkit-box-align: stretch;
+        -ms-flex-align: stretch;
+        align-items: stretch;
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+        -webkit-flex-direction: column;
+        -ms-flex-direction: column;
+        flex-direction: column;
+        gap: 8px;
+      }
+
+      .c40 {
+        -webkit-align-items: stretch;
+        -webkit-box-align: stretch;
+        -ms-flex-align: stretch;
+        align-items: stretch;
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+        -webkit-flex-direction: column;
+        -ms-flex-direction: column;
+        flex-direction: column;
+        gap: 4px;
+      }
+
+      .c53 {
         -webkit-align-items: center;
         -webkit-box-align: center;
         -ms-flex-align: center;
@@ -268,42 +343,42 @@ describe('Admin | containers | RoleEditPage', () => {
         justify-content: center;
       }
 
-      .c41 {
+      .c42 {
         border: 1px solid #f6f6f9;
       }
 
-      .c41:hover:not([aria-disabled='true']) {
+      .c42:hover:not([aria-disabled='true']) {
         border: 1px solid #4945ff;
       }
 
-      .c41:hover:not([aria-disabled='true']) .c11 {
+      .c42:hover:not([aria-disabled='true']) .c11 {
         color: #4945ff;
       }
 
-      .c41:hover:not([aria-disabled='true']) > .c8 {
+      .c42:hover:not([aria-disabled='true']) > .c8 {
         background: #f0f0ff;
       }
 
-      .c41:hover:not([aria-disabled='true']) [data-strapi-dropdown='true'] {
+      .c42:hover:not([aria-disabled='true']) [data-strapi-dropdown='true'] {
         background: #d9d8ff;
       }
 
-      .c47 {
+      .c48 {
         background: transparent;
         border: none;
         position: relative;
         outline: none;
       }
 
-      .c47[aria-disabled='true'] {
+      .c48[aria-disabled='true'] {
         pointer-events: none;
       }
 
-      .c47[aria-disabled='true'] svg path {
+      .c48[aria-disabled='true'] svg path {
         fill: #666687;
       }
 
-      .c47 svg {
+      .c48 svg {
         display: -webkit-box;
         display: -webkit-flex;
         display: -ms-flexbox;
@@ -311,11 +386,11 @@ describe('Admin | containers | RoleEditPage', () => {
         font-size: 0.625rem;
       }
 
-      .c47 svg path {
+      .c48 svg path {
         fill: #4945ff;
       }
 
-      .c47:after {
+      .c48:after {
         -webkit-transition-property: all;
         transition-property: all;
         -webkit-transition-duration: 0.2s;
@@ -330,11 +405,11 @@ describe('Admin | containers | RoleEditPage', () => {
         border: 2px solid transparent;
       }
 
-      .c47:focus-visible {
+      .c48:focus-visible {
         outline: none;
       }
 
-      .c47:focus-visible:after {
+      .c48:focus-visible:after {
         border-radius: 8px;
         content: '';
         position: absolute;
@@ -343,24 +418,6 @@ describe('Admin | containers | RoleEditPage', () => {
         left: -5px;
         right: -5px;
         border: 2px solid #4945ff;
-      }
-
-      .c21 > * {
-        margin-top: 0;
-        margin-bottom: 0;
-      }
-
-      .c21 > * + * {
-        margin-top: 32px;
-      }
-
-      .c23 > * {
-        margin-top: 0;
-        margin-bottom: 0;
-      }
-
-      .c23 > * + * {
-        margin-top: 16px;
       }
 
       .c27 > * {
@@ -372,60 +429,42 @@ describe('Admin | containers | RoleEditPage', () => {
         margin-top: 4px;
       }
 
-      .c37 > * {
-        margin-top: 0;
-        margin-bottom: 0;
-      }
-
-      .c37 > * + * {
-        margin-top: 24px;
-      }
-
-      .c38 > * {
-        margin-top: 0;
-        margin-bottom: 0;
-      }
-
-      .c38 > * + * {
-        margin-top: 8px;
-      }
-
-      .c45 > * {
+      .c46 > * {
         margin-left: 0;
         margin-right: 0;
       }
 
-      .c45 > * + * {
+      .c46 > * + * {
         margin-left: 12px;
       }
 
-      .c54 path {
+      .c55 path {
         fill: #666687;
       }
 
-      .c48 {
+      .c49 {
         text-align: left;
       }
 
-      .c48 > span {
+      .c49 > span {
         max-width: 100%;
       }
 
-      .c48 svg {
+      .c49 svg {
         width: 0.875rem;
         height: 0.875rem;
       }
 
-      .c48 svg path {
+      .c49 svg path {
         fill: #8e8ea9;
       }
 
-      .c43 {
+      .c44 {
         min-height: 5.5rem;
         border-radius: 4px;
       }
 
-      .c43:hover svg path {
+      .c44:hover svg path {
         fill: #4945ff;
       }
 
@@ -620,7 +659,7 @@ describe('Admin | containers | RoleEditPage', () => {
         box-shadow: #4945ff 0px 0px 0px 2px;
       }
 
-      .c25 {
+      .c24 {
         display: grid;
         grid-template-columns: repeat(12,1fr);
         gap: 16px;
@@ -631,7 +670,7 @@ describe('Admin | containers | RoleEditPage', () => {
         grid-template-columns: repeat(12,1fr);
       }
 
-      .c26 {
+      .c25 {
         grid-column: span 6;
         max-width: 100%;
       }
@@ -641,7 +680,7 @@ describe('Admin | containers | RoleEditPage', () => {
         max-width: 100%;
       }
 
-      .c55 {
+      .c56 {
         grid-column: span 5;
         max-width: 100%;
       }
@@ -814,13 +853,13 @@ describe('Admin | containers | RoleEditPage', () => {
       }
 
       @media (max-width:68.75rem) {
-        .c26 {
+        .c25 {
           grid-column: span;
         }
       }
 
       @media (max-width:34.375rem) {
-        .c26 {
+        .c25 {
           grid-column: span;
         }
       }
@@ -838,13 +877,13 @@ describe('Admin | containers | RoleEditPage', () => {
       }
 
       @media (max-width:68.75rem) {
-        .c55 {
+        .c56 {
           grid-column: span;
         }
       }
 
       @media (max-width:34.375rem) {
-        .c55 {
+        .c56 {
           grid-column: span;
         }
       }
@@ -950,24 +989,24 @@ describe('Admin | containers | RoleEditPage', () => {
             class="c1 c19"
           >
             <div
-              class="c1 c8 c20 c21"
+              class="c1 c8 c20"
             >
               <div
-                class="c1 c22"
+                class="c1 c21"
               >
                 <div
-                  class="c1 c8 c20 c23"
+                  class="c1 c8 c22"
                 >
                   <h2
-                    class="c11 c24"
+                    class="c11 c23"
                   >
                     Role details
                   </h2>
                   <div
-                    class="c1 c25"
+                    class="c1 c24"
                   >
                     <div
-                      class="c26"
+                      class="c25"
                     >
                       <div
                         class="c1 "
@@ -975,7 +1014,7 @@ describe('Admin | containers | RoleEditPage', () => {
                         <div>
                           <div>
                             <div
-                              class="c1 c8 c20 c27"
+                              class="c1 c8 c26 c27"
                             >
                               <label
                                 class="c11 c17"
@@ -1006,7 +1045,7 @@ describe('Admin | containers | RoleEditPage', () => {
                       </div>
                     </div>
                     <div
-                      class="c26"
+                      class="c25"
                     >
                       <div
                         class="c1 "
@@ -1016,7 +1055,7 @@ describe('Admin | containers | RoleEditPage', () => {
                         >
                           <div>
                             <div
-                              class="c1 c8 c20 c27"
+                              class="c1 c8 c26 c27"
                             >
                               <div
                                 class="c1 c8 c10"
@@ -1063,13 +1102,13 @@ describe('Admin | containers | RoleEditPage', () => {
                     class="c1 c36"
                   >
                     <div
-                      class="c1 c8 c20 c37"
+                      class="c1 c8 c37"
                     >
                       <div
-                        class="c1 c8 c20 c38"
+                        class="c1 c8 c38"
                       >
                         <h2
-                          class="c11 c24"
+                          class="c11 c23"
                         >
                           Permissions
                         </h2>
@@ -1080,33 +1119,33 @@ describe('Admin | containers | RoleEditPage', () => {
                         </p>
                       </div>
                       <div
-                        class="c1 c8 c20 c27"
+                        class="c1 c8 c40"
                       >
                         <div
                           aria-disabled="false"
-                          class="c1 c40 c41"
+                          class="c1 c41 c42"
                           data-strapi-expanded="false"
                         >
                           <div
-                            class="c1 c8 c42 c9 c43"
+                            class="c1 c8 c43 c9 c44"
                           >
                             <div
-                              class="c1 c8 c44 c10 c45"
+                              class="c1 c8 c45 c10 c46"
                             >
                               <button
                                 aria-controls="accordion-content-4"
                                 aria-disabled="false"
                                 aria-expanded="false"
                                 aria-labelledby="accordion-label-4"
-                                class="c1 c8 c46 c10 c47 c48"
+                                class="c1 c8 c47 c10 c48 c49"
                                 data-strapi-accordion-toggle="true"
                                 type="button"
                               >
                                 <span
-                                  class="c11 c49"
+                                  class="c11 c50"
                                 >
                                   <span
-                                    class="c11 c50"
+                                    class="c11 c51"
                                     id="accordion-label-4"
                                   >
                                     Address
@@ -1120,15 +1159,15 @@ describe('Admin | containers | RoleEditPage', () => {
                                 </span>
                               </button>
                               <div
-                                class="c1 c8 c10 c45"
+                                class="c1 c8 c10 c46"
                               >
                                 <span
                                   aria-hidden="true"
-                                  class="c1 c8 c51 c52"
+                                  class="c1 c8 c52 c53"
                                   data-strapi-dropdown="true"
                                 >
                                   <svg
-                                    class="c1 c53 c54"
+                                    class="c1 c54 c55"
                                     fill="none"
                                     height="1em"
                                     viewBox="0 0 14 8"
@@ -1152,17 +1191,17 @@ describe('Admin | containers | RoleEditPage', () => {
                   </div>
                 </div>
                 <div
-                  class="c55"
+                  class="c56"
                 >
                   <div
-                    class="c1 c56"
+                    class="c1 c57"
                     style="min-height: 100%;"
                   >
                     <div
-                      class="c1 c8 c20 c38"
+                      class="c1 c8 c38"
                     >
                       <h3
-                        class="c11 c24"
+                        class="c11 c23"
                       >
                         Advanced settings
                       </h3>


### PR DESCRIPTION
### What does it do?

* converts all Stack components to use Flex
* Adds an Eslint rule to tell people not to use Stack (can be removed once its removed from the DS in v2)

### Why is it needed?

* Stack is deprecated in the DS

### Notes

`Stack` by default is a wrapper around `Flex` that sets `direction="column"` & `alignItems="stretch"` hence why you'll see it used so much. In bigger refactors, this could be omitted.
