### PR TITLE
Add tests for the documentation overrides

### DIFF
--- a/examples/getstarted/config/plugins.js
+++ b/examples/getstarted/config/plugins.js
@@ -19,6 +19,17 @@ module.exports = () => ({
       info: {
         version: '2.0.0',
       },
+      webhooks: {
+        test: {
+          post: {
+            responses: {
+              200: {
+                description: 'Success',
+              },
+            },
+          },
+        },
+      },
     },
   },
   myplugin: {

--- a/packages/plugins/documentation/server/config/default-plugin-config.js
+++ b/packages/plugins/documentation/server/config/default-plugin-config.js
@@ -21,7 +21,7 @@ module.exports = {
     path: '/documentation',
     showGeneratedFiles: true,
     generateDefaultResponse: true,
-    plugins: ['email', 'upload', 'users-permissions'],
+    plugins: null,
   },
   servers: [],
   externalDocs: {
@@ -33,42 +33,4 @@ module.exports = {
       bearerAuth: [],
     },
   ],
-  components: {
-    securitySchemes: {
-      bearerAuth: {
-        type: 'http',
-        scheme: 'bearer',
-        bearerFormat: 'JWT',
-      },
-    },
-    schemas: {
-      Error: {
-        type: 'object',
-        required: ['error'],
-        properties: {
-          data: {
-            nullable: true,
-            oneOf: [{ type: 'object' }, { type: 'array', items: { type: 'object' } }],
-          },
-          error: {
-            type: 'object',
-            properties: {
-              status: {
-                type: 'integer',
-              },
-              name: {
-                type: 'string',
-              },
-              message: {
-                type: 'string',
-              },
-              details: {
-                type: 'object',
-              },
-            },
-          },
-        },
-      },
-    },
-  },
 };

