### PR TITLE
[Data Transfer] [Proof-of-concept] Import Strapi backup file -> remote Strapi destination

### DIFF
--- a/packages/core/strapi/bin/strapi.js
+++ b/packages/core/strapi/bin/strapi.js
@@ -342,7 +342,8 @@ program
         }
 
         await confirmMessage(
-          'The transfer will delete all data in the remote database and media files. Are you sure you want to proceed?'
+          'The transfer will delete all data in the remote database and media files. Are you sure you want to proceed?',
+          { failMessage: 'Transfer process aborted' }
         )(thisCommand);
       }
     )
@@ -450,7 +451,8 @@ program
   .hook(
     'preAction',
     confirmMessage(
-      'The import will delete all data in your database and media files. Are you sure you want to proceed?'
+      'The import will delete all data in your database and media files. Are you sure you want to proceed?',
+      { failMessage: 'Import process aborted' }
     )
   )
   .action(getLocalScript('transfer/import'));

--- a/packages/core/strapi/bin/strapi.js
+++ b/packages/core/strapi/bin/strapi.js
@@ -313,7 +313,7 @@ program
             },
           ]);
           if (!answers.fromToken?.length) {
-            exitWith(0, 'No token entered, aborting transfer.');
+            exitWith(1, 'No token entered, aborting transfer.');
           }
           thisCommand.opts().fromToken = answers.fromToken;
         }
@@ -336,7 +336,7 @@ program
             },
           ]);
           if (!answers.toToken?.length) {
-            exitWith(0, 'No token entered, aborting transfer.');
+            exitWith(1, 'No token entered, aborting transfer.');
           }
           thisCommand.opts().toToken = answers.toToken;
         }
@@ -412,7 +412,7 @@ program
           },
         ]);
         if (!answers.key?.length) {
-          exitWith(0, 'No key entered, aborting import.');
+          exitWith(1, 'No key entered, aborting import.');
         }
         opts.key = answers.key;
       }

--- a/packages/core/strapi/bin/strapi.js
+++ b/packages/core/strapi/bin/strapi.js
@@ -395,10 +395,40 @@ program
       'Provide encryption key in command instead of using the prompt'
     )
   )
+  .addOption(
+    new Option(
+      '--to <destinationURL>',
+      `URL of the remote Strapi instance to send data to`
+    ).argParser(parseURL)
+  )
+  .addOption(new Option('--to-token <token>', `Transfer token for the remote Strapi destination`))
   .addOption(forceOption)
   .addOption(excludeOption)
   .addOption(onlyOption)
   .hook('preAction', validateExcludeOnly)
