### PR TITLE
Upgrade to TS V5 and fix related breaking changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "supertest": "6.3.3",
     "ts-jest": "29.0.3",
     "typedoc": "0.23.26",
-    "typescript": "4.6.2",
+    "typescript": "5.0.4",
     "yargs": "17.6.0"
   },
   "engines": {

--- a/packages/core/admin/package.json
+++ b/packages/core/admin/package.json
@@ -133,7 +133,7 @@
     "sift": "16.0.1",
     "style-loader": "3.3.1",
     "styled-components": "5.3.3",
-    "typescript": "4.6.2",
+    "typescript": "5.0.4",
     "webpack": "^5.76.0",
     "webpack-cli": "^5.0.1",
     "webpack-dev-server": "^4.13.1",

--- a/packages/core/data-transfer/package.json
+++ b/packages/core/data-transfer/package.json
@@ -69,7 +69,7 @@
     "knex": "2.4.0",
     "koa": "2.13.4",
     "rimraf": "3.0.2",
-    "typescript": "4.6.2"
+    "typescript": "5.0.4"
   },
   "engines": {
     "node": ">=14.19.1 <=18.x.x",

--- a/packages/core/helper-plugin/package.json
+++ b/packages/core/helper-plugin/package.json
@@ -76,7 +76,7 @@
     "react-test-renderer": "^17.0.2",
     "rimraf": "3.0.2",
     "styled-components": "5.3.3",
-    "typescript": "4.6.2",
+    "typescript": "5.0.4",
     "webpack": "^5.76.0",
     "webpack-cli": "^5.0.1"
   },

