### PR TITLE
POC: Remove strapi global

### DIFF
--- a/packages/core/strapi/lib/Strapi.js
+++ b/packages/core/strapi/lib/Strapi.js
@@ -132,6 +132,15 @@ class Strapi {
     });
   }
 
+  // TODO: Use in every other Strapi instance methods
+  assertInitialized() {
+    if (!this.initialized) {
+      throw new Error(
+        'Strapi is not initialized, you can not use the instance before initialization.'
+      );
+    }
+  }
+
   get config() {
     return this.container.get('config');
   }
@@ -570,10 +579,15 @@ class Strapi {
   }
 }
 
-module.exports = (options) => {
-  const strapi = new Strapi(options);
+let strapi;
+
+const initialize = (config = {}) => {
+  strapi = new Strapi(config);
   global.strapi = strapi;
   return strapi;
 };
+
+module.exports.initialize = initialize;
+Object.defineProperty(module.exports, 'strapi', { get: () => strapi });
 
 module.exports.Strapi = Strapi;

--- a/packages/core/strapi/lib/commands/actions/admin/create-user/action.js
+++ b/packages/core/strapi/lib/commands/actions/admin/create-user/action.js
@@ -88,7 +88,7 @@ module.exports = async (cmdOptions = {}) => {
 
 async function createAdmin({ email, password, firstname, lastname }) {
   const appContext = await strapi.compile();
-  const app = await strapi(appContext).load();
+  const app = await strapi.initialize(appContext).load();
 
   const user = await app.admin.services.user.exists({ email });
 

--- a/packages/core/strapi/lib/commands/actions/admin/reset-user-password/action.js
+++ b/packages/core/strapi/lib/commands/actions/admin/reset-user-password/action.js
@@ -43,7 +43,7 @@ module.exports = async (cmdOptions = {}) => {
 
 async function changePassword({ email, password }) {
   const appContext = await strapi.compile();
-  const app = await strapi(appContext).load();
+  const app = await strapi.initialize(appContext).load();
 
   await app.admin.services.user.resetPasswordByEmail(email, password);
 

--- a/packages/core/strapi/lib/commands/actions/configuration/dump/action.js
+++ b/packages/core/strapi/lib/commands/actions/configuration/dump/action.js
@@ -13,7 +13,7 @@ module.exports = async ({ file: filePath, pretty }) => {
   const output = filePath ? fs.createWriteStream(filePath) : process.stdout;
 
   const appContext = await strapi.compile();
-  const app = await strapi(appContext).load();
+  const app = await strapi.initialize(appContext).load();
 
   const count = await app.query('strapi::core-store').count();
 

--- a/packages/core/strapi/lib/commands/actions/configuration/restore/action.js
+++ b/packages/core/strapi/lib/commands/actions/configuration/restore/action.js
@@ -14,7 +14,7 @@ module.exports = async ({ file: filePath, strategy = 'replace' }) => {
   const input = filePath ? fs.readFileSync(filePath) : await readStdin(process.stdin);
 
   const appContext = await strapi.compile();
-  const app = await strapi(appContext).load();
+  const app = await strapi.initialize(appContext).load();
 
   let dataToImport;
   try {

--- a/packages/core/strapi/lib/commands/actions/console/action.js
+++ b/packages/core/strapi/lib/commands/actions/console/action.js
@@ -9,7 +9,7 @@ const strapi = require('../../../index');
  */
 module.exports = async () => {
   const appContext = await strapi.compile();
-  const app = await strapi(appContext).load();
+  const app = await strapi.initialize(appContext).load();
 
   app.start().then(() => {
     const repl = REPL.start(app.config.info.name + ' > ' || 'strapi > '); // eslint-disable-line prefer-template

--- a/packages/core/strapi/lib/commands/actions/content-types/list/action.js
+++ b/packages/core/strapi/lib/commands/actions/content-types/list/action.js
@@ -7,7 +7,7 @@ const strapi = require('../../../../index');
 
 module.exports = async () => {
   const appContext = await strapi.compile();
-  const app = await strapi(appContext).register();
+  const app = await strapi.initialize(appContext).register();
 
   const list = app.container.get('content-types').keys();
 

--- a/packages/core/strapi/lib/commands/actions/controllers/list/action.js
+++ b/packages/core/strapi/lib/commands/actions/controllers/list/action.js
@@ -7,7 +7,7 @@ const strapi = require('../../../../index');
 
 module.exports = async () => {
   const appContext = await strapi.compile();
-  const app = await strapi(appContext).register();
+  const app = await strapi.initialize(appContext).register();
 
   const list = app.container.get('controllers').keys();
 

--- a/packages/core/strapi/lib/commands/actions/develop/action.js
+++ b/packages/core/strapi/lib/commands/actions/develop/action.js
@@ -107,11 +107,13 @@ const primaryProcess = async ({ distDir, appDir, build, isTSProject, watchAdmin,
 };
 
 const workerProcess = async ({ appDir, distDir, watchAdmin, polling, isTSProject }) => {
-  const strapiInstance = await strapi({
-    distDir,
-    autoReload: true,
-    serveAdminPanel: !watchAdmin,
-  }).load();
+  const strapiInstance = await strapi
+    .initialize({
+      distDir,
+      autoReload: true,
+      serveAdminPanel: !watchAdmin,
+    })
+    .load();
 
   /**
    * TypeScript automatic type generation upon dev server restart

--- a/packages/core/strapi/lib/commands/actions/hooks/list/action.js
+++ b/packages/core/strapi/lib/commands/actions/hooks/list/action.js
@@ -7,7 +7,7 @@ const strapi = require('../../../../index');
 
 module.exports = async () => {
   const appContext = await strapi.compile();
-  const app = await strapi(appContext).register();
+  const app = await strapi.initialize(appContext).register();
 
   const list = app.container.get('hooks').keys();
 

--- a/packages/core/strapi/lib/commands/actions/middlewares/list/action.js
+++ b/packages/core/strapi/lib/commands/actions/middlewares/list/action.js
@@ -7,7 +7,7 @@ const strapi = require('../../../../index');
 
 module.exports = async () => {
   const appContext = await strapi.compile();
-  const app = await strapi(appContext).register();
+  const app = await strapi.initialize(appContext).register();
 
   const list = app.container.get('middlewares').keys();
 

--- a/packages/core/strapi/lib/commands/actions/policies/list/action.js
+++ b/packages/core/strapi/lib/commands/actions/policies/list/action.js
@@ -7,7 +7,7 @@ const strapi = require('../../../../index');
 
 module.exports = async () => {
   const appContext = await strapi.compile();
-  const app = await strapi(appContext).register();
+  const app = await strapi.initialize(appContext).register();
 
   const list = app.container.get('policies').keys();
 

--- a/packages/core/strapi/lib/commands/actions/report/action.js
+++ b/packages/core/strapi/lib/commands/actions/report/action.js
@@ -10,7 +10,7 @@ module.exports = async ({ uuid, dependencies, all }) => {
   };
 
   const appContext = await strapi.compile();
-  const app = await strapi(appContext).register();
+  const app = await strapi.initialize(appContext).register();
 
   let debugInfo = `Launched In: ${Date.now() - app.config.launchedAt} ms
 Environment: ${app.config.environment}

--- a/packages/core/strapi/lib/commands/actions/routes/list/action.js
+++ b/packages/core/strapi/lib/commands/actions/routes/list/action.js
@@ -8,7 +8,7 @@ const strapi = require('../../../../index');
 
 module.exports = async () => {
   const appContext = await strapi.compile();
-  const app = await strapi(appContext).load();
+  const app = await strapi.initialize(appContext).load();
 
   const list = app.server.listRoutes();
 

--- a/packages/core/strapi/lib/commands/actions/services/list/action.js
+++ b/packages/core/strapi/lib/commands/actions/services/list/action.js
@@ -7,7 +7,7 @@ const strapi = require('../../../../index');
 
 module.exports = async () => {
   const appContext = await strapi.compile();
-  const app = await strapi(appContext).register();
+  const app = await strapi.initialize(appContext).register();
 
   const list = app.container.get('services').keys();
 

--- a/packages/core/strapi/lib/commands/actions/start/action.js
+++ b/packages/core/strapi/lib/commands/actions/start/action.js
@@ -21,5 +21,5 @@ module.exports = async () => {
       `${outDir} directory not found. Please run the build command before starting your application`
     );
 
-  return strapi({ appDir, distDir }).start();
+  return strapi.initialize({ appDir, distDir }).start();
 };

--- a/packages/core/strapi/lib/commands/actions/ts/generate-types/action.js
+++ b/packages/core/strapi/lib/commands/actions/ts/generate-types/action.js
@@ -11,7 +11,7 @@ module.exports = async ({ debug, silent, verbose, outDir }) => {
   }
 
   const appContext = await strapi.compile();
-  const app = await strapi(appContext).register();
+  const app = await strapi.initialize(appContext).register();
 
   await tsUtils.generators.generate({
     strapi: app,

--- a/packages/core/strapi/lib/commands/actions/watch-admin/action.js
+++ b/packages/core/strapi/lib/commands/actions/watch-admin/action.js
@@ -10,7 +10,7 @@ const strapi = require('../../../index');
 module.exports = async ({ browser }) => {
   const appContext = await strapi.compile();
 
-  const strapiInstance = strapi({
+  const strapiInstance = strapi.initialize({
     ...appContext,
     autoReload: true,
     serveAdminPanel: false,

--- a/packages/core/strapi/lib/commands/builders/admin.js
+++ b/packages/core/strapi/lib/commands/builders/admin.js
@@ -11,7 +11,7 @@ const strapi = require('../../index');
 const getEnabledPlugins = require('../../core/loaders/plugins/get-enabled-plugins');
 
 module.exports = async ({ buildDestDir, forceBuild = true, optimization, srcDir }) => {
-  const strapiInstance = strapi({
+  const strapiInstance = strapi.initialize({
     // Directories
     appDir: srcDir,
     distDir: buildDestDir,

--- a/packages/core/strapi/lib/commands/utils/data-transfer.js
+++ b/packages/core/strapi/lib/commands/utils/data-transfer.js
@@ -127,7 +127,7 @@ const setSignalHandler = async (handler, signals = ['SIGINT', 'SIGTERM', 'SIGQUI
 const createStrapiInstance = async (opts = {}) => {
   try {
     const appContext = await strapi.compile();
-    const app = strapi({ ...opts, ...appContext });
+    const app = strapi.initialize({ ...opts, ...appContext });
 
     app.log.level = opts.logLevel || 'error';
     return await app.load();

--- a/packages/core/upload/server/services/metrics/weekly-metrics.js
+++ b/packages/core/upload/server/services/metrics/weekly-metrics.js
@@ -7,11 +7,11 @@ const { getWeeklyCronScheduleAt } = require('../../utils/cron');
 
 const ONE_WEEK = 7 * 24 * 60 * 60 * 1000;
 
-const getMetricsStoreValue = async () => {
+const getMetricsStoreValue = async ({ strapi }) => {
   const value = await strapi.store.get({ type: 'plugin', name: 'upload', key: 'metrics' });
   return defaultTo({}, value);
 };
-const setMetricsStoreValue = (value) =>
+const setMetricsStoreValue = (value, { strapi }) =>
   strapi.store.set({ type: 'plugin', name: 'upload', key: 'metrics', value });
 
 module.exports = ({ strapi }) => ({
@@ -95,12 +95,15 @@ module.exports = ({ strapi }) => ({
       groupProperties: { metrics },
     });
 
-    const metricsInfoStored = await getMetricsStoreValue();
-    await setMetricsStoreValue({ ...metricsInfoStored, lastWeeklyUpdate: new Date().getTime() });
+    const metricsInfoStored = await getMetricsStoreValue({ strapi });
+    await setMetricsStoreValue(
+      { ...metricsInfoStored, lastWeeklyUpdate: new Date().getTime() },
+      { strapi }
+    );
   },
 
   async ensureWeeklyStoredCronSchedule() {
-    const metricsInfoStored = await getMetricsStoreValue();
+    const metricsInfoStored = await getMetricsStoreValue({ strapi });
     const { weeklySchedule: currentSchedule, lastWeeklyUpdate } = metricsInfoStored;
 
     const now = new Date();

--- a/packages/plugins/i18n/package.json
+++ b/packages/plugins/i18n/package.json
@@ -46,6 +46,7 @@
     "yup": "^0.32.9"
   },
   "peerDependencies": {
+    "@strapi/strapi": "4.11.2",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0",
     "react-router-dom": "5.3.4",

--- a/packages/plugins/i18n/server/services/__tests__/content-types.test.js
+++ b/packages/plugins/i18n/server/services/__tests__/content-types.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { ApplicationError } = require('@strapi/utils').errors;
+const { strapi } = require('@strapi/strapi');
 const {
   isLocalizedContentType,
   getValidLocale,
@@ -11,6 +12,14 @@ const {
   fillNonLocalizedAttributes,
   getNestedPopulateOfNonLocalizedAttributes,
 } = require('../content-types')();
+
+const mockStrapiServices = (services) => {
+  strapi.plugins = {
+    i18n: {
+      services,
+    },
+  };
+};
 
 describe('content-types service', () => {
   describe('isLocalizedContentType', () => {
@@ -142,17 +151,8 @@ describe('content-types service', () => {
   describe('getValidLocale', () => {
     test('set default locale if the provided one is nil', async () => {
       const getDefaultLocale = jest.fn(() => Promise.resolve('en'));
-      global.strapi = {
-        plugins: {
-          i18n: {
-            services: {
-              locales: {
-                getDefaultLocale,
-              },
-            },
-          },
-        },
-      };
+      mockStrapiServices({ locales: { getDefaultLocale } });
+
       const locale = await getValidLocale(null);
 
       expect(locale).toBe('en');
@@ -160,17 +160,8 @@ describe('content-types service', () => {
 
     test('set locale to the provided one if it exists', async () => {
       const findByCode = jest.fn(() => Promise.resolve('en'));
-      global.strapi = {
-        plugins: {
-          i18n: {
-            services: {
-              locales: {
-                findByCode,
-              },
-            },
-          },
-        },
-      };
+      mockStrapiServices({ locales: { findByCode } });
+
       const locale = await getValidLocale('en');
 
       expect(locale).toBe('en');
@@ -178,17 +169,8 @@ describe('content-types service', () => {
 
     test("throw if provided locale doesn't exist", async () => {
       const findByCode = jest.fn(() => Promise.resolve(undefined));
-      global.strapi = {
-        plugins: {
-          i18n: {
-            services: {
-              locales: {
-                findByCode,
-              },
-            },
-          },
-        },
-      };
+      mockStrapiServices({ locales: { findByCode } });
+
       try {
         await getValidLocale('en');
       } catch (e) {
@@ -210,12 +192,8 @@ describe('content-types service', () => {
         const model = 'api::country.country';
         const locale = 'fr';
 
-        global.strapi = {
-          query: () => ({
-            findOne,
-          }),
-          getModel: () => ({ kind }),
-        };
+        strapi.query.mockReturnValueOnce({ findOne });
+        strapi.getModel.mockReturnValueOnce({ kind });
 
         try {
           await getAndValidateRelatedEntity(relatedEntityId, model, locale);
@@ -243,12 +221,8 @@ describe('content-types service', () => {
         const model = 'api::country.country';
         const locale = 'en';
 
-        global.strapi = {
-          query: () => ({
-            findOne,
-          }),
-          getModel: () => ({ kind }),
-        };
+        strapi.query.mockReturnValueOnce({ findOne });
+        strapi.getModel.mockReturnValueOnce({ kind });
 
         try {
           await getAndValidateRelatedEntity(relatedEntityId, model, locale);
@@ -281,12 +255,8 @@ describe('content-types service', () => {
         const model = 'api::country.country';
         const locale = 'en';
 
-        global.strapi = {
-          query: () => ({
-            findOne,
-          }),
-          getModel: () => ({ kind }),
-        };
+        strapi.query.mockReturnValueOnce({ findOne });
+        strapi.getModel.mockReturnValueOnce({ kind });
 
         try {
           await getAndValidateRelatedEntity(relatedEntityId, model, locale);
@@ -319,12 +289,8 @@ describe('content-types service', () => {
         const model = 'api::country.country';
         const locale = 'it';
 
-        global.strapi = {
-          query: () => ({
-            findOne,
-          }),
-          getModel: () => ({ kind }),
-        };
+        strapi.query.mockReturnValueOnce({ findOne });
+        strapi.getModel.mockReturnValueOnce({ kind });
 
         const foundEntity = await getAndValidateRelatedEntity(relatedEntityId, model, locale);
 
@@ -463,11 +429,7 @@ describe('content-types service', () => {
         },
       };
 
-      global.strapi = {
-        components: {
-          compo: compoModel,
-        },
-      };
+      strapi.components = { compo: compoModel };
 
       const model = {
         attributes: {
@@ -554,8 +516,7 @@ describe('content-types service', () => {
         },
       };
 
-      const getModel = jest.fn(() => modelDef);
-      global.strapi = { getModel };
+      strapi.getModel.mockReturnValueOnce(modelDef);
 
       fillNonLocalizedAttributes(entry, relatedEntry, { model: 'model' });
 
@@ -642,7 +603,7 @@ describe('content-types service', () => {
           },
         }[model]);
 
-      global.strapi = { getModel };
+      strapi.getModel.mockImplementationOnce(getModel);
     });
 
     test('Populate component, dz and media and not relations', () => {

--- a/packages/plugins/i18n/server/services/content-types.js
+++ b/packages/plugins/i18n/server/services/content-types.js
@@ -4,6 +4,7 @@ const _ = require('lodash');
 const { pick, pipe, has, prop, isNil, cloneDeep, isArray, difference } = require('lodash/fp');
 const { isRelationalAttribute, getVisibleAttributes, isTypedAttribute, getScalarAttributes } =
   require('@strapi/utils').contentTypes;
+const { strapi } = require('@strapi/strapi');
 const { ApplicationError } = require('@strapi/utils').errors;
 const { getService } = require('../utils');
 

--- a/packages/plugins/i18n/server/services/core-api.js
+++ b/packages/plugins/i18n/server/services/core-api.js
@@ -3,6 +3,7 @@
 const _ = require('lodash');
 const { prop, pick, reduce, map, keys, toPath, isNil } = require('lodash/fp');
 const utils = require('@strapi/utils');
+const { strapi } = require('@strapi/strapi');
 const { getService } = require('../utils');
 
 const { contentTypes, parseMultipartData, sanitize } = utils;

--- a/packages/plugins/i18n/server/services/entity-service-decorator.js
+++ b/packages/plugins/i18n/server/services/entity-service-decorator.js
@@ -2,6 +2,7 @@
 
 const { has, get, omit, isArray } = require('lodash/fp');
 const { ApplicationError } = require('@strapi/utils').errors;
+const { strapi } = require('@strapi/strapi');
 
 const { getService } = require('../utils');
 

--- a/packages/plugins/i18n/server/services/locales.js
+++ b/packages/plugins/i18n/server/services/locales.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { isNil } = require('lodash/fp');
+const { strapi } = require('@strapi/strapi');
 const { DEFAULT_LOCALE } = require('../constants');
 const { getService } = require('../utils');
 

--- a/packages/plugins/i18n/server/services/localizations.js
+++ b/packages/plugins/i18n/server/services/localizations.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { prop, isNil, isEmpty, isArray } = require('lodash/fp');
-
+const { strapi } = require('@strapi/strapi');
 const { mapAsync } = require('@strapi/utils');
 const { getService } = require('../utils');
 

--- a/packages/plugins/i18n/server/services/metrics.js
+++ b/packages/plugins/i18n/server/services/metrics.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { reduce } = require('lodash/fp');
+const { strapi } = require('@strapi/strapi');
 const { getService } = require('../utils');
 
 const sendDidInitializeEvent = async () => {

--- a/packages/plugins/i18n/server/utils/index.js
+++ b/packages/plugins/i18n/server/utils/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { strapi } = require('@strapi/strapi');
+
 const getCoreStore = () => {
   return strapi.store({ type: 'plugin', name: 'i18n' });
 };

--- a/packages/plugins/i18n/server/validation/content-types.js
+++ b/packages/plugins/i18n/server/validation/content-types.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { yup, validateYupSchema } = require('@strapi/utils');
+const { strapi } = require('@strapi/strapi');
 
 const { get } = require('lodash/fp');
 

--- a/test/unit.setup.js
+++ b/test/unit.setup.js
@@ -33,6 +33,7 @@ jest.mock('@strapi/strapi', () => ({
     ...jest.requireActual('@strapi/strapi').strapi,
     query: jest.fn(),
     store: jest.fn(),
+    getModel: jest.fn(),
     controllers: {},
     controller(name) {
       return this.controllers[name];

--- a/test/unit.setup.js
+++ b/test/unit.setup.js
@@ -26,3 +26,37 @@ Object.defineProperty(global, 'strapi', {
     };
   },
 });
+
+// Mock the `strapi` package
+jest.mock('@strapi/strapi', () => ({
+  strapi: {
+    ...jest.requireActual('@strapi/strapi').strapi,
+    query: jest.fn(),
+    store: jest.fn(),
+    controllers: {},
+    controller(name) {
+      return this.controllers[name];
+    },
+    services: {},
+    service(name) {
+      return this.services[name];
+    },
+    plugins: {},
+    plugin(name) {
+      return {
+        services: this.plugins[name].services,
+        service(serviceName) {
+          return this.services[serviceName];
+        },
+      };
+    },
+    contentTypes: {},
+    contentType(name) {
+      return this.contentTypes[name];
+    },
+    policies: {},
+    policy(name) {
+      return this.policies[name];
+    },
+  },
+}));

--- a/yarn.lock
+++ b/yarn.lock
@@ -8426,6 +8426,7 @@ __metadata:
     styled-components: 5.3.3
     yup: ^0.32.9
   peerDependencies:
+    "@strapi/strapi": 4.11.2
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
     react-router-dom: 5.3.4


### PR DESCRIPTION
### What does it do?

⚠️ *V5* ⚙️

This is a proposal to remove the strapi global. It initializes the Strapi instance as a singleton an can be imported from anywhere as long as the package has "@strapi/strapi" in its dependencies.

Example
```js
const strapi = require("@strapi/strapi");

const myBeautifulMethod = () => {
   await strapi.entityService(...)
}
```

Even though this looks handy, it might come with some caveats: ❗️
- It requires having @strapi/strapi as a dependency, and it might cause circular dependencies inside our monorepo. 🔁
- Removing the global completely will require updating almost all unit tests (not that big of a deal tbh) 🧪


Unit testing code using strapi as a global variable will also be a bit different, instead of updating `global.strapi` one can `jest.mock` strapi, or use the mock that is generated in [`unit.setup.js`](https://github.com/strapi/strapi/pull/17082/files#diff-385d19101b11757b5b8c3b8e76a803dbdcf68aba7556a66ed7164979935bdfb6)

You can see an example of updated test here https://github.com/strapi/strapi/pull/17082/files#diff-385d3bd26ecea349b928792719c9edbed12e385433a0e6ea14ce5d75ca3f01d3


📝 TODO:
- Update necessary tests 🧪 
- Migration guide 🚀

I will wait for the review of this POC to fully update all tests, just in case we decide to go another route.


### Why is it needed?

Use of strapi global has been in the monorepo for some time, and we decided to take the next major as an opportunity to improve this.

Having said this, following a dependency injection pattern is a much more robust alternative than this proposal, but in some cases it might be hard to pass strapi as a dependency and could result in prop drilling or it could just be not possible.



### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
