### PR TITLE
Stop mocking useTracking

### DIFF
--- a/packages/admin-test-utils/custom.d.ts
+++ b/packages/admin-test-utils/custom.d.ts
@@ -10,6 +10,7 @@ declare global {
         isEnabled: (featureName?: string) => boolean;
       };
       projectType: string;
+      telemetryDisabled: boolean;
     };
   }
 }

--- a/packages/admin-test-utils/src/environment.ts
+++ b/packages/admin-test-utils/src/environment.ts
@@ -57,6 +57,7 @@ window.strapi = {
     isEnabled: () => false,
   },
   projectType: 'Community',
+  telemetryDisabled: true,
 };
 
 /* -------------------------------------------------------------------------------------------------

--- a/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/tests/index.test.js
+++ b/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/tests/index.test.js
@@ -17,7 +17,6 @@ jest.mock('@strapi/helper-plugin', () => ({
   // eslint-disable-next-line
   CheckPermissions: ({ children }) => <div>{children}</div>,
   useNotification: jest.fn(),
-  useTracking: jest.fn(() => ({ trackUsage: jest.fn() })),
 }));
 
 const client = new QueryClient({

--- a/packages/core/admin/admin/src/content-manager/pages/ListSettingsView/tests/index.test.js
+++ b/packages/core/admin/admin/src/content-manager/pages/ListSettingsView/tests/index.test.js
@@ -13,7 +13,6 @@ import ModelsContext from '../../../contexts/ModelsContext';
 jest.mock('@strapi/helper-plugin', () => ({
   ...jest.requireActual('@strapi/helper-plugin'),
   useNotification: jest.fn(),
-  useTracking: jest.fn(() => ({ trackUsage: jest.fn() })),
 }));
 
 const client = new QueryClient({
@@ -191,24 +190,26 @@ describe('ADMIN | CM | LV | Configure the view', () => {
         screen.getByText("This value overrides the label displayed in the table's head")
       ).toBeInTheDocument();
     });
-    
+
     it('should close edit modal onSubmit', async () => {
       const history = createMemoryHistory();
-      
+
       const { queryByText } = render(makeApp(history));
       await waitFor(() =>
         expect(screen.getByText('Configure the view - Michka')).toBeInTheDocument()
       );
-      
+
       fireEvent.click(screen.getByLabelText('Edit address'));
-      
+
       expect(
         screen.getByText("This value overrides the label displayed in the table's head")
       ).toBeInTheDocument();
-      
+
       fireEvent.click(screen.getByText('Finish'));
-      
-      expect(queryByText("This value overrides the label displayed in the table's head")).not.toBeInTheDocument();
+
+      expect(
+        queryByText("This value overrides the label displayed in the table's head")
+      ).not.toBeInTheDocument();
     });
 
     it('should not show sortable toggle input if field not sortable', async () => {

--- a/packages/core/admin/admin/src/pages/Admin/index.js
+++ b/packages/core/admin/admin/src/pages/Admin/index.js
@@ -44,6 +44,9 @@ const SettingsPage = lazy(() =>
 );
 
 // Simple hook easier for testing
+/**
+ * TODO: remove this, it's bad.
+ */
 const useTrackUsage = () => {
   const { trackUsage } = useTracking();
   const dispatch = useDispatch();

--- a/packages/core/admin/admin/src/pages/Admin/tests/index.test.js
+++ b/packages/core/admin/admin/src/pages/Admin/tests/index.test.js
@@ -17,7 +17,6 @@ jest.mock('react-redux', () => ({
 jest.mock('@strapi/helper-plugin', () => ({
   LoadingIndicatorPage: () => <div>Loading</div>,
   useStrapiApp: jest.fn(() => ({ menu: [] })),
-  useTracking: jest.fn(() => ({ trackUsage: jest.fn() })),
   NotFound: () => <div>not found</div>,
   CheckPagePermissions: ({ children }) => children,
   useGuidedTour: jest.fn(() => ({

--- a/packages/core/admin/admin/src/pages/Admin/tests/index.test.js
+++ b/packages/core/admin/admin/src/pages/Admin/tests/index.test.js
@@ -15,6 +15,7 @@ jest.mock('react-redux', () => ({
 }));
 
 jest.mock('@strapi/helper-plugin', () => ({
+  ...jest.requireActual('@strapi/helper-plugin'),
   LoadingIndicatorPage: () => <div>Loading</div>,
   useStrapiApp: jest.fn(() => ({ menu: [] })),
   NotFound: () => <div>not found</div>,
@@ -33,7 +34,6 @@ jest.mock('@strapi/helper-plugin', () => ({
 
 jest.mock('../../../hooks', () => ({
   useMenu: jest.fn(() => ({ isLoading: true, generalSectionLinks: [], pluginsSectionLinks: [] })),
-  useTrackUsage: jest.fn(),
   useReleaseNotification: jest.fn(),
   useConfigurations: jest.fn(() => ({ showTutorials: false })),
 }));

--- a/packages/core/admin/admin/src/pages/Admin/tests/useTrackUsage.test.js
+++ b/packages/core/admin/admin/src/pages/Admin/tests/useTrackUsage.test.js
@@ -1,7 +1,11 @@
 import { renderHook } from '@testing-library/react-hooks';
-import { useTrackUsage } from '..';
+import { useTrackUsage } from '../index';
 
 const trackUsageMock = jest.fn();
+
+jest.mock('@strapi/helper-plugin', () => ({
+  useTracking: jest.fn(() => ({ trackUsage: trackUsageMock })),
+}));
 
 jest.mock('react-redux', () => ({
   ...jest.requireActual('react-redux'),

--- a/packages/core/admin/admin/src/pages/Admin/tests/useTrackUsage.test.js
+++ b/packages/core/admin/admin/src/pages/Admin/tests/useTrackUsage.test.js
@@ -9,10 +9,6 @@ jest.mock('react-redux', () => ({
   useSelector: jest.fn(() => 'init'),
 }));
 
-jest.mock('@strapi/helper-plugin', () => ({
-  useTracking: jest.fn(() => ({ trackUsage: trackUsageMock })),
-}));
-
 describe('Admin | pages | Admin | useTrackUsage', () => {
   it('should call the trackUsage method on mount with didAccessAuthenticatedAdministration', () => {
     const { rerender } = renderHook(() => useTrackUsage());

--- a/packages/core/admin/admin/src/pages/HomePage/tests/index.test.js
+++ b/packages/core/admin/admin/src/pages/HomePage/tests/index.test.js
@@ -11,7 +11,6 @@ import { useModels } from '../../../hooks';
 jest.mock('@strapi/helper-plugin', () => ({
   ...jest.requireActual('@strapi/helper-plugin'),
   useAppInfo: jest.fn(() => ({ communityEdition: true })),
-  useTracking: jest.fn(() => ({ trackUsage: jest.fn() })),
   useGuidedTour: jest.fn(() => ({
     isGuidedTourVisible: false,
     guidedTourState: {

--- a/packages/core/admin/admin/src/pages/MarketplacePage/tests/__snapshots__/index.test.js.snap
+++ b/packages/core/admin/admin/src/pages/MarketplacePage/tests/__snapshots__/index.test.js.snap
@@ -115,10 +115,14 @@ exports[`Marketplace page - layout renders the online layout 1`] = `
 
 .c63 {
   color: #666687;
+  width: 0.75rem;
+  height: 0.75rem;
 }
 
 .c65 {
   color: #f29d41;
+  width: 0.75rem;
+  height: 0.75rem;
 }
 
 .c68 {
@@ -1114,6 +1118,7 @@ exports[`Marketplace page - layout renders the online layout 1`] = `
 }
 
 .c70 {
+  width: 0.75rem;
   -webkit-transform: rotate(90deg);
   -ms-transform: rotate(90deg);
   transform: rotate(90deg);

--- a/packages/core/admin/admin/src/pages/MarketplacePage/tests/index.test.js
+++ b/packages/core/admin/admin/src/pages/MarketplacePage/tests/index.test.js
@@ -17,6 +17,7 @@ jest.mock('../../../hooks/useNavigatorOnLine', () => jest.fn(() => true));
 
 jest.mock('@strapi/helper-plugin', () => ({
   ...jest.requireActual('@strapi/helper-plugin'),
+  useTracking: jest.fn(() => ({ trackUsage: jest.fn() })),
   useNotification: jest.fn(() => {
     return toggleNotification;
   }),

--- a/packages/core/admin/admin/src/pages/MarketplacePage/tests/index.test.js
+++ b/packages/core/admin/admin/src/pages/MarketplacePage/tests/index.test.js
@@ -20,9 +20,7 @@ jest.mock('@strapi/helper-plugin', () => ({
   useNotification: jest.fn(() => {
     return toggleNotification;
   }),
-  pxToRem: jest.fn(),
   CheckPagePermissions: ({ children }) => children,
-  useTracking: jest.fn(() => ({ trackUsage: jest.fn() })),
   useAppInfo: jest.fn(() => ({
     autoReload: true,
     dependencies: {

--- a/packages/core/admin/admin/src/pages/MarketplacePage/tests/plugins.test.js
+++ b/packages/core/admin/admin/src/pages/MarketplacePage/tests/plugins.test.js
@@ -20,9 +20,7 @@ jest.mock('@strapi/helper-plugin', () => ({
   useNotification: jest.fn(() => {
     return toggleNotification;
   }),
-  pxToRem: jest.fn(),
   CheckPagePermissions: ({ children }) => children,
-  useTracking: jest.fn(() => ({ trackUsage: jest.fn() })),
   useAppInfo: jest.fn(() => ({
     autoReload: true,
     dependencies: {

--- a/packages/core/admin/admin/src/pages/MarketplacePage/tests/providers.test.js
+++ b/packages/core/admin/admin/src/pages/MarketplacePage/tests/providers.test.js
@@ -22,9 +22,7 @@ jest.mock('@strapi/helper-plugin', () => ({
   useNotification: jest.fn(() => {
     return toggleNotification;
   }),
-  pxToRem: jest.fn(),
   CheckPagePermissions: ({ children }) => children,
-  useTracking: jest.fn(() => ({ trackUsage: jest.fn() })),
   useAppInfo: jest.fn(() => ({
     autoReload: true,
     dependencies: {

--- a/packages/core/admin/admin/src/pages/ProfilePage/tests/index.test.js
+++ b/packages/core/admin/admin/src/pages/ProfilePage/tests/index.test.js
@@ -20,7 +20,6 @@ jest.mock('@strapi/helper-plugin', () => ({
   useFocusWhenNavigate: jest.fn(),
   useAppInfo: jest.fn(() => ({ setUserDisplayName: jest.fn() })),
   useOverlayBlocker: jest.fn(() => ({ lockApp: jest.fn, unlockApp: jest.fn() })),
-  useTracking: jest.fn(() => ({ trackUsage: jest.fn() })),
 }));
 
 const client = new QueryClient({

--- a/packages/core/admin/admin/src/pages/SettingsPage/components/SettingsNav/tests/index.test.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/components/SettingsNav/tests/index.test.js
@@ -6,11 +6,6 @@ import { createMemoryHistory } from 'history';
 import { ThemeProvider, lightTheme } from '@strapi/design-system';
 import SettingsNav from '../index';
 
-jest.mock('@strapi/helper-plugin', () => ({
-  ...jest.requireActual('@strapi/helper-plugin'),
-  useTracking: jest.fn(() => ({ trackUsage: jest.fn() })),
-}));
-
 const menu = [
   {
     id: 'global',

--- a/packages/core/admin/admin/src/pages/SettingsPage/components/Tokens/Table/DeleteButton/tests/DeleteButton.test.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/components/Tokens/Table/DeleteButton/tests/DeleteButton.test.js
@@ -6,11 +6,6 @@ import { NotificationsProvider } from '@strapi/helper-plugin';
 
 import DeleteButton from '../index';
 
-jest.mock('@strapi/helper-plugin', () => ({
-  ...jest.requireActual('@strapi/helper-plugin'),
-  useTracking: jest.fn(() => ({ trackUsage: jest.fn() })),
-}));
-
 function ComponentToTest(props) {
   return (
     <IntlProvider locale="en" messages={{}}>

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/ApiTokens/EditView/tests/index.test.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/ApiTokens/EditView/tests/index.test.js
@@ -14,7 +14,6 @@ jest.mock('@strapi/helper-plugin', () => ({
   ...jest.requireActual('@strapi/helper-plugin'),
   useNotification: jest.fn(),
   useFocusWhenNavigate: jest.fn(),
-  useTracking: jest.fn(() => ({ trackUsage: jest.fn() })),
   useRBAC: jest.fn(() => ({
     allowedActions: {
       canCreate: true,

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/ApplicationInfosPage/components/CustomizationInfos/tests/index.test.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/ApplicationInfosPage/components/CustomizationInfos/tests/index.test.js
@@ -24,9 +24,6 @@ const PROJECT_SETTINGS_DATA_FIXTURES = {
   },
 };
 
-jest.mock('@strapi/helper-plugin', () => ({
-  useTracking: jest.fn(() => ({ trackUsage: jest.fn() })),
-}));
 jest.mock('../../../../../../../hooks', () => ({
   useConfigurations: jest.fn(() => ({
     logos: {

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/CreatePage/tests/index.test.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/CreatePage/tests/index.test.js
@@ -19,7 +19,6 @@ jest.mock('@strapi/helper-plugin', () => ({
   ...jest.requireActual('@strapi/helper-plugin'),
   useNotification: jest.fn(() => jest.fn()),
   useOverlayBlocker: jest.fn(() => ({ lockApp: jest.fn(), unlockApp: jest.fn() })),
-  useTracking: jest.fn(() => ({ trackUsage: jest.fn() })),
 }));
 
 const makeApp = (history) => (

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/tests/index.test.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/tests/index.test.js
@@ -19,7 +19,6 @@ jest.mock('@strapi/helper-plugin', () => ({
   ...jest.requireActual('@strapi/helper-plugin'),
   useNotification: jest.fn(() => jest.fn()),
   useOverlayBlocker: jest.fn(() => ({ lockApp: jest.fn(), unlockApp: jest.fn() })),
-  useTracking: jest.fn(() => ({ trackUsage: jest.fn() })),
 }));
 
 const makeApp = (history) => (

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/TransferTokens/EditView/tests/index.test.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/TransferTokens/EditView/tests/index.test.js
@@ -14,7 +14,6 @@ jest.mock('@strapi/helper-plugin', () => ({
   ...jest.requireActual('@strapi/helper-plugin'),
   useNotification: jest.fn(),
   useFocusWhenNavigate: jest.fn(),
-  useTracking: jest.fn(() => ({ trackUsage: jest.fn() })),
   useRBAC: jest.fn(() => ({
     allowedActions: {
       canCreate: true,

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/Stages/Stage/tests/Stage.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/Stages/Stage/tests/Stage.test.js
@@ -15,11 +15,6 @@ import { reducer } from '../../../../reducer';
 
 import { STAGE_COLOR_DEFAULT } from '../../../../constants';
 
-jest.mock('@strapi/helper-plugin', () => ({
-  ...jest.requireActual('@strapi/helper-plugin'),
-  useTracking: jest.fn().mockReturnValue({ trackUsage: jest.fn() }),
-}));
-
 const STAGES_FIXTURE = {
   id: 1,
   index: 0,

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/Stages/tests/Stages.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/Stages/tests/Stages.test.js
@@ -21,11 +21,6 @@ jest.mock('../../../actions', () => ({
   ...jest.requireActual('../../../actions'),
 }));
 
-jest.mock('@strapi/helper-plugin', () => ({
-  ...jest.requireActual('@strapi/helper-plugin'),
-  useTracking: jest.fn().mockReturnValue({ trackUsage: jest.fn() }),
-}));
-
 const STAGES_FIXTURE = [
   {
     id: 1,

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/tests/ReviewWorkflows.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/tests/ReviewWorkflows.test.js
@@ -18,7 +18,6 @@ import { reducer } from '../reducer';
 jest.mock('@strapi/helper-plugin', () => ({
   ...jest.requireActual('@strapi/helper-plugin'),
   useNotification: jest.fn().mockReturnValue(jest.fn()),
-  useTracking: jest.fn().mockReturnValue({ trackUsage: jest.fn() }),
   // eslint-disable-next-line react/prop-types
   CheckPagePermissions({ children }) {
     return children;

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/SingleSignOn/tests/index.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/SingleSignOn/tests/index.test.js
@@ -10,7 +10,6 @@ import { SingleSignOn } from '../index';
 
 jest.mock('@strapi/helper-plugin', () => ({
   ...jest.requireActual('@strapi/helper-plugin'),
-  useTracking: jest.fn(() => ({ trackUsage: jest.fn() })),
   useNotification: jest.fn().mockImplementation(() => jest.fn()),
   useOverlayBlocker: jest.fn(() => ({ lockApp: jest.fn(), unlockApp: jest.fn() })),
   useRBAC: jest.fn(),

--- a/packages/core/content-type-builder/admin/src/components/AttributeOptions/tests/index.test.js
+++ b/packages/core/content-type-builder/admin/src/components/AttributeOptions/tests/index.test.js
@@ -34,9 +34,6 @@ jest.mock('@strapi/helper-plugin', () => ({
     get: jest.fn().mockReturnValue(mockCustomField),
     getAll,
   }),
-  useTracking: jest.fn(() => ({
-    trackUsage: jest.fn(),
-  })),
 }));
 
 const mockAttributes = [

--- a/packages/core/content-type-builder/admin/src/components/FormModalNavigationProvider/tests/index.test.js
+++ b/packages/core/content-type-builder/admin/src/components/FormModalNavigationProvider/tests/index.test.js
@@ -3,12 +3,6 @@ import { INITIAL_STATE_DATA } from '../constants';
 import FormModalNavigationProvider from '../index';
 import useFormModalNavigation from '../../../hooks/useFormModalNavigation';
 
-jest.mock('@strapi/helper-plugin', () => ({
-  useTracking: jest.fn(() => ({
-    trackUsage: jest.fn(),
-  })),
-}));
-
 const removeFunctionsFromObject = (state) => {
   const stringified = JSON.stringify(state);
   const parsed = JSON.parse(stringified);

--- a/packages/core/content-type-builder/admin/src/pages/ListView/tests/index.test.js
+++ b/packages/core/content-type-builder/admin/src/pages/ListView/tests/index.test.js
@@ -32,7 +32,6 @@ jest.mock('@strapi/helper-plugin', () => ({
   ...jest.requireActual('@strapi/helper-plugin'),
   // eslint-disable-next-line
   CheckPermissions: ({ children }) => <div>{children}</div>,
-  useTracking: jest.fn(() => ({ trackUsage: jest.fn() })),
 }));
 
 const makeApp = () => {

--- a/packages/core/helper-plugin/src/features/Tracking.js
+++ b/packages/core/helper-plugin/src/features/Tracking.js
@@ -21,7 +21,7 @@ import { useAppInfo } from './AppInfo';
  * @typedef {Object} TrackingContextValue
  * @property {string | boolean} uuid
  * @property {string | undefined} deviceId
- * @property {TelemetryProperties} telemetryProperties
+ * @property {TelemetryProperties | undefined} telemetryProperties
  */
 
 /* -------------------------------------------------------------------------------------------------
@@ -32,7 +32,11 @@ import { useAppInfo } from './AppInfo';
  * @preserve
  * @type {React.Context<TrackingContextValue>}
  */
-const TrackingContext = React.createContext();
+const TrackingContext = React.createContext({
+  uuid: false,
+  deviceId: undefined,
+  telemetryProperties: undefined,
+});
 
 /* -------------------------------------------------------------------------------------------------
  * Provider

--- a/packages/core/helper-plugin/src/features/tests/Tracking.test.js
+++ b/packages/core/helper-plugin/src/features/tests/Tracking.test.js
@@ -34,6 +34,10 @@ const setup = (props) =>
   });
 
 describe('useTracking', () => {
+  beforeAll(() => {
+    window.strapi.telemetryDisabled = false;
+  });
+
   afterEach(() => {
     jest.clearAllMocks();
   });

--- a/packages/core/upload/admin/src/components/AssetDialog/BrowseStep/SearchAsset/tests/index.test.js
+++ b/packages/core/upload/admin/src/components/AssetDialog/BrowseStep/SearchAsset/tests/index.test.js
@@ -12,11 +12,6 @@ import SearchAsset from '../index';
 
 const handleChange = jest.fn();
 
-jest.mock('@strapi/helper-plugin', () => ({
-  ...jest.requireActual('@strapi/helper-plugin'),
-  useTracking: jest.fn(() => ({ trackUsage: jest.fn() })),
-}));
-
 const makeApp = (queryValue) => (
   <ThemeProvider theme={lightTheme}>
     <IntlProvider locale="en">

--- a/packages/core/upload/admin/src/components/AssetDialog/BrowseStep/tests/index.test.js
+++ b/packages/core/upload/admin/src/components/AssetDialog/BrowseStep/tests/index.test.js
@@ -14,7 +14,6 @@ jest.mock('../../../../hooks/useFolder');
 
 jest.mock('@strapi/helper-plugin', () => ({
   ...jest.requireActual('@strapi/helper-plugin'),
-  useTracking: jest.fn(() => ({ trackUsage: jest.fn() })),
   usePersistentState: jest.fn().mockReturnValue([0, jest.fn()]),
 }));
 

--- a/packages/core/upload/admin/src/components/AssetDialog/tests/AssetDialog.test.js
+++ b/packages/core/upload/admin/src/components/AssetDialog/tests/AssetDialog.test.js
@@ -15,7 +15,6 @@ jest.mock('@strapi/helper-plugin', () => ({
   ...jest.requireActual('@strapi/helper-plugin'),
   useNotification: jest.fn(() => jest.fn()),
   useQueryParams: jest.fn(),
-  useTracking: jest.fn(() => ({ trackUsage: jest.fn() })),
 }));
 
 jest.mock('../../../hooks/useMediaLibraryPermissions');

--- a/packages/core/upload/admin/src/components/EditFolderDialog/tests/EditFolderDialog.test.js
+++ b/packages/core/upload/admin/src/components/EditFolderDialog/tests/EditFolderDialog.test.js
@@ -13,7 +13,6 @@ import { useMediaLibraryPermissions } from '../../../hooks/useMediaLibraryPermis
 jest.mock('@strapi/helper-plugin', () => ({
   ...jest.requireActual('@strapi/helper-plugin'),
   useQueryParams: jest.fn().mockReturnValue([{ query: {} }]),
-  useTracking: jest.fn(() => ({ trackUsage: jest.fn() })),
   useFetchClient: jest.fn().mockReturnValue({
     put: jest.fn().mockImplementation({}),
   }),

--- a/packages/core/upload/admin/src/components/MediaLibraryInput/Carousel/tests/CarouselAssets.test.js
+++ b/packages/core/upload/admin/src/components/MediaLibraryInput/Carousel/tests/CarouselAssets.test.js
@@ -11,7 +11,6 @@ jest.mock('@strapi/helper-plugin', () => ({
   useNotification: jest.fn(() => ({
     toggleNotification: jest.fn(),
   })),
-  useTracking: jest.fn(() => ({ trackUsage: jest.fn() })),
 }));
 
 const ASSET_FIXTURES = [

--- a/packages/core/upload/admin/src/components/TableList/tests/TableList.test.js
+++ b/packages/core/upload/admin/src/components/TableList/tests/TableList.test.js
@@ -8,7 +8,6 @@ import { TableList } from '..';
 
 jest.mock('@strapi/helper-plugin', () => ({
   ...jest.requireActual('@strapi/helper-plugin'),
-  useTracking: jest.fn(() => ({ trackUsage: jest.fn() })),
   useQueryParams: jest.fn(() => [{ query: {} }]),
 }));
 

--- a/packages/core/upload/admin/src/components/UploadAssetDialog/PendingAssetStep/tests/PendingAssetStep.test.js
+++ b/packages/core/upload/admin/src/components/UploadAssetDialog/PendingAssetStep/tests/PendingAssetStep.test.js
@@ -9,7 +9,6 @@ jest.mock('../../../../utils/getTrad', () => (x) => x);
 
 jest.mock('@strapi/helper-plugin', () => ({
   ...jest.requireActual('@strapi/helper-plugin'),
-  useTracking: jest.fn(() => ({ trackUsage: jest.fn() })),
 }));
 
 const queryClient = new QueryClient({

--- a/packages/core/upload/admin/src/hooks/tests/useConfig.test.js
+++ b/packages/core/upload/admin/src/hooks/tests/useConfig.test.js
@@ -25,7 +25,6 @@ const notificationStatusMock = jest.fn();
 jest.mock('@strapi/helper-plugin', () => ({
   ...jest.requireActual('@strapi/helper-plugin'),
   useNotification: () => notificationStatusMock,
-  useTracking: jest.fn(() => ({ trackUsage: jest.fn() })),
   useFetchClient: jest.fn().mockReturnValue({
     put: jest.fn().mockResolvedValue({ data: { data: {} } }),
     get: jest.fn(),

--- a/packages/core/upload/admin/src/hooks/tests/useModalQueryParams.test.js
+++ b/packages/core/upload/admin/src/hooks/tests/useModalQueryParams.test.js
@@ -8,11 +8,6 @@ import { ThemeProvider, lightTheme } from '@strapi/design-system';
 
 import useModalQueryParams from '../useModalQueryParams';
 
-jest.mock('@strapi/helper-plugin', () => ({
-  ...jest.requireActual('@strapi/helper-plugin'),
-  useTracking: jest.fn(() => ({ trackUsage: jest.fn() })),
-}));
-
 const refetchQueriesMock = jest.fn();
 
 jest.mock('react-query', () => ({

--- a/packages/plugins/users-permissions/admin/src/pages/EmailTemplates/tests/index.test.js
+++ b/packages/plugins/users-permissions/admin/src/pages/EmailTemplates/tests/index.test.js
@@ -14,9 +14,6 @@ jest.mock('@strapi/helper-plugin', () => ({
   useOverlayBlocker: jest.fn(() => ({ lockApp: jest.fn, unlockApp: jest.fn() })),
   useRBAC: jest.fn(),
   CheckPagePermissions: ({ children }) => children,
-  useTracking: jest.fn(() => ({
-    trackUsage: jest.fn(),
-  })),
 }));
 
 const client = new QueryClient({

--- a/packages/plugins/users-permissions/admin/src/pages/Providers/tests/index.test.js
+++ b/packages/plugins/users-permissions/admin/src/pages/Providers/tests/index.test.js
@@ -9,7 +9,6 @@ import { ProvidersPage } from '../index';
 
 jest.mock('@strapi/helper-plugin', () => ({
   ...jest.requireActual('@strapi/helper-plugin'),
-  useTracking: jest.fn(() => ({ trackUsage: jest.fn() })),
   useNotification: jest.fn(),
   useOverlayBlocker: jest.fn(() => ({ lockApp: jest.fn(), unlockApp: jest.fn() })),
   useRBAC: jest.fn(),

--- a/packages/plugins/users-permissions/admin/src/pages/Roles/CreatePage/tests/index.test.js
+++ b/packages/plugins/users-permissions/admin/src/pages/Roles/CreatePage/tests/index.test.js
@@ -19,7 +19,6 @@ jest.mock('@strapi/helper-plugin', () => {
     ...jest.requireActual('@strapi/helper-plugin'),
     useNotification: mockUseNotification,
     useOverlayBlocker: jest.fn(() => ({ lockApp: jest.fn(), unlockApp: jest.fn() })),
-    useTracking: jest.fn(() => ({ trackUsage: jest.fn() })),
   };
 });
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* removes _all_ mocks (apart from when we're testing it's called, not sure we should be though...) to `useTracking`

### Why is it needed?

* Mocking makes tests brittle and annoying
* Removes an overhead of FE testing life

### How to test it?

* automated tests should still run
