### PR TITLE
Fix date parser

### DIFF
--- a/packages/core/database/lib/fields/shared/parsers.js
+++ b/packages/core/database/lib/fields/shared/parsers.js
@@ -25,6 +25,8 @@ const parseDateTimeOrTimestamp = (value) => {
 };
 
 const parseDate = (value) => {
+  if (dateFns.isDate(value)) return dateFns.format(value, 'yyyy-MM-dd');
+
   const found = isString(value) ? value.match(PARTIAL_DATE_REGEX) || [] : [];
   const extractedValue = found[0];
 


### PR DESCRIPTION
### What does it do?

If the provided value is a date, it formats it to yyyy-MM-dd

### Why is it needed?

To fix the filtering in the entity service when passing a date object

### How to test it?

Create a content type with a date value and customize the controller to filter the response by the date filter using date objects:

```
module.exports = createCoreController('api::temp.temp', ({ strapi }) => ({
  async find(ctx) {
    const entries = await strapi.entityService.findMany('api::temp.temp', {
      filters: {
        from: { $between: [new Date('2023-07-04T07:00:29.492Z'), new Date('2024')] }, 
      },
    });
    return entries;
  },
}));
```

### Related issue(s)/PR(s)