### PR TITLE
Chore: Apply default color to ReviewWorkflowsColumn

### DIFF
--- a/packages/core/admin/admin/src/content-manager/pages/ListView/components/TableRows/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/ListView/components/TableRows/index.js
@@ -7,7 +7,6 @@ import {
   Td,
   Tr,
   Flex,
-  lightTheme,
   Status,
   Typography,
 } from '@strapi/design-system';
@@ -176,9 +175,7 @@ export const TableRows = ({
                   <Td key={key}>
                     {data.strapi_reviewWorkflows_stage ? (
                       <ReviewWorkflowsStage
-                        color={
-                          data.strapi_reviewWorkflows_stage.color ?? lightTheme.colors.primary600
-                        }
+                        color={data.strapi_reviewWorkflows_stage.color}
                         name={data.strapi_reviewWorkflows_stage.name}
                       />
                     ) : (

--- a/packages/core/admin/ee/admin/content-manager/pages/ListView/ReviewWorkflowsColumn/ReviewWorkflowsStageEE.js
+++ b/packages/core/admin/ee/admin/content-manager/pages/ListView/ReviewWorkflowsColumn/ReviewWorkflowsStageEE.js
@@ -4,6 +4,7 @@ import { Box, Flex, Typography } from '@strapi/design-system';
 import { pxToRem } from '@strapi/helper-plugin';
 import PropTypes from 'prop-types';
 
+import { STAGE_COLOR_DEFAULT } from '../../../../pages/SettingsPage/pages/ReviewWorkflows/constants';
 import { getStageColorByHex } from '../../../../pages/SettingsPage/pages/ReviewWorkflows/utils/colors';
 
 export function ReviewWorkflowsStageEE({ color, name }) {
@@ -27,7 +28,11 @@ export function ReviewWorkflowsStageEE({ color, name }) {
   );
 }
 
+ReviewWorkflowsStageEE.defaultProps = {
+  color: STAGE_COLOR_DEFAULT,
+};
+
 ReviewWorkflowsStageEE.propTypes = {
-  color: PropTypes.string.isRequired,
+  color: PropTypes.string,
   name: PropTypes.string.isRequired,
 };


### PR DESCRIPTION
### What does it do?

Applies the default stage color to the review workflow cm list-view badge.

### Why is it needed?

Simplifies the setup in the cm list-view table.

