### PR TITLE
Fix: Fixes various review-workflow UI bugs

### DIFF
--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/Stages/Stage/Stage.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/Stages/Stage/Stage.js
@@ -196,6 +196,8 @@ export function Stage({
           }}
           expanded={isOpen}
           shadow="tableShadow"
+          error={nameMeta.error ?? colorMeta?.error ?? false}
+          hasErrorMessage={false}
         >
           <AccordionToggle
             title={nameField.value}

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/CreateView/CreateView.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/CreateView/CreateView.js
@@ -19,7 +19,7 @@ import { useContentTypes } from '../../../../../../../../admin/src/hooks/useCont
 import { useInjectReducer } from '../../../../../../../../admin/src/hooks/useInjectReducer';
 import { selectAdminPermissions } from '../../../../../../../../admin/src/pages/App/selectors';
 import { useLicenseLimits } from '../../../../../../hooks';
-import { resetWorkflow } from '../../actions';
+import { addStage, resetWorkflow } from '../../actions';
 import * as Layout from '../../components/Layout';
 import * as LimitsModal from '../../components/LimitsModal';
 import { Stages } from '../../components/Stages';
@@ -153,6 +153,13 @@ export function ReviewWorkflowsCreateView() {
 
   React.useEffect(() => {
     dispatch(resetWorkflow());
+
+    // Create an empty default stage
+    dispatch(
+      addStage({
+        name: '',
+      })
+    );
   }, [dispatch]);
 
   /**

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/EditView/EditView.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/EditView/EditView.js
@@ -20,7 +20,7 @@ import { useContentTypes } from '../../../../../../../../admin/src/hooks/useCont
 import { useInjectReducer } from '../../../../../../../../admin/src/hooks/useInjectReducer';
 import { selectAdminPermissions } from '../../../../../../../../admin/src/pages/App/selectors';
 import { useLicenseLimits } from '../../../../../../hooks';
-import { setWorkflow } from '../../actions';
+import { resetWorkflow, setWorkflow } from '../../actions';
 import * as Layout from '../../components/Layout';
 import * as LimitsModal from '../../components/LimitsModal';
 import { Stages } from '../../components/Stages';
@@ -180,6 +180,12 @@ export function ReviewWorkflowsEditView() {
 
   React.useEffect(() => {
     dispatch(setWorkflow({ status: workflowStatus, data: workflow }));
+
+    // reset the state to the initial state to avoid flashes if a user
+    // navigates from an edit-view to a create-view
+    return () => {
+      dispatch(resetWorkflow());
+    };
   }, [workflowStatus, workflow, dispatch]);
 
   /**

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/EditView/EditView.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/EditView/EditView.js
@@ -245,24 +245,29 @@ export function ReviewWorkflowsEditView() {
                 })}
               </Button>
             }
-            subtitle={formatMessage(
-              {
-                id: 'Settings.review-workflows.page.subtitle',
-                defaultMessage: '{count, plural, one {# stage} other {# stages}}',
-              },
-              { count: currentWorkflow?.stages?.length ?? 0 }
-            )}
+            subtitle={
+              currentWorkflow.stages.length > 0 &&
+              formatMessage(
+                {
+                  id: 'Settings.review-workflows.page.subtitle',
+                  defaultMessage: '{count, plural, one {# stage} other {# stages}}',
+                },
+                { count: currentWorkflow.stages.length }
+              )
+            }
             title={currentWorkflow.name}
           />
 
           <Layout.Root>
             {isLoadingModels || status === 'loading' ? (
-              <Loader>
-                {formatMessage({
-                  id: 'Settings.review-workflows.page.isLoading',
-                  defaultMessage: 'Workflow is loading',
-                })}
-              </Loader>
+              <Flex justifyContent="center">
+                <Loader>
+                  {formatMessage({
+                    id: 'Settings.review-workflows.page.isLoading',
+                    defaultMessage: 'Workflow is loading',
+                  })}
+                </Loader>
+              </Flex>
             ) : (
               <Flex alignItems="stretch" direction="column" gap={7}>
                 <WorkflowAttributes

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/ListView/ListView.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/ListView/ListView.js
@@ -187,7 +187,7 @@ export function ReviewWorkflowsListView() {
 
               if (
                 limits?.[CHARGEBEE_WORKFLOW_ENTITLEMENT_NAME] &&
-                meta?.workflowCount >= parseInt(limits[CHARGEBEE_WORKFLOW_ENTITLEMENT_NAME], 10)
+                meta?.workflowCount > parseInt(limits[CHARGEBEE_WORKFLOW_ENTITLEMENT_NAME], 10)
               ) {
                 event.preventDefault();
                 setShowLimitModal(true);
@@ -215,12 +215,14 @@ export function ReviewWorkflowsListView() {
 
       <Layout.Root>
         {isLoading || isLoadingModels ? (
-          <Loader>
-            {formatMessage({
-              id: 'Settings.review-workflows.page.list.isLoading',
-              defaultMessage: 'Workflows are loading',
-            })}
-          </Loader>
+          <Flex justifyContent="center">
+            <Loader>
+              {formatMessage({
+                id: 'Settings.review-workflows.page.list.isLoading',
+                defaultMessage: 'Workflows are loading',
+              })}
+            </Loader>
+          </Flex>
         ) : (
           <Table
             colCount={3}

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/index.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/index.js
@@ -22,13 +22,7 @@ export const initialState = {
       data: {
         name: '',
         contentTypes: [],
-        stages: [
-          {
-            color: STAGE_COLOR_DEFAULT,
-            name: '',
-            __temp_key__: 1,
-          },
-        ],
+        stages: [],
       },
       isDirty: false,
       hasDeletedServerStages: false,

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/tests/index.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/tests/index.test.js
@@ -554,7 +554,7 @@ describe('Admin | Settings | Review Workflows | reducer', () => {
           currentWorkflow: expect.objectContaining({
             data: expect.objectContaining({
               name: '',
-              stages: [expect.objectContaining({ name: '', __temp_key__: 1 })],
+              stages: [],
             }),
             isDirty: true,
           }),


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Fixes various UI bugs for review workflows that came up during QA:

- center the loader
- only display number of stages once they have been loaded
- render accordion in an error state if a subfield contains an error
- prevent an previously visited workflow from the edit view to show once the create view mounts

### Why is it needed?

QA!

