### PR TITLE
Find the origin & only load to modified data under the clone route

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/index.js
@@ -233,14 +233,18 @@ const EditViewDataManagerProvider = ({
     });
   }, []);
 
-  const relationLoad = useCallback(({ target: { initialDataPath, modifiedDataPath, value } }) => {
-    dispatch({
-      type: 'LOAD_RELATION',
-      modifiedDataPath,
-      initialDataPath,
-      value,
-    });
-  }, []);
+  const relationLoad = useCallback(
+    ({ target: { initialDataPath, modifiedDataPath, value, modifiedDataOnly } }) => {
+      dispatch({
+        type: 'LOAD_RELATION',
+        modifiedDataPath,
+        initialDataPath,
+        value,
+        modifiedDataOnly,
+      });
+    },
+    []
+  );
 
   const addRepeatableComponentToField = dispatchAddComponent('ADD_REPEATABLE_COMPONENT_TO_FIELD');
 

--- a/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/reducer.js
+++ b/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/reducer.js
@@ -96,7 +96,7 @@ const reducer = (state, action) =>
         break;
       }
       case 'LOAD_RELATION': {
-        const { initialDataPath, modifiedDataPath, value } = action;
+        const { initialDataPath, modifiedDataPath, value, modifiedDataOnly = false } = action;
 
         const initialDataRelations = get(state, initialDataPath);
         const modifiedDataRelations = get(state, modifiedDataPath);
@@ -125,11 +125,13 @@ const reducer = (state, action) =>
           __temp_key__: keys[index],
         }));
 
-        set(
-          draftState,
-          initialDataPath,
-          uniqBy([...valuesWithKeys, ...initialDataRelations], 'id')
-        );
+        if (!modifiedDataOnly) {
+          set(
+            draftState,
+            initialDataPath,
+            uniqBy([...valuesWithKeys, ...initialDataRelations], 'id')
+          );
+        }
 
         /**
          * We need to set the value also on modifiedData, because initialData

--- a/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/RelationInputDataManager.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/RelationInputDataManager.js
@@ -19,12 +19,14 @@ import { getInitialDataPathUsingTempKeys } from '../../utils/paths';
 
 export const RelationInputDataManager = ({
   error,
+  entityId,
   componentId,
   isComponentRelation,
   editable,
   description,
   intlLabel,
   isCreatingEntry,
+  isCloningEntry,
   isFieldAllowed,
   isFieldReadable,
   labelAction,
@@ -74,6 +76,7 @@ export const RelationInputDataManager = ({
               initialDataPath: ['initialData', ...initialDataPath],
               modifiedDataPath: ['modifiedData', ...nameSplit],
               value,
+              modifiedDataOnly: isCloningEntry,
             },
           });
         },
@@ -88,11 +91,12 @@ export const RelationInputDataManager = ({
         pageParams: {
           ...defaultParams,
           // eslint-disable-next-line no-nested-ternary
-          entityId: isCreatingEntry
-            ? undefined
-            : isComponentRelation
-            ? componentId
-            : initialData.id,
+          entityId:
+            isCreatingEntry && !isCloningEntry
+              ? undefined
+              : isComponentRelation
+              ? componentId
+              : entityId,
           pageSize: SEARCH_RESULTS_TO_DISPLAY,
         },
       },
@@ -374,6 +378,7 @@ export const RelationInputDataManager = ({
 
 RelationInputDataManager.defaultProps = {
   componentId: undefined,
+  entityId: undefined,
   editable: true,
   error: undefined,
   description: '',
@@ -386,6 +391,7 @@ RelationInputDataManager.defaultProps = {
 
 RelationInputDataManager.propTypes = {
   componentId: PropTypes.number,
+  entityId: PropTypes.number,
   editable: PropTypes.bool,
   error: PropTypes.string,
   description: PropTypes.string,
@@ -395,6 +401,7 @@ RelationInputDataManager.propTypes = {
     values: PropTypes.object,
   }).isRequired,
   labelAction: PropTypes.element,
+  isCloningEntry: PropTypes.bool.isRequired,
   isCreatingEntry: PropTypes.bool.isRequired,
   isComponentRelation: PropTypes.bool,
   isFieldAllowed: PropTypes.bool,

--- a/packages/core/admin/admin/src/content-manager/pages/ListView/components/TableRows/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/ListView/components/TableRows/index.js
@@ -55,7 +55,7 @@ export const TableRows = ({
   const handleCloneClick = (id) => async () => {
     try {
       const { data } = await post(
-        `/content-manager/collection-types/${contentType.uid}/clone/${id}`
+        `/content-manager/collection-types/${contentType.uid}/clone/${id}?${pluginsQueryParams}`
       );
 
       if ('id' in data) {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* uses the `originId` to fetch the relations and _only_ add them to the `modifiedData` via `useRouteMatch` hook

### Why is it needed?

* When you clone an entity and it cannot be automatically done because of prohibited fields we should show all the values from the original entity, in the case of relations we were only ever using the id from `modifiedData` to pre-populate the field, when cloning it want's to use the origin Id so you get the whole "cloning" experience.

### Related issue(s)/PR(s)

* resolves CONTENT-984
* completes this iteration of the feature 🤝🏼
