### PR TITLE
feat: ✨ Support to start strapi strapi declaration in dev dependencies

### DIFF
--- a/packages/core/strapi/bin/strapi.js
+++ b/packages/core/strapi/bin/strapi.js
@@ -40,7 +40,7 @@ const checkCwdIsStrapiApp = (name) => {
 
   try {
     const pkgJSON = require(`${process.cwd()}/package.json`);
-    if (!_.has(pkgJSON, 'dependencies.@strapi/strapi')) {
+    if (!_.has(pkgJSON, 'dependencies.@strapi/strapi') || !_.has(pkgJSON, 'devDependencies.@strapi/strapi')) {
       logErrorAndExit(name);
     }
   } catch (err) {


### PR DESCRIPTION
### What does it do?

Support to start strapi strapi declaration in dev dependencies

### Why is it needed?

Say a scenario: When deploying a Stratpi project to Serverless, place this dependency in the layer and introduce it by configuring environment variables. So it is actually feasible to declare in the package devDependencies that running npm install -- production during deployment is also feasible. But another issue was introduced, local startup failed
