### PR TITLE
fix: Uncaught error trying to nullify/remove a date field in Content Manager

### DIFF
--- a/packages/core/helper-plugin/lib/src/components/FilterPopoverURLQuery/Inputs.js
+++ b/packages/core/helper-plugin/lib/src/components/FilterPopoverURLQuery/Inputs.js
@@ -51,7 +51,7 @@ const Inputs = ({ label, onChange, options, type, value }) => {
         clearLabel={formatMessage({ id: 'clearLabel', defaultMessage: 'Clear' })}
         ariaLabel={label}
         name="datetimepicker"
-        onChange={(date) => onChange(date.toISOString())}
+        onChange={(date) => onChange(date ? date.toISOString() : null)}
         onClear={() => onChange(null)}
         value={value ? new Date(value) : null}
         selectedDateLabel={(formattedDate) => `Date picker, current is ${formattedDate}`}

--- a/packages/core/helper-plugin/lib/src/components/GenericInput/index.js
+++ b/packages/core/helper-plugin/lib/src/components/GenericInput/index.js
@@ -226,8 +226,7 @@ const GenericInput = ({
           hint={hint}
           name={name}
           onChange={(date) => {
-            const formattedDate = date.toISOString();
-
+            const formattedDate = date ? date.toISOString() : null;
             onChange({ target: { name, value: formattedDate, type } });
           }}
           step={step}

--- a/packages/core/upload/admin/src/components/FilterPopover/FilterValueInput.js
+++ b/packages/core/upload/admin/src/components/FilterPopover/FilterValueInput.js
@@ -13,7 +13,7 @@ const FilterValueInput = ({ label, onChange, options, type, value }) => {
         ariaLabel={label}
         name="datetimepicker"
         onChange={(date) => {
-          const formattedDate = new Date(date).toISOString();
+          const formattedDate = date ? new Date(date).toISOString() : '';
 
           onChange(formattedDate);
         }}


### PR DESCRIPTION
Fixes https://github.com/strapi/strapi/issues/16337

### What does it do?
Handles the `undefined` state of `DateTimeInput` field.

### Why is it needed?
It's currently not possible to clear the DateTimeInput field by clicking the clear icon.

### How to test it?

- Create an entity schema in the Content Builder with a date+time field. Do not make it required.
- Go to Content Manager and use the date+time picker to select values and save it.
- Go to Content Manager for that saved record and try to remove the datetime by clicking the "x" to the right of the field.
- Observe that the input field is null and no console errors are coming up.


## Demo

https://user-images.githubusercontent.com/45232708/230890897-26225cb8-cbfd-471a-8cb4-b64a3bec6c4c.mov


