### PR TITLE
Add new entities of RW content types to default stage

### DIFF
--- a/packages/core/admin/ee/server/bootstrap.js
+++ b/packages/core/admin/ee/server/bootstrap.js
@@ -18,6 +18,10 @@ module.exports = async () => {
   }
 
   if (features.isEnabled('review-workflows')) {
+    // Decorate the entity service with review workflow logic
+    const { decorator } = getService('review-workflows-decorator');
+    strapi.entityService.decorate(decorator);
+
     const { bootstrap: rwBootstrap } = getService('review-workflows');
 
     await rwBootstrap();

--- a/packages/core/admin/ee/server/migrations/review-workflows.js
+++ b/packages/core/admin/ee/server/migrations/review-workflows.js
@@ -1,17 +1,12 @@
 'use strict';
 
-/**
- * Determine if a content type has the review workflows feature enabled
- * @param {Object} contentType
- * @returns
- */
-const hasRWEnabled = (contentType) => contentType?.options?.reviewWorkflows || false;
+const { hasRWEnabled } = require('../utils/review-workflows');
 
 /**
  * Remove all stage information for all content types that have had review workflows disabled
  */
 /* eslint-disable no-continue */
-const disableReviewWorkFlows = async ({ oldContentTypes, contentTypes }) => {
+const disableOnContentTypes = async ({ oldContentTypes, contentTypes }) => {
   const uidsToRemove = [];
   for (const uid in contentTypes) {
     if (!oldContentTypes || !oldContentTypes[uid]) {
@@ -38,4 +33,4 @@ const disableReviewWorkFlows = async ({ oldContentTypes, contentTypes }) => {
     .del();
 };
 
-module.exports = disableReviewWorkFlows;
+module.exports = { disableOnContentTypes };

--- a/packages/core/admin/ee/server/services/index.js
+++ b/packages/core/admin/ee/server/services/index.js
@@ -8,4 +8,5 @@ module.exports = {
   workflows: require('./review-workflows/workflows'),
   stages: require('./review-workflows/stages'),
   'review-workflows': require('./review-workflows/review-workflows'),
+  'review-workflows-decorator': require('./review-workflows/entity-service-decorator'),
 };

--- a/packages/core/admin/ee/server/services/review-workflows/entity-service-decorator.js
+++ b/packages/core/admin/ee/server/services/review-workflows/entity-service-decorator.js
@@ -1,0 +1,58 @@
+'use strict';
+
+const { hasRWEnabled } = require('../../utils/review-workflows');
+const { WORKFLOW_MODEL_UID, ENTITY_STAGE_ATTRIBUTE } = require('../../constants/workflows');
+
+// TODO refactor shared logic between packages/core/admin/ee/server/services/review-workflows/review-workflows.js
+const assignEntityDefaultStage = async (uid, entityID) => {
+  const defaultWorkflow = await strapi.query(WORKFLOW_MODEL_UID).findOne({ populate: ['stages'] });
+  if (!defaultWorkflow) {
+    return;
+  }
+
+  const firstStage = defaultWorkflow.stages[0];
+
+  const contentTypeMetadata = strapi.db.metadata.get(uid);
+  const { target, morphBy } = contentTypeMetadata.attributes[ENTITY_STAGE_ATTRIBUTE];
+  const { joinTable } = strapi.db.metadata.get(target).attributes[morphBy];
+  const { idColumn, typeColumn } = joinTable.morphColumn;
+
+  const connection = strapi.db.getConnection();
+
+  // TODO test all db types
+  // Insert rows for all entries of the content type that do not have a
+  // default stage
+  await connection(joinTable.name).insert({
+    [idColumn.name]: entityID,
+    field: connection.raw('?', [ENTITY_STAGE_ATTRIBUTE]),
+    order: 1,
+    [joinTable.joinColumn.name]: firstStage.id,
+    [typeColumn.name]: connection.raw('?', [uid]),
+  });
+};
+
+/**
+ * Decorates the entity service with RW business logic
+ * @param {object} service - entity service
+ */
+const decorator = (service) => ({
+  async create(uid, opts = {}) {
+    const model = strapi.getModel(uid);
+
+    const hasRW = hasRWEnabled(model);
+
+    const entity = await service.create.call(this, uid, opts);
+    if (!hasRW) {
+      return;
+    }
+
+    // Assign this entity to the default workflow stage
+    await assignEntityDefaultStage(uid, entity.id);
+
+    return entity;
+  },
+});
+
+module.exports = () => ({
+  decorator,
+});

--- a/packages/core/admin/ee/server/services/review-workflows/review-workflows.js
+++ b/packages/core/admin/ee/server/services/review-workflows/review-workflows.js
@@ -8,7 +8,9 @@ const defaultStages = require('../../constants/default-stages.json');
 const defaultWorkflow = require('../../constants/default-workflow.json');
 const { WORKFLOW_MODEL_UID, ENTITY_STAGE_ATTRIBUTE } = require('../../constants/workflows');
 
-const disableReviewWorkFlows = require('../../migrations/review-workflows');
+const {
+  disableOnContentTypes: disableReviewWorkflows,
+} = require('../../migrations/review-workflows');
 
 const getContentTypeUIDsWithActivatedReviewWorkflows = pipe([
   // Pick only content-types with reviewWorkflows options set to true
@@ -168,7 +170,7 @@ module.exports = ({ strapi }) => {
     async register() {
       extendReviewWorkflowContentTypes({ strapi });
       strapi.hook('strapi::content-types.afterSync').register(enableReviewWorkflow({ strapi }));
-      strapi.hook('strapi::content-types.afterSync').register(disableReviewWorkFlows);
+      strapi.hook('strapi::content-types.afterSync').register(disableReviewWorkflows);
     },
   };
 };

--- a/packages/core/admin/ee/server/utils/review-workflows.js
+++ b/packages/core/admin/ee/server/utils/review-workflows.js
@@ -1,0 +1,12 @@
+'use strict';
+
+/**
+ * Determine if a content type has the review workflows feature enabled
+ * @param {Object} contentType
+ * @returns
+ */
+const hasRWEnabled = (contentType) => contentType?.options?.reviewWorkflows || false;
+
+module.exports = {
+  hasRWEnabled,
+};


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Decorates the entity service to add new entities of RW content types to the default workflow stage.

### Why is it needed?

Entity creation doesn't trigger server restart so EE bootstrap will not pick up these new entities

### How to test it?

WIP

### Related issue(s)/PR(s)

CONTENT-1180