### PR TITLE
fix: rw depends on should be an array

### DIFF
--- a/packages/core/admin/ee/server/services/review-workflows/review-workflows.js
+++ b/packages/core/admin/ee/server/services/review-workflows/review-workflows.js
@@ -119,7 +119,7 @@ module.exports = ({ strapi }) => {
     async register() {
       extendReviewWorkflowContentTypes({ strapi });
       strapi.hook('strapi::content-types.afterSync').register(enableReviewWorkflow({ strapi }));
-      strapi.hook('strapi::content-types.beforeSync').register(persistStagesJoinTables({ strapi }));
+      strapi.hook('strapi::content-types.afterSync').register(persistStagesJoinTables({ strapi }));
     },
   };
 };

--- a/packages/core/admin/ee/server/services/review-workflows/review-workflows.js
+++ b/packages/core/admin/ee/server/services/review-workflows/review-workflows.js
@@ -94,7 +94,7 @@ function persistStagesJoinTables({ strapi }) {
       // Persist the stage join table
       const { attributes, tableName } = strapi.db.metadata.get(contentTypeUID);
       const joinTableName = attributes[ENTITY_STAGE_ATTRIBUTE].joinTable.name;
-      return { name: joinTableName, dependsOn: { name: tableName } };
+      return { name: joinTableName, dependsOn: [{ name: tableName }] };
     };
 
     const joinTablesToPersist = pipe([
@@ -119,7 +119,7 @@ module.exports = ({ strapi }) => {
     async register() {
       extendReviewWorkflowContentTypes({ strapi });
       strapi.hook('strapi::content-types.afterSync').register(enableReviewWorkflow({ strapi }));
-      strapi.hook('strapi::content-types.afterSync').register(persistStagesJoinTables({ strapi }));
+      strapi.hook('strapi::content-types.beforeSync').register(persistStagesJoinTables({ strapi }));
     },
   };
 };

--- a/packages/core/admin/ee/server/utils/persisted-tables.js
+++ b/packages/core/admin/ee/server/utils/persisted-tables.js
@@ -124,6 +124,9 @@ const persistTablesWithPrefix = async (tableNamePrefix) => {
 const removePersistedTablesWithSuffix = async (tableNameSuffix) => {
   const tableNameRegex = new RegExp(`.*${tableNameSuffix}$`);
   const tableNames = await findTables({ strapi }, tableNameRegex);
+  if (!tableNames.length) {
+    return;
+  }
   await removePersistedTables({ strapi }, tableNames);
 };
 

--- a/packages/core/database/lib/schema/diff.js
+++ b/packages/core/database/lib/schema/diff.js
@@ -364,7 +364,10 @@ module.exports = (db) => {
       if (!helpers.hasTable(destSchema, srcTable.name) && !reservedTables.includes(srcTable.name)) {
         const dependencies = persistedTables
           .filter((table) => {
-            return table?.dependsOn?.some((table) => table.name === srcTable.name);
+            const dependsOn = table?.dependsOn;
+            if (_.isNil(dependsOn)) return;
+            // FIXME: The array parse should not be necessary
+            return _.toArray(dependsOn).some((table) => table.name === srcTable.name);
           })
           .map((dependsOnTable) => {
             return srcSchema.tables.find((srcTable) => srcTable.name === dependsOnTable.name);


### PR DESCRIPTION
### What does it do?

Depends on persisted tables should be an array not an object

### Why is it needed?
When deleting a CT you now get 
```
[2023-04-27 18:08:01.490] error: table?.dependsOn?.some is not a function
TypeError: table?.dependsOn?.some is not a function
    at /Users/marcroig/Documents/strapi/strapi/packages/core/database/lib/schema/diff.js:367:38
    at Array.filter (<anonymous>)
    at Object.diffSchemas [as diff] (/Users/marcroig/Documents/strapi/strapi/packages/core/database/lib/schema/diff.js:366:12)
    at async Object.syncSchema (/Users/marcroig/Documents/strapi/strapi/packages/core/database/lib/schema/index.js:53:32)
    at async Strapi.bootstrap (/Users/marcroig/Documents/strapi/strapi/packages/core/strapi/lib/Strapi.js:457:5)
    at async Strapi.load (/Users/marcroig/Documents/strapi/strapi/packages/core/strapi/lib/Strapi.js:491:5)
    at async Strapi.start (/Users/marcroig/Documents/strapi/strapi/packages/core/strapi/lib/Strapi.js:218:9)

```

if one of the CT has RW activated.

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
