### PR TITLE
Add the pagination param for the entity service types

### DIFF
--- a/packages/core/strapi/lib/services/entity-service/types/params/index.d.ts
+++ b/packages/core/strapi/lib/services/entity-service/types/params/index.d.ts
@@ -1,9 +1,11 @@
 import type { Common } from '@strapi/strapi';
 
 import type * as Sort from './sort';
+import type * as Pagination from './pagination';
 
 export type For<TSchemaUID extends Common.UID.Schema> = {
-  sort: Sort.Any<TSchemaUID>;
+  sort?: Sort.Any<TSchemaUID>;
+  pagination?: Pagination.Any;
 };
 
-export type { Sort };
+export type { Sort, Pagination };

--- a/packages/core/strapi/lib/services/entity-service/types/params/pagination.d.ts
+++ b/packages/core/strapi/lib/services/entity-service/types/params/pagination.d.ts
@@ -1,0 +1,11 @@
+export type PageNotation = {
+  page?: number;
+  pageSize?: number;
+};
+
+export type OffsetNotation = {
+  start?: number;
+  limit?: number;
+};
+
+export type Any = PageNotation | OffsetNotation;


### PR DESCRIPTION
### What does it do?

Adds the pagination parameters for the entity service.

### Why is it needed?

Part of the entity-service params typings feature.