### PR TITLE
Alignment should be center not flex-start

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/ComponentInitializer/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/ComponentInitializer/index.js
@@ -36,7 +36,7 @@ const ComponentInitializer = ({ error, isReadOnly, onClick }) => {
         paddingBottom={9}
         type="button"
       >
-        <Flex direction="column" alignItems="flex-start" gap={2}>
+        <Flex direction="column" gap={2}>
           <Flex justifyContent="center" style={{ cursor: isReadOnly ? 'not-allowed' : 'inherit' }}>
             <IconWrapper>
               <PlusCircle />


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* changes `align-items` to `center`

### Why is it needed?

* it didn't want to be `flex-start`

### Related issue(s)/PR(s)

* related to #15967 
