### PR TITLE
Fix/Documentation: filter attributes by private condition

### DIFF
--- a/packages/plugins/documentation/server/services/helpers/build-component-schema.js
+++ b/packages/plugins/documentation/server/services/helpers/build-component-schema.js
@@ -52,6 +52,16 @@ const getAllSchemasForContentType = ({ routeInfo, attributes, uniqueName }) => {
     isLocalizedPath(route.path)
   ).length;
 
+    // Filter the attributes that were set as 'private' in the Admin Panel
+  const privateAttributes = Object.entries(attributes).reduce((acc, attribute) => {
+    const [attributeKey, attributeValue] = attribute;
+      if (attributeValue.private) {
+        acc.push(attributeKey);
+      }
+    return acc;
+  }, []);
+  const publicAttributes = _.omit(attributes, [...privateAttributes]);
+
   const attributesToOmit = [
     'createdAt',
     'updatedAt',
@@ -61,7 +71,7 @@ const getAllSchemasForContentType = ({ routeInfo, attributes, uniqueName }) => {
     'createdBy',
     'localizations',
   ];
-  const attributesForRequest = _.omit(attributes, attributesToOmit);
+  const attributesForRequest = _.omit(publicAttributes, attributesToOmit);
   // Get a list of required attribute names
   const requiredRequestAttributes = getRequiredAttributes(attributesForRequest);
   // Build the request schemas when the route has POST or PUT methods


### PR DESCRIPTION
### What does it do?

Implement a filter to prevent private attributes from being exposed on the documentation generation

### Why is it needed?

Since the attributes are private, I don't want to expose them in my documentation. This is specially required for the ones that consume the API and use the documentation generate to build their SDK's.

### How to test it?

1. Create a content with private fields
2. Generate the documentation
3. Check the swagger doc: The private attributes are not exposed
