### PR TITLE
[enhancement]: Improve component population performance

### DIFF
--- a/packages/core/database/lib/metadata/index.js
+++ b/packages/core/database/lib/metadata/index.js
@@ -163,6 +163,10 @@ const createCompoLinkModelMeta = (baseModelMeta) => {
         columns: ['entity_id', 'component_id', 'field', 'component_type'],
         type: 'unique',
       },
+      {
+        name: `${baseModelMeta.tableName}_order_fk`,
+        columns: ['order'],
+      },
     ],
     foreignKeys: [
       {


### PR DESCRIPTION
### What does it do?
Adds an index on the column order of a component table.

Using Sqlite, when having 10k entities, with components, it can last 40 seconds to load a page of entities in the content manager.
With this it improves the query a bit, but there is more todo.

This problems only seems to be happening when using sqlite.

Next steps:
- Improve queries
- Do not load all relations and components in the CM list view if not necessary.

### Why is it needed?
Loading entities with components can get VERY slow if there are a lot of components stored in the table.

When executing a find many, populating its components, the resulting query in the database is:

```sql
select
  distinct `t1`.`order`,
  `t0`.*,
  `t1`.`entity_id`
from
  `:component-table` as `t0`
  left join `:content-type-component-table` as `t1` on `t0`.`id` = `t1`.`component_id`
  and `t1`.`field` = 'repeat_req_min'
where
  (
    `t1`.`entity_id` in (
      161811,
      161812,
      161813,
      161814,
      161815,
      161816,
      161817,
      161818,
      161819,
      161820
    )
  )
order by
  `t1`.`order` asc

```

Example, on the Addresses content type (in getstarted), for one of the components attributes:

`:component-table` = `components_blog_test_comos`
`:content-type-component-table` = `addresses_components` (table to link between the content type table and the component table)


There are two ways to solve this:
- Adding an index on the addresses_components order column
- Optimizing the query, for 50k components in the table:
	- 	This query last 2 minutes
	-  This query lasts 0.01 seconds if only filtering by one of the addresses_components id. 
```sql
select
  distinct `t1`.`order`,
  `t0`.*,
  `t1`.`entity_id`
from
  `:component-table` as `t0`
  left join `:content-type-component-table` as `t1` on `t0`.`id` = `t1`.`component_id`
  and `t1`.`field` = 'repeat_req_min'
where
  (
    `t1`.`entity_id` in (161811) -- <--- Doing this reduces the query time to 0.01s :/ 
  )
order by
  `t1`.`order` asc

```

So effectively, we could optimize queries for performance. But as we already have indexes on order columns for relations, I think we should do the same here.

Still, this is not the only bottleneck in this performance issue.

### How to test it?

In the bootstrap function, prepopulate database with a bunch of compos:

```js

async bootstrap({ strapi }) {
    const addresses = Array.from({ length: 100 }, (_, i) => ({
      data: {
        postal_code: '22',
        city: `City ${i}`,
        categories: [1, 2, 3],
        notrepeat_req: { name: 'toto' },
        repeat_req: [
          { name: 'toto' },
          { name: 'toto' },
          { name: 'toto' },
          { name: 'toto' },
          { name: 'toto' },
          { name: 'toto' },
        ],
        repeat_req_min: [{ name: 'toto' }, { name: 'toto' }],
      },
    }));

    for (const address of addresses) {
      await strapi.entityService.create('api::address.address', address);
    }
 }
```
