### PR TITLE
feat(review-workflows): migrate old to new stage attribute name

### DIFF
--- a/examples/getstarted/src/api/address/content-types/address/schema.json
+++ b/examples/getstarted/src/api/address/content-types/address/schema.json
@@ -9,6 +9,7 @@
     "name": "Address"
   },
   "options": {
+    "reviewWorkflows": true,
     "draftAndPublish": false
   },
   "pluginOptions": {},

--- a/examples/getstarted/src/api/category/content-types/category/schema.json
+++ b/examples/getstarted/src/api/category/content-types/category/schema.json
@@ -9,6 +9,7 @@
     "name": "Category"
   },
   "options": {
+    "reviewWorkflows": true,
     "draftAndPublish": true
   },
   "pluginOptions": {

--- a/packages/core/admin/ee/server/content-types/workflow-stage/index.js
+++ b/packages/core/admin/ee/server/content-types/workflow-stage/index.js
@@ -12,7 +12,9 @@ module.exports = {
       pluralName: 'workflow-stages',
       displayName: 'Stages',
     },
-    options: {},
+    options: {
+      version: '1.1.0',
+    },
     pluginOptions: {
       'content-manager': {
         visible: false,

--- a/packages/core/admin/ee/server/migrations/review-workflows-stage-attribute.js
+++ b/packages/core/admin/ee/server/migrations/review-workflows-stage-attribute.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const semver = require('semver');
+const { getOr } = require('lodash/fp');
+const { mapAsync } = require('@strapi/utils');
+const { STAGE_MODEL_UID } = require('../constants/workflows');
+const { findTables } = require('../utils/persisted-tables');
+
+function checkVersionThreshold(startVersion, currentVersion, thresholdVersion) {
+  return semver.gte(currentVersion, thresholdVersion) && semver.lt(startVersion, thresholdVersion);
+}
+
+async function migrateStageAttribute({ oldContentTypes, contentTypes }) {
+  const getRWVersion = getOr('0.0.0', `${STAGE_MODEL_UID}.options.version`);
+  const oldRWVersion = getRWVersion(oldContentTypes);
+  const currentRWVersion = getRWVersion(contentTypes);
+
+  const migrationNeeded = checkVersionThreshold(oldRWVersion, currentRWVersion, '1.1.0');
+
+  if (migrationNeeded) {
+    const oldAttributeTableName = 'strapi_review_workflows_stage';
+    const newAttributeTableName = 'strapi_stage';
+    const tables = await findTables({ strapi }, new RegExp(oldAttributeTableName));
+
+    await mapAsync(tables, (tableName) => {
+      const newTableName = tableName.replace(oldAttributeTableName, newAttributeTableName);
+      return strapi.db.connection.schema.renameTable(tableName, newTableName).catch((e) => {
+        strapi.log.warn(
+          `An error occurred during the migration of ${tableName} table to ${newTableName}.\nIf ${newTableName} already exists, migration can't be done automatically.`
+        );
+        strapi.log.warn(e.message);
+      });
+    });
+  }
+}
+
+module.exports = migrateStageAttribute;

--- a/packages/core/admin/ee/server/register.js
+++ b/packages/core/admin/ee/server/register.js
@@ -6,6 +6,7 @@ const migrateAuditLogsTable = require('./migrations/audit-logs-table');
 const migrateReviewWorkflowStagesColor = require('./migrations/review-workflows-stages-color');
 const migrateReviewWorkflowName = require('./migrations/review-workflows-workflow-name');
 const migrateWorkflowsContentTypes = require('./migrations/review-workflows-content-types');
+const migrateStageAttribute = require('./migrations/review-workflows-stage-attribute');
 const createAuditLogsService = require('./services/audit-logs');
 const reviewWorkflowsMiddlewares = require('./middlewares/review-workflows');
 const { getService } = require('./utils');
@@ -23,6 +24,7 @@ module.exports = async ({ strapi }) => {
     strapi.hook('strapi::content-types.afterSync').register(migrateReviewWorkflowStagesColor);
     strapi.hook('strapi::content-types.afterSync').register(migrateReviewWorkflowName);
     strapi.hook('strapi::content-types.afterSync').register(migrateWorkflowsContentTypes);
+    strapi.hook('strapi::content-types.afterSync').register(migrateStageAttribute);
     const reviewWorkflowService = getService('review-workflows');
 
     reviewWorkflowsMiddlewares.contentTypeMiddleware(strapi);


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Rename the tables of review workflow stages link to match the new attribute name.

### Why is it needed?

Smooth migration for users already using Review Workflow 1.0, content-types should change the attribute name from `strapi_reviewWorkflows_stage` to `strapi_stage`.

### How to test it?

- Use Strapi main version to enable review workflow on some content-types
- Change the stages of some entities
- Stop your Strapi project
- Switch to this branch
- Your content-types should still be working and the table name should have changed in your DB

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
