### PR TITLE
Settings: Update stage delete confirmation modal text

### DIFF
--- a/packages/core/admin/admin/src/translations/en.json
+++ b/packages/core/admin/admin/src/translations/en.json
@@ -222,7 +222,7 @@
   "Settings.review-workflows.page.title": "Review Workflows",
   "Settings.review-workflows.page.subtitle": "{count, plural, one {# stage} other {# stages}}",
   "Settings.review-workflows.page.isLoading": "Workflow is loading",
-  "Settings.review-workflows.page.delete.confirm.body": "All entries assigned to deleted stages will be moved to the first stage. Are you sure you want to save this?",
+  "Settings.review-workflows.page.delete.confirm.body": "All entries assigned to deleted stages will be moved to the previous stage. Are you sure you want to save?",
   "Settings.review-workflows.stage.name.label": "Stage name",
   "Settings.roles.create.description": "Define the rights given to the role",
   "Settings.roles.create.title": "Create a role",

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/ReviewWorkflows.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/ReviewWorkflows.js
@@ -185,7 +185,7 @@ export function ReviewWorkflowsPage() {
             bodyText={{
               id: 'Settings.review-workflows.page.delete.confirm.body',
               defaultMessage:
-                'All entries assigned to deleted stages will be moved to the first stage. Are you sure you want to save this?',
+                'All entries assigned to deleted stages will be moved to the previous stage. Are you sure you want to save?',
             }}
             isConfirmButtonLoading={isLoading}
             isOpen={isConfirmDeleteDialogOpen}


### PR DESCRIPTION
### What does it do?

Updates the stage was deleted confirmation text.

### Why is it needed?

The previous version was not accurate.
