### PR TITLE
[SSO] allow defaultRole to be nullable when autoRegister is false

### DIFF
--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/SingleSignOn/index.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/SingleSignOn/index.js
@@ -62,7 +62,7 @@ export const SingleSignOn = () => {
 
   const showLoader = isLoadingForPermissions || isLoading;
 
-  // TODO: select first error field, but it looks like that requires refactoring from useSettingsForm to Formik
+  // TODO: focus() first error field, but it looks like that requires refactoring from useSettingsForm to Formik
 
   const isHeaderButtonDisabled = isEqual(initialData, modifiedData);
 

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/SingleSignOn/index.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/SingleSignOn/index.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 
 import {
   Button,
@@ -62,13 +62,7 @@ export const SingleSignOn = () => {
 
   const showLoader = isLoadingForPermissions || isLoading;
 
-  useEffect(() => {
-    if (formErrors.defaultRole) {
-      const selector = `[name="defaultRole"]`;
-
-      document.querySelector(selector).focus();
-    }
-  }, [formErrors]);
+  // TODO: select first error field, but it looks like that requires refactoring from useSettingsForm to Formik
 
   const isHeaderButtonDisabled = isEqual(initialData, modifiedData);
 

--- a/packages/core/admin/ee/server/validation/authentication.js
+++ b/packages/core/admin/ee/server/validation/authentication.js
@@ -6,8 +6,13 @@ const providerOptionsUpdateSchema = yup.object().shape({
   autoRegister: yup.boolean().required(),
   defaultRole: yup
     .strapiID()
-    .required()
+    .when('autoRegister', (value, initSchema) => {
+      return value ? initSchema.required() : initSchema.nullable();
+    })
     .test('is-valid-role', 'You must submit a valid default role', (roleId) => {
+      if (roleId === null) {
+        return true;
+      }
       return strapi.admin.services.role.exists({ id: roleId });
     }),
   ssoLockedRoles: yup


### PR DESCRIPTION
### What does it do?

On the Single-Sign On settings page in the admin, allows defaultRole to be nullable when autoRegister is false

### Why is it needed?

Currently if a user who does not use auto-register and hasn't selected a default role chooses SSO Locked Roles and clicks 'save' a generic error message appears because the back-end is expecting to receive a valid role ID for the default role (previously this couldn't happen because the form was unsaveable until we added sso locked roles)

This change allows the field to be nullable, but only when autoRegister is false.

### How to test it?

On the SSO settings page, with a fresh database (or where defaultRole starts as null):

- do not touch auto register, it should be on false
- do not touch default role, it should be blank
- set an sso locked role
- click save
- the form should save correctly

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/pull/17341
