### PR TITLE
chore: release peer version constraint using ^

### DIFF
--- a/packages/core/content-type-builder/package.json
+++ b/packages/core/content-type-builder/package.json
@@ -63,8 +63,8 @@
   "peerDependencies": {
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-router-dom": "5.3.4",
-    "styled-components": "5.3.3"
+    "react-router-dom": "^5.3.4",
+    "styled-components": "^5.3.3"
   },
   "engines": {
     "node": ">=14.19.1 <=18.x.x",

--- a/packages/core/email/package.json
+++ b/packages/core/email/package.json
@@ -48,8 +48,8 @@
   "peerDependencies": {
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-router-dom": "5.3.4",
-    "styled-components": "5.3.3"
+    "react-router-dom": "^5.3.4",
+    "styled-components": "^5.3.3"
   },
   "engines": {
     "node": ">=14.19.1 <=18.x.x",

--- a/packages/core/helper-plugin/package.json
+++ b/packages/core/helper-plugin/package.json
@@ -82,12 +82,12 @@
     "webpack-cli": "^5.0.1"
   },
   "peerDependencies": {
-    "@strapi/design-system": "1.6.6",
-    "@strapi/icons": "1.6.6",
+    "@strapi/design-system": "^1.6.6",
+    "@strapi/icons": "^1.6.6",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-router-dom": "5.3.4",
-    "styled-components": "5.3.3"
+    "react-router-dom": "^5.3.4",
+    "styled-components": "^5.3.3"
   },
   "engines": {
     "node": ">=14.19.1 <=18.x.x",

--- a/packages/core/upload/package.json
+++ b/packages/core/upload/package.json
@@ -68,8 +68,8 @@
   "peerDependencies": {
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-router-dom": "5.3.4",
-    "styled-components": "5.3.3"
+    "react-router-dom": "^5.3.4",
+    "styled-components": "^5.3.3"
   },
   "engines": {
     "node": ">=14.19.1 <=18.x.x",

--- a/packages/plugins/color-picker/package.json
+++ b/packages/plugins/color-picker/package.json
@@ -27,8 +27,8 @@
     "@strapi/strapi": "^4.4.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-router-dom": "5.3.4",
-    "styled-components": "5.3.3"
+    "react-router-dom": "^5.3.4",
+    "styled-components": "^5.3.3"
   },
   "scripts": {
     "test:front": "run -T cross-env IS_EE=true jest --config ./jest.config.front.js",

--- a/packages/plugins/documentation/package.json
+++ b/packages/plugins/documentation/package.json
@@ -51,8 +51,8 @@
     "@strapi/strapi": "^4.0.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-router-dom": "5.3.4",
-    "styled-components": "5.3.3"
+    "react-router-dom": "^5.3.4",
+    "styled-components": "^5.3.3"
   },
   "devDependencies": {
     "@testing-library/react": "12.1.4",

--- a/packages/plugins/graphql/package.json
+++ b/packages/plugins/graphql/package.json
@@ -55,8 +55,8 @@
     "@strapi/strapi": "^4.0.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-router-dom": "5.3.4",
-    "styled-components": "5.3.3"
+    "react-router-dom": "^5.3.4",
+    "styled-components": "^5.3.3"
   },
   "engines": {
     "node": ">=14.19.1 <=18.x.x",

--- a/packages/plugins/i18n/package.json
+++ b/packages/plugins/i18n/package.json
@@ -44,8 +44,8 @@
   "peerDependencies": {
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-router-dom": "5.3.4",
-    "styled-components": "5.3.3"
+    "react-router-dom": "^5.3.4",
+    "styled-components": "^5.3.3"
   },
   "devDependencies": {
     "@testing-library/react": "12.1.4",

--- a/packages/plugins/sentry/package.json
+++ b/packages/plugins/sentry/package.json
@@ -41,8 +41,8 @@
     "@strapi/strapi": "^4.0.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-router-dom": "5.3.4",
-    "styled-components": "5.3.3"
+    "react-router-dom": "^5.3.4",
+    "styled-components": "^5.3.3"
   },
   "engines": {
     "node": ">=14.19.1 <=18.x.x",

--- a/packages/plugins/users-permissions/package.json
+++ b/packages/plugins/users-permissions/package.json
@@ -67,8 +67,8 @@
   "peerDependencies": {
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-router-dom": "5.3.4",
-    "styled-components": "5.3.3"
+    "react-router-dom": "^5.3.4",
+    "styled-components": "^5.3.3"
   },
   "engines": {
     "node": ">=14.19.1 <=18.x.x",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7279,12 +7279,12 @@ __metadata:
     webpack: ^5.76.0
     webpack-cli: ^5.0.1
   peerDependencies:
-    "@strapi/design-system": 1.6.6
-    "@strapi/icons": 1.6.6
+    "@strapi/design-system": ^1.6.6
+    "@strapi/icons": ^1.6.6
     react: ^17.0.2
     react-dom: ^17.0.2
-    react-router-dom: 5.3.4
-    styled-components: 5.3.3
+    react-router-dom: ^5.3.4
+    styled-components: ^5.3.3
   languageName: unknown
   linkType: soft
 
@@ -7349,8 +7349,8 @@ __metadata:
     "@strapi/strapi": ^4.4.0
     react: ^17.0.2
     react-dom: ^17.0.2
-    react-router-dom: 5.3.4
-    styled-components: 5.3.3
+    react-router-dom: ^5.3.4
+    styled-components: ^5.3.3
   languageName: unknown
   linkType: soft
 
@@ -7399,8 +7399,8 @@ __metadata:
   peerDependencies:
     react: ^17.0.2
     react-dom: ^17.0.2
-    react-router-dom: 5.3.4
-    styled-components: 5.3.3
+    react-router-dom: ^5.3.4
+    styled-components: ^5.3.3
   languageName: unknown
   linkType: soft
 
@@ -7441,8 +7441,8 @@ __metadata:
     "@strapi/strapi": ^4.0.0
     react: ^17.0.2
     react-dom: ^17.0.2
-    react-router-dom: 5.3.4
-    styled-components: 5.3.3
+    react-router-dom: ^5.3.4
+    styled-components: ^5.3.3
   languageName: unknown
   linkType: soft
 
@@ -7468,8 +7468,8 @@ __metadata:
   peerDependencies:
     react: ^17.0.2
     react-dom: ^17.0.2
-    react-router-dom: 5.3.4
-    styled-components: 5.3.3
+    react-router-dom: ^5.3.4
+    styled-components: ^5.3.3
   languageName: unknown
   linkType: soft
 
@@ -7505,8 +7505,8 @@ __metadata:
     "@strapi/strapi": ^4.0.0
     react: ^17.0.2
     react-dom: ^17.0.2
-    react-router-dom: 5.3.4
-    styled-components: 5.3.3
+    react-router-dom: ^5.3.4
+    styled-components: ^5.3.3
   languageName: unknown
   linkType: soft
 
@@ -7537,8 +7537,8 @@ __metadata:
   peerDependencies:
     react: ^17.0.2
     react-dom: ^17.0.2
-    react-router-dom: 5.3.4
-    styled-components: 5.3.3
+    react-router-dom: ^5.3.4
+    styled-components: ^5.3.3
   languageName: unknown
   linkType: soft
 
@@ -7558,8 +7558,8 @@ __metadata:
     "@strapi/strapi": ^4.0.0
     react: ^17.0.2
     react-dom: ^17.0.2
-    react-router-dom: 5.3.4
-    styled-components: 5.3.3
+    react-router-dom: ^5.3.4
+    styled-components: ^5.3.3
   languageName: unknown
   linkType: soft
 
@@ -7607,8 +7607,8 @@ __metadata:
   peerDependencies:
     react: ^17.0.2
     react-dom: ^17.0.2
-    react-router-dom: 5.3.4
-    styled-components: 5.3.3
+    react-router-dom: ^5.3.4
+    styled-components: ^5.3.3
   languageName: unknown
   linkType: soft
 
@@ -7651,8 +7651,8 @@ __metadata:
   peerDependencies:
     react: ^17.0.2
     react-dom: ^17.0.2
-    react-router-dom: 5.3.4
-    styled-components: 5.3.3
+    react-router-dom: ^5.3.4
+    styled-components: ^5.3.3
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Using `^` range to release the version constraints of the peerDependencies.

### Why is it needed?

The original peer constraints are way too strict. We have `styled-components@5.3.6` in our project and the version can't be accepted because it's not `5.3.3`.