### PR TITLE
fix "Uncaught error trying to nullify/remove a date field in Content Manager"

### DIFF
--- a/packages/core/helper-plugin/lib/src/components/FilterPopoverURLQuery/Inputs.js
+++ b/packages/core/helper-plugin/lib/src/components/FilterPopoverURLQuery/Inputs.js
@@ -51,7 +51,8 @@ const Inputs = ({ label, onChange, options, type, value }) => {
         clearLabel={formatMessage({ id: 'clearLabel', defaultMessage: 'Clear' })}
         ariaLabel={label}
         name="datetimepicker"
-        onChange={(date) => onChange(date.toISOString())}
+        // check if date is not null or undefined
+        onChange={(date) => onChange(date ? date.toISOString() : null)}
         onClear={() => onChange(null)}
         value={value ? new Date(value) : null}
         selectedDateLabel={(formattedDate) => `Date picker, current is ${formattedDate}`}

--- a/packages/core/helper-plugin/lib/src/components/GenericInput/index.js
+++ b/packages/core/helper-plugin/lib/src/components/GenericInput/index.js
@@ -226,7 +226,8 @@ const GenericInput = ({
           hint={hint}
           name={name}
           onChange={(date) => {
-            const formattedDate = date.toISOString();
+            // check if date is not null or undefined
+            const formattedDate = date ? date.toISOString() : null;
 
             onChange({ target: { name, value: formattedDate, type } });
           }}

--- a/packages/core/helper-plugin/lib/src/components/GenericInput/tests/index.test.js
+++ b/packages/core/helper-plugin/lib/src/components/GenericInput/tests/index.test.js
@@ -64,7 +64,11 @@ function setupDatetimePicker(props) {
     ...rendered,
   };
 }
-// Increase the jest timeout to accommodate long running tests
+/**
+ * We extend the timeout of these tests because the DS 
+ * DateTimePicker has a slow rendering issue at the moment. 
+ * It passes locally, but fails in the CI.
+ */
 jest.setTimeout(50000);
 
 describe('GenericInput', () => {

--- a/packages/core/helper-plugin/lib/src/components/GenericInput/tests/index.test.js
+++ b/packages/core/helper-plugin/lib/src/components/GenericInput/tests/index.test.js
@@ -64,7 +64,7 @@ function setupDatetimePicker(props) {
     ...rendered,
   };
 }
-
+// Increase the jest timeout to accommodate long running tests
 jest.setTimeout(50000);
 
 describe('GenericInput', () => {

--- a/packages/core/helper-plugin/lib/src/components/GenericInput/tests/index.test.js
+++ b/packages/core/helper-plugin/lib/src/components/GenericInput/tests/index.test.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import { ThemeProvider, lightTheme } from '@strapi/design-system';
 import { IntlProvider } from 'react-intl';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import GenericInput from '../index';
 
@@ -42,6 +43,29 @@ function setupNumber(props) {
     input,
   };
 }
+
+function setupDatetimePicker(props) {
+  const DATETIMEPICKER_FIXTURE_PROPS = {
+    type: 'datetime',
+    name: 'datetime-picker',
+    intlLabel: {
+      id: 'label.test',
+      defaultMessage: 'datetime picker',
+    },
+    value: null,
+    onChange: jest.fn(),
+    onClear: jest.fn(),
+    ...props,
+  };
+
+  const rendered = render(<ComponentFixture {...DATETIMEPICKER_FIXTURE_PROPS} />);
+
+  return {
+    ...rendered,
+  };
+}
+
+jest.setTimeout(50000);
 
 describe('GenericInput', () => {
   describe('number', () => {
@@ -127,5 +151,40 @@ describe('GenericInput', () => {
       );
       expect(container).toMatchSnapshot();
     });
+  });
+
+  describe('datetime', () => {
+    test('renders the datetime picker with the correct value for date and time', async () => {
+      const user = userEvent.setup();
+      const { getByRole } = setupDatetimePicker();
+
+      const btnDate = getByRole('textbox', { name: 'datetime picker' });
+
+      await user.click(btnDate);
+      const numberDayBtn = await getByRole('button', { name: /15/ });
+      await act(async () => {
+        await user.click(numberDayBtn);
+      });
+      
+      const today = new Date();
+      const month = today.getMonth() + 1;
+      const year = today.getFullYear();
+      expect(getByRole('textbox', { name: 'datetime picker' })).toHaveValue(`${month}/15/${year}`);
+      expect(getByRole('combobox', { name: /datetime picker/i })).toHaveValue('00:00');
+    });
+
+    test('simulate clicking on the Clear button in the date and check if the date and time are empty', async () => {
+      const user = userEvent.setup();
+      const { getByRole } = setupDatetimePicker();
+      const btnDate = getByRole('textbox', { name: /datetime picker/i });
+      await user.click(btnDate);
+      await act(async () => {
+        await user.click(getByRole('button', { name: /15/ }));
+      });
+      await user.click(getByRole('button', { name: /clear date/i }));
+
+      expect(getByRole('textbox', { name: 'datetime picker' })).toHaveValue('');
+      expect(getByRole('combobox', { name: /datetime picker/i })).toHaveValue('');
+  });
   });
 });

--- a/packages/core/upload/admin/src/components/FilterPopover/FilterValueInput.js
+++ b/packages/core/upload/admin/src/components/FilterPopover/FilterValueInput.js
@@ -13,7 +13,7 @@ const FilterValueInput = ({ label, onChange, options, type, value }) => {
         ariaLabel={label}
         name="datetimepicker"
         onChange={(date) => {
-          const formattedDate = new Date(date).toISOString();
+          const formattedDate = date ? new Date(date).toISOString() : '';
 
           onChange(formattedDate);
         }}


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

This PR tries to fix a problem inside the Helper Plugin when we use the DateTimePicker component. 

### Why is it needed?

When you try to delete the date content in a DateTimePicker field in the Content manager you have an error.

### How to test it?

1. Create an entity schema in the Content Builder with a date+time field.  Do not make it required.
2. Go to Content Manager and use the date+time picker to select values and save it.
3. Go to Content Manager for that saved record and try to remove the datetime by clicking the "x" to the right of the field.
4. Observe nothing happens and you receive a console error.

### Related issue(s)/PR(s)

The issue related to this PR is this one https://github.com/strapi/strapi/issues/16337
