### PR TITLE
Use pluralName as collectionName default in domain createContentType

### DIFF
--- a/packages/core/strapi/lib/core/domain/content-type/index.js
+++ b/packages/core/strapi/lib/core/domain/content-type/index.js
@@ -34,7 +34,7 @@ const createContentType = (uid, definition) => {
     Object.assign(schema, {
       uid,
       apiName: uid.split('::')[1].split('.')[0],
-      collectionName: schema.collectionName || schema.info.singularName,
+      collectionName: schema.collectionName || schema.info.pluralName,
       globalId: getGlobalId(schema, schema.info.singularName),
     });
   } else if (uid.startsWith('plugin::')) {


### PR DESCRIPTION
### What does it do?

Changes the default fallback for a collectionName in the ctb from singularName to pluralName

It might be safer instead to require a collectionName to be passed in and throw an error, rather than setting a default here to prevent data loss in case we missed something.

TODO: The safest thing would be to throw an error if collectionName is not passed in and remove the default. That way we don't accidentally cause data loss by changing a table name in the case that this code is somehow reached. Will update this PR later with that fix. Also, need to investigate if this is why plugins are singular? If so, this code needs to be left alone, but we need to add some safeguards to make sure this doesn't cause an issue later on.

### Why is it needed?

We are supposed to be setting pluralName as collectionName as seen in `packages/core/content-type-builder/server/services/schema-builder/content-type-builder.js`and other parts of Strapi make that same assumption.

However, I don't know if this is going to break something yet. At first glance it seems this is currently unreachable from the code calling it, but in theory there could be collections that were created from some edge case using a content type's singularName instead of pluralName, and changing this would cause users to lose that table.

### How to test it?

Use `createContentType` to create a contenttype that does not have a collectionName property and it should default to info.pluralName instead of info.singularName

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
