### PR TITLE
Fix broken populate traversal with no fragment

### DIFF
--- a/packages/core/strapi/tests/api/sanitize/resources/fixtures/document.js
+++ b/packages/core/strapi/tests/api/sanitize/resources/fixtures/document.js
@@ -16,6 +16,26 @@ module.exports = (fixtures) => {
         name_private: 'Private Component A Name A',
         password: 'compPass9101',
       },
+      dz: [
+        {
+          __component: 'default.component-a',
+          name: 'Name A',
+          name_private: 'Private Name A',
+          password: 'Password A',
+        },
+        {
+          __component: 'default.component-b',
+          name: 'Name B',
+          name_private: 'Private Name B',
+          password: 'Password B',
+        },
+        {
+          __component: 'default.component-a',
+          name: 'Name C',
+          name_private: 'Private Name C',
+          password: 'Password C',
+        },
+      ],
     },
     {
       name: '1 Document B OO',
@@ -29,6 +49,26 @@ module.exports = (fixtures) => {
         name_private: 'Private Component A Name B',
         password: 'compPass5678',
       },
+      dz: [
+        {
+          __component: 'default.component-a',
+          name: 'Name A',
+          name_private: 'Private Name A',
+          password: 'Password A',
+        },
+        {
+          __component: 'default.component-b',
+          name: 'Name B',
+          name_private: 'Private Name B',
+          password: 'Password B',
+        },
+        {
+          __component: 'default.component-a',
+          name: 'Name C',
+          name_private: 'Private Name C',
+          password: 'Password C',
+        },
+      ],
     },
     {
       name: '2 Document C OO',
@@ -42,6 +82,26 @@ module.exports = (fixtures) => {
         name_private: 'Private Component A Name C',
         password: 'compPass1234',
       },
+      dz: [
+        {
+          __component: 'default.component-a',
+          name: 'Name A',
+          name_private: 'Private Name A',
+          password: 'Password A',
+        },
+        {
+          __component: 'default.component-b',
+          name: 'Name B',
+          name_private: 'Private Name B',
+          password: 'Password B',
+        },
+        {
+          __component: 'default.component-a',
+          name: 'Name C',
+          name_private: 'Private Name C',
+          password: 'Password C',
+        },
+      ],
     },
   ];
 };

--- a/packages/core/strapi/tests/api/sanitize/resources/schemas/component-b.js
+++ b/packages/core/strapi/tests/api/sanitize/resources/schemas/component-b.js
@@ -1,0 +1,18 @@
+'use strict';
+
+module.exports = {
+  displayName: 'component-b',
+  category: 'default',
+  attributes: {
+    name: {
+      type: 'string',
+    },
+    name_private: {
+      type: 'string',
+      private: true,
+    },
+    password: {
+      type: 'password',
+    },
+  },
+};

--- a/packages/core/strapi/tests/api/sanitize/resources/schemas/document.js
+++ b/packages/core/strapi/tests/api/sanitize/resources/schemas/document.js
@@ -36,5 +36,9 @@ module.exports = {
       component: 'default.component-a',
       repeatable: false,
     },
+    dz: {
+      type: 'dynamiczone',
+      components: ['default.component-a', 'default.component-b'],
+    },
   },
 };

--- a/packages/core/strapi/tests/api/sanitize/resources/schemas/index.js
+++ b/packages/core/strapi/tests/api/sanitize/resources/schemas/index.js
@@ -7,5 +7,6 @@ module.exports = {
   },
   components: {
     'default.component-a': require('./component-a'),
+    'default.component-b': require('./component-b'),
   },
 };

--- a/packages/core/utils/lib/traverse/query-populate.js
+++ b/packages/core/utils/lib/traverse/query-populate.js
@@ -160,6 +160,8 @@ const populate = traverseFactory()
       const { components } = attribute;
       const { on, ...properties } = value;
 
+      const newValue = {};
+
       // Handle legacy DZ params
       let newProperties = properties;
 
@@ -168,11 +170,15 @@ const populate = traverseFactory()
         newProperties = await recurse(visitor, { schema: componentSchema, path }, newProperties);
       }
 
-      // Handle new morph fragment syntax
-      const newOn = await recurse(visitor, { schema, path }, { on });
+      Object.assign(newValue, newProperties);
 
-      // Recompose both syntaxes
-      const newValue = { ...newOn, ...newProperties };
+      // Handle new morph fragment syntax
+      if (on) {
+        const newOn = await recurse(visitor, { schema, path }, { on });
+
+        // Recompose both syntaxes
+        Object.assign(newValue, newOn);
+      }
 
       set(key, newValue);
     } else {


### PR DESCRIPTION
### What does it do?

Actual fix [here](https://github.com/strapi/strapi/pull/16109/files#diff-704f2d82e92aac3f6a5b36b9167b57cf4c255ed15d137f5816d7f4207eedf929), the rest of the changes are tests added to check we don't have this regression in the future

Prevent recursion on undefined populate fragment values upon populate traversal (during query sanitization)

### Why is it needed?

Null & undefined values for the populate fragment upon query traversal cause the traversal to throw due to an unexpected Object.entries operation on an undefined value.

### How to test it?

Using the API integration tests:
`yarn test:api packages/core/strapi/tests/api/sanitize/sanitize-query.test.api.js`

Or by starting the getstarted app, creating a new restaurant entity from the content manager, then heading to the content API and trying to access this URL
`http://localhost:1337/api/restaurants?populate[dz][populate]=*`
It should return you the restaurant and the content of its dynamic zone populated (at the second level)

### Related issue(s)/PR(s)

fix #16105
