### PR TITLE
feat: add transformations

### DIFF
--- a/packages/core/upload/package.json
+++ b/packages/core/upload/package.json
@@ -34,6 +34,7 @@
     "byte-size": "7.0.1",
     "cropperjs": "1.5.12",
     "date-fns": "2.30.0",
+    "file-type": "^16.5.4",
     "formik": "2.4.0",
     "fs-extra": "10.0.0",
     "immer": "9.0.19",

--- a/packages/core/upload/package.json
+++ b/packages/core/upload/package.json
@@ -51,6 +51,7 @@
     "react-redux": "8.0.5",
     "react-select": "5.7.0",
     "sharp": "0.32.0",
+    "stream-throttle": "^0.1.3",
     "yup": "^0.32.9"
   },
   "devDependencies": {

--- a/packages/core/upload/server/services/metrics/index.js
+++ b/packages/core/upload/server/services/metrics/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const _ = require('lodash');
+
 const getProviderName = () => strapi.config.get('plugin.upload.provider', 'local');
 const isProviderPrivate = async () => strapi.plugin('upload').provider.isPrivate();
 
@@ -14,5 +16,14 @@ module.exports = ({ strapi }) => ({
         privateProvider,
       },
     });
+  },
+  sendMediaSaveMetrics(file) {
+    if (_.has(file, 'caption') && !_.isEmpty(file.caption)) {
+      strapi.telemetry.send('didSaveMediaWithCaption');
+    }
+
+    if (_.has(file, 'alternativeText') && !_.isEmpty(file.alternativeText)) {
+      strapi.telemetry.send('didSaveMediaWithAlternativeText');
+    }
   },
 });

--- a/packages/core/upload/server/utils/file.js
+++ b/packages/core/upload/server/utils/file.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const os = require('os');
+const path = require('path');
+const fse = require('fs-extra');
+const crypto = require('crypto');
+const { fromStream } = require('file-type');
+const { nameToSlug } = require('@strapi/utils');
+
+/**
+ * Get the file type from a file stream.
+ * @param {File} file
+ * @returns {Promise<string>}
+ */
+const getFileType = async (file) => {
+  const fileType = await fromStream(file.getStream());
+  return fileType?.ext;
+};
+
+/**
+ * Generate a random file name based on the original file name.
+ */
+const generateFileName = (name) => {
+  const baseName = nameToSlug(name, { separator: '_', lowercase: false });
+  const randomSuffix = crypto.randomBytes(5).toString('hex');
+  return `${baseName}_${randomSuffix}`;
+};
+
+/**
+ * Creates a temporary directory and deletes it after the callback is executed.
+ * @param {*} callback
+ * @returns
+ */
+async function withTempDirectory(callback) {
+  const folderPath = path.join(os.tmpdir(), 'strapi-upload-');
+  const folder = await fse.mkdtemp(folderPath);
+
+  try {
+    const res = await callback(folder);
+    return res;
+  } finally {
+    await fse.remove(folder);
+  }
+}
+
+module.exports = {
+  getFileType,
+  generateFileName,
+  withTempDirectory,
+};

--- a/packages/core/upload/server/utils/media-builder/index.js
+++ b/packages/core/upload/server/utils/media-builder/index.js
@@ -29,8 +29,17 @@ const MediaBuilder = () => {
       );
     },
 
-    async build(file) {
-      return this.transform(file);
+    groupByFormats(transformedFiles, srcFile) {
+      // Merge files into one
+      const file = transformedFiles.find((file) => !file.format) || srcFile;
+      const formattedFiles = transformedFiles.filter((file) => !!file.format);
+
+      // Add formatted files into the original file
+      file.formats = {};
+      for (const formattedFile of formattedFiles) {
+        file.formats[formattedFile.format] = formattedFile;
+      }
+      return file;
     },
   };
 };

