### PR TITLE
Only run FE unit on 18 & run build in matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -115,7 +115,7 @@ jobs:
           key: ${{ runner.os }}-${{ matrix.node }}-${{ hashFiles('**/yarn.lock') }}
       - run: yarn install --frozen-lockfile
       - name: Build
-        run: yarn build
+        run: yarn build --scope @strapi/admin --scope @strapi/helper-plugin
 
   api_ce_pg:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [14, 16, 18]
+        node: [18]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -96,6 +96,26 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: ./coverage
           flags: front,unit_front
+
+  build:
+    name: 'build (node: ${{ matrix.node }})'
+    needs: [lint, unit_front]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [14, 16, 18]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node }}
+      - uses: actions/cache@v3
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-${{ matrix.node }}-${{ hashFiles('**/yarn.lock') }}
+      - run: yarn install --frozen-lockfile
+      - name: Build
+        run: yarn build
 
   api_ce_pg:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* remove running the `unit_front` tests in node matrix
* adds build check in all node versions we support

### Why is it needed?

* the unit tests run in `jsdom` they don't use node APIs therefore the node version has no impact, we can reduce time.
* the build however, does need to work across all node versions

### Related issue(s)/PR(s)

* mentioned in the FE sync
* resolves CONTENT-1129


### Note

We'll need the required checks to be changed on the branches before merging this, cc @alexandrebodin 
