### PR TITLE
add transformParamsToQuery back to fix error

### DIFF
--- a/packages/plugins/i18n/server/services/__tests__/entity-service-decorator.test.js
+++ b/packages/plugins/i18n/server/services/__tests__/entity-service-decorator.test.js
@@ -37,6 +37,7 @@ const singleTypeModel = {
       localized: true,
     },
   },
+  attributes: {}
 };
 
 const models = {
@@ -355,6 +356,7 @@ describe('Entity service decorator', () => {
       };
 
       const defaultService = {
+        wrapResult: jest.fn((input) => Promise.resolve(input)),
         wrapParams: jest.fn(() => Promise.resolve(entry)),
         findMany: jest.fn(() => Promise.resolve(entry)),
       };

--- a/packages/plugins/i18n/server/services/entity-service-decorator.js
+++ b/packages/plugins/i18n/server/services/entity-service-decorator.js
@@ -156,7 +156,7 @@ const decorator = (service) => ({
    * @param {string} uid - Model uid
    * @param {object} opts - Query options object (params, data, files, populate)
    */
-  async findMany(uid, opts) {
+  async findMany(uid, opts = {}) {
     const model = strapi.getModel(uid);
 
     const { isLocalizedContentType } = getService('content-types');

--- a/packages/plugins/i18n/server/services/entity-service-decorator.js
+++ b/packages/plugins/i18n/server/services/entity-service-decorator.js
@@ -156,7 +156,7 @@ const decorator = (service) => ({
    * @param {string} uid - Model uid
    * @param {object} opts - Query options object (params, data, files, populate)
    */
-  async findMany(uid, opts = {}) {
+  async findMany(uid, opts) {
     const model = strapi.getModel(uid);
 
     const { isLocalizedContentType } = getService('content-types');
@@ -165,13 +165,13 @@ const decorator = (service) => ({
       return service.findMany.call(this, uid, opts);
     }
 
-    const { kind } = strapi.getModel(uid);
+    const { kind } = model;
 
     if (kind === 'singleType') {
       if (opts[LOCALE_QUERY_FILTER] === 'all') {
         // TODO Fix so this won't break lower lying find many wrappers
-        const wrappedParams = await this.wrapParams(opts, { uid, action: 'findMany' });
-        const query = transformParamsToQuery(uid, wrappedParams);
+        const wrappedParams = await this.wrapParams(opts, { uid, action: 'findMany' }) || {};
+        const query = transformParamsToQuery(model, wrappedParams);
         return strapi.db.query(uid).findMany(query);
       }
 

--- a/packages/plugins/i18n/server/services/entity-service-decorator.js
+++ b/packages/plugins/i18n/server/services/entity-service-decorator.js
@@ -2,6 +2,7 @@
 
 const { has, get, omit, isArray } = require('lodash/fp');
 const { ApplicationError } = require('@strapi/utils').errors;
+const { transformParamsToQuery } = require('@strapi/utils').convertQueryParams;
 
 const { getService } = require('../utils');
 
@@ -170,7 +171,8 @@ const decorator = (service) => ({
       if (opts[LOCALE_QUERY_FILTER] === 'all') {
         // TODO Fix so this won't break lower lying find many wrappers
         const wrappedParams = await this.wrapParams(opts, { uid, action: 'findMany' });
-        return strapi.db.query(uid).findMany(wrappedParams);
+        const query = transformParamsToQuery(uid, wrappedParams);
+        return strapi.db.query(uid).findMany(query);
       }
 
       // This one gets transformed into a findOne on a lower layer

--- a/packages/plugins/i18n/server/services/entity-service-decorator.js
+++ b/packages/plugins/i18n/server/services/entity-service-decorator.js
@@ -81,12 +81,12 @@ const assignValidLocale = async (data) => {
 const decorator = (service) => ({
   /**
    * Wraps result
-   * @param {object} params - Query options object (params, data, files, populate)
+   * @param {object} result - result object of query
    * @param {object} ctx - Query context
    * @param {object} ctx.model - Model that is being used
    */
-  async wrapResult(params = {}, ctx = {}) {
-    return service.wrapResult.call(this, params, ctx);
+  async wrapResult(result = {}, ctx = {}) {
+    return service.wrapResult.call(this, result, ctx);
   },
 
 

--- a/packages/plugins/i18n/server/services/entity-service-decorator.js
+++ b/packages/plugins/i18n/server/services/entity-service-decorator.js
@@ -182,8 +182,6 @@ const decorator = (service) => ({
       if (opts[LOCALE_QUERY_FILTER] === 'all') {
         // TODO Fix so this won't break lower lying find many wrappers
         const wrappedParams = await this.wrapParams(opts, { uid, action: 'findMany' });
-        console.log("ABC")
-        console.log(wrappedParams)
         const query = transformParamsToQuery(uid, wrappedParams);
         const entities = await strapi.db.query(uid).findMany(query);
         return this.wrapResult(entities, { uid, action: 'findMany' });

--- a/packages/plugins/i18n/server/services/entity-service-decorator.js
+++ b/packages/plugins/i18n/server/services/entity-service-decorator.js
@@ -167,7 +167,7 @@ const decorator = (service) => ({
    * @param {string} uid - Model uid
    * @param {object} opts - Query options object (params, data, files, populate)
    */
-  async findMany(uid, opts = {}) {
+  async findMany(uid, opts) {
     const model = strapi.getModel(uid);
 
     const { isLocalizedContentType } = getService('content-types');


### PR DESCRIPTION

### What does it do?

transformParamsToQuery added back for local all so you an populate it correctly

### Why is it needed?

to stop it from erroring if you have local all and populate

### How to test it?

check if it errors when local all and populate are both pressent

### Related issue(s)/PR(s)

fixes https://github.com/strapi/strapi/issues/17116
