### PR TITLE
[documentation-plugin] Add persistance to swaggerUi credentials.

### DIFF
--- a/packages/plugins/documentation/server/public/index.html
+++ b/packages/plugins/documentation/server/public/index.html
@@ -58,6 +58,7 @@
             SwaggerUIBundle.plugins.DownloadUrl,
           ],
           layout: "StandaloneLayout",
+          persistAuthorization: true,
         });
 
         window.ui = ui;


### PR DESCRIPTION
This option is very good as it allows you to test your apis while remaining logged in even after a refresh.

This is a draft pull request because it is necessary to update the documentation and perhaps add a parameter to activate/deactivate this feature.

### What does it do?

I have added an option to enable "persistAuthorization" for SwaggerUi.

### Why is it needed?

It is needed for testing your apis and remaining logged in even after a refresh.

### How to test it?

1. Set a token via SwaggerUi's "Authorize" button;
2. Refresh the page;
3. Check that the previous credential is still set.