### PR TITLE
Chore: Add formatFormikError method to useAPIErrorHandler()

### DIFF
--- a/packages/core/helper-plugin/src/hooks/useAPIErrorHandler/useAPIErrorHandler.js
+++ b/packages/core/helper-plugin/src/hooks/useAPIErrorHandler/useAPIErrorHandler.js
@@ -3,6 +3,7 @@ import { useIntl } from 'react-intl';
 
 import { formatAPIError } from './utils/formatAPIError';
 import { formatAxiosError } from './utils/formatAxiosError';
+import { formatFormikError } from './utils/formatFormikError';
 
 /**
  * Hook that exports an error message formatting function.
@@ -28,6 +29,10 @@ export function useAPIErrorHandler(intlMessagePrefixCallback) {
 
         throw new Error('formatAPIError: Unknown error:', error);
       }
+    },
+
+    formatFormikError(error) {
+      return formatFormikError(error, { intlMessagePrefixCallback, formatMessage });
     },
   };
 }

--- a/packages/core/helper-plugin/src/hooks/useAPIErrorHandler/utils/formatFormikError/index.js
+++ b/packages/core/helper-plugin/src/hooks/useAPIErrorHandler/utils/formatFormikError/index.js
@@ -1,0 +1,35 @@
+import set from 'lodash/set';
+
+import { normalizeAPIError } from '../normalizeAPIError';
+
+/**
+ * Method to stringify an API error object to be a formik intialErrors object
+ *
+ * @export
+ * @param {object} API Reponse error object
+ * @param {{ formatMessage: Function, intlMessagePrefixCallback: Function }} - Object containing a formatMessage (from react-intl) callback and an intlMessagePrefixCallback (usually getTrad()
+ * @return {string} null | FormikError
+ */
+
+export function formatFormikError(error, { formatMessage, intlMessagePrefixCallback }) {
+  if (!formatMessage) {
+    throw new Error('The formatMessage callback is a mandatory argument.');
+  }
+
+  const normalizedError = normalizeAPIError(error, intlMessagePrefixCallback);
+
+  // stringify multiple errors
+  if (normalizedError?.errors) {
+    const errors = normalizedError.errors.reduce((acc, { id, defaultMessage, values }) => {
+      if (values?.path) {
+        set(acc, values.path, formatMessage({ id, defaultMessage }, values));
+      }
+
+      return acc;
+    }, {});
+
+    return Object.keys(errors).length > 0 ? errors : null;
+  }
+
+  return null;
+}

--- a/packages/core/helper-plugin/src/hooks/useAPIErrorHandler/utils/formatFormikError/tests/index.test.js
+++ b/packages/core/helper-plugin/src/hooks/useAPIErrorHandler/utils/formatFormikError/tests/index.test.js
@@ -1,0 +1,107 @@
+import { formatFormikError } from '..';
+
+const API_VALIDATION_ERROR_FIXTURE = {
+  response: {
+    data: {
+      error: {
+        name: 'ValidationError',
+        message: 'Main error',
+        details: {
+          errors: [
+            {
+              path: ['field', '0', 'name'],
+              message: 'Field contains errors',
+            },
+
+            {
+              path: ['field_other'],
+              message: 'Field must be unique',
+            },
+          ],
+        },
+      },
+    },
+  },
+};
+
+const formatMessage = jest.fn((t) => t.defaultMessage);
+
+describe('formatFormikError', () => {
+  test('Transforms an error response into an FormikError object', () => {
+    expect(
+      formatFormikError(API_VALIDATION_ERROR_FIXTURE, {
+        formatMessage,
+        getTrad: (translation) => translation,
+      })
+    ).toStrictEqual({
+      field: [
+        {
+          name: 'Field contains errors',
+        },
+      ],
+
+      field_other: 'Field must be unique',
+    });
+  });
+
+  test('In no details object was passed, return null', () => {
+    expect(
+      formatFormikError(
+        {
+          ...API_VALIDATION_ERROR_FIXTURE,
+          response: {
+            ...API_VALIDATION_ERROR_FIXTURE,
+            data: {
+              ...API_VALIDATION_ERROR_FIXTURE.response.data,
+              error: {
+                ...API_VALIDATION_ERROR_FIXTURE.response.data.error,
+                details: undefined,
+              },
+            },
+          },
+        },
+        {
+          formatMessage,
+          getTrad: (translation) => translation,
+        }
+      )
+    ).toStrictEqual(null);
+  });
+
+  test('Fields without a path are not included', () => {
+    expect(
+      formatFormikError(
+        {
+          ...API_VALIDATION_ERROR_FIXTURE,
+          response: {
+            ...API_VALIDATION_ERROR_FIXTURE,
+            data: {
+              ...API_VALIDATION_ERROR_FIXTURE.response.data,
+              error: {
+                ...API_VALIDATION_ERROR_FIXTURE.response.data.error,
+                details: {
+                  errors: [
+                    {
+                      path: ['field', '0', 'name'],
+                      message: 'Field contains errors',
+                    },
+
+                    {
+                      message: 'Field must be unique',
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        },
+        {
+          formatMessage,
+          getTrad: (translation) => translation,
+        }
+      )
+    ).toStrictEqual({
+      field: [{ name: 'Field contains errors' }],
+    });
+  });
+});


### PR DESCRIPTION
### What does it do?

> **Note**
> This is just an idea for now.

Adds a new helper `formatFormikError` to the `useAPIErrorHandler` hook.

### Why is it needed?

This helper would allow us to get a valid formik `initialErrors` object from the API response returned. That would simplify error handling in a couple of places, where we are building up the object manually at the moment.

Usage:

```
const [initialErrors, setInitialErrors] = React.useState(null);
const { formatFormikError, formatAPIErrror } = useAPIErrorHander();

const handleSubmit = () => {
  try {
    mutateAsync()
  } catch(error) {
    toggleNotification({
      type: 'warning',
      message: formatAPIError(error)
    });

    setInitialErrors(formatFormikError(error));
  }
};

const formik = useFormik({
  initialErrors
});
```

Example for review-workflows: https://github.com/strapi/strapi/blob/299105d26de2450e23296bf3ae7a8f3bf19ca6e1/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/CreateView/CreateView.js#L67

### How to test it?

Automated tests.

### Related issue(s)/PR(s)

- https://github.com/strapi/strapi/pull/17354
- https://github.com/strapi/strapi/pull/17332
- https://github.com/strapi/strapi/blob/299105d26de2450e23296bf3ae7a8f3bf19ca6e1/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/CreateView/CreateView.js#L67
