### PR TITLE
FIX: file separator for windows OS during import backup from local file

### DIFF
--- a/packages/core/data-transfer/src/file/providers/source/index.ts
+++ b/packages/core/data-transfer/src/file/providers/source/index.ts
@@ -184,7 +184,7 @@ class LocalFileSourceProvider implements ISourceProvider {
               return false;
             }
 
-            const parts = path.relative('.', filePath).split('/');
+            const parts = path.relative('.', filePath).split(path.sep);
 
             // TODO: this method is limiting us from having additional subdirectories and is requiring us to remove any "./" prefixes (the path.relative line above)
             if (parts.length !== 2) {


### PR DESCRIPTION
Hi! I'm facing with a problem when i tried to import backup file (windows os)
There is an error `error: [FATAL] Invalid schema changes detected during integrity checks (using the strict strategy)`

I changed specific `/` separator to `path.sep` and it helped me. And i think it fixes [this issue](https://github.com/strapi/strapi/issues/15616)
It is my first open source fix and pull request, do not judge strictly)
