### PR TITLE
Extend ExtendableContext instead of BaseContext for PolicyContext

### DIFF
--- a/packages/core/strapi/lib/core/registries/policies.d.ts
+++ b/packages/core/strapi/lib/core/registries/policies.d.ts
@@ -1,7 +1,7 @@
-import { BaseContext } from 'koa';
+import { ExtendableContext } from 'koa';
 import { Strapi } from '../../';
 
-interface PolicyContext extends BaseContext {
+interface PolicyContext extends ExtendableContext {
   type: string;
   is(name): boolean;
 }

--- a/packages/core/strapi/lib/core/registries/policies.d.ts
+++ b/packages/core/strapi/lib/core/registries/policies.d.ts
@@ -3,7 +3,7 @@ import { Strapi } from '../../';
 
 interface PolicyContext extends ExtendableContext {
   type: string;
-  is(name): boolean;
+  is(name: string): boolean;
 }
 
 export type Policy<T = unknown> = (


### PR DESCRIPTION
### What does it do?

Use [ExtendableContext](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/koa/index.d.ts#L720) instead of BaseContext

### Why is it needed?

Aligns the type with the functionality

### How to test it?

Confirm the type is fixed by using `PolicyContext` and you can use `request` and `response` without Typescript throwing an error

### Related issue(s)/PR(s)

Fix #16423 
