### PR TITLE
Fix knex error when updating an entity with large existing relations

### DIFF
--- a/packages/core/database/lib/entity-manager/regular-relations.js
+++ b/packages/core/database/lib/entity-manager/regular-relations.js
@@ -152,7 +152,7 @@ const deleteRelations = async ({
         .transacting(trx)
         .execute();
       done = batchToDelete.length < batchSize;
-      lastId = batchToDelete[batchToDelete.length - 1]?.id;
+      lastId = batchToDelete[batchToDelete.length - 1]?.id || 0;
 
       const batchIds = map(inverseJoinColumn.name, batchToDelete);
 


### PR DESCRIPTION
Added a fallback of 0 after null coalesce

### What does it do?

Fixes an error that was happening on our Strapi instance when updating an entity with over 100 links in a single relation.  The error was ` Undefined binding(s) detected when compiling`.

### Why is it needed?

This changes null to zero, which fixes an error in knex where it was searching for `id > undefined`.  The issue was traced back to the line `id: { $gt: lastId },` in this file. This change ensures that lastId is set to zero as a fallback, and it is never null or undefined.  

### How to test it?

Tested by editing the file in \node_modules@strapi\database\lib\entity-manager\regular-relations.js and confirmed that our issue was fixed.