### PR TITLE
Fix: Make stage theme color retrieval more defensive

### DIFF
--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/Stages/Stage/Stage.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/Stages/Stage/Stage.js
@@ -174,7 +174,7 @@ export function Stage({
     dragPreviewRef(getEmptyImage(), { captureDraggingState: false });
   }, [dragPreviewRef, index]);
 
-  const { themeColorName } = colorField.value ? getStageColorByHex(colorField.value) : {};
+  const { themeColorName } = getStageColorByHex(colorField.value) ?? {};
 
   return (
     <Box ref={composedRef}>

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/Stages/Stage/tests/Stage.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/Stages/Stage/tests/Stage.test.js
@@ -19,18 +19,22 @@ const STAGES_FIXTURE = {
   index: 0,
 };
 
-const ComponentFixture = (props) => {
+const ComponentFixture = ({
+  // eslint-disable-next-line react/prop-types
+  stages = [
+    {
+      color: STAGE_COLOR_DEFAULT,
+      name: 'something',
+    },
+  ],
+  ...props
+}) => {
   const store = configureStore([], [reducer]);
 
   const formik = useFormik({
     enableReinitialize: true,
     initialValues: {
-      stages: [
-        {
-          color: STAGE_COLOR_DEFAULT,
-          name: 'something',
-        },
-      ],
+      stages,
     },
     validateOnChange: false,
   });
@@ -95,5 +99,20 @@ describe('Admin | Settings | Review Workflow | Stage', () => {
         name: /delete stage/i,
       })
     ).not.toBeInTheDocument();
+  });
+
+  it('should not crash on a custom color code', async () => {
+    const { getByRole } = setup({
+      isOpen: true,
+      canDelete: false,
+      stages: [
+        {
+          color: '#FF4945',
+          name: 'something',
+        },
+      ],
+    });
+
+    expect(getByRole('textbox').value).toBe('something');
   });
 });

--- a/packages/core/admin/ee/server/constants/default-stages.json
+++ b/packages/core/admin/ee/server/constants/default-stages.json
@@ -9,7 +9,7 @@
   },
   {
     "name": "In progress",
-    "color": "#FF4945"
+    "color": "#EE5E52"
   },
   {
     "name": "Reviewed",


### PR DESCRIPTION
### What does it do?

- Update default stage color for "In progress" to be a valid theme color
- Make FE code for the retrieval of the theme color name more defensive. The function `getStageColorByHex` can return null and previously, this has let to a destructuring of `themeColorName` from `null` which leads to 💥 

### Why is it needed?

Fixes a bug.

@pwizla found a bug using multiple review workflows, which I could replicate using a fresh instance.

### How to test it?

Automated tests.

