### PR TITLE
Chore: Add eslint rule to forbid access to the strapi global

### DIFF
--- a/packages/core/admin/admin/src/pages/AuthPage/components/Register/index.js
+++ b/packages/core/admin/admin/src/pages/AuthPage/components/Register/index.js
@@ -62,7 +62,7 @@ const Register = ({ authType, fieldsToDisable, noSignin, onSubmit, schema }) => 
           const {
             data: { data },
           } = await axios.get(
-            `${strapi.backendURL}/admin/registration-info?registrationToken=${registrationToken}`
+            `${window.strapi.backendURL}/admin/registration-info?registrationToken=${registrationToken}`
           );
 
           if (data) {

--- a/packages/core/admin/admin/src/pages/AuthPage/index.js
+++ b/packages/core/admin/admin/src/pages/AuthPage/index.js
@@ -87,7 +87,7 @@ const AuthPage = ({ hasAdmin, setHasAdmin }) => {
     try {
       await axios({
         method: 'POST',
-        url: `${strapi.backendURL}${requestURL}`,
+        url: `${window.strapi.backendURL}${requestURL}`,
         data: body,
         cancelToken: source.token,
       });
@@ -110,7 +110,7 @@ const AuthPage = ({ hasAdmin, setHasAdmin }) => {
         },
       } = await axios({
         method: 'POST',
-        url: `${strapi.backendURL}${requestURL}`,
+        url: `${window.strapi.backendURL}${requestURL}`,
         data: omit(body, fieldsToOmit),
         cancelToken: source.token,
       });
@@ -158,7 +158,7 @@ const AuthPage = ({ hasAdmin, setHasAdmin }) => {
         },
       } = await axios({
         method: 'POST',
-        url: `${strapi.backendURL}${requestURL}`,
+        url: `${window.strapi.backendURL}${requestURL}`,
         data: omit(body, fieldsToOmit),
         cancelToken: source.token,
       });
@@ -214,7 +214,7 @@ const AuthPage = ({ hasAdmin, setHasAdmin }) => {
         },
       } = await axios({
         method: 'POST',
-        url: `${strapi.backendURL}${requestURL}`,
+        url: `${window.strapi.backendURL}${requestURL}`,
         data: { ...body, resetPasswordToken: query.get('code') },
         cancelToken: source.token,
       });