--- a/packages/core/strapi/package.json
+++ b/packages/core/strapi/package.json
@@ -136,7 +136,7 @@
   },
   "devDependencies": {
     "supertest": "6.3.3",
-    "typescript": "4.6.2"
+    "typescript": "5.0.4"
   },
   "engines": {
     "node": ">=14.19.1 <=18.x.x",

--- a/packages/generators/generators/lib/templates/ts/plugin-package.json.hbs
+++ b/packages/generators/generators/lib/templates/ts/plugin-package.json.hbs
@@ -23,7 +23,7 @@
     "react-dom": "^17.0.2",
     "react-router-dom": "^5.3.4",
     "styled-components": "^5.3.6",
-    "typescript": "4.6.3"
+    "typescript": "5.0.4"
   },
   "peerDependencies": {
     "react": "^17.0.2",

--- a/packages/utils/typescript/lib/generators/schemas/global.js
+++ b/packages/utils/typescript/lib/generators/schemas/global.js
@@ -36,17 +36,14 @@ const generateGlobalDefinition = (schemasDefinitions = []) => {
   const properties = schemasDefinitions.map(schemaDefinitionToPropertySignature);
 
   return factory.createModuleDeclaration(
-    undefined,
     [factory.createModifier(ts.SyntaxKind.DeclareKeyword)],
     factory.createIdentifier('global'),
     factory.createModuleBlock([
       factory.createModuleDeclaration(
         undefined,
-        undefined,
         factory.createIdentifier('Strapi'),
         factory.createModuleBlock([
           factory.createInterfaceDeclaration(
-            undefined,
             undefined,
             factory.createIdentifier('Schemas'),
             undefined,

--- a/packages/utils/typescript/lib/generators/schemas/imports.js
+++ b/packages/utils/typescript/lib/generators/schemas/imports.js
@@ -24,7 +24,6 @@ module.exports = {
 
     return factory.createImportDeclaration(
       undefined,
-      undefined,
       factory.createImportClause(false, undefined, factory.createNamedImports(formattedImports)),
       factory.createStringLiteral('@strapi/strapi'),
       undefined

--- a/packages/utils/typescript/lib/generators/schemas/index.js
+++ b/packages/utils/typescript/lib/generators/schemas/index.js
@@ -34,7 +34,10 @@ const emitDefinitions = (definitions) => {
     ts.ScriptKind.TS
   );
 
-  const printer = ts.createPrinter({ newLine: true, omitTrailingSemicolon: true });
+  const printer = ts.createPrinter({
+    newLine: ts.NewLineKind.LineFeed,
+    omitTrailingSemicolon: true,
+  });
 
   return printer.printList(ts.ListFormat.MultiLine, nodeArray, sourceFile);
 };

--- a/packages/utils/typescript/lib/generators/schemas/schema.js
+++ b/packages/utils/typescript/lib/generators/schemas/schema.js
@@ -69,7 +69,6 @@ const generateSchemaDefinition = (schema) => {
 
   // Generate the schema's interface declaration
   const schemaType = factory.createInterfaceDeclaration(
-    undefined,
     [factory.createModifier(ts.SyntaxKind.ExportKeyword)],
     factory.createIdentifier(interfaceName),
     undefined,

--- a/packages/utils/typescript/lib/generators/schemas/utils.js
+++ b/packages/utils/typescript/lib/generators/schemas/utils.js
@@ -120,13 +120,7 @@ const toTypeLiteral = (data) => {
 
     return [
       ...acc,
-      factory.createPropertyDeclaration(
-        undefined,
-        undefined,
-        identifier,
-        undefined,
-        toTypeLiteral(value)
-      ),
+      factory.createPropertyDeclaration(undefined, identifier, undefined, toTypeLiteral(value)),
     ];
   }, []);
 

--- a/packages/utils/typescript/package.json
+++ b/packages/utils/typescript/package.json
@@ -34,7 +34,7 @@
     "fs-extra": "10.0.1",
     "lodash": "4.17.21",
     "prettier": "2.8.4",
-    "typescript": "4.6.2"
+    "typescript": "5.0.4"
   },
   "engines": {
     "node": ">=14.19.1 <=18.x.x",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7080,7 +7080,7 @@ __metadata:
     speed-measure-webpack-plugin: 1.5.0
     style-loader: 3.3.1
     styled-components: 5.3.3
-    typescript: 4.6.2
+    typescript: 5.0.4
     webpack: ^5.76.0
     webpack-bundle-analyzer: ^4.8.0
     webpack-cli: ^5.0.1
@@ -7139,7 +7139,7 @@ __metadata:
     stream-json: 1.7.4
     tar: 6.1.13
     tar-stream: 2.2.0
-    typescript: 4.6.2
+    typescript: 5.0.4
     uuid: 9.0.0
     ws: 8.11.0
   languageName: unknown
@@ -7274,7 +7274,7 @@ __metadata:
     react-test-renderer: ^17.0.2
     rimraf: 3.0.2
     styled-components: 5.3.3
-    typescript: 4.6.2
+    typescript: 5.0.4
     webpack: ^5.76.0
     webpack-cli: ^5.0.1
   peerDependencies:
@@ -7816,7 +7816,7 @@ __metadata:
     semver: 7.3.8
     statuses: 2.0.1
     supertest: 6.3.3
-    typescript: 4.6.2
+    typescript: 5.0.4
     uuid: ^8.3.2
   bin:
     strapi: ./bin/strapi.js
@@ -7832,7 +7832,7 @@ __metadata:
     fs-extra: 10.0.1
     lodash: 4.17.21
     prettier: 2.8.4
-    typescript: 4.6.2
+    typescript: 5.0.4
   languageName: unknown
   linkType: soft
 
@@ -28801,7 +28801,7 @@ __metadata:
     supertest: 6.3.3
     ts-jest: 29.0.3
     typedoc: 0.23.26
-    typescript: 4.6.2
+    typescript: 5.0.4
     yargs: 17.6.0
   languageName: unknown
   linkType: soft
@@ -30373,13 +30373,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:4.6.2":
-  version: 4.6.2
-  resolution: "typescript@npm:4.6.2"
+"typescript@npm:5.0.4":
+  version: 5.0.4
+  resolution: "typescript@npm:5.0.4"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 8a44ed7e6f6c4cb1ebe8cf236ecda2fb119d84dcf0fbd77e707b2dfea1bbcfc4e366493a143513ce7f57203c75da9d4e20af6fe46de89749366351046be7577c
+  checksum: 82b94da3f4604a8946da585f7d6c3025fff8410779e5bde2855ab130d05e4fd08938b9e593b6ebed165bda6ad9292b230984f10952cf82f0a0ca07bbeaa08172
   languageName: node
   linkType: hard
 
@@ -30403,13 +30403,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@4.6.2#~builtin<compat/typescript>":
-  version: 4.6.2
-  resolution: "typescript@patch:typescript@npm%3A4.6.2#~builtin<compat/typescript>::version=4.6.2&hash=5d3a66"
+"typescript@patch:typescript@5.0.4#~builtin<compat/typescript>":
+  version: 5.0.4
+  resolution: "typescript@patch:typescript@npm%3A5.0.4#~builtin<compat/typescript>::version=5.0.4&hash=85af82"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 40b493a71747fb89fa70df104e2c4a5e284b43750af5bea024090a5261cefa387f7a9372411b13030f7bf5555cee4275443d08805642ae5c74ef76740854a4c7
+  checksum: bb309d320c59a26565fb3793dba550576ab861018ff3fd1b7fccabbe46ae4a35546bc45f342c0a0b6f265c801ccdf64ffd68f548f117ceb7f0eac4b805cd52a9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What does it do?

- Upgrade from TS 4.6.5 to TS 5.0.4 in all concerned packages.
- Fix breaking changes introduces by 4.7/8 and 4.5 which includes:
  - Declaration factories exported by the ts factory API (the first decorator parameter has been removed)
  - The ts printer configuration no longer accepts a boolean for the newLine property. It now needs to be explicitly defined.

### Why is it needed?

- Reduce technical debt
- Prepare other TS work
- Unlock new features brought by new TypeScript version

### How to test it?

- `cd examples/getstarted`
- `yarn strapi ts:generate-types --verbose`
- Everything should be generated in the schema.d.ts file

