### PR TITLE
Settings: Fix color badge with long stage names

### DIFF
--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/Stages/Stage/components/OptionColor/OptionColor.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/Stages/Stage/components/OptionColor/OptionColor.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { components } from 'react-select';
-import { Box, Flex, Typography } from '@strapi/design-system';
+import { Flex, Typography } from '@strapi/design-system';
 
 export function OptionColor({ children, ...props }) {
   const { color } = props.data;
@@ -9,7 +9,7 @@ export function OptionColor({ children, ...props }) {
   return (
     <components.Option {...props}>
       <Flex alignItems="center" gap={2}>
-        <Box height={2} background={color} hasRadius width={2} />
+        <Flex height={2} background={color} hasRadius shrink={0} width={2} />
 
         <Typography textColor="neutral800" ellipsis>
           {children}

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/Stages/Stage/components/SingleValueColor/SingleValueColor.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/Stages/Stage/components/SingleValueColor/SingleValueColor.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { components } from 'react-select';
-import { Box, Flex, Typography } from '@strapi/design-system';
+import { Flex, Typography } from '@strapi/design-system';
 
 export function SingleValueColor({ children, ...props }) {
   const { color } = props.data;
@@ -9,7 +9,7 @@ export function SingleValueColor({ children, ...props }) {
   return (
     <components.SingleValue {...props}>
       <Flex alignItems="center" gap={2}>
-        <Box height={2} background={color} hasRadius width={2} />
+        <Flex height={2} background={color} hasRadius shrink={0} width={2} />
 
         <Typography textColor="neutral800" ellipsis>
           {children}


### PR DESCRIPTION
### What does it do?

Makes the color badges for the stage select `flex-shrink: 0`.

### Why is it needed?

Long stage names caused the color dot to shrink.

### How to test it?

1. Create a stage using a very long name.
2. Make sure the color dot does not shrink and keeps it shape.


