### PR TITLE
chore: mark jsonSuperSetOf as experimental and for internal use

### DIFF
--- a/packages/core/database/lib/query/helpers/where.js
+++ b/packages/core/database/lib/query/helpers/where.js
@@ -276,6 +276,7 @@ const applyOperator = (qb, column, operator, value) => {
       break;
     }
 
+    // Experimental, only for internal use
     // Only on MySQL, PostgreSQL and CockroachDB.
     // https://knexjs.org/guide/query-builder.html#wherejsonsupersetof
     case '$jsonSupersetOf': {

--- a/packages/core/utils/src/operators.ts
+++ b/packages/core/utils/src/operators.ts
@@ -22,6 +22,7 @@ const WHERE_OPERATORS = [
   '$notContains',
   '$containsi',
   '$notContainsi',
+  // Experimental, only for internal use
   '$jsonSupersetOf',
 ];
 


### PR DESCRIPTION
### What does it do?
Marks json superset of operator as experimental.

Note: this operator has not been yet released (comes from review workflow multiple workflows).

