### PR TITLE
feat(rw): return workflow count in find workflow

### DIFF
--- a/packages/core/admin/ee/server/controllers/workflows/index.js
+++ b/packages/core/admin/ee/server/controllers/workflows/index.js
@@ -129,6 +129,12 @@ module.exports = {
 
     ctx.body = {
       data: await mapAsync(workflows, sanitizeOutput),
+      pagination: {
+        page: 1,
+        pageCount: 1,
+        pageSize: workflows.length,
+        total: workflows.length,
+      },
     };
   },
   /**

--- a/packages/core/admin/ee/server/controllers/workflows/index.js
+++ b/packages/core/admin/ee/server/controllers/workflows/index.js
@@ -129,11 +129,8 @@ module.exports = {
 
     ctx.body = {
       data: await mapAsync(workflows, sanitizeOutput),
-      pagination: {
-        page: 1,
-        pageCount: 1,
-        pageSize: workflows.length,
-        total: workflows.length,
+      meta: {
+        workflowCount: workflows.length,
       },
     };
   },


### PR DESCRIPTION
### What does it do?

In case we add pagination in the future, we are adding the workflow count inside the meta attribute into the `http://localhost:1337/admin/review-workflows/workflows`, to keep it consistent with the workflows find by id.

Response body:
```
interface Find {
	data: Workflow[]
	meta: {
        workflowCount: number
      },
}
```


