### PR TITLE
fix: make the permissions memoized

### DIFF
--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Users/ProtectedEditPage/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Users/ProtectedEditPage/index.js
@@ -10,13 +10,19 @@ import EditPage from '../EditPage';
 const ProtectedEditPage = () => {
   const toggleNotification = useNotification();
   const permissions = useSelector(selectAdminPermissions);
+
+  const memoizedPermissions = React.useMemo(
+    () => ({
+      read: permissions.settings.users.read,
+      update: permissions.settings.users.update,
+    }),
+    [permissions.settings.users]
+  );
+
   const {
     isLoading,
     allowedActions: { canRead, canUpdate },
-  } = useRBAC({
-    read: permissions.settings.users.read,
-    update: permissions.settings.users.update,
-  });
+  } = useRBAC(memoizedPermissions);
   const { state } = useLocation();
   const from = state?.from ?? '/';
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* Memoizes the permissions from the selector before passing to `useRBAC`

### Why is it needed?

* Theres a infinite loop bug in `useRBAC` that we're in the process of fixing, but this bug should be worked around in the meantime.

### How to test it?

* Go to users
* Edit a user
* See the edit page!
