### PR TITLE
CM: Cleanup props for CollectionType and SingleType form wrapper

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/CollectionTypeFormWrapper/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/CollectionTypeFormWrapper/index.js
@@ -222,6 +222,8 @@ const CollectionTypeFormWrapper = ({ allLayoutData, children, slug, id, origin }
 
         trackUsageRef.current('didDeleteEntry', trackerProperty);
 
+        replace(redirectionLink);
+
         return Promise.resolve(data);
       } catch (err) {
         trackUsageRef.current('didNotDeleteEntry', { error: err, ...trackerProperty });
@@ -229,12 +231,8 @@ const CollectionTypeFormWrapper = ({ allLayoutData, children, slug, id, origin }
         return Promise.reject(err);
       }
     },
-    [id, slug, toggleNotification, del]
+    [id, slug, toggleNotification, del, redirectionLink, replace]
   );
-
-  const onDeleteSucceeded = useCallback(() => {
-    replace(redirectionLink);
-  }, [redirectionLink, replace]);
 
   const onPost = useCallback(
     async (body, trackerProperty) => {
@@ -409,7 +407,6 @@ const CollectionTypeFormWrapper = ({ allLayoutData, children, slug, id, origin }
     isCreatingEntry,
     isLoadingForData: isLoading,
     onDelete,
-    onDeleteSucceeded,
     onPost,
     onPublish,
     onDraftRelationCheck,

--- a/packages/core/admin/admin/src/content-manager/components/SingleTypeFormWrapper/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/SingleTypeFormWrapper/index.js
@@ -172,6 +172,9 @@ const SingleTypeFormWrapper = ({ allLayoutData, children, slug }) => {
 
         trackUsageRef.current('didDeleteEntry', trackerProperty);
 
+        setIsCreatingEntry(true);
+        dispatch(initForm(rawQuery, true));
+
         return Promise.resolve(data);
       } catch (err) {
         trackUsageRef.current('didNotDeleteEntry', { error: err, ...trackerProperty });
@@ -181,14 +184,8 @@ const SingleTypeFormWrapper = ({ allLayoutData, children, slug }) => {
         return Promise.reject(err);
       }
     },
-    [del, slug, displayErrors, toggleNotification, searchToSend]
+    [del, slug, displayErrors, toggleNotification, searchToSend, dispatch, rawQuery]
   );
-
-  const onDeleteSucceeded = useCallback(() => {
-    setIsCreatingEntry(true);
-
-    dispatch(initForm(rawQuery, true));
-  }, [dispatch, rawQuery]);
 
   const onPost = useCallback(
     async (body, trackerProperty) => {
@@ -370,7 +367,6 @@ const SingleTypeFormWrapper = ({ allLayoutData, children, slug }) => {
     isCreatingEntry,
     isLoadingForData: isLoading,
     onDelete,
-    onDeleteSucceeded,
     onPost,
     onDraftRelationCheck,
     onPublish,

--- a/packages/core/admin/admin/src/content-manager/pages/EditView/DeleteLink/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/EditView/DeleteLink/index.js
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import { getTrad } from '../../../utils';
 import { connect, select } from './utils';
 
-const DeleteLink = ({ isCreatingEntry, onDelete, trackerProperty }) => {
+const DeleteLink = ({ onDelete, trackerProperty }) => {
   const [displayDeleteConfirmation, setDisplayDeleteConfirmation] = useState(false);
   const [isModalConfirmButtonLoading, setIsModalConfirmButtonLoading] = useState(false);
   const { formatMessage } = useIntl();
@@ -37,10 +37,6 @@ const DeleteLink = ({ isCreatingEntry, onDelete, trackerProperty }) => {
     }
   };
 
-  if (isCreatingEntry) {
-    return null;
-  }
-
   return (
     <>
       <Button onClick={toggleWarningDelete} size="S" startIcon={<Trash />} variant="danger-light">
@@ -61,7 +57,6 @@ const DeleteLink = ({ isCreatingEntry, onDelete, trackerProperty }) => {
 };
 
 DeleteLink.propTypes = {
-  isCreatingEntry: PropTypes.bool.isRequired,
   onDelete: PropTypes.func.isRequired,
   trackerProperty: PropTypes.object.isRequired,
 };

--- a/packages/core/admin/admin/src/content-manager/pages/EditView/DeleteLink/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/EditView/DeleteLink/index.js
@@ -8,14 +8,14 @@ import PropTypes from 'prop-types';
 import { getTrad } from '../../../utils';
 import { connect, select } from './utils';
 
-const DeleteLink = ({ isCreatingEntry, onDelete, onDeleteSucceeded, trackerProperty }) => {
-  const [showWarningDelete, setWarningDelete] = useState(false);
+const DeleteLink = ({ isCreatingEntry, onDelete, trackerProperty }) => {
+  const [displayDeleteConfirmation, setDisplayDeleteConfirmation] = useState(false);
   const [isModalConfirmButtonLoading, setIsModalConfirmButtonLoading] = useState(false);
   const { formatMessage } = useIntl();
   const { formatAPIError } = useAPIErrorHandler(getTrad);
   const toggleNotification = useNotification();
 
-  const toggleWarningDelete = () => setWarningDelete((prevState) => !prevState);
+  const toggleWarningDelete = () => setDisplayDeleteConfirmation((prevState) => !prevState);
 
   const handleConfirmDelete = async () => {
     try {
@@ -27,7 +27,6 @@ const DeleteLink = ({ isCreatingEntry, onDelete, onDeleteSucceeded, trackerPrope
       setIsModalConfirmButtonLoading(false);
 
       toggleWarningDelete();
-      onDeleteSucceeded();
     } catch (err) {
       setIsModalConfirmButtonLoading(false);
       toggleWarningDelete();
@@ -50,9 +49,10 @@ const DeleteLink = ({ isCreatingEntry, onDelete, onDeleteSucceeded, trackerPrope
           defaultMessage: 'Delete this entry',
         })}
       </Button>
+
       <ConfirmDialog
         isConfirmButtonLoading={isModalConfirmButtonLoading}
-        isOpen={showWarningDelete}
+        isOpen={displayDeleteConfirmation}
         onConfirm={handleConfirmDelete}
         onToggleDialog={toggleWarningDelete}
       />
@@ -63,7 +63,6 @@ const DeleteLink = ({ isCreatingEntry, onDelete, onDeleteSucceeded, trackerPrope
 DeleteLink.propTypes = {
   isCreatingEntry: PropTypes.bool.isRequired,
   onDelete: PropTypes.func.isRequired,
-  onDeleteSucceeded: PropTypes.func.isRequired,
   trackerProperty: PropTypes.object.isRequired,
 };
 

--- a/packages/core/admin/admin/src/content-manager/pages/EditView/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/EditView/index.js
@@ -220,8 +220,8 @@ const EditView = ({ allowedActions, isSingleType, goBack, slug, id, origin, user
                             </LinkButton>
                           </CheckPermissions>
 
-                          {allowedActions.canDelete && (
-                            <DeleteLink isCreatingEntry={isCreatingEntry} onDelete={onDelete} />
+                          {allowedActions.canDelete && !isCreatingEntry && (
+                            <DeleteLink onDelete={onDelete} />
                           )}
                         </Flex>
                       </Box>

--- a/packages/core/admin/admin/src/content-manager/pages/EditView/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/EditView/index.js
@@ -77,7 +77,6 @@ const EditView = ({ allowedActions, isSingleType, goBack, slug, id, origin, user
         isCreatingEntry,
         isLoadingForData,
         onDelete,
-        onDeleteSucceeded,
         onPost,
         onPublish,
         onDraftRelationCheck,
@@ -222,11 +221,7 @@ const EditView = ({ allowedActions, isSingleType, goBack, slug, id, origin, user
                           </CheckPermissions>
 
                           {allowedActions.canDelete && (
-                            <DeleteLink
-                              isCreatingEntry={isCreatingEntry}
-                              onDelete={onDelete}
-                              onDeleteSucceeded={onDeleteSucceeded}
-                            />
+                            <DeleteLink isCreatingEntry={isCreatingEntry} onDelete={onDelete} />
                           )}
                         </Flex>
                       </Box>


### PR DESCRIPTION
### What does it do?

Removes the `onDeleteSucceeded` prop from the `DeleteLink` in the CM edit view.

### Why is it needed?

I don't see the need to pass down the `onDeleteSucceeded` callback, when we can execute it directly as part of the `onDelete` handler which is already passed around. It only complicates things.

### How to test it?

Create a collection-type and single-type entry and delete them. Everything should work the same way as before.

