### PR TITLE
feat(review-workflows): remove deleted content-types in assigned workflows

### DIFF
--- a/packages/core/admin/ee/server/migrations/review-workflows-deleted-ct-in-workflows.js
+++ b/packages/core/admin/ee/server/migrations/review-workflows-deleted-ct-in-workflows.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const { difference, keys } = require('lodash/fp');
+const { mapAsync } = require('@strapi/utils');
+const { WORKFLOW_MODEL_UID } = require('../constants/workflows');
+const { getWorkflowContentTypeFilter } = require('../utils/review-workflows');
+
+/**
+ * @param {Object} oldContentTypes
+ * @param {Object} contentTypes
+ * @return {Promise<void>}
+ */
+async function migrateDeletedCTInWorkflows({ oldContentTypes, contentTypes }) {
+  const deletedContentTypes = difference(keys(oldContentTypes), keys(contentTypes)) ?? [];
+
+  if (deletedContentTypes.length) {
+    await mapAsync(deletedContentTypes, async (deletedContentTypeUID) => {
+      const workflow = await strapi.query(WORKFLOW_MODEL_UID).findOne({
+        select: ['id', 'contentTypes'],
+        where: {
+          contentTypes: getWorkflowContentTypeFilter({ strapi }, deletedContentTypeUID),
+        },
+      });
+
+      if (workflow) {
+        await strapi.query(WORKFLOW_MODEL_UID).update({
+          where: { id: workflow.id },
+          data: {
+            contentTypes: workflow.contentTypes.filter(
+              (contentTypeUID) => contentTypeUID !== deletedContentTypeUID
+            ),
+          },
+        });
+      }
+    });
+  }
+}
+
+module.exports = migrateDeletedCTInWorkflows;

--- a/packages/core/admin/ee/server/register.js
+++ b/packages/core/admin/ee/server/register.js
@@ -25,6 +25,7 @@ module.exports = async ({ strapi }) => {
     strapi.hook('strapi::content-types.afterSync').register(migrateReviewWorkflowStagesColor);
     strapi.hook('strapi::content-types.afterSync').register(migrateReviewWorkflowName);
     strapi.hook('strapi::content-types.afterSync').register(migrateWorkflowsContentTypes);
+    strapi.hook('strapi::content-types.afterSync').register(migrateStageAttribute);
     const reviewWorkflowService = getService('review-workflows');
 
     reviewWorkflowsMiddlewares.contentTypeMiddleware(strapi);

--- a/packages/core/admin/ee/server/register.js
+++ b/packages/core/admin/ee/server/register.js
@@ -7,6 +7,7 @@ const migrateReviewWorkflowStagesColor = require('./migrations/review-workflows-
 const migrateReviewWorkflowName = require('./migrations/review-workflows-workflow-name');
 const migrateWorkflowsContentTypes = require('./migrations/review-workflows-content-types');
 const migrateStageAttribute = require('./migrations/review-workflows-stage-attribute');
+const migrateDeletedCTInWorkflows = require('./migrations/review-workflows-deleted-ct-in-workflows');
 const createAuditLogsService = require('./services/audit-logs');
 const reviewWorkflowsMiddlewares = require('./middlewares/review-workflows');
 const { getService } = require('./utils');
@@ -22,10 +23,12 @@ module.exports = async ({ strapi }) => {
   }
   if (features.isEnabled('review-workflows')) {
     strapi.hook('strapi::content-types.beforeSync').register(migrateStageAttribute);
-    strapi.hook('strapi::content-types.afterSync').register(migrateReviewWorkflowStagesColor);
-    strapi.hook('strapi::content-types.afterSync').register(migrateReviewWorkflowName);
-    strapi.hook('strapi::content-types.afterSync').register(migrateWorkflowsContentTypes);
-    strapi.hook('strapi::content-types.afterSync').register(migrateStageAttribute);
+    strapi
+      .hook('strapi::content-types.afterSync')
+      .register(migrateReviewWorkflowStagesColor)
+      .register(migrateReviewWorkflowName)
+      .register(migrateWorkflowsContentTypes)
+      .register(migrateDeletedCTInWorkflows);
     const reviewWorkflowService = getService('review-workflows');
 
     reviewWorkflowsMiddlewares.contentTypeMiddleware(strapi);

--- a/packages/core/admin/ee/server/services/review-workflows/workflows/index.js
+++ b/packages/core/admin/ee/server/services/review-workflows/workflows/index.js
@@ -4,20 +4,14 @@ const { set, isString } = require('lodash/fp');
 const { ApplicationError, ValidationError } = require('@strapi/utils').errors;
 const { WORKFLOW_MODEL_UID } = require('../../../constants/workflows');
 const { getService } = require('../../../utils');
+const { getWorkflowContentTypeFilter } = require('../../../utils/review-workflows');
 const workflowsContentTypesFactory = require('./content-types');
-
-const getContentTypeFilter = ({ strapi }, contentType) => {
-  if (strapi.db.dialect.supportsOperator('$jsonSupersetOf')) {
-    return { $jsonSupersetOf: JSON.stringify([contentType]) };
-  }
-  return { $contains: `"${contentType}"` };
-};
 
 const processFilters = ({ strapi }, filters = {}) => {
   const processedFilters = { ...filters };
 
   if (isString(filters.contentTypes)) {
-    processedFilters.contentTypes = getContentTypeFilter({ strapi }, filters.contentTypes);
+    processedFilters.contentTypes = getWorkflowContentTypeFilter({ strapi }, filters.contentTypes);
   }
 
   return processedFilters;
@@ -169,7 +163,7 @@ module.exports = ({ strapi }) => {
     async getAssignedWorkflow(uid, opts = {}) {
       const workflows = await this.find({
         ...opts,
-        filters: { contentTypes: getContentTypeFilter({ strapi }, uid) },
+        filters: { contentTypes: getWorkflowContentTypeFilter({ strapi }, uid) },
       });
       return workflows.length > 0 ? workflows[0] : null;
     },

--- a/packages/core/admin/ee/server/utils/review-workflows.js
+++ b/packages/core/admin/ee/server/utils/review-workflows.js
@@ -16,7 +16,15 @@ const getVisibleContentTypesUID = pipe([
 
 const hasStageAttribute = has(['attributes', ENTITY_STAGE_ATTRIBUTE]);
 
+const getWorkflowContentTypeFilter = ({ strapi }, contentType) => {
+  if (strapi.db.dialect.supportsOperator('$jsonSupersetOf')) {
+    return { $jsonSupersetOf: JSON.stringify([contentType]) };
+  }
+  return { $contains: `"${contentType}"` };
+};
+
 module.exports = {
   getVisibleContentTypesUID,
   hasStageAttribute,
+  getWorkflowContentTypeFilter,
 };

--- a/packages/core/utils/lib/operators.js
+++ b/packages/core/utils/lib/operators.js
@@ -24,6 +24,7 @@ const WHERE_OPERATORS = [
   '$notContains',
   '$containsi',
   '$notContainsi',
+  '$jsonSupersetOf',
 ];
 
 const CAST_OPERATORS = [


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

If a content type is deleted, this code will check if it is part of any workflow and if so, delete the uid from the content-types array in the workflow.

### Why is it needed?

Having a clean data and really remove all occurrence of all deleted content types

### How to test it?

- Assign a content-type to any workflow
- Delete the content-type that have been assigned
- The workflow should be up to date without the deleted uid

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
