### PR TITLE
Chore: Remove fetch-mock from FE tests

### DIFF
--- a/jest.base-config.front.js
+++ b/jest.base-config.front.js
@@ -43,7 +43,6 @@ module.exports = {
   globalSetup: '<rootDir>/test/config/front/global-setup.js',
   setupFiles: [
     '<rootDir>/packages/admin-test-utils/lib/setup/test-bundler.js',
-    '<rootDir>/packages/admin-test-utils/lib/mocks/fetch.js',
     '<rootDir>/packages/admin-test-utils/lib/mocks/LocalStorageMock.js',
     '<rootDir>/packages/admin-test-utils/lib/mocks/IntersectionObserver.js',
     '<rootDir>/packages/admin-test-utils/lib/mocks/ResizeObserver.js',

--- a/packages/admin-test-utils/lib/mocks/fetch.js
+++ b/packages/admin-test-utils/lib/mocks/fetch.js
@@ -1,4 +1,0 @@
-'use strict';
-
-// Required as long as we are running tests on node@14 and node@16
-require('whatwg-fetch');

--- a/packages/admin-test-utils/package.json
+++ b/packages/admin-test-utils/package.json
@@ -24,8 +24,7 @@
     "react-dom": "^17.0.2",
     "react-is": "^17.0.2",
     "redux": "^4.2.1",
-    "styled-components": "5.3.3",
-    "whatwg-fetch": "3.6.2"
+    "styled-components": "5.3.3"
   },
   "peerDependencies": {
     "redux": "^4.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -17865,8 +17865,6 @@ path-case@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/path-case/-/path-case-2.1.1.tgz#94b8037c372d3fe2906e465bb45e25d226e8eea5"
   integrity sha1-lLgDfDctP+KQbkZbtF4l0ibo7qU=
-  dependencies:
-    no-case "^2.2.0"
 
 path-dirname@^1.0.0:
   version "1.0.2"
@@ -22562,11 +22560,6 @@ whatwg-encoding@^2.0.0:
   integrity sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==
   dependencies:
     iconv-lite "0.6.3"
-
-whatwg-fetch@3.6.2:
-  version "3.6.2"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz#dced24f37f2624ed0281725d51d0e2e3fe677f8c"
-  integrity sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==
 
 whatwg-mimetype@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
### What does it do?

The FE tests no longer run on node@14, which makes the `fetch` polyfill obsolete.

### Why is it needed?

Cleanup dependencies.

