### PR TITLE
fix(ee): use named export for user settings page

### DIFF
--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/Users/ListPage/index.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/Users/ListPage/index.js
@@ -10,4 +10,4 @@ function UserListPageEE() {
   return <UserListPageCE />;
 }
 
-export default UserListPageEE;
+export { UserListPageEE };


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Uses a named export for the user settings page

### Why is it needed?

The `useEnterprise` call was not expecting a default export and therefore the users list page was blank
