### PR TITLE
Change the autocomplete mode for the Add Locale dropdown to be "list".

### DIFF
--- a/packages/plugins/i18n/admin/src/components/LocaleSelect/index.js
+++ b/packages/plugins/i18n/admin/src/components/LocaleSelect/index.js
@@ -40,6 +40,7 @@ const LocaleSelect = React.memo(({ value, onClear, onLocaleChange, error }) => {
         id: getTrad('Settings.locales.modal.locales.label'),
         defaultMessage: 'Locales',
       })}
+      autocomplete="list"
       value={computedValue}
       onClear={value ? onClear : undefined}
       onChange={(selectedLocaleKey) => {


### PR DESCRIPTION

### What does it do?

The default autocomplete mode for Comboboxes is "both" which is not handled well in the i18n settings page for adding a new locale, and triggers some bad behaviour when using the filtering and trying to select a value.

Changing this to "list" still meets the requirements of filtering down the list, but does not try to fill in the search value, which seems to get confused in the "both" mode and auto complete to the wrong thing.

### Why is it needed?

The "both" mode makes it tough to get the correct locale without typing in the whole entry (or enough to make it the only entry in the list).

### How to test it?

The easiest way to test this change is to launch the admin portal in development mode. As this seems to be a UI quirk, and there were no broken tests from the change, I have not added additional ones. 

### Related issue(s)/PR(s)

None, just one we found.
