### PR TITLE
fix: don't import from react-router

### DIFF
--- a/packages/core/admin/ee/admin/hooks/useLicenseLimitNotification/index.js
+++ b/packages/core/admin/ee/admin/hooks/useLicenseLimitNotification/index.js
@@ -5,7 +5,7 @@
  */
 import { useEffect } from 'react';
 import { useIntl } from 'react-intl';
-import { useLocation } from 'react-router';
+import { useLocation } from 'react-router-dom';
 import { useNotification } from '@strapi/helper-plugin';
 import isNil from 'lodash/isNil';
 import useLicenseLimits from '../useLicenseLimits';


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* changes the import from `react-router` to `react-router-dom`

### Why is it needed?

* we shouldn't be importing from `react-router`

### Related issue(s)/PR(s)

* resolves #16373
