### PR TITLE
[bulk publish] Deselect the entries that were published from the list view

### DIFF
--- a/packages/core/admin/admin/src/content-manager/pages/ListView/components/BulkActionButtons/SelectedEntriesModal/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/ListView/components/BulkActionButtons/SelectedEntriesModal/index.js
@@ -221,7 +221,12 @@ const BoldChunk = (chunks) => <Typography fontWeight="bold">{chunks}</Typography
  * SelectedEntriesModalContent
  * -----------------------------------------------------------------------------------------------*/
 
-const SelectedEntriesModalContent = ({ toggleModal, refetchModalData, setEntriesToFetch }) => {
+const SelectedEntriesModalContent = ({
+  toggleModal,
+  refetchModalData,
+  setEntriesToFetch,
+  setSelectedListViewEntries,
+}) => {
   const { formatMessage } = useIntl();
   const { selectedEntries, rows, onSelectRow, isLoading, isFetching } = useTableContext();
   const [isDialogOpen, setIsDialogOpen] = React.useState(false);
@@ -257,8 +262,11 @@ const SelectedEntriesModalContent = ({ toggleModal, refetchModalData, setEntries
         });
 
         setRowsToDisplay(update);
+        const publishedIds = update.map(({ entity }) => entity.id);
         // Set the parent's entries to fetch when clicking refresh
-        setEntriesToFetch(update.map(({ entity }) => entity.id));
+        setEntriesToFetch(publishedIds);
+        // Deselect the entries that were published in the list view
+        setSelectedListViewEntries(publishedIds);
 
         if (update.length === 0) {
           toggleModal();
@@ -386,6 +394,7 @@ SelectedEntriesModalContent.propTypes = {
   toggleModal: PropTypes.func.isRequired,
   refetchModalData: PropTypes.func.isRequired,
   setEntriesToFetch: PropTypes.func.isRequired,
+  setSelectedListViewEntries: PropTypes.func.isRequired,
 };
 
 /* -------------------------------------------------------------------------------------------------
@@ -393,7 +402,10 @@ SelectedEntriesModalContent.propTypes = {
  * -----------------------------------------------------------------------------------------------*/
 
 const SelectedEntriesModal = ({ onToggle }) => {
-  const { selectedEntries: selectedListViewEntries } = useTableContext();
+  const {
+    selectedEntries: selectedListViewEntries,
+    setSelectedEntries: setSelectedListViewEntries,
+  } = useTableContext();
   const { contentType, components } = useSelector(listViewDomain());
   // The child table will update this value based on the entries that were published
   const [entriesToFetch, setEntriesToFetch] = React.useState(selectedListViewEntries);
@@ -453,6 +465,7 @@ const SelectedEntriesModal = ({ onToggle }) => {
       isFetching={isFetching}
     >
       <SelectedEntriesModalContent
+        setSelectedListViewEntries={setSelectedListViewEntries}
         setEntriesToFetch={setEntriesToFetch}
         toggleModal={onToggle}
         refetchModalData={refetch}


### PR DESCRIPTION
### What does it do?

- It deselects from the list view the entries that were successfully published

### Why is it needed?

- To improve the user experience. A user should only have entries that were not published selected when returning to this list view. 

### How to test it?

- Select a bunch of entries in the ListView
- In the modal deselect some and publish some
- The deselected entry should remain in the modal as deselected
- Return to the list view, the entries that were published should no longer be selected but the entries that were not publish should be selected
