### PR TITLE
Fix generator tests (upgrade to ts V5)

### DIFF
--- a/packages/utils/typescript/lib/__tests__/generators/schemas/utils.test.js
+++ b/packages/utils/typescript/lib/__tests__/generators/schemas/utils.test.js
@@ -69,7 +69,6 @@ describe('Utils', () => {
     const createMainNode = (members = []) => {
       return factory.createInterfaceDeclaration(
         undefined,
-        undefined,
         factory.createIdentifier('Foo'),
         undefined,
         undefined,
@@ -79,7 +78,6 @@ describe('Utils', () => {
 
     const createPropertyDeclaration = (name, type) => {
       return factory.createPropertyDeclaration(
-        undefined,
         undefined,
         factory.createIdentifier(name),
         undefined,


### PR DESCRIPTION
### What does it do?

Fix the unit tests broken by the upgrade from TS 4.6.2 to 5.0.4

### Why is it needed?

`@strapi/typescript-utils` unit tests are broken

### How to test it?

`nx run @strapi/typescript-utils:test:unit`, everything should pass
