### PR TITLE
[Fix] add published at attribute to be filterable and sortable

### DIFF
--- a/packages/core/admin/server/services/permission/permissions-manager/sanitize.js
+++ b/packages/core/admin/server/services/permission/permissions-manager/sanitize.js
@@ -34,6 +34,7 @@ const {
   ID_ATTRIBUTE,
   CREATED_AT_ATTRIBUTE,
   UPDATED_AT_ATTRIBUTE,
+  PUBLISHED_AT_ATTRIBUTE,
   CREATED_BY_ATTRIBUTE,
   UPDATED_BY_ATTRIBUTE,
 } = constants;
@@ -261,6 +262,7 @@ module.exports = ({ action, ability, model }) => {
       ...COMPONENT_FIELDS,
       CREATED_AT_ATTRIBUTE,
       UPDATED_AT_ATTRIBUTE,
+      PUBLISHED_AT_ATTRIBUTE,
     ]);
   };
 


### PR DESCRIPTION
### What does it do?
Fixes sorting an filtering by publishedAt attribute.

### Why is it needed?
https://github.com/strapi/strapi/issues/16099

So people can sort by `publishedAt`

### How to test it?

Follow issue thread and replicate what is described there.

### Related issue(s)/PR(s)

Fix https://github.com/strapi/strapi/issues/16099
