### PR TITLE
Add more flexibility to factory types

### DIFF
--- a/packages/core/strapi/lib/core-api/controller/index.d.ts
+++ b/packages/core/strapi/lib/core-api/controller/index.d.ts
@@ -23,5 +23,5 @@ export interface CollectionTypeController extends Controller {
 }
 
 export type GenericController = Partial<Controller> & {
-  [method: string | number | symbol]: (ctx: Context) => unknown;
+  [method: string | number | symbol]: (ctx: Context, next: Next) => unknown;
 };

--- a/packages/core/strapi/lib/core-api/controller/index.d.ts
+++ b/packages/core/strapi/lib/core-api/controller/index.d.ts
@@ -23,5 +23,5 @@ export interface CollectionTypeController extends Controller {
 }
 
 export type GenericController = Partial<Controller> & {
-  [method: string | number | symbol]: (ctx: Context, next: Next) => unknown;
+  [method: string | number | symbol]: (ctx: Context, next?: Next) => unknown;
 };

--- a/packages/core/strapi/lib/core-api/service/index.d.ts
+++ b/packages/core/strapi/lib/core-api/service/index.d.ts
@@ -18,8 +18,6 @@ export interface CollectionTypeService extends BaseService {
   delete?(entityId: string, params: object): Promise<Entity> | Entity;
 }
 
-export type Service = SingleTypeService | CollectionTypeService;
-
-export type GenericService = Partial<Service> & {
+export type GenericService = {
   [method: string | number | symbol]: (...args: any) => any;
 };

--- a/packages/core/strapi/lib/types/factories.d.ts
+++ b/packages/core/strapi/lib/types/factories.d.ts
@@ -1,8 +1,20 @@
-import { Service, GenericService } from '../core-api/service';
-import { CollectionTypeController, Controller, GenericController } from '../core-api/controller';
+import {
+  Service,
+  GenericService,
+  CollectionTypeService,
+  SingleTypeService,
+} from '../core-api/service';
+import {
+  CollectionTypeController,
+  SingleTypeController,
+  Controller,
+  GenericController,
+} from '../core-api/controller';
 import { Middleware } from '../middlewares';
 import { Policy } from '../core/registries/policies';
 import { Strapi } from './core/strapi';
+import { SchemaUID } from './utils';
+import { GenericService } from '../core-api/service/index';
 
 type ControllerConfig<T extends Controller = Controller> = T;
 
@@ -50,11 +62,22 @@ type ControllerCallback<T extends GenericController = GenericController> = (para
 type ServiceCallback<T extends GenericService = GenericService> = (params: { strapi: Strapi }) => T;
 
 export function createCoreRouter(uid: string, cfg?: RouterConfig = {}): () => Router;
-export function createCoreController<T extends Partial<CollectionTypeController>>(
-  uid: string,
-  cfg?: ControllerCallback<T> | T = {}
-): () => Required<T> & Controller;
-export function createCoreService<T extends GenericService = GenericService>(
-  uid: string,
-  cfg?: ServiceCallback<T> | T = {}
-): () => T;
+
+export function createCoreController<
+  T extends SchemaUID,
+  S extends Partial<GetBaseSchemaController<T>>
+>(uid: T, cfg?: ControllerCallback<S> | S): () => Required<S & GetBaseSchemaController<T>>;
+
+export function createCoreService<T extends SchemaUID, S extends Partial<GetBaseSchemaService<T>>>(
+  uid: T,
+  cfg?: ServiceCallback<S> | S
+): () => Required<S & GetBaseSchemaService<T>>;
+
+type GetBaseSchemaController<T extends SchemaUID> =
+  Strapi.Schemas[T]['kind'] extends 'collectionType'
+    ? CollectionTypeController & GenericController
+    : SingleTypeController & GenericController;
+
+type GetBaseSchemaService<T extends SchemaUID> = Strapi.Schemas[T]['kind'] extends 'collectionType'
+  ? CollectionTypeService & GenericService
+  : SingleTypeService & GenericService;

--- a/packages/core/strapi/lib/types/factories.d.ts
+++ b/packages/core/strapi/lib/types/factories.d.ts
@@ -79,15 +79,24 @@ export function createCoreService<T extends SchemaUID, S extends Partial<GetBase
   cfg?: ServiceCallback<S> | S
 ): () => Required<S & GetBaseSchemaService<T>>;
 
-type GetBaseSchemaController<T extends SchemaUID> =
-  Strapi.Schemas[T]['kind'] extends 'collectionType'
-    ? CollectionTypeController & GenericController
-    : SingleTypeController & GenericController;
+type GetBaseSchemaController<T extends SchemaUID> = IsCollectionType<
+  T,
+  CollectionTypeController,
+  SingleTypeController
+> &
+  GenericController;
 
-type GetBaseSchemaService<T extends SchemaUID> = Strapi.Schemas[T]['kind'] extends 'collectionType'
-  ? CollectionTypeService & GenericService
-  : SingleTypeService & GenericService;
+type GetBaseSchemaService<T extends SchemaUID> = IsCollectionType<
+  T,
+  CollectionTypeService,
+  SingleTypeService
+> &
+  GenericService;
 
-type GetBaseConfig<T extends SchemaUID> = Strapi.Schemas[T]['kind'] extends 'collectionType'
-  ? CollectionTypeRouterConfig
-  : SingleTypeRouterConfig;
+type GetBaseConfig<T extends SchemaUID> = IsCollectionType<
+  T,
+  CollectionTypeRouterConfig,
+  SingleTypeRouterConfig
+>;
+
+type IsCollectionType<T, Y, N> = Strapi.Schemas[T]['kind'] extends 'collectionType' ? Y : N;

--- a/packages/core/strapi/lib/types/factories.d.ts
+++ b/packages/core/strapi/lib/types/factories.d.ts
@@ -62,12 +62,12 @@ type ControllerCallback<T extends GenericController = GenericController> = (para
 }) => T;
 type ServiceCallback<T extends GenericService = GenericService> = (params: { strapi: Strapi }) => T;
 
