### PR TITLE
feat(core): load components from plugins

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -14,7 +14,7 @@ services:
       - '5432:5432'
 
   mysql:
-    image: mysql:5
+    image: mysql:oracle
     restart: always
     command: --default-authentication-plugin=mysql_native_password
     environment:

--- a/examples/getstarted/src/plugins/myplugin/server/components/index.js
+++ b/examples/getstarted/src/plugins/myplugin/server/components/index.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+  'my-component': require('./my-component'),
+};

--- a/examples/getstarted/src/plugins/myplugin/server/components/my-component/index.js
+++ b/examples/getstarted/src/plugins/myplugin/server/components/my-component/index.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const schema = require('./schema');
+
+module.exports = {
+  schema,
+};

--- a/examples/getstarted/src/plugins/myplugin/server/components/my-component/schema.json
+++ b/examples/getstarted/src/plugins/myplugin/server/components/my-component/schema.json
@@ -2,7 +2,6 @@
 	"collectionName": "components_myplugin_mycomponent",
 	"info": {
 		"displayName": "My Component",
-		"category": "my-plugin",
 		"singularName": "my-component"
 	},
 	"attributes": {

--- a/examples/getstarted/src/plugins/myplugin/server/components/my-component/schema.json
+++ b/examples/getstarted/src/plugins/myplugin/server/components/my-component/schema.json
@@ -1,0 +1,13 @@
+{
+	"collectionName": "components_myplugin_mycomponent",
+	"info": {
+		"displayName": "My Component",
+		"category": "my-plugin",
+		"singularName": "my-component"
+	},
+	"attributes": {
+    "title": {
+      "type": "string"
+    }
+	}
+}

--- a/examples/getstarted/src/plugins/myplugin/strapi-server.js
+++ b/examples/getstarted/src/plugins/myplugin/strapi-server.js
@@ -2,6 +2,7 @@
 
 const config = require('./server/config');
 const contentTypes = require('./server/content-types');
+const components = require('./server/components');
 const controllers = require('./server/controllers');
 const register = require('./server/register');
 const routes = require('./server/routes');
@@ -13,5 +14,6 @@ module.exports = () => {
     controllers,
     contentTypes,
     routes,
+    components,
   };
 };

--- a/packages/core/admin/server/services/permission/sections-builder/handlers.js
+++ b/packages/core/admin/server/services/permission/sections-builder/handlers.js
@@ -108,7 +108,7 @@ const buildNode = (model, attributeName, attribute) => {
   }
 
   if (attribute.type === 'component') {
-    const component = strapi.components[attribute.component];
+    const component = strapi.component(attribute.component);
     return { ...node, children: buildDeepAttributesCollection(component) };
   }
 

