### PR TITLE
[Data transfer] Add transfer command filters

### DIFF
--- a/packages/core/strapi/lib/commands/transfer/export.js
+++ b/packages/core/strapi/lib/commands/transfer/export.js
@@ -27,10 +27,12 @@ const { exitWith } = require('../utils/helpers');
 /**
  * @typedef ExportCommandOptions Options given to the CLI import command
  *
- * @property {string} [file] The file path to import
+ * @property {string} [file] The file path to export to
  * @property {boolean} [encrypt] Used to encrypt the final archive
- * @property {string} [key] Encryption key, only useful when encryption is enabled
+ * @property {string} [key] Encryption key, used only when encryption is enabled
  * @property {boolean} [compress] Used to compress the final archive
+ * @property {(keyof import('@strapi/data-transfer/src/engine').TransferGroupFilter)[]} [only] If present, only include these filtered groups of data
+ * @property {(keyof import('@strapi/data-transfer/src/engine').TransferGroupFilter)[]} [exclude] If present, exclude these filtered groups of data
  */
 
 const BYTES_IN_MB = 1024 * 1024;

--- a/packages/core/strapi/lib/commands/transfer/import.js
+++ b/packages/core/strapi/lib/commands/transfer/import.js
@@ -22,9 +22,25 @@ const {
 const { exitWith } = require('../utils/helpers');
 
 /**
- * @typedef {import('@strapi/data-transfer').ILocalFileSourceProviderOptions} ILocalFileSourceProviderOptions
+ * @typedef {import('@strapi/data-transfer/src/file/providers').ILocalFileSourceProviderOptions} ILocalFileSourceProviderOptions
  */
 
+/**
+ * @typedef ImportCommandOptions Options given to the CLI import command
+ *
+ * @property {string} [file] The file path to import
+ * @property {string} [key] Encryption key, used when encryption is enabled
+ * @property {(keyof import('@strapi/data-transfer/src/engine').TransferGroupFilter)[]} [only] If present, only include these filtered groups of data
+ * @property {(keyof import('@strapi/data-transfer/src/engine').TransferGroupFilter)[]} [exclude] If present, exclude these filtered groups of data
+ */
+
+/**
+ * Import command.
+ *
+ * It transfers data from a file to a local Strapi instance
+ *
+ * @param {ImportCommandOptions} opts
+ */
 module.exports = async (opts) => {
   // validate inputs from Commander
   if (!isObject(opts)) {

--- a/packages/core/strapi/lib/commands/transfer/transfer.js
+++ b/packages/core/strapi/lib/commands/transfer/transfer.js
@@ -29,6 +29,8 @@ const { exitWith } = require('../utils/helpers');
  * @property {URL|undefined} [from] The url of a remote Strapi to use as remote source
  * @property {string|undefined} [toToken] The transfer token for the remote Strapi destination
  * @property {string|undefined} [fromToken] The transfer token for the remote Strapi source
+ * @property {(keyof import('@strapi/data-transfer/src/engine').TransferGroupFilter)[]} [only] If present, only include these filtered groups of data
+ * @property {(keyof import('@strapi/data-transfer/src/engine').TransferGroupFilter)[]} [exclude] If present, exclude these filtered groups of data
  */
 
 /**
@@ -96,6 +98,8 @@ module.exports = async (opts) => {
   const engine = createTransferEngine(source, destination, {
     versionStrategy: 'exact',
     schemaStrategy: 'strict',
+    exclude: opts.exclude,
+    only: opts.only,
     transforms: {
       links: [
         {


### PR DESCRIPTION
### What does it do?

- fixes the typings (and comments) for import/export/transfer commands
- enables only/exclude options for transfer command

### Why is it needed?

--

### How to test it?

Use `strapi transfer` with the --only and --exclude options

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