-export function createCoreRouter<T extends SchemaUID>(
+export declare function createCoreRouter<T extends SchemaUID>(
   uid: T,
   cfg?: RouterConfig<GetBaseConfig<T>> = {}
 ): () => Router;
 
-export function createCoreController<
+export declare function createCoreController<
   T extends SchemaUID,
   S extends Partial<GetBaseSchemaController<T>>
 >(
@@ -75,10 +75,10 @@ export function createCoreController<
   cfg?: ControllerCallback<S> | S
 ): () => Required<S & GetBaseSchemaController<GetBaseConfig<T>>>;
 
-export function createCoreService<T extends SchemaUID, S extends Partial<GetBaseSchemaService<T>>>(
-  uid: T,
-  cfg?: ServiceCallback<S> | S
-): () => Required<S & GetBaseSchemaService<T>>;
+export declare function createCoreService<
+  T extends SchemaUID,
+  S extends Partial<GetBaseSchemaService<T>>
+>(uid: T, cfg?: ServiceCallback<S> | S): () => Required<S & GetBaseSchemaService<T>>;
 
 type GetBaseSchemaController<T extends SchemaUID> = IsCollectionType<
   T,

--- a/packages/core/strapi/lib/types/factories.d.ts
+++ b/packages/core/strapi/lib/types/factories.d.ts
@@ -42,6 +42,7 @@ type CollectionTypeRouterConfig = {
 
 type RouterConfig<T> = {
   prefix?: string;
+  // TODO Refactor when we have a controller registry
   only?: string[];
   except?: string[];
   config: T;

--- a/packages/core/strapi/lib/types/factories.d.ts
+++ b/packages/core/strapi/lib/types/factories.d.ts
@@ -40,7 +40,7 @@ type CollectionTypeRouterConfig = {
   delete?: HandlerConfig;
 };
 
-type RouterConfig<T> = {
+type RouterConfig<T = SingleTypeRouterConfig | CollectionTypeRouterConfig> = {
   prefix?: string;
   // TODO Refactor when we have a controller registry
   only?: string[];

--- a/packages/core/strapi/lib/types/factories.d.ts
+++ b/packages/core/strapi/lib/types/factories.d.ts
@@ -42,8 +42,8 @@ type CollectionTypeRouterConfig = {
 
 type RouterConfig<T> = {
   prefix?: string;
-  only?: Array<keyof T>;
-  except?: Array<keyof T>;
+  only?: string[];
+  except?: string[];
   config: T;
 };
 

--- a/packages/core/strapi/lib/types/factories.d.ts
+++ b/packages/core/strapi/lib/types/factories.d.ts
@@ -40,11 +40,11 @@ type CollectionTypeRouterConfig = {
   delete?: HandlerConfig;
 };
 
-type RouterConfig = {
+type RouterConfig<T> = {
   prefix?: string;
-  only?: string[];
-  except?: string[];
-  config: SingleTypeRouterConfig | CollectionTypeRouterConfig;
+  only?: Array<keyof T>;
+  except?: Array<keyof T>;
+  config: T;
 };
 
 interface Route {
@@ -61,12 +61,18 @@ type ControllerCallback<T extends GenericController = GenericController> = (para
 }) => T;
 type ServiceCallback<T extends GenericService = GenericService> = (params: { strapi: Strapi }) => T;
 
-export function createCoreRouter(uid: string, cfg?: RouterConfig = {}): () => Router;
+export function createCoreRouter<T extends SchemaUID>(
+  uid: T,
+  cfg?: RouterConfig<GetBaseConfig<T>> = {}
+): () => Router;
 
 export function createCoreController<
   T extends SchemaUID,
   S extends Partial<GetBaseSchemaController<T>>
->(uid: T, cfg?: ControllerCallback<S> | S): () => Required<S & GetBaseSchemaController<T>>;
+>(
+  uid: T,
+  cfg?: ControllerCallback<S> | S
+): () => Required<S & GetBaseSchemaController<GetBaseConfig<T>>>;
 
 export function createCoreService<T extends SchemaUID, S extends Partial<GetBaseSchemaService<T>>>(
   uid: T,
@@ -81,3 +87,7 @@ type GetBaseSchemaController<T extends SchemaUID> =
 type GetBaseSchemaService<T extends SchemaUID> = Strapi.Schemas[T]['kind'] extends 'collectionType'
   ? CollectionTypeService & GenericService
   : SingleTypeService & GenericService;
+
+type GetBaseConfig<T extends SchemaUID> = Strapi.Schemas[T]['kind'] extends 'collectionType'
+  ? CollectionTypeRouterConfig
+  : SingleTypeRouterConfig;

--- a/packages/core/strapi/lib/types/factories.d.ts
+++ b/packages/core/strapi/lib/types/factories.d.ts
@@ -1,5 +1,5 @@
 import { Service, GenericService } from '../core-api/service';
-import { Controller, GenericController } from '../core-api/controller';
+import { CollectionTypeController, Controller, GenericController } from '../core-api/controller';
 import { Middleware } from '../middlewares';
 import { Policy } from '../core/registries/policies';
 import { Strapi } from './core/strapi';
@@ -50,10 +50,10 @@ type ControllerCallback<T extends GenericController = GenericController> = (para
 type ServiceCallback<T extends GenericService = GenericService> = (params: { strapi: Strapi }) => T;
 
 export function createCoreRouter(uid: string, cfg?: RouterConfig = {}): () => Router;
-export function createCoreController<T extends GenericController = GenericController>(
+export function createCoreController<T extends Partial<CollectionTypeController>>(
   uid: string,
   cfg?: ControllerCallback<T> | T = {}
-): () => T & Controller;
+): () => Required<T> & Controller;
 export function createCoreService<T extends GenericService = GenericService>(
   uid: string,
   cfg?: ServiceCallback<T> | T = {}


### PR DESCRIPTION
### What does it do?

It merges the default types for a collection type controller and the new created methods for it. 

### Why is it needed?

To have more flexibility on the factory types

### How to test it?

- Go to a content type controller and write: 
```
export default factories.createCoreController('api::toy.toy', ({ strapi }) => ({
    // here you should have autocompletion for all the collection methods: find, findOne, update,delete... and you can create 	 
   //any other methods e.g
   hello(){}
})).hello() // this should be allowed + find, update, delete or any other you declared on the config object;
```

- Go to a content type (single or collection, it should make the distinguish automatically and provide the types accordingly) service and do the same as with the controller

- Go to a content type routes directory, to the typescript file inside, then play around following this documentation: https://docs.strapi.io/dev-docs/backend-customization/routes 

Keep in mind that if you replace the uuid of the first parameter of the functions for a collectionType or a singleType, the types should update automatically
### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
