### PR TITLE
use Object.defineProperty to redefine localStorage

### DIFF
--- a/packages/admin-test-utils/lib/mocks/LocalStorageMock.js
+++ b/packages/admin-test-utils/lib/mocks/LocalStorageMock.js
@@ -2,24 +2,36 @@
 
 class LocalStorageMock {
   constructor() {
-    this.store = {};
+    this.store = new Map();
   }
 
   clear() {
-    this.store = {};
+    this.store.clear();
   }
 
   getItem(key) {
-    return this.store[key] || null;
+    /**
+     * We return null to avoid returning `undefined`
+     * because `undefined` is not a valid JSON value.
+     */
+    return this.store.get(key) ?? null;
   }
 
   setItem(key, value) {
-    this.store[key] = String(value);
+    this.store.set(key, String(value));
   }
 
   removeItem(key) {
-    delete this.store[key];
+    this.store.delete(key);
+  }
+
+  get length() {
+    return this.store.size;
   }
 }
 
-global.localStorage = new LocalStorageMock();
+// eslint-disable-next-line no-undef
+Object.defineProperty(window, 'localStorage', {
+  writable: true,
+  value: new LocalStorageMock(),
+});


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* Converts localStorage to a Map because it's better imo and it has all the methods we want
* use Object.defineProperty instead of `=`.

### Why is it needed?

* to stop this madness

### How to test it?

* I'm hoping the FE test suite "just passes"
