### PR TITLE
fix: remove fixed id binding in WYSIWYG

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/Wysiwyg/WysiwygNav.js
+++ b/packages/core/admin/admin/src/content-manager/components/Wysiwyg/WysiwygNav.js
@@ -63,22 +63,16 @@ const WysiwygNav = ({
           </Select>
 
           <MainButtons>
-            <CustomIconButton disabled id="Bold" label="Bold" name="Bold" icon={<Bold />} />
-            <CustomIconButton disabled id="Italic" label="Italic" name="Italic" icon={<Italic />} />
-            <CustomIconButton
-              disabled
-              id="Underline"
-              label="Underline"
-              name="Underline"
-              icon={<Underline />}
-            />
+            <CustomIconButton disabled label="Bold" name="Bold" icon={<Bold />} />
+            <CustomIconButton disabled label="Italic" name="Italic" icon={<Italic />} />
+            <CustomIconButton disabled label="Underline" name="Underline" icon={<Underline />} />
           </MainButtons>
 
-          <MoreButton disabled id="more" label="More" icon={<More />} />
+          <MoreButton disabled label="More" icon={<More />} />
         </StyledFlex>
 
         {!isExpandMode && (
-          <Button onClick={onTogglePreviewMode} variant="tertiary" id="preview">
+          <Button onClick={onTogglePreviewMode} variant="tertiary">
             {formatMessage({
               id: 'components.Wysiwyg.ToggleMode.markdown-mode',
               defaultMessage: 'Markdown mode',
@@ -109,21 +103,18 @@ const WysiwygNav = ({
         <MainButtons>
           <CustomIconButton
             onClick={() => onActionClick('Bold', editorRef)}
-            id="Bold"
             label="Bold"
             name="Bold"
             icon={<Bold />}
           />
           <CustomIconButton
             onClick={() => onActionClick('Italic', editorRef)}
-            id="Italic"
             label="Italic"
             name="Italic"
             icon={<Italic />}
           />
           <CustomIconButton
             onClick={() => onActionClick('Underline', editorRef)}
-            id="Underline"
             label="Underline"
             name="Underline"
             icon={<Underline />}
@@ -133,37 +124,27 @@ const WysiwygNav = ({
         <MoreButton
           ref={buttonMoreRef}
           onClick={handleTogglePopover}
-          id="more"
           label="More"
           icon={<More />}
         />
         {visiblePopover && (
-          <Popover
-            onDismiss={handleTogglePopover}
-            centered
-            source={buttonMoreRef}
-            spacing={4}
-            id="popover"
-          >
+          <Popover onDismiss={handleTogglePopover} centered source={buttonMoreRef} spacing={4}>
             <Flex>
               <IconButtonGroupMargin>
                 <CustomIconButton
                   onClick={() => onActionClick('Strikethrough', editorRef, handleTogglePopover)}
-                  id="Strikethrough"
                   label="Strikethrough"
                   name="Strikethrough"
                   icon={<StrikeThrough />}
                 />
                 <CustomIconButton
                   onClick={() => onActionClick('BulletList', editorRef, handleTogglePopover)}
-                  id="BulletList"
                   label="BulletList"
                   name="BulletList"
                   icon={<BulletList />}
                 />
                 <CustomIconButton
                   onClick={() => onActionClick('NumberList', editorRef, handleTogglePopover)}
-                  id="NumberList"
                   label="NumberList"
                   name="NumberList"
                   icon={<NumberList />}
@@ -172,7 +153,6 @@ const WysiwygNav = ({
               <IconButtonGroup>
                 <CustomIconButton
                   onClick={() => onActionClick('Code', editorRef, handleTogglePopover)}
-                  id="Code"
                   label="Code"
                   name="Code"
                   icon={<Code />}
@@ -182,14 +162,12 @@ const WysiwygNav = ({
                     handleTogglePopover();
                     onToggleMediaLib();
                   }}
-                  id="Image"
                   label="Image"
                   name="Image"
                   icon={<Image />}
                 />
                 <CustomLinkIconButton
                   onClick={() => onActionClick('Link', editorRef, handleTogglePopover)}
-                  id="Link"
                   label="Link"
                   name="Link"
                   // eslint-disable-next-line jsx-a11y/anchor-is-valid
@@ -197,7 +175,6 @@ const WysiwygNav = ({
                 />
                 <CustomIconButton
                   onClick={() => onActionClick('Quote', editorRef, handleTogglePopover)}
-                  id="Quote"
                   label="Quote"
                   name="Quote"
                   icon={<Quote />}
@@ -209,7 +186,7 @@ const WysiwygNav = ({
       </StyledFlex>
 
       {onTogglePreviewMode && (
-        <Button onClick={onTogglePreviewMode} variant="tertiary" id="preview">
+        <Button onClick={onTogglePreviewMode} variant="tertiary">
           {formatMessage({
             id: 'components.Wysiwyg.ToggleMode.preview-mode',
             defaultMessage: 'Preview mode',


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Remove fixed `id` binding in WYSIWYG nav component

### Why is it needed?

Multiple richtext component make duplicated id attributes elements in the DOM

### How to test it?

Created a content type with a dynamic zone with 2 Richtext fields.

### Related issue(s)/PR(s)

Closes https://github.com/strapi/strapi/issues/16382
