### PR TITLE
Feature: Allow admin users to be assigned to entities

### DIFF
--- a/packages/core/admin/ee/server/constants/workflows.js
+++ b/packages/core/admin/ee/server/constants/workflows.js
@@ -6,4 +6,5 @@ module.exports = {
   STAGE_MODEL_UID: 'admin::workflow-stage',
   STAGE_DEFAULT_COLOR: '#4945FF',
   ENTITY_STAGE_ATTRIBUTE: 'strapi_reviewWorkflows_stage',
+  ENTITY_ASSIGNEE_ATTRIBUTE: 'strapi_assignee',
 };

--- a/packages/core/admin/ee/server/controllers/index.js
+++ b/packages/core/admin/ee/server/controllers/index.js
@@ -8,4 +8,5 @@ module.exports = {
   admin: require('./admin'),
   workflows: require('./workflows'),
   stages: require('./workflows/stages'),
+  assignees: require('./workflows/assignees'),
 };

--- a/packages/core/admin/ee/server/controllers/workflows/assignees/index.js
+++ b/packages/core/admin/ee/server/controllers/workflows/assignees/index.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const { ApplicationError } = require('@strapi/utils/lib/errors');
+const { getService } = require('../../../utils');
+const { hasReviewWorkflow } = require('../../../utils/review-workflows');
+const { validateUpdateAssigneeOnEntity } = require('../../../validation/review-workflows');
+
+module.exports = {
+  /**
+   * Updates an entity's assignee.
+   * @async
+   * @param {Object} ctx - The Koa context object.
+   * @param {Object} ctx.params - An object containing the parameters from the request URL.
+   * @param {string} ctx.params.model_uid - The model UID of the entity.
+   * @param {string} ctx.params.id - The ID of the entity to update.
+   * @param {Object} ctx.request.body.data - Optional data object containing the new assignee ID for the entity.
+   * @param {string} ctx.request.body.data.id - The ID of the new assignee for the entity.
+   * @throws {ApplicationError} If review workflows is not activated on the specified model UID.
+   * @throws {ValidationError} If the `data` object in the request body fails to pass validation.
+   * @returns {Promise<void>} A promise that resolves when the entity's assignee has been updated.
+   */
+  async updateEntity(ctx) {
+    const assigneeService = getService('assignees');
+    const { model_uid: modelUID, id: entityIdString } = ctx.params;
+    const entityId = Number(entityIdString);
+
+    const { id: assigneeId } = await validateUpdateAssigneeOnEntity(
+      ctx.request?.body?.data,
+      'You should pass an id to the body of the put request.'
+    );
+
+    if (!hasReviewWorkflow({ strapi }, modelUID)) {
+      throw new ApplicationError(`Review workflows is not activated on ${modelUID}.`);
+    }
+
+    const data = await assigneeService.updateEntity({ id: entityId, modelUID }, assigneeId);
+
+    ctx.body = { data };
+  },
+};

--- a/packages/core/admin/ee/server/routes/review-workflows.js
+++ b/packages/core/admin/ee/server/routes/review-workflows.js
@@ -108,5 +108,22 @@ module.exports = {
         ],
       },
     },
+    {
+      method: 'PUT',
+      path: '/content-manager/(collection|single)-types/:model_uid/:id/assignee',
+      handler: 'assignees.updateEntity',
+      config: {
+        middlewares: [enableFeatureMiddleware('review-workflows')],
+        policies: [
+          'admin::isAuthenticatedAdmin',
+          {
+            name: 'admin::hasPermissions',
+            config: {
+              actions: ['admin::users.read', 'admin::review-workflows.read'],
+            },
+          },
+        ],
+      },
+    },
   ],
 };

