### PR TITLE
fix(review-workflow): the feature shouldn't be deactivated on content type creation

### DIFF
--- a/api-tests/core/content-manager/search.test.api.js
+++ b/api-tests/core/content-manager/search.test.api.js
@@ -21,7 +21,7 @@ const bedModel = {
   pluralName: 'beds',
   kind: 'collectionType',
   options: {
-    reviewWorkflows: false,
+    noStageAttribute: true,
   },
   attributes: {
     name: {

--- a/packages/core/admin/ee/server/utils/review-workflows.js
+++ b/packages/core/admin/ee/server/utils/review-workflows.js
@@ -5,11 +5,7 @@ const { ENTITY_STAGE_ATTRIBUTE } = require('../constants/workflows');
 
 const getVisibleContentTypesUID = pipe([
   // Pick only content-types visible in the content-manager and option is not false
-  pickBy(
-    (value) =>
-      getOr(true, 'pluginOptions.content-manager.visible', value) &&
-      getOr(true, 'options.reviewWorkflows', value) !== false
-  ),
+  pickBy((value) => getOr(true, 'pluginOptions.content-manager.visible', value)),
   // Get UIDs
   keys,
 ]);

--- a/packages/core/admin/ee/server/utils/review-workflows.js
+++ b/packages/core/admin/ee/server/utils/review-workflows.js
@@ -5,7 +5,11 @@ const { ENTITY_STAGE_ATTRIBUTE } = require('../constants/workflows');
 
 const getVisibleContentTypesUID = pipe([
   // Pick only content-types visible in the content-manager and option is not false
-  pickBy((value) => getOr(true, 'pluginOptions.content-manager.visible', value)),
+  pickBy(
+    (value) =>
+      getOr(true, 'pluginOptions.content-manager.visible', value) &&
+      !getOr(false, 'options.noStageAttribute', value)
+  ),
   // Get UIDs
   keys,
 ]);

--- a/packages/core/content-type-builder/admin/src/components/FormModal/index.js
+++ b/packages/core/content-type-builder/admin/src/components/FormModal/index.js
@@ -190,7 +190,6 @@ const FormModal = () => {
           actionType,
           data: {
             draftAndPublish: true,
-            reviewWorkflows: false,
           },
           pluginOptions: {},
         });


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Remove the old way to create a content type with review workflow option set to false.

### Why is it needed?

We want all the content-type to have review workflow enabled by default.

### How to test it?

Create a new CT
Try assign it to a workflow

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
