### PR TITLE
Chore: Refactor useLicenseLimits() hook

### DIFF
--- a/docs/docs/docs/01-core/admin/01-ee/02-hooks/_category_.json
+++ b/docs/docs/docs/01-core/admin/01-ee/02-hooks/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Hooks",
+  "collapsible": true,
+  "collapsed": true
+}

--- a/docs/docs/docs/01-core/admin/01-ee/02-hooks/use-license-limits.mdx
+++ b/docs/docs/docs/01-core/admin/01-ee/02-hooks/use-license-limits.mdx
@@ -1,0 +1,40 @@
+---
+title: useLicenseLimits
+description: API reference for the useLicenseLimits hook
+tags:
+  - admin
+  - hooks
+  - users
+  - ee
+---
+
+An abstraction around `react-query`'s `useQuery` hook to fetch license limits for a project.
+
+## Usage
+
+```js
+const { license, isError, isLoading } = useLicenseLimits();
+```
+
+### `license`
+
+An object the contains the whole admin API response.
+
+## Typescript
+
+```ts
+import { UseQueryResult } from 'react-query';
+
+// Note: the list of attributes might be incomplete
+interface License {
+  enforcementUserCount: number,
+  currentActiveUserCount: number,
+  permittedSeats: number,
+  shouldNotify: boolean,
+  shouldStopCreate: boolean,
+  licenseLimitStatus: 'OVER_LIMIT' | 'AT_LIMIT',
+  isHostedOnStrapiCloud: boolean
+}
+
+type UseLicenseLimit = () => Pick<UseQueryResult, 'isError' | 'isLoading'> & { license: License }
+```

--- a/docs/docs/docs/01-core/admin/01-ee/02-hooks/use-license-limits.mdx
+++ b/docs/docs/docs/01-core/admin/01-ee/02-hooks/use-license-limits.mdx
@@ -13,12 +13,26 @@ An abstraction around `react-query`'s `useQuery` hook to fetch license limits fo
 ## Usage
 
 ```js
-const { license, isError, isLoading } = useLicenseLimits();
+const { license, getFeature, isError, isLoading } = useLicenseLimits();
 ```
 
 ### `license`
 
-An object the contains the whole admin API response.
+An object that contains the raw admin API response.
+
+### `getFeature(name: string)`
+
+Returns options for a given feature. If the feature was not found, it returns an empty object. This is mostly a
+convenience method, to avoid having to filter the features array on the license object every time.
+
+#### Usage
+
+```
+const { getFeature } = useLicenseLimits();
+
+const reviewWorkflowOptions = getFeature('review-workflows');
+```
+
 
 ## Typescript
 
@@ -27,13 +41,19 @@ import { UseQueryResult } from 'react-query';
 
 // Note: the list of attributes might be incomplete
 interface License {
-  enforcementUserCount: number,
-  currentActiveUserCount: number,
-  permittedSeats: number,
-  shouldNotify: boolean,
-  shouldStopCreate: boolean,
-  licenseLimitStatus: 'OVER_LIMIT' | 'AT_LIMIT',
-  isHostedOnStrapiCloud: boolean
+  enforcementUserCount: number;
+  currentActiveUserCount: number;
+  permittedSeats: number;
+  shouldNotify: boolean;
+  shouldStopCreate: boolean;
+  licenseLimitStatus: 'OVER_LIMIT' | 'AT_LIMIT';
+  isHostedOnStrapiCloud: boolean;
+  features: LicenseFeature[];
+}
+
+interface LicenseFeature {
+  name: string;
+  options?: object;
 }
 
 type UseLicenseLimit = () => Pick<UseQueryResult, 'isError' | 'isLoading'> & { license: License }

