### PR TITLE
hide move button in Media Library

### DIFF
--- a/packages/core/upload/admin/src/pages/App/MediaLibrary/components/BulkActions.js
+++ b/packages/core/upload/admin/src/pages/App/MediaLibrary/components/BulkActions.js
@@ -10,8 +10,23 @@ import getTrad from '../../../../utils/getTrad';
 import { BulkDeleteButton } from './BulkDeleteButton';
 import { BulkMoveButton } from './BulkMoveButton';
 
-export const BulkActions = ({ selected, onSuccess, currentFolder }) => {
+export const BulkActions = ({ selected, onSuccess, currentFolder, folderCount }) => {
   const { formatMessage } = useIntl();
+  const numberFolders = selected.filter(({ type }) => type === 'folder').length;
+  const numberAssets = selected.filter(({ type }) => type === 'asset').length;
+
+  let showMoveButton = false;
+  if (currentFolder) {
+    showMoveButton = true;
+  } else if (numberAssets && numberFolders) {
+    if (numberFolders < folderCount) {
+      showMoveButton = true;
+    }
+  } else if (numberAssets) {
+    showMoveButton = folderCount > 0;
+  } else if (numberFolders) {
+    showMoveButton = numberFolders < folderCount;
+  }
 
   return (
     <Flex gap={2} paddingBottom={5}>
@@ -30,7 +45,9 @@ export const BulkActions = ({ selected, onSuccess, currentFolder }) => {
       </Typography>
 
       <BulkDeleteButton selected={selected} onSuccess={onSuccess} />
-      <BulkMoveButton currentFolder={currentFolder} selected={selected} onSuccess={onSuccess} />
+      {showMoveButton ?
+        (<BulkMoveButton currentFolder={currentFolder} selected={selected} onSuccess={onSuccess} />) : null
+      }
     </Flex>
   );
 };
@@ -43,4 +60,5 @@ BulkActions.propTypes = {
   onSuccess: PropTypes.func.isRequired,
   currentFolder: FolderDefinition,
   selected: PropTypes.arrayOf(AssetDefinition, FolderDefinition).isRequired,
+  folderCount: PropTypes.number.isRequired,
 };

--- a/packages/core/upload/admin/src/pages/App/MediaLibrary/components/BulkActions.js
+++ b/packages/core/upload/admin/src/pages/App/MediaLibrary/components/BulkActions.js
@@ -14,8 +14,8 @@ export const BulkActions = ({ selected, onSuccess, currentFolder, folderCount })
   const { formatMessage } = useIntl();
   const numberFolders = selected.filter(({ type }) => type === 'folder').length;
   const numberAssets = selected.filter(({ type }) => type === 'asset').length;
-
   let showMoveButton = false;
+
   if (currentFolder) {
     showMoveButton = true;
   } else if (numberAssets && numberFolders) {

--- a/packages/core/upload/admin/src/pages/App/MediaLibrary/components/tests/BulkActions.test.js
+++ b/packages/core/upload/admin/src/pages/App/MediaLibrary/components/tests/BulkActions.test.js
@@ -19,6 +19,7 @@ jest.mock('@strapi/helper-plugin', () => ({
 const setup = (
   props = {
     selected: [],
+    folderCount: 0,
     onSuccess: jest.fn(),
   }
 ) => {
@@ -65,6 +66,7 @@ describe('BulkActions', () => {
         ...[...Array(ASSET_COUNT).keys()].map((index) => ({ id: index, type: 'asset' })),
         ...[...Array(FOLDER_COUNT).keys()].map((index) => ({ id: index, type: 'folder' })),
       ],
+      folderCount: 0,
     });
 
     expect(

--- a/packages/core/upload/admin/src/pages/App/MediaLibrary/components/tests/__snapshots__/BulkActions.test.js.snap
+++ b/packages/core/upload/admin/src/pages/App/MediaLibrary/components/tests/__snapshots__/BulkActions.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`BulkActions renders 1`] = `
-.c9 {
+.c8 {
   border: 0;
   -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
@@ -169,70 +169,6 @@ exports[`BulkActions renders 1`] = `
   fill: #b72b1a;
 }
 
-.c8 {
-  height: 2rem;
-  border: 1px solid #d9d8ff;
-  background: #f0f0ff;
-}
-
-.c8 svg {
-  height: 0.75rem;
-  width: auto;
-}
-
-.c8[aria-disabled='true'] {
-  border: 1px solid #dcdce4;
-  background: #eaeaef;
-}
-
-.c8[aria-disabled='true'] .c2 {
-  color: #666687;
-}
-
-.c8[aria-disabled='true'] svg > g,.c8[aria-disabled='true'] svg path {
-  fill: #666687;
-}
-
-.c8[aria-disabled='true']:active {
-  border: 1px solid #dcdce4;
-  background: #eaeaef;
-}
-
-.c8[aria-disabled='true']:active .c2 {
-  color: #666687;
-}
-
-.c8[aria-disabled='true']:active svg > g,.c8[aria-disabled='true']:active svg path {
-  fill: #666687;
-}
-
-.c8:hover {
-  background-color: #ffffff;
-}
-
-.c8:active {
-  background-color: #ffffff;
-  border: 1px solid #4945ff;
-}
-
-.c8:active .c2 {
-  color: #4945ff;
-}
-
-.c8:active svg > g,
-.c8:active svg path {
-  fill: #4945ff;
-}
-
-.c8 .c2 {
-  color: #271fe0;
-}
-
-.c8 svg > g,
-.c8 svg path {
-  fill: #271fe0;
-}
-
 <div>
   <div
     class="c0 c1"
@@ -270,37 +206,9 @@ exports[`BulkActions renders 1`] = `
         Delete
       </span>
     </button>
-    <button
-      aria-disabled="false"
-      class="c4 c1 c5 c8"
-      type="button"
-    >
-      <div
-        aria-hidden="true"
-        class=""
-      >
-        <svg
-          fill="none"
-          height="1rem"
-          viewBox="0 0 24 24"
-          width="1rem"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M12.414 5H21a1 1 0 0 1 1 1v14a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h7.414l2 2Z"
-            fill="#212134"
-          />
-        </svg>
-      </div>
-      <span
-        class="c2 c7"
-      >
-        Move
-      </span>
-    </button>
   </div>
   <div
-    class="c9"
+    class="c8"
   >
     <p
       aria-live="polite"

--- a/packages/core/upload/admin/src/pages/App/MediaLibrary/index.js
+++ b/packages/core/upload/admin/src/pages/App/MediaLibrary/index.js
@@ -307,6 +307,7 @@ export const MediaLibrary = () => {
               currentFolder={currentFolder}
               selected={selected}
               onSuccess={handleBulkActionSuccess}
+              folderCount={folderCount}
             />
           )}
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

In Media Library, while selecting the Assets/Folders there are two action buttons `Delete` & `Move`. When we try to perform move action then on the Move Element popup we might get an error if we try to move an items to the same root Folder. See screenshot below:

<img width="1725" alt="Screenshot 2023-07-10 at 12 20 31 PM" src="https://github.com/strapi/strapi/assets/40918526/59384d9b-90cc-4c72-9a9f-c16c943500a2">


### Why is it needed?

In order to prevent above error I've hide the move button in the case where move action can't be performed. Here are some cases when move button is not needed. All cases are within the root folder of the Media Library.

1. When we try to move an Assets where there's no Folder.
2. When we try to move Folder to another Folder, but we only have 1 Folder. 
3. When we try to move all Folders + all Assets.


### How to test it?

- Login to admin.
- Go to Media Library.
- Try all above cases mentioned above.

### Related issue(s)/PR(s)

No related issue for this PR.
