### PR TITLE
fix: Cannot save "required" dynamic-zone or component

### DIFF
--- a/api-tests/core/content-manager/api/basic-dp-compo.test.api.js
+++ b/api-tests/core/content-manager/api/basic-dp-compo.test.api.js
@@ -222,4 +222,60 @@ describe('CM API - Basic + compo + draftAndPublish', () => {
       data.productsWithCompoAndDP.push(res.body);
     });
   });
+
+  describe('Publication', () => {
+    test('Can publish product with compo - required', async () => {
+      const product = {
+        name: 'Product 1',
+        description: 'Product description',
+        compo: {
+          name: 'compo name',
+          description: 'short',
+        },
+      };
+      const res = await rq({
+        method: 'POST',
+        url: '/content-manager/collection-types/api::product-with-compo-and-dp.product-with-compo-and-dp',
+        body: product,
+      });
+
+      const publishRes = await rq({
+        method: 'POST',
+        url: `/content-manager/collection-types/api::product-with-compo-and-dp.product-with-compo-and-dp/${res.body.id}/actions/publish`,
+        body: product,
+      });
+
+      expect(publishRes.statusCode).toBe(200);
+      expect(publishRes.body).toMatchObject(product);
+      expect(publishRes.body.id).toEqual(res.body.id);
+      expect(publishRes.body.publishedAt).not.toBeNull();
+    });
+
+    test('Can bulk publish product with compo - required', async () => {
+      const product = {
+        name: 'Product 1',
+        description: 'Product description',
+        compo: {
+          name: 'compo name',
+          description: 'short',
+        },
+      };
+      const res = await rq({
+        method: 'POST',
+        url: '/content-manager/collection-types/api::product-with-compo-and-dp.product-with-compo-and-dp',
+        body: product,
+      });
+
+      const publishRes = await rq({
+        method: 'POST',
+        url: `/content-manager/collection-types/api::product-with-compo-and-dp.product-with-compo-and-dp/actions/bulkPublish`,
+        body: {
+          ids: [res.body.id],
+        },
+      });
+
+      expect(publishRes.statusCode).toBe(200);
+      expect(publishRes.body).toMatchObject({ count: 1 });
+    });
+  });
 });

--- a/packages/core/content-manager/server/controllers/collection-types.js
+++ b/packages/core/content-manager/server/controllers/collection-types.js
@@ -294,6 +294,8 @@ module.exports = {
     const permissionQuery = await permissionChecker.sanitizedQuery.publish(ctx.query);
     const populate = await getService('populate-builder')(model)
       .populateFromQuery(permissionQuery)
+      .populateDeep(Infinity)
+      .countRelations()
       .build();
 
     const entityPromises = ids.map((id) => entityManager.findOne(id, model, { populate }));

--- a/packages/core/content-manager/server/controllers/collection-types.js
+++ b/packages/core/content-manager/server/controllers/collection-types.js
@@ -253,6 +253,8 @@ module.exports = {
     const permissionQuery = await permissionChecker.sanitizedQuery.publish(ctx.query);
     const populate = await getService('populate-builder')(model)
       .populateFromQuery(permissionQuery)
+      .populateDeep(Infinity)
+      .countRelations()
       .build();
 
     const entity = await entityManager.findOne(id, model, { populate });


### PR DESCRIPTION
### What does it do?

In the content-manager publish service we were validating the entry creation like:

https://github.com/strapi/strapi/blob/553217bd1cd9b63a2c144e1aee7543810a478fc1/packages/core/content-manager/server/services/entity-manager.js

This required all components and dynamic zones to be populated. But we broke that functionality https://github.com/strapi/strapi/pull/16814 not populating those relations. Those relations were not automaticallly populated and so "validateEntityCreation" always received empty components.

### Why is it needed?
So required compos and dynamic zones work on publish.

### Related issue(s)/PR(s)
Fixes https://github.com/strapi/strapi/issues/17071