### PR TITLE
[Data transfer] Confirm delete of local data on 'pull' transfer

### DIFF
--- a/packages/core/strapi/bin/strapi.js
+++ b/packages/core/strapi/bin/strapi.js
@@ -322,6 +322,11 @@ program
           }
           thisCommand.opts().fromToken = answers.fromToken;
         }
+
+        await confirmMessage(
+          'The transfer will delete all data in the local database and media files. Are you sure you want to proceed?',
+          { failMessage: 'Transfer process aborted' }
+        )(thisCommand);
       }
     )
   )

--- a/packages/core/strapi/bin/strapi.js
+++ b/packages/core/strapi/bin/strapi.js
@@ -324,7 +324,7 @@ program
         }
 
         await confirmMessage(
-          'The transfer will delete all data in the local database and media files. Are you sure you want to proceed?',
+          'The transfer will delete all of the local Strapi assets and its database. Are you sure you want to proceed?',
           { failMessage: 'Transfer process aborted' }
         )(thisCommand);
       }
@@ -352,7 +352,7 @@ program
         }
 
         await confirmMessage(
-          'The transfer will delete all data in the remote database and media files. Are you sure you want to proceed?',
+          'The transfer will delete all of the remote Strapi assets and its database. Are you sure you want to proceed?',
           { failMessage: 'Transfer process aborted' }
         )(thisCommand);
       }

--- a/packages/core/strapi/bin/strapi.js
+++ b/packages/core/strapi/bin/strapi.js
@@ -324,7 +324,7 @@ program
         }
 
         await confirmMessage(
-          'The transfer will delete all of the local Strapi assets and its database. Are you sure you want to proceed?',
+          'The transfer will delete all the local Strapi assets and its database. Are you sure you want to proceed?',
           { failMessage: 'Transfer process aborted' }
         )(thisCommand);
       }
@@ -352,7 +352,7 @@ program
         }
 
         await confirmMessage(
-          'The transfer will delete all of the remote Strapi assets and its database. Are you sure you want to proceed?',
+          'The transfer will delete all the remote Strapi assets and its database. Are you sure you want to proceed?',
           { failMessage: 'Transfer process aborted' }
         )(thisCommand);
       }
@@ -456,7 +456,7 @@ program
   .hook(
     'preAction',
     confirmMessage(
-      'The import will delete all data in your database and media files. Are you sure you want to proceed?',
+      'The import will delete all assets and data in your database. Are you sure you want to proceed?',
       { failMessage: 'Import process aborted' }
     )
   )


### PR DESCRIPTION
### What does it do?

Displays a confirmation message before deleting local data

### Why is it needed?


### How to test it?

Do a pull transfer and you should be prompted before deleting data.

If --force is used, the prompt should be bypassed

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
