### PR TITLE
Fix: E2e app generator should install dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "packages/*",
     "packages/*/*",
     "examples/*",
-    "test-apps/*",
+    "test-apps/!(playwright)/**",
     ".github/actions/*",
     "scripts/*"
   ],
@@ -50,7 +50,7 @@
     "test:e2e": "playwright test",
     "test:e2e:codegen": "playwright codegen",
     "test:e2e:debug": "yarn test:e2e:setup && PWDEBUG=1 playwright test",
-    "test:e2e:setup": "yarn test:generate-app --appPath test-apps/playwright --template=./e2e/app-template",
+    "test:e2e:setup": "yarn test:generate-app --appPath test-apps/playwright --template=./e2e/app-template --installDependencies",
     "test:front:all": "cross-env IS_EE=true nx run-many --target=test:front --nx-ignore-cycles",
     "test:front": "cross-env IS_EE=true jest --config jest.config.front.js",
     "test:front:watch": "cross-env IS_EE=true run test:front --watch",

--- a/packages/generators/app/src/create-project.ts
+++ b/packages/generators/app/src/create-project.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 import { join } from 'path';
-import { openSync } from 'node:fs';
 import fse from 'fs-extra';
 import chalk from 'chalk';
 import execa from 'execa';

--- a/test/helpers/test-app.js
+++ b/test/helpers/test-app.js
@@ -24,7 +24,7 @@ const cleanTestApp = (appPath) => {
  * @param {string} options.appPath - Name of the app that will be created (also the name of the folder)
  * @param {database} options.database - Arguments to create the testApp with the provided database params
  */
-const generateTestApp = async ({ appPath, database, template }) => {
+const generateTestApp = async ({ appPath, database, installDependencies = false, template }) => {
   const scope = {
     database,
     rootPath: path.resolve(appPath),
@@ -40,7 +40,7 @@ const generateTestApp = async ({ appPath, database, template }) => {
     deviceId: null,
     // use yarn if available and --use-npm isn't true
     useYarn: true,
-    installDependencies: false,
+    installDependencies,
     strapiDependencies: [
       '@strapi/strapi',
       '@strapi/plugin-users-permissions',

--- a/test/scripts/generate-test-app.js
+++ b/test/scripts/generate-test-app.js
@@ -39,7 +39,12 @@ const databases = {
 const main = async (database, appPath, opts) => {
   try {
     await cleanTestApp(appPath);
-    await generateTestApp({ appPath, database, template: opts.template });
+    await generateTestApp({
+      appPath,
+      database,
+      installDependencies: opts.installDependencies,
+      template: opts.template,
+    });
 
     if (opts.run) {
       await runTestApp(appPath);
@@ -63,6 +68,8 @@ yargs
 
       yarg.boolean('run');
 
+      yarg.boolean('installDependencies');
+
       yarg.positional('appPath', {
         type: 'string',
         default: 'test-apps/base',
@@ -74,10 +81,10 @@ yargs
       });
     },
     (argv) => {
-      const { databaseName, run, appPath = 'test-apps/base', template } = argv;
+      const { databaseName, installDependencies, run, appPath = 'test-apps/base', template } = argv;
 
       if (databaseName) {
-        return main(databases[databaseName], appPath, { run, template });
+        return main(databases[databaseName], appPath, { installDependencies, run, template });
       }
 
       return main(
@@ -93,7 +100,7 @@ yargs
           },
         },
         appPath,
-        { run, template }
+        { installDependencies, run, template }
       );
     }
   )


### PR DESCRIPTION
### What does it do?

WIP: Fixes the e2e test-app generation:

1. Pass down `installDependencies` to make sure we are installing the dependencies
2. Create an empty lockfile. Together with the workspace glob exclude this allows us installing dependencies in the monorepo
3. Separate install commands between yarn versions

### Why is it needed?

When fully implemented, this will allow us to create and install a full-fledged dynamic e2e test app.

https://github.com/strapi/strapi/pull/14807
