### PR TITLE
fix: Prevent null stage on entity update

### DIFF
--- a/packages/core/admin/ee/server/services/review-workflows/__tests__/entity-service-decorator.test.js
+++ b/packages/core/admin/ee/server/services/review-workflows/__tests__/entity-service-decorator.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const { decorator } = require('../entity-service-decorator')();
 const { omit } = require('lodash/fp');
+const { decorator } = require('../entity-service-decorator')();
 
 jest.mock('../../../utils');
 

--- a/packages/core/admin/ee/server/services/review-workflows/__tests__/entity-service-decorator.test.js
+++ b/packages/core/admin/ee/server/services/review-workflows/__tests__/entity-service-decorator.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { decorator } = require('../entity-service-decorator')();
+const { omit } = require('lodash/fp');
 
 jest.mock('../../../utils');
 
@@ -73,6 +74,73 @@ describe('Entity service decorator', () => {
         data: {
           ...input.data,
           strapi_reviewWorkflows_stage: 1,
+        },
+      });
+    });
+  });
+
+  describe('Update', () => {
+    test('Calls original update for non review workflow content types', async () => {
+      const entry = {
+        id: 1,
+      };
+
+      const defaultService = {
+        update: jest.fn(() => Promise.resolve(entry)),
+      };
+
+      const service = decorator(defaultService);
+
+      const id = 1;
+      const input = { data: { title: 'title ' } };
+      await service.update('non-rw-model', id, input);
+
+      expect(defaultService.update).toHaveBeenCalledWith('non-rw-model', id, input);
+    });
+
+    test('Assigns a stage to new review workflow entity', async () => {
+      const entry = {
+        id: 1,
+      };
+
+      const defaultService = {
+        update: jest.fn(() => Promise.resolve(entry)),
+      };
+
+      const service = decorator(defaultService);
+
+      const id = 1;
+      const input = { data: { title: 'title ', strapi_reviewWorkflows_stage: 1 } };
+      await service.update('test-model', id, input);
+
+      expect(defaultService.update).toHaveBeenCalledWith('test-model', id, {
+        ...input,
+        data: {
+          ...input.data,
+          strapi_reviewWorkflows_stage: 1,
+        },
+      });
+    });
+
+    test('Can not assign a null stage to new review workflow entity', async () => {
+      const entry = {
+        id: 1,
+      };
+
+      const defaultService = {
+        update: jest.fn(() => Promise.resolve(entry)),
+      };
+
+      const service = decorator(defaultService);
+
+      const id = 1;
+      const input = { data: { title: 'title ', strapi_reviewWorkflows_stage: null } };
+      await service.update('test-model', id, input);
+
+      expect(defaultService.update).toHaveBeenCalledWith('test-model', id, {
+        ...input,
+        data: {
+          ...omit('strapi_reviewWorkflows_stage', input.data),
         },
       });
     });


### PR DESCRIPTION
### What does it do?
When updating an entity, it ignores the stage attribute if it is set to null.

### Why is it needed?
To enforce the business rule of "no entity stage should be null".

### How to test it?
See tests.


