### PR TITLE
Fix/overlapping date type

### DIFF
--- a/packages/core/strapi/lib/types/core/attributes/date.d.ts
+++ b/packages/core/strapi/lib/types/core/attributes/date.d.ts
@@ -1,6 +1,6 @@
 import type { Attribute } from '@strapi/strapi';
 
-export type Date = Attribute.OfType<'date'> &
+export type DateAttribute = Attribute.OfType<'date'> &
   // Options
   Attribute.ConfigurableOption &
   Attribute.DefaultOption<DateValue> &
@@ -10,4 +10,4 @@ export type Date = Attribute.OfType<'date'> &
 
 export type DateValue = Date;
 
-export type GetDateValue<T extends Attribute.Attribute> = T extends Date ? DateValue : never;
+export type GetDateValue<T extends Attribute.Attribute> = T extends DateAttribute ? DateValue : never;

--- a/packages/core/strapi/lib/types/core/attributes/date.d.ts
+++ b/packages/core/strapi/lib/types/core/attributes/date.d.ts
@@ -1,6 +1,6 @@
 import type { Attribute } from '@strapi/strapi';
 
-export type DateAttribute = Attribute.OfType<'date'> &
+export type Date = Attribute.OfType<'date'> &
   // Options
   Attribute.ConfigurableOption &
   Attribute.DefaultOption<DateValue> &
@@ -8,6 +8,6 @@ export type DateAttribute = Attribute.OfType<'date'> &
   Attribute.RequiredOption &
   Attribute.UniqueOption;
 
-export type DateValue = Date;
+export type DateValue = globalThis.Date;
 
-export type GetDateValue<T extends Attribute.Attribute> = T extends DateAttribute ? DateValue : never;
+export type GetDateValue<T extends Attribute.Attribute> = T extends Date ? DateValue : never;

--- a/packages/core/strapi/lib/types/core/attributes/date.d.ts
+++ b/packages/core/strapi/lib/types/core/attributes/date.d.ts
@@ -8,6 +8,6 @@ export type Date = Attribute.OfType<'date'> &
   Attribute.RequiredOption &
   Attribute.UniqueOption;
 
-export type DateValue = globalThis.Date;
+export type DateValue = globalThis.Date | string;
 
 export type GetDateValue<T extends Attribute.Attribute> = T extends Date ? DateValue : never;


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Enforces Typing System v1 to use Typescript Date in date fields.

### Why is it needed?

`DateValue` type was erroneously using `Attribute.OfType<'date'>` instead of Typescript Date. This causes `GetValues<'...'>` to infer dates as `Attribute.OfType<'date'>` preventing to perform Date operations on those date fields.

### How to test it?
- Create a ContentType or Component that includes a date field (type date)
- Generate the types using `strapi ts:generate` command.
- Use `GetValues` helper  from `@strapi/strapi` package to type a variable
```ts
const myComponent: GetValues<'category.component-name'> = {
  myDateField: new Date() // no complains from TS ✅ 
}

myComponent.myDateField.getUTCMinutes(); // Date API available ✅ 
```
