### PR TITLE
fix bug on Settings > Documentation & Advanced setting tab while saving

### DIFF
--- a/packages/plugins/documentation/admin/src/pages/SettingsPage/index.js
+++ b/packages/plugins/documentation/admin/src/pages/SettingsPage/index.js
@@ -57,7 +57,7 @@ const SettingsPage = () => {
           onSubmit={handleUpdateSettingsSubmit}
           validationSchema={schema}
         >
-          {({ handleSubmit, values, handleChange, errors, setFieldTouched, setFieldValue }) => {
+            {({ handleSubmit, values, handleChange, errors, setFieldTouched, setFieldValue, dirty }) => {
             return (
               <Form noValidate onSubmit={handleSubmit}>
                 <HeaderLayout
@@ -71,7 +71,7 @@ const SettingsPage = () => {
                   })}
                   primaryAction={
                     <CheckPermissions permissions={PERMISSIONS.update}>
-                      <Button type="submit" startIcon={<Check />}>
+                      <Button type="submit" startIcon={<Check />} disabled={!dirty}>
                         {formatMessage({
                           id: getTrad('pages.SettingsPage.Button.save'),
                           defaultMessage: 'Save',

--- a/packages/plugins/documentation/admin/src/pages/SettingsPage/tests/index.test.js
+++ b/packages/plugins/documentation/admin/src/pages/SettingsPage/tests/index.test.js
@@ -517,8 +517,9 @@ describe('Plugin | Documentation | SettingsPage', () => {
                   </h1>
                 </div>
                 <button
-                  aria-disabled="false"
+                  aria-disabled="true"
                   class="c7 c8 c9 c10"
+                  disabled=""
                   type="submit"
                 >
                   <div

--- a/packages/plugins/users-permissions/admin/src/pages/AdvancedSettings/index.js
+++ b/packages/plugins/users-permissions/admin/src/pages/AdvancedSettings/index.js
@@ -143,7 +143,7 @@ const AdvancedSettingsPage = () => {
         validationSchema={schema}
         enableReinitialize
       >
-        {({ errors, values, handleChange, isSubmitting }) => {
+        {({ errors, values, handleChange, isSubmitting, dirty }) => {
           return (
             <Form>
               <HeaderLayout
@@ -155,7 +155,7 @@ const AdvancedSettingsPage = () => {
                   <Button
                     loading={isSubmitting}
                     type="submit"
-                    disabled={!canUpdate}
+                    disabled={canUpdate ? !dirty : !canUpdate}
                     startIcon={<Check />}
                     size="S"
                   >

--- a/packages/plugins/users-permissions/admin/src/pages/AdvancedSettings/tests/index.test.js
+++ b/packages/plugins/users-permissions/admin/src/pages/AdvancedSettings/tests/index.test.js
@@ -784,8 +784,9 @@ describe('ADMIN | Pages | Settings | Advanced Settings', () => {
                   </h1>
                 </div>
                 <button
-                  aria-disabled="false"
+                  aria-disabled="true"
                   class="c7 c8 c9 c10"
+                  disabled=""
                   type="submit"
                 >
                   <div


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Fix the same bug as this [PR](https://github.com/strapi/strapi/pull/17102) for two more pages

- Settings > Documentation
- Settings > Advanced settings

### Why is it needed?

As a bug fix. Please refer below screen recording after fix:

https://github.com/strapi/strapi/assets/40918526/65f216c1-6b12-4f05-9f3e-90bd9c87dd86



### How to test it?

Please login to admin and navigate to these two sections `Settings > Documentation` & `Settings > Advanced settings`. Save button on top right going to be disabled by default.

### Related issue(s)/PR(s)

No related issue for this PR.
