### PR TITLE
Fix bug #17187: updated the handleClick function

### DIFF
--- a/packages/core/admin/admin/src/pages/SettingsPage/components/Tokens/TokenBox/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/components/Tokens/TokenBox/index.js
@@ -17,7 +17,7 @@ const TokenBox = ({ token, tokenType }) => {
     const didCopy = await copy(token);
 
     if (didCopy) {
-      trackUsage.current('didCopyTokenKey', {
+      trackUsage('didCopyTokenKey', {
         tokenType,
       });
       toggleNotification({


### PR DESCRIPTION


### What does it do?

It fixes the bug #17187 .

For copying the API token there is a function in the location [packages/core/admin/admin/src/pages/SettingsPage/components/Tokens/TokenBox/index.js](https://github.com/strapi/strapi/blob/670f4a65e1a27e0235200bfca9df54d6dda91161/packages/core/admin/admin/src/pages/SettingsPage/components/Tokens/TokenBox/index.js#L20)

```js
trackUsage.current.('didCopyTokenKey', {
    tokenType,
});
```

but trackUsage is a function and doesn't have 'current' property instead of this the implmentation should be

```js
trackUsage.('didCopyTokenKey', {
    tokenType,
});
```

