### PR TITLE
fix: only run the query if sso is enabled

### DIFF
--- a/packages/core/admin/admin/src/pages/ProfilePage/index.js
+++ b/packages/core/admin/admin/src/pages/ProfilePage/index.js
@@ -77,19 +77,14 @@ const ProfilePage = () => {
   const { isLoading: isLoadingSSO, data: dataSSO } = useQuery(
     ['providers', 'isSSOLocked'],
     async () => {
-      if (window.strapi.isEE) {
-        const {
-          data: { data },
-        } = await get('/admin/providers/isSSOLocked');
+      const {
+        data: { data },
+      } = await get('/admin/providers/isSSOLocked');
 
-        return data;
-      }
-
-      return {
-        isSSOLocked: false,
-      };
+      return data;
     },
     {
+      enabled: window.strapi.isEE && window.strapi.features.isEnabled('sso'),
       onError() {
         toggleNotification({
           type: 'warning',
@@ -178,7 +173,7 @@ const ProfilePage = () => {
     );
   }
 
-  const hasLockedRole = dataSSO?.isSSOLocked;
+  const hasLockedRole = dataSSO?.isSSOLocked ?? false;
   const { email, firstname, lastname, username, preferedLanguage } = data;
   const initialData = { email, firstname, lastname, username, preferedLanguage, currentTheme };
 
@@ -203,7 +198,12 @@ const ProfilePage = () => {
               <HeaderLayout
                 title={data.username || getFullName(data.firstname, data.lastname)}
                 primaryAction={
-                  <Button startIcon={<Check />} loading={isSubmitting} type="submit" disabled={!dirty}>
+                  <Button
+                    startIcon={<Check />}
+                    loading={isSubmitting}
+                    type="submit"
+                    disabled={!dirty}
+                  >
                     {formatMessage({ id: 'global.save', defaultMessage: 'Save' })}
                   </Button>
                 }

--- a/packages/core/admin/admin/src/pages/ProfilePage/tests/index.test.js
+++ b/packages/core/admin/admin/src/pages/ProfilePage/tests/index.test.js
@@ -26,6 +26,7 @@ const setup = (props) =>
   render(<ProfilePage {...props} />, {
     wrapper({ children }) {
       window.strapi.isEE = true;
+      window.strapi.features.isEnabled = () => true;
       const client = new QueryClient({
         defaultOptions: {
           queries: {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* sets the enabled flag on the query for `isSSOLocked` to be true if the product is EE & sso is enabled as a feature
* sets a fallback for `dataSSO?.isSSOLocked` to `false` which is the default

### Why is it needed?

* long wait times if the feature isn't enabled

### Related issue(s)/PR(s)

* resolves #17216

### Notes

NGL i still find it weird that it hangs for so long considering we have middleware on the BE to check if the feature is enabled, but tbf we shouldn't fire this query if its not!
