### PR TITLE
Fix: Remove content-type groups from workflow attrs conditionally

### DIFF
--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/WorkflowAttributes/WorkflowAttributes.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/WorkflowAttributes/WorkflowAttributes.js
@@ -63,29 +63,37 @@ export function WorkflowAttributes({ canUpdate, contentTypes: { collectionTypes,
             contentTypesHelper.setValue(values);
           }}
           options={[
-            {
-              label: formatMessage({
-                id: 'Settings.review-workflows.workflow.contentTypes.collectionTypes.label',
-                defaultMessage: 'Collection Types',
-              }),
-              children: collectionTypes
-                .sort((a, b) => formatter.compare(a.info.displayName, b.info.displayName))
-                .map((contentType) => ({
-                  label: contentType.info.displayName,
-                  value: contentType.uid,
-                })),
-            },
+            ...(collectionTypes.length > 0
+              ? [
+                  {
+                    label: formatMessage({
+                      id: 'Settings.review-workflows.workflow.contentTypes.collectionTypes.label',
+                      defaultMessage: 'Collection Types',
+                    }),
+                    children: collectionTypes
+                      .sort((a, b) => formatter.compare(a.info.displayName, b.info.displayName))
+                      .map((contentType) => ({
+                        label: contentType.info.displayName,
+                        value: contentType.uid,
+                      })),
+                  },
+                ]
+              : []),
 
-            {
-              label: formatMessage({
-                id: 'Settings.review-workflows.workflow.contentTypes.singleTypes.label',
-                defaultMessage: 'Single Types',
-              }),
-              children: singleTypes.map((contentType) => ({
-                label: contentType.info.displayName,
-                value: contentType.uid,
-              })),
-            },
+            ...(singleTypes.length > 0
+              ? [
+                  {
+                    label: formatMessage({
+                      id: 'Settings.review-workflows.workflow.contentTypes.singleTypes.label',
+                      defaultMessage: 'Single Types',
+                    }),
+                    children: singleTypes.map((contentType) => ({
+                      label: contentType.info.displayName,
+                      value: contentType.uid,
+                    })),
+                  },
+                ]
+              : []),
           ]}
           placeholder={formatMessage({
             id: 'Settings.review-workflows.workflow.contentTypes.placeholder',

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/WorkflowAttributes/tests/WorkflowAttributes.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/WorkflowAttributes/tests/WorkflowAttributes.test.js
@@ -93,4 +93,65 @@ describe('Admin | Settings | Review Workflow | WorkflowAttributes', () => {
       expect(getByRole('combobox', { name: /associated to/i })).toHaveAttribute('data-disabled');
     });
   });
+
+  it('should not render a collection-type group if there are not collection-types', async () => {
+    const { getByRole, queryByRole, user } = setup({
+      contentTypes: {
+        collectionTypes: [],
+
+        singleTypes: [
+          {
+            uid: 'uid2',
+            info: {
+              displayName: 'Content Type 2',
+            },
+          },
+        ],
+      },
+    });
+
+    const contentTypesSelect = getByRole('combobox', { name: /associated to/i });
+
+    await user.click(contentTypesSelect);
+
+    await waitFor(() => {
+      expect(getByRole('option', { name: /Single Types/i })).toBeInTheDocument();
+      expect(queryByRole('option', { name: /Collection Types/i })).not.toBeInTheDocument();
+    });
+  });
+
+  it('should not render a collection-type group if there are not single-types', async () => {
+    const { getByRole, queryByRole, user } = setup({
+      contentTypes: {
+        collectionTypes: [
+          {
+            uid: 'uid2',
+            info: {
+              displayName: 'Content Type 2',
+            },
+          },
+        ],
+
+        singleTypes: [],
+      },
+    });
+
+    const contentTypesSelect = getByRole('combobox', { name: /associated to/i });
+
+    await user.click(contentTypesSelect);
+
+    await waitFor(() => {
+      expect(queryByRole('option', { name: /Single Types/i })).not.toBeInTheDocument();
+      expect(getByRole('option', { name: /Collection Types/i })).toBeInTheDocument();
+    });
+  });
+
+  it('should disabled fields if canUpdate = false', async () => {
+    const { getByRole } = setup({ canUpdate: false });
+
+    await waitFor(() => {
+      expect(getByRole('textbox')).toHaveAttribute('disabled');
+      expect(getByRole('combobox', { name: /associated to/i })).toHaveAttribute('data-disabled');
+    });
+  });
 });


### PR DESCRIPTION
### What does it do?

Removes either `Single Types` or `Collection Types` from the workflow attributes, when one of the groups does not contain items.

### Why is it needed?

1. The group renders as `selected` if it doesn't contain items, which is debatable.
2. It leads to a weird looking UI state, when the user starts with a fresh project, because it does not have a any single-types. It is not possible to run Strapi without neither of them, so that case does not need covering.

### How to test it?

Automated tests.

