### PR TITLE
fix: Clear transaction context just before committing

### DIFF
--- a/packages/core/database/lib/index.js
+++ b/packages/core/database/lib/index.js
@@ -57,15 +57,15 @@ class Database {
 
     async function commit() {
       if (notNestedTransaction) {
-        await trx.commit();
         transactionCtx.clear();
+        await trx.commit();
       }
     }
 
     async function rollback() {
       if (notNestedTransaction) {
-        await trx.rollback();
         transactionCtx.clear();
+        await trx.rollback();
       }
     }
 


### PR DESCRIPTION
### What does it do?
Follow up of https://github.com/strapi/strapi/pull/16341

In some concurrent cases , during the await trx.commit() another async process picked up the transacion.

This. PR makes sure the transaction Context is cleared just before committing.

