### PR TITLE
[Data transfer] Allow trailing slash from admin url in remote transfer

### DIFF
--- a/packages/core/data-transfer/src/strapi/providers/remote-destination/index.ts
+++ b/packages/core/data-transfer/src/strapi/providers/remote-destination/index.ts
@@ -10,6 +10,7 @@ import type { client, server } from '../../../../types/remote/protocol';
 import type { ILocalStrapiDestinationProviderOptions } from '../local-destination';
 import { TRANSFER_PATH } from '../../remote/constants';
 import { ProviderTransferError, ProviderValidationError } from '../../../errors/providers';
+import { trimTrailingSlash } from '../../../utils/providers';
 
 interface ITransferTokenAuth {
   type: 'token';
@@ -210,9 +211,8 @@ class RemoteStrapiDestinationProvider implements IDestinationProvider {
       });
     }
     const wsProtocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
-    const wsUrl = `${wsProtocol}//${url.host}${url.pathname.replace(
-      /\/$/,
-      ''
+    const wsUrl = `${wsProtocol}//${url.host}${trimTrailingSlash(
+      url.pathname
     )}${TRANSFER_PATH}/push`;
 
     // No auth defined, trying public access for transfer

--- a/packages/core/data-transfer/src/strapi/providers/remote-destination/index.ts
+++ b/packages/core/data-transfer/src/strapi/providers/remote-destination/index.ts
@@ -210,7 +210,10 @@ class RemoteStrapiDestinationProvider implements IDestinationProvider {
       });
     }
     const wsProtocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
-    const wsUrl = `${wsProtocol}//${url.host}${url.pathname}${TRANSFER_PATH}/push`;
+    const wsUrl = `${wsProtocol}//${url.host}${url.pathname.replace(
+      /\/$/,
+      ''
+    )}${TRANSFER_PATH}/push`;
 
     // No auth defined, trying public access for transfer
     if (!auth) {

--- a/packages/core/data-transfer/src/strapi/providers/remote-destination/index.ts
+++ b/packages/core/data-transfer/src/strapi/providers/remote-destination/index.ts
@@ -3,14 +3,13 @@ import { v4 } from 'uuid';
 import { Writable } from 'stream';
 import { once } from 'lodash/fp';
 
-import { createDispatcher } from '../utils';
+import { createDispatcher, trimTrailingSlash } from '../utils';
 
 import type { IDestinationProvider, IMetadata, ProviderType, IAsset } from '../../../../types';
 import type { client, server } from '../../../../types/remote/protocol';
 import type { ILocalStrapiDestinationProviderOptions } from '../local-destination';
 import { TRANSFER_PATH } from '../../remote/constants';
 import { ProviderTransferError, ProviderValidationError } from '../../../errors/providers';
-import { trimTrailingSlash } from '../../../utils/providers';
 
 interface ITransferTokenAuth {
   type: 'token';

--- a/packages/core/data-transfer/src/strapi/providers/remote-source/index.ts
+++ b/packages/core/data-transfer/src/strapi/providers/remote-source/index.ts
@@ -16,10 +16,9 @@ import {
   ProviderTransferError,
   ProviderValidationError,
 } from '../../../errors/providers';
-import { trimTrailingSlash } from '../../../utils/providers';
 import { TRANSFER_PATH } from '../../remote/constants';
 import { ILocalStrapiSourceProviderOptions } from '../local-source';
-import { createDispatcher } from '../utils';
+import { createDispatcher, trimTrailingSlash } from '../utils';
 
 interface ITransferTokenAuth {
   type: 'token';

--- a/packages/core/data-transfer/src/strapi/providers/remote-source/index.ts
+++ b/packages/core/data-transfer/src/strapi/providers/remote-source/index.ts
@@ -227,7 +227,10 @@ class RemoteStrapiSourceProvider implements ISourceProvider {
     let ws: WebSocket;
     this.assertValidProtocol(url);
     const wsProtocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
-    const wsUrl = `${wsProtocol}//${url.host}${url.pathname}${TRANSFER_PATH}/pull`;
+    const wsUrl = `${wsProtocol}//${url.host}${url.pathname.replace(
+      /\/$/,
+      ''
+    )}${TRANSFER_PATH}/pull`;
 
     // No auth defined, trying public access for transfer
     if (!auth) {

--- a/packages/core/data-transfer/src/strapi/providers/remote-source/index.ts
+++ b/packages/core/data-transfer/src/strapi/providers/remote-source/index.ts
@@ -16,6 +16,7 @@ import {
   ProviderTransferError,
   ProviderValidationError,
 } from '../../../errors/providers';
+import { trimTrailingSlash } from '../../../utils/providers';
 import { TRANSFER_PATH } from '../../remote/constants';
 import { ILocalStrapiSourceProviderOptions } from '../local-source';
 import { createDispatcher } from '../utils';
@@ -227,9 +228,8 @@ class RemoteStrapiSourceProvider implements ISourceProvider {
     let ws: WebSocket;
     this.assertValidProtocol(url);
     const wsProtocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
-    const wsUrl = `${wsProtocol}//${url.host}${url.pathname.replace(
-      /\/$/,
-      ''
+    const wsUrl = `${wsProtocol}//${url.host}${trimTrailingSlash(
+      url.pathname
     )}${TRANSFER_PATH}/pull`;
 
     // No auth defined, trying public access for transfer

--- a/packages/core/data-transfer/src/strapi/providers/utils.ts
+++ b/packages/core/data-transfer/src/strapi/providers/utils.ts
@@ -14,7 +14,7 @@ interface IDispatchOptions {
 
 type Dispatch<T> = Omit<T, 'transferID' | 'uuid'>;
 
-const createDispatcher = (ws: WebSocket) => {
+export const createDispatcher = (ws: WebSocket) => {
   const state: IDispatcherState = {};
 
   type DispatchMessage = Dispatch<client.Message>;
@@ -119,4 +119,6 @@ const createDispatcher = (ws: WebSocket) => {
   };
 };
 
-export { createDispatcher };
+export const trimTrailingSlash = (input: string): string => {
+  return input.replace(/\/$/, '');
+};

--- a/packages/core/data-transfer/src/utils/providers.ts
+++ b/packages/core/data-transfer/src/utils/providers.ts
@@ -10,7 +10,3 @@ export const assertValidStrapi: ValidStrapiAssertion = (strapi?: unknown, msg = 
     throw new ProviderInitializationError(`${msg}. Strapi instance not found.`);
   }
 };
-
-export const trimTrailingSlash = (input: string): string => {
-  return input.replace(/\/$/, '');
-};

--- a/packages/core/data-transfer/src/utils/providers.ts
+++ b/packages/core/data-transfer/src/utils/providers.ts
@@ -10,3 +10,7 @@ export const assertValidStrapi: ValidStrapiAssertion = (strapi?: unknown, msg = 
     throw new ProviderInitializationError(`${msg}. Strapi instance not found.`);
   }
 };
+
+export const trimTrailingSlash = (input: string): string => {
+  return input.replace(/\/$/, '');
+};


### PR DESCRIPTION
### What does it do?

Strips a single trailing slash, if present, from the admin url path provided by the user for a remote transfer

### Why is it needed?

Some users may enter a URL such as `http://localhost/admin` and others may enter `http://localhost/admin/` and both are valid admin url paths

Entering more than a single slash is indicative of an error however, and could lead to unexpected behavior if we allowed it.

### How to test it?

Run a transfer (push and pull) with a URL that contains a trailing slash, and that does not contain a trailing slash

### Related issue(s)/PR(s)

