### PR TITLE
Fix links always opening current version instead of selected version

### DIFF
--- a/packages/plugins/documentation/admin/src/pages/PluginPage/index.js
+++ b/packages/plugins/documentation/admin/src/pages/PluginPage/index.js
@@ -51,9 +51,9 @@ const PluginPage = () => {
   const colCount = 4;
   const rowCount = (data?.docVersions?.length || 0) + 1;
 
-  const openDocVersion = () => {
+  const openDocVersion = (version) => {
     const slash = data?.prefix.startsWith('/') ? '' : '/';
-    openWithNewTab(`${slash}${data?.prefix}/v${data?.currentVersion}`);
+    openWithNewTab(`${slash}${data?.prefix}/v${version}`);
   };
 
   const handleRegenerateDoc = (version) => {
@@ -141,7 +141,7 @@ const PluginPage = () => {
                       <Td>
                         <Flex justifyContent="end" {...stopPropagation}>
                           <IconButton
-                            onClick={openDocVersion}
+                            onClick={() => openDocVersion(doc.version)}
                             noBorder
                             icon={<Show />}
                             label={formatMessage(


### PR DESCRIPTION
### What does it do?

If you have several version of your documentation, every link on the documentation plugin page http://localhost:4000/admin/plugins/documentation will always open the current version.

### Why is it needed?

To easily access every version of generated documentation

### How to test it?

Generate a new documentation version by updating the plugins config

```
config: {
	info: {version: 'x.x.x'}
}
```

Run 4000 or build the admin on 1337
Go to http://localhost:4000/admin/plugins/documentation
Click the links and confirm it opens the correct version in the Swagger UI


### Related issue(s)/PR(s)

https://github.com/strapi/strapi/issues/16263
