### PR TITLE
CM: Add onChange handler to entity stage select

### DIFF
--- a/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/InformationBoxEE.js
+++ b/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/InformationBoxEE.js
@@ -44,11 +44,16 @@ export function InformationBoxEE() {
   const formattedError = error ? formatAPIError(error) : null;
 
   const handleStageChange = async ({ value: stageId }) => {
-    await mutateAsync({
-      entityId: initialData.id,
-      stageId,
-      uid,
-    });
+    try {
+      await mutateAsync({
+        entityId: initialData.id,
+        stageId,
+        uid,
+      });
+    } catch (error) {
+      // react-query@v3: the error doesn't have to be handled here
+      // see: https://github.com/TanStack/query/issues/121
+    }
   };
 
   return (

--- a/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/InformationBoxEE.js
+++ b/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/InformationBoxEE.js
@@ -1,6 +1,6 @@
-import React from 'react';
-import { ReactSelect, useCMEditViewDataManager } from '@strapi/helper-plugin';
-import { FieldLabel, Flex } from '@strapi/design-system';
+import React, { useState } from 'react';
+import { ReactSelect, useCMEditViewDataManager, useAPIErrorHandler } from '@strapi/helper-plugin';
+import { Field, FieldLabel, FieldError, Flex } from '@strapi/design-system';
 import { useIntl } from 'react-intl';
 
 import { useReviewWorkflows } from '../../../../pages/SettingsPage/pages/ReviewWorkflows/hooks/useReviewWorkflows';
@@ -9,39 +9,67 @@ import Information from '../../../../../../admin/src/content-manager/pages/EditV
 const ATTRIBUTE_NAME = 'strapi_reviewWorkflows_stage';
 
 export function InformationBoxEE() {
-  const { initialData, isCreatingEntry } = useCMEditViewDataManager();
-  const { formatMessage } = useIntl();
-
+  const {
+    initialData,
+    isCreatingEntry,
+    layout: { uid },
+  } = useCMEditViewDataManager();
   const activeWorkflowStage = initialData?.[ATTRIBUTE_NAME] ?? null;
+  const { formatMessage } = useIntl();
+  const { formatAPIError } = useAPIErrorHandler();
   const {
     workflows: { data: workflow },
-  } = useReviewWorkflows(1);
-  // stages are empty while the workflow is loaded
+    entityStageMutation,
+    setStageForEntity,
+  } = useReviewWorkflows(activeWorkflowStage?.id);
+  // stages are empty while the workflow is loading
   const options = (workflow?.stages ?? []).map(({ id, name }) => ({ value: id, label: name }));
+  const [error, setError] = useState(null);
+
+  const handleStageChange = async ({ value: stageId }) => {
+    try {
+      await setStageForEntity({
+        entityId: initialData.id,
+        stageId,
+        uid,
+      });
+    } catch (error) {
+      setError(formatAPIError(error));
+    }
+  };
 
   return (
     <Information.Root>
       <Information.Title />
-      {activeWorkflowStage && (
-        <Flex direction="column" gap={2} alignItems="stretch">
-          <FieldLabel htmlFor={ATTRIBUTE_NAME}>
-            {formatMessage({
-              id: 'content-manager.reviewWorkflows.stage.label',
-              defaultMessage: 'Review stage',
-            })}
-          </FieldLabel>
 
-          <ReactSelect
-            inputId={ATTRIBUTE_NAME}
-            isDisabled={isCreatingEntry}
-            options={options}
-            name={ATTRIBUTE_NAME}
-            defaultValue={{ value: activeWorkflowStage?.id, label: activeWorkflowStage?.name }}
-            isSearchable={false}
-            isClearable={false}
-          />
-        </Flex>
+      {activeWorkflowStage && (
+        <Field error={error} name={ATTRIBUTE_NAME}>
+          <Flex direction="column" gap={2} alignItems="stretch">
+            <FieldLabel>
+              {formatMessage({
+                id: 'content-manager.reviewWorkflows.stage.label',
+                defaultMessage: 'Review stage',
+              })}
+            </FieldLabel>
+
+            <ReactSelect
+              error={error}
+              inputId={ATTRIBUTE_NAME}
+              isDisabled={isCreatingEntry}
+              options={options}
+              name={ATTRIBUTE_NAME}
+              defaultValue={{ value: activeWorkflowStage?.id, label: activeWorkflowStage?.name }}
+              isLoading={entityStageMutation.isLoading}
+              isSearchable={false}
+              isClearable={false}
+              onChange={handleStageChange}
+            />
+
+            {error && <FieldError />}
+          </Flex>
+        </Field>
       )}
+
       <Information.Body />
     </Information.Root>
   );

--- a/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/InformationBoxEE.js
+++ b/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/InformationBoxEE.js
@@ -61,7 +61,7 @@ export function InformationBoxEE() {
       <Information.Title />
 
       {activeWorkflowStage && (
-        <Field error={formattedError} name={ATTRIBUTE_NAME}>
+        <Field error={formattedError} name={ATTRIBUTE_NAME} id={ATTRIBUTE_NAME}>
           <Flex direction="column" gap={2} alignItems="stretch">
             <FieldLabel>
               {formatMessage({
@@ -83,7 +83,7 @@ export function InformationBoxEE() {
               onChange={handleStageChange}
             />
 
-            {error && <FieldError />}
+            <FieldError />
           </Flex>
         </Field>
       )}

--- a/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/tests/InformationBoxEE.test.js
+++ b/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/tests/InformationBoxEE.test.js
@@ -75,6 +75,7 @@ describe('EE | Content Manager | EditView | InformationBox', () => {
     useCMEditViewDataManager.mockReturnValue({
       initialData: {},
       isCreatingEntry: true,
+      layout: { uid: 'api::articles:articles' },
     });
 
     const { getByText } = setup();
@@ -87,6 +88,7 @@ describe('EE | Content Manager | EditView | InformationBox', () => {
     useCMEditViewDataManager.mockReturnValue({
       initialData: {},
       isCreatingEntry: true,
+      layout: { uid: 'api::articles:articles' },
     });
 
     const { queryByRole } = setup();
@@ -98,6 +100,7 @@ describe('EE | Content Manager | EditView | InformationBox', () => {
     useCMEditViewDataManager.mockReturnValue({
       initialData: {},
       isCreatingEntry: true,
+      layout: { uid: 'api::articles:articles' },
     });
 
     const { queryByRole } = setup();
@@ -111,6 +114,7 @@ describe('EE | Content Manager | EditView | InformationBox', () => {
         [STAGE_ATTRIBUTE_NAME]: STAGE_FIXTURE,
       },
       isCreatingEntry: true,
+      layout: { uid: 'api::articles:articles' },
     });
 
     const { queryByRole } = setup();
@@ -126,6 +130,7 @@ describe('EE | Content Manager | EditView | InformationBox', () => {
         [STAGE_ATTRIBUTE_NAME]: STAGE_FIXTURE,
       },
       isCreatingEntry: false,
+      layout: { uid: 'api::articles:articles' },
     });
 
     const { queryByRole } = setup();
@@ -141,6 +146,7 @@ describe('EE | Content Manager | EditView | InformationBox', () => {
         [STAGE_ATTRIBUTE_NAME]: STAGE_FIXTURE,
       },
       isCreatingEntry: false,
+      layout: { uid: 'api::articles:articles' },
     });
 
     const { queryByRole, getByText } = setup();

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/hooks/tests/useReviewWorkflows.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/hooks/tests/useReviewWorkflows.test.js
@@ -227,40 +227,4 @@ describe('useReviewWorkflows', () => {
 
     expect(toggleNotification).toBeCalled();
   });
-
-  test('display error notification on a failed entityStageMutation mutation', async () => {
-    const originalError = console.error;
-    console.error = jest.fn();
-
-    const { put } = useFetchClient();
-    const toggleNotification = useNotification();
-    const idFixture = 1;
-    const stageIdFixture = 2;
-
-    put.mockRejectedValue({
-      response: {
-        data: {
-          error: {
-            name: 'ValidationError',
-            message: 'Failed',
-          },
-        },
-      },
-    });
-
-    const { result, waitFor } = await setup(idFixture);
-
-    try {
-      await act(async () => {
-        await result.current.setStageForEntity(idFixture, stageIdFixture);
-      });
-
-      await waitFor(() => result.current.workflows.isLoading);
-    } catch (error) {
-      // mutation is expected to throw an error
-    }
-
-    expect(toggleNotification).toBeCalled();
-    console.error = originalError;
-  });
 });

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/hooks/tests/useReviewWorkflows.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/hooks/tests/useReviewWorkflows.test.js
@@ -197,34 +197,4 @@ describe('useReviewWorkflows', () => {
 
     expect(spy).toBeCalledWith(['review-workflows', 1]);
   });
-
-  test('send put request on the entityStageMutation mutation', async () => {
-    const { put } = useFetchClient();
-    const toggleNotification = useNotification();
-    const idFixture = 1;
-    const stageIdFixture = 2;
-
-    put.mockResolvedValue({
-      data: {},
-    });
-
-    const { result, waitFor } = await setup(idFixture);
-
-    await act(async () => {
-      await result.current.setStageForEntity(idFixture, stageIdFixture);
-    });
-
-    await waitFor(() => expect(result.current.workflows.isLoading).toBe(false));
-
-    expect(put).toBeCalledWith(
-      `/admin/content-manager/collection-types/:model_uid/${idFixture}/stage`,
-      {
-        data: {
-          id: stageIdFixture,
-        },
-      }
-    );
-
-    expect(toggleNotification).toBeCalled();
-  });
 });

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/hooks/useReviewWorkflows.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/hooks/useReviewWorkflows.js
@@ -30,11 +30,11 @@ export function useReviewWorkflows(workflowId) {
     return data;
   }
 
-  async function updateEntityStage({ entityId, stageId }) {
+  async function updateEntityStage({ entityId, stageId, uid }) {
     const {
       data: { data },
       // TODO: endpoint differs for collection-types and single-types
-    } = await put(`${API_CM_BASE_URL}/collection-types/:model_uid/${entityId}/stage`, {
+    } = await put(`${API_CM_BASE_URL}/collection-types/${uid}/${entityId}/stage`, {
       data: { id: stageId },
     });
 
@@ -45,8 +45,8 @@ export function useReviewWorkflows(workflowId) {
     return workflowUpdateMutation.mutateAsync({ workflowId, stages });
   }
 
-  function setStageForEntity(entityId, stageId) {
-    return entityStageMutation.mutateAsync({ entityId, stageId });
+  function setStageForEntity(...args) {
+    return entityStageMutation.mutateAsync(...args);
   }
 
   function refetchWorkflow() {
@@ -71,24 +71,11 @@ export function useReviewWorkflows(workflowId) {
     },
   });
 
-  const entityStageMutation = useMutation(updateEntityStage, {
-    async onError(error) {
-      toggleNotification({
-        type: 'warning',
-        message: formatAPIError(error),
-      });
-    },
-
-    async onSuccess() {
-      toggleNotification({
-        type: 'success',
-        message: { id: 'notification.success.saved', defaultMessage: 'Saved' },
-      });
-    },
-  });
+  const entityStageMutation = useMutation(updateEntityStage);
 
   return {
     workflows,
+    entityStageMutation,
     updateWorkflowStages,
     refetchWorkflow,
     setStageForEntity,

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/hooks/useReviewWorkflows.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/hooks/useReviewWorkflows.js
@@ -3,7 +3,6 @@ import { useFetchClient, useNotification, useAPIErrorHandler } from '@strapi/hel
 
 const QUERY_BASE_KEY = 'review-workflows';
 const API_BASE_URL = '/admin/review-workflows';
-const API_CM_BASE_URL = '/admin/content-manager';
 
 export function useReviewWorkflows(workflowId) {
   const { get, put } = useFetchClient();
@@ -30,23 +29,8 @@ export function useReviewWorkflows(workflowId) {
     return data;
   }
 
-  async function updateEntityStage({ entityId, stageId, uid }) {
-    const {
-      data: { data },
-      // TODO: endpoint differs for collection-types and single-types
-    } = await put(`${API_CM_BASE_URL}/collection-types/${uid}/${entityId}/stage`, {
-      data: { id: stageId },
-    });
-
-    return data;
-  }
-
   function updateWorkflowStages(workflowId, stages) {
     return workflowUpdateMutation.mutateAsync({ workflowId, stages });
-  }
-
-  function setStageForEntity(...args) {
-    return entityStageMutation.mutateAsync(...args);
   }
 
   function refetchWorkflow() {
@@ -71,13 +55,9 @@ export function useReviewWorkflows(workflowId) {
     },
   });
 
-  const entityStageMutation = useMutation(updateEntityStage);
-
   return {
     workflows,
-    entityStageMutation,
     updateWorkflowStages,
     refetchWorkflow,
-    setStageForEntity,
   };
 }


### PR DESCRIPTION
### What does it do?

Adds the onChange handler to the stage select in the CM edit view for entities.

> **Note**
> Right now this is broken, because the route is not yet implemented by the admin API and `useAPIErrorHandler()` does not handle `AxiosError`s yet. This capability is being added in https://github.com/strapi/strapi/pull/16090.

### Why is it needed?

This will allow users to change the stage of an entity. This is missing tests at the moment - I will add them in a follow-up PR once the BE is working.

### How to test it?

1. Enable Review-Workflows on a content-type in the CTB
2. Create an entity
3. Change the stage and reload the page; the stage should be persisted

