### PR TITLE
fix(i18n): entity locale actions were aimed at default locale

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/SingleTypeFormWrapper/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/SingleTypeFormWrapper/index.js
@@ -159,7 +159,7 @@ const SingleTypeFormWrapper = ({ allLayoutData, children, slug }) => {
         trackUsageRef.current('willDeleteEntry', trackerProperty);
 
         const { data } = await del(getRequestUrl(slug), {
-          params: query,
+          params,
         });
 
         toggleNotification({
@@ -181,7 +181,7 @@ const SingleTypeFormWrapper = ({ allLayoutData, children, slug }) => {
         return Promise.reject(err);
       }
     },
-    [del, slug, displayErrors, toggleNotification, query, dispatch, rawQuery]
+    [del, slug, params, toggleNotification, dispatch, rawQuery, displayErrors]
   );
 
   const onPost = useCallback(
@@ -265,7 +265,7 @@ const SingleTypeFormWrapper = ({ allLayoutData, children, slug }) => {
         endPoint,
         {},
         {
-          params: query,
+          params,
         }
       );
 
@@ -287,7 +287,7 @@ const SingleTypeFormWrapper = ({ allLayoutData, children, slug }) => {
 
       return Promise.reject(err);
     }
-  }, [post, cleanReceivedData, displayErrors, slug, query, dispatch, toggleNotification]);
+  }, [slug, dispatch, post, params, toggleNotification, cleanReceivedData, displayErrors]);
 
   const onPut = useCallback(
     async (body, trackerProperty) => {
@@ -341,7 +341,7 @@ const SingleTypeFormWrapper = ({ allLayoutData, children, slug }) => {
         endPoint,
         {},
         {
-          params: query,
+          params,
         }
       );
 
@@ -358,7 +358,7 @@ const SingleTypeFormWrapper = ({ allLayoutData, children, slug }) => {
       dispatch(setStatus('resolved'));
       displayErrors(err);
     }
-  }, [post, cleanReceivedData, toggleNotification, displayErrors, slug, dispatch, query]);
+  }, [slug, dispatch, post, params, toggleNotification, cleanReceivedData, displayErrors]);
 
   return children({
     componentsDataStructure,


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* Changes the publish / unpublish & delete network calls to use the `params` object built by `buildValidGetParams` as opposed to the querystring from the URL

### Why is it needed?

A small regression in #17074 meant we were sending the query `{ plugins: { i18n: { locale: 'es' } } }` when in actuality we just wanted to send `{ locale: 'es' }`, this meant publish / unpublish & delete would not work.

### Related issue(s)/PR(s)

* resolves #17314
* resolves CONTENT-1591
