### PR TITLE
Fix: Improve stage change success notification

### DIFF
--- a/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/InformationBoxEE.js
+++ b/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/InformationBoxEE.js
@@ -63,7 +63,7 @@ export function InformationBoxEE() {
           type: 'success',
           message: {
             id: 'content-manager.reviewWorkflows.stage.notification.saved',
-            defaultMessage: 'Success: Review stage updated',
+            defaultMessage: 'Review stage updated',
           },
         });
       },


### PR DESCRIPTION
### What does it do?

Fixes the notification text for stage updates in the CM edit view.

### Why is it needed?

Previously "Success" was displayed twice.

### How to test it?

Change a stage in the CM edit view, Verify the notification contains "Success" only once