+  // If --to is used, validate the URL and token
+  .hook(
+    'preAction',
+    ifOptions(
+      (opts) => opts.to,
+      async (thisCommand) => {
+        assertUrlHasProtocol(thisCommand.opts().to, ['https:', 'http:']);
+        if (!thisCommand.opts().toToken) {
+          const answers = await inquirer.prompt([
+            {
+              type: 'password',
+              message: 'Please enter your transfer token for the remote Strapi destination',
+              name: 'toToken',
+            },
+          ]);
+          if (!answers.toToken?.length) {
+            exitWith(1, 'No token entered, aborting transfer.');
+          }
+          thisCommand.opts().toToken = answers.toToken;
+        }
+      }
+    )
+  )
   .hook('preAction', async (thisCommand) => {
     const opts = thisCommand.opts();
     const ext = path.extname(String(opts.file));

--- a/packages/core/strapi/bin/strapi.js
+++ b/packages/core/strapi/bin/strapi.js
@@ -279,13 +279,12 @@ program
   .description('Transfer data from one source to another')
   .allowExcessArguments(false)
   .addOption(
-    new Option('--from <sourceURL>', `URL of the remote Strapi instance to get data from`)
-      .argParser(parseURL)
-      .hideHelp() // Hidden until pull feature is released
+    new Option(
+      '--from <sourceURL>',
+      `URL of the remote Strapi instance to get data from`
+    ).argParser(parseURL)
   )
-  .addOption(
-    new Option('--from-token <token>', `Transfer token for the remote Strapi source`).hideHelp() // Hidden until pull feature is released
-  )
+  .addOption(new Option('--from-token <token>', `Transfer token for the remote Strapi source`))
   .addOption(
     new Option(
       '--to <destinationURL>',
@@ -297,6 +296,15 @@ program
   .addOption(excludeOption)
   .addOption(onlyOption)
   .hook('preAction', validateExcludeOnly)
+  // require either a source or destination
+  .hook(
+    'preAction',
+    ifOptions(
+      (opts) => !opts.from && !opts.to,
+      () =>
+        exitWith(1, 'At least one source (--from) or destination (--to) option must be provided')
+    )
+  )
   // If --from is used, validate the URL and token
   .hook(
     'preAction',
@@ -348,13 +356,6 @@ program
       }
     )
   )
-  // .hook(
-  //   'preAction',
-  //   ifOptions(
-  //     (opts) => !opts.from && !opts.to,
-  //     () => exitWith(1, 'At least one source (from) or destination (to) option must be provided')
-  //   )
-  // )
   .action(getLocalScript('transfer/transfer'));
 
 // `$ strapi export`

--- a/packages/core/strapi/lib/commands/transfer/import.js
+++ b/packages/core/strapi/lib/commands/transfer/import.js
@@ -4,7 +4,11 @@ const {
   providers: { createLocalFileSourceProvider },
 } = require('@strapi/data-transfer/lib/file');
 const {
-  providers: { createLocalStrapiDestinationProvider, DEFAULT_CONFLICT_STRATEGY },
+  providers: {
+    createLocalStrapiDestinationProvider,
+    createRemoteStrapiDestinationProvider,
+    DEFAULT_CONFLICT_STRATEGY,
+  },
 } = require('@strapi/data-transfer/lib/strapi');
 const {
   createTransferEngine,
@@ -14,9 +18,6 @@ const {
 
 const { isObject } = require('lodash/fp');
 
-const {
-  providers: createRemoteStrapiDestinationProvider,
-} = require('@strapi/data-transfer/lib/strapi');
 const {
   buildTransferTable,
   DEFAULT_IGNORED_CONTENT_TYPES,
@@ -51,20 +52,6 @@ module.exports = async (opts) => {
   let destination;
   // if no URL provided, use local Strapi
   if (!opts.to) {
-    destination = createRemoteStrapiDestinationProvider({
-      url: opts.to,
-      auth: {
-        type: 'token',
-        token: opts.toToken,
-      },
-      strategy: 'restore',
-      restore: {
-        entities: { exclude: DEFAULT_IGNORED_CONTENT_TYPES },
-      },
-    });
-  }
-  // if URL provided, set up a remote source provider
-  else {
     const destinationOptions = {
       async getStrapi() {
         return strapiInstance;
@@ -76,6 +63,20 @@ module.exports = async (opts) => {
       },
     };
     destination = createLocalStrapiDestinationProvider(destinationOptions);
+  }
+  // if URL provided, set up a remote source provider
+  else {
+    destination = createRemoteStrapiDestinationProvider({
+      url: opts.to,
+      auth: {
+        type: 'token',
+        token: opts.toToken,
+      },
+      strategy: 'restore',
+      restore: {
+        entities: { exclude: DEFAULT_IGNORED_CONTENT_TYPES },
+      },
+    });
   }
 
   /**

--- a/packages/core/strapi/lib/commands/utils/commander.js
+++ b/packages/core/strapi/lib/commands/utils/commander.js
@@ -116,7 +116,7 @@ const confirmMessage = (message) => {
       },
     ]);
     if (!answers.confirm) {
-      exitWith(0);
+      exitWith(1);
     }
   };
 };

--- a/packages/core/strapi/lib/commands/utils/commander.js
+++ b/packages/core/strapi/lib/commands/utils/commander.js
@@ -96,6 +96,7 @@ const promptEncryptionKey = async (thisCommand) => {
  *
  * @param {string} message The message to confirm with user
  * @param {object} options Additional options
+ * @param {string|undefined} options.failMessage The message to display when prompt is not confirmed
  */
 const confirmMessage = (message, { failMessage } = {}) => {
   return async (command) => {

--- a/packages/core/strapi/lib/commands/utils/commander.js
+++ b/packages/core/strapi/lib/commands/utils/commander.js
@@ -97,7 +97,7 @@ const promptEncryptionKey = async (thisCommand) => {
  * @param {string} message The message to confirm with user
  * @param {object} options Additional options
  */
-const confirmMessage = (message) => {
+const confirmMessage = (message, { failMessage } = {}) => {
   return async (command) => {
     // if we have a force option, assume yes
     const opts = command.opts();
@@ -116,7 +116,7 @@ const confirmMessage = (message) => {
       },
     ]);
     if (!answers.confirm) {
-      exitWith(1);
+      exitWith(1, failMessage);
     }
   };
 };


### PR DESCRIPTION
### What does it do?

Quick example of how data could be loaded from a file and sent to a remote strapi without Adds --to and --to-token to the `strapi import` command to allow sending data from a Strapi backup file to a remote Strapi destination

Conceptually, it's not appropriate at this time to add to the `strapi` command like this, since this action does not involve a local instance of Strapi. We may need to create a separate CLI tool to perform actions such as this one, for example.

### Why is it needed?

Because it would allow sending data directly to a remote instance of Strapi without first loading it into a local instance of Strapi. That would allow more easily and efficiently scripting backup/restore operations on a remote Strapi.

### How to test it?

`yarn strapi import --to http://localhost:1337/admin --to-token your_token --key file_password --file your_file.tar.gz.enc`

