### PR TITLE
Fix: filter users based on `email` and `isActive`

### DIFF
--- a/packages/core/admin/server/domain/user.js
+++ b/packages/core/admin/server/domain/user.js
@@ -19,7 +19,7 @@ const hasSuperAdminRole = (user) => {
   return user.roles.filter((role) => role.code === SUPER_ADMIN_CODE).length > 0;
 };
 
-const ADMIN_USER_ALLOWED_FIELDS = ['id', 'firstname', 'lastname', 'username'];
+const ADMIN_USER_ALLOWED_FIELDS = ['id', 'firstname', 'lastname', 'username', 'email', 'isActive'];
 
 module.exports = {
   createUser,


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Enables filtering based on email & Active User in settings page on Admin panel.

### Why is it needed?

Email and active user filters are present on the Users page in the admin panel, but filtering did not work - it would return all of the records when either of the filters were used.

### How to test it?

1. In the Admin Pane go to Settings > Administration Panel > Users:
2. Verify that filtering works with the above filters.

### Related issue(s)/PR(s)

Fixes #16554 

### Screenshots
 *Filtering based on email:*
![Screenshot 2023-05-14 135350](https://github.com/strapi/strapi/assets/11196460/2b2c8249-190d-45bb-9c3b-3e7d061208ea)

*Filtering based on active user:*
![Screenshot 2023-05-14 140558](https://github.com/strapi/strapi/assets/11196460/a71c34e1-71c6-4152-bcfe-e3905b734784)


