### PR TITLE
CM: Render stage color in the list-view

### DIFF
--- a/packages/core/admin/ee/admin/content-manager/components/DynamicTable/CellContent/ReviewWorkflowsStage/ReviewWorkflowsStageEE.js
+++ b/packages/core/admin/ee/admin/content-manager/components/DynamicTable/CellContent/ReviewWorkflowsStage/ReviewWorkflowsStageEE.js
@@ -1,15 +1,20 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Typography } from '@strapi/design-system';
+import { Box, Flex, Typography } from '@strapi/design-system';
 
-export function ReviewWorkflowsStageEE({ name }) {
+export function ReviewWorkflowsStageEE({ color, name }) {
   return (
-    <Typography fontWeight="regular" textColor="neutral700">
-      {name}
-    </Typography>
+    <Flex alignItems="center" gap={2}>
+      <Box height={2} background={color} hasRadius width={2} />
+
+      <Typography fontWeight="regular" textColor="neutral700">
+        {name}
+      </Typography>
+    </Flex>
   );
 }
 
 ReviewWorkflowsStageEE.propTypes = {
+  color: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
 };

--- a/packages/core/admin/ee/admin/content-manager/components/DynamicTable/CellContent/ReviewWorkflowsStage/getTableColumn.js
+++ b/packages/core/admin/ee/admin/content-manager/components/DynamicTable/CellContent/ReviewWorkflowsStage/getTableColumn.js
@@ -4,6 +4,7 @@ import { Typography } from '@strapi/design-system';
 
 import ReviewWorkflowsStage from '.';
 import getTrad from '../../../../../../../admin/src/content-manager/utils/getTrad';
+import { STAGE_COLOR_DEFAULT } from '../../../../../pages/SettingsPage/pages/ReviewWorkflows/constants';
 
 export default (layout) => {
   const { formatMessage } = useIntl();
@@ -41,7 +42,9 @@ export default (layout) => {
         return <Typography textColor="neutral800">-</Typography>;
       }
 
-      return <ReviewWorkflowsStage name={strapi_reviewWorkflows_stage.name} />;
+      const { color, name } = strapi_reviewWorkflows_stage;
+
+      return <ReviewWorkflowsStage color={color ?? STAGE_COLOR_DEFAULT} name={name} />;
     },
   };
 };

--- a/packages/core/admin/ee/admin/content-manager/components/DynamicTable/CellContent/ReviewWorkflowsStage/tests/ReviewWorkflowsStage.test.js
+++ b/packages/core/admin/ee/admin/content-manager/components/DynamicTable/CellContent/ReviewWorkflowsStage/tests/ReviewWorkflowsStage.test.js
@@ -17,7 +17,7 @@ const setup = (props) => render(<ComponentFixture {...props} />);
 
 describe('DynamicTable | ReviewWorkflowsStage', () => {
   test('render stage name', () => {
-    const { getByText } = setup({ name: 'reviewed' });
+    const { getByText } = setup({ color: 'red', name: 'reviewed' });
 
     expect(getByText('reviewed')).toBeInTheDocument();
   });


### PR DESCRIPTION
### What does it do?

Renders the stage color in the CM list-view next to the stage.

### Why is it needed?

It may help users to differentiate stages better.

