### PR TITLE
feat(review-workflows): apply license restrictions

### DIFF
--- a/api-tests/core/admin/ee/review-workflows-content-types.test.api.js
+++ b/api-tests/core/admin/ee/review-workflows-content-types.test.api.js
@@ -39,7 +39,7 @@ describeOnCondition(edition === 'EE')('Review workflows - Content Types', () => 
   let strapi;
 
   const createWorkflow = async (data) => {
-    const name = `${data.name}-${Math.random().toString(36)}`;
+    const name = `workflow-${Math.random().toString(36)}`;
     return requests.admin.post('/admin/review-workflows/workflows?populate=*', {
       body: { data: { ...baseWorkflow, name, ...data } },
     });
@@ -108,10 +108,13 @@ describeOnCondition(edition === 'EE')('Review workflows - Content Types', () => 
 
     describe('Create workflow and assign content type', () => {
       test('It should create a workflow and assign a content type', async () => {
-        const res = await createWorkflow({ contentTypes: [productUID] });
+        const res = await createWorkflow({ name: 'test-workflow', contentTypes: [productUID] });
 
         expect(res.status).toBe(200);
-        expect(res.body.data).toMatchObject({ contentTypes: [productUID] });
+        expect(res.body.data).toMatchObject({
+          name: expect.any(String),
+          contentTypes: [productUID],
+        });
         workflow1 = res.body.data;
       });
 

--- a/api-tests/core/admin/ee/review-workflows.test.api.js
+++ b/api-tests/core/admin/ee/review-workflows.test.api.js
@@ -483,7 +483,7 @@ describeOnCondition(edition === 'EE')('Review workflows', () => {
     describe('Review Workflow is enabled', () => {
       beforeAll(async () => {
         // Update workflow to unassign content type
-        const workflow = await requests.admin.put(
+        await requests.admin.put(
           `/admin/review-workflows/workflows/${testWorkflow.id}?populate=*`,
           { body: { data: { contentTypes: [productUID] } } }
         );

--- a/packages/core/admin/ee/server/constants/workflows.js
+++ b/packages/core/admin/ee/server/constants/workflows.js
@@ -8,4 +8,11 @@ module.exports = {
   ENTITY_STAGE_ATTRIBUTE: 'strapi_stage',
   MAX_WORKFLOWS: 200,
   MAX_STAGES_PER_WORKFLOW: 200,
+  ERRORS: {
+    WORKFLOW_WITHOUT_STAGES: 'A workflow must have at least one stage.',
+    WORKFLOWS_LIMIT:
+      'You’ve reached the limit of workflows in your plan. Delete a workflow or contact Sales to enable more workflows.',
+    STAGES_LIMIT:
+      'You have reached the limit of stages for this workflow in your plan. Try deleting some stages or contact Sales to enable more stages.',
+  },
 };

--- a/packages/core/admin/ee/server/constants/workflows.js
+++ b/packages/core/admin/ee/server/constants/workflows.js
@@ -13,6 +13,6 @@ module.exports = {
     WORKFLOWS_LIMIT:
       'You’ve reached the limit of workflows in your plan. Delete a workflow or contact Sales to enable more workflows.',
     STAGES_LIMIT:
-      'You have reached the limit of stages for this workflow in your plan. Try deleting some stages or contact Sales to enable more stages.',
+      'You’ve reached the limit of stages for this workflow in your plan. Try deleting some stages or contact Sales to enable more stages.',
   },
 };

--- a/packages/core/admin/ee/server/constants/workflows.js
+++ b/packages/core/admin/ee/server/constants/workflows.js
@@ -6,4 +6,6 @@ module.exports = {
   STAGE_MODEL_UID: 'admin::workflow-stage',
   STAGE_DEFAULT_COLOR: '#4945FF',
   ENTITY_STAGE_ATTRIBUTE: 'strapi_stage',
+  MAX_WORKFLOWS: 200,
+  MAX_STAGES_PER_WORKFLOW: 200,
 };

--- a/packages/core/admin/ee/server/register.js
+++ b/packages/core/admin/ee/server/register.js
@@ -32,7 +32,7 @@ module.exports = async ({ strapi }) => {
     const reviewWorkflowService = getService('review-workflows');
 
     reviewWorkflowsMiddlewares.contentTypeMiddleware(strapi);
-    await reviewWorkflowService.register();
+    await reviewWorkflowService.register(features.get('review-workflows'));
   }
   await executeCERegister({ strapi });
 };

--- a/packages/core/admin/ee/server/services/__tests__/review-workflows-validation.test.js
+++ b/packages/core/admin/ee/server/services/__tests__/review-workflows-validation.test.js
@@ -1,0 +1,92 @@
+'use strict';
+
+jest.mock('@strapi/strapi/lib/utils/ee', () => {
+  const eeModule = () => true;
+
+  Object.assign(eeModule, {
+    features: {
+      isEnabled() {
+        return true;
+      },
+      getEnabled() {
+        return ['review-workflows'];
+      },
+    },
+  });
+
+  return eeModule;
+});
+
+jest.mock('../review-workflows/workflows/content-types', () => {
+  return jest.fn(() => ({
+    migrate: jest.fn(),
+  }));
+});
+
+const validationServiceFactory = require('../review-workflows/validation');
+const { MAX_WORKFLOWS, MAX_STAGES_PER_WORKFLOW } = require('../../constants/workflows');
+
+const workflowsServiceMock = {
+  count: jest.fn(() => 1),
+};
+
+const servicesMock = {
+  'admin::workflows': workflowsServiceMock,
+};
+
+const strapiMock = {
+  service: jest.fn((serviceName) => console.log(serviceName) || servicesMock[serviceName]),
+};
+let validationService;
+
+describe('Review workflows - Validation service', () => {
+  beforeEach(() => {
+    validationService = validationServiceFactory({ strapi: strapiMock });
+  });
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+  describe('register', () => {
+    test('Limits object should be frozen after register', () => {
+      validationService.register({ workflows: 2, stagesPerWorkflow: 10 });
+      expect(validationService.limits.workflows).toEqual(2);
+      expect(validationService.limits.stagesPerWorkflow).toEqual(10);
+      expect(Object.isFrozen(validationService.limits)).toBe(true);
+    });
+    test(`Limits object shouldn't be frozen before register`, () => {
+      expect(validationService.limits.workflows).toEqual(MAX_WORKFLOWS);
+      expect(validationService.limits.stagesPerWorkflow).toEqual(MAX_STAGES_PER_WORKFLOW);
+      expect(Object.isFrozen(validationService.limits)).toBe(false);
+    });
+    test('Limits object should not be modified after first register', () => {
+      validationService.register({ workflows: 2, stagesPerWorkflow: 10 });
+      expect(validationService.limits.workflows).toEqual(2);
+      expect(validationService.limits.stagesPerWorkflow).toEqual(10);
+      validationService.register({ workflows: 99, stagesPerWorkflow: 99 });
+      expect(validationService.limits.workflows).toEqual(2);
+      expect(validationService.limits.stagesPerWorkflow).toEqual(10);
+    });
+  });
+  describe('validateWorkflowCount', () => {
+    test('Should not throw because limit is not reached', async () => {
+      validationService.register({ workflows: 2 });
+      workflowsServiceMock.count.mockReturnValue(1);
+      await expect(validationService.validateWorkflowCount()).resolves.not.toThrowError();
+    });
+    test('Should throw because limit is reached', async () => {
+      validationService.register({ workflows: 2 });
+      workflowsServiceMock.count.mockReturnValue(2);
+      await expect(validationService.validateWorkflowCount(1)).rejects.toThrowError();
+    });
+  });
+  describe('validateWorkflowStages', () => {
+    test('Should not throw because limit is not reached and at least 1 stage', async () => {
+      validationService.register({ stagesPerWorkflow: 2 });
+      expect(() => validationService.validateWorkflowStages([{}, {}])).not.toThrowError();
+    });
+    test('Should throw because limit is reached', async () => {
+      validationService.register({ stagesPerWorkflow: 2 });
+      expect(() => validationService.validateWorkflowStages([{}, {}, {}])).toThrowError();
+    });
+  });
+});

--- a/packages/core/admin/ee/server/services/__tests__/review-workflows.test.js
+++ b/packages/core/admin/ee/server/services/__tests__/review-workflows.test.js
@@ -67,6 +67,12 @@ const containerMock = {
   }),
 };
 
+const reviewWorkflowsValidationMock = {
+  register: jest.fn(),
+  validateWorkflowCount: jest.fn().mockResolvedValue(true),
+  validateWorkflowStages: jest.fn(),
+};
+
 const hookMock = jest.fn().mockReturnValue({ register: jest.fn() });
 
 const strapiMock = {
@@ -80,6 +86,8 @@ const strapiMock = {
         return stagesServiceMock;
       case 'admin::workflows':
         return workflowsServiceMock;
+      case 'admin::review-workflows-validation':
+        return reviewWorkflowsValidationMock;
       default:
         return null;
     }

--- a/packages/core/admin/ee/server/services/__tests__/stages.test.js
+++ b/packages/core/admin/ee/server/services/__tests__/stages.test.js
@@ -73,6 +73,11 @@ const servicesMock = {
     sendDidDeleteStage: jest.fn(),
     sendDidChangeEntryStage: jest.fn(),
   },
+  'admin::review-workflows-validation': {
+    register: jest.fn(),
+    validateWorkflowCount: jest.fn().mockResolvedValue(true),
+    validateWorkflowStages: jest.fn(),
+  },
 };
 
 const queryUpdateMock = jest.fn(() => Promise.resolve());

--- a/packages/core/admin/ee/server/services/__tests__/workflows.test.js
+++ b/packages/core/admin/ee/server/services/__tests__/workflows.test.js
@@ -47,9 +47,19 @@ const pluginsMock = {
   },
 };
 
+const reviewWorkflowsValidationMock = {
+  validateWorkflowCount: jest.fn().mockResolvedValue(true),
+  validateWorkflowStages: jest.fn(),
+};
+
+const servicesMock = {
+  'admin::review-workflows-validation': reviewWorkflowsValidationMock,
+};
+
 const strapiMock = {
   entityService: entityServiceMock,
   plugin: jest.fn((name) => pluginsMock[name]),
+  service: jest.fn((serviceName) => servicesMock[serviceName]),
 };
 
 const workflowsService = workflowsServiceFactory({ strapi: strapiMock });

--- a/packages/core/admin/ee/server/services/index.js
+++ b/packages/core/admin/ee/server/services/index.js
@@ -9,6 +9,7 @@ module.exports = {
   workflows: require('./review-workflows/workflows'),
   stages: require('./review-workflows/stages'),
   'review-workflows': require('./review-workflows/review-workflows'),
+  'review-workflows-validation': require('./review-workflows/validation'),
   'review-workflows-decorator': require('./review-workflows/entity-service-decorator'),
   'review-workflows-metrics': require('./review-workflows/metrics'),
 };

--- a/packages/core/admin/ee/server/services/review-workflows/review-workflows.js
+++ b/packages/core/admin/ee/server/services/review-workflows/review-workflows.js
@@ -1,12 +1,16 @@
 'use strict';
 
-const { filter, set, forEach, pipe, map, stubTrue, cond } = require('lodash/fp');
+const { filter, set, forEach, pipe, map, stubTrue, cond, defaultsDeep } = require('lodash/fp');
 const { getService } = require('../../utils');
 const { getVisibleContentTypesUID, hasStageAttribute } = require('../../utils/review-workflows');
 
 const defaultStages = require('../../constants/default-stages.json');
 const defaultWorkflow = require('../../constants/default-workflow.json');
-const { ENTITY_STAGE_ATTRIBUTE } = require('../../constants/workflows');
+const {
+  ENTITY_STAGE_ATTRIBUTE,
+  MAX_WORKFLOWS,
+  MAX_STAGES_PER_WORKFLOW,
+} = require('../../constants/workflows');
 
 const { persistTables, removePersistedTablesWithSuffix } = require('../../utils/persisted-tables');
 const webhookEvents = require('../../constants/webhookEvents');
@@ -16,6 +20,11 @@ const MAX_DB_TABLE_NAME_LEN = 63; // Postgres limit
 const MAX_JOIN_TABLE_NAME_SUFFIX =
   1 /* _ */ + ENTITY_STAGE_ATTRIBUTE.length + '_links_inv_fk'.length;
 const MAX_CONTENT_TYPE_NAME_LEN = MAX_DB_TABLE_NAME_LEN - MAX_JOIN_TABLE_NAME_SUFFIX;
+
+const DEFAULT_OPTIONS = {
+  workflows: MAX_WORKFLOWS,
+  stagesPerWorkflow: MAX_STAGES_PER_WORKFLOW,
+};
 
 async function initDefaultWorkflow({ workflowsService, stagesService }) {
   const wfCount = await workflowsService.count();
@@ -103,9 +112,13 @@ module.exports = ({ strapi }) => {
       await registerWebhookEvents({ strapi });
       await initDefaultWorkflow({ workflowsService, stagesService, strapi });
     },
-    async register() {
+    async register({ options }) {
       extendReviewWorkflowContentTypes({ strapi });
       strapi.hook('strapi::content-types.afterSync').register(persistStagesJoinTables({ strapi }));
+
+      const reviewWorkflowsOptions = defaultsDeep(DEFAULT_OPTIONS, options);
+      workflowsService.register(reviewWorkflowsOptions);
+      stagesService.register(reviewWorkflowsOptions);
     },
   };
 };

--- a/packages/core/admin/ee/server/services/review-workflows/review-workflows.js
+++ b/packages/core/admin/ee/server/services/review-workflows/review-workflows.js
@@ -88,7 +88,7 @@ function persistStagesJoinTables({ strapi }) {
 
     const joinTablesToPersist = pipe([
       getVisibleContentTypesUID,
-      filter(hasStageAttribute),
+      filter((uid) => hasStageAttribute(contentTypes[uid])),
       map(getStageTableToPersist),
     ])(contentTypes);
 

--- a/packages/core/admin/ee/server/services/review-workflows/review-workflows.js
+++ b/packages/core/admin/ee/server/services/review-workflows/review-workflows.js
@@ -113,7 +113,7 @@ module.exports = ({ strapi }) => {
       await registerWebhookEvents({ strapi });
       await initDefaultWorkflow({ workflowsService, stagesService, strapi });
     },
-    async register({ options }) {
+    async register({ options } = { options: {} }) {
       extendReviewWorkflowContentTypes({ strapi });
       strapi.hook('strapi::content-types.afterSync').register(persistStagesJoinTables({ strapi }));
 

--- a/packages/core/admin/ee/server/services/review-workflows/review-workflows.js
+++ b/packages/core/admin/ee/server/services/review-workflows/review-workflows.js
@@ -106,6 +106,7 @@ const registerWebhookEvents = async ({ strapi }) =>
 module.exports = ({ strapi }) => {
   const workflowsService = getService('workflows', { strapi });
   const stagesService = getService('stages', { strapi });
+  const workflowsValidationService = getService('review-workflows-validation', { strapi });
 
   return {
     async bootstrap() {
@@ -117,8 +118,7 @@ module.exports = ({ strapi }) => {
       strapi.hook('strapi::content-types.afterSync').register(persistStagesJoinTables({ strapi }));
 
       const reviewWorkflowsOptions = defaultsDeep(DEFAULT_OPTIONS, options);
-      workflowsService.register(reviewWorkflowsOptions);
-      stagesService.register(reviewWorkflowsOptions);
+      workflowsValidationService.register(reviewWorkflowsOptions);
     },
   };
 };

--- a/packages/core/admin/ee/server/services/review-workflows/stages.js
+++ b/packages/core/admin/ee/server/services/review-workflows/stages.js
@@ -106,7 +106,7 @@ module.exports = ({ strapi }) => {
           // Find the nearest stage in the workflow and newly created stages
           // that is not deleted, prioritizing the previous stages
           const nearestStage = findNearestMatchingStage(
-            [...srcStages, ...createdStages],
+            srcStages,
             srcStages.findIndex((s) => s.id === stage.id),
             (targetStage) => {
               return !deleted.find((s) => s.id === targetStage.id);

--- a/packages/core/admin/ee/server/services/review-workflows/stages.js
+++ b/packages/core/admin/ee/server/services/review-workflows/stages.js
@@ -100,14 +100,7 @@ module.exports = ({ strapi }) => {
 
       // Update stages and assign entity stages
       return strapi.db.transaction(async ({ trx }) => {
-        // Create the new stages
-        const createdStages = await this.createMany(created, { fields: ['id'] });
-        // Put all the newly created stages ids
-        const createdStagesIds = map('id', createdStages);
-
-        // Update the workflow stages
-        await mapAsync(updated, (stage) => this.update(stage.id, stage));
-
+        // ⚠️ Delete first as we can have a limit on stages
         // Delete the stages that are not in the new stages list
         await mapAsync(deleted, async (stage) => {
           // Find the nearest stage in the workflow and newly created stages
@@ -131,6 +124,13 @@ module.exports = ({ strapi }) => {
 
           return this.delete(stage.id);
         });
+        // Create the new stages
+        const createdStages = await this.createMany(created, { fields: ['id'] });
+        // Put all the newly created stages ids
+        const createdStagesIds = map('id', createdStages);
+
+        // Update the workflow stages
+        await mapAsync(updated, (stage) => this.update(stage.id, stage));
 
         return destStages.map((stage) => ({ ...stage, id: stage.id ?? createdStagesIds.shift() }));
       });

--- a/packages/core/admin/ee/server/services/review-workflows/stages.js
+++ b/packages/core/admin/ee/server/services/review-workflows/stages.js
@@ -6,13 +6,29 @@ const {
 } = require('@strapi/utils');
 const { map } = require('lodash/fp');
 
-const { STAGE_MODEL_UID, ENTITY_STAGE_ATTRIBUTE } = require('../../constants/workflows');
+const {
+  STAGE_MODEL_UID,
+  ENTITY_STAGE_ATTRIBUTE,
+  MAX_STAGES_PER_WORKFLOW,
+} = require('../../constants/workflows');
 const { getService } = require('../../utils');
+const { clampMaxStagesPerWorkflow } = require('../../utils/review-workflows');
 
 module.exports = ({ strapi }) => {
   const metrics = getService('review-workflows-metrics', { strapi });
+  const limits = {
+    stagesPerWorkflow: MAX_STAGES_PER_WORKFLOW,
+  };
 
   return {
+    register({ stagesPerWorkflow }) {
+      if (!Object.isFrozen(limits)) {
+        limits.stagesPerWorkflow = clampMaxStagesPerWorkflow(
+          stagesPerWorkflow || limits.stagesPerWorkflow
+        );
+        Object.freeze(limits);
+      }
+    },
     find({ workflowId, populate }) {
       const params = {
         filters: { workflow: workflowId },

--- a/packages/core/admin/ee/server/services/review-workflows/validation.js
+++ b/packages/core/admin/ee/server/services/review-workflows/validation.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const { ValidationError } = require('@strapi/utils').errors;
+const { getService } = require('../../utils');
+const { ERRORS, MAX_WORKFLOWS, MAX_STAGES_PER_WORKFLOW } = require('../../constants/workflows');
+const { clampMaxWorkflows, clampMaxStagesPerWorkflow } = require('../../utils/review-workflows');
+
+module.exports = ({ strapi }) => {
+  const limits = {
+    workflows: MAX_WORKFLOWS,
+    stagesPerWorkflow: MAX_STAGES_PER_WORKFLOW,
+  };
+
+  return {
+    register({ workflows, stagesPerWorkflow }) {
+      if (!Object.isFrozen(limits)) {
+        limits.workflows = clampMaxWorkflows(workflows || limits.workflows);
+        limits.stagesPerWorkflow = clampMaxStagesPerWorkflow(
+          stagesPerWorkflow || limits.stagesPerWorkflow
+        );
+        Object.freeze(limits);
+      }
+    },
+    /**
+     * Validates the stages of a workflow.
+     * @param {Array} stages - Array of stages to be validated.
+     * @throws {ValidationError} - If the workflow has no stages or exceeds the limit.
+     */
+    validateWorkflowStages(stages) {
+      if (!stages || stages.length === 0) {
+        throw new ValidationError(ERRORS.WORKFLOW_WITHOUT_STAGES);
+      }
+      if (stages.length > limits.stagesPerWorkflow) {
+        throw new ValidationError(ERRORS.STAGES_LIMIT);
+      }
+    },
+
+    /**
+     * Validates the count of existing and added workflows.
+     * @param {number} [countAddedWorkflows=0] - The count of workflows to be added.
+     * @throws {ValidationError} - If the total count of workflows exceeds the limit.
+     * @returns {Promise<void>} - A Promise that resolves when the validation is completed.
+     */
+    async validateWorkflowCount(countAddedWorkflows = 0) {
+      const workflowsService = getService('workflows', { strapi });
+      const countWorkflows = await workflowsService.count();
+      if (countWorkflows + countAddedWorkflows > limits.workflows) {
+        throw new ValidationError(ERRORS.WORKFLOWS_LIMIT);
+      }
+    },
+  };
+};

--- a/packages/core/admin/ee/server/services/review-workflows/validation.js
+++ b/packages/core/admin/ee/server/services/review-workflows/validation.js
@@ -6,19 +6,18 @@ const { ERRORS, MAX_WORKFLOWS, MAX_STAGES_PER_WORKFLOW } = require('../../consta
 const { clampMaxWorkflows, clampMaxStagesPerWorkflow } = require('../../utils/review-workflows');
 
 module.exports = ({ strapi }) => {
-  const limits = {
-    workflows: MAX_WORKFLOWS,
-    stagesPerWorkflow: MAX_STAGES_PER_WORKFLOW,
-  };
-
   return {
+    limits: {
+      workflows: MAX_WORKFLOWS,
+      stagesPerWorkflow: MAX_STAGES_PER_WORKFLOW,
+    },
     register({ workflows, stagesPerWorkflow }) {
-      if (!Object.isFrozen(limits)) {
-        limits.workflows = clampMaxWorkflows(workflows || limits.workflows);
-        limits.stagesPerWorkflow = clampMaxStagesPerWorkflow(
-          stagesPerWorkflow || limits.stagesPerWorkflow
+      if (!Object.isFrozen(this.limits)) {
+        this.limits.workflows = clampMaxWorkflows(workflows || this.limits.workflows);
+        this.limits.stagesPerWorkflow = clampMaxStagesPerWorkflow(
+          stagesPerWorkflow || this.limits.stagesPerWorkflow
         );
-        Object.freeze(limits);
+        Object.freeze(this.limits);
       }
     },
     /**
@@ -30,7 +29,7 @@ module.exports = ({ strapi }) => {
       if (!stages || stages.length === 0) {
         throw new ValidationError(ERRORS.WORKFLOW_WITHOUT_STAGES);
       }
-      if (stages.length > limits.stagesPerWorkflow) {
+      if (stages.length > this.limits.stagesPerWorkflow) {
         throw new ValidationError(ERRORS.STAGES_LIMIT);
       }
     },
@@ -44,7 +43,7 @@ module.exports = ({ strapi }) => {
     async validateWorkflowCount(countAddedWorkflows = 0) {
       const workflowsService = getService('workflows', { strapi });
       const countWorkflows = await workflowsService.count();
-      if (countWorkflows + countAddedWorkflows > limits.workflows) {
+      if (countWorkflows + countAddedWorkflows > this.limits.workflows) {
         throw new ValidationError(ERRORS.WORKFLOWS_LIMIT);
       }
     },

--- a/packages/core/admin/ee/server/services/review-workflows/validation.js
+++ b/packages/core/admin/ee/server/services/review-workflows/validation.js
@@ -34,6 +34,15 @@ module.exports = ({ strapi }) => {
       }
     },
 
+    async validateWorkflowCountStages(workflowId, countAddedStages = 0) {
+      const stagesService = getService('stages', { strapi });
+      const countWorkflowStages = await stagesService.count({ workflowId });
+
+      if (countWorkflowStages + countAddedStages > this.limits.stagesPerWorkflow) {
+        throw new ValidationError(ERRORS.STAGES_LIMIT);
+      }
+    },
+
     /**
      * Validates the count of existing and added workflows.
      * @param {number} [countAddedWorkflows=0] - The count of workflows to be added.

--- a/packages/core/admin/ee/server/services/review-workflows/workflows/__tests__/content-types.test.js
+++ b/packages/core/admin/ee/server/services/review-workflows/workflows/__tests__/content-types.test.js
@@ -11,9 +11,16 @@ const workflowsServiceMock = {
   getAssignedWorkflow: jest.fn(),
 };
 
+const reviewWorkflowsValidationMock = {
+  register: jest.fn(),
+  validateWorkflowCount: jest.fn().mockResolvedValue(true),
+  validateWorkflowStages: jest.fn(),
+};
+
 const getServiceMock = {
   stages: stagesServiceMock,
   workflows: workflowsServiceMock,
+  'review-workflows-validation': reviewWorkflowsValidationMock,
 };
 
 jest.mock('../../../../utils', () => {

--- a/packages/core/admin/ee/server/services/review-workflows/workflows/__tests__/content-types.test.js
+++ b/packages/core/admin/ee/server/services/review-workflows/workflows/__tests__/content-types.test.js
@@ -57,7 +57,7 @@ const strapiMock = {
 
 describe('Review Workflows', () => {
   afterEach(() => {
-    jest.resetAllMocks();
+    jest.clearAllMocks();
   });
 
   describe('content types service', () => {

--- a/packages/core/admin/ee/server/services/review-workflows/workflows/content-types.js
+++ b/packages/core/admin/ee/server/services/review-workflows/workflows/content-types.js
@@ -28,17 +28,12 @@ module.exports = ({ strapi }) => {
      * @param {Array<string>} options.srcContentTypes - The content types assigned to the previous workflow
      * @param {Array<string>} options.destContentTypes - The content types assigned to the new workflow
      * @param {Workflow.Stage} options.stageId - The new stage to assign the entities to
-     * @param {boolean} force - Override validations to force the migration (e.g. on workflow deletion)
      */
-    async migrate({ srcContentTypes = [], destContentTypes, stageId }, force = false) {
+    async migrate({ srcContentTypes = [], destContentTypes, stageId }) {
       // Workflows service is using this content-types service, to avoid an infinite loop, we need to get the service in the method
       const workflowsService = getService('workflows', { strapi });
-      const workflowsValidationService = getService('review-workflows-validation', { strapi });
       const { created, deleted } = diffContentTypes(srcContentTypes, destContentTypes);
 
-      if (!force) {
-        await workflowsValidationService.validateWorkflowCount();
-      }
       await mapAsync(created, async (uid) => {
         // If it was assigned to another workflow, transfer it from the previous workflow
         const srcWorkflow = await workflowsService.getAssignedWorkflow(uid);

--- a/packages/core/admin/ee/server/services/review-workflows/workflows/index.js
+++ b/packages/core/admin/ee/server/services/review-workflows/workflows/index.js
@@ -226,6 +226,11 @@ module.exports = ({ strapi }) => {
       }
     },
 
+    /**
+     * Validates the stages of a workflow.
+     * @param {Array} stages - Array of stages to be validated.
+     * @throws {ValidationError} - If the workflow has no stages or exceeds the limit.
+     */
     validateWorkflowStages(stages) {
       if (!stages || stages.length === 0) {
         throw new ValidationError(ERRORS.WORKFLOW_WITHOUT_STAGES);
@@ -235,6 +240,12 @@ module.exports = ({ strapi }) => {
       }
     },
 
+    /**
+     * Validates the count of existing and added workflows.
+     * @param {number} [countAddedWorkflows=0] - The count of workflows to be added.
+     * @throws {ValidationError} - If the total count of workflows exceeds the limit.
+     * @returns {Promise<void>} - A Promise that resolves when the validation is completed.
+     */
     async validateWorkflowCount(countAddedWorkflows = 0) {
       const countWorkflows = await this.count();
       if (countWorkflows + countAddedWorkflows > limits.workflows) {

--- a/packages/core/admin/ee/server/services/review-workflows/workflows/index.js
+++ b/packages/core/admin/ee/server/services/review-workflows/workflows/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { set, isString } = require('lodash/fp');
+const { set, isString, omit } = require('lodash/fp');
 const { ApplicationError } = require('@strapi/utils').errors;
 const { WORKFLOW_MODEL_UID } = require('../../../constants/workflows');
 const { getService } = require('../../../utils');
@@ -50,29 +50,32 @@ module.exports = ({ strapi }) => {
      * @throws {ValidationError} - If the workflow has no stages.
      */
     async create(opts) {
-      let createOpts = { ...opts, populate: { stages: true } };
-
       workflowsValidationService.validateWorkflowStages(opts.data.stages);
       await workflowsValidationService.validateWorkflowCount(1);
 
       return strapi.db.transaction(async () => {
-        // Create stages
-        const stageIds = await getService('stages', { strapi })
-          .replaceStages([], opts.data.stages)
-          .then((stages) => stages.map((stage) => stage.id));
+        // Create Workflow
+        const workflow = await strapi.entityService.create(WORKFLOW_MODEL_UID, {
+          select: '*',
+          data: omit('stages')(opts.data),
+        });
 
-        createOpts = set('data.stages', stageIds, createOpts);
+        const stagesToCreate = opts.data.stages.map((stage) => ({
+          ...stage,
+          workflow: workflow.id,
+        }));
+        // Create stages
+        const stages = await getService('stages', { strapi }).createMany(stagesToCreate);
 
         // Update (un)assigned Content Types
         if (opts.data.contentTypes) {
           await workflowsContentTypes.migrate({
             destContentTypes: opts.data.contentTypes,
-            stageId: stageIds[0],
+            stageId: stages[0].id,
           });
         }
 
-        // Create Workflow
-        return strapi.entityService.create(WORKFLOW_MODEL_UID, createOpts);
+        return { ...workflow, stages };
       });
     },
 

--- a/packages/core/admin/ee/server/services/review-workflows/workflows/index.js
+++ b/packages/core/admin/ee/server/services/review-workflows/workflows/index.js
@@ -140,13 +140,10 @@ module.exports = ({ strapi }) => {
         await stageService.deleteMany(workflow.stages.map((stage) => stage.id));
 
         // Unassign all content types, this will migrate the content types to null
-        await workflowsContentTypes.migrate(
-          {
-            srcContentTypes: workflow.contentTypes,
-            destContentTypes: [],
-          },
-          true
-        );
+        await workflowsContentTypes.migrate({
+          srcContentTypes: workflow.contentTypes,
+          destContentTypes: [],
+        });
 
         // Delete Workflow
         return strapi.entityService.delete(WORKFLOW_MODEL_UID, workflow.id, opts);

--- a/packages/core/admin/ee/server/utils/review-workflows.js
+++ b/packages/core/admin/ee/server/utils/review-workflows.js
@@ -1,7 +1,11 @@
 'use strict';
 
-const { getOr, keys, pickBy, pipe, has } = require('lodash/fp');
-const { ENTITY_STAGE_ATTRIBUTE } = require('../constants/workflows');
+const { getOr, keys, pickBy, pipe, has, clamp } = require('lodash/fp');
+const {
+  ENTITY_STAGE_ATTRIBUTE,
+  MAX_WORKFLOWS,
+  MAX_STAGES_PER_WORKFLOW,
+} = require('../constants/workflows');
 
 const getVisibleContentTypesUID = pipe([
   // Pick only content-types visible in the content-manager and option is not false
@@ -23,7 +27,12 @@ const getWorkflowContentTypeFilter = ({ strapi }, contentType) => {
   return { $contains: `"${contentType}"` };
 };
 
+const clampMaxWorkflows = clamp(1, MAX_WORKFLOWS);
+const clampMaxStagesPerWorkflow = clamp(1, MAX_STAGES_PER_WORKFLOW);
+
 module.exports = {
+  clampMaxWorkflows,
+  clampMaxStagesPerWorkflow,
   getVisibleContentTypesUID,
   hasStageAttribute,
   getWorkflowContentTypeFilter,

--- a/packages/core/strapi/ee/license.js
+++ b/packages/core/strapi/ee/license.js
@@ -9,9 +9,13 @@ const machineId = require('../lib/utils/machine-id');
 const DEFAULT_FEATURES = {
   bronze: [],
   silver: [],
-  // Set a null retention duration to allow the user to override it
-  // The default of 90 days is set in the audit logs service
-  gold: ['sso', { name: 'audit-logs', options: { retentionDays: null } }, 'review-workflows'],
+  gold: [
+    { name: 'sso' },
+    // Set a null retention duration to allow the user to override it
+    // The default of 90 days is set in the audit logs service
+    { name: 'audit-logs', options: { retentionDays: null } },
+    { name: 'review-workflows', options: { workflows: 2, stagesPerWorkflow: 20 } },
+  ],
 };
 
 const publicKey = fs.readFileSync(join(__dirname, 'resources/key.pub'));

--- a/packages/core/strapi/ee/license.js
+++ b/packages/core/strapi/ee/license.js
@@ -14,7 +14,7 @@ const DEFAULT_FEATURES = {
     // Set a null retention duration to allow the user to override it
     // The default of 90 days is set in the audit logs service
     { name: 'audit-logs', options: { retentionDays: null } },
-    { name: 'review-workflows', options: { workflows: 2, stagesPerWorkflow: 20 } },
+    { name: 'review-workflows' },
   ],
 };
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Adding EE licenses limits options to multiple workflows.
Depending on the plan, the number of available workflows and a number of stages per workflow can be restricted.
Also adding a hard limit to mitigate potential issues (e.g. infinite loop on workflow creation)

### Why is it needed?

As Review Workflows is an EE feature, we need to be able to limit how users can use the feature on Cloud plans.
Self-hosted EE is not impacted by those limitations.

### How to test it?

- Create workflows and try to bypass the limit of workflows available for your license.
- Create stages on a workflow and try to bypass the limit of stagesPerWorkflow available for your license.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
