### PR TITLE
fix template data.db location

### DIFF
--- a/packages/generators/app/src/resources/templates/database-templates/js/database.template
+++ b/packages/generators/app/src/resources/templates/database-templates/js/database.template
@@ -75,7 +75,7 @@ module.exports = ({ env }) => {
         filename: path.join(
           __dirname,
           '..',
-          env('DATABASE_FILENAME', 'data.db')
+          env('DATABASE_FILENAME', '.tmp/data.db')
         ),
       },
       useNullAsDefault: true,

--- a/packages/generators/app/src/resources/templates/database-templates/ts/database.template
+++ b/packages/generators/app/src/resources/templates/database-templates/ts/database.template
@@ -76,7 +76,7 @@ export default ({ env }) => {
           __dirname,
           '..',
           '..',
-          env('DATABASE_FILENAME', 'data.db')
+          env('DATABASE_FILENAME', '.tmp/data.db')
         ),
       },
       useNullAsDefault: true,


### PR DESCRIPTION
### What does it do?

Fix the location where sql database file gets created.

### Why is it needed?

Since the current defualt is wrong.

### How to test it?

Remove DATABASE_FILENAME from env and see that it now defaults to `.tmp/data.db` instad of `data.db`

### Related issue(s)/PR(s)

fixes https://github.com/strapi/strapi/issues/16774