### PR TITLE
[TS][Entity-Service] Add the sort param for the entity service

### DIFF
--- a/packages/core/strapi/lib/services/entity-service/types/index.d.ts
+++ b/packages/core/strapi/lib/services/entity-service/types/index.d.ts
@@ -1,0 +1,1 @@
+export * as Params from './params';

--- a/packages/core/strapi/lib/services/entity-service/types/params/index.d.ts
+++ b/packages/core/strapi/lib/services/entity-service/types/params/index.d.ts
@@ -1,0 +1,9 @@
+import type { Common } from '@strapi/strapi';
+
+import type * as Sort from './sort';
+
+export type For<TSchemaUID extends Common.UID.Schema> = {
+  sort: Sort.Any<TSchemaUID>;
+};
+
+export type { Sort };

--- a/packages/core/strapi/lib/services/entity-service/types/params/sort.d.ts
+++ b/packages/core/strapi/lib/services/entity-service/types/params/sort.d.ts
@@ -1,0 +1,112 @@
+import type { Attribute, Common } from '@strapi/strapi';
+
+export module OrderKind {
+  export type Asc = 'asc';
+  export type Desc = 'desc';
+
+  export type Any = Asc | Desc;
+}
+
+// String
+
+/**
+ * Single non-populatable attribute representation
+ *
+ * @example
+ * type A = 'title'; // ✅
+ * type B = 'description'; // ✅
+ * type C = 'title:asc'; // ❌
+ * type D = 'title,description'; // ❌
+ */
+type SingleAttribute<TSchemaUID extends Common.UID.Schema> =
+  Attribute.GetNonPopulatableKeys<TSchemaUID>;
+
+/**
+ * Ordered single non-populatable attribute representation
+ *
+ * @example
+ * type A = 'title:asc'; // ✅
+ * type B = 'description:desc'; // ✅
+ * type C = 'title'; // ❌
+ * type D = 'title,description'; // ❌
+ */
+type OrderedSingleAttribute<TSchemaUID extends Common.UID.Schema> =
+  `${SingleAttribute<TSchemaUID>}:${OrderKind.Any}`;
+
+/**
+ * Union of all possible string representation for a sort
+ *
+ * @example
+ * type A = 'title:asc'; // ✅
+ * type B = 'description:desc'; // ✅
+ * type C = 'title'; // ✅
+ * type D = 'title,description:asc'; // ✅
+ * type E = [42]; // ❌
+ * type F = { title: 'asc' }; // ❌
+ */
+export type StringNotation<TSchemaUID extends Common.UID.Schema> =
+  | SingleAttribute<TSchemaUID>
+  | OrderedSingleAttribute<TSchemaUID>
+  // TODO: Improve type checking for comma separated strings
+  // Loose checking for comma separated literal sort (complex to typecheck as the combination are near infinite)
+  | `${string},${string}`;
+
+// Array
+
+/**
+ * Array notation for a sort
+ *
+ * @example
+ * type A = ['title:asc', 'description']; // ✅
+ * type B = ['title']; // ✅
+ * type C = ['count', 'title,description:asc']; // ✅
+ * type D = { title: 'asc' }; // ❌
+ * type E = [42]; // ❌
+ * type F = 'title'; // ❌
+ */
+export type ArrayNotation<TSchemaUID extends Common.UID.Schema> = StringNotation<TSchemaUID>[];
+
+// Objects
+
+/**
+ * Object notation for a sort
+ *
+ * @example
+ * type A = { title: 'asc' }; // ✅
+ * type B = { title: 'asc', description: 'desc' }; // ✅
+ * type C = { title: 'asc', author: { name: 'asc' } }; // ✅
+ * type D = { author: { email: 'asc', role: { name: 'desc' } } }; // ✅
+ * type E = ['title']; // ❌
+ * type F = 'title'; // ❌
+ */
+export type ObjectNotation<TSchemaUID extends Common.UID.Schema> = {
+  // First level sort
+  [key in Attribute.GetNonPopulatableKeys<TSchemaUID>]?: OrderKind.Any;
+} & {
+  // Deep sort, only add populatable keys that have a
+  // target (remove dynamic zones and other polymorphic links)
+  [key in Attribute.GetKeysWithTarget<TSchemaUID>]?: ObjectNotation<
+    Attribute.GetTarget<TSchemaUID, key>
+  >;
+};
+
+/**
+ * Represents any notation for a sort (string, array, object)
+ *
+ * @example
+ * type A = 'title:asc'; // ✅
+ * type B = 'description:desc'; // ✅
+ * type C = 'title'; // ✅
+ * type D = 'title,description:asc'; // ✅
+ * type E = ['title:asc', 'description']; // ✅
+ * type F = ['title']; // ✅
+ * type G = ['count', 'title,description:asc']; // ✅
+ * type H = { title: 'asc' }; // ✅
+ * type I = { title: 'asc', description: 'desc' }; // ✅
+ * type J = { title: 'asc', author: { name: 'asc' } }; // ✅
+ * type K = { author: { email: 'asc', role: { name: 'desc' } } }; // ✅
+ */
+export type Any<TSchemaUID extends Common.UID.Schema> =
+  | StringNotation<TSchemaUID>
+  | ArrayNotation<TSchemaUID>
+  | ObjectNotation<TSchemaUID>;

