### PR TITLE
Don't use a named export, export an object for audit-logs content-type

### DIFF
--- a/packages/providers/audit-logs-local/src/content-types/audit-log/index.ts
+++ b/packages/providers/audit-logs-local/src/content-types/audit-log/index.ts
@@ -1,1 +1,5 @@
-export { default as schema } from './schema';
+import schema from './schema';
+
+export default {
+  schema,
+};

--- a/packages/providers/audit-logs-local/src/index.ts
+++ b/packages/providers/audit-logs-local/src/index.ts
@@ -1,5 +1,5 @@
 import type { Strapi } from '@strapi/strapi';
-import { schema as auditLogContentType } from './content-types/audit-log';
+import auditLogContentType from './content-types/audit-log';
 
 interface Event {
   action: string;


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* correctly exports the `audit-logs` content type schema

### Why is it needed?

* there was a regression caused by #16323 where we converted it to a named export, this is not the same as what was happening before, where we were exporting an object by default that had the key "schema"

### How to test it?

* run `yarn develop` in the examples folder and it should work
