### PR TITLE
Chore: Improve and extend dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,16 +10,31 @@ updates:
         exclude-patterns:
           - '@strapi/babel-plugin-switch-ee-ce'
 
+      eslint:
+        patterns:
+          - 'eslint'
+          - 'eslint-*'
+          - '@typescript-eslint/*'
+
       jest:
         patterns:
           - 'jest'
-          - 'jest-circus'
-          - 'jest-cli'
+          - 'jest-*'
 
       react:
         patterns:
           - 'react'
           - 'react-dom'
+
+      react-dnd:
+        patterns:
+          - 'react-dnd'
+          - 'react-dnd-*'
+
+      redux:
+        patterns:
+          - 'redux'
+          - 'react-redux'
 
       richtext-editor:
         patterns:


### PR DESCRIPTION
### What does it do?

Extends the existing dependabot groups:

- new group for eslint related dependencies
- new group for redux related dependencies
- new groups for react-dnd related dependencies
- extended jest group to also match https://github.com/strapi/strapi/pull/17240

### Why is it needed?

Less PRs and less manual labor, when updating dependencies.

### How to test it?

Dependabot will do the job for us.

### Related issue(s)/PR(s)

- https://github.com/strapi/strapi/pull/17184
