### PR TITLE
Fix error on adding relations

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/RelationInput/components/Option.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInput/components/Option.js
@@ -20,6 +20,7 @@ const StyledBullet = styled.div`
 
 export const Option = ({ publicationState, mainField, id }) => {
   const { formatMessage } = useIntl();
+  const stringifiedDisplayValue = (mainField ?? id).toString();
 
   if (publicationState) {
     const isDraft = publicationState === 'draft';
@@ -34,18 +35,18 @@ export const Option = ({ publicationState, mainField, id }) => {
     const title = isDraft ? formatMessage(draftMessage) : formatMessage(publishedMessage);
 
     return (
-      <ComboboxOption value={id} textValue={mainField ?? id}>
+      <ComboboxOption value={id} textValue={stringifiedDisplayValue}>
         <Flex>
           <StyledBullet title={title} isDraft={isDraft} />
-          <Typography ellipsis>{mainField ?? id}</Typography>
+          <Typography ellipsis>{stringifiedDisplayValue}</Typography>
         </Flex>
       </ComboboxOption>
     );
   }
 
   return (
-    <ComboboxOption value={id} textValue={mainField ?? id}>
-      {mainField ?? id}
+    <ComboboxOption value={id} textValue={stringifiedDisplayValue}>
+      {stringifiedDisplayValue}
     </ComboboxOption>
   );
 };
@@ -57,6 +58,6 @@ Option.defaultProps = {
 
 Option.propTypes = {
   id: PropTypes.number.isRequired,
-  mainField: PropTypes.string,
+  mainField: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   publicationState: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
 };

--- a/packages/core/admin/admin/src/content-manager/components/RelationInput/components/tests/Option.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInput/components/tests/Option.test.js
@@ -44,4 +44,14 @@ describe('Content-Manager || RelationInput || Option', () => {
     expect(getByText('relation 1')).toBeInTheDocument();
     expect(getByTitle('State: Draft')).toBeInTheDocument();
   });
+
+  it('should render custom Option with mainField prop as number type', async () => {
+    const { user, getByRole } = setup({
+      options: [{ id: 1, mainField: 1, publicationState: 'published' }],
+    });
+
+    await user.click(getByRole('combobox'));
+
+    expect(getByRole('option', { publicationState: 'State: Published' })).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Stringify `mainField ?? id` before using because `ComboboxOption` is expecting `string` in `textValue` prop.

### Why is it needed?

Users were unable to add content for tables who have relations with tables containing only numbers or relations

### How to test it?

Create a table Table 1 with only `Number` or `Relations` fields.
Add some content in Table 1.
Create an other table Table 2 and add relation of `Table 1` in it.
Now add content in Table 2. Notice when you select `Table 1` dropdown it will give error.

### Related issue(s)/PR(s)

* resolves #17260
* closes #17315
