### PR TITLE
Settings: Track didViewWorkflow event only when component mounts

### DIFF
--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/ReviewWorkflows.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/ReviewWorkflows.js
@@ -122,7 +122,8 @@ export function ReviewWorkflowsPage() {
 
   useEffect(() => {
     trackUsage('didViewWorkflow');
-  }, [trackUsage]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <CheckPagePermissions permissions={adminPermissions.settings['review-workflows'].main}>


### PR DESCRIPTION
### What does it do?

Changes the dependency array of the `didViewWorkflow` tracking event, so that it only runs when the component mounts and not on every render.

### Why is it needed?

The component re-renders when e.g. new stages are added, but the event should only be send once.

### How to test it?

1. Start Strapi in EE mode
2. Navigate to http://localhost:4000/admin/settings/review-workflows
3. Confirm the event it sent
4. Add a new stage
5. Confirm the event is not send again
