### PR TITLE
fixed: Fatal error on import: Invalid schema changes detected during integrity checks

### DIFF
--- a/packages/core/data-transfer/src/file/providers/source/index.ts
+++ b/packages/core/data-transfer/src/file/providers/source/index.ts
@@ -184,7 +184,7 @@ class LocalFileSourceProvider implements ISourceProvider {
               return false;
             }
 
-            const parts = path.relative('.', filePath).split('/');
+            const parts = path.relative('.', filePath).split('\\');
 
             // TODO: this method is limiting us from having additional subdirectories and is requiring us to remove any "./" prefixes (the path.relative line above)
             if (parts.length !== 2) {


### PR DESCRIPTION
**Issue-** #15616
path.relative method is converting `filePath =  schemas\\schemas_00001.jsonl` from `schemas/schemas_00001.jsonl` so split method was unable to find '/' thats why `parts = [ 'schemas\\schemas_00001.jsonl' ]` instead of `['schemas', 'schemas_00001.jsonl']`. Now split method splits filepath with \\\ which is returned by path.relative().