### PR TITLE
fix: Assigning multiple content types in a workflow

### DIFF
--- a/packages/core/admin/ee/server/services/review-workflows/workflows/__tests__/content-types.test.js
+++ b/packages/core/admin/ee/server/services/review-workflows/workflows/__tests__/content-types.test.js
@@ -9,6 +9,7 @@ const stagesServiceMock = {
 
 const workflowsServiceMock = {
   getAssignedWorkflow: jest.fn(),
+  _getAssignedWorkflows: jest.fn(),
 };
 
 const reviewWorkflowsValidationMock = {
@@ -67,7 +68,7 @@ describe('Review Workflows', () => {
       test('should update the configuration of newly added content types', async () => {
         const prevOptions = { testOptions: true };
 
-        workflowsServiceMock.getAssignedWorkflow.mockResolvedValueOnce(null);
+        workflowsServiceMock._getAssignedWorkflows.mockResolvedValueOnce([]);
         CTMPContentTypesServiceMock.findConfiguration.mockResolvedValueOnce({
           options: prevOptions,
         });

--- a/packages/core/admin/ee/server/services/review-workflows/workflows/index.js
+++ b/packages/core/admin/ee/server/services/review-workflows/workflows/index.js
@@ -163,11 +163,23 @@ module.exports = ({ strapi }) => {
      * @returns {Promise<object|null>} - Assigned workflow object if found, or null.
      */
     async getAssignedWorkflow(uid, opts = {}) {
-      const workflows = await this.find({
+      const workflows = await this._getAssignedWorkflows(uid, opts);
+      return workflows.length > 0 ? workflows[0] : null;
+    },
+
+    /**
+     * Finds all the assigned workflows for a given content type ID.
+     * Normally, there should only be one workflow assigned to a content type.
+     * However, edge cases can occur where a content type is assigned to multiple workflows.
+     * @param {string} uid - Content type ID to find the assigned workflows for.
+     * @param {object} opts - Options for the query.
+     * @returns {Promise<object[]>} - List of assigned workflow objects.
+     */
+    async _getAssignedWorkflows(uid, opts = {}) {
+      return this.find({
         ...opts,
         filters: { contentTypes: getWorkflowContentTypeFilter({ strapi }, uid) },
       });
-      return workflows.length > 0 ? workflows[0] : null;
     },
 
     /**


### PR DESCRIPTION
### What does it do?

When you tried to assign multiple content types in a workflow, and those CT were previously assigned to another workflow, those Content Types were not removed  from the original workflow.

This resulted in users seeing the content types assigned in two different workflows.

This was a concurrency issue that was  handled by removing the concurrency of some operations. Ideally, I would like to introduce more json operators in the database queries so we can make this operations async again. 

As this operations are quite quick , this shouldn't impact performance that much, nevertheless I will do some perf checks.


