### PR TITLE
feat: Remove orphaned persisted tables when deleting CT

### DIFF
--- a/packages/core/admin/ee/server/bootstrap.js
+++ b/packages/core/admin/ee/server/bootstrap.js
@@ -5,7 +5,7 @@ const { features } = require('@strapi/strapi/lib/utils/ee');
 const executeCEBootstrap = require('../../server/bootstrap');
 const { getService } = require('../../server/utils');
 const actions = require('./config/admin-actions');
-const { persistTablesWithPrefix, persistTablesWithSuffix } = require('./utils/persisted-tables');
+const { persistTablesWithPrefix } = require('./utils/persisted-tables');
 
 module.exports = async () => {
   const { actionProvider } = getService('permission');
@@ -22,7 +22,6 @@ module.exports = async () => {
 
   if (features.isEnabled('review-workflows')) {
     await persistTablesWithPrefix('strapi_workflows');
-    await persistTablesWithSuffix('_strapi_review_workflows_stage_links');
 
     const { bootstrap: rwBootstrap } = getService('review-workflows');
 

--- a/packages/core/admin/ee/server/utils/persisted-tables.js
+++ b/packages/core/admin/ee/server/utils/persisted-tables.js
@@ -66,7 +66,7 @@ async function addPersistTables({ strapi }, tableNames) {
  * @return {Promise<void>}
  */
 async function removePersistedTables({ strapi }, tableNames) {
-  const persistedTables = await getPersistedTables({ strapi }); // Array<{name: string, dependsOn: Array<{name: string}>}>
+  const persistedTables = await getPersistedTables({ strapi });
 
   // Get new tables to be persisted, remove tables if they already were persisted
   const newPersistedTables = differenceWith(

--- a/packages/core/admin/ee/server/utils/persisted-tables.js
+++ b/packages/core/admin/ee/server/utils/persisted-tables.js
@@ -92,13 +92,15 @@ async function removePersistedTables({ strapi }, tableNames) {
  * @param {Strapi} ctx.strapi
  * @returns {Promise<string[]>}
  */
-const getPersistedTables = async ({ strapi }) =>
-  (
-    await strapi.store.get({
-      type: 'core',
-      key: 'persisted_tables',
-    })
-  ).map(transformTableName) ?? [];
+
+async function getPersistedTables({ strapi }) {
+  const persistedTables = await strapi.store.get({
+    type: 'core',
+    key: 'persisted_tables',
+  });
+
+  return (persistedTables || []).map(transformTableName);
+}
 
 /**
  * Add all table names that start with a prefix to the reserved tables in

--- a/packages/core/admin/ee/server/utils/persisted-tables.js
+++ b/packages/core/admin/ee/server/utils/persisted-tables.js
@@ -68,7 +68,7 @@ async function addPersistTables({ strapi }, tableNames) {
 async function removePersistedTables({ strapi }, tableNames) {
   const persistedTables = await getPersistedTables({ strapi }); // Array<{name: string, dependsOn: Array<{name: string}>}>
 
-  // Using differenceWith instead of filter to avoid mutating the original array
+  // Get new tables to be persisted, remove tables if they already were persisted
   const newPersistedTables = differenceWith(
     (t1, t2) => t1.name === t2,
     persistedTables,

--- a/packages/core/database/lib/schema/diff.js
+++ b/packages/core/database/lib/schema/diff.js
@@ -383,7 +383,7 @@ module.exports = (db) => {
           added: addedTables,
           updated: updatedTables,
           unchanged: unchangedTables,
-          removed: [...removedTables],
+          removed: removedTables,
         },
       },
     };

--- a/packages/core/database/lib/schema/diff.js
+++ b/packages/core/database/lib/schema/diff.js
@@ -348,7 +348,7 @@ module.exports = (db) => {
       if (typeof persistedTable === 'string') {
         return persistedTable;
       }
-      return persistedTable.table;
+      return persistedTable.name;
     };
 
     const persistedTables = helpers.hasTable(srcSchema, 'strapi_core_store_settings')
@@ -364,10 +364,10 @@ module.exports = (db) => {
       if (!helpers.hasTable(destSchema, srcTable.name) && !reservedTables.includes(srcTable.name)) {
         const dependencies = persistedTables
           .filter((table) => {
-            return table?.dependsOn?.some((dep) => dep.table === srcTable.name);
+            return table?.dependsOn?.some((table) => table.name === srcTable.name);
           })
-          .map((table) => {
-            return srcSchema.tables.find((t) => t.name === table.table);
+          .map((dependsOnTable) => {
+            return srcSchema.tables.find((srcTable) => srcTable.name === dependsOnTable.name);
           });
 
         removedTables.push(srcTable, ...dependencies);


### PR DESCRIPTION
### What does it do?

Persisted tables are now removed if you remove their dependent tables.

Meaning, review workflow stage persisted table is removed if you remove it's Content Type.

