### PR TITLE
Chore: Split user RBAC permissions from useLicenseLimits hook

### DIFF
--- a/docs/docs/docs/01-core/admin/01-ee/02-hooks/use-license-limits.mdx
+++ b/docs/docs/docs/01-core/admin/01-ee/02-hooks/use-license-limits.mdx
@@ -13,8 +13,17 @@ An abstraction around `react-query`'s `useQuery` hook to fetch license limits fo
 ## Usage
 
 ```js
-const { license, getFeature, isError, isLoading } = useLicenseLimits();
+const { license, getFeature, isError, isLoading } = useLicenseLimits(options);
 ```
+
+## Options
+
+### `enabled`
+
+Boolean flag which is passed onto react-query indicating whether the license check should be performed. This
+can be useful if e.g. other permissions need to be checked before.
+
+## Result
 
 ### `license`
 
@@ -56,5 +65,9 @@ interface LicenseFeature {
   options?: object;
 }
 
-type UseLicenseLimit = () => Pick<UseQueryResult, 'isError' | 'isLoading'> & { license: License }
+type Options {
+  enabled?: boolean;
+}
+
+type UseLicenseLimit = (options: Options) => Pick<UseQueryResult, 'isError' | 'isLoading'> & { license: License, getFeature: (name: string) => object }
 ```

--- a/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/InformationBoxEE.js
+++ b/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/InformationBoxEE.js
@@ -11,7 +11,7 @@ import { useIntl } from 'react-intl';
 import { useMutation } from 'react-query';
 
 import { Information } from '../../../../../../admin/src/content-manager/pages/EditView/Information';
-import useLicenseLimits from '../../../../hooks/useLicenseLimits';
+import { useLicenseLimits } from '../../../../hooks/useLicenseLimits';
 import * as LimitsModal from '../../../../pages/SettingsPage/pages/ReviewWorkflows/components/LimitsModal';
 import { useReviewWorkflows } from '../../../../pages/SettingsPage/pages/ReviewWorkflows/hooks/useReviewWorkflows';
 import { getStageColorByHex } from '../../../../pages/SettingsPage/pages/ReviewWorkflows/utils/colors';

--- a/packages/core/admin/ee/admin/hooks/index.js
+++ b/packages/core/admin/ee/admin/hooks/index.js
@@ -1,4 +1,4 @@
 // eslint-disable-next-line import/prefer-default-export
 export { default as useAuthProviders } from './useAuthProviders';
 export { default as useLicenseLimitNotification } from './useLicenseLimitNotification';
-export { default as useLicenseLimits } from './useLicenseLimits';
+export { useLicenseLimits } from './useLicenseLimits';

--- a/packages/core/admin/ee/admin/hooks/useLicenseLimitNotification/index.js
+++ b/packages/core/admin/ee/admin/hooks/useLicenseLimitNotification/index.js
@@ -10,7 +10,7 @@ import isNil from 'lodash/isNil';
 import { useIntl } from 'react-intl';
 import { useLocation } from 'react-router-dom';
 
-import useLicenseLimits from '../useLicenseLimits';
+import { useLicenseLimits } from '../useLicenseLimits';
 
 const STORAGE_KEY_PREFIX = 'strapi-notification-seat-limit';
 

--- a/packages/core/admin/ee/admin/hooks/useLicenseLimitNotification/tests/index.test.js
+++ b/packages/core/admin/ee/admin/hooks/useLicenseLimitNotification/tests/index.test.js
@@ -4,7 +4,7 @@ import { renderHook } from '@testing-library/react';
 import { IntlProvider } from 'react-intl';
 
 import useLicenseLimitNotification from '..';
-import useLicenseLimits from '../../useLicenseLimits';
+import { useLicenseLimits } from '../../useLicenseLimits';
 
 const baseLicenseInfo = {
   enforcementUserCount: 5,
@@ -34,11 +34,11 @@ jest.mock('@strapi/helper-plugin', () => {
   };
 });
 
-jest.mock('../../useLicenseLimits', () => {
-  return jest.fn(() => ({
+jest.mock('../../useLicenseLimits', () => ({
+  useLicenseLimits: jest.fn(() => ({
     license: baseLicenseInfo,
-  }));
-});
+  })),
+}));
 
 const setup = (...args) =>
   renderHook(() => useLicenseLimitNotification(...args), {

--- a/packages/core/admin/ee/admin/hooks/useLicenseLimits/__mocks__/index.js
+++ b/packages/core/admin/ee/admin/hooks/useLicenseLimits/__mocks__/index.js
@@ -1,0 +1,8 @@
+export const useLicenseLimits = jest.fn().mockReturnValue({
+    isError: false,
+    isLoading: false,
+    license: {},
+    getFeature() {
+        return {}
+    }
+});

--- a/packages/core/admin/ee/admin/hooks/useLicenseLimits/index.js
+++ b/packages/core/admin/ee/admin/hooks/useLicenseLimits/index.js
@@ -1,3 +1,1 @@
-import { useLicenseLimits } from './useLicenseLimits';
-
-export default useLicenseLimits;
+export { useLicenseLimits } from './useLicenseLimits';

--- a/packages/core/admin/ee/admin/hooks/useLicenseLimits/useLicenseLimits.js
+++ b/packages/core/admin/ee/admin/hooks/useLicenseLimits/useLicenseLimits.js
@@ -1,20 +1,10 @@
 import * as React from 'react';
 
-import { useFetchClient, useRBAC } from '@strapi/helper-plugin';
+import { useFetchClient } from '@strapi/helper-plugin';
 import { useQuery } from 'react-query';
-import { useSelector } from 'react-redux';
 
-import { selectAdminPermissions } from '../../../../admin/src/pages/App/selectors';
-
-export function useLicenseLimits() {
-  const permissions = useSelector(selectAdminPermissions);
+export function useLicenseLimits({ enabled } = { enabled: true}) {
   const { get } = useFetchClient();
-  const {
-    isLoading: isRBACLoading,
-    allowedActions: { canRead, canCreate, canUpdate, canDelete },
-  } = useRBAC(permissions.settings.users);
-  const hasPermissions = canRead && canCreate && canUpdate && canDelete;
-
   const { data, isError, isLoading } = useQuery(
     ['ee', 'license-limit-info'],
     async () => {
@@ -25,7 +15,7 @@ export function useLicenseLimits() {
       return data;
     },
     {
-      enabled: !isRBACLoading && hasPermissions,
+      enabled,
     }
   );
 

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ApplicationInfosPage/components/AdminSeatInfo/index.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ApplicationInfosPage/components/AdminSeatInfo/index.js
@@ -2,22 +2,37 @@ import React from 'react';
 
 import { Flex, GridItem, Icon, Tooltip, Typography } from '@strapi/design-system';
 import { Link } from '@strapi/design-system/v2';
-import { pxToRem } from '@strapi/helper-plugin';
+import { pxToRem, useRBAC } from '@strapi/helper-plugin';
 import { ExclamationMarkCircle, ExternalLink } from '@strapi/icons';
 import { useIntl } from 'react-intl';
+import { useSelector } from 'react-redux';
 
-import { useLicenseLimits } from '../../../../../../hooks';
+import { selectAdminPermissions } from '../../../../../../../../admin/src/pages/App/selectors';
+import { useLicenseLimits } from '../../../../../../hooks/useLicenseLimits';
 
 const BILLING_STRAPI_CLOUD_URL = 'https://cloud.strapi.io/profile/billing';
 const BILLING_SELF_HOSTED_URL = 'https://strapi.io/billing/request-seats';
 
 export const AdminSeatInfoEE = () => {
   const { formatMessage } = useIntl();
+  const permissions = useSelector(selectAdminPermissions);
+  const {
+    isLoading: isRBACLoading,
+    allowedActions: { canRead, canCreate, canUpdate, canDelete },
+  } = useRBAC(permissions.settings.users);
   const {
     license: { licenseLimitStatus, enforcementUserCount, permittedSeats, isHostedOnStrapiCloud },
     isError,
-    isLoading,
-  } = useLicenseLimits();
+    isLoading: isLicenseLoading,
+  } = useLicenseLimits({
+    // TODO: this creates a waterfall which we should avoid to render earlier, but for that
+    // we will have to move away from data-fetching hooks to query functions.
+    // Short-term we could at least implement a loader, for the user to have visual feedback
+    // in case the requests take a while
+    enabled: !isRBACLoading && canRead && canCreate && canUpdate && canDelete
+  });
+
+  const isLoading = isRBACLoading || isLicenseLoading;
 
   if (isError || isLoading || !permittedSeats) {
     return null;


### PR DESCRIPTION
### What does it do?

1. Make `useLicenseLimits` more atomic

Previously it was coupled with user permissions, which doesn't work well for e.g. review-workflows because it assumes a user needs access to other admin users.

The affected code was extracted and inlined into `ApplicationInfo`.

2. Allow to programmatically enabled/ disable license checks

Now `useLicenseLimits` can receive options, which (similar to react-query) allows to pass in an `enabled: boolean` flag. This is helpful to not run a query e.g. if a previous RBAC check did not succeed.

3. Add a manual mock for `useLicenseLimits`

Makes testing easier.

4. Export `useLicenseLimits` as a named export.

### How to test it?

Automated tests.

Application infos can be tested in CE and EE here: http://localhost:4000/admin/settings/application-infos

