### PR TITLE
write to stderr

### DIFF
--- a/packages/utils/typescript/lib/compile.js
+++ b/packages/utils/typescript/lib/compile.js
@@ -5,7 +5,7 @@ const getConfigPath = require('./utils/get-config-path');
 
 module.exports = async (srcDir, { watch = false, configOptions = {} } = {}) => {
   // TODO: Use the Strapi debug logger instead or don't log at all
-  console.log(`Starting the compilation for TypeScript files in ${srcDir}`);
+  process.stderr.write(`Starting the compilation for TypeScript files in ${srcDir}\n`);
 
   const compiler = watch ? compilers.watch : compilers.basic;
   const configPath = getConfigPath(srcDir);


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Write the compile message from typescript utils to stderr instead of stdout.

### Why is it needed?

Otherwise the message will appear in `strapi config:dump` output and possibly other undesired locations as well.

### How to test it?

Create new strapi config with typescript and do a `strapi config:dump > config.json`. The file only contains JSON data.

### Related issue(s)/PR(s)


