### PR TITLE
CM: Add max length for stage names in the list-view

### DIFF
--- a/packages/core/admin/ee/admin/content-manager/components/DynamicTable/CellContent/ReviewWorkflowsStage/ReviewWorkflowsStageEE.js
+++ b/packages/core/admin/ee/admin/content-manager/components/DynamicTable/CellContent/ReviewWorkflowsStage/ReviewWorkflowsStageEE.js
@@ -1,13 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Box, Flex, Typography } from '@strapi/design-system';
+import { pxToRem } from '@strapi/helper-plugin';
 
 export function ReviewWorkflowsStageEE({ color, name }) {
   return (
-    <Flex alignItems="center" gap={2}>
-      <Box height={2} background={color} hasRadius width={2} />
+    <Flex alignItems="center" gap={2} maxWidth={pxToRem(300)}>
+      <Box height={2} background={color} hasRadius shrink={0} width={2} />
 
-      <Typography fontWeight="regular" textColor="neutral700">
+      <Typography fontWeight="regular" textColor="neutral700" ellipsis>
         {name}
       </Typography>
     </Flex>


### PR DESCRIPTION
### What does it do?

Adds a max-length for stage names.

### Why is it needed?

Long stage names are cut off everywhere but can still exceed the CM list view.
