### PR TITLE
CM: DynamicTable - Move review workflow column code into ee folder

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/DynamicTable/CellContent/ReviewWorkflowsStage/getTableColumn.js
+++ b/packages/core/admin/admin/src/content-manager/components/DynamicTable/CellContent/ReviewWorkflowsStage/getTableColumn.js
@@ -1,0 +1,2 @@
+// Overwritten in EE
+export default () => null;

--- a/packages/core/admin/admin/src/content-manager/components/DynamicTable/CellContent/ReviewWorkflowsStage/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/DynamicTable/CellContent/ReviewWorkflowsStage/index.js
@@ -1,1 +1,0 @@
-export * from './ReviewWorkflowsStage';

--- a/packages/core/admin/admin/src/content-manager/components/DynamicTable/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/DynamicTable/index.js
@@ -4,6 +4,7 @@ import { useIntl } from 'react-intl';
 import { DynamicTable as Table, useStrapiApp } from '@strapi/helper-plugin';
 import { useSelector } from 'react-redux';
 
+import getReviewWorkflowsColumn from 'ee_else_ce/content-manager/components/DynamicTable/CellContent/ReviewWorkflowsStage/getTableColumn';
 import { INJECT_COLUMN_IN_TABLE } from '../../../exposedHooks';
 import { selectDisplayedHeaders } from '../../pages/ListView/selectors';
 import { getTrad } from '../../utils';
@@ -11,7 +12,6 @@ import TableRows from './TableRows';
 import ConfirmDialogDeleteAll from './ConfirmDialogDeleteAll';
 import ConfirmDialogDelete from './ConfirmDialogDelete';
 import { PublicationState } from './CellContent/PublicationState/PublicationState';
-import { ReviewWorkflowsStage } from './CellContent/ReviewWorkflowsStage';
 
 const DynamicTable = ({
   canCreate,
@@ -27,7 +27,6 @@ const DynamicTable = ({
 }) => {
   const { runHookWaterfall } = useStrapiApp();
   const hasDraftAndPublish = layout.contentType.options?.draftAndPublish ?? false;
-  const hasReviewWorkflows = layout.contentType.options?.reviewWorkflows ?? false;
   const { formatMessage } = useIntl();
   const displayedHeaders = useSelector(selectDisplayedHeaders);
 
@@ -74,36 +73,19 @@ const DynamicTable = ({
       });
     }
 
-    if (hasReviewWorkflows) {
-      formattedHeaders.push({
-        key: '__strapi_reviewWorkflows_stage_temp_key__',
-        name: 'strapi_reviewWorkflows_stage',
-        fieldSchema: {
-          type: 'custom',
-        },
-        metadatas: {
-          label: formatMessage({
-            id: getTrad(`containers.ListPage.table-headers.reviewWorkflows.stage`),
-            defaultMessage: 'Review stage',
-          }),
-          searchable: false,
-          sortable: false,
-        },
-        cellFormatter({ strapi_reviewWorkflows_stage }) {
-          return <ReviewWorkflowsStage name={strapi_reviewWorkflows_stage.name} />;
-        },
-      });
+    // this should not exist. Ideally we would use registerHook() similar to what has been done
+    // in the i18n plugin. In order to do that review-workflows should have been a plugin. In
+    // a future iteration we need to find a better pattern.
+
+    // In CE this will return null - in EE a column definition including the custom formatting component.
+    const reviewWorkflowColumn = getReviewWorkflowsColumn(layout);
+
+    if (reviewWorkflowColumn) {
+      formattedHeaders.push(reviewWorkflowColumn);
     }
 
     return formattedHeaders;
-  }, [
-    runHookWaterfall,
-    displayedHeaders,
-    layout,
-    hasDraftAndPublish,
-    hasReviewWorkflows,
-    formatMessage,
-  ]);
+  }, [runHookWaterfall, displayedHeaders, layout, hasDraftAndPublish, formatMessage]);
 
   return (
     <Table

--- a/packages/core/admin/admin/src/content-manager/components/DynamicTable/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/DynamicTable/index.js
@@ -1,7 +1,6 @@
 import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
-import { Typography } from '@strapi/design-system';
 import { DynamicTable as Table, useStrapiApp } from '@strapi/helper-plugin';
 import { useSelector } from 'react-redux';
 

--- a/packages/core/admin/ee/admin/content-manager/components/DynamicTable/CellContent/ReviewWorkflowsStage/ReviewWorkflowsStageEE.js
+++ b/packages/core/admin/ee/admin/content-manager/components/DynamicTable/CellContent/ReviewWorkflowsStage/ReviewWorkflowsStageEE.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Typography } from '@strapi/design-system';
 
