### PR TITLE
test(upload-local): make sure file url is always relative

### DIFF
--- a/packages/providers/upload-local/jest.config.js
+++ b/packages/providers/upload-local/jest.config.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const baseConfig = require('../../../jest.base-config');
+const pkg = require('./package.json');
+
+module.exports = {
+  ...baseConfig,
+  displayName: pkg.name,
+  roots: [__dirname],
+};

--- a/packages/providers/upload-local/lib/__tests__/upload-local.test.js
+++ b/packages/providers/upload-local/lib/__tests__/upload-local.test.js
@@ -1,0 +1,77 @@
+'use strict';
+
+jest.mock('fs', () => {
+  return { writeFile: jest.fn((_path, _buffer, callback) => callback()) };
+});
+
+jest.mock('fs-extra', () => {
+  return { pathExistsSync: jest.fn(() => true) };
+});
+
+const localProvider = require('../index');
+
+describe('Local provider', () => {
+  beforeAll(() => {
+    globalThis.strapi = globalThis.strapi ?? {};
+    globalThis.strapi.dirs = { static: { public: '' } };
+    globalThis.strapi.config = { server: { url: 'http://localhost:1337' } };
+  });
+
+  afterAll(() => {
+    globalThis.strapi.dirs = undefined;
+    globalThis.strapi.config = undefined;
+  });
+
+  describe('upload', () => {
+    test('Should have relative url to file object without providing useRelateiveUrl', async () => {
+      const providerInstance = localProvider.init({});
+
+      const file = {
+        path: '/tmp/',
+        hash: 'test',
+        ext: '.json',
+        mime: 'application/json',
+        buffer: '',
+      };
+
+      await providerInstance.upload(file);
+
+      expect(file.url).toBeDefined();
+      expect(file.url).toEqual('/uploads/test.json');
+    });
+
+    test('Should have relative url to file object with providing true useRelateiveUrl', async () => {
+      const providerInstance = localProvider.init({ useRelativeUrl: true });
+
+      const file = {
+        path: '/tmp/',
+        hash: 'test',
+        ext: '.json',
+        mime: 'application/json',
+        buffer: '',
+      };
+
+      await providerInstance.upload(file);
+
+      expect(file.url).toBeDefined();
+      expect(file.url).toEqual('/uploads/test.json');
+    });
+
+    test('Should have absolute url to file object with providing false useRelateiveUrl', async () => {
+      const providerInstance = localProvider.init({ useRelativeUrl: false });
+
+      const file = {
+        path: '/tmp/',
+        hash: 'test',
+        ext: '.json',
+        mime: 'application/json',
+        buffer: '',
+      };
+
+      await providerInstance.upload(file);
+
+      expect(file.url).toBeDefined();
+      expect(file.url).toEqual('http://localhost:1337/uploads/test.json');
+    });
+  });
+});

--- a/packages/providers/upload-local/lib/__tests__/upload-local.test.js
+++ b/packages/providers/upload-local/lib/__tests__/upload-local.test.js
@@ -1,11 +1,15 @@
 'use strict';
 
 jest.mock('fs', () => {
-  return { writeFile: jest.fn((_path, _buffer, callback) => callback()) };
+  return {
+    writeFile: jest.fn((_path, _buffer, callback) => callback()),
+  };
 });
 
 jest.mock('fs-extra', () => {
-  return { pathExistsSync: jest.fn(() => true) };
+  return {
+    pathExistsSync: jest.fn(() => true),
+  };
 });
 
 const localProvider = require('../index');
