### PR TITLE
fixed:#15994  Fatal error on import: Invalid schema changes detected during integrity checks

### DIFF
--- a/packages/core/data-transfer/src/file/providers/source/index.ts
+++ b/packages/core/data-transfer/src/file/providers/source/index.ts
@@ -184,7 +184,7 @@ class LocalFileSourceProvider implements ISourceProvider {
               return false;
             }
 
-            const parts = path.relative('.', filePath).split('/');
+            const parts = path.relative('.', filePath).split('\\');
 
             // TODO: this method is limiting us from having additional subdirectories and is requiring us to remove any "./" prefixes (the path.relative line above)
             if (parts.length !== 2) {


### PR DESCRIPTION
Fix #15994 
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

_path.relative()_ method is converting `filePath =  schemas\\schemas_00001.jsonl` from `schemas/schemas_00001.jsonl` so split method was unable to find **/** that's why `parts = [ 'schemas\\schemas_00001.jsonl' ]` instead of `['schemas', 'schemas_00001.jsonl']`. Now split method splits filepath with \\\ which is returned by _path.relative()_.

### Why is it needed?

On `npm run strapi import` we are getting error **error: [FATAL] Invalid schema changes detected during integrity checks (using the strict strategy)** because of _sourceProvider.getSchema_ is getting no entry from _tar parse()_ beacuse of its _filter_.

### How to test it?

you can test it on windows by `npm run strapi import` this should successfully import all and  _sourceProvider.getSchema_ is getting schema from export file

### Related issue(s)/PR(s)

no related PRs and READY TO MERGE
