### PR TITLE
Add the lao language (i18n)

### DIFF
--- a/packages/plugins/i18n/server/constants/iso-locales.json
+++ b/packages/plugins/i18n/server/constants/iso-locales.json
@@ -1096,6 +1096,10 @@
     "name":"Galician (Spain) (gl-ES)"
   },
   {
+    "code":"lao",
+    "name":"Lao (Laos) (lao)"
+  },
+  {
     "code":"lg",
     "name":"Ganda (lg)"
   },


### PR DESCRIPTION
## What does it do?

Add the `lao` language to the list of supported locales (i18n plugin)

The lao locale is defined as follow:
```json
  {
    "code":"lao",
    "name":"Lao (Laos) (lao)"
  },
```