### PR TITLE
fix community to enterprise data transfer

### DIFF
--- a/packages/core/data-transfer/src/engine/validation/schemas/index.ts
+++ b/packages/core/data-transfer/src/engine/validation/schemas/index.ts
@@ -3,7 +3,7 @@ import { isArray, isObject, reject } from 'lodash/fp';
 import type { Diff } from '../../../utils/json';
 import * as utils from '../../../utils';
 
-const OPTIONAL_CONTENT_TYPES = ['audit-log'] as const;
+const OPTIONAL_CONTENT_TYPES = ['audit-log', 'workflow', 'workflow-stage'] as const;
 
 const isAttributeIgnorable = (diff: Diff) => {
   return (


### PR DESCRIPTION
### What does it do?

Added to OPTIONAL_CONTENT_TYPES the new workflow content types
### Why is it needed?

So you can do transfers from community to cloud this included strapi cloud

### How to test it?

Run DTS from local comunity edition to strapi cloud and see it fail

### Related issue(s)/PR(s)
fixes https://github.com/strapi/strapi/issues/16573

Note can't test if this fixes it myself since I don't have enterprise 
