### PR TITLE
feat: endpoint to get swagger documentation in JSON

### DIFF
--- a/packages/plugins/documentation/README.md
+++ b/packages/plugins/documentation/README.md
@@ -146,6 +146,10 @@ When we can't know by the controller name the type of the returned response (lik
 
 You can use the `tag` key in your route. If you provide a `tag` which is a string like `"tag": "Product"` the algorithm will know that the end-point retrieves data from the **`Product`** table. Creating a tag object `{ "tag": { "name": "User", "plugin": "User-Permissions } }` will result in generating a response with the **`User`** model from the plugin users-permissions.
 
+#### How to access the full documentation in JSON via the API ?
+
+There is a route that you can use to access the full documentation in JSON format via the API. The endpoint is `/documentation/swagger.json` or `/documentation/:documentationVersion/swagger.json` if you want to access a specific version. You can use it to access your own documentation.
+
 ---
 
 Each entry of the object is easily customisable take look at the users-permissions ones they are a good example on how to do it.

--- a/packages/plugins/documentation/server/routes/index.js
+++ b/packages/plugins/documentation/server/routes/index.js
@@ -23,6 +23,24 @@ module.exports = [
   },
   {
     method: 'GET',
+    path: '/swagger.json',
+    handler: 'documentation.json',
+    config: {
+      auth: false,
+      middlewares: [restrictAccess],
+    },
+  },
+  {
+    method: 'GET',
+    path: '/v:major(\\d+).:minor(\\d+).:patch(\\d+)/swagger.json',
+    handler: 'documentation.json',
+    config: {
+      auth: false,
+      middlewares: [restrictAccess],
+    },
+  },
+  {
+    method: 'GET',
     path: '/login',
     handler: 'documentation.loginView',
     config: {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->
- [x] Create or update the tests (**There are no tests for routes in the Documentation plugin**)
- [x] Create or update the documentation at https://github.com/strapi/documentation (**Updated README.md in the plugin folder**)
- [x] Refer to the issue you are closing in the PR description: Fix #issue (**Referred to feature request on Strapi feedback portal**)
- [x] Specify if the PR is ready to be merged or work in progress (by opening a draft PR) (**It works on my machine** 😃)

### What does it do?

The PR adds two new endpoints for the [Documentation](https://market.strapi.io/plugins/@strapi-plugin-documentation) plugin so that users can get the plain JSON documentation on the new API endpoints `/documentation/swagger.json` or `documentation/v1.0.0/swagger.json` (or any specific version).

<img width="1497" alt="image" src="https://github.com/strapi/strapi/assets/5487217/5db3fec5-23d3-4e0c-b7f4-f66d9c2c664d">

### Why is it needed?

Thanks to this feature, developers can get the swagger specification in JSON format on those two API endpoints and with tools such as (OpenAPI Generator)[https://github.com/OpenAPITools/openapi-generator] generate SDKs and, for example, in my case with Typescript generate corresponding types for my frontend application.

### How to test it?

I haven't found any tests to test routes in the plugin source code.

To test the new feature, you can follow these steps:

1. Install the Documentation plugin
2. Open `[strapi url]/documentation/swagger.json` or `[strapi url]/documentation/:documentationVersion/swagger.json`. For example, http://localhost:1337/documentation/swagger.json and http://localhost:1337/documentation/v1.0.0/swagger.json must both work properly and serve the plain JSON of the Swagger documentation.

### Related issue(s)/PR(s)

There is no related issue or PR, but I created a feature request on the Strapi feedback portal: (API Endpoint for Swagger JSON in Documentation Plugin)[https://feedback.strapi.io/feature-requests/p/api-endpoint-for-swagger-json-in-documentation-plugin]


Thanks for considering merging my contribution. If anything needs to be added, please feel free to let me know.
