### PR TITLE
Fix: Fix infinite rendering loop of role edit page

### DIFF
--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/ProtectedEditPage/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Roles/ProtectedEditPage/index.js
@@ -9,13 +9,20 @@ import EditPage from '../EditPage';
 
 const ProtectedEditPage = () => {
   const permissions = useSelector(selectAdminPermissions);
+
+  // TODO: this is necessary because otherwise we run into an
+  // infinite rendering loop
+  const permissionsMemoized = React.useMemo(() => {
+    return {
+      read: permissions.settings.roles.read,
+      update: permissions.settings.roles.update,
+    };
+  }, [permissions.settings.roles.read, permissions.settings.roles.update]);
+
   const {
     isLoading,
     allowedActions: { canRead, canUpdate },
-  } = useRBAC({
-    read: permissions.settings.roles.read,
-    update: permissions.settings.roles.update,
-  });
+  } = useRBAC(permissionsMemoized);
 
   if (isLoading) {
     return <LoadingIndicatorPage />;


### PR DESCRIPTION
### What does it do?

Memoize permissions before handing them to useRBAC.

### Why is it needed?

This is a quickfix to fix an infinite rendering loop on a edit role page. The problem here is really the useRBAC hook, but refactoring it will take a bit longer.

### How to test it?

Validate `/admin/settings/roles/2` only renders once.

### Related issue(s)/PR(s)

- Introduced in https://github.com/strapi/strapi/pull/17035
