### PR TITLE
CM Information: Add rw stage label and improve alignment

### DIFF
--- a/packages/core/admin/admin/src/content-manager/pages/EditView/Information/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/EditView/Information/index.js
@@ -30,10 +30,12 @@ const Title = () => {
 const KeyValuePair = ({ label, value }) => {
   return (
     <Flex justifyContent="space-between">
-      <Typography as="dt" fontWeight="bold" textColor="neutral600">
+      <Typography as="dt" fontWeight="bold" textColor="neutral800" variant="pi">
         {label}
       </Typography>
-      <Typography as="dd">{value}</Typography>
+      <Typography as="dd" variant="pi" textColor="neutral600">
+        {value}
+      </Typography>
     </Flex>
   );
 };
@@ -109,7 +111,7 @@ const Body = () => {
 };
 
 const Root = ({ children }) => {
-  return <Stack spacing={6}>{children}</Stack>;
+  return <Stack spacing={4}>{children}</Stack>;
 };
 
 Root.propTypes = {

--- a/packages/core/admin/admin/src/translations/en.json
+++ b/packages/core/admin/admin/src/translations/en.json
@@ -785,6 +785,7 @@
   "content-manager.relation.add": "Add relation",
   "content-manager.relation.publicationState.draft": "Draft",
   "content-manager.relation.publicationState.published": "Published",
+  "content-manager.reviewWorkflows.stage.label": "Review stage",
   "form.button.continue": "Continue",
   "form.button.done": "Done",
   "global.search": "Search",

--- a/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/InformationBoxEE.js
+++ b/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/InformationBoxEE.js
@@ -1,5 +1,7 @@
 import React from 'react';
 import { ReactSelect, useCMEditViewDataManager } from '@strapi/helper-plugin';
+import { FieldLabel, Flex } from '@strapi/design-system';
+import { useIntl } from 'react-intl';
 
 import { useReviewWorkflows } from '../../../../pages/SettingsPage/pages/ReviewWorkflows/hooks/useReviewWorkflows';
 import Information from '../../../../../../admin/src/content-manager/pages/EditView/Information';
@@ -8,6 +10,8 @@ const ATTRIBUTE_NAME = 'strapi_reviewWorkflows_stage';
 
 export function InformationBoxEE() {
   const { initialData, isCreatingEntry } = useCMEditViewDataManager();
+  const { formatMessage } = useIntl();
+
   const activeWorkflowStage = initialData?.[ATTRIBUTE_NAME] ?? null;
   const {
     workflows: { data: workflow },
@@ -19,14 +23,24 @@ export function InformationBoxEE() {
     <Information.Root>
       <Information.Title />
       {activeWorkflowStage && (
-        <ReactSelect
-          isDisabled={isCreatingEntry}
-          options={options}
-          name={ATTRIBUTE_NAME}
-          value={{ value: activeWorkflowStage?.id, label: activeWorkflowStage?.name }}
-          isSearchable={false}
-          isClearable={false}
-        />
+        <Flex direction="column" gap={2} alignItems="stretch">
+          <FieldLabel htmlFor={ATTRIBUTE_NAME}>
+            {formatMessage({
+              id: 'content-manager.reviewWorkflows.stage.label',
+              defaultMessage: 'Review stage',
+            })}
+          </FieldLabel>
+
+          <ReactSelect
+            inputId={ATTRIBUTE_NAME}
+            isDisabled={isCreatingEntry}
+            options={options}
+            name={ATTRIBUTE_NAME}
+            defaultValue={{ value: activeWorkflowStage?.id, label: activeWorkflowStage?.name }}
+            isSearchable={false}
+            isClearable={false}
+          />
+        </Flex>
       )}
       <Information.Body />
     </Information.Root>

--- a/packages/core/helper-plugin/lib/src/components/ReactSelect/utils/getSelectStyles.js
+++ b/packages/core/helper-plugin/lib/src/components/ReactSelect/utils/getSelectStyles.js
@@ -75,6 +75,7 @@ const getSelectStyles = (theme, error) => {
 
       return {
         ...base,
+        color: theme.colors.neutral800,
         lineHeight: theme.spaces[5],
         backgroundColor,
         borderRadius: theme.borderRadius,


### PR DESCRIPTION
### What does it do?

- Improves the alignment of the items in the CM information sidebar
- Fixes the text-color of the active option in a react-select
- Adds a visible label to the information box stage select input

### Why is it needed?

Papercut fixes.

