### PR TITLE
fix: Clone entities Not Found Error

### DIFF
--- a/packages/core/content-manager/server/controllers/collection-types.js
+++ b/packages/core/content-manager/server/controllers/collection-types.js
@@ -205,7 +205,7 @@ module.exports = {
       );
     }
 
-    this.clone(ctx);
+    await this.clone(ctx);
   },
 
   async delete(ctx) {


### PR DESCRIPTION
### What does it do?

We were not awaiting an async method and so it returned a 404 error when cloning entities without relations&unique fields in the content manager. 

API tests seems to not fail because of luck and even if the method was not awaited , the event loop executed it first.

### Why is it needed?

So you can clone entities properly.

### How to test it?

Clone a relation without relations or unique fields.
