### PR TITLE
deps(provider-email-mailgun): upgrade mailgun.js to 8.2.1

### DIFF
--- a/packages/providers/email-mailgun/package.json
+++ b/packages/providers/email-mailgun/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@strapi/utils": "4.8.2",
     "form-data": "^4.0.0",
-    "mailgun.js": "5.2.2"
+    "mailgun.js": "8.2.1"
   },
   "engines": {
     "node": ">=14.19.1 <=18.x.x",


### PR DESCRIPTION

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Upgraded mailgun.js to the latest version which has critical fixes

### Why is it needed?

Mailgun provider was not working and was always returning the following error when sending emails.
```js
{
  status: 400,
  details: { message: 'from parameter is missing' }
}
```

### How to test it?
- [Setup mailgun provider 
](https://market.strapi.io/providers/@strapi-provider-email-mailgun)
- Send a test email from Settings > Configuration > Send test email

### Related issue(s)/PR(s)
-  https://github.com/mailgun/mailgun.js/issues/92