### PR TITLE
fix: Reintroduce webhook events utils

### DIFF
--- a/packages/core/utils/lib/index.js
+++ b/packages/core/utils/lib/index.js
@@ -29,6 +29,7 @@ const { getConfigUrls, getAbsoluteAdminUrl, getAbsoluteServerUrl } = require('./
 const { generateTimestampCode } = require('./code-generator');
 const contentTypes = require('./content-types');
 const env = require('./env-helper');
+const webhook = require('./webhook');
 const relations = require('./relations');
 const setCreatorFields = require('./set-creator-fields');
 const hooks = require('./hooks');
@@ -74,6 +75,7 @@ module.exports = {
   isKebabCase,
   isCamelCase,
   toKebabCase,
+  webhook,
   contentTypes,
   env,
   relations,

--- a/packages/core/utils/lib/webhook.js
+++ b/packages/core/utils/lib/webhook.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const webhookEvents = {
+  ENTRY_CREATE: 'entry.create',
+  ENTRY_UPDATE: 'entry.update',
+  ENTRY_DELETE: 'entry.delete',
+  ENTRY_PUBLISH: 'entry.publish',
+  ENTRY_UNPUBLISH: 'entry.unpublish',
+  MEDIA_CREATE: 'media.create',
+  MEDIA_UPDATE: 'media.update',
+  MEDIA_DELETE: 'media.delete',
+};
+
+// TODO V5: remove this file
+const deprecatedWebhookEvents = new Proxy(webhookEvents, {
+  get(target, prop) {
+    console.warn(
+      '[deprecated] @strapi/utils/webhook will no longer exist in the next major release of Strapi. ' +
+        'Instead, the webhookEvents object can be retrieved from strapi.webhookStore.allowedEvents'
+    );
+    return target[prop];
+  },
+});
+
+module.exports = {
+  webhookEvents: deprecatedWebhookEvents,
+};

--- a/packages/core/utils/lib/webhook.js
+++ b/packages/core/utils/lib/webhook.js
@@ -1,5 +1,9 @@
 'use strict';
 
+/**
+ * TODO V5: remove this file
+ * @deprecated
+ */
 const webhookEvents = {
   ENTRY_CREATE: 'entry.create',
   ENTRY_UPDATE: 'entry.update',
@@ -11,7 +15,6 @@ const webhookEvents = {
   MEDIA_DELETE: 'media.delete',
 };
 
-// TODO V5: remove this file
 const deprecatedWebhookEvents = new Proxy(webhookEvents, {
   get(target, prop) {
     console.warn(

--- a/packages/core/utils/lib/webhook.js
+++ b/packages/core/utils/lib/webhook.js
@@ -1,9 +1,5 @@
 'use strict';
 
-/**
- * TODO V5: remove this file
- * @deprecated
- */
 const webhookEvents = {
   ENTRY_CREATE: 'entry.create',
   ENTRY_UPDATE: 'entry.update',
@@ -15,6 +11,10 @@ const webhookEvents = {
   MEDIA_DELETE: 'media.delete',
 };
 
+/**
+ * TODO V5: remove this file
+ * @deprecated
+ */
 const deprecatedWebhookEvents = new Proxy(webhookEvents, {
   get(target, prop) {
     console.warn(


### PR DESCRIPTION
### What does it do?

Recently, webhooks were refactored => (https://github.com/strapi/strapi/pull/16835). Now the list of emitable events are extendable from any package. 

Unfortunately we removed a package that was exposed through @strapi/utils/webhooks which was used in many other plugins.

This PR brings back that file, but also adds a log that warns the file will be removed and deprecated in the future. So anyone importing this file or using a package that imports it will have this warning error.


### Related issue(s)/PR(s)

Fixes: https://github.com/strapi/strapi/issues/16955
