### PR TITLE
docs: Fix default expire time of private assets

### DIFF
--- a/packages/providers/upload-aws-s3/README.md
+++ b/packages/providers/upload-aws-s3/README.md
@@ -74,7 +74,7 @@ module.exports = ({ env }) => ({
 
 If your bucket is configured to be private, you will need to set the `ACL` option to `private` in the `params` object. This will ensure that the signed URL is generated with the correct permissions.
 
-You can also define the expiration time of the signed URL by setting the `signedUrlExpires` option in the `params` object. The default value is 7 days.
+You can also define the expiration time of the signed URL by setting the `signedUrlExpires` option in the `params` object. The default value is 15 minutes.
 
 `./config/plugins.js`
 
@@ -90,7 +90,7 @@ module.exports = ({ env }) => ({
         region: env('AWS_REGION'),
         params: {
           ACL: 'private', // <== set ACL to private
-          signedUrlExpires: env('AWS_SIGNED_URL_EXPIRES', 60 * 60 * 24 * 7),
+          signedUrlExpires: env('AWS_SIGNED_URL_EXPIRES', 15 * 60),
           Bucket: env('AWS_BUCKET'),
         },
       },


### PR DESCRIPTION
### What does it do?
Default expiration time of signed s3 bucket files is 15 minutes, not 7 days. 
