### PR TITLE
`origin` will be type `string` if present

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/CollectionTypeFormWrapper/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/CollectionTypeFormWrapper/index.js
@@ -242,7 +242,7 @@ const CollectionTypeFormWrapper = ({ allLayoutData, children, slug, id, origin }
        * are correctly attached to the entry.
        */
       const endPoint =
-        typeof origin !== 'undefined'
+        typeof origin === 'string'
           ? `${getRequestUrl(`collection-types/${slug}/clone/${origin}`)}${rawQuery}`
           : `${getRequestUrl(`collection-types/${slug}`)}${rawQuery}`;
       try {

--- a/packages/core/database/package.json
+++ b/packages/core/database/package.json
@@ -33,7 +33,7 @@
     "lint": "run -T eslint ."
   },
   "dependencies": {
-    "@strapi/utils": "4.10.2",
+    "@strapi/utils": "4.10.4",
     "date-fns": "2.29.3",
     "debug": "4.3.4",
     "fs-extra": "10.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7872,7 +7872,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@strapi/database@workspace:packages/core/database"
   dependencies:
-    "@strapi/utils": 4.10.2
+    "@strapi/utils": 4.10.4
     date-fns: 2.29.3
     debug: 4.3.4
     fs-extra: 10.0.0


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* changes the check for `origin` to see if it'll be a `string`

### Why is it needed?

* turns out it can be `string | null | undefined` – I wasn't prepared for `null`

### How to test it?

* With an Editor user
* Create a new entity
* It should save and not attempt to `clone`

### Related issue(s)/PR(s)

* resolves CONTENT-1384
