### PR TITLE
Fix: Update stage keys for the CM list-view

### DIFF
--- a/packages/core/admin/admin/src/content-manager/pages/ListView/components/TableRows/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/ListView/components/TableRows/index.js
@@ -181,10 +181,10 @@ export const TableRows = ({
               if (hasReviewWorkflows && name === 'strapi_reviewWorkflows_stage') {
                 return (
                   <Td key={key}>
-                    {data.strapi_reviewWorkflows_stage ? (
+                    {data.strapi_stage ? (
                       <ReviewWorkflowsStage
-                        color={data.strapi_reviewWorkflows_stage.color}
-                        name={data.strapi_reviewWorkflows_stage.name}
+                        color={data.strapi_stage.color}
+                        name={data.strapi_stage.name}
                       />
                     ) : (
                       <Typography textColor="neutral800">-</Typography>


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Renames the review workflow stage keys used in the CM list-view from `strapi_reviewWorkflows_stage` to `strapi_stage`.

### Why is it needed?

They have been changed on the feature branch and the [merge](https://github.com/strapi/strapi/pull/17229) missed them.

