### PR TITLE
Settings: Inline update stage mutation, refactor tests

### DIFF
--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/ReviewWorkflows.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/ReviewWorkflows.js
@@ -2,11 +2,15 @@ import React, { useEffect, useState } from 'react';
 import { FormikProvider, useFormik, Form } from 'formik';
 import { useIntl } from 'react-intl';
 import { useSelector, useDispatch } from 'react-redux';
+import { useMutation } from 'react-query';
 
 import {
   CheckPagePermissions,
   ConfirmDialog,
   SettingsPageTitle,
+  useAPIErrorHandler,
+  useFetchClient,
+  useNotification,
   useTracking,
 } from '@strapi/helper-plugin';
 import { Button, ContentLayout, HeaderLayout, Layout, Loader, Main } from '@strapi/design-system';
@@ -25,7 +29,10 @@ export function ReviewWorkflowsPage() {
   const { trackUsage } = useTracking();
   const { formatMessage } = useIntl();
   const dispatch = useDispatch();
-  const { workflows: workflowsData, updateWorkflowStages, refetchWorkflow } = useReviewWorkflows();
+  const { put } = useFetchClient();
+  const { formatAPIError } = useAPIErrorHandler();
+  const toggleNotification = useNotification();
+  const { workflows: workflowsData, refetchWorkflow } = useReviewWorkflows();
   const {
     status,
     clientState: {
@@ -37,6 +44,46 @@ export function ReviewWorkflowsPage() {
     },
   } = useSelector((state) => state?.[REDUX_NAMESPACE] ?? initialState);
   const [isConfirmDeleteDialogOpen, setIsConfirmDeleteDialogOpen] = useState(false);
+
+  const { mutateAsync, isLoading } = useMutation(
+    async ({ workflowId, stages }) => {
+      try {
+        const {
+          data: { data },
+        } = await put(`/admin/review-workflows/workflows/${workflowId}/stages`, {
+          data: stages,
+        });
+
+        return data;
+      } catch (error) {
+        toggleNotification({
+          type: 'warning',
+          message: formatAPIError(error),
+        });
+      }
+
+      return null;
+    },
+    {
+      onError(error) {
+        toggleNotification({
+          type: 'warning',
+          message: formatAPIError(error),
+        });
+      },
+
+      onSuccess() {
+        toggleNotification({
+          type: 'success',
+          message: { id: 'notification.success.saved', defaultMessage: 'Saved' },
+        });
+      },
+    }
+  );
+
+  const updateWorkflowStages = (workflowId, stages) => {
+    return mutateAsync({ workflowId, stages });
+  };
 
   const submitForm = async () => {
     setIsConfirmDeleteDialogOpen(false);
@@ -136,6 +183,7 @@ export function ReviewWorkflowsPage() {
               defaultMessage:
                 'All entries assigned to deleted stages will be moved to the first stage. Are you sure you want to save this?',
             }}
+            isConfirmButtonLoading={isLoading}
             isOpen={isConfirmDeleteDialogOpen}
             onToggleDialog={toggleConfirmDeleteDialog}
             onConfirm={handleConfirmDeleteDialog}

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/hooks/useReviewWorkflows.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/hooks/useReviewWorkflows.js
@@ -1,36 +1,25 @@
-import { useQuery, useMutation, useQueryClient } from 'react-query';
-import { useFetchClient, useNotification, useAPIErrorHandler } from '@strapi/helper-plugin';
+import { useQuery, useQueryClient } from 'react-query';
+import { useFetchClient } from '@strapi/helper-plugin';
 
 const QUERY_BASE_KEY = 'review-workflows';
 const API_BASE_URL = '/admin/review-workflows';
 
 export function useReviewWorkflows(workflowId) {
-  const { get, put } = useFetchClient();
-  const toggleNotification = useNotification();
+  const { get } = useFetchClient();
   const client = useQueryClient();
-  const { formatAPIError } = useAPIErrorHandler();
   const workflowQueryKey = [QUERY_BASE_KEY, workflowId ?? 'default'];
 
   async function fetchWorkflows({ params = { populate: 'stages' } }) {
-    const {
-      data: { data },
-    } = await get(`${API_BASE_URL}/workflows/${workflowId ?? ''}`, { params });
+    try {
+      const {
+        data: { data },
+      } = await get(`${API_BASE_URL}/workflows/${workflowId ?? ''}`, { params });
 
-    return data;
-  }
-
-  async function updateRemoteWorkflowStages({ workflowId, stages }) {
-    const {
-      data: { data },
-    } = await put(`${API_BASE_URL}/workflows/${workflowId}/stages`, {
-      data: stages,
-    });
-
-    return data;
-  }
-
-  function updateWorkflowStages(workflowId, stages) {
-    return workflowUpdateMutation.mutateAsync({ workflowId, stages });
+      return data;
+    } catch (err) {
+      // silence
+      return null;
+    }
   }
 
   function refetchWorkflow() {
@@ -39,25 +28,8 @@ export function useReviewWorkflows(workflowId) {
 
   const workflows = useQuery(workflowQueryKey, fetchWorkflows);
 
-  const workflowUpdateMutation = useMutation(updateRemoteWorkflowStages, {
-    async onError(error) {
-      toggleNotification({
-        type: 'warning',
-        message: formatAPIError(error),
-      });
-    },
-
-    async onSuccess() {
-      toggleNotification({
-        type: 'success',
-        message: { id: 'notification.success.saved', defaultMessage: 'Saved' },
-      });
-    },
-  });
-
   return {
     workflows,
-    updateWorkflowStages,
     refetchWorkflow,
   };
 }

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/tests/ReviewWorkflows.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/tests/ReviewWorkflows.test.js
@@ -77,9 +77,12 @@ const ComponentFixture = () => {
   );
 };
 
-const setup = (props) => render(<ComponentFixture {...props} />);
-
-const user = userEvent.setup();
+const setup = (props) => {
+  return {
+    ...render(<ComponentFixture {...props} />),
+    user: userEvent.setup(),
+  };
+};
 
 describe('Admin | Settings | Review Workflow | ReviewWorkflowsPage', () => {
   beforeAll(() => {
@@ -125,7 +128,7 @@ describe('Admin | Settings | Review Workflow | ReviewWorkflowsPage', () => {
   });
 
   test('Save button is enabled after a stage has been added', async () => {
-    const { getByText, getByRole } = setup();
+    const { user, getByText, getByRole } = setup();
 
     await user.click(
       getByRole('button', {
@@ -141,7 +144,7 @@ describe('Admin | Settings | Review Workflow | ReviewWorkflowsPage', () => {
 
   test('Successful Stage update', async () => {
     const toggleNotification = useNotification();
-    const { getByRole } = setup();
+    const { user, getByRole } = setup();
 
     await user.click(
       getByRole('button', {
@@ -166,7 +169,7 @@ describe('Admin | Settings | Review Workflow | ReviewWorkflowsPage', () => {
   test('Stage update with error', async () => {
     SHOULD_ERROR = true;
     const toggleNotification = useNotification();
-    const { getByRole } = setup();
+    const { user, getByRole } = setup();
 
     await user.click(
       getByRole('button', {
@@ -195,7 +198,7 @@ describe('Admin | Settings | Review Workflow | ReviewWorkflowsPage', () => {
   });
 
   test('Show confirmation dialog when a stage was deleted', async () => {
-    const { getByRole, getAllByRole } = setup();
+    const { user, getByRole, getAllByRole } = setup();
 
     await user.click(
       getByRole('button', {
@@ -203,9 +206,7 @@ describe('Admin | Settings | Review Workflow | ReviewWorkflowsPage', () => {
       })
     );
 
-    fireEvent.change(getByRole('textbox', { name: /stage name/i }), {
-      target: { value: 'stage-2' },
-    });
+    await user.type(getByRole('textbox', { name: /stage name/i }), 'stage-2');
 
     const deleteButtons = getAllByRole('button', { name: /delete stage/i });
 


### PR DESCRIPTION
### What does it do?

- Moves the stage update mutation from the hook into the settings page
- Extend integration tests for the RW settings page

### Why is it needed?

- Simplifies the data fetching hook and brings it in line with the other components
- Makes testing of the page easier, less mocking

