### PR TITLE
Settings: Improve error handling for stage update errors

### DIFF
--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/ReviewWorkflows.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/ReviewWorkflows.js
@@ -59,31 +59,15 @@ export function ReviewWorkflowsPage() {
 
   const { mutateAsync, isLoading } = useMutation(
     async ({ workflowId, stages }) => {
-      try {
-        const {
-          data: { data },
-        } = await put(`/admin/review-workflows/workflows/${workflowId}/stages`, {
-          data: stages,
-        });
+      const {
+        data: { data },
+      } = await put(`/admin/review-workflows/workflows/${workflowId}/stages`, {
+        data: stages,
+      });
 
-        return data;
-      } catch (error) {
-        toggleNotification({
-          type: 'warning',
-          message: formatAPIError(error),
-        });
-      }
-
-      return null;
+      return data;
     },
     {
-      onError(error) {
-        toggleNotification({
-          type: 'warning',
-          message: formatAPIError(error),
-        });
-      },
-
       onSuccess() {
         toggleNotification({
           type: 'success',
@@ -93,8 +77,19 @@ export function ReviewWorkflowsPage() {
     }
   );
 
-  const updateWorkflowStages = (workflowId, stages) => {
-    return mutateAsync({ workflowId, stages });
+  const updateWorkflowStages = async (workflowId, stages) => {
+    try {
+      const res = await mutateAsync({ workflowId, stages });
+
+      return res;
+    } catch (error) {
+      toggleNotification({
+        type: 'warning',
+        message: formatAPIError(error),
+      });
+
+      return null;
+    }
   };
 
   const submitForm = async () => {


### PR DESCRIPTION
### What does it do?

Updates the error handling when editing stages.

### Why is it needed?

Before in case the content API threw an error both success and error notifications were shown. Now only one can be visible.

To make testing easier you can set the limit in https://github.com/strapi/strapi/blob/09e21070815dd1fad10071ca69f7fe2239a25a14/packages/core/admin/ee/server/validation/review-workflows.js#L10-L14

to a very low value.


