### PR TITLE
remove dependency react-router

### DIFF
--- a/packages/core/admin/webpack.alias.js
+++ b/packages/core/admin/webpack.alias.js
@@ -25,7 +25,6 @@ const aliasExactMatch = [
   'react-intl',
   'react-query',
   'react-redux',
-  'react-router',
   'react-router-dom',
   'react-window',
   'react-select',


### PR DESCRIPTION
### What does it do?

Remove unused dependency `react-router`.

### Why is it needed?

I'm still experiencing the problem described in #16372 

```
> strapi build

This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). The promise rejected with the reason:
Error: Cannot find module 'react-router'
Require stack:
- .../node_modules/@strapi/admin/webpack.alias.js
 ```

The changes made in #16375 didn't remove all references of the dependency `react-router`. The file [webpack.alias.js](https://github.com/strapi/strapi/blob/c33855d39e99304d23eef568f0689bdb7f4c981e/packages/core/admin/webpack.alias.js#L28) still contains a reference to the dependency.

### Related issue(s)/PR(s)

- Fix #16372
- #16375

