### PR TITLE
Persist RW db tables when feature is enabled

### DIFF
--- a/packages/core/admin/ee/server/bootstrap.js
+++ b/packages/core/admin/ee/server/bootstrap.js
@@ -21,6 +21,8 @@ module.exports = async () => {
   }
 
   if (features.isEnabled('review-workflows')) {
+    await persistTablesWithPrefix('strapi_workflows');
+
     const { bootstrap: rwBootstrap } = getService('review-workflows');
 
     await rwBootstrap();


### PR DESCRIPTION

### What does it do?

- [x] EE - Persists DB tables for RW

### Why is it needed?

Review Workflows have the need to persist feature settings while the user switches between CE and EE

This way once each feature is enabled once, it's tables will be saved to the DB
