### PR TITLE
[Fix]: S3 Upload Provider "baseUrl" for Video uploads on DO spaces

### DIFF
--- a/packages/providers/upload-aws-s3/lib/__tests__/upload-aws-s3.test.js
+++ b/packages/providers/upload-aws-s3/lib/__tests__/upload-aws-s3.test.js
@@ -61,7 +61,7 @@ describe('AWS-S3 provider', () => {
       const providerInstance = awsProvider.init({ baseUrl: 'https://cdn.test' });
 
       S3InstanceMock.upload.mockImplementationOnce((params, callback) =>
-        callback(null, { Location: 'https://validurl.test' })
+        callback(null, { Location: 'validurl.test' })
       );
       const file = {
         path: 'tmp/test',

--- a/packages/providers/upload-aws-s3/lib/index.js
+++ b/packages/providers/upload-aws-s3/lib/index.js
@@ -10,7 +10,7 @@ const { getOr } = require('lodash/fp');
 const AWS = require('aws-sdk');
 const { isUrlFromBucket } = require('./utils');
 
-function assertUrlProtocol(url) {
+function hasUrlProtocol(url) {
   // Regex to test protocol like "http://", "https://"
   return /^\w*:\/\//.test(url);
 }

--- a/packages/providers/upload-aws-s3/lib/index.js
+++ b/packages/providers/upload-aws-s3/lib/index.js
@@ -65,13 +65,15 @@ module.exports = {
               return reject(err);
             }
 
-            // set the bucket file url
-            if (assertUrlProtocol(data.Location)) {
-              file.url = baseUrl ? `${baseUrl}/${fileKey}` : data.Location;
+            if (baseUrl) {
+              // Construct the url with the baseUrl
+              file.url = `${baseUrl}/${fileKey}`;
             } else {
-              // Default protocol to https protocol
-              file.url = `https://${data.Location}`;
+              // Add the protocol if it is missing
+              // Some providers like DigitalOcean Spaces return the url without the protocol
+              file.url = hasUrlProtocol(data.Location) ? data.Location : `https://${data.Location}`;
             }
+
             resolve();
           }
         );


### PR DESCRIPTION
### What does it do?

Ignores data.Location when CDN baseUrl is set.

Some users complained videos where not using the baseUrl when using DO spaces, and that is because it does not return the url with any protocol.

### Why is it needed?
So videos using DO spaces use the baseUrl CDN.


### How to test it?
Using a CDN url (ask me if you don't have one) try to upload a video or any file and see if it uses the CDN baseURL.

### Related issue(s)/PR(s)
Fixes: https://github.com/strapi/strapi/issues/16247