### PR TITLE
Bulk Publish: fix Select All not working inside the Modal

### DIFF
--- a/packages/core/admin/admin/src/content-manager/pages/ListView/components/BulkActionButtons/SelectedEntriesModal/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/ListView/components/BulkActionButtons/SelectedEntriesModal/index.js
@@ -99,7 +99,7 @@ const EntryValidationText = ({ validationErrors, isPublished }) => {
 };
 
 EntryValidationText.defaultProps = {
-  validationErrors: null,
+  validationErrors: undefined,
   isPublished: false,
 };
 
@@ -178,7 +178,7 @@ const SelectedEntriesTableContent = ({
                 </Flex>
               ) : (
                 <EntryValidationText
-                  validationErrors={validationErrors && validationErrors[row.id]}
+                  validationErrors={validationErrors[row.id]}
                   isPublished={row.publishedAt !== null}
                 />
               )}
@@ -211,7 +211,7 @@ SelectedEntriesTableContent.defaultProps = {
   isPublishing: false,
   rowsToDisplay: [],
   entriesToPublish: [],
-  validationErrors: null,
+  validationErrors: {},
 };
 
 SelectedEntriesTableContent.propTypes = {
@@ -258,7 +258,7 @@ const SelectedEntriesModalContent = ({
   const { contentType } = useSelector(listViewDomain());
 
   const selectedEntriesWithErrorsCount = rowsToDisplay.filter(
-    ({ id }) => selectedEntries.includes(id) && validationErrors && validationErrors[id]
+    ({ id }) => selectedEntries.includes(id) && validationErrors[id]
   ).length;
   const selectedEntriesWithNoErrorsCount = selectedEntries.length - selectedEntriesWithErrorsCount;
 
@@ -408,7 +408,7 @@ const SelectedEntriesModalContent = ({
 };
 
 SelectedEntriesModalContent.defaultProps = {
-  validationErrors: null,
+  validationErrors: {},
 };
 
 SelectedEntriesModalContent.propTypes = {


### PR DESCRIPTION
### What does it do?

It fixes the problem we had inside the Confirm Publish All Modal when you try to select/deselect all the entries
Like you can see in this video
https://www.loom.com/share/47fb5ce7c2fd48988c6ece8ad939ac44 

### Why is it needed?

Because inside the SelectedEntriesModal component we have a different response, with a entity property wrapping every entries selected and it was not in line with the definition of the rows inside the Table handleSelectAll handler https://github.com/strapi/strapi/blob/2aee20a2172832c866e397b68364bfc5fad2c535/packages/core/helper-plugin/src/components/Table/index.js#L156

### How to test it?

Go to a Collection and select some entries in the content manager and click Publish, then inside the Modal try to select and deselect all the entries, the checkboxes need to work correctly now

### Related issue(s)/PR(s)

CX-130
