### PR TITLE
feat: filter by non visible attributes

### DIFF
--- a/packages/core/admin/server/services/permission/permissions-manager/sanitize.js
+++ b/packages/core/admin/server/services/permission/permissions-manager/sanitize.js
@@ -256,6 +256,8 @@ module.exports = ({ action, ability, model }) => {
   };
 
   const getQueryFields = (fields = []) => {
+    const nonVisibleAttributes = getNonVisibleAttributes(schema);
+
     return uniq([
       ...fields,
       ...STATIC_FIELDS,
@@ -263,6 +265,7 @@ module.exports = ({ action, ability, model }) => {
       CREATED_AT_ATTRIBUTE,
       UPDATED_AT_ATTRIBUTE,
       PUBLISHED_AT_ATTRIBUTE,
+      ...nonVisibleAttributes,
     ]);
   };
 


### PR DESCRIPTION
### What does it do?

I am trying to explore how this could be an issue , based on your comments @Convly 

As I see it right now, this would not allow a user to infer any data that's not suposed to.

For context, non visible fields are always included in the ouptut of a request:
```js
  const getOutputFields = (fields = []) => {
    const nonWritableAttributes = getNonWritableAttributes(schema);
    const nonVisibleAttributes = getNonVisibleAttributes(schema); 

    return uniq([
      ...fields,
      ...STATIC_FIELDS,
      ...COMPONENT_FIELDS,
      ...nonWritableAttributes,
      ...nonVisibleAttributes, // <======
      CREATED_AT_ATTRIBUTE,
      UPDATED_AT_ATTRIBUTE,
    ]);
  };
```

So, if they are already visible, there is no more data you can infer from filtering them.


### Why is it needed?

Describe the issue you are solving.

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