--- a/packages/core/upload/server/utils/media-builder/index.js
+++ b/packages/core/upload/server/utils/media-builder/index.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const { mapAsync, reduceAsync } = require('@strapi/utils');
+
+const MediaBuilder = () => {
+  const transformations = new Map();
+
+  return {
+    transformOn(key, fileTypes, transforms) {
+      transformations.set(key, { fileTypes, transforms });
+      return this;
+    },
+
+    deleteTransform(key) {
+      transformations.delete(key);
+      return this;
+    },
+
+    async transform(file) {
+      // Get all transformations for the given file extension
+      const _transformations = Array.from(transformations.values())
+        .filter(({ fileTypes }) => fileTypes.includes(file.type))
+        .flatMap(({ transforms }) => transforms);
+
+      return reduceAsync(
+        _transformations,
+        (files, transformation) => transformFiles(files, transformation),
+        [file]
+      );
+    },
+
+    async build(file) {
+      return this.transform(file);
+    },
+  };
+};
+
+const transformFiles = async (files, transformation) => {
+  const transformedFiles = await mapAsync(files, transformation);
+  // Some transformations might return multiple files (e.g. resize)
+  return transformedFiles.flat();
+};
+
+module.exports = MediaBuilder;

--- a/packages/core/upload/server/utils/media-builder/transforms/sharp/auto-rotate.js
+++ b/packages/core/upload/server/utils/media-builder/transforms/sharp/auto-rotate.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const sharp = require('sharp');
+
+const autoRotate = async (file) => {
+  return {
+    ...file,
+    getStream: () => file.getStream().pipe(sharp().rotate()),
+  };
+};
+
+module.exports = autoRotate;

--- a/packages/core/upload/server/utils/media-builder/transforms/sharp/breakpoints.js
+++ b/packages/core/upload/server/utils/media-builder/transforms/sharp/breakpoints.js
@@ -2,25 +2,58 @@
 
 const sharp = require('sharp');
 
+const DEFAULT_BREAKPOINTS = { large: 1000, medium: 750, small: 500 };
+const getBreakpoints = () => strapi.config.get('plugin.upload.breakpoints', DEFAULT_BREAKPOINTS);
+
+/**
+ * Resize image to fit within the specified dimensions,
+ * but only if the image is larger. If the image is smaller, it is not resized.
+ */
+const calculateInlineResizing = (size, { width, height }) => {
+  // No need to resize if the image is smaller
+  if (size > width && size > height) {
+    return undefined;
+  }
+
+  let newWidth = size;
+  let newHeight = size;
+
+  // Adjust the newWidth and height to maintain aspect ratio
+  if (width > height) {
+    newHeight = Math.round((height / width) * size);
+  } else {
+    newWidth = Math.round((width / height) * size);
+  }
+
+  return { width: newWidth, height: newHeight };
+};
+
 const breakpoints = async (file) => {
-  const breakpoints = [
-    { format: 'xs', width: 250, height: 250 },
-    { format: 'md', width: 500, height: 500 },
-  ];
+  // Only resize original image and not other responsive formats (e.g thumbnail)
+  if (file.format) {
+    return [file];
+  }
 
-  const resizedFiles = breakpoints.map(({ format, width, height }) => {
-    // TODO: Clone same stream for each breakpoint
-    // TODO: Add size to file somehow
-    return {
-      ...file,
-      format,
-      width,
-      height,
-      getStream: () => file.getStream().pipe(sharp().resize(width, height)),
-    };
-  });
+  const breakpoints = getBreakpoints();
+  const files = [file];
 
-  return [file, ...resizedFiles];
+  for (const [format, breakpoint] of Object.entries(breakpoints)) {
+    const resize = calculateInlineResizing(breakpoint, file);
+
+    if (resize) {
+      files.push({
+        ...file,
+        name: `${format}_${file.name}`,
+        hash: `${format}_${file.hash}`,
+        format,
+        width: resize.width,
+        height: resize.height,
+        getStream: () => file.getStream().pipe(sharp().resize(resize.width, resize.height)),
+      });
+    }
+  }
+
+  return files;
 };
 
 module.exports = breakpoints;

