### PR TITLE
fix null response of /upload/configuration

### DIFF
--- a/packages/core/upload/server/controllers/view-configuration.js
+++ b/packages/core/upload/server/controllers/view-configuration.js
@@ -22,8 +22,9 @@ module.exports = {
   },
 
   async findViewConfiguration(ctx) {
-    const data = await getService('upload').getConfiguration();
-
+    let data = await getService('upload').getConfiguration();
+    
+    if (!data) { data = { pageSize: 10, sort: "createdAt:DESC" } }
     ctx.body = { data };
   },
 };


### PR DESCRIPTION


### What does it do?

Set default value for /upload/configuration, if there is no value 

### Why is it needed?

Sometimes /upload/configuration return null, lead to frontend page crash

### How to test it?

There are some issues, and use their info to test it.

### Related issue(s)/PR(s)

No
