### PR TITLE
Fix: Add border to stage color badges

### DIFF
--- a/packages/core/admin/ee/admin/content-manager/components/DynamicTable/CellContent/ReviewWorkflowsStage/ReviewWorkflowsStageEE.js
+++ b/packages/core/admin/ee/admin/content-manager/components/DynamicTable/CellContent/ReviewWorkflowsStage/ReviewWorkflowsStageEE.js
@@ -3,10 +3,21 @@ import PropTypes from 'prop-types';
 import { Box, Flex, Typography } from '@strapi/design-system';
 import { pxToRem } from '@strapi/helper-plugin';
 
+import { getStageColorByHex } from '../../../../../pages/SettingsPage/pages/ReviewWorkflows/utils/colors';
+
 export function ReviewWorkflowsStageEE({ color, name }) {
+  const { themeColorName } = getStageColorByHex(color);
+
   return (
     <Flex alignItems="center" gap={2} maxWidth={pxToRem(300)}>
-      <Box height={2} background={color} borderColor="neutral150" hasRadius shrink={0} width={2} />
+      <Box
+        height={2}
+        background={color}
+        borderColor={themeColorName === 'neutral0' ? 'neutral150' : 'transparent'}
+        hasRadius
+        shrink={0}
+        width={2}
+      />
 
       <Typography fontWeight="regular" textColor="neutral700" ellipsis>
         {name}

--- a/packages/core/admin/ee/admin/content-manager/components/DynamicTable/CellContent/ReviewWorkflowsStage/ReviewWorkflowsStageEE.js
+++ b/packages/core/admin/ee/admin/content-manager/components/DynamicTable/CellContent/ReviewWorkflowsStage/ReviewWorkflowsStageEE.js
@@ -6,7 +6,7 @@ import { pxToRem } from '@strapi/helper-plugin';
 export function ReviewWorkflowsStageEE({ color, name }) {
   return (
     <Flex alignItems="center" gap={2} maxWidth={pxToRem(300)}>
-      <Box height={2} background={color} hasRadius shrink={0} width={2} />
+      <Box height={2} background={color} borderColor="neutral150" hasRadius shrink={0} width={2} />
 
       <Typography fontWeight="regular" textColor="neutral700" ellipsis>
         {name}

--- a/packages/core/admin/ee/admin/content-manager/components/DynamicTable/CellContent/ReviewWorkflowsStage/tests/ReviewWorkflowsStage.test.js
+++ b/packages/core/admin/ee/admin/content-manager/components/DynamicTable/CellContent/ReviewWorkflowsStage/tests/ReviewWorkflowsStage.test.js
@@ -17,7 +17,7 @@ const setup = (props) => render(<ComponentFixture {...props} />);
 
 describe('DynamicTable | ReviewWorkflowsStage', () => {
   test('render stage name', () => {
-    const { getByText } = setup({ color: 'red', name: 'reviewed' });
+    const { getByText } = setup({ color: '#4945FF', name: 'reviewed' });
 
     expect(getByText('reviewed')).toBeInTheDocument();
   });

--- a/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/tests/InformationBoxEE.test.js
+++ b/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/tests/InformationBoxEE.test.js
@@ -12,7 +12,7 @@ import { InformationBoxEE } from '../InformationBoxEE';
 const STAGE_ATTRIBUTE_NAME = 'strapi_reviewWorkflows_stage';
 const STAGE_FIXTURE = {
   id: 1,
-  color: 'red',
+  color: '#4945FF',
   name: 'Stage 1',
   worklow: 1,
 };
@@ -36,11 +36,12 @@ jest.mock(
             stages: [
               {
                 id: 1,
+                color: '#4945FF',
                 name: 'Stage 1',
               },
-
               {
                 id: 2,
+                color: '#4945FF',
                 name: 'Stage 2',
               },
             ],

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/Stages/Stage/components/OptionColor/OptionColor.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/Stages/Stage/components/OptionColor/OptionColor.js
@@ -9,7 +9,14 @@ export function OptionColor({ children, ...props }) {
   return (
     <components.Option {...props}>
       <Flex alignItems="center" gap={2}>
-        <Flex height={2} background={color} hasRadius shrink={0} width={2} />
+        <Flex
+          height={2}
+          background={color}
+          borderColor="neutral150"
+          hasRadius
+          shrink={0}
+          width={2}
+        />
 
         <Typography textColor="neutral800" ellipsis>
           {children}

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/Stages/Stage/components/OptionColor/OptionColor.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/Stages/Stage/components/OptionColor/OptionColor.js
@@ -3,8 +3,11 @@ import PropTypes from 'prop-types';
 import { components } from 'react-select';
 import { Flex, Typography } from '@strapi/design-system';
 
+import { getStageColorByHex } from '../../../../../utils/colors';
+
 export function OptionColor({ children, ...props }) {
   const { color } = props.data;
+  const { themeColorName } = getStageColorByHex(color);
 
   return (
     <components.Option {...props}>
@@ -12,7 +15,7 @@ export function OptionColor({ children, ...props }) {
         <Flex
           height={2}
           background={color}
-          borderColor="neutral150"
+          borderColor={themeColorName === 'neutral0' ? 'neutral150' : 'transparent'}
           hasRadius
           shrink={0}
           width={2}

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/Stages/Stage/components/SingleValueColor/SingleValueColor.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/Stages/Stage/components/SingleValueColor/SingleValueColor.js
@@ -7,7 +7,10 @@ import { getStageColorByHex } from '../../../../../utils/colors';
 
 export function SingleValueColor({ children, ...props }) {
   const { color } = props.data;
-  const { themeColorName } = getStageColorByHex(color);
+  // in case an entity was not assigned to a stage (which displays an error)
+  // there is no color to display and we have to make sure the component does
+  // not crash
+  const { themeColorName } = color ? getStageColorByHex(color) : {};
 
   return (
     <components.SingleValue {...props}>

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/Stages/Stage/components/SingleValueColor/SingleValueColor.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/Stages/Stage/components/SingleValueColor/SingleValueColor.js
@@ -9,7 +9,14 @@ export function SingleValueColor({ children, ...props }) {
   return (
     <components.SingleValue {...props}>
       <Flex alignItems="center" gap={2}>
-        <Flex height={2} background={color} hasRadius shrink={0} width={2} />
+        <Flex
+          height={2}
+          background={color}
+          borderColor="neutral150"
+          hasRadius
+          shrink={0}
+          width={2}
+        />
 
         <Typography textColor="neutral800" ellipsis>
           {children}

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/Stages/Stage/components/SingleValueColor/SingleValueColor.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/Stages/Stage/components/SingleValueColor/SingleValueColor.js
@@ -3,8 +3,11 @@ import PropTypes from 'prop-types';
 import { components } from 'react-select';
 import { Flex, Typography } from '@strapi/design-system';
 
+import { getStageColorByHex } from '../../../../../utils/colors';
+
 export function SingleValueColor({ children, ...props }) {
   const { color } = props.data;
+  const { themeColorName } = getStageColorByHex(color);
 
   return (
     <components.SingleValue {...props}>
@@ -12,7 +15,7 @@ export function SingleValueColor({ children, ...props }) {
         <Flex
           height={2}
           background={color}
-          borderColor="neutral150"
+          borderColor={themeColorName === 'neutral0' ? 'neutral150' : 'transparent'}
           hasRadius
           shrink={0}
           width={2}

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/tests/index.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/tests/index.test.js
@@ -14,12 +14,13 @@ const WORKFLOWS_FIXTURE = [
     stages: [
       {
         id: 1,
-        color: 'red',
+        color: '#4945FF',
         name: 'stage-1',
       },
 
       {
         id: 2,
+        color: '#4945FF',
         name: 'stage-2',
       },
     ],
@@ -353,7 +354,7 @@ describe('Admin | Settings | Review Workflows | reducer', () => {
               stages: expect.arrayContaining([
                 {
                   id: 1,
-                  color: 'red',
+                  color: '#4945FF',
                   name: 'stage-1-modified',
                 },
               ]),

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/utils/colors.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/utils/colors.js
@@ -6,7 +6,9 @@ export function getStageColorByHex(hex) {
   // there are multiple colors with the same hex code in the design tokens. In order to find
   // the correct one we have to find all matching colors and then check, which ones are usable
   // for stages.
-  const themeColors = Object.entries(lightTheme.colors).filter(([, value]) => value === hex);
+  const themeColors = Object.entries(lightTheme.colors).filter(
+    ([, value]) => value.toUpperCase() === hex.toUpperCase()
+  );
   const themeColorName = themeColors.reduce((acc, [name]) => {
     if (STAGE_COLORS?.[name]) {
       acc = name;

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/utils/colors.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/utils/colors.js
@@ -3,6 +3,10 @@ import { lightTheme } from '@strapi/design-system';
 import { STAGE_COLORS } from '../constants';
 
 export function getStageColorByHex(hex) {
+  if (!hex) {
+    return null;
+  }
+
   // there are multiple colors with the same hex code in the design tokens. In order to find
   // the correct one we have to find all matching colors and then check, which ones are usable
   // for stages.

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/utils/tests/colors.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/utils/tests/colors.test.js
@@ -22,6 +22,11 @@ describe('Settings | Review Workflows | colors', () => {
       themeColorName: 'primary600',
     });
 
+    expect(getStageColorByHex('#4945FF')).toStrictEqual({
+      name: 'Blue',
+      themeColorName: 'primary600',
+    });
+
     expect(getStageColorByHex('random')).toStrictEqual(null);
     expect(getStageColorByHex()).toStrictEqual(null);
   });


### PR DESCRIPTION
### What does it do?

Adds a border to stage color badges.

| Before | After |
|-|-|
| <img width="1001" alt="Screenshot 2023-05-04 at 14 56 00" src="https://user-images.githubusercontent.com/2244375/236211045-c7d12eac-bc77-41fc-930b-7df7329f5de3.png"> | <img width="1001" alt="Screenshot 2023-05-04 at 14 55 47" src="https://user-images.githubusercontent.com/2244375/236211051-bc312eff-4766-40af-888e-d2b59f3b0aca.png"> |

### Why is it needed?

Design requirement. Came up during QA.

