### PR TITLE
CM: Apply partial entity update after a stage has been updated

### DIFF
--- a/packages/core/admin/admin/src/content-manager/sharedReducers/crudReducer/actions.js
+++ b/packages/core/admin/admin/src/content-manager/sharedReducers/crudReducer/actions.js
@@ -2,6 +2,7 @@ import {
   GET_DATA,
   GET_DATA_SUCCEEDED,
   INIT_FORM,
+  UPDATE_PARTIAL_DATA,
   RESET_PROPS,
   SET_DATA_STRUCTURES,
   SET_STATUS,
@@ -46,4 +47,9 @@ export const submitSucceeded = (data) => ({
 
 export const clearSetModifiedDataOnly = () => ({
   type: CLEAR_SET_MODIFIED_DATA_ONLY,
+});
+
+export const updatePartialData = (data) => ({
+  type: UPDATE_PARTIAL_DATA,
+  data,
 });

--- a/packages/core/admin/admin/src/content-manager/sharedReducers/crudReducer/constants.js
+++ b/packages/core/admin/admin/src/content-manager/sharedReducers/crudReducer/constants.js
@@ -7,3 +7,4 @@ export const SET_STATUS = 'ContentManager/CrudReducer/SET_STATUS';
 export const SUBMIT_SUCCEEDED = 'ContentManager/CrudReducer/SUBMIT_SUCCEEDED';
 export const CLEAR_SET_MODIFIED_DATA_ONLY =
   'ContentManager/CrudReducer/CLEAR_SET_MODIFIED_DATA_ONLY';
+export const UPDATE_PARTIAL_DATA = 'ContentManager/CrudReducer/PARTIAL_DATA_UPDATE';

--- a/packages/core/admin/admin/src/content-manager/sharedReducers/crudReducer/reducer.js
+++ b/packages/core/admin/admin/src/content-manager/sharedReducers/crudReducer/reducer.js
@@ -12,6 +12,7 @@ import {
   GET_DATA,
   GET_DATA_SUCCEEDED,
   INIT_FORM,
+  UPDATE_PARTIAL_DATA,
   RESET_PROPS,
   SET_DATA_STRUCTURES,
   SET_STATUS,
@@ -51,6 +52,10 @@ const crudReducer = (state = crudInitialState, action) =>
 
         draftState.isLoading = false;
         draftState.data = state.contentTypeDataStructure;
+        break;
+      }
+      case UPDATE_PARTIAL_DATA: {
+        draftState.data = { ...state.data, ...action.data };
         break;
       }
       case RESET_PROPS: {

--- a/packages/core/admin/admin/src/content-manager/sharedReducers/crudReducer/tests/crudReducer.test.js
+++ b/packages/core/admin/admin/src/content-manager/sharedReducers/crudReducer/tests/crudReducer.test.js
@@ -3,6 +3,7 @@ import {
   GET_DATA,
   GET_DATA_SUCCEEDED,
   INIT_FORM,
+  UPDATE_PARTIAL_DATA,
   SET_DATA_STRUCTURES,
   SET_STATUS,
   SUBMIT_SUCCEEDED,
@@ -95,7 +96,7 @@ describe('CONTENT MANAGER | sharedReducers | crudReducer', () => {
     expect(crudReducer(state, action)).toEqual(expected);
   });
 
-  it('should handle the SUBMIt_SUCCEEDED action correctly', () => {
+  it('should handle the SUBMIT_SUCCEEDED action correctly', () => {
     const action = { type: SUBMIT_SUCCEEDED, data: 'test' };
 
     const expected = produce(state, (draft) => {
@@ -103,5 +104,41 @@ describe('CONTENT MANAGER | sharedReducers | crudReducer', () => {
     });
 
     expect(crudReducer(state, action)).toEqual(expected);
+  });
+
+  it('should set data using the UPDATE_PARTIAL_DATA action', () => {
+    const action = { type: UPDATE_PARTIAL_DATA, data: { new: true } };
+
+    expect(crudReducer(state, action)).toEqual(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          new: true,
+        }),
+      })
+    );
+  });
+
+  it('should merge data using the UPDATE_PARTIAL_DATA action', () => {
+    const setupAction = {
+      type: GET_DATA_SUCCEEDED,
+      data: {
+        something: true,
+      },
+    };
+
+    state = crudReducer(state, setupAction);
+
+    const action = { type: UPDATE_PARTIAL_DATA, data: { new: true } };
+
+    state = crudReducer(state, action);
+
+    expect(state).toEqual(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          something: true,
+          new: true,
+        }),
+      })
+    );
   });
 });

--- a/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/InformationBoxEE.js
+++ b/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/InformationBoxEE.js
@@ -13,7 +13,7 @@ import { useDispatch } from 'react-redux';
 
 import { useReviewWorkflows } from '../../../../pages/SettingsPage/pages/ReviewWorkflows/hooks/useReviewWorkflows';
 import Information from '../../../../../../admin/src/content-manager/pages/EditView/Information';
-import { submitSucceeded } from '../../../../../../admin/src/content-manager/sharedReducers/crudReducer/actions';
+import { updatePartialData } from '../../../../../../admin/src/content-manager/sharedReducers/crudReducer/actions';
 
 const ATTRIBUTE_NAME = 'strapi_reviewWorkflows_stage';
 
@@ -50,7 +50,7 @@ export function InformationBoxEE() {
         data: { id: stageId },
       });
 
-      dispatch(submitSucceeded(createdEntity));
+      dispatch(updatePartialData({ [ATTRIBUTE_NAME]: createdEntity[ATTRIBUTE_NAME] }));
 
       return createdEntity;
     },


### PR DESCRIPTION
### What does it do?

Updates the action executed after a stage has been changed.

### Why is it needed?

The stage update response contains an entity, but it is not the same entity as the CM returns (e.g. components are missing). Therefore we can only take the partial data about the stage information to update the redux state. I've made the action name very generic because otherwise, we'd have to extend the CM reducers from the EE `InformationBox` component, which I find confusing.
