### PR TITLE
[Data transfer] aborting prompts displays as error

### DIFF
--- a/packages/core/strapi/bin/strapi.js
+++ b/packages/core/strapi/bin/strapi.js
@@ -342,7 +342,8 @@ program
         }
 
         await confirmMessage(
-          'The transfer will delete all data in the remote database and media files. Are you sure you want to proceed?'
+          'The transfer will delete all data in the remote database and media files. Are you sure you want to proceed?',
+          { failMessage: 'Transfer process aborted' }
         )(thisCommand);
       }
     )
@@ -450,7 +451,8 @@ program
   .hook(
     'preAction',
     confirmMessage(
-      'The import will delete all data in your database and media files. Are you sure you want to proceed?'
+      'The import will delete all data in your database and media files. Are you sure you want to proceed?',
+      { failMessage: 'Import process aborted' }
     )
   )
   .action(getLocalScript('transfer/import'));

--- a/packages/core/strapi/bin/strapi.js
+++ b/packages/core/strapi/bin/strapi.js
@@ -313,7 +313,7 @@ program
             },
           ]);
           if (!answers.fromToken?.length) {
-            exitWith(0, 'No token entered, aborting transfer.');
+            exitWith(1, 'No token entered, aborting transfer.');
           }
           thisCommand.opts().fromToken = answers.fromToken;
         }
@@ -336,7 +336,7 @@ program
             },
           ]);
           if (!answers.toToken?.length) {
-            exitWith(0, 'No token entered, aborting transfer.');
+            exitWith(1, 'No token entered, aborting transfer.');
           }
           thisCommand.opts().toToken = answers.toToken;
         }
@@ -412,7 +412,7 @@ program
           },
         ]);
         if (!answers.key?.length) {
-          exitWith(0, 'No key entered, aborting import.');
+          exitWith(1, 'No key entered, aborting import.');
         }
         opts.key = answers.key;
       }

--- a/packages/core/strapi/lib/commands/utils/commander.js
+++ b/packages/core/strapi/lib/commands/utils/commander.js
@@ -116,7 +116,7 @@ const confirmMessage = (message) => {
       },
     ]);
     if (!answers.confirm) {
-      exitWith(0);
+      exitWith(1);
     }
   };
 };

--- a/packages/core/strapi/lib/commands/utils/commander.js
+++ b/packages/core/strapi/lib/commands/utils/commander.js
@@ -96,6 +96,7 @@ const promptEncryptionKey = async (thisCommand) => {
  *
  * @param {string} message The message to confirm with user
  * @param {object} options Additional options
+ * @param {string|undefined} options.failMessage The message to display when prompt is not confirmed
  */
 const confirmMessage = (message, { failMessage } = {}) => {
   return async (command) => {

--- a/packages/core/strapi/lib/commands/utils/commander.js
+++ b/packages/core/strapi/lib/commands/utils/commander.js
@@ -97,7 +97,7 @@ const promptEncryptionKey = async (thisCommand) => {
  * @param {string} message The message to confirm with user
  * @param {object} options Additional options
  */
-const confirmMessage = (message) => {
+const confirmMessage = (message, { failMessage } = {}) => {
   return async (command) => {
     // if we have a force option, assume yes
     const opts = command.opts();
@@ -116,7 +116,7 @@ const confirmMessage = (message) => {
       },
     ]);
     if (!answers.confirm) {
-      exitWith(1);
+      exitWith(1, failMessage);
     }
   };
 };


### PR DESCRIPTION
### What does it do?

When a user doesn't enter data for a prompt, the error message works as described below.

### Why is it needed?

As a shipper

- when I run the transfer
  - when I don’t put any transfer token
    - then I want the message No token entered, aborting transfer to be in red, and no information about the process's completion time
  - when I select “N” (no) to the question The transfer will delete all data in the remote database and media files. Are you sure you want to proceed?
    - then I want the error message in red Transfer process aborted

### How to test it?

see above
