### PR TITLE
Add `module` to mainFields

### DIFF
--- a/packages/core/admin/webpack.config.js
+++ b/packages/core/admin/webpack.config.js
@@ -221,7 +221,7 @@ module.exports = ({
       alias,
       symlinks: false,
       extensions: ['.js', '.jsx', '.react.js', '.ts', '.tsx'],
-      mainFields: ['browser', 'jsnext:main', 'main'],
+      mainFields: ['browser', 'module', 'jsnext:main', 'main'],
       modules: ['node_modules', path.resolve(__dirname, 'node_modules')],
     },
     plugins: [


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* Adds `module` to the `mainFields` in webpack after `browser`

### Why is it needed?

By default when you don't specify a `target` webpack assumes `web` and puts the `mainFields` as `['browser', 'module', 'main']` whereby it checks those fields (typically looking for ESM files as the priority). We've declared a custom `mainFields` adding `jsnext:main` which is deemed to be legacy and superseeded by `module` see [here](https://github.com/jsforum/jsforum/issues/5), but we'll keep it anyway. This will ensure that we're using the correct fields from the packages in the correct order to keep lighter bundles and not importing `cjs` files which is what `main` normally is now – `@react-dnd/asap` as an example that broke `pnpm` builds.

### Related issue(s)/PR(s)

* related to #15992 
