### PR TITLE
Fix Warning: Each child in a list should have a unique "key" prop in AssetGridList

### DIFF
--- a/packages/core/upload/admin/src/components/AssetGridList/index.js
+++ b/packages/core/upload/admin/src/components/AssetGridList/index.js
@@ -31,8 +31,8 @@ export const AssetGridList = ({
 
           if (onReorderAsset) {
             return (
-              <GridItem col={3} height="100%">
-                <Draggable key={asset.id} index={index} moveItem={onReorderAsset} id={asset.id}>
+              <GridItem key={asset.id} col={3} height="100%">
+                <Draggable index={index} moveItem={onReorderAsset} id={asset.id}>
                   <AssetCard
                     allowedTypes={allowedTypes}
                     asset={asset}


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?
It does fix the issue in media Library on selected tab that the was missing a key prop on return element of AssetGridList

### Why is it needed?
it shows warning: Warning: Each child in a list should have a unique "key" prop.

### How to test it?
open a collection with input for images. Select an image and switch to selected Files. check console for warning

### Related issue(s)/PR(s)
not related
