### PR TITLE
Fix entity-service filter $between operator to allow Date objects

### DIFF
--- a/packages/core/utils/src/__tests__/convert-query-params.test.ts
+++ b/packages/core/utils/src/__tests__/convert-query-params.test.ts
@@ -1,0 +1,67 @@
+import cqp from '../convert-query-params';
+import { Model } from '../types';
+
+const schema: Model = {
+  kind: 'collectionType',
+  info: {
+    singularName: 'dog',
+    pluralName: 'dogs',
+  },
+  options: {
+    populateCreatorFields: true,
+  },
+  attributes: {
+    title: {
+      type: 'string',
+    },
+    createdAt: { type: 'timestamp' },
+    updatedAt: { type: 'timestamp' },
+  },
+};
+
+describe('convert-query-params', () => {
+  describe('convertFiltersQueryParams', () => {
+    // test filters that should be kept
+    test.each<[string, object]>([
+      ['id', { id: 1234 }],
+      ['string', { title: 'Hello World' }],
+      ['Date', { createdAt: new Date() }],
+      ['$gt Date', { createdAt: { $gt: new Date() } }],
+      ['$gt string', { createdAt: { $gt: '2022-03-17T15:06:57.878Z' } }],
+      ['$gt number', { createdAt: { $gt: 1234 } }],
+      ['$gt number', { createdAt: { $gt: 1234 } }],
+      ['$and', { $and: [{ title: 'value' }, { createdAt: { $gt: new Date() } }] }],
+      ['$between Date Date', { $between: [new Date(), new Date()] }],
+      ['$between String Date', { $between: ['2022-03-17T15:06:57.878Z', new Date()] }],
+      [
+        '$between String String',
+        { $between: ['2022-03-17T15:06:57.878Z', '2022-03-17T15:06:57.878Z'] },
+      ],
+    ])('keeps: %s', (key, input) => {
+      const expectedOutput = { ...input };
+
+      const res = cqp.convertFiltersQueryParams(input, schema);
+      expect(res).toEqual(expectedOutput);
+    });
+
+    // test filters that should be removed
+    test.each<[string, object]>([
+      ['invalid attribute', { invAttribute: 'test' }],
+      ['invalid operator', { $nope: 'test' }],
+      ['uppercase operator', { $GT: new Date() }],
+    ])('removes: %s', (key, input) => {
+      const res = cqp.convertFiltersQueryParams(input, schema);
+      expect(res).toEqual({});
+    });
+
+    test.todo('partial filtering works');
+  });
+
+  test.todo('convertSortQueryParams');
+  test.todo('convertStartQueryParams');
+  test.todo('convertLimitQueryParams');
+  test.todo('convertPopulateQueryParams');
+  test.todo('convertFieldsQueryParams');
+  test.todo('convertPublicationStateParams');
+  test.todo('transformParamsToQuery');
+});

--- a/packages/core/utils/src/__tests__/convert-query-params.test.ts
+++ b/packages/core/utils/src/__tests__/convert-query-params.test.ts
@@ -1,4 +1,4 @@
-import cqp from '../convert-query-params';
+import convertQueryParams from '../convert-query-params';
 import { Model } from '../types';
 
 const schema: Model = {
@@ -40,7 +40,7 @@ describe('convert-query-params', () => {
     ])('keeps: %s', (key, input) => {
       const expectedOutput = { ...input };
 
-      const res = cqp.convertFiltersQueryParams(input, schema);
+      const res = convertQueryParams.convertFiltersQueryParams(input, schema);
       expect(res).toEqual(expectedOutput);
     });
 
@@ -50,7 +50,7 @@ describe('convert-query-params', () => {
       ['invalid operator', { $nope: 'test' }],
       ['uppercase operator', { $GT: new Date() }],
     ])('removes: %s', (key, input) => {
-      const res = cqp.convertFiltersQueryParams(input, schema);
+      const res = convertQueryParams.convertFiltersQueryParams(input, schema);
       expect(res).toEqual({});
     });
 

--- a/packages/core/utils/src/convert-query-params.ts
+++ b/packages/core/utils/src/convert-query-params.ts
@@ -18,7 +18,6 @@ import {
   mergeAll,
   isArray,
   isString,
-  isDate,
 } from 'lodash/fp';
 import _ from 'lodash';
 import parseType from './parse-type';

--- a/packages/core/utils/src/convert-query-params.ts
+++ b/packages/core/utils/src/convert-query-params.ts
@@ -18,6 +18,7 @@ import {
   mergeAll,
   isArray,
   isString,
+  isDate,
 } from 'lodash/fp';
 import _ from 'lodash';
 import parseType from './parse-type';
@@ -530,7 +531,7 @@ const convertAndSanitizeFilters = (filters: FiltersParams, schema: Model): Where
         // Sanitize each filter
         .map((filter) => convertAndSanitizeFilters(filter, schema))
         // Filter out empty filters
-        .filter((filter) => !isObject(filter) || !isEmpty(filter))
+        .filter((filter) => !isPlainObject(filter) || !isEmpty(filter))
     );
   }
 


### PR DESCRIPTION
### What does it do?

Fixes entity service `$between` operator which is currently broken when given Date objects for the between values

### Why is it needed?

When the filters sanitization was added in a recent security fix, we had to reorder the isPlainObject check to after the Array check, but that meant that Date objects were filtered out when they came inside an array (which only happens with the $between operator)

GraphQL passes Date objects directly to the entity service so between stopped working.

### How to test it?

without this PR:
- use entity service filters with `$between: [new Date(), new Date()]` and you will receive an error because they are filtered out and we attempt to do a between query with an empty array

with this PR:
- use entity service filters with `$between: [new Date(), new Date()]` and it should now work

Unit tests have been added for this exact test which you can try in both scenarios.

### Related issue(s)/PR(s)

Discovered while trying to reproduce https://github.com/strapi/strapi/issues/16170

Blocking https://github.com/strapi/strapi/pull/17143