### PR TITLE
Use { failOnError : false } for sharp

### DIFF
--- a/packages/core/upload/server/services/image-manipulation.js
+++ b/packages/core/upload/server/services/image-manipulation.js
@@ -47,7 +47,7 @@ const THUMBNAIL_RESIZE_OPTIONS = {
 const resizeFileTo = async (file, options, { name, hash }) => {
   const filePath = join(file.tmpWorkingDirectory, hash);
 
-  await writeStreamToFile(file.getStream().pipe(sharp().resize(options)), filePath);
+  await writeStreamToFile(file.getStream().pipe(sharp({ failOnError: false }).resize(options)), filePath);
   const newFile = {
     name,
     hash,
@@ -94,7 +94,7 @@ const optimize = async (file) => {
   const { width, height, size, format } = await getMetadata(newFile);
 
   if (sizeOptimization || autoOrientation) {
-    const transformer = sharp();
+    const transformer = sharp({ failOnError: false });
     // reduce image quality
     transformer[format]({ quality: sizeOptimization ? 80 : 100 });
     // rotate image based on EXIF data


### PR DESCRIPTION
If a corrupted image is uploaded to strapi it cause the whole app to stop with error . This will prevent strapi from stop .

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Describe the technical changes you did.

### Why is it needed?

Describe the issue you are solving.

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
