### PR TITLE
fix: Reorder relations in dynamic components crashes page

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/reducer.js
+++ b/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/reducer.js
@@ -186,20 +186,15 @@ const reducer = (state, action) =>
         const newRelations = [...modifiedDataRelations];
 
         if (action.type === 'REORDER_RELATION') {
-          // Swap the order of the arguments to ensure the lesser value is always passed first to generateNKeysBetween
-          const newKey = (
+          const startKey =
             oldIndex > newIndex
-              ? generateNKeysBetween(
-                  modifiedDataRelations[newIndex - 1]?.__temp_key__,
-                  modifiedDataRelations[newIndex]?.__temp_key__,
-                  1
-                )
-              : generateNKeysBetween(
-                  modifiedDataRelations[newIndex]?.__temp_key__,
-                  modifiedDataRelations[newIndex + 1]?.__temp_key__,
-                  1
-                )
-          )[0];
+              ? modifiedDataRelations[newIndex - 1]?.__temp_key__
+              : modifiedDataRelations[newIndex]?.__temp_key__;
+          const endKey =
+            oldIndex > newIndex
+              ? modifiedDataRelations[newIndex]?.__temp_key__
+              : modifiedDataRelations[newIndex + 1]?.__temp_key__;
+          const [newKey] = generateNKeysBetween(startKey, endKey, 1);
 
           newRelations.splice(oldIndex, 1);
           newRelations.splice(newIndex, 0, { ...currentItem, __temp_key__: newKey });

--- a/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/reducer.js
+++ b/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/reducer.js
@@ -186,11 +186,20 @@ const reducer = (state, action) =>
         const newRelations = [...modifiedDataRelations];
 
         if (action.type === 'REORDER_RELATION') {
-          const [newKey] = generateNKeysBetween(
-            modifiedDataRelations[newIndex - 1]?.__temp_key__,
-            modifiedDataRelations[newIndex]?.__temp_key__,
-            1
-          );
+          // Swap the order of the arguments to ensure the lesser value is always passed first to generateNKeysBetween
+          const newKey = (
+            oldIndex > newIndex
+              ? generateNKeysBetween(
+                  modifiedDataRelations[newIndex - 1]?.__temp_key__,
+                  modifiedDataRelations[newIndex]?.__temp_key__,
+                  1
+                )
+              : generateNKeysBetween(
+                  modifiedDataRelations[newIndex]?.__temp_key__,
+                  modifiedDataRelations[newIndex + 1]?.__temp_key__,
+                  1
+                )
+          )[0];
 
           newRelations.splice(oldIndex, 1);
           newRelations.splice(newIndex, 0, { ...currentItem, __temp_key__: newKey });

--- a/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/tests/reducer.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/tests/reducer.test.js
@@ -3102,7 +3102,7 @@ describe('CONTENT MANAGER | COMPONENTS | EditViewDataManagerProvider | reducer',
           { name: 'third', __temp_key__: 'Zz' },
           { name: 'second', __temp_key__: 'a0G' },
           { name: 'fourth', __temp_key__: 'a0V' },
-          { name: 'first', __temp_key__: 'a0O' },
+          { name: 'first', __temp_key__: 'a1' },
         ])
       );
 
@@ -3113,7 +3113,7 @@ describe('CONTENT MANAGER | COMPONENTS | EditViewDataManagerProvider | reducer',
           { name: 'third', __temp_key__: 'Zz' },
           { name: 'fourth', __temp_key__: 'a0' },
           { name: 'second', __temp_key__: 'a0G' },
-          { name: 'first', __temp_key__: 'a0O' },
+          { name: 'first', __temp_key__: 'a1' },
         ])
       );
     });


### PR DESCRIPTION
Fixes https://github.com/strapi/strapi/issues/16282

### What does it do?
Resolves the error that comes up based on the order of parameters passed to `generateNKeysBetween` function during list re-ordering

### Why is it needed?
App crashes whenever a multi related item input is re-orderd.

### How to test it?

- Create a multiple relation entry fields (1 to many).
- Add a number of related inputs to it.
- Re-order the input such that thesame item is dragged from same index and dropped in same index multiple times.
- Notice that the app does not break as a result.

https://user-images.githubusercontent.com/45232708/230404829-f6fed6dd-ec62-4892-9a0d-42bfc3b916e4.mov


## Demo

https://user-images.githubusercontent.com/45232708/230402426-66176cfc-019b-4249-bc1f-871d4b65ec50.mov



