### PR TITLE
Do not try to add API endpoint for content type plugins using i18N

### DIFF
--- a/examples/getstarted/src/extensions/myplugin/content-types/test/schema.json
+++ b/examples/getstarted/src/extensions/myplugin/content-types/test/schema.json
@@ -1,4 +1,5 @@
 {
+  "kind": "collectionType",
   "info": {
     "displayName": "Test",
     "singularName": "test",
@@ -18,7 +19,6 @@
       "type": "string",
       "required": true,
       "unique": true,
-      "configurable": true,
       "pluginOptions": {
         "i18n": {
           "localized": true

--- a/packages/plugins/i18n/server/services/core-api.js
+++ b/packages/plugins/i18n/server/services/core-api.js
@@ -179,6 +179,11 @@ const createLocalizationRoute = (contentType) => {
 const addCreateLocalizationAction = (contentType) => {
   const { modelName, apiName } = contentType;
 
+  // in case we add i18N to a content type that is not in an api
+  if (!apiName) {
+    return;
+  }
+
   const localizationRoute = createLocalizationRoute(contentType);
 
   strapi.api[apiName].routes[modelName].routes.push(localizationRoute);


### PR DESCRIPTION
### What does it do?

Fixes #10120

### Why is it needed?

Allow plugin content-types to use i18N

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
