### PR TITLE
Chore: Give precedence to error.message over error.details

### DIFF
--- a/packages/core/helper-plugin/src/hooks/useAPIErrorHandler/utils/formatAPIError/index.js
+++ b/packages/core/helper-plugin/src/hooks/useAPIErrorHandler/utils/formatAPIError/index.js
@@ -16,6 +16,10 @@ export function formatAPIError(error, { formatMessage, intlMessagePrefixCallback
 
   const normalizedError = normalizeAPIError(error, intlMessagePrefixCallback);
 
+  if (normalizedError.message) {
+    return normalizedError.message;
+  }
+
   // stringify multiple errors
   if (normalizedError?.errors) {
     return normalizedError.errors

--- a/packages/core/helper-plugin/src/hooks/useAPIErrorHandler/utils/formatAPIError/tests/index.test.js
+++ b/packages/core/helper-plugin/src/hooks/useAPIErrorHandler/utils/formatAPIError/tests/index.test.js
@@ -62,4 +62,25 @@ describe('formatAPIError', () => {
   test('error if formatMessage was not passed', () => {
     expect(() => formatAPIError(API_VALIDATION_ERROR_FIXTURE)).toThrow();
   });
+
+  test('give precedence to error.message over error.details', () => {
+    expect(
+      formatAPIError(
+        {
+          ...API_VALIDATION_ERROR_FIXTURE,
+          response: {
+            ...API_VALIDATION_ERROR_FIXTURE.response,
+            data: {
+              ...API_VALIDATION_ERROR_FIXTURE.response.data,
+              error: {
+                ...API_VALIDATION_ERROR_FIXTURE.response.data.error,
+                message: 'Main error message',
+              },
+            },
+          },
+        },
+        { formatMessage, getTrad: (translation) => translation }
+      )
+    ).toBe('Main error message');
+  });
 });

--- a/packages/core/helper-plugin/src/hooks/useAPIErrorHandler/utils/normalizeAPIError/index.js
+++ b/packages/core/helper-plugin/src/hooks/useAPIErrorHandler/utils/normalizeAPIError/index.js
@@ -20,6 +20,7 @@ export function normalizeAPIError(apiError, intlMessagePrefixCallback) {
   if (error?.details?.errors) {
     return {
       name: error.name,
+      message: error?.message || null,
       errors: error.details.errors.map((err) =>
         normalizeError(err, { name: error.name, intlMessagePrefixCallback })
       ),

--- a/packages/core/helper-plugin/src/hooks/useAPIErrorHandler/utils/normalizeAPIError/tests/index.test.js
+++ b/packages/core/helper-plugin/src/hooks/useAPIErrorHandler/utils/normalizeAPIError/tests/index.test.js
@@ -38,6 +38,7 @@ describe('normalizeAPIError', () => {
   test('Handle ValidationError', () => {
     expect(normalizeAPIError(API_VALIDATION_ERROR_FIXTURE)).toStrictEqual({
       name: 'ValidationError',
+      message: null,
       errors: [
         {
           defaultMessage: 'Field contains errors',
@@ -65,6 +66,7 @@ describe('normalizeAPIError', () => {
 
     expect(normalizeAPIError(API_VALIDATION_ERROR_FIXTURE, prefixFunction)).toStrictEqual({
       name: 'ValidationError',
+      message: null,
       errors: [
         {
           name: 'ValidationError',


### PR DESCRIPTION
### What does it do?

Gives precedence to `error.message` over concatenating `error.details`.

### Why is it needed?

Concatenating error message from the `details` object should be a last resort. This became a problem for multiple review-workflows, because at least two stages can have a is-duplicated error message, which would then print the message several times.

This response:

```
{
  data: {
    error: {
      name: "ValidationError",
      message: "Main error message",
      details: {
        errors: [
          { /**/ }
        ]
      }
    }
  }
}
```

should give precedence to `Main error message`, since it can be provided the admin API and is much better than concatenating.

### How to test it?

Automated tests

### Related issue(s)/PR(s)

- https://github.com/strapi/strapi/pull/17332
