### PR TITLE
Add CodeQL security scanning

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,50 @@
+name: Code Scanning
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: 0 0 * * MON
+
+permissions: read-all
+
+jobs:
+  codeql-build:
+    name: CodeQL Build
+
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          # https://aka.ms/codeql-docs/language-support
+          - javascript
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout tree
+        uses: actions/checkout@v3
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: ${{ matrix.language }}
+          # https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/customizing-code-scanning#using-queries-in-ql-packs
+          queries: security-extended,security-and-quality
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v2
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2
+        with:
+          category: /language:${{matrix.language}}


### PR DESCRIPTION
### What does it do?

This PR adds CodeQL to GitHub Actions workflows to perform security scanning.
Actually, I must admit that this kind of stuff does not always report very good findings, but much better than nothing.
CodeQL supports TypeScript by default, so it's all we have to do here.

### Why is it needed?

Why not?

### How to test it?

https://github.com/strapi/strapi/actions/runs/4451317988/jobs/7817830636?pr=16127

### Related issue(s)/PR(s)

None
