### PR TITLE
[Fix] typo when returning a component category

### DIFF
--- a/packages/core/content-manager/server/services/__tests__/components.test.js
+++ b/packages/core/content-manager/server/services/__tests__/components.test.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const componentsService = require('../components');
+
+const configuration = {
+  test: 'value',
+  some: 'config',
+};
+
+jest.mock('../configuration', () =>
+  jest.fn(() => ({
+    getConfiguration: jest.fn(() => configuration),
+  }))
+);
+
+describe('componentService', () => {
+  test('findComponent', async () => {
+    const { findConfiguration } = componentsService({});
+
+    const component = {
+      uid: 'blog.test-compo',
+      category: 'blog',
+    };
+    const result = await findConfiguration(component);
+
+    expect(result).toEqual({ ...component, ...configuration });
+  });
+});

--- a/packages/core/content-manager/server/services/components.js
+++ b/packages/core/content-manager/server/services/components.js
@@ -41,7 +41,7 @@ module.exports = ({ strapi }) => ({
 
     return {
       uid: component.uid,
-      category: component.categoru,
+      category: component.category,
       ...configuration,
     };
   },


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### Why is it needed?

Fixes a bug where we were incorrectly returning `component.categoru`

### How to test it?

Added unit test

### Related issue(s)/PR(s)

Closes https://github.com/strapi/strapi/pull/15873

@campmedia thank you for your fix, I've only extended it slightly, adding a test to make sure we're selecting the category correctly
