### PR TITLE
CM: Load workflow mapped to the current content-type

### DIFF
--- a/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/InformationBoxEE.js
+++ b/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/InformationBoxEE.js
@@ -38,10 +38,13 @@ export function InformationBoxEE() {
   const { formatAPIError } = useAPIErrorHandler();
   const toggleNotification = useNotification();
 
-  const { workflows: { data: workflows, isLoading: workflowIsLoading } = {} } =
-    useReviewWorkflows();
-  // TODO: this works only as long as we support one workflow
-  const workflow = workflows?.[0] ?? null;
+  const { workflows: { data: workflows, isLoading: isWorkflowLoading } = {} } = useReviewWorkflows(
+    undefined,
+    { filters: { contentTypes: uid } }
+  );
+
+  // Filtering will still return an array, which should contain only one workflow
+  const [workflow] = workflows ?? [];
 
   const { error, isLoading, mutateAsync } = useMutation(
     async ({ entityId, stageId, uid }) => {
@@ -72,21 +75,7 @@ export function InformationBoxEE() {
     }
   );
 
-  // if entities are created e.g. through lifecycle methods
-  // they may not have a stage assigned. Updating the entity won't
-  // set the default stage either which may lead to entities that
-  // do not have a stage assigned for a while. By displaying an
-  // error by default we are trying to nudge users into assigning a stage.
-  const initialStageNullError =
-    activeWorkflowStage === null &&
-    !workflowIsLoading &&
-    !isCreatingEntry &&
-    formatMessage({
-      id: 'content-manager.reviewWorkflows.stage.select.placeholder',
-      defaultMessage: 'Select a stage',
-    });
-  const formattedMutationError = error && formatAPIError(error);
-  const formattedError = formattedMutationError || initialStageNullError || null;
+  const formattedError = (error && formatAPIError(error)) || null;
 
   const handleStageChange = async ({ value: stageId }) => {
     try {
@@ -123,7 +112,7 @@ export function InformationBoxEE() {
               }}
               error={formattedError}
               inputId={ATTRIBUTE_NAME}
-              isLoading={isLoading}
+              isLoading={isWorkflowLoading || isLoading}
               isSearchable={false}
               isClearable={false}
               name={ATTRIBUTE_NAME}

--- a/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/tests/InformationBoxEE.test.js
+++ b/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/tests/InformationBoxEE.test.js
@@ -8,6 +8,7 @@ import { Provider } from 'react-redux';
 import { createStore } from 'redux';
 
 import { InformationBoxEE } from '../InformationBoxEE';
+import { useReviewWorkflows } from '../../../../../pages/SettingsPage/pages/ReviewWorkflows/hooks/useReviewWorkflows';
 
 const STAGE_ATTRIBUTE_NAME = 'strapi_reviewWorkflows_stage';
 const STAGE_FIXTURE = {
@@ -94,6 +95,18 @@ describe('EE | Content Manager | EditView | InformationBox', () => {
     expect(getByText('Last update')).toBeInTheDocument();
   });
 
+  it('filters workflows based on the model uid', () => {
+    useCMEditViewDataManager.mockReturnValue({
+      initialData: {},
+      isCreatingEntry: true,
+      layout: { uid: 'api::articles:articles' },
+    });
+
+    expect(useReviewWorkflows).toHaveBeenCalledWith(undefined, {
+      filters: { contentTypes: 'api::articles:articles' },
+    });
+  });
+
   it('renders no select input, if no workflow stage is assigned to the entity', () => {
     useCMEditViewDataManager.mockReturnValue({
       initialData: {},
@@ -105,21 +118,7 @@ describe('EE | Content Manager | EditView | InformationBox', () => {
     expect(queryByRole('combobox')).not.toBeInTheDocument();
   });
 
-  it('renders an error, if no workflow stage is assigned to the entity', () => {
-    useCMEditViewDataManager.mockReturnValue({
-      initialData: {
-        [STAGE_ATTRIBUTE_NAME]: null,
-      },
-      layout: { uid: 'api::articles:articles' },
-    });
-
-    const { getByText, queryByRole } = setup();
-
-    expect(getByText(/select a stage/i)).toBeInTheDocument();
-    expect(queryByRole('combobox')).toBeInTheDocument();
-  });
-
-  it('does not render the select input, if the entity is created', () => {
+  it('does not render the select input, if the entity is being created', () => {
     useCMEditViewDataManager.mockReturnValue({
       initialData: {
         [STAGE_ATTRIBUTE_NAME]: STAGE_FIXTURE,

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/hooks/tests/useReviewWorkflows.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/hooks/tests/useReviewWorkflows.test.js
@@ -64,9 +64,7 @@ describe('useReviewWorkflows', () => {
     const { result, waitFor } = await setup();
 
     expect(result.current.workflows.isLoading).toBe(true);
-    expect(get).toBeCalledWith('/admin/review-workflows/workflows/', {
-      params: { sort: 'name:asc', populate: 'stages' },
-    });
+    expect(get).toBeCalledWith('/admin/review-workflows/workflows/?populate=stages&sort=name:asc');
 
     await waitFor(() => expect(result.current.workflows.isLoading).toBe(false));
 

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/hooks/useReviewWorkflows.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/hooks/useReviewWorkflows.js
@@ -1,19 +1,29 @@
 import { useQuery, useQueryClient } from 'react-query';
 import { useFetchClient } from '@strapi/helper-plugin';
+import { stringify } from 'qs';
 
 const QUERY_BASE_KEY = 'review-workflows';
 const API_BASE_URL = '/admin/review-workflows';
 
-export function useReviewWorkflows(workflowId) {
+export function useReviewWorkflows(workflowId, { filters = undefined } = {}) {
   const { get } = useFetchClient();
   const client = useQueryClient();
   const workflowQueryKey = [QUERY_BASE_KEY, workflowId ?? 'default'];
 
-  async function fetchWorkflows({ params = { sort: 'name:asc', populate: 'stages' } }) {
+  async function fetchWorkflows() {
     try {
       const {
         data: { data },
-      } = await get(`${API_BASE_URL}/workflows/${workflowId ?? ''}`, { params });
+      } = await get(
+        `${API_BASE_URL}/workflows/${workflowId ?? ''}?${stringify(
+          {
+            populate: 'stages',
+            sort: 'name:asc',
+            filters,
+          },
+          { encode: false }
+        )}`
+      );
 
       return data;
     } catch (err) {


### PR DESCRIPTION
### What does it do?

Instead of loading all workflows, with this PR only the one workflow mapped to the current content-type will be loaded (through the `filters` URL param).

### Why is it needed?

Because every content-type can only have one workflow mapped.

### How to test it?

Can not yet be tested, because the filtering is not implemented. Implementation follow the contract in https://strapi-inc.atlassian.net/browse/CONTENT-1378
