### PR TITLE
Use upload_chunked_stream instead if upload_stream

### DIFF
--- a/packages/providers/upload-cloudinary/src/index.ts
+++ b/packages/providers/upload-cloudinary/src/index.ts
@@ -42,7 +42,7 @@ export = {
           config.folder = file.path;
         }
 
-        const uploadStream = cloudinary.uploader.upload_stream(
+        const uploadStream = cloudinary.uploader.upload_chunked_stream(
           { ...config, ...customConfig },
           (err, image) => {
             if (err) {


### PR DESCRIPTION
Cloudinary limits the filesize to 100 MB when uploading in a single request: https://cloudinary.com/documentation/upload_images#chunked_asset_upload

Larger files must be uploaded in chunks.

Use the `upload_chunked_stream` to upload all files in chunks. This works for small files just as well.

Fix #16601

