### PR TITLE
Fix : Content manager shows 403 (permissions error) on page reload

### DIFF
--- a/packages/core/admin/admin/src/components/AuthenticatedApp/index.js
+++ b/packages/core/admin/admin/src/components/AuthenticatedApp/index.js
@@ -38,7 +38,7 @@ const AuthenticatedApp = () => {
   const [
     { data: appInfos, status },
     { data: tagName, isLoading },
-    { data: permissions, status: fetchPermissionsStatus, refetch, isFetched, isFetching },
+    { data: permissions, status: fetchPermissionsStatus, refetch, isFetching },
     { data: userRoles },
   ] = useQueries([
     { queryKey: 'app-infos', queryFn: fetchAppInfo },

--- a/packages/core/admin/admin/src/components/AuthenticatedApp/index.js
+++ b/packages/core/admin/admin/src/components/AuthenticatedApp/index.js
@@ -86,7 +86,7 @@ const AuthenticatedApp = () => {
   // We don't need to wait for the release query to be fetched before rendering the plugins
   // however, we need the appInfos and the permissions
   const shouldShowNotDependentQueriesLoader =
-    (isFetching && isFetched) || status === 'loading' || fetchPermissionsStatus === 'loading';
+    isFetching || status === 'loading' || fetchPermissionsStatus === 'loading';
 
   const shouldShowLoader = isLoading || shouldShowNotDependentQueriesLoader;
 


### PR DESCRIPTION
### What does it do?

The change ensures that the content manager displays the loader until `admin-users-permission` data is fetched (among other APIs). As a result of this change, the content display logic kicks in only after the `admin-user-permissions` response is available.

This ensures that the 403 page isn't incorrectly displayed when reloading content-manager links (eg : `/dashboard/content-manager/collectionType/api::subscriber.subscriber/3`)

### Why is it needed?

Currently, within `core/admin/admin/src/components/AuthenticatedApp/index.js`, we fetch data via API call `admin-users-permission` through `react-query`. We use `isFetched` and `isFetching` to know if this API data is fetched. But, the logic to determine if the loader should be displayed (pasted below) is incorrect. Note that `(isFetching && isFetched)` will always be false.

```
  const shouldShowNotDependentQueriesLoader =
    (isFetching && isFetched) || status === 'loading' || fetchPermissionsStatus === 'loading';
```

As a result of the above, the `shouldShowNotDependentQueriesLoader` turns false once the other requests are fetched even if the response for `admin-users-permission` isn't yet available. In such situations, with an empty user-permissions, the render redirects to a 403 (assuming the user doesn't have permission to see the content).

### How to test it?

I have seen this issue occur on pages with a lot of data & relationships and on slow networks. Reloading any content manager pages that have a lot of data (eg : `/dashboard/content-manager/collectionType/api::subscriber.subscriber/3`) on slow networks is the way to test this.

### Related issue(s)/PR(s)

[16039](https://github.com/strapi/strapi/issues/16039)