--- a/packages/core/upload/server/utils/media-builder/transforms/sharp/breakpoints.js
+++ b/packages/core/upload/server/utils/media-builder/transforms/sharp/breakpoints.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const sharp = require('sharp');
+
+const breakpoints = async (file) => {
+  const breakpoints = [
+    { format: 'xs', width: 250, height: 250 },
+    { format: 'md', width: 500, height: 500 },
+  ];
+
+  const resizedFiles = breakpoints.map(({ format, width, height }) => {
+    // TODO: Clone same stream for each breakpoint
+    // TODO: Add size to file somehow
+    return {
+      ...file,
+      format,
+      width,
+      height,
+      getStream: () => file.getStream().pipe(sharp().resize(width, height)),
+    };
+  });
+
+  return [file, ...resizedFiles];
+};
+
+module.exports = breakpoints;

--- a/packages/core/upload/server/utils/media-builder/transforms/sharp/index.js
+++ b/packages/core/upload/server/utils/media-builder/transforms/sharp/index.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const optimize = require('./optimize');
+const breakpoints = require('./breakpoints');
+const autoRotate = require('./auto-rotate');
+const metadata = require('./metadata');
+
+module.exports = {
+  optimize,
+  breakpoints,
+  autoRotate,
+  metadata,
+};

--- a/packages/core/upload/server/utils/media-builder/transforms/sharp/index.js
+++ b/packages/core/upload/server/utils/media-builder/transforms/sharp/index.js
@@ -1,13 +1,15 @@
 'use strict';
 
-const optimize = require('./optimize');
-const breakpoints = require('./breakpoints');
 const autoRotate = require('./auto-rotate');
+const breakpoints = require('./breakpoints');
 const metadata = require('./metadata');
+const optimize = require('./optimize');
+const thumbnail = require('./thumbnail');
 
 module.exports = {
-  optimize,
-  breakpoints,
   autoRotate,
+  breakpoints,
   metadata,
+  optimize,
+  thumbnail,
 };

--- a/packages/core/upload/server/utils/media-builder/transforms/sharp/metadata.js
+++ b/packages/core/upload/server/utils/media-builder/transforms/sharp/metadata.js
@@ -16,7 +16,6 @@ const metadata = async (file) => {
     ...file,
     width: metadata.width,
     height: metadata.height,
-    size: metadata.size,
   };
 };
 

--- a/packages/core/upload/server/utils/media-builder/transforms/sharp/metadata.js
+++ b/packages/core/upload/server/utils/media-builder/transforms/sharp/metadata.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const sharp = require('sharp');
+
+const getMetadata = (file) =>
+  new Promise((resolve, reject) => {
+    const pipeline = sharp();
+    pipeline.metadata().then(resolve).catch(reject);
+    file.getStream().pipe(pipeline);
+  });
+
+const metadata = async (file) => {
+  const metadata = await getMetadata(file);
+
+  return {
+    ...file,
+    width: metadata.width,
+    height: metadata.height,
+    size: metadata.size,
+  };
+};
+
+module.exports = metadata;

--- a/packages/core/upload/server/utils/media-builder/transforms/sharp/optimize.js
+++ b/packages/core/upload/server/utils/media-builder/transforms/sharp/optimize.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const sharp = require('sharp');
+
+const optimize = async (file) => {
+  return {
+    ...file,
+    getStream() {
+      const stream = file.getStream();
+      if (sharp()[file?.type]) {
+        stream.pipe(sharp()[file.type]({ quality: 80 }));
+      }
+      return stream;
+    },
+  };
+};
+
+module.exports = optimize;

--- a/packages/core/upload/server/utils/media-builder/transforms/sharp/thumbnail.js
+++ b/packages/core/upload/server/utils/media-builder/transforms/sharp/thumbnail.js
@@ -1,0 +1,53 @@
+'use strict';
+
+const sharp = require('sharp');
+
+const THUMBNAIL_SIZE = { width: 245, height: 156 };
+
+const calculateInsideResizing = (srcSize, destSize) => {
+  // No need to resize if the image is smaller than the thumbnail size
+  if (srcSize.width < destSize.width && srcSize.height < destSize.height) {
+    return;
+  }
+
+  const srcAspectRatio = srcSize.width / srcSize.height;
+  const destAspectRatio = destSize.width / destSize.height;
+
+  let width = destSize.width;
+  let height = destSize.height;
+
+  if (srcAspectRatio > destAspectRatio) {
+    height = Math.round(destSize.width / srcAspectRatio);
+  } else {
+    width = Math.round(destSize.height * srcAspectRatio);
+  }
+
+  return { width, height };
+};
+
+const thumbnail = async (file) => {
+  // Only resize original image and not other responsive formats (e.g breakpoints)
+  if (file.format) {
+    return [file];
+  }
+
+  const files = [file];
+
+  const resize = calculateInsideResizing(file, THUMBNAIL_SIZE);
+
+  if (resize) {
+    files.push({
+      ...file,
+      name: `thumbnail_${file.name}`,
+      hash: `thumbnail_${file.hash}`,
+      format: 'thumbnail',
+      width: resize.width,
+      height: resize.height,
+      getStream: () => file.getStream().pipe(sharp().resize(resize.width, resize.height)),
+    });
+  }
+
+  return files;
+};
+
+module.exports = thumbnail;

