### PR TITLE
Remove @vscode/sqlite3 from example and CI matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -236,7 +236,7 @@ jobs:
     strategy:
       matrix:
         node: [14, 16, 18]
-        sqlite_pkg: ['better-sqlite3', 'sqlite3', '@vscode/sqlite3']
+        sqlite_pkg: ['better-sqlite3', 'sqlite3']
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -342,7 +342,7 @@ jobs:
     strategy:
       matrix:
         node: [14, 16, 18]
-        sqlite_pkg: ['better-sqlite3', 'sqlite3', '@vscode/sqlite3']
+        sqlite_pkg: ['better-sqlite3', 'sqlite3']
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/examples/getstarted/package.json
+++ b/examples/getstarted/package.json
@@ -23,7 +23,6 @@
     "@strapi/provider-upload-aws-s3": "4.10.5",
     "@strapi/provider-upload-cloudinary": "4.10.5",
     "@strapi/strapi": "4.10.5",
-    "@vscode/sqlite3": "5.1.2",
     "better-sqlite3": "8.3.0",
     "lodash": "4.17.21",
     "mysql": "2.18.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10219,16 +10219,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vscode/sqlite3@npm:5.1.2":
-  version: 5.1.2
-  resolution: "@vscode/sqlite3@npm:5.1.2"
-  dependencies:
-    node-addon-api: ^4.2.0
-    node-gyp: latest
-  checksum: d3f43cc9582b46841906193500c40dcf448bb85954c8d6260e9fbd524f440a298a6d589a28a89f1c331ce0ebc831ebf814fb3cbcb0061498aa6932161f88dec5
-  languageName: node
-  linkType: hard
-
 "@webassemblyjs/ast@npm:1.11.1":
   version: 1.11.1
   resolution: "@webassemblyjs/ast@npm:1.11.1"
@@ -18352,7 +18342,6 @@ __metadata:
     "@strapi/provider-upload-aws-s3": 4.10.5
     "@strapi/provider-upload-cloudinary": 4.10.5
     "@strapi/strapi": 4.10.5
-    "@vscode/sqlite3": 5.1.2
     better-sqlite3: 8.3.0
     lodash: 4.17.21
     mysql: 2.18.1


### PR DESCRIPTION
As per discovery on CI time, see https://github.com/strapi/strapi/pull/16638#issuecomment-1544412101

I'd like to propose to remove the @vscode/sqlite from the getting-started example. @vscode/sqlite looks to be a compatible fork of sqlite3 (node-sqlite) which is already supported by strapi and won't be touched in this pr. Diff 
https://github.com/TryGhost/node-sqlite3/compare/master...microsoft:vscode-node-sqlite3:release/vscode

The context

- the getting started install by default 3 drivers for sqlite (better-sqlite, sqlite3 and  @vscode/sqlite).
- @vscode/sqlite is a slightly modified fork of sqlite3. They should be compatible. 
- strapi prioritize the better-sqlite3 if present https://github.com/strapi/strapi/blob/main/packages/core/database/lib/connection.js#L38. Then @vscode/sqlite. Then sqlite3. Better-sqlite3 is probably the one most users have. Per install docs.
- in most situations (docker, ci, package manager...) the node-gyp based @vscode/sqlite will attempt to compile the extension which tend to take time and is a common cause of failures. For our ci and users

Reasons why ?

- On the ci yarn `link step` will run faster (the entire CI will probably save >45s per install, there's a lot of steps -> >45 seconds * steps)
- Remove one level of confusion for users.

The reason why not ?

- Maybe some users prefer to use this driver. But they have to be sure they don't have the better-sqlite3 installed... so anyway it looks counter-intuitive. 

The possibles ?

- 1. Remove the driver from getting-started, 
- 2. (exclude examples/* from the workspace and create a separate install that does not interfere with ou CI)

This PR suggest the first. It just removes the dep.

@gu-stav wdyt ?

 
