### PR TITLE
feat(RW): add stage color attribute

### DIFF
--- a/api-tests/core/admin/ee/review-workflows.test.api.js
+++ b/api-tests/core/admin/ee/review-workflows.test.api.js
@@ -270,10 +270,25 @@ describeOnCondition(edition === 'EE')('Review workflows', () => {
       ];
     });
 
+    test("It should assign a default color to stages if they don't have one", async () => {
+      await requests.admin.put(`/admin/review-workflows/workflows/${testWorkflow.id}/stages`, {
+        body: {
+          data: [defaultStage, { id: secondStage.id, name: 'new_name', color: '#000000' }],
+        },
+      });
+
+      const workflowRes = await requests.admin.get(
+        `/admin/review-workflows/workflows/${testWorkflow.id}?populate=*`
+      );
+
+      expect(workflowRes.status).toBe(200);
+      expect(workflowRes.body.data.stages[0].color).toBe('#4945FF');
+      expect(workflowRes.body.data.stages[1].color).toBe('#000000');
+    });
     test("It shouldn't be available for public", async () => {
       const stagesRes = await requests.public.put(
         `/admin/review-workflows/workflows/${testWorkflow.id}/stages`,
-        stagesUpdateData
+        { body: { data: stagesUpdateData } }
       );
       const workflowRes = await requests.public.get(
         `/admin/review-workflows/workflows/${testWorkflow.id}`

--- a/packages/core/admin/ee/server/content-types/workflow-stage/index.js
+++ b/packages/core/admin/ee/server/content-types/workflow-stage/index.js
@@ -24,6 +24,11 @@ module.exports = {
         type: 'string',
         configurable: false,
       },
+      color: {
+        type: 'string',
+        configurable: false,
+        default: '#4945FF',
+      },
       workflow: {
         type: 'relation',
         target: 'admin::workflow',

--- a/packages/core/admin/ee/server/validation/review-workflows.js
+++ b/packages/core/admin/ee/server/validation/review-workflows.js
@@ -5,10 +5,7 @@ const { yup, validateYupSchema } = require('@strapi/utils');
 const stageObject = yup.object().shape({
   id: yup.number().integer().min(1),
   name: yup.string().max(255).required(),
-  color: yup
-    .string()
-    .matches(/^#(?:[0-9a-fA-F]{3}){1,2}$/i)
-    .nullable(), // hex color
+  color: yup.string().matches(/^#(?:[0-9a-fA-F]{3}){1,2}$/i), // hex color
 });
 
 const validateUpdateStagesSchema = yup.array().of(stageObject).required();

--- a/packages/core/admin/ee/server/validation/review-workflows.js
+++ b/packages/core/admin/ee/server/validation/review-workflows.js
@@ -5,6 +5,10 @@ const { yup, validateYupSchema } = require('@strapi/utils');
 const stageObject = yup.object().shape({
   id: yup.number().integer().min(1),
   name: yup.string().max(255).required(),
+  color: yup
+    .string()
+    .matches(/^#(?:[0-9a-fA-F]{3}){1,2}$/i)
+    .nullable(), // hex color
 });
 
 const validateUpdateStagesSchema = yup.array().of(stageObject).required();


### PR DESCRIPTION
### What does it do?

Modified `PUT /review-workflows/workflows/:workflow_id/stages`

To send the stage color
```js
{
  [
    {
        id: number;
        name: string;
        color: string;
    },
  ]
}
``` 

- Added color attribute in Stage Content Type.
- Default color is “blue“ (`#4945FF`).
- Added regex validation  `^#(?:[0-9a-fA-F]{3}){1,2}$`

Right now front is sending a null value for the `stage` `color` attribute, and so the validation is failing. 
@gu-stav maybe the frontend work can continue on top of this PR.


