### PR TITLE
ci(perf): use alpine docker based images for postgresql + no fsync (wip)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -128,7 +128,7 @@ jobs:
     services:
       postgres:
         # Docker Hub image
-        image: postgres
+        image: postgres:alpine
         # Provide the password for postgres
         env:
           POSTGRES_USER: strapi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -134,6 +134,7 @@ jobs:
           POSTGRES_USER: strapi
           POSTGRES_PASSWORD: strapi
           POSTGRES_DB: strapi_test
+          POSTGRES_INITDB_ARGS: '--locale-provider=icu --icu-locale=en'
         # Set health checks to wait until postgres has started
         options: >-
           --health-cmd pg_isready

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -134,7 +134,7 @@ jobs:
           POSTGRES_USER: strapi
           POSTGRES_PASSWORD: strapi
           POSTGRES_DB: strapi_test
-          POSTGRES_INITDB_ARGS: '--locale-provider=icu --icu-locale=en'
+          POSTGRES_INITDB_ARGS: '--locale-provider=icu --icu-locale=en --no-sync'
         # Set health checks to wait until postgres has started
         options: >-
           --health-cmd pg_isready

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -128,13 +128,12 @@ jobs:
     services:
       postgres:
         # Docker Hub image
-        image: postgres:alpine
-        # Provide the password for postgres
+        image: postgres:15.3-alpine3.18
         env:
           POSTGRES_USER: strapi
           POSTGRES_PASSWORD: strapi
           POSTGRES_DB: strapi_test
-          POSTGRES_INITDB_ARGS: '--locale-provider=icu --icu-locale=en --no-sync'
+          POSTGRES_INITDB_ARGS: '--locale-provider=icu --icu-locale=en-US --no-sync'
         # Set health checks to wait until postgres has started
         options: >-
           --health-cmd pg_isready


### PR DESCRIPTION
Exploration part of ci optimizations. To be measured... The goal is to run the pg ce suite in less than 30m. Is it possible only by doing this ? 

![image](https://github.com/strapi/strapi/assets/259798/1d7634bb-2b6a-431c-97ea-7f8d69d687e9)





Currently we're using postgresql latest bulleye. here a reference action https://github.com/strapi/strapi/actions/runs/4971467403


**Install inspact**: alpine shaves-off 150Mb (minor, probably few seconds)

![image](https://github.com/strapi/strapi/assets/259798/b6603e4c-5886-4da0-85ec-6e0286760e6c)

![image](https://github.com/strapi/strapi/assets/259798/f1f504c2-5e11-443b-8508-a9550abe7f8c)


**Run time impact**: Alpine should be a bit faster, but I expect that disabling fsync will help reducing the test suite runtime (a lot)

![image](https://github.com/strapi/strapi/assets/259798/ecb482bc-5eaa-41de-b374-aef22930588f)


![image](https://github.com/strapi/strapi/assets/259798/15ff67b7-bcaf-4a03-bfc1-ac171f39d440)


To be measured... 