--- a/packages/core/admin/ee/admin/hooks/useLicenseLimitNotification/index.js
+++ b/packages/core/admin/ee/admin/hooks/useLicenseLimitNotification/index.js
@@ -19,17 +19,17 @@ const BILLING_SELF_HOSTED_URL = 'https://strapi.io/billing/request-seats';
 
 const useLicenseLimitNotification = () => {
   const { formatMessage } = useIntl();
-  let { license } = useLicenseLimits();
+  let { license, isError, isLoading } = useLicenseLimits();
   const toggleNotification = useNotification();
   const { pathname } = useLocation();
 
+  const { enforcementUserCount, permittedSeats, licenseLimitStatus, isHostedOnStrapiCloud } =
+    license;
+
   useEffect(() => {
-    if (!license?.data) {
+    if (isError || isLoading) {
       return;
     }
-
-    const { enforcementUserCount, permittedSeats, licenseLimitStatus, isHostedOnStrapiCloud } =
-      license?.data ?? {};
 
     const shouldDisplayNotification =
       !isNil(permittedSeats) &&
@@ -84,7 +84,18 @@ const useLicenseLimitNotification = () => {
         },
       });
     }
-  }, [toggleNotification, license.data, pathname, formatMessage]);
+  }, [
+    toggleNotification,
+    license,
+    pathname,
+    formatMessage,
+    isLoading,
+    permittedSeats,
+    licenseLimitStatus,
+    enforcementUserCount,
+    isHostedOnStrapiCloud,
+    isError,
+  ]);
 };
 
 export default useLicenseLimitNotification;

