### PR TITLE
Cloning entities FE fixes

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/CollectionTypeFormWrapper/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/CollectionTypeFormWrapper/index.js
@@ -236,7 +236,15 @@ const CollectionTypeFormWrapper = ({ allLayoutData, children, slug, id, origin }
 
   const onPost = useCallback(
     async (body, trackerProperty) => {
-      const endPoint = `${getRequestUrl(`collection-types/${slug}`)}${rawQuery}`;
+      /**
+       * If we're cloning we want to post directly to this endpoint
+       * so that the relations even if they're not listed in the EditView
+       * are correctly attached to the entry.
+       */
+      const endPoint =
+        typeof origin !== 'undefined'
+          ? `${getRequestUrl(`collection-types/${slug}/clone/${origin}`)}${rawQuery}`
+          : `${getRequestUrl(`collection-types/${slug}`)}${rawQuery}`;
       try {
         // Show a loading button in the EditView/Header.js && lock the app => no navigation
         dispatch(setStatus('submit-pending'));
@@ -271,6 +279,7 @@ const CollectionTypeFormWrapper = ({ allLayoutData, children, slug, id, origin }
       }
     },
     [
+      origin,
       cleanReceivedData,
       displayErrors,
       replace,

--- a/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/reducer.js
+++ b/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/reducer.js
@@ -96,7 +96,7 @@ const reducer = (state, action) =>
         break;
       }
       case 'LOAD_RELATION': {
-        const { initialDataPath, modifiedDataPath, value, modifiedDataOnly = false } = action;
+        const { initialDataPath, modifiedDataPath, value } = action;
 
         const initialDataRelations = get(state, initialDataPath);
         const modifiedDataRelations = get(state, modifiedDataPath);
@@ -125,19 +125,16 @@ const reducer = (state, action) =>
           __temp_key__: keys[index],
         }));
 
-        if (!modifiedDataOnly) {
-          set(
-            draftState,
-            initialDataPath,
-            uniqBy([...valuesWithKeys, ...initialDataRelations], 'id')
-          );
-        }
-
         /**
          * We need to set the value also on modifiedData, because initialData
          * and modifiedData need to stay in sync, so that the CM can compare
          * both states, to render the dirty UI state
          */
+        set(
+          draftState,
+          initialDataPath,
+          uniqBy([...valuesWithKeys, ...initialDataRelations], 'id')
+        );
         set(
           draftState,
           modifiedDataPath,

--- a/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/RelationInputDataManager.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/RelationInputDataManager.js
@@ -76,7 +76,6 @@ export const RelationInputDataManager = ({
               initialDataPath: ['initialData', ...initialDataPath],
               modifiedDataPath: ['modifiedData', ...nameSplit],
               value,
-              modifiedDataOnly: isCloningEntry,
             },
           });
         },
@@ -306,7 +305,7 @@ export const RelationInputDataManager = ({
       })} ${totalRelations > 0 ? `(${totalRelations})` : ''}`}
       labelAction={labelAction}
       labelLoadMore={
-        !isCreatingEntry
+        !isCreatingEntry || isCloningEntry
           ? formatMessage({
               id: getTrad('relation.loadMore'),
               defaultMessage: 'Load More',


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* Posts to `/clone/origin` if we're "cloning" (I should have done this before, I misunderstood)
* removes the workaround for relations, because we're creating an entity the save button is active regardless, this also fixes a bug I introduced 👍🏼 

### Why is it needed?

* Posting to `clone/origin` is important because that's where we clone relations not loaded in the entity
* Fixes a bug with relations count & loading but also ensures our data-packet that we send is slim af

### How to test it?

* make an entity with more than 5 relations
* clone that entity
* you should see "load more" (don't click it)
* save the clone
* your new entity should have the same clone even though you didn't send them all 🥳 

### Related issue(s)/PR(s)

* resolves CONTENT-1292
