### PR TITLE
Settings: Render actual workflow name in list-view

### DIFF
--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/ListView/ListView.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/ListView/ListView.js
@@ -113,10 +113,7 @@ export function ReviewWorkflowsListView() {
                 >
                   <Td width={pxToRem(250)}>
                     <Typography textColor="neutral800" fontWeight="bold" ellipsis>
-                      {formatMessage({
-                        id: 'Settings.review-workflows.list.page.list.column.name.defaultName',
-                        defaultMessage: 'Default workflow',
-                      })}
+                      {workflow.name}
                     </Typography>
                   </Td>
                   <Td>
@@ -131,7 +128,7 @@ export function ReviewWorkflowsListView() {
                             id: 'Settings.review-workflows.list.page.list.column.actions.edit.label',
                             defaultMessage: 'Edit {name}',
                           },
-                          { name: 'Default workflow' }
+                          { name: workflow.name }
                         )}
                       >
                         <Pencil />


### PR DESCRIPTION
### What does it do?

Replaces a static workflow name placeholder with an actual value.

### Why is it needed?

Now all workflows have a name and the migration for the default workflow is in place.
