### PR TITLE
Enhancement: Enable more granular webpack vendor chunks

### DIFF
--- a/.github/workflows/adminBundleSize.yml
+++ b/.github/workflows/adminBundleSize.yml
@@ -7,6 +7,8 @@ on:
       - '**/ee/admin/**.js'
       - '**/helper-plugin/src/**.js'
       - '**/translations/**.json'
+      - '**/.github/workflows/adminBundleSize.yml'
+      - '**/admin/webpack.*.js'
 
       # Might be too broad, but it runs the action even if a
       # package.json wasn't changed, e.g. for non-pinned dependencies

--- a/packages/core/admin/webpack.config.js
+++ b/packages/core/admin/webpack.config.js
@@ -77,6 +77,26 @@ module.exports = ({
       ],
       moduleIds: 'deterministic',
       runtimeChunk: true,
+      splitChunks: {
+        chunks: 'all',
+        cacheGroups: {
+          vendor: {
+            // Make sure every dependency from node_modules is moved into it's own
+            // chunk. Since dependencies don't change that often, each of these
+            // chunks will already be cached by browsers and therefore they only
+            // have to download the ones that have changed across versions.
+            test: /node_modules/,
+            name(module, chunks, cacheGroupKey) {
+              const moduleFileName = module
+                .identifier()
+                .split('/')
+                .reduceRight((item) => item);
+              const allChunksNames = chunks.map((item) => item.name).join('~');
+              return `${cacheGroupKey}-${allChunksNames}-${moduleFileName}`;
+            },
+          },
+        },
+      },
     },
     module: {
       rules: [


### PR DESCRIPTION
### What does it do?

- Updates the webpack chunking algorithm to use one chunk per vendor dependency
- Runs the bundle-size action if the action was updated itself
- Runs the bundle-size action, if the webpack configuration was changed (which lives outside of `admin/src`)

### Why is it needed?

At the moment webpack is configured to bundle all vendor dependencies (from node_modules) into one chunk. This leads to two problems:

- the runtime chunk is very big (~1.7 MB); nothing is visible until the browser has loaded this file
- if we update one dependency, every user has to download the runtime again, because the chunk hash has changed

Today applications are typically deployed & accessed using HTTP2, which downloads chunks in parallel. In general it is preferred to load many smaller files, rather than one big file.

With the new chunking algorithm, every vendor chunk stays stable and only updated ones need to be: 1) rebuild 2) downloaded, which enables a very granular cache for our users.

### How to test it?

Load the application and see:

- all vendor chunks are prefixed with `vendor-`
- the number of requests slightly increased, but the size of the main runtime chunk has gone down a lot (1.7 MB -> 22kB)



### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
