### PR TITLE
Fix components not found

### DIFF
--- a/packages/core/admin/admin/src/content-manager/pages/App/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/App/index.js
@@ -4,7 +4,7 @@ import { Switch, Route, useRouteMatch, Redirect, useLocation } from 'react-route
 import {
   CheckPagePermissions,
   LoadingIndicatorPage,
-  NotFound,
+  AnErrorOccurred,
   useGuidedTour,
 } from '@strapi/helper-plugin';
 import { Layout, HeaderLayout, Main } from '@strapi/design-system';
@@ -104,7 +104,7 @@ const App = () => {
           <Route path="/content-manager/no-content-types">
             <NoContentType />
           </Route>
-          <Route path="" component={NotFound} />
+          <Route path="" component={AnErrorOccurred} />
         </Switch>
       </ModelsContext.Provider>
     </Layout>

--- a/packages/core/admin/admin/src/pages/MarketplacePage/components/EmptyNpmPackageSearch/index.js
+++ b/packages/core/admin/admin/src/pages/MarketplacePage/components/EmptyNpmPackageSearch/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Typography, Box, Flex, Icon } from '@strapi/design-system';
-import { EmptyStateDocument } from '@strapi/icons';
+import { EmptyDocuments } from '@strapi/icons';
 import { EmptyNpmPackageGrid } from './EmptyNpmPackageGrid';
 
 const EmptyNpmPackageSearch = ({ content }) => {
@@ -10,7 +10,7 @@ const EmptyNpmPackageSearch = ({ content }) => {
       <EmptyNpmPackageGrid />
       <Box position="absolute" top={11} width="100%">
         <Flex alignItems="center" justifyContent="center" direction="column">
-          <Icon as={EmptyStateDocument} color="" width="160px" height="88px" />
+          <Icon as={EmptyDocuments} color="" width="160px" height="88px" />
           <Box paddingTop={6}>
             <Typography variant="delta" as="p" textColor="neutral600">
               {content}

--- a/packages/core/content-type-builder/admin/src/components/AttributeOptions/EmptyAttributes/index.js
+++ b/packages/core/content-type-builder/admin/src/components/AttributeOptions/EmptyAttributes/index.js
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { useIntl } from 'react-intl';
 import qs from 'qs';
 import { Box, Flex, Typography, LinkButton, Icon } from '@strapi/design-system';
-import { Plus, EmptyStateDocument } from '@strapi/icons';
+import { Plus, EmptyDocuments } from '@strapi/icons';
 import { getTrad } from '../../../utils';
 
 const EmptyCard = styled(Box)`
@@ -38,7 +38,7 @@ const EmptyAttributes = () => {
       <EmptyCardGrid />
       <Box position="absolute" top={6} width="100%">
         <Flex alignItems="center" justifyContent="center" direction="column">
-          <Icon as={EmptyStateDocument} color="" width="160px" height="88px" />
+          <Icon as={EmptyDocuments} color="" width="160px" height="88px" />
           <Box paddingTop={6} paddingBottom={4}>
             <Box textAlign="center">
               <Typography variant="delta" as="p" textColor="neutral600">

--- a/packages/core/upload/admin/src/components/EmptyAssets/index.js
+++ b/packages/core/upload/admin/src/components/EmptyAssets/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Typography, Flex, Box, Icon } from '@strapi/design-system';
-import { EmptyStateDocuments } from '@strapi/icons';
+import { EmptyDocuments } from '@strapi/icons';
 import { EmptyAssetGrid } from './EmptyAssetGrid';
 
 export const EmptyAssets = ({ icon, content, action, size, count }) => {
@@ -12,7 +12,7 @@ export const EmptyAssets = ({ icon, content, action, size, count }) => {
       <Box position="absolute" top={11} width="100%">
         <Flex direction="column" alignItems="center" gap={4} textAlign="center">
           <Flex direction="column" alignItems="center" gap={6}>
-            <Icon as={icon || EmptyStateDocuments} color="" width="160px" height="88px" />
+            <Icon as={icon || EmptyDocuments} color="" width="160px" height="88px" />
 
             <Typography variant="delta" as="p" textColor="neutral600">
               {content}

--- a/packages/generators/generators/lib/files/js/plugin/admin/src/pages/App/index.js
+++ b/packages/generators/generators/lib/files/js/plugin/admin/src/pages/App/index.js
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import { Switch, Route } from 'react-router-dom';
-import { NotFound } from '@strapi/helper-plugin';
+import { AnErrorOccurred } from '@strapi/helper-plugin';
 import pluginId from '../../pluginId';
 import HomePage from '../HomePage';
 
@@ -16,7 +16,7 @@ const App = () => {
     <div>
       <Switch>
         <Route path={`/plugins/${pluginId}`} component={HomePage} exact />
-        <Route component={NotFound} />
+        <Route component={AnErrorOccurred} />
       </Switch>
     </div>
   );

--- a/packages/generators/generators/lib/files/ts/plugin/admin/src/pages/App/index.tsx
+++ b/packages/generators/generators/lib/files/ts/plugin/admin/src/pages/App/index.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import { Switch, Route } from 'react-router-dom';
-import { NotFound } from '@strapi/helper-plugin';
+import { AnErrorOccurred } from '@strapi/helper-plugin';
 import pluginId from '../../pluginId';
 import HomePage from '../HomePage';
 
@@ -16,7 +16,7 @@ const App = () => {
     <div>
       <Switch>
         <Route path={`/plugins/${pluginId}`} component={HomePage} exact />
-        <Route component={NotFound} />
+        <Route component={AnErrorOccurred} />
       </Switch>
     </div>
   );

--- a/packages/plugins/users-permissions/admin/src/pages/Roles/index.js
+++ b/packages/plugins/users-permissions/admin/src/pages/Roles/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Switch, Route } from 'react-router-dom';
-import { CheckPagePermissions, NotFound } from '@strapi/helper-plugin';
+import { CheckPagePermissions, AnErrorOccurred } from '@strapi/helper-plugin';
 import pluginId from '../../pluginId';
 import pluginPermissions from '../../permissions';
 import ProtectedRolesListPage from './ProtectedListPage';
@@ -18,7 +18,7 @@ const Roles = () => {
         />
         <Route path={`/settings/${pluginId}/roles/:id`} component={ProtectedRolesEditPage} exact />
         <Route path={`/settings/${pluginId}/roles`} component={ProtectedRolesListPage} exact />
-        <Route path="" component={NotFound} />
+        <Route path="" component={AnErrorOccurred} />
       </Switch>
     </CheckPagePermissions>
   );


### PR DESCRIPTION
### What does it do?

There are two components being used that don't actually exist. NotFound from the helper-plugin and EmptyStateDocument. This PR replaces them with components that do exist.

Putting this up for review since it uses components that do exist. However I'm not sure `AnErrorOcurred` is the correct component to use for the catch-all routes. Also I'm not sure the catch-all routes are even being reached, as far as I can tell so far we are stuck with a loader or blank page. We could merge this to resolve the issue of not found components quicker and fix the rest in a second PR, either way I'm still looking into it.

### Why is it needed?

A component needs to exist for it to be used

### How to test it?

There should be no errors in the console when running yarn develop in the admin


Fixes https://github.com/strapi/strapi/issues/16266
