### PR TITLE
Fix inability to sort/filter media associations in graphql #17132

### DIFF
--- a/docs/docs/docs/01-core/admin/02-permissions/02-frontend/using-permissions.mdx
+++ b/docs/docs/docs/01-core/admin/02-permissions/02-frontend/using-permissions.mdx
@@ -31,7 +31,7 @@ const MyComponent = () => {
 
   const canSeeMyComponent = allPermissions.some(
     // this string will declared in the backend.
-    (permission) => permission.action === 'plugins::my-plugin.my-component.read'
+    (permission) => permission.action === 'plugin::my-plugin.my-component.read'
   );
 
   return (
@@ -81,7 +81,7 @@ be redirect to the homepage.
 ```tsx
 import { CheckPagePermissions } from '@strapi/helper-plugin';
 
-const permissions = [{ action: 'plugins::my-plugin.access', subject: null }];
+const permissions = [{ action: 'plugin::my-plugin.access', subject: null }];
 
 const MyPage = () => {
   return (
@@ -122,7 +122,7 @@ This would be useful in the content-manager when you're trying to hide fields ba
 ```tsx
 import { CheckPermissions } from '@strapi/helper-plugin';
 
-const permissions = [{ action: 'plugins::my-plugin.access', subject: null }];
+const permissions = [{ action: 'plugin::my-plugin.access', subject: null }];
 
 const MyComponent = () => {
   return (

--- a/packages/core/helper-plugin/src/components/CheckPagePermissions/CheckPagePermissions.stories.mdx
+++ b/packages/core/helper-plugin/src/components/CheckPagePermissions/CheckPagePermissions.stories.mdx
@@ -14,7 +14,7 @@ This component is used in order to apply RBAC to a view. If the user does not ha
 ```
 import { CheckPagePermissions } from '@strapi/helper-plugin';
 
-const permissions = [{ action: 'plugins::my-plugin.access', subject: null }];
+const permissions = [{ action: 'plugin::my-plugin.access', subject: null }];
 
 const HomePage = () => {
   return (

--- a/packages/core/helper-plugin/src/components/CheckPermissions/CheckPermissions.stories.mdx
+++ b/packages/core/helper-plugin/src/components/CheckPermissions/CheckPermissions.stories.mdx
@@ -14,7 +14,7 @@ This component is used in order to apply RBAC to a component. If the user does n
 ```
 import { CheckPermissions } from '@strapi/helper-plugin';
 
-const permissions = [{ action: 'plugins::my-plugin.read', subject: null }];
+const permissions = [{ action: 'plugin::my-plugin.read', subject: null }];
 
 const HomePage = () => {
   return (

--- a/packages/plugins/graphql/server/services/builders/resolvers/association.js
+++ b/packages/plugins/graphql/server/services/builders/resolvers/association.js
@@ -28,7 +28,7 @@ module.exports = ({ strapi }) => {
       const isMediaAttribute = isMedia(attribute);
       const isMorphAttribute = isMorphRelation(attribute);
 
-      const targetUID = isMediaAttribute ? 'plugins::upload.file' : attribute.target;
+      const targetUID = isMediaAttribute ? 'plugin::upload.file' : attribute.target;
       const isToMany = isMediaAttribute ? attribute.multiple : attribute.relation.endsWith('Many');
 
       const targetContentType = strapi.getModel(targetUID);


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Updated incorrect plugin uid reference which used the prefix `plugins::` instead of `plugin::`.  

### Why is it needed?

Filtering media associations is broken in graphql.

### How to test it?

Create a content type with a field that allows multiple media. Try to sort and filter via graphl.

### Related issue(s)/PR(s)

* #17132 
