### PR TITLE
Fix the check for any legacyS3Options remaining

### DIFF
--- a/packages/providers/upload-aws-s3/lib/index.js
+++ b/packages/providers/upload-aws-s3/lib/index.js
@@ -17,7 +17,7 @@ function assertUrlProtocol(url) {
 
 module.exports = {
   init({ baseUrl = null, rootPath = null, s3Options, ...legacyS3Options }) {
-    if (legacyS3Options) {
+    if (Object.keys(legacyS3Options).length !== 0) {
       process.emitWarning(
         "S3 configuration options passed at root level of the plugin's providerOptions is deprecated and will be removed in a future release. Please wrap them inside the 's3Options:{}' property."
       );


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Adjust the check that detects if any legacyS3Options left

### Why is it needed?

The `...legacyS3Options` will always be an object, that means is a truthy value

### How to test it?

Check if there is no warning in the console when starting Strapi.

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/pull/13040
