### PR TITLE
fix collection names check for plural names in edit

### DIFF
--- a/packages/core/content-type-builder/admin/src/components/FormModal/forms/index.js
+++ b/packages/core/content-type-builder/admin/src/components/FormModal/forms/index.js
@@ -193,8 +193,9 @@ const forms = {
 
       const takenCollectionNames = isEditing ? collectionNames.filter((collectionName) => {
         const currentPluralName = get(contentTypes, [ctUid, 'schema', 'pluralName'], '');
+        const currentCollectionName = get(contentTypes, [ctUid, 'schema', 'collectionName'], '');
 
-        return collectionName !== currentPluralName;
+        return collectionName !== currentPluralName || collectionName !== currentCollectionName;
       }) : collectionNames;
 
       const contentTypeShape = createContentTypeSchema({

--- a/packages/core/content-type-builder/admin/src/components/FormModal/forms/index.js
+++ b/packages/core/content-type-builder/admin/src/components/FormModal/forms/index.js
@@ -191,12 +191,18 @@ const forms = {
         return get(contentType, ['schema', 'collectionName'], '');
       });
 
+      const takenCollectionNames = isEditing ? collectionNames.filter((collectionName) => {
+        const currentPluralName = get(contentTypes, [ctUid, 'schema', 'pluralName'], '');
+
+        return collectionName !== currentPluralName;
+      }) : collectionNames;
+
       const contentTypeShape = createContentTypeSchema({
         usedContentTypeNames: takenNames,
         reservedModels: reservedNames.models,
         singularNames: takenSingularNames,
         pluralNames: takenPluralNames,
-        collectionNames,
+        collectionNames: takenCollectionNames,
       });
 
       // FIXME


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

I fixed a wrong check that we had in the Edit of a Collection Type, there was a problem with the validation of the plural name based on the collection names array

### Why is it needed?

Because we have the same check in Create and Edit and in edit you can't save an update of the Collection

### How to test it?

Go to a collection Type in the CTB and try to Edit for example the name of the collection type, you can't save

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
