### PR TITLE
Fix: Fix license limits for workflow settings pages

### DIFF
--- a/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/InformationBoxEE.js
+++ b/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/InformationBoxEE.js
@@ -88,7 +88,7 @@ export function InformationBoxEE() {
        *
        */
 
-      if (limits?.workflows && limits.workflows > meta.workflowCount) {
+      if (limits?.workflows && parseInt(limits.workflows, 10) > meta.workflowCount) {
         setShowLimitModal('workflow');
 
         /**
@@ -100,7 +100,10 @@ export function InformationBoxEE() {
          * do nothing (for now).
          *
          */
-      } else if (limits?.stagesPerWorkflow && limits.stagesPerWorkflow > workflow.stages.length) {
+      } else if (
+        limits?.stagesPerWorkflow &&
+        parseInt(limits.stagesPerWorkflow, 10) > workflow.stages.length
+      ) {
         setShowLimitModal('stage');
       } else {
         await mutateAsync({

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/CreateView/CreateView.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/CreateView/CreateView.js
@@ -91,7 +91,7 @@ export function ReviewWorkflowsCreateView() {
        * update, because it would throw an API error.
        */
 
-      if (limits?.workflows && meta?.workflowCount >= limits.workflows) {
+      if (limits?.workflows && meta?.workflowCount >= parseInt(limits.workflows, 10)) {
         setShowLimitModal('workflow');
 
         /**
@@ -101,7 +101,7 @@ export function ReviewWorkflowsCreateView() {
          */
       } else if (
         limits?.stagesPerWorkflow &&
-        currentWorkflow.stages.length >= limits.stagesPerWorkflow
+        currentWorkflow.stages.length >= parseInt(limits.stagesPerWorkflow, 10)
       ) {
         setShowLimitModal('stage');
       } else {
@@ -132,11 +132,11 @@ export function ReviewWorkflowsCreateView() {
 
   React.useEffect(() => {
     if (!isWorkflowLoading && !isLicenseLoading) {
-      if (limits.workflows && meta?.workflowsTotal >= limits.workflows) {
+      if (limits.workflows && meta?.workflowsTotal >= parseInt(limits.workflows, 10)) {
         setShowLimitModal('workflow');
       } else if (
         limits.stagesPerWorkflow &&
-        currentWorkflow.stages.length >= limits.stagesPerWorkflow
+        currentWorkflow.stages.length >= parseInt(limits.stagesPerWorkflow, 10)
       ) {
         setShowLimitModal('stage');
       }

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/EditView/EditView.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/EditView/EditView.js
@@ -114,6 +114,24 @@ export function ReviewWorkflowsEditView() {
     async onSubmit() {
       if (currentWorkflowHasDeletedServerStages) {
         setIsConfirmDeleteDialogOpen(true);
+      } else if (limits?.workflows && meta?.workflowCount > parseInt(limits.workflows, 10)) {
+      /**
+       * If the current license has a limit, check if the total count of workflows
+       * exceeds that limit and display the limits modal instead of sending the
+       * update, because it would throw an API error.
+       */
+        setShowLimitModal('workflow');
+
+        /**
+         * If the current license has a limit, check if the total count of stages
+         * exceeds that limit and display the limits modal instead of sending the
+         * update, because it would throw an API error.
+         */
+      } else if (
+        limits?.stagesPerWorkflow &&
+        currentWorkflow.stages.length > parseInt(limits.stagesPerWorkflow, 10)
+      ) {
+        setShowLimitModal('stage');
       } else {
         submitForm();
       }
@@ -149,11 +167,11 @@ export function ReviewWorkflowsEditView() {
 
   React.useEffect(() => {
     if (!isWorkflowLoading && !isLicenseLoading) {
-      if (limits?.workflows && meta?.workflowCount >= limits.workflows) {
+      if (limits?.workflows && meta?.workflowCount > parseInt(limits.workflows, 10)) {
         setShowLimitModal('workflow');
       } else if (
         limits?.stagesPerWorkflow &&
-        currentWorkflow.stages.length >= limits.stagesPerWorkflow
+        currentWorkflow.stages.length > parseInt(limits.stagesPerWorkflow, 10)
       ) {
         setShowLimitModal('stage');
       }

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/ListView/ListView.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/ListView/ListView.js
@@ -146,7 +146,7 @@ export function ReviewWorkflowsListView() {
 
   React.useEffect(() => {
     if (!isLoading && !isLicenseLoading) {
-      if (limits?.workflows && meta?.workflowCount >= limits.workflows) {
+      if (limits?.workflows && meta?.workflowCount >= parseInt(limits.workflows, 10)) {
         setShowLimitModal(true);
       }
     }
@@ -178,7 +178,7 @@ export function ReviewWorkflowsListView() {
                * current hard-limit of 200 they will see an error thrown by the API.
                */
 
-              if (limits?.workflows && meta?.workflowCount >= limits.workflows) {
+              if (limits?.workflows && meta?.workflowCount >= parseInt(limits.workflows, 10)) {
                 event.preventDefault();
                 setShowLimitModal(true);
               }
@@ -226,7 +226,7 @@ export function ReviewWorkflowsListView() {
                    * current hard-limit of 200 they will see an error thrown by the API.
                    */
 
-                  if (limits?.workflows && meta?.workflowCount >= limits.workflows) {
+                  if (limits?.workflows && meta?.workflowCount >= parseInt(limits.workflows, 10)) {
                     setShowLimitModal(true);
                   } else {
                     push('/settings/review-workflows/create');


### PR DESCRIPTION
### What does it do?

Updates the license limits checks:

- chargebee returns strings always, so until we've fixed the underlying problem we should parse the limits to be integers (follow up Jira task)
- fix some conditionals after real world testing

### Why is it needed?

- `CreateView`: all good - on submit we can display the modal again already if the user is at limit, because the intent is to create a new workflow, which would then exceed the limit.
- `EditView`: changed the onload condition from `>=` to `>`, because otherwise a user sees the modal every time, even if they are within limits. They already see it on the list-view, which is annoying enough. Added onsubmit conditions, which trigger the modal.

