### PR TITLE
Review Workflows: Fix various bugs found by QA

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/DynamicTable/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/DynamicTable/index.js
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
+import { Typography } from '@strapi/design-system';
 import { DynamicTable as Table, useStrapiApp } from '@strapi/helper-plugin';
 import { useSelector } from 'react-redux';
 
@@ -90,6 +91,12 @@ const DynamicTable = ({
           sortable: false,
         },
         cellFormatter({ strapi_reviewWorkflows_stage }) {
+          // if entities are created e.g. through lifecycle methods
+          // they may not have a stage assigned
+          if (!strapi_reviewWorkflows_stage) {
+            return <Typography textColor="neutral800">-</Typography>;
+          }
+
           return <ReviewWorkflowsStage name={strapi_reviewWorkflows_stage.name} />;
         },
       });

--- a/packages/core/admin/admin/src/content-manager/components/RelationInput/tests/__snapshots__/RelationInput.test.js.snap
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInput/tests/__snapshots__/RelationInput.test.js.snap
@@ -589,7 +589,7 @@ exports[`Content-Manager || RelationInput should render and match snapshot 1`] =
             class=" css-1ckpxei-control"
           >
             <div
-              class=" css-1drmnx5-ValueContainer"
+              class=" css-onz4xi-ValueContainer"
             >
               <div
                 class=" css-sh9ym6-placeholder"

--- a/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/InformationBoxEE.js
+++ b/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/InformationBoxEE.js
@@ -20,6 +20,7 @@ export function InformationBoxEE() {
     initialData,
     isCreatingEntry,
     layout: { uid },
+    isSingleType,
   } = useCMEditViewDataManager();
   const { put } = useFetchClient();
   const activeWorkflowStage = initialData?.[ATTRIBUTE_NAME] ?? null;
