### PR TITLE
Fix broken links in contributor docs

### DIFF
--- a/docs/docs/docs/01-core/admin/01-ee/01-review-workflows.md
+++ b/docs/docs/docs/01-core/admin/01-ee/01-review-workflows.md
@@ -135,5 +135,5 @@ The Review Workflow feature is currently included as a core feature within the S
 - https://docs.strapi.io/user-docs/settings/review-workflows
 - https://docs.strapi.io/user-docs/content-type-builder/creating-new-content-type#creating-a-new-content-type
 - https://docs.strapi.io/user-docs/users-roles-permissions/configuring-administrator-roles#plugins-and-settings
-- [Content manager](/content-manager/review-workflows)
-- [Content type builder](/content-type-builder/review-workflows)
+- [Content Manager Review Workflows](../../content-manager/02-review-workflows.mdx)
+- [Content Type Builder Review Workflows](../../content-type-builder/01-review-workflows.mdx)

--- a/docs/docs/docs/01-core/admin/02-permissions/02-frontend/fetching-permissions.mdx
+++ b/docs/docs/docs/01-core/admin/02-permissions/02-frontend/fetching-permissions.mdx
@@ -77,7 +77,7 @@ Because permissions are based on users in this case the individual logged in, we
 }
 ```
 
-An explanation on how these work can be found [here](/core/permissions/how-they-work). But as a quick overview we can see that permissions
+An explanation on how these work can be found [here](../01-how-they-work.mdx). But as a quick overview we can see that permissions
 typically associate to actions and in the case of the content manager they have subjects to be more granular and then fields & locales to
 be even more granular. These actions are defined by domains of the application registered via the application as they also have effect
 when calling APIs.
@@ -93,4 +93,4 @@ as well as injecting the information into the global `redux` store – see diagr
 />
 
 Inside the `RBACProviderContext` we also pass the ability to refetch the permissions. These two inconjunction with one another are accessed
-via the `useRBACProvider` hook. You can see the API for this hook [here](/core/permissions/frontend/using-permissions#typescript)
+via the `useRBACProvider` hook. You can see the API for this hook [here](../../02-permissions/02-frontend/using-permissions.mdx#typescript)

--- a/docs/docs/docs/01-core/admin/02-permissions/02-frontend/using-permissions.mdx
+++ b/docs/docs/docs/01-core/admin/02-permissions/02-frontend/using-permissions.mdx
@@ -7,12 +7,11 @@ tags:
 ---
 
 Currently, there are a few different ways to use permissions in the application. This document will explain the different ways, how to use them and suggestions
-on when is best to use them. It's advised that you've read [how they work](/core/permissions/how-they-work) and [fetching permissions](/core/permissions/frontend/fetching-permissions)
-before reading this document so you have the full context.
+on when is best to use them. It's advised that you've read [how they work](../01-how-they-work.mdx) and [fetching permissions](fetching-permissions.mdx) before reading this document so you have the full context.
 
 ## useRBACProvider
 
-In [fetching permissions](/core/permissions/frontend/fetching-permissions) we briefly mentioned the `useRBACProvider` hook which is used to access the [context](https://beta.reactjs.org/learn/passing-data-deeply-with-context)
+In [fetching permissions](./fetching-permissions.mdx) we briefly mentioned the `useRBACProvider` hook which is used to access the [context](https://beta.reactjs.org/learn/passing-data-deeply-with-context)
 that contains the permissions. This is very low level and does nothing but give you access to _every_ permission for the user and a way to refetch them from the API.
 
 ### Usage

--- a/docs/docs/docs/01-core/admin/03-settings/01-review-workflows.mdx
+++ b/docs/docs/docs/01-core/admin/03-settings/01-review-workflows.mdx
@@ -57,7 +57,7 @@ type Stage {
     updatedAt: Date
 }
 
-type Worklow {
+type Workflow {
     id: int,
     stages: Stage[]
     createdAt: Date

--- a/docs/docs/docs/01-core/content-manager/02-review-workflows.mdx
+++ b/docs/docs/docs/01-core/content-manager/02-review-workflows.mdx
@@ -8,7 +8,7 @@ tags:
 
 ## Summary
 
-Review workflows are disabled for all content-types by default and have to be enabled for each of them. More about how to [enable review-workflows for a content-type](/content-type-builder/review-workflows).
+Review workflows are disabled for all content-types by default and have to be enabled for each of them. More about how to [enable review-workflows for a content-type](../content-type-builder/01-review-workflows.mdx).
 
 The feature is visible in two locations of the content-manager:
 
@@ -50,7 +50,7 @@ This means at any place where the UI displays a stage, it has to be prepared to 
 ## List view
 
 The information which stage is current assigned to an entity is send as part of the content-type response payload for each entity in the attribute `strapi_reviewWorkflows_stage`.
-Please see [Data Shapes](/settings/review-workflows#data-shapes) for type definitions.
+Please see [Data Shapes](../admin/03-settings/01-review-workflows.mdx#data-shapes) for type definitions.
 
 ```ts
 {
@@ -67,7 +67,7 @@ add an additional check if the feature toggle returned in `http://localhost:1337
 ## Edit View
 
 The information which stage is current assigned to an entity is send as part of the entity response payload in the attribute `strapi_reviewWorkflows_stage`.
-Please see [Data Shapes](/settings/review-workflows#data-shapes) for type definitions.
+Please see [Data Shapes](../admin/03-settings/01-review-workflows.mdx#data-shapes) for type definitions.
 
 ```ts
 {

--- a/docs/docs/docs/01-core/content-manager/hooks/use-drag-and-drop.mdx
+++ b/docs/docs/docs/01-core/content-manager/hooks/use-drag-and-drop.mdx
@@ -213,7 +213,7 @@ You might notice in the [basic usage](#basic-usage) section this piece of code:
 </IconButton>
 ```
 
-In `firefox` the drag handler will not work if you click and drag when the element is a `button`, this is known [bug in the browser](bugzilla.mozilla.org/show_bug.cgi?id=568313).
+In `firefox` the drag handler will not work if you click and drag when the element is a `button`, this is known [bug in the browser](https://bugzilla.mozilla.org/show_bug.cgi?id=568313).
 Therefore the workaround is to use the `forwardedAs` prop to render a `div` instead of a `button`
 and add the `role` and `tabIndex` props to make this accessible. The actual `IconButton` component
 adds an accessible lable from the `aria-label` prop. So we don't have to concern ourselves with that.

--- a/docs/docs/docs/01-core/utils/async.md
+++ b/docs/docs/docs/01-core/utils/async.md
@@ -18,7 +18,7 @@ Available functions:
 - mapAsync
 - reduceAsync
 
-[See API reference](../../api/Utils) (TODO)
+[See API reference](../../../api/api.mdx) (TODO)
 
 ### When to use
 


### PR DESCRIPTION
### What does it do?

Fixes broken links in contributor docs

### Why is it needed?

Links should not be broken

### How to test it?

in /docs, run `yarn build` and there should not be any broken link warnings

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
