### PR TITLE
CM: ListView - Check if review-workflows are enabled instead of relying on isEE

### DIFF
--- a/packages/core/admin/ee/admin/content-manager/components/DynamicTable/CellContent/ReviewWorkflowsStage/getTableColumn.js
+++ b/packages/core/admin/ee/admin/content-manager/components/DynamicTable/CellContent/ReviewWorkflowsStage/getTableColumn.js
@@ -12,7 +12,9 @@ export default (layout) => {
   // `false` once a user is in CE mode again. We shouldn't have to perform the window.strapi.isEE check here
   // and it is meant to be in interim solution until we find a better one.
   const hasReviewWorkflows =
-    (window.strapi.isEE && layout.contentType.options?.reviewWorkflows) ?? false;
+    (window.strapi.features.isEnabled(window.strapi.features.REVIEW_WORKFLOWS) &&
+      layout.contentType.options?.reviewWorkflows) ??
+    false;
 
   if (!hasReviewWorkflows) {
     return null;


### PR DESCRIPTION
### What does it do?

Checks if the review-workflow feature is enabled rather than relying on `isEE`.

### Why is it needed?

While writing the documentation I realized I made a mistake here. Even in EE mode the feature can be disabled. This should be the only part which is still executed when the feature is disabled manually via https://github.com/strapi/strapi/pull/16458

### Related issue(s)/PR(s)

- https://github.com/strapi/strapi/pull/16458