--- a/packages/core/admin/ee/admin/pages/AuthPage/components/Login/index.js
+++ b/packages/core/admin/ee/admin/pages/AuthPage/components/Login/index.js
@@ -13,7 +13,7 @@ const DividerFull = styled(Divider)`
 `;
 
 const Login = (loginProps) => {
-  const ssoEnabled = strapi.features.isEnabled(strapi.features.SSO);
+  const ssoEnabled = window.strapi.features.isEnabled(window.strapi.features.SSO);
   const { isLoading, data: providers } = useAuthProviders({ ssoEnabled });
   const { formatMessage } = useIntl();
 

--- a/packages/core/admin/ee/admin/pages/AuthPage/components/Providers/SSOProviders.js
+++ b/packages/core/admin/ee/admin/pages/AuthPage/components/Providers/SSOProviders.js
@@ -35,7 +35,7 @@ const SSOProvidersWrapper = styled(Flex)`
 const SSOProviderButton = ({ provider }) => {
   return (
     <Tooltip label={provider.displayName}>
-      <SSOButton href={`${strapi.backendURL}/admin/connect/${provider.uid}`}>
+      <SSOButton href={`${window.strapi.backendURL}/admin/connect/${provider.uid}`}>
         {provider.icon ? (
           <img src={provider.icon} aria-hidden alt="" height="32px" />
         ) : (

--- a/packages/core/admin/ee/admin/pages/AuthPage/components/Providers/index.js
+++ b/packages/core/admin/ee/admin/pages/AuthPage/components/Providers/index.js
@@ -17,7 +17,7 @@ const DividerFull = styled(Divider)`
 `;
 
 const Providers = () => {
-  const ssoEnabled = strapi.features.isEnabled(strapi.features.SSO);
+  const ssoEnabled = window.strapi.features.isEnabled(window.strapi.features.SSO);
 
   const { push } = useHistory();
   const { formatMessage } = useIntl();

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/Users/ListPage/ModalForm/utils/formDataModel.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/Users/ListPage/ModalForm/utils/formDataModel.js
@@ -1,6 +1,6 @@
 import baseModel from '../../../../../../../../../admin/src/pages/SettingsPage/pages/Users/ListPage/ModalForm/utils/formDataModel';
 
-const ssoInputsModel = strapi.features.isEnabled(strapi.features.SSO)
+const ssoInputsModel = window.strapi.features.isEnabled(window.strapi.features.SSO)
   ? {
       useSSORegistration: true,
     }

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/Users/ListPage/ModalForm/utils/roleSettingsForm.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/Users/ListPage/ModalForm/utils/roleSettingsForm.js
@@ -1,4 +1,4 @@
-const form = strapi.features.isEnabled(strapi.features.SSO)
+const form = window.strapi.features.isEnabled(window.strapi.features.SSO)
   ? [
       [
         {

--- a/packages/core/content-type-builder/admin/src/components/DataManagerProvider/utils/serverRestartWatcher.js
+++ b/packages/core/content-type-builder/admin/src/components/DataManagerProvider/utils/serverRestartWatcher.js
@@ -10,7 +10,7 @@ const SERVER_HAS_BEEN_KILLED_MESSAGE = 'server is down';
  */
 export default function serverRestartWatcher(response, didShutDownServer) {
   return new Promise((resolve) => {
-    fetch(`${strapi.backendURL}/_health`, {
+    fetch(`${window.strapi.backendURL}/_health`, {
       method: 'HEAD',
       mode: 'no-cors',
       headers: {

--- a/packages/plugins/documentation/admin/src/utils/openWithNewTab.js
+++ b/packages/plugins/documentation/admin/src/utils/openWithNewTab.js
@@ -1,14 +1,14 @@
 const openWithNewTab = (path) => {
   const url = (() => {
     if (path.startsWith('/')) {
-      return `${strapi.backendURL}${path}`;
+      return `${window.strapi.backendURL}${path}`;
     }
 
     if (path.startsWith('http')) {
       return path;
     }
 
-    return `${strapi.backendURL}/${path}`;
+    return `${window.strapi.backendURL}/${path}`;
   })();
 
   window.open(url, '_blank');

--- a/packages/plugins/users-permissions/admin/src/components/FormModal/Input/index.js
+++ b/packages/plugins/users-permissions/admin/src/components/FormModal/Input/index.js
@@ -23,7 +23,9 @@ const Input = ({
 }) => {
   const { formatMessage } = useIntl();
   const inputValue =
-    name === 'noName' ? `${strapi.backendURL}/api/connect/${providerToEditName}/callback` : value;
+    name === 'noName'
+      ? `${window.strapi.backendURL}/api/connect/${providerToEditName}/callback`
+      : value;
 
   const label = formatMessage(
     { id: intlLabel.id, defaultMessage: intlLabel.defaultMessage },

--- a/packages/plugins/users-permissions/admin/src/components/FormModal/Input/tests/index.test.js
+++ b/packages/plugins/users-permissions/admin/src/components/FormModal/Input/tests/index.test.js
@@ -184,7 +184,9 @@ describe('<Input />', () => {
   it('should set the value correctly when the input\'s name is "noName"', () => {
     const { getByLabelText } = render(makeApp('noName', 'text', 'test'));
 
-    expect(getByLabelText('noName').value).toBe(`${strapi.backendURL}/api/connect/email/callback`);
+    expect(getByLabelText('noName').value).toBe(
+      `${window.strapi.backendURL}/api/connect/email/callback`
+    );
   });
 
   it('should display the toggleCheckbox correctly', () => {

--- a/packages/utils/eslint-config-custom/front.js
+++ b/packages/utils/eslint-config-custom/front.js
@@ -76,5 +76,12 @@ module.exports = {
         ],
       },
     ],
+    'no-restricted-globals': [
+      'error',
+      {
+        name: 'strapi',
+        message: 'Use window.strapi instead.',
+      },
+    ],
   },
 };


### PR DESCRIPTION
### What does it do?

Adds a new eslint rule forbidding access to `strapi` as a global variable.

### Why is it needed?

Right now the codebase contains a mix of `strapi` and `window.strapi`. Since the strapi global is also used by the backend and will be faded out, it has some ambiguity. Once we make it clear we mean `window.strapi` it becomes easier to grep for it and remove any ambiguity about what this variable refers to (e.g. the BE main class, FE main class, a global variable within a module ...).

### How to test it?

Eslint will help you.

