### PR TITLE
fix: Prioritize admin bootstrap

### DIFF
--- a/packages/core/strapi/lib/Strapi.js
+++ b/packages/core/strapi/lib/Strapi.js
@@ -536,16 +536,16 @@ class Strapi {
     // plugins
     await this.container.get('modules')[lifecycleName]();
 
-    // user
-    const userLifecycleFunction = this.app && this.app[lifecycleName];
-    if (isFunction(userLifecycleFunction)) {
-      await userLifecycleFunction({ strapi: this });
-    }
-
     // admin
     const adminLifecycleFunction = this.admin && this.admin[lifecycleName];
     if (isFunction(adminLifecycleFunction)) {
       await adminLifecycleFunction({ strapi: this });
+    }
+
+    // user
+    const userLifecycleFunction = this.app && this.app[lifecycleName];
+    if (isFunction(userLifecycleFunction)) {
+      await userLifecycleFunction({ strapi: this });
     }
   }
 


### PR DESCRIPTION
### What does it do?

Admin code should not be related to anything related to admin, so at first this change doesn't seem necessary.

But we do have EE code that might interact with things outside Admin. In Review Workflows we want to decorate the entity service `create` to add parameters, the same we do in i18n.

User lifecycles were prioritized so if you tried to use the entityService `create` in a bootstrap method, the RW decorator was not executed. 

Impact analysis:
- Admin register/bootsrap/destroy lifecycles will be executed before user ones.
	- 	Admin bootsraps:
		- Admin User DB hooks
		- Add permissions and other permissions
		- AuditLogs Provider
		- SSO Provider
	-  Admin registers: 
		- passportMiddleware
		- add adminAuthStrategy and apiTokenAuthStrategy
		- AuditLogs migrations and add register audit logs services

It seems unlikely this change breaks the functionality for a user, and if it does it would mean they were executing code where they should not imo.

### Why is it needed?

So we can decorate the entityService in RW.


