### PR TITLE
Settings: Split review workflows into list and edit-view

### DIFF
--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/index.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/index.js
@@ -1,3 +1,0 @@
-import { ReviewWorkflowsPage } from './ReviewWorkflows';
-
-export default ReviewWorkflowsPage;

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/EditView/EditView.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/EditView/EditView.js
@@ -16,16 +16,16 @@ import {
 import { Button, ContentLayout, HeaderLayout, Layout, Loader, Main } from '@strapi/design-system';
 import { Check } from '@strapi/icons';
 
-import { Stages } from './components/Stages';
-import { reducer, initialState } from './reducer';
-import { REDUX_NAMESPACE, DRAG_DROP_TYPES } from './constants';
-import { useInjectReducer } from '../../../../../../admin/src/hooks/useInjectReducer';
-import { useReviewWorkflows } from './hooks/useReviewWorkflows';
-import { setWorkflows } from './actions';
-import { getWorkflowValidationSchema } from './utils/getWorkflowValidationSchema';
-import adminPermissions from '../../../../../../admin/src/permissions';
-import { StageDragPreview } from './components/StageDragPreview';
-import { DragLayer } from '../../../../../../admin/src/components/DragLayer';
+import { Stages } from '../../components/Stages';
+import { reducer, initialState } from '../../reducer';
+import { REDUX_NAMESPACE, DRAG_DROP_TYPES } from '../../constants';
+import { useInjectReducer } from '../../../../../../../../admin/src/hooks/useInjectReducer';
+import { useReviewWorkflows } from '../../hooks/useReviewWorkflows';
+import { setWorkflows } from '../../actions';
+import { getWorkflowValidationSchema } from '../../utils/getWorkflowValidationSchema';
+import adminPermissions from '../../../../../../../../admin/src/permissions';
+import { StageDragPreview } from '../../components/StageDragPreview';
+import { DragLayer } from '../../../../../../../../admin/src/components/DragLayer';
 
 function renderDragLayerItem({ type, item }) {
   switch (type) {
@@ -37,7 +37,7 @@ function renderDragLayerItem({ type, item }) {
   }
 }
 
-export function ReviewWorkflowsPage() {
+export function ReviewWorkflowsEditView() {
   const { trackUsage } = useTracking();
   const { formatMessage } = useIntl();
   const dispatch = useDispatch();

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/EditView/EditView.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/EditView/EditView.js
@@ -7,6 +7,7 @@ import { useMutation } from 'react-query';
 import {
   CheckPagePermissions,
   ConfirmDialog,
+  Link,
   SettingsPageTitle,
   useAPIErrorHandler,
   useFetchClient,
@@ -14,7 +15,7 @@ import {
   useTracking,
 } from '@strapi/helper-plugin';
 import { Button, ContentLayout, HeaderLayout, Layout, Loader, Main } from '@strapi/design-system';
-import { Check } from '@strapi/icons';
+import { ArrowLeft, Check } from '@strapi/icons';
 
 import { Stages } from '../../components/Stages';
 import { reducer, initialState } from '../../reducer';
@@ -147,6 +148,14 @@ export function ReviewWorkflowsEditView() {
           <FormikProvider value={formik}>
             <Form onSubmit={formik.handleSubmit}>
               <HeaderLayout
+                navigationAction={
+                  <Link startIcon={<ArrowLeft />} to="/settings/review-workflows">
+                    {formatMessage({
+                      id: 'global.back',
+                      defaultMessage: 'Back',
+                    })}
+                  </Link>
+                }
                 primaryAction={
                   <Button
                     startIcon={<Check />}

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/EditView/index.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/EditView/index.js
@@ -1,0 +1,3 @@
+import { ReviewWorkflowsEditView } from './EditView';
+
+export default ReviewWorkflowsEditView;

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/EditView/tests/EditView.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/EditView/tests/EditView.test.js
@@ -62,27 +62,25 @@ const client = new QueryClient({
   },
 });
 
-const ComponentFixture = () => {
-  const store = configureStore([], [reducer]);
-
-  return (
-    <DndProvider backend={HTML5Backend}>
-      <QueryClientProvider client={client}>
-        <Provider store={store}>
-          <IntlProvider locale="en" messages={{}}>
-            <ThemeProvider theme={lightTheme}>
-              <ReviewWorkflowsEditView />
-            </ThemeProvider>
-          </IntlProvider>
-        </Provider>
-      </QueryClientProvider>
-    </DndProvider>
-  );
-};
-
 const setup = (props) => {
   return {
-    ...render(<ComponentFixture {...props} />),
+    ...render(<ReviewWorkflowsEditView {...props} />, {
+      wrapper({ children }) {
+        const store = configureStore([], [reducer]);
+
+        return (
+          <DndProvider backend={HTML5Backend}>
+            <QueryClientProvider client={client}>
+              <Provider store={store}>
+                <IntlProvider locale="en" messages={{}}>
+                  <ThemeProvider theme={lightTheme}>{children}</ThemeProvider>
+                </IntlProvider>
+              </Provider>
+            </QueryClientProvider>
+          </DndProvider>
+        );
+      },
+    }),
     user: userEvent.setup(),
   };
 };

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/EditView/tests/EditView.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/EditView/tests/EditView.test.js
@@ -10,6 +10,7 @@ import { useNotification } from '@strapi/helper-plugin';
 import { ThemeProvider, lightTheme } from '@strapi/design-system';
 import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
+import { MemoryRouter } from 'react-router-dom';
 
 import configureStore from '../../../../../../../../../admin/src/core/store/configureStore';
 import ReviewWorkflowsEditView from '..';
@@ -69,15 +70,17 @@ const setup = (props) => {
         const store = configureStore([], [reducer]);
 
         return (
-          <DndProvider backend={HTML5Backend}>
-            <QueryClientProvider client={client}>
-              <Provider store={store}>
-                <IntlProvider locale="en" messages={{}}>
-                  <ThemeProvider theme={lightTheme}>{children}</ThemeProvider>
-                </IntlProvider>
-              </Provider>
-            </QueryClientProvider>
-          </DndProvider>
+          <MemoryRouter>
+            <DndProvider backend={HTML5Backend}>
+              <QueryClientProvider client={client}>
+                <Provider store={store}>
+                  <IntlProvider locale="en" messages={{}}>
+                    <ThemeProvider theme={lightTheme}>{children}</ThemeProvider>
+                  </IntlProvider>
+                </Provider>
+              </QueryClientProvider>
+            </DndProvider>
+          </MemoryRouter>
         );
       },
     }),
@@ -106,8 +109,10 @@ describe('Admin | Settings | Review Workflow | EditView', () => {
     expect(getByText('Workflow is loading')).toBeInTheDocument();
   });
 
-  test('loading state is not present', () => {
+  test('loading state is not present', async () => {
     const { queryByText } = setup();
+
+    await waitFor(() => expect(queryByText('Workflow is loading')).not.toBeInTheDocument());
 
     expect(queryByText('Workflow is loading')).not.toBeInTheDocument();
   });

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/EditView/tests/EditView.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/EditView/tests/EditView.test.js
@@ -87,7 +87,7 @@ const setup = (props) => {
   };
 };
 
-describe('Admin | Settings | Review Workflow | ReviewWorkflowsEditView', () => {
+describe('Admin | Settings | Review Workflow | EditView', () => {
   beforeAll(() => {
     server.listen();
   });

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/EditView/tests/EditView.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/EditView/tests/EditView.test.js
@@ -11,9 +11,9 @@ import { ThemeProvider, lightTheme } from '@strapi/design-system';
 import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 
-import configureStore from '../../../../../../../admin/src/core/store/configureStore';
-import ReviewWorkflowsPage from '..';
-import { reducer } from '../reducer';
+import configureStore from '../../../../../../../../../admin/src/core/store/configureStore';
+import ReviewWorkflowsEditView from '..';
+import { reducer } from '../../../reducer';
 
 jest.mock('@strapi/helper-plugin', () => ({
   ...jest.requireActual('@strapi/helper-plugin'),
@@ -71,7 +71,7 @@ const ComponentFixture = () => {
         <Provider store={store}>
           <IntlProvider locale="en" messages={{}}>
             <ThemeProvider theme={lightTheme}>
-              <ReviewWorkflowsPage />
+              <ReviewWorkflowsEditView />
             </ThemeProvider>
           </IntlProvider>
         </Provider>
@@ -87,7 +87,7 @@ const setup = (props) => {
   };
 };
 
-describe('Admin | Settings | Review Workflow | ReviewWorkflowsPage', () => {
+describe('Admin | Settings | Review Workflow | ReviewWorkflowsEditView', () => {
   beforeAll(() => {
     server.listen();
   });

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/ListView/ListView.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/ListView/ListView.js
@@ -9,6 +9,7 @@ import {
   Flex,
   HeaderLayout,
   Layout,
+  Loader,
   Main,
   Table,
   Thead,
@@ -50,7 +51,7 @@ export function ReviewWorkflowsListView() {
   const { push } = useHistory();
   const { workflows: workflowsData } = useReviewWorkflows();
   const dispatch = useDispatch();
-  const workflows = useSelector((state) => state?.[REDUX_NAMESPACE] ?? initialState);
+  const { status, serverState } = useSelector((state) => state?.[REDUX_NAMESPACE] ?? initialState);
 
   useInjectReducer(REDUX_NAMESPACE, reducer);
 
@@ -81,6 +82,15 @@ export function ReviewWorkflowsListView() {
           />
 
           <ContentLayout>
+            {status === 'loading' && (
+              <Loader>
+                {formatMessage({
+                  id: 'Settings.review-workflows.page.list.isLoading',
+                  defaultMessage: 'Workflows are loading',
+                })}
+              </Loader>
+            )}
+
             <Table colCount={3} rowCount={1}>
               <Thead>
                 <Tr>
@@ -112,8 +122,11 @@ export function ReviewWorkflowsListView() {
               </Thead>
 
               <Tbody>
-                {workflows?.serverState?.workflows.map((workflow) => (
-                  <Tr onClick={() => push(`/settings/review-workflows/${workflow.id}`)}>
+                {serverState?.workflows.map((workflow) => (
+                  <Tr
+                    onClick={() => push(`/settings/review-workflows/${workflow.id}`)}
+                    key={`workflow-${workflow.id}`}
+                  >
                     <Td width={pxToRem(250)}>
                       <Typography textColor="neutral800" fontWeight="bold" ellipsis>
                         {formatMessage({

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/ListView/ListView.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/ListView/ListView.js
@@ -124,7 +124,7 @@ export function ReviewWorkflowsListView() {
               <Tbody>
                 {serverState?.workflows.map((workflow) => (
                   <Tr
-                    onClick={() => push(`/settings/review-workflows/${workflow.id}`)}
+                    onRowClick={() => push(`/settings/review-workflows/${workflow.id}`)}
                     key={`workflow-${workflow.id}`}
                   >
                     <Td width={pxToRem(250)}>

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/ListView/ListView.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/ListView/ListView.js
@@ -1,0 +1,153 @@
+import React, { useEffect } from 'react';
+import styled from 'styled-components';
+import { useIntl } from 'react-intl';
+import { useHistory } from 'react-router-dom';
+import { useSelector, useDispatch } from 'react-redux';
+import { CheckPagePermissions, Link, pxToRem, SettingsPageTitle } from '@strapi/helper-plugin';
+import {
+  ContentLayout,
+  Flex,
+  HeaderLayout,
+  Layout,
+  Main,
+  Table,
+  Thead,
+  Tbody,
+  Tr,
+  Td,
+  Th,
+  Typography,
+  VisuallyHidden,
+} from '@strapi/design-system';
+import { Pencil } from '@strapi/icons';
+
+import { reducer, initialState } from '../../reducer';
+import { REDUX_NAMESPACE } from '../../constants';
+import { useInjectReducer } from '../../../../../../../../admin/src/hooks/useInjectReducer';
+import { useReviewWorkflows } from '../../hooks/useReviewWorkflows';
+import { setWorkflows } from '../../actions';
+import adminPermissions from '../../../../../../../../admin/src/permissions';
+
+const ActionLink = styled(Link)`
+  svg {
+    path {
+      fill: ${({ theme }) => theme.colors.neutral500};
+    }
+  }
+
+  &:hover,
+  &:focus {
+    svg {
+      path {
+        fill: ${({ theme }) => theme.colors.neutral800};
+      }
+    }
+  }
+`;
+
+export function ReviewWorkflowsListView() {
+  const { formatMessage } = useIntl();
+  const { push } = useHistory();
+  const { workflows: workflowsData } = useReviewWorkflows();
+  const dispatch = useDispatch();
+  const workflows = useSelector((state) => state?.[REDUX_NAMESPACE] ?? initialState);
+
+  useInjectReducer(REDUX_NAMESPACE, reducer);
+
+  useEffect(() => {
+    dispatch(setWorkflows({ status: workflowsData.status, data: workflowsData.data }));
+  }, [workflowsData.status, workflowsData.data, dispatch]);
+
+  return (
+    <CheckPagePermissions permissions={adminPermissions.settings['review-workflows'].main}>
+      <Layout>
+        <SettingsPageTitle
+          name={formatMessage({
+            id: 'Settings.review-workflows.page.title',
+            defaultMessage: 'Review Workflows',
+          })}
+        />
+        <Main tabIndex={-1}>
+          <HeaderLayout
+            subtitle={formatMessage({
+              id: 'Settings.review-workflows.list.page.subtitle',
+              defaultMessage:
+                'Manage content review stages and collaborate during content creation from draft to publication',
+            })}
+            title={formatMessage({
+              id: 'Settings.review-workflows.list.page.title',
+              defaultMessage: 'Review Workflows',
+            })}
+          />
+
+          <ContentLayout>
+            <Table colCount={3} rowCount={1}>
+              <Thead>
+                <Tr>
+                  <Th>
+                    <Typography variant="sigma">
+                      {formatMessage({
+                        id: 'Settings.review-workflows.list.page.list.column.name.title',
+                        defaultMessage: 'Name',
+                      })}
+                    </Typography>
+                  </Th>
+                  <Th>
+                    <Typography variant="sigma">
+                      {formatMessage({
+                        id: 'Settings.review-workflows.list.page.list.column.stages.title',
+                        defaultMessage: 'Stages',
+                      })}
+                    </Typography>
+                  </Th>
+                  <Th>
+                    <VisuallyHidden>
+                      {formatMessage({
+                        id: 'Settings.review-workflows.list.page.list.column.actions.title',
+                        defaultMessage: 'Actions',
+                      })}
+                    </VisuallyHidden>
+                  </Th>
+                </Tr>
+              </Thead>
+
+              <Tbody>
+                {workflows?.serverState?.workflows.map((workflow) => (
+                  <Tr onClick={() => push(`/settings/review-workflows/${workflow.id}`)}>
+                    <Td width={pxToRem(250)}>
+                      <Typography textColor="neutral800" fontWeight="bold" ellipsis>
+                        {formatMessage({
+                          id: 'Settings.review-workflows.list.page.list.column.name.defaultName',
+                          defaultMessage: 'Default workflow',
+                        })}
+                      </Typography>
+                    </Td>
+                    <Td>
+                      <Typography textColor="neutral800">{workflow.stages.length}</Typography>
+                    </Td>
+                    <Td>
+                      <Flex gap={2} justifyContent="end">
+                        <ActionLink
+                          to={`/settings/review-workflows/${workflow.id}`}
+                          aria-label={formatMessage(
+                            {
+                              id: 'Settings.review-workflows.list.page.list.column.actions.edit.label',
+                              defaultMessage: 'Edit {name}',
+                            },
+                            { name: 'Default workflow' }
+                          )}
+                        >
+                          <Pencil />
+                        </ActionLink>
+                      </Flex>
+                    </Td>
+                  </Tr>
+                ))}
+              </Tbody>
+            </Table>
+          </ContentLayout>
+        </Main>
+      </Layout>
+    </CheckPagePermissions>
+  );
+}

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/ListView/index.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/ListView/index.js
@@ -1,0 +1,3 @@
+import { ReviewWorkflowsListView } from './ListView';
+
+export default ReviewWorkflowsListView;

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/ListView/tests/ListView.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/ListView/tests/ListView.test.js
@@ -1,0 +1,122 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
+import { Provider } from 'react-redux';
+import { QueryClientProvider, QueryClient } from 'react-query';
+import userEvent from '@testing-library/user-event';
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import { ThemeProvider, lightTheme } from '@strapi/design-system';
+import { MemoryRouter } from 'react-router-dom';
+
+import configureStore from '../../../../../../../../../admin/src/core/store/configureStore';
+import ReviewWorkflowsListView from '..';
+import { reducer } from '../../../reducer';
+
+jest.mock('@strapi/helper-plugin', () => ({
+  ...jest.requireActual('@strapi/helper-plugin'),
+  // eslint-disable-next-line react/prop-types
+  CheckPagePermissions({ children }) {
+    return children;
+  },
+}));
+
+const FIXTURE_WORKFLOW = {
+  id: 1,
+  stages: [
+    {
+      id: 1,
+      name: 'stage-1',
+    },
+  ],
+};
+
+const server = setupServer(
+  rest.get('*/review-workflows/workflows', (req, res, ctx) => {
+    return res(
+      ctx.json({
+        data: [FIXTURE_WORKFLOW],
+      })
+    );
+  })
+);
+
+const client = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+    },
+  },
+});
+
+const ComponentFixture = () => {
+  const store = configureStore([], [reducer]);
+
+  return (
+    <MemoryRouter>
+      <QueryClientProvider client={client}>
+        <Provider store={store}>
+          <IntlProvider locale="en" messages={{}}>
+            <ThemeProvider theme={lightTheme}>
+              <ReviewWorkflowsListView />
+            </ThemeProvider>
+          </IntlProvider>
+        </Provider>
+      </QueryClientProvider>
+    </MemoryRouter>
+  );
+};
+
+const setup = (props) => {
+  return {
+    ...render(<ComponentFixture {...props} />),
+    user: userEvent.setup(),
+  };
+};
+
+describe('Admin | Settings | Review Workflow | ListView', () => {
+  beforeAll(() => {
+    server.listen();
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+  });
+
+  test('Loading state', () => {
+    const { getByText } = setup();
+
+    expect(getByText('Workflows are loading')).toBeInTheDocument();
+    expect(getByText('Review Workflows')).toBeInTheDocument();
+    expect(
+      getByText(
+        'Manage content review stages and collaborate during content creation from draft to publication'
+      )
+    ).toBeInTheDocument();
+  });
+
+  test('loading state is not present', async () => {
+    const { queryByText } = setup();
+
+    await waitFor(() => expect(queryByText('Workflows are loading')).not.toBeInTheDocument());
+
+    expect(queryByText('Workflows are loading')).not.toBeInTheDocument();
+  });
+
+  test('displays a list of workflows', async () => {
+    const { getByRole, getByText, queryByText } = setup();
+
+    await waitFor(() => expect(queryByText('Workflows are loading')).not.toBeInTheDocument());
+
+    expect(getByText('Default workflow')).toBeInTheDocument();
+    expect(getByRole('link', { name: /Edit Default workflow/gi })).toHaveAttribute(
+      'href',
+      `/settings/review-workflows/${FIXTURE_WORKFLOW.id}`
+    );
+  });
+});

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/ListView/tests/ListView.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/ListView/tests/ListView.test.js
@@ -49,27 +49,25 @@ const client = new QueryClient({
   },
 });
 
-const ComponentFixture = () => {
-  const store = configureStore([], [reducer]);
-
-  return (
-    <MemoryRouter>
-      <QueryClientProvider client={client}>
-        <Provider store={store}>
-          <IntlProvider locale="en" messages={{}}>
-            <ThemeProvider theme={lightTheme}>
-              <ReviewWorkflowsListView />
-            </ThemeProvider>
-          </IntlProvider>
-        </Provider>
-      </QueryClientProvider>
-    </MemoryRouter>
-  );
-};
-
 const setup = (props) => {
   return {
-    ...render(<ComponentFixture {...props} />),
+    ...render(<ReviewWorkflowsListView {...props} />, {
+      wrapper({ children }) {
+        const store = configureStore([], [reducer]);
+
+        return (
+          <MemoryRouter>
+            <QueryClientProvider client={client}>
+              <Provider store={store}>
+                <IntlProvider locale="en" messages={{}}>
+                  <ThemeProvider theme={lightTheme}>{children}</ThemeProvider>
+                </IntlProvider>
+              </Provider>
+            </QueryClientProvider>
+          </MemoryRouter>
+        );
+      },
+    }),
     user: userEvent.setup(),
   };
 };

--- a/packages/core/admin/ee/admin/pages/SettingsPage/utils/customRoutes.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/utils/customRoutes.js
@@ -18,12 +18,24 @@ if (window.strapi.features.isEnabled(window.strapi.features.REVIEW_WORKFLOWS)) {
   routes.push({
     async Component() {
       const component = await import(
-        /* webpackChunkName: "review-workflows-settings" */ '../pages/ReviewWorkflows'
+        /* webpackChunkName: "review-workflows-settings-list-view" */ '../pages/ReviewWorkflows/pages/ListView'
       );
 
       return component;
     },
     to: '/settings/review-workflows',
+    exact: true,
+  });
+
+  routes.push({
+    async Component() {
+      const component = await import(
+        /* webpackChunkName: "review-workflows-settings-edit-view" */ '../pages/ReviewWorkflows/pages/EditView'
+      );
+
+      return component;
+    },
+    to: '/settings/review-workflows/:workflowId',
     exact: true,
   });
 }


### PR DESCRIPTION
### What does it do?

Changes the default review-workflow settings page to display the list-view and splits list-view and edit-view into separate views.

| List view | Edit view |
|-|-|
| <img width="1295" alt="Screenshot 2023-05-10 at 13 44 31" src="https://github.com/strapi/strapi/assets/2244375/292daea5-740a-4010-ab07-a5b9a82692ef"> | <img width="1295" alt="Screenshot 2023-05-10 at 13 44 36" src="https://github.com/strapi/strapi/assets/2244375/a88fc795-9ab7-423b-8f55-9db2cb0108a7"> |

### Why is it needed?

First step to display multiple workflows in the FE.

