### PR TITLE
feat (Review Workflow): Return meta in workflow findById

### DIFF
--- a/api-tests/core/admin/ee/review-workflows.test.api.js
+++ b/api-tests/core/admin/ee/review-workflows.test.api.js
@@ -177,6 +177,7 @@ describeOnCondition(edition === 'EE')('Review workflows', () => {
         expect(res.status).toBe(200);
         expect(res.body.data).toBeInstanceOf(Object);
         expect(res.body.data).toEqual(testWorkflow);
+        expect(typeof res.body.meta.workflowCount).toBe('number');
       } else {
         expect(res.status).toBe(404);
         expect(res.body.data).toBeUndefined();
@@ -486,8 +487,6 @@ describeOnCondition(edition === 'EE')('Review workflows', () => {
           `/admin/review-workflows/workflows/${testWorkflow.id}?populate=*`,
           { body: { data: { contentTypes: [productUID] } } }
         );
-
-        console.log(workflow);
       });
 
       test('Should update the accordingly on an entity', async () => {

--- a/packages/core/admin/ee/server/controllers/workflows/index.js
+++ b/packages/core/admin/ee/server/controllers/workflows/index.js
@@ -145,10 +145,15 @@ module.exports = {
     const { populate } = await sanitizedQuery.read(query);
 
     const workflowService = getService('workflows');
-    const workflow = await workflowService.findById(id, { populate });
+
+    const [workflow, workflowCount] = await Promise.all([
+      workflowService.findById(id, { populate }),
+      workflowService.count(),
+    ]);
 
     ctx.body = {
       data: await sanitizeOutput(workflow),
+      meta: { workflowCount },
     };
   },
 };

--- a/packages/core/admin/ee/server/controllers/workflows/index.js
+++ b/packages/core/admin/ee/server/controllers/workflows/index.js
@@ -133,6 +133,8 @@ module.exports = {
   },
   /**
    * Get one workflow based on its id contained in request parameters
+   * Returns count of workflows in meta, used to prevent workflow edition when
+   * max workflow count is reached for the current plan
    * @param {import('koa').BaseContext} ctx - koa context
    */
   async findById(ctx) {

--- a/packages/core/admin/ee/server/controllers/workflows/stages/index.js
+++ b/packages/core/admin/ee/server/controllers/workflows/stages/index.js
@@ -78,6 +78,8 @@ module.exports = {
     const workflowService = getService('workflows');
 
     const { model_uid: modelUID, id: entityIdString } = ctx.params;
+    const { body } = ctx.request;
+
     const entityId = Number(entityIdString);
 
     const { sanitizeOutput } = strapi
@@ -86,7 +88,7 @@ module.exports = {
       .create({ userAbility: ctx.state.userAbility, model: modelUID });
 
     const { id: stageId } = await validateUpdateStageOnEntity(
-      ctx.request?.body?.data,
+      { id: Number(body?.data?.id) },
       'You should pass an id to the body of the put request.'
     );
 


### PR DESCRIPTION
### What does it do?

Returns count of workflows in `/review-workflows/workflows/:id` inside meta

the format of the response will now be:
```ts
interface findById {
	data: Workflow
	meta: { workflowCount: number }
}
```

### Why is it needed?
So frontend knows the number of workflows in the workflow edit view.
