### PR TITLE
fix: AutoReload context value had incorrect names for object properties

### DIFF
--- a/packages/core/helper-plugin/src/features/AutoReloadOverlayBlocker.js
+++ b/packages/core/helper-plugin/src/features/AutoReloadOverlayBlocker.js
@@ -34,8 +34,8 @@ import pxToRem from '../utils/pxToRem';
 /**
  * @preserve
  * @typedef {Object} AutoReloadOverlayBlockerContextValue
- * @property {(config: AutoReloadOverlayBlockerConfig) => void} lockApp
- * @property {() => void} unlockApp
+ * @property {(config: AutoReloadOverlayBlockerConfig) => void} lockAppWithAutoreload
+ * @property {() => void} unlockAppWithAutoreload
  */
 
 /**
@@ -111,8 +111,8 @@ const AutoReloadOverlayBlockerProvider = ({ children }) => {
 
   const autoReloadValue = React.useMemo(
     () => ({
-      lockApp: lockAppWithAutoreload,
-      unlockApp: unlockAppWithAutoreload,
+      lockAppWithAutoreload,
+      unlockAppWithAutoreload,
     }),
     [lockAppWithAutoreload, unlockAppWithAutoreload]
   );


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* Changes the property names for AutoReloadOverlayBlockerContextValue to what they _should_ have been

### Why is it needed?

* It was a breaking change in the `helper-plugin` and subsequently broke the CTB 

### How to test it?

* add a new field to a content-type in the CTB
* save
* no errors 🪄 

### Related issue(s)/PR(s)

* resolves #16542
