### PR TITLE
Fix upload faulty image

### DIFF
--- a/api-tests/core/upload/admin/settings.test.api.js
+++ b/api-tests/core/upload/admin/settings.test.api.js
@@ -43,6 +43,7 @@ describe('Settings', () => {
           autoOrientation: false,
           sizeOptimization: true,
           responsiveDimensions: true,
+          sharpFailOn: 'warning',
         },
       });
     });

--- a/packages/core/upload/admin/src/components/AssetCard/UploadingAssetCard.js
+++ b/packages/core/upload/admin/src/components/AssetCard/UploadingAssetCard.js
@@ -12,6 +12,7 @@ import {
   Flex,
   Typography,
 } from '@strapi/design-system';
+import { useNotification } from '@strapi/helper-plugin';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 import styled from 'styled-components';
@@ -39,6 +40,7 @@ export const UploadingAssetCard = ({
 }) => {
   const { upload, cancel, error, progress, status } = useUpload();
   const { formatMessage } = useIntl();
+  const toggleNotification = useNotification();
 
   let badgeContent = formatMessage({
     id: getTrad('settings.section.doc.label'),
@@ -65,6 +67,7 @@ export const UploadingAssetCard = ({
   useEffect(() => {
     const uploadFile = async () => {
       const files = await upload(asset, folderId);
+      checkFaultyFile(files, asset);
 
       if (addUploadedFiles) {
         addUploadedFiles(files);
@@ -82,6 +85,25 @@ export const UploadingAssetCard = ({
   const handleCancel = () => {
     cancel();
     onCancel(asset.rawFile);
+  };
+
+  const checkFaultyFile = (files, asset) => {
+    const file = files.find((file) => file.name === asset.name);
+
+    if (file.isFaulty) {
+      showFultyFileAlert();
+    }
+  };
+
+  const showFultyFileAlert = () => {
+    toggleNotification({
+      type: 'softWarning',
+      message: {
+        id: getTrad('upload.file-warning'),
+        defaultMessage:
+          'The file is faulty. Proceed with the upload but processing the image (resizing, rotation, metadata removal, cropping, ect) may be impossible.',
+      },
+    });
   };
 
   return (

--- a/packages/core/upload/admin/src/translations/en.json
+++ b/packages/core/upload/admin/src/translations/en.json
@@ -1,6 +1,7 @@
 {
   "apiError.FileTooBig": "The uploaded file exceeds the maximum allowed asset size.",
   "upload.generic-error": "An error occurred while uploading the file.",
+  "upload.file-warning": "The file is faulty. Proceed with the upload but processing the image (resizing, rotation, metadata removal, cropping, ect) may be impossible.",
   "bulk.select.label": "Select all assets",
   "button.next": "Next",
   "checkControl.crop-duplicate": "Duplicate & crop the asset",

--- a/packages/core/upload/server/__tests__/bootstrap.test.js
+++ b/packages/core/upload/server/__tests__/bootstrap.test.js
@@ -80,6 +80,7 @@ describe('Upload plugin bootstrap function', () => {
         autoOrientation: false,
         sizeOptimization: true,
         responsiveDimensions: true,
+        sharpFailOn: 'warning',
       },
     });
   });

--- a/packages/core/upload/server/bootstrap.js
+++ b/packages/core/upload/server/bootstrap.js
@@ -9,6 +9,7 @@ module.exports = async ({ strapi }) => {
       sizeOptimization: true,
       responsiveDimensions: true,
       autoOrientation: false,
+      sharpFailOn: 'warning',
     },
     view_configuration: {
       pageSize: 10,

--- a/packages/core/upload/server/content-types/file/schema.js
+++ b/packages/core/upload/server/content-types/file/schema.js
@@ -101,6 +101,12 @@ module.exports = {
       private: true,
       searchable: false,
     },
+    isFaulty: {
+      type: 'boolean',
+      required: true,
+      private: true,
+      searchable: false,
+    },
   },
   // experimental feature:
   indexes: [

--- a/packages/core/upload/server/services/__tests__/upload/uploadImage.test.js
+++ b/packages/core/upload/server/services/__tests__/upload/uploadImage.test.js
@@ -11,7 +11,7 @@ const imageFilePath = path.join(__dirname, './image.png');
 const tmpWorkingDirectory = path.join(__dirname, './tmp');
 
 function mockUploadProvider(uploadFunc, props) {
-  const { responsiveDimensions = false } = props || {};
+  const { responsiveDimensions = false, sharpFailOn = 'warning' } = props || {};
 
   const defaultConfig = {
     plugin: {
@@ -35,7 +35,7 @@ function mockUploadProvider(uploadFunc, props) {
             upload: uploadFunc,
           },
           upload: {
-            getSettings: () => ({ responsiveDimensions }),
+            getSettings: () => ({ responsiveDimensions, sharpFailOn }),
           },
           'image-manipulation': require('../../image-manipulation')(),
         },
@@ -56,6 +56,7 @@ const getFileData = (filePath) => ({
   size: 4,
   width: 1500,
   tmpWorkingDirectory,
+  isFaulty: false,
 });
 
 describe('Upload image', () => {

--- a/packages/core/upload/server/services/image-manipulation.js
+++ b/packages/core/upload/server/services/image-manipulation.js
@@ -45,9 +45,13 @@ const THUMBNAIL_RESIZE_OPTIONS = {
 };
 
 const resizeFileTo = async (file, options, { name, hash }) => {
+  const { sharpFailOn } = await getService('upload').getSettings();
   const filePath = join(file.tmpWorkingDirectory, hash);
 
-  await writeStreamToFile(file.getStream().pipe(sharp().resize(options)), filePath);
+  await writeStreamToFile(
+    file.getStream().pipe(sharp({ failOn: sharpFailOn }).resize(options)),
+    filePath
+  );
   const newFile = {
     name,
     hash,
@@ -85,16 +89,18 @@ const generateThumbnail = async (file) => {
  *
  */
 const optimize = async (file) => {
-  const { sizeOptimization = false, autoOrientation = false } = await getService(
-    'upload'
-  ).getSettings();
+  const {
+    sizeOptimization = false,
+    autoOrientation = false,
+    sharpFailOn,
+  } = await getService('upload').getSettings();
 
   const newFile = { ...file };
 
   const { width, height, size, format } = await getMetadata(newFile);
 
   if (sizeOptimization || autoOrientation) {
-    const transformer = sharp();
+    const transformer = sharp({ failOn: sharpFailOn });
     // reduce image quality
     transformer[format]({ quality: sizeOptimization ? 80 : 100 });
     // rotate image based on EXIF data


### PR DESCRIPTION
### What does it do?

The proposed fix introduces a modification to sharp() passing a new parameter called "failOn" with two possible values: 'warning' and 'none'. By default, the value is set to 'warning', but it will be set to 'none', only in cases where the image is faulty or damaged. This change effectively disables the exception caused by the sharp() library.
In the case where a faulty or corrupted image is loaded and the process succeeds, a warning level alert is returned to the frontend. This warning specifically highlights the problem encountered and informs the user that further changes to the image may cause errors. In this way, users are informed of the image problem.

N.B. In the related issue was discussed to pass as parameter to sharp() the value "failOnError", but I saw this was deprecated. Other information can be founded to the [sharp library changelog](https://github.com/lovell/sharp/blob/main/docs/changelog.md#v0304---18th-april-2022)

### Why is it needed?

The problem occurred when the software attempted to load corrupted images produced by Samsung devices with a certain firmware, throwing an exception caused by the sharp() library, which prevented them from loading correctly.

### How to test it?

The author of the related issue provided an image corrupted, download and upload in the media library.

### Related issue(s)/PR(s)

#16838