### PR TITLE
[RepeatableComponents]: Use the full key par the index for the type

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/RepeatableComponent/components/Component.js
+++ b/packages/core/admin/admin/src/content-manager/components/RepeatableComponent/components/Component.js
@@ -97,11 +97,17 @@ const DraggedItem = ({
   const accordionRef = useRef(null);
   const { formatMessage } = useIntl();
 
-  const [parentFieldName] = componentFieldName.split('.');
+  /**
+   * The last item in the fieldName array will be the index of this component.
+   * Drag and drop should be isolated to the parent component so nested repeatable
+   * components are not affected by the drag and drop of the parent component in
+   * their own re-ordering context.
+   */
+  const componentKey = componentFieldName.split('.').slice(0, -1).join('.');
 
   const [{ handlerId, isDragging, handleKeyDown }, boxRef, dropRef, dragRef, dragPreviewRef] =
     useDragAndDrop(!isReadOnly, {
-      type: `${ItemTypes.COMPONENT}_${parentFieldName}`,
+      type: `${ItemTypes.COMPONENT}_${componentKey}`,
       index,
       item: {
         displayedValue,


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* changes the `type` we pass to `useDragAndDrop` to use the full componentFieldName par the last item (the index of the path)

### Why is it needed?

* Nested repeatable components would use the initial parent name (foolishly forgetting they could be nested) therefore using the full `fieldName` par the `index` of the individual component re-isolates the components drag and drop bounds

### How to test it?

* Have a nested repeatable component
* Move an item in the "outer level"
* Move an item in the "lower level" while dragging it to the space the "outer-level" occupies
* the "outer level" items should not reorder then

### Related issue(s)/PR(s)

* resolves #15764
