### PR TITLE
Enhancement: Add a getFeature convenience method to the useLicenseLimit hook

### DIFF
--- a/docs/docs/docs/01-core/admin/01-ee/02-hooks/use-license-limits.mdx
+++ b/docs/docs/docs/01-core/admin/01-ee/02-hooks/use-license-limits.mdx
@@ -18,7 +18,7 @@ const { license, getFeature, isError, isLoading } = useLicenseLimits();
 
 ### `license`
 
-An object the contains the raw admin API response.
+An object that contains the raw admin API response.
 
 ### `getFeature(name: string)`
 

--- a/docs/docs/docs/01-core/admin/01-ee/02-hooks/use-license-limits.mdx
+++ b/docs/docs/docs/01-core/admin/01-ee/02-hooks/use-license-limits.mdx
@@ -13,12 +13,26 @@ An abstraction around `react-query`'s `useQuery` hook to fetch license limits fo
 ## Usage
 
 ```js
-const { license, isError, isLoading } = useLicenseLimits();
+const { license, getFeature, isError, isLoading } = useLicenseLimits();
 ```
 
 ### `license`
 
-An object the contains the whole admin API response.
+An object the contains the raw admin API response.
+
+### `getFeature(name: string)`
+
+Returns options for a given feature. If the feature was not found, it returns an empty object. This is mostly a
+convenience method, to avoid having to filter the features array on the license object every time.
+
+#### Usage
+
+```
+const { getFeature } = useLicenseLimits();
+
+const reviewWorkflowOptions = getFeature('review-workflows');
+```
+
 
 ## Typescript
 
@@ -27,13 +41,19 @@ import { UseQueryResult } from 'react-query';
 
 // Note: the list of attributes might be incomplete
 interface License {
-  enforcementUserCount: number,
-  currentActiveUserCount: number,
-  permittedSeats: number,
-  shouldNotify: boolean,
-  shouldStopCreate: boolean,
-  licenseLimitStatus: 'OVER_LIMIT' | 'AT_LIMIT',
-  isHostedOnStrapiCloud: boolean
+  enforcementUserCount: number;
+  currentActiveUserCount: number;
+  permittedSeats: number;
+  shouldNotify: boolean;
+  shouldStopCreate: boolean;
+  licenseLimitStatus: 'OVER_LIMIT' | 'AT_LIMIT';
+  isHostedOnStrapiCloud: boolean;
+  features: LicenseFeature[];
+}
+
+interface LicenseFeature {
+  name: string;
+  options?: object;
 }
 
 type UseLicenseLimit = () => Pick<UseQueryResult, 'isError' | 'isLoading'> & { license: License }

--- a/packages/core/admin/ee/admin/hooks/useLicenseLimits/useLicenseLimits.js
+++ b/packages/core/admin/ee/admin/hooks/useLicenseLimits/useLicenseLimits.js
@@ -27,5 +27,13 @@ export function useLicenseLimits() {
     }
   );
 
-  return { license: data ?? {}, isError, isLoading };
+  const license = data ?? {};
+
+  const getFeature = (name) => {
+    const feature = (license?.features ?? []).find((feature) => feature.name === name);
+
+    return feature?.options ?? {};
+  };
+
+  return { license, getFeature, isError, isLoading };
 }


### PR DESCRIPTION
### What does it do?

> **Note**
> Tests are failing because of the base branch and will be fixed there. This PR is ready to review.

Returns a new method called `getFeature(name: string)` from the useLicenseLimit hook. This method allows accessing the options object for each feature.

The data-structure for a license looks like:

```js
{
  data: {
    features: [
      { name: 'sso' },
      { name: 'review-workflows', options: { something: true } }
    ]
  }
}
```

To avoid having to filter the `features` array in many different ways in different places, I think it makes sense to add this convenience method.

It always returns an object, to avoid having to have bullish checks every time an option is being accessed.

### Why is it needed?

In https://github.com/strapi/strapi/pull/17101 I had introduced a new hook `useReviewWorkflowLicenseLimits()`, but I think it would be better to have a more generic solution for accessing the feature options in the long term.

#### Alternative API

Originally I was thinking about a proxy API, which would allow:

```js
const { features } = useLicenseLimits();

const options = features['review-workflows'];
```

I'd still be open to discussing this. The reason why I've decided against is was primarily that features often contain hyphens and therefore we'd have to use the array notation, which. I find the method a bit more readable.

### How to test it?

Automated tests.

### Related issue(s)/PR(s)

- Builds on https://github.com/strapi/strapi/pull/17050
- Refs https://github.com/strapi/strapi/pull/17101
