### PR TITLE
Make sure the admin user email is defined before trying to use it

### DIFF
--- a/packages/core/strapi/lib/services/metrics/admin-user-hash.js
+++ b/packages/core/strapi/lib/services/metrics/admin-user-hash.js
@@ -10,7 +10,7 @@ const crypto = require('crypto');
  */
 const generateAdminUserHash = (strapi) => {
   const ctx = strapi?.requestContext?.get();
-  if (!ctx?.state?.user) {
+  if (!ctx?.state?.user?.email) {
     return '';
   }
   return crypto.createHash('sha256').update(ctx.state.user.email).digest('hex');


### PR DESCRIPTION
### What does it do?

Ensure the admin user's email is defined when trying to create an anonymous hash from it (telemetry)

### Why is it needed?

If the email field has been manually disabled, it will cause the application to crash whenever it tries to create a hash

### How to test it?

- Disable the admin email attribute
- Try to authenticated requests to the admin API
- The server shouldn't crash

### Related issue(s)/PR(s)

fix #16699