@@ -14,16 +18,14 @@ describe('Local provider', () => {
   beforeAll(() => {
     globalThis.strapi = globalThis.strapi ?? {};
     globalThis.strapi.dirs = { static: { public: '' } };
-    globalThis.strapi.config = { server: { url: 'http://localhost:1337' } };
   });
 
   afterAll(() => {
     globalThis.strapi.dirs = undefined;
-    globalThis.strapi.config = undefined;
   });
 
   describe('upload', () => {
-    test('Should have relative url to file object without providing useRelateiveUrl', async () => {
+    test('Should have relative url to file object', async () => {
       const providerInstance = localProvider.init({});
 
       const file = {
@@ -38,40 +40,6 @@ describe('Local provider', () => {
 
       expect(file.url).toBeDefined();
       expect(file.url).toEqual('/uploads/test.json');
-    });
-
-    test('Should have relative url to file object with providing true useRelateiveUrl', async () => {
-      const providerInstance = localProvider.init({ useRelativeUrl: true });
-
-      const file = {
-        path: '/tmp/',
-        hash: 'test',
-        ext: '.json',
-        mime: 'application/json',
-        buffer: '',
-      };
-
-      await providerInstance.upload(file);
-
-      expect(file.url).toBeDefined();
-      expect(file.url).toEqual('/uploads/test.json');
-    });
-
-    test('Should have absolute url to file object with providing false useRelateiveUrl', async () => {
-      const providerInstance = localProvider.init({ useRelativeUrl: false });
-
-      const file = {
-        path: '/tmp/',
-        hash: 'test',
-        ext: '.json',
-        mime: 'application/json',
-        buffer: '',
-      };
-
-      await providerInstance.upload(file);
-
-      expect(file.url).toBeDefined();
-      expect(file.url).toEqual('http://localhost:1337/uploads/test.json');
     });
   });
 });

--- a/packages/providers/upload-local/lib/index.js
+++ b/packages/providers/upload-local/lib/index.js
@@ -17,7 +17,7 @@ const {
 const UPLOADS_FOLDER_NAME = 'uploads';
 
 module.exports = {
-  init({ sizeLimit: providerOptionsSizeLimit } = {}) {
+  init({ sizeLimit: providerOptionsSizeLimit, useRelativeUrl = true } = {}) {
     // TODO V5: remove providerOptions sizeLimit
     if (providerOptionsSizeLimit) {
       process.emitWarning(
@@ -60,7 +60,7 @@ module.exports = {
                 return reject(err);
               }
 
-              file.url = `/uploads/${file.hash}${file.ext}`;
+              file.url = getFileUrl(file, useRelativeUrl);
 
               resolve();
             }
@@ -75,7 +75,7 @@ module.exports = {
               return reject(err);
             }
 
-            file.url = `/${UPLOADS_FOLDER_NAME}/${file.hash}${file.ext}`;
+            file.url = getFileUrl(file, useRelativeUrl);
 
             resolve();
           });
@@ -103,3 +103,13 @@ module.exports = {
     };
   },
 };
+
+/**
+ * @param {*} file
+ * @param {boolean} relative
+ * @returns {string}
+ */
+function getFileUrl(file, relative) {
+  const pathname = `/${UPLOADS_FOLDER_NAME}/${file.hash}${file.ext}`;
+  return relative ? pathname : `${strapi.config.server.url}${pathname}`;
+}

--- a/packages/providers/upload-local/lib/index.js
+++ b/packages/providers/upload-local/lib/index.js
@@ -17,7 +17,7 @@ const {
 const UPLOADS_FOLDER_NAME = 'uploads';
 
 module.exports = {
-  init({ sizeLimit: providerOptionsSizeLimit, useRelativeUrl = true } = {}) {
+  init({ sizeLimit: providerOptionsSizeLimit } = {}) {
     // TODO V5: remove providerOptions sizeLimit
     if (providerOptionsSizeLimit) {
       process.emitWarning(
@@ -60,7 +60,7 @@ module.exports = {
                 return reject(err);
               }
 
-              file.url = getFileUrl(file, useRelativeUrl);
+              file.url = `/${UPLOADS_FOLDER_NAME}/${file.hash}${file.ext}`;
 
               resolve();
             }
@@ -75,7 +75,7 @@ module.exports = {
               return reject(err);
             }
 
-            file.url = getFileUrl(file, useRelativeUrl);
+            file.url = `/${UPLOADS_FOLDER_NAME}/${file.hash}${file.ext}`;
 
             resolve();
           });
@@ -103,13 +103,3 @@ module.exports = {
     };
   },
 };
-
-/**
- * @param {*} file
- * @param {boolean} relative
- * @returns {string}
- */
-function getFileUrl(file, relative) {
-  const pathname = `/${UPLOADS_FOLDER_NAME}/${file.hash}${file.ext}`;
-  return relative ? pathname : `${strapi.config.server.url}${pathname}`;
-}


### PR DESCRIPTION
> **Warning**
> Was decided to not add this feature (see discussions). Instead, a custom local upload provider or a library patch can be created to allow this feature.
> PR will add only the test to make sure the File URL is always relative

<details>
<summary>Patch to enable this feature</summary>

Create this file `patches/@strapi+provider-upload-local+4.7.1.patch` with the content below

Use [patch-package](https://github.com/ds300/patch-package) to apply it.

```diff
diff --git a/node_modules/@strapi/provider-upload-local/lib/index.js b/node_modules/@strapi/provider-upload-local/lib/index.js
index 230d920..4588eeb 100644
--- a/node_modules/@strapi/provider-upload-local/lib/index.js
+++ b/node_modules/@strapi/provider-upload-local/lib/index.js
@@ -17,7 +17,7 @@ const {
 const UPLOADS_FOLDER_NAME = 'uploads';
 
 module.exports = {
-  init({ sizeLimit: providerOptionsSizeLimit } = {}) {
+  init({ sizeLimit: providerOptionsSizeLimit, useRelativeUrl = true } = {}) {
     // TODO V5: remove providerOptions sizeLimit
     if (providerOptionsSizeLimit) {
       process.emitWarning(
@@ -60,7 +60,7 @@ module.exports = {
                 return reject(err);
               }
 
-              file.url = `/uploads/${file.hash}${file.ext}`;
+              file.url = getFileUrl(file, useRelativeUrl)
 
               resolve();
             }
@@ -75,7 +75,7 @@ module.exports = {
               return reject(err);
             }
 
-            file.url = `/${UPLOADS_FOLDER_NAME}/${file.hash}${file.ext}`;
+            file.url = getFileUrl(file, useRelativeUrl)
 
             resolve();
           });
@@ -103,3 +103,8 @@ module.exports = {
     };
   },
 };
+
+function getFileUrl(file, relative) {
+	const pathname = `/${UPLOADS_FOLDER_NAME}/${file.hash}${file.ext}`
+	return relative ? pathname : `${strapi.config.server.url}${pathname}`;
+}
\ No newline at end of file
```
</details>


<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Add an option for the local upload provider to use an absolute URL instead of a relative URL

```js
module.exports = {
	upload: {
		config: {
			provider: 'local',
			providerOptions: {
				useRelativeUrl: false, // true or false
			},
		},
	},
};
```

### Why is it needed?

When using the local upload provider, and having some app on a different domain that fetches the data through REST/GQL API, you will get media URLs relative to the Strapi instance domain.

Strapi instance is on origin `http://localhost:1337`
App instance is on origin `http://localhost:3000`

If trying to serve media as is, your requests will look like this:

```html
<img src="http://localhost:3000/uploads/some-media.png" />
```

With this option, you will be able to tell Strapi to prepend the instance URL instead, so we will have absolute URLs

```html
<img src="http://localhost:1337/uploads/some-media.png" />
```

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/issues/12590
https://github.com/strapi/strapi/pull/4822
https://github.com/strapi/strapi/issues/4791
https://github.com/strapi/strapi/issues/10931
