### PR TITLE
Fix: Avoid replacing entire generatedDocumentation components

### DIFF
--- a/packages/plugins/documentation/server/services/documentation.js
+++ b/packages/plugins/documentation/server/services/documentation.js
@@ -182,9 +182,7 @@ module.exports = ({ strapi }) => {
 
         generatedDocumentation = produce(generatedDocumentation, (draft) => {
           if (generatedSchemas) {
-            draft.components = {
-              schemas: { ...draft.components.schemas, ...generatedSchemas },
-            };
+            draft.components.schemas = { ...draft.components.schemas, ...generatedSchemas };
           }
 
           if (newApiPath) {


### PR DESCRIPTION
Hello, Thanks for the amazing works on the strapi v4
I was facing this issue #16714.
I Investigated the problem and found out the `schemas` object was replacing entirely and removing the `securitySchemes` field.

### What does it do?
It replaces the whole `schemas` object with something new which lacks `securitySchemes` field.

### Why is it needed?

Its needed because documents authorizations depends on it.

### How to test it?

after adding a new content type you should be able to see the authorization button on swagger.

### Related issue(s)/PR(s)
 #16714 