### PR TITLE
upgrade sharp to 0.32.0 to fix #16227

### DIFF
--- a/packages/core/upload/package.json
+++ b/packages/core/upload/package.json
@@ -50,7 +50,7 @@
     "react-query": "3.24.3",
     "react-redux": "8.0.5",
     "react-select": "5.7.0",
-    "sharp": "0.31.1",
+    "sharp": "0.32.0",
     "yup": "^0.32.9"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6895,7 +6895,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@strapi/admin@4.8.2, @strapi/admin@workspace:packages/core/admin":
+"@strapi/admin@4.9.0, @strapi/admin@workspace:packages/core/admin":
   version: 0.0.0-use.local
   resolution: "@strapi/admin@workspace:packages/core/admin"
   dependencies:
@@ -6907,15 +6907,15 @@ __metadata:
     "@casl/ability": ^5.4.3
     "@fingerprintjs/fingerprintjs": 3.3.6
     "@pmmmwh/react-refresh-webpack-plugin": 0.5.10
-    "@strapi/babel-plugin-switch-ee-ce": 4.8.2
-    "@strapi/data-transfer": 4.8.2
+    "@strapi/babel-plugin-switch-ee-ce": 4.9.0
+    "@strapi/data-transfer": 4.9.0
     "@strapi/design-system": 1.6.6
-    "@strapi/helper-plugin": 4.8.2
+    "@strapi/helper-plugin": 4.9.0
     "@strapi/icons": 1.6.6
-    "@strapi/permissions": 4.8.2
-    "@strapi/provider-audit-logs-local": 4.8.2
-    "@strapi/typescript-utils": 4.8.2
-    "@strapi/utils": 4.8.2
+    "@strapi/permissions": 4.9.0
+    "@strapi/provider-audit-logs-local": 4.9.0
+    "@strapi/typescript-utils": 4.9.0
+    "@strapi/utils": 4.9.0
     "@testing-library/dom": 8.19.0
     "@testing-library/react": 12.1.4
     "@testing-library/react-hooks": 8.0.1
@@ -7013,7 +7013,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@strapi/babel-plugin-switch-ee-ce@4.8.2, @strapi/babel-plugin-switch-ee-ce@workspace:packages/utils/babel-plugin-switch-ee-ce":
+"@strapi/babel-plugin-switch-ee-ce@4.9.0, @strapi/babel-plugin-switch-ee-ce@workspace:packages/utils/babel-plugin-switch-ee-ce":
   version: 0.0.0-use.local
   resolution: "@strapi/babel-plugin-switch-ee-ce@workspace:packages/utils/babel-plugin-switch-ee-ce"
   dependencies:
@@ -7031,12 +7031,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@strapi/data-transfer@4.8.2, @strapi/data-transfer@workspace:packages/core/data-transfer":
+"@strapi/data-transfer@4.9.0, @strapi/data-transfer@workspace:packages/core/data-transfer":
   version: 0.0.0-use.local
   resolution: "@strapi/data-transfer@workspace:packages/core/data-transfer"
   dependencies:
-    "@strapi/logger": 4.8.2
-    "@strapi/strapi": 4.8.2
+    "@strapi/logger": 4.9.0
+    "@strapi/strapi": 4.9.0
     "@tsconfig/node16": 1.0.3
     "@types/fs-extra": 9.0.13
     "@types/jest": 29.2.0
@@ -7066,7 +7066,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@strapi/database@4.8.2, @strapi/database@workspace:packages/core/database":
+"@strapi/database@4.9.0, @strapi/database@workspace:packages/core/database":
   version: 0.0.0-use.local
   resolution: "@strapi/database@workspace:packages/core/database"
   dependencies:
@@ -7127,7 +7127,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@strapi/generate-new@4.8.2, @strapi/generate-new@workspace:packages/generators/app":
+"@strapi/generate-new@4.9.0, @strapi/generate-new@workspace:packages/generators/app":
   version: 0.0.0-use.local
   resolution: "@strapi/generate-new@workspace:packages/generators/app"
   dependencies:
@@ -7146,13 +7146,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@strapi/generators@4.8.2, @strapi/generators@workspace:packages/generators/generators":
+"@strapi/generators@4.9.0, @strapi/generators@workspace:packages/generators/generators":
   version: 0.0.0-use.local
   resolution: "@strapi/generators@workspace:packages/generators/generators"
   dependencies:
     "@sindresorhus/slugify": 1.1.0
