### PR TITLE
Allow clearing of the RW assignee select

### DIFF
--- a/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/components/AssigneeSelect/AssigneeSelect.js
+++ b/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/components/AssigneeSelect/AssigneeSelect.js
@@ -99,8 +99,15 @@ export function AssigneeSelect() {
           isSearchable
           isClearable
           name={ASSIGNEE_ATTRIBUTE_NAME}
-          onChange={handleChange}
-          onClear={() => handleChange({ value: null })}
+          onChange={(selectedOption, triggeredAction) => {
+            if (triggeredAction.action === 'clear') {
+              handleChange({ value: null });
+
+              return;
+            }
+
+            handleChange({ value: selectedOption.value });
+          }}
           options={users.map(({ id, firstname, lastname }) => ({
             value: id,
             label: formatMessage(


### PR DESCRIPTION
<!--

Enhancement: Allow admin users to be assigned to an entity in the CM edit view<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Fixes the react-select usage for the assignee select to allow clearing by detecting the type of react-select event in the onChange handler

### Why is it needed?

Previously clicking the clear button would not trigger the onClear event but the onChange event
