### PR TITLE
useAPIErrorHandler: Reverse error handling (API -> Axios)

### DIFF
--- a/packages/core/helper-plugin/lib/src/hooks/useAPIErrorHandler/useAPIErrorHandler.js
+++ b/packages/core/helper-plugin/lib/src/hooks/useAPIErrorHandler/useAPIErrorHandler.js
@@ -17,11 +17,17 @@ export function useAPIErrorHandler(intlMessagePrefixCallback) {
 
   return {
     formatAPIError(error) {
-      if (error instanceof AxiosError) {
-        return formatAxiosError(error, { intlMessagePrefixCallback, formatMessage });
-      }
+      // Try to normalize the passed error first. This will fail for e.g. network
+      // errors which are thrown by Axios directly.
+      try {
+        return formatAPIError(error, { intlMessagePrefixCallback, formatMessage });
+      } catch (_) {
+        if (error instanceof AxiosError) {
+          return formatAxiosError(error, { intlMessagePrefixCallback, formatMessage });
+        }
 
-      return formatAPIError(error, { intlMessagePrefixCallback, formatMessage });
+        throw new Error('formatAPIError: Unknown error:', error);
+      }
     },
   };
 }


### PR DESCRIPTION
### What does it do?

Reverses the `AxiosError` handling of `useFormatAPIError`. Instead of normalizing `AxiosError` before the response error, it should work the other way around.

### Why is it needed?

I made a conceptual mistake in https://github.com/strapi/strapi/pull/16090. Axios always throws an `AxiosError` regardless if the error origin is the network or an HTTP response code. Therefore we have to check first, whether the API returned an error (e.g. `ValidationError`), and only if this error can not be normalized, we should try and normalize the AxiosError.

The error response is always more specific and should therefore have more priority.

### Related issue(s)/PR(s)

- https://github.com/strapi/strapi/pull/16090
- Fixes https://github.com/strapi/strapi/issues/16148
- https://github.com/strapi/strapi/pull/15321
