### PR TITLE
String and Array notation types for entity service populate Param

### DIFF
--- a/packages/core/strapi/lib/services/entity-service/types/params/index.d.ts
+++ b/packages/core/strapi/lib/services/entity-service/types/params/index.d.ts
@@ -4,11 +4,13 @@ import type * as Sort from './sort';
 import type * as Pagination from './pagination';
 import type * as Fields from './fields';
 import type * as Filters from './filters';
+import type * as Populate from './populate';
 
 export type For<TSchemaUID extends Common.UID.Schema> = {
   sort?: Sort.Any<TSchemaUID>;
   fields?: Fields.Any<TSchemaUID>;
   filters?: Filters.Any<TSchemaUID>;
+  populate?: Populate.Any<TSchemaUID>;
 } & Pagination.Any;
 
 export type { Sort, Pagination, Fields, Filters };

--- a/packages/core/strapi/lib/services/entity-service/types/params/index.d.ts
+++ b/packages/core/strapi/lib/services/entity-service/types/params/index.d.ts
@@ -15,4 +15,4 @@ export type For<TSchemaUID extends Common.UID.Schema> = {
 } & Pagination.Any &
   PublicationState.For<TSchemaUID>;
 
-export type { Sort, Pagination, Fields, Filters, PublicationState };
+export type { Sort, Pagination, Fields, Filters, Populate, PublicationState };

--- a/packages/core/strapi/lib/services/entity-service/types/params/populate.d.ts
+++ b/packages/core/strapi/lib/services/entity-service/types/params/populate.d.ts
@@ -26,7 +26,7 @@ type StringNotation<TSchemaUID extends Common.UID.Schema> =
   | WildcardNotation
   | PopulatableKeys<TSchemaUID>
   | `${string},${string}`
-  | `${PopulatableKeys}.${string}`;
+  | `${PopulatableKeys<TSchemaUID>}.${string}`;
 
 /**
  * Array notation for populate

--- a/packages/core/strapi/lib/services/entity-service/types/params/populate.d.ts
+++ b/packages/core/strapi/lib/services/entity-service/types/params/populate.d.ts
@@ -1,0 +1,39 @@
+import type { Attribute, Common, Utils } from '@strapi/strapi';
+
+/**
+ * Wildcard notation for populate
+ *
+ * To populate all the root level relations
+ */
+type WildcardNotation = '*';
+
+/**
+ * Union of all possible string representation for populate
+ *
+ * @example
+ * type A = 'image'; // ✅
+ * type B = 'image,component'; // ✅
+ * type c = '*'; // ✅
+ * type D = 'populatableField'; // ✅
+ * type E = '<random_string>'; // ❌
+ */
+type StringNotation<TSchemaUID extends Common.UID.Schema> =
+  | WildcardNotation
+  | Attribute.GetPopulatableKeys<TSchemaUID>
+  | `${string},${string}`;
+
+/**
+ * Array notation for populate
+ *
+ * @example
+ * type A = ['image']; // ✅
+ * type B = ['image', 'component']; // ✅
+ * type C = ['populatableField']; // ✅
+ * type D = ['<random_string>']; // ❌
+ */
+type ArrayNotation<TSchemaUID extends Common.UID.Schema> =
+  Attribute.GetPopulatableKeys<TSchemaUID>[];
+
+export type Any<TSchemaUID extends Common.UID.Schema> =
+  | StringNotation<TSchemaUID>
+  | ArrayNotation<TSchemaUID>;

--- a/packages/core/strapi/lib/services/entity-service/types/params/populate.d.ts
+++ b/packages/core/strapi/lib/services/entity-service/types/params/populate.d.ts
@@ -7,6 +7,11 @@ import type { Attribute, Common, Utils } from '@strapi/strapi';
  */
 type WildcardNotation = '*';
 
+type PopulatableKeys<TSchemaUID extends Common.UID.Schema> = Utils.Guard.Never<
+  Attribute.GetPopulatableKeys<TSchemaUID>,
+  string
+>;
+
 /**
  * Union of all possible string representation for populate
  *
@@ -19,8 +24,9 @@ type WildcardNotation = '*';
  */
 type StringNotation<TSchemaUID extends Common.UID.Schema> =
   | WildcardNotation
-  | Attribute.GetPopulatableKeys<TSchemaUID>
-  | `${string},${string}`;
+  | PopulatableKeys<TSchemaUID>
+  | `${string},${string}`
+  | `${PopulatableKeys}.${string}`;
 
 /**
  * Array notation for populate
@@ -31,9 +37,9 @@ type StringNotation<TSchemaUID extends Common.UID.Schema> =
  * type C = ['populatableField']; // ✅
  * type D = ['<random_string>']; // ❌
  */
-type ArrayNotation<TSchemaUID extends Common.UID.Schema> =
-  Attribute.GetPopulatableKeys<TSchemaUID>[];
+type ArrayNotation<TSchemaUID extends Common.UID.Schema> = StringNotation<TSchemaUID>[];
 
 export type Any<TSchemaUID extends Common.UID.Schema> =
   | StringNotation<TSchemaUID>
-  | ArrayNotation<TSchemaUID>;
+  | ArrayNotation<TSchemaUID>
+  | Object;


### PR DESCRIPTION
### What does it do?

- Add string and array notation types 
- add populate as a possible param

### Why is it needed?

- To complete entity service typings
