### PR TITLE
[Fix]: Do not throw if localizations entry is empty

### DIFF
--- a/packages/plugins/i18n/server/services/localizations.js
+++ b/packages/plugins/i18n/server/services/localizations.js
@@ -31,7 +31,7 @@ const assignDefaultLocaleToEntries = async (data) => {
  * @param {Object} options.model corresponding model
  */
 const syncLocalizations = async (entry, { model }) => {
-  if (Array.isArray(entry.localizations)) {
+  if (Array.isArray(entry?.localizations)) {
     const newLocalizations = [entry.id, ...entry.localizations.map(prop('id'))];
 
     const updateLocalization = (id) => {
@@ -56,7 +56,7 @@ const syncLocalizations = async (entry, { model }) => {
 const syncNonLocalizedAttributes = async (entry, { model }) => {
   const { copyNonLocalizedAttributes } = getService('content-types');
 
-  if (Array.isArray(entry.localizations)) {
+  if (Array.isArray(entry?.localizations)) {
     const nonLocalizedAttributes = copyNonLocalizedAttributes(model, entry);
 
     if (isEmpty(nonLocalizedAttributes)) {


### PR DESCRIPTION
### What does it do?

When you try to update an entity that not exists and has internationalization enabled, Strapi will throw a 500 error.
Example: [PUT] api/collection-name/id-that-not-exists.

### Why is it needed?

So you receive a 400 Not found error.

### Related issue(s)/PR(s)

Fixes: #16306
