### PR TITLE
Reduce and optimize lodash usage in the admin app

### DIFF
--- a/.eslintrc.front.js
+++ b/.eslintrc.front.js
@@ -48,6 +48,10 @@ module.exports = {
             message:
               "'Stack' has been deprecated. Please import 'Flex' from '@strapi/design-system' instead.",
           },
+          {
+            name: 'lodash',
+            message: 'Please use import [method] from lodash/[method]',
+          },
         ],
         patterns: [
           {

--- a/packages/core/admin/admin/src/components/GuidedTour/tests/init.test.js
+++ b/packages/core/admin/admin/src/components/GuidedTour/tests/init.test.js
@@ -1,4 +1,4 @@
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 import init from '../init';
 import { initialState } from '../reducer';
 

--- a/packages/core/admin/admin/src/content-manager/components/DynamicZone/utils/select.js
+++ b/packages/core/admin/admin/src/content-manager/components/DynamicZone/utils/select.js
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { get } from 'lodash';
+import get from 'lodash/get';
 import { useCMEditViewDataManager } from '@strapi/helper-plugin';
 
 function useSelect(name) {

--- a/packages/core/admin/admin/src/content-manager/components/FieldComponent/utils/select.js
+++ b/packages/core/admin/admin/src/content-manager/components/FieldComponent/utils/select.js
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
-import { get, take } from 'lodash';
+import get from 'lodash/get';
+import take from 'lodash/take';
 import { useCMEditViewDataManager } from '@strapi/helper-plugin';
 
 import { getFieldName } from '../../../utils';

--- a/packages/core/admin/admin/src/content-manager/components/Inputs/utils/getInputType.js
+++ b/packages/core/admin/admin/src/content-manager/components/Inputs/utils/getInputType.js
@@ -1,4 +1,4 @@
-import { toLower } from 'lodash';
+import toLower from 'lodash/toLower';
 
 const getInputType = (type = '') => {
   switch (toLower(type)) {

--- a/packages/core/admin/admin/src/content-manager/components/Inputs/utils/select.js
+++ b/packages/core/admin/admin/src/content-manager/components/Inputs/utils/select.js
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { get } from 'lodash';
+import get from 'lodash/get';
 import { useCMEditViewDataManager } from '@strapi/helper-plugin';
 
 function useSelect(keys) {

--- a/packages/core/admin/admin/src/content-manager/hooks/useContentTypeLayout/index.js
+++ b/packages/core/admin/admin/src/content-manager/hooks/useContentTypeLayout/index.js
@@ -1,5 +1,4 @@
 import { useCallback } from 'react';
-import { get } from 'lodash';
 import { useSelector } from 'react-redux';
 import selectLayout from '../../pages/EditViewLayoutManager/selectors';
 
@@ -8,7 +7,7 @@ const useContentTypeLayout = () => {
 
   const getComponentLayout = useCallback(
     (componentUid) => {
-      return get(currentLayout, ['components', componentUid], {});
+      return currentLayout?.components?.[componentUid] ?? {};
     },
     [currentLayout]
   );

--- a/packages/core/admin/admin/src/content-manager/hooks/useFetchContentTypeLayout/utils/formatLayouts.js
+++ b/packages/core/admin/admin/src/content-manager/hooks/useFetchContentTypeLayout/utils/formatLayouts.js
@@ -1,4 +1,7 @@
-import { cloneDeep, get, set } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
+import get from 'lodash/get';
+import set from 'lodash/set';
+
 import { mergeMetasWithSchema } from '../../../utils';
 
 const getRelationModel = (targetModel, models) => models.find((model) => model.uid === targetModel);

--- a/packages/core/admin/admin/src/content-manager/pages/CollectionTypeRecursivePath/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/CollectionTypeRecursivePath/index.js
@@ -1,7 +1,6 @@
 import React, { memo, useMemo } from 'react';
 import { Switch, Route } from 'react-router-dom';
 import { ErrorBoundary } from 'react-error-boundary';
-import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import { LoadingIndicatorPage, CheckPagePermissions } from '@strapi/helper-plugin';
 import permissions from '../../../permissions';
@@ -43,7 +42,7 @@ const CollectionTypeRecursivePath = ({
     return { rawContentTypeLayout, rawComponentsLayouts };
   }, [layout]);
 
-  const uid = get(layout, ['contentType', 'uid'], null);
+  const uid = layout?.contentType?.uid ?? null;
 
   // This statement is needed in order to prevent the CollectionTypeFormWrapper effects clean up phase to be run twice.
   // What can happen is that when navigating from one entry to another the cleanup phase of the fetch data effect is run twice : once when

--- a/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/init.js
+++ b/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/init.js
@@ -1,4 +1,6 @@
-import { cloneDeep, set } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
+import set from 'lodash/set';
+
 import { createLayout, formatLayout } from './utils/layout';
 
 const init = (initialState, mainLayout, components) => {

--- a/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/utils/createPossibleMainFieldsForModelsAndComponents.js
+++ b/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/utils/createPossibleMainFieldsForModelsAndComponents.js
@@ -1,8 +1,6 @@
-import { get } from 'lodash';
-
 const createPossibleMainFieldsForModelsAndComponents = (array) => {
   return array.reduce((acc, current) => {
-    const attributes = get(current, ['attributes'], {});
+    const attributes = current?.attributes ?? {};
     const possibleMainFields = Object.keys(attributes).filter((attr) => {
       return ![
         'boolean',
@@ -14,7 +12,7 @@ const createPossibleMainFieldsForModelsAndComponents = (array) => {
         'relation',
         'text',
         'richtext',
-      ].includes(get(attributes, [attr, 'type'], ''));
+      ].includes(attributes?.[attr]?.type ?? '');
     });
 
     acc[current.uid] = possibleMainFields;

--- a/packages/core/admin/admin/src/content-manager/pages/EditView/DeleteLink/utils/select.js
+++ b/packages/core/admin/admin/src/content-manager/pages/EditView/DeleteLink/utils/select.js
@@ -1,4 +1,4 @@
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 import { useCMEditViewDataManager } from '@strapi/helper-plugin';
 
 function useSelect() {

--- a/packages/core/admin/admin/src/content-manager/pages/EditView/utils/createAttributesLayout.js
+++ b/packages/core/admin/admin/src/content-manager/pages/EditView/utils/createAttributesLayout.js
@@ -1,4 +1,5 @@
-import { get, isEmpty } from 'lodash';
+import get from 'lodash/get';
+import isEmpty from 'lodash/isEmpty';
 
 const createAttributesLayout = (currentContentTypeLayoutData) => {
   if (!currentContentTypeLayoutData.layouts) {

--- a/packages/core/admin/admin/src/content-manager/pages/EditView/utils/getFieldsActionMatchingPermissions.js
+++ b/packages/core/admin/admin/src/content-manager/pages/EditView/utils/getFieldsActionMatchingPermissions.js
@@ -1,4 +1,5 @@
-import { uniq, flatMap } from 'lodash';
+import uniq from 'lodash/uniq';
+import flatMap from 'lodash/flatMap';
 import { findMatchingPermissions } from '@strapi/helper-plugin';
 
 const getFieldsActionMatchingPermissions = (userPermissions, slug) => {

--- a/packages/core/admin/admin/src/content-manager/utils/checkIfAttributeIsDisplayable.js
+++ b/packages/core/admin/admin/src/content-manager/utils/checkIfAttributeIsDisplayable.js
@@ -1,4 +1,4 @@
-import { toLower } from 'lodash';
+import toLower from 'lodash/toLower';
 
 const checkIfAttributeIsDisplayable = (attribute) => {
   const type = attribute.type;

--- a/packages/core/admin/admin/src/content-manager/utils/createDefaultForm.js
+++ b/packages/core/admin/admin/src/content-manager/utils/createDefaultForm.js
@@ -1,4 +1,4 @@
-import { get } from 'lodash';
+import get from 'lodash/get';
 
 const createDefaultForm = (attributes, allComponentsSchema) => {
   return Object.keys(attributes).reduce((acc, current) => {
@@ -10,7 +10,7 @@ const createDefaultForm = (attributes, allComponentsSchema) => {
     }
 
     if (type === 'component') {
-      const currentComponentSchema = get(allComponentsSchema, [component, 'attributes'], {});
+      const currentComponentSchema = allComponentsSchema?.[component]?.attributes ?? {};
       const currentComponentDefaultForm = createDefaultForm(
         currentComponentSchema,
         allComponentsSchema

--- a/packages/core/admin/admin/src/content-manager/utils/formatLayoutToApi.js
+++ b/packages/core/admin/admin/src/content-manager/utils/formatLayoutToApi.js
@@ -1,4 +1,5 @@
-import { omit, get } from 'lodash';
+import get from 'lodash/get';
+import omit from 'lodash/omit';
 
 const formatLayoutToApi = ({ layouts, metadatas, ...rest }) => {
   const list = layouts.list.map((obj) => {

--- a/packages/core/admin/admin/src/content-manager/utils/getFieldName.js
+++ b/packages/core/admin/admin/src/content-manager/utils/getFieldName.js
@@ -1,4 +1,4 @@
-import { isNaN } from 'lodash';
+import isNaN from 'lodash/isNaN';
 
 const getFieldName = (stringName) =>
   stringName.split('.').filter((string) => isNaN(parseInt(string, 10)));

--- a/packages/core/admin/admin/src/content-manager/utils/mergeMetasWithSchema.js
+++ b/packages/core/admin/admin/src/content-manager/utils/mergeMetasWithSchema.js
@@ -1,4 +1,4 @@
-import { set } from 'lodash';
+import set from 'lodash/set';
 
 const mergeMetasWithSchema = (data, schemas, mainSchemaKey) => {
   const findSchema = (refUid) => schemas.find((obj) => obj.uid === refUid);

--- a/packages/core/admin/admin/src/content-manager/utils/paths.js
+++ b/packages/core/admin/admin/src/content-manager/utils/paths.js
@@ -1,7 +1,7 @@
 /**
  * This file is for all helpers related to `paths` in the CM.
  */
-import { get } from 'lodash';
+import get from 'lodash/get';
 
 /**
  * This is typically used in circumstances where there are re-orderable pieces e.g. Dynamic Zones

--- a/packages/core/admin/admin/src/content-manager/utils/removePasswordFieldsFromData.js
+++ b/packages/core/admin/admin/src/content-manager/utils/removePasswordFieldsFromData.js
@@ -1,4 +1,4 @@
-import { get } from 'lodash';
+import get from 'lodash/get';
 import { getType, getOtherInfos } from '@strapi/helper-plugin';
 
 const removePasswordFieldsFromData = (data, contentTypeSchema, componentSchema) => {

--- a/packages/core/admin/admin/src/hooks/useRegenerate/index.js
+++ b/packages/core/admin/admin/src/hooks/useRegenerate/index.js
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { get } from 'lodash';
+import get from 'lodash/get';
 import { useFetchClient, useNotification } from '@strapi/helper-plugin';
 
 const useRegenerate = (url, id, onRegenerate) => {

--- a/packages/core/admin/admin/src/hooks/useSettingsForm/index.js
+++ b/packages/core/admin/admin/src/hooks/useSettingsForm/index.js
@@ -1,6 +1,6 @@
 import { useEffect, useReducer } from 'react';
 import { request, useNotification, useOverlayBlocker } from '@strapi/helper-plugin';
-import { get, has, omit } from 'lodash';
+import omit from 'lodash/omit';
 import { checkFormValidity, formatAPIErrors } from '../../utils';
 import { initialState, reducer } from './reducer';
 import init from './init';
@@ -102,9 +102,9 @@ const useSettingsForm = (endPoint, schema, cbSuccess, fieldsToPick) => {
           message: { id: 'notification.success.saved' },
         });
       } catch (err) {
-        const data = get(err, 'response.payload', { data: {} });
+        const data = err?.response?.payload ?? { data: {} };
 
-        if (has(data, 'data') && typeof data.data === 'string') {
+        if (!!data?.data && typeof data.data === 'string') {
           toggleNotification({
             type: 'warning',
             message: data.data,

--- a/packages/core/admin/admin/src/hooks/useSettingsForm/reducer.js
+++ b/packages/core/admin/admin/src/hooks/useSettingsForm/reducer.js
@@ -1,6 +1,8 @@
 /* eslint-disable consistent-return */
 import produce from 'immer';
-import { pick, set, unset } from 'lodash';
+import pick from 'lodash/pick';
+import set from 'lodash/set';
+import unset from 'lodash/unset';
 
 const initialState = {
   fieldsToPick: [],

--- a/packages/core/admin/admin/src/hooks/useSettingsMenu/reducer.js
+++ b/packages/core/admin/admin/src/hooks/useSettingsMenu/reducer.js
@@ -1,5 +1,5 @@
 import produce from 'immer';
-import { set } from 'lodash';
+import set from 'lodash/set';
 
 const initialState = {
   menu: [],

--- a/packages/core/admin/admin/src/pages/AuthPage/reducer.js
+++ b/packages/core/admin/admin/src/pages/AuthPage/reducer.js
@@ -1,5 +1,5 @@
 import produce from 'immer';
-import { set } from 'lodash';
+import set from 'lodash/set';
 /* eslint-disable consistent-return */
 
 const initialState = {

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/ApiTokens/EditView/components/CollapsableContentType/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/ApiTokens/EditView/components/CollapsableContentType/index.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { capitalize } from 'lodash';
+import capitalize from 'lodash/capitalize';
 import { useIntl } from 'react-intl';
 import {
   Accordion,

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/ApiTokens/EditView/reducer.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/ApiTokens/EditView/reducer.js
@@ -1,6 +1,6 @@
 /* eslint-disable consistent-return */
 import produce from 'immer';
-import { pull } from 'lodash';
+import pull from 'lodash/pull';
 import { transformPermissionsData } from './utils';
 
 export const initialState = {

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/ApiTokens/EditView/utils/transformPermissionsData.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/ApiTokens/EditView/utils/transformPermissionsData.js
@@ -1,5 +1,3 @@
-import { flatten } from 'lodash';
-
 const transformPermissionsData = (data) => {
   const layout = {
     allActionsIds: [],
@@ -9,11 +7,11 @@ const transformPermissionsData = (data) => {
   layout.permissions = Object.keys(data).map((apiId) => ({
     apiId,
     label: apiId.split('::')[1],
-    controllers: flatten(
-      Object.keys(data[apiId].controllers).map((controller) => ({
+    controllers: Object.keys(data[apiId].controllers)
+      .map((controller) => ({
         controller,
-        actions: flatten(
-          data[apiId].controllers[controller].map((action) => {
+        actions: data[apiId].controllers[controller]
+          .map((action) => {
             const actionId = `${apiId}.${controller}.${action}`;
 
             if (apiId.includes('api::')) {
@@ -25,9 +23,9 @@ const transformPermissionsData = (data) => {
               actionId,
             };
           })
-        ),
+          .flat(),
       }))
-    ),
+      .flat(),
   }));
 
   return layout;

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/ConditionsModal/utils/createDefaultConditionsForm.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/ConditionsModal/utils/createDefaultConditionsForm.js
@@ -1,4 +1,4 @@
-import { get } from 'lodash';
+import get from 'lodash/get';
 
 const createConditionsForm = (conditions, valueObject) => {
   return conditions.reduce((acc, current) => {

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/ContentTypeCollapse/Collapse/utils/generateCheckboxesActions.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/ContentTypeCollapse/Collapse/utils/generateCheckboxesActions.js
@@ -1,4 +1,5 @@
-import { get, isEmpty } from 'lodash';
+import get from 'lodash/get';
+import isEmpty from 'lodash/isEmpty';
 import { createArrayOfValues, getCheckboxState } from '../../../utils';
 
 const generateCheckboxesActions = (availableActions, modifiedData, pathToData) => {

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/ContentTypeCollapse/CollapsePropertyMatrix/ActionRow/utils/getRowLabelCheckboxeState.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/ContentTypeCollapse/CollapsePropertyMatrix/ActionRow/utils/getRowLabelCheckboxeState.js
@@ -1,4 +1,5 @@
-import { get } from 'lodash';
+import get from 'lodash/get';
+
 import { getCheckboxState } from '../../../../utils';
 
 /**

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/GlobalActions/utils/getRowLabelCheckboxesState.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/GlobalActions/utils/getRowLabelCheckboxesState.js
@@ -1,4 +1,4 @@
-import { get } from 'lodash';
+import get from 'lodash/get';
 import { getCheckboxState, removeConditionKeyFromData } from '../../utils';
 
 const getActionsIds = (array) => array.map(({ actionId }) => actionId);

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/Permissions/reducer.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/Permissions/reducer.js
@@ -1,5 +1,10 @@
 import produce from 'immer';
-import { cloneDeep, has, isObject, get, set } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
+import has from 'lodash/has';
+import isObject from 'lodash/isObject';
+import get from 'lodash/get';
+import set from 'lodash/set';
+
 import updateConditionsToFalse from './utils/updateConditionsToFalse';
 import updateValues from './utils/updateValues';
 

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/Permissions/utils/createDefaultCTFormFromLayout.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/Permissions/utils/createDefaultCTFormFromLayout.js
@@ -1,4 +1,8 @@
-import { merge, get, isEmpty, set } from 'lodash';
+import get from 'lodash/get';
+import isEmpty from 'lodash/isEmpty';
+import merge from 'lodash/merge';
+import set from 'lodash/set';
+
 import findMatchingPermission from './findMatchingPermissions';
 /**
  * Creates the default condition form: { [conditionId]: false }

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/Permissions/utils/createDefaultPluginsFormFromLayout.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/Permissions/utils/createDefaultPluginsFormFromLayout.js
@@ -1,4 +1,3 @@
-import { get } from 'lodash';
 import { createDefaultConditionsForm } from './createDefaultCTFormFromLayout';
 import findMatchingPermission from './findMatchingPermissions';
 
@@ -12,7 +11,7 @@ const createSubCategoryForm = (actions, conditions, permissions) => {
       },
       conditions: createDefaultConditionsForm(
         conditions,
-        get(foundMatchingPermission, 'conditions', [])
+        foundMatchingPermission?.conditions ?? []
       ),
     };
 

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/Permissions/utils/formatContentTypesPermissionToAPI.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/Permissions/utils/formatContentTypesPermissionToAPI.js
@@ -1,4 +1,4 @@
-import { has, isObject } from 'lodash';
+import isObject from 'lodash/isObject';
 import { createArrayOfValues } from '../../utils';
 import { createConditionsArray } from './formatSettingsPermissionsToAPI';
 
@@ -77,7 +77,7 @@ const createSubjectPermissions = (subject, actions) => {
       return acc;
     }
 
-    if (!has(permissions, 'properties.enabled')) {
+    if (!permissions?.properties?.enabled) {
       const createdPermissionsArray = createPermissionWithProperties(
         actionName,
         subject,

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/Permissions/utils/updateConditionsToFalse.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/Permissions/utils/updateConditionsToFalse.js
@@ -1,4 +1,7 @@
-import { isObject, has, omit } from 'lodash';
+import isObject from 'lodash/isObject';
+import has from 'lodash/has';
+import omit from 'lodash/omit';
+
 import { createArrayOfValues } from '../../utils';
 
 /**

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/Permissions/utils/updateValues.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/Permissions/utils/updateValues.js
@@ -1,4 +1,4 @@
-import { isObject } from 'lodash';
+import isObject from 'lodash/isObject';
 
 /**
  * Sets all the none object values of an object to the given one

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/PluginsAndSettings/SubCategory/utils/formatActions.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/PluginsAndSettings/SubCategory/utils/formatActions.js
@@ -1,4 +1,4 @@
-import { get } from 'lodash';
+import get from 'lodash/get';
 import { createArrayOfValues } from '../../../utils';
 
 /**

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/utils/createArrayOfValues.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/utils/createArrayOfValues.js
@@ -1,4 +1,5 @@
-import { flattenDeep, isObject } from 'lodash';
+import flattenDeep from 'lodash/flattenDeep';
+import isObject from 'lodash/isObject';
 
 const createArrayOfValues = (obj) => {
   if (!isObject(obj)) {

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/ListPage/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/ListPage/index.js
@@ -26,7 +26,7 @@ import {
   Typography,
   VisuallyHidden,
 } from '@strapi/design-system';
-import { get } from 'lodash';
+import get from 'lodash/get';
 import matchSorter from 'match-sorter';
 import { useIntl } from 'react-intl';
 import { useHistory } from 'react-router-dom';

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Users/ProtectedEditPage/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Users/ProtectedEditPage/index.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo } from 'react';
 import { useRBAC, LoadingIndicatorPage, useNotification } from '@strapi/helper-plugin';
 import { Redirect, useLocation } from 'react-router-dom';
-import { get } from 'lodash';
+
 import adminPermissions from '../../../../../permissions';
 import EditPage from '../EditPage';
 
@@ -19,7 +19,7 @@ const ProtectedEditPage = () => {
     allowedActions: { canRead, canUpdate },
   } = useRBAC(permissions);
   const { state } = useLocation();
-  const from = get(state, 'from', '/');
+  const from = state?.from ?? '/';
 
   useEffect(() => {
     if (!isLoading) {

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Webhooks/EditView/utils/formatData.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Webhooks/EditView/utils/formatData.js
@@ -1,11 +1,5 @@
-import { set } from 'lodash';
-
 const cleanData = (data) => {
-  const webhooks = { ...data };
-
-  set(webhooks, 'headers', unformatHeaders(data.headers));
-
-  return webhooks;
+  return { ...data, headers: unformatHeaders(data.headers) };
 };
 
 const unformatHeaders = (headers) => {

--- a/packages/core/admin/admin/src/permissions/index.js
+++ b/packages/core/admin/admin/src/permissions/index.js
@@ -1,4 +1,4 @@
-import { merge } from 'lodash';
+import merge from 'lodash/merge';
 import customPermissions from 'ee_else_ce/permissions/customPermissions';
 import defaultPermissions from './defaultPermissions';
 

--- a/packages/core/admin/admin/src/utils/getAttributesToDisplay.js
+++ b/packages/core/admin/admin/src/utils/getAttributesToDisplay.js
@@ -1,13 +1,11 @@
-import { get } from 'lodash';
-
 const getAttributesToDisplay = (contentType) => {
-  const timestamps = get(contentType, ['options', 'timestamps']);
+  const timestamps = contentType?.options?.timestamps;
 
   // Sometimes timestamps is false
   let timestampsArray = Array.isArray(timestamps) ? timestamps : [];
   const idsAttributes = ['id', '_id']; // For both SQL and mongo
   const unwritableAttributes = [...idsAttributes, ...timestampsArray, 'publishedAt'];
-  const schemaAttributes = get(contentType, ['attributes'], {});
+  const schemaAttributes = contentType?.attributes ?? {};
 
   return Object.keys(schemaAttributes).reduce((acc, current) => {
     if (!unwritableAttributes.includes(current)) {

--- a/packages/core/admin/admin/src/utils/getExistingActions.js
+++ b/packages/core/admin/admin/src/utils/getExistingActions.js
@@ -1,5 +1,3 @@
-import { get } from 'lodash';
-
 const getExistingActions = (permissions) => {
   return Array.from(
     new Set(
@@ -23,7 +21,7 @@ const getExistingActions = (permissions) => {
           ...acc,
           ...getActionsPermission([
             ...Object.values(current[1].attributes || {}),
-            get(current[1], 'contentTypeActions', {}),
+            current[1]?.contentTypeActions ?? {},
           ]),
         ];
       }, [])

--- a/packages/core/admin/admin/src/utils/sortLinks.js
+++ b/packages/core/admin/admin/src/utils/sortLinks.js
@@ -1,4 +1,4 @@
-import { sortBy } from 'lodash';
+import sortBy from 'lodash/sortBy';
 
 const sortLinks = (links) => sortBy(links, (object) => object.name);
 

--- a/packages/core/content-type-builder/admin/src/components/DataManagerProvider/index.js
+++ b/packages/core/content-type-builder/admin/src/components/DataManagerProvider/index.js
@@ -1,6 +1,9 @@
 import React, { memo, useEffect, useMemo, useRef } from 'react';
 import PropTypes from 'prop-types';
-import { get, groupBy, set, size } from 'lodash';
+import get from 'lodash/get';
+import groupBy from 'lodash/groupBy';
+import set from 'lodash/set';
+import size from 'lodash/size';
 import {
   LoadingIndicatorPage,
   useTracking,

--- a/packages/core/content-type-builder/admin/src/components/DataManagerProvider/utils/cleanData.js
+++ b/packages/core/content-type-builder/admin/src/components/DataManagerProvider/utils/cleanData.js
@@ -1,4 +1,8 @@
-import { get, isEqual, omit, sortBy, camelCase } from 'lodash';
+import get from 'lodash/get';
+import isEqual from 'lodash/isEqual';
+import omit from 'lodash/omit';
+import sortBy from 'lodash/sortBy';
+import camelCase from 'lodash/camelCase';
 
 import pluginId from '../../../pluginId';
 import makeUnique from '../../../utils/makeUnique';

--- a/packages/core/content-type-builder/admin/src/components/DataManagerProvider/utils/retrieveNestedComponents.js
+++ b/packages/core/content-type-builder/admin/src/components/DataManagerProvider/utils/retrieveNestedComponents.js
@@ -1,9 +1,8 @@
-import { get } from 'lodash';
 import makeUnique from '../../../utils/makeUnique';
 
 const retrieveNestedComponents = (appComponents) => {
   const nestedComponents = Object.keys(appComponents).reduce((acc, current) => {
-    const componentAttributes = get(appComponents, [current, 'schema', 'attributes'], []);
+    const componentAttributes = appComponents?.[current]?.schema?.attributes ?? [];
     const currentComponentNestedCompos = getComponentsFromComponent(componentAttributes);
 
     return [...acc, ...currentComponentNestedCompos];

--- a/packages/core/content-type-builder/admin/src/components/DataManagerProvider/utils/retrieveSpecificInfoFromComponents.js
+++ b/packages/core/content-type-builder/admin/src/components/DataManagerProvider/utils/retrieveSpecificInfoFromComponents.js
@@ -1,4 +1,4 @@
-import { get } from 'lodash';
+import get from 'lodash/get';
 import makeUnique from '../../../utils/makeUnique';
 
 const retrieveSpecificInfoFromComponents = (allComponents, keysToRetrieve) => {

--- a/packages/core/content-type-builder/admin/src/components/FormModal/attributes/validation/common.js
+++ b/packages/core/content-type-builder/admin/src/components/FormModal/attributes/validation/common.js
@@ -1,6 +1,7 @@
 import * as yup from 'yup';
-import { get, toNumber } from 'lodash';
+import toNumber from 'lodash/toNumber';
 import { translatedErrors as errorsTrads } from '@strapi/helper-plugin';
+
 import getTrad from '../../../../utils/getTrad';
 
 const NAME_REGEX = /^[A-Za-z][_0-9A-Za-z]*$/;
@@ -20,7 +21,7 @@ const alreadyUsedAttributeNames = (usedNames) => {
 };
 
 const getUsedContentTypeAttributeNames = (ctShema, isEdition, attributeNameToEdit) => {
-  const attributes = get(ctShema, ['schema', 'attributes'], {});
+  const attributes = ctShema?.schema?.attributes ?? {};
 
   return Object.keys(attributes).filter((attr) => {
     if (isEdition) {

--- a/packages/core/content-type-builder/admin/src/components/FormModal/category/createCategorySchema.js
+++ b/packages/core/content-type-builder/admin/src/components/FormModal/category/createCategorySchema.js
@@ -1,6 +1,6 @@
 import * as yup from 'yup';
-import { toLower } from 'lodash';
 import { translatedErrors as errorsTrads } from '@strapi/helper-plugin';
+
 import CATEGORY_NAME_REGEX from './regex';
 
 const createCategorySchema = (usedCategoryNames) => {
@@ -16,7 +16,7 @@ const createCategorySchema = (usedCategoryNames) => {
             return false;
           }
 
-          return !usedCategoryNames.includes(toLower(value));
+          return !usedCategoryNames.includes(value?.toLowerCase());
         },
       })
       .required(errorsTrads.required),

--- a/packages/core/content-type-builder/admin/src/components/FormModal/component/createComponentSchema.js
+++ b/packages/core/content-type-builder/admin/src/components/FormModal/component/createComponentSchema.js
@@ -1,6 +1,6 @@
 import * as yup from 'yup';
-import { toLower, trim } from 'lodash';
 import { translatedErrors as errorsTrads } from '@strapi/helper-plugin';
+
 import getTrad from '../../../utils/getTrad';
 import { createComponentUid } from '../utils/createUid';
 import { CATEGORY_NAME_REGEX } from '../category';
@@ -30,7 +30,7 @@ const createComponentSchema = (usedComponentNames, reservedNames, category) => {
             return false;
           }
 
-          return !reservedNames.includes(toLower(trim(value)));
+          return !reservedNames.includes(value?.trim()?.toLowerCase());
         },
       })
       .required(errorsTrads.required),

--- a/packages/core/content-type-builder/admin/src/components/FormModal/contentType/createContentTypeSchema.js
+++ b/packages/core/content-type-builder/admin/src/components/FormModal/contentType/createContentTypeSchema.js
@@ -1,6 +1,6 @@
 import * as yup from 'yup';
-import { toLower, trim } from 'lodash';
 import { translatedErrors as errorsTrads } from '@strapi/helper-plugin';
+
 import getTrad from '../../../utils/getTrad';
 import { createUid } from '../utils/createUid';
 
@@ -34,7 +34,7 @@ const createContentTypeSchema = ({
             return false;
           }
 
-          return !reservedModels.includes(toLower(trim(value)));
+          return !reservedModels.includes(value?.trim()?.toLowerCase());
         },
       })
       .required(errorsTrads.required),
@@ -70,7 +70,7 @@ const createContentTypeSchema = ({
             return false;
           }
 
-          return !reservedModels.includes(toLower(trim(value)));
+          return !reservedModels.includes(value?.trim()?.toLowerCase());
         },
       })
       .required(errorsTrads.required),
@@ -106,7 +106,7 @@ const createContentTypeSchema = ({
             return false;
           }
 
-          return !reservedModels.includes(toLower(trim(value)));
+          return !reservedModels.includes(value?.trim()?.toLowerCase());
         },
       })
       .required(errorsTrads.required),

--- a/packages/core/content-type-builder/admin/src/components/FormModal/index.js
+++ b/packages/core/content-type-builder/admin/src/components/FormModal/index.js
@@ -27,7 +27,7 @@ import {
   TabPanel,
   Flex,
 } from '@strapi/design-system';
-import { isEqual } from 'lodash';
+import isEqual from 'lodash/isEqual';
 import pluginId from '../../pluginId';
 import useDataManager from '../../hooks/useDataManager';
 import useFormModalNavigation from '../../hooks/useFormModalNavigation';

--- a/packages/core/content-type-builder/admin/src/components/FormModal/reducer.js
+++ b/packages/core/content-type-builder/admin/src/components/FormModal/reducer.js
@@ -2,7 +2,7 @@ import produce from 'immer';
 import pluralize from 'pluralize';
 import set from 'lodash/set';
 import snakeCase from 'lodash/snakeCase';
-import _ from 'lodash';
+
 import getRelationType from '../../utils/getRelationType';
 import nameToSlug from '../../utils/nameToSlug';
 import { createComponentUid } from './utils/createUid';
@@ -312,7 +312,7 @@ const reducer = (state = initialState, action) =>
 
         if (optionDefaults.length) {
           optionDefaults.forEach(({ name, defaultValue }) =>
-            _.set(draftState.modifiedData, name, defaultValue)
+            set(draftState.modifiedData, name, defaultValue)
           );
         }
 

--- a/packages/core/helper-plugin/lib/src/content-manager/utils/contentManagementUtilRemoveFieldsFromData.js
+++ b/packages/core/helper-plugin/lib/src/content-manager/utils/contentManagementUtilRemoveFieldsFromData.js
@@ -1,4 +1,5 @@
-import { get } from 'lodash';
+import get from 'lodash/get';
+
 import { getType, getOtherInfos } from './getAttributeInfos';
 
 const defaultFields = ['createdBy', 'updatedBy', 'publishedAt', 'id', '_id'];

--- a/packages/core/helper-plugin/lib/src/utils/auth/index.js
+++ b/packages/core/helper-plugin/lib/src/utils/auth/index.js
@@ -1,6 +1,6 @@
 // TODO @soupette we need to refactor this file
 
-import { isNil } from 'lodash';
+import isNil from 'lodash/isNil';
 import isEmpty from 'lodash/isEmpty';
 
 const TOKEN_KEY = 'jwtToken';

--- a/packages/core/helper-plugin/lib/src/utils/hasPermissions/index.js
+++ b/packages/core/helper-plugin/lib/src/utils/hasPermissions/index.js
@@ -1,4 +1,7 @@
-import { isEmpty, pickBy, transform } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
+import pickBy from 'lodash/pickBy';
+import transform from 'lodash/transform';
+
 import request from '../request';
 
 const findMatchingPermissions = (userPermissions, permissions) => {

--- a/packages/plugins/documentation/admin/src/utils/openWithNewTab.js
+++ b/packages/plugins/documentation/admin/src/utils/openWithNewTab.js
@@ -1,11 +1,10 @@
-import { startsWith } from 'lodash';
-
 const openWithNewTab = (path) => {
   const url = (() => {
-    if (startsWith(path, '/')) {
+    if (path.startsWith('/')) {
       return `${strapi.backendURL}${path}`;
     }
-    if (startsWith(path, 'https') || startsWith(path, 'http')) {
+
+    if (path.startsWith('http')) {
       return path;
     }
 

--- a/packages/plugins/i18n/admin/src/components/CMEditViewInjectedComponents/CMEditViewCopyLocale/utils/removePasswordAndRelationsFieldFromData.js
+++ b/packages/plugins/i18n/admin/src/components/CMEditViewInjectedComponents/CMEditViewCopyLocale/utils/removePasswordAndRelationsFieldFromData.js
@@ -1,4 +1,4 @@
-import { get } from 'lodash';
+import get from 'lodash/get';
 import { getType, getOtherInfos } from '@strapi/helper-plugin';
 
 const removePasswordAndRelationsFieldFromData = (data, contentTypeSchema, componentSchema) => {

--- a/packages/plugins/i18n/admin/src/middlewares/extendCTBInitialDataMiddleware.js
+++ b/packages/plugins/i18n/admin/src/middlewares/extendCTBInitialDataMiddleware.js
@@ -1,5 +1,3 @@
-import { has } from 'lodash';
-
 const extendCTBInitialDataMiddleware = () => {
   return () => (next) => (action) => {
     if (
@@ -20,7 +18,7 @@ const extendCTBInitialDataMiddleware = () => {
 
       // Override the action if the pluginOption config does not contain i18n
       // In this case we need to set the proper initialData shape
-      if (!has(action.data.pluginOptions, 'i18n.localized')) {
+      if (!action.data.pluginOptions?.i18n?.localized) {
         return next({ ...action, data });
       }
     }

--- a/packages/plugins/i18n/admin/src/utils/mutateCTBContentTypeSchema.js
+++ b/packages/plugins/i18n/admin/src/utils/mutateCTBContentTypeSchema.js
@@ -1,4 +1,7 @@
-import { has, get, omit } from 'lodash';
+import get from 'lodash/get';
+import has from 'lodash/has';
+import omit from 'lodash/omit';
+
 import LOCALIZED_FIELDS from './localizedFields';
 
 const localizedPath = ['pluginOptions', 'i18n', 'localized'];

--- a/packages/plugins/users-permissions/admin/src/components/Permissions/PermissionRow/SubCategory.js
+++ b/packages/plugins/users-permissions/admin/src/components/Permissions/PermissionRow/SubCategory.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo } from 'react';
-import { get } from 'lodash';
+import get from 'lodash/get';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import { Box, Checkbox, Flex, Typography, Grid, GridItem } from '@strapi/design-system';

--- a/packages/plugins/users-permissions/admin/src/components/Policies/index.js
+++ b/packages/plugins/users-permissions/admin/src/components/Policies/index.js
@@ -1,7 +1,10 @@
 import React from 'react';
 import { useIntl } from 'react-intl';
 import { Typography, Flex, GridItem } from '@strapi/design-system';
-import { get, isEmpty, without } from 'lodash';
+import get from 'lodash/get';
+import isEmpty from 'lodash/isEmpty';
+import without from 'lodash/without';
+
 import { useUsersPermissions } from '../../contexts/UsersPermissionsContext';
 import BoundRoute from '../BoundRoute';
 

--- a/packages/plugins/users-permissions/admin/src/components/UsersPermissions/reducer.js
+++ b/packages/plugins/users-permissions/admin/src/components/UsersPermissions/reducer.js
@@ -1,6 +1,8 @@
 /* eslint-disable consistent-return */
 import produce from 'immer';
-import { set, get, take } from 'lodash';
+import get from 'lodash/get';
+import set from 'lodash/set';
+import take from 'lodash/take';
 
 export const initialState = {
   initialData: {},

--- a/packages/plugins/users-permissions/admin/src/hooks/usePlugins/index.js
+++ b/packages/plugins/users-permissions/admin/src/hooks/usePlugins/index.js
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useReducer } from 'react';
 import { useNotification, useFetchClient } from '@strapi/helper-plugin';
-import { get } from 'lodash';
+import get from 'lodash/get';
 import init from './init';
 import pluginId from '../../pluginId';
 import { cleanPermissions } from '../../utils';

--- a/packages/plugins/users-permissions/admin/src/hooks/useRolesList/index.js
+++ b/packages/plugins/users-permissions/admin/src/hooks/useRolesList/index.js
@@ -1,6 +1,6 @@
 import { useEffect, useReducer, useRef } from 'react';
 import { request, useNotification } from '@strapi/helper-plugin';
-import { get } from 'lodash';
+import get from 'lodash/get';
 import init from './init';
 import pluginId from '../../pluginId';
 import reducer, { initialState } from './reducer';

--- a/packages/plugins/users-permissions/admin/src/pages/Providers/reducer.js
+++ b/packages/plugins/users-permissions/admin/src/pages/Providers/reducer.js
@@ -1,5 +1,5 @@
 import produce from 'immer';
-import { set } from 'lodash';
+import set from 'lodash/set';
 
 const initialState = {
   formErrors: {},

--- a/packages/plugins/users-permissions/admin/src/pages/Providers/utils/createProvidersArray.js
+++ b/packages/plugins/users-permissions/admin/src/pages/Providers/utils/createProvidersArray.js
@@ -1,4 +1,4 @@
-import { sortBy } from 'lodash';
+import sortBy from 'lodash/sortBy';
 
 const createProvidersArray = (data) => {
   return sortBy(

--- a/packages/plugins/users-permissions/admin/src/utils/cleanPermissions.js
+++ b/packages/plugins/users-permissions/admin/src/utils/cleanPermissions.js
@@ -1,4 +1,4 @@
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 
 const cleanPermissions = (permissions) =>
   Object.keys(permissions).reduce((acc, current) => {


### PR DESCRIPTION
### What does it do?

- Optimizes all lodash imports, so that the admin app never has to bundle the whole library (2% bundle-size win)
- Replace lodash with native functions in some easy cases
- Add eslint rule to disallow `import { method} from 'lodash'` to make sure we do not regress on this.

### Why is it needed?

Bundle-size and DX.
