### PR TITLE
Feature: RW Assignee permissions

### DIFF
--- a/packages/core/admin/ee/server/controllers/workflows/assignees/index.js
+++ b/packages/core/admin/ee/server/controllers/workflows/assignees/index.js
@@ -28,7 +28,9 @@ module.exports = {
       .service('permission-checker')
       .create({ userAbility: ctx.state.userAbility, model });
 
-    // TODO: check if user has update permission on the entity
+    if (permissionChecker.cannot.update()) {
+      return ctx.forbidden('You cannot update this entity assignee');
+    }
 
     const { id: assigneeId } = await validateUpdateAssigneeOnEntity(
       ctx.request?.body?.data,
@@ -39,8 +41,8 @@ module.exports = {
       throw new ApplicationError(`Review workflows is not activated on ${model}.`);
     }
 
-    const entity = await assigneeService.updateEntityAssignee(id, model, assigneeId);
-    const sanitizedEntity = await permissionChecker.sanitizeOutput(entity);
+    const updatedEntity = await assigneeService.updateEntityAssignee(id, model, assigneeId);
+    const sanitizedEntity = await permissionChecker.sanitizeOutput(updatedEntity);
 
     ctx.body = { data: sanitizedEntity };
   },

--- a/packages/core/admin/ee/server/routes/review-workflows.js
+++ b/packages/core/admin/ee/server/routes/review-workflows.js
@@ -119,7 +119,7 @@ module.exports = {
           {
             name: 'admin::hasPermissions',
             config: {
-              actions: ['admin::users.read', 'admin::review-workflows.read'],
+              actions: ['admin::users.read'],
             },
           },
         ],


### PR DESCRIPTION
### What does it do?
Do not allow users without entity update permissions to update assignee field.

![image](https://github.com/strapi/strapi/assets/20578351/e7feff27-da3a-44e2-95e6-42964774dd70)

