### PR TITLE
Add correct typing to collectionName

### DIFF
--- a/packages/utils/typescript/lib/generators/schemas/schema.js
+++ b/packages/utils/typescript/lib/generators/schemas/schema.js
@@ -55,7 +55,7 @@ const generateSchemaDefinition = (schema) => {
   addImport(parentType);
 
   // Properties whose values can be mapped to a literal type expression
-  const literalPropertiesDefinitions = ['info', 'options', 'pluginOptions']
+  const literalPropertiesDefinitions = ['collectionName', 'info', 'options', 'pluginOptions']
     // Ignore non-existent or empty declarations
     .filter((key) => !isEmpty(schema[key]))
     // Generate literal definition for each property


### PR DESCRIPTION

### What does it do?

It adds the correct typing to the collectionName of a content type.

### Why is it needed?

To get better autocompletion when using typescript

### How to test it?

Create a content type in a strapi typescript project, generate the types and go to the index.ts of your project, to the bootstrap function and create the next constant: 
```
import '@strapi/strapi';
...
  async bootstrap({ strapi }: { strapi: Strapi.Strapi }) {
    const toy = {} as Strapi.Schemas['api::toy.toy'];
    toy.collectionName == "toys" // should be OK 
    toy.collectionName == "food" // should highlight an error
  },
...
```

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
