### PR TITLE
Persist DB tables for EE features

### DIFF
--- a/packages/core/admin/ee/server/bootstrap.js
+++ b/packages/core/admin/ee/server/bootstrap.js
@@ -20,10 +20,6 @@ module.exports = async () => {
     await actionProvider.registerMany(actions.auditLogs);
   }
 
-  if (features.isEnabled('review-workflows')) {
-    await reserveTablesWithPrefix('strapi_workflows');
-  }
-
   await getService('seat-enforcement').seatEnforcementWorkflow();
 
   await executeCEBootstrap();

--- a/packages/core/admin/ee/server/bootstrap.js
+++ b/packages/core/admin/ee/server/bootstrap.js
@@ -2,11 +2,23 @@
 
 // eslint-disable-next-line node/no-extraneous-require
 const { features } = require('@strapi/strapi/lib/utils/ee');
+const { mapAsync } = require('@strapi/utils');
 const executeCEBootstrap = require('../../server/bootstrap');
 const { getService } = require('../../server/utils');
 const actions = require('./config/admin-actions');
+const {
+  createReservedTable,
+  findTablesThatStartWithPrefix,
+  doesReservedTableEntryExist,
+  createReservedTableEntries,
+} = require('./utils/reserved-tables');
 
-module.exports = async () => {
+module.exports = async ({ strapi }) => {
+  const connection = strapi.db.getSchemaConnection();
+  await createReservedTable(connection);
+
+  const tablesToPersist = [];
+
   const { actionProvider } = getService('permission');
 
   if (features.isEnabled('sso')) {
@@ -14,7 +26,24 @@ module.exports = async () => {
   }
 
   if (features.isEnabled('audit-logs')) {
+    const auditLogTables = await findTablesThatStartWithPrefix('strapi_audit_logs');
+    tablesToPersist.push(...auditLogTables);
+
     await actionProvider.registerMany(actions.auditLogs);
+  }
+
+  if (features.isEnabled('review-workflows')) {
+    const reviewWorkflowTables = await findTablesThatStartWithPrefix('strapi_workflows');
+    tablesToPersist.push(...reviewWorkflowTables);
+  }
+
+  let recordsToInsert = await mapAsync(tablesToPersist, (tableName) =>
+    doesReservedTableEntryExist(tableName)
+  );
+  recordsToInsert = recordsToInsert.filter((record) => record);
+
+  if (recordsToInsert.length > 0) {
+    await createReservedTableEntries(recordsToInsert);
   }
 
   await getService('seat-enforcement').seatEnforcementWorkflow();

--- a/packages/core/admin/ee/server/bootstrap.js
+++ b/packages/core/admin/ee/server/bootstrap.js
@@ -5,7 +5,7 @@ const { features } = require('@strapi/strapi/lib/utils/ee');
 const executeCEBootstrap = require('../../server/bootstrap');
 const { getService } = require('../../server/utils');
 const actions = require('./config/admin-actions');
-const { reserveTablesWithPrefix } = require('./utils/reserved-tables');
+const { persistTablesWithPrefix } = require('./utils/persisted-tables');
 
 module.exports = async () => {
   const { actionProvider } = getService('permission');
@@ -15,7 +15,7 @@ module.exports = async () => {
   }
 
   if (features.isEnabled('audit-logs')) {
-    await reserveTablesWithPrefix('strapi_audit_logs');
+    await persistTablesWithPrefix('strapi_audit_logs');
 
     await actionProvider.registerMany(actions.auditLogs);
   }

--- a/packages/core/admin/ee/server/bootstrap.js
+++ b/packages/core/admin/ee/server/bootstrap.js
@@ -2,23 +2,12 @@
 
 // eslint-disable-next-line node/no-extraneous-require
 const { features } = require('@strapi/strapi/lib/utils/ee');
-const { mapAsync } = require('@strapi/utils');
 const executeCEBootstrap = require('../../server/bootstrap');
 const { getService } = require('../../server/utils');
 const actions = require('./config/admin-actions');
-const {
-  createReservedTable,
-  findTablesThatStartWithPrefix,
-  doesReservedTableEntryExist,
-  createReservedTableEntries,
-} = require('./utils/reserved-tables');
+const { reserveTablesWithPrefix } = require('./utils/reserved-tables');
 
-module.exports = async ({ strapi }) => {
-  const connection = strapi.db.getSchemaConnection();
-  await createReservedTable(connection);
-
-  const tablesToPersist = [];
-
+module.exports = async () => {
   const { actionProvider } = getService('permission');
 
   if (features.isEnabled('sso')) {
@@ -26,24 +15,13 @@ module.exports = async ({ strapi }) => {
   }
 
   if (features.isEnabled('audit-logs')) {
-    const auditLogTables = await findTablesThatStartWithPrefix('strapi_audit_logs');
-    tablesToPersist.push(...auditLogTables);
+    await reserveTablesWithPrefix('strapi_audit_logs');
 
     await actionProvider.registerMany(actions.auditLogs);
   }
 
   if (features.isEnabled('review-workflows')) {
-    const reviewWorkflowTables = await findTablesThatStartWithPrefix('strapi_workflows');
-    tablesToPersist.push(...reviewWorkflowTables);
-  }
-
-  let recordsToInsert = await mapAsync(tablesToPersist, (tableName) =>
-    doesReservedTableEntryExist(tableName)
-  );
-  recordsToInsert = recordsToInsert.filter((record) => record);
-
-  if (recordsToInsert.length > 0) {
-    await createReservedTableEntries(recordsToInsert);
+    await reserveTablesWithPrefix('strapi_workflows');
   }
 
   await getService('seat-enforcement').seatEnforcementWorkflow();

--- a/packages/core/admin/ee/server/utils/persisted-tables.js
+++ b/packages/core/admin/ee/server/utils/persisted-tables.js
@@ -27,7 +27,7 @@ const getPersistedTables = async () =>
  */
 
 const persistTablesWithPrefix = async (tableNamePrefix) => {
-  const persistedTables = (await getPersistedTables()) || [];
+  const persistedTables = await getPersistedTables();
   const tableNames = await findTablesThatStartWithPrefix(tableNamePrefix);
   const notReservedTableNames = tableNames.filter((name) => !persistedTables.includes(name));
 

--- a/packages/core/admin/ee/server/utils/persisted-tables.js
+++ b/packages/core/admin/ee/server/utils/persisted-tables.js
@@ -15,10 +15,10 @@ const findTablesThatStartWithPrefix = async (prefix) => {
  * @returns {Array}
  */
 const getPersistedTables = async () =>
-  strapi.store.get({
+  (await strapi.store.get({
     type: 'core',
     key: 'persisted_tables',
-  }) ?? [];
+  })) ?? [];
 
 /**
  * Add all table names that start with a prefix to the reserved tables in

--- a/packages/core/admin/ee/server/utils/persisted-tables.js
+++ b/packages/core/admin/ee/server/utils/persisted-tables.js
@@ -14,36 +14,36 @@ const findTablesThatStartWithPrefix = async (prefix) => {
  * Get all reserved table names from the core store
  * @returns {Array}
  */
-const getReservedTables = async () =>
+const getPersistedTables = async () =>
   strapi.store.get({
     type: 'core',
-    key: 'reserved_tables',
-  });
+    key: 'persisted_tables',
+  }) ?? [];
 
 /**
  * Add all table names that start with a prefix to the reserved tables in
  * core store
  * @param {string} tableNamePrefix
  */
-const reserveTablesWithPrefix = async (tableNamePrefix) => {
-  const reservedTables = (await getReservedTables()) || [];
 
+const persistTablesWithPrefix = async (tableNamePrefix) => {
+  const persistedTables = (await getPersistedTables()) || [];
   const tableNames = await findTablesThatStartWithPrefix(tableNamePrefix);
+  const notReservedTableNames = tableNames.filter((name) => !persistedTables.includes(name));
 
-  if (!tableNames.length) {
+  if (!notReservedTableNames.length) {
     return;
   }
 
-  reservedTables.push(...tableNames.filter((name) => !reservedTables.includes(name)));
-
+  persistedTables.push(...notReservedTableNames);
   await strapi.store.set({
     type: 'core',
-    key: 'reserved_tables',
-    value: reservedTables,
+    key: 'persisted_tables',
+    value: persistedTables,
   });
 };
 
 module.exports = {
-  reserveTablesWithPrefix,
+  persistTablesWithPrefix,
   findTablesThatStartWithPrefix,
 };

--- a/packages/core/admin/ee/server/utils/reserved-tables.js
+++ b/packages/core/admin/ee/server/utils/reserved-tables.js
@@ -1,0 +1,57 @@
+'use strict';
+
+const reservedTableName = 'strapi_reserved_table_names';
+
+/**
+ * Finds all tables in the database that start with a prefix
+ * @param {string} prefix
+ * @returns {Array}
+ */
+const findTablesThatStartWithPrefix = async (prefix) => {
+  const tables = await strapi.db.dialect.schemaInspector.getTables();
+  return tables.filter((tableName) => tableName.startsWith(prefix));
+};
+
+/**
+ * Check whether an entry exists in the DB for a reserved table name
+ * If no entry does exist return the tableName to be added to the DB
+ * @param {string} tableName
+ * @returns {string|undefined}
+ */
+const doesReservedTableEntryExist = async (tableName) => {
+  const rows = await strapi.db.getConnection()(reservedTableName).select().where('name', tableName);
+
+  if (rows.length === 0) {
+    return tableName;
+  }
+};
+
+/**
+ * Create entries in the DB for an array of reserved table names
+ * @param {Array} tableNames
+ */
+const createReservedTableEntries = async (tableNames) =>
+  strapi.db
+    .getConnection()(reservedTableName)
+    .insert(tableNames.map((tableName) => ({ name: tableName })));
+
+/**
+ * Create the DB table 'strapi_reserved_table_names' if it does not exist
+ * @param {SchemaBuilder} connection to the strapi db
+ */
+const createReservedTable = async (connection) => {
+  if (await connection.hasTable(reservedTableName)) {
+    return;
+  }
+  return connection.createTable(reservedTableName, (table) => {
+    table.increments('id');
+    table.string('name');
+  });
+};
+
+module.exports = {
+  findTablesThatStartWithPrefix,
+  doesReservedTableEntryExist,
+  createReservedTableEntries,
+  createReservedTable,
+};

--- a/packages/core/database/lib/schema/diff.js
+++ b/packages/core/database/lib/schema/diff.js
@@ -345,10 +345,10 @@ module.exports = (db) => {
     }
 
     const persistedTables = helpers.hasTable(srcSchema, 'strapi_core_store_settings')
-      ? await strapi.store.get({
+      ? (await strapi.store.get({
           type: 'core',
-          key: 'reserved_tables',
-        })
+          key: 'persisted_tables',
+        })) ?? []
       : [];
 
     for (const srcTable of srcSchema.tables) {

--- a/packages/core/database/lib/schema/index.js
+++ b/packages/core/database/lib/schema/index.js
@@ -50,7 +50,7 @@ const createSchemaProvider = (db) => {
 
       const DBSchema = await db.dialect.schemaInspector.getSchema();
 
-      const { status, diff } = this.schemaDiff.diff(DBSchema, schema);
+      const { status, diff } = await this.schemaDiff.diff(DBSchema, schema);
 
       if (status === 'CHANGED') {
         await this.builder.updateSchema(diff);


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md

### How to test it?

Provide information about the environment and the path to verify the behaviour.
-->

### What does it do?

- [x] EE - Adds feature table names to the DB in order to persist them when moving between EE & CE
- [x] DB - Accounts for table names from the DB when diffing database schemas 

### Why is it needed?

Audit logs and Review Workflows have the need to persist feature settings while the user switches between CE and EE

This way once each feature is enabled once, it's tables will be saved to the DB

### Questions

- [x] Should this be opt in behaviour? 



