### PR TITLE
[TS][Entity-Service] Add the fields param for the entity service

### DIFF
--- a/packages/core/strapi/lib/services/entity-service/types/params/fields.d.ts
+++ b/packages/core/strapi/lib/services/entity-service/types/params/fields.d.ts
@@ -1,0 +1,71 @@
+import type { Attribute, Common, Utils } from '@strapi/strapi';
+
+/**
+ * Wildcard notation for the fields.
+ *
+ * When used, it represents every non-populatable field from the given schema
+ */
+export type WildcardNotation = '*';
+
+/**
+ * Single non-populatable attribute representation
+ *
+ * @example
+ * type A = 'title'; // ✅
+ * type B = 'description'; // ✅
+ * type C = 'populatableField'; // ❌
+ * type D = '<random_string>'; // ❌
+ */
+export type SingleAttribute<TSchemaUID extends Common.UID.Schema> =
+  | 'id'
+  | Utils.Guard.Never<Attribute.GetNonPopulatableKeys<TSchemaUID>, string>;
+
+/**
+ * Union of all possible string representation for fields
+ *
+ * @example
+ * type A = 'title'; // ✅
+ * type B = 'title,description'; // ✅
+ * type C = 'id'; // ✅
+ * type D = '*'; // ✅
+ * type E = 'populatableField'; // ❌
+ * type F = '<random_string>'; // ❌
+ */
+export type StringNotation<TSchemaUID extends Common.UID.Schema> =
+  | WildcardNotation
+  | SingleAttribute<TSchemaUID>
+  // TODO: Loose type checking to avoid circular dependencies & infinite recursion
+  | `${string},${string}`;
+
+/**
+ * Array notation for fields
+ *
+ * @example
+ * type A = ['title']; // ✅
+ * type B = ['title', 'description']; // ✅
+ * type C = ['id,title']; // ✅
+ * type D = ['*']; // ✅
+ * type E = ['populatableField']; // ❌
+ * type F = ['<random_string>']; // ❌
+ */
+export type ArrayNotation<TSchemaUID extends Common.UID.Schema> = Any<TSchemaUID>[];
+
+/**
+ * Represents any notation for a sort (string, array, object)
+ *
+ * @example
+ * type A = '*'; // ✅
+ * type B = 'id'; // ✅
+ * type C = 'title'; // ✅
+ * type D = 'title,description'; // ✅
+ * type E = ['title', 'description']; // ✅
+ * type F = [id, 'title,description']; // ✅
+ * type G = ['*']; // ✅
+ * type H = ['populatableField']; // ❌
+ * type I = ['<random_string>']; // ❌
+ * type J = 'populatableField'; // ❌
+ * type K = '<random_string>'; // ❌
+ */
+export type Any<TSchemaUID extends Common.UID.Schema> =
+  | StringNotation<TSchemaUID>
+  | ArrayNotation<TSchemaUID>;

--- a/packages/core/strapi/lib/services/entity-service/types/params/index.d.ts
+++ b/packages/core/strapi/lib/services/entity-service/types/params/index.d.ts
@@ -2,10 +2,11 @@ import type { Common } from '@strapi/strapi';
 
 import type * as Sort from './sort';
 import type * as Pagination from './pagination';
+import type * as Fields from './fields';
 
 export type For<TSchemaUID extends Common.UID.Schema> = {
   sort?: Sort.Any<TSchemaUID>;
-  pagination?: Pagination.Any;
-};
+  fields?: Fields.Any<TSchemaUID>;
+} & Pagination.Any;
 
-export type { Sort, Pagination };
+export type { Sort, Pagination, Fields };

--- a/packages/core/strapi/lib/services/entity-service/types/params/sort.d.ts
+++ b/packages/core/strapi/lib/services/entity-service/types/params/sort.d.ts
@@ -7,8 +7,6 @@ export module OrderKind {
   export type Any = Asc | Desc;
 }
 
-// String
-
 /**
  * Single non-populatable attribute representation
  *
@@ -19,7 +17,8 @@ export module OrderKind {
  * type D = 'title,description'; // ❌
  */
 type SingleAttribute<TSchemaUID extends Common.UID.Schema> =
-  Attribute.GetNonPopulatableKeys<TSchemaUID>;
+  | 'id'
+  | Attribute.GetNonPopulatableKeys<TSchemaUID>;
 
 /**
  * Ordered single non-populatable attribute representation
@@ -47,11 +46,8 @@ type OrderedSingleAttribute<TSchemaUID extends Common.UID.Schema> =
 export type StringNotation<TSchemaUID extends Common.UID.Schema> =
   | SingleAttribute<TSchemaUID>
   | OrderedSingleAttribute<TSchemaUID>
-  // TODO: Improve type checking for comma separated strings
-  // Loose checking for comma separated literal sort (complex to typecheck as the combination are near infinite)
+  // TODO: Loose type checking to avoid circular dependencies & infinite recursion
   | `${string},${string}`;
-
-// Array
 
 /**
  * Array notation for a sort
@@ -66,8 +62,6 @@ export type StringNotation<TSchemaUID extends Common.UID.Schema> =
  */
 export type ArrayNotation<TSchemaUID extends Common.UID.Schema> = Any<TSchemaUID>[];
 
-// Objects
-
 /**
  * Object notation for a sort
  *
@@ -81,7 +75,7 @@ export type ArrayNotation<TSchemaUID extends Common.UID.Schema> = Any<TSchemaUID
  */
 export type ObjectNotation<TSchemaUID extends Common.UID.Schema> = {
   // First level sort
-  [key in Attribute.GetNonPopulatableKeys<TSchemaUID>]?: OrderKind.Any;
+  [key in SingleAttribute<TSchemaUID>]?: OrderKind.Any;
 } & {
   // Deep sort, only add populatable keys that have a
   // target (remove dynamic zones and other polymorphic links)

--- a/packages/core/strapi/lib/services/entity-service/types/params/sort.d.ts
+++ b/packages/core/strapi/lib/services/entity-service/types/params/sort.d.ts
@@ -1,4 +1,4 @@
-import type { Attribute, Common } from '@strapi/strapi';
+import type { Attribute, Common, Utils } from '@strapi/strapi';
 
 export module OrderKind {
   export type Asc = 'asc';
@@ -18,7 +18,7 @@ export module OrderKind {
  */
 type SingleAttribute<TSchemaUID extends Common.UID.Schema> =
   | 'id'
-  | Attribute.GetNonPopulatableKeys<TSchemaUID>;
+  | Utils.Guard.Never<Attribute.GetNonPopulatableKeys<TSchemaUID>, string>;
 
 /**
  * Ordered single non-populatable attribute representation


### PR DESCRIPTION
### What does it do?
Adds the fields parameter for the entity service with all different notations: string, array.

### Why is it needed?
Part of the entity-service params typings feature.