--- a/packages/plugins/documentation/server/services/__tests__/documentation.test.js
+++ b/packages/plugins/documentation/server/services/__tests__/documentation.test.js
@@ -65,7 +65,7 @@ describe('Documentation service', () => {
       const docService = documentation({ strapi: global.strapi });
 
       const pluginsToDocument = docService.getPluginsThatNeedDocumentation();
-      const expectededPlugins = ['email', 'upload', 'users-permissions'];
+      const expectededPlugins = ['upload', 'users-permissions'];
       expect(pluginsToDocument).toEqual(expectededPlugins);
 
       await docService.generateFullDoc();
@@ -78,17 +78,17 @@ describe('Documentation service', () => {
     it("generates documentation only for plugins in the user's config", async () => {
       global.strapi.config.get.mockReturnValueOnce({
         ...defaultConfig,
-        'x-strapi-config': { ...defaultConfig['x-strapi-config'], plugins: ['email'] },
+        'x-strapi-config': { ...defaultConfig['x-strapi-config'], plugins: ['upload'] },
       });
       const docService = documentation({ strapi: global.strapi });
 
       const pluginsToDocument = docService.getPluginsThatNeedDocumentation();
-      expect(pluginsToDocument).toEqual(['email']);
+      expect(pluginsToDocument).toEqual(['upload']);
 
       await docService.generateFullDoc();
       const lastMockCall = fse.writeJson.mock.calls[fse.writeJson.mock.calls.length - 1];
       const mockFinalDoc = lastMockCall[1];
-      expect(mockFinalDoc['x-strapi-config'].plugins).toEqual(['email']);
+      expect(mockFinalDoc['x-strapi-config'].plugins).toEqual(['upload']);
     });
 
     it('does not generate documentation for any plugins', async () => {

--- a/packages/plugins/documentation/server/services/__tests__/documentation.test.js
+++ b/packages/plugins/documentation/server/services/__tests__/documentation.test.js
@@ -118,11 +118,13 @@ describe('Documentation service', () => {
 
       docService.registerDoc(
         {
-          '/test': {
-            get: {
-              tags: ['Users-Permissions - Users & Roles'],
-              summary: 'Get list of users',
-              responses: {},
+          paths: {
+            '/test': {
+              get: {
+                tags: ['Users-Permissions - Users & Roles'],
+                summary: 'Get list of users',
+                responses: {},
+              },
             },
           },
         },

--- a/packages/plugins/documentation/server/services/documentation.js
+++ b/packages/plugins/documentation/server/services/documentation.js
@@ -5,16 +5,29 @@ const fs = require('fs-extra');
 const _ = require('lodash');
 const { getAbsoluteServerUrl } = require('@strapi/utils');
 
-const defaultPluginConfig = require('../config/default-plugin-config');
 const { builApiEndpointPath, buildComponentSchema } = require('./helpers');
+
+const defaultOpenApiComponents = require('./utils/default-openapi-components');
 
 module.exports = ({ strapi }) => {
   const config = strapi.config.get('plugin.documentation');
-
   const registeredDocs = [];
 
   return {
-    registerDoc(doc) {
+    registerDoc(doc, pluginOrigin) {
+      const plugins = this.getPluginsThatNeedDocumentation();
+      if (pluginOrigin) {
+        if (!plugins.includes(pluginOrigin)) {
+          return strapi.log.info(
+            `@strapi/documentation will not use the override provided by ${pluginOrigin} since the plugin was not specified in the x-strapi-config.plugins array`
+          );
+        }
+      } else {
+        strapi.log.warn(
+          '@strapi/documentation received an override that did not specify its origin, this could cause unexpected schema generation'
+        );
+      }
+
       let registeredDoc = doc;
       // parseYaml
       if (typeof doc === 'string') {
@@ -29,11 +42,6 @@ module.exports = ({ strapi }) => {
 
     getFullDocumentationPath() {
       return path.join(strapi.dirs.app.extensions, 'documentation', 'documentation');
-    },
-
-    getCustomDocumentationPath() {
-      // ??
-      return path.join(strapi.dirs.app.extensions, 'documentation', 'config', 'settings.json');
     },
 
     getDocumentationVersions() {
@@ -98,9 +106,28 @@ module.exports = ({ strapi }) => {
       await fs.remove(path.join(this.getFullDocumentationPath(), version));
     },
 
-    getPluginAndApiInfo() {
-      const plugins = _.get(config, 'x-strapi-config.plugins');
+    getPluginsThatNeedDocumentation() {
+      // Default plugins that need documentation generated
+      const defaultPlugins = ['email', 'upload', 'users-permissions'];
+      // User specified plugins that need documentation generated
+      const userPluginsConfig = _.get(config, 'x-strapi-config.plugins');
 
+      if (userPluginsConfig === null) {
+        // The user hasn't specified any plugins to document, use the defaults
+        return defaultPlugins;
+      }
+
+      if (userPluginsConfig.length) {
+        // The user has specified certain plugins to document, use them
+        return userPluginsConfig;
+      }
+
+      // The user has specified that no plugins should be documented
+      return [];
+    },
+
+    getPluginAndApiInfo() {
+      const plugins = this.getPluginsThatNeedDocumentation();
       const pluginsToDocument = plugins.map((plugin) => {
         return {
           name: plugin,
@@ -120,16 +147,6 @@ module.exports = ({ strapi }) => {
       return [...apisToDocument, ...pluginsToDocument];
     },
 
-    async getCustomConfig() {
-      const customConfigPath = this.getCustomDocumentationPath();
-      const pathExists = await fs.pathExists(customConfigPath);
-      if (pathExists) {
-        return fs.readJson(customConfigPath);
-      }
-
-      return {};
-    },
-
     /**
      * @description - Creates the Swagger json files
      */
@@ -139,8 +156,9 @@ module.exports = ({ strapi }) => {
       const apis = this.getPluginAndApiInfo();
       for (const api of apis) {
         const apiName = api.name;
+        // TODO: check if this is necessary
         const apiDirPath = path.join(this.getApiDocumentationPath(api), version);
-
+        // TODO: check if this is necessary
         const apiDocPath = path.join(apiDirPath, `${apiName}.json`);
 
         const apiPath = builApiEndpointPath(api);
@@ -149,6 +167,7 @@ module.exports = ({ strapi }) => {
           continue;
         }
 
+        // TODO: check if this is necessary
         await fs.ensureFile(apiDocPath);
         await fs.writeJson(apiDocPath, apiPath, { spaces: 2 });
 
@@ -168,34 +187,30 @@ module.exports = ({ strapi }) => {
         'full_documentation.json'
       );
 
-      const defaultConfig = _.cloneDeep(defaultPluginConfig);
-
+      // Set config defaults
       const serverUrl = getAbsoluteServerUrl(strapi.config);
       const apiPath = strapi.config.get('api.rest.prefix');
-
-      _.set(defaultConfig, 'servers', [
+      _.set(config, 'servers', [
         {
           url: `${serverUrl}${apiPath}`,
           description: 'Development server',
         },
       ]);
-      _.set(defaultConfig, ['info', 'x-generation-date'], new Date().toISOString());
-      _.set(defaultConfig, ['info', 'version'], version);
-      _.merge(defaultConfig.components, { schemas });
-
-      const customConfig = await this.getCustomConfig();
-      const config = _.merge(defaultConfig, customConfig);
-
+      _.set(config, ['info', 'x-generation-date'], new Date().toISOString());
+      _.set(config, ['info', 'version'], version);
+      // Prepare final doc with default config and generated paths
       const finalDoc = { ...config, paths };
-
+      // Add the default components to the final doc
+      _.set(finalDoc, 'components', defaultOpenApiComponents);
+      // Merge the generated component schemas with the defaults
+      _.merge(finalDoc.components, { schemas });
+      // Apply the the registered overrides
       registeredDocs.forEach((doc) => {
         // Add tags
         finalDoc.tags = finalDoc.tags || [];
         finalDoc.tags.push(...(doc.tags || []));
-
         // Add Paths
         _.assign(finalDoc.paths, doc.paths);
-
         // Add components
         _.forEach(doc.components || {}, (val, key) => {
           finalDoc.components[key] = finalDoc.components[key] || {};

--- a/packages/plugins/documentation/server/services/documentation.js
+++ b/packages/plugins/documentation/server/services/documentation.js
@@ -109,7 +109,7 @@ module.exports = ({ strapi }) => {
 
     getPluginsThatNeedDocumentation() {
       // Default plugins that need documentation generated
-      const defaultPlugins = ['email', 'upload', 'users-permissions'];
+      const defaultPlugins = ['upload', 'users-permissions'];
       // User specified plugins that need documentation generated
       const userPluginsConfig = config['x-strapi-config'].plugins;
 

--- a/packages/plugins/documentation/server/services/documentation.js
+++ b/packages/plugins/documentation/server/services/documentation.js
@@ -16,6 +16,8 @@ module.exports = ({ strapi }) => {
   return {
     registerDoc(doc, pluginOrigin) {
       const plugins = this.getPluginsThatNeedDocumentation();
+      let registeredDoc = doc;
+
       if (pluginOrigin) {
         if (!plugins.includes(pluginOrigin)) {
           return strapi.log.info(
@@ -28,7 +30,6 @@ module.exports = ({ strapi }) => {
         );
       }
 
-      let registeredDoc = doc;
       // parseYaml
       if (typeof doc === 'string') {
         registeredDoc = require('yaml').parse(registeredDoc);
@@ -110,7 +111,7 @@ module.exports = ({ strapi }) => {
       // Default plugins that need documentation generated
       const defaultPlugins = ['email', 'upload', 'users-permissions'];
       // User specified plugins that need documentation generated
-      const userPluginsConfig = _.get(config, 'x-strapi-config.plugins');
+      const userPluginsConfig = config['x-strapi-config'].plugins;
 
       if (userPluginsConfig === null) {
         // The user hasn't specified any plugins to document, use the defaults
@@ -198,6 +199,7 @@ module.exports = ({ strapi }) => {
       ]);
       _.set(config, ['info', 'x-generation-date'], new Date().toISOString());
       _.set(config, ['info', 'version'], version);
+      _.set(config, ['x-strapi-config', 'plugins'], this.getPluginsThatNeedDocumentation());
       // Prepare final doc with default config and generated paths
       const finalDoc = { ...config, paths };
       // Add the default components to the final doc
@@ -206,15 +208,19 @@ module.exports = ({ strapi }) => {
       _.merge(finalDoc.components, { schemas });
       // Apply the the registered overrides
       registeredDocs.forEach((doc) => {
-        // Add tags
+        // Merge ovveride tags with the generated tags
         finalDoc.tags = finalDoc.tags || [];
         finalDoc.tags.push(...(doc.tags || []));
-        // Add Paths
+        // Merge override paths with the generated paths,
+        // If the override has common properties with the finalDoc,
+        // the properties specificed on the override will replace those found on the final doc
         _.assign(finalDoc.paths, doc.paths);
         // Add components
         _.forEach(doc.components || {}, (val, key) => {
           finalDoc.components[key] = finalDoc.components[key] || {};
-
+          // Merge override components with the generated components,
+          // If the override has common properties with the finalDoc,
+          // the properties specificed on the override will replace those found on the final doc
           _.assign(finalDoc.components[key], val);
         });
       });

--- a/packages/plugins/documentation/server/services/utils/default-openapi-components.js
+++ b/packages/plugins/documentation/server/services/utils/default-openapi-components.js
@@ -1,0 +1,40 @@
+'use strict';
+
+module.exports = {
+  securitySchemes: {
+    bearerAuth: {
+      type: 'http',
+      scheme: 'bearer',
+      bearerFormat: 'JWT',
+    },
+  },
+  schemas: {
+    Error: {
+      type: 'object',
+      required: ['error'],
+      properties: {
+        data: {
+          nullable: true,
+          oneOf: [{ type: 'object' }, { type: 'array', items: { type: 'object' } }],
+        },
+        error: {
+          type: 'object',
+          properties: {
+            status: {
+              type: 'integer',
+            },
+            name: {
+              type: 'string',
+            },
+            message: {
+              type: 'string',
+            },
+            details: {
+              type: 'object',
+            },
+          },
+        },
+      },
+    },
+  },
+};

--- a/packages/plugins/users-permissions/server/register.js
+++ b/packages/plugins/users-permissions/server/register.js
@@ -18,6 +18,6 @@ module.exports = ({ strapi }) => {
     const specPath = path.join(__dirname, '../documentation/content-api.yaml');
     const spec = fs.readFileSync(specPath, 'utf8');
 
-    strapi.plugin('documentation').service('documentation').registerDoc(spec);
+    strapi.plugin('documentation').service('documentation').registerDoc(spec, 'users-permissions');
   }
 };


### PR DESCRIPTION
⚠️ This PR includes work from on https://github.com/strapi/strapi/pull/16074 and should be merged after ⚠️ 

### What does it do?

- Tests the current override system works as expected

### Why is it needed?

- To be setup for improving the overrides

### How to test it?

```
yarn test:unit packages/plugins/documentation/server/services/__tests__/
```


