### PR TITLE
Chore: Remove legacy uid attribute of workflows

### DIFF
--- a/packages/core/admin/ee/server/content-types/workflow/index.js
+++ b/packages/core/admin/ee/server/content-types/workflow/index.js
@@ -20,9 +20,6 @@ module.exports = {
       },
     },
     attributes: {
-      uid: {
-        type: 'string',
-      },
       stages: {
         type: 'relation',
         target: 'admin::workflow-stage',


### PR DESCRIPTION

### What does it do?

Removes the `uid` attribute from workflows.

### Why is it needed?

It was never used and still shows up in the response.

