### PR TITLE
fix(rw): return workflow count instead of data lenght

### DIFF
--- a/packages/core/admin/ee/server/controllers/workflows/index.js
+++ b/packages/core/admin/ee/server/controllers/workflows/index.js
@@ -121,16 +121,15 @@ module.exports = {
     );
     const { populate, filters, sort } = await sanitizedQuery.read(query);
 
-    const workflows = await workflowService.find({
-      populate,
-      filters,
-      sort,
-    });
+    const [workflows, workflowCount] = await Promise.all([
+      workflowService.find({ populate, filters, sort }),
+      workflowService.count(),
+    ]);
 
     ctx.body = {
       data: await mapAsync(workflows, sanitizeOutput),
       meta: {
-        workflowCount: workflows.length,
+        workflowCount,
       },
     };
   },


### PR DESCRIPTION
### What does it do?

I was returning the number of workflows returned not counting the total number of workflows, forgot we can filter workflows. 

