### PR TITLE
feat: remove sort attribute oneOf validation

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/DynamicTable/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/DynamicTable/index.js
@@ -78,7 +78,7 @@ const DynamicTable = ({
     // a future iteration we need to find a better pattern.
 
     // In CE this will return null - in EE a column definition including the custom formatting component.
-    const reviewWorkflowColumn = getReviewWorkflowsColumn(layout);
+    const reviewWorkflowColumn = getReviewWorkflowsColumn(layout, { formatMessage });
 
     if (reviewWorkflowColumn) {
       formattedHeaders.push(reviewWorkflowColumn);

--- a/packages/core/admin/admin/src/content-manager/pages/ListSettingsView/components/EditFieldForm.js
+++ b/packages/core/admin/admin/src/content-manager/pages/ListSettingsView/components/EditFieldForm.js
@@ -31,6 +31,7 @@ const EditFieldForm = ({
   attributes,
   fieldForm,
   fieldToEdit,
+  isOpen,
   onCloseModal,
   onChangeEditLabel,
   onSubmit,
@@ -38,8 +39,11 @@ const EditFieldForm = ({
 }) => {
   const { formatMessage } = useIntl();
 
-  const relationType = attributes[fieldToEdit].relationType;
+  if (!isOpen) {
+    return null;
+  }
 
+  const relationType = attributes[fieldToEdit].relationType;
   let shouldDisplaySortToggle = !['media', 'relation'].includes(type);
 
   if (['oneWay', 'oneToOne', 'manyToOne'].includes(relationType)) {
@@ -47,7 +51,7 @@ const EditFieldForm = ({
   }
 
   return (
-    <ModalLayout onClose={onCloseModal} labelledBy="title">
+    <ModalLayout onClose={onCloseModal} labelledBy="title" isOpen={isOpen}>
       <form onSubmit={onSubmit}>
         <ModalHeader>
           <HeaderContainer>
@@ -135,6 +139,7 @@ EditFieldForm.propTypes = {
     sortable: PropTypes.bool,
   }).isRequired,
   fieldToEdit: PropTypes.string.isRequired,
+  isOpen: PropTypes.bool.isRequired,
   onChangeEditLabel: PropTypes.func.isRequired,
   onCloseModal: PropTypes.func.isRequired,
   onSubmit: PropTypes.func.isRequired,

--- a/packages/core/admin/admin/src/content-manager/pages/ListSettingsView/components/Settings.js
+++ b/packages/core/admin/admin/src/content-manager/pages/ListSettingsView/components/Settings.js
@@ -15,7 +15,7 @@ import { getTrad } from '../../../utils';
 
 const Settings = ({ modifiedData, onChange, sortOptions }) => {
   const { formatMessage } = useIntl();
-  const { settings, metadatas } = modifiedData;
+  const { settings } = modifiedData;
 
   return (
     <Flex direction="column" alignItems="stretch" gap={4}>
@@ -127,9 +127,9 @@ const Settings = ({ modifiedData, onChange, sortOptions }) => {
             name="settings.defaultSortBy"
             value={modifiedData.settings.defaultSortBy || ''}
           >
-            {sortOptions.map((sortBy) => (
-              <Option key={sortBy} value={sortBy}>
-                {metadatas[sortBy].list.label || sortBy}
+            {sortOptions.map(({ value, label }) => (
+              <Option key={value} value={value}>
+                {label}
               </Option>
             ))}
           </Select>
@@ -164,7 +164,12 @@ Settings.defaultProps = {
 Settings.propTypes = {
   modifiedData: PropTypes.object,
   onChange: PropTypes.func.isRequired,
-  sortOptions: PropTypes.array,
+  sortOptions: PropTypes.arrayOf(
+    PropTypes.shape({
+      value: PropTypes.string,
+      label: PropTypes.string,
+    }).isRequired
+  ),
 };
 
 export default Settings;

--- a/packages/core/admin/admin/src/content-manager/pages/ListSettingsView/utils/getReviewWorkflowSortOption.js
+++ b/packages/core/admin/admin/src/content-manager/pages/ListSettingsView/utils/getReviewWorkflowSortOption.js
@@ -1,0 +1,4 @@
+// in EE this returns an option
+export default function getReviewWorkflowOption() {
+  return null;
+}

--- a/packages/core/admin/admin/src/translations/en.json
+++ b/packages/core/admin/admin/src/translations/en.json
@@ -713,6 +713,7 @@
   "content-manager.containers.SettingPage.relations": "Related fields",
   "content-manager.containers.SettingPage.settings": "Settings",
   "content-manager.containers.SettingPage.view": "View",
+  "content-manager.containers.SettingPage.defaultSortOrder.reviewWorkflows": "Review Stage",
   "content-manager.containers.SettingViewModel.pluginHeader.title": "Content Manager — {name}",
   "content-manager.containers.SettingsPage.Block.contentType.description": "Configure the specific settings",
   "content-manager.containers.SettingsPage.Block.contentType.title": "Collection Types",

--- a/packages/core/admin/ee/admin/content-manager/components/DynamicTable/CellContent/ReviewWorkflowsStage/getTableColumn.js
+++ b/packages/core/admin/ee/admin/content-manager/components/DynamicTable/CellContent/ReviewWorkflowsStage/getTableColumn.js
@@ -1,13 +1,10 @@
 import React from 'react';
-import { useIntl } from 'react-intl';
 import { Typography } from '@strapi/design-system';
 
 import ReviewWorkflowsStage from '.';
 import getTrad from '../../../../../../../admin/src/content-manager/utils/getTrad';
 
-export default (layout) => {
-  const { formatMessage } = useIntl();
-
+export default (layout, { formatMessage }) => {
   // TODO: As soon as the feature was enabled in EE mode, the BE currently does not have a way to send
   // `false` once a user is in CE mode again. We shouldn't have to perform the window.strapi.isEE check here
   // and it is meant to be in interim solution until we find a better one.

--- a/packages/core/admin/ee/admin/content-manager/pages/ListSettingsView/utils/getReviewWorkflowSortOption.js
+++ b/packages/core/admin/ee/admin/content-manager/pages/ListSettingsView/utils/getReviewWorkflowSortOption.js
@@ -1,0 +1,9 @@
+export default function getReviewWorkflowSortOption({ formatMessage }) {
+  return {
+    value: 'strapi_reviewWorkflows_stage[name]',
+    label: formatMessage({
+      id: 'content-manager.containers.SettingPage.defaultSortOrder.reviewWorkflows',
+      message: 'Review Stage',
+    }),
+  };
+}

--- a/packages/core/content-manager/server/controllers/validation/model-configuration.js
+++ b/packages/core/content-manager/server/controllers/validation/model-configuration.js
@@ -30,8 +30,7 @@ const createSettingsSchema = (schema) => {
       searchable: yup.boolean().required(),
       // should be reset when the type changes
       mainField: yup.string().oneOf(validAttributes.concat('id')).default('id'),
-      // should be reset when the type changes
-      defaultSortBy: yup.string().oneOf(validAttributes.concat('id')).default('id'),
+      defaultSortBy: yup.string().default('id'),
       defaultSortOrder: yup.string().oneOf(['ASC', 'DESC']).default('ASC'),
     })
     .noUnknown();


### PR DESCRIPTION
### What does it do?

We were validating the defaultSort was a visible attribute before. It didn't  prevent anyone sorting by any private or non visible field in the admin, it was just defined like that as a bussiness rule.

Downside of this change: This will not prevent anyone tweaking the Admin API request manually and add an invalid sort by. 

Now we want to sort by non visible fields `strapi_reviewWorkflows_stage`, so this PR removes that limitation.


### Why is it needed?

When trying to set Content Type default sort to Strapi Review Workflow stages it would return a 400 error.

That is because that field is `strapi_reviewWorkflows_stage` field is non visible, and we were not allowing to set such attribute as default sortBy .

### How to test it?


https://user-images.githubusercontent.com/20578351/235736276-41987481-5ea6-4afc-bb8a-d21e1d45be77.mp4



