### PR TITLE
Fix `yarn strapi build` to use admin package .browserslistrc

### DIFF
--- a/packages/core/admin/package.json
+++ b/packages/core/admin/package.json
@@ -61,6 +61,7 @@
     "babel-loader": "^9.1.2",
     "babel-plugin-styled-components": "2.0.2",
     "bcryptjs": "2.4.3",
+    "browserslist": "^4.17.3",
     "browserslist-to-esbuild": "1.2.0",
     "chalk": "^4.1.2",
     "chokidar": "^3.5.1",

--- a/packages/core/admin/webpack.config.js
+++ b/packages/core/admin/webpack.config.js
@@ -9,6 +9,7 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const { ESBuildMinifyPlugin } = require('esbuild-loader');
 const WebpackBar = require('webpackbar');
 const ReactRefreshWebpackPlugin = require('@pmmmwh/react-refresh-webpack-plugin');
+const browserslist = require('browserslist');
 const browserslistToEsbuild = require('browserslist-to-esbuild');
 
 const alias = require('./webpack.alias');
@@ -52,7 +53,10 @@ module.exports = ({
 
   const excludeRegex = createPluginsExcludePath(pluginsPath);
 
-  const buildTarget = browserslistToEsbuild();
+  // Ensure we use the config in this directory, even if run with a different
+  // working directory
+  const browserslistConfig = browserslist.loadConfig({ path: __dirname });
+  const buildTarget = browserslistToEsbuild(browserslistConfig);
 
   return {
     mode: isProduction ? 'production' : 'development',

--- a/yarn.lock
+++ b/yarn.lock
@@ -7003,6 +7003,7 @@ __metadata:
     babel-loader: ^9.1.2
     babel-plugin-styled-components: 2.0.2
     bcryptjs: 2.4.3
+    browserslist: ^4.17.3
     browserslist-to-esbuild: 1.2.0
     chalk: ^4.1.2
     chokidar: ^3.5.1


### PR DESCRIPTION
### What does it do?

Make running `yarn strapi build` actually use the .browserslistrc in `node_modules/@strapi/admin`. Previously, it would just look in the project directory and its parents.

### Why is it needed?

Conflicting .browserslistrc in parent directories can cause Strapi to fail to build. To reproduce:

### How to test it?

1. In a directory (say `~/parent`), create a .browserlistrc with these contents:

```
>0.5% in US
ios_saf >=9
```

2. Create a new project within parent

```sh
yarn create strapi-app test --dbclient mysql --dbhost localhost --dbport 3306 --dbname strapi --dbusername strapi --dbpassword test --dbssl false --typescript
```

3. Try running `yarn strapi build`

**Previously:** It'll fail with a message like "Transforming destructuring to the configured target environment ("chrome109", "edge109", "firefox108", "ios9") is not supported yet". This failure is because of the ios9 rule isn't supported by the current version of webpack/esbuild

**With this fix:** It builds normally

### Related issue(s)/PR(s)

N/A