### PR TITLE
chore: run dependabot sunday night

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+      day: sunday
+      time: '22:00'
     labels:
       - 'source: dependencies'
       - 'pr: chore'


### PR DESCRIPTION
### What does it do?
Run dependabot only on weekends. Github action scheduler allows you to define so
https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#scheduleday

### Why is it needed?

Just today dependabot executed more than 25 actions that take more than 30 min each.
https://github.com/strapi/strapi/actions?query=actor%3Adependabot+