@@ -38,9 +39,11 @@ export function InformationBoxEE() {
 
   const { error, isLoading, mutateAsync } = useMutation(
     async ({ entityId, stageId, uid }) => {
+      const typeSlug = isSingleType ? 'single-types' : 'collection-types';
+
       const {
         data: { data },
-      } = await put(`/admin/content-manager/collection-types/${uid}/${entityId}/stage`, {
+      } = await put(`/admin/content-manager/${typeSlug}/${uid}/${entityId}/stage`, {
         data: { id: stageId },
       });
 

--- a/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/InformationBoxEE.js
+++ b/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/InformationBoxEE.js
@@ -4,6 +4,7 @@ import {
   useCMEditViewDataManager,
   useAPIErrorHandler,
   useFetchClient,
+  useNotification,
 } from '@strapi/helper-plugin';
 import { Field, FieldLabel, FieldError, Flex } from '@strapi/design-system';
 import { useIntl } from 'react-intl';
@@ -24,18 +25,29 @@ export function InformationBoxEE() {
   const activeWorkflowStage = initialData?.[ATTRIBUTE_NAME] ?? null;
   const { formatMessage } = useIntl();
   const { formatAPIError } = useAPIErrorHandler();
+  const toggleNotification = useNotification();
 
   const { workflows: { data: [workflow] = [] } = {} } = useReviewWorkflows();
 
-  const { error, isLoading, mutateAsync } = useMutation(async ({ entityId, stageId, uid }) => {
-    const {
-      data: { data },
-    } = await put(`/admin/content-manager/collection-types/${uid}/${entityId}/stage`, {
-      data: { id: stageId },
-    });
+  const { error, isLoading, mutateAsync } = useMutation(
+    async ({ entityId, stageId, uid }) => {
+      const {
+        data: { data },
+      } = await put(`/admin/content-manager/collection-types/${uid}/${entityId}/stage`, {
+        data: { id: stageId },
+      });
 
-    return data;
-  });
+      return data;
+    },
+    {
+      onSuccess() {
+        toggleNotification({
+          type: 'success',
+          message: { id: 'notification.success.saved', defaultMessage: 'Saved' },
+        });
+      },
+    }
+  );
 
   // stages are empty while the workflow is loading
   const options = (workflow?.stages ?? []).map(({ id, name }) => ({ value: id, label: name }));

--- a/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/InformationBoxEE.js
+++ b/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/InformationBoxEE.js
@@ -99,7 +99,7 @@ export function InformationBoxEE() {
     <Information.Root>
       <Information.Title />
 
-      {hasReviewWorkflowsEnabled && (
+      {hasReviewWorkflowsEnabled && !isCreatingEntry && (
         <Field error={formattedError} name={ATTRIBUTE_NAME} id={ATTRIBUTE_NAME}>
           <Flex direction="column" gap={2} alignItems="stretch">
             <FieldLabel>
@@ -116,7 +116,6 @@ export function InformationBoxEE() {
               defaultValue={{ value: activeWorkflowStage?.id, label: activeWorkflowStage?.name }}
               error={formattedError}
               inputId={ATTRIBUTE_NAME}
-              isDisabled={isCreatingEntry}
               isLoading={isLoading}
               isSearchable={false}
               isClearable={false}

--- a/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/InformationBoxEE.js
+++ b/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/InformationBoxEE.js
@@ -9,9 +9,11 @@ import {
 import { Field, FieldLabel, FieldError, Flex, Loader } from '@strapi/design-system';
 import { useIntl } from 'react-intl';
 import { useMutation } from 'react-query';
+import { useDispatch } from 'react-redux';
 
 import { useReviewWorkflows } from '../../../../pages/SettingsPage/pages/ReviewWorkflows/hooks/useReviewWorkflows';
 import Information from '../../../../../../admin/src/content-manager/pages/EditView/Information';
+import { submitSucceeded } from '../../../../../../admin/src/content-manager/sharedReducers/crudReducer/actions';
 
 const ATTRIBUTE_NAME = 'strapi_reviewWorkflows_stage';
 
@@ -22,6 +24,7 @@ export function InformationBoxEE() {
     layout: { uid },
     isSingleType,
   } = useCMEditViewDataManager();
+  const dispatch = useDispatch();
   const { put } = useFetchClient();
   const activeWorkflowStage = initialData?.[ATTRIBUTE_NAME] ?? null;
   const hasReviewWorkflowsEnabled = Object.prototype.hasOwnProperty.call(
@@ -42,12 +45,16 @@ export function InformationBoxEE() {
       const typeSlug = isSingleType ? 'single-types' : 'collection-types';
 
       const {
-        data: { data },
+        // TODO: Once the API response is wrapped in a data attribute this
+        // needs to be updated
+        data: createdEntry,
       } = await put(`/admin/content-manager/${typeSlug}/${uid}/${entityId}/stage`, {
         data: { id: stageId },
       });
 
-      return data;
+      dispatch(submitSucceeded(createdEntry));
+
+      return createdEntry;
     },
     {
       onSuccess() {
@@ -92,7 +99,7 @@ export function InformationBoxEE() {
     <Information.Root>
       <Information.Title />
 
-      {(hasReviewWorkflowsEnabled || isCreatingEntry) && (
+      {hasReviewWorkflowsEnabled && (
         <Field error={formattedError} name={ATTRIBUTE_NAME} id={ATTRIBUTE_NAME}>
           <Flex direction="column" gap={2} alignItems="stretch">
             <FieldLabel>

--- a/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/InformationBoxEE.js
+++ b/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/InformationBoxEE.js
@@ -92,7 +92,7 @@ export function InformationBoxEE() {
     <Information.Root>
       <Information.Title />
 
-      {!isCreatingEntry && hasReviewWorkflowsEnabled && (
+      {(hasReviewWorkflowsEnabled || isCreatingEntry) && (
         <Field error={formattedError} name={ATTRIBUTE_NAME} id={ATTRIBUTE_NAME}>
           <Flex direction="column" gap={2} alignItems="stretch">
             <FieldLabel>

--- a/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/tests/InformationBoxEE.test.js
+++ b/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/tests/InformationBoxEE.test.js
@@ -4,6 +4,8 @@ import { IntlProvider } from 'react-intl';
 import { useCMEditViewDataManager } from '@strapi/helper-plugin';
 import { ThemeProvider, lightTheme } from '@strapi/design-system';
 import { QueryClientProvider, QueryClient } from 'react-query';
+import { Provider } from 'react-redux';
+import { createStore } from 'redux';
 
 import { InformationBoxEE } from '../InformationBoxEE';
 
@@ -57,14 +59,18 @@ const queryClient = new QueryClient({
 });
 
 const ComponentFixture = (props) => {
+  const store = createStore((state = {}) => state, {});
+
   return (
-    <QueryClientProvider client={queryClient}>
-      <IntlProvider locale="en" defaultLocale="en">
-        <ThemeProvider theme={lightTheme}>
-          <InformationBoxEE {...props} />
-        </ThemeProvider>
-      </IntlProvider>
-    </QueryClientProvider>
+    <Provider store={store}>
+      <QueryClientProvider client={queryClient}>
+        <IntlProvider locale="en" defaultLocale="en">
+          <ThemeProvider theme={lightTheme}>
+            <InformationBoxEE {...props} />
+          </ThemeProvider>
+        </IntlProvider>
+      </QueryClientProvider>
+    </Provider>
   );
 };
 

--- a/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/tests/InformationBoxEE.test.js
+++ b/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/tests/InformationBoxEE.test.js
@@ -89,7 +89,6 @@ describe('EE | Content Manager | EditView | InformationBox', () => {
   it('renders no select input, if no workflow stage is assigned to the entity', () => {
     useCMEditViewDataManager.mockReturnValue({
       initialData: {},
-      isCreatingEntry: true,
       layout: { uid: 'api::articles:articles' },
     });
 
@@ -98,16 +97,18 @@ describe('EE | Content Manager | EditView | InformationBox', () => {
     expect(queryByRole('combobox')).not.toBeInTheDocument();
   });
 
-  it('renders no select input, if no workflow stage is assigned to the entity', () => {
+  it('renders an error, if no workflow stage is assigned to the entity', () => {
     useCMEditViewDataManager.mockReturnValue({
-      initialData: {},
-      isCreatingEntry: true,
+      initialData: {
+        [STAGE_ATTRIBUTE_NAME]: null,
+      },
       layout: { uid: 'api::articles:articles' },
     });
 
-    const { queryByRole } = setup();
+    const { getByText, queryByRole } = setup();
 
-    expect(queryByRole('combobox')).not.toBeInTheDocument();
+    expect(getByText(/select a stage/i)).toBeInTheDocument();
+    expect(queryByRole('combobox')).toBeInTheDocument();
   });
 
   it('renders a disabled select input, if the entity is created', () => {

--- a/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/tests/InformationBoxEE.test.js
+++ b/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/tests/InformationBoxEE.test.js
@@ -111,7 +111,7 @@ describe('EE | Content Manager | EditView | InformationBox', () => {
     expect(queryByRole('combobox')).toBeInTheDocument();
   });
 
-  it('renders a disabled select input, if the entity is created', () => {
+  it('does not render the select input, if the entity is created', () => {
     useCMEditViewDataManager.mockReturnValue({
       initialData: {
         [STAGE_ATTRIBUTE_NAME]: STAGE_FIXTURE,
@@ -123,8 +123,7 @@ describe('EE | Content Manager | EditView | InformationBox', () => {
     const { queryByRole } = setup();
     const select = queryByRole('combobox');
 
-    expect(select).toBeInTheDocument();
-    expect(select).toHaveAttribute('disabled');
+    expect(select).not.toBeInTheDocument();
   });
 
   it('renders an enabled select input, if the entity is edited', () => {
@@ -140,7 +139,6 @@ describe('EE | Content Manager | EditView | InformationBox', () => {
     const select = queryByRole('combobox');
 
     expect(select).toBeInTheDocument();
-    expect(select).not.toHaveAttribute('disabled');
   });
 
   it('renders a select input, if a workflow stage is assigned to the entity', () => {

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/ReviewWorkflows.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/ReviewWorkflows.js
@@ -89,7 +89,7 @@ export function ReviewWorkflowsPage() {
     setIsConfirmDeleteDialogOpen(false);
 
     await updateWorkflowStages(currentWorkflow.id, currentWorkflow.stages);
-    refetchWorkflow();
+    await refetchWorkflow();
   };
 
   const handleConfirmDeleteDialog = async () => {

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/ReviewWorkflows.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/ReviewWorkflows.js
@@ -143,6 +143,7 @@ export function ReviewWorkflowsPage() {
                     type="submit"
                     size="M"
                     disabled={!currentWorkflowIsDirty}
+                    loading={isLoading}
                   >
                     {formatMessage({
                       id: 'global.save',

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/ReviewWorkflows.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/ReviewWorkflows.js
@@ -86,10 +86,10 @@ export function ReviewWorkflowsPage() {
   };
 
   const submitForm = async () => {
-    setIsConfirmDeleteDialogOpen(false);
-
     await updateWorkflowStages(currentWorkflow.id, currentWorkflow.stages);
     await refetchWorkflow();
+
+    setIsConfirmDeleteDialogOpen(false);
   };
 
   const handleConfirmDeleteDialog = async () => {
@@ -143,7 +143,9 @@ export function ReviewWorkflowsPage() {
                     type="submit"
                     size="M"
                     disabled={!currentWorkflowIsDirty}
-                    loading={isLoading}
+                    // if the confirm dialog is open the loading state is on
+                    // the confirm button already
+                    loading={!isConfirmDeleteDialogOpen && isLoading}
                   >
                     {formatMessage({
                       id: 'global.save',

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/Stages/Stage/Stage.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/Stages/Stage/Stage.js
@@ -57,7 +57,7 @@ function Stage({ id, name, index, canDelete, isOpen: isOpenDefault = false }) {
           ) : null
         }
       />
-      <AccordionContent padding={6} background="neutral0">
+      <AccordionContent padding={6} background="neutral0" hasRadius>
         <Grid gap={4}>
           <GridItem col={6}>
             <TextInput

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/Stages/Stage/Stage.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/Stages/Stage/Stage.js
@@ -45,7 +45,7 @@ function Stage({ id, name, index, canDelete, isOpen: isOpenDefault = false }) {
         action={
           canDelete ? (
             <IconButton
-              backgroundColor="transparent"
+              background="transparent"
               noBorder
               onClick={() => dispatch(deleteStage(id))}
               label={formatMessage({

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/hooks/useReviewWorkflows.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/hooks/useReviewWorkflows.js
@@ -22,8 +22,8 @@ export function useReviewWorkflows(workflowId) {
     }
   }
 
-  function refetchWorkflow() {
-    return client.refetchQueries(workflowQueryKey);
+  async function refetchWorkflow() {
+    await client.refetchQueries(workflowQueryKey);
   }
 
   const workflows = useQuery(workflowQueryKey, fetchWorkflows);

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/hooks/useReviewWorkflows.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/hooks/useReviewWorkflows.js
@@ -23,7 +23,7 @@ export function useReviewWorkflows(workflowId) {
   }
 
   function refetchWorkflow() {
-    client.refetchQueries(workflowQueryKey);
+    return client.refetchQueries(workflowQueryKey);
   }
 
   const workflows = useQuery(workflowQueryKey, fetchWorkflows);

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/index.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/index.js
@@ -35,6 +35,7 @@ export function reducer(state = initialState, action) {
           draft.serverState.workflows = workflows;
           draft.serverState.currentWorkflow = defaultWorkflow;
           draft.clientState.currentWorkflow.data = defaultWorkflow;
+          draft.clientState.currentWorkflow.hasDeletedServerStages = false;
         }
         break;
       }

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/index.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/index.js
@@ -97,7 +97,7 @@ export function reducer(state = initialState, action) {
     if (state.clientState.currentWorkflow.data) {
       draft.clientState.currentWorkflow.isDirty = !isEqual(
         current(draft.clientState.currentWorkflow).data,
-        state.serverState.currentWorkflow
+        draft.serverState.currentWorkflow
       );
     }
   });

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/tests/index.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/tests/index.test.js
@@ -52,6 +52,7 @@ describe('Admin | Settings | Review Workflows | reducer', () => {
           currentWorkflow: expect.objectContaining({
             data: WORKFLOWS_FIXTURE[0],
             isDirty: false,
+            hasDeletedServerStages: false,
           }),
         }),
       })

--- a/packages/core/helper-plugin/lib/src/components/ReactSelect/utils/getSelectStyles.js
+++ b/packages/core/helper-plugin/lib/src/components/ReactSelect/utils/getSelectStyles.js
@@ -104,6 +104,7 @@ const getSelectStyles = (theme, error) => {
     },
     valueContainer: (base) => ({
       ...base,
+      cursor: 'pointer',
       padding: 0,
       paddingLeft: theme.spaces[4],
       marginLeft: 0,

--- a/packages/core/upload/admin/src/components/BulkMoveDialog/tests/__snapshots__/BulkMoveDialog.test.js.snap
+++ b/packages/core/upload/admin/src/components/BulkMoveDialog/tests/__snapshots__/BulkMoveDialog.test.js.snap
@@ -540,7 +540,7 @@ exports[`BulkMoveDialog renders and matches the snapshot 1`] = `
                             class=" css-1ckpxei-control"
                           >
                             <div
-                              class=" css-1drmnx5-ValueContainer"
+                              class=" css-onz4xi-ValueContainer"
                             >
                               <div
                                 class=" css-1ryi7up-singleValue"

--- a/packages/core/upload/admin/src/components/EditAssetDialog/tests/__snapshots__/EditAssetDialog.test.js.snap
+++ b/packages/core/upload/admin/src/components/EditAssetDialog/tests/__snapshots__/EditAssetDialog.test.js.snap
@@ -1161,7 +1161,7 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
                               class=" css-1ckpxei-control"
                             >
                               <div
-                                class=" css-1drmnx5-ValueContainer"
+                                class=" css-onz4xi-ValueContainer"
                               >
                                 <div
                                   class=" css-1ryi7up-singleValue"

--- a/packages/core/upload/admin/src/components/EditAssetDialog/tests/__snapshots__/index.test.js.snap
+++ b/packages/core/upload/admin/src/components/EditAssetDialog/tests/__snapshots__/index.test.js.snap
@@ -1161,7 +1161,7 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
                               class=" css-1ckpxei-control"
                             >
                               <div
-                                class=" css-1drmnx5-ValueContainer"
+                                class=" css-onz4xi-ValueContainer"
                               >
                                 <div
                                   class=" css-1ryi7up-singleValue"

--- a/packages/core/upload/admin/src/components/EditFolderDialog/tests/__snapshots__/EditFolderDialog.test.js.snap
+++ b/packages/core/upload/admin/src/components/EditFolderDialog/tests/__snapshots__/EditFolderDialog.test.js.snap
@@ -638,7 +638,7 @@ exports[`EditFolderDialog renders and matches the snapshot 1`] = `
                             class=" css-1ckpxei-control"
                           >
                             <div
-                              class=" css-1drmnx5-ValueContainer"
+                              class=" css-onz4xi-ValueContainer"
                             >
                               <div
                                 class=" css-1ryi7up-singleValue"

--- a/packages/core/upload/admin/src/components/SelectTree/tests/__snapshots__/SelectTree.test.js.snap
+++ b/packages/core/upload/admin/src/components/SelectTree/tests/__snapshots__/SelectTree.test.js.snap
@@ -67,7 +67,7 @@ exports[`SelectTree renders 1`] = `
           class=" css-1ckpxei-control"
         >
           <div
-            class=" css-1drmnx5-ValueContainer"
+            class=" css-onz4xi-ValueContainer"
           >
             <div
               class=" css-1ryi7up-singleValue"
@@ -198,7 +198,7 @@ exports[`SelectTree renders 1`] = `
         class=" css-1ckpxei-control"
       >
         <div
-          class=" css-1drmnx5-ValueContainer"
+          class=" css-onz4xi-ValueContainer"
         >
           <div
             class=" css-1ryi7up-singleValue"


### PR DESCRIPTION
### What does it do?

Fixes several bugs in the admin app for review-workflows such as:

#### Settings

- Add loading state to Save button
- Add loading state to Confirm button
- Display Save button as disabled after changes have been saved
- Fix border-overflow on Stage component
- Fix background-color (white -> transparent) of Stage delete button
- Reset `hasDeletedServerStages` after a workflow has been saved

#### List-view

- Display stage empty, if no stage has been assigned (instead of crashing)


##### Edit-view

- Add loading state to Select component
- Add error message in case no stage has been assigned
- Fix assigning stages for single-types
- Add success toast message

> **Note**
> If you want to review these bugs one-by-one you can review them by commit.

### Why is it needed?

Who likes 🐛 s?

### How to test it?

See above.