-    "@strapi/typescript-utils": 4.8.2
-    "@strapi/utils": 4.8.2
+    "@strapi/typescript-utils": 4.9.0
+    "@strapi/utils": 4.9.0
     chalk: 4.1.2
     fs-extra: 10.0.0
     node-plop: 0.26.3
@@ -7161,7 +7161,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@strapi/helper-plugin@4.8.2, @strapi/helper-plugin@workspace:packages/core/helper-plugin":
+"@strapi/helper-plugin@4.9.0, @strapi/helper-plugin@workspace:packages/core/helper-plugin":
   version: 0.0.0-use.local
   resolution: "@strapi/helper-plugin@workspace:packages/core/helper-plugin"
   dependencies:
@@ -7229,7 +7229,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@strapi/logger@4.8.2, @strapi/logger@workspace:packages/utils/logger":
+"@strapi/logger@4.9.0, @strapi/logger@workspace:packages/utils/logger":
   version: 0.0.0-use.local
   resolution: "@strapi/logger@workspace:packages/utils/logger"
   dependencies:
@@ -7239,23 +7239,23 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@strapi/permissions@4.8.2, @strapi/permissions@workspace:packages/core/permissions":
+"@strapi/permissions@4.9.0, @strapi/permissions@workspace:packages/core/permissions":
   version: 0.0.0-use.local
   resolution: "@strapi/permissions@workspace:packages/core/permissions"
   dependencies:
     "@casl/ability": 5.4.4
-    "@strapi/utils": 4.8.2
+    "@strapi/utils": 4.9.0
     lodash: 4.17.21
     sift: 16.0.0
   languageName: unknown
   linkType: soft
 
-"@strapi/plugin-color-picker@4.8.2, @strapi/plugin-color-picker@workspace:packages/plugins/color-picker":
+"@strapi/plugin-color-picker@4.9.0, @strapi/plugin-color-picker@workspace:packages/plugins/color-picker":
   version: 0.0.0-use.local
   resolution: "@strapi/plugin-color-picker@workspace:packages/plugins/color-picker"
   dependencies:
     "@strapi/design-system": 1.6.6
-    "@strapi/helper-plugin": 4.8.2
+    "@strapi/helper-plugin": 4.9.0
     "@strapi/icons": 1.6.6
     "@testing-library/react": 12.1.4
     prop-types: ^15.7.2
@@ -7274,28 +7274,28 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@strapi/plugin-content-manager@4.8.2, @strapi/plugin-content-manager@workspace:packages/core/content-manager":
+"@strapi/plugin-content-manager@4.9.0, @strapi/plugin-content-manager@workspace:packages/core/content-manager":
   version: 0.0.0-use.local
   resolution: "@strapi/plugin-content-manager@workspace:packages/core/content-manager"
   dependencies:
     "@sindresorhus/slugify": 1.1.0
-    "@strapi/utils": 4.8.2
+    "@strapi/utils": 4.9.0
     lodash: 4.17.21
   languageName: unknown
   linkType: soft
 
-"@strapi/plugin-content-type-builder@4.8.2, @strapi/plugin-content-type-builder@workspace:packages/core/content-type-builder":
+"@strapi/plugin-content-type-builder@4.9.0, @strapi/plugin-content-type-builder@workspace:packages/core/content-type-builder":
   version: 0.0.0-use.local
   resolution: "@strapi/plugin-content-type-builder@workspace:packages/core/content-type-builder"
   dependencies:
     "@sindresorhus/slugify": 1.1.0
-    "@strapi/admin": 4.8.2
+    "@strapi/admin": 4.9.0
     "@strapi/design-system": 1.6.6
-    "@strapi/generators": 4.8.2
-    "@strapi/helper-plugin": 4.8.2
+    "@strapi/generators": 4.9.0
+    "@strapi/helper-plugin": 4.9.0
     "@strapi/icons": 1.6.6
-    "@strapi/strapi": 4.8.2
-    "@strapi/utils": 4.8.2
+    "@strapi/strapi": 4.9.0
+    "@strapi/utils": 4.9.0
     "@testing-library/react": 12.1.4
     "@testing-library/react-hooks": 8.0.1
     fs-extra: 10.0.0
