### PR TITLE
fix(RW): Persist all RW stage join tables

### DIFF
--- a/packages/core/admin/ee/server/services/review-workflows/review-workflows.js
+++ b/packages/core/admin/ee/server/services/review-workflows/review-workflows.js
@@ -10,7 +10,7 @@ const defaultWorkflow = require('../../constants/default-workflow.json');
 const { ENTITY_STAGE_ATTRIBUTE } = require('../../constants/workflows');
 
 const { getDefaultWorkflow } = require('../../utils/review-workflows');
-const { persistTable, removePersistedTablesWithSuffix } = require('../../utils/persisted-tables');
+const { persistTables, removePersistedTablesWithSuffix } = require('../../utils/persisted-tables');
 
 async function initDefaultWorkflow({ workflowsService, stagesService, strapi }) {
   const wfCount = await workflowsService.count();

--- a/packages/core/admin/ee/server/services/review-workflows/review-workflows.js
+++ b/packages/core/admin/ee/server/services/review-workflows/review-workflows.js
@@ -119,6 +119,7 @@ module.exports = ({ strapi }) => {
     async register() {
       extendReviewWorkflowContentTypes({ strapi });
       strapi.hook('strapi::content-types.afterSync').register(enableReviewWorkflow({ strapi }));
+      strapi.hook('strapi::content-types.afterSync').register(persistStagesJoinTables({ strapi }));
     },
   };
 };

--- a/packages/core/admin/ee/server/utils/persisted-tables.js
+++ b/packages/core/admin/ee/server/utils/persisted-tables.js
@@ -127,15 +127,17 @@ const removePersistedTablesWithSuffix = async (tableNameSuffix) => {
   await removePersistedTables({ strapi }, tableNames);
 };
 
-const persistTable = async (tableName, dependsOn) => {
-  await addPersistTables({ strapi }, [
-    { name: tableName, dependsOn: dependsOn?.map((depTableName) => ({ name: depTableName })) },
-  ]);
+/**
+ * Add tables to the reserved tables in core store
+ * @param {Array<string|{ table: string; dependsOn?: Array<{ table: string;}> }} tables
+ */
+const persistTables = async (tables) => {
+  await addPersistTables({ strapi }, tables);
 };
 
 module.exports = {
   persistTablesWithPrefix,
   removePersistedTablesWithSuffix,
-  persistTable,
+  persistTables,
   findTables,
 };


### PR DESCRIPTION
### What does it do?

Before, we were persisting stage join tables one by one, concurrently. They were stepping on each other and only one of them was eventually stored.

Now they are stored at once to prevent that.

### Why is it needed?

To persist all stages join tables.

### How to test it?
Have multiple CT with RW, downgrade to CE and updgrade to EE again. All stage information should be kept.


