### PR TITLE
Skip cache on `build:ts` in CI

### DIFF
--- a/.github/actions/run-api-tests/script.sh
+++ b/.github/actions/run-api-tests/script.sh
@@ -10,6 +10,6 @@ export JWT_SECRET="aSecret"
 
 opts=($DB_OPTIONS)
 
-yarn run build:ts
+yarn nx run-many --target=build:ts --nx-ignore-cycles --skip-nx-cache
 yarn run test:generate-app "${opts[@]}"
 yarn run test:api --no-generate-app

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: nrwl/nx-set-shas@v3
       - run: yarn install --immutable
       - name: Run build:ts
-        run: yarn nx run-many --target=build:ts --nx-ignore-cycles
+        run: yarn nx run-many --target=build:ts --nx-ignore-cycles --skip-nx-cache
       - name: Run lint
         run: yarn nx affected --target=lint --parallel --nx-ignore-cycles
 
@@ -63,7 +63,7 @@ jobs:
       - uses: nrwl/nx-set-shas@v3
       - run: yarn install --immutable
       - name: Run build:ts
-        run: yarn nx run-many --target=build:ts --nx-ignore-cycles
+        run: yarn nx run-many --target=build:ts --nx-ignore-cycles --skip-nx-cache
       - name: Run tests
         run: yarn nx affected --target=test:unit --nx-ignore-cycles
 
@@ -86,7 +86,7 @@ jobs:
           path: '**/node_modules'
           key: ${{ runner.os }}-${{ matrix.node }}-${{ hashFiles('**/yarn.lock') }}
       - uses: nrwl/nx-set-shas@v3
-      - run: yarn install  --immutable
+      - run: yarn install --immutable
       - name: Run test
         run: yarn nx affected --target=test:front --nx-ignore-cycles
 
@@ -106,7 +106,7 @@ jobs:
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-${{ matrix.node }}-${{ hashFiles('**/yarn.lock') }}
-      - run: yarn install  --immutable
+      - run: yarn install --immutable
       - name: Build
         run: yarn build --projects=@strapi/admin,@strapi/helper-plugin
 
@@ -145,7 +145,7 @@ jobs:
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-${{ matrix.node }}-${{ hashFiles('**/yarn.lock') }}
-      - run: yarn install  --immutable
+      - run: yarn install --immutable
       - uses: ./.github/actions/run-api-tests
         with:
           dbOptions: '--dbclient=postgres --dbhost=localhost --dbport=5432 --dbname=strapi_test --dbusername=strapi --dbpassword=strapi'
@@ -183,7 +183,7 @@ jobs:
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-${{ matrix.node }}-${{ hashFiles('**/yarn.lock') }}
-      - run: yarn install  --immutable
+      - run: yarn install --immutable
       - uses: ./.github/actions/run-api-tests
         with:
           dbOptions: '--dbclient=mysql --dbhost=localhost --dbport=3306 --dbname=strapi_test --dbusername=strapi --dbpassword=strapi'
@@ -220,7 +220,7 @@ jobs:
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-${{ matrix.node }}-${{ hashFiles('**/yarn.lock') }}
-      - run: yarn install  --immutable
+      - run: yarn install --immutable
       - uses: ./.github/actions/run-api-tests
         with:
           dbOptions: '--dbclient=mysql --dbhost=localhost --dbport=3306 --dbname=strapi_test --dbusername=strapi --dbpassword=strapi'
@@ -242,7 +242,7 @@ jobs:
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-${{ matrix.node }}-${{ hashFiles('**/yarn.lock') }}
-      - run: yarn install  --immutable
+      - run: yarn install --immutable
       - uses: ./.github/actions/run-api-tests
         env:
           SQLITE_PKG: ${{ matrix.sqlite_pkg }}
@@ -288,7 +288,7 @@ jobs:
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-${{ matrix.node }}-${{ hashFiles('**/yarn.lock') }}
-      - run: yarn install  --immutable
+      - run: yarn install --immutable
       - uses: ./.github/actions/run-api-tests
         with:
           dbOptions: '--dbclient=postgres --dbhost=localhost --dbport=5432 --dbname=strapi_test --dbusername=strapi --dbpassword=strapi'
@@ -330,7 +330,7 @@ jobs:
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-${{ matrix.node }}-${{ hashFiles('**/yarn.lock') }}
-      - run: yarn install  --immutable
+      - run: yarn install --immutable
       - uses: ./.github/actions/run-api-tests
         with:
           dbOptions: '--dbclient=mysql --dbhost=localhost --dbport=3306 --dbname=strapi_test --dbusername=strapi --dbpassword=strapi'
@@ -356,7 +356,7 @@ jobs:
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-${{ matrix.node }}-${{ hashFiles('**/yarn.lock') }}
-      - run: yarn install  --immutable
+      - run: yarn install --immutable
       - uses: ./.github/actions/run-api-tests
         env:
           SQLITE_PKG: ${{ matrix.sqlite_pkg }}

--- a/vercel.json
+++ b/vercel.json
@@ -4,7 +4,7 @@
     "silent": true,
     "autoJobCancelation": true
   },
-  "installCommand": "yarn setup",
+  "installCommand": "yarn install --immutable",
   "ignoreCommand": "git diff HEAD^ HEAD --quiet './packages/core/helper-plugin'",
   "outputDirectory": "packages/core/helper-plugin/storybook-static"
 }


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* adds `--skip-nx-cache` argument when we `build:ts` in the CI in `lint` `unit_back` & `actions/run-api-tests`

### Why is it needed?

* There was a cache issue in the CI where it (fairly) assumed that the `build:ts` action did not need to run again because no files were changed, however it didn't then seem to populate the correct folders with said cache which meant the CI couldn't find the packages `logger` and `data-transfer`.
