### PR TITLE
feat: throw ValidationError if stage has a duplicated name

### DIFF
--- a/api-tests/core/admin/ee/review-workflows.test.api.js
+++ b/api-tests/core/admin/ee/review-workflows.test.api.js
@@ -464,6 +464,25 @@ describeOnCondition(edition === 'EE')('Review workflows', () => {
         expect(workflowRes.body.data).toBeUndefined();
       }
     });
+    test('It should throw an error if trying to create stages with duplicated names', async () => {
+      const stagesRes = await requests.admin.put(
+        `/admin/review-workflows/workflows/${testWorkflow.id}?populate=*`,
+        {
+          body: {
+            data: {
+              stages: [{ name: 'To Do' }, { name: 'To Do' }],
+            },
+          },
+        }
+      );
+
+      if (hasRW) {
+        expect(stagesRes.status).toBe(400);
+        expect(stagesRes.body.error).toBeDefined();
+        expect(stagesRes.body.error.name).toEqual('ValidationError');
+        expect(stagesRes.body.error.message).toBeDefined();
+      }
+    });
     test('It should throw an error if trying to create more than 200 stages', async () => {
       const stagesRes = await requests.admin.put(
         `/admin/review-workflows/workflows/${testWorkflow.id}?populate=*`,

--- a/api-tests/core/admin/ee/review-workflows.test.api.js
+++ b/api-tests/core/admin/ee/review-workflows.test.api.js
@@ -100,6 +100,7 @@ describeOnCondition(edition === 'EE')('Review workflows', () => {
     });
     testWorkflow = await strapi.query(WORKFLOW_MODEL_UID).create({
       data: {
+        contentTypes: [],
         name: 'workflow',
         stages: [defaultStage.id, secondStage.id],
       },

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/EditView/EditView.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/EditView/EditView.js
@@ -9,6 +9,7 @@ import {
 } from '@strapi/helper-plugin';
 import { Check } from '@strapi/icons';
 import { useFormik, Form, FormikProvider } from 'formik';
+import set from 'lodash/set';
 import { useIntl } from 'react-intl';
 import { useMutation } from 'react-query';
 import { useSelector, useDispatch } from 'react-redux';
@@ -55,6 +56,7 @@ export function ReviewWorkflowsEditView() {
   const [isConfirmDeleteDialogOpen, setIsConfirmDeleteDialogOpen] = React.useState(false);
   const { getFeature, isLoading: isLicenseLoading } = useLicenseLimits();
   const [showLimitModal, setShowLimitModal] = React.useState(false);
+  const [initialErrors, setInitialErrors] = React.useState(null);
 
   const { mutateAsync, isLoading } = useMutation(
     async ({ workflow }) => {
@@ -77,15 +79,41 @@ export function ReviewWorkflowsEditView() {
   );
 
   const updateWorkflow = async (workflow) => {
+    // reset the error messages
+    setInitialErrors(null);
+
     try {
       const res = await mutateAsync({ workflow });
 
       return res;
     } catch (error) {
-      toggleNotification({
-        type: 'warning',
-        message: formatAPIError(error),
-      });
+      // TODO: the current implementation of `formatAPIError` prints all error messages of all details,
+      // which get's hairy when we have duplicated-name errors, because the same error message is printed
+      // several times. What we want instead in these scenarios is to print only the error summary and
+      // display the individual error messages for each field. This is a workaround, until we change the
+      // implementation of `formatAPIError`.
+      if (
+        error.response.data?.error?.name === 'ValidationError' &&
+        error.response.data?.error?.details?.errors?.length > 0
+      ) {
+        toggleNotification({
+          type: 'warning',
+          message: error.response.data.error.message,
+        });
+
+        setInitialErrors(
+          error.response.data?.error?.details?.errors.reduce((acc, error) => {
+            set(acc, error.path, error.message);
+
+            return acc;
+          }, {})
+        );
+      } else {
+        toggleNotification({
+          type: 'warning',
+          message: formatAPIError(error),
+        });
+      }
 
       return null;
     }
@@ -108,16 +136,17 @@ export function ReviewWorkflowsEditView() {
 
   const formik = useFormik({
     enableReinitialize: true,
+    initialErrors,
     initialValues: currentWorkflow,
     async onSubmit() {
       if (currentWorkflowHasDeletedServerStages) {
         setIsConfirmDeleteDialogOpen(true);
       } else if (limits?.workflows && meta?.workflowCount > parseInt(limits.workflows, 10)) {
-      /**
-       * If the current license has a limit, check if the total count of workflows
-       * exceeds that limit and display the limits modal instead of sending the
-       * update, because it would throw an API error.
-       */
+        /**
+         * If the current license has a limit, check if the total count of workflows
+         * exceeds that limit and display the limits modal instead of sending the
+         * update, because it would throw an API error.
+         */
         setShowLimitModal('workflow');
 
         /**

--- a/packages/core/admin/ee/server/constants/workflows.js
+++ b/packages/core/admin/ee/server/constants/workflows.js
@@ -14,5 +14,6 @@ module.exports = {
       'You’ve reached the limit of workflows in your plan. Delete a workflow or contact Sales to enable more workflows.',
     STAGES_LIMIT:
       'You’ve reached the limit of stages for this workflow in your plan. Try deleting some stages or contact Sales to enable more stages.',
+    DUPLICATED_STAGE_NAME: 'Stage names must be unique.',
   },
 };

--- a/packages/core/admin/ee/server/services/__tests__/review-workflows-validation.test.js
+++ b/packages/core/admin/ee/server/services/__tests__/review-workflows-validation.test.js
@@ -82,11 +82,19 @@ describe('Review workflows - Validation service', () => {
   describe('validateWorkflowStages', () => {
     test('Should not throw because limit is not reached and at least 1 stage', async () => {
       validationService.register({ stagesPerWorkflow: 2 });
-      expect(() => validationService.validateWorkflowStages([{}, {}])).not.toThrowError();
+      expect(() =>
+        validationService.validateWorkflowStages([{ name: 'a' }, { name: 'b' }])
+      ).not.toThrowError();
     });
     test('Should throw because limit is reached', async () => {
       validationService.register({ stagesPerWorkflow: 2 });
       expect(() => validationService.validateWorkflowStages([{}, {}, {}])).toThrowError();
+    });
+    test('Should throw because stage name is duplicated', async () => {
+      validationService.register({ stagesPerWorkflow: 200 });
+      expect(() =>
+        validationService.validateWorkflowStages([{ name: 'a' }, { name: 'a' }])
+      ).toThrowError();
     });
   });
 });

--- a/packages/core/admin/ee/server/services/review-workflows/validation.js
+++ b/packages/core/admin/ee/server/services/review-workflows/validation.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { uniq } = require('lodash/fp');
 const { ValidationError } = require('@strapi/utils').errors;
 const { getService } = require('../../utils');
 const { ERRORS, MAX_WORKFLOWS, MAX_STAGES_PER_WORKFLOW } = require('../../constants/workflows');
@@ -31,6 +32,11 @@ module.exports = ({ strapi }) => {
       }
       if (stages.length > this.limits.stagesPerWorkflow) {
         throw new ValidationError(ERRORS.STAGES_LIMIT);
+      }
+      // Validate stage names are not duplicated
+      const stageNames = stages.map((stage) => stage.name);
+      if (uniq(stageNames).length !== stageNames.length) {
+        throw new ValidationError(ERRORS.DUPLICATED_STAGE_NAME);
       }
     },
 

--- a/packages/core/admin/ee/server/validation/review-workflows.js
+++ b/packages/core/admin/ee/server/validation/review-workflows.js
@@ -64,7 +64,7 @@ const validateWorkflowUpdateSchema = yup.object().shape({
     .test('unique', function (stages) {
       const errors = [];
 
-      stages.forEach((stage, index) => {
+      stages?.forEach((stage, index) => {
         const sameNameStages = stages.filter((s) => s.name === stage.name);
         if (sameNameStages.length > 1) {
           errors.push(

--- a/packages/core/admin/ee/server/validation/review-workflows.js
+++ b/packages/core/admin/ee/server/validation/review-workflows.js
@@ -45,7 +45,7 @@ const validateContentTypes = yup.array().of(
 );
 
 const validateWorkflowCreateSchema = yup.object().shape({
-  name: yup.string().max(255).required(),
+  name: yup.string().max(255).min(1, 'Workflow name can not be empty').required(),
   stages: yup
     .array()
     .of(stageObject)
@@ -56,7 +56,7 @@ const validateWorkflowCreateSchema = yup.object().shape({
 });
 
 const validateWorkflowUpdateSchema = yup.object().shape({
-  name: yup.string().max(255),
+  name: yup.string().max(255).min(1, 'Workflow name can not be empty'),
   stages: yup
     .array()
     .of(stageObject)

--- a/packages/core/admin/ee/server/validation/review-workflows.js
+++ b/packages/core/admin/ee/server/validation/review-workflows.js
@@ -63,9 +63,10 @@ const validateWorkflowUpdateSchema = yup.object().shape({
     // Check that the stages name are unique
     .test('unique', function (stages) {
       const errors = [];
+
       stages.forEach((stage, index) => {
-        const duplicatedStageNames = stages.filter((s) => s.name === stage.name);
-        if (duplicatedStageNames.length > 1) {
+        const sameNameStages = stages.filter((s) => s.name === stage.name);
+        if (sameNameStages.length > 1) {
           errors.push(
             this.createError({
               path: `${this.path}[${index}].name`,
@@ -74,6 +75,7 @@ const validateWorkflowUpdateSchema = yup.object().shape({
           );
         }
       });
+
       if (!isEmpty(errors)) {
         throw new yup.ValidationError(errors);
       }

--- a/packages/core/admin/ee/server/validation/review-workflows.js
+++ b/packages/core/admin/ee/server/validation/review-workflows.js
@@ -70,7 +70,7 @@ const validateWorkflowUpdateSchema = yup.object().shape({
           errors.push(
             this.createError({
               path: `${this.path}[${index}].name`,
-              message: 'Stage must be unique',
+              message: 'Stage name must be unique',
             })
           );
         }

--- a/packages/core/admin/ee/server/validation/review-workflows.js
+++ b/packages/core/admin/ee/server/validation/review-workflows.js
@@ -2,7 +2,6 @@
 
 /* eslint-disable func-names */
 
-const { isEmpty } = require('lodash/fp');
 const { yup, validateYupSchema } = require('@strapi/utils');
 const { hasStageAttribute } = require('../utils/review-workflows');
 
@@ -49,6 +48,7 @@ const validateWorkflowCreateSchema = yup.object().shape({
   stages: yup
     .array()
     .of(stageObject)
+    .uniqueProperty('name', 'Stage name must be unique')
     .min(1, 'Can not create a workflow without stages')
     .max(200, 'Can not have more than 200 stages')
     .required('Can not create a workflow without stages'),
@@ -60,27 +60,7 @@ const validateWorkflowUpdateSchema = yup.object().shape({
   stages: yup
     .array()
     .of(stageObject)
-    // Check that the stages name are unique
-    .test('unique', function (stages) {
-      const errors = [];
-
-      stages?.forEach((stage, index) => {
-        const sameNameStages = stages.filter((s) => s.name === stage.name);
-        if (sameNameStages.length > 1) {
-          errors.push(
-            this.createError({
-              path: `${this.path}[${index}].name`,
-              message: 'Stage name must be unique',
-            })
-          );
-        }
-      });
-
-      if (!isEmpty(errors)) {
-        throw new yup.ValidationError(errors);
-      }
-      return true;
-    })
+    .uniqueProperty('name', 'Stage name must be unique')
     .min(1, 'Can not update a workflow without stages')
     .max(200, 'Can not have more than 200 stages'),
   contentTypes: validateContentTypes,

--- a/packages/core/admin/ee/server/validation/review-workflows.js
+++ b/packages/core/admin/ee/server/validation/review-workflows.js
@@ -1,5 +1,8 @@
 'use strict';
 
+/* eslint-disable func-names */
+
+const { isEmpty } = require('lodash/fp');
 const { yup, validateYupSchema } = require('@strapi/utils');
 const { hasStageAttribute } = require('../utils/review-workflows');
 
@@ -57,6 +60,25 @@ const validateWorkflowUpdateSchema = yup.object().shape({
   stages: yup
     .array()
     .of(stageObject)
+    // Check that the stages name are unique
+    .test('unique', function (stages) {
+      const errors = [];
+      stages.forEach((stage, index) => {
+        const duplicatedStageNames = stages.filter((s) => s.name === stage.name);
+        if (duplicatedStageNames.length > 1) {
+          errors.push(
+            this.createError({
+              path: `${this.path}[${index}].name`,
+              message: 'Stage must be unique',
+            })
+          );
+        }
+      });
+      if (!isEmpty(errors)) {
+        throw new yup.ValidationError(errors);
+      }
+      return true;
+    })
     .min(1, 'Can not update a workflow without stages')
     .max(200, 'Can not have more than 200 stages'),
   contentTypes: validateContentTypes,


### PR DESCRIPTION
### What does it do?

![image](https://github.com/strapi/strapi/assets/20578351/a9851a28-6176-40ac-a5eb-96b610ef9b8f)

Throws an error if a workflow stage names are duplicated.

