### PR TITLE
Settings: Use nested multiple select for content-types

### DIFF
--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/WorkflowAttributes/WorkflowAttributes.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/WorkflowAttributes/WorkflowAttributes.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { useField } from 'formik';
 import { useIntl } from 'react-intl';
 import { useDispatch } from 'react-redux';
-import { Grid, GridItem, MultiSelect, MultiSelectOption, TextInput } from '@strapi/design-system';
+import { Grid, GridItem, MultiSelectNested, TextInput } from '@strapi/design-system';
 
 import { updateWorkflow } from '../../actions';
 
@@ -33,12 +33,12 @@ export function WorkflowAttributes({ contentTypes: { collectionTypes, singleType
       </GridItem>
 
       <GridItem col={6}>
-        <MultiSelect
+        <MultiSelectNested
           {...contentTypesField}
           customizeContent={() =>
             formatMessage(
               {
-                id: 'Settings.review-workflows.workflow.mappedContentTypes.displayValue',
+                id: 'Settings.review-workflows.workflow.contentTypes.displayValue',
                 defaultMessage:
                   '{count} {count, plural, one {content type} other {content types}} selected',
               },
@@ -48,21 +48,42 @@ export function WorkflowAttributes({ contentTypes: { collectionTypes, singleType
           error={contentTypesMeta.error ?? false}
           id={contentTypesField.name}
           label={formatMessage({
-            id: 'Settings.review-workflows.workflow.mappedContentTypes.label',
+            id: 'Settings.review-workflows.workflow.contentTypes.label',
             defaultMessage: 'Associated to',
           })}
           onChange={(values) => {
-            dispatch(updateWorkflow({ mappedContentTypes: values }));
+            dispatch(updateWorkflow({ contentTypes: values }));
             contentTypesField.onChange({ target: { value: values } });
           }}
+          options={[
+            {
+              label: formatMessage({
+                id: 'Settings.review-workflows.workflow.contentTypes.collectionTypes.label',
+                defaultMessage: 'Collection Types',
+              }),
+              children: collectionTypes.map((contentType) => ({
+                label: contentType.info.displayName,
+                value: contentType.uid,
+              })),
+            },
+
+            {
+              label: formatMessage({
+                id: 'Settings.review-workflows.workflow.contentTypes.singleTypes.label',
+                defaultMessage: 'Single Types',
+              }),
+              children: singleTypes.map((contentType) => ({
+                label: contentType.info.displayName,
+                value: contentType.uid,
+              })),
+            },
+          ]}
+          placeholder={formatMessage({
+            id: 'Settings.review-workflows.workflow.contentTypes.placeholder',
+            defaultMessage: 'Select',
+          })}
           required
-        >
-          {[...collectionTypes, ...singleTypes].map((contentType) => (
-            <MultiSelectOption key={contentType.uid} value={contentType.uid}>
-              {contentType.info.displayName}
-            </MultiSelectOption>
-          ))}
-        </MultiSelect>
+        />
       </GridItem>
     </Grid>
   );

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/WorkflowAttributes/WorkflowAttributes.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/WorkflowAttributes/WorkflowAttributes.js
@@ -35,14 +35,14 @@ export function WorkflowAttributes({ contentTypes: { collectionTypes, singleType
       <GridItem col={6}>
         <MultiSelectNested
           {...contentTypesField}
-          customizeContent={() =>
+          customizeContent={(value) =>
             formatMessage(
               {
                 id: 'Settings.review-workflows.workflow.contentTypes.displayValue',
                 defaultMessage:
                   '{count} {count, plural, one {content type} other {content types}} selected',
               },
-              { count: contentTypesField.value.length }
+              { count: value.length }
             )
           }
           error={contentTypesMeta.error ?? false}

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/EditView/EditView.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/EditView/EditView.js
@@ -52,11 +52,11 @@ export function ReviewWorkflowsEditView() {
   const [isConfirmDeleteDialogOpen, setIsConfirmDeleteDialogOpen] = React.useState(false);
 
   const { mutateAsync, isLoading } = useMutation(
-    async ({ workflowId, stages }) => {
+    async ({ workflow }) => {
       const {
         data: { data },
-      } = await put(`/admin/review-workflows/workflows/${workflowId}`, {
-        data: stages,
+      } = await put(`/admin/review-workflows/workflows/${workflow.id}`, {
+        data: workflow,
       });
 
       return data;
@@ -71,9 +71,9 @@ export function ReviewWorkflowsEditView() {
     }
   );
 
-  const updateWorkflowStages = async (workflowId, stages) => {
+  const updateWorkflow = async (workflow) => {
     try {
-      const res = await mutateAsync({ workflowId, stages });
+      const res = await mutateAsync({ workflow });
 
       return res;
     } catch (error) {
@@ -87,7 +87,7 @@ export function ReviewWorkflowsEditView() {
   };
 
   const submitForm = async () => {
-    await updateWorkflowStages(currentWorkflow.id, currentWorkflow.stages);
+    await updateWorkflow(currentWorkflow);
     await refetchWorkflow();
 
     setIsConfirmDeleteDialogOpen(false);


### PR DESCRIPTION
### What does it do?

- Uses a nested multi select instead of a multi select for content-types
- Fixes PUT requests when editing a content type (send whole CT instead of ID and stages only)