--- a/packages/core/admin/ee/admin/hooks/useLicenseLimitNotification/tests/index.test.js
+++ b/packages/core/admin/ee/admin/hooks/useLicenseLimitNotification/tests/index.test.js
@@ -54,9 +54,7 @@ describe('useLicenseLimitNotification', () => {
 
   it('should return if no license info is available', () => {
     useLicenseLimits.mockImplementationOnce(() => ({
-      license: {
-        data: {},
-      },
+      license: {},
     }));
 
     renderHook(() => useLicenseLimitNotification());
@@ -66,10 +64,8 @@ describe('useLicenseLimitNotification', () => {
   it('should not display notification if permittedSeat info is missing', () => {
     useLicenseLimits.mockImplementationOnce(() => ({
       license: {
-        data: {
-          ...baseLicenseInfo,
-          permittedSeats: undefined,
-        },
+        ...baseLicenseInfo,
+        permittedSeats: undefined,
       },
     }));
 
@@ -80,10 +76,8 @@ describe('useLicenseLimitNotification', () => {
   it('should not display notification if status is not AT_LIMIT or OVER_LIMIT', () => {
     useLicenseLimits.mockImplementationOnce(() => ({
       license: {
-        data: {
-          ...baseLicenseInfo,
-          licenseLimitStatus: 'SOME_STRING',
-        },
+        ...baseLicenseInfo,
+        licenseLimitStatus: 'SOME_STRING',
       },
     }));
 
@@ -117,10 +111,8 @@ describe('useLicenseLimitNotification', () => {
   it('should display a warning notification when license limit is at limit', () => {
     useLicenseLimits.mockImplementationOnce(() => ({
       license: {
-        data: {
-          ...baseLicenseInfo,
-          licenseLimitStatus: 'OVER_LIMIT',
-        },
+        ...baseLicenseInfo,
+        licenseLimitStatus: 'OVER_LIMIT',
       },
     }));
 
@@ -144,10 +136,8 @@ describe('useLicenseLimitNotification', () => {
   it('should have cloud billing url if is hosted on strapi cloud', () => {
     useLicenseLimits.mockImplementationOnce(() => ({
       license: {
-        data: {
-          ...baseLicenseInfo,
-          isHostedOnStrapiCloud: true,
-        },
+        ...baseLicenseInfo,
+        isHostedOnStrapiCloud: true,
       },
     }));
 

--- a/packages/core/admin/ee/admin/hooks/useLicenseLimitNotification/tests/index.test.js
+++ b/packages/core/admin/ee/admin/hooks/useLicenseLimitNotification/tests/index.test.js
@@ -14,14 +14,7 @@ const baseLicenseInfo = {
   licenseType: 'gold',
 };
 
-jest.mock('react-intl', () => {
-  return {
-    useIntl: jest.fn(() => ({
-      formatMessage: jest.fn((options) => options.defaultMessage),
-    })),
-  };
-});
-
+// TODO: refactor
 jest.mock('react-router', () => {
   return {
     useLocation: jest.fn(() => ({
@@ -40,9 +33,7 @@ jest.mock('@strapi/helper-plugin', () => {
 
 jest.mock('../../useLicenseLimits', () => {
   return jest.fn(() => ({
-    license: {
-      data: baseLicenseInfo,
-    },
+    license: baseLicenseInfo,
   }));
 });
 

--- a/packages/core/admin/ee/admin/hooks/useLicenseLimitNotification/tests/index.test.js
+++ b/packages/core/admin/ee/admin/hooks/useLicenseLimitNotification/tests/index.test.js
@@ -1,4 +1,7 @@
+import React from 'react';
+
 import { renderHook } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
 
 import useLicenseLimitNotification from '..';
 import useLicenseLimits from '../../useLicenseLimits';
@@ -37,6 +40,13 @@ jest.mock('../../useLicenseLimits', () => {
   }));
 });
 
+const setup = (...args) =>
+  renderHook(() => useLicenseLimitNotification(...args), {
+    wrapper({ children }) {
+      return <IntlProvider>{children}</IntlProvider>;
+    },
+  });
+
 describe('useLicenseLimitNotification', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -48,7 +58,7 @@ describe('useLicenseLimitNotification', () => {
       license: {},
     }));
 
-    renderHook(() => useLicenseLimitNotification());
+    setup();
     expect(toggleNotification).not.toHaveBeenCalled();
   });
 
@@ -60,7 +70,7 @@ describe('useLicenseLimitNotification', () => {
       },
     }));
 
-    renderHook(() => useLicenseLimitNotification());
+    setup();
     expect(toggleNotification).not.toHaveBeenCalled();
   });
 
@@ -72,27 +82,26 @@ describe('useLicenseLimitNotification', () => {
       },
     }));
 
-    renderHook(() => useLicenseLimitNotification());
+    setup();
     expect(toggleNotification).not.toHaveBeenCalled();
   });
 
   it('should display a notification when license limit is over or at limit', () => {
-    renderHook(() => useLicenseLimitNotification());
+    setup();
     expect(toggleNotification).toHaveBeenCalled();
   });
 
   it('should display a soft warning notification when license limit is at limit', () => {
-    renderHook(() => useLicenseLimitNotification());
+    setup();
 
     expect(toggleNotification).toHaveBeenCalledWith({
       type: 'softWarning',
       message:
-        "Add seats to {licenseLimitStatus, select, OVER_LIMIT {invite} other {re-enable}} Users. If you already did it but it's not reflected in Strapi yet, make sure to restart your app.",
-      title:
-        '{licenseLimitStatus, select, OVER_LIMIT {Over} other {At}} seat limit ({enforcementUserCount}/{permittedSeats})',
+        "Add seats to re-enable Users. If you already did it but it's not reflected in Strapi yet, make sure to restart your app.",
+      title: 'At seat limit (5/5)',
       link: {
         url: 'https://strapi.io/billing/request-seats',
-        label: '{isHostedOnStrapiCloud, select, true {ADD SEATS} other {CONTACT SALES}}',
+        label: 'CONTACT SALES',
       },
       blockTransition: true,
       onClose: expect.any(Function),
@@ -107,17 +116,16 @@ describe('useLicenseLimitNotification', () => {
       },
     }));
 
-    renderHook(() => useLicenseLimitNotification());
+    setup();
 
     expect(toggleNotification).toHaveBeenCalledWith({
       type: 'warning',
       message:
-        "Add seats to {licenseLimitStatus, select, OVER_LIMIT {invite} other {re-enable}} Users. If you already did it but it's not reflected in Strapi yet, make sure to restart your app.",
-      title:
-        '{licenseLimitStatus, select, OVER_LIMIT {Over} other {At}} seat limit ({enforcementUserCount}/{permittedSeats})',
+        "Add seats to invite Users. If you already did it but it's not reflected in Strapi yet, make sure to restart your app.",
+      title: 'Over seat limit (5/5)',
       link: {
         url: 'https://strapi.io/billing/request-seats',
-        label: '{isHostedOnStrapiCloud, select, true {ADD SEATS} other {CONTACT SALES}}',
+        label: 'CONTACT SALES',
       },
       blockTransition: true,
       onClose: expect.any(Function),
@@ -132,17 +140,16 @@ describe('useLicenseLimitNotification', () => {
       },
     }));
 
-    renderHook(() => useLicenseLimitNotification());
+    setup();
 
     expect(toggleNotification).toHaveBeenCalledWith({
       type: 'softWarning',
       message:
-        "Add seats to {licenseLimitStatus, select, OVER_LIMIT {invite} other {re-enable}} Users. If you already did it but it's not reflected in Strapi yet, make sure to restart your app.",
-      title:
-        '{licenseLimitStatus, select, OVER_LIMIT {Over} other {At}} seat limit ({enforcementUserCount}/{permittedSeats})',
+        "Add seats to re-enable Users. If you already did it but it's not reflected in Strapi yet, make sure to restart your app.",
+      title: 'At seat limit (5/5)',
       link: {
         url: 'https://cloud.strapi.io/profile/billing',
-        label: '{isHostedOnStrapiCloud, select, true {ADD SEATS} other {CONTACT SALES}}',
+        label: 'ADD SEATS',
       },
       blockTransition: true,
       onClose: expect.any(Function),

--- a/packages/core/admin/ee/admin/hooks/useLicenseLimits/index.js
+++ b/packages/core/admin/ee/admin/hooks/useLicenseLimits/index.js
@@ -1,34 +1,3 @@
-import { useFetchClient, useRBAC } from '@strapi/helper-plugin';
-import { useQuery } from 'react-query';
-import { useSelector } from 'react-redux';
-
-import { selectAdminPermissions } from '../../../../admin/src/pages/App/selectors';
-
-const useLicenseLimits = () => {
-  const permissions = useSelector(selectAdminPermissions);
-  const rbac = useRBAC(permissions.settings.users);
-
-  const {
-    isLoading: isRBACLoading,
-    allowedActions: { canRead, canCreate, canUpdate, canDelete },
-  } = rbac;
-
-  const isRBACAllowed = canRead && canCreate && canUpdate && canDelete;
-
-  const { get } = useFetchClient();
-  const fetchLicenseLimitInfo = async () => {
-    const {
-      data: { data },
-    } = await get('/admin/license-limit-information');
-
-    return data;
-  };
-
-  const license = useQuery(['ee', 'license-limit-info'], fetchLicenseLimitInfo, {
-    enabled: !isRBACLoading && isRBACAllowed,
-  });
-
-  return { license };
-};
+import { useLicenseLimits } from './useLicenseLimits';
 
 export default useLicenseLimits;

--- a/packages/core/admin/ee/admin/hooks/useLicenseLimits/tests/index.test.js
+++ b/packages/core/admin/ee/admin/hooks/useLicenseLimits/tests/index.test.js
@@ -1,19 +1,32 @@
 import React from 'react';
 
 import { fixtures } from '@strapi/admin-test-utils';
-import { useFetchClient } from '@strapi/helper-plugin';
-import { renderHook } from '@testing-library/react';
-import { useQuery } from 'react-query';
+import { useRBAC } from '@strapi/helper-plugin';
+import { renderHook, waitFor } from '@testing-library/react';
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import { QueryClient, QueryClientProvider } from 'react-query';
 import { Provider } from 'react-redux';
 import { createStore } from 'redux';
 
 import useLicenseLimits from '..';
 
+const server = setupServer(
+  ...[
+    rest.get('*/license-limit-information', (req, res, ctx) => {
+      return res(
+        ctx.json({
+          data: {
+            attribute: 1,
+          },
+        })
+      );
+    }),
+  ]
+);
+
 jest.mock('@strapi/helper-plugin', () => ({
-  // TODO: Replace with msw
-  useFetchClient: jest.fn(() => ({
-    get: jest.fn(),
-  })),
+  ...jest.requireActual('@strapi/helper-plugin'),
   useRBAC: jest.fn(() => ({
     isLoading: false,
     allowedActions: {
@@ -25,55 +38,71 @@ jest.mock('@strapi/helper-plugin', () => ({
   })),
 }));
 
-// TODO: Replace with msw
-jest.mock('react-query', () => ({
-  useQuery: jest.fn(),
-}));
-
 const setup = (...args) =>
   renderHook(() => useLicenseLimits(...args), {
     wrapper({ children }) {
+      const client = new QueryClient({
+        defaultOptions: {
+          queries: {
+            refetchOnWindowFocus: false,
+          },
+        },
+      });
+
       return (
         <Provider
           store={createStore((state) => state, {
             admin_app: { permissions: fixtures.permissions.app },
           })}
         >
-          {children}
+          <QueryClientProvider client={client}>{children}</QueryClientProvider>
         </Provider>
       );
     },
   });
 
 describe('useLicenseLimits', () => {
+  beforeAll(() => server.listen());
+
+  afterEach(() => {
+    server.resetHandlers();
+    jest.clearAllMocks();
+  });
+
   it('should fetch the license limit information', async () => {
-    const data = { data: { id: 1, name: 'Test License' } };
-    useQuery.mockReturnValue({
-      data: { id: 1, name: 'Test License' },
-      isLoading: false,
-    });
-
     const { result } = setup();
 
-    expect(useFetchClient).toHaveBeenCalled();
-    expect(useQuery).toHaveBeenCalledWith(['ee', 'license-limit-info'], expect.any(Function), {
-      enabled: true,
+    expect(result.current.license).toEqual({});
+
+    await waitFor(() => expect(result.current.isLoading).toBeFalsy());
+
+    expect(result.current.license).toEqual({
+      attribute: 1,
     });
-    expect(result.current.license.data).toEqual(data.data);
   });
 
-  it('data should be undefined if there is an API error', async () => {
-    // const data = { data: { id: 1, name: 'Test License' } };
-    useQuery.mockReturnValue({
-      isError: true,
-    });
+  it.each(['canRead', 'canCreate', 'canUpdate', 'canDelete'])(
+    'should not fetch the license limit information, when the user does not have the %s permissions',
+    async (permission) => {
+      const allowedActions = {
+        canRead: true,
+        canCreate: true,
+        canUpdate: true,
+        canDelete: true,
+      };
 
-    const { result } = setup();
+      allowedActions[permission] = false;
 
-    expect(useFetchClient).toHaveBeenCalled();
-    expect(useQuery).toHaveBeenCalledWith(['ee', 'license-limit-info'], expect.any(Function), {
-      enabled: true,
-    });
-    expect(result.current.license.data).toEqual(undefined);
-  });
+      useRBAC.mockReturnValue({
+        isLoading: false,
+        allowedActions,
+      });
+
+      const { result } = setup();
+
+      await waitFor(() => expect(result.current.isLoading).toBeFalsy());
+
+      expect(result.current.license).toEqual({});
+    }
+  );
 });

--- a/packages/core/admin/ee/admin/hooks/useLicenseLimits/useLicenseLimits.js
+++ b/packages/core/admin/ee/admin/hooks/useLicenseLimits/useLicenseLimits.js
@@ -1,0 +1,31 @@
+import { useFetchClient, useRBAC } from '@strapi/helper-plugin';
+import { useQuery } from 'react-query';
+import { useSelector } from 'react-redux';
+
+import { selectAdminPermissions } from '../../../../admin/src/pages/App/selectors';
+
+export function useLicenseLimits() {
+  const permissions = useSelector(selectAdminPermissions);
+  const { get } = useFetchClient();
+  const {
+    isLoading: isRBACLoading,
+    allowedActions: { canRead, canCreate, canUpdate, canDelete },
+  } = useRBAC(permissions.settings.users);
+  const hasPermissions = canRead && canCreate && canUpdate && canDelete;
+
+  const { data, isError, isLoading } = useQuery(
+    ['ee', 'license-limit-info'],
+    async () => {
+      const {
+        data: { data },
+      } = await get('/admin/license-limit-information');
+
+      return data;
+    },
+    {
+      enabled: !isRBACLoading && hasPermissions,
+    }
+  );
+
+  return { license: data ?? {}, isError, isLoading };
+}

--- a/packages/core/admin/ee/admin/hooks/useLicenseLimits/useLicenseLimits.js
+++ b/packages/core/admin/ee/admin/hooks/useLicenseLimits/useLicenseLimits.js
@@ -1,3 +1,5 @@
+import * as React from 'react';
+
 import { useFetchClient, useRBAC } from '@strapi/helper-plugin';
 import { useQuery } from 'react-query';
 import { useSelector } from 'react-redux';
@@ -27,5 +29,16 @@ export function useLicenseLimits() {
     }
   );
 
-  return { license: data ?? {}, isError, isLoading };
+  const license = data ?? {};
+
+  const getFeature = React.useCallback(
+    (name) => {
+      const feature = (license?.features ?? []).find((feature) => feature.name === name);
+
+      return feature?.options ?? {};
+    },
+    [license?.features]
+  );
+
+  return { license, getFeature, isError, isLoading };
 }

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ApplicationInfosPage/components/AdminSeatInfo/index.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ApplicationInfosPage/components/AdminSeatInfo/index.js
@@ -19,7 +19,7 @@ const AdminSeatInfo = () => {
     isLoading,
   } = useLicenseLimits();
 
-  if (isError || isLoading) {
+  if (isError || isLoading || !permittedSeats) {
     return null;
   }
 

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ApplicationInfosPage/components/AdminSeatInfo/index.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ApplicationInfosPage/components/AdminSeatInfo/index.js
@@ -13,11 +13,13 @@ const BILLING_SELF_HOSTED_URL = 'https://strapi.io/billing/request-seats';
 
 const AdminSeatInfo = () => {
   const { formatMessage } = useIntl();
-  const { license } = useLicenseLimits();
-  const { licenseLimitStatus, enforcementUserCount, permittedSeats, isHostedOnStrapiCloud } =
-    license?.data ?? {};
+  const {
+    license: { licenseLimitStatus, enforcementUserCount, permittedSeats, isHostedOnStrapiCloud },
+    isError,
+    isLoading,
+  } = useLicenseLimits();
 
-  if (!permittedSeats) {
+  if (isError || isLoading) {
     return null;
   }
 

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ApplicationInfosPage/components/AdminSeatInfo/tests/index.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ApplicationInfosPage/components/AdminSeatInfo/tests/index.test.js
@@ -8,13 +8,13 @@ import AdminSeatInfo from '..';
 import { useLicenseLimits } from '../../../../../../../hooks';
 
 const LICENSE_MOCK = {
+  isLoading: false,
+  isError: false,
   license: {
-    data: {
-      enforcementUserCount: 10,
-      licenseLimitStatus: '',
-      permittedSeats: 100,
-      isHostedOnStrapiCloud: false,
-    },
+    enforcementUserCount: 10,
+    licenseLimitStatus: '',
+    permittedSeats: 100,
+    isHostedOnStrapiCloud: false,
   },
 };
 
@@ -28,37 +28,33 @@ const withMarkup = (query) => (text) =>
 
 jest.mock('../../../../../../../hooks', () => ({
   ...jest.requireActual('../../../../../../../hooks'),
-  useLicenseLimits: jest.fn(),
+  useLicenseLimits: jest.fn(() => LICENSE_MOCK),
 }));
 
-const ComponentFixture = (props) => (
-  <ThemeProvider theme={lightTheme}>
-    <IntlProvider locale="en" messages={{}}>
-      <AdminSeatInfo {...props} />
-    </IntlProvider>
-  </ThemeProvider>
-);
-
-function setup(props) {
-  return render(<ComponentFixture {...props} />);
-}
+const setup = (props) =>
+  render(<AdminSeatInfo {...props} />, {
+    wrapper({ children }) {
+      return (
+        <ThemeProvider theme={lightTheme}>
+          <IntlProvider locale="en" messages={{}}>
+            {children}
+          </IntlProvider>
+        </ThemeProvider>
+      );
+    },
+  });
 
 describe('<AdminSeatInfo />', () => {
-  beforeEach(() => {
+  afterEach(() => {
     jest.clearAllMocks();
-
-    useLicenseLimits.mockReturnValue(LICENSE_MOCK);
   });
 
   test('Do not render anything, when permittedSeats is falsy', () => {
-    useLicenseLimits.mockReturnValue({
+    useLicenseLimits.mockReturnValueOnce({
       ...LICENSE_MOCK,
       license: {
         ...LICENSE_MOCK.license,
-        data: {
-          ...LICENSE_MOCK.license.data,
-          permittedSeats: null,
-        },
+        permittedSeats: null,
       },
     });
 
@@ -69,6 +65,7 @@ describe('<AdminSeatInfo />', () => {
 
   test('Render seat info', () => {
     const { getByText } = setup();
+
     const getByTextWithMarkup = withMarkup(getByText);
 
     expect(getByText('Admin seats')).toBeInTheDocument();
@@ -86,14 +83,11 @@ describe('<AdminSeatInfo />', () => {
   });
 
   test('Render billing link (on strapi cloud)', () => {
-    useLicenseLimits.mockReturnValue({
+    useLicenseLimits.mockReturnValueOnce({
       ...LICENSE_MOCK,
       license: {
         ...LICENSE_MOCK.license,
-        data: {
-          ...LICENSE_MOCK.license.data,
-          isHostedOnStrapiCloud: true,
-        },
+        isHostedOnStrapiCloud: true,
       },
     });
 
@@ -107,14 +101,11 @@ describe('<AdminSeatInfo />', () => {
   });
 
   test('Render OVER_LIMIT icon', () => {
-    useLicenseLimits.mockReturnValue({
+    useLicenseLimits.mockReturnValueOnce({
       ...LICENSE_MOCK,
       license: {
         ...LICENSE_MOCK.license,
-        data: {
-          ...LICENSE_MOCK.license.data,
-          licenseLimitStatus: 'OVER_LIMIT',
-        },
+        licenseLimitStatus: 'OVER_LIMIT',
       },
     });
 

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/Users/ListPage/CreateAction/index.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/Users/ListPage/CreateAction/index.js
@@ -10,8 +10,15 @@ import { useLicenseLimits } from '../../../../../../hooks';
 
 const CreateAction = ({ onClick }) => {
   const { formatMessage } = useIntl();
-  const { license } = useLicenseLimits();
-  const { permittedSeats, shouldStopCreate } = license?.data ?? {};
+  const {
+    license: { permittedSeats, shouldStopCreate },
+    isError,
+    isLoading,
+  } = useLicenseLimits();
+
+  if (isError || isLoading) {
+    return null;
+  }
 
   return (
     <Flex gap={2}>


### PR DESCRIPTION
### What does it do?

Simplifies the `useLicenseLimits()` hook

### Why is it needed?

- by returning an object always we can simplify the destructuring
- by flattening the `license` object the consuming code becomes easier to read
- by returning `isLoading` components can handle that state
- by returning `isError` components can handle that state
