### PR TITLE
Feature: Allow admin users to be assigned to entities

### DIFF
--- a/packages/core/admin/ee/server/constants/workflows.js
+++ b/packages/core/admin/ee/server/constants/workflows.js
@@ -6,4 +6,5 @@ module.exports = {
   STAGE_MODEL_UID: 'admin::workflow-stage',
   STAGE_DEFAULT_COLOR: '#4945FF',
   ENTITY_STAGE_ATTRIBUTE: 'strapi_reviewWorkflows_stage',
+  ENTITY_ASSIGNEE_ATTRIBUTE: 'strapi_assignee',
 };

--- a/packages/core/admin/ee/server/services/__tests__/review-workflows.test.js
+++ b/packages/core/admin/ee/server/services/__tests__/review-workflows.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const reviewWorkflowsServiceFactory = require('../review-workflows/review-workflows');
-const { ENTITY_STAGE_ATTRIBUTE } = require('../../constants/workflows');
+const { ENTITY_STAGE_ATTRIBUTE, ENTITY_ASSIGNEE_ATTRIBUTE } = require('../../constants/workflows');
 
 const workflowMock = {
   id: 1,
@@ -112,7 +112,7 @@ describe('Review workflows service', () => {
     });
   });
   describe('register', () => {
-    test('Content types with review workflows options should have a new attribute', async () => {
+    test('Content types with review workflows options should have new attributes for assignee and stage relations', async () => {
       await reviewWorkflowsService.register();
       expect(containerMock.extend).toHaveBeenCalledTimes(1);
       expect(containerMock.extend).not.toHaveBeenCalledWith('test1', expect.any(Function));
@@ -125,6 +125,11 @@ describe('Review workflows service', () => {
           [ENTITY_STAGE_ATTRIBUTE]: expect.objectContaining({
             relation: 'oneToOne',
             target: 'admin::workflow-stage',
+            type: 'relation',
+          }),
+          [ENTITY_ASSIGNEE_ATTRIBUTE]: expect.objectContaining({
+            relation: 'oneToOne',
+            target: 'admin::user',
             type: 'relation',
           }),
         },


### PR DESCRIPTION
<!--
…e-users

Enhancement: Allow admin users to be assigned to an entity in the CM edit view<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md

-->


### What does it do?

Adds the `strapi_assignee` attribute to all content types that have RW enabled

### Why is it needed?

So we can assign admin users to content

### How to test it?

Unit test

### Related issue(s)/PR(s)

CONTENT-1438

