### PR TITLE
Fix bulk publish removed

### DIFF
--- a/packages/core/admin/admin/src/content-manager/pages/ListView/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/ListView/index.js
@@ -47,6 +47,7 @@ import { INJECT_COLUMN_IN_TABLE } from '../../../exposedHooks';
 import { selectAdminPermissions } from '../../../pages/App/selectors';
 import { InjectionZone } from '../../../shared/components';
 import AttributeFilter from '../../components/AttributeFilter';
+import BulkActionsBar from '../../components/DynamicTable/BulkActionsBar';
 import { createYupSchema, getRequestUrl, getTrad } from '../../utils';
 
 import { getData, getDataSucceeded, onChangeListHeaders, onResetListHeaders } from './actions';
@@ -550,6 +551,18 @@ function ListView({
               onOpenDeleteAllModalTrackedEvent="willBulkDeleteEntries"
               withBulkActions
               withMainAction={canDelete && isBulkable}
+              renderBulkActionsBar={({ selectedEntries, clearSelectedEntries }) => (
+                <BulkActionsBar
+                  showPublish={canPublish && hasDraftAndPublish}
+                  showDelete={canDelete}
+                  onConfirmDeleteAll={handleConfirmDeleteAllData}
+                  onConfirmPublishAll={handleConfirmPublishAllData}
+                  onConfirmUnpublishAll={handleConfirmUnpublishAllData}
+                  selectedEntries={selectedEntries}
+                  clearSelectedEntries={clearSelectedEntries}
+                />
+              )}
+              bulkAction
             >
               <TableRows
                 canCreate={canCreate}


### PR DESCRIPTION

### What does it do?

Adds bulk publish back

### Why is it needed?

It was removed in https://github.com/strapi/strapi/commit/c7363e4feb680e1ccb03ae77969e08cff4210898

### How to test it?

You should be able to see the bulk publish bar in the CM list view, publish, unpublish and delete in bulk

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
