### PR TITLE
Enhancement: Allow admin users to be assigned to an entity in the CM edit view

### DIFF
--- a/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/InformationBoxEE.js
+++ b/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/InformationBoxEE.js
@@ -14,8 +14,10 @@ import { useReviewWorkflows } from '../../../../pages/SettingsPage/pages/ReviewW
 import { OptionColor } from '../../../../pages/SettingsPage/pages/ReviewWorkflows/components/Stages/Stage/components/OptionColor';
 import { SingleValueColor } from '../../../../pages/SettingsPage/pages/ReviewWorkflows/components/Stages/Stage/components/SingleValueColor';
 import Information from '../../../../../../admin/src/content-manager/pages/EditView/Information';
+import { useAdminUsers } from '../../../../../../admin/src/hooks/useAdminUsers';
 
-const ATTRIBUTE_NAME = 'strapi_reviewWorkflows_stage';
+const STAGE_ATTRIBUTE_NAME = 'strapi_reviewWorkflows_stage';
+const ASSIGNEE_ATTRIBUTE_NAME = 'strapi_assignee';
 
 export function InformationBoxEE() {
   const {
@@ -29,20 +31,21 @@ export function InformationBoxEE() {
   // it is possible to rely on initialData here, because it always will
   // be updated at the same time when modifiedData is updated, otherwise
   // the entity is flagged as modified
-  const activeWorkflowStage = initialData?.[ATTRIBUTE_NAME] ?? null;
+  const currentWorkflowStage = initialData?.[STAGE_ATTRIBUTE_NAME] ?? null;
+  const currentAssignee = initialData?.[ASSIGNEE_ATTRIBUTE_NAME] ?? null;
   const hasReviewWorkflowsEnabled = Object.prototype.hasOwnProperty.call(
     initialData,
-    ATTRIBUTE_NAME
+    STAGE_ATTRIBUTE_NAME
   );
   const { formatMessage } = useIntl();
   const { formatAPIError } = useAPIErrorHandler();
   const toggleNotification = useNotification();
-
+  const { users, isLoading: usersIsLoading, isError: usersIsError } = useAdminUsers();
   const { workflows, isLoading: workflowIsLoading } = useReviewWorkflows();
   // TODO: this works only as long as we support one workflow
   const workflow = workflows?.[0] ?? null;
 
-  const { error, isLoading, mutateAsync } = useMutation(
+  const stageMutation = useMutation(
     async ({ entityId, stageId, uid }) => {
       const typeSlug = isSingleType ? 'single-types' : 'collection-types';
 
@@ -54,7 +57,10 @@ export function InformationBoxEE() {
 
       // initialData and modifiedData have to stay in sync, otherwise the entity would be flagged
       // as modified, which is what the boolean flag is for
-      onChange({ target: { name: ATTRIBUTE_NAME, value: createdEntity[ATTRIBUTE_NAME] } }, true);
+      onChange(
+        { target: { name: STAGE_ATTRIBUTE_NAME, value: createdEntity[STAGE_ATTRIBUTE_NAME] } },
+        true
+      );
 
       return createdEntity;
     },
@@ -71,33 +77,72 @@ export function InformationBoxEE() {
     }
   );
 
+  const assigneeMutation = useMutation(
+    async ({ entityId, assigneeId, uid }) => {
+      const typeSlug = isSingleType ? 'single-types' : 'collection-types';
+
+      const {
+        data: { data: createdEntity },
+      } = await put(`/admin/content-manager/${typeSlug}/${uid}/${entityId}/assignee`, {
+        data: { id: assigneeId },
+      });
+
+      // initialData and modifiedData have to stay in sync, otherwise the entity would be flagged
+      // as modified, which is what the boolean flag is for
+      onChange(
+        {
+          target: { name: ASSIGNEE_ATTRIBUTE_NAME, value: createdEntity[ASSIGNEE_ATTRIBUTE_NAME] },
+        },
+        true
+      );
+
+      return createdEntity;
+    },
+    {
+      onSuccess() {
+        toggleNotification({
+          type: 'success',
+          message: {
+            id: 'content-manager.reviewWorkflows.assignee.notification.saved',
+            defaultMessage: 'Success: Assignee updated',
+          },
+        });
+      },
+    }
+  );
+
   // if entities are created e.g. through lifecycle methods
   // they may not have a stage assigned. Updating the entity won't
   // set the default stage either which may lead to entities that
   // do not have a stage assigned for a while. By displaying an
   // error by default we are trying to nudge users into assigning a stage.
   const initialStageNullError =
-    activeWorkflowStage === null &&
+    currentWorkflowStage === null &&
     !workflowIsLoading &&
     !isCreatingEntry &&
     formatMessage({
       id: 'content-manager.reviewWorkflows.stage.select.placeholder',
       defaultMessage: 'Select a stage',
     });
-  const formattedMutationError = error && formatAPIError(error);
-  const formattedError = formattedMutationError || initialStageNullError || null;
 
-  const handleStageChange = async ({ value: stageId }) => {
-    try {
-      await mutateAsync({
-        entityId: initialData.id,
-        stageId,
-        uid,
-      });
-    } catch (error) {
-      // react-query@v3: the error doesn't have to be handled here
-      // see: https://github.com/TanStack/query/issues/121
-    }
+  const formattedStageError =
+    (stageMutation.error && formatAPIError(stageMutation.error)) || initialStageNullError || null;
+  const formattedAssigneeError = assigneeMutation.error && formatAPIError(assigneeMutation.error);
+
+  const handleChangeStage = async ({ value: stageId }) => {
+    stageMutation.mutate({
+      entityId: initialData.id,
+      stageId,
+      uid,
+    });
+  };
+
+  const handleChangeAssignee = async ({ value: assigneeId }) => {
+    assigneeMutation.mutate({
+      entityId: initialData.id,
+      assigneeId,
+      uid,
+    });
   };
 
   return (
@@ -105,49 +150,112 @@ export function InformationBoxEE() {
       <Information.Title />
 
       {hasReviewWorkflowsEnabled && !isCreatingEntry && (
-        <Field error={formattedError} name={ATTRIBUTE_NAME} id={ATTRIBUTE_NAME}>
-          <Flex direction="column" gap={2} alignItems="stretch">
-            <FieldLabel>
-              {formatMessage({
-                id: 'content-manager.reviewWorkflows.stage.label',
-                defaultMessage: 'Review stage',
-              })}
-            </FieldLabel>
+        <>
+          <Field error={formattedStageError} name={STAGE_ATTRIBUTE_NAME} id={STAGE_ATTRIBUTE_NAME}>
+            <Flex direction="column" gap={2} alignItems="stretch">
+              <FieldLabel>
+                {formatMessage({
+                  id: 'content-manager.reviewWorkflows.stage.label',
+                  defaultMessage: 'Review stage',
+                })}
+              </FieldLabel>
 
-            <ReactSelect
-              components={{
-                LoadingIndicator: () => <Loader small />,
-                Option: OptionColor,
-                SingleValue: SingleValueColor,
-              }}
-              error={formattedError}
-              inputId={ATTRIBUTE_NAME}
-              isLoading={isLoading}
-              isSearchable={false}
-              isClearable={false}
-              name={ATTRIBUTE_NAME}
-              onChange={handleStageChange}
-              options={
-                workflow
-                  ? workflow.stages.map(({ id, color, name }) => ({
-                      value: id,
-                      label: name,
-                      color,
-                    }))
-                  : []
-              }
-              value={{
-                value: activeWorkflowStage?.id,
-                label: activeWorkflowStage?.name,
-                color: activeWorkflowStage?.color,
-              }}
-            />
+              <ReactSelect
+                components={{
+                  LoadingIndicator: () => <Loader small />,
+                  Option: OptionColor,
+                  SingleValue: SingleValueColor,
+                }}
+                error={formattedStageError}
+                inputId={STAGE_ATTRIBUTE_NAME}
+                isLoading={stageMutation.isLoading}
+                isSearchable={false}
+                isClearable={false}
+                name={STAGE_ATTRIBUTE_NAME}
+                onChange={handleChangeStage}
+                options={
+                  workflow
+                    ? workflow.stages.map(({ id, color, name }) => ({
+                        value: id,
+                        label: name,
+                        color,
+                      }))
+                    : []
+                }
+                value={{
+                  value: currentWorkflowStage?.id,
+                  label: currentWorkflowStage?.name,
+                  color: currentWorkflowStage?.color,
+                }}
+              />
 
-            <FieldError />
-          </Flex>
-        </Field>
+              <FieldError />
+            </Flex>
+          </Field>
+
+          <Field
+            error={formattedAssigneeError}
+            name={ASSIGNEE_ATTRIBUTE_NAME}
+            id={ASSIGNEE_ATTRIBUTE_NAME}
+          >
+            <Flex direction="column" gap={2} alignItems="stretch">
+              <FieldLabel>
+                {formatMessage({
+                  id: 'content-manager.reviewWorkflows.assignee.label',
+                  defaultMessage: 'Assignee',
+                })}
+              </FieldLabel>
+
+              <ReactSelect
+                components={{
+                  LoadingIndicator: () => <Loader small />,
+                }}
+                disabled={usersIsError}
+                error={formattedAssigneeError}
+                inputId={ASSIGNEE_ATTRIBUTE_NAME}
+                isLoading={usersIsLoading || assigneeMutation.isLoading}
+                isSearchable
+                isClearable
+                name={ASSIGNEE_ATTRIBUTE_NAME}
+                onChange={handleChangeAssignee}
+                onClear={() => handleChangeAssignee({ value: null })}
+                options={users.map(({ id, firstname, lastname }) => ({
+                  value: id,
+                  label: formatMessage(
+                    {
+                      id: 'content-manager.reviewWorkflows.assignee.name',
+                      defaultMessage: '{firstname} {lastname}',
+                    },
+                    {
+                      firstname,
+                      lastname,
+                    }
+                  ),
+                }))}
+                value={
+                  currentAssignee
+                    ? {
+                        value: currentAssignee.id,
+                        label: formatMessage(
+                          {
+                            id: 'content-manager.reviewWorkflows.assignee.name',
+                            defaultMessage: '{firstname} {lastname}',
+                          },
+                          {
+                            firstname: currentAssignee.firstname,
+                            lastname: currentAssignee.lastname,
+                          }
+                        ),
+                      }
+                    : null
+                }
+              />
+
+              <FieldError />
+            </Flex>
+          </Field>
+        </>
       )}
-
       <Information.Body />
     </Information.Root>
   );

--- a/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/InformationBoxEE.js
+++ b/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/InformationBoxEE.js
@@ -1,149 +1,20 @@
 import React from 'react';
-import {
-  ReactSelect,
-  useCMEditViewDataManager,
-  useAPIErrorHandler,
-  useFetchClient,
-  useNotification,
-} from '@strapi/helper-plugin';
-import { Field, FieldLabel, FieldError, Flex, Loader } from '@strapi/design-system';
-import { useIntl } from 'react-intl';
-import { useMutation } from 'react-query';
+import { useCMEditViewDataManager } from '@strapi/helper-plugin';
 
-import { useReviewWorkflows } from '../../../../pages/SettingsPage/pages/ReviewWorkflows/hooks/useReviewWorkflows';
-import { OptionColor } from '../../../../pages/SettingsPage/pages/ReviewWorkflows/components/Stages/Stage/components/OptionColor';
-import { SingleValueColor } from '../../../../pages/SettingsPage/pages/ReviewWorkflows/components/Stages/Stage/components/SingleValueColor';
 import Information from '../../../../../../admin/src/content-manager/pages/EditView/Information';
-import { useAdminUsers } from '../../../../../../admin/src/hooks/useAdminUsers';
-
-const STAGE_ATTRIBUTE_NAME = 'strapi_reviewWorkflows_stage';
-const ASSIGNEE_ATTRIBUTE_NAME = 'strapi_assignee';
+import { AssigneeSelect } from './components/AssigneeSelect';
+import { StageSelect } from './components/StageSelect';
+import { STAGE_ATTRIBUTE_NAME } from './constants';
 
 export function InformationBoxEE() {
-  const {
-    initialData,
-    isCreatingEntry,
-    layout: { uid },
-    isSingleType,
-    onChange,
-  } = useCMEditViewDataManager();
-  const { put } = useFetchClient();
+  const { initialData, isCreatingEntry } = useCMEditViewDataManager();
   // it is possible to rely on initialData here, because it always will
   // be updated at the same time when modifiedData is updated, otherwise
   // the entity is flagged as modified
-  const currentWorkflowStage = initialData?.[STAGE_ATTRIBUTE_NAME] ?? null;
-  const currentAssignee = initialData?.[ASSIGNEE_ATTRIBUTE_NAME] ?? null;
   const hasReviewWorkflowsEnabled = Object.prototype.hasOwnProperty.call(
     initialData,
     STAGE_ATTRIBUTE_NAME
   );
-  const { formatMessage } = useIntl();
-  const { formatAPIError } = useAPIErrorHandler();
-  const toggleNotification = useNotification();
-  const { users, isLoading: usersIsLoading, isError: usersIsError } = useAdminUsers();
-  const { workflows, isLoading: workflowIsLoading } = useReviewWorkflows();
-  // TODO: this works only as long as we support one workflow
-  const workflow = workflows?.[0] ?? null;
-
-  const stageMutation = useMutation(
-    async ({ entityId, stageId, uid }) => {
-      const typeSlug = isSingleType ? 'single-types' : 'collection-types';
-
-      const {
-        data: { data: createdEntity },
-      } = await put(`/admin/content-manager/${typeSlug}/${uid}/${entityId}/stage`, {
-        data: { id: stageId },
-      });
-
-      // initialData and modifiedData have to stay in sync, otherwise the entity would be flagged
-      // as modified, which is what the boolean flag is for
-      onChange(
-        { target: { name: STAGE_ATTRIBUTE_NAME, value: createdEntity[STAGE_ATTRIBUTE_NAME] } },
-        true
-      );
-
-      return createdEntity;
-    },
-    {
-      onSuccess() {
-        toggleNotification({
-          type: 'success',
-          message: {
-            id: 'content-manager.reviewWorkflows.stage.notification.saved',
-            defaultMessage: 'Success: Review stage updated',
-          },
-        });
-      },
-    }
-  );
-
-  const assigneeMutation = useMutation(
-    async ({ entityId, assigneeId, uid }) => {
-      const typeSlug = isSingleType ? 'single-types' : 'collection-types';
-
-      const {
-        data: { data: createdEntity },
-      } = await put(`/admin/content-manager/${typeSlug}/${uid}/${entityId}/assignee`, {
-        data: { id: assigneeId },
-      });
-
-      // initialData and modifiedData have to stay in sync, otherwise the entity would be flagged
-      // as modified, which is what the boolean flag is for
-      onChange(
-        {
-          target: { name: ASSIGNEE_ATTRIBUTE_NAME, value: createdEntity[ASSIGNEE_ATTRIBUTE_NAME] },
-        },
-        true
-      );
-
-      return createdEntity;
-    },
-    {
-      onSuccess() {
-        toggleNotification({
-          type: 'success',
-          message: {
-            id: 'content-manager.reviewWorkflows.assignee.notification.saved',
-            defaultMessage: 'Success: Assignee updated',
-          },
-        });
-      },
-    }
-  );
-
-  // if entities are created e.g. through lifecycle methods
-  // they may not have a stage assigned. Updating the entity won't
-  // set the default stage either which may lead to entities that
-  // do not have a stage assigned for a while. By displaying an
-  // error by default we are trying to nudge users into assigning a stage.
-  const initialStageNullError =
-    currentWorkflowStage === null &&
-    !workflowIsLoading &&
-    !isCreatingEntry &&
-    formatMessage({
-      id: 'content-manager.reviewWorkflows.stage.select.placeholder',
-      defaultMessage: 'Select a stage',
-    });
-
-  const formattedStageError =
-    (stageMutation.error && formatAPIError(stageMutation.error)) || initialStageNullError || null;
-  const formattedAssigneeError = assigneeMutation.error && formatAPIError(assigneeMutation.error);
-
-  const handleChangeStage = async ({ value: stageId }) => {
-    stageMutation.mutate({
-      entityId: initialData.id,
-      stageId,
-      uid,
-    });
-  };
-
-  const handleChangeAssignee = async ({ value: assigneeId }) => {
-    assigneeMutation.mutate({
-      entityId: initialData.id,
-      assigneeId,
-      uid,
-    });
-  };
 
   return (
     <Information.Root>
@@ -151,109 +22,8 @@ export function InformationBoxEE() {
 
       {hasReviewWorkflowsEnabled && !isCreatingEntry && (
         <>
-          <Field error={formattedStageError} name={STAGE_ATTRIBUTE_NAME} id={STAGE_ATTRIBUTE_NAME}>
-            <Flex direction="column" gap={2} alignItems="stretch">
-              <FieldLabel>
-                {formatMessage({
-                  id: 'content-manager.reviewWorkflows.stage.label',
-                  defaultMessage: 'Review stage',
-                })}
-              </FieldLabel>
-
-              <ReactSelect
-                components={{
-                  LoadingIndicator: () => <Loader small />,
-                  Option: OptionColor,
-                  SingleValue: SingleValueColor,
-                }}
-                error={formattedStageError}
-                inputId={STAGE_ATTRIBUTE_NAME}
-                isLoading={stageMutation.isLoading}
-                isSearchable={false}
-                isClearable={false}
-                name={STAGE_ATTRIBUTE_NAME}
-                onChange={handleChangeStage}
-                options={
-                  workflow
-                    ? workflow.stages.map(({ id, color, name }) => ({
-                        value: id,
-                        label: name,
-                        color,
-                      }))
-                    : []
-                }
-                value={{
-                  value: currentWorkflowStage?.id,
-                  label: currentWorkflowStage?.name,
-                  color: currentWorkflowStage?.color,
-                }}
-              />
-
-              <FieldError />
-            </Flex>
-          </Field>
-
-          <Field
-            error={formattedAssigneeError}
-            name={ASSIGNEE_ATTRIBUTE_NAME}
-            id={ASSIGNEE_ATTRIBUTE_NAME}
-          >
-            <Flex direction="column" gap={2} alignItems="stretch">
-              <FieldLabel>
-                {formatMessage({
-                  id: 'content-manager.reviewWorkflows.assignee.label',
-                  defaultMessage: 'Assignee',
-                })}
-              </FieldLabel>
-
-              <ReactSelect
-                components={{
-                  LoadingIndicator: () => <Loader small />,
-                }}
-                disabled={usersIsError}
-                error={formattedAssigneeError}
-                inputId={ASSIGNEE_ATTRIBUTE_NAME}
-                isLoading={usersIsLoading || assigneeMutation.isLoading}
-                isSearchable
-                isClearable
-                name={ASSIGNEE_ATTRIBUTE_NAME}
-                onChange={handleChangeAssignee}
-                onClear={() => handleChangeAssignee({ value: null })}
-                options={users.map(({ id, firstname, lastname }) => ({
-                  value: id,
-                  label: formatMessage(
-                    {
-                      id: 'content-manager.reviewWorkflows.assignee.name',
-                      defaultMessage: '{firstname} {lastname}',
-                    },
-                    {
-                      firstname,
-                      lastname,
-                    }
-                  ),
-                }))}
-                value={
-                  currentAssignee
-                    ? {
-                        value: currentAssignee.id,
-                        label: formatMessage(
-                          {
-                            id: 'content-manager.reviewWorkflows.assignee.name',
-                            defaultMessage: '{firstname} {lastname}',
-                          },
-                          {
-                            firstname: currentAssignee.firstname,
-                            lastname: currentAssignee.lastname,
-                          }
-                        ),
-                      }
-                    : null
-                }
-              />
-
-              <FieldError />
-            </Flex>
-          </Field>
+          <StageSelect />
+          <AssigneeSelect />
         </>
       )}
       <Information.Body />

--- a/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/components/AssigneeSelect/AssigneeSelect.js
+++ b/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/components/AssigneeSelect/AssigneeSelect.js
@@ -1,0 +1,134 @@
+import * as React from 'react';
+import {
+  ReactSelect,
+  useCMEditViewDataManager,
+  useAPIErrorHandler,
+  useFetchClient,
+  useNotification,
+} from '@strapi/helper-plugin';
+import { Field, FieldLabel, FieldError, Flex, Loader } from '@strapi/design-system';
+import { useIntl } from 'react-intl';
+import { useMutation } from 'react-query';
+
+import { useAdminUsers } from '../../../../../../../../admin/src/hooks/useAdminUsers';
+import { ASSIGNEE_ATTRIBUTE_NAME } from '../../constants';
+
+export function AssigneeSelect() {
+  const {
+    initialData,
+    layout: { uid },
+    isSingleType,
+    onChange,
+  } = useCMEditViewDataManager();
+  const { formatMessage } = useIntl();
+  const { formatAPIError } = useAPIErrorHandler();
+  const toggleNotification = useNotification();
+  const { put } = useFetchClient();
+  const { users, isLoading, isError } = useAdminUsers();
+
+  const currentAssignee = initialData?.[ASSIGNEE_ATTRIBUTE_NAME] ?? null;
+
+  const handleChange = async ({ value: assigneeId }) => {
+    mutation.mutate({
+      entityId: initialData.id,
+      assigneeId,
+      uid,
+    });
+  };
+
+  const mutation = useMutation(
+    async ({ entityId, assigneeId, uid }) => {
+      const typeSlug = isSingleType ? 'single-types' : 'collection-types';
+
+      const {
+        data: { data: createdEntity },
+      } = await put(`/admin/content-manager/${typeSlug}/${uid}/${entityId}/assignee`, {
+        data: { id: assigneeId },
+      });
+
+      // initialData and modifiedData have to stay in sync, otherwise the entity would be flagged
+      // as modified, which is what the boolean flag is for
+      onChange(
+        {
+          target: { name: ASSIGNEE_ATTRIBUTE_NAME, value: createdEntity[ASSIGNEE_ATTRIBUTE_NAME] },
+        },
+        true
+      );
+
+      return createdEntity;
+    },
+    {
+      onSuccess() {
+        toggleNotification({
+          type: 'success',
+          message: {
+            id: 'content-manager.reviewWorkflows.assignee.notification.saved',
+            defaultMessage: 'Success: Assignee updated',
+          },
+        });
+      },
+    }
+  );
+
+  const formattedError = mutation.error && formatAPIError(mutation.error);
+
+  return (
+    <Field error={formattedError} name={ASSIGNEE_ATTRIBUTE_NAME} id={ASSIGNEE_ATTRIBUTE_NAME}>
+      <Flex direction="column" gap={2} alignItems="stretch">
+        <FieldLabel>
+          {formatMessage({
+            id: 'content-manager.reviewWorkflows.assignee.label',
+            defaultMessage: 'Assignee',
+          })}
+        </FieldLabel>
+
+        <ReactSelect
+          components={{
+            LoadingIndicator: () => <Loader small />,
+          }}
+          disabled={isError}
+          error={formattedError}
+          inputId={ASSIGNEE_ATTRIBUTE_NAME}
+          isLoading={isLoading || mutation.isLoading}
+          isSearchable
+          isClearable
+          name={ASSIGNEE_ATTRIBUTE_NAME}
+          onChange={handleChange}
+          onClear={() => handleChange({ value: null })}
+          options={users.map(({ id, firstname, lastname }) => ({
+            value: id,
+            label: formatMessage(
+              {
+                id: 'content-manager.reviewWorkflows.assignee.name',
+                defaultMessage: '{firstname} {lastname}',
+              },
+              {
+                firstname,
+                lastname,
+              }
+            ),
+          }))}
+          value={
+            currentAssignee
+              ? {
+                  value: currentAssignee.id,
+                  label: formatMessage(
+                    {
+                      id: 'content-manager.reviewWorkflows.assignee.name',
+                      defaultMessage: '{firstname} {lastname}',
+                    },
+                    {
+                      firstname: currentAssignee.firstname,
+                      lastname: currentAssignee.lastname,
+                    }
+                  ),
+                }
+              : null
+          }
+        />
+
+        <FieldError />
+      </Flex>
+    </Field>
+  );
+}

--- a/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/components/AssigneeSelect/AssigneeSelect.js
+++ b/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/components/AssigneeSelect/AssigneeSelect.js
@@ -70,7 +70,13 @@ export function AssigneeSelect() {
     }
   );
 
-  const formattedError = mutation.error && formatAPIError(mutation.error);
+  const formattedError =
+    (isError &&
+      formatMessage({
+        id: 'content-manager.reviewWorkflows.assignee.error',
+        defaultMessage: 'An error occurred while fetching users',
+      })) ||
+    (mutation.error && formatAPIError(mutation.error));
 
   return (
     <Field error={formattedError} name={ASSIGNEE_ATTRIBUTE_NAME} id={ASSIGNEE_ATTRIBUTE_NAME}>
@@ -84,7 +90,7 @@ export function AssigneeSelect() {
 
         <ReactSelect
           components={{
-            LoadingIndicator: () => <Loader small />,
+            LoadingIndicator: () => <Loader data-testid="loader" small />,
           }}
           disabled={isError}
           error={formattedError}

--- a/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/components/AssigneeSelect/index.js
+++ b/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/components/AssigneeSelect/index.js
@@ -1,0 +1,1 @@
+export * from './AssigneeSelect';

--- a/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/components/AssigneeSelect/tests/AssigneeSelect.test.js
+++ b/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/components/AssigneeSelect/tests/AssigneeSelect.test.js
@@ -1,0 +1,171 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { IntlProvider } from 'react-intl';
+import { useCMEditViewDataManager } from '@strapi/helper-plugin';
+import { ThemeProvider, lightTheme } from '@strapi/design-system';
+import { QueryClientProvider, QueryClient } from 'react-query';
+import { Provider } from 'react-redux';
+import { createStore } from 'redux';
+import { setupServer } from 'msw/node';
+import { rest } from 'msw';
+
+import { AssigneeSelect } from '../AssigneeSelect';
+import { ASSIGNEE_ATTRIBUTE_NAME } from '../../../constants';
+
+const server = setupServer(
+  rest.get('*/users', (req, res, ctx) =>
+    res(
+      ctx.json({
+        data: {
+          results: [
+            {
+              id: 1,
+              firstname: 'Firstname 1',
+              lastname: 'Lastname 1',
+            },
+
+            {
+              id: 2,
+              firstname: 'Firstname 2',
+              lastname: 'Lastname 2',
+            },
+          ],
+        },
+      })
+    )
+  )
+);
+
+jest.mock('@strapi/helper-plugin', () => ({
+  ...jest.requireActual('@strapi/helper-plugin'),
+  useCMEditViewDataManager: jest.fn(),
+  useNotification: jest.fn(() => ({
+    toggleNotification: jest.fn(),
+  })),
+}));
+
+const setup = (props) => {
+  return {
+    user: userEvent.setup(),
+    ...render(<AssigneeSelect {...props} />, {
+      wrapper({ children }) {
+        const store = createStore((state = {}) => state, {});
+        const queryClient = new QueryClient({
+          defaultOptions: {
+            queries: {
+              retry: false,
+            },
+          },
+        });
+
+        return (
+          <Provider store={store}>
+            <QueryClientProvider client={queryClient}>
+              <IntlProvider locale="en" defaultLocale="en">
+                <ThemeProvider theme={lightTheme}>{children}</ThemeProvider>
+              </IntlProvider>
+            </QueryClientProvider>
+          </Provider>
+        );
+      },
+    }),
+  };
+};
+
+useCMEditViewDataManager.mockReturnValue({
+  initialData: {
+    [ASSIGNEE_ATTRIBUTE_NAME]: null,
+  },
+  layout: { uid: 'api::articles:articles' },
+});
+
+describe('EE | Content Manager | EditView | InformationBox | AssigneeSelect', () => {
+  beforeAll(() => {
+    server.listen();
+    jest.clearAllMocks();
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
+  it('renders a select with users, none is selected', async () => {
+    const { queryByRole, getByText, queryByText, user } = setup();
+    const select = queryByRole('combobox');
+
+    expect(queryByText('Firstname 1 Lastname 1')).not.toBeInTheDocument();
+
+    await user.click(select);
+
+    expect(getByText('Firstname 1 Lastname 1')).toBeInTheDocument();
+  });
+
+  it('renders a select with users, first user is selected', async () => {
+    useCMEditViewDataManager.mockReturnValue({
+      initialData: {
+        [ASSIGNEE_ATTRIBUTE_NAME]: {
+          id: 1,
+          firstname: 'Firstname 1',
+          lastname: 'Lastname 1',
+        },
+      },
+      layout: { uid: 'api::articles:articles' },
+    });
+
+    const { getByText } = setup();
+
+    expect(getByText('Firstname 1 Lastname 1')).toBeInTheDocument();
+  });
+
+  it('renders an error message, when fetching user fails', async () => {
+    const origConsoleError = console.error;
+
+    console.error = jest.fn();
+
+    server.use(
+      rest.get('*/users', (req, res, ctx) => {
+        return res.once(
+          ctx.status(500),
+          ctx.json({
+            data: {
+              error: {
+                message: 'Error message',
+              },
+            },
+          })
+        );
+      })
+    );
+
+    const { getByText, queryByTestId } = setup();
+
+    await waitFor(() => expect(queryByTestId('loader')).not.toBeInTheDocument());
+
+    expect(getByText('An error occurred while fetching users')).toBeInTheDocument();
+
+    console.error = origConsoleError;
+  });
+
+  it('renders a loading state when running the mutation', async () => {
+    const { getByTestId, queryByTestId } = setup();
+
+    expect(getByTestId('loader')).toBeInTheDocument();
+
+    await waitFor(() => expect(queryByTestId('loader')).not.toBeInTheDocument());
+  });
+
+  it('renders an error message, when the mutation fails', async () => {
+    const origConsoleError = console.error;
+
+    console.error = jest.fn();
+
+    const { queryByTestId } = setup();
+
+    await waitFor(() => expect(queryByTestId('loader')).not.toBeInTheDocument());
+
+    // TODO
+
+    console.error = origConsoleError;
+  });
+});

--- a/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/components/StageSelect/StageSelect.js
+++ b/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/components/StageSelect/StageSelect.js
@@ -106,7 +106,7 @@ export function StageSelect() {
 
         <ReactSelect
           components={{
-            LoadingIndicator: () => <Loader small />,
+            LoadingIndicator: () => <Loader data-testid="loader" small />,
             Option: OptionColor,
             SingleValue: SingleValueColor,
           }}

--- a/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/components/StageSelect/StageSelect.js
+++ b/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/components/StageSelect/StageSelect.js
@@ -1,0 +1,140 @@
+import * as React from 'react';
+import {
+  ReactSelect,
+  useCMEditViewDataManager,
+  useAPIErrorHandler,
+  useFetchClient,
+  useNotification,
+} from '@strapi/helper-plugin';
+import { Field, FieldLabel, FieldError, Flex, Loader } from '@strapi/design-system';
+import { useIntl } from 'react-intl';
+import { useMutation } from 'react-query';
+
+import { useReviewWorkflows } from '../../../../../../pages/SettingsPage/pages/ReviewWorkflows/hooks/useReviewWorkflows';
+import { OptionColor } from '../../../../../../pages/SettingsPage/pages/ReviewWorkflows/components/Stages/Stage/components/OptionColor';
+import { SingleValueColor } from '../../../../../../pages/SettingsPage/pages/ReviewWorkflows/components/Stages/Stage/components/SingleValueColor';
+import { STAGE_ATTRIBUTE_NAME } from '../../constants';
+
+export function StageSelect() {
+  const {
+    initialData,
+    isCreatingEntry,
+    layout: { uid },
+    isSingleType,
+    onChange,
+  } = useCMEditViewDataManager();
+  const { put } = useFetchClient();
+  const { formatMessage } = useIntl();
+  const { formatAPIError } = useAPIErrorHandler();
+  const toggleNotification = useNotification();
+  const { workflows, isLoading } = useReviewWorkflows();
+
+  // TODO: this works only as long as we support one workflow
+  const workflow = workflows?.[0] ?? null;
+
+  // it is possible to rely on initialData here, because it always will
+  // be updated at the same time when modifiedData is updated, otherwise
+  // the entity is flagged as modified
+  const currentWorkflowStage = initialData?.[STAGE_ATTRIBUTE_NAME] ?? null;
+
+  const mutation = useMutation(
+    async ({ entityId, stageId, uid }) => {
+      const typeSlug = isSingleType ? 'single-types' : 'collection-types';
+
+      const {
+        data: { data: createdEntity },
+      } = await put(`/admin/content-manager/${typeSlug}/${uid}/${entityId}/stage`, {
+        data: { id: stageId },
+      });
+
+      // initialData and modifiedData have to stay in sync, otherwise the entity would be flagged
+      // as modified, which is what the boolean flag is for
+      onChange(
+        { target: { name: STAGE_ATTRIBUTE_NAME, value: createdEntity[STAGE_ATTRIBUTE_NAME] } },
+        true
+      );
+
+      return createdEntity;
+    },
+    {
+      onSuccess() {
+        toggleNotification({
+          type: 'success',
+          message: {
+            id: 'content-manager.reviewWorkflows.stage.notification.saved',
+            defaultMessage: 'Success: Review stage updated',
+          },
+        });
+      },
+    }
+  );
+
+  // if entities are created e.g. through lifecycle methods
+  // they may not have a stage assigned. Updating the entity won't
+  // set the default stage either which may lead to entities that
+  // do not have a stage assigned for a while. By displaying an
+  // error by default we are trying to nudge users into assigning a stage.
+  const initialStageNullError =
+    currentWorkflowStage === null &&
+    !isLoading &&
+    !isCreatingEntry &&
+    formatMessage({
+      id: 'content-manager.reviewWorkflows.stage.select.placeholder',
+      defaultMessage: 'Select a stage',
+    });
+
+  const formattedError =
+    (mutation.error && formatAPIError(mutation.error)) || initialStageNullError || null;
+
+  const handleChange = async ({ value: stageId }) => {
+    mutation.mutate({
+      entityId: initialData.id,
+      stageId,
+      uid,
+    });
+  };
+
+  return (
+    <Field error={formattedError} name={STAGE_ATTRIBUTE_NAME} id={STAGE_ATTRIBUTE_NAME}>
+      <Flex direction="column" gap={2} alignItems="stretch">
+        <FieldLabel>
+          {formatMessage({
+            id: 'content-manager.reviewWorkflows.stage.label',
+            defaultMessage: 'Review stage',
+          })}
+        </FieldLabel>
+
+        <ReactSelect
+          components={{
+            LoadingIndicator: () => <Loader small />,
+            Option: OptionColor,
+            SingleValue: SingleValueColor,
+          }}
+          error={formattedError}
+          inputId={STAGE_ATTRIBUTE_NAME}
+          isLoading={mutation.isLoading}
+          isSearchable={false}
+          isClearable={false}
+          name={STAGE_ATTRIBUTE_NAME}
+          onChange={handleChange}
+          options={
+            workflow
+              ? workflow.stages.map(({ id, color, name }) => ({
+                  value: id,
+                  label: name,
+                  color,
+                }))
+              : []
+          }
+          value={{
+            value: currentWorkflowStage?.id,
+            label: currentWorkflowStage?.name,
+            color: currentWorkflowStage?.color,
+          }}
+        />
+
+        <FieldError />
+      </Flex>
+    </Field>
+  );
+}

--- a/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/components/StageSelect/index.js
+++ b/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/components/StageSelect/index.js
@@ -1,0 +1,1 @@
+export * from './StageSelect';

--- a/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/components/StageSelect/tests/StageSelect.test.js
+++ b/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/components/StageSelect/tests/StageSelect.test.js
@@ -1,0 +1,145 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { IntlProvider } from 'react-intl';
+import { useCMEditViewDataManager } from '@strapi/helper-plugin';
+import { ThemeProvider, lightTheme } from '@strapi/design-system';
+import { QueryClientProvider, QueryClient } from 'react-query';
+import { Provider } from 'react-redux';
+import { createStore } from 'redux';
+import { setupServer } from 'msw/node';
+import { rest } from 'msw';
+
+import { StageSelect } from '../StageSelect';
+import { STAGE_ATTRIBUTE_NAME } from '../../../constants';
+
+const STAGE_1_STATE_FIXTURE = {
+  id: 1,
+  color: '#4945FF',
+  name: 'Stage 1',
+  worklow: 1,
+};
+
+const server = setupServer(
+  rest.get('*/review-workflows/workflows/', (req, res, ctx) =>
+    res(
+      ctx.json({
+        data: [
+          {
+            id: 1,
+            stages: [
+              {
+                id: 1,
+                color: '#4945FF',
+                name: 'Stage 1',
+              },
+              {
+                id: 2,
+                color: '#4945FF',
+                name: 'Stage 2',
+              },
+            ],
+          },
+        ],
+      })
+    )
+  )
+);
+
+jest.mock('@strapi/helper-plugin', () => ({
+  ...jest.requireActual('@strapi/helper-plugin'),
+  useCMEditViewDataManager: jest.fn(),
+  useNotification: jest.fn(() => ({
+    toggleNotification: jest.fn(),
+  })),
+}));
+
+const setup = (props) => {
+  return {
+    user: userEvent.setup(),
+    ...render(<StageSelect {...props} />, {
+      wrapper({ children }) {
+        const store = createStore((state = {}) => state, {});
+        const queryClient = new QueryClient({
+          defaultOptions: {
+            queries: {
+              retry: false,
+            },
+          },
+        });
+
+        return (
+          <Provider store={store}>
+            <QueryClientProvider client={queryClient}>
+              <IntlProvider locale="en" defaultLocale="en">
+                <ThemeProvider theme={lightTheme}>{children}</ThemeProvider>
+              </IntlProvider>
+            </QueryClientProvider>
+          </Provider>
+        );
+      },
+    }),
+  };
+};
+
+describe('EE | Content Manager | EditView | InformationBox | StageSelect', () => {
+  beforeAll(() => {
+    server.listen();
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
+  it('renders an error, if no workflow stage is assigned to the entity', async () => {
+    useCMEditViewDataManager.mockReturnValue({
+      initialData: {
+        [STAGE_ATTRIBUTE_NAME]: null,
+      },
+      layout: { uid: 'api::articles:articles' },
+    });
+
+    const { getByText, queryByRole } = setup();
+
+    expect(queryByRole('combobox')).toBeInTheDocument();
+
+    await waitFor(() => expect(getByText(/select a stage/i)).toBeInTheDocument());
+  });
+
+  it('renders an enabled select input, if the entity is edited', () => {
+    useCMEditViewDataManager.mockReturnValue({
+      initialData: {
+        [STAGE_ATTRIBUTE_NAME]: null,
+      },
+      isCreatingEntry: false,
+      layout: { uid: 'api::articles:articles' },
+    });
+
+    const { queryByRole } = setup();
+    const select = queryByRole('combobox');
+
+    expect(select).toBeInTheDocument();
+  });
+
+  it('renders a select input, if a workflow stage is assigned to the entity', async () => {
+    useCMEditViewDataManager.mockReturnValue({
+      initialData: {
+        [STAGE_ATTRIBUTE_NAME]: STAGE_1_STATE_FIXTURE,
+      },
+      isCreatingEntry: false,
+      layout: { uid: 'api::articles:articles' },
+    });
+
+    const { queryByRole, queryByTestId, getByText, user } = setup();
+
+    await waitFor(() => expect(queryByTestId('loader')).not.toBeInTheDocument());
+
+    const select = queryByRole('combobox');
+
+    expect(getByText('Stage 1')).toBeInTheDocument();
+
+    await user.click(select);
+
+    expect(getByText('Stage 2')).toBeInTheDocument();
+  });
+});

--- a/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/constants.js
+++ b/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/constants.js
@@ -1,0 +1,2 @@
+export const STAGE_ATTRIBUTE_NAME = 'strapi_reviewWorkflows_stage';
+export const ASSIGNEE_ATTRIBUTE_NAME = 'strapi_assignee';

--- a/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/tests/InformationBoxEE.test.js
+++ b/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/tests/InformationBoxEE.test.js
@@ -1,21 +1,16 @@
 import React from 'react';
-import { fireEvent, render } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { IntlProvider } from 'react-intl';
 import { useCMEditViewDataManager } from '@strapi/helper-plugin';
 import { ThemeProvider, lightTheme } from '@strapi/design-system';
 import { QueryClientProvider, QueryClient } from 'react-query';
 import { Provider } from 'react-redux';
 import { createStore } from 'redux';
+import { setupServer } from 'msw/node';
+import { rest } from 'msw';
 
+import { STAGE_ATTRIBUTE_NAME, ASSIGNEE_ATTRIBUTE_NAME } from '../constants';
 import { InformationBoxEE } from '../InformationBoxEE';
-
-const STAGE_ATTRIBUTE_NAME = 'strapi_reviewWorkflows_stage';
-const STAGE_FIXTURE = {
-  id: 1,
-  color: '#4945FF',
-  name: 'Stage 1',
-  worklow: 1,
-};
 
 jest.mock('@strapi/helper-plugin', () => ({
   ...jest.requireActual('@strapi/helper-plugin'),
@@ -25,60 +20,72 @@ jest.mock('@strapi/helper-plugin', () => ({
   })),
 }));
 
-jest.mock(
-  '../../../../../pages/SettingsPage/pages/ReviewWorkflows/hooks/useReviewWorkflows',
-  () => ({
-    useReviewWorkflows: jest.fn(() => ({
-      isLoading: false,
-      workflows: [
-        {
-          stages: [
+const server = setupServer(
+  rest.get('*/users', (req, res, ctx) =>
+    res(
+      ctx.json({
+        data: {
+          results: [
             {
               id: 1,
-              color: '#4945FF',
-              name: 'Stage 1',
-            },
-            {
-              id: 2,
-              color: '#4945FF',
-              name: 'Stage 2',
             },
           ],
+
+          pagination: {
+            page: 1,
+          },
         },
-      ],
-    })),
-  })
+      })
+    )
+  ),
+
+  rest.get('*/review-workflows/workflows', (req, res, ctx) =>
+    res(
+      ctx.json({
+        data: [
+          {
+            id: 1,
+          },
+        ],
+      })
+    )
+  )
 );
 
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      refetchOnWindowFocus: false,
-    },
-  },
-});
-
-const ComponentFixture = (props) => {
-  const store = createStore((state = {}) => state, {});
-
-  return (
-    <Provider store={store}>
-      <QueryClientProvider client={queryClient}>
-        <IntlProvider locale="en" defaultLocale="en">
-          <ThemeProvider theme={lightTheme}>
-            <InformationBoxEE {...props} />
-          </ThemeProvider>
-        </IntlProvider>
-      </QueryClientProvider>
-    </Provider>
-  );
-};
-
 const setup = (props) => {
-  return render(<ComponentFixture {...props} />);
+  return render(<InformationBoxEE {...props} />, {
+    wrapper({ children }) {
+      const store = createStore((state = {}) => state, {});
+      const queryClient = new QueryClient({
+        defaultOptions: {
+          queries: {
+            retry: false,
+          },
+        },
+      });
+
+      return (
+        <Provider store={store}>
+          <QueryClientProvider client={queryClient}>
+            <IntlProvider locale="en" defaultLocale="en">
+              <ThemeProvider theme={lightTheme}>{children}</ThemeProvider>
+            </IntlProvider>
+          </QueryClientProvider>
+        </Provider>
+      );
+    },
+  });
 };
 
 describe('EE | Content Manager | EditView | InformationBox', () => {
+  beforeAll(() => {
+    server.listen();
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
   it('renders the title and body of the Information component', () => {
     useCMEditViewDataManager.mockReturnValue({
       initialData: {},
@@ -92,7 +99,7 @@ describe('EE | Content Manager | EditView | InformationBox', () => {
     expect(getByText('Last update')).toBeInTheDocument();
   });
 
-  it('renders no select input, if no workflow stage is assigned to the entity', () => {
+  it('renders neither stage nor assignee select inputs, if no nothing is returned for an entity', () => {
     useCMEditViewDataManager.mockReturnValue({
       initialData: {},
       layout: { uid: 'api::articles:articles' },
@@ -103,67 +110,27 @@ describe('EE | Content Manager | EditView | InformationBox', () => {
     expect(queryByRole('combobox')).not.toBeInTheDocument();
   });
 
-  it('renders an error, if no workflow stage is assigned to the entity', () => {
+  it('renders stage and assignee select inputs, if it is returned for an entity', () => {
     useCMEditViewDataManager.mockReturnValue({
       initialData: {
-        [STAGE_ATTRIBUTE_NAME]: null,
+        [STAGE_ATTRIBUTE_NAME]: {
+          id: 1,
+          color: '#4945FF',
+          name: 'Stage 1',
+          worklow: 1,
+        },
+
+        [ASSIGNEE_ATTRIBUTE_NAME]: {
+          id: 1,
+          firstname: 'Firstname',
+          lastname: 'Lastname',
+        },
       },
       layout: { uid: 'api::articles:articles' },
     });
 
-    const { getByText, queryByRole } = setup();
+    const { queryAllByRole } = setup();
 
-    expect(getByText(/select a stage/i)).toBeInTheDocument();
-    expect(queryByRole('combobox')).toBeInTheDocument();
-  });
-
-  it('does not render the select input, if the entity is created', () => {
-    useCMEditViewDataManager.mockReturnValue({
-      initialData: {
-        [STAGE_ATTRIBUTE_NAME]: STAGE_FIXTURE,
-      },
-      isCreatingEntry: true,
-      layout: { uid: 'api::articles:articles' },
-    });
-
-    const { queryByRole } = setup();
-    const select = queryByRole('combobox');
-
-    expect(select).not.toBeInTheDocument();
-  });
-
-  it('renders an enabled select input, if the entity is edited', () => {
-    useCMEditViewDataManager.mockReturnValue({
-      initialData: {
-        [STAGE_ATTRIBUTE_NAME]: STAGE_FIXTURE,
-      },
-      isCreatingEntry: false,
-      layout: { uid: 'api::articles:articles' },
-    });
-
-    const { queryByRole } = setup();
-    const select = queryByRole('combobox');
-
-    expect(select).toBeInTheDocument();
-  });
-
-  it('renders a select input, if a workflow stage is assigned to the entity', () => {
-    useCMEditViewDataManager.mockReturnValue({
-      initialData: {
-        [STAGE_ATTRIBUTE_NAME]: STAGE_FIXTURE,
-      },
-      isCreatingEntry: false,
-      layout: { uid: 'api::articles:articles' },
-    });
-
-    const { queryByRole, getByText } = setup();
-    const select = queryByRole('combobox');
-
-    expect(select).toBeInTheDocument();
-    expect(getByText('Stage 1')).toBeInTheDocument();
-
-    fireEvent.mouseDown(select);
-
-    expect(getByText('Stage 2')).toBeInTheDocument();
+    expect(queryAllByRole('combobox').length).toBe(2);
   });
 });


### PR DESCRIPTION
### What does it do?

Renders a new select for admin users. It will be disabled if the admin users can not be fetched.

It also splits up the `InformationboxEE` component into smaller chunks that are easier to test.

### Why is it needed?

Implements the bulk of the work needed to assign admin users to entities in the CM edit view.

### How to test it?

I will add tests once the API is ready and we know this is how everything is going to work.

