### PR TITLE
fix: dynamic zone component data

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/DynamicZone/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/DynamicZone/index.js
@@ -43,7 +43,7 @@ const DynamicZone = ({ name, labelAction, fieldSchema, metadatas }) => {
     [modifiedData, name]
   );
 
-  const { getComponentLayout } = useContentTypeLayout();
+  const { getComponentLayout, components: allComponents } = useContentTypeLayout();
 
   /**
    * @type {Record<string, Array<{category: string; info: unknown, attributes: Record<string, unknown>}>>}
@@ -94,19 +94,11 @@ const DynamicZone = ({ name, labelAction, fieldSchema, metadatas }) => {
 
     const componentLayoutData = getComponentLayout(componentUid);
 
-    const allComponents = Object.values(dynamicComponentsByCategory).reduce((acc, components) => {
-      const componentObjects = components.reduce((acc, { componentUid, attributes }) => {
-        acc[componentUid] = {
-          attributes,
-          uid: componentUid,
-        };
-
-        return acc;
-      }, {});
-
-      return { ...acc, ...componentObjects };
-    }, {});
-
+    /**
+     * You have to pass _every component_ because the EditViewDataManager is not part of redux
+     * and you could have a dynamic component option that contains a component that is not part
+     * of the former list. Therefore it's schema is inaccessible leading to a crash.
+     */
     addComponentToDynamicZone(name, componentLayoutData, allComponents, hasError, position);
   };
 

--- a/packages/core/admin/admin/src/content-manager/components/DynamicZone/tests/index.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/DynamicZone/tests/index.test.js
@@ -39,6 +39,7 @@ jest.mock('@strapi/helper-plugin', () => ({
 jest.mock('../../../hooks', () => ({
   ...jest.requireActual('../../../hooks'),
   useContentTypeLayout: jest.fn().mockReturnValue({
+    components: {},
     getComponentLayout: jest.fn().mockImplementation((componentUid) => layoutData[componentUid]),
   }),
 }));


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* Passes every component schema to the context reducer instead of the ones listed for dynamic components

### Why is it needed?

* You can have a component listed in the dynamic zone component choice that contains a component not in that former list leading to a crash.

### Related issue(s)/PR(s)

* resolves #16966 