### PR TITLE
Fix: Handle undefined routes in registerAPIRoutes forEach loop

### DIFF
--- a/packages/core/strapi/lib/services/server/register-routes.js
+++ b/packages/core/strapi/lib/services/server/register-routes.js
@@ -94,7 +94,7 @@ const registerAPIRoutes = (strapi) => {
       // TODO: remove once auth setup
       // pass meta down to compose endpoint
       router.type = 'content-api';
-      router.routes.forEach((route) => {
+      router.routes?.forEach((route) => {
         generateRouteScope(route);
         route.info = { apiName };
       });


### PR DESCRIPTION
### What does it do?


I encountered this issue while working with strapi on mac, mac stores internal hidden files with name DS_STORE in folders.
The same was stored at src/api/apiname/routes folder as a result server gave error and was unable to start, this file was not even visible at vs_code so i figured out 

Describe the technical changes you did.

### Why is it needed?

Describe the issue you are solving.

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
