### PR TITLE
CTB: Set default review-workflow value from admin API as input value

### DIFF
--- a/packages/core/content-type-builder/admin/src/components/FormModal/contentType/createContentTypeSchema.js
+++ b/packages/core/content-type-builder/admin/src/components/FormModal/contentType/createContentTypeSchema.js
@@ -112,6 +112,7 @@ const createContentTypeSchema = ({
       .required(errorsTrads.required),
     draftAndPublish: yup.boolean(),
     kind: yup.string().oneOf(['singleType', 'collectionType']),
+    reviewWorkflows: yup.boolean(),
   };
 
   return yup.object(shape);

--- a/packages/core/content-type-builder/admin/src/components/FormModal/index.js
+++ b/packages/core/content-type-builder/admin/src/components/FormModal/index.js
@@ -184,6 +184,7 @@ const FormModal = () => {
           actionType,
           data: {
             draftAndPublish: true,
+            reviewWorkflows: false,
           },
           pluginOptions: {},
         });
@@ -191,16 +192,20 @@ const FormModal = () => {
 
       // Edit content type
       if (modalType === 'contentType' && actionType === 'edit') {
-        const { displayName, draftAndPublish, kind, pluginOptions, pluralName, singularName } = get(
-          allDataSchema,
-          [...pathToSchema, 'schema'],
-          {
-            displayName: null,
-            pluginOptions: {},
-            singularName: null,
-            pluralName: null,
-          }
-        );
+        const {
+          displayName,
+          draftAndPublish,
+          kind,
+          pluginOptions,
+          pluralName,
+          reviewWorkflows,
+          singularName,
+        } = get(allDataSchema, [...pathToSchema, 'schema'], {
+          displayName: null,
+          pluginOptions: {},
+          singularName: null,
+          pluralName: null,
+        });
 
         dispatch({
           type: SET_DATA_TO_EDIT,
@@ -212,6 +217,10 @@ const FormModal = () => {
             kind,
             pluginOptions,
             pluralName,
+            // because review-workflows is an EE feature the attribute does
+            // not always exist, but the component prop-types expect a boolean,
+            // so we have to ensure undefined is casted to false
+            reviewWorkflows: reviewWorkflows ?? false,
             singularName,
           },
         });

--- a/packages/core/content-type-builder/server/controllers/validation/model-schema.js
+++ b/packages/core/content-type-builder/server/controllers/validation/model-schema.js
@@ -17,6 +17,7 @@ const createSchema = (types, relations, { modelType } = {}) => {
     pluginOptions: yup.object(),
     collectionName: yup.string().nullable().test(isValidCollectionName),
     attributes: createAttributesValidator({ types, relations, modelType }),
+    reviewWorkflows: yup.boolean(),
   };
 
   if (modelType === modelTypes.CONTENT_TYPE) {


### PR DESCRIPTION
### What does it do?

Ensures the value returned from the admin API about whether the feature is turned on or off for a given content-type is set as default value for the feature checkbox.

### Why is it needed?

Otherwise users would loose the setting whether the feature is enabled/ disabled every time they save.

### How to test it?

1. Go to the CTB
2. Enable RW on a content-type
3. Wait for restart
4. Open the content-type edit modal again
5. Verify the checkbox is set to checked


