### PR TITLE
fix: change alignment from stretch to center

### DIFF
--- a/packages/core/admin/admin/src/pages/AuthPage/components/Register/index.js
+++ b/packages/core/admin/admin/src/pages/AuthPage/components/Register/index.js
@@ -149,7 +149,7 @@ const Register = ({ authType, fieldsToDisable, noSignin, onSubmit, schema }) => 
             return (
               <Form noValidate>
                 <Main>
-                  <Flex direction="column" alignItems="stretch" gap={3}>
+                  <Flex direction="column" alignItems="center" gap={3}>
                     <Logo />
 
                     <Typography as="h1" variant="alpha" textAlign="center">


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?
Updates the css property 'alignItems' of auth logo container on register page to 'center'.

### Why is it needed?

The auth logo on the register page was being stretched due to incorrect css. This stretched the logo which looked unpleasant. 

### How to test it?

Navigate to the url: <strapi url>/admin/auth/register

### Screenshots:

Previous:
![Screenshot 2023-05-07 181529](https://user-images.githubusercontent.com/11196460/236678967-f67da7e5-0132-49a3-bcde-0f9193ce6545.png)

Now:
![Screenshot 2023-05-07 181623](https://user-images.githubusercontent.com/11196460/236678973-e1bb9962-5589-429d-99d8-ad7a082a7cf7.png)



### Related issue(s)/PR(s)

Fixes #16624 