--- a/packages/core/admin/ee/server/services/__tests__/review-workflows.test.js
+++ b/packages/core/admin/ee/server/services/__tests__/review-workflows.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const reviewWorkflowsServiceFactory = require('../review-workflows/review-workflows');
-const { ENTITY_STAGE_ATTRIBUTE } = require('../../constants/workflows');
+const { ENTITY_STAGE_ATTRIBUTE, ENTITY_ASSIGNEE_ATTRIBUTE } = require('../../constants/workflows');
 
 const workflowMock = {
   id: 1,
@@ -115,7 +115,7 @@ describe('Review workflows service', () => {
     });
   });
   describe('register', () => {
-    test('Content types with review workflows options should have a new attribute', async () => {
+    test('Content types with review workflows options should have new attributes for assignee and stage relations', async () => {
       await reviewWorkflowsService.register();
       expect(containerMock.extend).toHaveBeenCalledTimes(1);
       expect(containerMock.extend).not.toHaveBeenCalledWith('test1', expect.any(Function));
@@ -128,6 +128,11 @@ describe('Review workflows service', () => {
           [ENTITY_STAGE_ATTRIBUTE]: expect.objectContaining({
             relation: 'oneToOne',
             target: 'admin::workflow-stage',
+            type: 'relation',
+          }),
+          [ENTITY_ASSIGNEE_ATTRIBUTE]: expect.objectContaining({
+            relation: 'oneToOne',
+            target: 'admin::user',
             type: 'relation',
           }),
         },

--- a/packages/core/admin/ee/server/services/index.js
+++ b/packages/core/admin/ee/server/services/index.js
@@ -7,6 +7,7 @@ module.exports = {
   'seat-enforcement': require('./seat-enforcement'),
   workflows: require('./review-workflows/workflows'),
   stages: require('./review-workflows/stages'),
+  assignees: require('./review-workflows/assignees'),
   'review-workflows': require('./review-workflows/review-workflows'),
   'review-workflows-decorator': require('./review-workflows/entity-service-decorator'),
   'review-workflows-metrics': require('./review-workflows/metrics'),

--- a/packages/core/admin/ee/server/services/review-workflows/assignees.js
+++ b/packages/core/admin/ee/server/services/review-workflows/assignees.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { ApplicationError } = require('@strapi/utils').errors;
+const { isNil } = require('lodash/fp');
 const { ENTITY_ASSIGNEE_ATTRIBUTE } = require('../../constants/workflows');
 const { getService } = require('../../utils');
 
@@ -9,16 +10,29 @@ module.exports = () => {
     /**
      * Update the assignee of an entity
      */
-    async updateEntity(entityInfo, assigneeId) {
+    async updateEntityAssignee(id, model, assigneeId) {
+      if (isNil(assigneeId)) {
+        return this.deleteEntityAssignee(id, model);
+      }
+
       const userExists = await getService('user').exists({ id: assigneeId });
 
       if (!userExists) {
         throw new ApplicationError(`Selected user does not exist`);
       }
 
-      return strapi.entityService.update(entityInfo.modelUID, entityInfo.id, {
+      return strapi.entityService.update(model, id, {
         data: { [ENTITY_ASSIGNEE_ATTRIBUTE]: assigneeId },
         populate: [ENTITY_ASSIGNEE_ATTRIBUTE],
+        fields: [],
+      });
+    },
+
+    async deleteEntityAssignee(id, model) {
+      return strapi.entityService.update(model, id, {
+        data: { [ENTITY_ASSIGNEE_ATTRIBUTE]: null },
+        populate: [ENTITY_ASSIGNEE_ATTRIBUTE],
+        fields: [],
       });
     },
   };

--- a/packages/core/admin/ee/server/services/review-workflows/assignees.js
+++ b/packages/core/admin/ee/server/services/review-workflows/assignees.js
@@ -1,13 +1,25 @@
 'use strict';
 
+const { ApplicationError } = require('@strapi/utils').errors;
+const { ENTITY_ASSIGNEE_ATTRIBUTE } = require('../../constants/workflows');
+const { getService } = require('../../utils');
+
 module.exports = () => {
   return {
     /**
      * Update the assignee of an entity
      */
     async updateEntity(entityInfo, assigneeId) {
-      // TODO find a user by the assignee ID and update the entity
-      // const user = await usersService.findOne(assigneeId);
+      const userExists = await getService('user').exists({ id: assigneeId });
+
+      if (!userExists) {
+        throw new ApplicationError(`Selected user does not exist`);
+      }
+
+      return strapi.entityService.update(entityInfo.modelUID, entityInfo.id, {
+        data: { [ENTITY_ASSIGNEE_ATTRIBUTE]: assigneeId },
+        populate: [ENTITY_ASSIGNEE_ATTRIBUTE],
+      });
     },
   };
 };

--- a/packages/core/admin/ee/server/services/review-workflows/assignees.js
+++ b/packages/core/admin/ee/server/services/review-workflows/assignees.js
@@ -5,7 +5,7 @@ const { isNil } = require('lodash/fp');
 const { ENTITY_ASSIGNEE_ATTRIBUTE } = require('../../constants/workflows');
 const { getService } = require('../../utils');
 
-module.exports = () => {
+module.exports = ({ strapi }) => {
   return {
     /**
      * Update the assignee of an entity
@@ -15,7 +15,7 @@ module.exports = () => {
         return this.deleteEntityAssignee(id, model);
       }
 
-      const userExists = await getService('user').exists({ id: assigneeId });
+      const userExists = await getService('user', { strapi }).exists({ id: assigneeId });
 
       if (!userExists) {
         throw new ApplicationError(`Selected user does not exist`);

--- a/packages/core/admin/ee/server/services/review-workflows/assignees.js
+++ b/packages/core/admin/ee/server/services/review-workflows/assignees.js
@@ -1,0 +1,13 @@
+'use strict';
+
+module.exports = () => {
+  return {
+    /**
+     * Update the assignee of an entity
+     */
+    async updateEntity(entityInfo, assigneeId) {
+      // TODO find a user by the assignee ID and update the entity
+      // const user = await usersService.findOne(assigneeId);
+    },
+  };
+};

--- a/packages/core/admin/ee/server/services/review-workflows/review-workflows.js
+++ b/packages/core/admin/ee/server/services/review-workflows/review-workflows.js
@@ -7,7 +7,11 @@ const { getContentTypeUIDsWithActivatedReviewWorkflows } = require('../../utils/
 
 const defaultStages = require('../../constants/default-stages.json');
 const defaultWorkflow = require('../../constants/default-workflow.json');
-const { ENTITY_STAGE_ATTRIBUTE, ENTITY_ASSIGNEE_ATTRIBUTE } = require('../../constants/workflows');
+const {
+  ENTITY_STAGE_ATTRIBUTE,
+  ENTITY_ASSIGNEE_ATTRIBUTE,
+  STAGE_MODEL_UID,
+} = require('../../constants/workflows');
 
 const { getDefaultWorkflow } = require('../../utils/review-workflows');
 const { persistTables, removePersistedTablesWithSuffix } = require('../../utils/persisted-tables');
@@ -35,7 +39,7 @@ async function initDefaultWorkflow({ workflowsService, stagesService, strapi }) 
 
 function extendReviewWorkflowContentTypes({ strapi }) {
   const extendContentType = (contentTypeUID) => {
-    const setAttribute = (path, target) =>
+    const setRelation = (path, target) =>
       set(path, {
         writable: true,
         private: false,
@@ -48,8 +52,8 @@ function extendReviewWorkflowContentTypes({ strapi }) {
       });
 
     const setReviewWorkflowAttributes = pipe([
-      setAttribute(`attributes.${ENTITY_STAGE_ATTRIBUTE}`, 'admin::workflow-stage'),
-      setAttribute(`attributes.${ENTITY_ASSIGNEE_ATTRIBUTE}`, 'admin::user'),
+      setRelation(`attributes.${ENTITY_STAGE_ATTRIBUTE}`, STAGE_MODEL_UID),
+      setRelation(`attributes.${ENTITY_ASSIGNEE_ATTRIBUTE}`, 'admin::user'),
     ]);
 
     strapi.container.get('content-types').extend(contentTypeUID, setReviewWorkflowAttributes);

--- a/packages/core/admin/ee/server/validation/review-workflows.js
+++ b/packages/core/admin/ee/server/validation/review-workflows.js
@@ -14,10 +14,17 @@ const validateUpdateStagesSchema = yup
   .required()
   .max(200, 'You can not create more than 200 stages');
 
-const validateEntityUpdate = yup
+const validateUpdateStageOnEntity = yup
   .object()
   .shape({
     id: yup.number().integer().min(1).required(),
+  })
+  .required();
+
+const validateUpdateAssigneeOnEntity = yup
+  .object()
+  .shape({
+    id: yup.number().integer().min(1),
   })
   .required();
 
@@ -26,6 +33,6 @@ module.exports = {
     strict: false,
     stripUnknown: true,
   }),
-  validateUpdateStageOnEntity: validateYupSchema(validateEntityUpdate),
-  validateUpdateAssigneeOnEntity: validateYupSchema(validateEntityUpdate),
+  validateUpdateStageOnEntity: validateYupSchema(validateUpdateStageOnEntity),
+  validateUpdateAssigneeOnEntity: validateYupSchema(validateUpdateAssigneeOnEntity),
 };

--- a/packages/core/admin/ee/server/validation/review-workflows.js
+++ b/packages/core/admin/ee/server/validation/review-workflows.js
@@ -14,7 +14,7 @@ const validateUpdateStagesSchema = yup
   .required()
   .max(200, 'You can not create more than 200 stages');
 
-const validateUpdateStageOnEntity = yup
+const validateEntityUpdate = yup
   .object()
   .shape({
     id: yup.number().integer().min(1).required(),
@@ -26,5 +26,6 @@ module.exports = {
     strict: false,
     stripUnknown: true,
   }),
-  validateUpdateStageOnEntity: validateYupSchema(validateUpdateStageOnEntity),
+  validateUpdateStageOnEntity: validateYupSchema(validateEntityUpdate),
+  validateUpdateAssigneeOnEntity: validateYupSchema(validateEntityUpdate),
 };


### PR DESCRIPTION


https://github.com/strapi/strapi/assets/20578351/69447ff2-f40b-4873-970e-61620ce9801c

### What does it do?



- Assign a user in a RW activated Content Type.
- Unassign a user in a RW activated Content Type.
- It sanitizes the assignee data so it does not filter sensitive data.


