### PR TITLE
Chore: Add docs and auto-mock for useContentTypes()

### DIFF
--- a/docs/docs/docs/01-core/content-manager/hooks/use-content-types.mdx
+++ b/docs/docs/docs/01-core/content-manager/hooks/use-content-types.mdx
@@ -1,0 +1,25 @@
+---
+title: useContentTypes
+description: API reference for the useContentTypes hook in Strapi's Content Manager
+tags:
+  - content-manager
+  - hooks
+  - fetch
+  - content-types
+  - components
+---
+
+An abstraction around `react-query` to fetch content-types and components. It returns the raw API response
+for components. `collectionTypes` and `singleTypes` are filtered by `isDisplayed=true`.
+
+## Usage
+
+```jsx
+import { useContentTypes } from 'path/to/hooks';
+
+const MyComponent = () => {
+  const { isLoading, collectionTypes, singleTypes, components } = useContentTypes();
+
+  return (/* ... */);
+};
+```

--- a/jest-preset.front.js
+++ b/jest-preset.front.js
@@ -30,6 +30,8 @@ const moduleNameMapper = {
 module.exports = {
   rootDir: __dirname,
   moduleNameMapper,
+  /* Tells jest to ignore duplicated manual mock files, such as index.js */
+  modulePathIgnorePatterns: ['.*__mocks__.*'],
   testPathIgnorePatterns: ['node_modules/', '__tests__'],
   globalSetup: '@strapi/admin-test-utils/global-setup',
   setupFiles: ['@strapi/admin-test-utils/environment'],

--- a/packages/core/admin/admin/src/hooks/useContentTypes/__mocks__/index.js
+++ b/packages/core/admin/admin/src/hooks/useContentTypes/__mocks__/index.js
@@ -1,0 +1,6 @@
+export const useContentTypes = jest.fn().mockReturnValue({
+  isLoading: false,
+  components: [],
+  collectionTypes: [],
+  singleTypes: [],
+});

--- a/packages/core/admin/admin/src/hooks/useContentTypes/tests/index.test.js
+++ b/packages/core/admin/admin/src/hooks/useContentTypes/tests/index.test.js
@@ -5,7 +5,7 @@ import { renderHook } from '@testing-library/react-hooks';
 import { IntlProvider } from 'react-intl';
 import { QueryClient, QueryClientProvider } from 'react-query';
 
-import { useContentTypes } from '../useContentTypes';
+import { useContentTypes } from '..';
 
 jest.mock('@strapi/helper-plugin', () => ({
   ...jest.requireActual('@strapi/helper-plugin'),

--- a/packages/core/admin/admin/src/hooks/useContentTypes/useContentTypes.js
+++ b/packages/core/admin/admin/src/hooks/useContentTypes/useContentTypes.js
@@ -2,6 +2,8 @@ import { useAPIErrorHandler, useFetchClient, useNotification } from '@strapi/hel
 import { useQueries } from 'react-query';
 
 export function useContentTypes() {
+  console.log('----> read');
+
   const { get } = useFetchClient();
   const { formatAPIError } = useAPIErrorHandler();
   const toggleNotification = useNotification();

--- a/packages/core/admin/admin/src/pages/HomePage/index.js
+++ b/packages/core/admin/admin/src/pages/HomePage/index.js
@@ -11,6 +11,7 @@ import { useHistory } from 'react-router-dom';
 import { LoadingIndicatorPage, useGuidedTour } from '@strapi/helper-plugin';
 import { Layout, Main, Box, Grid, GridItem } from '@strapi/design-system';
 import useLicenseLimitNotification from 'ee_else_ce/hooks/useLicenseLimitNotification';
+
 import cornerOrnamentPath from './assets/corner-ornament.svg';
 import { useContentTypes } from '../../hooks/useContentTypes';
 import isGuidedTourCompleted from '../../components/GuidedTour/utils/isGuidedTourCompleted';

--- a/packages/core/admin/admin/src/pages/HomePage/tests/index.test.js
+++ b/packages/core/admin/admin/src/pages/HomePage/tests/index.test.js
@@ -50,12 +50,6 @@ const App = (
 );
 
 describe('Homepage', () => {
-  useContentTypes.mockReturnValue({
-    isLoading: false,
-    collectionTypes: [],
-    singleTypes: [],
-  });
-
   test('should render all homepage links', () => {
     const { getByRole } = render(App);
     expect(getByRole('link', { name: /we are hiring/i })).toBeInTheDocument();


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

- Adds docs use `useContentTypes()`
- Adds an auto-mock for `useContentTypes()`

### Why is it needed?

Better tests, more docs.
