### PR TITLE
Enhancement: Show confirmation modal if a workflow would 'steal' a content-type

### DIFF
--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/constants.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/constants.js
@@ -36,3 +36,6 @@ export const DRAG_DROP_TYPES = {
 export const CHARGEBEE_WORKFLOW_ENTITLEMENT_NAME = 'review-workflows-number-of-workflows';
 export const CHARGEBEE_STAGES_PER_WORKFLOW_ENTITLEMENT_NAME =
   'review-workflows--stages-per-workflow';
+
+export const PROMPT_CONTENT_TYPE_REASSIGNMENT = 'reassign-content-type';
+export const PROMPT_HAS_DELETED_SERVER_STAGE = 'has-deleted-server-stage';

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/index.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/index.js
@@ -73,7 +73,7 @@ export function reducer(state = initialState, action) {
 
         if (!currentWorkflow.hasDeletedServerStages) {
           draft.clientState.currentWorkflow.hasDeletedServerStages = !!(
-            state.serverState.currentWorkflow?.stages ?? []
+            state.serverState.workflow?.stages ?? []
           ).find((stage) => stage.id === stageId);
         }
 

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/tests/index.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/tests/index.test.js
@@ -104,7 +104,7 @@ describe('Admin | Settings | Review Workflows | reducer', () => {
     state = {
       status: expect.any(String),
       serverState: {
-        currentWorkflow: WORKFLOW_FIXTURE,
+        workflow: WORKFLOW_FIXTURE,
       },
       clientState: {
         currentWorkflow: {
@@ -172,7 +172,7 @@ describe('Admin | Settings | Review Workflows | reducer', () => {
     state = {
       status: expect.any(String),
       serverState: {
-        currentWorkflow: WORKFLOW_FIXTURE,
+        workflow: WORKFLOW_FIXTURE,
       },
       clientState: {
         currentWorkflow: {

--- a/packages/core/helper-plugin/src/components/ConfirmDialog/index.js
+++ b/packages/core/helper-plugin/src/components/ConfirmDialog/index.js
@@ -35,10 +35,12 @@ const ConfirmDialog = ({
         <Flex direction="column" alignItems="stretch" gap={2}>
           <Flex justifyContent="center">
             <Typography variant="omega" id="confirm-description">
-              {formatMessage({
-                id: bodyText.id,
-                defaultMessage: bodyText.defaultMessage,
-              })}
+              {typeof bodyText === 'string'
+                ? bodyText
+                : formatMessage({
+                    id: bodyText.id,
+                    defaultMessage: bodyText.defaultMessage,
+                  })}
             </Typography>
           </Flex>
         </Flex>


### PR DESCRIPTION
### What does it do?

It refactors the way prompts are displayed on the review-workflows edit and create (TODO) pages: Now two different prompts can be shown to a user on a save attempt.

- a stage that is up for deletion on the server
- a content-type has already been assigned to another workflow

These prompts appear after each other in case both are triggered.

For this @Marc-Roig and I have agreed to load the full list of workflows for now until we have a good way the get all content-types from all other workflows on the single-workflow endpoint.

This PR ensures it is ready for 4.12 until we find a better solution.

#### TODO

- [ ] final copy
- [ ] implement on create page
- [x] update reducer tests

### Why is it needed?

This will make sure users understand the impact of selecting a specific content-type for a workflow.

### How to test it?

tbd

