### PR TITLE
NPS survey frontend logic

### DIFF
--- a/packages/core/admin/admin/src/components/AuthenticatedApp/index.js
+++ b/packages/core/admin/admin/src/components/AuthenticatedApp/index.js
@@ -14,6 +14,7 @@ import { useQueries } from 'react-query';
 import packageJSON from '../../../../package.json';
 import { useConfigurations } from '../../hooks';
 import { getFullName, hashAdminUserEmail } from '../../utils';
+import NpsSurvey from '../NpsSurvey';
 import PluginsInitializer from '../PluginsInitializer';
 import RBACProvider from '../RBACProvider';
 
@@ -109,6 +110,7 @@ const AuthenticatedApp = () => {
       userDisplayName={userDisplayName}
     >
       <RBACProvider permissions={permissions} refetchPermissions={refetch}>
+        <NpsSurvey />
         <PluginsInitializer />
       </RBACProvider>
     </AppInfoProvider>

--- a/packages/core/admin/admin/src/components/AuthenticatedApp/index.js
+++ b/packages/core/admin/admin/src/components/AuthenticatedApp/index.js
@@ -110,8 +110,10 @@ const AuthenticatedApp = () => {
       userDisplayName={userDisplayName}
     >
       <RBACProvider permissions={permissions} refetchPermissions={refetch}>
-        <NpsSurvey />
-        <PluginsInitializer />
+        <>
+          <NpsSurvey />
+          <PluginsInitializer />
+        </>
       </RBACProvider>
     </AppInfoProvider>
   );

--- a/packages/core/admin/admin/src/components/NpsSurvey/index.js
+++ b/packages/core/admin/admin/src/components/NpsSurvey/index.js
@@ -2,21 +2,117 @@ import * as React from 'react';
 
 import { Flex, Button, Typography } from '@strapi/design-system';
 
+const storageKeys = {
+  lastResponseDate: 'NPS_SURVEY_LAST_RESPONSE_DATE',
+  firstDismissalDate: 'NPS_SURVEY_FIRST_DISMISSAL_DATE',
+  lastDismissalDate: 'NPS_SURVEY_LAST_DISMISSAL_DATE',
+};
+
+const delays = {
+  postResponse: 90 * 24 * 60 * 60 * 1000, // 90 days in ms
+  postFirstDismissal: 7 * 24 * 60 * 60 * 1000, // 7 days in ms
+  postSubsequentDismissal: 90 * 24 * 60 * 60 * 1000, // 90 days in ms
+};
+
+const getLocalStorageDate = (key) => {
+  const value = window.localStorage.getItem(key);
+
+  if (!value) {
+    return null;
+  }
+
+  return new Date(parseInt(value, 10));
+};
+
+const setLocalStorageDate = (key, date) => {
+  if (date == null) {
+    window.localStorage.removeItem(key);
+
+    return;
+  }
+
+  window.localStorage.setItem(key, date.getTime().toString());
+};
+
+const checkIfShouldShowSurvey = ({ lastResponseDate, firstDismissalDate, lastDismissalDate }) => {
+  console.log({ lastResponseDate, firstDismissalDate, lastDismissalDate });
+
+  if (lastResponseDate) {
+    // If the user has already responded to the survey
+    const timeSinceLastResponse = Date.now() - lastResponseDate.getTime();
+
+    if (timeSinceLastResponse >= delays.postResponse) {
+      return true;
+    }
+
+    return false;
+  }
+
+  if (lastDismissalDate) {
+    // If the user has dismissed the survey twice or more before
+    const timeSinceLastDismissal = Date.now() - lastDismissalDate.getTime();
+
+    if (timeSinceLastDismissal >= delays.postSubsequentDismissal) {
+      return true;
+    }
+
+    return false;
+  }
+
+  if (firstDismissalDate) {
+    // If the user has dismissed the survey before
+    const timeSinceFirstDismissal = Date.now() - firstDismissalDate.getTime();
+
+    if (timeSinceFirstDismissal >= delays.postFirstDismissal) {
+      return true;
+    }
+
+    return false;
+  }
+
+  // If the user has not interacted with the survey before
+  return true;
+};
+
 const NpsSurvey = () => {
-  const [surveyIsShown, setSurveyIsShown] = React.useState(true);
+  const lastResponseDate = getLocalStorageDate(storageKeys.lastResponseDate);
+  const firstDismissalDate = getLocalStorageDate(storageKeys.firstDismissalDate);
+  const lastDismissalDate = getLocalStorageDate(storageKeys.lastDismissalDate);
+
+  const [surveyIsShown, setSurveyIsShown] = React.useState(
+    checkIfShouldShowSurvey({
+      lastResponseDate,
+      firstDismissalDate,
+      lastDismissalDate,
+    })
+  );
 
   if (!surveyIsShown) {
     return null;
   }
 
   const handleSubmitResponse = () => {
+    setLocalStorageDate(storageKeys.lastResponseDate, new Date());
+    setLocalStorageDate(storageKeys.firstDismissalDate, null);
+    setLocalStorageDate(storageKeys.lastDismissalDate, null);
+    // TODO: send response to the backend
     setSurveyIsShown(false);
   };
 
   const handleDismiss = () => {
+    if (firstDismissalDate) {
+      // If the user dismisses the survey for the second time
+      setLocalStorageDate(storageKeys.lastDismissalDate, new Date());
+    } else {
+      // If the user dismisses the survey for the first time
+      setLocalStorageDate(storageKeys.firstDismissalDate, new Date());
+    }
+
+    setLocalStorageDate(storageKeys.lastResponseDate, null);
     setSurveyIsShown(false);
   };
 
+  // TODO: replace with the proper UI
   return (
     <Flex gap={2} padding={2}>
       <Typography>NPS SURVEY</Typography>

--- a/packages/core/admin/admin/src/components/NpsSurvey/index.js
+++ b/packages/core/admin/admin/src/components/NpsSurvey/index.js
@@ -2,7 +2,8 @@ import * as React from 'react';
 
 import { Flex, Button, Typography } from '@strapi/design-system';
 
-const storageKeys = {
+export const npsStorageKeys = {
+  enabled: 'NPS_SURVEY_ENABLED',
   lastResponseDate: 'NPS_SURVEY_LAST_RESPONSE_DATE',
   firstDismissalDate: 'NPS_SURVEY_FIRST_DISMISSAL_DATE',
   lastDismissalDate: 'NPS_SURVEY_LAST_DISMISSAL_DATE',
@@ -35,7 +36,9 @@ const setLocalStorageDate = (key, date) => {
 };
 
 const checkIfShouldShowSurvey = ({ lastResponseDate, firstDismissalDate, lastDismissalDate }) => {
-  console.log({ lastResponseDate, firstDismissalDate, lastDismissalDate });
+  if (window.localStorage.getItem(npsStorageKeys.enabled) !== 'true') {
+    return false;
+  }
 
   if (lastResponseDate) {
     // If the user has already responded to the survey
@@ -75,10 +78,12 @@ const checkIfShouldShowSurvey = ({ lastResponseDate, firstDismissalDate, lastDis
 };
 
 const NpsSurvey = () => {
-  const lastResponseDate = getLocalStorageDate(storageKeys.lastResponseDate);
-  const firstDismissalDate = getLocalStorageDate(storageKeys.firstDismissalDate);
-  const lastDismissalDate = getLocalStorageDate(storageKeys.lastDismissalDate);
+  // Get timestamps from local storage
+  const lastResponseDate = getLocalStorageDate(npsStorageKeys.lastResponseDate);
+  const firstDismissalDate = getLocalStorageDate(npsStorageKeys.firstDismissalDate);
+  const lastDismissalDate = getLocalStorageDate(npsStorageKeys.lastDismissalDate);
 
+  // Only check on first render if the survey should be shown
   const [surveyIsShown, setSurveyIsShown] = React.useState(
     checkIfShouldShowSurvey({
       lastResponseDate,
@@ -92,9 +97,9 @@ const NpsSurvey = () => {
   }
 
   const handleSubmitResponse = () => {
-    setLocalStorageDate(storageKeys.lastResponseDate, new Date());
-    setLocalStorageDate(storageKeys.firstDismissalDate, null);
-    setLocalStorageDate(storageKeys.lastDismissalDate, null);
+    setLocalStorageDate(npsStorageKeys.lastResponseDate, new Date());
+    setLocalStorageDate(npsStorageKeys.firstDismissalDate, null);
+    setLocalStorageDate(npsStorageKeys.lastDismissalDate, null);
     // TODO: send response to the backend
     setSurveyIsShown(false);
   };
@@ -102,13 +107,13 @@ const NpsSurvey = () => {
   const handleDismiss = () => {
     if (firstDismissalDate) {
       // If the user dismisses the survey for the second time
-      setLocalStorageDate(storageKeys.lastDismissalDate, new Date());
+      setLocalStorageDate(npsStorageKeys.lastDismissalDate, new Date());
     } else {
       // If the user dismisses the survey for the first time
-      setLocalStorageDate(storageKeys.firstDismissalDate, new Date());
+      setLocalStorageDate(npsStorageKeys.firstDismissalDate, new Date());
     }
 
-    setLocalStorageDate(storageKeys.lastResponseDate, null);
+    setLocalStorageDate(npsStorageKeys.lastResponseDate, null);
     setSurveyIsShown(false);
   };
 

--- a/packages/core/admin/admin/src/components/NpsSurvey/index.js
+++ b/packages/core/admin/admin/src/components/NpsSurvey/index.js
@@ -66,12 +66,15 @@ const checkIfShouldShowSurvey = (settings) => {
 // Exported to make it available during admin user registration.
 // Because we only enable the NPS for users who subscribe to the newsletter when signing up
 export function useNpsSurveySettings() {
-  const [npsSurveySettings, setNpsSurveySettings] = usePersistentState('NPS_SURVEY_SETTINGS', {
-    enabled: true,
-    lastResponseDate: null,
-    firstDismissalDate: null,
-    lastDismissalDate: null,
-  });
+  const [npsSurveySettings, setNpsSurveySettings] = usePersistentState(
+    'strapi_NPS_SURVEY_SETTINGS',
+    {
+      enabled: true,
+      lastResponseDate: null,
+      firstDismissalDate: null,
+      lastDismissalDate: null,
+    }
+  );
 
   return { npsSurveySettings, setNpsSurveySettings };
 }

--- a/packages/core/admin/admin/src/components/NpsSurvey/index.js
+++ b/packages/core/admin/admin/src/components/NpsSurvey/index.js
@@ -1,0 +1,29 @@
+import * as React from 'react';
+
+import { Flex, Button, Typography } from '@strapi/design-system';
+
+const NpsSurvey = () => {
+  const [surveyIsShown, setSurveyIsShown] = React.useState(true);
+
+  if (!surveyIsShown) {
+    return null;
+  }
+
+  const handleSubmitResponse = () => {
+    setSurveyIsShown(false);
+  };
+
+  const handleDismiss = () => {
+    setSurveyIsShown(false);
+  };
+
+  return (
+    <Flex gap={2} padding={2}>
+      <Typography>NPS SURVEY</Typography>
+      <Button onClick={handleDismiss}>Dismiss</Button>
+      <Button onClick={handleSubmitResponse}>Submit</Button>
+    </Flex>
+  );
+};
+
+export default NpsSurvey;

--- a/packages/core/admin/admin/src/components/NpsSurvey/index.js
+++ b/packages/core/admin/admin/src/components/NpsSurvey/index.js
@@ -67,7 +67,7 @@ const checkIfShouldShowSurvey = (settings) => {
 // Because we only enable the NPS for users who subscribe to the newsletter when signing up
 export function useNpsSurveySettings() {
   const [npsSurveySettings, setNpsSurveySettings] = usePersistentState(
-    'strapi_NPS_SURVEY_SETTINGS',
+    'STRAPI_NPS_SURVEY_SETTINGS',
     {
       enabled: true,
       lastResponseDate: null,

--- a/packages/core/admin/admin/src/components/NpsSurvey/tests/index.test.js
+++ b/packages/core/admin/admin/src/components/NpsSurvey/tests/index.test.js
@@ -17,11 +17,11 @@ const originalLocalStorage = global.localStorage;
 const user = userEvent.setup();
 
 const setup = () =>
-  render(
-    <ThemeProvider theme={lightTheme}>
-      <NpsSurvey />
-    </ThemeProvider>
-  );
+  render(<NpsSurvey />, {
+    wrapper({ children }) {
+      return <ThemeProvider theme={lightTheme}>{children}</ThemeProvider>;
+    },
+  });
 
 describe('NPS survey', () => {
   beforeAll(() => {

--- a/packages/core/admin/admin/src/components/NpsSurvey/tests/index.test.js
+++ b/packages/core/admin/admin/src/components/NpsSurvey/tests/index.test.js
@@ -1,0 +1,195 @@
+import React from 'react';
+
+import { lightTheme, ThemeProvider } from '@strapi/design-system';
+import { render, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import NpsSurvey from '..';
+
+const localStorageMock = {
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  removeItem: jest.fn(),
+  clear: jest.fn(),
+};
+const originalLocalStorage = global.localStorage;
+
+const user = userEvent.setup();
+
+const setup = () =>
+  render(
+    <ThemeProvider theme={lightTheme}>
+      <NpsSurvey />
+    </ThemeProvider>
+  );
+
+describe('NPS survey', () => {
+  beforeAll(() => {
+    global.localStorage = localStorageMock;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders survey if enabled', () => {
+    localStorageMock.getItem.mockReturnValueOnce({ enabled: true });
+    setup();
+    expect(screen.getByText(/nps survey/i)).toBeInTheDocument();
+  });
+
+  it('does not render survey if disabled', () => {
+    localStorageMock.getItem.mockReturnValueOnce({ enabled: false });
+    setup();
+    expect(screen.queryByText(/nps survey/i)).not.toBeInTheDocument();
+  });
+
+  it('saves user response', async () => {
+    localStorageMock.getItem.mockReturnValueOnce({ enabled: true });
+    setup();
+
+    await user.click(screen.getByRole('button', { name: /submit/i }));
+    expect(screen.queryByText(/nps survey/i)).not.toBeInTheDocument();
+
+    const storedData = JSON.parse(localStorageMock.setItem.mock.calls.at(-1).at(1));
+    expect(storedData).toEqual({
+      enabled: true,
+      lastResponseDate: expect.any(String),
+      firstDismissalDate: null,
+      lastDismissalDate: null,
+    });
+    expect(new Date(storedData.lastResponseDate)).toBeInstanceOf(Date);
+  });
+
+  it('saves first user dismissal', async () => {
+    localStorageMock.getItem.mockReturnValueOnce({ enabled: true });
+    setup();
+
+    await user.click(screen.getByRole('button', { name: /dismiss/i }));
+    expect(screen.queryByText(/nps survey/i)).not.toBeInTheDocument();
+
+    const storedData = JSON.parse(localStorageMock.setItem.mock.calls.at(-1).at(1));
+    expect(storedData).toEqual({
+      enabled: true,
+      lastResponseDate: null,
+      firstDismissalDate: expect.any(String),
+    });
+    expect(new Date(storedData.firstDismissalDate)).toBeInstanceOf(Date);
+  });
+
+  it('saves subsequent user dismissal', async () => {
+    const firstDismissalDate = '2000-07-20T09:28:51.963Z';
+    localStorageMock.getItem.mockReturnValueOnce({
+      enabled: true,
+      firstDismissalDate,
+    });
+    setup();
+
+    await user.click(screen.getByRole('button', { name: /dismiss/i }));
+    expect(screen.queryByText(/nps survey/i)).not.toBeInTheDocument();
+
+    const storedData = JSON.parse(localStorageMock.setItem.mock.calls.at(-1).at(1));
+    expect(storedData).toEqual({
+      enabled: true,
+      lastResponseDate: null,
+      firstDismissalDate,
+      lastDismissalDate: expect.any(String),
+    });
+    expect(new Date(storedData.lastDismissalDate)).toBeInstanceOf(Date);
+  });
+
+  it('respects the delay after user submission', async () => {
+    const initialDate = new Date('2020-01-01');
+    const withinDelay = new Date('2020-01-31');
+    const beyondDelay = new Date('2020-03-31');
+
+    localStorageMock.getItem.mockReturnValue({ enabled: true, lastResponseDate: initialDate });
+
+    jest.useFakeTimers();
+    jest.setSystemTime(initialDate);
+
+    // Survey should not show up right after submission
+    setup();
+    expect(screen.queryByText(/nps survey/i)).not.toBeInTheDocument();
+
+    // Survey should not show up during delay
+    jest.advanceTimersByTime(withinDelay - initialDate);
+    setup();
+    expect(screen.queryByText(/nps survey/i)).not.toBeInTheDocument();
+
+    // Survey should show up again after delay
+    jest.advanceTimersByTime(beyondDelay - withinDelay);
+    setup();
+    expect(screen.getByText(/nps survey/i)).toBeInTheDocument();
+
+    jest.useRealTimers();
+  });
+
+  it('respects the delay after first user dismissal', async () => {
+    const initialDate = new Date('2020-01-01');
+    const withinDelay = new Date('2020-01-04');
+    const beyondDelay = new Date('2020-01-08');
+
+    localStorageMock.getItem.mockReturnValue({
+      enabled: true,
+      firstDismissalDate: initialDate,
+      lastDismissalDate: null,
+      lastResponseDate: null,
+    });
+
+    jest.useFakeTimers();
+    jest.setSystemTime(initialDate);
+
+    // Survey should not show up right after dismissal
+    setup();
+    expect(screen.queryByText(/nps survey/i)).not.toBeInTheDocument();
+
+    // Survey should not show up during delay
+    jest.advanceTimersByTime(withinDelay - initialDate);
+    setup();
+    expect(screen.queryByText(/nps survey/i)).not.toBeInTheDocument();
+
+    // Survey should show up again after delay
+    jest.advanceTimersByTime(beyondDelay - withinDelay);
+    setup();
+    expect(screen.getByText(/nps survey/i)).toBeInTheDocument();
+
+    jest.useRealTimers();
+  });
+
+  it('respects the delay after subsequent user dismissal', async () => {
+    const initialDate = new Date('2020-01-01');
+    const withinDelay = new Date('2020-03-30');
+    const beyondDelay = new Date('2020-04-01');
+
+    localStorageMock.getItem.mockReturnValue({
+      enabled: true,
+      firstDismissalDate: initialDate,
+      lastDismissalDate: initialDate,
+      lastResponseDate: null,
+    });
+
+    jest.useFakeTimers();
+    jest.setSystemTime(initialDate);
+
+    // Survey should not show up right after dismissal
+    setup();
+    expect(screen.queryByText(/nps survey/i)).not.toBeInTheDocument();
+
+    // Survey should not show up during delay
+    jest.advanceTimersByTime(withinDelay - initialDate);
+    setup();
+    expect(screen.queryByText(/nps survey/i)).not.toBeInTheDocument();
+
+    // Survey should show up again after delay
+    jest.advanceTimersByTime(beyondDelay - withinDelay);
+    setup();
+    expect(screen.getByText(/nps survey/i)).toBeInTheDocument();
+
+    jest.useRealTimers();
+  });
+
+  afterAll(() => {
+    global.localStorage = originalLocalStorage;
+  });
+});

--- a/packages/core/admin/admin/src/components/NpsSurvey/tests/index.test.js
+++ b/packages/core/admin/admin/src/components/NpsSurvey/tests/index.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { lightTheme, ThemeProvider } from '@strapi/design-system';
-import { render, screen, act } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import NpsSurvey from '..';

--- a/packages/core/admin/admin/src/pages/AuthPage/components/Register/index.js
+++ b/packages/core/admin/admin/src/pages/AuthPage/components/Register/index.js
@@ -29,6 +29,7 @@ import { useIntl } from 'react-intl';
 import { useHistory } from 'react-router-dom';
 import styled from 'styled-components';
 
+import { npsStorageKeys } from '../../../../components/NpsSurvey';
 import Logo from '../../../../components/UnauthenticatedLogo';
 import UnauthenticatedLayout, { LayoutContent } from '../../../../layouts/UnauthenticatedLayout';
 import FieldActionWrapper from '../FieldActionWrapper';
@@ -139,6 +140,9 @@ const Register = ({ authType, fieldsToDisable, noSignin, onSubmit, schema }) => 
               } else {
                 onSubmit(normalizedData, formik);
               }
+
+              // Only enable EE survey if user accepted the newsletter
+              window.localStorage.setItem(npsStorageKeys.enabled, data.news);
             } catch (err) {
               const errors = getYupInnerErrors(err);
               setSubmitCount(submitCount + 1);

--- a/packages/core/admin/admin/src/pages/AuthPage/components/Register/index.js
+++ b/packages/core/admin/admin/src/pages/AuthPage/components/Register/index.js
@@ -29,7 +29,7 @@ import { useIntl } from 'react-intl';
 import { useHistory } from 'react-router-dom';
 import styled from 'styled-components';
 
-import { npsStorageKeys } from '../../../../components/NpsSurvey';
+import { useNpsSurveySettings } from '../../../../components/NpsSurvey';
 import Logo from '../../../../components/UnauthenticatedLogo';
 import UnauthenticatedLayout, { LayoutContent } from '../../../../layouts/UnauthenticatedLayout';
 import FieldActionWrapper from '../FieldActionWrapper';
@@ -56,6 +56,7 @@ const Register = ({ authType, fieldsToDisable, noSignin, onSubmit, schema }) => 
   const query = useQuery();
   const { formatAPIError } = useAPIErrorHandler();
   const { get } = useFetchClient();
+  const { setNpsSurveySettings } = useNpsSurveySettings();
 
   const registrationToken = query.get('registrationToken');
 
@@ -142,7 +143,7 @@ const Register = ({ authType, fieldsToDisable, noSignin, onSubmit, schema }) => 
               }
 
               // Only enable EE survey if user accepted the newsletter
-              window.localStorage.setItem(npsStorageKeys.enabled, data.news);
+              setNpsSurveySettings({ enabled: data.news });
             } catch (err) {
               const errors = getYupInnerErrors(err);
               setSubmitCount(submitCount + 1);


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

This PR manages the logic to determine when the NPS survey should be shown. The acceptance rules are:

- Only enable the feature is the admin user subscribed to the newsletter when signing up
- If a user responds to the survey, we should not show it again before 90 days
- If a user does not respond to the survey for the first time, we should show it again 7 days later
- If a user does not respond to the survey for the second time, we should not show it again before 90 days

Still left to do, hence the draft PR:

- [x] write the test suite
- [ ] handle users who had already signed up and therefore haven't set the `NPS_SURVEY_ENABLED` in localStorage

edit by @markkaylor I believe the outstanding task is done ^

I would appreciate feedback on 2 aspects in particular that I'm not sure of:

- Where to load this component. Since it's app-wide and only for authenticated users, I currently have it in `AuthenticatedApp`.
- Whether the logic to decide when to show the survey should be outside the component. Currently it's inside.

### Why is it needed?

To kickstart the in-app NPS project, which is about getting more insights from users.

### How to test it?

Easiest way is to replace the delays object with something like this:

```js
const delays = {
  postResponse: 30_000,
  postFirstDismissal: 10_000,
  postSubsequentDismissal: 20_000,
};
```

So that you can click on "dismiss" or "dismiss", and count the delays to make sure the rules mentioned above are respected.

You can also try signing up with a new user and making sure the surveys only show up if you've checked the "keep me updated" checkbox.

