### PR TITLE
[Clone Entity Relations]: add entity-repository cloneRelations method

### DIFF
--- a/packages/core/database/lib/entity-manager/entity-repository.js
+++ b/packages/core/database/lib/entity-manager/entity-repository.js
@@ -104,8 +104,8 @@ const createRepository = (uid, db) => {
       return db.entityManager.deleteRelations(uid, id);
     },
 
-    cloneRelations(id, cloneId, params) {
-      return db.entityManager.cloneRelations(uid, id, cloneId, params);
+    cloneRelations(targetId, sourceId, params) {
+      return db.entityManager.cloneRelations(uid, targetId, sourceId, params);
     },
 
     populate(entity, populate) {

--- a/packages/core/database/lib/entity-manager/entity-repository.js
+++ b/packages/core/database/lib/entity-manager/entity-repository.js
@@ -104,6 +104,10 @@ const createRepository = (uid, db) => {
       return db.entityManager.deleteRelations(uid, id);
     },
 
+    cloneRelations(id, cloneId, params) {
+      return db.entityManager.cloneRelations(uid, id, cloneId, params);
+    },
+
     populate(entity, populate) {
       return db.entityManager.populate(uid, entity, populate);
     },

--- a/packages/core/database/lib/entity-manager/index.js
+++ b/packages/core/database/lib/entity-manager/index.js
@@ -1172,8 +1172,6 @@ const createEntityManager = (db) => {
 
     // TODO: Clone polymorphic relations
     // TODO: Excluded relation attributes
-    // TODO: Excluded relations (e.g. don't clone id X )
-    // async cloneRelations(uid, id, cloneId, { transaction: trx }) {
     /**
      *
      * @param {*} uid - uid of the entity to clone

--- a/packages/core/database/lib/entity-manager/index.js
+++ b/packages/core/database/lib/entity-manager/index.js
@@ -1174,9 +1174,9 @@ const createEntityManager = (db) => {
     // TODO: Excluded relation attributes
     /**
      *
-     * @param {*} uid - uid of the entity to clone
-     * @param {*} id - id of the entity to clone
-     * @param {*} cloneId - id of the cloned entity
+     * @param {string} uid - uid of the entity to clone
+     * @param {number} id - id of the entity to clone
+     * @param {number} cloneId - id of the cloned entity
      * @param {object} opt
      * @param {object} opt.cloneAttrs - key value pair of attributes to clone
      * @param {object} opt.transaction - transaction to use

--- a/packages/core/database/lib/entity-manager/index.js
+++ b/packages/core/database/lib/entity-manager/index.js
@@ -21,6 +21,7 @@ const {
   difference,
   uniqBy,
 } = require('lodash/fp');
+const { mapAsync } = require('@strapi/utils');
 const types = require('../types');
 const { createField } = require('../fields');
 const { createQueryBuilder } = require('../query');
@@ -40,6 +41,11 @@ const {
   cleanOrderColumns,
 } = require('./regular-relations');
 const { relationsOrderer } = require('./relations-orderer');
+const {
+  replaceRegularRelations,
+  cloneRegularRelations,
+} = require('./relations/cloning/regular-relations');
+const { DatabaseError } = require('../errors');
 
 const toId = (value) => value.id || value;
 const toIds = (value) => castArray(value || []).map(toId);
@@ -1162,6 +1168,52 @@ const createEntityManager = (db) => {
           await deleteRelations({ id, attribute, db, relIdsToDelete: 'all', transaction: trx });
         }
       }
+    },
+
+    // TODO: Clone polymorphic relations
+    // TODO: Excluded relation attributes
+    // TODO: Excluded relations (e.g. don't clone id X )
+    // async cloneRelations(uid, id, cloneId, { transaction: trx }) {
+    /**
+     *
+     * @param {*} uid - uid of the entity to clone
+     * @param {*} id - id of the entity to clone
+     * @param {*} cloneId - id of the cloned entity
+     * @param {object} opt
+     * @param {object} opt.cloneAttrs - key value pair of attributes to clone
+     * @param {object} opt.transaction - transaction to use
+     * @example cloneRelations('article', 1, 2, { cloneAttrs: { categories: true } })
+     */
+    async cloneRelations(uid, id, cloneId, { cloneAttrs = {}, transaction }) {
+      const { attributes } = db.metadata.get(uid);
+
+      if (!attributes) {
+        return;
+      }
+
+      await mapAsync(Object.entries(cloneAttrs), async ([attrName, shouldClone]) => {
+        if (!shouldClone) return;
+        const attribute = attributes[attrName];
+
+        if (attribute.type !== 'relation') {
+          throw new DatabaseError(
+            `Attribute ${attrName} is not a relation attribute. Cloning relations is only supported for relation attributes.`
+          );
+        }
+
+        // TODO: add support for cloning polymorphic relations
+        if (!attribute.joinTable) {
+          throw new DatabaseError(
+            `Cloning relations of type ${attribute.relation} is not supported`
+          );
+        }
+
+        if (isOneToAny(attribute) && isBidirectional(attribute)) {
+          await replaceRegularRelations({ id, cloneId, attribute, transaction });
+        } else {
+          await cloneRegularRelations({ id, cloneId, attribute, transaction });
+        }
+      });
     },
 
     // TODO: add lifecycle events

--- a/packages/core/database/lib/entity-manager/index.js
+++ b/packages/core/database/lib/entity-manager/index.js
@@ -1199,11 +1199,14 @@ const createEntityManager = (db) => {
           );
         }
 
-        // TODO: add support for cloning polymorphic relations
+        if (attribute.joinColumn) {
+          // TODO: add support for cloning oneToMany relations on the owning side
+          return;
+        }
+
         if (!attribute.joinTable) {
-          throw new DatabaseError(
-            `Cloning relations of type ${attribute.relation} is not supported`
-          );
+          // TODO: add support for cloning polymorphic relations
+          return;
         }
 
         if (isOneToAny(attribute) && isBidirectional(attribute)) {

--- a/packages/core/database/lib/entity-manager/index.js
+++ b/packages/core/database/lib/entity-manager/index.js
@@ -1175,14 +1175,15 @@ const createEntityManager = (db) => {
     /**
      *
      * @param {string} uid - uid of the entity to clone
-     * @param {number} id - id of the entity to clone
-     * @param {number} cloneId - id of the cloned entity
+     * @param {number} targetId - id of the entity to clone into
+     * @param {number} sourceId - id of the entity to clone from
      * @param {object} opt
      * @param {object} opt.cloneAttrs - key value pair of attributes to clone
      * @param {object} opt.transaction - transaction to use
-     * @example cloneRelations('article', 1, 2, { cloneAttrs: { categories: true } })
+     * @example cloneRelations('user', 3, 1, { cloneAttrs: { friends: true }})
+     * @example cloneRelations('post', 5, 2, { cloneAttrs: { comments: true, likes: true } })
      */
-    async cloneRelations(uid, id, cloneId, { cloneAttrs = {}, transaction }) {
+    async cloneRelations(uid, targetId, sourceId, { cloneAttrs = {}, transaction }) {
       const { attributes } = db.metadata.get(uid);
 
       if (!attributes) {
@@ -1210,9 +1211,9 @@ const createEntityManager = (db) => {
         }
 
         if (isOneToAny(attribute) && isBidirectional(attribute)) {
-          await replaceRegularRelations({ id, cloneId, attribute, transaction });
+          await replaceRegularRelations({ targetId, sourceId, attribute, transaction });
         } else {
-          await cloneRegularRelations({ id, cloneId, attribute, transaction });
+          await cloneRegularRelations({ targetId, sourceId, attribute, transaction });
         }
       });
     },

--- a/packages/core/database/lib/entity-manager/relations/cloning/regular-relations.js
+++ b/packages/core/database/lib/entity-manager/relations/cloning/regular-relations.js
@@ -60,7 +60,7 @@ const cloneRegularRelations = async ({ targetId, sourceId, attribute, transactio
   // Clean the inverse order column
   if (inverseOrderColumnName) {
     await cleanInverseOrderColumn({
-      targetId,
+      id: targetId,
       attribute,
       trx,
     });

--- a/packages/core/database/lib/entity-manager/relations/cloning/regular-relations.js
+++ b/packages/core/database/lib/entity-manager/relations/cloning/regular-relations.js
@@ -1,0 +1,73 @@
+'use strict';
+
+const { cleanInverseOrderColumn } = require('../../regular-relations');
+
+const replaceRegularRelations = async ({ id, cloneId, attribute, transaction: trx }) => {
+  const { joinTable } = attribute;
+  const { joinColumn, inverseJoinColumn } = joinTable;
+
+  // We are effectively stealing the relation from the cloned entity
+  await strapi.db.entityManager
+    .createQueryBuilder(joinTable.name)
+    .update({ [joinColumn.name]: id })
+    .where({ [joinColumn.name]: cloneId })
+    // TODO: Exclude some relations from being replaced
+    // .where({ $not: { [inverseJoinColumn.name]: relationsToDeleteIds } })
+    .onConflict([joinColumn.name, inverseJoinColumn.name])
+    .ignore()
+    .transacting(trx)
+    .execute();
+};
+
+const cloneRegularRelations = async ({ id, cloneId, attribute, transaction: trx }) => {
+  const { joinTable } = attribute;
+  const { joinColumn, inverseJoinColumn, orderColumnName, inverseOrderColumnName } = joinTable;
+  const connection = strapi.db.getConnection();
+
+  // Get the columns to select
+  const columns = [joinColumn.name, inverseJoinColumn.name];
+  if (orderColumnName) columns.push(orderColumnName);
+  if (inverseOrderColumnName) columns.push(inverseOrderColumnName);
+  if (joinTable.on) columns.push(...Object.keys(joinTable.on));
+
+  const selectStatement = connection
+    .select(
+      // Override joinColumn with the new id
+      { [joinColumn.name]: id },
+      // The rest of columns will be the same
+      ...columns.slice(1)
+    )
+    .where(joinColumn.name, cloneId)
+    // TODO: Exclude some relations from being replaced
+    // .where({ $not: { [inverseJoinColumn.name]: relationsToDeleteIds } })
+    .from(joinTable.name)
+    .toSQL();
+
+  // Insert the clone relations
+  await strapi.db.entityManager
+    .createQueryBuilder(joinTable.name)
+    .insert(
+      strapi.db.connection.raw(
+        `(${columns.join(',')})  ${selectStatement.sql}`,
+        selectStatement.bindings
+      )
+    )
+    .onConflict([joinColumn.name, inverseJoinColumn.name])
+    .ignore()
+    .transacting(trx)
+    .execute();
+
+  // Clean the inverse order column
+  if (inverseOrderColumnName) {
+    await cleanInverseOrderColumn({
+      id,
+      attribute,
+      trx,
+    });
+  }
+};
+
+module.exports = {
+  replaceRegularRelations,
+  cloneRegularRelations,
+};

--- a/packages/core/database/package.json
+++ b/packages/core/database/package.json
@@ -31,6 +31,7 @@
     "test:unit": "jest --verbose"
   },
   "dependencies": {
+    "@strapi/utils": "4.7.1",
     "date-fns": "2.29.3",
     "debug": "4.3.4",
     "fs-extra": "10.0.0",


### PR DESCRIPTION
### What does it do?

First step towards being able to clone entity relations.

This implements the `cloneRelations` method in the `entity-manager` db layer, which takes


```js
    /**
     *
     * @param {*} uid - uid of the entity to clone
     * @param {*} id - id of the entity to clone
     * @param {*} cloneId - id of the cloned entity
     * @param {object} opt
     * @param {object} opt.cloneAttrs - key value pair of attributes to clone
     * @param {object} opt.transaction - transaction to use
     * @example cloneRelations('article', 1, 2, { cloneAttrs: { categories: true } })
     */
    async cloneRelations(uid, id, cloneId, { cloneAttrs = {}, transaction }) {
```

The clone attributes will receive the list of all attributes that should be cloned.
It's an object because in further iterations, each attribute will be able to specify some specific relations to not be copied. 

### Why is it needed?

So we can clone relations.

### How to test it?

In the get started project, create two kitchensinks, the first one (id 1) add some relations, then execute this sin the `bootsrap` method.

```js
    const trx = await strapi.db.transaction();
    try {
     // This clones id 1 relations into id 2
      await strapi.db.query('api::kitchensink.kitchensink').cloneRelations(2, 1, {
        cloneAttrs: {
          many_to_one_tag: true,
          one_to_one_tag: true,
          one_to_many_tags: true,
          many_to_many_tags: true,
          one_way_tag: true,
          many_way_tags: true,
        },
        transaction: trx.get(),
      });
      await trx.commit();
    } catch (err) {
      await trx.rollback();
      throw err;
    }
```

