### PR TITLE
Fix a keys problem with the social links on homepage

### DIFF
--- a/packages/core/admin/admin/src/pages/HomePage/SocialLinks.js
+++ b/packages/core/admin/admin/src/pages/HomePage/SocialLinks.js
@@ -187,7 +187,7 @@ const SocialLinks = () => {
       <GridGap>
         {socialLinksExtended.map(({ icon, link, name }) => {
           return (
-            <GridItem col={6} s={12} key={name}>
+            <GridItem col={6} s={12} key={name.id}>
               <LinkCustom size="L" startIcon={icon} variant="tertiary" href={link} isExternal>
                 {formatMessage(name)}
               </LinkCustom>


### PR DESCRIPTION
### What does it do?

Fix a small bug with the keys of social links on the homepage

### Why is it needed?

To avoid unnecessary errors on tests 

### How to test it?

1. Run the app
2. Go to the homepage
3. Check there is no error with "two children with the same key" anymore
