### PR TITLE
[plugin documentation] Fix single types using wrong response schema component

### DIFF
--- a/packages/plugins/documentation/server/services/__mocks__/mock-content-types.js
+++ b/packages/plugins/documentation/server/services/__mocks__/mock-content-types.js
@@ -250,4 +250,20 @@ module.exports = {
     actions: {},
     lifecycles: {},
   },
+  'api::homepage.homepage': {
+    kind: 'singleType',
+    collectionName: 'homepages',
+    info: { displayName: 'Homepage', singularName: 'homepage', pluralName: 'homepages' },
+    options: { draftAndPublish: true },
+    pluginOptions: { i18n: { localized: true } },
+    attributes: {
+      title: { type: 'string', required: true, pluginOptions: { i18n: { localized: true } } },
+      slug: {
+        type: 'uid',
+        targetField: 'title',
+        required: true,
+        pluginOptions: { i18n: { localized: true } },
+      },
+    },
+  },
 };

--- a/packages/plugins/documentation/server/services/__mocks__/mock-strapi-data.js
+++ b/packages/plugins/documentation/server/services/__mocks__/mock-strapi-data.js
@@ -92,6 +92,46 @@ module.exports = {
     },
   },
   api: {
+    homepage: {
+      contentTypes: {
+        homepage: contentTypes['api::homepage.homepage'],
+      },
+      routes: {
+        homepage: {
+          type: 'content-api',
+          routes: [
+            {
+              method: 'GET',
+              path: '/homepage',
+              handler: 'api::homepage.homepage.find',
+              config: { auth: { scope: ['api::homepage.homepage.find'] } },
+              info: { apiName: 'homepage', type: 'content-api' },
+            },
+            {
+              method: 'PUT',
+              path: '/homepage',
+              handler: 'api::homepage.homepage.update',
+              config: { auth: { scope: ['api::homepage.homepage.update'] } },
+              info: { apiName: 'homepage', type: 'content-api' },
+            },
+            {
+              method: 'DELETE',
+              path: '/homepage',
+              handler: 'api::homepage.homepage.delete',
+              config: { auth: { scope: ['api::homepage.homepage.delete'] } },
+              info: { apiName: 'homepage', type: 'content-api' },
+            },
+            {
+              method: 'POST',
+              path: '/homepage',
+              handler: 'api::homepage.homepage.create',
+              config: { auth: { scope: ['api::homepage.homepage.create'] } },
+              info: { apiName: 'homepage', type: 'content-api' },
+            },
+          ],
+        },
+      },
+    },
     kitchensink: {
       contentTypes: {
         kitchensink: contentTypes['api::kitchensink.kitchensink'],

--- a/packages/plugins/documentation/server/services/__tests__/documentation.test.js
+++ b/packages/plugins/documentation/server/services/__tests__/documentation.test.js
@@ -78,6 +78,57 @@ describe('Documentation service', () => {
     await expect(validatePromise).resolves.not.toThrow();
   });
 
+  it('generates the correct response component schema for a single type', async () => {
+    const docService = documentation({ strapi: global.strapi });
+    await docService.generateFullDoc();
+    const lastMockCall = fse.writeJson.mock.calls[fse.writeJson.mock.calls.length - 1];
+    const mockFinalDoc = lastMockCall[1];
+    const expected = {
+      description: 'OK',
+      content: {
+        'application/json': {
+          schema: {
+            $ref: '#/components/schemas/HomepageResponse',
+          },
+        },
+      },
+    };
+    expect(mockFinalDoc.paths['/homepage'].get.responses['200']).toEqual(expected);
+    expect(mockFinalDoc.paths['/homepage'].put.responses['200']).toEqual(expected);
+    expect(mockFinalDoc.paths['/homepage'].post.responses['200']).toEqual(expected);
+  });
+
+  it('generates the correct response component schema for a collection type', async () => {
+    const docService = documentation({ strapi: global.strapi });
+    await docService.generateFullDoc();
+    const lastMockCall = fse.writeJson.mock.calls[fse.writeJson.mock.calls.length - 1];
+    const mockFinalDoc = lastMockCall[1];
+    const expectedList = {
+      description: 'OK',
+      content: {
+        'application/json': {
+          schema: {
+            $ref: '#/components/schemas/KitchensinkListResponse',
+          },
+        },
+      },
+    };
+    const expectedOne = {
+      description: 'OK',
+      content: {
+        'application/json': {
+          schema: {
+            $ref: '#/components/schemas/KitchensinkResponse',
+          },
+        },
+      },
+    };
+    expect(mockFinalDoc.paths['/kitchensinks'].get.responses['200']).toEqual(expectedList);
+    expect(mockFinalDoc.paths['/kitchensinks'].post.responses['200']).toEqual(expectedOne);
+    expect(mockFinalDoc.paths['/kitchensinks/{id}'].get.responses['200']).toEqual(expectedOne);
+    expect(mockFinalDoc.paths['/kitchensinks/{id}'].put.responses['200']).toEqual(expectedOne);
+  });
+
   describe('Determines the plugins that need documentation', () => {
     it('generates documentation for the default plugins if the user provided nothing in the config', async () => {
       const docService = documentation({ strapi: global.strapi });

--- a/packages/plugins/documentation/server/services/helpers/build-api-endpoint-path.js
+++ b/packages/plugins/documentation/server/services/helpers/build-api-endpoint-path.js
@@ -81,7 +81,7 @@ const getPathWithPrefix = (prefix, route) => {
  *
  * @returns {object}
  */
-const getPaths = ({ routeInfo, uniqueName, contentTypeInfo }) => {
+const getPaths = ({ routeInfo, uniqueName, contentTypeInfo, kind }) => {
   // Get the routes for the current content type
   const contentTypeRoutes = routeInfo.routes.filter((route) => {
     return (
@@ -98,10 +98,11 @@ const getPaths = ({ routeInfo, uniqueName, contentTypeInfo }) => {
     const hasPathParams = route.path.includes('/:');
     const pathWithPrefix = getPathWithPrefix(routeInfo.prefix, route);
     const routePath = hasPathParams ? parsePathWithVariables(pathWithPrefix) : pathWithPrefix;
+
     const { responses } = getApiResponses({
       uniqueName,
       route,
-      isListOfEntities,
+      isListOfEntities: kind !== 'singleType' && isListOfEntities,
       isLocalizationPath,
     });
 

--- a/packages/plugins/documentation/server/services/helpers/utils/loop-content-type-names.js
+++ b/packages/plugins/documentation/server/services/helpers/utils/loop-content-type-names.js
@@ -16,7 +16,7 @@ const loopContentTypeNames = (api, callback) => {
     // Get the attributes found on the api's contentType
     const uid = `${api.getter}::${api.name}.${contentTypeName}`;
 
-    const { attributes, info: contentTypeInfo } = strapi.contentType(uid);
+    const { attributes, info: contentTypeInfo, kind } = strapi.contentType(uid);
 
     // Get the routes for the current api
     const routeInfo =
@@ -40,6 +40,7 @@ const loopContentTypeNames = (api, callback) => {
       attributes,
       uniqueName,
       contentTypeInfo,
+      kind,
     };
 
     result = {


### PR DESCRIPTION
### What does it do?

Check the "kind" property on the schema to determine if the response should be a list or not

### Why is it needed?

Single types are using a schema component that references is a list of entities but it should just be a single entity

### How to test it?

- Run yarn develop
- Go to swagger UI
- http://localhost:1337/documentation/v1.0.0#/Kitchensink/get%2Fkitchensinks should have 200 with an array value for data
- http://localhost:1337/documentation/v1.0.0#/Homepage/get%2Fhomepage should have 200 with an object value for data

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/issues/16409
