### PR TITLE
Chore: Cleanup eslint/front configuration

### DIFF
--- a/packages/utils/eslint-config-custom/front.js
+++ b/packages/utils/eslint-config-custom/front.js
@@ -6,7 +6,6 @@ module.exports = {
     commonjs: true,
     es6: true,
     jest: true,
-    mocha: true,
   },
   parserOptions: {
     requireConfigFile: false,
@@ -15,14 +14,7 @@ module.exports = {
     },
   },
   globals: {
-    strapi: false,
     window: false,
-    cy: false,
-    Cypress: false,
-    expect: false,
-    assert: false,
-    chai: false,
-    ENABLED_EE_FEATURES: false,
     // TODO: put all this in process.env in webpack to avoid having to set them here
     ADMIN_PATH: true,
     BACKEND_URL: true,


### PR DESCRIPTION
### What does it do?

Cleanup eslint config and remove unused attributes.

### Why is it needed?

Keep the setup small and close to what we need.
