### PR TITLE
CM: EditView - Update API response structure

### DIFF
--- a/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/InformationBoxEE.js
+++ b/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/InformationBoxEE.js
@@ -45,16 +45,14 @@ export function InformationBoxEE() {
       const typeSlug = isSingleType ? 'single-types' : 'collection-types';
 
       const {
-        // TODO: Once the API response is wrapped in a data attribute this
-        // needs to be updated
-        data: createdEntry,
+        data: { data: createdEntity },
       } = await put(`/admin/content-manager/${typeSlug}/${uid}/${entityId}/stage`, {
         data: { id: stageId },
       });
 
-      dispatch(submitSucceeded(createdEntry));
+      dispatch(submitSucceeded(createdEntity));
 
-      return createdEntry;
+      return createdEntity;
     },
     {
       onSuccess() {


### PR DESCRIPTION
### What does it do?

Fixes updating the initial state of the CM with the updated response format from https://github.com/strapi/strapi/pull/16357

### Why is it needed?

In https://github.com/strapi/strapi/pull/16357 the response format was updated to be wrapped in a `data` attribute to follow the rest of the CM.

### Related issue(s)/PR(s)

- https://github.com/strapi/strapi/pull/16357
