### PR TITLE
useAPIErrorHandler: Handle AxiosError

### DIFF
--- a/packages/core/helper-plugin/lib/src/hooks/useAPIErrorHandler/tests/useAPIErrorHandler.test.js
+++ b/packages/core/helper-plugin/lib/src/hooks/useAPIErrorHandler/tests/useAPIErrorHandler.test.js
@@ -1,5 +1,6 @@
 import { renderHook, act } from '@testing-library/react-hooks';
 import { useIntl } from 'react-intl';
+import { AxiosError } from 'axios';
 
 import { useAPIErrorHandler } from '../useAPIErrorHandler';
 
@@ -19,6 +20,10 @@ function setup(...args) {
 }
 
 describe('useAPIErrorHandler', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   test('exports formatAPIError()', async () => {
     const handler = await setup();
 
@@ -80,6 +85,29 @@ describe('useAPIErrorHandler', () => {
     });
 
     expect(message).toBe('Field contains errors\nField must be unique');
-    expect(formatMessage).toBeCalledTimes(3);
+    expect(formatMessage).toBeCalledTimes(2);
+  });
+
+  test('formats AxiosErrors', async () => {
+    let message;
+    const handler = await setup();
+    const { formatAPIError } = handler.result.current;
+
+    const axiosError = new AxiosError(
+      'Error message',
+      '409',
+      undefined,
+      {},
+      {
+        status: 405,
+        data: { message: 'Error message' },
+      }
+    );
+
+    act(() => {
+      message = formatAPIError(axiosError);
+    });
+
+    expect(message).toBe('Error message');
   });
 });

--- a/packages/core/helper-plugin/lib/src/hooks/useAPIErrorHandler/useAPIErrorHandler.js
+++ b/packages/core/helper-plugin/lib/src/hooks/useAPIErrorHandler/useAPIErrorHandler.js
@@ -1,6 +1,8 @@
 import { useIntl } from 'react-intl';
+import { AxiosError } from 'axios';
 
 import { formatAPIError } from './utils/formatAPIError';
+import { formatAxiosError } from './utils/formatAxiosError';
 
 /**
  * Hook that exports an error message formatting function.
@@ -15,6 +17,10 @@ export function useAPIErrorHandler(intlMessagePrefixCallback) {
 
   return {
     formatAPIError(error) {
+      if (error instanceof AxiosError) {
+        return formatAxiosError(error, { intlMessagePrefixCallback, formatMessage });
+      }
+
       return formatAPIError(error, { intlMessagePrefixCallback, formatMessage });
     },
   };

--- a/packages/core/helper-plugin/lib/src/hooks/useAPIErrorHandler/utils/formatAxiosError/index.js
+++ b/packages/core/helper-plugin/lib/src/hooks/useAPIErrorHandler/utils/formatAxiosError/index.js
@@ -1,0 +1,13 @@
+import { getPrefixedId } from '../getPrefixedId';
+
+export function formatAxiosError(error, { intlMessagePrefixCallback, formatMessage }) {
+  const { code, message } = error;
+
+  return formatMessage({
+    id: getPrefixedId(message, intlMessagePrefixCallback),
+    defaultMessage: message,
+    values: {
+      code,
+    },
+  });
+}

--- a/packages/core/helper-plugin/lib/src/hooks/useAPIErrorHandler/utils/formatAxiosError/tests/index.test.js
+++ b/packages/core/helper-plugin/lib/src/hooks/useAPIErrorHandler/utils/formatAxiosError/tests/index.test.js
@@ -1,0 +1,26 @@
+import { AxiosError } from 'axios';
+
+import { formatAxiosError } from '..';
+
+describe('formatAxiosError', () => {
+  test('serializes AxiosError', () => {
+    const error = new AxiosError(
+      'Error message',
+      '409',
+      undefined,
+      {},
+      {
+        status: 405,
+        data: { message: 'Error message' },
+      }
+    );
+
+    expect(formatAxiosError(error, { formatMessage: (obj) => obj })).toStrictEqual({
+      defaultMessage: 'Error message',
+      id: 'apiError.Error message',
+      values: {
+        code: '409',
+      },
+    });
+  });
+});

--- a/packages/core/helper-plugin/lib/src/hooks/useAPIErrorHandler/utils/getPrefixedId/index.js
+++ b/packages/core/helper-plugin/lib/src/hooks/useAPIErrorHandler/utils/getPrefixedId/index.js
@@ -1,0 +1,14 @@
+const ERROR_PREFIX = 'apiError.';
+
+export function getPrefixedId(message, callback) {
+  const prefixedMessage = `${ERROR_PREFIX}${message}`;
+
+  // if a prefix function has been passed in it is used to
+  // prefix the id, e.g. to allow an error message to be
+  // set only for a localization namespace
+  if (callback) {
+    return callback(prefixedMessage);
+  }
+
+  return prefixedMessage;
+}

--- a/packages/core/helper-plugin/lib/src/hooks/useAPIErrorHandler/utils/normalizeAPIError/index.js
+++ b/packages/core/helper-plugin/lib/src/hooks/useAPIErrorHandler/utils/normalizeAPIError/index.js
@@ -1,17 +1,4 @@
-const ERROR_PREFIX = 'apiError.';
-
-function getPrefixedId(message, callback) {
-  const prefixedMessage = `${ERROR_PREFIX}${message}`;
-
-  // if a prefix function has been passed in it is used to
-  // prefix the id, e.g. to allow an error message to be
-  // set only for a localization namespace
-  if (callback) {
-    return callback(prefixedMessage);
-  }
-
-  return prefixedMessage;
-}
+import { getPrefixedId } from '../getPrefixedId';
 
 function normalizeError(error, { name, intlMessagePrefixCallback }) {
   const { message, path } = error;


### PR DESCRIPTION
### What does it do?

This teaches `useAPIErrorHandler()` how to serialize `AxiosError`s.

### Why is it needed?

This makes frontend error handling very convenient in case the API is e.g. not available or not implemented. Before it would have crashed, because it tried to access nested properties that don't necessarily exist on `AxiosError`.

```js
try {
  await reactQueryMuration();
} catch (error) {
  // error can be an error thrown by the API or by axios
  toggleNotification({
    type: 'warning',
    message: formatAPIError(error),
  });
}
```

### How to test it?

Follow the automated tests.

