### PR TITLE
do not require an array with media if attribute is not required

### DIFF
--- a/packages/core/strapi/lib/services/entity-validator/index.js
+++ b/packages/core/strapi/lib/services/entity-validator/index.js
@@ -163,7 +163,8 @@ const createMediaAttributeValidator = (createOrUpdate) => (metas, options) => {
   let validator;
 
   if (metas.attr.multiple) {
-    validator = yup.array().of(yup.mixed()).min(1);
+    validator = yup.array().of(yup.mixed());
+    if (metas.attr.required) validator = validator.min(1);
   } else {
     validator = yup.mixed();
   }

--- a/packages/core/strapi/tests/api/basic-media.test.api.js
+++ b/packages/core/strapi/tests/api/basic-media.test.api.js
@@ -30,6 +30,12 @@ const productWithMedia = {
       required: true,
       allowedTypes: ['images', 'files', 'videos', 'audios'],
     },
+    nonRequiredMultipleMedia: {
+      type: 'media',
+      multiple: true,
+      required: false,
+      allowedTypes: ['images', 'files', 'videos', 'audios'],
+    },
   },
   displayName: 'product-with-media',
   singularName: 'product-with-media',
@@ -67,6 +73,7 @@ describe('Core API - Basic + required media', () => {
       name: 'product',
       description: 'description',
       media: file.id,
+      nonRequiredMultipleMedia: [],
     };
 
     const res = await rq({


### PR DESCRIPTION
### What does it do?

We introduced a Content API validation to ensure a required media field was actually required during the parameter validation.

After that change, you were not able to pass an empty media array [] even if the required flag was set to false. It only worked when the field was undefined or null.

### Why is it needed?

So you can pass an empty array for repeatable media fields.

### How to test it?

See tests. 

### Related issue(s)/PR(s)

Fix: https://github.com/strapi/strapi/issues/15951
