### PR TITLE
feat(review workflow): Prevent too long table name for rw join table attributes

### DIFF
--- a/api-tests/core/admin/ee/review-workflows-content-types.test.api.js
+++ b/api-tests/core/admin/ee/review-workflows-content-types.test.api.js
@@ -46,7 +46,7 @@ const longCTModel = {
   },
 };
 
-describe('Review workflows', () => {
+describeOnCondition(edition === 'EE')('Review workflows', () => {
   const builder = createTestBuilder();
 
   const requests = { admin: null };

--- a/api-tests/core/admin/ee/review-workflows-content-types.test.api.js
+++ b/api-tests/core/admin/ee/review-workflows-content-types.test.api.js
@@ -30,12 +30,23 @@ const productModel = {
       type: 'string',
     },
   },
-  options: {
-    reviewWorkflows: true,
+};
+const longCTUID = 'api::thatsanabsurdlongcontenttypename.thatsanabsurdlongcontenttypename';
+const longCTModel = {
+  draftAndPublish: true,
+  pluginOptions: {},
+  singularName: 'thatsanabsurdlongcontenttypename',
+  pluralName: 'thatsanabsurdlongcontenttypenamewithans',
+  displayName: 'Thats an absurd long content type name',
+  kind: 'collectionType',
+  attributes: {
+    name: {
+      type: 'string',
+    },
   },
 };
 
-describeOnCondition(edition === 'EE')('Review workflows', () => {
+describe('Review workflows', () => {
   const builder = createTestBuilder();
 
   const requests = { admin: null };
@@ -90,7 +101,7 @@ describeOnCondition(edition === 'EE')('Review workflows', () => {
   };
 
   beforeAll(async () => {
-    await builder.addContentTypes([productModel]).build();
+    await builder.addContentTypes([productModel, longCTModel]).build();
 
     strapi = await createStrapiInstance();
     requests.admin = await createAuthRequest({ strapi });
@@ -98,6 +109,8 @@ describeOnCondition(edition === 'EE')('Review workflows', () => {
     await Promise.all([
       createEntry(productUID, { name: 'Product 1' }),
       createEntry(productUID, { name: 'Product 2' }),
+      createEntry(longCTUID, { name: 'Product 1' }),
+      createEntry(longCTUID, { name: 'Product 2' }),
     ]);
   });
 
@@ -329,6 +342,15 @@ describeOnCondition(edition === 'EE')('Review workflows', () => {
         where: { id: workflow1.id },
         data: { contentTypes: [] },
       });
+    });
+  });
+
+  describe('With long content type names', () => {
+    test('Should not load Review Workflow on too long content-type name', async () => {
+      const contentType = strapi.contentTypes[longCTUID];
+
+      expect(contentType.attributes[ENTITY_STAGE_ATTRIBUTE]).toBeUndefined();
+      // Cannot test the log as it happens during the Strapi instance creation (in the beforeAll)
     });
   });
 });

--- a/api-tests/core/admin/ee/review-workflows-content-types.test.api.js
+++ b/api-tests/core/admin/ee/review-workflows-content-types.test.api.js
@@ -31,13 +31,14 @@ const productModel = {
     },
   },
 };
-const longCTUID = 'api::thatsanabsurdlongcontenttypename.thatsanabsurdlongcontenttypename';
+const longCTUID =
+  'api::thatsanabsurdreallyreallylongcontenttypename.thatsanabsurdreallyreallylongcontenttypename';
 const longCTModel = {
   draftAndPublish: true,
   pluginOptions: {},
-  singularName: 'thatsanabsurdlongcontenttypename',
-  pluralName: 'thatsanabsurdlongcontenttypenamewithans',
-  displayName: 'Thats an absurd long content type name',
+  singularName: 'thatsanabsurdreallyreallylongcontenttypename',
+  pluralName: 'thatsanabsurdreallyreallylongcontenttypenamewithans',
+  displayName: 'Thats an absurd really really long content type name',
   kind: 'collectionType',
   attributes: {
     name: {

--- a/api-tests/core/content-manager/search.test.api.js
+++ b/api-tests/core/content-manager/search.test.api.js
@@ -20,6 +20,9 @@ const bedModel = {
   singularName: 'bed',
   pluralName: 'beds',
   kind: 'collectionType',
+  options: {
+    reviewWorkflows: false,
+  },
   attributes: {
     name: {
       type: 'string',

--- a/packages/core/admin/ee/server/services/review-workflows/review-workflows.js
+++ b/packages/core/admin/ee/server/services/review-workflows/review-workflows.js
@@ -28,17 +28,13 @@ async function initDefaultWorkflow({ workflowsService, stagesService }) {
 
 function extendReviewWorkflowContentTypes({ strapi }) {
   const extendContentType = (contentTypeUID) => {
-    const assertContentTypeCompatibility = (contentType) => {
-      const joinTableNameLength =
-        contentType.collectionName.length +
-        1 /* _ */ +
-        ENTITY_STAGE_ATTRIBUTE.length +
-        '_links_inv_fk'.length;
-      return joinTableNameLength < 63; // This is the maximum length limit of table name in PostgreSQL (64 for MariaDB)
-    };
+    const maxContentTypeNameLength =
+      63 - 1 /* _ */ - ENTITY_STAGE_ATTRIBUTE.length - '_links_inv_fk'.length;
+    const assertContentTypeCompatibility = (contentType) =>
+      contentType.collectionName.length <= maxContentTypeNameLength; // This is the maximum length limit of table name in PostgreSQL (64 for MariaDB)
     const incompatibleContentTypeAlert = (contentType) => {
       strapi.log.warn(
-        `ContentType ${contentType.name} cannot have Review Workflow activated as the name is too long.`
+        `Content type "${contentType.info.displayName}" cannot have Review Workflow activated as the name is too long. (${maxContentTypeNameLength} maximum characters)`
       );
       return contentType;
     };

--- a/packages/core/admin/ee/server/services/review-workflows/review-workflows.js
+++ b/packages/core/admin/ee/server/services/review-workflows/review-workflows.js
@@ -11,6 +11,10 @@ const { ENTITY_STAGE_ATTRIBUTE } = require('../../constants/workflows');
 const { persistTables, removePersistedTablesWithSuffix } = require('../../utils/persisted-tables');
 
 const MAX_DB_TABLE_NAME_LEN = 63; // Postgres limit
+// The suffix should looks like _strapi_reviewWorkflow_stage_links_inv_fk
+const MAX_JOIN_TABLE_NAME_SUFFIX =
+  1 /* _ */ + ENTITY_STAGE_ATTRIBUTE.length + '_links_inv_fk'.length;
+const MAX_CONTENT_TYPE_NAME_LEN = MAX_DB_TABLE_NAME_LEN - MAX_JOIN_TABLE_NAME_SUFFIX;
 
 async function initDefaultWorkflow({ workflowsService, stagesService }) {
   const wfCount = await workflowsService.count();
@@ -30,13 +34,11 @@ async function initDefaultWorkflow({ workflowsService, stagesService }) {
 
 function extendReviewWorkflowContentTypes({ strapi }) {
   const extendContentType = (contentTypeUID) => {
-    const maxContentTypeNameLength =
-      MAX_DB_TABLE_NAME_LEN - 1 /* _ */ - ENTITY_STAGE_ATTRIBUTE.length - '_links_inv_fk'.length;
     const assertContentTypeCompatibility = (contentType) =>
-      contentType.collectionName.length <= maxContentTypeNameLength;
+      contentType.collectionName.length <= MAX_CONTENT_TYPE_NAME_LEN;
     const incompatibleContentTypeAlert = (contentType) => {
       strapi.log.warn(
-        `Content type "${contentType.info.displayName}" cannot have Review Workflow activated as the name is too long. (${maxContentTypeNameLength} maximum characters)`
+        `Content type "${contentType.info.displayName}" cannot have Review Workflow activated as the name is too long. (${MAX_CONTENT_TYPE_NAME_LEN} maximum characters)`
       );
       return contentType;
     };

--- a/packages/core/admin/ee/server/services/review-workflows/review-workflows.js
+++ b/packages/core/admin/ee/server/services/review-workflows/review-workflows.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const { has, filter, set, forEach, pipe, map, stubTrue, cond } = require('lodash/fp');
+const { filter, set, forEach, pipe, map, stubTrue, cond } = require('lodash/fp');
 const { getService } = require('../../utils');
-const { getVisibleContentTypesUID } = require('../../utils/review-workflows');
+const { getVisibleContentTypesUID, hasStageAttribute } = require('../../utils/review-workflows');
 
 const defaultStages = require('../../constants/default-stages.json');
 const defaultWorkflow = require('../../constants/default-workflow.json');
@@ -69,7 +69,6 @@ function extendReviewWorkflowContentTypes({ strapi }) {
 
 function persistStagesJoinTables({ strapi }) {
   return async ({ contentTypes }) => {
-    const hasStageAttribute = has('attributes', ENTITY_STAGE_ATTRIBUTE);
     const getStageTableToPersist = (contentTypeUID) => {
       // Persist the stage join table
       const { attributes, tableName } = strapi.db.metadata.get(contentTypeUID);

--- a/packages/core/admin/ee/server/services/review-workflows/review-workflows.js
+++ b/packages/core/admin/ee/server/services/review-workflows/review-workflows.js
@@ -10,6 +10,8 @@ const { ENTITY_STAGE_ATTRIBUTE } = require('../../constants/workflows');
 
 const { persistTables, removePersistedTablesWithSuffix } = require('../../utils/persisted-tables');
 
+const MAX_DB_TABLE_NAME_LEN = 63; // Postgres limit
+
 async function initDefaultWorkflow({ workflowsService, stagesService }) {
   const wfCount = await workflowsService.count();
   const stagesCount = await stagesService.count();
@@ -29,9 +31,9 @@ async function initDefaultWorkflow({ workflowsService, stagesService }) {
 function extendReviewWorkflowContentTypes({ strapi }) {
   const extendContentType = (contentTypeUID) => {
     const maxContentTypeNameLength =
-      63 - 1 /* _ */ - ENTITY_STAGE_ATTRIBUTE.length - '_links_inv_fk'.length;
+      MAX_DB_TABLE_NAME_LEN - 1 /* _ */ - ENTITY_STAGE_ATTRIBUTE.length - '_links_inv_fk'.length;
     const assertContentTypeCompatibility = (contentType) =>
-      contentType.collectionName.length <= maxContentTypeNameLength; // This is the maximum length limit of table name in PostgreSQL (64 for MariaDB)
+      contentType.collectionName.length <= maxContentTypeNameLength;
     const incompatibleContentTypeAlert = (contentType) => {
       strapi.log.warn(
         `Content type "${contentType.info.displayName}" cannot have Review Workflow activated as the name is too long. (${maxContentTypeNameLength} maximum characters)`

--- a/packages/core/admin/ee/server/services/review-workflows/review-workflows.js
+++ b/packages/core/admin/ee/server/services/review-workflows/review-workflows.js
@@ -11,7 +11,7 @@ const { ENTITY_STAGE_ATTRIBUTE } = require('../../constants/workflows');
 const { persistTables, removePersistedTablesWithSuffix } = require('../../utils/persisted-tables');
 
 const MAX_DB_TABLE_NAME_LEN = 63; // Postgres limit
-// The suffix should looks like _strapi_reviewWorkflow_stage_links_inv_fk
+// The longest index name that Strapi can create is prefixed with '_strapi_reviewWorkflow_stage_links_inv_fk', so the content type name  should be no longer than this.
 const MAX_JOIN_TABLE_NAME_SUFFIX =
   1 /* _ */ + ENTITY_STAGE_ATTRIBUTE.length + '_links_inv_fk'.length;
 const MAX_CONTENT_TYPE_NAME_LEN = MAX_DB_TABLE_NAME_LEN - MAX_JOIN_TABLE_NAME_SUFFIX;

--- a/packages/core/admin/ee/server/services/review-workflows/review-workflows.js
+++ b/packages/core/admin/ee/server/services/review-workflows/review-workflows.js
@@ -38,7 +38,7 @@ function extendReviewWorkflowContentTypes({ strapi }) {
       contentType.collectionName.length <= MAX_CONTENT_TYPE_NAME_LEN;
     const incompatibleContentTypeAlert = (contentType) => {
       strapi.log.warn(
-        `Content type "${contentType.info.displayName}" cannot have Review Workflow activated as the name is too long. (${MAX_CONTENT_TYPE_NAME_LEN} maximum characters)`
+        `Review Workflow cannot be activated for the content type with the name '${contentType.info.displayName}' because the name exceeds the maximum length of ${MAX_CONTENT_TYPE_NAME_LEN} characters.`
       );
       return contentType;
     };

--- a/packages/core/admin/ee/server/utils/review-workflows.js
+++ b/packages/core/admin/ee/server/utils/review-workflows.js
@@ -1,12 +1,10 @@
 'use strict';
 
-const { get, keys, pickBy, pipe } = require('lodash/fp');
+const { getOr, keys, pickBy, pipe } = require('lodash/fp');
 
 const getVisibleContentTypesUID = pipe([
-  // FIXME: Swap with the commented line below when figure out how to shorten strapi_reviewWorkflows_stage
-  pickBy(get('options.reviewWorkflows')),
   // Pick only content-types visible in the content-manager
-  // pickBy(getOr(true, 'pluginOptions.content-manager.visible')),
+  pickBy(getOr(true, 'pluginOptions.content-manager.visible')),
   // Get UIDs
   keys,
 ]);

--- a/packages/core/admin/ee/server/utils/review-workflows.js
+++ b/packages/core/admin/ee/server/utils/review-workflows.js
@@ -1,6 +1,7 @@
 'use strict';
 
-const { getOr, keys, pickBy, pipe } = require('lodash/fp');
+const { getOr, keys, pickBy, pipe, has } = require('lodash/fp');
+const { ENTITY_STAGE_ATTRIBUTE } = require('../constants/workflows');
 
 const getVisibleContentTypesUID = pipe([
   // Pick only content-types visible in the content-manager
@@ -9,6 +10,9 @@ const getVisibleContentTypesUID = pipe([
   keys,
 ]);
 
+const hasStageAttribute = has(['attributes', ENTITY_STAGE_ATTRIBUTE]);
+
 module.exports = {
   getVisibleContentTypesUID,
+  hasStageAttribute,
 };

--- a/packages/core/admin/ee/server/utils/review-workflows.js
+++ b/packages/core/admin/ee/server/utils/review-workflows.js
@@ -4,8 +4,12 @@ const { getOr, keys, pickBy, pipe, has } = require('lodash/fp');
 const { ENTITY_STAGE_ATTRIBUTE } = require('../constants/workflows');
 
 const getVisibleContentTypesUID = pipe([
-  // Pick only content-types visible in the content-manager
-  pickBy(getOr(true, 'pluginOptions.content-manager.visible')),
+  // Pick only content-types visible in the content-manager and option is not false
+  pickBy(
+    (value) =>
+      getOr(true, 'pluginOptions.content-manager.visible', value) &&
+      getOr(true, 'options.reviewWorkflows', value) !== false
+  ),
   // Get UIDs
   keys,
 ]);

--- a/packages/core/admin/ee/server/validation/review-workflows.js
+++ b/packages/core/admin/ee/server/validation/review-workflows.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { yup, validateYupSchema } = require('@strapi/utils');
-const { getVisibleContentTypesUID } = require('../utils/review-workflows');
+const { getVisibleContentTypesUID, hasStageAttribute } = require('../utils/review-workflows');
 
 const stageObject = yup.object().shape({
   id: yup.number().integer().min(1),
@@ -33,6 +33,12 @@ const validateContentTypes = yup.array().of(
       message: (value) =>
         `Content type ${value.originalValue} does not have review workflow enabled`,
       test(uid) {
+        const model = strapi.getModel(uid);
+
+        if (!hasStageAttribute(model)) {
+          // This content type doesn't handle review workflows
+          return false;
+        }
         // It's not a valid  content type if it's not visible in the content manager
         return getVisibleContentTypesUID({ [uid]: strapi.getModel(uid) }).includes(uid);
       },

--- a/packages/core/admin/ee/server/validation/review-workflows.js
+++ b/packages/core/admin/ee/server/validation/review-workflows.js
@@ -35,12 +35,8 @@ const validateContentTypes = yup.array().of(
       test(uid) {
         const model = strapi.getModel(uid);
 
-        if (!hasStageAttribute(model)) {
-          // This content type doesn't handle review workflows
-          return false;
-        }
-        // It's not a valid  content type if it's not visible in the content manager
-        return getVisibleContentTypesUID({ [uid]: strapi.getModel(uid) }).includes(uid);
+        // It's not a valid content type if it doesn't have the stage attribute
+        return hasStageAttribute(model);
       },
     })
 );

--- a/packages/core/admin/ee/server/validation/review-workflows.js
+++ b/packages/core/admin/ee/server/validation/review-workflows.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { yup, validateYupSchema } = require('@strapi/utils');
-const { getVisibleContentTypesUID, hasStageAttribute } = require('../utils/review-workflows');
+const { hasStageAttribute } = require('../utils/review-workflows');
 
 const stageObject = yup.object().shape({
   id: yup.number().integer().min(1),


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Before injecting the new review workflow attribute inside any content-type, the length of the future join table will be calculated and it should not exceed 63 characters.

### Why is it needed?

PostgreSQL doesn't handle tables with names longer than 63 characters

### How to test it?

Create a content-type with >30 characters name and see a warning inside the console at the initialisation of the Strapi instance.
The review workflow will not be possible to use on this one.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
