### PR TITLE
Add audit-deps to checks action

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -26,3 +26,15 @@ jobs:
         with:
           cache: yarn
       - uses: ./.github/actions/security/lockfile
+
+  audit-deps:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: pnpm/action-setup@v2.2.4
+      - uses: actions/setup-node@v3
+        with:
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      # check prod dependencies as these would affect users
+      - run: pnpm audit --prod


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* Adds a PNPM install check to the `checks` action

### Why is it needed?

* We had ~5 issues related to `yarn3` and `pnpm` install issues because of how they work & our bad handling of dependencies in the repo, this action should keep an eye on it for us.

### Notes

I've added it to the checks because it felt similar to the `snyk` check, however, we could make it its own action & then we could dial it back to a CRON job if we wanted too. Be interested to hear thoughts on this.
