### PR TITLE
chore: update aws sdk

### DIFF
--- a/packages/providers/upload-aws-s3/lib/index.js
+++ b/packages/providers/upload-aws-s3/lib/index.js
@@ -7,6 +7,7 @@
 /* eslint-disable no-unused-vars */
 // Public node modules.
 const { getOr } = require('lodash/fp');
+require('aws-sdk/lib/maintenance_mode_message').suppress = true;
 const AWS = require('aws-sdk');
 const { getBucketFromUrl } = require('./utils');
 

--- a/packages/providers/upload-aws-s3/lib/index.js
+++ b/packages/providers/upload-aws-s3/lib/index.js
@@ -7,6 +7,7 @@
 /* eslint-disable no-unused-vars */
 // Public node modules.
 const { getOr } = require('lodash/fp');
+// TODO V5: Migrate to aws-sdk v3
 require('aws-sdk/lib/maintenance_mode_message').suppress = true;
 const AWS = require('aws-sdk');
 const { getBucketFromUrl } = require('./utils');

--- a/packages/providers/upload-aws-s3/package.json
+++ b/packages/providers/upload-aws-s3/package.json
@@ -39,7 +39,7 @@
     "lint": "run -T eslint ."
   },
   "dependencies": {
-    "aws-sdk": "2.1287.0",
+    "aws-sdk": "2.1351.0",
     "lodash": "4.17.21"
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7712,7 +7712,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@strapi/provider-upload-aws-s3@workspace:packages/providers/upload-aws-s3"
   dependencies:
-    aws-sdk: 2.1287.0
+    aws-sdk: 2.1351.0
     lodash: 4.17.21
   languageName: unknown
   linkType: soft
@@ -10925,9 +10925,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"aws-sdk@npm:2.1287.0":
-  version: 2.1287.0
-  resolution: "aws-sdk@npm:2.1287.0"
+"aws-sdk@npm:2.1351.0":
+  version: 2.1351.0
+  resolution: "aws-sdk@npm:2.1351.0"
   dependencies:
     buffer: 4.9.2
     events: 1.1.1
@@ -10939,7 +10939,7 @@ __metadata:
     util: ^0.12.4
     uuid: 8.0.0
     xml2js: 0.4.19
-  checksum: 528bbddd87b49782f50bfd4763c7d7c2b45f6c71ef3f303c72e0881e2799fff81d7fa24aa09af8e5fd493e9ce396437529d3dd6db6d53cde4ba78bd9ede53cd4
+  checksum: e0ff895e40e10ca79cd9af6706a6f0a731112812caea7a08cffcb0ab9d21146100ad8795c29f441f7c5fa19f42f50824d75da98e43f0e1ed52f13d5d4bb5fb2e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What does it do?

Updated aws-sdk package and ignores deprecation warning, which might be confusing for the users.

### Why is it needed?

New versions of the v2 sdk log this:
```
The AWS SDK for JavaScript (v2) will be put into maintenance mode in 2023.
Please migrate your code to use AWS SDK for JavaScript (v3).
```

We also have this PR open https://github.com/strapi/strapi/pull/16319 to migrate the sdk to v3.

### How to test it?
Run strapi and see no warning message.

### Related issue(s)/PR(s)

Closes https://github.com/strapi/strapi/pull/16045
