### PR TITLE
feat(review-workflow): content api

### DIFF
--- a/api-tests/core/admin/ee/review-workflows.test.api.js
+++ b/api-tests/core/admin/ee/review-workflows.test.api.js
@@ -561,7 +561,7 @@ describeOnCondition(edition === 'EE')('Review workflows', () => {
 
   describe('Content-API - Get workflows', () => {
     test('It should return a list of workflows', async () => {
-      const res = await requests.contentAPI.get('/strapi_workflows');
+      const res = await requests.contentAPI.get('/strapi-workflows');
       expect(res.status).toBe(200);
       expect(res.body.data).toBeDefined();
       expect(res.body.data.length).toBeGreaterThan(0);
@@ -569,7 +569,7 @@ describeOnCondition(edition === 'EE')('Review workflows', () => {
       expect(res.body.data[0]).toEqual(expect.not.objectContaining({ stages: expect.anything() }));
     });
     test('It should return a list of workflows with stages', async () => {
-      const res = await requests.contentAPI.get('/strapi_workflows?populate=stages');
+      const res = await requests.contentAPI.get('/strapi-workflows?populate=stages');
       expect(res.status).toBe(200);
       expect(res.body.data).toBeDefined();
       expect(res.body.data.length).toBeGreaterThan(0);
@@ -589,7 +589,7 @@ describeOnCondition(edition === 'EE')('Review workflows', () => {
   });
   describe('Content-API - Get one workflow', () => {
     test('It should return a workflow', async () => {
-      const res = await requests.contentAPI.get(`/strapi_workflows/${testWorkflow.id}`);
+      const res = await requests.contentAPI.get(`/strapi-workflows/${testWorkflow.id}`);
       expect(res.status).toBe(200);
       expect(res.body.data).toBeDefined();
       expect(res.body.data.id).toEqual(testWorkflow.id);
@@ -597,7 +597,7 @@ describeOnCondition(edition === 'EE')('Review workflows', () => {
     });
     test('It should return a workflow with stages', async () => {
       const res = await requests.contentAPI.get(
-        `/strapi_workflows/${testWorkflow.id}?populate=stages`
+        `/strapi-workflows/${testWorkflow.id}?populate=stages`
       );
       expect(res.status).toBe(200);
       expect(res.body.data).toBeDefined();
@@ -617,7 +617,7 @@ describeOnCondition(edition === 'EE')('Review workflows', () => {
   describe('Content-API - Get one stage', () => {
     test('It should return a stage', async () => {
       const res = await requests.contentAPI.get(
-        `/strapi_workflows/${testWorkflow.id}/stages/${defaultStage.id}`
+        `/strapi-workflows/${testWorkflow.id}/stages/${defaultStage.id}`
       );
       expect(res.status).toBe(200);
       expect(res.body.data).toBeDefined();
@@ -626,7 +626,7 @@ describeOnCondition(edition === 'EE')('Review workflows', () => {
     });
     test('It should return a stage with a workflow', async () => {
       const res = await requests.contentAPI.get(
-        `/strapi_workflows/${testWorkflow.id}/stages/${defaultStage.id}?populate=workflow`
+        `/strapi-workflows/${testWorkflow.id}/stages/${defaultStage.id}?populate=workflow`
       );
       expect(res.status).toBe(200);
       expect(res.body.data).toBeDefined();
@@ -642,7 +642,7 @@ describeOnCondition(edition === 'EE')('Review workflows', () => {
   describe('Content-API - Update a stage', () => {
     test('It should update a stage', async () => {
       const res = await requests.contentAPI.put(
-        `/strapi_workflows/${testWorkflow.id}/stages/${defaultStage.id}`,
+        `/strapi-workflows/${testWorkflow.id}/stages/${defaultStage.id}`,
         {
           body: {
             data: {
@@ -658,7 +658,7 @@ describeOnCondition(edition === 'EE')('Review workflows', () => {
     });
     test('It should fail updating a stage without a name', async () => {
       const res = await requests.contentAPI.put(
-        `/strapi_workflows/${testWorkflow.id}/stages/${defaultStage.id}`,
+        `/strapi-workflows/${testWorkflow.id}/stages/${defaultStage.id}`,
         {
           body: {
             data: {
@@ -676,7 +676,7 @@ describeOnCondition(edition === 'EE')('Review workflows', () => {
   describe('Content-API - Replace stages for a workflow', () => {
     test('It should replace stages for a workflow', async () => {
       const res = await requests.contentAPI.put(
-        `/strapi_workflows/${testWorkflow.id}/stages?populate=stages`,
+        `/strapi-workflows/${testWorkflow.id}/stages?populate=stages`,
         {
           body: {
             data: [
@@ -703,7 +703,7 @@ describeOnCondition(edition === 'EE')('Review workflows', () => {
       );
     });
     test('It should fail replacing stages for a workflow without stages', async () => {
-      const res = await requests.contentAPI.put(`/strapi_workflows/${testWorkflow.id}/stages`, {
+      const res = await requests.contentAPI.put(`/strapi-workflows/${testWorkflow.id}/stages`, {
         body: {
           data: [],
         },
@@ -716,7 +716,7 @@ describeOnCondition(edition === 'EE')('Review workflows', () => {
   });
   describe('Content-API - Create a stage', () => {
     test('It should create a stage', async () => {
-      const res = await requests.contentAPI.post(`/strapi_workflows/${testWorkflow.id}/stages`, {
+      const res = await requests.contentAPI.post(`/strapi-workflows/${testWorkflow.id}/stages`, {
         body: {
           data: {
             name: 'Last',
@@ -730,12 +730,12 @@ describeOnCondition(edition === 'EE')('Review workflows', () => {
 
       const {
         body: { data: workflow },
-      } = await requests.contentAPI.get(`/strapi_workflows/${testWorkflow.id}?populate=stages`);
+      } = await requests.contentAPI.get(`/strapi-workflows/${testWorkflow.id}?populate=stages`);
       expect(workflow.stages).toBeDefined();
       expect(workflow.stages[workflow.stages.length - 1]).toMatchObject(res.body.data);
     });
     test('It should fail creating a stage without a name', async () => {
-      const res = await requests.contentAPI.post(`/strapi_workflows/${testWorkflow.id}/stages`, {
+      const res = await requests.contentAPI.post(`/strapi-workflows/${testWorkflow.id}/stages`, {
         body: {
           data: {
             unknown: 'New name',

--- a/api-tests/core/admin/ee/review-workflows.test.api.js
+++ b/api-tests/core/admin/ee/review-workflows.test.api.js
@@ -98,19 +98,6 @@ describeOnCondition(edition === 'EE')('Review workflows', () => {
     requests.public = createRequest({ strapi });
     requests.admin = await createAuthRequest({ strapi });
     requests.contentAPI = await createContentAPIRequest({ strapi });
-
-    defaultStage = await strapi.query(STAGE_MODEL_UID).create({
-      data: { name: 'Stage' },
-    });
-    secondStage = await strapi.query(STAGE_MODEL_UID).create({
-      data: { name: 'Stage 2' },
-    });
-    testWorkflow = await strapi.query(WORKFLOW_MODEL_UID).create({
-      data: {
-        uid: 'workflow',
-        stages: [defaultStage.id, secondStage.id],
-      },
-    });
   });
 
   afterAll(async () => {
@@ -119,16 +106,32 @@ describeOnCondition(edition === 'EE')('Review workflows', () => {
   });
 
   beforeEach(async () => {
-    testWorkflow = await strapi.query(WORKFLOW_MODEL_UID).update({
-      where: { id: testWorkflow.id },
+    defaultStage = await strapi.query(STAGE_MODEL_UID).create({
+      data: { name: 'Stage' },
+    });
+    secondStage = await strapi.query(STAGE_MODEL_UID).create({
+      data: { name: 'Stage 2' },
+    });
+    testWorkflow = await strapi.query(WORKFLOW_MODEL_UID).create({
       data: {
-        uid: 'workflow',
         stages: [defaultStage.id, secondStage.id],
       },
     });
     await updateContentType(productUID, {
       components: [],
       contentType: model,
+    });
+  });
+
+  afterEach(async () => {
+    await strapi.query(STAGE_MODEL_UID).delete({
+      where: { id: defaultStage.id },
+    });
+    await strapi.query(STAGE_MODEL_UID).delete({
+      where: { id: secondStage.id },
+    });
+    await strapi.query(WORKFLOW_MODEL_UID).delete({
+      where: { id: testWorkflow.id },
     });
   });
 

--- a/api-tests/core/admin/ee/review-workflows.test.api.js
+++ b/api-tests/core/admin/ee/review-workflows.test.api.js
@@ -3,7 +3,7 @@
 const { mapAsync } = require('@strapi/utils');
 
 const { createStrapiInstance } = require('api-tests/strapi');
-const { createAuthRequest, createRequest } = require('api-tests/request');
+const { createAuthRequest, createRequest, createContentAPIRequest } = require('api-tests/request');
 const { createTestBuilder } = require('api-tests/builder');
 const { describeOnCondition } = require('api-tests/utils');
 
@@ -38,6 +38,7 @@ describeOnCondition(edition === 'EE')('Review workflows', () => {
   const requests = {
     public: null,
     admin: null,
+    contentAPI: null,
   };
   let strapi;
   let hasRW;
@@ -85,6 +86,7 @@ describeOnCondition(edition === 'EE')('Review workflows', () => {
     await strapi.destroy();
     strapi = await createStrapiInstance();
     requests.admin = await createAuthRequest({ strapi });
+    requests.contentAPI = await createContentAPIRequest({ strapi });
   };
 
   beforeAll(async () => {
@@ -95,6 +97,7 @@ describeOnCondition(edition === 'EE')('Review workflows', () => {
     hasRW = require('@strapi/strapi/lib/utils/ee').features.isEnabled('review-workflows');
     requests.public = createRequest({ strapi });
     requests.admin = await createAuthRequest({ strapi });
+    requests.contentAPI = await createContentAPIRequest({ strapi });
 
     defaultStage = await strapi.query(STAGE_MODEL_UID).create({
       data: { name: 'Stage' },
@@ -550,6 +553,196 @@ describeOnCondition(edition === 'EE')('Review workflows', () => {
       for (const entry of productsAfter.results) {
         expect(entry[ENTITY_STAGE_ATTRIBUTE].name).toEqual(defaultStage.name);
       }
+    });
+  });
+
+  describe('Content-API - Get workflows', () => {
+    test('It should return a list of workflows', async () => {
+      const res = await requests.contentAPI.get('/strapi_workflows');
+      expect(res.status).toBe(200);
+      expect(res.body.data).toBeDefined();
+      expect(res.body.data.length).toBeGreaterThan(0);
+      expect(res.body.data[0]).toMatchObject({ id: expect.any(Number) });
+      expect(res.body.data[0]).toEqual(expect.not.objectContaining({ stages: expect.anything() }));
+    });
+    test('It should return a list of workflows with stages', async () => {
+      const res = await requests.contentAPI.get('/strapi_workflows?populate=stages');
+      expect(res.status).toBe(200);
+      expect(res.body.data).toBeDefined();
+      expect(res.body.data.length).toBeGreaterThan(0);
+      expect(res.body.data[0]).toMatchObject({ id: expect.any(Number) });
+      expect(res.body.data[0]).toEqual(
+        expect.objectContaining({
+          stages: expect.arrayContaining([
+            expect.objectContaining({
+              id: expect.any(Number),
+              name: expect.any(String),
+              color: expect.any(String),
+            }),
+          ]),
+        })
+      );
+    });
+  });
+  describe('Content-API - Get one workflow', () => {
+    test('It should return a workflow', async () => {
+      const res = await requests.contentAPI.get(`/strapi_workflows/${testWorkflow.id}`);
+      expect(res.status).toBe(200);
+      expect(res.body.data).toBeDefined();
+      expect(res.body.data.id).toEqual(testWorkflow.id);
+      expect(res.body.data.stages).toBeUndefined();
+    });
+    test('It should return a workflow with stages', async () => {
+      const res = await requests.contentAPI.get(
+        `/strapi_workflows/${testWorkflow.id}?populate=stages`
+      );
+      expect(res.status).toBe(200);
+      expect(res.body.data).toBeDefined();
+      expect(res.body.data.id).toEqual(testWorkflow.id);
+      expect(res.body.data.stages).toBeDefined();
+      expect(res.body.data.stages).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: expect.any(Number),
+            name: expect.any(String),
+            color: expect.any(String),
+          }),
+        ])
+      );
+    });
+  });
+  describe('Content-API - Get one stage', () => {
+    test('It should return a stage', async () => {
+      const res = await requests.contentAPI.get(
+        `/strapi_workflows/${testWorkflow.id}/stages/${defaultStage.id}`
+      );
+      expect(res.status).toBe(200);
+      expect(res.body.data).toBeDefined();
+      expect(res.body.data.id).toEqual(defaultStage.id);
+      expect(res.body.data.workflow).toBeUndefined();
+    });
+    test('It should return a stage with a workflow', async () => {
+      const res = await requests.contentAPI.get(
+        `/strapi_workflows/${testWorkflow.id}/stages/${defaultStage.id}?populate=workflow`
+      );
+      expect(res.status).toBe(200);
+      expect(res.body.data).toBeDefined();
+      expect(res.body.data.id).toEqual(defaultStage.id);
+      expect(res.body.data.workflow).toBeDefined();
+      expect(res.body.data.workflow).toEqual(
+        expect.objectContaining({
+          id: expect.any(Number),
+        })
+      );
+    });
+  });
+  describe('Content-API - Update a stage', () => {
+    test('It should update a stage', async () => {
+      const res = await requests.contentAPI.put(
+        `/strapi_workflows/${testWorkflow.id}/stages/${defaultStage.id}`,
+        {
+          body: {
+            data: {
+              name: 'New name',
+            },
+          },
+        }
+      );
+      expect(res.status).toBe(200);
+      expect(res.body.data).toBeDefined();
+      expect(res.body.data.id).toEqual(defaultStage.id);
+      expect(res.body.data.name).toEqual('New name');
+    });
+    test('It should fail updating a stage without a name', async () => {
+      const res = await requests.contentAPI.put(
+        `/strapi_workflows/${testWorkflow.id}/stages/${defaultStage.id}`,
+        {
+          body: {
+            data: {
+              unknown: 'New name',
+            },
+          },
+        }
+      );
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBeDefined();
+      expect(res.body.error.name).toEqual('ValidationError');
+      expect(res.body.error.message).toEqual('name is a required field');
+    });
+  });
+  describe('Content-API - Replace stages for a workflow', () => {
+    test('It should replace stages for a workflow', async () => {
+      const res = await requests.contentAPI.put(
+        `/strapi_workflows/${testWorkflow.id}/stages?populate=stages`,
+        {
+          body: {
+            data: [
+              {
+                id: defaultStage.id,
+                name: 'New name',
+              },
+            ],
+          },
+        }
+      );
+      expect(res.status).toBe(200);
+      expect(res.body.data).toBeDefined();
+      expect(res.body.data.id).toEqual(testWorkflow.id);
+      expect(res.body.data.stages).toBeDefined();
+      expect(res.body.data.stages).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: expect.any(Number),
+            name: expect.any(String),
+            color: expect.any(String),
+          }),
+        ])
+      );
+    });
+    test('It should fail replacing stages for a workflow without stages', async () => {
+      const res = await requests.contentAPI.put(`/strapi_workflows/${testWorkflow.id}/stages`, {
+        body: {
+          data: [],
+        },
+      });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBeDefined();
+      expect(res.body.error.name).toEqual('ApplicationError');
+      expect(res.body.error.message).toEqual('At least one stage must remain in the workflow.');
+    });
+  });
+  describe('Content-API - Create a stage', () => {
+    test('It should create a stage', async () => {
+      const res = await requests.contentAPI.post(`/strapi_workflows/${testWorkflow.id}/stages`, {
+        body: {
+          data: {
+            name: 'Last',
+          },
+        },
+      });
+      expect(res.status).toBe(200);
+      expect(res.body.data).toBeDefined();
+      expect(res.body.data.id).toEqual(expect.any(Number));
+      expect(res.body.data.name).toEqual('Last');
+
+      const {
+        body: { data: workflow },
+      } = await requests.contentAPI.get(`/strapi_workflows/${testWorkflow.id}?populate=stages`);
+      expect(workflow.stages).toBeDefined();
+      expect(workflow.stages[workflow.stages.length - 1]).toMatchObject(res.body.data);
+    });
+    test('It should fail creating a stage without a name', async () => {
+      const res = await requests.contentAPI.post(`/strapi_workflows/${testWorkflow.id}/stages`, {
+        body: {
+          data: {
+            unknown: 'New name',
+          },
+        },
+      });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBeDefined();
+      expect(res.body.error.name).toEqual('ValidationError');
+      expect(res.body.error.message).toEqual('name is a required field');
     });
   });
 });

--- a/packages/core/admin/ee/server/controllers/content-api/workflows/index.js
+++ b/packages/core/admin/ee/server/controllers/content-api/workflows/index.js
@@ -1,6 +1,21 @@
 'use strict';
 
+const { sanitize } = require('@strapi/utils');
 const { getService } = require('../../../utils');
+const { WORKFLOW_MODEL_UID } = require('../../../constants/workflows');
+
+function sanitizeOuput({ strapi }, data, ctx) {
+  const schema = strapi.getModel(WORKFLOW_MODEL_UID);
+  const { auth } = ctx.state;
+
+  return sanitize.contentAPI.output(data, schema, { auth });
+}
+function sanitizeQuery({ strapi }, data, ctx) {
+  const schema = strapi.getModel(WORKFLOW_MODEL_UID);
+  const { auth } = ctx.state;
+
+  return sanitize.contentAPI.query(data, schema, { auth });
+}
 
 module.exports = {
   /**
@@ -8,14 +23,14 @@ module.exports = {
    * @param {import('koa').BaseContext} ctx - koa context
    */
   async find(ctx) {
-    const { populate } = ctx.query;
+    const params = await sanitizeQuery({ strapi }, ctx.query, ctx);
     const workflowService = getService('workflows');
     const data = await workflowService.find({
-      populate,
+      populate: params.populate,
     });
 
     ctx.body = {
-      data,
+      data: await sanitizeOuput({ strapi }, data, ctx),
     };
   },
   /**
@@ -24,13 +39,13 @@ module.exports = {
    */
   async findById(ctx) {
     const { id } = ctx.params;
-    const { populate } = ctx.query;
+    const params = await sanitizeQuery({ strapi }, ctx.query, ctx);
 
     const workflowService = getService('workflows');
-    const data = await workflowService.findById(id, { populate });
+    const data = await workflowService.findById(id, { populate: params.populate });
 
     ctx.body = {
-      data,
+      data: await sanitizeOuput({ strapi }, data, ctx),
     };
   },
 };

--- a/packages/core/admin/ee/server/controllers/content-api/workflows/index.js
+++ b/packages/core/admin/ee/server/controllers/content-api/workflows/index.js
@@ -4,7 +4,7 @@ const { sanitize } = require('@strapi/utils');
 const { getService } = require('../../../utils');
 const { WORKFLOW_MODEL_UID } = require('../../../constants/workflows');
 
-function sanitizeOuput({ strapi }, data, ctx) {
+function sanitizeOutput({ strapi }, data, ctx) {
   const schema = strapi.getModel(WORKFLOW_MODEL_UID);
   const { auth } = ctx.state;
 
@@ -30,7 +30,7 @@ module.exports = {
     });
 
     ctx.body = {
-      data: await sanitizeOuput({ strapi }, data, ctx),
+      data: await sanitizeOutput({ strapi }, data, ctx),
     };
   },
   /**
@@ -45,7 +45,7 @@ module.exports = {
     const data = await workflowService.findById(id, { populate: params.populate });
 
     ctx.body = {
-      data: await sanitizeOuput({ strapi }, data, ctx),
+      data: await sanitizeOutput({ strapi }, data, ctx),
     };
   },
 };

--- a/packages/core/admin/ee/server/controllers/content-api/workflows/index.js
+++ b/packages/core/admin/ee/server/controllers/content-api/workflows/index.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const { getService } = require('../../../utils');
+
+module.exports = {
+  /**
+   * List all workflows
+   * @param {import('koa').BaseContext} ctx - koa context
+   */
+  async find(ctx) {
+    const { populate } = ctx.query;
+    const workflowService = getService('workflows');
+    const data = await workflowService.find({
+      populate,
+    });
+
+    ctx.body = {
+      data,
+    };
+  },
+  /**
+   * Get one workflow based on its id contained in request parameters
+   * @param {import('koa').BaseContext} ctx - koa context
+   */
+  async findById(ctx) {
+    const { id } = ctx.params;
+    const { populate } = ctx.query;
+
+    const workflowService = getService('workflows');
+    const data = await workflowService.findById(id, { populate });
+
+    ctx.body = {
+      data,
+    };
+  },
+};

--- a/packages/core/admin/ee/server/controllers/content-api/workflows/stages/index.js
+++ b/packages/core/admin/ee/server/controllers/content-api/workflows/stages/index.js
@@ -37,7 +37,9 @@ module.exports = {
 
     const stagesValidated = await validateUpdateStages(stages);
 
-    const data = await stagesService.replaceWorkflowStages(workflowId, stagesValidated);
+    const data = await stagesService.replaceWorkflowStages(workflowId, stagesValidated, {
+      populate: ['stages'],
+    });
 
     ctx.body = { data };
   },

--- a/packages/core/admin/ee/server/controllers/content-api/workflows/stages/index.js
+++ b/packages/core/admin/ee/server/controllers/content-api/workflows/stages/index.js
@@ -1,0 +1,85 @@
+'use strict';
+
+const { getService } = require('../../../../utils');
+const { validateUpdateStages, validateStage } = require('../../../../validation/review-workflows');
+
+module.exports = {
+  /**
+   * Get one stage
+   * @param {import('koa').BaseContext} ctx - koa context
+   */
+  async findById(ctx) {
+    const { id, workflow_id: workflowId } = ctx.params;
+    const { populate } = ctx.query;
+    const stagesService = getService('stages');
+
+    const data = await stagesService.findById(id, {
+      workflowId,
+      populate,
+    });
+
+    ctx.body = {
+      data,
+    };
+  },
+
+  /**
+   * Replace all stages in a workflow
+   * @param {import('koa').BaseContext} ctx - koa context
+   *
+   */
+  async replace(ctx) {
+    const { workflow_id: workflowId } = ctx.params;
+    const stagesService = getService('stages');
+    const {
+      body: { data: stages },
+    } = ctx.request;
+
+    const stagesValidated = await validateUpdateStages(stages);
+
+    const data = await stagesService.replaceWorkflowStages(workflowId, stagesValidated);
+
+    ctx.body = { data };
+  },
+
+  /**
+   * Update a specific stage
+   * @param {import('koa').BaseContext} ctx - koa context
+   *
+   */
+  async updateOne(ctx) {
+    const { id: stageId } = ctx.params;
+    const stagesService = getService('stages');
+    const {
+      body: { data: stage },
+    } = ctx.request;
+
+    const stageValidated = await validateStage(stage);
+
+    const data = await stagesService.update(stageId, stageValidated);
+
+    ctx.body = { data };
+  },
+
+  /**
+   * Create a new stage at the end of the targeted workflow
+   * @param {import('koa').BaseContext} ctx - koa context
+   *
+   */
+  async create(ctx) {
+    const { workflow_id: workflowId } = ctx.params;
+    const stagesService = getService('stages');
+    const {
+      body: { data: stage },
+    } = ctx.request;
+
+    const stageValidated = await validateStage(stage);
+
+    const data = await stagesService.create(
+      { ...stageValidated, workflow: workflowId },
+      { fields: ['id', 'name', 'color'] }
+    );
+
+    ctx.body = { data };
+  },
+};

--- a/packages/core/admin/ee/server/controllers/index.js
+++ b/packages/core/admin/ee/server/controllers/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+// TODO move admin controllers to `admin-ctrl-name` form
 module.exports = {
   authentication: require('./authentication'),
   role: require('./role'),
@@ -8,4 +9,6 @@ module.exports = {
   admin: require('./admin'),
   workflows: require('./workflows'),
   stages: require('./workflows/stages'),
+  'content-api-workflows': require('./content-api/workflows'),
+  'content-api-stages': require('./content-api/workflows/stages'),
 };

--- a/packages/core/admin/ee/server/routes/review-workflows.js
+++ b/packages/core/admin/ee/server/routes/review-workflows.js
@@ -2,7 +2,7 @@
 
 const { enableFeatureMiddleware } = require('./utils');
 
-const CONTENT_API_PREFIX = 'strapi_workflows';
+const CONTENT_API_PREFIX = 'strapi-workflows';
 
 module.exports = [
   {

--- a/packages/core/admin/ee/server/routes/review-workflows.js
+++ b/packages/core/admin/ee/server/routes/review-workflows.js
@@ -2,111 +2,175 @@
 
 const { enableFeatureMiddleware } = require('./utils');
 
-module.exports = {
-  type: 'admin',
-  routes: [
-    // Review workflow
-    {
-      method: 'GET',
-      path: '/review-workflows/workflows',
-      handler: 'workflows.find',
-      config: {
-        middlewares: [enableFeatureMiddleware('review-workflows')],
-        policies: [
-          'admin::isAuthenticatedAdmin',
-          {
-            name: 'admin::hasPermissions',
-            config: {
-              actions: ['admin::review-workflows.read'],
+const CONTENT_API_PREFIX = 'strapi_workflows';
+
+module.exports = [
+  {
+    type: 'admin',
+    routes: [
+      // Review workflow
+      {
+        method: 'GET',
+        path: '/review-workflows/workflows',
+        handler: 'workflows.find',
+        config: {
+          middlewares: [enableFeatureMiddleware('review-workflows')],
+          policies: [
+            'admin::isAuthenticatedAdmin',
+            {
+              name: 'admin::hasPermissions',
+              config: {
+                actions: ['admin::review-workflows.read'],
+              },
             },
-          },
-        ],
+          ],
+        },
       },
-    },
-    {
-      method: 'GET',
-      path: '/review-workflows/workflows/:id',
-      handler: 'workflows.findById',
-      config: {
-        middlewares: [enableFeatureMiddleware('review-workflows')],
-        policies: [
-          'admin::isAuthenticatedAdmin',
-          {
-            name: 'admin::hasPermissions',
-            config: {
-              actions: ['admin::review-workflows.read'],
+      {
+        method: 'GET',
+        path: '/review-workflows/workflows/:id',
+        handler: 'workflows.findById',
+        config: {
+          middlewares: [enableFeatureMiddleware('review-workflows')],
+          policies: [
+            'admin::isAuthenticatedAdmin',
+            {
+              name: 'admin::hasPermissions',
+              config: {
+                actions: ['admin::review-workflows.read'],
+              },
             },
-          },
-        ],
+          ],
+        },
       },
-    },
-    {
-      method: 'GET',
-      path: '/review-workflows/workflows/:workflow_id/stages',
-      handler: 'stages.find',
-      config: {
-        middlewares: [enableFeatureMiddleware('review-workflows')],
-        policies: [
-          'admin::isAuthenticatedAdmin',
-          {
-            name: 'admin::hasPermissions',
-            config: {
-              actions: ['admin::review-workflows.read'],
+      {
+        method: 'GET',
+        path: '/review-workflows/workflows/:workflow_id/stages',
+        handler: 'stages.find',
+        config: {
+          middlewares: [enableFeatureMiddleware('review-workflows')],
+          policies: [
+            'admin::isAuthenticatedAdmin',
+            {
+              name: 'admin::hasPermissions',
+              config: {
+                actions: ['admin::review-workflows.read'],
+              },
             },
-          },
-        ],
+          ],
+        },
       },
-    },
-    {
-      method: 'PUT',
-      path: '/review-workflows/workflows/:workflow_id/stages',
-      handler: 'stages.replace',
-      config: {
-        middlewares: [enableFeatureMiddleware('review-workflows')],
-        policies: [
-          'admin::isAuthenticatedAdmin',
-          {
-            name: 'admin::hasPermissions',
-            config: {
-              actions: ['admin::review-workflows.read'],
+      {
+        method: 'PUT',
+        path: '/review-workflows/workflows/:workflow_id/stages',
+        handler: 'stages.replace',
+        config: {
+          middlewares: [enableFeatureMiddleware('review-workflows')],
+          policies: [
+            'admin::isAuthenticatedAdmin',
+            {
+              name: 'admin::hasPermissions',
+              config: {
+                actions: ['admin::review-workflows.read'],
+              },
             },
-          },
-        ],
+          ],
+        },
       },
-    },
-    {
-      method: 'GET',
-      path: '/review-workflows/workflows/:workflow_id/stages/:id',
-      handler: 'stages.findById',
-      config: {
-        middlewares: [enableFeatureMiddleware('review-workflows')],
-        policies: [
-          'admin::isAuthenticatedAdmin',
-          {
-            name: 'admin::hasPermissions',
-            config: {
-              actions: ['admin::review-workflows.read'],
+      {
+        method: 'GET',
+        path: '/review-workflows/workflows/:workflow_id/stages/:id',
+        handler: 'stages.findById',
+        config: {
+          middlewares: [enableFeatureMiddleware('review-workflows')],
+          policies: [
+            'admin::isAuthenticatedAdmin',
+            {
+              name: 'admin::hasPermissions',
+              config: {
+                actions: ['admin::review-workflows.read'],
+              },
             },
-          },
-        ],
+          ],
+        },
       },
-    },
-    {
-      method: 'PUT',
-      path: '/content-manager/(collection|single)-types/:model_uid/:id/stage',
-      handler: 'stages.updateEntity',
-      config: {
-        middlewares: [enableFeatureMiddleware('review-workflows')],
-        policies: [
-          'admin::isAuthenticatedAdmin',
-          {
-            name: 'admin::hasPermissions',
-            config: {
-              actions: ['admin::review-workflows.read'],
+      {
+        method: 'PUT',
+        path: '/content-manager/(collection|single)-types/:model_uid/:id/stage',
+        handler: 'stages.updateEntity',
+        config: {
+          middlewares: [enableFeatureMiddleware('review-workflows')],
+          policies: [
+            'admin::isAuthenticatedAdmin',
+            {
+              name: 'admin::hasPermissions',
+              config: {
+                actions: ['admin::review-workflows.read'],
+              },
             },
-          },
-        ],
+          ],
+        },
       },
-    },
-  ],
-};
+    ],
+  },
+  {
+    type: 'content-api',
+    prefix: `/${CONTENT_API_PREFIX}`,
+    routes: [
+      {
+        method: 'GET',
+        path: '/',
+        handler: 'content-api-workflows.find',
+        config: {
+          middlewares: [enableFeatureMiddleware('review-workflows')],
+          policies: [],
+        },
+      },
+      {
+        method: 'GET',
+        path: '/:id',
+        handler: 'content-api-workflows.findById',
+        config: {
+          middlewares: [enableFeatureMiddleware('review-workflows')],
+          policies: [],
+        },
+      },
+      {
+        method: 'GET',
+        path: '/:workflow_id/stages/:id',
+        handler: 'content-api-stages.findById',
+        config: {
+          middlewares: [enableFeatureMiddleware('review-workflows')],
+          policies: [],
+        },
+      },
+      {
+        method: 'PUT',
+        path: '/:workflow_id/stages/:id',
+        handler: 'content-api-stages.updateOne',
+        config: {
+          middlewares: [enableFeatureMiddleware('review-workflows')],
+          policies: [],
+        },
+      },
+      {
+        method: 'PUT',
+        path: '/:workflow_id/stages',
+        handler: 'content-api-stages.replace',
+        config: {
+          middlewares: [enableFeatureMiddleware('review-workflows')],
+          policies: [],
+        },
+      },
+      {
+        method: 'POST',
+        path: '/:workflow_id/stages',
+        handler: 'content-api-stages.create',
+        config: {
+          middlewares: [enableFeatureMiddleware('review-workflows')],
+          policies: [],
+        },
+      },
+    ],
+  },
+];

--- a/packages/core/admin/ee/server/services/__tests__/stages.test.js
+++ b/packages/core/admin/ee/server/services/__tests__/stages.test.js
@@ -177,9 +177,13 @@ describe('Review workflows - Stages service', () => {
       expect(entityServiceMock.update).toBeCalled();
       expect(entityServiceMock.delete).not.toBeCalled();
       expect(servicesMock['admin::workflows'].update).toBeCalled();
-      expect(servicesMock['admin::workflows'].update).toBeCalledWith(workflowMock.id, {
-        stages: updateStages.map((stage) => stage.id),
-      });
+      expect(servicesMock['admin::workflows'].update).toBeCalledWith(
+        workflowMock.id,
+        {
+          stages: updateStages.map((stage) => stage.id),
+        },
+        {}
+      );
     });
     test('Should delete a stage contained in the workflow', async () => {
       const selectedIndexes = [0, 2, 3];
@@ -194,9 +198,13 @@ describe('Review workflows - Stages service', () => {
       expect(entityServiceMock.delete).toBeCalled();
 
       expect(servicesMock['admin::workflows'].update).toBeCalled();
-      expect(servicesMock['admin::workflows'].update).toBeCalledWith(workflowMock.id, {
-        stages: selectedIndexes.map((index) => workflowMock.stages[index].id),
-      });
+      expect(servicesMock['admin::workflows'].update).toBeCalledWith(
+        workflowMock.id,
+        {
+          stages: selectedIndexes.map((index) => workflowMock.stages[index].id),
+        },
+        {}
+      );
     });
 
     test('Should move entities in a deleted stage to the previous stage', async () => {
@@ -213,9 +221,13 @@ describe('Review workflows - Stages service', () => {
       });
 
       expect(servicesMock['admin::workflows'].update).toBeCalled();
-      expect(servicesMock['admin::workflows'].update).toBeCalledWith(workflowMock.id, {
-        stages: [workflowMock.stages[0].id, workflowMock.stages[1].id, workflowMock.stages[2].id],
-      });
+      expect(servicesMock['admin::workflows'].update).toBeCalledWith(
+        workflowMock.id,
+        {
+          stages: [workflowMock.stages[0].id, workflowMock.stages[1].id, workflowMock.stages[2].id],
+        },
+        {}
+      );
     });
 
     test('When deleting all stages, all entities should be moved to the new stage', async () => {
@@ -237,9 +249,13 @@ describe('Review workflows - Stages service', () => {
       }
 
       expect(servicesMock['admin::workflows'].update).toBeCalled();
-      expect(servicesMock['admin::workflows'].update).toBeCalledWith(workflowMock.id, {
-        stages: [newStageID],
-      });
+      expect(servicesMock['admin::workflows'].update).toBeCalledWith(
+        workflowMock.id,
+        {
+          stages: [newStageID],
+        },
+        {}
+      );
 
       mockUpdateEntitiesStage.mockRestore();
     });
@@ -257,14 +273,18 @@ describe('Review workflows - Stages service', () => {
       expect(entityServiceMock.update).toBeCalled();
       expect(entityServiceMock.delete).toBeCalled();
       expect(servicesMock['admin::workflows'].update).toBeCalled();
-      expect(servicesMock['admin::workflows'].update).toBeCalledWith(workflowMock.id, {
-        stages: [
-          workflowMock.stages[0].id,
-          workflowMock.stages[1].id,
-          expect.any(Number),
-          expect.any(Number),
-        ],
-      });
+      expect(servicesMock['admin::workflows'].update).toBeCalledWith(
+        workflowMock.id,
+        {
+          stages: [
+            workflowMock.stages[0].id,
+            workflowMock.stages[1].id,
+            expect.any(Number),
+            expect.any(Number),
+          ],
+        },
+        {}
+      );
     });
   });
 });

--- a/packages/core/admin/ee/server/services/review-workflows/stages.js
+++ b/packages/core/admin/ee/server/services/review-workflows/stages.js
@@ -44,6 +44,18 @@ module.exports = ({ strapi }) => {
       return stages;
     },
 
+    async create(stage, { fields }) {
+      const params = { select: fields };
+      const newStage = await strapi.entityService.create(STAGE_MODEL_UID, {
+        data: stage,
+        ...params,
+      });
+
+      metrics.sendDidCreateStage();
+
+      return newStage;
+    },
+
     async update(stageId, stageData) {
       const stage = await strapi.entityService.update(STAGE_MODEL_UID, stageId, {
         data: stageData,

--- a/packages/core/admin/ee/server/services/review-workflows/stages.js
+++ b/packages/core/admin/ee/server/services/review-workflows/stages.js
@@ -78,7 +78,7 @@ module.exports = ({ strapi }) => {
       return strapi.entityService.count(STAGE_MODEL_UID);
     },
 
-    async replaceWorkflowStages(workflowId, stages) {
+    async replaceWorkflowStages(workflowId, stages, opts = {}) {
       const workflow = await workflowsService.findById(workflowId, { populate: ['stages'] });
 
       const { created, updated, deleted } = getDiffBetweenStages(workflow.stages, stages);
@@ -120,9 +120,13 @@ module.exports = ({ strapi }) => {
           return this.delete(stage.id);
         });
 
-        return workflowsService.update(workflowId, {
-          stages: stagesIds,
-        });
+        return workflowsService.update(
+          workflowId,
+          {
+            stages: stagesIds,
+          },
+          opts
+        );
       });
     },
 

--- a/packages/core/admin/ee/server/services/review-workflows/workflows.js
+++ b/packages/core/admin/ee/server/services/review-workflows/workflows.js
@@ -19,7 +19,7 @@ module.exports = ({ strapi }) => ({
     return strapi.entityService.count(WORKFLOW_MODEL_UID);
   },
 
-  update(id, workflowData) {
-    return strapi.entityService.update(WORKFLOW_MODEL_UID, id, { data: workflowData });
+  update(id, workflowData, opts = {}) {
+    return strapi.entityService.update(WORKFLOW_MODEL_UID, id, { ...opts, data: workflowData });
   },
 });

--- a/packages/core/admin/ee/server/validation/review-workflows.js
+++ b/packages/core/admin/ee/server/validation/review-workflows.js
@@ -22,6 +22,10 @@ const validateUpdateStageOnEntity = yup
   .required();
 
 module.exports = {
+  validateStage: validateYupSchema(stageObject, {
+    strict: false,
+    stripUnknown: true,
+  }),
   validateUpdateStages: validateYupSchema(validateUpdateStagesSchema, {
     strict: false,
     stripUnknown: true,


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Adding routes available from the content-api to manipulate the review workflow feature.


### How to test it?

- Run your project in Enterprise edition
- Use an API-Token (permissions are not part of this PR but we need a valid token)

There is a set of routes that you can use:
- GET `/api/strapi-workflows` -> Get all workflows
- GET `/api/strapi-workflows/:workflow_id` -> Get one workflow
- GET `/api/strapi-workflows/:workflow_id/stages/:id` -> Get a specific stage 
- PUT `/api/strapi-workflows/:workflow_id/stages` -> Replace all stages for a specific workflow
```json
{
  "data": [ { "id": 3, "name": "todo" } ]
}
```
- PUT `/api/strapi-workflows/:workflow_id/stages/:id` -> Update a specific stage
```json
{
  "data":  { "name": "review" }
}
```
- POST `/api/strapi-workflows/:workflow_id/stages` -> Create a new stage and put it as the last stage of the workflow
```json
{
  "data":  { "name": "done" }
}
```

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
