### PR TITLE
Check Mime or Ext are not nullish in useAsset hook

### DIFF
--- a/packages/core/upload/admin/src/hooks/tests/useAssets.test.js
+++ b/packages/core/upload/admin/src/hooks/tests/useAssets.test.js
@@ -243,4 +243,97 @@ describe('useAssets', () => {
 
     console.error = originalConsoleError;
   });
+
+  it('should filter out any assets without a name', async () => {
+    const { get } = useFetchClient();
+
+    get.mockReturnValue({
+      data: {
+        results: [
+          {
+            name: null,
+            mime: 'image/jpeg',
+            ext: 'jpg',
+          },
+          {
+            name: 'test',
+            mime: 'image/jpeg',
+            ext: 'jpg',
+          },
+        ],
+      },
+    });
+
+    const { result, waitFor } = await setup({});
+
+    await waitFor(() => result.current.data !== undefined);
+
+    expect(result.current.data.results).toEqual([
+      {
+        name: 'test',
+        mime: 'image/jpeg',
+        ext: 'jpg',
+      },
+    ]);
+  });
+
+  it('should set mime and ext to strings as defaults if they are nullish', async () => {
+    const { get } = useFetchClient();
+
+    get.mockReturnValue({
+      data: {
+        results: [
+          {
+            name: 'test 1',
+            mime: null,
+            ext: 'jpg',
+          },
+          {
+            name: 'test 2',
+            mime: 'image/jpeg',
+            ext: null,
+          },
+          {
+            name: 'test 3',
+            mime: null,
+            ext: null,
+          },
+          {
+            name: 'test 4',
+            mime: 'image/jpeg',
+            ext: 'jpg',
+          },
+        ],
+      },
+    });
+
+    const { result, waitFor } = await setup({});
+
+    await waitFor(() => result.current.data !== undefined);
+
+    expect(result.current.data.results).toMatchInlineSnapshot(`
+      [
+        {
+          "ext": "jpg",
+          "mime": "",
+          "name": "test 1",
+        },
+        {
+          "ext": "",
+          "mime": "image/jpeg",
+          "name": "test 2",
+        },
+        {
+          "ext": "",
+          "mime": "",
+          "name": "test 3",
+        },
+        {
+          "ext": "jpg",
+          "mime": "image/jpeg",
+          "name": "test 4",
+        },
+      ]
+    `);
+  });
 });

--- a/packages/core/upload/admin/src/hooks/useAssets.js
+++ b/packages/core/upload/admin/src/hooks/useAssets.js
@@ -71,6 +71,31 @@ export const useAssets = ({ skipWhen = false, query = {} } = {}) => {
     enabled: !skipWhen,
     staleTime: 0,
     cacheTime: 0,
+    select(data) {
+      if (data?.results && Array.isArray(data.results)) {
+        return {
+          ...data,
+          results: data.results
+            /**
+             * Filter out assets that don't have a name.
+             * So we don't try to render them as assets
+             * and get errors.
+             */
+            .filter((asset) => asset.name)
+            .map((asset) => ({
+              ...asset,
+              /**
+               * Mime and ext cannot be null in the front-end because
+               * we expect them to be strings and use the `includes` method.
+               */
+              mime: asset.mime ?? '',
+              ext: asset.ext ?? '',
+            })),
+        };
+      }
+
+      return data;
+    },
   });
 
   return { data, error, isLoading };


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* Checks if the name of an asset is present and removes it from the list if not
* Checks if either `mime` or `ext` are nullish after fetching from the server and replaces with empty strings

### Why is it needed?

* Having no `name` errors the admin panel
* `mime` or `ext` not being a string causes a complete crash as we run `includes` on the strings.

### How to test it?

* You'll need to set mime to `null` in your DB and fetch your images
* There are automated tests simulating server response and what the hook now does

### Related issue(s)/PR(s)

* partially resolves #16005

CC @gu-stav for visibility as he looked into the original issue.