@@ -7324,14 +7324,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@strapi/plugin-documentation@4.8.2, @strapi/plugin-documentation@workspace:packages/plugins/documentation":
+"@strapi/plugin-documentation@4.9.0, @strapi/plugin-documentation@workspace:packages/plugins/documentation":
   version: 0.0.0-use.local
   resolution: "@strapi/plugin-documentation@workspace:packages/plugins/documentation"
   dependencies:
     "@strapi/design-system": 1.6.6
-    "@strapi/helper-plugin": 4.8.2
+    "@strapi/helper-plugin": 4.9.0
     "@strapi/icons": 1.6.6
-    "@strapi/utils": 4.8.2
+    "@strapi/utils": 4.9.0
     "@testing-library/react": 12.1.4
     bcryptjs: 2.4.3
     cheerio: ^1.0.0-rc.12
@@ -7366,15 +7366,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@strapi/plugin-email@4.8.2, @strapi/plugin-email@workspace:packages/core/email":
+"@strapi/plugin-email@4.9.0, @strapi/plugin-email@workspace:packages/core/email":
   version: 0.0.0-use.local
   resolution: "@strapi/plugin-email@workspace:packages/core/email"
   dependencies:
     "@strapi/design-system": 1.6.6
-    "@strapi/helper-plugin": 4.8.2
+    "@strapi/helper-plugin": 4.9.0
     "@strapi/icons": 1.6.6
-    "@strapi/provider-email-sendmail": 4.8.2
-    "@strapi/utils": 4.8.2
+    "@strapi/provider-email-sendmail": 4.9.0
+    "@strapi/utils": 4.9.0
     "@testing-library/react": 12.1.4
     lodash: 4.17.21
     msw: 1.0.0
@@ -7393,16 +7393,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@strapi/plugin-graphql@4.8.2, @strapi/plugin-graphql@workspace:packages/plugins/graphql":
+"@strapi/plugin-graphql@4.9.0, @strapi/plugin-graphql@workspace:packages/plugins/graphql":
   version: 0.0.0-use.local
   resolution: "@strapi/plugin-graphql@workspace:packages/plugins/graphql"
   dependencies:
     "@graphql-tools/schema": 8.5.1
     "@graphql-tools/utils": ^8.12.0
     "@strapi/design-system": 1.6.6
-    "@strapi/helper-plugin": 4.8.2
+    "@strapi/helper-plugin": 4.9.0
     "@strapi/icons": 1.6.6
-    "@strapi/utils": 4.8.2
+    "@strapi/utils": 4.9.0
     apollo-server-core: 3.11.1
     apollo-server-koa: 3.10.0
     cross-env: ^7.0.3
@@ -7430,14 +7430,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@strapi/plugin-i18n@4.8.2, @strapi/plugin-i18n@workspace:packages/plugins/i18n":
+"@strapi/plugin-i18n@4.9.0, @strapi/plugin-i18n@workspace:packages/plugins/i18n":
   version: 0.0.0-use.local
   resolution: "@strapi/plugin-i18n@workspace:packages/plugins/i18n"
   dependencies:
     "@strapi/design-system": 1.6.6
-    "@strapi/helper-plugin": 4.8.2
+    "@strapi/helper-plugin": 4.9.0
     "@strapi/icons": 1.6.6
-    "@strapi/utils": 4.8.2
+    "@strapi/utils": 4.9.0
     "@testing-library/react": 12.1.4
     formik: 2.2.9
     immer: 9.0.19
@@ -7462,13 +7462,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@strapi/plugin-sentry@4.8.2, @strapi/plugin-sentry@workspace:packages/plugins/sentry":
+"@strapi/plugin-sentry@4.9.0, @strapi/plugin-sentry@workspace:packages/plugins/sentry":
   version: 0.0.0-use.local
   resolution: "@strapi/plugin-sentry@workspace:packages/plugins/sentry"
   dependencies:
     "@sentry/node": 6.19.7
     "@strapi/design-system": 1.6.6
-    "@strapi/helper-plugin": 4.8.2
+    "@strapi/helper-plugin": 4.9.0
     "@strapi/icons": 1.6.5
     react: ^17.0.2
     react-dom: ^17.0.2
@@ -7483,15 +7483,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@strapi/plugin-upload@4.8.2, @strapi/plugin-upload@workspace:packages/core/upload":
+"@strapi/plugin-upload@4.9.0, @strapi/plugin-upload@workspace:packages/core/upload":
   version: 0.0.0-use.local
   resolution: "@strapi/plugin-upload@workspace:packages/core/upload"
   dependencies:
     "@strapi/design-system": 1.6.6
