### PR TITLE
fix: Prevent race conditions when creating folders

### DIFF
--- a/packages/core/upload/server/services/folder.js
+++ b/packages/core/upload/server/services/folder.js
@@ -31,8 +31,6 @@ const create = async (folderData, { user } = {}) => {
       enrichedFolder = await setCreatorFields({ user })(enrichedFolder);
     }
 
-    enrichedFolder.name = enrichedFolder.name.trim() + enrichedFolder.pathId;
-
     return strapi.entityService.create(FOLDER_MODEL_UID, { data: enrichedFolder });
   });
 


### PR DESCRIPTION
### What does it do?

Wraps folder creation into a transaction, so it locks the folder table and prevents race conditions.

### Why is it needed?

It was reported in https://github.com/strapi/strapi/issues/16071 that concurrent file uploads resulted in race conditions, that is caused 

### How to test it?

Call getAPIUploadFolder concurrently when there is no Api Folder in your instance and see no error.
`/src/index.js`
```js


  async bootstrap({ strapi }) {
    await Promise.all(
      Array(10)
        .fill(0)
        .map((_, i) => {
          return strapi.plugin('upload').service('api-upload-folder').getAPIUploadFolder();
        })
    );
  },
```
### Related issue(s)/PR(s)

Fixes https://github.com/strapi/strapi/issues/16071 
