### PR TITLE
feat(helper-plugin): expose axios request method

### DIFF
--- a/packages/core/helper-plugin/lib/src/utils/getFetchClient/index.js
+++ b/packages/core/helper-plugin/lib/src/utils/getFetchClient/index.js
@@ -3,6 +3,7 @@ import instance from '../fetchClient';
 const getFetchClient = (defaultOptions = {}) => {
   instance.defaults.baseURL = window.strapi.backendURL;
   return {
+    request: (config) => instance.request({ ...defaultOptions, ...config }),
     get: (url, config) => instance.get(url, { ...defaultOptions, ...config }),
     put: (url, data, config) => instance.put(url, data, { ...defaultOptions, ...config }),
     post: (url, data, config) => instance.post(url, data, { ...defaultOptions, ...config }),

--- a/packages/core/helper-plugin/lib/src/utils/getFetchClient/tests/getFetchClient.test.js
+++ b/packages/core/helper-plugin/lib/src/utils/getFetchClient/tests/getFetchClient.test.js
@@ -5,13 +5,19 @@ const token = 'coolToken';
 auth.getToken = jest.fn().mockReturnValue(token);
 
 describe('HELPER-PLUGIN | utils | getFetchClient', () => {
-  it('should return the 4 HTTP methods to call GET, POST, PUT and DELETE apis', () => {
+  it('should return the 4 HTTP methods to call GET, POST, PUT and DELETE APIs', () => {
     const response = getFetchClient();
     expect(response).toHaveProperty('get');
     expect(response).toHaveProperty('post');
     expect(response).toHaveProperty('put');
     expect(response).toHaveProperty('del');
   });
+
+  it('should return the client request method to call any API', () => {
+    const response = getFetchClient();
+    expect(response).toHaveProperty('request');
+  });
+
   it('should contain the headers config values and the data when we try to reach an unknown API', async () => {
     const response = getFetchClient();
     try {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Expose `request` method of common axios instance

### Why is it needed?

It will make it easier to use `axios-hooks` and make your code more declarative

**use-fetch.js**

```js
import { makeUseAxios } from 'axios-hooks';
import { getFetchClient } from '@strapi/helper-plugin';
import qs from 'qs';

export const fetchClient = getFetchClient({
	paramsSerializer: {
		serialize: (params) => qs.stringify(params, { encodeValuesOnly: true }),
	},
});

export const useFetch = makeUseAxios({
	axios: (config) => fetchClient.request(config),
});
```

**your-component.js**

```jsx
import { useFetch } from './use-fetch';

function YourComponent() {
	const [{ data, loading, error, response }] = useFetch({
		url: '/contents',
		// Your query here, it will get serialized with `qs`
		params: {
			sort: ['createdAt:DESC'],
			pagination: { pageSize: 5, page: 1 },
			filters: { status: { $eq: 'pending' } },
		},
	});
```
