### PR TITLE
[Clone Entity Relations]: Entity service clone

### DIFF
--- a/packages/core/database/lib/entity-manager/entity-repository.js
+++ b/packages/core/database/lib/entity-manager/entity-repository.js
@@ -80,6 +80,10 @@ const createRepository = (uid, db) => {
       return db.entityManager.updateMany(uid, params);
     },
 
+    clone(id, params) {
+      return db.entityManager.clone(uid, id, params);
+    },
+
     delete(params) {
       return db.entityManager.delete(uid, params);
     },

--- a/packages/core/database/lib/entity-manager/index.js
+++ b/packages/core/database/lib/entity-manager/index.js
@@ -383,8 +383,8 @@ const createEntityManager = (db) => {
       const dataToInsert = flow(
         // Omit unwanted properties
         omit(['id', 'created_at', 'updated_at']),
-        // Merge with provided data, override to null if data attribute is null
-        mergeWith(params.data || {}, (a, b) => (b === null ? b : a)),
+        // Merge with provided data, set attribute to null if data attribute is null
+        mergeWith(data || {}, (original, override) => (override === null ? override : original)),
         // Process data with metadata
         (entity) => processData(metadata, entity, { withDefaults: true })
       )(entity);

--- a/packages/core/database/lib/entity-manager/index.js
+++ b/packages/core/database/lib/entity-manager/index.js
@@ -1,26 +1,30 @@
 'use strict';
 
 const {
-  isUndefined,
   castArray,
   compact,
-  isNil,
-  has,
-  isString,
-  isInteger,
-  pick,
-  isPlainObject,
-  isEmpty,
-  isArray,
-  isNull,
-  uniqWith,
-  isEqual,
-  differenceWith,
-  isNumber,
-  map,
   difference,
+  differenceWith,
+  flow,
+  has,
+  isArray,
+  isEmpty,
+  isEqual,
+  isInteger,
+  isNil,
+  isNull,
+  isNumber,
+  isPlainObject,
+  isString,
+  isUndefined,
+  map,
+  mergeWith,
+  omit,
+  pick,
   uniqBy,
+  uniqWith,
 } = require('lodash/fp');
+
 const { mapAsync } = require('@strapi/utils');
 const types = require('../types');
 const { createField } = require('../fields');
@@ -28,6 +32,7 @@ const { createQueryBuilder } = require('../query');
 const { createRepository } = require('./entity-repository');
 const { deleteRelatedMorphOneRelationsAfterMorphToManyUpdate } = require('./morph-relations');
 const {
+  isPolymorphic,
   isBidirectional,
   isAnyToOne,
   isOneToAny,
@@ -358,6 +363,63 @@ const createEntityManager = (db) => {
       const result = { count: updatedRows };
 
       await db.lifecycles.run('afterUpdateMany', uid, { params, result }, states);
+
+      return result;
+    },
+
+    async clone(uid, cloneId, params = {}) {
+      const states = await db.lifecycles.run('beforeCreate', uid, { params });
+
+      const metadata = db.metadata.get(uid);
+      const { data } = params;
+
+      if (!isNil(data) && !isPlainObject(data)) {
+        throw new Error('Create expects a data object');
+      }
+
+      // TODO: Handle join columns?
+      const entity = await this.findOne(uid, { where: { id: cloneId } });
+
+      const dataToInsert = flow(
+        // Omit unwanted properties
+        omit(['id', 'created_at', 'updated_at']),
+        // Merge with provided data, override to null if data attribute is null
+        mergeWith(params.data || {}, (a, b) => (b === null ? b : a)),
+        // Process data with metadata
+        (entity) => processData(metadata, entity, { withDefaults: true })
+      )(entity);
+
+      const res = await this.createQueryBuilder(uid).insert(dataToInsert).execute();
+
+      const id = res[0].id || res[0];
+
+      // TODO: try strapi.db.transaction(method) instead of trx.get()
+      const trx = await strapi.db.transaction();
+      try {
+        const cloneAttrs = Object.entries(metadata.attributes).reduce((acc, [attrName, attr]) => {
+          if (attr.type === 'relation' && attr.joinTable && !attr.component) {
+            acc[attrName] = true;
+          }
+          return acc;
+        }, {});
+
+        // How to get the relations of the clone entity ?
+        await this.cloneRelations(uid, id, cloneId, { cloneAttrs, transaction: trx.get() });
+        await this.updateRelations(uid, id, data, { transaction: trx.get() });
+        await trx.commit();
+      } catch (e) {
+        await trx.rollback();
+        await this.createQueryBuilder(uid).where({ id }).delete().execute();
+        throw e;
+      }
+
+      const result = await this.findOne(uid, {
+        where: { id },
+        select: params.select,
+        populate: params.populate,
+      });
+
+      await db.lifecycles.run('afterCreate', uid, { params, result }, states);
 
       return result;
     },
@@ -1199,13 +1261,17 @@ const createEntityManager = (db) => {
           );
         }
 
+        if (isPolymorphic(attribute)) {
+          // TODO: add support for cloning polymorphic relations
+          return;
+        }
+
         if (attribute.joinColumn) {
           // TODO: add support for cloning oneToMany relations on the owning side
           return;
         }
 
         if (!attribute.joinTable) {
-          // TODO: add support for cloning polymorphic relations
           return;
         }
 

--- a/packages/core/database/lib/entity-manager/index.js
+++ b/packages/core/database/lib/entity-manager/index.js
@@ -393,11 +393,8 @@ const createEntityManager = (db) => {
 
       const id = res[0].id || res[0];
 
-      // TODO: try strapi.db.transaction(method) instead of trx.get()
       const trx = await strapi.db.transaction();
       try {
-        // TODO: Should we do this here? Or should we do it in the service layer.
-        // TODO: Do this for components too?
         const cloneAttrs = Object.entries(metadata.attributes).reduce((acc, [attrName, attr]) => {
           if (attr.type === 'relation' && attr.joinTable && !attr.component) {
             acc[attrName] = true;

--- a/packages/core/database/lib/entity-manager/relations/cloning/regular-relations.js
+++ b/packages/core/database/lib/entity-manager/relations/cloning/regular-relations.js
@@ -60,7 +60,7 @@ const cloneRegularRelations = async ({ targetId, sourceId, attribute, transactio
   // Clean the inverse order column
   if (inverseOrderColumnName) {
     await cleanInverseOrderColumn({
-      targetId,
+      id: targetId,
       attribute,
       trx,
     });

--- a/packages/core/database/lib/metadata/relations.js
+++ b/packages/core/database/lib/metadata/relations.js
@@ -9,6 +9,8 @@ const _ = require('lodash/fp');
 const hasInversedBy = _.has('inversedBy');
 const hasMappedBy = _.has('mappedBy');
 
+const isPolymorphic = (attribute) =>
+  ['morphOne', 'morphMany', 'morphToOne', 'morphToMany'].includes(attribute.relation);
 const isOneToAny = (attribute) => ['oneToOne', 'oneToMany'].includes(attribute.relation);
 const isManyToAny = (attribute) => ['manyToMany', 'manyToOne'].includes(attribute.relation);
 const isAnyToOne = (attribute) => ['oneToOne', 'manyToOne'].includes(attribute.relation);
@@ -554,7 +556,7 @@ const hasInverseOrderColumn = (attribute) => isBidirectional(attribute) && isMan
 
 module.exports = {
   createRelation,
-
+  isPolymorphic,
   isBidirectional,
   isOneToAny,
   isManyToAny,

--- a/packages/core/strapi/lib/services/entity-service/index.d.ts
+++ b/packages/core/strapi/lib/services/entity-service/index.d.ts
@@ -86,6 +86,11 @@ export interface EntityService {
     entityId: ID,
     params: Params<T>
   ): Promise<any>;
+  clone<K extends keyof AllTypes, T extends AllTypes[K]>(
+    uid: K,
+    cloneId: ID,
+    params: Params<T>
+  ): Promise<any>;
 }
 
 export default function (opts: {


### PR DESCRIPTION
### What does it do?

Clone a single entity via the entity service.
This will:
- Clone the entity itself
- Clone entity relations
- Adds the possibility to override data from the original entity
- ⚠️ Will not clone components. Component cloning will be in another PR.


### Why is it needed?

So we can clone from the CM.

### How to test it?

In the `bootstrap.js` file, using the `getstarted` project, and with some `kitchensinks` and `tags` created:
```js
   // Clones kitchensink with entity 1 and replaces some fields
    await strapi.entityService.clone('api::kitchensink.kitchensink', 1, {
      data: {
        short_text: 'My new name',
        boolean: null,
        many_to_many_tags: [2],
        // Overriding compos will not work in this pr
        single_compo: {
          id: 3,
          name: 'My new name',
        },
      },
    });
```

