### PR TITLE
feature(content-manager): display full user names in list view

### DIFF
--- a/packages/core/admin/admin/src/content-manager/pages/ListView/components/TableRows/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/ListView/components/TableRows/index.js
@@ -15,6 +15,7 @@ import {
   useFetchClient,
   useAPIErrorHandler,
   useQueryParams,
+  getDisplayName,
 } from '@strapi/helper-plugin';
 import { Trash, Duplicate, Pencil } from '@strapi/icons';
 import { AxiosError } from 'axios';
@@ -189,6 +190,17 @@ export const TableRows = ({
                     ) : (
                       <Typography textColor="neutral800">-</Typography>
                     )}
+                  </Td>
+                );
+              }
+
+              if (['createdBy', 'updatedBy'].includes(name.split('.')[0])) {
+                // Display the users full name
+                return (
+                  <Td key={key}>
+                    <Typography textColor="neutral800">
+                      {getDisplayName(data[name.split('.')[0]], formatMessage)}
+                    </Typography>
                   </Td>
                 );
               }


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

An enhancement based on the ongoing work in the target branch

Uses the `getDisplayName` util to display the users full name in the CM list view

