### PR TITLE
Delete merge presence in data transfer strategies

### DIFF
--- a/packages/core/data-transfer/src/strapi/providers/local-destination/__tests__/index.test.ts
+++ b/packages/core/data-transfer/src/strapi/providers/local-destination/__tests__/index.test.ts
@@ -51,7 +51,7 @@ describe('Local Strapi Source Destination', () => {
   });
 
   describe('Strategy', () => {
-    test('requires strategy to be either restore or merge', async () => {
+    test('requires strategy to be restore', async () => {
       const restoreProvider = createLocalStrapiDestinationProvider({
         getStrapi: getStrapiFactory({
           db: { transaction },
@@ -60,15 +60,6 @@ describe('Local Strapi Source Destination', () => {
       });
       await restoreProvider.bootstrap();
       expect(restoreProvider.strapi).toBeDefined();
-
-      const mergeProvider = createLocalStrapiDestinationProvider({
-        getStrapi: getStrapiFactory({
-          db: { transaction },
-        }),
-        strategy: 'merge',
-      });
-      await mergeProvider.bootstrap();
-      expect(mergeProvider.strapi).toBeDefined();
 
       await expect(
         (async () => {
@@ -152,22 +143,6 @@ describe('Local Strapi Source Destination', () => {
       await provider.beforeTransfer();
 
       expect(deleteAllSpy).toBeCalledTimes(1);
-    });
-
-    test('Should not delete if it is a merge strategy', async () => {
-      const provider = createLocalStrapiDestinationProvider({
-        getStrapi: getStrapiFactory({
-          db: {
-            transaction,
-          },
-        }),
-        strategy: 'merge',
-      });
-      const deleteAllSpy = jest.spyOn(restoreApi, 'deleteRecords');
-      await provider.bootstrap();
-      await provider.beforeTransfer();
-
-      expect(deleteAllSpy).not.toBeCalled();
     });
   });
 });

--- a/packages/core/data-transfer/src/strapi/providers/local-destination/index.ts
+++ b/packages/core/data-transfer/src/strapi/providers/local-destination/index.ts
@@ -14,7 +14,7 @@ import * as utils from '../../../utils';
 import { ProviderTransferError, ProviderValidationError } from '../../../errors/providers';
 import { assertValidStrapi } from '../../../utils/providers';
 
-export const VALID_CONFLICT_STRATEGIES = ['restore', 'merge'];
+export const VALID_CONFLICT_STRATEGIES = ['restore'];
 export const DEFAULT_CONFLICT_STRATEGY = 'restore';
 
 export interface ILocalStrapiDestinationProviderOptions {


### PR DESCRIPTION
### What does it do?

It deletes 'merge' as a valid strategy and removes its presence in the tests, since we are not supporting it at the moment.

### Why is it needed?

To avoid misleading the users and because it wasn't allowed in other parts of the code base, causing syntax errors in the tests.

### How to test it?

Check that all tests pass and there aren't any merge mentions in the data transfer package nor in the commands

### Related issue(s)/PR(s)
