### PR TITLE
feat(rw): delete workflows

### DIFF
--- a/api-tests/core/admin/ee/review-workflows-content-types.test.api.js
+++ b/api-tests/core/admin/ee/review-workflows-content-types.test.api.js
@@ -50,6 +50,10 @@ describeOnCondition(edition === 'EE')('Review workflows', () => {
     });
   };
 
+  const deleteWorkflow = async (id) => {
+    return requests.admin.delete(`/admin/review-workflows/workflows/${id}`);
+  };
+
   const getWorkflow = async (id) => {
     const { body } = await requests.admin.get(`/admin/review-workflows/workflows/${id}?populate=*`);
     return body.data;
@@ -253,6 +257,25 @@ describeOnCondition(edition === 'EE')('Review workflows', () => {
     });
   });
 
+  describe('Delete workflow', () => {
+    let workflow;
+    test('Can delete workflow', async () => {
+      workflow = await createWorkflow({ contentTypes: [productUID] }).then((res) => res.body.data);
+
+      const res = await deleteWorkflow(workflow.id);
+      expect(res.status).toBe(200);
+    });
+
+    // Depends on the previous test
+    test('All entities have null stage', async () => {
+      const products = await findAll(productUID);
+
+      expect(products.results).toHaveLength(2);
+      for (const product of products.results) {
+        expect(product[ENTITY_STAGE_ATTRIBUTE]).toBeNull();
+      }
+    });
+  });
   describe('Creating an entity in a review workflow content type', () => {
     let workflow;
     test('when content type is assigned to workflow, new entries should be added to the first stage of the default workflow', async () => {

--- a/api-tests/core/admin/ee/review-workflows.test.api.js
+++ b/api-tests/core/admin/ee/review-workflows.test.api.js
@@ -174,7 +174,7 @@ describeOnCondition(edition === 'EE')('Review workflows', () => {
   });
 
   describe('Create workflow', () => {
-    test('You can not create a workflow without stages', async () => {
+    test('It should create a workflow without stages', async () => {
       const res = await requests.admin.post('/admin/review-workflows/workflows', {
         body: {
           name: 'testWorkflow',
@@ -190,7 +190,7 @@ describeOnCondition(edition === 'EE')('Review workflows', () => {
         expect(res.body.data).toBeUndefined();
       }
     });
-    test('You can create a workflow with stages', async () => {
+    test('It should create a workflow with stages', async () => {
       const res = await requests.admin.post('/admin/review-workflows/workflows?populate=stages', {
         body: {
           name: 'createdWorkflow',
@@ -214,7 +214,7 @@ describeOnCondition(edition === 'EE')('Review workflows', () => {
   });
 
   describe('Update workflow', () => {
-    test('You can update a workflow', async () => {
+    test('It should update a workflow', async () => {
       const res = await requests.admin.put(
         `/admin/review-workflows/workflows/${createdWorkflow.id}`,
         { body: { name: 'updatedWorkflow' } }
@@ -229,7 +229,7 @@ describeOnCondition(edition === 'EE')('Review workflows', () => {
       }
     });
 
-    test('You can update a workflow with stages', async () => {
+    test('It should update a workflow with stages', async () => {
       const res = await requests.admin.put(
         `/admin/review-workflows/workflows/${createdWorkflow.id}?populate=stages`,
         {
@@ -256,6 +256,27 @@ describeOnCondition(edition === 'EE')('Review workflows', () => {
         expect(res.status).toBe(404);
         expect(res.body.data).toBeUndefined();
       }
+    });
+  });
+
+  describe('Delete workflow', () => {
+    test('It should delete a workflow', async () => {
+      const createdRes = await requests.admin.post('/admin/review-workflows/workflows', {
+        body: { name: 'testWorkflow', stages: [{ name: 'Stage 1' }] },
+      });
+
+      const res = await requests.admin.delete(
+        `/admin/review-workflows/workflows/${createdRes.body.data.id}`
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.body.data).toMatchObject({ name: 'testWorkflow' });
+    });
+    test("It shouldn't delete a workflow that does not exist", async () => {
+      const res = await requests.admin.delete(`/admin/review-workflows/workflows/123456789`);
+
+      expect(res.status).toBe(404);
+      expect(res.body.data).toBeNull();
     });
   });
 

--- a/packages/core/admin/ee/server/config/admin-actions.js
+++ b/packages/core/admin/ee/server/config/admin-actions.js
@@ -47,6 +47,14 @@ module.exports = {
       subCategory: 'options',
     },
     {
+      uid: 'review-workflows.delete',
+      displayName: 'Delete',
+      pluginName: 'admin',
+      section: 'settings',
+      category: 'review workflows',
+      subCategory: 'options',
+    },
+    {
       uid: 'review-workflows.read',
       displayName: 'Read',
       pluginName: 'admin',

--- a/packages/core/admin/ee/server/controllers/workflows/index.js
+++ b/packages/core/admin/ee/server/controllers/workflows/index.js
@@ -51,6 +51,27 @@ module.exports = {
   },
 
   /**
+   * Delete a workflow
+   * @param {import('koa').BaseContext} ctx - koa context
+   */
+  async delete(ctx) {
+    const { id } = ctx.params;
+    const { populate } = ctx.query;
+    const workflowService = getService('workflows');
+
+    const workflow = await workflowService.findById(id, { populate: ['stages'] });
+    if (!workflow) {
+      return ctx.notFound("Workflow doesn't exist");
+    }
+
+    const data = await workflowService.delete(workflow, { populate });
+
+    ctx.body = {
+      data,
+    };
+  },
+
+  /**
    * List all workflows
    * @param {import('koa').BaseContext} ctx - koa context
    */

--- a/packages/core/admin/ee/server/routes/review-workflows.js
+++ b/packages/core/admin/ee/server/routes/review-workflows.js
@@ -41,6 +41,23 @@ module.exports = {
       },
     },
     {
+      method: 'DELETE',
+      path: '/review-workflows/workflows/:id',
+      handler: 'workflows.delete',
+      config: {
+        middlewares: [enableFeatureMiddleware('review-workflows')],
+        policies: [
+          'admin::isAuthenticatedAdmin',
+          {
+            name: 'admin::hasPermissions',
+            config: {
+              actions: ['admin::review-workflows.delete'],
+            },
+          },
+        ],
+      },
+    },
+    {
       method: 'GET',
       path: '/review-workflows/workflows',
       handler: 'workflows.find',

--- a/packages/core/admin/ee/server/services/review-workflows/stages.js
+++ b/packages/core/admin/ee/server/services/review-workflows/stages.js
@@ -60,6 +60,12 @@ module.exports = ({ strapi }) => {
       return stage;
     },
 
+    async deleteMany(stagesId) {
+      return strapi.entityService.deleteMany(STAGE_MODEL_UID, {
+        filters: { id: { $in: stagesId } },
+      });
+    },
+
     count() {
       return strapi.entityService.count(STAGE_MODEL_UID);
     },

--- a/packages/core/admin/ee/server/services/review-workflows/workflows/index.js
+++ b/packages/core/admin/ee/server/services/review-workflows/workflows/index.js
@@ -123,6 +123,30 @@ module.exports = ({ strapi }) => {
     },
 
     /**
+     * Deletes an existing workflow.
+     * Also deletes all the workflow stages and migrate all assigned the content types.
+     * @param {*} workflow
+     * @param {*} opts
+     * @returns
+     */
+    async delete(workflow, opts) {
+      const stageService = getService('stages', { strapi });
+
+      return strapi.db.transaction(async () => {
+        // Delete stages
+        await stageService.deleteMany(workflow.stages.map((stage) => stage.id));
+
+        // Unassign all content types, this will migrate the content types to null
+        await workflowsContentTypes.migrate({
+          srcContentTypes: workflow.contentTypes,
+          destContentTypes: [],
+        });
+
+        // Delete Workflow
+        return strapi.entityService.delete(WORKFLOW_MODEL_UID, workflow.id, opts);
+      });
+    },
+    /**
      * Returns the total count of workflows.
      * @returns {Promise<number>} - Total count of workflows.
      */

--- a/packages/core/admin/ee/server/services/review-workflows/workflows/index.js
+++ b/packages/core/admin/ee/server/services/review-workflows/workflows/index.js
@@ -132,6 +132,12 @@ module.exports = ({ strapi }) => {
     async delete(workflow, opts) {
       const stageService = getService('stages', { strapi });
 
+      const workflowCount = await this.count();
+
+      if (workflowCount <= 1) {
+        throw new ApplicationError('Can not delete the last workflow');
+      }
+
       return strapi.db.transaction(async () => {
         // Delete stages
         await stageService.deleteMany(workflow.stages.map((stage) => stage.id));


### PR DESCRIPTION
### What does it do?

- Adds admin route to delete workflows
DELETE `/admin/review-workflows/workflows/:id`
- Migrates all entities stages (to null) that were assigned to that workflow.
- Prevents deleting the last workflow