-    "@strapi/helper-plugin": 4.8.2
+    "@strapi/helper-plugin": 4.9.0
     "@strapi/icons": 1.6.6
-    "@strapi/provider-upload-local": 4.8.2
-    "@strapi/utils": 4.8.2
+    "@strapi/provider-upload-local": 4.9.0
+    "@strapi/utils": 4.9.0
     "@testing-library/dom": 8.19.0
     "@testing-library/react": 12.1.4
     "@testing-library/react-hooks": 8.0.1
@@ -7532,14 +7532,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@strapi/plugin-users-permissions@4.8.2, @strapi/plugin-users-permissions@workspace:packages/plugins/users-permissions":
+"@strapi/plugin-users-permissions@4.9.0, @strapi/plugin-users-permissions@workspace:packages/plugins/users-permissions":
   version: 0.0.0-use.local
   resolution: "@strapi/plugin-users-permissions@workspace:packages/plugins/users-permissions"
   dependencies:
     "@strapi/design-system": 1.6.6
-    "@strapi/helper-plugin": 4.8.2
+    "@strapi/helper-plugin": 4.9.0
     "@strapi/icons": 1.6.6
-    "@strapi/utils": 4.8.2
+    "@strapi/utils": 4.9.0
     "@testing-library/dom": 8.19.0
     "@testing-library/react": 12.1.4
     "@testing-library/react-hooks": 8.0.1
@@ -7576,7 +7576,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@strapi/provider-audit-logs-local@4.8.2, @strapi/provider-audit-logs-local@workspace:packages/providers/audit-logs-local":
+"@strapi/provider-audit-logs-local@4.9.0, @strapi/provider-audit-logs-local@workspace:packages/providers/audit-logs-local":
   version: 0.0.0-use.local
   resolution: "@strapi/provider-audit-logs-local@workspace:packages/providers/audit-logs-local"
   languageName: unknown
@@ -7586,16 +7586,16 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@strapi/provider-email-amazon-ses@workspace:packages/providers/email-amazon-ses"
   dependencies:
-    "@strapi/utils": 4.8.2
+    "@strapi/utils": 4.9.0
     node-ses: ^3.0.3
   languageName: unknown
   linkType: soft
 
-"@strapi/provider-email-mailgun@4.8.2, @strapi/provider-email-mailgun@workspace:packages/providers/email-mailgun":
+"@strapi/provider-email-mailgun@4.9.0, @strapi/provider-email-mailgun@workspace:packages/providers/email-mailgun":
   version: 0.0.0-use.local
   resolution: "@strapi/provider-email-mailgun@workspace:packages/providers/email-mailgun"
   dependencies:
-    "@strapi/utils": 4.8.2
+    "@strapi/utils": 4.9.0
     form-data: ^4.0.0
     mailgun.js: 5.2.2
   languageName: unknown
@@ -7615,20 +7615,20 @@ __metadata:
   resolution: "@strapi/provider-email-sendgrid@workspace:packages/providers/email-sendgrid"
   dependencies:
     "@sendgrid/mail": 7.7.0
-    "@strapi/utils": 4.8.2
+    "@strapi/utils": 4.9.0
   languageName: unknown
   linkType: soft
 
-"@strapi/provider-email-sendmail@4.8.2, @strapi/provider-email-sendmail@workspace:packages/providers/email-sendmail":
+"@strapi/provider-email-sendmail@4.9.0, @strapi/provider-email-sendmail@workspace:packages/providers/email-sendmail":
   version: 0.0.0-use.local
   resolution: "@strapi/provider-email-sendmail@workspace:packages/providers/email-sendmail"
   dependencies:
-    "@strapi/utils": 4.8.2
+    "@strapi/utils": 4.9.0
     sendmail: ^1.6.1
   languageName: unknown
   linkType: soft
 
-"@strapi/provider-upload-aws-s3@4.8.2, @strapi/provider-upload-aws-s3@workspace:packages/providers/upload-aws-s3":
+"@strapi/provider-upload-aws-s3@4.9.0, @strapi/provider-upload-aws-s3@workspace:packages/providers/upload-aws-s3":
   version: 0.0.0-use.local
   resolution: "@strapi/provider-upload-aws-s3@workspace:packages/providers/upload-aws-s3"
   dependencies:
@@ -7637,44 +7637,44 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@strapi/provider-upload-cloudinary@4.8.2, @strapi/provider-upload-cloudinary@workspace:packages/providers/upload-cloudinary":
+"@strapi/provider-upload-cloudinary@4.9.0, @strapi/provider-upload-cloudinary@workspace:packages/providers/upload-cloudinary":
   version: 0.0.0-use.local
   resolution: "@strapi/provider-upload-cloudinary@workspace:packages/providers/upload-cloudinary"
   dependencies:
-    "@strapi/utils": 4.8.2
+    "@strapi/utils": 4.9.0
     cloudinary: ^1.33.0
     into-stream: ^5.1.0
   languageName: unknown
   linkType: soft
 
-"@strapi/provider-upload-local@4.8.2, @strapi/provider-upload-local@workspace:packages/providers/upload-local":
+"@strapi/provider-upload-local@4.9.0, @strapi/provider-upload-local@workspace:packages/providers/upload-local":
   version: 0.0.0-use.local
   resolution: "@strapi/provider-upload-local@workspace:packages/providers/upload-local"
   dependencies:
-    "@strapi/utils": 4.8.2
+    "@strapi/utils": 4.9.0
     fs-extra: 10.0.0
   languageName: unknown
   linkType: soft
 
-"@strapi/strapi@4.8.2, @strapi/strapi@workspace:packages/core/strapi":
+"@strapi/strapi@4.9.0, @strapi/strapi@workspace:packages/core/strapi":
   version: 0.0.0-use.local
   resolution: "@strapi/strapi@workspace:packages/core/strapi"
   dependencies:
     "@koa/cors": 3.4.3
     "@koa/router": 10.1.1
-    "@strapi/admin": 4.8.2
-    "@strapi/data-transfer": 4.8.2
-    "@strapi/database": 4.8.2
-    "@strapi/generate-new": 4.8.2
-    "@strapi/generators": 4.8.2
-    "@strapi/logger": 4.8.2
-    "@strapi/permissions": 4.8.2
-    "@strapi/plugin-content-manager": 4.8.2
-    "@strapi/plugin-content-type-builder": 4.8.2
-    "@strapi/plugin-email": 4.8.2
-    "@strapi/plugin-upload": 4.8.2
-    "@strapi/typescript-utils": 4.8.2
-    "@strapi/utils": 4.8.2
+    "@strapi/admin": 4.9.0
+    "@strapi/data-transfer": 4.9.0
+    "@strapi/database": 4.9.0
+    "@strapi/generate-new": 4.9.0
+    "@strapi/generators": 4.9.0
+    "@strapi/logger": 4.9.0
+    "@strapi/permissions": 4.9.0
+    "@strapi/plugin-content-manager": 4.9.0
+    "@strapi/plugin-content-type-builder": 4.9.0
+    "@strapi/plugin-email": 4.9.0
+    "@strapi/plugin-upload": 4.9.0
+    "@strapi/typescript-utils": 4.9.0
+    "@strapi/utils": 4.9.0
     bcryptjs: 2.4.3
     boxen: 5.1.2
     chalk: 4.1.2
@@ -7721,7 +7721,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@strapi/typescript-utils@4.8.2, @strapi/typescript-utils@workspace:packages/utils/typescript":
+"@strapi/typescript-utils@4.9.0, @strapi/typescript-utils@workspace:packages/utils/typescript":
   version: 0.0.0-use.local
   resolution: "@strapi/typescript-utils@workspace:packages/utils/typescript"
   dependencies:
@@ -7734,7 +7734,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@strapi/utils@4.8.2, @strapi/utils@workspace:packages/core/utils":
+"@strapi/utils@4.9.0, @strapi/utils@workspace:packages/core/utils":
   version: 0.0.0-use.local
   resolution: "@strapi/utils@workspace:packages/core/utils"
   dependencies:
@@ -13468,7 +13468,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "create-strapi-app@workspace:packages/cli/create-strapi-app"
   dependencies:
-    "@strapi/generate-new": 4.8.2
+    "@strapi/generate-new": 4.9.0
     commander: 8.3.0
     inquirer: 8.2.5
   bin:
@@ -13480,7 +13480,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "create-strapi-starter@workspace:packages/cli/create-strapi-starter"
   dependencies:
-    "@strapi/generate-new": 4.8.2
+    "@strapi/generate-new": 4.9.0
     chalk: 4.1.2
     ci-info: 3.8.0
     commander: 8.3.0
