### PR TITLE
Chore: Update license limits in create, edit and list-views

### DIFF
--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/hooks/tests/useReviewWorkflowLicenseLimits.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/hooks/tests/useReviewWorkflowLicenseLimits.test.js
@@ -24,6 +24,10 @@ jest.mock('../../../../../../hooks', () => ({
           },
         ],
       },
+
+      meta: {
+        workflowCount: 2,
+      },
     },
   })),
 }));
@@ -39,6 +43,10 @@ describe('useReviewWorkflowLicenseLimits', () => {
     expect(result.current.limits).toStrictEqual({
       workflows: 10,
       stagesPerWorkflow: 10,
+    });
+
+    expect(result.current.meta).toStrictEqual({
+      workflowCount: 2,
     });
   });
 });

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/hooks/tests/useReviewWorkflowLicenseLimits.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/hooks/tests/useReviewWorkflowLicenseLimits.test.js
@@ -24,10 +24,6 @@ jest.mock('../../../../../../hooks', () => ({
           },
         ],
       },
-
-      meta: {
-        workflowCount: 2,
-      },
     },
   })),
 }));
@@ -43,10 +39,6 @@ describe('useReviewWorkflowLicenseLimits', () => {
     expect(result.current.limits).toStrictEqual({
       workflows: 10,
       stagesPerWorkflow: 10,
-    });
-
-    expect(result.current.meta).toStrictEqual({
-      workflowCount: 2,
     });
   });
 });

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/hooks/tests/useReviewWorkflows.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/hooks/tests/useReviewWorkflows.test.js
@@ -26,11 +26,8 @@ const server = setupServer(
           },
         ],
 
-        pagination: {
-          page: 1,
-          pageSize: 100,
-          pageCount: 1,
-          total: 1,
+        meta: {
+          workflowCount: 1,
         },
       })
     );
@@ -46,11 +43,8 @@ const server = setupServer(
           stages: populate === 'stages' ? [STAGE_FIXTURE] : [],
         },
 
-        pagination: {
-          page: 1,
-          pageSize: 100,
-          pageCount: 1,
-          total: 1,
+        meta: {
+          workflowCount: 1,
         },
       })
     );
