### PR TITLE
Fix db generated config - pg port

### DIFF
--- a/packages/generators/app/lib/resources/templates/database-templates/js/database.template
+++ b/packages/generators/app/lib/resources/templates/database-templates/js/database.template
@@ -30,7 +30,7 @@ module.exports = ({ env }) => {
       connection: {
         connectionString: env('DATABASE_URL'),
         host: env('DATABASE_HOST', 'localhost'),
-        port: env.int('DATABASE_PORT', 3306),
+        port: env.int('DATABASE_PORT', 5432),
         database: env('DATABASE_NAME', 'strapi'),
         user: env('DATABASE_USERNAME', 'strapi'),
         password: env('DATABASE_PASSWORD', 'strapi'),


### PR DESCRIPTION
### What does it do?

PG port was wrong when generating the database.js config it was using 3306 instead of 5432 as the default

### Why is it needed?

Wrong default port

### How to test it?

Generate a new project and see proper port in generated database config

### Related issue(s)/PR(s)

N/A