### PR TITLE
Fix linting error in CSS

### DIFF
--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Webhooks/EditView/components/Events/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Webhooks/EditView/components/Events/index.js
@@ -54,8 +54,10 @@ const StyledTable = styled(Table)`
   }
 
   tbody tr td:first-child {
-    // Add padding to the start of the first column to avoid the checkbox appearing
-    // too close to the edge of the table
+    /**
+     * Add padding to the start of the first column to avoid the checkbox appearing
+     * too close to the edge of the table
+     */
     padding-inline-start: ${({ theme }) => theme.spaces[2]};
   }
 `;


### PR DESCRIPTION
### What does it do?

Fixes a linting error

### Why is it needed?

It's invalid CSS and I can't commit because of the lint hook because of this line

### How to test it?

Should still work fine and now `yarn lint` should work

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
