### PR TITLE
Use components that exist

### DIFF
--- a/packages/core/admin/admin/src/content-manager/pages/App/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/App/index.js
@@ -4,7 +4,7 @@ import { Switch, Route, useRouteMatch, Redirect, useLocation } from 'react-route
 import {
   CheckPagePermissions,
   LoadingIndicatorPage,
-  NotFound,
+  AnErrorOccurred,
   useGuidedTour,
 } from '@strapi/helper-plugin';
 import { Layout, HeaderLayout, Main } from '@strapi/design-system';
@@ -104,7 +104,7 @@ const App = () => {
           <Route path="/content-manager/no-content-types">
             <NoContentType />
           </Route>
-          <Route path="" component={NotFound} />
+          <Route path="" component={AnErrorOccurred} />
         </Switch>
       </ModelsContext.Provider>
     </Layout>

--- a/packages/core/admin/admin/src/pages/MarketplacePage/components/EmptyNpmPackageSearch/index.js
+++ b/packages/core/admin/admin/src/pages/MarketplacePage/components/EmptyNpmPackageSearch/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Typography, Box, Flex, Icon } from '@strapi/design-system';
-import { EmptyStateDocument } from '@strapi/icons';
+import { EmptyDocuments } from '@strapi/icons';
 import { EmptyNpmPackageGrid } from './EmptyNpmPackageGrid';
 
 const EmptyNpmPackageSearch = ({ content }) => {
@@ -10,7 +10,7 @@ const EmptyNpmPackageSearch = ({ content }) => {
       <EmptyNpmPackageGrid />
       <Box position="absolute" top={11} width="100%">
         <Flex alignItems="center" justifyContent="center" direction="column">
-          <Icon as={EmptyStateDocument} color="" width="160px" height="88px" />
+          <Icon as={EmptyDocuments} color="" width="160px" height="88px" />
           <Box paddingTop={6}>
             <Typography variant="delta" as="p" textColor="neutral600">
               {content}

--- a/packages/core/content-type-builder/admin/src/components/AttributeOptions/EmptyAttributes/index.js
+++ b/packages/core/content-type-builder/admin/src/components/AttributeOptions/EmptyAttributes/index.js
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { useIntl } from 'react-intl';
 import qs from 'qs';
 import { Box, Flex, Typography, LinkButton, Icon } from '@strapi/design-system';
-import { Plus, EmptyStateDocument } from '@strapi/icons';
+import { Plus, EmptyDocuments } from '@strapi/icons';
 import { getTrad } from '../../../utils';
 
 const EmptyCard = styled(Box)`
@@ -38,7 +38,7 @@ const EmptyAttributes = () => {
       <EmptyCardGrid />
       <Box position="absolute" top={6} width="100%">
         <Flex alignItems="center" justifyContent="center" direction="column">
-          <Icon as={EmptyStateDocument} color="" width="160px" height="88px" />
+          <Icon as={EmptyDocuments} color="" width="160px" height="88px" />
           <Box paddingTop={6} paddingBottom={4}>
             <Box textAlign="center">
               <Typography variant="delta" as="p" textColor="neutral600">

--- a/packages/core/helper-plugin/lib/src/components/CheckPagePermissions/index.js
+++ b/packages/core/helper-plugin/lib/src/components/CheckPagePermissions/index.js
@@ -1,10 +1,10 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { Redirect } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import useNotification from '../../hooks/useNotification';
 import useRBACProvider from '../../hooks/useRBACProvider';
 import hasPermissions from '../../utils/hasPermissions';
 import LoadingIndicatorPage from '../LoadingIndicatorPage';
+import NoPermissions from '../NoPermissions';
 
 const CheckPagePermissions = ({ permissions, children }) => {
   const abortController = new AbortController();
@@ -59,7 +59,7 @@ const CheckPagePermissions = ({ permissions, children }) => {
   }
 
   if (!state.canAccess) {
-    return <Redirect to="/" />;
+    return <NoPermissions />;
   }
 
   return children;

--- a/packages/core/upload/admin/src/components/EmptyAssets/index.js
+++ b/packages/core/upload/admin/src/components/EmptyAssets/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Typography, Flex, Box, Icon } from '@strapi/design-system';
-import { EmptyStateDocuments } from '@strapi/icons';
+import { EmptyDocuments } from '@strapi/icons';
 import { EmptyAssetGrid } from './EmptyAssetGrid';
 
 export const EmptyAssets = ({ icon, content, action, size, count }) => {
@@ -12,7 +12,7 @@ export const EmptyAssets = ({ icon, content, action, size, count }) => {
       <Box position="absolute" top={11} width="100%">
         <Flex direction="column" alignItems="center" gap={4} textAlign="center">
           <Flex direction="column" alignItems="center" gap={6}>
-            <Icon as={icon || EmptyStateDocuments} color="" width="160px" height="88px" />
+            <Icon as={icon || EmptyDocuments} color="" width="160px" height="88px" />
 
             <Typography variant="delta" as="p" textColor="neutral600">
               {content}

--- a/packages/generators/generators/lib/files/ts/plugin/admin/src/pages/App/index.tsx
+++ b/packages/generators/generators/lib/files/ts/plugin/admin/src/pages/App/index.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import { Switch, Route } from 'react-router-dom';
-import { NotFound } from '@strapi/helper-plugin';
+import { AnErrorOccurred } from '@strapi/helper-plugin';
 import pluginId from '../../pluginId';
 import HomePage from '../HomePage';
 
@@ -16,7 +16,7 @@ const App = () => {
     <div>
       <Switch>
         <Route path={`/plugins/${pluginId}`} component={HomePage} exact />
-        <Route component={NotFound} />
+        <Route component={AnErrorOccurred} />
       </Switch>
     </div>
   );

--- a/packages/plugins/users-permissions/admin/src/pages/Roles/index.js
+++ b/packages/plugins/users-permissions/admin/src/pages/Roles/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Switch, Route } from 'react-router-dom';
-import { CheckPagePermissions, NotFound } from '@strapi/helper-plugin';
+import { CheckPagePermissions, AnErrorOccurred } from '@strapi/helper-plugin';
 import pluginId from '../../pluginId';
 import pluginPermissions from '../../permissions';
 import ProtectedRolesListPage from './ProtectedListPage';
@@ -18,7 +18,7 @@ const Roles = () => {
         />
         <Route path={`/settings/${pluginId}/roles/:id`} component={ProtectedRolesEditPage} exact />
         <Route path={`/settings/${pluginId}/roles`} component={ProtectedRolesListPage} exact />
-        <Route path="" component={NotFound} />
+        <Route path="" component={AnErrorOccurred} />
       </Switch>
     </CheckPagePermissions>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -6895,7 +6895,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@strapi/admin@4.8.2, @strapi/admin@workspace:packages/core/admin":
+"@strapi/admin@4.9.0, @strapi/admin@workspace:packages/core/admin":
   version: 0.0.0-use.local
   resolution: "@strapi/admin@workspace:packages/core/admin"
   dependencies:
@@ -6907,15 +6907,15 @@ __metadata:
     "@casl/ability": ^5.4.3
     "@fingerprintjs/fingerprintjs": 3.3.6
     "@pmmmwh/react-refresh-webpack-plugin": 0.5.10
-    "@strapi/babel-plugin-switch-ee-ce": 4.8.2
-    "@strapi/data-transfer": 4.8.2
+    "@strapi/babel-plugin-switch-ee-ce": 4.9.0
+    "@strapi/data-transfer": 4.9.0
     "@strapi/design-system": 1.6.6
-    "@strapi/helper-plugin": 4.8.2
+    "@strapi/helper-plugin": 4.9.0
     "@strapi/icons": 1.6.6
-    "@strapi/permissions": 4.8.2
-    "@strapi/provider-audit-logs-local": 4.8.2
-    "@strapi/typescript-utils": 4.8.2
-    "@strapi/utils": 4.8.2
+    "@strapi/permissions": 4.9.0
+    "@strapi/provider-audit-logs-local": 4.9.0
+    "@strapi/typescript-utils": 4.9.0
+    "@strapi/utils": 4.9.0
     "@testing-library/dom": 8.19.0
     "@testing-library/react": 12.1.4
     "@testing-library/react-hooks": 8.0.1
@@ -7013,7 +7013,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@strapi/babel-plugin-switch-ee-ce@4.8.2, @strapi/babel-plugin-switch-ee-ce@workspace:packages/utils/babel-plugin-switch-ee-ce":
+"@strapi/babel-plugin-switch-ee-ce@4.9.0, @strapi/babel-plugin-switch-ee-ce@workspace:packages/utils/babel-plugin-switch-ee-ce":
   version: 0.0.0-use.local
   resolution: "@strapi/babel-plugin-switch-ee-ce@workspace:packages/utils/babel-plugin-switch-ee-ce"
   dependencies:
@@ -7031,12 +7031,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@strapi/data-transfer@4.8.2, @strapi/data-transfer@workspace:packages/core/data-transfer":
+"@strapi/data-transfer@4.9.0, @strapi/data-transfer@workspace:packages/core/data-transfer":
   version: 0.0.0-use.local
   resolution: "@strapi/data-transfer@workspace:packages/core/data-transfer"
   dependencies:
-    "@strapi/logger": 4.8.2
-    "@strapi/strapi": 4.8.2
+    "@strapi/logger": 4.9.0
+    "@strapi/strapi": 4.9.0
     "@tsconfig/node16": 1.0.3
     "@types/fs-extra": 9.0.13
     "@types/jest": 29.2.0
@@ -7066,7 +7066,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@strapi/database@4.8.2, @strapi/database@workspace:packages/core/database":
+"@strapi/database@4.9.0, @strapi/database@workspace:packages/core/database":
   version: 0.0.0-use.local
   resolution: "@strapi/database@workspace:packages/core/database"
   dependencies:
@@ -7127,7 +7127,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@strapi/generate-new@4.8.2, @strapi/generate-new@workspace:packages/generators/app":
+"@strapi/generate-new@4.9.0, @strapi/generate-new@workspace:packages/generators/app":
   version: 0.0.0-use.local
   resolution: "@strapi/generate-new@workspace:packages/generators/app"
   dependencies:
@@ -7146,13 +7146,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@strapi/generators@4.8.2, @strapi/generators@workspace:packages/generators/generators":
+"@strapi/generators@4.9.0, @strapi/generators@workspace:packages/generators/generators":
   version: 0.0.0-use.local
   resolution: "@strapi/generators@workspace:packages/generators/generators"
   dependencies:
     "@sindresorhus/slugify": 1.1.0
-    "@strapi/typescript-utils": 4.8.2
-    "@strapi/utils": 4.8.2
+    "@strapi/typescript-utils": 4.9.0
+    "@strapi/utils": 4.9.0
     chalk: 4.1.2
     fs-extra: 10.0.0
     node-plop: 0.26.3
@@ -7161,7 +7161,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@strapi/helper-plugin@4.8.2, @strapi/helper-plugin@workspace:packages/core/helper-plugin":
+"@strapi/helper-plugin@4.9.0, @strapi/helper-plugin@workspace:packages/core/helper-plugin":
   version: 0.0.0-use.local
   resolution: "@strapi/helper-plugin@workspace:packages/core/helper-plugin"
   dependencies:
@@ -7229,7 +7229,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@strapi/logger@4.8.2, @strapi/logger@workspace:packages/utils/logger":
+"@strapi/logger@4.9.0, @strapi/logger@workspace:packages/utils/logger":
   version: 0.0.0-use.local
   resolution: "@strapi/logger@workspace:packages/utils/logger"
   dependencies:
@@ -7239,23 +7239,23 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@strapi/permissions@4.8.2, @strapi/permissions@workspace:packages/core/permissions":
+"@strapi/permissions@4.9.0, @strapi/permissions@workspace:packages/core/permissions":
   version: 0.0.0-use.local
   resolution: "@strapi/permissions@workspace:packages/core/permissions"
   dependencies:
     "@casl/ability": 5.4.4
-    "@strapi/utils": 4.8.2
+    "@strapi/utils": 4.9.0
     lodash: 4.17.21
     sift: 16.0.0
   languageName: unknown
   linkType: soft
 
-"@strapi/plugin-color-picker@4.8.2, @strapi/plugin-color-picker@workspace:packages/plugins/color-picker":
+"@strapi/plugin-color-picker@4.9.0, @strapi/plugin-color-picker@workspace:packages/plugins/color-picker":
   version: 0.0.0-use.local
   resolution: "@strapi/plugin-color-picker@workspace:packages/plugins/color-picker"
   dependencies:
     "@strapi/design-system": 1.6.6
-    "@strapi/helper-plugin": 4.8.2
+    "@strapi/helper-plugin": 4.9.0
     "@strapi/icons": 1.6.6
     "@testing-library/react": 12.1.4
     prop-types: ^15.7.2
@@ -7274,28 +7274,28 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@strapi/plugin-content-manager@4.8.2, @strapi/plugin-content-manager@workspace:packages/core/content-manager":
+"@strapi/plugin-content-manager@4.9.0, @strapi/plugin-content-manager@workspace:packages/core/content-manager":
   version: 0.0.0-use.local
   resolution: "@strapi/plugin-content-manager@workspace:packages/core/content-manager"
   dependencies:
     "@sindresorhus/slugify": 1.1.0
-    "@strapi/utils": 4.8.2
+    "@strapi/utils": 4.9.0
     lodash: 4.17.21
   languageName: unknown
   linkType: soft
 
-"@strapi/plugin-content-type-builder@4.8.2, @strapi/plugin-content-type-builder@workspace:packages/core/content-type-builder":
+"@strapi/plugin-content-type-builder@4.9.0, @strapi/plugin-content-type-builder@workspace:packages/core/content-type-builder":
   version: 0.0.0-use.local
   resolution: "@strapi/plugin-content-type-builder@workspace:packages/core/content-type-builder"
   dependencies:
     "@sindresorhus/slugify": 1.1.0
-    "@strapi/admin": 4.8.2
+    "@strapi/admin": 4.9.0
     "@strapi/design-system": 1.6.6
-    "@strapi/generators": 4.8.2
-    "@strapi/helper-plugin": 4.8.2
+    "@strapi/generators": 4.9.0
+    "@strapi/helper-plugin": 4.9.0
     "@strapi/icons": 1.6.6
-    "@strapi/strapi": 4.8.2
-    "@strapi/utils": 4.8.2
+    "@strapi/strapi": 4.9.0
+    "@strapi/utils": 4.9.0
     "@testing-library/react": 12.1.4
     "@testing-library/react-hooks": 8.0.1
     fs-extra: 10.0.0
@@ -7324,14 +7324,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@strapi/plugin-documentation@4.8.2, @strapi/plugin-documentation@workspace:packages/plugins/documentation":
+"@strapi/plugin-documentation@4.9.0, @strapi/plugin-documentation@workspace:packages/plugins/documentation":
   version: 0.0.0-use.local
   resolution: "@strapi/plugin-documentation@workspace:packages/plugins/documentation"
   dependencies:
     "@strapi/design-system": 1.6.6
-    "@strapi/helper-plugin": 4.8.2
+    "@strapi/helper-plugin": 4.9.0
     "@strapi/icons": 1.6.6
-    "@strapi/utils": 4.8.2
+    "@strapi/utils": 4.9.0
     "@testing-library/react": 12.1.4
     bcryptjs: 2.4.3
     cheerio: ^1.0.0-rc.12
@@ -7366,15 +7366,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@strapi/plugin-email@4.8.2, @strapi/plugin-email@workspace:packages/core/email":
+"@strapi/plugin-email@4.9.0, @strapi/plugin-email@workspace:packages/core/email":
   version: 0.0.0-use.local
   resolution: "@strapi/plugin-email@workspace:packages/core/email"
   dependencies:
     "@strapi/design-system": 1.6.6
-    "@strapi/helper-plugin": 4.8.2
+    "@strapi/helper-plugin": 4.9.0
     "@strapi/icons": 1.6.6
-    "@strapi/provider-email-sendmail": 4.8.2
-    "@strapi/utils": 4.8.2
+    "@strapi/provider-email-sendmail": 4.9.0
+    "@strapi/utils": 4.9.0
     "@testing-library/react": 12.1.4
     lodash: 4.17.21
     msw: 1.0.0
@@ -7393,16 +7393,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@strapi/plugin-graphql@4.8.2, @strapi/plugin-graphql@workspace:packages/plugins/graphql":
+"@strapi/plugin-graphql@4.9.0, @strapi/plugin-graphql@workspace:packages/plugins/graphql":
   version: 0.0.0-use.local
   resolution: "@strapi/plugin-graphql@workspace:packages/plugins/graphql"
   dependencies:
     "@graphql-tools/schema": 8.5.1
     "@graphql-tools/utils": ^8.12.0
     "@strapi/design-system": 1.6.6
-    "@strapi/helper-plugin": 4.8.2
+    "@strapi/helper-plugin": 4.9.0
     "@strapi/icons": 1.6.6
-    "@strapi/utils": 4.8.2
+    "@strapi/utils": 4.9.0
     apollo-server-core: 3.11.1
     apollo-server-koa: 3.10.0
     cross-env: ^7.0.3
@@ -7430,14 +7430,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@strapi/plugin-i18n@4.8.2, @strapi/plugin-i18n@workspace:packages/plugins/i18n":
+"@strapi/plugin-i18n@4.9.0, @strapi/plugin-i18n@workspace:packages/plugins/i18n":
   version: 0.0.0-use.local
   resolution: "@strapi/plugin-i18n@workspace:packages/plugins/i18n"
   dependencies:
     "@strapi/design-system": 1.6.6
-    "@strapi/helper-plugin": 4.8.2
+    "@strapi/helper-plugin": 4.9.0
     "@strapi/icons": 1.6.6
-    "@strapi/utils": 4.8.2
+    "@strapi/utils": 4.9.0
     "@testing-library/react": 12.1.4
     formik: 2.2.9
     immer: 9.0.19
@@ -7462,13 +7462,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@strapi/plugin-sentry@4.8.2, @strapi/plugin-sentry@workspace:packages/plugins/sentry":
+"@strapi/plugin-sentry@4.9.0, @strapi/plugin-sentry@workspace:packages/plugins/sentry":
   version: 0.0.0-use.local
   resolution: "@strapi/plugin-sentry@workspace:packages/plugins/sentry"
   dependencies:
     "@sentry/node": 6.19.7
     "@strapi/design-system": 1.6.6
-    "@strapi/helper-plugin": 4.8.2
+    "@strapi/helper-plugin": 4.9.0
     "@strapi/icons": 1.6.5
     react: ^17.0.2
     react-dom: ^17.0.2
@@ -7483,15 +7483,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@strapi/plugin-upload@4.8.2, @strapi/plugin-upload@workspace:packages/core/upload":
+"@strapi/plugin-upload@4.9.0, @strapi/plugin-upload@workspace:packages/core/upload":
   version: 0.0.0-use.local
   resolution: "@strapi/plugin-upload@workspace:packages/core/upload"
   dependencies:
     "@strapi/design-system": 1.6.6
-    "@strapi/helper-plugin": 4.8.2
+    "@strapi/helper-plugin": 4.9.0
     "@strapi/icons": 1.6.6
-    "@strapi/provider-upload-local": 4.8.2
-    "@strapi/utils": 4.8.2
+    "@strapi/provider-upload-local": 4.9.0
+    "@strapi/utils": 4.9.0
     "@testing-library/dom": 8.19.0
     "@testing-library/react": 12.1.4
     "@testing-library/react-hooks": 8.0.1
@@ -7532,14 +7532,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@strapi/plugin-users-permissions@4.8.2, @strapi/plugin-users-permissions@workspace:packages/plugins/users-permissions":
+"@strapi/plugin-users-permissions@4.9.0, @strapi/plugin-users-permissions@workspace:packages/plugins/users-permissions":
   version: 0.0.0-use.local
   resolution: "@strapi/plugin-users-permissions@workspace:packages/plugins/users-permissions"
   dependencies:
     "@strapi/design-system": 1.6.6
-    "@strapi/helper-plugin": 4.8.2
+    "@strapi/helper-plugin": 4.9.0
     "@strapi/icons": 1.6.6
-    "@strapi/utils": 4.8.2
+    "@strapi/utils": 4.9.0
     "@testing-library/dom": 8.19.0
     "@testing-library/react": 12.1.4
     "@testing-library/react-hooks": 8.0.1
@@ -7576,7 +7576,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@strapi/provider-audit-logs-local@4.8.2, @strapi/provider-audit-logs-local@workspace:packages/providers/audit-logs-local":
+"@strapi/provider-audit-logs-local@4.9.0, @strapi/provider-audit-logs-local@workspace:packages/providers/audit-logs-local":
   version: 0.0.0-use.local
   resolution: "@strapi/provider-audit-logs-local@workspace:packages/providers/audit-logs-local"
   languageName: unknown
@@ -7586,16 +7586,16 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@strapi/provider-email-amazon-ses@workspace:packages/providers/email-amazon-ses"
   dependencies:
-    "@strapi/utils": 4.8.2
+    "@strapi/utils": 4.9.0
     node-ses: ^3.0.3
   languageName: unknown
   linkType: soft
 
-"@strapi/provider-email-mailgun@4.8.2, @strapi/provider-email-mailgun@workspace:packages/providers/email-mailgun":
+"@strapi/provider-email-mailgun@4.9.0, @strapi/provider-email-mailgun@workspace:packages/providers/email-mailgun":
   version: 0.0.0-use.local
   resolution: "@strapi/provider-email-mailgun@workspace:packages/providers/email-mailgun"
   dependencies:
-    "@strapi/utils": 4.8.2
+    "@strapi/utils": 4.9.0
     form-data: ^4.0.0
     mailgun.js: 5.2.2
   languageName: unknown
@@ -7615,20 +7615,20 @@ __metadata:
   resolution: "@strapi/provider-email-sendgrid@workspace:packages/providers/email-sendgrid"
   dependencies:
     "@sendgrid/mail": 7.7.0
-    "@strapi/utils": 4.8.2
+    "@strapi/utils": 4.9.0
   languageName: unknown
   linkType: soft
 
-"@strapi/provider-email-sendmail@4.8.2, @strapi/provider-email-sendmail@workspace:packages/providers/email-sendmail":
+"@strapi/provider-email-sendmail@4.9.0, @strapi/provider-email-sendmail@workspace:packages/providers/email-sendmail":
   version: 0.0.0-use.local
   resolution: "@strapi/provider-email-sendmail@workspace:packages/providers/email-sendmail"
   dependencies:
-    "@strapi/utils": 4.8.2
+    "@strapi/utils": 4.9.0
     sendmail: ^1.6.1
   languageName: unknown
   linkType: soft
 
-"@strapi/provider-upload-aws-s3@4.8.2, @strapi/provider-upload-aws-s3@workspace:packages/providers/upload-aws-s3":
+"@strapi/provider-upload-aws-s3@4.9.0, @strapi/provider-upload-aws-s3@workspace:packages/providers/upload-aws-s3":
   version: 0.0.0-use.local
   resolution: "@strapi/provider-upload-aws-s3@workspace:packages/providers/upload-aws-s3"
   dependencies:
@@ -7637,44 +7637,44 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@strapi/provider-upload-cloudinary@4.8.2, @strapi/provider-upload-cloudinary@workspace:packages/providers/upload-cloudinary":
+"@strapi/provider-upload-cloudinary@4.9.0, @strapi/provider-upload-cloudinary@workspace:packages/providers/upload-cloudinary":
   version: 0.0.0-use.local
   resolution: "@strapi/provider-upload-cloudinary@workspace:packages/providers/upload-cloudinary"
   dependencies:
-    "@strapi/utils": 4.8.2
+    "@strapi/utils": 4.9.0
     cloudinary: ^1.33.0
     into-stream: ^5.1.0
   languageName: unknown
   linkType: soft
 
-"@strapi/provider-upload-local@4.8.2, @strapi/provider-upload-local@workspace:packages/providers/upload-local":
+"@strapi/provider-upload-local@4.9.0, @strapi/provider-upload-local@workspace:packages/providers/upload-local":
   version: 0.0.0-use.local
   resolution: "@strapi/provider-upload-local@workspace:packages/providers/upload-local"
   dependencies:
-    "@strapi/utils": 4.8.2
+    "@strapi/utils": 4.9.0
     fs-extra: 10.0.0
   languageName: unknown
   linkType: soft
 
-"@strapi/strapi@4.8.2, @strapi/strapi@workspace:packages/core/strapi":
+"@strapi/strapi@4.9.0, @strapi/strapi@workspace:packages/core/strapi":
   version: 0.0.0-use.local
   resolution: "@strapi/strapi@workspace:packages/core/strapi"
   dependencies:
     "@koa/cors": 3.4.3
     "@koa/router": 10.1.1
-    "@strapi/admin": 4.8.2
-    "@strapi/data-transfer": 4.8.2
-    "@strapi/database": 4.8.2
-    "@strapi/generate-new": 4.8.2
-    "@strapi/generators": 4.8.2
-    "@strapi/logger": 4.8.2
-    "@strapi/permissions": 4.8.2
-    "@strapi/plugin-content-manager": 4.8.2
-    "@strapi/plugin-content-type-builder": 4.8.2
-    "@strapi/plugin-email": 4.8.2
-    "@strapi/plugin-upload": 4.8.2
-    "@strapi/typescript-utils": 4.8.2
-    "@strapi/utils": 4.8.2
+    "@strapi/admin": 4.9.0
+    "@strapi/data-transfer": 4.9.0
+    "@strapi/database": 4.9.0
+    "@strapi/generate-new": 4.9.0
+    "@strapi/generators": 4.9.0
+    "@strapi/logger": 4.9.0
+    "@strapi/permissions": 4.9.0
+    "@strapi/plugin-content-manager": 4.9.0
+    "@strapi/plugin-content-type-builder": 4.9.0
+    "@strapi/plugin-email": 4.9.0
+    "@strapi/plugin-upload": 4.9.0
+    "@strapi/typescript-utils": 4.9.0
+    "@strapi/utils": 4.9.0
     bcryptjs: 2.4.3
     boxen: 5.1.2
     chalk: 4.1.2
@@ -7721,7 +7721,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@strapi/typescript-utils@4.8.2, @strapi/typescript-utils@workspace:packages/utils/typescript":
+"@strapi/typescript-utils@4.9.0, @strapi/typescript-utils@workspace:packages/utils/typescript":
   version: 0.0.0-use.local
   resolution: "@strapi/typescript-utils@workspace:packages/utils/typescript"
   dependencies:
@@ -7734,7 +7734,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@strapi/utils@4.8.2, @strapi/utils@workspace:packages/core/utils":
+"@strapi/utils@4.9.0, @strapi/utils@workspace:packages/core/utils":
   version: 0.0.0-use.local
   resolution: "@strapi/utils@workspace:packages/core/utils"
   dependencies:
@@ -13468,7 +13468,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "create-strapi-app@workspace:packages/cli/create-strapi-app"
   dependencies:
-    "@strapi/generate-new": 4.8.2
+    "@strapi/generate-new": 4.9.0
     commander: 8.3.0
     inquirer: 8.2.5
   bin:
@@ -13480,7 +13480,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "create-strapi-starter@workspace:packages/cli/create-strapi-starter"
   dependencies:
-    "@strapi/generate-new": 4.8.2
+    "@strapi/generate-new": 4.9.0
     chalk: 4.1.2
     ci-info: 3.8.0
     commander: 8.3.0
@@ -17204,16 +17204,16 @@ __metadata:
   resolution: "getstarted@workspace:examples/getstarted"
   dependencies:
     "@strapi/icons": 1.6.6
-    "@strapi/plugin-color-picker": 4.8.2
-    "@strapi/plugin-documentation": 4.8.2
-    "@strapi/plugin-graphql": 4.8.2
-    "@strapi/plugin-i18n": 4.8.2
-    "@strapi/plugin-sentry": 4.8.2
-    "@strapi/plugin-users-permissions": 4.8.2
-    "@strapi/provider-email-mailgun": 4.8.2
-    "@strapi/provider-upload-aws-s3": 4.8.2
-    "@strapi/provider-upload-cloudinary": 4.8.2
-    "@strapi/strapi": 4.8.2
+    "@strapi/plugin-color-picker": 4.9.0
+    "@strapi/plugin-documentation": 4.9.0
+    "@strapi/plugin-graphql": 4.9.0
+    "@strapi/plugin-i18n": 4.9.0
+    "@strapi/plugin-sentry": 4.9.0
+    "@strapi/plugin-users-permissions": 4.9.0
+    "@strapi/provider-email-mailgun": 4.9.0
+    "@strapi/provider-upload-aws-s3": 4.9.0
+    "@strapi/provider-upload-cloudinary": 4.9.0
+    "@strapi/strapi": 4.9.0
     "@vscode/sqlite3": 5.1.2
     better-sqlite3: 8.0.1
     lodash: 4.17.21
@@ -20913,9 +20913,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "kitchensink-ts@workspace:examples/kitchensink-ts"
   dependencies:
-    "@strapi/plugin-i18n": 4.8.2
-    "@strapi/plugin-users-permissions": 4.8.2
-    "@strapi/strapi": 4.8.2
+    "@strapi/plugin-i18n": 4.9.0
+    "@strapi/plugin-users-permissions": 4.9.0
+    "@strapi/strapi": 4.9.0
     better-sqlite3: 8.0.1
   languageName: unknown
   linkType: soft
@@ -20924,10 +20924,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "kitchensink@workspace:examples/kitchensink"
   dependencies:
-    "@strapi/provider-email-mailgun": 4.8.2
-    "@strapi/provider-upload-aws-s3": 4.8.2
-    "@strapi/provider-upload-cloudinary": 4.8.2
-    "@strapi/strapi": 4.8.2
+    "@strapi/provider-email-mailgun": 4.9.0
+    "@strapi/provider-upload-aws-s3": 4.9.0
+    "@strapi/provider-upload-cloudinary": 4.9.0
+    "@strapi/strapi": 4.9.0
     lodash: 4.17.21
     mysql: 2.18.1
     passport-google-oauth2: 0.2.0


### PR DESCRIPTION
### What does it do?

There are two components being used that don't actually exist. NotFound from the helper-plugin and EmptyStateDocument. This PR replaces them with components that do exist.

### Why is it needed?

A component needs to exist for it to be used

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
