### PR TITLE
[Private S3]: public-read as default ACL

### DIFF
--- a/packages/providers/upload-aws-s3/lib/index.js
+++ b/packages/providers/upload-aws-s3/lib/index.js
@@ -6,7 +6,7 @@
 
 /* eslint-disable no-unused-vars */
 // Public node modules.
-const { get } = require('lodash/fp');
+const { get } = require('lodash');
 const AWS = require('aws-sdk');
 const { getBucketFromUrl } = require('./utils');
 
@@ -22,7 +22,7 @@ module.exports = {
       ...config,
     });
 
-    const ACL = get(['params', 'ACL'], config, 'public-read');
+    const ACL = get(config, ['params', 'ACL'], 'public-read');
 
     const upload = (file, customParams = {}) =>
       new Promise((resolve, reject) => {
@@ -82,7 +82,7 @@ module.exports = {
             {
               Bucket: config.params.Bucket,
               Key: fileKey,
-              Expires: get(['params', 'signedUrlExpires'], config, 60 * 60 * 24 * 7), // 7 days
+              Expires: get(config, ['params', 'signedUrlExpires'], 60 * 60 * 24 * 7), // 7 days
             },
             (err, url) => {
               if (err) {


### PR DESCRIPTION
### What does it do?
Use lodash instead of lodash/fp for getting the default ACL value. We try to use fp normally, but I think it's cleaner to use this one in this case.

### Why is it needed?
So ACL is set to `public-read` by default.

### How to test it?
Do not assign any ACL configuration and try to upload an image to a public s3 provider.

