### PR TITLE
Add cellFormatter support

### DIFF
--- a/packages/core/admin/admin/src/content-manager/pages/ListView/components/TableRows/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/ListView/components/TableRows/index.js
@@ -193,6 +193,10 @@ export const TableRows = ({
                 );
               }
 
+              if (typeof cellFormatter === 'function') {
+                cellFormatter(data, { key, name, ...rest });
+              }
+
               return (
                 <Td key={key}>
                   <CellContent

--- a/packages/core/admin/admin/src/content-manager/pages/ListView/components/TableRows/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/ListView/components/TableRows/index.js
@@ -194,7 +194,7 @@ export const TableRows = ({
               }
 
               if (typeof cellFormatter === 'function') {
-                cellFormatter(data, { key, name, ...rest });
+                return <Td key={key}>{cellFormatter(data, { key, name, ...rest })}</Td>;
               }
 
               return (


### PR DESCRIPTION
### What does it do?

Adds the cellFormatter back since we removed in favor of composition.

### Why is it needed?

Even if internally in the content-manager we are moving away from this API we still need to support the cellFormatter since plugins like i18n use it: 

https://github.com/strapi/strapi/blob/489927e8e161dd5c3d48f0c97ab4efade802c3e3/packages/plugins/i18n/admin/src/index.js#L52

### How to test it?

Go to any content-type in the content manager that has i18n enabled. You should have the following column.

![Screenshot 2023-07-18 at 11 10 45](https://github.com/strapi/strapi/assets/26598053/be99f15b-dd78-4403-ad12-5454c234dff5)

