### PR TITLE
chore: make initRouting synchronous

### DIFF
--- a/packages/core/strapi/lib/Strapi.js
+++ b/packages/core/strapi/lib/Strapi.js
@@ -468,7 +468,7 @@ class Strapi {
     await this.startWebhooks();
 
     await this.server.initMiddlewares();
-    await this.server.initRouting();
+    this.server.initRouting();
 
     await this.contentAPI.permissions.registerActions();
 

--- a/packages/core/strapi/lib/services/server/index.js
+++ b/packages/core/strapi/lib/services/server/index.js
@@ -92,8 +92,8 @@ const createServer = (strapi) => {
       return this;
     },
 
-    async initRouting() {
-      await registerAllRoutes(strapi);
+    initRouting() {
+      registerAllRoutes(strapi);
 
       return this;
     },


### PR DESCRIPTION
…llRoutes is a normal one

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Set registerAllRoutes(packages/core/strapi/lib/Strapi.js)/initRouting(packages/core/strapi/lib/services/server/index.js) to ordinary function.

### Why is it needed?

Make the code more elegant.

### How to test it?

No need to test, as no effect introduced.

### Related issue(s)/PR(s)

None
