### PR TITLE
feat(rw): Colors to the default stages

### DIFF
--- a/packages/core/admin/ee/server/constants/default-stages.json
+++ b/packages/core/admin/ee/server/constants/default-stages.json
@@ -1,14 +1,18 @@
 [
   {
-    "name": "To do"
+    "name": "To do",
+    "color": "#4945FF"
   },
   {
-    "name": "Ready to review"
+    "name": "Ready to review",
+    "color": "#9736E8"
   },
   {
-    "name": "In progress"
+    "name": "In progress",
+    "color": "#FF4945"
   },
   {
-    "name": "Reviewed"
+    "name": "Reviewed",
+    "color": "#328048"
   }
 ]


### PR DESCRIPTION
### What does it do?

When upgrading strapi to a version with RW we generate, some default stages. They all had "blue" color, which imo could be better if the default ones had colors.

<table>
<tr>
 <td>Before
 <td>After
<tr>
 <td> <img src=https://github.com/strapi/strapi/assets/20578351/f11304b6-d1f1-4761-9fa2-3476cf3a6d31/>
 <td> <img src=https://github.com/strapi/strapi/assets/20578351/2019de27-1108-4903-aa4d-158e3893e547/>
</table>

