### PR TITLE
refactor: use version 2 of breadcrumbs in anticipation of deprecation

### DIFF
--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/ConditionsModal/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/EditPage/components/ConditionsModal/index.js
@@ -6,10 +6,9 @@ import {
   ModalHeader,
   ModalLayout,
   ModalBody,
-  Breadcrumbs,
-  Crumb,
   Typography,
 } from '@strapi/design-system';
+import { Breadcrumbs, Crumb } from '@strapi/design-system/v2';
 import produce from 'immer';
 import get from 'lodash/get';
 import groupBy from 'lodash/groupBy';
@@ -79,8 +78,8 @@ const ConditionsModal = ({ actions, headerBreadCrumbs, isFormDisabled, onClosed,
     <ModalLayout labelledBy="condition-modal-breadcrumbs" onClose={onClosed}>
       <ModalHeader>
         <Breadcrumbs id="condition-modal-breadcrumbs" label={headerBreadCrumbs.join(', ')}>
-          {headerBreadCrumbs.map((label) => (
-            <Crumb key={label}>
+          {headerBreadCrumbs.map((label, index, arr) => (
+            <Crumb isCurrent={index === arr.length - 1} key={label}>
               {upperFirst(
                 formatMessage({
                   id: label,

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Users/ListPage/ModalForm/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Users/ListPage/ModalForm/index.js
@@ -8,13 +8,12 @@ import {
   ModalBody,
   Grid,
   GridItem,
-  Breadcrumbs,
-  Crumb,
   Box,
   Button,
   Flex,
   Typography,
 } from '@strapi/design-system';
+import { Breadcrumbs, Crumb } from '@strapi/design-system/v2';
 import { Formik } from 'formik';
 import {
   Form,
@@ -114,7 +113,7 @@ const ModalForm = ({ onSuccess, onToggle }) => {
     <ModalLayout onClose={onToggle} labelledBy="title">
       <ModalHeader>
         <Breadcrumbs label={headerTitle}>
-          <Crumb>{headerTitle}</Crumb>
+          <Crumb isCurrent>{headerTitle}</Crumb>
         </Breadcrumbs>
       </ModalHeader>
       <Formik

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Users/ListPage/ModalForm/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Users/ListPage/ModalForm/index.js
@@ -112,6 +112,9 @@ const ModalForm = ({ onSuccess, onToggle }) => {
   return (
     <ModalLayout onClose={onToggle} labelledBy="title">
       <ModalHeader>
+        {/**
+         * TODO: this is not semantically correct and should be amended.
+         */}
         <Breadcrumbs label={headerTitle}>
           <Crumb isCurrent>{headerTitle}</Crumb>
         </Breadcrumbs>

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/AuditLogs/ListView/Modal/index.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/AuditLogs/ListView/Modal/index.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useQuery } from 'react-query';
-import { ModalLayout, ModalHeader, ModalBody, Breadcrumbs, Crumb } from '@strapi/design-system';
+import { ModalLayout, ModalHeader, ModalBody } from '@strapi/design-system';
+import { Breadcrumbs, Crumb } from '@strapi/design-system/v2';
 import { useNotification, useFetchClient } from '@strapi/helper-plugin';
 import useFormatTimeStamp from '../hooks/useFormatTimeStamp';
 import ActionBody from './ActionBody';
@@ -37,7 +38,7 @@ const Modal = ({ handleClose, logId }) => {
     <ModalLayout onClose={handleClose} labelledBy="title">
       <ModalHeader>
         <Breadcrumbs label={formattedDate} id="title">
-          <Crumb>{formattedDate}</Crumb>
+          <Crumb isCurrent>{formattedDate}</Crumb>
         </Breadcrumbs>
       </ModalHeader>
       <ModalBody>

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/AuditLogs/ListView/Modal/index.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/AuditLogs/ListView/Modal/index.js
@@ -37,6 +37,9 @@ const Modal = ({ handleClose, logId }) => {
   return (
     <ModalLayout onClose={handleClose} labelledBy="title">
       <ModalHeader>
+        {/**
+         * TODO: this is not semantically correct and should be amended.
+         */}
         <Breadcrumbs label={formattedDate} id="title">
           <Crumb isCurrent>{formattedDate}</Crumb>
         </Breadcrumbs>

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/AuditLogs/ListView/tests/index.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/AuditLogs/ListView/tests/index.test.js
@@ -6,7 +6,6 @@ import { render, screen, waitFor, within, fireEvent } from '@testing-library/rea
 import { QueryClient, QueryClientProvider } from 'react-query';
 import userEvent from '@testing-library/user-event';
 import { ThemeProvider, lightTheme } from '@strapi/design-system';
-import { TrackingProvider } from '@strapi/helper-plugin';
 import useAuditLogsData from '../hooks/useAuditLogsData';
 import ListView from '../index';
 import { TEST_PAGE_DATA, TEST_SINGLE_DATA, getBigTestPageData } from './utils/data';
@@ -45,15 +44,13 @@ const client = new QueryClient({
 
 const App = (
   <QueryClientProvider client={client}>
-    <TrackingProvider>
-      <ThemeProvider theme={lightTheme}>
-        <IntlProvider locale="en" messages={{}} defaultLocale="en" textComponent="span">
-          <Router history={history}>
-            <ListView />
-          </Router>
-        </IntlProvider>
-      </ThemeProvider>
-    </TrackingProvider>
+    <ThemeProvider theme={lightTheme}>
+      <IntlProvider locale="en" messages={{}} defaultLocale="en" textComponent="span">
+        <Router history={history}>
+          <ListView />
+        </Router>
+      </IntlProvider>
+    </ThemeProvider>
   </QueryClientProvider>
 );
 
@@ -135,7 +132,7 @@ describe('ADMIN | Pages | AUDIT LOGS | ListView', () => {
     const modalContainer = within(modal);
     expect(modalContainer.getByText('Create role')).toBeInTheDocument();
     expect(modalContainer.getByText('test user')).toBeInTheDocument();
-    expect(modalContainer.getAllByText('December 22, 2022, 16:11:03')).toHaveLength(3);
+    expect(modalContainer.getAllByText('December 22, 2022, 16:11:03')).toHaveLength(2);
 
     const closeButton = modalContainer.getByText(/close the modal/i).closest('button');
     await user.click(closeButton);

--- a/packages/core/content-type-builder/admin/src/components/FormModalHeader/index.js
+++ b/packages/core/content-type-builder/admin/src/components/FormModalHeader/index.js
@@ -8,7 +8,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 import upperFirst from 'lodash/upperFirst';
-import { Breadcrumbs, Crumb, ModalHeader, Box, Flex, Typography } from '@strapi/design-system';
+import { ModalHeader, Box, Flex, Typography } from '@strapi/design-system';
+import { Breadcrumbs, Crumb } from '@strapi/design-system/v2';
 import useDataManager from '../../hooks/useDataManager';
 import getTrad from '../../utils/getTrad';
 import AttributeIcon from '../AttributeIcon';
@@ -101,32 +102,30 @@ const FormModalHeader = ({
     headers = [{ label }, { label: categoryName }];
   }
 
-  const breadcrumbsLabel = headers.map(({ label }) => label).join(',');
-
   return (
     <ModalHeader>
       <Flex gap={3}>
         <AttributeIcon type={icon} customField={customFieldUid} />
 
-        <Breadcrumbs label={breadcrumbsLabel}>
-          {headers.map((header, index) => {
-            const label = upperFirst(header.label);
+        <Breadcrumbs label={headers.map(({ label }) => label).join(',')}>
+          {headers.map(({ label, info }, index, arr) => {
+            label = upperFirst(label);
 
             if (!label) {
               return null;
             }
 
-            const key = `${header.label}.${index}`;
+            const key = `${label}.${index}`;
 
-            if (header.info?.category) {
-              const content = `${label} (${upperFirst(header.info.category)} - ${upperFirst(
-                header.info.name
-              )})`;
-
-              return <Crumb key={key}>{content}</Crumb>;
+            if (info?.category) {
+              label = `${label} (${upperFirst(info.category)} - ${upperFirst(info.name)})`;
             }
 
-            return <Crumb key={key}>{label}</Crumb>;
+            return (
+              <Crumb isCurrent={index === arr.length - 1} key={key}>
+                {label}
+              </Crumb>
+            );
           })}
         </Breadcrumbs>
       </Flex>

--- a/packages/plugins/users-permissions/admin/src/components/FormModal/index.js
+++ b/packages/plugins/users-permissions/admin/src/components/FormModal/index.js
@@ -9,8 +9,6 @@ import { useIntl } from 'react-intl';
 import {
   Button,
   Flex,
-  Breadcrumbs,
-  Crumb,
   Grid,
   GridItem,
   ModalLayout,
@@ -18,6 +16,7 @@ import {
   ModalFooter,
   ModalBody,
 } from '@strapi/design-system';
+import { Breadcrumbs, Crumb } from '@strapi/design-system/v2';
 import PropTypes from 'prop-types';
 import { Formik } from 'formik';
 import { Form } from '@strapi/helper-plugin';
@@ -43,8 +42,10 @@ const FormModal = ({
     <ModalLayout onClose={onToggle} labelledBy="title">
       <ModalHeader>
         <Breadcrumbs label={headerBreadcrumbs.join(', ')}>
-          {headerBreadcrumbs.map((crumb) => (
-            <Crumb key={crumb}>{crumb}</Crumb>
+          {headerBreadcrumbs.map((crumb, index, arr) => (
+            <Crumb isCurrent={index === arr.length - 1} key={crumb}>
+              {crumb}
+            </Crumb>
           ))}
         </Breadcrumbs>
       </ModalHeader>

--- a/packages/plugins/users-permissions/admin/src/pages/EmailTemplates/components/EmailForm.js
+++ b/packages/plugins/users-permissions/admin/src/pages/EmailTemplates/components/EmailForm.js
@@ -11,10 +11,9 @@ import {
   Grid,
   GridItem,
   Button,
-  Breadcrumbs,
-  Crumb,
   Textarea,
 } from '@strapi/design-system';
+import { Breadcrumbs, Crumb } from '@strapi/design-system/v2';
 import { getTrad } from '../../../utils';
 import schema from '../utils/schema';
 
@@ -45,7 +44,7 @@ const EmailForm = ({ template, onToggle, onSubmit }) => {
               defaultMessage: 'Edit email template',
             })}
           </Crumb>
-          <Crumb>
+          <Crumb isCurrent>
             {formatMessage({ id: getTrad(template.display), defaultMessage: template.display })}
           </Crumb>
         </Breadcrumbs>


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* Changes the use of `Breadcrumbs` to v2 component from the design-system

### Why is it needed?

* We'll be deprecating and removing the v1 component

### Related issue(s)/PR(s)

* Part of CONTENT-1484
