### PR TITLE
refactor(review-workflow): shorten the stage attribute name on entities

### DIFF
--- a/docs/docs/docs/01-core/content-manager/02-review-workflows.mdx
+++ b/docs/docs/docs/01-core/content-manager/02-review-workflows.mdx
@@ -49,13 +49,13 @@ This means at any place where the UI displays a stage, it has to be prepared to 
 
 ## List view
 
-The information which stage is current assigned to an entity is send as part of the content-type response payload for each entity in the attribute `strapi_reviewWorkflows_stage`.
+The information which stage is current assigned to an entity is send as part of the content-type response payload for each entity in the attribute `strapi_stage`.
 Please see [Data Shapes](/settings/review-workflows#data-shapes) for type definitions.
 
 ```ts
 {
   // ... entity attributes
-  strapi_reviewWorkflows_stage?: Stage | null
+  strapi_stage?: Stage | null
 }
 ```
 
@@ -66,13 +66,13 @@ add an additional check if the feature toggle returned in `http://localhost:1337
 
 ## Edit View
 
-The information which stage is current assigned to an entity is send as part of the entity response payload in the attribute `strapi_reviewWorkflows_stage`.
+The information which stage is current assigned to an entity is send as part of the entity response payload in the attribute `strapi_stage`.
 Please see [Data Shapes](/settings/review-workflows#data-shapes) for type definitions.
 
 ```ts
 {
   // ... entity attributes
-  strapi_reviewWorkflows_stage?: Stage | null
+  strapi_stage?: Stage | null
 }
 ```
 

--- a/packages/core/admin/ee/admin/content-manager/components/DynamicTable/CellContent/ReviewWorkflowsStage/getTableColumn.js
+++ b/packages/core/admin/ee/admin/content-manager/components/DynamicTable/CellContent/ReviewWorkflowsStage/getTableColumn.js
@@ -22,8 +22,8 @@ export default (layout) => {
   }
 
   return {
-    key: '__strapi_reviewWorkflows_stage_temp_key__',
-    name: 'strapi_reviewWorkflows_stage',
+    key: '__strapi_stage_temp_key__',
+    name: 'strapi_stage',
     fieldSchema: {
       type: 'relation',
     },
@@ -41,14 +41,14 @@ export default (layout) => {
         },
       },
     },
-    cellFormatter({ strapi_reviewWorkflows_stage }) {
+    cellFormatter({ strapi_stage }) {
       // if entities are created e.g. through lifecycle methods
       // they may not have a stage assigned
-      if (!strapi_reviewWorkflows_stage) {
+      if (!strapi_stage) {
         return <Typography textColor="neutral800">-</Typography>;
       }
 
-      const { color, name } = strapi_reviewWorkflows_stage;
+      const { color, name } = strapi_stage;
 
       return <ReviewWorkflowsStage color={color ?? STAGE_COLOR_DEFAULT} name={name} />;
     },

--- a/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/InformationBoxEE.js
+++ b/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/InformationBoxEE.js
@@ -15,7 +15,7 @@ import { OptionColor } from '../../../../pages/SettingsPage/pages/ReviewWorkflow
 import { SingleValueColor } from '../../../../pages/SettingsPage/pages/ReviewWorkflows/components/Stages/Stage/components/SingleValueColor';
 import Information from '../../../../../../admin/src/content-manager/pages/EditView/Information';
 
-const ATTRIBUTE_NAME = 'strapi_reviewWorkflows_stage';
+const ATTRIBUTE_NAME = 'strapi_stage';
 
 export function InformationBoxEE() {
   const {

--- a/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/tests/InformationBoxEE.test.js
+++ b/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/tests/InformationBoxEE.test.js
@@ -10,7 +10,7 @@ import { createStore } from 'redux';
 import { InformationBoxEE } from '../InformationBoxEE';
 import { useReviewWorkflows } from '../../../../../pages/SettingsPage/pages/ReviewWorkflows/hooks/useReviewWorkflows';
 
-const STAGE_ATTRIBUTE_NAME = 'strapi_reviewWorkflows_stage';
+const STAGE_ATTRIBUTE_NAME = 'strapi_stage';
 const STAGE_FIXTURE = {
   id: 1,
   color: '#4945FF',

--- a/packages/core/admin/ee/server/constants/workflows.js
+++ b/packages/core/admin/ee/server/constants/workflows.js
@@ -5,5 +5,5 @@ module.exports = {
   WORKFLOW_MODEL_UID: 'admin::workflow',
   STAGE_MODEL_UID: 'admin::workflow-stage',
   STAGE_DEFAULT_COLOR: '#4945FF',
-  ENTITY_STAGE_ATTRIBUTE: 'strapi_reviewWorkflows_stage',
+  ENTITY_STAGE_ATTRIBUTE: 'strapi_stage',
 };

--- a/packages/core/admin/ee/server/services/__tests__/stages.test.js
+++ b/packages/core/admin/ee/server/services/__tests__/stages.test.js
@@ -94,9 +94,9 @@ const strapiMock = {
       get: () => ({
         tableName: 'test',
         attributes: {
-          strapi_reviewWorkflows_stage: {
+          strapi_stage: {
             joinColumn: {
-              name: 'strapi_reviewWorkflows_stage_id',
+              name: 'strapi_stage_id',
             },
           },
         },

--- a/packages/core/admin/ee/server/services/review-workflows/__tests__/entity-service-decorator.test.js
+++ b/packages/core/admin/ee/server/services/review-workflows/__tests__/entity-service-decorator.test.js
@@ -83,7 +83,7 @@ describe('Entity service decorator', () => {
         ...input,
         data: {
           ...input.data,
-          strapi_reviewWorkflows_stage: 1,
+          strapi_stage: 1,
         },
       });
     });
@@ -120,14 +120,14 @@ describe('Entity service decorator', () => {
       const service = decorator(defaultService);
 
       const id = 1;
-      const input = { data: { title: 'title ', strapi_reviewWorkflows_stage: 1 } };
+      const input = { data: { title: 'title ', strapi_stage: 1 } };
       await service.update('test-model', id, input);
 
       expect(defaultService.update).toHaveBeenCalledWith('test-model', id, {
         ...input,
         data: {
           ...input.data,
-          strapi_reviewWorkflows_stage: 1,
+          strapi_stage: 1,
         },
       });
     });
@@ -144,13 +144,13 @@ describe('Entity service decorator', () => {
       const service = decorator(defaultService);
 
       const id = 1;
-      const input = { data: { title: 'title ', strapi_reviewWorkflows_stage: null } };
+      const input = { data: { title: 'title ', strapi_stage: null } };
       await service.update('test-model', id, input);
 
       expect(defaultService.update).toHaveBeenCalledWith('test-model', id, {
         ...input,
         data: {
-          ...omit('strapi_reviewWorkflows_stage', input.data),
+          ...omit('strapi_stage', input.data),
         },
       });
     });

--- a/packages/core/admin/ee/server/services/review-workflows/review-workflows.js
+++ b/packages/core/admin/ee/server/services/review-workflows/review-workflows.js
@@ -11,7 +11,7 @@ const { ENTITY_STAGE_ATTRIBUTE } = require('../../constants/workflows');
 const { persistTables, removePersistedTablesWithSuffix } = require('../../utils/persisted-tables');
 
 const MAX_DB_TABLE_NAME_LEN = 63; // Postgres limit
-// The longest index name that Strapi can create is prefixed with '_strapi_reviewWorkflow_stage_links_inv_fk', so the content type name  should be no longer than this.
+// The longest index name that Strapi can create is prefixed with '_strapi_stage_links_inv_fk', so the content type name  should be no longer than this.
 const MAX_JOIN_TABLE_NAME_SUFFIX =
   1 /* _ */ + ENTITY_STAGE_ATTRIBUTE.length + '_links_inv_fk'.length;
 const MAX_CONTENT_TYPE_NAME_LEN = MAX_DB_TABLE_NAME_LEN - MAX_JOIN_TABLE_NAME_SUFFIX;
@@ -83,7 +83,7 @@ function persistStagesJoinTables({ strapi }) {
     ])(contentTypes);
 
     // TODO: Instead of removing all the tables, we should only remove the ones that are not in the joinTablesToPersist
-    await removePersistedTablesWithSuffix('_strapi_review_workflows_stage_links');
+    await removePersistedTablesWithSuffix('_strapi_stage_links');
     await persistTables(joinTablesToPersist);
   };
 }

--- a/packages/core/strapi/lib/commands/utils/data-transfer.js
+++ b/packages/core/strapi/lib/commands/utils/data-transfer.js
@@ -291,7 +291,7 @@ const getDiffHandler = (engine, { force, action }) => {
         if (
           uid === 'admin::workflow' ||
           uid === 'admin::workflow-stage' ||
-          endPath?.startsWith('strapi_reviewWorkflows_')
+          endPath?.startsWith('strapi_stage')
         ) {
           workflowsStatus = diff.kind;
         }


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

It replaces all `strapi_reviewWorkflows_stage` names with `strapi_stage` as the Content Platform squad decided.

### Why is it needed?

Reduce the impact of a too long database table name that can happen when the name of the table is longer than 63 characters. We are, for now, computing the database table name by concatenating the content type name + attribute name + _links for the join tables, so it can happen very often with an attribute as long as `strapi_reviewWorkflows_stage`.

### How to test it?

Run your strapi project with EE and assign a workflow to a content-type, then you will be able to retrieve any entity with a stage assigned stored in `strapi_stage` field.

⚠️ For previous users of the Review Workflow feature, all stage assignments will be lost. Another PR is coming to propose a script to migrate the data from the old attribute name to the new one.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
