### PR TITLE
Fix(transactions): Do not return completed transactions

### DIFF
--- a/packages/core/database/lib/index.js
+++ b/packages/core/database/lib/index.js
@@ -59,13 +59,16 @@ class Database {
       if (notNestedTransaction) {
         await trx.commit();
       }
+      transactionCtx.clear();
     }
 
     async function rollback() {
       if (notNestedTransaction) {
         await trx.rollback();
       }
+      transactionCtx.clear();
     }
+
     if (!cb) {
       return {
         commit,

--- a/packages/core/database/lib/index.js
+++ b/packages/core/database/lib/index.js
@@ -58,15 +58,15 @@ class Database {
     async function commit() {
       if (notNestedTransaction) {
         await trx.commit();
+        transactionCtx.clear();
       }
-      transactionCtx.clear();
     }
 
     async function rollback() {
       if (notNestedTransaction) {
         await trx.rollback();
+        transactionCtx.clear();
       }
-      transactionCtx.clear();
     }
 
     if (!cb) {

--- a/packages/core/database/lib/transaction-context.js
+++ b/packages/core/database/lib/transaction-context.js
@@ -10,7 +10,8 @@ const transactionCtx = {
   },
 
   get() {
-    return storage.getStore();
+    const trx = storage.getStore();
+    return trx?.isCompleted() ? undefined : trx;
   },
 };
 

--- a/packages/core/database/lib/transaction-context.js
+++ b/packages/core/database/lib/transaction-context.js
@@ -6,12 +6,19 @@ const storage = new AsyncLocalStorage();
 
 const transactionCtx = {
   async run(store, cb) {
-    return storage.run(store, cb);
+    return storage.run({ trx: store }, cb);
   },
 
   get() {
-    const trx = storage.getStore();
-    return trx?.isCompleted() ? undefined : trx;
+    const store = storage.getStore();
+    return store?.trx;
+  },
+
+  clear() {
+    const store = storage.getStore();
+    if (store?.trx) {
+      store.trx = null;
+    }
   },
 };
 


### PR DESCRIPTION
### What does it do?
Not awaited async functions that used transactions had a weird behaviour.

If you tried , in a straipi bootsrap:
```js
const insertTag = async (strapi) => {
  await strapi.entityService.create('api::tag.tag', {
    data: {
      name: 'tag4',
    },
  });
};

    await strapi.db.transaction(async (trx) => {
      // Without awaiting
      insertTag(strapi);
    });
```

Would result in the following error:
```
This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). The promise rejected with the reason:
Error: Transaction query already complete, run with DEBUG=knex:tx for more info
```

TLDR: Any async code running inside a transaction	will throw an error.

### Why is it needed?

This edge case happens for any event like subscriber there is in strapi (audit logs, event hub, ...)
During the development of Review Workflows, we noticed an audit logs error like this one, and it was only caused when we were using `strapi.db.transactions`

Everything inside the strpai.db.transaction should be encapsulated inside the same transaction, but if there is any async code execution and the transaction is already completed at the time it is executed, we should provide an alternative.

### How to test it?

In `getstarted/src/index.js`
```js
'use strict';

const insertTag = async (strapi) => {
  await strapi.entityService.create('api::tag.tag', {
    data: {
      name: 'tag1',
    },
  });
};
module.exports = {
  async bootstrap({ strapi }) {
    await strapi.db.transaction(async (trx) => {
      insertTag(strapi);
    });
  },

};

```

This should not print any error.


