### PR TITLE
Update users-permissions registration field blacklist

### DIFF
--- a/packages/plugins/users-permissions/server/controllers/auth.js
+++ b/packages/plugins/users-permissions/server/controllers/auth.js
@@ -280,6 +280,11 @@ module.exports = {
         'confirmationToken',
         'resetPasswordToken',
         'provider',
+        'id',
+        'createdAt',
+        'updatedAt',
+        'createdBy',
+        'updatedBy',
       ]),
       provider: 'local',
     };

--- a/packages/plugins/users-permissions/server/controllers/auth.js
+++ b/packages/plugins/users-permissions/server/controllers/auth.js
@@ -285,6 +285,7 @@ module.exports = {
         'updatedAt',
         'createdBy',
         'updatedBy',
+        'role',
       ]),
       provider: 'local',
     };


### PR DESCRIPTION
### What does it do?

Updates the users-permissions registration field blacklist during register

### Why is it needed?

Making sure that certain fields cannot be set during register

### How to test it?

Try to register a new user and set the ID during register and ensure that it cannot

### Related issue(s)/PR(s)

Related to: https://github.com/strapi/strapi/pull/16333
