### PR TITLE
Add cellformatter back to support plugins

### DIFF
--- a/packages/core/admin/admin/src/content-manager/pages/ListView/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/ListView/index.js
@@ -575,7 +575,7 @@ function ListView({
                         {/* Bulk action row checkbox */}
                         <Body.CheckboxDataCell rowId={rowData.id} index={index} />
                         {/* Field data */}
-                        {tableHeaders.map(({ key, name, ...rest }) => {
+                        {tableHeaders.map(({ key, name, cellFormatter, ...rest }) => {
                           if (hasDraftAndPublish && name === 'publishedAt') {
                             return (
                               <Td key={key}>
@@ -621,6 +621,10 @@ function ListView({
                                 )}
                               </Td>
                             );
+                          }
+
+                          if (typeof cellFormatter === 'function') {
+                            cellFormatter(rowData, { key, name, ...rest });
                           }
 
                           return (


### PR DESCRIPTION
### What does it do?

Adds the cellFormatter back since we removed in favor of composition.

### Why is it needed?

Even if internally in the content-manager we are moving away from this API we still need to support the cellFormatter since plugins like i18n use it: 

https://github.com/strapi/strapi/blob/489927e8e161dd5c3d48f0c97ab4efade802c3e3/packages/plugins/i18n/admin/src/index.js#L52

### How to test it?

Go to any content-type in the content manager that has i18n enabled. You should have the following column.

![Screenshot 2023-07-18 at 09 53 37](https://github.com/strapi/strapi/assets/26598053/942f114b-f44d-4098-bacf-00d3e067d6e2)

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/pull/17047
https://forum.strapi.io/t/why-has-the-cellformatter-been-removed-from-the-content-manager-list-view/30271/2