--- a/packages/core/strapi/lib/types/core/attributes/common.d.ts
+++ b/packages/core/strapi/lib/types/core/attributes/common.d.ts
@@ -72,3 +72,13 @@ export type Any =
   | Attribute.Time
   | Attribute.Timestamp
   | Attribute.UID<Common.UID.Schema | undefined>;
+
+export type PopulatableKind = Extract<
+  Attribute.Kind,
+  'relation' | 'component' | 'dynamiczone' | 'media'
+>;
+
+export type NonPopulatableKind = Exclude<
+  Attribute.Kind,
+  'relation' | 'component' | 'dynamiczone' | 'media'
+>;

--- a/packages/core/strapi/lib/types/core/attributes/component.d.ts
+++ b/packages/core/strapi/lib/types/core/attributes/component.d.ts
@@ -31,3 +31,6 @@ export type GetComponentValue<TAttribute extends Attribute.Attribute> =
   TAttribute extends Component<infer TComponentUID, infer TRepeatable>
     ? ComponentValue<TComponentUID, TRepeatable>
     : never;
+
+export type GetComponentTarget<TAttribute extends Attribute.Attribute> =
+  TAttribute extends Component<infer TComponentUID, infer _TRepeatable> ? TComponentUID : never;

--- a/packages/core/strapi/lib/types/core/attributes/media.d.ts
+++ b/packages/core/strapi/lib/types/core/attributes/media.d.ts
@@ -1,5 +1,6 @@
 import type { Attribute, Utils } from '@strapi/strapi';
 
+export type MediaTarget = 'plugin::upload.file';
 export type MediaKind = 'images' | 'videos' | 'files' | 'audios';
 
 export interface MediaProperties<
@@ -31,4 +32,11 @@ export type GetMediaValue<TAttribute extends Attribute.Attribute> = TAttribute e
   infer TMultiple
 >
   ? MediaValue<TMultiple>
+  : never;
+
+export type GetMediaTarget<TAttribute extends Attribute.Attribute> = TAttribute extends Media<
+  infer _TKind,
+  infer _TMultiple
+>
+  ? MediaTarget
   : never;

--- a/packages/core/strapi/lib/types/core/attributes/relation.d.ts
+++ b/packages/core/strapi/lib/types/core/attributes/relation.d.ts
@@ -76,6 +76,14 @@ export type GetRelationValue<TAttribute extends Attribute.Attribute> = TAttribut
   ? RelationValue<TRelationKind, TTarget>
   : never;
 
