### PR TITLE
Fix lineHeight breaking card spacing

### DIFF
--- a/packages/core/admin/admin/src/pages/MarketplacePage/components/NpmPackageCard/PackageStats.js
+++ b/packages/core/admin/admin/src/pages/MarketplacePage/components/NpmPackageCard/PackageStats.js
@@ -32,7 +32,7 @@ const PackageStats = ({ githubStars, npmDownloads, npmPackageType }) => {
               }
             )}
           >
-            <Typography variant="pi" textColor="neutral800" lineHeight={16}>
+            <Typography variant="pi" textColor="neutral800">
               {githubStars}
             </Typography>
           </p>
@@ -52,7 +52,7 @@ const PackageStats = ({ githubStars, npmDownloads, npmPackageType }) => {
           }
         )}
       >
-        <Typography variant="pi" textColor="neutral800" lineHeight={16}>
+        <Typography variant="pi" textColor="neutral800">
           {npmDownloads}
         </Typography>
       </p>

--- a/packages/core/admin/admin/src/pages/MarketplacePage/tests/__snapshots__/index.test.js.snap
+++ b/packages/core/admin/admin/src/pages/MarketplacePage/tests/__snapshots__/index.test.js.snap
@@ -83,7 +83,6 @@ exports[`Marketplace page - layout renders the online layout 1`] = `
 .c67 {
   font-size: 0.75rem;
   line-height: 1.33;
-  line-height: 16;
   color: #32324d;
 }
 


### PR DESCRIPTION
### What does it do?

Fixes a spacing issue on the Marketplace cards

### Why is it needed?

It looks like this:
![Screenshot 2023-06-12 at 09 44 39](https://github.com/strapi/strapi/assets/26598053/a53e476d-fee4-47be-9bc1-8199e4d137a8)

When it should look like this:
![Screenshot 2023-06-12 at 09 44 55](https://github.com/strapi/strapi/assets/26598053/652b63ac-cc0a-4d90-b3e4-cc4694137081)

### How to test it?

Go to the Marketplace page and take a look

