### PR TITLE
Reintroduce the environment property in the tracking system

### DIFF
--- a/packages/core/strapi/lib/Strapi.js
+++ b/packages/core/strapi/lib/Strapi.js
@@ -255,7 +255,7 @@ class Strapi {
         numberOfAllContentTypes: _.size(this.contentTypes), // TODO: V5: This event should be renamed numberOfContentTypes in V5 as the name is already taken to describe the number of content types using i18n.
         numberOfComponents: _.size(this.components),
         numberOfDynamicZones: getNumberOfDynamicZones(),
-        environment: strapi.config.environment
+        environment: strapi.config.environment,
         // TODO: to add back
         // providers: this.config.installedProviders,
       },

--- a/packages/core/strapi/lib/Strapi.js
+++ b/packages/core/strapi/lib/Strapi.js
@@ -255,6 +255,7 @@ class Strapi {
         numberOfAllContentTypes: _.size(this.contentTypes), // TODO: V5: This event should be renamed numberOfContentTypes in V5 as the name is already taken to describe the number of content types using i18n.
         numberOfComponents: _.size(this.components),
         numberOfDynamicZones: getNumberOfDynamicZones(),
+        environment: strapi.config.environment
         // TODO: to add back
         // providers: this.config.installedProviders,
       },


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Since v4.4 (or v4.5) the environment property in the tracking system is no more tracked.
With this pull request, I'm reintroducing it on the `didStartServer` event of the tracking system.

### Why is it needed?

Data per environment.

### How to test it?

- edit in `/packages/core/strapi/lib/services/metrics/sender.js` the `ANALYTICS_URI` constant with`'http://localhost`
- in another terminal run `npx http-echo-server 80`
- start the getstarted example or any example
- check the didStartServer event logged with the environment property matching the current environment

