### PR TITLE
fix(RW): Validate stage id exists when updating entity

### DIFF
--- a/api-tests/core/admin/ee/review-workflows.test.api.js
+++ b/api-tests/core/admin/ee/review-workflows.test.api.js
@@ -425,6 +425,22 @@ describeOnCondition(edition === 'EE')('Review workflows', () => {
           expect.objectContaining({ id: secondStage.id })
         );
       });
+      test('Should throw an error if stage does not exist', async () => {
+        const entry = await createEntry(productUID, { name: 'Product' });
+
+        const response = await requests.admin({
+          method: 'PUT',
+          url: `/admin/content-manager/collection-types/${productUID}/${entry.id}/stage`,
+          body: {
+            data: { id: 1234 },
+          },
+        });
+
+        expect(response.status).toEqual(400);
+        expect(response.body.error).toBeDefined();
+        expect(response.body.error.name).toEqual('ApplicationError');
+        expect(response.body.error.message).toEqual('Selected stage does not exist');
+      });
     });
     describe('Review Workflow is disabled', () => {
       beforeAll(async () => {

--- a/packages/core/admin/ee/server/services/__tests__/stages.test.js
+++ b/packages/core/admin/ee/server/services/__tests__/stages.test.js
@@ -104,9 +104,7 @@ describe('Review workflows - Stages service', () => {
 
       expect(entityServiceMock.findMany).not.toBeCalled();
       expect(entityServiceMock.findOne).toBeCalled();
-      expect(entityServiceMock.findOne).toBeCalledWith(STAGE_MODEL_UID, 1, {
-        filters: { workflow: 1 },
-      });
+      expect(entityServiceMock.findOne).toBeCalledWith(STAGE_MODEL_UID, 1, {});
     });
   });
   describe('replaceWorkflowStages', () => {

--- a/packages/core/admin/ee/server/services/review-workflows/stages.js
+++ b/packages/core/admin/ee/server/services/review-workflows/stages.js
@@ -21,9 +21,8 @@ module.exports = ({ strapi }) => {
       return strapi.entityService.findMany(STAGE_MODEL_UID, params);
     },
 
-    findById(id, { workflowId, populate }) {
+    findById(id, { populate } = {}) {
       const params = {
-        filters: { workflow: workflowId },
         populate,
       };
       return strapi.entityService.findOne(STAGE_MODEL_UID, id, params);
@@ -70,7 +69,6 @@ module.exports = ({ strapi }) => {
         await mapAsync(deleted, async (stage) => {
           // Find any entities related to this stage
           const stageInfo = await this.findById(stage.id, {
-            workflowId: defaultWorkflow.id,
             populate: ['related'],
           });
 
@@ -122,7 +120,13 @@ module.exports = ({ strapi }) => {
      * @param {string} entityInfo.modelUID - the content-type of the entity
      * @param {number} stageId - The id of the stage to assign to the entity
      */
-    updateEntity(entityInfo, stageId) {
+    async updateEntity(entityInfo, stageId) {
+      const stage = await this.findById(stageId);
+
+      if (!stage) {
+        throw new ApplicationError(`Selected stage does not exist`);
+      }
+
       return strapi.entityService.update(entityInfo.modelUID, entityInfo.id, {
         data: { [ENTITY_STAGE_ATTRIBUTE]: stageId },
         populate: [ENTITY_STAGE_ATTRIBUTE],


### PR DESCRIPTION
### What does it do?
Displays a more user friendly error when selecting a non existing Stage.

<table border="0">
 <tr>
    <td><b style="font-size:30px">Before</b></td>
    <td><b style="font-size:30px">After</b></td>
 </tr>
 <tr>
    <td>
<img src="https://user-images.githubusercontent.com/20578351/231213869-9be3023c-9355-4f00-b386-feeea52ad6ec.png"/>
</td>
    <td><img src="https://user-images.githubusercontent.com/20578351/231213355-717a6c92-f795-4316-b419-a5b10b57bb7c.png"/></td>
 </tr>
</table>


### How to test it?

- Open the edit view of one entity with RW activated
- On another tab, delete one of the RW stages
- On the original tab, try to assign the deleted RW stage without refreshing the page.

