### PR TITLE
Allow configuration of SSO Cookie Domain

### DIFF
--- a/packages/core/admin/ee/server/controllers/authentication/middlewares.js
+++ b/packages/core/admin/ee/server/controllers/authentication/middlewares.js
@@ -95,13 +95,14 @@ const redirectWithAuth = (ctx) => {
     params: { provider },
   } = ctx;
   const redirectUrls = utils.getPrefixedRedirectUrls();
+  const domain = strapi.config.get('server.admin.auth.domain');
   const { user } = ctx.state;
 
   const jwt = getService('token').createJwtToken(user);
 
   const isProduction = strapi.config.get('environment') === 'production';
 
-  const cookiesOptions = { httpOnly: false, secure: isProduction, overwrite: true };
+  const cookiesOptions = { httpOnly: false, secure: isProduction, overwrite: true, domain };
 
   const sanitizedUser = getService('user').sanitizeUser(user);
   strapi.eventHub.emit('admin.auth.success', { user: sanitizedUser, provider });


### PR DESCRIPTION
### What does it do?

Adds a new configuration option to the admin config to allow setting the cookie domain used as a transmit method for SSO authentication between different admin/backend domains.

Example configuration:

```js
module.exports = ({ env }) => ({
  auth: {
    // ...
    domain: env("SSO_DOMAIN", ".example.com"),
    providers: [
      // ...
    ],
  },
  url: env("ADMIN_URL"),
  serveAdminPanel: env.bool("SERVE_ADMIN", true),
  // ...
});
```

### Why is it needed?

Currently we set the cookie to the backend domain which is not valid for the admin to pull the JWT from.

### How to test it?

Complicated, see internal slack threads on the issue: https://strapihq.slack.com/archives/CEN0F9WF6/p1682085852948869
Was validated by me, @Convly, @christiancp100, @simotae14, @alexandrebodin, and @marcoautiero in Discord

### Related issue(s)/PR(s)

fixes #16468 
