### PR TITLE
fix[S3-Provider]: Do not sign files if using baseURL

### DIFF
--- a/packages/providers/upload-aws-s3/README.md
+++ b/packages/providers/upload-aws-s3/README.md
@@ -70,9 +70,11 @@ module.exports = ({ env }) => ({
 });
 ```
 
-### Configuration for a private S3 bucket
+### Configuration for a private S3 bucket and signed URLs
 
-If your bucket is configured to be private, you will need to set the `ACL` option to `private` in the `params` object. This will ensure that the signed URL is generated with the correct permissions.
+If your bucket is configured to be private, you will need to set the `ACL` option to `private` in the `params` object. This will ensure file URLs are signed.
+
+**Note:** If you are using a CDN, the URLs will not be signed.
 
 You can also define the expiration time of the signed URL by setting the `signedUrlExpires` option in the `params` object. The default value is 15 minutes.
 

--- a/packages/providers/upload-aws-s3/src/__tests__/is-url-from-bucket.test.ts
+++ b/packages/providers/upload-aws-s3/src/__tests__/is-url-from-bucket.test.ts
@@ -73,6 +73,6 @@ describe('Test for URLs', () => {
   test('CDN', async () => {
     const url = 'https://cdn.example.com/v1/img.png';
     const isFromBucket = isUrlFromBucket(url, 'bucket', 'https://cdn.example.com/v1/');
-    expect(isFromBucket).toEqual(true);
+    expect(isFromBucket).toEqual(false);
   });
 });

--- a/packages/providers/upload-aws-s3/src/__tests__/upload-aws-s3.test.ts
+++ b/packages/providers/upload-aws-s3/src/__tests__/upload-aws-s3.test.ts
@@ -143,4 +143,36 @@ describe('AWS-S3 provider', () => {
       expect(file.url).toEqual('https://cdn.test/dir/dir2/tmp/test/test.json');
     });
   });
+
+  describe('isPrivate', () => {
+    test('Should sign files if ACL is private', async () => {
+      const providerInstance = awsProvider.init({
+        s3Options: {
+          params: {
+            Bucket: 'test',
+            ACL: 'private',
+          },
+        },
+      });
+
+      const isPrivate = providerInstance.isPrivate();
+
+      expect(isPrivate).toBe(true);
+    });
+
+    test('Should not sign files if ACL is public', async () => {
+      const providerInstance = awsProvider.init({
+        s3Options: {
+          params: {
+            Bucket: 'test',
+            ACL: 'public',
+          },
+        },
+      });
+
+      const isPrivate = providerInstance.isPrivate();
+
+      expect(isPrivate).toBe(false);
+    });
+  });
 });

--- a/packages/providers/upload-aws-s3/src/index.ts
+++ b/packages/providers/upload-aws-s3/src/index.ts
@@ -69,14 +69,6 @@ export = {
 
     const ACL = getOr('public-read', ['params', 'ACL'], config);
 
-    // if ACL is private and baseUrl is set, we need to warn the user
-    // signed url's will not have the baseUrl prefix
-    if (ACL === 'private' && baseUrl) {
-      process.emitWarning(
-        'You are using a private ACL with a baseUrl. This is not recommended as the files will be accessible without the baseUrl prefix.'
-      );
-    }
-
     const upload = (file: File, customParams = {}): Promise<void> =>
       new Promise((resolve, reject) => {
         const fileKey = getFileKey(file);

--- a/packages/providers/upload-aws-s3/src/utils.ts
+++ b/packages/providers/upload-aws-s3/src/utils.ts
@@ -5,14 +5,13 @@ interface BucketInfo {
   err?: string;
 }
 
-export function isUrlFromBucket(fileUrl: string, bucketName: string, bucketBaseUrl = ''): boolean {
+export function isUrlFromBucket(fileUrl: string, bucketName: string, baseUrl = ''): boolean {
   const url = new URL(fileUrl);
 
   // Check if the file URL is using a base URL (e.g. a CDN).
-  // In this case, check if the file URL starts with the same base URL as the bucket URL.
-  if (bucketBaseUrl) {
-    const baseUrl = new URL(bucketBaseUrl);
-    return url.href.startsWith(baseUrl.href);
+  // In this case do not sign the URL.
+  if (baseUrl) {
+    return false;
   }
 
   const { bucket } = getBucketFromAwsUrl(fileUrl);


### PR DESCRIPTION
### What does it do?

From the [PR](https://github.com/strapi/strapi/issues/17144) conv we had with @travisdieckmann:
When setting the S3 Plugin ACL property to private and utilizing a CDN, the plugin generated a signed S3 URL instead of utilizing the CDN URL. This proved to be incorrect.

An example of why this is incorrect:
CloudFront accesses the S3 object as an authenticated identity. This allows S3 objects to be private yet the CloudFront URL can be used to access the object in S3. Files should not be signed in this case.

There could be cases where a CDN needs signed files, in those cases, users should extend the s3 provider implementation and implement the signing with the appropiate libraries. As each CDN has a different package or methods to sign files.

### Why is it needed?

So CDN URLs are not signed when ACL is set to private.

### How to test it?

See tests.

### Related issue(s)/PR(s)

Fixes https://github.com/strapi/strapi/issues/17144
Fixes https://github.com/strapi/strapi/issues/17042
