### PR TITLE
Fix tbody cannot appear as child of div test error

### DIFF
--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/AuditLogs/ListView/TableRows/tests/index.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/AuditLogs/ListView/TableRows/tests/index.test.js
@@ -67,7 +67,9 @@ const App = (
   <ThemeProvider theme={lightTheme}>
     <IntlProvider locale="en" messages={{}} defaultLocale="en" textComponent="span">
       <Router history={history}>
-        <TableRows headers={headers} rows={rows} onOpenModal={onModalOpen} />
+        <table>
+          <TableRows headers={headers} rows={rows} onOpenModal={onModalOpen} />
+        </table>
       </Router>
     </IntlProvider>
   </ThemeProvider>


### PR DESCRIPTION
### What does it do?

- Fixes an error in the tests caused by tbody with no parent table element

### Why is it needed?

- To get rid of an error in the tests

### How to test it?

Run 

```
yarn test:front packages/core/admin/ee/admin/pages/SettingsPage/pages/AuditLogs/ListView/TableRows/tests/index.test.js
```

- The tests should pass
- There should be no errors
