### PR TITLE
TempKeys should be calculated based on Ids & TempKeys not array length

### DIFF
--- a/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/tests/InformationBoxEE.test.js
+++ b/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/tests/InformationBoxEE.test.js
@@ -28,19 +28,21 @@ jest.mock(
     useReviewWorkflows: jest.fn(() => ({
       workflows: {
         isLoading: false,
-        data: {
-          stages: [
-            {
-              id: 1,
-              name: 'Stage 1',
-            },
+        data: [
+          {
+            stages: [
+              {
+                id: 1,
+                name: 'Stage 1',
+              },
 
-            {
-              id: 2,
-              name: 'Stage 2',
-            },
-          ],
-        },
+              {
+                id: 2,
+                name: 'Stage 2',
+              },
+            ],
+          },
+        ],
       },
     })),
   })

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/index.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/index.js
@@ -64,9 +64,11 @@ export function reducer(state = initialState, action) {
           };
         }
 
+        const newTempKey = getMaxTempKey(draft.clientState.currentWorkflow.data.stages);
+
         draft.clientState.currentWorkflow.data.stages.push({
           ...payload,
-          __temp_key__: (currentWorkflow.data?.stages?.length ?? 0) + 1,
+          __temp_key__: newTempKey,
         });
 
         break;
@@ -100,3 +102,20 @@ export function reducer(state = initialState, action) {
     }
   });
 }
+
+/**
+ * @type {(stages: Array<{id?: number; __temp_key__: number}>) => number}
+ */
+const getMaxTempKey = (stages = []) => {
+  /**
+   * We check if there are ids or __temp_key__ because you may add a stage to a list of stages
+   * already in the DB, alternatively you might add multiple new stages at once.
+   */
+  const ids = stages.map((stage) => stage.id ?? stage.__temp_key__);
+
+  /**
+   * If there are no ids it will return 0 as the max value
+   * because the max value is -1.
+   */
+  return Math.max(...ids, -1) + 1;
+};

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/tests/index.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/tests/index.test.js
@@ -255,7 +255,56 @@ describe('Admin | Settings | Review Workflows | reducer', () => {
             data: expect.objectContaining({
               stages: expect.arrayContaining([
                 {
-                  __temp_key__: 1,
+                  __temp_key__: 0,
+                  name: 'something',
+                },
+              ]),
+            }),
+          }),
+        }),
+      })
+    );
+  });
+
+  test('ACTION_ADD_STAGE should correctly append the key when the ids are not sequential', () => {
+    const WORKFLOWS_FIXTURE = [
+      {
+        id: 1,
+        stages: [
+          {
+            id: 1,
+            name: 'stage-1',
+          },
+
+          {
+            id: 3,
+            name: 'stage-2',
+          },
+        ],
+      },
+    ];
+
+    const action = {
+      type: ACTION_ADD_STAGE,
+      payload: { name: 'something' },
+    };
+
+    state = {
+      status: expect.any(String),
+      serverState: expect.any(Object),
+      clientState: {
+        currentWorkflow: { data: WORKFLOWS_FIXTURE[0], isDirty: false },
+      },
+    };
+
+    expect(reducer(state, action)).toStrictEqual(
+      expect.objectContaining({
+        clientState: expect.objectContaining({
+          currentWorkflow: expect.objectContaining({
+            data: expect.objectContaining({
+              stages: expect.arrayContaining([
+                {
+                  __temp_key__: 4,
                   name: 'something',
                 },
               ]),


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* Adds a getMaxKey function that looks at the current list of workflows stages ids/_temp_key_ to calculate the next one
* Fixes the test for InformationBoxEE

### Why is it needed?

* Using the length of the array assumes your stages' ids are in sequential order which isn't true
* FE unit tests will fail otherwise

### How to test it?

* I've added an automated test & corrected another test because imo it should default to 0 if there are no stages 😓 

### Related issue(s)/PR(s)

- resolves CONTENT-1225
