### PR TITLE
feat(webhook): add configurable timeout for webhooks

### DIFF
--- a/packages/core/strapi/lib/services/webhook-runner.js
+++ b/packages/core/strapi/lib/services/webhook-runner.js
@@ -89,7 +89,7 @@ class WebhookRunner {
         'X-Strapi-Event': event,
         'Content-Type': 'application/json',
       },
-      timeout: 10000,
+      timeout: this.config.timeout || 10000,
     })
       .then(async (res) => {
         if (res.ok) {


### PR DESCRIPTION
add configurable timeout for webhooks

### What does it do?

Added ability to set webhook timeout

### Why is it needed?

Right now there is no way to set the webhook timeout

