### PR TITLE
Fix audit logs permissions error

### DIFF
--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/AuditLogs/ListView/hooks/useAuditLogsData.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/AuditLogs/ListView/hooks/useAuditLogsData.js
@@ -2,7 +2,7 @@ import { useQuery } from 'react-query';
 import { useNotification, useFetchClient } from '@strapi/helper-plugin';
 import { useLocation } from 'react-router-dom';
 
-const useAuditLogsData = ({ canRead }) => {
+const useAuditLogsData = ({ canReadAuditLogs, canReadUsers }) => {
   const { get } = useFetchClient();
   const { search } = useLocation();
   const toggleNotification = useNotification();
@@ -21,7 +21,6 @@ const useAuditLogsData = ({ canRead }) => {
   };
 
   const queryOptions = {
-    enabled: canRead,
     keepPreviousData: true,
     retry: false,
     staleTime: 1000 * 20, // 20 seconds
@@ -32,10 +31,14 @@ const useAuditLogsData = ({ canRead }) => {
     data: auditLogs,
     isLoading,
     isError: isAuditLogsError,
-  } = useQuery(['auditLogs', search], fetchAuditLogsPage, queryOptions);
+  } = useQuery(['auditLogs', search], fetchAuditLogsPage, {
+    ...queryOptions,
+    enabled: canReadAuditLogs,
+  });
 
   const { data: users, isError: isUsersError } = useQuery(['auditLogsUsers'], fetchAllUsers, {
     ...queryOptions,
+    enabled: canReadUsers,
     staleTime: 2 * (1000 * 60), // 2 minutes
   });
 

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/AuditLogs/ListView/index.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/AuditLogs/ListView/index.js
@@ -25,15 +25,17 @@ import Filters from '../../../../../../../admin/src/pages/SettingsPage/component
 import getDisplayedFilters from './utils/getDisplayedFilters';
 import useAuditLogsData from './hooks/useAuditLogsData';
 
+const auditLogsPermissions = {
+  ...adminPermissions.settings.auditLogs,
+  readUsers: adminPermissions.settings.users.read,
+};
+
 const ListView = () => {
   const { formatMessage } = useIntl();
-  const {
-    allowedActions: { canRead: canReadAuditLogs },
-  } = useRBAC(adminPermissions.settings.auditLogs);
 
   const {
-    allowedActions: { canRead: canReadUsers },
-  } = useRBAC(adminPermissions.settings.users);
+    allowedActions: { canRead: canReadAuditLogs, canReadUsers },
+  } = useRBAC(auditLogsPermissions);
 
   const [{ query }, setQuery] = useQueryParams();
   const { auditLogs, users, isLoading, hasError } = useAuditLogsData({

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/AuditLogs/ListView/index.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/AuditLogs/ListView/index.js
@@ -28,14 +28,22 @@ import useAuditLogsData from './hooks/useAuditLogsData';
 const ListView = () => {
   const { formatMessage } = useIntl();
   const {
-    allowedActions: { canRead },
+    allowedActions: { canRead: canReadAuditLogs },
   } = useRBAC(adminPermissions.settings.auditLogs);
+
+  const {
+    allowedActions: { canRead: canReadUsers },
+  } = useRBAC(adminPermissions.settings.users);
+
   const [{ query }, setQuery] = useQueryParams();
-  const { auditLogs, users, isLoading, hasError } = useAuditLogsData({ canRead });
+  const { auditLogs, users, isLoading, hasError } = useAuditLogsData({
+    canReadAuditLogs,
+    canReadUsers,
+  });
 
   useFocusWhenNavigate();
 
-  const displayedFilters = getDisplayedFilters({ formatMessage, users });
+  const displayedFilters = getDisplayedFilters({ formatMessage, users, canReadUsers });
 
   const title = formatMessage({
     id: 'global.auditLogs',
@@ -73,7 +81,7 @@ const ListView = () => {
         })}
       />
       <ActionLayout startActions={<Filters displayedFilters={displayedFilters} />} />
-      <ContentLayout canRead={canRead}>
+      <ContentLayout canRead={canReadAuditLogs}>
         <DynamicTable
           contentType="Audit logs"
           headers={headers}

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/AuditLogs/ListView/tests/getDisplayedFilters.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/AuditLogs/ListView/tests/getDisplayedFilters.test.js
@@ -1,0 +1,42 @@
+import getDisplayedFilters from '../utils/getDisplayedFilters';
+
+const mockUsers = {
+  results: [
+    {
+      id: 1,
+      firstname: 'test',
+      lastname: 'tester',
+      username: null,
+      email: 'test@test.com',
+    },
+    {
+      id: 2,
+      firstname: 'test2',
+      lastname: 'tester2',
+      username: null,
+      email: 'test2@test.com',
+    },
+  ],
+};
+
+describe('Audit Logs getDisplayedFilters', () => {
+  it('should return all filters when canReadUsers is true', () => {
+    const filters = getDisplayedFilters({
+      users: mockUsers,
+      formatMessage: jest.fn(({ defaultMessage }) => defaultMessage),
+      canReadUsers: true,
+    });
+    const filterNames = filters.map((filter) => filter.name);
+    expect(filterNames).toEqual(['action', 'date', 'user']);
+  });
+
+  it('should not return user filter when canReadUsers is false', () => {
+    const filters = getDisplayedFilters({
+      users: mockUsers,
+      formatMessage: jest.fn(({ defaultMessage }) => defaultMessage),
+      canReadUsers: false,
+    });
+    const filterNames = filters.map((filter) => filter.name);
+    expect(filterNames).toEqual(['action', 'date']);
+  });
+});

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/AuditLogs/ListView/utils/getDisplayedFilters.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/AuditLogs/ListView/utils/getDisplayedFilters.js
@@ -13,27 +13,6 @@ const customOperators = [
 ];
 
 const getDisplayedFilters = ({ formatMessage, users, canReadUsers }) => {
-  const getDisplaynameFromUser = (user) => {
-    if (user.username) {
-      return user.username;
-    }
-
-    if (user.firstname && user.lastname) {
-      return formatMessage(
-        {
-          id: 'Settings.permissions.auditLogs.user.fullname',
-          defaultMessage: '{firstname} {lastname}',
-        },
-        {
-          firstname: user.firstname,
-          lastname: user.lastname,
-        }
-      );
-    }
-
-    return user.email;
-  };
-
   const actionOptions = Object.keys(actionTypes).map((action) => {
     return {
       label: formatMessage(
@@ -46,16 +25,6 @@ const getDisplayedFilters = ({ formatMessage, users, canReadUsers }) => {
       customValue: action,
     };
   });
-
-  const userOptions =
-    users &&
-    users.results.map((user) => {
-      return {
-        label: getDisplaynameFromUser(user),
-        // Combobox expects a string value
-        customValue: user.id.toString(),
-      };
-    });
 
   const filters = [
     {
@@ -83,7 +52,36 @@ const getDisplayedFilters = ({ formatMessage, users, canReadUsers }) => {
     },
   ];
 
-  if (canReadUsers) {
+  if (canReadUsers && users) {
+    const getDisplaynameFromUser = (user) => {
+      if (user.username) {
+        return user.username;
+      }
+
+      if (user.firstname && user.lastname) {
+        return formatMessage(
+          {
+            id: 'Settings.permissions.auditLogs.user.fullname',
+            defaultMessage: '{firstname} {lastname}',
+          },
+          {
+            firstname: user.firstname,
+            lastname: user.lastname,
+          }
+        );
+      }
+
+      return user.email;
+    };
+
+    const userOptions = users.results.map((user) => {
+      return {
+        label: getDisplaynameFromUser(user),
+        // Combobox expects a string value
+        customValue: user.id.toString(),
+      };
+    });
+
     return [
       ...filters,
       {

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/AuditLogs/ListView/utils/getDisplayedFilters.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/AuditLogs/ListView/utils/getDisplayedFilters.js
@@ -53,7 +53,7 @@ const getDisplayedFilters = ({ formatMessage, users, canReadUsers }) => {
   ];
 
   if (canReadUsers && users) {
-    const getDisplaynameFromUser = (user) => {
+    const getDisplayNameFromUser = (user) => {
       if (user.username) {
         return user.username;
       }
@@ -76,7 +76,7 @@ const getDisplayedFilters = ({ formatMessage, users, canReadUsers }) => {
 
     const userOptions = users.results.map((user) => {
       return {
-        label: getDisplaynameFromUser(user),
+        label: getDisplayNameFromUser(user),
         // Combobox expects a string value
         customValue: user.id.toString(),
       };

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/AuditLogs/ListView/utils/getDisplayedFilters.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/AuditLogs/ListView/utils/getDisplayedFilters.js
@@ -12,11 +12,12 @@ const customOperators = [
   },
 ];
 
-const getDisplayedFilters = ({ formatMessage, users }) => {
+const getDisplayedFilters = ({ formatMessage, users, canReadUsers }) => {
   const getDisplaynameFromUser = (user) => {
     if (user.username) {
       return user.username;
     }
+
     if (user.firstname && user.lastname) {
       return formatMessage(
         {
@@ -56,7 +57,7 @@ const getDisplayedFilters = ({ formatMessage, users }) => {
       };
     });
 
-  return [
+  const filters = [
     {
       name: 'action',
       metadatas: {
@@ -80,20 +81,28 @@ const getDisplayedFilters = ({ formatMessage, users }) => {
       },
       fieldSchema: { type: 'datetime' },
     },
-    {
-      name: 'user',
-      metadatas: {
-        customOperators,
-        label: formatMessage({
-          id: 'Settings.permissions.auditLogs.user',
-          defaultMessage: 'User',
-        }),
-        options: userOptions,
-        customInput: ComboboxFilter,
-      },
-      fieldSchema: { type: 'relation', mainField: { name: 'id' } },
-    },
   ];
+
+  if (canReadUsers) {
+    return [
+      ...filters,
+      {
+        name: 'user',
+        metadatas: {
+          customOperators,
+          label: formatMessage({
+            id: 'Settings.permissions.auditLogs.user',
+            defaultMessage: 'User',
+          }),
+          options: userOptions,
+          customInput: ComboboxFilter,
+        },
+        fieldSchema: { type: 'relation', mainField: { name: 'id' } },
+      },
+    ];
+  }
+
+  return filters;
 };
 
 export default getDisplayedFilters;


### PR DESCRIPTION
### What does it do?

Audit logs currently throws a 403 forbidden error when a user has the permissions to access audit logs but not the permissions to access users.

The request to users is only made for the filters

This PR proposes only displaying the filter by "user" option if the current role has permissions to users, otherwise a user will only be able to filter by "action" and "date"

### Why is it needed?

- It creates an unhandled error that is not clear to the user

### How to test it?
Run the tests in: 
```
packages/core/admin/ee/admin/pages/SettingsPage/pages/AuditLogs/ListView/tests/getDisplayedFilters.test.js
```

Test manually:

Can read audit logs and users
- As a super admin user create a new user with the Editor role
- Go to roles -> editor -> settings
- Grant the Editor role read permissions on Audit Logs and Users (under Users and Roles)
- In another browser logged in as the Editor role user, go to the audit logs page, you should see the logs
- You should be able to filter by action, date, and user

Can read audit logs but can NOT read users
- As a super admin remove the read permission on user from the Editor role
- In another browser logged in as the Editor role user, go to the audits logs page, you should see the logs
- You should only be able to filter by action and date

Can NOT read audit logs or users
- As a super admin remove the read permission on audit logs from the Editor role
- In another browser logged in as the Editor role user, you should no longer have access to the audit logs page
- If you were already on the audit logs page it should redirect to the dashboard

### Related issue(s)/PR(s)

resolves https://github.com/strapi/strapi/issues/16184
