### PR TITLE
Separate Experimental & Nightly releases

### DIFF
--- a/.github/workflows/experimental.yml
+++ b/.github/workflows/experimental.yml
@@ -1,8 +1,7 @@
-name: 'Nightly Releases'
+name: 'Experimental Releases'
 
 on:
-  schedule:
-    - cron: '0 0 * * 2-6'
+  workflow_dispatch:
 
 permissions:
   contents: read # to fetch code (actions/checkout)
@@ -22,5 +21,5 @@ jobs:
       - run: yarn
       - run: ./scripts/pre-publish.sh --yes
         env:
-          VERSION: '0.0.0-next.${{ github.sha }}'
-          DIST_TAG: next
+          VERSION: '0.0.0-experimental.${{ github.sha }}'
+          DIST_TAG: experimental


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* removes the ability to dispatch the `nightly` workflow
* adds `experimental` workflow that you can dispatch
* changes `nightly` to be `next`

### Why is it needed?

* `next` will now always be "main" so we can suggest users who want fixes faster to update with `strapi@next`
* `experimental` releases are now just for devs to try / test solutions
