### PR TITLE
Dev docs for transfer engine

### DIFF
--- a/docs/docs/docs/01-core/data-transfer/00-intro.md
+++ b/docs/docs/docs/01-core/data-transfer/00-intro.md
@@ -1,0 +1,18 @@
+---
+title: Introduction
+slug: /data-transfer
+tags:
+  - data-transfer
+  - experimental
+---
+
+# Data Transfer
+
+This section is an overview of all the features related to the data-transfer package:
+
+```mdx-code-block
+import DocCardList from '@theme/DocCardList';
+import { useCurrentSidebarCategory } from '@docusaurus/theme-common';
+
+<DocCardList items={useCurrentSidebarCategory().items} />
+```

--- a/docs/docs/docs/01-core/data-transfer/01-engine.md
+++ b/docs/docs/docs/01-core/data-transfer/01-engine.md
@@ -1,0 +1,23 @@
+---
+title: Transfer Engine
+description: Conceptual guide to the data transfer engine
+tags:
+  - data-transfer
+  - experimental
+---
+
+The transfer engine manages the data transfer process by facilitating communication between a source provider and a destination provider.
+
+## Code location
+
+`packages/core/data-transfer/src/engine/index.ts`
+
+## Setting up a transfer
+
+### Excluding data
+
+### Transforms
+
+## Running a transfer
+
+Note: The transfer engine (and the providers) current only support a single `engine.transfer()` and must be re-instantiated if intended to run multiple times. In the future it is expected to allow them to be used for multiple transfers in a row, but that usage is untested and will result in unpredictable behavior.

--- a/docs/docs/docs/01-core/data-transfer/01-source-providers/00-overview.md
+++ b/docs/docs/docs/01-core/data-transfer/01-source-providers/00-overview.md
@@ -1,0 +1,12 @@
+---
+title: Source Providers
+slug: /source-providers
+tags:
+  - providers
+  - data-transfer
+  - experimental
+---
+
+# Destination Providers
+
+TODO

--- a/docs/docs/docs/01-core/data-transfer/01-source-providers/01-strapi-file.md
+++ b/docs/docs/docs/01-core/data-transfer/01-source-providers/01-strapi-file.md
@@ -1,0 +1,12 @@
+---
+title: Strapi File
+slug: /source-providers/strapi-file
+tags:
+  - providers
+  - data-transfer
+  - experimental
+---
+
+# Strapi File Source Provider
+
+TODO

--- a/docs/docs/docs/01-core/data-transfer/01-source-providers/02-local-strapi copy.md
+++ b/docs/docs/docs/01-core/data-transfer/01-source-providers/02-local-strapi copy.md
@@ -1,0 +1,12 @@
+---
+title: Local Strapi
+slug: /source-providers/local-strapi
+tags:
+  - providers
+  - data-transfer
+  - experimental
+---
+
+# Destination Providers
+
+TODO

--- a/docs/docs/docs/01-core/data-transfer/01-source-providers/03-remote-strapi.md
+++ b/docs/docs/docs/01-core/data-transfer/01-source-providers/03-remote-strapi.md
@@ -1,0 +1,14 @@
+---
+title: Remote Strapi
+slug: /source-providers/remote-strapi
+tags:
+  - providers
+  - data-transfer
+  - experimental
+---
+
+# Remote Strapi Source Provider
+
+Note: This provider is a websocket interface wrapper for the Local Strapi Source Provider
+
+**TODO**

--- a/docs/docs/docs/01-core/data-transfer/01-source-providers/_category_.json
+++ b/docs/docs/docs/01-core/data-transfer/01-source-providers/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Source Providers",
+  "collapsible": true,
+  "collapsed": true
+}

--- a/docs/docs/docs/01-core/data-transfer/02-destination-providers/00-overview.md
+++ b/docs/docs/docs/01-core/data-transfer/02-destination-providers/00-overview.md
@@ -1,0 +1,12 @@
+---
+title: Destination Providers
+slug: /destination-providers
+tags:
+  - providers
+  - data-transfer
+  - experimental
+---
+
+# Destination Providers
+
+TODO

--- a/docs/docs/docs/01-core/data-transfer/02-destination-providers/01-strapi-file.md
+++ b/docs/docs/docs/01-core/data-transfer/02-destination-providers/01-strapi-file.md
@@ -1,0 +1,16 @@
+---
+title: Strapi File
+slug: /destination-providers/strapi-file
+tags:
+  - providers
+  - data-transfer
+  - experimental
+---
+
+# Strapi File Destination Provider
+
+This provider will output a Strapi Data File
+
+Note: this destination provider does not provide a schema or metadata, and will therefore never report a schema match error or version validation error
+
+**TODO**

--- a/docs/docs/docs/01-core/data-transfer/02-destination-providers/02-local-strapi copy.md
+++ b/docs/docs/docs/01-core/data-transfer/02-destination-providers/02-local-strapi copy.md
@@ -1,0 +1,12 @@
+---
+title: Local Strapi
+slug: /destination-providers/local-strapi
+tags:
+  - providers
+  - data-transfer
+  - experimental
+---
+
+# Local Strapi Destination Provider
+
+TODO

--- a/docs/docs/docs/01-core/data-transfer/02-destination-providers/03-remote-strapi.md
+++ b/docs/docs/docs/01-core/data-transfer/02-destination-providers/03-remote-strapi.md
@@ -1,0 +1,14 @@
+---
+title: Remote Strapi
+slug: /destination-providers/remote-strapi
+tags:
+  - providers
+  - data-transfer
+  - experimental
+---
+
+# Remote Strapi Destination Provider
+
+Note: This provider is a websocket wrapper for the Local Strapi Destination Provider
+
+**TODO**

--- a/docs/docs/docs/01-core/data-transfer/02-destination-providers/_category_.json
+++ b/docs/docs/docs/01-core/data-transfer/02-destination-providers/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Destination Providers",
+  "collapsible": true,
+  "collapsed": true
+}

--- a/docs/docs/docs/01-core/data-transfer/_category_.json
+++ b/docs/docs/docs/01-core/data-transfer/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Data Transfer",
+  "collapsible": true,
+  "collapsed": true
+}


### PR DESCRIPTION
### What does it do?

Adds developer documentation for  **experimental** programmatic usage of the transfer engine and its providers.

### Why is it needed?

To give some direction for developers to start scripting data transfers in their Strapi code.

Not recommended for usage by plugin writers yet as it is still experimental and the interface is still subject to change in the future.

### How to test it?

n/a

### Related issue(s)/PR(s)

n/a
