### PR TITLE
fix: Media library folders and files can get unintentionally deleted

### DIFF
--- a/api-tests/core/upload/admin/folder-file.test.api.js
+++ b/api-tests/core/upload/admin/folder-file.test.api.js
@@ -20,6 +20,7 @@ const createFolder = async (name, parent = null) => {
     url: '/upload/folders',
     body: { name, parent },
   });
+  console.log('createFolder', res.body.data);
   return res.body.data;
 };
 
@@ -233,12 +234,15 @@ describe('Bulk actions for folders & files', () => {
       // Create folders
       const folder1 = await createFolder('folderToDelete', null);
       await Promise.all(
-        Array.from({ length: 20 }).map((_, i) => createFolder(`folder-${i}`, null))
+        Array.from({ length: 20 }).map((_, i) => createFolder(`folderToKeep-${i}`, null))
       );
 
       // Delete folder1
-      await rq.post('/upload/actions/bulk-delete', { body: { folderIds: [folder1.id] } });
+      const res = await rq.post('/upload/actions/bulk-delete', {
+        body: { folderIds: [folder1.id] },
+      });
 
+      console.log('deleteFolders', JSON.stringify(res.body, null, 2));
       const folderIds = await rq
         .get('/upload/folders')
         .then((res) => res.body.data.map((f) => f.id));

--- a/api-tests/core/upload/admin/folder-file.test.api.js
+++ b/api-tests/core/upload/admin/folder-file.test.api.js
@@ -15,19 +15,11 @@ const data = {
 };
 
 const createFolder = async (name, parent = null) => {
-  const log = name.startsWith('folderToKeep');
-  if (log) {
-    console.log('=====================');
-    console.log('createFolderBefore', name, parent);
-  }
   const res = await rq({
     method: 'POST',
     url: '/upload/folders',
     body: { name, parent },
   });
-  if (log) {
-    console.log('createFolder', res.body.data);
-  }
   return res.body.data;
 };
 
@@ -240,18 +232,14 @@ describe('Bulk actions for folders & files', () => {
 
       // Create folders
       const folder1 = await createFolder('folderToDelete', null);
-      // await Promise.all(
-      //   Array.from({ length: 20 }).map((_, i) => createFolder(`folderToKeep-${i}`, null))
-      // );
       for (let i = 0; i < 20; i++) {
         await createFolder(`folderToKeep-${i}`, null);
       }
       // Delete folder1
-      const res = await rq.post('/upload/actions/bulk-delete', {
+      await rq.post('/upload/actions/bulk-delete', {
         body: { folderIds: [folder1.id] },
       });
 
-      console.log('deleteFolders', JSON.stringify(res.body, null, 2));
       const folderIds = await rq
         .get('/upload/folders')
         .then((res) => res.body.data.map((f) => f.id));

--- a/api-tests/core/upload/admin/folder-file.test.api.js
+++ b/api-tests/core/upload/admin/folder-file.test.api.js
@@ -239,13 +239,13 @@ describe('Bulk actions for folders & files', () => {
       // Delete folder1
       await rq.post('/upload/actions/bulk-delete', { body: { folderIds: [folder1.id] } });
 
-      const afterFolderIds = await rq
+      const folderIds = await rq
         .get('/upload/folders')
         .then((res) => res.body.data.map((f) => f.id));
 
       // Should include all folders except the one we deleted
-      expect(afterFolderIds.length).toBe(20);
-      expect(afterFolderIds).toEqual(expect.not.arrayContaining([folder1.id]));
+      expect(folderIds.length).toBe(20);
+      expect(folderIds).toEqual(expect.not.arrayContaining([folder1.id]));
     });
   });
 

--- a/api-tests/core/upload/admin/folder-file.test.api.js
+++ b/api-tests/core/upload/admin/folder-file.test.api.js
@@ -15,12 +15,19 @@ const data = {
 };
 
 const createFolder = async (name, parent = null) => {
+  const log = name.startsWith('folderToKeep');
+  if (log) {
+    console.log('=====================');
+    console.log('createFolderBefore', name, parent);
+  }
   const res = await rq({
     method: 'POST',
     url: '/upload/folders',
     body: { name, parent },
   });
-  console.log('createFolder', res.body.data);
+  if (log) {
+    console.log('createFolder', res.body.data);
+  }
   return res.body.data;
 };
 
@@ -233,10 +240,12 @@ describe('Bulk actions for folders & files', () => {
 
       // Create folders
       const folder1 = await createFolder('folderToDelete', null);
-      await Promise.all(
-        Array.from({ length: 20 }).map((_, i) => createFolder(`folderToKeep-${i}`, null))
-      );
-
+      // await Promise.all(
+      //   Array.from({ length: 20 }).map((_, i) => createFolder(`folderToKeep-${i}`, null))
+      // );
+      for (let i = 0; i < 20; i++) {
+        await createFolder(`folderToKeep-${i}`, null);
+      }
       // Delete folder1
       const res = await rq.post('/upload/actions/bulk-delete', {
         body: { folderIds: [folder1.id] },

--- a/api-tests/core/upload/admin/folder-file.test.api.js
+++ b/api-tests/core/upload/admin/folder-file.test.api.js
@@ -221,7 +221,7 @@ describe('Bulk actions for folders & files', () => {
       expect(existingfoldersIds).toEqual(expect.not.arrayContaining([folder.id]));
     });
 
-    test('Can delete folders without deleting others with similar name', async () => {
+    test('Can delete folders without deleting others with similar path', async () => {
       // Ensure the folder algo does not only delete by folders that start with the same path (startswith /1 matches /10 too)
 
       // Delete all previous folders, so first file path is /1

--- a/api-tests/core/upload/admin/folder-file.test.api.js
+++ b/api-tests/core/upload/admin/folder-file.test.api.js
@@ -232,8 +232,8 @@ describe('Bulk actions for folders & files', () => {
 
       // Create folders
       const folder1 = await createFolder('folderToDelete', null);
-      data.folders = await Promise.all(
-        Array.from({ length: 20 }).map((_, i) => createFolder(`${i}`, null))
+      await Promise.all(
+        Array.from({ length: 20 }).map((_, i) => createFolder(`folder-${i}`, null))
       );
 
       // Delete folder1

--- a/api-tests/core/upload/admin/folder-file.test.api.js
+++ b/api-tests/core/upload/admin/folder-file.test.api.js
@@ -220,6 +220,33 @@ describe('Bulk actions for folders & files', () => {
       const existingfoldersIds = resFolder.body.data.map((f) => f.id);
       expect(existingfoldersIds).toEqual(expect.not.arrayContaining([folder.id]));
     });
+
+    test('Can delete folders without deleting others with similar name', async () => {
+      // Ensure the folder algo does not only delete by folders that start with the same path (startswith /1 matches /10 too)
+
+      // Delete all previous folders, so first file path is /1
+      await rq
+        .get('/upload/folders')
+        .then((res) => res.body.data.map((f) => f.id))
+        .then((folderIds) => rq.post('/upload/actions/bulk-delete', { body: { folderIds } }));
+
+      // Create folders
+      const folder1 = await createFolder('folderToDelete', null);
+      data.folders = await Promise.all(
+        Array.from({ length: 20 }).map((_, i) => createFolder(`${i}`, null))
+      );
+
+      // Delete folder1
+      await rq.post('/upload/actions/bulk-delete', { body: { folderIds: [folder1.id] } });
+
+      const afterFolderIds = await rq
+        .get('/upload/folders')
+        .then((res) => res.body.data.map((f) => f.id));
+
+      // Should include all folders except the one we deleted
+      expect(afterFolderIds.length).toBe(20);
+      expect(afterFolderIds).toEqual(expect.not.arrayContaining([folder1.id]));
+    });
   });
 
   describe('move', () => {

--- a/packages/core/upload/server/services/folder.js
+++ b/packages/core/upload/server/services/folder.js
@@ -56,16 +56,22 @@ const deleteByIds = async (ids = []) => {
   // delete files
   const filesToDelete = await strapi.db.query(FILE_MODEL_UID).findMany({
     where: {
-      $or: pathsToDelete.map((path) => ({ folderPath: { $startsWith: path } })),
+      $or: pathsToDelete.flatMap((path) => [
+        { folderPath: { $eq: path } },
+        { folderPath: { $startsWith: `${path}/` } },
+      ]),
     },
   });
 
   await Promise.all(filesToDelete.map((file) => getService('upload').remove(file)));
 
-  // delete folders
+  // delete folders and subfolders
   const { count: totalFolderNumber } = await strapi.db.query(FOLDER_MODEL_UID).deleteMany({
     where: {
-      $or: pathsToDelete.map((path) => ({ path: { $startsWith: path } })),
+      $or: pathsToDelete.flatMap((path) => [
+        { path: { $eq: path } },
+        { path: { $startsWith: `${path}/` } },
+      ]),
     },
   });
 


### PR DESCRIPTION
### What does it do?
Delete folder logic was doing something like:

```js
 await strapi.db.query(FILE_MODEL_UID).findMany({
    where: { folderPath: { $startsWith: path } },
  });
```

And we were missing an edge case. In a list of folder paths like:
```
/1
/2
/3
/10
```

If you want to delete `/1`, and you match by doing `{ $startsWith: "/1" }`, you would get `/1` but also `/10`.

This PR improves the query to prevent this behaviour.


### Related issue(s)/PR(s)

Fixes https://github.com/strapi/strapi/issues/16734
