### PR TITLE
Fix broken open documentation link

### DIFF
--- a/packages/plugins/documentation/admin/src/pages/PluginPage/index.js
+++ b/packages/plugins/documentation/admin/src/pages/PluginPage/index.js
@@ -14,6 +14,7 @@ import {
   stopPropagation,
   EmptyStateLayout,
   useFocusWhenNavigate,
+  AnErrorOccurred,
 } from '@strapi/helper-plugin';
 import { Helmet } from 'react-helmet';
 import {
@@ -31,6 +32,7 @@ import {
   Th,
   Tbody,
   Td,
+  Box,
 } from '@strapi/design-system';
 
 import { Trash, Eye as Show, Refresh as Reload } from '@strapi/icons';
@@ -43,7 +45,7 @@ import useReactQuery from '../utils/useReactQuery';
 const PluginPage = () => {
   useFocusWhenNavigate();
   const { formatMessage } = useIntl();
-  const { data, isLoading, deleteMutation, regenerateDocMutation } = useReactQuery();
+  const { data, isLoading, isError, deleteMutation, regenerateDocMutation } = useReactQuery();
   const [showConfirmDelete, setShowConfirmDelete] = useState(false);
   const [isConfirmButtonLoading, setIsConfirmButtonLoading] = useState(false);
   const [versionToDelete, setVersionToDelete] = useState();
@@ -81,6 +83,18 @@ const PluginPage = () => {
     defaultMessage: 'Documentation',
   });
 
+  if (isError) {
+    return (
+      <Layout>
+        <ContentLayout>
+          <Box paddingTop={8}>
+            <AnErrorOccurred />
+          </Box>
+        </ContentLayout>
+      </Layout>
+    );
+  }
+
   return (
     <Layout>
       <Helmet title={title} />
@@ -94,7 +108,7 @@ const PluginPage = () => {
           primaryAction={
             //  eslint-disable-next-line
             <CheckPermissions permissions={permissions.open}>
-              <Button onClick={openDocVersion} startIcon={<Show />}>
+              <Button onClick={() => openDocVersion(data?.currentVersion)} startIcon={<Show />}>
                 {formatMessage({
                   id: getTrad('pages.PluginPage.Button.open'),
                   defaultMessage: 'Open Documentation',

--- a/packages/plugins/documentation/admin/src/pages/utils/useReactQuery.js
+++ b/packages/plugins/documentation/admin/src/pages/utils/useReactQuery.js
@@ -6,7 +6,7 @@ import getTrad from '../../utils/getTrad';
 const useReactQuery = () => {
   const queryClient = useQueryClient();
   const toggleNotification = useNotification();
-  const { isLoading, data } = useQuery(['get-documentation', pluginId], async () => {
+  const { isLoading, isError, data } = useQuery(['get-documentation', pluginId], async () => {
     try {
       const { data } = await get(`/${pluginId}/getInfos`);
 
@@ -60,7 +60,7 @@ const useReactQuery = () => {
     }
   );
 
-  return { data, isLoading, deleteMutation, submitMutation, regenerateDocMutation };
+  return { data, isLoading, isError, deleteMutation, submitMutation, regenerateDocMutation };
 };
 
 export default useReactQuery;


### PR DESCRIPTION
### What does it do?

- Passes the current version when click open documentation

### Why is it needed?

- Currently it's broken

### How to test it?

Go to the documentation plugin, click open documentation. It should open the current version set in the config. For examples/getstarted that's 1.0.0

closes #16617 
