### PR TITLE
FIX - Detect is webhook form is dirty

### DIFF
--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Webhooks/EditView/components/WebhookForm/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Webhooks/EditView/components/WebhookForm/index.js
@@ -53,7 +53,12 @@ const WebhookForm = ({
       headers: mapHeaders(data?.headers || {}),
       events: data?.events || [],
     },
-    onSubmit: handleSubmit,
+    onSubmit(values, { resetForm, setSubmitting }) {
+      handleSubmit(values);
+
+      resetForm({ values });
+      setSubmitting(false);
+    },
     validationSchema: makeWebhookValidationSchema({ formatMessage }),
     validateOnChange: false,
     validateOnBlur: false,

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Webhooks/EditView/components/WebhookForm/tests/index.test.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Webhooks/EditView/components/WebhookForm/tests/index.test.js
@@ -78,7 +78,8 @@ describe('Create Webhook', () => {
     fireEvent.change(screen.getByLabelText(/url/i), { target: { value: 'https://google.fr' } });
     fireEvent.click(screen.getByRole('checkbox', { name: /entry.create/i }));
 
-    fireEvent.click(screen.getByRole('button', { name: /Save/i }));
+    const saveButton = screen.getByRole('button', { name: /Save/i });
+    fireEvent.click(saveButton);
 
     await waitFor(() => {
       expect(handleSubmit).toHaveBeenCalledTimes(1);
@@ -88,6 +89,7 @@ describe('Create Webhook', () => {
         events: ['entry.create'],
         headers: [{ key: '', value: '' }],
       });
+      expect(saveButton).toHaveAttribute('aria-disabled', 'true');
     });
   });
 });

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Webhooks/EditView/components/WebhookForm/tests/index.test.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Webhooks/EditView/components/WebhookForm/tests/index.test.js
@@ -89,7 +89,8 @@ describe('Create Webhook', () => {
         events: ['entry.create'],
         headers: [{ key: '', value: '' }],
       });
-      expect(saveButton).toHaveAttribute('aria-disabled', 'true');
     });
+
+    expect(saveButton).toHaveAttribute('aria-disabled', 'true');
   });
 });


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Correctly disables the save button on the webhook edit view
@Marc-Roig spotted the bug here https://github.com/strapi/strapi/pull/16956#issuecomment-1596815498

### Why is it needed?

So you are able to save a webhook when modified

### How to test it?

Updated FE tests
