### PR TITLE
Settings: Close delete confirmation modal after deletion

### DIFF
--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/ListView/ListView.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/ListView/ListView.js
@@ -102,7 +102,8 @@ export function ReviewWorkflowsListView() {
     try {
       const res = await mutateAsync({ workflowId: workflowToDelete });
 
-      refetchWorkflow();
+      await refetchWorkflow();
+      setWorkflowToDelete(null);
 
       return res;
     } catch (error) {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Closes the confirmation modal after a workflow has been deleted.

### Why is it needed?

Because otherwise the UX is not great.
