### PR TITLE
feature(rw): create workflow

### DIFF
--- a/api-tests/core/admin/admin-permission.test.api.js
+++ b/api-tests/core/admin/admin-permission.test.api.js
@@ -374,6 +374,12 @@ describe('Role CRUD End to End', () => {
                   "subCategory": "options",
                 },
                 {
+                  "action": "admin::review-workflows.create",
+                  "category": "review workflows",
+                  "displayName": "Create",
+                  "subCategory": "options",
+                },
+                {
                   "action": "admin::review-workflows.read",
                   "category": "review workflows",
                   "displayName": "Read",

--- a/api-tests/core/admin/ee/review-workflows.test.api.js
+++ b/api-tests/core/admin/ee/review-workflows.test.api.js
@@ -181,7 +181,7 @@ describeOnCondition(edition === 'EE')('Review workflows', () => {
   });
 
   describe('Create workflow', () => {
-    test('You can create a workflow', async () => {
+    test('You can not create a workflow without stages', async () => {
       const res = await requests.admin.post('/admin/review-workflows/workflows', {
         body: {
           name: 'testWorkflow',
@@ -189,10 +189,9 @@ describeOnCondition(edition === 'EE')('Review workflows', () => {
       });
 
       if (hasRW) {
-        expect(res.status).toBe(200);
-        expect(res.body.data).toMatchObject({
-          name: 'testWorkflow',
-        });
+        expect(res.status).toBe(400);
+        expect(res.body.error.name).toBe('ApplicationError');
+        expect(res.body.error.message).toBe('Can not create a workflow without stages');
       } else {
         expect(res.status).toBe(404);
         expect(res.body.data).toBeUndefined();

--- a/api-tests/core/admin/ee/review-workflows.test.api.js
+++ b/api-tests/core/admin/ee/review-workflows.test.api.js
@@ -180,6 +180,45 @@ describeOnCondition(edition === 'EE')('Review workflows', () => {
     });
   });
 
+  describe('Create workflow', () => {
+    test('You can create a workflow', async () => {
+      const res = await requests.admin.post('/admin/review-workflows/workflows', {
+        body: {
+          name: 'testWorkflow',
+        },
+      });
+
+      if (hasRW) {
+        expect(res.status).toBe(200);
+        expect(res.body.data).toMatchObject({
+          name: 'testWorkflow',
+        });
+      } else {
+        expect(res.status).toBe(404);
+        expect(res.body.data).toBeUndefined();
+      }
+    });
+    test('You can create a workflow with stages', async () => {
+      const res = await requests.admin.post('/admin/review-workflows/workflows?populate=stages', {
+        body: {
+          name: 'testWorkflow',
+          stages: [{ name: 'Stage 1' }, { name: 'Stage 2' }],
+        },
+      });
+
+      if (hasRW) {
+        expect(res.status).toBe(200);
+        expect(res.body.data).toMatchObject({
+          name: 'testWorkflow',
+          stages: [{ name: 'Stage 1' }, { name: 'Stage 2' }],
+        });
+      } else {
+        expect(res.status).toBe(404);
+        expect(res.body.data).toBeUndefined();
+      }
+    });
+  });
+
   describe('Get workflow stages', () => {
     test("It shouldn't be available for public", async () => {
       const res = await requests.public.get(
@@ -527,8 +566,7 @@ describeOnCondition(edition === 'EE')('Review workflows', () => {
     });
   });
 
-  //FIXME Flaky test
-  describe.skip('Deleting a stage when content already exists', () => {
+  describe('Deleting a stage when content already exists', () => {
     test('When content exists in a review stage and this stage is deleted, the content should be moved to the nearest available stage', async () => {
       const products = await findAll(productUID);
 

--- a/api-tests/core/admin/ee/review-workflows.test.api.js
+++ b/api-tests/core/admin/ee/review-workflows.test.api.js
@@ -190,7 +190,6 @@ describeOnCondition(edition === 'EE')('Review workflows', () => {
 
       if (hasRW) {
         expect(res.status).toBe(400);
-        expect(res.body.error.name).toBe('ApplicationError');
         expect(res.body.error.message).toBe('Can not create a workflow without stages');
       } else {
         expect(res.status).toBe(404);

--- a/packages/core/admin/ee/server/config/admin-actions.js
+++ b/packages/core/admin/ee/server/config/admin-actions.js
@@ -31,6 +31,14 @@ module.exports = {
   ],
   reviewWorkflows: [
     {
+      uid: 'review-workflows.create',
+      displayName: 'Create',
+      pluginName: 'admin',
+      section: 'settings',
+      category: 'review workflows',
+      subCategory: 'options',
+    },
+    {
       uid: 'review-workflows.read',
       displayName: 'Read',
       pluginName: 'admin',

--- a/packages/core/admin/ee/server/controllers/workflows/index.js
+++ b/packages/core/admin/ee/server/controllers/workflows/index.js
@@ -2,7 +2,26 @@
 
 const { getService } = require('../../utils');
 
+const { validateWorkflowCreate } = require('../../validation/review-workflows');
+
 module.exports = {
+  /**
+   * Create a new workflow
+   * @param {import('koa').BaseContext} ctx - koa context
+   */
+  async create(ctx) {
+    const { body } = ctx.request;
+    const { populate } = ctx.query;
+
+    const workflow = await validateWorkflowCreate(body);
+
+    const workflowService = getService('workflows');
+    const data = await workflowService.create({ data: workflow, populate });
+
+    ctx.body = {
+      data,
+    };
+  },
   /**
    * List all workflows
    * @param {import('koa').BaseContext} ctx - koa context

--- a/packages/core/admin/ee/server/routes/review-workflows.js
+++ b/packages/core/admin/ee/server/routes/review-workflows.js
@@ -7,6 +7,23 @@ module.exports = {
   routes: [
     // Review workflow
     {
+      method: 'POST',
+      path: '/review-workflows/workflows',
+      handler: 'workflows.create',
+      config: {
+        middlewares: [enableFeatureMiddleware('review-workflows')],
+        policies: [
+          'admin::isAuthenticatedAdmin',
+          {
+            name: 'admin::hasPermissions',
+            config: {
+              actions: ['admin::review-workflows.create'],
+            },
+          },
+        ],
+      },
+    },
+    {
       method: 'GET',
       path: '/review-workflows/workflows',
       handler: 'workflows.find',

--- a/packages/core/admin/ee/server/services/__tests__/review-workflows.test.js
+++ b/packages/core/admin/ee/server/services/__tests__/review-workflows.test.js
@@ -87,7 +87,6 @@ describe('Review workflows service', () => {
       expect(workflowsServiceMock.count).toBeCalled();
       expect(stagesServiceMock.count).toBeCalled();
 
-      expect(stagesServiceMock.createMany).toBeCalled();
       expect(workflowsServiceMock.create).toBeCalled();
     });
     test('With a workflow in DB', async () => {

--- a/packages/core/admin/ee/server/services/review-workflows/review-workflows.js
+++ b/packages/core/admin/ee/server/services/review-workflows/review-workflows.js
@@ -19,15 +19,12 @@ async function initDefaultWorkflow({ workflowsService, stagesService, strapi }) 
   // Check if there is nothing about review-workflow in DB
   // If any, the feature has already been initialized with a workflow and stages
   if (wfCount === 0 && stagesCount === 0) {
-    const stages = await stagesService.createMany(defaultStages, { fields: ['id'] });
     const workflow = {
       ...defaultWorkflow,
-      stages: {
-        connect: stages.map((stage) => stage.id),
-      },
+      stages: defaultStages,
     };
 
-    await workflowsService.create(workflow);
+    await workflowsService.create({ data: workflow });
     // If there is any manually activated RW on content-types, we want to migrate the related entities
     await enableReviewWorkflow({ strapi })({ contentTypes: strapi.contentTypes });
   }

--- a/packages/core/admin/ee/server/services/review-workflows/workflows.js
+++ b/packages/core/admin/ee/server/services/review-workflows/workflows.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { set } = require('lodash/fp');
-const { ApplicationError } = require('@strapi/utils').errors;
+const { ValidationError } = require('@strapi/utils').errors;
 const { WORKFLOW_MODEL_UID } = require('../../constants/workflows');
 const { getService } = require('../../utils');
 
@@ -16,7 +16,7 @@ module.exports = ({ strapi }) => ({
 
   async create(opts) {
     if (!opts.data.stages) {
-      throw new ApplicationError('Can not create a workflow without stages');
+      throw new ValidationError('Can not create a workflow without stages');
     }
 
     const stageIds = await getService('stages', { strapi })

--- a/packages/core/admin/ee/server/services/review-workflows/workflows.js
+++ b/packages/core/admin/ee/server/services/review-workflows/workflows.js
@@ -16,7 +16,7 @@ module.exports = ({ strapi }) => ({
 
   async create(opts) {
     if (!opts.data.stages) {
-      throw ApplicationError('Can not create a workflow without stages');
+      throw new ApplicationError('Can not create a workflow without stages');
     }
 
     const stageIds = await getService('stages', { strapi })

--- a/packages/core/admin/ee/server/services/review-workflows/workflows.js
+++ b/packages/core/admin/ee/server/services/review-workflows/workflows.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { set } = require('lodash/fp');
+const { ApplicationError } = require('@strapi/utils').errors;
 const { WORKFLOW_MODEL_UID } = require('../../constants/workflows');
 const { getService } = require('../../utils');
 
@@ -14,16 +15,15 @@ module.exports = ({ strapi }) => ({
   },
 
   async create(opts) {
-    let createOpts = opts;
-
-    // Create stages if provided
-    if (opts.data.stages) {
-      const stageIds = await getService('stages', { strapi })
-        .replaceStages([], opts.data.stages)
-        .then((stages) => stages.map((stage) => stage.id));
-
-      createOpts = set('data.stages', stageIds, opts);
+    if (!opts.data.stages) {
+      throw ApplicationError('Can not create a workflow without stages');
     }
+
+    const stageIds = await getService('stages', { strapi })
+      .replaceStages([], opts.data.stages)
+      .then((stages) => stages.map((stage) => stage.id));
+
+    const createOpts = set('data.stages', stageIds, opts);
 
     return strapi.entityService.create(WORKFLOW_MODEL_UID, createOpts);
   },

--- a/packages/core/admin/ee/server/validation/review-workflows.js
+++ b/packages/core/admin/ee/server/validation/review-workflows.js
@@ -23,7 +23,11 @@ const validateUpdateStageOnEntity = yup
 
 const validateWorkflowCreateSchema = yup.object().shape({
   name: yup.string().max(255).required(),
-  stages: yup.array().of(stageObject).min(1, 'Can not create a workflow without stages').required(),
+  stages: yup
+    .array()
+    .of(stageObject)
+    .min(1, 'Can not create a workflow without stages')
+    .required('Can not create a workflow without stages'),
 });
 
 const validateWorkflowUpdateSchema = yup.object().shape({

--- a/packages/core/admin/ee/server/validation/review-workflows.js
+++ b/packages/core/admin/ee/server/validation/review-workflows.js
@@ -23,7 +23,6 @@ const validateUpdateStageOnEntity = yup
 
 const validateWorkflowCreateSchema = yup.object().shape({
   name: yup.string().max(255).required(),
-  default: yup.boolean().default(false),
   stages: yup.array().of(stageObject),
 });
 

--- a/packages/core/admin/ee/server/validation/review-workflows.js
+++ b/packages/core/admin/ee/server/validation/review-workflows.js
@@ -21,7 +21,14 @@ const validateUpdateStageOnEntity = yup
   })
   .required();
 
+const validateWorkflowCreateSchema = yup.object().shape({
+  name: yup.string().max(255).required(),
+  default: yup.boolean().default(false),
+  stages: yup.array().of(stageObject),
+});
+
 module.exports = {
+  validateWorkflowCreate: validateYupSchema(validateWorkflowCreateSchema),
   validateUpdateStages: validateYupSchema(validateUpdateStagesSchema, {
     strict: false,
     stripUnknown: true,

--- a/packages/core/admin/ee/server/validation/review-workflows.js
+++ b/packages/core/admin/ee/server/validation/review-workflows.js
@@ -23,6 +23,11 @@ const validateUpdateStageOnEntity = yup
 
 const validateWorkflowCreateSchema = yup.object().shape({
   name: yup.string().max(255).required(),
+  stages: yup.array().of(stageObject).min(1, 'Can not create a workflow without stages').required(),
+});
+
+const validateWorkflowUpdateSchema = yup.object().shape({
+  name: yup.string().max(255),
   stages: yup.array().of(stageObject),
 });
 
@@ -33,4 +38,5 @@ module.exports = {
     stripUnknown: true,
   }),
   validateUpdateStageOnEntity: validateYupSchema(validateUpdateStageOnEntity),
+  validateWorkflowUpdate: validateYupSchema(validateWorkflowUpdateSchema),
 };


### PR DESCRIPTION
### What does it do?

Admin workflow create route, it also allows to create and populate stages.

POST `/admin/strapi-workflows/workflows?populate=stages` 

Example body:
```js
{
	name: "Workflow Name", 
	stages: [
		{ name: "Stage1", color: ... }
	]
}
```

Some comments:
- Workflows is now responsible of the lifecycles of stages. Meaning, the workflow service is the one responsible to create, update and delete stages (similar as how we deal components)
- replaceWorkflowStages should be deleted when this multiple workflows iteration is working.


### Why is it needed?

So we can create workflows.

