### PR TITLE
Single components should not populate if they're not required

### DIFF
--- a/examples/getstarted/src/api/relation-locale/content-types/relation-locale/schema.json
+++ b/examples/getstarted/src/api/relation-locale/content-types/relation-locale/schema.json
@@ -51,6 +51,27 @@
         "basic.relation",
         "basic.simple"
       ]
+    },
+    "single_relation": {
+      "type": "component",
+      "repeatable": false,
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "component": "basic.relation"
+    },
+    "require_single_relation": {
+      "type": "component",
+      "repeatable": false,
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "component": "basic.relation",
+      "required": true
     }
   }
 }

--- a/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/reducer.js
+++ b/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/reducer.js
@@ -220,7 +220,9 @@ const reducer = (state, action) =>
 
         const findAllRelationsAndReplaceWithEmptyArray = findAllAndReplace(
           components,
-          (value) => value.type === 'relation',
+          (value) => {
+            return value.type === 'relation';
+          },
           (_, { path }) => {
             if (state.modifiedData?.id === data.id && get(state.modifiedData, path)) {
               return get(state.modifiedData, path);

--- a/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/tests/reducer.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/tests/reducer.test.js
@@ -571,7 +571,6 @@ describe('CONTENT MANAGER | COMPONENTS | EditViewDataManagerProvider | reducer',
             level_one_repeatable: [
               {
                 __temp_key__: 0,
-                level_two_single_component: {},
               },
             ],
           },

--- a/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/utils/findAllAndReplace.js
+++ b/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/utils/findAllAndReplace.js
@@ -50,7 +50,7 @@ const findAllAndReplaceSetup = (components, predicate = () => false, replacement
         if (value.type === 'component') {
           const componentAttributes = components[value.component].attributes;
 
-          if (!value.repeatable && typeof acc[key] === 'object') {
+          if (!value.repeatable && acc[key] && typeof acc[key] === 'object') {
             acc[key] = findAllAndReplace(acc[key], componentAttributes, {
               ignoreFalseyValues,
               path: [...path, key],

--- a/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/utils/tests/findAllAndReplace.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/utils/tests/findAllAndReplace.test.js
@@ -130,6 +130,106 @@ describe('findAllAndReplace', () => {
     });
   });
 
+  describe('null values', () => {
+    const nullishData = {
+      categories: null,
+      repeatable_repeatable_relations: null,
+      repeatable_relations: null,
+      dynamic_relations: null,
+      comp_relation: null,
+    };
+
+    it('should replace the first level of relations', () => {
+      const data = findAllAndReplace(
+        components,
+        (value) => value.type === 'relation',
+        'replaced'
+      )(nullishData, schema);
+
+      expect(data).toMatchInlineSnapshot(`
+        {
+          "categories": "replaced",
+          "comp_relation": null,
+          "dynamic_relations": null,
+          "repeatable_relations": null,
+          "repeatable_repeatable_relations": null,
+        }
+      `);
+    });
+
+    it('should not replace relations in single components', () => {
+      const data = findAllAndReplace(
+        components,
+        (value) => value.type === 'relation',
+        'replaced'
+      )(nullishData, schema);
+
+      expect(data).toMatchInlineSnapshot(`
+        {
+          "categories": "replaced",
+          "comp_relation": null,
+          "dynamic_relations": null,
+          "repeatable_relations": null,
+          "repeatable_repeatable_relations": null,
+        }
+      `);
+    });
+
+    it('should not replace relation instances in a repeatable component', () => {
+      const data = findAllAndReplace(
+        components,
+        (value) => value.type === 'relation',
+        'replaced'
+      )(nullishData, schema);
+
+      expect(data).toMatchInlineSnapshot(`
+        {
+          "categories": "replaced",
+          "comp_relation": null,
+          "dynamic_relations": null,
+          "repeatable_relations": null,
+          "repeatable_repeatable_relations": null,
+        }
+      `);
+    });
+
+    it('should not replace all relation instances in nested repeatable components', () => {
+      const data = findAllAndReplace(
+        components,
+        (value) => value.type === 'relation',
+        'replaced'
+      )(nullishData, schema);
+
+      expect(data).toMatchInlineSnapshot(`
+        {
+          "categories": "replaced",
+          "comp_relation": null,
+          "dynamic_relations": null,
+          "repeatable_relations": null,
+          "repeatable_repeatable_relations": null,
+        }
+      `);
+    });
+
+    it('should not replace relation instances in dynamic zones correctly', () => {
+      const data = findAllAndReplace(
+        components,
+        (value) => value.type === 'relation',
+        'replaced'
+      )(nullishData, schema);
+
+      expect(data).toMatchInlineSnapshot(`
+        {
+          "categories": "replaced",
+          "comp_relation": null,
+          "dynamic_relations": null,
+          "repeatable_relations": null,
+          "repeatable_repeatable_relations": null,
+        }
+      `);
+    });
+  });
+
   describe('replacement as a function', () => {
     it('should pass the data object (not the schema) and use the returned value', () => {
       const data = findAllAndReplace(

--- a/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/utils/tests/findAllAndReplace.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/utils/tests/findAllAndReplace.test.js
@@ -69,14 +69,11 @@ describe('findAllAndReplace', () => {
       expect(data).toMatchInlineSnapshot(`
         {
           "categories": "replaced",
-          "comp_relation": {
-            "categories": "replaced",
-          },
         }
       `);
     });
 
-    it('should replace relations in single components', () => {
+    it('should not replace relations in single components', () => {
       const data = findAllAndReplace(
         components,
         (value) => value.type === 'relation',
@@ -86,9 +83,6 @@ describe('findAllAndReplace', () => {
       expect(data).toMatchInlineSnapshot(`
         {
           "categories": "replaced",
-          "comp_relation": {
-            "categories": "replaced",
-          },
         }
       `);
     });
@@ -103,9 +97,6 @@ describe('findAllAndReplace', () => {
       expect(data).toMatchInlineSnapshot(`
         {
           "categories": "replaced",
-          "comp_relation": {
-            "categories": "replaced",
-          },
         }
       `);
     });
@@ -120,9 +111,6 @@ describe('findAllAndReplace', () => {
       expect(data).toMatchInlineSnapshot(`
         {
           "categories": "replaced",
-          "comp_relation": {
-            "categories": "replaced",
-          },
         }
       `);
     });
@@ -137,9 +125,6 @@ describe('findAllAndReplace', () => {
       expect(data).toMatchInlineSnapshot(`
         {
           "categories": "replaced",
-          "comp_relation": {
-            "categories": "replaced",
-          },
         }
       `);
     });


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* Checks if the component exists in the `initialData` we receive
* Adds some new schema patterns to the `relations` entry so we can easier manually test relation changes
* Fixes parent on the `predicate` function to pass the `attributes` parent not the `data` parent as it should in the replacement function.

### Why is it needed?

* Single components are _always_ rendered and added to the entity's schema regardless of it's required or not

### How to test it?

* Automated tests were fixed

### Related issue(s)/PR(s)

* resolves #16111 
* resolves CONTENT-1190
