### PR TITLE
feat: Better lifecycle types

### DIFF
--- a/packages/core/database/lib/lifecycles/index.d.ts
+++ b/packages/core/database/lib/lifecycles/index.d.ts
@@ -38,6 +38,8 @@ export interface Event {
   action: Action;
   model: Model;
   params: Params;
+  result?: any;
+  state?: any;
 }
 
 export interface LifecycleProvider {

--- a/packages/core/database/lib/lifecycles/subscribers/index.d.ts
+++ b/packages/core/database/lib/lifecycles/subscribers/index.d.ts
@@ -2,8 +2,12 @@ import { Event, Action } from '../';
 
 type SubscriberFn = (event: Event) => Promise<void> | void;
 
-type SubscriberMap = {
-  [k in Action]: SubscriberFn;
+type SubscriberActions = {
+  [key in Action]?: SubscriberFn;
 };
+
+interface SubscriberMap extends SubscriberActions {
+  models?: [],
+}
 
 export type Subscriber = SubscriberFn | SubscriberMap;


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

It alters the types written for the lifecycle methods. Specifically for the db lifecycle subscriber (`strapi.db.lifecycles.subscribe`).

### Why is it needed?

I'm trying to implement the `strapi.db.lifecycles.subscribe` function in a typescript file though I can't because I get all kinds of typescript errors. See the screenshot below:

![Scherm­afbeelding 2023-07-03 om 20 26 17](https://github.com/strapi/strapi/assets/9551934/527fa617-a98c-426b-a14c-7c01da23e110)

![Scherm­afbeelding 2023-07-03 om 20 23 41](https://github.com/strapi/strapi/assets/9551934/73ef22f1-a3ad-429b-95f6-6ad9b2f6b6e0)

### How to test it?

1. Pull this PR
2. Install it as `@strapi/strapi` locally
3. Create a test file with the following contents

```
import strapi from '@strapi/strapi';

const test = async () => {
  const appDir = process.cwd();
  const app = await strapi({ appDir, distDir: appDir }).load();

  app.db.lifecycles.subscribe({
    models: [],
    afterCreate(event) {
      console.log(event);
    },
  });
};

test();
```

4. See a nice typescript file without any of the errors mentioned above.

### Extra

I've also altered the `Event` type and added the `result` and `state` properties as optional with a value of `any`.
I noticed in the docs that these are possible properties of an event so I figured I add em.
Docs source: https://docs.strapi.io/dev-docs/backend-customization/models#hook-event-object

Please do let me know if there is a better way to type these. Maby without any :)

### Related issue(s)/PR(s)

None that I know of
