### PR TITLE
Chunk Cloudinary uploads only for large files

### DIFF
--- a/packages/providers/upload-cloudinary/src/index.ts
+++ b/packages/providers/upload-cloudinary/src/index.ts
@@ -47,12 +47,12 @@ export = {
         // https://support.cloudinary.com/hc/en-us/community/posts/360009586100-Upload-movie-video-with-large-size?page=1#community_comment_360002140099
         // The Cloudinary's max limit for regular upload is actually 100 MB but add some headroom
         // for size counting shenanigans. (Strapi provides the size in kilobytes rounded to two decimal places here).
-        const upload_method =
+        const uploadMethod =
           file.size && file.size < 1000 * 99
             ? cloudinary.uploader.upload_stream
             : cloudinary.uploader.upload_chunked_stream;
 
-        const uploadStream = upload_method(
+        const uploadStream = uploadMethod(
           { ...config, ...customConfig },
           (err, image) => {
             if (err) {


### PR DESCRIPTION
@Marc-Roig turns out that your [suggestion](https://github.com/strapi/strapi/pull/16621#discussion_r1185726369)

> What do you think if , based on the file.size available here, we use one or another. 

actually does yield significant performance improvements! .)

See the commit message for details.