### PR TITLE
Add error message when empty content type directory exists in project

### DIFF
--- a/packages/core/strapi/lib/core/loaders/apis.js
+++ b/packages/core/strapi/lib/core/loaders/apis.js
@@ -5,6 +5,7 @@ const { existsSync } = require('fs-extra');
 const _ = require('lodash');
 const fse = require('fs-extra');
 const { isKebabCase, importDefault } = require('@strapi/utils');
+const { isEmpty } = require('lodash/fp');
 
 const DEFAULT_CONTENT_TYPE = {
   schema: {},
@@ -114,6 +115,10 @@ const loadContentTypes = async (dir) => {
 
     const contentTypeName = normalizeName(fd.name);
     const contentType = await loadDir(join(dir, fd.name));
+
+    if (isEmpty(contentType.schema)) {
+      strapi?.log?.error(`Could not load content type found at ${dir}`);
+    }
 
     contentTypes[normalizeName(contentTypeName)] = _.defaults(contentType, DEFAULT_CONTENT_TYPE);
   }

--- a/packages/core/strapi/lib/core/loaders/apis.js
+++ b/packages/core/strapi/lib/core/loaders/apis.js
@@ -116,8 +116,13 @@ const loadContentTypes = async (dir) => {
     const contentTypeName = normalizeName(fd.name);
     const contentType = await loadDir(join(dir, fd.name));
 
-    if (isEmpty(contentType.schema)) {
-      strapi?.log?.error(`Could not load content type found at ${dir}`);
+    if (
+      isEmpty(contentType) ||
+      (isEmpty(contentType.schema) &&
+        isEmpty(contentType.actions) &&
+        isEmpty(contentType.lifecycles))
+    ) {
+      throw new Error(`Could not load content type found at ${dir}`);
     }
 
     contentTypes[normalizeName(contentTypeName)] = _.defaults(contentType, DEFAULT_CONTENT_TYPE);

--- a/packages/core/strapi/lib/core/loaders/apis.js
+++ b/packages/core/strapi/lib/core/loaders/apis.js
@@ -116,12 +116,7 @@ const loadContentTypes = async (dir) => {
     const contentTypeName = normalizeName(fd.name);
     const contentType = await loadDir(join(dir, fd.name));
 
-    if (
-      isEmpty(contentType) ||
-      (isEmpty(contentType.schema) &&
-        isEmpty(contentType.actions) &&
-        isEmpty(contentType.lifecycles))
-    ) {
+    if (isEmpty(contentType) || isEmpty(contentType.schema)) {
       throw new Error(`Could not load content type found at ${dir}`);
     }
 


### PR DESCRIPTION
### What does it do?

Strapi outputs a server error message when a schema fails to load on startup

### Why is it needed?

To prevent confusion when a developer accidentally leaves an empty content type directory structure in a Strapi project.

Currently when a Strapi project has an empty content type directory structure and the project is started, an error is thrown in `validateContentTypesUnicity` because schema.info doesn't exist because it was never loaded:

<img width="986" alt="image" src="https://user-images.githubusercontent.com/999278/234537599-c28b4459-020c-408a-b471-7d0e486ae7a2.png">

This PR adds an actual error check for an empty schema before it gets to that point, so that the user knows exactly what is causing the error instead of it appearing to be a general strapi error that is difficult to solve:

<img width="1290" alt="image" src="https://user-images.githubusercontent.com/999278/234537441-430c55fb-e122-467f-9f1d-31959a743af6.png">

### How to test it?

Create a content type in the CTB and then delete the schema files without removing the directory structure and try to start Strapi. You should get a nicer error message informing of the issue.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
