### PR TITLE
Disabled property for JSONInput (GenericInput)

### DIFF
--- a/packages/core/helper-plugin/lib/src/components/GenericInput/index.js
+++ b/packages/core/helper-plugin/lib/src/components/GenericInput/index.js
@@ -142,6 +142,7 @@ const GenericInput = ({
           labelAction={labelAction}
           value={value}
           error={errorMessage}
+          disabled={disabled}
           hint={hint}
           required={required}
           onChange={(json) => {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Describe the technical changes you did.

### Why is it needed?

The GenericInput component does not currently pass the disabled attribute to the JSONInput component, so for advanced use cases, it is not possible to achieve a readonly JSON field

### How to test it?

Add a new GenericInput to a wiew with ``type="json"`` and ``disabled={true}`` 

### Related issue(s)/PR(s)

FIXES #16030 
