### PR TITLE
chore: remove react-fast-compare

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/CollectionTypeFormWrapper/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/CollectionTypeFormWrapper/index.js
@@ -15,7 +15,7 @@ import {
 } from '@strapi/helper-plugin';
 import { useSelector, useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
-import isEqual from 'react-fast-compare';
+import isEqual from 'lodash/isEqual';
 import {
   createDefaultForm,
   getTrad,

--- a/packages/core/admin/admin/src/content-manager/components/DynamicZone/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/DynamicZone/index.js
@@ -1,6 +1,6 @@
 import React, { memo, useMemo, useState } from 'react';
 import get from 'lodash/get';
-import isEqual from 'react-fast-compare';
+import isEqual from 'lodash/isEqual';
 import PropTypes from 'prop-types';
 import { Box, Flex, VisuallyHidden } from '@strapi/design-system';
 import { NotAllowedInput, useNotification } from '@strapi/helper-plugin';

--- a/packages/core/admin/admin/src/content-manager/components/FieldComponent/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/FieldComponent/index.js
@@ -2,7 +2,7 @@
 import React, { memo, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import size from 'lodash/size';
-import isEqual from 'react-fast-compare';
+import isEqual from 'lodash/isEqual';
 import { useIntl } from 'react-intl';
 
 import { NotAllowedInput } from '@strapi/helper-plugin';

--- a/packages/core/admin/admin/src/content-manager/components/Inputs/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/Inputs/index.js
@@ -4,7 +4,7 @@ import { useIntl } from 'react-intl';
 import get from 'lodash/get';
 import omit from 'lodash/omit';
 import take from 'lodash/take';
-import isEqual from 'react-fast-compare';
+import isEqual from 'lodash/isEqual';
 import { GenericInput, NotAllowedInput, useLibrary } from '@strapi/helper-plugin';
 import { useContentTypeLayout } from '../../hooks';
 import { getFieldName } from '../../utils';

--- a/packages/core/admin/admin/src/content-manager/pages/EditView/DeleteLink/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/EditView/DeleteLink/index.js
@@ -1,6 +1,6 @@
 import React, { memo, useState } from 'react';
 import { useIntl } from 'react-intl';
-import isEqual from 'react-fast-compare';
+import isEqual from 'lodash/isEqual';
 import { Button } from '@strapi/design-system';
 import { Trash } from '@strapi/icons';
 import { ConfirmDialog, useNotification, useAPIErrorHandler } from '@strapi/helper-plugin';

--- a/packages/core/admin/admin/src/content-manager/pages/EditView/Header/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/EditView/Header/index.js
@@ -2,7 +2,7 @@ import React, { memo, useState } from 'react';
 import { useIntl } from 'react-intl';
 import { useHistory } from 'react-router-dom';
 import PropTypes from 'prop-types';
-import isEqualFastCompare from 'react-fast-compare';
+import isEqualFastCompare from 'lodash/isEqual';
 import get from 'lodash/get';
 import isEqual from 'lodash/isEqual';
 import isEmpty from 'lodash/isEmpty';

--- a/packages/core/admin/admin/src/content-manager/pages/EditViewLayoutManager/Permissions.js
+++ b/packages/core/admin/admin/src/content-manager/pages/EditViewLayoutManager/Permissions.js
@@ -1,7 +1,7 @@
 import React, { memo, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { useRBAC, LoadingIndicatorPage } from '@strapi/helper-plugin';
-import isEqual from 'react-fast-compare';
+import isEqual from 'lodash/isEqual';
 import EditView from '../EditView';
 import { generatePermissionsObject } from '../../utils';
 

--- a/packages/core/admin/admin/src/content-manager/pages/ListView/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/ListView/index.js
@@ -2,7 +2,7 @@ import React, { memo, useCallback, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { connect } from 'react-redux';
-import isEqual from 'react-fast-compare';
+import isEqual from 'lodash/isEqual';
 import { bindActionCreators, compose } from 'redux';
 import { useIntl } from 'react-intl';
 import { useHistory, useLocation, Link as ReactRouterLink } from 'react-router-dom';

--- a/packages/core/admin/package.json
+++ b/packages/core/admin/package.json
@@ -115,7 +115,6 @@
     "react-dnd-html5-backend": "15.1.3",
     "react-dom": "^17.0.2",
     "react-error-boundary": "3.1.4",
-    "react-fast-compare": "^3.2.0",
     "react-helmet": "^6.1.0",
     "react-intl": "6.4.1",
     "react-is": "^17.0.2",

--- a/packages/core/admin/webpack.alias.js
+++ b/packages/core/admin/webpack.alias.js
@@ -19,7 +19,6 @@ const aliasExactMatch = [
   'react-dnd-html5-backend',
   'react-dom',
   'react-error-boundary',
-  'react-fast-compare',
   'react-helmet',
   'react-is',
   'react-intl',

--- a/yarn.lock
+++ b/yarn.lock
@@ -7795,7 +7795,6 @@ __metadata:
     react-dnd-html5-backend: 15.1.3
     react-dom: ^17.0.2
     react-error-boundary: 3.1.4
-    react-fast-compare: ^3.2.0
     react-helmet: ^6.1.0
     react-intl: 6.4.1
     react-is: ^17.0.2
@@ -27823,7 +27822,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-fast-compare@npm:^3.1.1, react-fast-compare@npm:^3.2.0":
+"react-fast-compare@npm:^3.1.1":
   version: 3.2.0
   resolution: "react-fast-compare@npm:3.2.0"
   checksum: 8ef272c825ae329f61633ce4ce7f15aa5b84e5214d88bc0823880236e03e985a13195befa2c7a4eda7db3b017dc7985729152d88445823f652403cf36c2b86aa


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* removes react-fast-compare and replace with `lodash/isEqual`

### Why is it needed?

* reduce dependencies footprint inline with the v5 initiatives
