### PR TITLE
Chore: Move playwright webServer command into its own script

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "packages/*",
     "packages/*/*",
     "examples/*",
-    "test-apps/*",
     ".github/actions/*",
     "scripts/*"
   ],
@@ -62,7 +61,7 @@
     "test:unit:all": "nx run-many --target=test:unit --nx-ignore-cycles",
     "test:unit": "jest --config jest.config.js",
     "test:unit:watch": "run test:unit --watch",
-    "test:api": "node test/api.js",
+    "test:api": "node test/scripts/run-api-tests.js",
     "test:generate-app": "yarn build:ts && node test/scripts/generate-test-app.js",
     "doc:api": "node scripts/open-api/serve.js"
   },

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -95,7 +95,7 @@ const config = {
 
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: 'cd test-apps/playwright && yarn start',
+    command: 'node test/scripts/run-e2e-tests.js',
     port: 1337,
     timeout: 30 * 1000,
     reuseExistingServer: !process.env.CI,

--- a/test/scripts/run-e2e-tests.js
+++ b/test/scripts/run-e2e-tests.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const path = require('path');
+const execa = require('execa');
+const yargs = require('yargs');
+
+process.env.NODE_ENV = 'test';
+
+const main = async () => {
+  try {
+    execa('yarn', ['start'], {
+      stdio: 'inherit',
+      cwd: path.resolve(__dirname, '../..'),
+      env: {
+        // if STRAPI_LICENSE is in the env the test will run in ee automatically
+        STRAPI_DISABLE_EE: !process.env.STRAPI_LICENSE,
+        FORCE_COLOR: 1,
+        ENV_PATH: process.env.ENV_PATH,
+        JWT_SECRET: 'aSecret',
+      },
+    });
+  } catch (error) {
+    console.error(error);
+    process.exit(1);
+  }
+};
+
+yargs
+  .command(
+    '$0',
+    'Run E2E tests',
+    (yarg) => {},
+    (argv) => {
+      main();
+    }
+  )
+  .help()
+  .parse();


### PR DESCRIPTION
### What does it do?

- Fixes API tests
- Makes E2E tests runnable: this way yarn does not complain about not being in the workspace 🤷🏼 

### Why is it needed?

@innerdvations had a good point in https://github.com/strapi/strapi/pull/14807#issuecomment-1536177377: it does make a difference whether you run `yarn` as a user vs. execa. Please don't ask me why, but it is working and in line with API tests.

With this branch you are able to run `yarn test:api` and `yarn test:e2e:setup && yarn test:e2e` locally again.
