### PR TITLE
Added an option to set a CDN host which is then used for media URLs

### DIFF
--- a/packages/providers/upload-aws-s3/README.md
+++ b/packages/providers/upload-aws-s3/README.md
@@ -46,7 +46,10 @@ module.exports = ({ env }) => ({
         params: {
           Bucket: env('AWS_BUCKET'),
         },
-        cdn: env('AWS_CDN_URL'), //e.g.: ddehgnixh0ene.cloudfront.net
+        cloudFrontUrl: {
+          protocol: env('AWS_CLOUDFRONT_PROTOCOL', 'https'),
+          domain: env('AWS_CLOUDFRONT_DOMAIN'), //e.g.: ddehgnixh0ene.cloudfront.net
+        }
       },
       actionOptions: {
         upload: {},

--- a/packages/providers/upload-aws-s3/README.md
+++ b/packages/providers/upload-aws-s3/README.md
@@ -46,6 +46,7 @@ module.exports = ({ env }) => ({
         params: {
           Bucket: env('AWS_BUCKET'),
         },
+        cdn: env('AWS_CDN_URL'), //e.g.: ddehgnixh0ene.cloudfront.net
       },
       actionOptions: {
         upload: {},

--- a/packages/providers/upload-aws-s3/README.md
+++ b/packages/providers/upload-aws-s3/README.md
@@ -46,7 +46,7 @@ module.exports = ({ env }) => ({
         params: {
           Bucket: env('AWS_BUCKET'),
         },
-        cloudFrontUrl: {
+        cloudFrontConfig: {
           protocol: env('AWS_CLOUDFRONT_PROTOCOL', 'https'),
           domain: env('AWS_CLOUDFRONT_DOMAIN'), //e.g.: ddehgnixh0ene.cloudfront.net
         }

--- a/packages/providers/upload-aws-s3/README.md
+++ b/packages/providers/upload-aws-s3/README.md
@@ -46,9 +46,9 @@ module.exports = ({ env }) => ({
         params: {
           Bucket: env('AWS_BUCKET'),
         },
-        cloudFrontConfig: {
+        cloudFrontUrl: {
           protocol: env('AWS_CLOUDFRONT_PROTOCOL', 'https'),
-          domain: env('AWS_CLOUDFRONT_DOMAIN'), //e.g.: ddehgnixh0ene.cloudfront.net
+          domain: env('AWS_CLOUDFRONT_DOMAIN'), //e.g.: xyz.cloudfront.net
         }
       },
       actionOptions: {

--- a/packages/providers/upload-aws-s3/lib/index.js
+++ b/packages/providers/upload-aws-s3/lib/index.js
@@ -16,6 +16,9 @@ function assertUrlProtocol(url) {
 
 module.exports = {
   init(config) {
+    const cloudFrontConfig = config.cloudFrontConfig;
+    delete config.cloudFrontConfig;
+
     const S3 = new AWS.S3({
       apiVersion: '2006-03-01',
       ...config,
@@ -39,8 +42,8 @@ module.exports = {
             }
 
             // set the bucket file url
-            if (config.cdn) {
-              file.url='https://' + config.cdn + '/' + data.Key;
+            if (cloudFrontConfig.protocol && cloudFrontConfig.domain) {
+              file.url = cloudFrontConfig.protocol + '://' + cloudFrontConfig.domain + '/' + data.Key;
             } else {
               if (assertUrlProtocol(data.Location)) {
                 file.url = data.Location;

--- a/packages/providers/upload-aws-s3/lib/index.js
+++ b/packages/providers/upload-aws-s3/lib/index.js
@@ -16,8 +16,8 @@ function assertUrlProtocol(url) {
 
 module.exports = {
   init(config) {
-    const cloudFrontConfig = config.cloudFrontConfig;
-    delete config.cloudFrontConfig;
+    const cloudFrontUrl = config.cloudFrontUrl;
+    delete config.cloudFrontUrl;
 
     const S3 = new AWS.S3({
       apiVersion: '2006-03-01',
@@ -42,8 +42,8 @@ module.exports = {
             }
 
             // set the bucket file url
-            if (cloudFrontConfig.protocol && cloudFrontConfig.domain) {
-              file.url = cloudFrontConfig.protocol + '://' + cloudFrontConfig.domain + '/' + data.Key;
+            if (cloudFrontUrl.protocol && cloudFrontUrl.domain) {
+              file.url = cloudFrontUrl.protocol + '://' + cloudFrontUrl.domain + '/' + data.Key;
             } else {
               if (assertUrlProtocol(data.Location)) {
                 file.url = data.Location;

--- a/packages/providers/upload-aws-s3/lib/index.js
+++ b/packages/providers/upload-aws-s3/lib/index.js
@@ -39,11 +39,15 @@ module.exports = {
             }
 
             // set the bucket file url
-            if (assertUrlProtocol(data.Location)) {
-              file.url = data.Location;
+            if (config.cdn) {
+              file.url='https://' + config.cdn + '/' + data.Key;
             } else {
-              // Default protocol to https protocol
-              file.url = `https://${data.Location}`;
+              if (assertUrlProtocol(data.Location)) {
+                file.url = data.Location;
+              } else {
+                // Default protocol to https protocol
+                file.url = `https://${data.Location}`;
+              }
             }
 
             resolve();


### PR DESCRIPTION
### What does it do?

Updates the upload-aws-s3 provider to include a new **cdn** option. 
This option is used when a new media file is uploaded to change the URL of the file to point to the CDN URL instead of the URL on the S3 bucket.

### Why is it needed?

It is very common to run an S3 bucket behind CDN like Cloudfront. If we don't want to grant CDN a write access to S3 bucket we need to upload media to S3 directly. That is especially useful when Strapi runs on the same VPC as S3. 
But the problem is that in that case URL returned by API or URL of thumbnails in Admin panel points to S3 bucket which is not accessible. The added feature then replaces S3 URL with Cloudfront one which ensures that media are loaded correctly.   

### How to test it?



### Related issue(s)/PR(s)

no
