### PR TITLE
feat: mark uid as a prohibited field & separate auto-clone route

### DIFF
--- a/api-tests/core/content-manager/api/relations.test.api.js
+++ b/api-tests/core/content-manager/api/relations.test.api.js
@@ -921,7 +921,7 @@ describe('Relations', () => {
   });
 
   describe('Clone entity with relations', () => {
-    test('Clone entity with relations', async () => {
+    test('Auto cloning entity with relations should fail', async () => {
       const createdShop = await createEntry(
         'shop',
         {
@@ -943,7 +943,7 @@ describe('Relations', () => {
       // Clone with empty data
       const res = await rq({
         method: 'POST',
-        url: `/content-manager/collection-types/api::shop.shop/clone/${createdShop.id}`,
+        url: `/content-manager/collection-types/api::shop.shop/auto-clone/${createdShop.id}`,
         body: {},
       });
 

--- a/packages/core/admin/admin/src/content-manager/pages/ListView/components/TableRows/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/ListView/components/TableRows/index.js
@@ -55,7 +55,7 @@ export const TableRows = ({
   const handleCloneClick = (id) => async () => {
     try {
       const { data } = await post(
-        `/content-manager/collection-types/${contentType.uid}/clone/${id}?${pluginsQueryParams}`
+        `/content-manager/collection-types/${contentType.uid}/auto-clone/${id}?${pluginsQueryParams}`
       );
 
       if ('id' in data) {

--- a/packages/core/content-manager/server/controllers/collection-types.js
+++ b/packages/core/content-manager/server/controllers/collection-types.js
@@ -167,11 +167,9 @@ module.exports = {
 
   async autoClone(ctx) {
     const { model } = ctx.params;
-    const { body } = ctx.request;
 
-    // Trying to automatically clone the entity
-    // and model has unique or relational fields
-    if (isEmpty(body) && hasProhibitedCloningFields(model)) {
+    // Trying to automatically clone the entity and model has unique or relational fields
+    if (hasProhibitedCloningFields(model)) {
       throw new ApplicationError(
         'Entity could not be cloned as it has unique and/or relational fields. Please edit those fields manually and save to complete the cloning.'
       );

--- a/packages/core/content-manager/server/controllers/collection-types.js
+++ b/packages/core/content-manager/server/controllers/collection-types.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const { setCreatorFields, pipeAsync } = require('@strapi/utils');
-const { isEmpty } = require('lodash/fp');
 const { ApplicationError } = require('@strapi/utils').errors;
 
 const { getService, pickWritableAttributes } = require('../utils');

--- a/packages/core/content-manager/server/controllers/collection-types.js
+++ b/packages/core/content-manager/server/controllers/collection-types.js
@@ -140,14 +140,6 @@ module.exports = {
       return ctx.forbidden();
     }
 
-    // Trying to automatically clone the entity
-    // and model has unique or relational fields
-    if (isEmpty(body) && hasProhibitedCloningFields(model)) {
-      throw new ApplicationError(
-        'Entity could not be cloned as it has unique and/or relational fields. Please edit those fields manually and save to complete the cloning.'
-      );
-    }
-
     const entity = await entityManager.findOneWithCreatorRoles(id, model);
 
     if (!entity) {
@@ -171,6 +163,21 @@ module.exports = {
     const clonedEntity = await entityManager.clone(entity, sanitizedBody, model);
 
     ctx.body = await permissionChecker.sanitizeOutput(clonedEntity);
+  },
+
+  async autoClone(ctx) {
+    const { model } = ctx.params;
+    const { body } = ctx.request;
+
+    // Trying to automatically clone the entity
+    // and model has unique or relational fields
+    if (isEmpty(body) && hasProhibitedCloningFields(model)) {
+      throw new ApplicationError(
+        'Entity could not be cloned as it has unique and/or relational fields. Please edit those fields manually and save to complete the cloning.'
+      );
+    }
+
+    this.clone(ctx);
   },
 
   async delete(ctx) {

--- a/packages/core/content-manager/server/controllers/collection-types.js
+++ b/packages/core/content-manager/server/controllers/collection-types.js
@@ -171,7 +171,8 @@ module.exports = {
     // Trying to automatically clone the entity and model has unique or relational fields
     if (hasProhibitedCloningFields(model)) {
       throw new ApplicationError(
-        'Entity could not be cloned as it has unique and/or relational fields. Please edit those fields manually and save to complete the cloning.'
+        'Entity could not be cloned as it has unique and/or relational fields. ' +
+          'Please edit those fields manually and save to complete the cloning.'
       );
     }
 

--- a/packages/core/content-manager/server/controllers/utils/clone.js
+++ b/packages/core/content-manager/server/controllers/utils/clone.js
@@ -29,6 +29,8 @@ const hasProhibitedCloningFields = (uid) => {
         return (attribute.components || []).some((componentUID) =>
           hasProhibitedCloningFields(componentUID)
         );
+      case 'uid':
+        return true;
       default:
         return attribute?.unique ?? false;
     }

--- a/packages/core/content-manager/server/routes/admin.js
+++ b/packages/core/content-manager/server/routes/admin.js
@@ -247,6 +247,21 @@ module.exports = {
       },
     },
     {
+      method: 'POST',
+      path: '/collection-types/:model/auto-clone/:sourceId',
+      handler: 'collection-types.autoClone',
+      config: {
+        middlewares: [routing],
+        policies: [
+          'admin::isAuthenticatedAdmin',
+          {
+            name: 'plugin::content-manager.hasPermissions',
+            config: { actions: ['plugin::content-manager.explorer.create'] },
+          },
+        ],
+      },
+    },
+    {
       method: 'GET',
       path: '/collection-types/:model/:id',
       handler: 'collection-types.findOne',


### PR DESCRIPTION
### What does it do?

Create new route to automatically clone entities. 

### Why is it needed?

We were relying on the body payload before, if it was empty we agreed the intent was to auto clone, but that was not possible on i18n enabled Content Types, as the backend always injects a `locale` and a `localizations` fields.

### Related issues

* resolves CONTENT-1476
* resolves CONTENT-1453


