### PR TITLE
Fix typo in build:measure script

### DIFF
--- a/packages/core/admin/package.json
+++ b/packages/core/admin/package.json
@@ -28,7 +28,7 @@
     "develop:webpack": "cross-env NODE_ENV=development webpack serve --config webpack.config.dev.js --progress profile",
     "prepublishOnly": "yarn build",
     "build": "rimraf build && node ./scripts/build.js",
-    "build:mesure": "rimraf build && cross-env MESURE_BUILD_SPEED=true node ./scripts/build.js",
+    "build:measure": "rimraf build && cross-env MEASURE_BUILD_SPEED=true node ./scripts/build.js",
     "test": "echo \"no tests yet\"",
     "test:unit": "jest",
     "test:unit:watch": "jest --watch",


### PR DESCRIPTION
### What does it do?

Fixes the packages/core/admin `build:measure` script which was previously called `build:mesure` and sending an env variable that was similarly misspelled, so it wasn't working.

### Why is it needed?

Makes the build:measure script work

### How to test it?

Run `yarn build:measure` from packages/core/admin

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
