### PR TITLE
Save schemas in memory and use them instead of calling providers every time

### DIFF
--- a/packages/core/data-transfer/src/engine/index.ts
+++ b/packages/core/data-transfer/src/engine/index.ts
@@ -95,6 +95,8 @@ class TransferEngine<
 
   #metadata: { source?: IMetadata; destination?: IMetadata } = {};
 
+  #schema: { source?: SchemaMap; destination?: SchemaMap } = {};
+
   // Progress of the current stage
   progress: {
     // metrics on the progress such as size and record count
@@ -623,12 +625,12 @@ class TransferEngine<
       );
     }
 
-    const sourceSchemas = (await this.sourceProvider.getSchemas?.()) as SchemaMap;
-    const destinationSchemas = (await this.destinationProvider.getSchemas?.()) as SchemaMap;
+    this.#schema.source = (await this.sourceProvider.getSchemas?.()) as SchemaMap;
+    this.#schema.destination = (await this.destinationProvider.getSchemas?.()) as SchemaMap;
 
     try {
-      if (sourceSchemas && destinationSchemas) {
-        this.#assertSchemasMatching(sourceSchemas, destinationSchemas);
+      if (this.#schema.source && this.#schema.destination) {
+        this.#assertSchemasMatching(this.#schema.source, this.#schema.destination);
       }
     } catch (error) {
       // if this is a schema matching error, allow handlers to resolve it
@@ -760,7 +762,7 @@ class TransferEngine<
       new Transform({
         objectMode: true,
         transform: async (entity: IEntity, _encoding, callback) => {
-          const schemas = await this.destinationProvider.getSchemas?.();
+          const schemas = this.#schema.destination;
 
           if (!schemas) {
             return callback(null, entity);
@@ -801,7 +803,7 @@ class TransferEngine<
       new Transform({
         objectMode: true,
         transform: async (link: ILink, _encoding, callback) => {
-          const schemas = await this.destinationProvider.getSchemas?.();
+          const schemas = this.#schema.destination;
 
           if (!schemas) {
             return callback(null, link);


### PR DESCRIPTION
### What does it do?

- Save schemas in memory and use them when doing checks

### Why is it needed?

- Calling destination provider to get the schemas every time causes performance issues, the transfer becomes a lot slower as it tries to get the same schema every time from the server.

### How to test it?

- Try transfer push it should be a lot faster when testing with the cloud
- Everything should be working the same and shouldn't be broken when you try the transfer

