### PR TITLE
[Data transfer] Add throttle option (delays) to data transfers

### DIFF
--- a/packages/core/data-transfer/types/transfer-engine.d.ts
+++ b/packages/core/data-transfer/types/transfer-engine.d.ts
@@ -144,4 +144,7 @@ export interface ITransferEngineOptions {
   // List of TransferTransformList preset options to exclude/include
   exclude: TransferFilterPreset[];
   only: TransferFilterPreset[];
+
+  // delay after each record
+  throttle: number;
 }

--- a/packages/core/strapi/bin/strapi.js
+++ b/packages/core/strapi/bin/strapi.js
@@ -24,6 +24,7 @@ const { exitWith, ifOptions, assertUrlHasProtocol } = require('../lib/commands/u
 const {
   excludeOption,
   onlyOption,
+  throttleOption,
   validateExcludeOnly,
 } = require('../lib/commands/transfer/utils');
 
@@ -295,6 +296,7 @@ program
   .addOption(forceOption)
   .addOption(excludeOption)
   .addOption(onlyOption)
+  .addOption(throttleOption)
   .hook('preAction', validateExcludeOnly)
   // If --from is used, validate the URL and token
   .hook(
@@ -367,6 +369,7 @@ program
   .addOption(new Option('-f, --file <file>', 'name to use for exported file (without extensions)'))
   .addOption(excludeOption)
   .addOption(onlyOption)
+  .addOption(throttleOption)
   .hook('preAction', validateExcludeOnly)
   .hook('preAction', promptEncryptionKey)
   .action(getLocalScript('transfer/export'));
@@ -389,6 +392,7 @@ program
   .addOption(forceOption)
   .addOption(excludeOption)
   .addOption(onlyOption)
+  .addOption(throttleOption)
   .hook('preAction', validateExcludeOnly)
   .hook('preAction', async (thisCommand) => {
     const opts = thisCommand.opts();

--- a/packages/core/strapi/lib/commands/transfer/export.js
+++ b/packages/core/strapi/lib/commands/transfer/export.js
@@ -33,6 +33,7 @@ const { exitWith } = require('../utils/helpers');
  * @property {boolean} [compress] Used to compress the final archive
  * @property {(keyof import('@strapi/data-transfer/src/engine').TransferGroupFilter)[]} [only] If present, only include these filtered groups of data
  * @property {(keyof import('@strapi/data-transfer/src/engine').TransferGroupFilter)[]} [exclude] If present, exclude these filtered groups of data
+ * @property {number|undefined} [throttle] Delay in ms after each record
  */
 
 const BYTES_IN_MB = 1024 * 1024;
@@ -60,6 +61,7 @@ module.exports = async (opts) => {
     schemaStrategy: 'ignore', // for an export to file, schemaStrategy will always be skipped
     exclude: opts.exclude,
     only: opts.only,
+    throttle: opts.throttle,
     transforms: {
       links: [
         {

--- a/packages/core/strapi/lib/commands/transfer/import.js
+++ b/packages/core/strapi/lib/commands/transfer/import.js
@@ -32,6 +32,7 @@ const { exitWith } = require('../utils/helpers');
  * @property {string} [key] Encryption key, used when encryption is enabled
  * @property {(keyof import('@strapi/data-transfer/src/engine').TransferGroupFilter)[]} [only] If present, only include these filtered groups of data
  * @property {(keyof import('@strapi/data-transfer/src/engine').TransferGroupFilter)[]} [exclude] If present, exclude these filtered groups of data
+ * @property {number|undefined} [throttle] Delay in ms after each record
  */
 
 /**
@@ -79,6 +80,7 @@ module.exports = async (opts) => {
     schemaStrategy: opts.schemaStrategy || DEFAULT_SCHEMA_STRATEGY,
     exclude: opts.exclude,
     only: opts.only,
+    throttle: opts.throttle,
     rules: {
       links: [
         {

--- a/packages/core/strapi/lib/commands/transfer/transfer.js
+++ b/packages/core/strapi/lib/commands/transfer/transfer.js
@@ -31,6 +31,7 @@ const { exitWith } = require('../utils/helpers');
  * @property {string|undefined} [fromToken] The transfer token for the remote Strapi source
  * @property {(keyof import('@strapi/data-transfer/src/engine').TransferGroupFilter)[]} [only] If present, only include these filtered groups of data
  * @property {(keyof import('@strapi/data-transfer/src/engine').TransferGroupFilter)[]} [exclude] If present, exclude these filtered groups of data
+ * @property {number|undefined} [throttle] Delay in ms after each record
  */
 
 /**
@@ -100,6 +101,7 @@ module.exports = async (opts) => {
     schemaStrategy: 'strict',
     exclude: opts.exclude,
     only: opts.only,
+    throttle: opts.throttle,
     transforms: {
       links: [
         {

--- a/packages/core/strapi/lib/commands/transfer/utils.js
+++ b/packages/core/strapi/lib/commands/transfer/utils.js
@@ -14,7 +14,7 @@ const {
 const ora = require('ora');
 const { readableBytes, exitWith } = require('../utils/helpers');
 const strapi = require('../../index');
-const { getParseListWithChoices } = require('../utils/commander');
+const { getParseListWithChoices, parseInteger } = require('../utils/commander');
 
 const pad = (n) => {
   return (n < 10 ? '0' : '') + String(n);
@@ -106,6 +106,13 @@ const createStrapiInstance = async (logLevel = 'error') => {
 };
 
 const transferDataTypes = Object.keys(TransferGroupPresets);
+
+const throttleOption = new Option(
+  '--throttle <max messages per minute>',
+  `Include only these types of data (plus schemas). Available types: ${transferDataTypes.join(',')}`
+)
+  .argParser(parseInteger)
+  .hideHelp();
 
 const excludeOption = new Option(
   '--exclude <comma-separated data types>',
@@ -220,6 +227,7 @@ module.exports = {
   createStrapiInstance,
   excludeOption,
   onlyOption,
+  throttleOption,
   validateExcludeOnly,
   formatDiagnostic,
 };

--- a/packages/core/strapi/lib/commands/transfer/utils.js
+++ b/packages/core/strapi/lib/commands/transfer/utils.js
@@ -108,11 +108,11 @@ const createStrapiInstance = async (logLevel = 'error') => {
 const transferDataTypes = Object.keys(TransferGroupPresets);
 
 const throttleOption = new Option(
-  '--throttle <max messages per minute>',
-  `Include only these types of data (plus schemas). Available types: ${transferDataTypes.join(',')}`
+  '--throttle <delay after each entity>',
+  `Add a delay in milliseconds between each transferred entity`
 )
   .argParser(parseInteger)
-  .hideHelp();
+  .hideHelp(); // This option is not publicly documented
 
 const excludeOption = new Option(
   '--exclude <comma-separated data types>',

--- a/packages/core/strapi/lib/commands/utils/commander.js
+++ b/packages/core/strapi/lib/commands/utils/commander.js
@@ -7,6 +7,7 @@
 const inquirer = require('inquirer');
 const { InvalidOptionArgumentError, Option } = require('commander');
 const { bold, green, cyan } = require('chalk');
+const { isNaN } = require('lodash/fp');
 const { exitWith } = require('./helpers');
 
 /**
@@ -38,6 +39,18 @@ const getParseListWithChoices = (choices, errorMessage = 'Invalid options:') => 
 
     return list;
   };
+};
+
+/**
+ * argParser: Parse a string as a URL object
+ */
+const parseInteger = (value) => {
+  // parseInt takes a string and a radix
+  const parsedValue = parseInt(value, 10);
+  if (isNaN(parsedValue)) {
+    throw new InvalidOptionArgumentError(`Not an integer: ${value}`);
+  }
+  return parsedValue;
 };
 
 /**
@@ -131,6 +144,7 @@ module.exports = {
   getParseListWithChoices,
   parseList,
   parseURL,
+  parseInteger,
   promptEncryptionKey,
   confirmMessage,
   forceOption,

--- a/packages/core/strapi/lib/commands/utils/commander.js
+++ b/packages/core/strapi/lib/commands/utils/commander.js
@@ -42,7 +42,7 @@ const getParseListWithChoices = (choices, errorMessage = 'Invalid options:') => 
 };
 
 /**
- * argParser: Parse a string as a URL object
+ * argParser: Parse a string as an integer
  */
 const parseInteger = (value) => {
   // parseInt takes a string and a radix


### PR DESCRIPTION
[super low priority by the way]

### What does it do?

Adds a hidden --throttle option to the transfer/export/import CLI to add a delay between each entity

### Why is it needed?

To slow down transfers either for debugging purposes or (if documented in the future) to reduce server load.

### How to test it?

Run a transfer/export/import and add `--throttle 1000` to add a 1000ms delay between each entity transferred.
