### PR TITLE
Refactor review workflow column using the new Table

### DIFF
--- a/packages/core/admin/admin/src/content-manager/pages/ListView/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/ListView/index.js
@@ -614,11 +614,24 @@ function ListView({
                         {/* Bulk action row checkbox */}
                         <Body.CheckboxDataCell rowId={rowData.id} index={index} />
                         {/* Field data */}
-                        {tableHeaders.map(({ key, name, ...rest }) => {
+                        {tableHeaders.map(({ key, name, cellFormatter, ...rest }) => {
                           if (name === 'publishedAt') {
                             return (
                               <Td key={key}>
                                 <PublicationState isPublished={Boolean(rowData.publishedAt)} />
+                              </Td>
+                            );
+                          }
+
+                          if (typeof cellFormatter === 'function') {
+                            return (
+                              <Td key={key}>
+                                {cellFormatter(rowData, {
+                                  key,
+                                  name,
+                                  formatMessage,
+                                  ...rest,
+                                })}
                               </Td>
                             );
                           }


### PR DESCRIPTION
### What does it do?

The next iteration of bulk publish includes the refactored table component. Currently the Table component in the ListView does not handle the cellFormatter

It refactors (or fixes) the review workflow column so it works with the new refactored Table

### Why is it needed?

Otherwise we don't have the column since cellFormatter wasn't handled

### How to test it?

Go to the list view for a review workflow content type, you should see the review workflow column for entries in the list

