### PR TITLE
Add workflowInputs & remove-dist-tag action

### DIFF
--- a/.github/workflows/remove-dist-tag.yml
+++ b/.github/workflows/remove-dist-tag.yml
@@ -1,11 +1,11 @@
-name: 'Experimental Releases'
+name: 'Remove dist-tag from NPM'
 
 on:
   workflow_dispatch:
     inputs:
       dist-tag:
         description: 'The tag you want to remove from NPM'
-        default: 'experimental'
+        required: true
 
 permissions:
   contents: read # to fetch code (actions/checkout)
@@ -23,7 +23,6 @@ jobs:
         with:
           node-version: 16
       - run: yarn
-      - run: ./scripts/pre-publish.sh --yes
+      - run: ./scripts/remove-dist-tag
         env:
-          VERSION: '0.0.0-experimental.${{ github.sha }}'
           DIST_TAG: ${{ github.event.inputs.dist-tag }}

--- a/scripts/remove-dist-tag.sh
+++ b/scripts/remove-dist-tag.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Force start from root folder
+cd "$(dirname "$0")/.."
+
+set -e
+
+distTag=$DIST_TAG
+
+if [[ -z "$distTag" ]]; then
+  echo "Please enter the dist-tag you want to remove"
+  read -r distTag
+fi
+
+# Check if dist tag is latest, beta, alpha or next and reject
+if [[ "$distTag" == "latest" || "$distTag" == "beta" || "$distTag" == "alpha" || "$distTag" == "next" ]]; then
+  echo "You cannot remove the dist-tag $distTag"
+  exit 1
+fi
+
+# Get all the packages
+packages=$(./node_modules/.bin/lerna ls)
+
+# Loop through the packages
+for package in $packages; do
+  echo "Removing dist-tag $distTag from $package"
+  # Run npm dist-tag rm $distTag
+  npm dist-tag rm $package $distTag
+done


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* Adds `inputs` to experimental workflow
* Adds `remove-dist-tag.sh` script
* Adds `remove-dist-tag` workflow

### Why is it needed?

* We'll be able to publish custom dist-tags with experimentals e.g. `react18` so it's easier to share externally
* We can complete delete a dist-tag from the strapi packages once we're done (with the exception of `latest`, `beta`, `alpha` and `next`).