+export type GetRelationTarget<TAttribute extends Attribute.Attribute> = TAttribute extends Relation<
+  infer _TOrigin,
+  infer _TRelationKind,
+  infer TTarget
+>
+  ? TTarget
+  : never;
+
 export module RelationKind {
   type GetOppositePlurality<TPlurality extends RelationKind.Left | RelationKind.Right> = {
     one: 'many';

--- a/packages/core/strapi/lib/types/core/attributes/utils.d.ts
+++ b/packages/core/strapi/lib/types/core/attributes/utils.d.ts
@@ -28,7 +28,33 @@ export type GetAll<TSchemaUID extends Common.UID.Schema> = Utils.Get<
   'attributes'
 >;
 
+export type GetTarget<TSchemaUID extends Common.UID.Schema, TKey extends GetKeys<TSchemaUID>> = Get<
+  TSchemaUID,
+  TKey
+> extends infer TAttribute extends Attribute.Attribute
+  ?
+      | Attribute.GetRelationTarget<TAttribute>
+      | Attribute.GetComponentTarget<TAttribute>
+      | Attribute.GetMediaTarget<TAttribute>
+  : never;
+
 export type GetKeys<TSchemaUID extends Common.UID.Schema> = keyof GetAll<TSchemaUID>;
+
+export type GetNonPopulatableKeys<TSchemaUID extends Common.UID.Schema> = GetKeysByType<
+  TSchemaUID,
+  Attribute.NonPopulatableKind
+>;
+
+export type GetPopulatableKeys<TSchemaUID extends Common.UID.Schema> = GetKeysByType<
+  TSchemaUID,
+  Attribute.PopulatableKind
+>;
+
+export type GetKeysWithTarget<TSchemaUID extends Common.UID.Schema> = keyof {
+  [key in GetKeys<TSchemaUID> as GetTarget<TSchemaUID, key> extends never ? never : key]: never;
+} extends infer TKey extends GetKeys<TSchemaUID>
+  ? TKey
+  : never;
 
 export type GetValue<TAttribute extends Attribute.Attribute> =
   | Attribute.GetBigIntegerValue<TAttribute>

--- a/packages/core/strapi/lib/types/utils/expression.d.ts
+++ b/packages/core/strapi/lib/types/utils/expression.d.ts
@@ -4,6 +4,10 @@ export type True = true;
 export type False = false;
 export type BooleanValue = True | False;
 
+export type IsNever<TValue> = [TValue] extends [never] ? True : False;
+
+export type IsNotNever<TValue> = Not<IsNever<TValue>>;
+
 export type Extends<TLeft, TRight> = [TLeft] extends [TRight] ? True : False;
 
 export type Not<TExpression extends BooleanValue> = If<TExpression, False, True>;

--- a/packages/core/strapi/lib/types/utils/object.d.ts
+++ b/packages/core/strapi/lib/types/utils/object.d.ts
@@ -10,9 +10,10 @@
  * type X = KeysBy<Obj, Base>
  * // 'foo' | 'bar'
  */
-export type KeysBy<TValue, TTest> = {
-  [key in keyof TValue]: TValue[key] extends TTest ? key : never;
-}[keyof TValue];
+export type KeysBy<TValue, TTest> = string &
+  {
+    [key in keyof TValue]: TValue[key] extends TTest ? key : never;
+  }[keyof TValue];
 
 /**
  * Retrieve object's (`TValue`) properties if their value extends the given `TTest` type.

--- a/packages/core/strapi/lib/types/utils/string.d.ts
+++ b/packages/core/strapi/lib/types/utils/string.d.ts
@@ -1,3 +1,5 @@
+import type { Utils } from '@strapi/strapi';
+
 /**
  * Alias for any literal type (useful for template string parameters)
  */
@@ -39,3 +41,19 @@ export type Prefix<TValue extends string, TPrefix extends Literal> = `${TPrefix}
  * Creates a record where every key is a string and every value is `T`
  */
 export type Dict<T> = Record<string, T>;
+
+/**
+ * Checks if a given string ends with the given literal
+ */
+export type EndsWith<TValue extends string, TSuffix extends Literal> = Utils.Expression.Extends<
+  TValue,
+  `${string}${TSuffix}`
+>;
+
+/**
+ * Checks if a given string starts with the given literal
+ */
+export type StartsWith<TValue extends string, TPrefix extends Literal> = Utils.Expression.Extends<
+  TValue,
+  `${TPrefix}${string}`
+>;


### PR DESCRIPTION
### What does it do?

Adds the sort parameter for the entity service with all different notations: string, array, object.

### Why is it needed?

Part of the entity-service params typings feature.
