### PR TITLE
[Fix]: add links for database docs

### DIFF
--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -88,6 +88,27 @@ const sidebars = {
         },
         {
           type: 'category',
+          label: 'Database',
+          link: {
+            type: 'doc',
+            id: 'core/database/intro',
+          },
+          items: [
+            {
+              type: 'category',
+              label: 'Relations',
+              items: [
+                {
+                  type: 'doc',
+                  label: 'Reordering',
+                  id: 'core/database/relations/reordering',
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: 'category',
           label: 'Helper Plugin',
           items: [
             {


### PR DESCRIPTION
### What does it do?
Forgot to add sidebar links in our contributor docs, caused the build to fail.

### Why is it needed?
To fix docs deploy.
