### PR TITLE
Show localhost in URL for IPv6 addresses

### DIFF
--- a/packages/core/utils/src/config.ts
+++ b/packages/core/utils/src/config.ts
@@ -77,7 +77,7 @@ const getAbsoluteUrl =
 
     const hostname =
       config.get('environment') === 'development' &&
-      ['127.0.0.1', '0.0.0.0'].includes(config.get('server.host'))
+      ['127.0.0.1', '0.0.0.0', '::1', '::'].includes(config.get('server.host'))
         ? 'localhost'
         : config.get('server.host');
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Treat `::` like `0.0.0.0` and `::1` like `127.0.0.1` when showing the local Strapi URL.

### Why is it needed?

By default Strapi listens on `0.0.0.0` i.e. only on IPv4. This is a problem because Node v18 (current LTS) [defaults to IPv6](https://github.com/nodejs/node/issues/40537). So if you're running another Node process, say a Next.js app, that tries to connect to Strapi it will probably fail with `ECONNREFUSED ::1:1337`. (_Probably_ because it depends on how exactly the network is configured on your machine.)

That's why I set `HOST=::` in `.env`. `::` the IPv6 equivalent of `0.0.0.0`.

But that way Strapi shows an invalid URL in the logs, which won't work if somebody tries to open it in the browser. Either `strapi develop` or `strapi start` print:
```
To manage your project 🚀, go to the administration panel at:
http://:::1337/admin

To access the server ⚡️, go to:
http://:::1337
```

This change should make it show `http://localhost:1337`, like it already does for `0.0.0.0`.

### How to test it?

Start a Strapi app and see what URL it prints to the console.

### Related issue(s)/PR(s)

#12285 

