### PR TITLE
Run build:ts before unit-test back

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,6 +62,8 @@ jobs:
           key: ${{ runner.os }}-${{ matrix.node }}-${{ hashFiles('**/yarn.lock') }}
       - uses: nrwl/nx-set-shas@v3
       - run: yarn install --frozen-lockfile
+      - name: Run build:ts
+        run: yarn nx run-many --target=build:ts --nx-ignore-cycles
       - name: Run tests
         run: yarn nx affected --target=test:unit --nx-ignore-cycles
 


### PR DESCRIPTION
### What does it do?

Fix back unit test not working because nx affected isn't doing what I want.
