### PR TITLE
admin lastname defaults to undefined

### DIFF
--- a/packages/core/admin/admin/src/pages/AuthPage/components/Register/index.js
+++ b/packages/core/admin/admin/src/pages/AuthPage/components/Register/index.js
@@ -98,6 +98,10 @@ const Register = ({ authType, fieldsToDisable, noSignin, onSubmit, schema }) => 
 
       if (!['password', 'confirmPassword'].includes(key) && typeof value === 'string') {
         normalizedvalue = normalizedvalue.trim();
+
+        if (key === 'lastname') {
+          normalizedvalue = normalizedvalue || null;
+        }
       }
 
       acc[key] = normalizedvalue;
@@ -113,7 +117,7 @@ const Register = ({ authType, fieldsToDisable, noSignin, onSubmit, schema }) => 
           enableReinitialize
           initialValues={{
             firstname: userInfo.firstname || '',
-            lastname: userInfo.lastname || undefined,
+            lastname: userInfo.lastname || '',
             email: userInfo.email || '',
             password: '',
             confirmPassword: '',

--- a/packages/core/admin/admin/src/pages/AuthPage/components/Register/index.js
+++ b/packages/core/admin/admin/src/pages/AuthPage/components/Register/index.js
@@ -113,7 +113,7 @@ const Register = ({ authType, fieldsToDisable, noSignin, onSubmit, schema }) => 
           enableReinitialize
           initialValues={{
             firstname: userInfo.firstname || '',
-            lastname: userInfo.lastname || '',
+            lastname: userInfo.lastname || undefined,
             email: userInfo.email || '',
             password: '',
             confirmPassword: '',

--- a/packages/core/admin/admin/src/pages/AuthPage/components/Register/tests/index.test.js
+++ b/packages/core/admin/admin/src/pages/AuthPage/components/Register/tests/index.test.js
@@ -136,6 +136,61 @@ describe('ADMIN | PAGES | AUTH | Register', () => {
     );
   });
 
+  it('Validates optional Lastname value to be null', async () => {
+    const spy = jest.fn();
+    const { getByRole, getByLabelText, user } = setup({ onSubmit: spy });
+
+    await user.type(getByLabelText(/Firstname/i), 'First name');
+    await user.type(getByLabelText(/Email/i), 'test@strapi.io');
+    await user.type(getByLabelText(/^Password/i), 'secret');
+    await user.type(getByLabelText(/Confirm Password/i), 'secret');
+
+    fireEvent.click(getByRole('button', { name: /let's start/i }));
+
+    await waitFor(() =>
+      expect(spy).toHaveBeenCalledWith(
+        {
+          firstname: 'First name',
+          lastname: null,
+          email: 'test@strapi.io',
+          news: false,
+          registrationToken: undefined,
+          confirmPassword: 'secret',
+          password: 'secret',
+        },
+        expect.any(Object)
+      )
+    );
+  });
+
+  it('Validates optional Lastname value to be empty space', async () => {
+    const spy = jest.fn();
+    const { getByRole, getByLabelText, user } = setup({ onSubmit: spy });
+
+    await user.type(getByLabelText(/Firstname/i), 'First name');
+    await user.type(getByLabelText(/Lastname/i), ' ');
+    await user.type(getByLabelText(/Email/i), 'test@strapi.io');
+    await user.type(getByLabelText(/^Password/i), 'secret');
+    await user.type(getByLabelText(/Confirm Password/i), 'secret');
+
+    fireEvent.click(getByRole('button', { name: /let's start/i }));
+
+    await waitFor(() =>
+      expect(spy).toHaveBeenCalledWith(
+        {
+          firstname: 'First name',
+          lastname: null,
+          email: 'test@strapi.io',
+          news: false,
+          registrationToken: undefined,
+          confirmPassword: 'secret',
+          password: 'secret',
+        },
+        expect.any(Object)
+      )
+    );
+  });
+
   it('Disable fields', () => {
     const { getByLabelText } = setup({
       fieldsToDisable: ['email', 'firstname'],


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Sets the default value of admin lastname as undefined instead of empty string

### Why is it needed?

Fix #17287 

### How to test it?

Run the example project, register an admin with empty last name, and validate that the lastname is retrieved at the endpoint /admin/me as null

### Related issue(s)/PR(s)

Fix #17287 
