### PR TITLE
Fix GraphQL pagination results

### DIFF
--- a/api-tests/plugins/graphql/crud.test.api.js
+++ b/api-tests/plugins/graphql/crud.test.api.js
@@ -243,6 +243,58 @@ describe('Test Graphql API End to End', () => {
       });
     });
 
+    test('Pagination counts are correct', async () => {
+      const res = await graphqlQuery({
+        query: /* GraphQL */ `
+          {
+            posts(filters: { name: { eq: "post 2" } }) {
+              data {
+                id
+                attributes {
+                  name
+                  bigint
+                  nullable
+                  category
+                }
+              }
+              meta {
+                pagination {
+                  total
+                  pageSize
+                  page
+                  pageCount
+                }
+              }
+            }
+          }
+        `,
+      });
+
+      const expectedPost = data.posts[1];
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body).toEqual({
+        data: {
+          posts: {
+            data: [
+              {
+                id: expectedPost.id,
+                attributes: omit('id', expectedPost),
+              },
+            ],
+            meta: {
+              pagination: {
+                total: 1,
+                pageSize: 10,
+                page: 1,
+                pageCount: 1,
+              },
+            },
+          },
+        },
+      });
+    });
+
     test.skip('List posts with `createdBy` and `updatedBy`', async () => {
       const res = await graphqlQuery({
         query: /* GraphQL */ `

--- a/packages/plugins/graphql/server/services/internals/types/response-collection-meta.js
+++ b/packages/plugins/graphql/server/services/internals/types/response-collection-meta.js
@@ -25,8 +25,9 @@ module.exports = ({ strapi }) => {
             const { args, resourceUID } = parent;
             const { start, limit } = args;
             const safeLimit = Math.max(limit, 1);
+            const contentType = strapi.contentTypes[resourceUID];
 
-            const sanitizedQuery = await sanitize.contentAPI.query(args, parent.contentType, {
+            const sanitizedQuery = await sanitize.contentAPI.query(args, contentType, {
               auth: ctx?.state?.auth,
             });
             const total = await strapi.entityService.count(resourceUID, sanitizedQuery);

--- a/packages/plugins/graphql/server/services/internals/types/response-collection-meta.js
+++ b/packages/plugins/graphql/server/services/internals/types/response-collection-meta.js
@@ -25,7 +25,7 @@ module.exports = ({ strapi }) => {
             const { args, resourceUID } = parent;
             const { start, limit } = args;
             const safeLimit = Math.max(limit, 1);
-            const contentType = strapi.contentTypes[resourceUID];
+            const contentType = strapi.getModel(resourceUID);
 
             const sanitizedQuery = await sanitize.contentAPI.query(args, contentType, {
               auth: ctx?.state?.auth,


### PR DESCRIPTION
### What does it do?

Fixes the GraphQL pagination query sanitization, which was previously sanitizing against a content type of `undefined` instead of the actual content type.

### Why is it needed?

GraphQL pagination counts are wrong

### How to test it?

GraphQL pagination should report the correct count for a query

An API pagination test has been provided that fails on the previous code and passes with the changes in this PR.

### Related issue(s)/PR(s)

Based on branch (and pending acceptance of) https://github.com/strapi/strapi/pull/17139

Fixes #16170 
