### PR TITLE
Maintain consistent backend validation for publish and bulk publish

### DIFF
--- a/packages/core/content-manager/server/services/entity-manager.js
+++ b/packages/core/content-manager/server/services/entity-manager.js
@@ -186,7 +186,7 @@ module.exports = ({ strapi }) => ({
         return strapi.entityValidator.validateEntityCreation(
           strapi.getModel(uid),
           entity,
-          { isDraft: true },
+          undefined,
           entity
         );
       })


### PR DESCRIPTION
### What does it do?

Passes the same arguments to the validator as the publish action so draft is false by default

This PR imitates the behavior of the EditView but there is maybe a bigger discussion to be had around how we should be handling the required validations for relations. 

### Why is it needed?

To maintain a consistent publishing behavior between EditVIew and ListView.

I do not believe required relations are officially supported by Strapi. 
https://feedback.strapi.io/customization/p/specify-relation-column-as-required.

### How to test it?

Read the issue below for instructions on how to test

### Related issue(s)/PR(s)

#17022
