### PR TITLE
[TS] Fix GetDynamicAttributeValue type

### DIFF
--- a/packages/core/strapi/lib/types/core/attributes/dynamic-zone.d.ts
+++ b/packages/core/strapi/lib/types/core/attributes/dynamic-zone.d.ts
@@ -1,6 +1,6 @@
 import type { Utils, Attribute, Common } from '@strapi/strapi';
 
-export interface DynamicZoneProperties<T extends Common.UID.Component[] = []> {
+export interface DynamicZoneProperties<T extends Common.UID.Component[]> {
   components: T;
 }
 
@@ -15,7 +15,7 @@ export type DynamicZone<T extends Common.UID.Component[] = Common.UID.Component[
 
 type DynamicZoneValue<T extends Common.UID.Component[]> = Array<
   Utils.Array.Values<T> extends infer P
-    ? P extends Common.UID.ContentType
+    ? P extends Common.UID.Component
       ? Attribute.GetValues<P> & { __component: P }
       : never
     : never


### PR DESCRIPTION
### What does it do?

- Use component uid instead of content-type uid for the generic inference.

### Why is it needed?

- `Attribute.DynamicZone` are using a `uid[]` generic to customize which component it can hold, but the current type is referring to content-types uid instead of components.

### How to test it?

```ts
import type { Attribute } from '@strapi/strapi';

type DZ = Attribute.DynamicZone<['default.c1', 'default.c2', 'default.c3']>;

declare const val: Attribute.GetValue<DZ>;

val.filter(comp => comp.__component === 'default.c1');
```

![image](https://github.com/strapi/strapi/assets/25851739/7b4eb02e-c9b6-48da-86c6-e03c2c4aa09e)


### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
