### PR TITLE
Chore: Implement multiple workflow tracking events 

### DIFF
--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/EditView/EditView.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/EditView/EditView.js
@@ -6,7 +6,6 @@ import {
   useAPIErrorHandler,
   useFetchClient,
   useNotification,
-  useTracking,
 } from '@strapi/helper-plugin';
 import { Check } from '@strapi/icons';
 import { useFormik, Form, FormikProvider } from 'formik';
@@ -29,7 +28,6 @@ import { reducer, initialState } from '../../reducer';
 import { getWorkflowValidationSchema } from '../../utils/getWorkflowValidationSchema';
 
 export function ReviewWorkflowsEditView() {
-  const { trackUsage } = useTracking();
   const { workflowId } = useParams();
   const { formatMessage } = useIntl();
   const dispatch = useDispatch();
@@ -124,11 +122,6 @@ export function ReviewWorkflowsEditView() {
   useInjectReducer(REDUX_NAMESPACE, reducer);
 
   const limits = getFeature('review-workflows');
-
-  React.useEffect(() => {
-    trackUsage('didViewWorkflow');
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   React.useEffect(() => {
     dispatch(setWorkflow({ status: workflowStatus, data: workflow }));

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/ListView/ListView.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/ListView/ListView.js
@@ -23,6 +23,7 @@ import {
   useAPIErrorHandler,
   useFetchClient,
   useNotification,
+  useTracking,
 } from '@strapi/helper-plugin';
 import { Pencil, Plus, Trash } from '@strapi/icons';
 import { useIntl } from 'react-intl';
@@ -74,6 +75,7 @@ export function ReviewWorkflowsListView() {
   const { formatAPIError } = useAPIErrorHandler();
   const toggleNotification = useNotification();
   const { getFeature, isLoading: isLicenseLoading } = useLicenseLimits();
+  const { trackUsage } = useTracking();
 
   const limits = getFeature('review-workflows');
 
@@ -181,6 +183,8 @@ export function ReviewWorkflowsListView() {
               if (limits?.workflows && meta?.workflowCount >= limits.workflows) {
                 event.preventDefault();
                 setShowLimitModal(true);
+              } else {
+                trackUsage('willCreateWorkflow');
               }
             }}
           >
@@ -230,6 +234,7 @@ export function ReviewWorkflowsListView() {
                     setShowLimitModal(true);
                   } else {
                     push('/settings/review-workflows/create');
+                    trackUsage('willCreateWorkflow');
                   }
                 }}
               >


### PR DESCRIPTION
### What does it do?

Implement tracking events for multiple workflows:

- `willCreateWorkflow` for create workflow actions
- Move `didViewWorkflow` from edit to list-view

> **Note**
> Needs to be merged after https://github.com/strapi/strapi/pull/17244

### Why is it needed?

To understand the usage of the feature.
