### PR TITLE
Fix: Remove delete button from the list-view instead of disabling it

### DIFF
--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/ListView/ListView.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/ListView/ListView.js
@@ -342,21 +342,22 @@ export function ReviewWorkflowsListView() {
                         <Pencil />
                       </ActionLink>
 
-                      <IconButton
-                        aria-label={formatMessage(
-                          {
-                            id: 'Settings.review-workflows.list.page.list.column.actions.delete.label',
-                            defaultMessage: 'Delete {name}',
-                          },
-                          { name: 'Default workflow' }
-                        )}
-                        disabled={workflows.length === 1 || !canDelete}
-                        icon={<Trash />}
-                        noBorder
-                        onClick={() => {
-                          handleDeleteWorkflow(workflow.id);
-                        }}
-                      />
+                      {workflows.length > 1 && canDelete && (
+                        <IconButton
+                          aria-label={formatMessage(
+                            {
+                              id: 'Settings.review-workflows.list.page.list.column.actions.delete.label',
+                              defaultMessage: 'Delete {name}',
+                            },
+                            { name: 'Default workflow' }
+                          )}
+                          icon={<Trash />}
+                          noBorder
+                          onClick={() => {
+                            handleDeleteWorkflow(workflow.id);
+                          }}
+                        />
+                      )}
                     </Flex>
                   </Td>
                 </Tr>


### PR DESCRIPTION
### What does it do?

Removes the delete button from the list-view if: 1) the user does not have permission 2) it is the last workflow.

### Why is it needed?

This solves several issues:

- the disabled button doesn't receive any events and therefore clicking on the disabled button would take you to the edit-view (which is a problem of the `onRowClick` click helper)
- the disabled button looks more prominent than it should

### How to test it?

Delete all but the last workflow or take away delete permissions from role.
