### PR TITLE
[Fix] CTB return private config on media types

### DIFF
--- a/packages/core/content-type-builder/server/utils/attributes.js
+++ b/packages/core/content-type-builder/server/utils/attributes.js
@@ -48,6 +48,7 @@ const formatAttribute = (key, attribute) => {
       multiple: !!attribute.multiple,
       required: !!required,
       configurable: configurable === false ? false : undefined,
+      private: !!attribute.private,
       allowedTypes: attribute.allowedTypes,
       pluginOptions,
     };


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Returns the private configuration of media attributes on the CTB. Before , when you set a media field to be private and reload the CTB, you would see the private field was not checked.

### How to test it?

1. Create a content-type with a media field
2. Set the media-field to private
3. Reload the page and edit the content-type
4. See the private field is checked

### Related issue(s)/PR(s)
https://github.com/strapi/strapi/issues/10105