### PR TITLE
strapi::public middleware bug fix

### DIFF
--- a/packages/core/strapi/lib/middlewares/public/index.js
+++ b/packages/core/strapi/lib/middlewares/public/index.js
@@ -25,7 +25,7 @@ module.exports = (config, { strapi }) => {
     filePath = `./public/${index}`;
   }
 
-  if (!defaultIndex && fs.existsSync('./public/index.html')) {
+  if (filePath === 'index.html' && fs.existsSync('./public/index.html')) {
     filePath = './public/index.html';
   }
   filePath = filePath === 'index.html' ? path.join(__dirname, filePath) : filePath;

--- a/packages/core/strapi/lib/middlewares/public/index.js
+++ b/packages/core/strapi/lib/middlewares/public/index.js
@@ -18,77 +18,84 @@ const defaults = {
  * @type {import('../').MiddlewareFactory}
  */
 module.exports = (config, { strapi }) => {
-  const { defaultIndex, maxAge } = defaultsDeep(defaults, config);
+  const { defaultIndex, index, maxAge } = defaultsDeep(defaults, config);
 
-  if (defaultIndex === true) {
-    const index = fs.readFileSync(path.join(__dirname, 'index.html'), 'utf8');
-
-    const serveIndexPage = async (ctx, next) => {
-      // defer rendering of strapi index page
-      await next();
-
-      if (ctx.body != null || ctx.status !== 404) return;
-
-      ctx.url = 'index.html';
-      const isInitialized = await utils.isInitialized(strapi);
-      const data = {
-        serverTime: new Date().toUTCString(),
-        isInitialized,
-        ..._.pick(strapi, [
-          'config.info.version',
-          'config.info.name',
-          'config.admin.url',
-          'config.server.url',
-          'config.environment',
-          'config.serveAdminPanel',
-        ]),
-      };
-      const content = _.template(index)(data);
-      const body = stream.Readable({
-        read() {
-          this.push(Buffer.from(content));
-          this.push(null);
-        },
-      });
-      // Serve static.
-      ctx.type = 'html';
-      ctx.body = body;
-    };
-
-    strapi.server.routes([
-      {
-        method: 'GET',
-        path: '/',
-        handler: serveIndexPage,
-        config: { auth: false },
-      },
-      {
-        method: 'GET',
-        path: '/index.html',
-        handler: serveIndexPage,
-        config: { auth: false },
-      },
-      {
-        method: 'GET',
-        path: '/assets/images/(.*)',
-        handler: serveStatic(path.resolve(__dirname, 'assets/images'), {
-          maxage: maxAge,
-          defer: true,
-        }),
-        config: { auth: false },
-      },
-      // All other public GET-routes except /uploads/(.*) which is handled in upload middleware
-      {
-        method: 'GET',
-        path: '/((?!uploads/).+)',
-        handler: koaStatic(strapi.dirs.static.public, {
-          maxage: maxAge,
-          defer: true,
-        }),
-        config: { auth: false },
-      },
-    ]);
+  let filePath = 'index.html';
+  if (!defaultIndex && index && index !== 'index.html') {
+    filePath = `./public/${index}`;
   }
+
+  if (!defaultIndex && fs.existsSync('./public/index.html')) {
+    filePath = './public/index.html';
+  }
+  filePath = filePath === 'index.html' ? path.join(__dirname, filePath) : filePath;
+  const indexFile = fs.readFileSync(filePath, 'utf8');
+
+  const serveIndexPage = async (ctx, next) => {
+    // defer rendering of strapi index page
+    await next();
+
+    if (ctx.body != null || ctx.status !== 404) return;
+
+    ctx.url = index ? '/' : ctx.url;
+    const isInitialized = await utils.isInitialized(strapi);
+    const data = {
+      serverTime: new Date().toUTCString(),
+      isInitialized,
+      ..._.pick(strapi, [
+        'config.info.version',
+        'config.info.name',
+        'config.admin.url',
+        'config.server.url',
+        'config.environment',
+        'config.serveAdminPanel',
+      ]),
+    };
+    const content = _.template(indexFile)(data);
+    const body = stream.Readable({
+      read() {
+        this.push(Buffer.from(content));
+        this.push(null);
+      },
+    });
+    // Serve static.
+    ctx.type = 'html';
+    ctx.body = body;
+  };
+
+  strapi.server.routes([
+    {
+      method: 'GET',
+      path: '/',
+      handler: serveIndexPage,
+      config: { auth: false },
+    },
+    {
+      method: 'GET',
+      path: '/index.html',
+      handler: serveIndexPage,
+      config: { auth: false },
+    },
+    {
+      method: 'GET',
+      path: '/assets/images/(.*)',
+      handler: serveStatic(path.resolve(__dirname, 'assets/images'), {
+        maxage: maxAge,
+        defer: true,
+      }),
+      config: { auth: false },
+    },
+    // All other public GET-routes except /uploads/(.*) which is handled in upload middleware
+    {
+      method: 'GET',
+      path: '/((?!uploads/).+)',
+      handler: koaStatic(strapi.dirs.static.public, {
+        maxage: maxAge,
+        defer: true,
+      }),
+      config: { auth: false },
+    },
+  ]);
 
   return null;
 };


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

This PR fixes the issue of `strapi::public` middleware as reported by this issue #17382 

### Why is it needed?

To allow access to files within public folder of a project. Currently if doesn't allow to access, and seems to be broken functionality. 

### How to test it?

Followings are the different cases which I have covered, please do let me know if anything missing:
1. `defaultIndex = true` => Which is the default value, It will serve index.html page from admin core folder.
2. `defaultIndex = false` => It will serve index.html from admin core folder, in addition if index.html file is presence in project's public folder then it will serve that file. (Allow users to overwrite default index.html file)
3. `defaultIndex = false` & `index = 'test.html'` => It will server test.html file from the project's public folder.
4. In addition to all above if someone wants to access any other files from the public folder then they simply append the filename to the url like `http://localhost:1337/any.html`.

### Related issue(s)/PR(s)

This fixes #17382 

PS: If you accept this PR then I will be more than happy to update tests & documentation if needed.
