### PR TITLE
STRAP-481 - Field named "conditions" break the checkboxes on the "Edit a role" screen

### DIFF
--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/Permissions/utils/tests/updateValues.test.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/Permissions/utils/tests/updateValues.test.js
@@ -1,7 +1,7 @@
 import updateValues from '../updateValues';
 
 describe('ADMIN | COMPONENTS | Permissions | utils | updateValues', () => {
-  it('should not the conditions values of given object', () => {
+  it('should not update the conditions values of given object', () => {
     const simpleObject = {
       properties: {
         enabled: true,
@@ -16,6 +16,31 @@ describe('ADMIN | COMPONENTS | Permissions | utils | updateValues', () => {
     };
 
     expect(updateValues(simpleObject, false)).toEqual(expected);
+  });
+
+  it('should update the conditions values if they are fields names', () => {
+    const simpleObject = {
+      conditions: 'test',
+      properties: {
+        fields: {
+          description: false,
+          restaurant: false,
+          conditions: false,
+        },
+      },
+    };
+    const expected = {
+      conditions: 'test',
+      properties: {
+        fields: {
+          description: true,
+          restaurant: true,
+          conditions: true,
+        },
+      },
+    };
+
+    expect(updateValues(simpleObject, true)).toEqual(expected);
   });
 
   it('set the leafs of an object with the second argument passed to the function', () => {

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/Permissions/utils/updateValues.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/Permissions/utils/updateValues.js
@@ -8,18 +8,18 @@ import isObject from 'lodash/isObject';
  * of an object.
  * This utility is very helpful when dealing with parent<>children checkboxes
  */
-const updateValues = (obj, valueToSet) => {
+const updateValues = (obj, valueToSet, isFieldUpdate = false) => {
   return Object.keys(obj).reduce((acc, current) => {
     const currentValue = obj[current];
 
-    if (current === 'conditions') {
+    if (current === 'conditions' && !isFieldUpdate) {
       acc[current] = currentValue;
 
       return acc;
     }
 
     if (isObject(currentValue)) {
-      return { ...acc, [current]: updateValues(currentValue, valueToSet) };
+      return { ...acc, [current]: updateValues(currentValue, valueToSet, current === 'fields') };
     }
 
     acc[current] = valueToSet;


### PR DESCRIPTION
Fixes https://github.com/strapi/strapi/issues/16176

### What does it do?
Handles the edge case where it's not possible to update the role of a field named `conditions` 

### Why is it needed?
Based on existing logic, any field named `conditions` would not be updated whenever we attempt to update the field role from parent checkbox

### How to test it?

- Steps to reproduce the behavior
- Create a new Strapi project
- Create a new Collection Type and add a text field named as "conditions"
- Go to the Settings -> Roles page and select any role to edit
- Click the checkbox next to the name of the previously created Collection Type to check/uncheck all permissions
- Notice that everything is working as expected.


## Demo


https://user-images.githubusercontent.com/45232708/232027924-d87a3ea8-3714-4bc6-8214-2f8c48d3915c.mov



---
This code was written and reviewed by GitStart Community. Growing great engineers, one PR at a time.