-export function ReviewWorkflowsStage({ name }) {
+export function ReviewWorkflowsStageEE({ name }) {
   return (
     <Typography fontWeight="regular" textColor="neutral700">
       {name}
@@ -10,6 +10,6 @@ export function ReviewWorkflowsStage({ name }) {
   );
 }
 
-ReviewWorkflowsStage.propTypes = {
+ReviewWorkflowsStageEE.propTypes = {
   name: PropTypes.string.isRequired,
 };

--- a/packages/core/admin/ee/admin/content-manager/components/DynamicTable/CellContent/ReviewWorkflowsStage/getTableColumn.js
+++ b/packages/core/admin/ee/admin/content-manager/components/DynamicTable/CellContent/ReviewWorkflowsStage/getTableColumn.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useIntl } from 'react-intl';
+import { Typography } from '@strapi/design-system';
 
 import ReviewWorkflowsStage from '.';
 import getTrad from '../../../../../../../admin/src/content-manager/utils/getTrad';
@@ -32,6 +33,12 @@ export default (layout) => {
       sortable: false,
     },
     cellFormatter({ strapi_reviewWorkflows_stage }) {
+      // if entities are created e.g. through lifecycle methods
+      // they may not have a stage assigned
+      if (!strapi_reviewWorkflows_stage) {
+        return <Typography textColor="neutral800">-</Typography>;
+      }
+
       return <ReviewWorkflowsStage name={strapi_reviewWorkflows_stage.name} />;
     },
   };

--- a/packages/core/admin/ee/admin/content-manager/components/DynamicTable/CellContent/ReviewWorkflowsStage/getTableColumn.js
+++ b/packages/core/admin/ee/admin/content-manager/components/DynamicTable/CellContent/ReviewWorkflowsStage/getTableColumn.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import { useIntl } from 'react-intl';
+
+import ReviewWorkflowsStage from '.';
+import getTrad from '../../../../../../../admin/src/content-manager/utils/getTrad';
+
+export default (layout) => {
+  const { formatMessage } = useIntl();
+
+  // TODO: As soon as the feature was enabled in EE mode, the BE currently does not have a way to send
+  // `false` once a user is in CE mode again. We shouldn't have to perform the window.strapi.isEE check here
+  // and it is meant to be in interim solution until we find a better one.
+  const hasReviewWorkflows =
+    (window.strapi.isEE && layout.contentType.options?.reviewWorkflows) ?? false;
+
+  if (!hasReviewWorkflows) {
+    return null;
+  }
+
+  return {
+    key: '__strapi_reviewWorkflows_stage_temp_key__',
+    name: 'strapi_reviewWorkflows_stage',
+    fieldSchema: {
+      type: 'custom',
+    },
+    metadatas: {
+      label: formatMessage({
+        id: getTrad(`containers.ListPage.table-headers.reviewWorkflows.stage`),
+        defaultMessage: 'Review stage',
+      }),
+      searchable: false,
+      sortable: false,
+    },
+    cellFormatter({ strapi_reviewWorkflows_stage }) {
+      return <ReviewWorkflowsStage name={strapi_reviewWorkflows_stage.name} />;
+    },
+  };
+};

--- a/packages/core/admin/ee/admin/content-manager/components/DynamicTable/CellContent/ReviewWorkflowsStage/index.js
+++ b/packages/core/admin/ee/admin/content-manager/components/DynamicTable/CellContent/ReviewWorkflowsStage/index.js
@@ -1,0 +1,3 @@
+import { ReviewWorkflowsStageEE } from './ReviewWorkflowsStageEE';
+
+export default ReviewWorkflowsStageEE;

--- a/packages/core/admin/ee/admin/content-manager/components/DynamicTable/CellContent/ReviewWorkflowsStage/tests/ReviewWorkflowsStage.test.js
+++ b/packages/core/admin/ee/admin/content-manager/components/DynamicTable/CellContent/ReviewWorkflowsStage/tests/ReviewWorkflowsStage.test.js
@@ -3,7 +3,7 @@ import { render } from '@testing-library/react';
 import { ThemeProvider, lightTheme } from '@strapi/design-system';
 import { IntlProvider } from 'react-intl';
 
-import { ReviewWorkflowsStage } from '..';
+import ReviewWorkflowsStage from '..';
 
 const ComponentFixture = (props) => (
   <ThemeProvider theme={lightTheme}>


### PR DESCRIPTION
### What does it do?

Moves the `ReviewWorkflowsStage` component and column definition into the `ee` folder.

### Why is it needed?

Nathan mentioned rightfully yesterday that it shouldn't be in the CE code. The main problem is that because review-workflows is not a plugin it is not possible to inject it. As a plugin this would be done using the `registerHook` function (see i18n).

