### PR TITLE
fix(RW): update stage if only color changes 

### DIFF
--- a/api-tests/core/admin/ee/review-workflows.test.api.js
+++ b/api-tests/core/admin/ee/review-workflows.test.api.js
@@ -282,7 +282,7 @@ describeOnCondition(edition === 'EE')('Review workflows', () => {
     test("It should assign a default color to stages if they don't have one", async () => {
       await requests.admin.put(`/admin/review-workflows/workflows/${testWorkflow.id}/stages`, {
         body: {
-          data: [defaultStage, { id: secondStage.id, name: 'new_name', color: '#000000' }],
+          data: [defaultStage, { id: secondStage.id, name: secondStage.name, color: '#000000' }],
         },
       });
 

--- a/packages/core/admin/ee/server/services/review-workflows/stages.js
+++ b/packages/core/admin/ee/server/services/review-workflows/stages.js
@@ -208,7 +208,7 @@ function getDiffBetweenStages(sourceStages, comparisonStages) {
 
       if (!srcStage) {
         acc.created.push(stageToCompare);
-      } else if (srcStage.name !== stageToCompare.name) {
+      } else if (srcStage.name !== stageToCompare.name || srcStage.color !== stageToCompare.color) {
         acc.updated.push(stageToCompare);
       }
       return acc;


### PR DESCRIPTION
### What does it do?

RW stage color was not being updated if the stage name was not also updated at the same time.

