### PR TITLE
fix(review-workflows): update migration to happen before content-type sync

### DIFF
--- a/packages/core/admin/ee/server/register.js
+++ b/packages/core/admin/ee/server/register.js
@@ -21,10 +21,10 @@ module.exports = async ({ strapi }) => {
     await auditLogsService.register();
   }
   if (features.isEnabled('review-workflows')) {
+    strapi.hook('strapi::content-types.beforeSync').register(migrateStageAttribute);
     strapi.hook('strapi::content-types.afterSync').register(migrateReviewWorkflowStagesColor);
     strapi.hook('strapi::content-types.afterSync').register(migrateReviewWorkflowName);
     strapi.hook('strapi::content-types.afterSync').register(migrateWorkflowsContentTypes);
-    strapi.hook('strapi::content-types.afterSync').register(migrateStageAttribute);
     const reviewWorkflowService = getService('review-workflows');
 
     reviewWorkflowsMiddlewares.contentTypeMiddleware(strapi);


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Change the order of the renaming table migration

### Why is it needed?

During sync, the indexes are rebuilt.