@@ -17204,16 +17204,16 @@ __metadata:
   resolution: "getstarted@workspace:examples/getstarted"
   dependencies:
     "@strapi/icons": 1.6.6
-    "@strapi/plugin-color-picker": 4.8.2
-    "@strapi/plugin-documentation": 4.8.2
-    "@strapi/plugin-graphql": 4.8.2
-    "@strapi/plugin-i18n": 4.8.2
-    "@strapi/plugin-sentry": 4.8.2
-    "@strapi/plugin-users-permissions": 4.8.2
-    "@strapi/provider-email-mailgun": 4.8.2
-    "@strapi/provider-upload-aws-s3": 4.8.2
-    "@strapi/provider-upload-cloudinary": 4.8.2
-    "@strapi/strapi": 4.8.2
+    "@strapi/plugin-color-picker": 4.9.0
+    "@strapi/plugin-documentation": 4.9.0
+    "@strapi/plugin-graphql": 4.9.0
+    "@strapi/plugin-i18n": 4.9.0
+    "@strapi/plugin-sentry": 4.9.0
+    "@strapi/plugin-users-permissions": 4.9.0
+    "@strapi/provider-email-mailgun": 4.9.0
+    "@strapi/provider-upload-aws-s3": 4.9.0
+    "@strapi/provider-upload-cloudinary": 4.9.0
+    "@strapi/strapi": 4.9.0
     "@vscode/sqlite3": 5.1.2
     better-sqlite3: 8.0.1
     lodash: 4.17.21
@@ -20913,9 +20913,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "kitchensink-ts@workspace:examples/kitchensink-ts"
   dependencies:
-    "@strapi/plugin-i18n": 4.8.2
-    "@strapi/plugin-users-permissions": 4.8.2
-    "@strapi/strapi": 4.8.2
+    "@strapi/plugin-i18n": 4.9.0
+    "@strapi/plugin-users-permissions": 4.9.0
+    "@strapi/strapi": 4.9.0
     better-sqlite3: 8.0.1
   languageName: unknown
   linkType: soft
@@ -20924,10 +20924,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "kitchensink@workspace:examples/kitchensink"
   dependencies:
-    "@strapi/provider-email-mailgun": 4.8.2
-    "@strapi/provider-upload-aws-s3": 4.8.2
-    "@strapi/provider-upload-cloudinary": 4.8.2
-    "@strapi/strapi": 4.8.2
+    "@strapi/provider-email-mailgun": 4.9.0
+    "@strapi/provider-upload-aws-s3": 4.9.0
+    "@strapi/provider-upload-cloudinary": 4.9.0
+    "@strapi/strapi": 4.9.0
     lodash: 4.17.21
     mysql: 2.18.1
     passport-google-oauth2: 0.2.0
@@ -28003,7 +28003,7 @@ __metadata:
     simple-get: ^4.0.1
     tar-fs: ^2.1.1
     tunnel-agent: ^0.6.0
-  checksum: 42d00c9c6c61e5cf752c29583253782b3d821ee15fc2648c1f59892b94e9bc170a47ee9d138aa0a61c1c2ee9b7573ee54444c857fff887908701c4208710480d
+  checksum: 82c6046038f45f1fdeb732cff8be6a8a3fb5eb25f46f4c3ecb4b71363c2c387b52de8c0c5c4674f2400663e467b8a7b93dbc5d70b3f0e145cb45fc27d39c5709
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7521,7 +7521,7 @@ __metadata:
     react-router-dom: 5.3.4
     react-select: 5.7.0
     react-test-renderer: ^17.0.2
-    sharp: 0.31.1
+    sharp: 0.32.0
     styled-components: 5.3.3
     yup: ^0.32.9
   peerDependencies:
@@ -27990,9 +27990,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sharp@npm:0.31.1":
-  version: 0.31.1
-  resolution: "sharp@npm:0.31.1"
+"sharp@npm:0.32.0":
+  version: 0.32.0
+  resolution: "sharp@npm:0.32.0"
   dependencies:
     color: ^4.2.3
     detect-libc: ^2.0.1


### PR DESCRIPTION
## Fixes #16227 

### What does it do?

Upgrade `sharp` from `0.31.1` to `0.32.0` to fix the issue described with uploading PNGs in #16227.

### Why is it needed?

PNGs are uploading incorrectly as described in #16227.

### How to test it?

Replication behavior description provided in #16227.

### Related issue(s)/PR(s)

#16227.
