### PR TITLE
[Fix]: Reorder relations with null order values

### DIFF
--- a/packages/core/database/lib/entity-manager/__tests__/relations-orderer.test.js
+++ b/packages/core/database/lib/entity-manager/__tests__/relations-orderer.test.js
@@ -121,6 +121,28 @@ describe('Given I have some relations in the database', () => {
       ]);
     });
   });
+
+  describe('When you connect a relation before one with null order', () => {
+    test('Then it is placed at the end with the correct order', () => {
+      const orderer = relationsOrderer(
+        [
+          { id: 2, order: null },
+          { id: 3, order: null },
+        ],
+        'id',
+        'order'
+      );
+
+      orderer.connect([{ id: 4, position: { before: 3 } }, { id: 5 }]);
+
+      expect(orderer.get()).toMatchObject([
+        { id: 2, order: 1 },
+        { id: 4, order: 0.5 },
+        { id: 3, order: 1 },
+        { id: 5, order: 1.5 },
+      ]);
+    });
+  });
 });
 
 describe('Given there are no relations in the database', () => {

--- a/packages/core/database/lib/entity-manager/relations-orderer.js
+++ b/packages/core/database/lib/entity-manager/relations-orderer.js
@@ -135,7 +135,7 @@ const relationsOrderer = (initArr, idColumn, orderColumn, strict) => {
   const computedRelations = _.castArray(initArr || []).map((r) => ({
     init: true,
     id: r[idColumn],
-    order: r[orderColumn],
+    order: r[orderColumn] || 1,
   }));
 
   const maxOrder = _.maxBy('order', computedRelations)?.order || 0;


### PR DESCRIPTION
### What does it do?
Prevents order value to be negative in case database relations orders are null.

### Why is it needed?
People migrating from older versions might have null relation order values, that resulted in some errors if you tried to reorder a relation.

This does not completely solves the issue, which is having null order values, but to prevent migrations we decided to do it this way.

The first time you add a relation for the entity its relations order values are recomputed, so eventually all order values should be ok.

### How to test it?

- See unit test.

### Related issue(s)/PR(s)

Fixes https://github.com/strapi/strapi/issues/15987