### PR TITLE
Biginteger field validation issue

### DIFF
--- a/packages/core/strapi/lib/services/entity-validator/validators.js
+++ b/packages/core/strapi/lib/services/entity-validator/validators.js
@@ -195,6 +195,12 @@ const floatValidator = composeValidators(
   addUniqueValidator
 );
 
+const bigIntValidator = composeValidators(
+  () => yup.string().transform((val, originalVal) => originalVal),
+  (validator) => validator.matches(/^-?\d*$/),
+  addUniqueValidator
+);
+
 module.exports = {
   string: stringValidator,
   text: stringValidator,
@@ -206,7 +212,7 @@ module.exports = {
   uid: uidValidator,
   json: () => yup.mixed(),
   integer: integerValidator,
-  biginteger: composeValidators(addUniqueValidator),
+  biginteger: bigIntValidator,
   float: floatValidator,
   decimal: floatValidator,
   date: composeValidators(addUniqueValidator),


### PR DESCRIPTION


### What does it do?

It fixed the issue Biginteger field validation.

### Why is it needed?
Because we don't want to submit random values in place of BigInt
### How to test it?
- Create a collection with a field of type BigInt
- Use the API (since the bug is not present in frontend part) to make a POST request to the endpoint
- Use any random value instead of BigInt like "abcd"
