### PR TITLE
Chore: Increase dependabot open-pr limit to 10

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ updates:
       interval: weekly
       day: sunday
       time: '22:00'
+    open-pull-requests-limit: 10
     versioning-strategy: increase
     ignore:
       # Only allow patch as minor babel versions need to be upgraded all together
@@ -23,6 +24,7 @@ updates:
       - 'source: dependencies'
       - 'pr: chore'
   - package-ecosystem: github-actions
+    open-pull-requests-limit: 10
     directory: /
     schedule:
       interval: weekly


### PR DESCRIPTION
### What does it do?

Bumps the limit of open dependabot PRs to 10 (default: 5).

### Why is it needed?

Before https://github.com/strapi/strapi/pull/16527 we've been receiving dependabot updates on a daily basis with a limit of 5. That also meant we are able to move much faster if these PR's were merged in time.

With updates only once a week, we'd fall behind quite a lot given the number of our dependencies. I'd like to try out slowly where the limit for us to handle is, but I think 10 version bumps a week should be possible to handle by the whole team.

