### PR TITLE
Implement the not implemented error class

### DIFF
--- a/packages/core/strapi/lib/services/errors.js
+++ b/packages/core/strapi/lib/services/errors.js
@@ -1,8 +1,14 @@
 'use strict';
 
 const createError = require('http-errors');
-const { NotFoundError, UnauthorizedError, ForbiddenError, PayloadTooLargeError, RateLimitError } =
-  require('@strapi/utils').errors;
+const {
+  NotFoundError,
+  UnauthorizedError,
+  ForbiddenError,
+  PayloadTooLargeError,
+  RateLimitError,
+  NotImplementedError,
+} = require('@strapi/utils').errors;
 
 const mapErrorsAndStatus = [
   {
@@ -24,6 +30,10 @@ const mapErrorsAndStatus = [
   {
     classError: RateLimitError,
     status: 429,
+  },
+  {
+    classError: NotImplementedError,
+    status: 501,
   },
 ];
 

--- a/packages/core/utils/lib/errors.js
+++ b/packages/core/utils/lib/errors.js
@@ -89,6 +89,14 @@ class PolicyError extends ForbiddenError {
   }
 }
 
+class NotImplementedError extends ApplicationError {
+  constructor(message, details) {
+    super(message, details);
+    this.name = 'NotImplementedError';
+    this.message = message || 'This feature is not implemented yet';
+  }
+}
+
 module.exports = {
   HttpError,
   ApplicationError,
@@ -101,4 +109,5 @@ module.exports = {
   RateLimitError,
   PayloadTooLargeError,
   PolicyError,
+  NotImplementedError,
 };


### PR DESCRIPTION
### What does it do?

Implements the not implemented error class

### Why is it needed?

Could be used for the DEITS feature and handle the error class

### How to test it?

```js
const utils = require('@strapi/utils');
const { NotImplementedError } = utils.errors;

module.exports = (policyContext, config, { strapi }) => {
  let blah = false

  if (blah === false) {
    throw new NotImplementedError('This isn't implemented', { policy: 'test' })
  } else {
    return true
  }
}
```

### Related issue(s)/PR(s)

N/A
