### PR TITLE
When deleting a stage move entities to the nearest available stage

### DIFF
--- a/packages/core/admin/ee/server/controllers/workflows/stages/index.js
+++ b/packages/core/admin/ee/server/controllers/workflows/stages/index.js
@@ -46,6 +46,11 @@ module.exports = {
     };
   },
 
+  /**
+   * Replace all stages in a workflow
+   * @param {import('koa').BaseContext} ctx - koa context
+   *
+   */
   async replace(ctx) {
     const { workflow_id: workflowId } = ctx.params;
     const stagesService = getService('stages');

--- a/packages/core/admin/ee/server/services/__tests__/stages.test.js
+++ b/packages/core/admin/ee/server/services/__tests__/stages.test.js
@@ -156,7 +156,7 @@ describe('Review workflows - Stages service', () => {
     });
 
     test('Should move entities in a deleted stage to the previous stage', async () => {
-      await stagesService.replaceWorkflowStages(1, workflowMock.stages.slice(0, 1));
+      await stagesService.replaceWorkflowStages(1, workflowMock.stages.slice(0, 2));
 
       expect(servicesMock['admin::workflows'].findById).toBeCalled();
       expect(entityServiceMock.create).not.toBeCalled();
@@ -173,7 +173,7 @@ describe('Review workflows - Stages service', () => {
 
       expect(servicesMock['admin::workflows'].update).toBeCalled();
       expect(servicesMock['admin::workflows'].update).toBeCalledWith(workflowMock.id, {
-        stages: [workflowMock.stages[0].id],
+        stages: [workflowMock.stages[0].id, workflowMock.stages[1].id],
       });
     });
 

--- a/packages/core/admin/ee/server/services/__tests__/stages.test.js
+++ b/packages/core/admin/ee/server/services/__tests__/stages.test.js
@@ -28,6 +28,7 @@ const stageMock = {
   workflow: 1,
 };
 
+const relatedUID = 'uid';
 const workflowMock = {
   id: 1,
   stages: [
@@ -41,12 +42,16 @@ const workflowMock = {
       id: 3,
       name: 'done',
       workflow: 1,
+      related: [
+        { id: 1, __type: relatedUID },
+        { id: 2, __type: relatedUID },
+      ],
     },
   ],
 };
 
 const entityServiceMock = {
-  findOne: jest.fn(() => stageMock),
+  findOne: jest.fn((uid, id) => workflowMock.stages.find((stage) => stage.id === id)),
   findMany: jest.fn(() => [stageMock]),
   create: jest.fn((uid, { data }) => ({
     ...data,
@@ -135,7 +140,10 @@ describe('Review workflows - Stages service', () => {
       });
     });
     test('Should delete a stage contained in the workflow', async () => {
-      await stagesService.replaceWorkflowStages(1, [workflowMock.stages[0]]);
+      await stagesService.replaceWorkflowStages(1, [
+        workflowMock.stages[0],
+        workflowMock.stages[2],
+      ]);
 
       expect(servicesMock['admin::workflows'].findById).toBeCalled();
       expect(entityServiceMock.create).not.toBeCalled();
@@ -143,9 +151,32 @@ describe('Review workflows - Stages service', () => {
       expect(entityServiceMock.delete).toBeCalled();
       expect(servicesMock['admin::workflows'].update).toBeCalled();
       expect(servicesMock['admin::workflows'].update).toBeCalledWith(workflowMock.id, {
+        stages: [workflowMock.stages[0].id, workflowMock.stages[2].id],
+      });
+    });
+
+    test('Should move entities in a deleted stage to the previous stage', async () => {
+      await stagesService.replaceWorkflowStages(1, workflowMock.stages.slice(0, 1));
+
+      expect(servicesMock['admin::workflows'].findById).toBeCalled();
+      expect(entityServiceMock.create).not.toBeCalled();
+      expect(entityServiceMock.delete).toBeCalled();
+
+      expect(entityServiceMock.update).toBeCalledWith(relatedUID, 1, {
+        data: { strapi_reviewWorkflows_stage: 2 },
+        populate: ['strapi_reviewWorkflows_stage'],
+      });
+      expect(entityServiceMock.update).toBeCalledWith(relatedUID, 2, {
+        data: { strapi_reviewWorkflows_stage: 2 },
+        populate: ['strapi_reviewWorkflows_stage'],
+      });
+
+      expect(servicesMock['admin::workflows'].update).toBeCalled();
+      expect(servicesMock['admin::workflows'].update).toBeCalledWith(workflowMock.id, {
         stages: [workflowMock.stages[0].id],
       });
     });
+
     test('New stage + updated + deleted', async () => {
       await stagesService.replaceWorkflowStages(1, [
         workflowMock.stages[0],

--- a/packages/core/admin/ee/server/services/__tests__/stages.test.js
+++ b/packages/core/admin/ee/server/services/__tests__/stages.test.js
@@ -63,6 +63,9 @@ const servicesMock = {
 };
 
 const strapiMock = {
+  query: jest.fn(() => ({
+    findOne: jest.fn(() => workflowMock),
+  })),
   entityService: entityServiceMock,
   service: jest.fn((serviceName) => {
     return servicesMock[serviceName];

--- a/packages/core/admin/ee/server/services/review-workflows/stages.js
+++ b/packages/core/admin/ee/server/services/review-workflows/stages.js
@@ -74,7 +74,7 @@ module.exports = ({ strapi }) => {
             populate: ['related'],
           });
 
-          if ((stageInfo?.related?.length ?? 0) === 0) {
+          if (!stageInfo?.related?.length) {
             // If there are no related entities, just delete the stage
             return this.delete(stage.id);
           }
@@ -192,25 +192,26 @@ function assertAtLeastOneStageRemain(workflowStages, diffStages) {
 }
 
 /**
- * Find the nearest object in an array that matches a condition.
+ * Find the id of the nearest object in an array that matches a condition.
+ * Used for searching for the nearest stage that is not deleted.
  * Starts by searching the elements before the index, then the remaining elements in the array.
  *
- * @param {Array} array of stages
- * @param {Number} index the index to start searching from
+ * @param {Array} stages of stages
+ * @param {Number} startIndex the index to start searching from
  * @param {Function} condition must evaluate to true for the object to be considered a match
- * @returns {Object}
+ * @returns {Number}
  */
-function findNearestMatchingStageID(array, index, condition) {
-  // Start by searching the elements before the index
-  for (let i = index; i >= 0; i -= 1) {
-    if (condition(array[i])) {
-      return array[i].id;
+function findNearestMatchingStageID(stages, startIndex, condition) {
+  // Start by searching the elements before the startIndex
+  for (let i = startIndex; i >= 0; i -= 1) {
+    if (condition(stages[i])) {
+      return stages[i].id;
     }
   }
 
-  // If no matching element is found before the index,
+  // If no matching element is found before the startIndex,
   // search the remaining elements in the array
-  const remainingArray = array.slice(index + 1);
+  const remainingArray = stages.slice(startIndex + 1);
   const nearestObject = remainingArray.filter(condition)[0];
   return nearestObject.id;
 }

--- a/packages/core/admin/ee/server/services/review-workflows/stages.js
+++ b/packages/core/admin/ee/server/services/review-workflows/stages.js
@@ -196,7 +196,7 @@ function assertAtLeastOneStageRemain(workflowStages, diffStages) {
  * Used for searching for the nearest stage that is not deleted.
  * Starts by searching the elements before the index, then the remaining elements in the array.
  *
- * @param {Array} stages of stages
+ * @param {Array} stages
  * @param {Number} startIndex the index to start searching from
  * @param {Function} condition must evaluate to true for the object to be considered a match
  * @returns {Number}

--- a/packages/core/admin/ee/server/services/review-workflows/stages.js
+++ b/packages/core/admin/ee/server/services/review-workflows/stages.js
@@ -98,7 +98,7 @@ module.exports = ({ strapi }) => {
         });
 
         // Move all the entities whose stage was deleted to their target stage
-        mapAsync(entitiesToMove, (entity) => {
+        await mapAsync(entitiesToMove, (entity) => {
           return this.updateEntity(
             {
               id: entity.id,

--- a/packages/core/admin/ee/server/tests/review-workflows.test.api.js
+++ b/packages/core/admin/ee/server/tests/review-workflows.test.api.js
@@ -481,7 +481,7 @@ describeOnCondition(edition === 'EE')('Review workflows', () => {
             `/admin/content-manager/collection-types/${productUID}/${entry.id}/stage`,
             {
               body: {
-                data: { id: defaultStages.at(-1).id },
+                data: { id: defaultStages.slice(-1)[0].id },
               },
             }
           );


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Moves entities related to a stage to the nearest available stage when that stage is deleted. Prioritising earlier stages in the workflow

### Why is it needed?

Entities must always be in a valid stage

### How to test it?

Added Unit test and API test

### Related issue(s)/PR(s)

CONTENT-1221
