### PR TITLE
[Clone Entity Relations]: Entity service clone components

### DIFF
--- a/packages/core/database/lib/entity-manager/relations/cloning/regular-relations.js
+++ b/packages/core/database/lib/entity-manager/relations/cloning/regular-relations.js
@@ -60,7 +60,7 @@ const cloneRegularRelations = async ({ targetId, sourceId, attribute, transactio
   // Clean the inverse order column
   if (inverseOrderColumnName) {
     await cleanInverseOrderColumn({
-      targetId,
+      id: targetId,
       attribute,
       trx,
     });

--- a/packages/core/strapi/lib/services/entity-service/components.js
+++ b/packages/core/strapi/lib/services/entity-service/components.js
@@ -343,6 +343,10 @@ const cloneComponents = async (uid, entityToClone, data) => {
         ? data[attributeName]
         : componentData[attributeName];
 
+      if (componentValue === null) {
+        continue;
+      }
+
       if (repeatable === true) {
         if (!Array.isArray(componentValue)) {
           throw new Error('Expected an array to create repeatable component');

--- a/packages/core/strapi/lib/services/entity-service/index.js
+++ b/packages/core/strapi/lib/services/entity-service/index.js
@@ -20,6 +20,7 @@ const {
   createComponents,
   updateComponents,
   deleteComponents,
+  cloneComponents,
 } = require('./components');
 const { pickSelectionParams } = require('./params');
 const { applyTransforms } = require('./attributes');
@@ -267,9 +268,7 @@ const createDefaultImplementation = ({ strapi, db, eventHub, entityValidator }) 
     const query = transformParamsToQuery(uid, pickSelectionParams(wrappedParams));
 
     // TODO: wrap into transaction
-    // TODO: Implement cloneComponents
-    // const componentData = await cloneComponents(uid, validData);
-    const componentData = await createComponents(uid, validData);
+    const componentData = await cloneComponents(uid, entityToClone, validData);
 
     const entityData = creationPipeline(
       Object.assign(omitComponentData(model, validData), componentData),


### PR DESCRIPTION
### What does it do?
Follow up of https://github.com/strapi/strapi/pull/16150.

Clone a single entity and its components via the entity service.

### Why is it needed?

So we can clone from the CM, including the entity components and dynamic zones.

### How to test it?

In the `bootstrap.js` file, using the `getstarted` project, and with some `kitchensinks` and `tags` created:
```js
   // Clones kitchensink with id 1 and replaces some fields
    await strapi.entityService.clone('api::kitchensink.kitchensink', 1, {
      data: {
        short_text: 'My new name',
        boolean: null,
        many_to_many_tags: [2],
        single_compo: {
          id: 3, // <-- This will clone the original component, use the corersponding id
          name: 'My new name',
          category: 2,
        },
        repeatable_compo: [
          {
            id: 11, // <-- This will clone the original component, use the corersponding id
            test: 'My new test',
            category: 1,
          },
          { // <-- This will create a new component
            name: 'My new name',
            test: 'My new test',
          },
        ],
        dynamiczone: [
          {
            __component: 'basic.simple',
            id: 10, , // <-- This will clone the original component, use the corersponding id
            name: 'My new name',
          },
          {
            __component: 'basic.simple',  // <-- This will create a new component
            name: 'My new name',
            test: 'My new test',
          },
        ],
      },
    });
```

