### PR TITLE
Copy "uploads" folder content to backup folder instead of rename while transferring

### DIFF
--- a/packages/core/data-transfer/src/strapi/providers/local-destination/index.ts
+++ b/packages/core/data-transfer/src/strapi/providers/local-destination/index.ts
@@ -158,8 +158,8 @@ class LocalStrapiDestinationProvider implements IDestinationProvider {
     );
 
     try {
-      await fse.move(assetsDirectory, backupDirectory);
-      await fse.mkdir(assetsDirectory);
+      await fse.copy(assetsDirectory, backupDirectory, { recursive: true });
+      await fse.emptyDir(assetsDirectory);
       // Create a .gitkeep file to ensure the directory is not empty
       await fse.outputFile(path.join(assetsDirectory, '.gitkeep'), '');
     } catch (err) {
@@ -190,8 +190,8 @@ class LocalStrapiDestinationProvider implements IDestinationProvider {
                 : ' ';
 
             try {
-              await fse.rm(assetsDirectory, { recursive: true, force: true });
-              await fse.move(backupDirectory, assetsDirectory);
+              await fse.emptyDir(assetsDirectory);
+              await fse.copy(backupDirectory, assetsDirectory, { recursive: true });
               this.destroy(
                 new ProviderTransferError(
                   `There was an error during the transfer process.${errorMessage}The original files have been restored to ${assetsDirectory}`


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Fix error `"The backup folder for the assets could not be created inside the public folder. Please ensure Strapi has write permissions on the public directory"` when you run `strapi transfer` from docker container. 
Command example: `docker exec strapi strapi transfer --from ${STRAPI_INSTANCE_URL}/admin --from-token ${TOKEN} --force`

### Why is it needed?

To allows run `strapi transfer` from docker container (In my case it was only one way to transfer data)
As far as I understood docker blocks mounted `public/uploads` **folder** (exactly folder but not content) it allows to write and read any data inside but blocks renaming/moving

### How to test it?

1. Create a strapi project inside a docker container with the public/uploads folder in a volume
2. Run `docker-compose up`
3. Run one more strapi instance if you need
4. Run `docker exec strapi strapi transfer --from ${STRAPI_INSTANCE_URL}/admin --from-token ${TOKEN} --force`

You will got in console:
```
user@mac project % docker exec strapi strapi transfer --from ${URL}/admin --from-token ${TOKEN} --force
? The transfer will delete all the local Strapi assets and its database. Are you sure you want to proceed? Yes
Starting the compilation for TypeScript files in /opt/app
Starting transfer...
- entities: 0 transfered (size: 0) (elapsed: 0 ms) 
✔ entities: 99 transfered (size: 64.3 KB) (elapsed: 16418 ms) 
[2023-07-11 13:20:08.301] error: [FATAL] The backup folder for the assets could not be created inside the public folder. Please ensure Strapi has write permissions on the public directory
Transfer process failed.
```

But actual error:
```
[Error: EBUSY: resource busy or locked, rename 'public/uploads' -> 'public/uploads_backup_1689076840641'] {
  errno: -16,
  code: 'EBUSY',
  syscall: 'rename',
  path: 'public/uploads',
  dest: 'public/uploads_backup_1689076840641'
}
```

Attached files:
```
#Dockerfile
FROM node:16-alpine
# Installing libvips-dev for sharp Compatibility
RUN apk update && apk add --no-cache build-base gcc autoconf automake zlib-dev libpng-dev nasm bash vips-dev
ARG NODE_ENV=development
ENV NODE_ENV=${NODE_ENV}

WORKDIR /opt/
COPY package.json package-lock.json ./
RUN npm config set network-timeout 600000 -g && npm install
ENV PATH /opt/node_modules/.bin:$PATH

WORKDIR /opt/app
COPY . .
RUN chown -R node:node /opt/app
USER node
RUN ["npm", "run", "build"]
EXPOSE 1337
CMD ["npm", "run", "develop"]
``` 

```
# doocker-compose.yaml
version: '3.9'
services:
  strapi:
    container_name: strapi
    build: .
    env_file: .env
    environment:
      - DATABASE_CLIENT=${DATABASE_CLIENT}
      - DATABASE_HOST=postgres
      - DATABASE_PORT=${DATABASE_PORT}
      - DATABASE_NAME=${DATABASE_NAME}
      - DATABASE_USERNAME=${DATABASE_USERNAME}
      - DATABASE_PASSWORD=${DATABASE_PASSWORD}
      - JWT_SECRET=${JWT_SECRET}
      - ADMIN_JWT_SECRET=${ADMIN_JWT_SECRET}
      - APP_KEYS=${APP_KEYS}
      - NODE_ENV=${NODE_ENV}
    volumes:
      - ./config:/opt/app/config
      - ./src:/opt/app/src
      - ./package.json:/opt/package.json
      - ./public/uploads:/opt/app/public/uploads
      - ./.env:/opt/app/.env
    ports:
      - 1337:1337
    networks:
      - strapi
    depends_on:
      - postgres

  postgres:
    image: postgres:14.6-alpine
    env_file: .env
    environment:
      - POSTGRES_USER=${DATABASE_USERNAME}
      - POSTGRES_PASSWORD=${DATABASE_PASSWORD}
      - POSTGRES_DB=${DATABASE_NAME}
    volumes:
      - strapi-data:/var/lib/postgresql/data/
    ports:
      - 5432:5432
    networks:
      - strapi

volumes:
  strapi-data:

networks:
  strapi:
    name: Strapi
    driver: bridge
```

1. Install strapi instance

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