--- a/packages/core/upload/server/utils/media-builder/transforms/throttle.js
+++ b/packages/core/upload/server/utils/media-builder/transforms/throttle.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const { ThrottleGroup } = require('stream-throttle');
+
+const THROTTLE_MB_MULTIPLIER = 1024 * 1024;
+
+const tg = new ThrottleGroup({
+  // Rate in bytes per second  e.g 10240 = 10KB/s.
+  rate: 1 * THROTTLE_MB_MULTIPLIER, // 100 MB/s
+});
+
+const throttle = async (file) => {
+  return {
+    ...file,
+    getStream: () => file.getStream().pipe(tg.throttle()),
+  };
+};
+
+module.exports = throttle;

--- a/yarn.lock
+++ b/yarn.lock
@@ -8472,6 +8472,7 @@ __metadata:
     byte-size: 7.0.1
     cropperjs: 1.5.12
     date-fns: 2.30.0
+    file-type: ^16.5.4
     formik: 2.4.0
     fs-extra: 10.0.0
     immer: 9.0.19
@@ -17723,6 +17724,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"file-type@npm:^16.5.4":
+  version: 16.5.4
+  resolution: "file-type@npm:16.5.4"
+  dependencies:
+    readable-web-to-node-stream: ^3.0.0
+    strtok3: ^6.2.4
+    token-types: ^4.1.1
+  checksum: d983c0f36491c57fcb6cc70fcb02c36d6b53f312a15053263e1924e28ca8314adf0db32170801ad777f09432c32155f31715ceaee66310947731588120d7ec27
+  languageName: node
+  linkType: hard
+
 "file-type@npm:^17.1.6":
   version: 17.1.6
   resolution: "file-type@npm:17.1.6"
@@ -26948,6 +26960,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"peek-readable@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "peek-readable@npm:4.1.0"
+  checksum: 02c673f9bc816f8e4e74a054c097225ad38d457d745b775e2b96faf404a54473b2f62f5bcd496f5ebc28696708bcc5e95bed409856f4bef5ed62eae9b4ac0dab
+  languageName: node
+  linkType: hard
+
 "peek-readable@npm:^5.0.0":
   version: 5.0.0
   resolution: "peek-readable@npm:5.0.0"
@@ -28633,7 +28652,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"readable-web-to-node-stream@npm:^3.0.2":
+"readable-web-to-node-stream@npm:^3.0.0, readable-web-to-node-stream@npm:^3.0.2":
   version: 3.0.2
   resolution: "readable-web-to-node-stream@npm:3.0.2"
   dependencies:
@@ -31095,6 +31114,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"strtok3@npm:^6.2.4":
+  version: 6.3.0
+  resolution: "strtok3@npm:6.3.0"
+  dependencies:
+    "@tokenizer/token": ^0.3.0
+    peek-readable: ^4.1.0
+  checksum: 90732cff3f325aef7c47c511f609b593e0873ec77b5081810071cde941344e6a0ee3ccb0cae1a9f5b4e12c81a2546fd6b322fabcdfbd1dd08362c2ce5291334a
+  languageName: node
+  linkType: hard
+
 "strtok3@npm:^7.0.0-alpha.9":
   version: 7.0.0
   resolution: "strtok3@npm:7.0.0"
