### PR TITLE
fix: change Ukraine letter code from uk => ua

### DIFF
--- a/packages/plugins/i18n/server/constants/iso-locales.json
+++ b/packages/plugins/i18n/server/constants/iso-locales.json
@@ -2256,12 +2256,12 @@
     "name":"Turks And Caicos Creole English"
   },
   {
-    "code":"uk",
-    "name":"Ukrainian (uk)"
+    "code":"ua",
+    "name":"Ukrainian (ua)"
   },
   {
-    "code":"uk-UA",
-    "name":"Ukrainian (Ukraine) (uk-UA)"
+    "code":"ua-UA",
+    "name":"Ukrainian (Ukraine) (ua-UA)"
   },
   {
     "code":"ur",

--- a/packages/plugins/i18n/server/constants/iso-locales.json
+++ b/packages/plugins/i18n/server/constants/iso-locales.json
@@ -2261,7 +2261,7 @@
   },
   {
     "code":"uk-UA",
-    "name":"Ukrainian (Ukraine) (uk-UA)"
+    "name":"Ukrainian (Ukraine) (ua-UA)"
   },
   {
     "code":"ur",

--- a/packages/plugins/i18n/server/constants/iso-locales.json
+++ b/packages/plugins/i18n/server/constants/iso-locales.json
@@ -2260,8 +2260,8 @@
     "name":"Ukrainian (ua)"
   },
   {
-    "code":"ua-UA",
-    "name":"Ukrainian (Ukraine) (ua-UA)"
+    "code":"uk-UA",
+    "name":"Ukrainian (Ukraine) (uk-UA)"
   },
   {
     "code":"ur",


### PR DESCRIPTION

### What does it do?

This PR will fix the incorrect letter country code for Ukraine.

### Why is it needed?

It was using the incorrect country code for Ukraine. I changed it to official ISO 3166-1 alpha-2. 

### How to test it?

Run strapi with those changes locally, go to Internationalization, add a new language, and from the list choose Ukrainian. It should contain 
![CleanShot 2023-05-03 at 14 02 23](https://user-images.githubusercontent.com/3836798/236049096-50fbed8c-6213-4190-913a-5aed9cf411fe.png)


### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
