### PR TITLE
Init Git on project creation

### DIFF
--- a/packages/generators/app/src/create-project.ts
+++ b/packages/generators/app/src/create-project.ts
@@ -9,6 +9,7 @@ import _ from 'lodash';
 import stopProcess from './utils/stop-process';
 import { trackUsage, captureStderr } from './utils/usage';
 import mergeTemplate from './utils/merge-template.js';
+import tryGitInit from './utils/git';
 
 import packageJSON from './resources/json/common/package.json';
 import { createDatabaseConfig, generateDbEnvariables } from './resources/templates/database';
@@ -183,6 +184,12 @@ export default async function createProject(
   }
 
   await trackUsage({ event: 'didCreateProject', scope });
+
+  // Init git
+  if (await tryGitInit(rootPath)) {
+    console.log('Initialized a git repository.');
+    console.log();
+  }
 
   console.log();
   console.log(`Your application was created at ${chalk.green(rootPath)}.\n`);

--- a/packages/generators/app/src/utils/git.ts
+++ b/packages/generators/app/src/utils/git.ts
@@ -1,0 +1,34 @@
+import execa from 'execa';
+
+async function isInGitRepository(rootDir: string) {
+  try {
+    await execa('git', ['rev-parse', '--is-inside-work-tree'], { stdio: 'ignore', cwd: rootDir });
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
+async function isInMercurialRepository(rootDir: string) {
+  try {
+    await execa('hg', ['-cwd', '.', 'root'], { stdio: 'ignore', cwd: rootDir });
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
+export default async function tryGitInit(rootDir: string) {
+  try {
+    await execa('git', ['--version'], { stdio: 'ignore' });
+    if ((await isInGitRepository(rootDir)) || (await isInMercurialRepository(rootDir))) {
+      return false;
+    }
+
+    await execa('git', ['init'], { stdio: 'ignore', cwd: rootDir });
+
+    return true;
+  } catch (_) {
+    return false;
+  }
+}


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Automatically init a Git repository in any newly created Strapi project.

### Why is it needed?

It avoids users having to do this manually.

### How to test it?

 - Clone this repository
 - Run `yarn`.
 - Run `yarn setup`.
 - In `test/helpers/test-app-generator.js`, replace `rootPath: path.resolve(appName),` with `rootPath: path.resolve('..', appName),` so the new project will be created outside of the `strapi` folder (which already has Git initiated).
 -  Run `yarn test:generate-app sqlite`.

### Related issue(s)/PR(s)

None.
