### PR TITLE
Chore: Update e2e tests with recent TS and API test changes

### DIFF
--- a/jest-preset.unit.js
+++ b/jest-preset.unit.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = {
-  setupFilesAfterEnv: [__dirname + '/test/unit.setup.js'],
+  setupFilesAfterEnv: [__dirname + '/test/setup/unit.setup.js'],
   modulePathIgnorePatterns: ['.cache', 'dist'],
   testPathIgnorePatterns: ['.testdata.js', '.test.utils.js'],
   testMatch: ['/**/__tests__/**/*.[jt]s?(x)'],

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "test:unit": "jest --config jest.config.js",
     "test:unit:watch": "run test:unit --watch",
     "test:api": "node test/api.js",
-    "test:generate-app": "node test/create-test-app.js",
+    "test:generate-app": "yarn build:ts && node test/scripts/generate-test-app.js",
     "doc:api": "node scripts/open-api/serve.js"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "@babel/core": "^7.20.12",
     "@babel/eslint-parser": "^7.19.1",
     "@babel/preset-react": "7.18.6",
-    "@playwright/test": "1.27.1",
+    "@playwright/test": "1.33.0",
     "@strapi/admin-test-utils": "workspace:*",
     "@strapi/eslint-config": "0.1.2",
     "@swc/cli": "0.1.62",

--- a/test/helpers/test-app.js
+++ b/test/helpers/test-app.js
@@ -3,7 +3,7 @@
 const path = require('path');
 const rimraf = require('rimraf');
 const execa = require('execa');
-const generateNew = require('../../packages/generators/app/lib/generate-new');
+const generateNew = require('../../packages/generators/app/dist/generate-new').default;
 
 /**
  * Deletes a test app

--- a/test/scripts/generate-test-app.js
+++ b/test/scripts/generate-test-app.js
@@ -3,7 +3,7 @@
 process.env.NODE_ENV = 'test';
 
 const yargs = require('yargs');
-const { cleanTestApp, generateTestApp } = require('../helpers/test-app');
+const { cleanTestApp, generateTestApp, runTestApp } = require('../helpers/test-app');
 
 const databases = {
   postgres: {
@@ -40,6 +40,10 @@ const main = async (database, appPath, opts) => {
   try {
     await cleanTestApp(appPath);
     await generateTestApp({ appPath, database, template: opts.template });
+
+    if (opts.run) {
+      await runTestApp(appPath);
+    }
   } catch (error) {
     console.error(error);
     process.exit(1);

--- a/test/scripts/generate-test-app.js
+++ b/test/scripts/generate-test-app.js
@@ -3,7 +3,7 @@
 process.env.NODE_ENV = 'test';
 
 const yargs = require('yargs');
-const { cleanTestApp, generateTestApp, runTestApp } = require('../helpers/test-app');
+const { cleanTestApp, generateTestApp } = require('../helpers/test-app');
 
 const databases = {
   postgres: {
@@ -40,10 +40,6 @@ const main = async (database, appPath, opts) => {
   try {
     await cleanTestApp(appPath);
     await generateTestApp({ appPath, database, template: opts.template });
-
-    if (opts.run) {
-      await runTestApp(appPath);
-    }
   } catch (error) {
     console.error(error);
     process.exit(1);
@@ -53,12 +49,10 @@ const main = async (database, appPath, opts) => {
 // eslint-disable-next-line no-unused-expressions
 yargs
   .command(
-    '$0 [appName]',
-    'Create test app',
+    '$0 [databaseName]',
+    'Generate test app',
     (yarg) => {
-      yarg.option('database', {
-        alias: 'db',
-        describe: 'Database',
+      yarg.positional('databaseName', {
         choices: Object.keys(databases),
         default: 'sqlite',
       });
@@ -76,22 +70,24 @@ yargs
       });
     },
     (argv) => {
-      const { database, run, appPath = 'test-apps/base', template } = argv;
+      const { databaseName, run, appPath = 'test-apps/base', template } = argv;
+
+      if (databaseName) {
+        return main(databases[databaseName], appPath, { run, template });
+      }
 
       return main(
-        argv.dbclient
-          ? {
-              client: argv.dbclient,
-              connection: {
-                host: argv.dbhost,
-                port: argv.dbport,
-                database: argv.dbname,
-                username: argv.dbusername,
-                password: argv.dbpassword,
-                filename: argv.dbfile,
-              },
-            }
-          : databases[database],
+        {
+          client: argv.dbclient,
+          connection: {
+            host: argv.dbhost,
+            port: argv.dbport,
+            database: argv.dbname,
+            username: argv.dbusername,
+            password: argv.dbpassword,
+            filename: argv.dbfile,
+          },
+        },
         appPath,
         { run, template }
       );

--- a/yarn.lock
+++ b/yarn.lock
@@ -12259,17 +12259,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"better-sqlite3@npm:8.0.1":
-  version: 8.0.1
-  resolution: "better-sqlite3@npm:8.0.1"
-  dependencies:
-    bindings: ^1.5.0
-    node-gyp: latest
-    prebuild-install: ^7.1.0
-  checksum: 533b2cc32bd54e2a943a4f63e079f8cc8945879b7a0ebd2085b948824ea067792f6f903ab75ba75d7cafc5f8f973354cdf9a042fa6216e077925d07a8df1bead
-  languageName: node
-  linkType: hard
-
 "better-sqlite3@npm:8.3.0":
   version: 8.3.0
   resolution: "better-sqlite3@npm:8.3.0"
@@ -26681,19 +26670,6 @@ __metadata:
   checksum: 5fb7bda06a8b73b56b85b5a0b8f711211dde57a375d9379289e22239b2de879c6d93c8fdc9ba44b932bf100914ab1ca1a55697ad88440fdd0a39101fc020b77f
   languageName: node
   linkType: hard
-
-"playwright@workspace:test-apps/playwright":
-  version: 0.0.0-use.local
-  resolution: "playwright@workspace:test-apps/playwright"
-  dependencies:
-    "@strapi/plugin-documentation": 4.10.1
-    "@strapi/plugin-graphql": 4.10.1
-    "@strapi/plugin-i18n": 4.10.1
-    "@strapi/plugin-users-permissions": 4.10.1
-    "@strapi/strapi": 4.10.1
-    better-sqlite3: 8.0.1
-  languageName: unknown
-  linkType: soft
 
 "plop@npm:2.7.6":
   version: 2.7.6

--- a/yarn.lock
+++ b/yarn.lock
@@ -12255,6 +12255,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"better-sqlite3@npm:8.0.1":
+  version: 8.0.1
+  resolution: "better-sqlite3@npm:8.0.1"
+  dependencies:
+    bindings: ^1.5.0
+    node-gyp: latest
+    prebuild-install: ^7.1.0
+  checksum: 533b2cc32bd54e2a943a4f63e079f8cc8945879b7a0ebd2085b948824ea067792f6f903ab75ba75d7cafc5f8f973354cdf9a042fa6216e077925d07a8df1bead
+  languageName: node
+  linkType: hard
+
 "better-sqlite3@npm:8.3.0":
   version: 8.3.0
   resolution: "better-sqlite3@npm:8.3.0"
@@ -26666,6 +26677,19 @@ __metadata:
   checksum: fd65d3eb29978e0e7a755158625e8922a66ca9d599b7c24ddf920822b261d81c51a5964ef8e0e5ed9b2b12dc64541c5949b6a898d965e107f43261964e8c29a0
   languageName: node
   linkType: hard
+
+"playwright@workspace:test-apps/playwright":
+  version: 0.0.0-use.local
+  resolution: "playwright@workspace:test-apps/playwright"
+  dependencies:
+    "@strapi/plugin-documentation": 4.10.1
+    "@strapi/plugin-graphql": 4.10.1
+    "@strapi/plugin-i18n": 4.10.1
+    "@strapi/plugin-users-permissions": 4.10.1
+    "@strapi/strapi": 4.10.1
+    better-sqlite3: 8.0.1
+  languageName: unknown
+  linkType: soft
 
 "plop@npm:2.7.6":
   version: 2.7.6

--- a/yarn.lock
+++ b/yarn.lock
@@ -5087,15 +5087,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@playwright/test@npm:1.27.1":
-  version: 1.27.1
-  resolution: "@playwright/test@npm:1.27.1"
+"@playwright/test@npm:1.33.0":
+  version: 1.33.0
+  resolution: "@playwright/test@npm:1.33.0"
   dependencies:
     "@types/node": "*"
-    playwright-core: 1.27.1
+    fsevents: 2.3.2
+    playwright-core: 1.33.0
+  dependenciesMeta:
+    fsevents:
+      optional: true
   bin:
     playwright: cli.js
-  checksum: 92f219a78c21da03c6599d92c313c914e73cc374306366130fb3bd4701555179394ec5a3000d9375ce59f5a03c00f20d1ddaae50c85583ce475e17795a622699
+  checksum: cec3215fc92c1cb9f5bfba357ea1cbe97b54979ab82f9d34a2287b1687cda5e0966b8ea7290dcd35416e18668e56d5781b6b8c4cec64baf12f3ae8dde0f68f5e
   languageName: node
   linkType: hard
 
@@ -17869,6 +17873,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fsevents@npm:2.3.2, fsevents@npm:^2.1.2, fsevents@npm:^2.3.2, fsevents@npm:~2.3.2":
+  version: 2.3.2
+  resolution: "fsevents@npm:2.3.2"
+  dependencies:
+    node-gyp: latest
+  checksum: 97ade64e75091afee5265e6956cb72ba34db7819b4c3e94c431d4be2b19b8bb7a2d4116da417950c3425f17c8fe693d25e20212cac583ac1521ad066b77ae31f
+  conditions: os=darwin
+  languageName: node
+  linkType: hard
+
 "fsevents@npm:^1.2.7":
   version: 1.2.13
   resolution: "fsevents@npm:1.2.13"
@@ -17880,12 +17894,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fsevents@npm:^2.1.2, fsevents@npm:^2.3.2, fsevents@npm:~2.3.2":
+"fsevents@patch:fsevents@2.3.2#~builtin<compat/fsevents>, fsevents@patch:fsevents@^2.1.2#~builtin<compat/fsevents>, fsevents@patch:fsevents@^2.3.2#~builtin<compat/fsevents>, fsevents@patch:fsevents@~2.3.2#~builtin<compat/fsevents>":
   version: 2.3.2
-  resolution: "fsevents@npm:2.3.2"
+  resolution: "fsevents@patch:fsevents@npm%3A2.3.2#~builtin<compat/fsevents>::version=2.3.2&hash=df0bf1"
   dependencies:
     node-gyp: latest
-  checksum: 97ade64e75091afee5265e6956cb72ba34db7819b4c3e94c431d4be2b19b8bb7a2d4116da417950c3425f17c8fe693d25e20212cac583ac1521ad066b77ae31f
   conditions: os=darwin
   languageName: node
   linkType: hard
@@ -17896,15 +17909,6 @@ __metadata:
   dependencies:
     bindings: ^1.5.0
     nan: ^2.12.1
-  conditions: os=darwin
-  languageName: node
-  linkType: hard
-
-"fsevents@patch:fsevents@^2.1.2#~builtin<compat/fsevents>, fsevents@patch:fsevents@^2.3.2#~builtin<compat/fsevents>, fsevents@patch:fsevents@~2.3.2#~builtin<compat/fsevents>":
-  version: 2.3.2
-  resolution: "fsevents@patch:fsevents@npm%3A2.3.2#~builtin<compat/fsevents>::version=2.3.2&hash=df0bf1"
-  dependencies:
-    node-gyp: latest
   conditions: os=darwin
   languageName: node
   linkType: hard
@@ -26669,12 +26673,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"playwright-core@npm:1.27.1":
-  version: 1.27.1
-  resolution: "playwright-core@npm:1.27.1"
+"playwright-core@npm:1.33.0":
+  version: 1.33.0
+  resolution: "playwright-core@npm:1.33.0"
   bin:
     playwright: cli.js
-  checksum: fd65d3eb29978e0e7a755158625e8922a66ca9d599b7c24ddf920822b261d81c51a5964ef8e0e5ed9b2b12dc64541c5949b6a898d965e107f43261964e8c29a0
+  checksum: 5fb7bda06a8b73b56b85b5a0b8f711211dde57a375d9379289e22239b2de879c6d93c8fdc9ba44b932bf100914ab1ca1a55697ad88440fdd0a39101fc020b77f
   languageName: node
   linkType: hard
 
@@ -30160,7 +30164,7 @@ __metadata:
     "@babel/core": ^7.20.12
     "@babel/eslint-parser": ^7.19.1
     "@babel/preset-react": 7.18.6
-    "@playwright/test": 1.27.1
+    "@playwright/test": 1.33.0
     "@strapi/admin-test-utils": "workspace:*"
     "@strapi/eslint-config": 0.1.2
     "@swc/cli": 0.1.62


### PR DESCRIPTION
### What does it do?

Changes necessary, because on `main` the way API tests run were changed and generators are now based on TS.

### Why is it needed?

This is an attempt to merge work from https://github.com/strapi/strapi/pull/16242, https://github.com/strapi/strapi/pull/16392 and https://github.com/strapi/strapi/pull/14807.

