### PR TITLE
[TS] Allow unsafe calls for abstract services

### DIFF
--- a/packages/core/strapi/lib/types/core/common/service.d.ts
+++ b/packages/core/strapi/lib/types/core/common/service.d.ts
@@ -1,3 +1,3 @@
 export type Service = {
-  [key: keyof any]: unknown;
+  [key: keyof any]: any;
 };

--- a/packages/core/strapi/lib/types/core/common/service.d.ts
+++ b/packages/core/strapi/lib/types/core/common/service.d.ts
@@ -1,3 +1,5 @@
 export type Service = {
+  // TODO [V5] Consider changing the any value to unknown.
+  // See: https://github.com/strapi/strapi/issues/16993 and https://github.com/strapi/strapi/pull/17020 for further information
   [key: keyof any]: any;
 };

--- a/packages/core/strapi/lib/types/core/strapi/index.d.ts
+++ b/packages/core/strapi/lib/types/core/strapi/index.d.ts
@@ -82,7 +82,9 @@ export interface Strapi {
   /**
    * Find a controller using its unique identifier
    */
-  controller<TContentTypeUID extends Common.UID.Controller>(uid: TContentTypeUID): Shared.Controllers[TContentTypeUID];
+  controller<TContentTypeUID extends Common.UID.Controller>(
+    uid: TContentTypeUID
+  ): Shared.Controllers[TContentTypeUID];
 
   /**
    * Getter for the Strapi content types container


### PR DESCRIPTION
### What does it do?

Replace `unknown` with `any` for the `Common.Service` value type. This allows unsafe references to services' values.

This is a temporary fix while waiting for the next iteration of type generation (including services) that will remove this need.

**However this shouldn't be changed back (and shouldn't have been changed in the first place) until V5 as it's considered as a breaking change.**

### Why is it needed?

The current vision for 4.11.1 and newer (and the TS System V1) was to force users to provide type safety through a generic parameter (e.g. from the `strapi.service` getter) or by casting the service property before using it.
It was also a change made anticipating the release of better type generation tooling that would remove those issues. 

**This obviously wasn't a good idea as it broke current users' implementation, the choice is to revert back to a looser `any` representation if no type is provided by the user.**


### How to test it?

- `cd examples/kitchensink-ts`
- open the src/index.ts file
- Try using the following snippet in the bootstrap or register method: `strapi.service('unsafe').anyProp.anyMethod()`
- TypeScript shouldn't complain

### Related issue(s)/PR(s)

fix https://github.com/strapi/strapi/issues/16993