### PR TITLE
Chore: Notification - Add missing translation

### DIFF
--- a/packages/core/admin/admin/src/translations/en.json
+++ b/packages/core/admin/admin/src/translations/en.json
@@ -826,6 +826,7 @@
   "global.back": "Back",
   "global.cancel": "Cancel",
   "global.change-password": "Change password",
+  "global.close": "Close",
   "global.content-manager": "Content Manager",
   "global.continue": "Continue",
   "global.delete": "Delete",

--- a/packages/core/helper-plugin/src/features/Notifications.js
+++ b/packages/core/helper-plugin/src/features/Notifications.js
@@ -211,7 +211,10 @@ const Notification = ({
         ) : undefined
       }
       onClose={handleClose}
-      closeLabel="Close"
+      closeLabel={formatMessage({
+        id: 'global.close',
+        defaultMessage: 'Close',
+      })}
       title={alertTitle}
       variant={variant}
     >


### PR DESCRIPTION
### What does it do?

Replace a static string with a proper translation for the `Notification` component.

### Why is it needed?

Makes the close label translateable.

