### PR TITLE
Manage error if transfer token salt is missing

### DIFF
--- a/packages/core/admin/server/middlewares/data-transfer.js
+++ b/packages/core/admin/server/middlewares/data-transfer.js
@@ -12,8 +12,11 @@ module.exports = () => async (ctx, next) => {
   }
 
   if (!hasValidTokenSalt()) {
-    return ctx.notImplemented(
-      'The server configuration for data transfer is invalid. Please contact your server administrator.'
+    return ctx.badRequest(
+      'The server configuration for data transfer is invalid. Please contact your server administrator.',
+      {
+        code: 'INVALID_TOKEN_SALT',
+      }
     );
   }
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Provide an error when we try to reach a transfer API without TRANSFER_TOKEN_SALT

### Why is it needed?

Because right now we don't have a specific error so can be confusing for the user who has this kind of error.

### How to test it?

 - As a builder managing the configuration
   - when the transfer.token.salt is missing in the configuration of the admin
   - when I access the transfer token settings in the admin panel
     - then I want an error to be prompted to the user You have an invalid configuration, check your server log for more information. 

### Related issue(s)/PR(s)

The ticket related is this one