@@ -31891,6 +31920,16 @@ __metadata:
   version: 1.0.1
   resolution: "toidentifier@npm:1.0.1"
   checksum: 952c29e2a85d7123239b5cfdd889a0dde47ab0497f0913d70588f19c53f7e0b5327c95f4651e413c74b785147f9637b17410ac8c846d5d4a20a5a33eb6dc3a45
+  languageName: node
+  linkType: hard
+
+"token-types@npm:^4.1.1":
+  version: 4.2.1
+  resolution: "token-types@npm:4.2.1"
+  dependencies:
+    "@tokenizer/token": ^0.3.0
+    ieee754: ^1.2.1
+  checksum: cce256766b33e0f08ceffefa2198fb4961a417866d00780e58625999ab5c0699821407053e64eadc41b00bbb6c0d0c4d02fbd2199940d8a3ccb71e1b148ab9a2
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8493,6 +8493,7 @@ __metadata:
     react-router-dom: 5.3.4
     react-select: 5.7.0
     sharp: 0.32.0
+    stream-throttle: ^0.1.3
     styled-components: 5.3.3
     yup: ^0.32.9
   peerDependencies:
@@ -14174,7 +14175,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"commander@npm:^2.19.0, commander@npm:^2.20.0, commander@npm:^2.20.3":
+"commander@npm:^2.19.0, commander@npm:^2.2.0, commander@npm:^2.20.0, commander@npm:^2.20.3":
   version: 2.20.3
   resolution: "commander@npm:2.20.3"
   checksum: ab8c07884e42c3a8dbc5dd9592c606176c7eb5c1ca5ff274bcf907039b2c41de3626f684ea75ccf4d361ba004bbaff1f577d5384c155f3871e456bdf27becf9e
@@ -23335,6 +23336,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"limiter@npm:^1.0.5":
+  version: 1.1.5
+  resolution: "limiter@npm:1.1.5"
+  checksum: 2d51d3a8bef131aada820b76530f8223380a0079aa0fffdfd3ec47ac2f65763225cb4c62a2f22347f4898c5eeb248edfec991c4a4f5b608dfca0aaa37ac48071
+  languageName: node
+  linkType: hard
+
 "lines-and-columns@npm:^1.1.6":
   version: 1.2.4
   resolution: "lines-and-columns@npm:1.2.4"
@@ -30771,6 +30779,18 @@ __metadata:
   version: 0.1.2
   resolution: "stream-slice@npm:0.1.2"
   checksum: 027111397bd709f299fb1bb34902baf4707bba8851219c9115df673be1075a2cecf54d8671e6258c94483d1fa4e931c6784e49f2e005b1b6d5e3b8b61028fbe1
+  languageName: node
+  linkType: hard
+
+"stream-throttle@npm:^0.1.3":
+  version: 0.1.3
+  resolution: "stream-throttle@npm:0.1.3"
+  dependencies:
+    commander: ^2.2.0
+    limiter: ^1.0.5
+  bin:
+    throttleproxy: ./bin/throttleproxy.js
+  checksum: 93d870b37266e61753c2d0c1227cf4c7bef3562b0d018291b4ccc1fe7063041a04ec165f2dcfe6f1b9dfb749fecb58abd34377b10cd793277eff3a652695831b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What does it do?

Proposes a more composable way to define file transformations, that allows:
- Using other libraries rather than sharp for image transformations (gm, jimp, ...)
- Better handling of libvips and sharp memory configurations 
- Remove transformations and let the provider such as cloudinary to do handle them.

This is still a draft and a work in progress.

### Why is it needed?

Sharp is a fast and reliable tool to transform images that we rely upon in Strapi. Unfortunately, in some Linux machines, there seems to be some sort of memory fragmentation that causes RAM spikes and memory fragmentation.

https://github.com/lovell/sharp/issues/3052
https://github.com/lovell/sharp/issues/1710
https://github.com/lovell/sharp/issues/955

Because of the nature of this issue  we decided to move this forward in an extensible way, where anyone can create it's own custom solution that works for each setup.

We are going to continue exploring this and see what tools we can provide to better handle issues like this one.

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

Fixes https://github.com/strapi/strapi/issues/14417
