### PR TITLE
fix to create core router types definition

### DIFF
--- a/packages/core/strapi/lib/factories.d.ts
+++ b/packages/core/strapi/lib/factories.d.ts
@@ -5,7 +5,7 @@ type WithStrapiCallback<T> = <S extends { strapi: Strapi }>(params: S) => T;
 export declare function createCoreRouter<T extends Common.UID.ContentType>(
   uid: T,
   cfg?: CoreApi.Router.RouterConfig<T>
-): () => CoreApi.Router.Router;
+): CoreApi.Router.Router;
 
 export declare function createCoreController<
   T extends Common.UID.ContentType,


### PR DESCRIPTION
### What does it do?

Small bugfix to the types definition of _createCoreRouter_ factory function.

### Why is it needed?

If one looks at [**implementation**](https://github.com/strapi/strapi/blob/main/packages/core/strapi/lib/factories.js#L47) of createCoreRouter one can see that function returns an object of type [**Router**](https://github.com/strapi/strapi/blob/main/packages/core/strapi/lib/types/core-api/router.d.ts#L65). However, in corresponding types definitions there is a mismatch that causes confusion in typescript projects. This PR resolves such inaccuracy.

### How to test it?

In Strapi project when declaring [routes](https://docs.strapi.io/dev-docs/backend-customization/routes) code snippet below will not cause any issues in typescript project

    import { factories } from "@strapi/strapi";
    
    const customRoutes = [
      {
        method: "POST",
        path: "/articles/:id/viewed",
        handler: "article.setViewed",
      },
      {
        method: "GET",
        path: "/articles/:id/viewed",
        handler: "article.getViewed",
      },
    ];
    
    const routerCore = factories.createCoreRouter("api::article.article");
    
    export default {
      prefix: routerCore.prefix,
      get routes() {
        return [...routerCore.routes, ...customRoutes];
      },
    };


### Related issue(s)/PR(s)
None found
