### PR TITLE
Fix "UID placeholder not meeting naming requirements"

### DIFF
--- a/packages/core/content-type-builder/admin/src/components/FormModal/attributes/baseForm.js
+++ b/packages/core/content-type-builder/admin/src/components/FormModal/attributes/baseForm.js
@@ -415,7 +415,7 @@ const baseForm = {
               ...nameField,
               placeholder: {
                 id: getTrad('modalForm.attribute.form.base.name.placeholder'),
-                defaultMessage: 'e.g. Slug, SEO URL, Canonical URL',
+                defaultMessage: 'e.g. slug, seoUrl, canonicalUrl',
               },
             },
             {

--- a/packages/core/content-type-builder/admin/src/translations/de.json
+++ b/packages/core/content-type-builder/admin/src/translations/de.json
@@ -134,7 +134,7 @@
   "menu.section.models.name": "Sammlungen",
   "menu.section.single-types.name": "Einzel-Einträge",
   "modalForm.attribute.form.base.name.description": "Leerzeichen sind im Name eines Attributs nicht erlaubt",
-  "modalForm.attribute.form.base.name.placeholder": "z.B. Slug, SEO URL, Canonical URL",
+  "modalForm.attribute.form.base.name.placeholder": "z.B. slug, seoUrl, canonicalUrl",
   "modalForm.attribute.target-field": "Verknüpftes Feld",
   "modalForm.attributes.select-component": "Wähle eine Komponente",
   "modalForm.attributes.select-components": "Wähle die Komponenten",

--- a/packages/core/content-type-builder/admin/src/translations/dk.json
+++ b/packages/core/content-type-builder/admin/src/translations/dk.json
@@ -125,7 +125,7 @@
   "from": "fra",
   "listView.headerLayout.description": "Byg datastrukturen for dit indhold",
   "modalForm.attribute.form.base.name.description": "Mellemrum er ikke tilladt i navnet",
-  "modalForm.attribute.form.base.name.placeholder": "f.eks. Slug, SEO URL, Canonical URL",
+  "modalForm.attribute.form.base.name.placeholder": "f.eks. slug, seoUrl, canonicalUrl",
   "modalForm.attribute.target-field": "Vedhæftet felt",
   "modalForm.attributes.select-component": "Vælg et komponent",
   "modalForm.attributes.select-components": "Vælg komponenterne",

--- a/packages/core/content-type-builder/admin/src/translations/en.json
+++ b/packages/core/content-type-builder/admin/src/translations/en.json
@@ -135,7 +135,7 @@
   "menu.section.models.name": "Collection Types",
   "menu.section.single-types.name": "Single Types",
   "modalForm.attribute.form.base.name.description": "No space is allowed for the name of the attribute",
-  "modalForm.attribute.form.base.name.placeholder": "e.g. Slug, SEO URL, Canonical URL",
+  "modalForm.attribute.form.base.name.placeholder": "e.g. slug, seoUrl, canonicalUrl",
   "modalForm.attribute.target-field": "Attached field",
   "modalForm.attributes.select-component": "Select a component",
   "modalForm.attributes.select-components": "Select the components",

--- a/packages/core/content-type-builder/admin/src/translations/es.json
+++ b/packages/core/content-type-builder/admin/src/translations/es.json
@@ -125,7 +125,7 @@
   "from": "de",
   "listView.headerLayout.description": "Construya la arquitectura de datos de su contenido",
   "modalForm.attribute.form.base.name.description": "No se permiten espacios para el nombre del atributo",
-  "modalForm.attribute.form.base.name.placeholder": "p. ej. Slug, URL SEO, URL canónica",
+  "modalForm.attribute.form.base.name.placeholder": "p. ej. slug, urlSeo, urlCanónica",
   "modalForm.attribute.target-field": "Campo adjunto",
   "modalForm.attributes.select-component": "Seleccione un componente",
   "modalForm.attributes.select-components": "Seleccionar los componentes",

--- a/packages/core/content-type-builder/admin/src/translations/fr.json
+++ b/packages/core/content-type-builder/admin/src/translations/fr.json
@@ -43,7 +43,7 @@
   "form.button.cancel": "Annuler",
   "form.button.configure-view": "Configurer la vue",
   "from": "de",
-  "modalForm.attribute.form.base.name.placeholder": "ex : Slug, URL SEO, URL Canonique",
+  "modalForm.attribute.form.base.name.placeholder": "ex : slug, urlSeo, urlCanonique",
   "modalForm.attribute.target-field": "Champ associé",
   "modalForm.singleType.header-create": "Créer un single type",
   "modalForm.sub-header.chooseAttribute.collectionType": "Selectionnez un champ pour votre collection",

--- a/packages/core/content-type-builder/admin/src/translations/id.json
+++ b/packages/core/content-type-builder/admin/src/translations/id.json
@@ -114,7 +114,7 @@
   "form.button.single-type.description": "Terbaik untuk satu contoh seperti tentang kami, beranda, dll.",
   "from": "dari",
   "modalForm.attribute.form.base.name.description": "Tidak ada spasi yang diperbolehkan untuk nama atribut",
-  "modalForm.attribute.form.base.name.placeholder": "Misalnya Siput, URL SEO, URL Kanonis",
+  "modalForm.attribute.form.base.name.placeholder": "Misalnya Siput, urlSeo, urlKanonis",
   "modalForm.attribute.target-field": "Bidang terlampir",
   "modalForm.attributes.select-component": "Pilih komponen",
   "modalForm.attributes.select-components": "Pilih komponen",

--- a/packages/core/content-type-builder/admin/src/translations/it.json
+++ b/packages/core/content-type-builder/admin/src/translations/it.json
@@ -115,7 +115,7 @@
   "form.button.single-type.description": "Indicato per entità uniche come home page, chi siamo, ecc...",
   "from": "da",
   "modalForm.attribute.form.base.name.description": "Spazi non ammessi per il nome dell'attributo",
-  "modalForm.attribute.form.base.name.placeholder": "Es: Slug, URL SEO, URL Canonico",
+  "modalForm.attribute.form.base.name.placeholder": "Es: slug, urlSeo, urlCanonico",
   "modalForm.attribute.target-field": "Campo collegato",
   "modalForm.attributes.select-component": "Seleziona un componente",
   "modalForm.attributes.select-components": "Seleziona i componenti",

--- a/packages/core/content-type-builder/admin/src/translations/ko.json
+++ b/packages/core/content-type-builder/admin/src/translations/ko.json
@@ -125,7 +125,7 @@
   "from": "from",
   "listView.headerLayout.description": "콘텐츠 구조를 만듭니다.",
   "modalForm.attribute.form.base.name.description": "속성 이름에는 공백을 사용할 수 없습니다.",
-  "modalForm.attribute.form.base.name.placeholder": "예: Slug, SEO URL, 표준 URL",
+  "modalForm.attribute.form.base.name.placeholder": "예: slug, seoUrl, 표준Url",
   "modalForm.attribute.target-field": "Attached field",
   "modalForm.attributes.select-component": "컴포넌트 선택",
   "modalForm.attributes.select-components": "컴포넌트 여러개 선택",

--- a/packages/core/content-type-builder/admin/src/translations/ms.json
+++ b/packages/core/content-type-builder/admin/src/translations/ms.json
@@ -112,7 +112,7 @@
   "form.button.single-type.description": "Sesuai untuk data tunggal seperti mengenai kami, laman utama dan lain-lain",
   "from": "dari",
   "modalForm.attribute.form.base.name.description": "Tidak boleh ada jarak dalam nama",
-  "modalForm.attribute.form.base.name.placeholder": "cth. Slug, URL SEO, URL Canonical",
+  "modalForm.attribute.form.base.name.placeholder": "cth. slug, urlSeo, urlCanonical",
   "modalForm.attribute.target-field": "Ruang terpasang",
   "modalForm.attributes.select-component": "Pilih komponen",
   "modalForm.attributes.select-components": "Pilih komponen",

--- a/packages/core/content-type-builder/admin/src/translations/nl.json
+++ b/packages/core/content-type-builder/admin/src/translations/nl.json
@@ -105,7 +105,7 @@
   "form.button.single-type.description": "Het beste voor een enkele instantie zoals over ons, homepage, enz.",
   "from": "van",
   "modalForm.attribute.form.base.name.description": "Er is geen ruimte toegestaan voor de naam van het attribuut",
-  "modalForm.attribute.form.base.name.placeholder": "Bijv.: Slug, SEO URL, Canonical URL",
+  "modalForm.attribute.form.base.name.placeholder": "Bijv.: slug, seoUrl, canonicalUrl",
   "modalForm.attribute.target-field": "Gekoppeld veld",
   "modalForm.attributes.select-component": "Selecteer een component",
   "modalForm.attributes.select-components": "Selecteer de componenten",

--- a/packages/core/content-type-builder/admin/src/translations/pl.json
+++ b/packages/core/content-type-builder/admin/src/translations/pl.json
@@ -134,7 +134,7 @@
   "menu.section.models.name": "Kolekcje",
   "menu.section.single-types.name": "Pojedyncze typy",
   "modalForm.attribute.form.base.name.description": "Spacja nie jest dozwolona dla nazwy",
-  "modalForm.attribute.form.base.name.placeholder": "np. Slug, SEO URL, Canonical URL",
+  "modalForm.attribute.form.base.name.placeholder": "np. slug, seoUrl, canonicalUrl",
   "modalForm.attribute.target-field": "Dołączone pole",
   "modalForm.attributes.select-component": "Wybierz komponent",
   "modalForm.attributes.select-components": "Wybierz komponenty",

--- a/packages/core/content-type-builder/admin/src/translations/pt-BR.json
+++ b/packages/core/content-type-builder/admin/src/translations/pt-BR.json
@@ -134,7 +134,7 @@
   "menu.section.models.name": "Tipos de Coleção",
   "menu.section.single-types.name": "Tipos Únicos",
   "modalForm.attribute.form.base.name.description": "Nenhum espaço é permitido para o nome do atributo",
-  "modalForm.attribute.form.base.name.placeholder": "por exemplo. Slug, URL de SEO, URL canônica",
+  "modalForm.attribute.form.base.name.placeholder": "por exemplo. slug, urlDeSeo, urlCanônica",
   "modalForm.attribute.target-field": "Campo anexado",
   "modalForm.attributes.select-component": "Selecione um componente",
   "modalForm.attributes.select-components": "Selecione os componentes",

--- a/packages/core/content-type-builder/admin/src/translations/ru.json
+++ b/packages/core/content-type-builder/admin/src/translations/ru.json
@@ -116,7 +116,7 @@
   "form.button.single-type.description": "Лучше всего подходит для одного экземпляра, например, о нас, домашняя страница и т.д.",
   "from": "из",
   "modalForm.attribute.form.base.name.description": "Пробелы в имени атрибута недопустимы",
-  "modalForm.attribute.form.base.name.placeholder": "e.g. Slug, SEO URL, Canonical URL",
+  "modalForm.attribute.form.base.name.placeholder": "e.g. slug, seoUrl, canonicalUrl",
   "modalForm.attribute.target-field": "Добавленные поля",
   "modalForm.attributes.select-component": "Выбор компонента",
   "modalForm.attributes.select-components": "Выбор компонентов",

--- a/packages/core/content-type-builder/admin/src/translations/sk.json
+++ b/packages/core/content-type-builder/admin/src/translations/sk.json
@@ -115,7 +115,7 @@
   "form.button.single-type.description": "Ideálne pre jednorazové inštancie ako sú napríklad domovská stránka, atď.",
   "from": "od",
   "modalForm.attribute.form.base.name.description": "Medzery nie sú povolené v názve políčka",
-  "modalForm.attribute.form.base.name.placeholder": "napr. slug, SEO URL, kanonická URL",
+  "modalForm.attribute.form.base.name.placeholder": "napr. slug, seoUrl, kanonickáUrl",
   "modalForm.attribute.target-field": "Priložené políčko",
   "modalForm.attributes.select-component": "Vyberte komponent",
   "modalForm.attributes.select-components": "Vyberte komponenty",

--- a/packages/core/content-type-builder/admin/src/translations/sv.json
+++ b/packages/core/content-type-builder/admin/src/translations/sv.json
@@ -135,7 +135,7 @@
   "menu.section.models.name": "Samlingstyper",
   "menu.section.single-types.name": "Engångstyper",
   "modalForm.attribute.form.base.name.description": "Mellanslag tillåts inte i namnet på attributet",
-  "modalForm.attribute.form.base.name.placeholder": "t.ex Titel, Slug, Canonical URL",
+  "modalForm.attribute.form.base.name.placeholder": "t.ex titel, slug, canonicalUrl",
   "modalForm.attribute.target-field": "Kopplat fält",
   "modalForm.attributes.select-component": "Välj komponent",
   "modalForm.attributes.select-components": "Välj komponenter",

--- a/packages/core/content-type-builder/admin/src/translations/th.json
+++ b/packages/core/content-type-builder/admin/src/translations/th.json
@@ -113,7 +113,7 @@
   "form.button.single-type.description": "ที่ดีที่สุดสำหรับอินสแตนซ์เดี่ยวเช่น เกี่ยวกับเรา, โฮมเพจ, เป็นต้น",
   "from": "จาก",
   "modalForm.attribute.form.base.name.description": "ไม่มีพื้นที่ว่างที่อนุญาตให้ใช้สำหรับชื่อของแอ็ตทริบิวต์",
-  "modalForm.attribute.form.base.name.placeholder": "เช่น Slug, SEO URL, Canonical URL",
+  "modalForm.attribute.form.base.name.placeholder": "เช่น slug, seoUrl, canonicalUrl",
   "modalForm.attribute.target-field": "ฟิลด์ที่แนบ",
   "modalForm.attributes.select-component": "เลือกคอมโพเนนต์",
   "modalForm.attributes.select-components": "เลือกคอมโพเนนต์",

--- a/packages/core/content-type-builder/admin/src/translations/tr.json
+++ b/packages/core/content-type-builder/admin/src/translations/tr.json
@@ -113,7 +113,7 @@
   "menu.section.models.name": "Koleksiyon Tipleri",
   "menu.section.single-types.name": "Tekil Tipler",
   "modalForm.attribute.form.base.name.description": "Nitelik adında boşluk olamaz",
-  "modalForm.attribute.form.base.name.placeholder": "ör. Slug, SEO URL, Canonical URL",
+  "modalForm.attribute.form.base.name.placeholder": "ör. slug, seoUrl, canonicalUrl",
   "modalForm.attribute.target-field": "İliştirilmiş alan",
   "modalForm.attributes.select-component": "Bir bileşen seç",
   "modalForm.attributes.select-components": "Bileşenleri seç",

--- a/packages/core/content-type-builder/admin/src/translations/uk.json
+++ b/packages/core/content-type-builder/admin/src/translations/uk.json
@@ -113,7 +113,7 @@
   "form.button.single-type.description": "Підходить для поодиноких об'єктів, як-то домашня сторінка, про нас тощо",
   "from": "з",
   "modalForm.attribute.form.base.name.description": "Для назви атрибута не допускається пробілів",
-  "modalForm.attribute.form.base.name.placeholder": "наприклад, Slug, SEO URL, Canonical URL",
+  "modalForm.attribute.form.base.name.placeholder": "наприклад, slug, seoUrl, canonicalUrl",
   "modalForm.attribute.target-field": "Пов'язане поле",
   "modalForm.attributes.select-component": "Виберіть компонент",
   "modalForm.attributes.select-components": "Виберіть компоненти",

--- a/packages/core/content-type-builder/admin/src/translations/zh.json
+++ b/packages/core/content-type-builder/admin/src/translations/zh.json
@@ -135,7 +135,7 @@
   "menu.section.models.name": "集合型別",
   "menu.section.single-types.name": "單一型別",
   "modalForm.attribute.form.base.name.description": "欄位名稱不允許空白",
-  "modalForm.attribute.form.base.name.placeholder": "例如：Slug、SEO 網址、Canonical 網址",
+  "modalForm.attribute.form.base.name.placeholder": "例如：slug、seo網址、canonical網址",
   "modalForm.attribute.target-field": "關聯目標欄位",
   "modalForm.attributes.select-component": "選擇一個元件",
   "modalForm.attributes.select-components": "選擇多個元件",


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?
I have changed the placeholder content of the UID to follow a camel case format

### Why is it needed?

UID Field component in Content builder in admin shows field naming examples that won't be possible because no space are allowed

### How to test it?

Create a UID field and test the different language translations.

### Related issue(s)/PR(s)

The issue related to it is https://github.com/strapi/strapi/issues/16349
