### PR TITLE
feat(rw): add default stage color constant

### DIFF
--- a/packages/core/admin/ee/server/constants/workflows.js
+++ b/packages/core/admin/ee/server/constants/workflows.js
@@ -4,5 +4,6 @@
 module.exports = {
   WORKFLOW_MODEL_UID: 'admin::workflow',
   STAGE_MODEL_UID: 'admin::workflow-stage',
+  STAGE_DEFAULT_COLOR: '#4945FF',
   ENTITY_STAGE_ATTRIBUTE: 'strapi_reviewWorkflows_stage',
 };

--- a/packages/core/admin/ee/server/content-types/workflow-stage/index.js
+++ b/packages/core/admin/ee/server/content-types/workflow-stage/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { STAGE_DEFAULT_COLOR } = require('../../constants/workflows');
+
 module.exports = {
   schema: {
     collectionName: 'strapi_workflows_stages',
@@ -27,7 +29,7 @@ module.exports = {
       color: {
         type: 'string',
         configurable: false,
-        default: '#4945FF',
+        default: STAGE_DEFAULT_COLOR,
       },
       workflow: {
         type: 'relation',

--- a/packages/core/admin/ee/server/migrations/review-workflows-stages-color.js
+++ b/packages/core/admin/ee/server/migrations/review-workflows-stages-color.js
@@ -3,7 +3,7 @@
 const { STAGE_DEFAULT_COLOR } = require('../constants/workflows');
 
 async function migrateReviewWorkflowStagesColor({ oldContentTypes, contentTypes }) {
-  // Check if stages table name has a color attribute
+  // Look for CT's color attribute
   const hadColor = !!oldContentTypes?.['admin::workflow-stage']?.attributes?.color;
   const hasColor = !!contentTypes['admin::workflow-stage']?.attributes?.color;
 

--- a/packages/core/admin/ee/server/migrations/review-workflows-stages-color.js
+++ b/packages/core/admin/ee/server/migrations/review-workflows-stages-color.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const { STAGE_DEFAULT_COLOR } = require('../constants/workflows');
+
+async function migrateReviewWorkflowStagesColor({ oldContentTypes, contentTypes }) {
+  // Check if stages table name has a color attribute
+  const hadColor = !!oldContentTypes?.['admin::workflow-stage']?.attributes?.color;
+  const hasColor = !!contentTypes['admin::workflow-stage']?.attributes?.color;
+
+  // Add the default stage color if color attribute was added
+  if (!hadColor || hasColor) {
+    await strapi.query('admin::workflow-stage').updateMany({
+      data: {
+        color: STAGE_DEFAULT_COLOR,
+      },
+    });
+  }
+}
+
+module.exports = migrateReviewWorkflowStagesColor;

--- a/packages/core/admin/ee/server/register.js
+++ b/packages/core/admin/ee/server/register.js
@@ -3,6 +3,7 @@
 const { features } = require('@strapi/strapi/lib/utils/ee');
 const executeCERegister = require('../../server/register');
 const migrateAuditLogsTable = require('./migrations/audit-logs-table');
+const migrateReviewWorkflowStagesColor = require('./migrations/review-workflows-stages-color');
 const createAuditLogsService = require('./services/audit-logs');
 const reviewWorkflowsMiddlewares = require('./middlewares/review-workflows');
 const { getService } = require('./utils');
@@ -17,6 +18,7 @@ module.exports = async ({ strapi }) => {
     await auditLogsService.register();
   }
   if (features.isEnabled('review-workflows')) {
+    strapi.hook('strapi::content-types.afterSync').register(migrateReviewWorkflowStagesColor);
     const reviewWorkflowService = getService('review-workflows');
 
     reviewWorkflowsMiddlewares.contentTypeMiddleware(strapi);


### PR DESCRIPTION
### What does it do?
Migration to add default color.

### Why is it needed?
People upgrading from <4.10.2 do not have the stage color attribute, and so, when adding it is created empty.
This migration adds it.

### How to test it?
Upgrade from main to this branch and see stages have default color.