### PR TITLE
CM: EditView - persist stage changes in context instead of redux

### DIFF
--- a/packages/core/admin/admin/src/content-manager/pages/EditViewLayoutManager/reducer.js
+++ b/packages/core/admin/admin/src/content-manager/pages/EditViewLayoutManager/reducer.js
@@ -12,18 +12,18 @@ export const initialState = {
 
 const editViewManagerReducer = (state = initialState, action) =>
   // eslint-disable-next-line consistent-return
-  produce(state, (drafState) => {
+  produce(state, (draftState) => {
     switch (action.type) {
       case RESET_PROPS: {
-        drafState.currentLayout = null;
+        draftState.currentLayout = null;
         break;
       }
       case SET_LAYOUT: {
-        drafState.currentLayout = action.layout;
+        draftState.currentLayout = action.layout;
         break;
       }
       default:
-        return drafState;
+        return draftState;
     }
   });
 

--- a/packages/core/admin/admin/src/content-manager/sharedReducers/crudReducer/actions.js
+++ b/packages/core/admin/admin/src/content-manager/sharedReducers/crudReducer/actions.js
@@ -2,7 +2,6 @@ import {
   GET_DATA,
   GET_DATA_SUCCEEDED,
   INIT_FORM,
-  UPDATE_PARTIAL_DATA,
   RESET_PROPS,
   SET_DATA_STRUCTURES,
   SET_STATUS,
@@ -47,9 +46,4 @@ export const submitSucceeded = (data) => ({
 
 export const clearSetModifiedDataOnly = () => ({
   type: CLEAR_SET_MODIFIED_DATA_ONLY,
-});
-
-export const updatePartialData = (data) => ({
-  type: UPDATE_PARTIAL_DATA,
-  data,
 });

--- a/packages/core/admin/admin/src/content-manager/sharedReducers/crudReducer/constants.js
+++ b/packages/core/admin/admin/src/content-manager/sharedReducers/crudReducer/constants.js
@@ -7,4 +7,3 @@ export const SET_STATUS = 'ContentManager/CrudReducer/SET_STATUS';
 export const SUBMIT_SUCCEEDED = 'ContentManager/CrudReducer/SUBMIT_SUCCEEDED';
 export const CLEAR_SET_MODIFIED_DATA_ONLY =
   'ContentManager/CrudReducer/CLEAR_SET_MODIFIED_DATA_ONLY';
-export const UPDATE_PARTIAL_DATA = 'ContentManager/CrudReducer/PARTIAL_DATA_UPDATE';

--- a/packages/core/admin/admin/src/content-manager/sharedReducers/crudReducer/reducer.js
+++ b/packages/core/admin/admin/src/content-manager/sharedReducers/crudReducer/reducer.js
@@ -12,7 +12,6 @@ import {
   GET_DATA,
   GET_DATA_SUCCEEDED,
   INIT_FORM,
-  UPDATE_PARTIAL_DATA,
   RESET_PROPS,
   SET_DATA_STRUCTURES,
   SET_STATUS,
@@ -52,10 +51,6 @@ const crudReducer = (state = crudInitialState, action) =>
 
         draftState.isLoading = false;
         draftState.data = state.contentTypeDataStructure;
-        break;
-      }
-      case UPDATE_PARTIAL_DATA: {
-        draftState.data = { ...state.data, ...action.data };
         break;
       }
       case RESET_PROPS: {

--- a/packages/core/admin/admin/src/content-manager/sharedReducers/crudReducer/tests/crudReducer.test.js
+++ b/packages/core/admin/admin/src/content-manager/sharedReducers/crudReducer/tests/crudReducer.test.js
@@ -3,7 +3,6 @@ import {
   GET_DATA,
   GET_DATA_SUCCEEDED,
   INIT_FORM,
-  UPDATE_PARTIAL_DATA,
   SET_DATA_STRUCTURES,
   SET_STATUS,
   SUBMIT_SUCCEEDED,
@@ -104,41 +103,5 @@ describe('CONTENT MANAGER | sharedReducers | crudReducer', () => {
     });
 
     expect(crudReducer(state, action)).toEqual(expected);
-  });
-
-  it('should set data using the UPDATE_PARTIAL_DATA action', () => {
-    const action = { type: UPDATE_PARTIAL_DATA, data: { new: true } };
-
-    expect(crudReducer(state, action)).toEqual(
-      expect.objectContaining({
-        data: expect.objectContaining({
-          new: true,
-        }),
-      })
-    );
-  });
-
-  it('should merge data using the UPDATE_PARTIAL_DATA action', () => {
-    const setupAction = {
-      type: GET_DATA_SUCCEEDED,
-      data: {
-        something: true,
-      },
-    };
-
-    state = crudReducer(state, setupAction);
-
-    const action = { type: UPDATE_PARTIAL_DATA, data: { new: true } };
-
-    state = crudReducer(state, action);
-
-    expect(state).toEqual(
-      expect.objectContaining({
-        data: expect.objectContaining({
-          something: true,
-          new: true,
-        }),
-      })
-    );
   });
 });

--- a/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/InformationBoxEE.js
+++ b/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/InformationBoxEE.js
@@ -9,11 +9,9 @@ import {
 import { Field, FieldLabel, FieldError, Flex, Loader } from '@strapi/design-system';
 import { useIntl } from 'react-intl';
 import { useMutation } from 'react-query';
-import { useDispatch } from 'react-redux';
 
 import { useReviewWorkflows } from '../../../../pages/SettingsPage/pages/ReviewWorkflows/hooks/useReviewWorkflows';
 import Information from '../../../../../../admin/src/content-manager/pages/EditView/Information';
-import { updatePartialData } from '../../../../../../admin/src/content-manager/sharedReducers/crudReducer/actions';
 
 const ATTRIBUTE_NAME = 'strapi_reviewWorkflows_stage';
 
@@ -23,9 +21,12 @@ export function InformationBoxEE() {
     isCreatingEntry,
     layout: { uid },
     isSingleType,
+    onChange,
   } = useCMEditViewDataManager();
-  const dispatch = useDispatch();
   const { put } = useFetchClient();
+  // it is possible to rely on initialData here, because it always will
+  // be updated at the same time when modifiedData is updated, otherwise
+  // the entity is flagged as modified
   const activeWorkflowStage = initialData?.[ATTRIBUTE_NAME] ?? null;
   const hasReviewWorkflowsEnabled = Object.prototype.hasOwnProperty.call(
     initialData,
@@ -50,7 +51,9 @@ export function InformationBoxEE() {
         data: { id: stageId },
       });
 
-      dispatch(updatePartialData({ [ATTRIBUTE_NAME]: createdEntity[ATTRIBUTE_NAME] }));
+      // initialData and modifiedData have to stay in sync, otherwise the entity would be flagged
+      // as modified, which is what the boolean flag is for
+      onChange({ target: { name: ATTRIBUTE_NAME, value: createdEntity[ATTRIBUTE_NAME] } }, true);
 
       return createdEntity;
     },


### PR DESCRIPTION
### What does it do?

Update the entity stage using context.

### Why is it needed?

When updating a stage on an entity which has modified (unsaved) fields the changes would be lost. Why? Because updating redux resets the entity context to the initial state from the CRUD redux reducer.

The only good part about this PR is that it is less code.

### How to test it?

See https://strapi-inc.atlassian.net/browse/CONTENT-1271

### Related issue(s)/PR(s)

Reverts https://github.com/strapi/strapi/pull/16415