@@ -94,7 +88,7 @@ describe('useReviewWorkflows', () => {
     expect(result.current).toStrictEqual(
       expect.objectContaining({
         status: 'success',
-        pagination: expect.objectContaining({ total: 1 }),
+        meta: expect.objectContaining({ workflowCount: 1 }),
         workflows: [{ id: expect.any(Number), stages: expect.any(Array) }],
       })
     );
@@ -107,7 +101,7 @@ describe('useReviewWorkflows', () => {
 
     expect(result.current).toStrictEqual(
       expect.objectContaining({
-        pagination: expect.objectContaining({ total: 1 }),
+        meta: expect.objectContaining({ workflowCount: 1 }),
         workflows: [expect.objectContaining({ id: 1, stages: expect.any(Array) })],
       })
     );

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/hooks/useReviewWorkflows.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/hooks/useReviewWorkflows.js
@@ -36,7 +36,9 @@ export function useReviewWorkflows(params = {}) {
   }
 
   return {
-    pagination: data?.pagination ?? {},
+    // meta contains e.g. the total of all workflows. we can not use
+    // the pagination object here, because the list is not paginated.
+    meta: data?.meta ?? {},
     workflows,
     isLoading,
     status,

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/CreateView/CreateView.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/CreateView/CreateView.js
@@ -37,7 +37,7 @@ export function ReviewWorkflowsCreateView() {
   } = useSelector((state) => state?.[REDUX_NAMESPACE] ?? initialState);
   const [showLimitModal, setShowLimitModal] = React.useState(false);
   const { limits, isLoading: isLicenseLoading } = useReviewWorkflowLicenseLimits();
-  const { pagination, isLoading: isWorkflowLoading } = useReviewWorkflows();
+  const { meta, isLoading: isWorkflowLoading } = useReviewWorkflows();
 
   const { mutateAsync, isLoading } = useMutation(
     async ({ workflow }) => {
@@ -94,21 +94,34 @@ export function ReviewWorkflowsCreateView() {
     dispatch(resetWorkflow());
   }, [dispatch]);
 
+  /**
+   * If the current license has a limit:
+   * check if the total count of workflows or stages exceeds that limit and display
+   * the limits modal on page load. It can be closed by the user, but the
+   * API will throw an error in case they try to create a new workflow or update the
+   * stages.
+   *
+   * If the current license does not have a limit (e.g. offline license):
+   * do nothing (for now). In case they are trying to create the 201st workflow/ stage
+   * the API will throw an error.
+   *
+   */
+
   React.useEffect(() => {
     if (!isWorkflowLoading && !isLicenseLoading) {
-      if (pagination?.total >= limits?.workflows) {
+      if (meta?.workflowsTotal >= limits?.workflows) {
         setShowLimitModal('workflow');
       } else if (currentWorkflow.stages.length >= limits.stagesPerWorkflow) {
         setShowLimitModal('stage');
       }
     }
   }, [
-    currentWorkflow.stages.length,
     isLicenseLoading,
     isWorkflowLoading,
     limits.stagesPerWorkflow,
     limits?.workflows,
-    pagination?.total,
+    meta?.workflowsTotal,
+    currentWorkflow.stages.length,
   ]);
 
   return (

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/CreateView/CreateView.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/CreateView/CreateView.js
@@ -83,7 +83,28 @@ export function ReviewWorkflowsCreateView() {
     enableReinitialize: true,
     initialValues: currentWorkflow,
     async onSubmit() {
-      submitForm();
+      /**
+       * If the current license has a limit, check if the total count of workflows
+       * exceeds that limit and display the limits modal instead of sending the
+       * update, because it would throw an API error.
+       */
+
+      if (limits?.workflows && meta?.workflowCount >= limits.workflows) {
+        setShowLimitModal('workflow');
+
+        /**
+         * If the current license has a limit, check if the total count of stages
+         * exceeds that limit and display the limits modal instead of sending the
+         * update, because it would throw an API error.
+         */
+      } else if (
+        limits?.stagesPerWorkflow &&
+        currentWorkflow.stages.length >= limits.stagesPerWorkflow
+      ) {
+        setShowLimitModal('stage');
+      } else {
+        submitForm();
+      }
     },
     validationSchema: getWorkflowValidationSchema({ formatMessage }),
   });

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/EditView/EditView.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/EditView/EditView.js
@@ -38,7 +38,7 @@ export function ReviewWorkflowsEditView() {
   const toggleNotification = useNotification();
   const {
     isLoading: isWorkflowLoading,
-    pagination,
+    meta,
     workflows: [workflow],
     status: workflowStatus,
     refetch,
@@ -132,11 +132,27 @@ export function ReviewWorkflowsEditView() {
     dispatch(setWorkflow({ status: workflowStatus, data: workflow }));
   }, [workflowStatus, workflow, dispatch]);
 
+  /**
+   * If the current license has a limit:
+   * check if the total count of workflows or stages exceeds that limit and display
+   * the limits modal on page load. It can be closed by the user, but the
+   * API will throw an error in case they try to create a new workflow or update the
+   * stages.
+   *
+   * If the current license does not have a limit (e.g. offline license):
+   * do nothing (for now). In case they are trying to create the 201st workflow/ stage
+   * the API will throw an error.
+   *
+   */
+
   React.useEffect(() => {
     if (!isWorkflowLoading && !isLicenseLoading) {
-      if (pagination?.total >= limits?.workflows) {
+      if (limits?.workflows && meta?.workflowCount >= limits.workflows) {
         setShowLimitModal('workflow');
-      } else if (currentWorkflow.stages.length >= limits?.stagesPerWorkflow) {
+      } else if (
+        limits?.stagesPerWorkflow &&
+        currentWorkflow.stages.length >= limits.stagesPerWorkflow
+      ) {
         setShowLimitModal('stage');
       }
     }
@@ -144,12 +160,13 @@ export function ReviewWorkflowsEditView() {
     currentWorkflow.stages.length,
     isLicenseLoading,
     isWorkflowLoading,
-    limits?.stagesPerWorkflow,
-    limits?.workflows,
-    pagination?.total,
+    limits.stagesPerWorkflow,
+    limits.workflows,
+    meta?.workflowCount,
+    meta.workflowsTotal,
   ]);
 
-  // TODO redirect back to list-view if workflow is not found?
+  // TODO: redirect back to list-view if workflow is not found?
 
   return (
     <>

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/ListView/ListView.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/ListView/ListView.js
@@ -67,7 +67,7 @@ export function ReviewWorkflowsListView() {
   const { formatMessage } = useIntl();
   const { push } = useHistory();
   const { collectionTypes, singleTypes, isLoading: isLoadingModels } = useContentTypes();
-  const { pagination, workflows, isLoading, refetch } = useReviewWorkflows();
+  const { meta, workflows, isLoading, refetch } = useReviewWorkflows();
   const [workflowToDelete, setWorkflowToDelete] = React.useState(null);
   const [showLimitModal, setShowLimitModal] = React.useState(false);
   const { del } = useFetchClient();
@@ -138,7 +138,17 @@ export function ReviewWorkflowsListView() {
             size="S"
             to="/settings/review-workflows/create"
             onClick={(event) => {
-              if (pagination?.total >= limits.workflows) {
+              /**
+               * If the current license has a workflow limit:
+               * check if the total count of workflows exceeds that limit. If so,
+               * prevent the navigation and show the limits overlay.
+               *
+               * If the current license does not have a limit (e.g. offline license):
+               * allow the user to navigate to the create-view. In case they exceed the
+               * current hard-limit of 200 they will see an error thrown by the API.
+               */
+
+              if (limits?.workflows && meta?.workflowCount >= limits.workflows) {
                 event.preventDefault();
                 setShowLimitModal(true);
               }
@@ -177,7 +187,16 @@ export function ReviewWorkflowsListView() {
               <TFooter
                 icon={<Plus />}
                 onClick={() => {
-                  if (pagination?.total >= limits?.workflows) {
+                  /**
+                   * If the current license has a workflow limit:
+                   * check if the total count of workflows exceeds that limit
+                   *
+                   * If the current license does not have a limit (e.g. offline license):
+                   * allow the user to navigate to the create-view. In case they exceed the
+                   * current hard-limit of 200 they will see an error thrown by the API.
+                   */
+
+                  if (limits?.workflows && meta?.workflowCount >= limits.workflows) {
                     setShowLimitModal(true);
                   } else {
                     push('/settings/review-workflows/create');


### PR DESCRIPTION
### What does it do?

Updates the license limit checks on the create, edit and list-views setting pages and CM edit view:

- use `meta.workflowCount` instead of `pagination.total`

### Why is it needed?

Changes have been introduced in:

- https://github.com/strapi/strapi/pull/17222
- https://github.com/strapi/strapi/pull/17221
- https://github.com/strapi/strapi/pull/17123
