### PR TITLE
Settings: Display content-type display names over uids

### DIFF
--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/ListView/ListView.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/ListView/ListView.js
@@ -31,6 +31,7 @@ import { Pencil, Plus, Trash } from '@strapi/icons';
 
 import { useReviewWorkflows } from '../../hooks/useReviewWorkflows';
 import adminPermissions from '../../../../../../../../admin/src/permissions';
+import { useModels } from '../../../../../../../../admin/src/hooks';
 
 import * as Layout from '../../components/Layout';
 
@@ -64,6 +65,7 @@ const ActionLink = styled(Link)`
 export function ReviewWorkflowsListView() {
   const { formatMessage } = useIntl();
   const { push } = useHistory();
+  const { collectionTypes, singleTypes, isLoading: isLoadingModels } = useModels();
   const { workflows: workflowsData, refetchWorkflow } = useReviewWorkflows();
   const [workflowToDelete, setWorkflowToDelete] = React.useState(null);
   const { del } = useFetchClient();
@@ -89,6 +91,14 @@ export function ReviewWorkflowsListView() {
       },
     }
   );
+
+  const getContentTypeDisplayName = (uid) => {
+    const contentType = [...collectionTypes, ...singleTypes].find(
+      (contentType) => contentType.uid === uid
+    );
+
+    return contentType.info.displayName;
+  };
 
   const handleDeleteWorkflow = (workflowId) => {
     setWorkflowToDelete(workflowId);
@@ -138,7 +148,7 @@ export function ReviewWorkflowsListView() {
       />
 
       <Layout.Root>
-        {workflowsData.status === 'loading' ? (
+        {workflowsData.status === 'loading' || isLoadingModels ? (
           <Loader>
             {formatMessage({
               id: 'Settings.review-workflows.page.list.isLoading',
@@ -209,7 +219,7 @@ export function ReviewWorkflowsListView() {
                   </Td>
                   <Td>
                     <Typography textColor="neutral800">
-                      {(workflow?.contentTypes ?? []).join(', ')}
+                      {(workflow?.contentTypes ?? []).map(getContentTypeDisplayName).join(', ')}
                     </Typography>
                   </Td>
                   <Td>


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Displays `info.displayName` instead of the plain content-type uid in the settings list-view.

### Why is it needed?

Better ux.

