### PR TITLE
Chore: Refactor ee_else_ce component imports to new useEnterprise hook

### DIFF
--- a/packages/core/admin/admin/src/content-manager/pages/EditView/Information/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/EditView/Information/index.js
@@ -124,7 +124,7 @@ Root.propTypes = {
   children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]).isRequired,
 };
 
-export default {
+export const Information = {
   Root,
   Title,
   Body,

--- a/packages/core/admin/admin/src/content-manager/pages/EditView/Information/tests/index.test.js
+++ b/packages/core/admin/admin/src/content-manager/pages/EditView/Information/tests/index.test.js
@@ -11,7 +11,7 @@ import { useCMEditViewDataManager } from '@strapi/helper-plugin';
 import { render } from '@testing-library/react';
 import { IntlProvider } from 'react-intl';
 
-import Information from '..';
+import { Information } from '..';
 
 jest.mock('@strapi/helper-plugin', () => ({
   ...jest.requireActual('@strapi/helper-plugin'),

--- a/packages/core/admin/admin/src/content-manager/pages/EditView/InformationBox/InformationBoxCE.js
+++ b/packages/core/admin/admin/src/content-manager/pages/EditView/InformationBox/InformationBoxCE.js
@@ -1,8 +1,7 @@
 import React from 'react';
 
-import Information from '../Information';
+import { Information } from '../Information';
 
-// This component is overwritten by the EE counterpart
 export function InformationBoxCE() {
   return (
     <Information.Root>

--- a/packages/core/admin/admin/src/content-manager/pages/EditView/InformationBox/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/EditView/InformationBox/index.js
@@ -1,3 +1,1 @@
-import { InformationBoxCE } from './InformationBoxCE';
-
-export default InformationBoxCE;
+export * from './InformationBoxCE';

--- a/packages/core/admin/admin/src/content-manager/pages/EditView/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/EditView/index.js
@@ -9,12 +9,12 @@ import {
   useTracking,
 } from '@strapi/helper-plugin';
 import { Layer, Pencil } from '@strapi/icons';
-import InformationBox from 'ee_else_ce/content-manager/pages/EditView/InformationBox';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 import { useSelector } from 'react-redux';
 import { useLocation } from 'react-router-dom';
 
+import { useEnterprise } from '../../../hooks/useEnterprise';
 import { selectAdminPermissions } from '../../../pages/App/selectors';
 import { InjectionZone } from '../../../shared/components';
 import CollectionTypeFormWrapper from '../../components/CollectionTypeFormWrapper';
@@ -29,6 +29,7 @@ import DraftAndPublishBadge from './DraftAndPublishBadge';
 import GridRow from './GridRow';
 import Header from './Header';
 import { useOnce } from './hooks/useOnce';
+import { InformationBoxCE } from './InformationBox';
 import { selectCurrentLayout, selectAttributesLayout, selectCustomFieldUids } from './selectors';
 import { getFieldsActionMatchingPermissions } from './utils';
 
@@ -42,6 +43,12 @@ const EditView = ({ allowedActions, isSingleType, goBack, slug, id, origin, user
   const permissions = useSelector(selectAdminPermissions);
   const location = useLocation();
   const toggleNotification = useNotification();
+  const Information = useEnterprise(
+    InformationBoxCE,
+    async () =>
+      (await import('../../../../../ee/admin/content-manager/pages/EditView/InformationBox'))
+        .InformationBoxEE
+  );
 
   useOnce(() => {
     /**
@@ -89,6 +96,11 @@ const EditView = ({ allowedActions, isSingleType, goBack, slug, id, origin, user
 
   if (isLazyLoading) {
     return <LoadingIndicatorPage />;
+  }
+
+  // wait until the EE component is fully loaded before rendering, to prevent flickering
+  if (!Information) {
+    return null;
   }
 
   return (
@@ -202,7 +214,7 @@ const EditView = ({ allowedActions, isSingleType, goBack, slug, id, origin, user
                         paddingTop={6}
                         shadow="tableShadow"
                       >
-                        <InformationBox />
+                        <Information />
                         <InjectionZone area="contentManager.editView.informations" />
                       </Box>
                       <Box as="aside" aria-labelledby="links">

--- a/packages/core/admin/admin/src/pages/AuthPage/components/Login/index.js
+++ b/packages/core/admin/admin/src/pages/AuthPage/components/Login/index.js
@@ -6,7 +6,7 @@ import UnauthenticatedLayout from '../../../../layouts/UnauthenticatedLayout';
 
 import BaseLogin from './BaseLogin';
 
-const Login = (loginProps) => {
+export const LoginCE = (loginProps) => {
   return (
     <UnauthenticatedLayout>
       <BaseLogin {...loginProps} />
@@ -14,12 +14,10 @@ const Login = (loginProps) => {
   );
 };
 
-Login.defaultProps = {
+LoginCE.defaultProps = {
   onSubmit: (e) => e.preventDefault(),
 };
 
-Login.propTypes = {
+LoginCE.propTypes = {
   onSubmit: PropTypes.func,
 };
-
-export default Login;

--- a/packages/core/admin/admin/src/pages/AuthPage/constants.js
+++ b/packages/core/admin/admin/src/pages/AuthPage/constants.js
@@ -1,5 +1,4 @@
 import { translatedErrors } from '@strapi/helper-plugin';
-import Login from 'ee_else_ce/pages/AuthPage/components/Login';
 import * as yup from 'yup';
 
 import ForgotPassword from './components/ForgotPassword';
@@ -27,8 +26,10 @@ export const FORMS = {
     schema: null,
     inputsPrefix: '',
   },
+
+  // the `Component` attribute is set after all forms and CE/EE components are loaded, but since we
+  // are here outside of a React component we can not use the hook directly
   login: {
-    Component: Login,
     endPoint: 'login',
     fieldsToDisable: [],
     fieldsToOmit: ['rememberMe'],

--- a/packages/core/admin/admin/src/pages/AuthPage/index.js
+++ b/packages/core/admin/admin/src/pages/AuthPage/index.js
@@ -13,6 +13,7 @@ import useLocalesProvider from '../../components/LocalesProvider/useLocalesProvi
 import { useEnterprise } from '../../hooks/useEnterprise';
 import formatAPIErrors from '../../utils/formatAPIErrors';
 
+import { LoginCE } from './components/Login';
 import { FORMS } from './constants';
 import init from './init';
 import { initialState, reducer } from './reducer';
@@ -29,6 +30,10 @@ const AuthPage = ({ hasAdmin, setHasAdmin }) => {
     params: { authType },
   } = useRouteMatch('/auth/:authType');
   const query = useQuery();
+  const Login = useEnterprise(
+    LoginCE,
+    async () => (await import('../../../../ee/admin/pages/AuthPage/components/Login')).LoginEE
+  );
   const forms = useEnterprise(
     FORMS,
     async () => (await import('../../../../ee/admin/pages/AuthPage/constants')).FORMS,
@@ -50,7 +55,7 @@ const AuthPage = ({ hasAdmin, setHasAdmin }) => {
   );
   const CancelToken = axios.CancelToken;
   const source = CancelToken.source();
-  const { Component, endPoint, fieldsToDisable, fieldsToOmit, inputsPrefix, schema, ...rest } =
+  const { endPoint, fieldsToDisable, fieldsToOmit, inputsPrefix, schema, ...rest } =
     forms?.[authType] ?? {};
 
   useEffect(() => {
@@ -273,6 +278,18 @@ const AuthPage = ({ hasAdmin, setHasAdmin }) => {
       />
     );
   }
+
+  if (Login) {
+    // Assign the component to render for the login form
+    forms.login.Component = Login;
+  }
+
+  // block rendering until the Login EE component is fully loaded
+  if (!Login) {
+    return null;
+  }
+
+  const { Component } = forms?.[authType] ?? {};
 
   return (
     <Component

--- a/packages/core/admin/admin/src/pages/HomePage/index.js
+++ b/packages/core/admin/admin/src/pages/HomePage/index.js
@@ -3,11 +3,10 @@
  *
  */
 
-import React, { memo, useMemo } from 'react';
+import React, { useMemo } from 'react';
 
 import { Box, Grid, GridItem, Layout, Main } from '@strapi/design-system';
 import { LoadingIndicatorPage, useGuidedTour } from '@strapi/helper-plugin';
-import useLicenseLimitNotification from 'ee_else_ce/hooks/useLicenseLimitNotification';
 import { Helmet } from 'react-helmet';
 import { FormattedMessage } from 'react-intl';
 import { useHistory } from 'react-router-dom';
@@ -16,6 +15,7 @@ import styled from 'styled-components';
 import GuidedTourHomepage from '../../components/GuidedTour/Homepage';
 import isGuidedTourCompleted from '../../components/GuidedTour/utils/isGuidedTourCompleted';
 import { useContentTypes } from '../../hooks/useContentTypes';
+import { useEnterprise } from '../../hooks/useEnterprise';
 
 import cornerOrnamentPath from './assets/corner-ornament.svg';
 import ContentBlocks from './ContentBlocks';
@@ -32,15 +32,12 @@ const LogoContainer = styled(Box)`
   }
 `;
 
-const HomePage = () => {
+export const HomePageCE = () => {
   // Temporary until we develop the menu API
   const { collectionTypes, singleTypes, isLoading: isLoadingForModels } = useContentTypes();
   const { guidedTourState, isGuidedTourVisible, isSkipped } = useGuidedTour();
-  useLicenseLimitNotification();
-
   const showGuidedTour =
     !isGuidedTourCompleted(guidedTourState) && isGuidedTourVisible && !isSkipped;
-
   const { push } = useHistory();
   const handleClick = (e) => {
     e.preventDefault();
@@ -92,4 +89,19 @@ const HomePage = () => {
   );
 };
 
-export default memo(HomePage);
+function HomePageSwitch() {
+  const HomePage = useEnterprise(
+    HomePageCE,
+    // eslint-disable-next-line import/no-cycle
+    async () => (await import('../../../../ee/admin/pages/HomePage')).HomePageEE
+  );
+
+  // block rendering until the EE component is fully loaded
+  if (!HomePage) {
+    return null;
+  }
+
+  return <HomePage />;
+}
+
+export default HomePageSwitch;

--- a/packages/core/admin/admin/src/pages/HomePage/tests/index.test.js
+++ b/packages/core/admin/admin/src/pages/HomePage/tests/index.test.js
@@ -34,11 +34,6 @@ jest.mock('@strapi/helper-plugin', () => ({
 
 jest.mock('../../../hooks/useContentTypes');
 
-jest.mock('ee_else_ce/hooks/useLicenseLimitNotification', () => ({
-  __esModule: true,
-  default: jest.fn(),
-}));
-
 const history = createMemoryHistory();
 
 const App = (

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/ApplicationInfosPage/components/AdminSeatInfo/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/ApplicationInfosPage/components/AdminSeatInfo/index.js
@@ -1,5 +1,0 @@
-const AdminSeatInfo = () => {
-  return null;
-};
-
-export default AdminSeatInfo;

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/ApplicationInfosPage/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/ApplicationInfosPage/index.js
@@ -22,17 +22,19 @@ import {
   useTracking,
 } from '@strapi/helper-plugin';
 import { Check, ExternalLink } from '@strapi/icons';
-import AdminSeatInfo from 'ee_else_ce/pages/SettingsPage/pages/ApplicationInfosPage/components/AdminSeatInfo';
 import { useIntl } from 'react-intl';
 import { useMutation, useQuery, useQueryClient } from 'react-query';
 import { useSelector } from 'react-redux';
 
 import { useConfigurations } from '../../../../hooks';
+import { useEnterprise } from '../../../../hooks/useEnterprise';
 import { selectAdminPermissions } from '../../../App/selectors';
 
 import CustomizationInfos from './components/CustomizationInfos';
 import { fetchProjectSettings, postProjectSettings } from './utils/api';
 import getFormData from './utils/getFormData';
+
+const AdminSeatInfoCE = () => null;
 
 const ApplicationInfosPage = () => {
   const inputsRef = useRef();
@@ -50,6 +52,15 @@ const ApplicationInfosPage = () => {
   } = useAppInfo();
   const { updateProjectSettings } = useConfigurations();
   const permissions = useSelector(selectAdminPermissions);
+  const AdminSeatInfo = useEnterprise(
+    AdminSeatInfoCE,
+    async () =>
+      (
+        await import(
+          '../../../../../../ee/admin/pages/SettingsPage/pages/ApplicationInfosPage/components/AdminSeatInfo'
+        )
+      ).AdminSeatInfoEE
+  );
 
   const {
     allowedActions: { canRead, canUpdate },
@@ -104,6 +115,11 @@ const ApplicationInfosPage = () => {
       },
     });
   };
+
+  // block rendering until the EE component is fully loaded
+  if (!AdminSeatInfo) {
+    return null;
+  }
 
   return (
     <Layout>

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/ApplicationInfosPage/tests/index.test.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/ApplicationInfosPage/tests/index.test.js
@@ -82,13 +82,6 @@ jest.mock('../../../../../hooks', () => ({
   })),
 }));
 
-jest.mock(
-  'ee_else_ce/pages/SettingsPage/pages/ApplicationInfosPage/components/AdminSeatInfo',
-  () => () => {
-    return <></>;
-  }
-);
-
 const setup = (props) => ({
   ...render(<ApplicationInfosPage {...props} />, {
     wrapper({ children }) {

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Users/EditPage/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Users/EditPage/index.js
@@ -24,7 +24,6 @@ import {
   useOverlayBlocker,
 } from '@strapi/helper-plugin';
 import { ArrowLeft, Check } from '@strapi/icons';
-import MagicLink from 'ee_else_ce/pages/SettingsPage/pages/Users/components/MagicLink';
 import { Formik } from 'formik';
 import get from 'lodash/get';
 import omit from 'lodash/omit';
@@ -34,7 +33,9 @@ import { useIntl } from 'react-intl';
 import { useHistory, useRouteMatch } from 'react-router-dom';
 
 import { useAdminUsers } from '../../../../../hooks/useAdminUsers';
+import { useEnterprise } from '../../../../../hooks/useEnterprise';
 import { formatAPIErrors, getFullName } from '../../../../../utils';
+import { MagicLinkCE } from '../components/MagicLink';
 import SelectRoles from '../components/SelectRoles';
 import { editValidation } from '../utils/validations/users';
 
@@ -52,11 +53,21 @@ const EditPage = ({ canUpdate }) => {
   const { setUserDisplayName } = useAppInfo();
   const toggleNotification = useNotification();
   const { lockApp, unlockApp } = useOverlayBlocker();
+  const MagicLink = useEnterprise(
+    MagicLinkCE,
+    async () =>
+      (
+        await import(
+          '../../../../../../../ee/admin/pages/SettingsPage/pages/Users/components/MagicLink'
+        )
+      ).MagicLinkEE
+  );
+
   useFocusWhenNavigate();
 
   const {
     users: [user],
-    isLoading,
+    isLoading: isLoadingAdminUsers,
   } = useAdminUsers(
     { id },
     {
@@ -125,6 +136,8 @@ const EditPage = ({ canUpdate }) => {
     unlockApp();
   };
 
+  const isLoading = isLoadingAdminUsers || !MagicLink;
+
   const headerLabel = isLoading
     ? { id: 'app.containers.Users.EditPage.header.label-loading', defaultMessage: 'Edit user' }
     : { id: 'app.containers.Users.EditPage.header.label', defaultMessage: 'Edit {name}' };
@@ -189,7 +202,7 @@ const EditPage = ({ canUpdate }) => {
               <HeaderLayout
                 primaryAction={
                   <Button
-                    disabled={(isSubmitting || !canUpdate) ? true : !dirty}
+                    disabled={isSubmitting || !canUpdate ? true : !dirty}
                     startIcon={<Check />}
                     loading={isSubmitting}
                     type="submit"

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Users/ListPage/CreateAction/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Users/ListPage/CreateAction/index.js
@@ -5,7 +5,7 @@ import { Envelop } from '@strapi/icons';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 
-const CreateAction = ({ onClick }) => {
+export const CreateActionCE = ({ onClick }) => {
   const { formatMessage } = useIntl();
 
   return (
@@ -18,8 +18,6 @@ const CreateAction = ({ onClick }) => {
   );
 };
 
-CreateAction.propTypes = {
+CreateActionCE.propTypes = {
   onClick: PropTypes.func.isRequired,
 };
-
-export default CreateAction;

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Users/ListPage/CreateAction/tests/index.test.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Users/ListPage/CreateAction/tests/index.test.js
@@ -4,14 +4,14 @@ import { lightTheme, ThemeProvider } from '@strapi/design-system';
 import { fireEvent, render } from '@testing-library/react';
 import { IntlProvider } from 'react-intl';
 
-import CreateAction from '..';
+import { CreateActionCE } from '..';
 
 const onClickSpy = jest.fn();
 
 const ComponentFixture = (props) => (
   <ThemeProvider theme={lightTheme}>
     <IntlProvider locale="en" messages={{}}>
-      <CreateAction onClick={onClickSpy} {...props} />
+      <CreateActionCE onClick={onClickSpy} {...props} />
     </IntlProvider>
   </ThemeProvider>
 );

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Users/ListPage/ModalForm/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Users/ListPage/ModalForm/index.js
@@ -20,13 +20,13 @@ import {
   useNotification,
   useOverlayBlocker,
 } from '@strapi/helper-plugin';
-import MagicLink from 'ee_else_ce/pages/SettingsPage/pages/Users/components/MagicLink';
 import { Formik } from 'formik';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 import { useMutation } from 'react-query';
 
 import { useEnterprise } from '../../../../../../hooks/useEnterprise';
+import { MagicLinkCE } from '../../components/MagicLink';
 import SelectRoles from '../../components/SelectRoles';
 
 import { FORM_LAYOUT, FORM_SCHEMA, FORM_INITIAL_VALUES, ROLE_LAYOUT, STEPPER } from './constants';
@@ -73,6 +73,15 @@ const ModalForm = ({ onSuccess, onToggle }) => {
 
       defaultValue: FORM_INITIAL_VALUES,
     }
+  );
+  const MagicLink = useEnterprise(
+    MagicLinkCE,
+    async () =>
+      (
+        await import(
+          '../../../../../../../../ee/admin/pages/SettingsPage/pages/Users/components/MagicLink'
+        )
+      ).MagicLinkEE
   );
   const postMutation = useMutation(
     (body) => {
@@ -141,6 +150,11 @@ const ModalForm = ({ onSuccess, onToggle }) => {
         {formatMessage(buttonSubmitLabel)}
       </Button>
     );
+
+  // block rendering until the EE component is fully loaded
+  if (!MagicLink) {
+    return null;
+  }
 
   return (
     <ModalLayout onClose={onToggle} labelledBy="title">

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Users/ListPage/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Users/ListPage/index.js
@@ -12,7 +12,6 @@ import {
   useNotification,
   useRBAC,
 } from '@strapi/helper-plugin';
-import useLicenseLimitNotification from 'ee_else_ce/hooks/useLicenseLimitNotification';
 import qs from 'qs';
 import { useIntl } from 'react-intl';
 import { useMutation, useQueryClient } from 'react-query';
@@ -33,7 +32,7 @@ import tableHeaders from './utils/tableHeaders';
 
 const EE_LICENSE_LIMIT_QUERY_KEY = ['ee', 'license-limit-info'];
 
-const ListPage = () => {
+export const UserListPageCE = () => {
   const { post } = useFetchClient();
   const { formatAPIError } = useAPIErrorHandler();
   const [isModalOpened, setIsModalOpen] = useState(false);
@@ -46,7 +45,6 @@ const ListPage = () => {
   const { formatMessage } = useIntl();
   const { search } = useLocation();
   useFocusWhenNavigate();
-  useLicenseLimitNotification();
   const {
     users,
     pagination,
@@ -181,4 +179,22 @@ const ListPage = () => {
   );
 };
 
-export default ListPage;
+// component which determines whether this page should render the CE or EE page
+const UsersListPageSwitch = () => {
+  const UsersListPage = useEnterprise(
+    UserListPageCE,
+    async () =>
+      // eslint-disable-next-line import/no-cycle
+      (await import('../../../../../../../ee/admin/pages/SettingsPage/pages/Users/ListPage'))
+        .UserListPageEE
+  );
+
+  // block rendering until the EE component is fully loaded
+  if (!UsersListPage) {
+    return null;
+  }
+
+  return <UsersListPage />;
+};
+
+export default UsersListPageSwitch;

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Users/ListPage/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Users/ListPage/index.js
@@ -13,7 +13,6 @@ import {
   useRBAC,
 } from '@strapi/helper-plugin';
 import useLicenseLimitNotification from 'ee_else_ce/hooks/useLicenseLimitNotification';
-import CreateAction from 'ee_else_ce/pages/SettingsPage/pages/Users/ListPage/CreateAction';
 import qs from 'qs';
 import { useIntl } from 'react-intl';
 import { useMutation, useQueryClient } from 'react-query';
@@ -21,9 +20,11 @@ import { useSelector } from 'react-redux';
 import { useLocation } from 'react-router-dom';
 
 import { useAdminUsers } from '../../../../../hooks/useAdminUsers';
+import { useEnterprise } from '../../../../../hooks/useEnterprise';
 import { selectAdminPermissions } from '../../../../App/selectors';
 import Filters from '../../../components/Filters';
 
+import { CreateActionCE } from './CreateAction';
 import TableRows from './DynamicTable/TableRows';
 import ModalForm from './ModalForm';
 import PaginationFooter from './PaginationFooter';
@@ -55,6 +56,15 @@ const ListPage = () => {
   } = useAdminUsers(qs.parse(search, { ignoreQueryPrefix: true }), {
     enabled: canRead,
   });
+  const CreateAction = useEnterprise(
+    CreateActionCE,
+    async () =>
+      (
+        await import(
+          '../../../../../../../ee/admin/pages/SettingsPage/pages/Users/ListPage/CreateAction'
+        )
+      ).CreateActionEE
+  );
 
   const headers = tableHeaders.map((header) => ({
     ...header,
@@ -96,6 +106,11 @@ const ListPage = () => {
       },
     }
   );
+
+  // block rendering until the EE component is fully loaded
+  if (!CreateAction) {
+    return null;
+  }
 
   return (
     <Main aria-busy={isLoading}>

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Users/ListPage/tests/index.test.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Users/ListPage/tests/index.test.js
@@ -63,11 +63,6 @@ jest.mock('@strapi/helper-plugin', () => ({
   })),
 }));
 
-jest.mock('ee_else_ce/hooks/useLicenseLimitNotification', () => ({
-  __esModule: true,
-  default: jest.fn(),
-}));
-
 const setup = (props) =>
   render(() => <ListPage {...props} />, {
     wrapper({ children }) {

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Users/components/MagicLink/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Users/components/MagicLink/index.js
@@ -7,7 +7,7 @@ import basename from '../../../../../../core/utils/basename';
 
 import MagicLinkWrapper from './MagicLinkWrapper';
 
-const MagicLink = ({ registrationToken }) => {
+export const MagicLinkCE = ({ registrationToken }) => {
   const { formatMessage } = useIntl();
   const target = `${window.location.origin}${basename}auth/register?registrationToken=${registrationToken}`;
 
@@ -21,12 +21,10 @@ const MagicLink = ({ registrationToken }) => {
   );
 };
 
-MagicLink.defaultProps = {
+MagicLinkCE.defaultProps = {
   registrationToken: '',
 };
 
-MagicLink.propTypes = {
+MagicLinkCE.propTypes = {
   registrationToken: PropTypes.string,
 };
-
-export default MagicLink;

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Webhooks/EditView/components/EventTable/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Webhooks/EditView/components/EventTable/index.js
@@ -1,3 +1,1 @@
-import { EventTableCE } from './EventTableCE';
-
-export default EventTableCE;
+export * from './EventTableCE';

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Webhooks/EditView/components/WebhookForm/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Webhooks/EditView/components/WebhookForm/index.js
@@ -12,11 +12,12 @@ import {
 } from '@strapi/design-system';
 import { Form, Link } from '@strapi/helper-plugin';
 import { ArrowLeft, Check, Play as Publish } from '@strapi/icons';
-import EventTable from 'ee_else_ce/pages/SettingsPage/pages/Webhooks/EditView/components/EventTable';
 import { Field, FormikProvider, useFormik } from 'formik';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 
+import { useEnterprise } from '../../../../../../../hooks/useEnterprise';
+import { EventTableCE } from '../EventTable';
 import HeadersInput from '../HeadersInput';
 import TriggerContainer from '../TriggerContainer';
 
@@ -32,6 +33,15 @@ const WebhookForm = ({
 }) => {
   const { formatMessage } = useIntl();
   const [showTriggerResponse, setShowTriggerResponse] = useState(false);
+  const EventTable = useEnterprise(
+    EventTableCE,
+    async () =>
+      (
+        await import(
+          '../../../../../../../../../ee/admin/pages/SettingsPage/pages/Webhooks/EditView/components/EventTable'
+        )
+      ).EventTableEE
+  );
 
   /**
    * Map the headers into a form that can be used within the formik form
@@ -63,6 +73,11 @@ const WebhookForm = ({
     validateOnChange: false,
     validateOnBlur: false,
   });
+
+  // block rendering until the EE component is fully loaded
+  if (!EventTable) {
+    return null;
+  }
 
   return (
     <FormikProvider value={formik}>

--- a/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/InformationBoxEE.js
+++ b/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/InformationBoxEE.js
@@ -10,7 +10,7 @@ import {
 import { useIntl } from 'react-intl';
 import { useMutation } from 'react-query';
 
-import Information from '../../../../../../admin/src/content-manager/pages/EditView/Information';
+import { Information } from '../../../../../../admin/src/content-manager/pages/EditView/Information';
 import { useReviewWorkflows } from '../../../../pages/SettingsPage/pages/ReviewWorkflows/hooks/useReviewWorkflows';
 import { getStageColorByHex } from '../../../../pages/SettingsPage/pages/ReviewWorkflows/utils/colors';
 

--- a/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/index.js
+++ b/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/index.js
@@ -1,3 +1,1 @@
-import { InformationBoxEE } from './InformationBoxEE';
-
-export default InformationBoxEE;
+export * from './InformationBoxEE';

--- a/packages/core/admin/ee/admin/pages/AuthPage/components/Login/index.js
+++ b/packages/core/admin/ee/admin/pages/AuthPage/components/Login/index.js
@@ -14,7 +14,7 @@ const DividerFull = styled(Divider)`
   flex: 1;
 `;
 
-const Login = (loginProps) => {
+export const LoginEE = (loginProps) => {
   const ssoEnabled = window.strapi.features.isEnabled(window.strapi.features.SSO);
   const { isLoading, data: providers } = useAuthProviders({ ssoEnabled });
   const { formatMessage } = useIntl();
@@ -49,17 +49,15 @@ const Login = (loginProps) => {
   );
 };
 
-Login.defaultProps = {
+LoginEE.defaultProps = {
   onSubmit: (e) => e.preventDefault(),
   requestError: null,
 };
 
-Login.propTypes = {
+LoginEE.propTypes = {
   formErrors: PropTypes.object.isRequired,
   modifiedData: PropTypes.object.isRequired,
   onChange: PropTypes.func.isRequired,
   onSubmit: PropTypes.func,
   requestError: PropTypes.object,
 };
-
-export default Login;

--- a/packages/core/admin/ee/admin/pages/HomePage/index.js
+++ b/packages/core/admin/ee/admin/pages/HomePage/index.js
@@ -1,0 +1,11 @@
+import * as React from 'react';
+
+// eslint-disable-next-line import/no-cycle
+import { HomePageCE } from '../../../../admin/src/pages/HomePage';
+import { useLicenseLimitNotification } from '../../hooks';
+
+export function HomePageEE() {
+  useLicenseLimitNotification();
+
+  return <HomePageCE />;
+}

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ApplicationInfosPage/components/AdminSeatInfo/index.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ApplicationInfosPage/components/AdminSeatInfo/index.js
@@ -11,7 +11,7 @@ import { useLicenseLimits } from '../../../../../../hooks';
 const BILLING_STRAPI_CLOUD_URL = 'https://cloud.strapi.io/profile/billing';
 const BILLING_SELF_HOSTED_URL = 'https://strapi.io/billing/request-seats';
 
-const AdminSeatInfo = () => {
+export const AdminSeatInfoEE = () => {
   const { formatMessage } = useIntl();
   const {
     license: { licenseLimitStatus, enforcementUserCount, permittedSeats, isHostedOnStrapiCloud },
@@ -88,5 +88,3 @@ const AdminSeatInfo = () => {
     </GridItem>
   );
 };
-
-export default AdminSeatInfo;

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ApplicationInfosPage/components/AdminSeatInfo/tests/index.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ApplicationInfosPage/components/AdminSeatInfo/tests/index.test.js
@@ -4,7 +4,7 @@ import { lightTheme, ThemeProvider } from '@strapi/design-system';
 import { render } from '@testing-library/react';
 import { IntlProvider } from 'react-intl';
 
-import AdminSeatInfo from '..';
+import { AdminSeatInfoEE } from '..';
 import { useLicenseLimits } from '../../../../../../../hooks';
 
 const LICENSE_MOCK = {
@@ -32,7 +32,7 @@ jest.mock('../../../../../../../hooks', () => ({
 }));
 
 const setup = (props) =>
-  render(<AdminSeatInfo {...props} />, {
+  render(<AdminSeatInfoEE {...props} />, {
     wrapper({ children }) {
       return (
         <ThemeProvider theme={lightTheme}>

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/Users/ListPage/CreateAction/index.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/Users/ListPage/CreateAction/index.js
@@ -8,7 +8,7 @@ import { useIntl } from 'react-intl';
 
 import { useLicenseLimits } from '../../../../../../hooks';
 
-const CreateAction = ({ onClick }) => {
+export const CreateActionEE = ({ onClick }) => {
   const { formatMessage } = useIntl();
   const {
     license: { permittedSeats, shouldStopCreate },
@@ -54,8 +54,6 @@ const CreateAction = ({ onClick }) => {
   );
 };
 
-CreateAction.propTypes = {
+CreateActionEE.propTypes = {
   onClick: PropTypes.func.isRequired,
 };
-
-export default CreateAction;

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/Users/ListPage/index.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/Users/ListPage/index.js
@@ -1,0 +1,13 @@
+import * as React from 'react';
+
+// eslint-disable-next-line import/no-cycle
+import { UserListPageCE } from '../../../../../../../admin/src/pages/SettingsPage/pages/Users/ListPage';
+import { useLicenseLimitNotification } from '../../../../../hooks';
+
+function UserListPageEE() {
+  useLicenseLimitNotification();
+
+  return <UserListPageCE />;
+}
+
+export default UserListPageEE;

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/Users/components/MagicLink/index.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/Users/components/MagicLink/index.js
@@ -7,7 +7,7 @@ import basename from '../../../../../../../../admin/src/core/utils/basename';
 import MagicLinkWrapper from '../../../../../../../../admin/src/pages/SettingsPage/pages/Users/components/MagicLink/MagicLinkWrapper';
 
 // FIXME replace with parts compo when ready
-const MagicLink = ({ registrationToken }) => {
+export const MagicLinkEE = ({ registrationToken }) => {
   const { formatMessage } = useIntl();
 
   if (registrationToken) {
@@ -34,12 +34,10 @@ const MagicLink = ({ registrationToken }) => {
   );
 };
 
-MagicLink.defaultProps = {
+MagicLinkEE.defaultProps = {
   registrationToken: '',
 };
 
-MagicLink.propTypes = {
+MagicLinkEE.propTypes = {
   registrationToken: PropTypes.string,
 };
-
-export default MagicLink;

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/Webhooks/EditView/components/EventTable/index.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/Webhooks/EditView/components/EventTable/index.js
@@ -1,3 +1,1 @@
-import { EventTableEE } from './EventTableEE';
-
-export default EventTableEE;
+export * from './EventTableEE';


### PR DESCRIPTION
### What does it do?

Refactors all component imports to use `useEnterprise` instead of the babel `ee_else_ce` plugin.

> **Note**
> This is currently a draft, because @remidej is working on another approach using Suspense.

### Why is it needed?

Will allow us to do real runtime switches for the admin app.

