### PR TITLE
refactor: useAsset query to use folderPath

### DIFF
--- a/packages/core/upload/admin/src/components/Breadcrumbs/CrumbSimpleMenuAsync.js
+++ b/packages/core/upload/admin/src/components/Breadcrumbs/CrumbSimpleMenuAsync.js
@@ -59,7 +59,10 @@ export const CrumbSimpleMenuAsync = ({ parentsToOmit, currentFolderId, onChangeF
             );
           }
 
-          const url = getFolderURL(pathname, query, ascendant?.id);
+          const url = getFolderURL(pathname, query, {
+            folder: ascendant?.id,
+            folderPath: ascendant?.path,
+          });
 
           return (
             <MenuItem isLink as={NavLink} to={url} key={ascendant.id}>

--- a/packages/core/upload/admin/src/hooks/tests/useAssets.test.js
+++ b/packages/core/upload/admin/src/hooks/tests/useAssets.test.js
@@ -82,10 +82,8 @@ describe('useAssets', () => {
       filters: {
         $and: [
           {
-            folder: {
-              id: {
-                $null: true,
-              },
+            folderPath: {
+              $eq: '/',
             },
           },
         ],
@@ -100,7 +98,7 @@ describe('useAssets', () => {
   });
 
   test('fetches data from the right URL if a query was set', async () => {
-    const { result } = await setup({ query: { folder: 1 } });
+    const { result } = await setup({ query: { folderPath: '/1/2' } });
 
     await waitFor(() => result.current.isSuccess);
     const { get } = useFetchClient();
@@ -109,8 +107,8 @@ describe('useAssets', () => {
       filters: {
         $and: [
           {
-            folder: {
-              id: 1,
+            folderPath: {
+              $eq: '/1/2',
             },
           },
         ],
@@ -126,7 +124,7 @@ describe('useAssets', () => {
 
   test('allows to merge filter query params using filters.$and', async () => {
     const { result } = await setup({
-      query: { folder: 5, filters: { $and: [{ something: 'true' }] } },
+      query: { folderPath: '/1/2', filters: { $and: [{ something: 'true' }] } },
     });
 
     await waitFor(() => result.current.isSuccess);
@@ -139,8 +137,8 @@ describe('useAssets', () => {
             something: true,
           },
           {
-            folder: {
-              id: 5,
+            folderPath: {
+              $eq: '/1/2',
             },
           },
         ],
@@ -154,9 +152,9 @@ describe('useAssets', () => {
     );
   });
 
-  test('does not use folder filter in params if _q', async () => {
+  test('does not use folderPath filter in params if _q', async () => {
     const { result } = await setup({
-      query: { folder: 5, _q: 'something', filters: { $and: [{ something: 'true' }] } },
+      query: { folderPath: '/1/2', _q: 'something', filters: { $and: [{ something: 'true' }] } },
     });
 
     await waitFor(() => result.current.isSuccess);
@@ -183,7 +181,7 @@ describe('useAssets', () => {
   test('correctly encodes the search query _q', async () => {
     const _q = 'something&else';
     const { result } = await setup({
-      query: { folder: 5, _q, filters: { $and: [{ something: 'true' }] } },
+      query: { folderPath: '/1/2', _q, filters: { $and: [{ something: 'true' }] } },
     });
 
     await waitFor(() => result.current.isSuccess);

--- a/packages/core/upload/admin/src/pages/App/MediaLibrary/components/Header.js
+++ b/packages/core/upload/admin/src/pages/App/MediaLibrary/components/Header.js
@@ -25,6 +25,7 @@ export const Header = ({
   const backQuery = {
     ...query,
     folder: folder?.parent?.id ?? undefined,
+    folderPath: folder?.parent?.path ?? undefined,
   };
 
   return (

--- a/packages/core/upload/admin/src/pages/App/MediaLibrary/components/tests/__snapshots__/Header.test.js.snap
+++ b/packages/core/upload/admin/src/pages/App/MediaLibrary/components/tests/__snapshots__/Header.test.js.snap
@@ -366,7 +366,7 @@ exports[`Header renders 1`] = `
         <a
           aria-current="page"
           class="c2 active"
-          href="/?folder=2"
+          href="/?folder=2&folderPath=/1"
         >
           <span
             aria-hidden="true"

--- a/packages/core/upload/admin/src/pages/App/MediaLibrary/index.js
+++ b/packages/core/upload/admin/src/pages/App/MediaLibrary/index.js
@@ -367,7 +367,10 @@ export const MediaLibrary = () => {
                       (currentFolder) => currentFolder.id === folder.id
                     );
 
-                    const url = getFolderURL(pathname, query, folder?.id);
+                    const url = getFolderURL(pathname, query, {
+                      folder: folder?.id,
+                      folderPath: folder?.path,
+                    });
 
                     return (
                       <GridItem col={3} key={`folder-${folder.id}`}>

--- a/packages/core/upload/admin/src/utils/getBreadcrumbDataML.js
+++ b/packages/core/upload/admin/src/utils/getBreadcrumbDataML.js
@@ -18,7 +18,10 @@ const getBreadcrumbDataML = (folder, { pathname, query }) => {
     data.push({
       id: folder.parent.id,
       label: folder.parent.name,
-      href: getFolderURL(pathname, query, folder.parent?.id),
+      href: getFolderURL(pathname, query, {
+        folder: folder.parent.id,
+        folderPath: folder.parent.path,
+      }),
     });
   }
 

--- a/packages/core/upload/admin/src/utils/getFolderURL.js
+++ b/packages/core/upload/admin/src/utils/getFolderURL.js
@@ -1,19 +1,22 @@
 /**
  * @param {string} pathname
- * @param {object} query
+ * @param {object} currentQuery
  * @param {string} query._q Search value of the query
- * @param {number|undefined} folderID
+ * @param {object} newQuery
+ * @param {string} newQuery.folder
+ * @param {string} newQuery.folderPath
  * @returns {string}
  */
 
 import { stringify } from 'qs';
 
-const getFolderURL = (pathname, query, folderID) => {
-  const { _q, ...queryParamsWithoutQ } = query;
+const getFolderURL = (pathname, currentQuery, { folder, folderPath } = {}) => {
+  const { _q, ...queryParamsWithoutQ } = currentQuery;
   const queryParamsString = stringify(
     {
       ...queryParamsWithoutQ,
-      folder: folderID,
+      folder,
+      folderPath,
     },
     { encode: false }
   );

--- a/packages/core/upload/admin/src/utils/tests/getFolderURL.test.js
+++ b/packages/core/upload/admin/src/utils/tests/getFolderURL.test.js
@@ -3,27 +3,47 @@ import { getFolderURL } from '..';
 const FIXTURE_PATHNAME = '/media-library';
 const FIXTURE_QUERY = {};
 const FIXTURE_FOLDER = 1;
+const FIXTURE_FOLDER_PATH = '/1/2/3';
 
 describe('getFolderURL', () => {
   test('returns a path for the root of the media library', () => {
-    expect(getFolderURL(FIXTURE_PATHNAME, FIXTURE_QUERY)).toStrictEqual(FIXTURE_PATHNAME);
+    expect(getFolderURL(FIXTURE_PATHNAME, FIXTURE_QUERY)).toMatchInlineSnapshot(`"/media-library"`);
   });
 
   test('returns a path for a folder', () => {
-    expect(getFolderURL(FIXTURE_PATHNAME, FIXTURE_QUERY, FIXTURE_FOLDER)).toStrictEqual(
-      `${FIXTURE_PATHNAME}?folder=${FIXTURE_FOLDER}`
-    );
+    expect(
+      getFolderURL(FIXTURE_PATHNAME, FIXTURE_QUERY, { folder: FIXTURE_FOLDER })
+    ).toMatchInlineSnapshot(`"/media-library?folder=1"`);
   });
 
   test('removes _q query parameter', () => {
     expect(
-      getFolderURL(FIXTURE_PATHNAME, { ...FIXTURE_QUERY, _q: 'search' }, FIXTURE_FOLDER)
-    ).toStrictEqual(`${FIXTURE_PATHNAME}?folder=${FIXTURE_FOLDER}`);
+      getFolderURL(FIXTURE_PATHNAME, { ...FIXTURE_QUERY, _q: 'search' }, { folder: FIXTURE_FOLDER })
+    ).toMatchInlineSnapshot(`"/media-library?folder=1"`);
   });
 
   test('keeps and stringifies query parameter', () => {
     expect(
-      getFolderURL(FIXTURE_PATHNAME, { ...FIXTURE_QUERY, some: 'thing' }, FIXTURE_FOLDER)
-    ).toStrictEqual(`${FIXTURE_PATHNAME}?some=thing&folder=${FIXTURE_FOLDER}`);
+      getFolderURL(
+        FIXTURE_PATHNAME,
+        { ...FIXTURE_QUERY, some: 'thing' },
+        { folder: FIXTURE_FOLDER }
+      )
+    ).toMatchInlineSnapshot(`"/media-library?some=thing&folder=1"`);
+  });
+
+  test('includes folderPath if provided', () => {
+    expect(
+      getFolderURL(FIXTURE_PATHNAME, FIXTURE_QUERY, {
+        folder: FIXTURE_FOLDER,
+        folderPath: FIXTURE_FOLDER_PATH,
+      })
+    ).toMatchInlineSnapshot(`"/media-library?folder=1&folderPath=/1/2/3"`);
+  });
+
+  test('includes fodlerPath if provided and folder is undefined', () => {
+    expect(
+      getFolderURL(FIXTURE_PATHNAME, FIXTURE_QUERY, { folderPath: FIXTURE_FOLDER_PATH })
+    ).toMatchInlineSnapshot(`"/media-library?folderPath=/1/2/3"`);
   });
 });


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* refactors the useAsset hook to fetch using `folderPath` instead of `folder`
* refactors getFolderURL to supply both `folder` and `folderPath`

### Why is it needed?

* `folder` is just the id and is not indexed in the DB so using this can be a very slow query

### Related issue(s)/PR(s)

* resolves #16710
