### PR TITLE
Fix: Fix refetching users

### DIFF
--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Users/ListPage/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Users/ListPage/index.js
@@ -47,7 +47,7 @@ const ListPage = () => {
     pagination,
     isError,
     isLoading,
-    refetchQueries: refetchAdminUsers,
+    refetch: refetchAdminUsers,
   } = useAdminUsers(qs.parse(search, { ignoreQueryPrefix: true }), {
     enabled: canRead,
   });


### PR DESCRIPTION
### What does it do?

Fixes refetching admin users, after a new invite has been sent. The method is now called `refetch`.

### Why is it needed?

Describe the issue you are solving. I haven't added a milestone because it doesn't have to show up in the release notes.

### How to test it?

1. Invite a new user /admin/settings/users
2. See no error

### Related issue(s)/PR(s)

Broke in https://github.com/strapi/strapi/pull/16816
