### PR TITLE
fix: ids in query.createMany return type

### DIFF
--- a/packages/core/database/lib/index.d.ts
+++ b/packages/core/database/lib/index.d.ts
@@ -3,6 +3,8 @@ import { LifecycleProvider } from './lifecycles';
 import { MigrationProvider } from './migrations';
 import { SchemaProvider } from './schema';
 
+type ID = number | string;
+
 type LogicalOperators<T> = {
   $and?: WhereParams<T>[];
   $or?: WhereParams<T>[];

--- a/packages/core/database/lib/index.d.ts
+++ b/packages/core/database/lib/index.d.ts
@@ -54,6 +54,7 @@ interface FindParams<T> {
     | { [K in Sortables<T>]?: Direction }[];
   // TODO: define nested obj
   populate?: (keyof T)[];
+  fre;
 }
 
 interface CreateParams<T> {
@@ -84,7 +85,7 @@ interface EntityManager {
   createMany<K extends keyof AllTypes>(
     uid: K,
     params: CreateManyParams<AllTypes[K]>
-  ): Promise<{ count: number }>;
+  ): Promise<{ count: number; ids: ID[] }>;
 
   update<K extends keyof AllTypes>(uid: K, params: any): Promise<any>;
   updateMany<K extends keyof AllTypes>(uid: K, params: any): Promise<{ count: number }>;
@@ -119,7 +120,7 @@ interface QueryFromContentType<T extends keyof AllTypes> {
   findPage(params: FindParams<AllTypes[T]>): Promise<{ results: any[]; pagination: Pagination }>;
 
   create(params: CreateParams<AllTypes[T]>): Promise<any>;
-  createMany(params: CreateManyParams<AllTypes[T]>): Promise<{ count: number }>;
+  createMany(params: CreateManyParams<AllTypes[T]>): Promise<{ count: number; ids: ID[] }>;
 
   update(params: any): Promise<any>;
   updateMany(params: any): Promise<{ count: number }>;

--- a/packages/core/database/lib/index.d.ts
+++ b/packages/core/database/lib/index.d.ts
@@ -54,7 +54,6 @@ interface FindParams<T> {
     | { [K in Sortables<T>]?: Direction }[];
   // TODO: define nested obj
   populate?: (keyof T)[];
-  fre;
 }
 
 interface CreateParams<T> {

--- a/packages/core/strapi/lib/services/entity-service/index.d.ts
+++ b/packages/core/strapi/lib/services/entity-service/index.d.ts
@@ -1,4 +1,4 @@
-import { Database, ID } from '@strapi/database';
+import type { Database, ID } from '@strapi/database';
 import { Strapi } from '../../';
 
 type EntityServiceAction =

--- a/packages/core/strapi/lib/services/entity-service/index.d.ts
+++ b/packages/core/strapi/lib/services/entity-service/index.d.ts
@@ -1,7 +1,7 @@
 import { Database } from '@strapi/database';
-import { Strapi } from '../../';
+import type { ID } from '@strapi/database';
 
-type ID = number | string;
+import { Strapi } from '../../';
 
 type EntityServiceAction =
   | 'findMany'

--- a/packages/core/strapi/lib/services/entity-service/index.d.ts
+++ b/packages/core/strapi/lib/services/entity-service/index.d.ts
@@ -1,6 +1,5 @@
 import { Database } from '@strapi/database';
 import type { ID } from '@strapi/database';
-
 import { Strapi } from '../../';
 
 type EntityServiceAction =

--- a/packages/core/strapi/lib/services/entity-service/index.d.ts
+++ b/packages/core/strapi/lib/services/entity-service/index.d.ts
@@ -1,5 +1,4 @@
-import { Database } from '@strapi/database';
-import type { ID } from '@strapi/database';
+import { Database, ID } from '@strapi/database';
 import { Strapi } from '../../';
 
 type EntityServiceAction =


### PR DESCRIPTION
### What does it do?

`strapi.db.query(uid).createMany()` returns:

https://github.com/strapi/strapi/blob/e3bb9a99942a8373355fdf88259ebddfa28a2108/packages/core/database/lib/entity-manager/index.js#L273-L276

But our current types were defined as if it only returned the count.

https://github.com/strapi/strapi/blob/e3bb9a99942a8373355fdf88259ebddfa28a2108/packages/core/database/lib/index.d.ts#L122

This PRs updates those types.


### Related issue(s)/PR(s)

Fixes #16877 