### PR TITLE
CM: Set value instead of defaultValue to account for i18n re-renders

### DIFF
--- a/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/InformationBoxEE.js
+++ b/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/InformationBoxEE.js
@@ -111,7 +111,6 @@ export function InformationBoxEE() {
               components={{
                 LoadingIndicator: () => <Loader small />,
               }}
-              defaultValue={{ value: activeWorkflowStage?.id, label: activeWorkflowStage?.name }}
               error={formattedError}
               inputId={ATTRIBUTE_NAME}
               isLoading={isLoading}
@@ -122,6 +121,7 @@ export function InformationBoxEE() {
               options={
                 workflow ? workflow.stages.map(({ id, name }) => ({ value: id, label: name })) : []
               }
+              value={{ value: activeWorkflowStage?.id, label: activeWorkflowStage?.name }}
             />
 
             <FieldError />


### PR DESCRIPTION
### What does it do?

Updates `ReactSelect` to use `value` over `defaultValue`.

### Why is it needed?

`defaultValue` is only applied once, whereas `value` is every time. When switching locales the value of the Select was properly send, but the component did not re-render and therefore didn't show the updated value.

### How to test it?

1. Create a localized CT with RW enabled
2. Create 2 localized entities and switch between them
3. Validate the stage information is set properly on every switch


