### PR TITLE
Fix: Fix toOne sorting in CM list-view

### DIFF
--- a/packages/core/admin/ee/admin/content-manager/components/DynamicTable/CellContent/ReviewWorkflowsStage/getTableColumn.js
+++ b/packages/core/admin/ee/admin/content-manager/components/DynamicTable/CellContent/ReviewWorkflowsStage/getTableColumn.js
@@ -34,7 +34,12 @@ export default (layout) => {
       }),
       searchable: false,
       sortable: true,
-      mainField: 'name',
+      mainField: {
+        name: 'name',
+        schema: {
+          type: 'string',
+        },
+      },
     },
     cellFormatter({ strapi_reviewWorkflows_stage }) {
       // if entities are created e.g. through lifecycle methods

--- a/packages/core/helper-plugin/src/components/DynamicTable/TableHead/index.js
+++ b/packages/core/helper-plugin/src/components/DynamicTable/TableHead/index.js
@@ -52,7 +52,7 @@ const TableHead = ({
             // relations always have to be sorted by their main field instead of only the
             // attribute name; sortBy e.g. looks like: &sortBy=attributeName[mainField]:ASC
             if (fieldSchema?.type === 'relation' && mainField) {
-              isSorted = sortBy === `${name}[${mainField}]`;
+              isSorted = sortBy === `${name.split('.')[0]}[${mainField.name}]`;
             }
 
             const sortLabel = formatMessage(
@@ -67,7 +67,7 @@ const TableHead = ({
                 // relations always have to be sorted by their main field instead of only the
                 // attribute name; nextSort e.g. looks like: &nextSort=attributeName[mainField]:ASC
                 if (fieldSchema?.type === 'relation' && mainField) {
-                  nextSort = `${name}[${mainField}]`;
+                  nextSort = `${name.split('.')[0]}[${mainField.name}]`;
                 }
 
                 setQuery({


### PR DESCRIPTION
### What does it do?

Fixes sorting by `xToOne` relations in the CM list-view by using the full main field schema configuration instead of a string.

### Why is it needed?

In https://github.com/strapi/strapi/pull/16548 I had introduced sorting by review-stage, which is a relation under the hood. I had assumed that would not affect other relations, but it turns out that `xToOne` relations are already setting the main-field. Instead of using a plain string they are using the full schema part, which is an object. That broken filtering by `xToOne` relations.

### How to test it?

Display every kitchen-sink field in the CM list-view and sort by them.

### Related issue(s)/PR(s)

- Fixes https://github.com/strapi/strapi/issues/16661
