### PR TITLE
Keep same locale in strapi admin

### DIFF
--- a/packages/plugins/i18n/admin/src/components/CMEditViewInjectedComponents/CMEditViewLocalePicker/index.js
+++ b/packages/plugins/i18n/admin/src/components/CMEditViewInjectedComponents/CMEditViewLocalePicker/index.js
@@ -72,6 +72,11 @@ const CMEditViewLocalePicker = ({
     });
   };
 
+  const handleChangeAndReloadPage = (value) => {
+    handleChange(value);
+    location.reload();
+  }
+
   const options = createLocalesOption(appLocales, localizations).filter(({ status, value }) => {
     if (status === 'did-not-create-locale') {
       return createPermissions.find(({ properties }) =>
@@ -107,7 +112,7 @@ const CMEditViewLocalePicker = ({
             label={formatMessage({
               id: getTrad('Settings.locales.modal.locales.label'),
             })}
-            onChange={handleChange}
+            onChange={handleChangeAndReloadPage}
             value={value?.value}
           >
             <Option

--- a/packages/plugins/i18n/admin/src/components/LocalePicker/index.js
+++ b/packages/plugins/i18n/admin/src/components/LocalePicker/index.js
@@ -66,6 +66,7 @@ const LocalePicker = () => {
         page: 1,
         plugins: { ...query.plugins, i18n: { locale: code } },
       });
+      location.reload();
     });
   };
 

--- a/packages/plugins/i18n/admin/src/contentManagerHooks/utils/addLocaleToLinksSearch.js
+++ b/packages/plugins/i18n/admin/src/contentManagerHooks/utils/addLocaleToLinksSearch.js
@@ -3,8 +3,16 @@ import { stringify, parse } from 'qs';
 import getDefaultLocale from '../../utils/getDefaultLocale';
 
 const addLocaleToLinksSearch = (links, kind, contentTypeSchemas, locales, permissions) => {
+  console.log('links', kind)
+
   return links.map((link) => {
     const contentTypeUID = link.to.split(`/${kind}/`)[1];
+
+    const currentURL = new URL(window.location.href);
+
+    console.log('window.location.href', window.location.href)
+
+    const currentLocale = currentURL.searchParams.get('plugins[i18n][locale]');
 
     const contentTypeSchema = contentTypeSchemas.find(({ uid }) => uid === contentTypeUID);
 
@@ -35,12 +43,14 @@ const addLocaleToLinksSearch = (links, kind, contentTypeSchemas, locales, permis
       {}
     );
 
-    const defaultLocale = getDefaultLocale(contentTypeNeededPermissions, locales);
+    const defaultLocale = currentLocale !== null 
+      ? currentLocale 
+      : getDefaultLocale(contentTypeNeededPermissions, locales);
 
     if (!defaultLocale) {
       return { ...link, isDisplayed: false };
     }
-
+    console.log('link.plugins[i18n][locale]', link['plugins[i18n][locale]'])
     const linkParams = link.search ? parse(link.search) : {};
 
     const params = linkParams

--- a/packages/plugins/i18n/admin/src/contentManagerHooks/utils/addLocaleToLinksSearch.js
+++ b/packages/plugins/i18n/admin/src/contentManagerHooks/utils/addLocaleToLinksSearch.js
@@ -3,12 +3,12 @@ import { stringify, parse } from 'qs';
 import getDefaultLocale from '../../utils/getDefaultLocale';
 
 const addLocaleToLinksSearch = (links, kind, contentTypeSchemas, locales, permissions) => {
+  const currentURL = new URL(window.location.href);
+
+  const currentLocale = currentURL.searchParams.get('plugins[i18n][locale]');
+  
   return links.map((link) => {
     const contentTypeUID = link.to.split(`/${kind}/`)[1];
-
-    const currentURL = new URL(window.location.href);
-
-    const currentLocale = currentURL.searchParams.get('plugins[i18n][locale]');
 
     const contentTypeSchema = contentTypeSchemas.find(({ uid }) => uid === contentTypeUID);
 

--- a/packages/plugins/i18n/admin/src/contentManagerHooks/utils/addLocaleToLinksSearch.js
+++ b/packages/plugins/i18n/admin/src/contentManagerHooks/utils/addLocaleToLinksSearch.js
@@ -3,14 +3,10 @@ import { stringify, parse } from 'qs';
 import getDefaultLocale from '../../utils/getDefaultLocale';
 
 const addLocaleToLinksSearch = (links, kind, contentTypeSchemas, locales, permissions) => {
-  console.log('links', kind)
-
   return links.map((link) => {
     const contentTypeUID = link.to.split(`/${kind}/`)[1];
 
     const currentURL = new URL(window.location.href);
-
-    console.log('window.location.href', window.location.href)
 
     const currentLocale = currentURL.searchParams.get('plugins[i18n][locale]');
 
@@ -50,7 +46,6 @@ const addLocaleToLinksSearch = (links, kind, contentTypeSchemas, locales, permis
     if (!defaultLocale) {
       return { ...link, isDisplayed: false };
     }
-    console.log('link.plugins[i18n][locale]', link['plugins[i18n][locale]'])
     const linkParams = link.search ? parse(link.search) : {};
 
     const params = linkParams


### PR DESCRIPTION
### What does it do?

- This feature allows users to keep the same locale while navigating between Single types/Collections types.

- When a user changes the locale in a specific Single type/Collections type, we retain this locale for all other Single types and Collection types, instead of reverting to the default locale each time.

### Why is it needed?

- When we have several locales (e.g. more than 60 locales) it's hard to find each time the last used locale.

### How to test it?

- Change the locale to a non default one.
- Navigate to an other Single type/Collections type, you should see the previous selected locale

