### PR TITLE
feat: Add an any type for strapi.admin

### DIFF
--- a/packages/core/strapi/lib/types/core/strapi/index.d.ts
+++ b/packages/core/strapi/lib/types/core/strapi/index.d.ts
@@ -46,6 +46,11 @@ export interface Strapi {
   readonly config: any;
 
   /**
+   * Getter for the Strapi admin container
+   */
+  readonly admin: any;
+
+  /**
    * Getter for the Strapi auth container
    */
   readonly auth: any;


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

It adds an `any` type for `strapi.admin`.

### Why is it needed?

Because right now I am unable to use `strapi.admin` in a typescript file.

### How to test it?

1. Pull PR
2. Install it in a project
3. Use `strapi.admin.*` in a typescript file.

This should now only give a warning instead of an error.

### Related issue(s)/PR(s)

None that I know of.