--- a/packages/core/content-manager/server/services/components.js
+++ b/packages/core/content-manager/server/services/components.js
@@ -29,7 +29,7 @@ module.exports = ({ strapi }) => ({
   findComponent(uid) {
     const { toContentManagerModel } = getService('data-mapper');
 
-    const component = strapi.components[uid];
+    const component = strapi.component(uid);
 
     return isNil(component) ? component : toContentManagerModel(component);
   },

--- a/packages/core/content-type-builder/server/controllers/components.js
+++ b/packages/core/content-type-builder/server/controllers/components.js
@@ -19,7 +19,7 @@ module.exports = {
     const componentService = getService('components');
 
     const data = Object.keys(strapi.components).map((uid) => {
-      return componentService.formatComponent(strapi.components[uid]);
+      return componentService.formatComponent(strapi.component(uid));
     });
 
     ctx.send({ data });
@@ -33,7 +33,7 @@ module.exports = {
   async getComponent(ctx) {
     const { uid } = ctx.params;
 
-    const component = strapi.components[uid];
+    const component = strapi.component(uid);
 
     if (!component) {
       return ctx.send({ error: 'component.notFound' }, 404);

--- a/packages/core/content-type-builder/server/controllers/validation/types.js
+++ b/packages/core/content-type-builder/server/controllers/validation/types.js
@@ -211,7 +211,7 @@ const getTypeShape = (attribute, { modelType, attributes } = {}) => {
           .test({
             name: 'Check max component nesting is 1 lvl',
             test(compoUID) {
-              const targetCompo = strapi.components[compoUID];
+              const targetCompo = strapi.component(compoUID);
               if (!targetCompo) return true; // ignore this error as it will fail beforehand
 
               if (modelType === modelTypes.COMPONENT && hasComponent(targetCompo)) {

--- a/packages/core/content-type-builder/server/services/component-categories.js
+++ b/packages/core/content-type-builder/server/services/component-categories.js
@@ -34,7 +34,7 @@ const editCategory = async (name, infos) => {
     // only edit the components in this specific category
     if (component.category !== name) return;
 
-    component.setUID(newUID).setDir(join(component.__dirname__, newName));
+    component.setUID(newUID).setDir(join(component.dir, newName));
 
     builder.components.forEach((compo) => {
       compo.updateComponent(oldUID, newUID);

--- a/packages/core/content-type-builder/server/services/component-categories.js
+++ b/packages/core/content-type-builder/server/services/component-categories.js
@@ -34,7 +34,7 @@ const editCategory = async (name, infos) => {
     // only edit the components in this specific category
     if (component.category !== name) return;
 
-    component.setUID(newUID).setDir(join(strapi.dirs.app.components, newName));
+    component.setUID(newUID).setDir(join(component.__dirname__, newName));
 
     builder.components.forEach((compo) => {
       compo.updateComponent(oldUID, newUID);

--- a/packages/core/content-type-builder/server/services/schema-builder/index.js
+++ b/packages/core/content-type-builder/server/services/schema-builder/index.js
@@ -15,7 +15,7 @@ const createContentTypeBuilder = require('./content-type-builder');
  */
 module.exports = function createBuilder() {
   const components = Object.keys(strapi.components).map((key) => {
-    const compo = strapi.components[key];
+    const compo = strapi.component(key);
 
     return {
       category: compo.category,

--- a/packages/core/content-type-builder/server/services/schema-builder/index.js
+++ b/packages/core/content-type-builder/server/services/schema-builder/index.js
@@ -23,7 +23,7 @@ module.exports = function createBuilder() {
       plugin: compo.modelName,
       uid: compo.uid,
       filename: compo.__filename__,
-      dir: join(strapi.dirs.app.components, compo.category),
+      dir: compo.__dirname__,
       schema: compo.__schema__,
       config: compo.config,
     };

--- a/packages/core/content-type-builder/server/services/schema-builder/index.js
+++ b/packages/core/content-type-builder/server/services/schema-builder/index.js
@@ -8,6 +8,9 @@ const createSchemaHandler = require('./schema-handler');
 const createComponentBuilder = require('./component-builder');
 const createContentTypeBuilder = require('./content-type-builder');
 
+let logged = false;
+let logged1 = false;
+
 /**
  * Creates a content type schema builder instance
  *
@@ -17,16 +20,38 @@ module.exports = function createBuilder() {
   const components = Object.keys(strapi.components).map((key) => {
     const compo = strapi.component(key);
 
-    return {
+    if (compo.modelName === 'my-component') {
+      console.log(compo);
+    } else if (!logged) {
+      logged = true;
+      console.log(compo);
+    }
+
+    const dir = compo.plugin
+      ? join(strapi.dirs.app.extensions, compo.plugin, 'components', compo.info.singularName)
+      : join(strapi.dirs.app.components, compo.category);
+
+    const filename = compo.plugin ? 'schema.json' : compo.__filename__;
+
+    const result = {
       category: compo.category,
       modelName: compo.modelName,
       plugin: compo.modelName,
       uid: compo.uid,
-      filename: compo.__filename__,
-      dir: compo.__dirname__,
+      filename,
+      dir,
       schema: compo.__schema__,
       config: compo.config,
     };
+
+    if (compo.modelName === 'my-component') {
+      console.log(result);
+    } else if (!logged1) {
+      logged1 = true;
+      console.log(result);
+    }
+
+    return result;
   });
 
   const contentTypes = Object.keys(strapi.contentTypes).map((key) => {

--- a/packages/core/content-type-builder/server/services/schema-builder/schema-handler.js
+++ b/packages/core/content-type-builder/server/services/schema-builder/schema-handler.js
@@ -205,6 +205,8 @@ module.exports = function createSchemaHandler(infos) {
         return;
       }
 
+      // console.log(initialState);
+
       const initialPath = path.join(initialState.dir, initialState.filename);
       const filePath = path.join(state.dir, state.filename);
 

--- a/packages/core/strapi/lib/Strapi.js
+++ b/packages/core/strapi/lib/Strapi.js
@@ -30,6 +30,7 @@ const createStartupLogger = require('./utils/startup-logger');
 const { LIFECYCLES } = require('./utils/lifecycles');
 const ee = require('./utils/ee');
 const contentTypesRegistry = require('./core/registries/content-types');
+const componentsRegistry = require('./core/registries/components');
 const servicesRegistry = require('./core/registries/services');
 const policiesRegistry = require('./core/registries/policies');
 const middlewaresRegistry = require('./core/registries/middlewares');
@@ -85,6 +86,7 @@ class Strapi {
     // Register every Strapi registry in the container
     this.container.register('config', createConfigProvider(appConfig));
     this.container.register('content-types', contentTypesRegistry(this));
+    this.container.register('components', componentsRegistry(this));
     this.container.register('services', servicesRegistry(this));
     this.container.register('policies', policiesRegistry(this));
     this.container.register('middlewares', middlewaresRegistry(this));
@@ -155,6 +157,14 @@ class Strapi {
 
   contentType(name) {
     return this.container.get('content-types').get(name);
+  }
+
+  get components() {
+    return this.container.get('components').getAll();
+  }
+
+  component(name) {
+    return this.container.get('components').get(name);
   }
 
   get policies() {
@@ -347,7 +357,7 @@ class Strapi {
   }
 
   async loadComponents() {
-    this.components = await loaders.loadComponents(this);
+    await loaders.loadComponents(this);
   }
 
   async loadMiddlewares() {

--- a/packages/core/strapi/lib/core-api/controller/transform.js
+++ b/packages/core/strapi/lib/core-api/controller/transform.js
@@ -65,14 +65,14 @@ const transformEntry = (entry, type) => {
 
       attributeValues[key] = { data };
     } else if (attribute && attribute.type === 'component') {
-      attributeValues[key] = transformComponent(property, strapi.components[attribute.component]);
+      attributeValues[key] = transformComponent(property, strapi.component(attribute.component));
     } else if (attribute && attribute.type === 'dynamiczone') {
       if (isNil(property)) {
         attributeValues[key] = property;
       }
 
       attributeValues[key] = property.map((subProperty) => {
-        return transformComponent(subProperty, strapi.components[subProperty.__component]);
+        return transformComponent(subProperty, strapi.component(subProperty.__component));
       });
     } else if (attribute && attribute.type === 'media') {
       const data = transformEntry(property, strapi.contentType('plugin::upload.file'));

--- a/packages/core/strapi/lib/core/domain/component/index.js
+++ b/packages/core/strapi/lib/core/domain/component/index.js
@@ -1,22 +1,30 @@
 'use strict';
 
-const { cloneDeep, camelCase } = require('lodash/fp');
+const upperFirst = require('lodash/upperFirst');
+const cloneDeep = require('lodash/cloneDeep');
+const camelCase = require('lodash/camelCase');
 const { validateComponentDefinition } = require('./validator');
 
-const createComponent = (definition = {}) => {
-  validateComponentDefinition(definition);
+const createComponent = (uid, definition = {}) => {
+  try {
+    validateComponentDefinition(definition);
+  } catch (e) {
+    throw new Error(`Component Definition is invalid for ${uid}'.\n${e.errors}`);
+  }
 
   const createdComponent = cloneDeep(definition);
-  const category = camelCase(definition.info.category);
+  const category = camelCase(createdComponent.schema.info.category);
 
-  const uid = `${category}.${definition.info.singularModelName}`;
-
-  Object.assign(createdComponent, {
+  Object.assign(createdComponent.schema, {
+    __schema__: cloneDeep(createdComponent.schema),
     uid,
     category,
+    modelType: 'component',
+    modelName: createdComponent.schema.info.singularName,
+    globalId: createdComponent.schema.globalId || upperFirst(camelCase(`component_${uid}`)),
   });
 
-  return createdComponent;
+  return createdComponent.schema;
 };
 
 module.exports = {

--- a/packages/core/strapi/lib/core/domain/component/index.js
+++ b/packages/core/strapi/lib/core/domain/component/index.js
@@ -17,6 +17,8 @@ const createComponent = (uid, definition = {}) => {
   return Object.assign(schema, {
     uid,
     modelType: 'component',
+    modelName: schema.info.singularName,
+    category: schema.info.category,
     globalId: schema.globalId || upperFirst(camelCase(`component_${uid}`)),
   });
 };

--- a/packages/core/strapi/lib/core/domain/component/index.js
+++ b/packages/core/strapi/lib/core/domain/component/index.js
@@ -12,19 +12,13 @@ const createComponent = (uid, definition = {}) => {
     throw new Error(`Component Definition is invalid for ${uid}'.\n${e.errors}`);
   }
 
-  const createdComponent = cloneDeep(definition);
-  const category = camelCase(createdComponent.schema.info.category);
+  const { schema } = cloneDeep(definition);
 
-  Object.assign(createdComponent.schema, {
-    __schema__: cloneDeep(createdComponent.schema),
+  return Object.assign(schema, {
     uid,
-    category,
     modelType: 'component',
-    modelName: createdComponent.schema.info.singularName,
-    globalId: createdComponent.schema.globalId || upperFirst(camelCase(`component_${uid}`)),
+    globalId: schema.globalId || upperFirst(camelCase(`component_${uid}`)),
   });
-
-  return createdComponent.schema;
 };
 
 module.exports = {

--- a/packages/core/strapi/lib/core/domain/component/index.js
+++ b/packages/core/strapi/lib/core/domain/component/index.js
@@ -3,7 +3,20 @@
 const upperFirst = require('lodash/upperFirst');
 const cloneDeep = require('lodash/cloneDeep');
 const camelCase = require('lodash/camelCase');
+const startCase = require('lodash/startCase');
 const { validateComponentDefinition } = require('./validator');
+
+/** @param {string} uid */
+function getCategoryFromUid(uid) {
+  let category = uid;
+  if (category.includes('::')) {
+    category = category.split('::')[1];
+  }
+  if (category.includes('.')) {
+    category = category.split('.')[0];
+  }
+  return startCase(category);
+}
 
 const createComponent = (uid, definition = {}) => {
   try {
@@ -18,7 +31,7 @@ const createComponent = (uid, definition = {}) => {
     uid,
     modelType: 'component',
     modelName: schema.info.singularName,
-    category: schema.info.category,
+    category: getCategoryFromUid(uid),
     globalId: schema.globalId || upperFirst(camelCase(`component_${uid}`)),
   });
 };

--- a/packages/core/strapi/lib/core/domain/component/index.js
+++ b/packages/core/strapi/lib/core/domain/component/index.js
@@ -27,13 +27,23 @@ const createComponent = (uid, definition = {}) => {
 
   const { schema } = cloneDeep(definition);
 
-  return Object.assign(schema, {
+  Object.assign(schema, {
+    __schema__: definition.schema,
     uid,
     modelType: 'component',
     modelName: schema.info.singularName,
     category: getCategoryFromUid(uid),
     globalId: schema.globalId || upperFirst(camelCase(`component_${uid}`)),
   });
+
+  if (uid.includes('::')) {
+    const pluginName = uid.split('::')[1].split('.')[0];
+    Object.assign(schema, {
+      plugin: pluginName,
+    });
+  }
+
+  return schema;
 };
 
 module.exports = {

--- a/packages/core/strapi/lib/core/domain/component/validator.js
+++ b/packages/core/strapi/lib/core/domain/component/validator.js
@@ -9,7 +9,6 @@ const componentSchemaValidator = yup.object().shape({
       .shape({
         displayName: yup.string().required(),
         singularName: yup.string().isKebabCase().required(),
-        category: yup.string().isKebabCase().required(),
       })
       .required(),
     attributes: yup.object(),

--- a/packages/core/strapi/lib/core/domain/component/validator.js
+++ b/packages/core/strapi/lib/core/domain/component/validator.js
@@ -2,17 +2,19 @@
 
 const { yup } = require('@strapi/utils');
 
-const componentSchemaValidator = () =>
-  yup.object().shape({
+const componentSchemaValidator = yup.object().shape({
+  schema: yup.object().shape({
     info: yup
       .object()
       .shape({
-        singularName: yup.string().isCamelCase().required(),
-        pluralName: yup.string().isCamelCase().required(),
         displayName: yup.string().required(),
+        singularName: yup.string().isKebabCase().required(),
+        category: yup.string().isKebabCase().required(),
       })
       .required(),
-  });
+    attributes: yup.object(),
+  }),
+});
 
 const validateComponentDefinition = (data) => {
   return componentSchemaValidator.validateSync(data, { strict: true, abortEarly: false });

--- a/packages/core/strapi/lib/core/domain/module/index.js
+++ b/packages/core/strapi/lib/core/domain/module/index.js
@@ -17,6 +17,7 @@ const defaultModule = {
   controllers: {},
   services: {},
   contentTypes: {},
+  components: {},
   policies: {},
   middlewares: {},
 };
@@ -55,6 +56,7 @@ const createModule = (namespace, rawModule, strapi) => {
     },
     load() {
       strapi.container.get('content-types').add(namespace, rawModule.contentTypes);
+      strapi.container.get('components').add(namespace, rawModule.components);
       strapi.container.get('services').add(namespace, rawModule.services);
       strapi.container.get('policies').add(namespace, rawModule.policies);
       strapi.container.get('middlewares').add(namespace, rawModule.middlewares);
@@ -73,6 +75,13 @@ const createModule = (namespace, rawModule, strapi) => {
     get contentTypes() {
       const contentTypes = strapi.container.get('content-types').getAll(namespace);
       return removeNamespacedKeys(contentTypes, namespace);
+    },
+    component(cName) {
+      return strapi.container.get('component').get(`${namespace}.${cName}`);
+    },
+    get components() {
+      const components = strapi.container.get('components').getAll(namespace);
+      return removeNamespacedKeys(components, namespace);
     },
     service(serviceName) {
       return strapi.container.get('services').get(`${namespace}.${serviceName}`);

--- a/packages/core/strapi/lib/core/domain/module/validation.js
+++ b/packages/core/strapi/lib/core/domain/module/validation.js
@@ -20,6 +20,7 @@ const strapiServerSchema = yup
     policies: yup.object(),
     middlewares: yup.object(),
     contentTypes: yup.object(),
+    components: yup.object(),
   })
   .noUnknown();
 

--- a/packages/core/strapi/lib/core/loaders/components.js
+++ b/packages/core/strapi/lib/core/loaders/components.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const { join } = require('path');
-const _ = require('lodash');
 const { pathExists } = require('fs-extra');
 const loadFiles = require('../../load/load-files');
 
@@ -16,7 +15,7 @@ module.exports = async (strapi) => {
     const entries = Object.entries(schemas).map(([key, schema]) => {
       if (!schema.collectionName) {
         // NOTE: We're using the filepath from the app directory instead of the dist for information purpose
-        const filePath = join(schema.__dirname__, schema.__filename__);
+        const filePath = join(strapi.dirs.app.components, category, schema.__filename__);
 
         return strapi.stopWithError(
           `Component ${key} is missing a "collectionName" property.\nVerify file ${filePath}.`
@@ -25,7 +24,6 @@ module.exports = async (strapi) => {
 
       const definition = {
         schema: Object.assign(schema, {
-          __schema__: _.cloneDeep(schema),
           info: Object.assign(schema.info, {
             singularName: key,
           }),

--- a/packages/core/strapi/lib/core/loaders/components.js
+++ b/packages/core/strapi/lib/core/loaders/components.js
@@ -12,10 +12,8 @@ module.exports = async (strapi) => {
 
   const map = await loadFiles(strapi.dirs.dist.components, '*/*.*(js|json)');
 
-  const components = Object.keys(map).reduce((acc, category) => {
-    Object.keys(map[category]).forEach((key) => {
-      const schema = map[category][key];
-
+  Object.entries(map).forEach(([category, schemas]) => {
+    const entries = Object.entries(schemas).map(([key, schema]) => {
       if (!schema.collectionName) {
         // NOTE: We're using the filepath from the app directory instead of the dist for information purpose
         const filePath = join(schema.__dirname__, schema.__filename__);
@@ -25,20 +23,21 @@ module.exports = async (strapi) => {
         );
       }
 
-      const uid = `${category}.${key}`;
+      const definition = {
+        schema: Object.assign(schema, {
+          __schema__: _.cloneDeep(schema),
+          category,
+          modelName: key,
+          info: Object.assign(schema.info, {
+            singularName: key,
+          }),
+        }),
+      };
 
-      acc[uid] = Object.assign(schema, {
-        __schema__: _.cloneDeep(schema),
-        uid,
-        category,
-        modelType: 'component',
-        modelName: key,
-        globalId: schema.globalId || _.upperFirst(_.camelCase(`component_${uid}`)),
-      });
-    });
+      return [key, definition];
+    }, {});
 
-    return acc;
-  }, {});
-
-  strapi.container.get('components').addAppComponents(components);
+    const components = Object.fromEntries(entries);
+    strapi.container.get('components').add(category, components);
+  });
 };

--- a/packages/core/strapi/lib/core/loaders/components.js
+++ b/packages/core/strapi/lib/core/loaders/components.js
@@ -26,10 +26,9 @@ module.exports = async (strapi) => {
       const definition = {
         schema: Object.assign(schema, {
           __schema__: _.cloneDeep(schema),
-          category,
-          modelName: key,
           info: Object.assign(schema.info, {
             singularName: key,
+            category,
           }),
         }),
       };

--- a/packages/core/strapi/lib/core/loaders/components.js
+++ b/packages/core/strapi/lib/core/loaders/components.js
@@ -12,7 +12,7 @@ module.exports = async (strapi) => {
 
   const map = await loadFiles(strapi.dirs.dist.components, '*/*.*(js|json)');
 
-  return Object.keys(map).reduce((acc, category) => {
+  const components = Object.keys(map).reduce((acc, category) => {
     Object.keys(map[category]).forEach((key) => {
       const schema = map[category][key];
 
@@ -39,4 +39,6 @@ module.exports = async (strapi) => {
 
     return acc;
   }, {});
+
+  strapi.container.get('components').addAppComponents(components);
 };

--- a/packages/core/strapi/lib/core/loaders/components.js
+++ b/packages/core/strapi/lib/core/loaders/components.js
@@ -18,7 +18,7 @@ module.exports = async (strapi) => {
 
       if (!schema.collectionName) {
         // NOTE: We're using the filepath from the app directory instead of the dist for information purpose
-        const filePath = join(strapi.dirs.app.components, category, schema.__filename__);
+        const filePath = join(schema.__dirname__, schema.__filename__);
 
         return strapi.stopWithError(
           `Component ${key} is missing a "collectionName" property.\nVerify file ${filePath}.`

--- a/packages/core/strapi/lib/core/loaders/components.js
+++ b/packages/core/strapi/lib/core/loaders/components.js
@@ -28,7 +28,6 @@ module.exports = async (strapi) => {
           __schema__: _.cloneDeep(schema),
           info: Object.assign(schema.info, {
             singularName: key,
-            category,
           }),
         }),
       };

--- a/packages/core/strapi/lib/core/loaders/plugins/index.js
+++ b/packages/core/strapi/lib/core/loaders/plugins/index.js
@@ -102,6 +102,9 @@ const loadPlugins = async (strapi) => {
     }
 
     const pluginServer = loadConfigFile(serverEntrypointPath);
+    if (pluginName === 'myplugin') {
+      // console.dir(pluginServer, { depth: Infinity})
+    }
     plugins[pluginName] = {
       ...defaultPlugin,
       ...pluginServer,

--- a/packages/core/strapi/lib/core/loaders/plugins/index.js
+++ b/packages/core/strapi/lib/core/loaders/plugins/index.js
@@ -23,6 +23,7 @@ const defaultPlugin = {
   policies: {},
   middlewares: {},
   contentTypes: {},
+  components: {},
 };
 
 const applyUserExtension = async (plugins) => {

--- a/packages/core/strapi/lib/core/registries/components.js
+++ b/packages/core/strapi/lib/core/registries/components.js
@@ -74,16 +74,6 @@ const componentsRegistry = () => {
       }
     },
 
-    addAppComponents(newComponents) {
-      for (const rawComponentName of Object.keys(newComponents)) {
-        if (has(rawComponentName, components)) {
-          throw new Error(`Component ${rawComponentName} has already been registered.`);
-        }
-
-        components[rawComponentName] = newComponents[rawComponentName];
-      }
-    },
-
     /**
      * Wraps a component to extend it
      * @param {string} uid

--- a/packages/core/strapi/lib/core/registries/components.js
+++ b/packages/core/strapi/lib/core/registries/components.js
@@ -1,0 +1,107 @@
+'use strict';
+
+const { pickBy, has } = require('lodash/fp');
+const { createComponent } = require('../domain/component');
+const { hasNamespace, addNamespace } = require('../utils');
+
+const validateKeySameToSingularName = (components) => {
+  for (const cName of Object.keys(components)) {
+    const component = components[cName];
+
+    if (cName !== component.schema.info.singularName) {
+      throw new Error(
+        `The key of the component should be the same as its singularName. Found ${cName} and ${component.schema.info.singularName}.`
+      );
+    }
+  }
+};
+
+const componentsRegistry = () => {
+  const components = {};
+
+  return {
+    /**
+     * Returns this list of registered components uids
+     * @returns {string[]}
+     */
+    keys() {
+      return Object.keys(components);
+    },
+
+    /**
+     * Returns the instance of a component. Instantiate the component if not already done
+     * @param {string} uid
+     * @returns
+     */
+    get(uid) {
+      return components[uid];
+    },
+
+    /**
+     * Returns a map with all the components in a namespace
+     * @param {string} namespace
+     */
+    getAll(namespace) {
+      return pickBy((_, uid) => hasNamespace(uid, namespace))(components);
+    },
+
+    /**
+     * Registers a component
+     * @param {string} uid
+     * @param {Object} component
+     */
+    set(uid, component) {
+      components[uid] = component;
+      return this;
+    },
+
+    /**
+     * Registers a map of components for a specific namespace
+     * @param {string} namespace
+     * @param {{ [key: string]: Object }} newComponents
+     */
+    add(namespace, newComponents) {
+      validateKeySameToSingularName(newComponents);
+
+      for (const rawComponentName of Object.keys(newComponents)) {
+        const uid = addNamespace(rawComponentName, namespace);
+
+        if (has(uid, components)) {
+          throw new Error(`Component ${uid} has already been registered.`);
+        }
+
+        components[uid] = createComponent(uid, newComponents[rawComponentName]);
+      }
+    },
+
+    addAppComponents(newComponents) {
+      for (const rawComponentName of Object.keys(newComponents)) {
+        if (has(rawComponentName, components)) {
+          throw new Error(`Component ${rawComponentName} has already been registered.`);
+        }
+
+        components[rawComponentName] = newComponents[rawComponentName];
+      }
+    },
+
+    /**
+     * Wraps a component to extend it
+     * @param {string} uid
+     * @param {(component: Object) => Object} extendFn
+     */
+    extend(cUID, extendFn) {
+      const currentComponent = this.get(cUID);
+
+      if (!currentComponent) {
+        throw new Error(`Component ${cUID} doesn't exist`);
+      }
+
+      const newComponent = extendFn(currentComponent);
+      components[cUID] = newComponent;
+
+      return this;
+    },
+  };
+};
+
+module.exports = componentsRegistry;

--- a/packages/core/strapi/lib/load/load-files.js
+++ b/packages/core/strapi/lib/load/load-files.js
@@ -46,6 +46,13 @@ const loadFiles = async (
       value: path.basename(file),
     });
 
+    Object.defineProperty(mod, '__dirname__', {
+      enumerable: true,
+      configurable: false,
+      writable: false,
+      value: path.dirname(absolutePath),
+    });
+
     const propPath = filePathToPath(file, shouldUseFileNameAsKey(file));
 
     if (propPath.length === 0) _.merge(root, mod);

--- a/packages/core/strapi/lib/services/utils/upload-files.js
+++ b/packages/core/strapi/lib/services/utils/upload-files.js
@@ -43,7 +43,7 @@ module.exports = async (uid, entity, files) => {
 
       if (attr.type === 'component') {
         modelUID = attr.component;
-        tmpModel = strapi.components[attr.component];
+        tmpModel = strapi.component(attr.component);
       } else if (attr.type === 'dynamiczone') {
         const entryIdx = path[i + 1]; // get component index
         const value = _.get(entity, [...currentPath, entryIdx]);
@@ -51,7 +51,7 @@ module.exports = async (uid, entity, files) => {
         if (!value) return {};
 
         modelUID = value.__component; // get component type
-        tmpModel = strapi.components[modelUID];
+        tmpModel = strapi.component(modelUID);
       } else if (attr.type === 'relation') {
         modelUID = attr.target;
         tmpModel = strapi.getModel(modelUID);

--- a/packages/core/strapi/lib/types/core/strapi/index.d.ts
+++ b/packages/core/strapi/lib/types/core/strapi/index.d.ts
@@ -100,6 +100,11 @@ export interface Strapi {
   readonly components: any;
 
   /**
+   * Find a component using its unique identifier
+   */
+  component(uid: string): any;
+
+  /**
    * The custom fields registry
    *
    * It returns the custom fields interface

--- a/packages/plugins/documentation/server/services/helpers/utils/clean-schema-attributes.js
+++ b/packages/plugins/documentation/server/services/helpers/utils/clean-schema-attributes.js
@@ -93,7 +93,7 @@ const cleanSchemaAttributes = (
         break;
       }
       case 'component': {
-        const componentAttributes = strapi.components[attribute.component].attributes;
+        const componentAttributes = strapi.component(attribute.component).attributes;
         const rawComponentSchema = {
           type: 'object',
           properties: {
@@ -124,7 +124,7 @@ const cleanSchemaAttributes = (
       }
       case 'dynamiczone': {
         const components = attribute.components.map((component) => {
-          const componentAttributes = strapi.components[component].attributes;
+          const componentAttributes = strapi.component(component).attributes;
           const rawComponentSchema = {
             type: 'object',
             properties: {

--- a/packages/plugins/graphql/server/services/builders/dynamic-zones.js
+++ b/packages/plugins/graphql/server/services/builders/dynamic-zones.js
@@ -11,7 +11,7 @@ module.exports = ({ strapi }) => {
     const isEmpty = components.length === 0;
 
     const componentsTypeNames = components.map((componentUID) => {
-      const component = strapi.components[componentUID];
+      const component = strapi.component(componentUID);
 
       if (!component) {
         throw new ApplicationError(
@@ -30,7 +30,7 @@ module.exports = ({ strapi }) => {
           return ERROR_TYPE_NAME;
         }
 
-        return strapi.components[obj.__component].globalId;
+        return strapi.component(obj.__component).globalId;
       },
 
       definition(t) {
@@ -48,7 +48,7 @@ module.exports = ({ strapi }) => {
       if (!component) {
         throw new ApplicationError(
           `Component not found. expected one of: ${components
-            .map((uid) => strapi.components[uid].globalId)
+            .map((uid) => strapi.component(uid).globalId)
             .join(', ')}`
         );
       }

--- a/packages/plugins/graphql/server/services/builders/input.js
+++ b/packages/plugins/graphql/server/services/builders/input.js
@@ -97,7 +97,7 @@ module.exports = (context) => {
             // Components
             else if (isComponent(attribute)) {
               const isRepeatable = attribute.repeatable === true;
-              const component = strapi.components[attribute.component];
+              const component = strapi.component(attribute.component);
               const componentInputType = getComponentInputName(component);
 
               if (isRepeatable) {

--- a/packages/plugins/graphql/server/services/utils/naming.js
+++ b/packages/plugins/graphql/server/services/utils/naming.js
@@ -105,7 +105,7 @@ module.exports = ({ strapi }) => {
    * @return {string}
    */
   const getComponentNameFromAttribute = (attribute) => {
-    return strapi.components[attribute.component].globalId;
+    return strapi.component(attribute.component).globalId;
   };
 
   /**

--- a/packages/plugins/i18n/server/services/content-types.js
+++ b/packages/plugins/i18n/server/services/content-types.js
@@ -126,12 +126,12 @@ const removeIdsMut = (model, entry) => {
     if (attr.type === 'dynamiczone' && isArray(value)) {
       value.forEach((compo) => {
         if (has('__component', compo)) {
-          const model = strapi.components[compo.__component];
+          const model = strapi.component(compo.__component);
           removeIdsMut(model, compo);
         }
       });
     } else if (attr.type === 'component') {
-      const model = strapi.components[attr.component];
+      const model = strapi.component(attr.component);
       if (isArray(value)) {
         value.forEach((compo) => removeIdsMut(model, compo));
       } else {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

This is a Work in Progress (for learning purposes)

### What does it do?

- Move the components storage to the registry
- Load components provided by plugins
- Load app components through the registry

<img width="276" alt="image" src="https://user-images.githubusercontent.com/1881266/226107773-15d86295-0f17-4413-b275-4bde5519ce07.png">


### Why is it needed?

Adds the ability to load components from plugins.

### How to test it?

Add components to a plugin the same way as content types are added.

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/pull/12965
https://github.com/strapi/strapi/pull/9104
https://github.com/strapi/strapi/issues/7640
https://feedback.strapi.io/developer-experience/p/components-inside-of-plugins

Depends on https://github.com/strapi/strapi/pull/16273

ps: would be much easier if `api` and `components` from `src` were loaded the same way as the plugins.
ps2: having components namespaced would also be easier 🤔 
