### PR TITLE
Chore: Group dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,40 @@ version: 2
 updates:
   - package-ecosystem: npm
     directory: /
+    groups:
+      babel:
+        patterns:
+          - '@babel/*'
+          - 'babel-*'
+        exclude-patterns:
+          - '@strapi/babel-plugin-switch-ee-ce'
+
+      jest:
+        patterns:
+          - 'jest'
+          - 'jest-circus'
+          - 'jest-cli'
+
+      react:
+        patterns:
+          - 'react'
+          - 'react-dom'
+
+      richtext-editor:
+        patterns:
+          - 'markdown-it'
+          - 'markdown-it-*'
+
+      testing-library:
+        patterns:
+          - '@testing-library/*'
+
+      webpack:
+        patterns:
+          - 'webpack'
+          - 'webpack-cli'
+          - 'webpack-dev-server'
+
     schedule:
       interval: weekly
       day: sunday


### PR DESCRIPTION
### What does it do?

Groups a few dependencies together for dependabot, which need to be updated in parallel.

### Why is it needed?

It will reduce the amount of open PRs and reduce a manual labor step e.g. for jest or babel dependencies.

More: https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/

