### PR TITLE
Enhancement: Show confirmation modal if a workflow would 'steal' a content-type

### DIFF
--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/WorkflowAttributes/WorkflowAttributes.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/WorkflowAttributes/WorkflowAttributes.js
@@ -1,15 +1,37 @@
 import * as React from 'react';
 
-import { Grid, GridItem, MultiSelectNested, TextInput } from '@strapi/design-system';
+import {
+  Grid,
+  GridItem,
+  MultiSelect,
+  MultiSelectGroup,
+  MultiSelectOption,
+  TextInput,
+  Typography,
+} from '@strapi/design-system';
 import { useCollator } from '@strapi/helper-plugin';
 import { useField } from 'formik';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 import { useDispatch } from 'react-redux';
+import styled from 'styled-components';
 
 import { updateWorkflow } from '../../actions';
 
-export function WorkflowAttributes({ canUpdate, contentTypes: { collectionTypes, singleTypes } }) {
+const NestedOption = styled(MultiSelectOption)`
+  padding-left: ${({ theme }) => theme.spaces[7]};
+`;
+
+const ContentTypeTakeNotice = styled(Typography)`
+  font-style: italic;
+`;
+
+export function WorkflowAttributes({
+  canUpdate,
+  contentTypes: { collectionTypes, singleTypes },
+  currentWorkflow,
+  workflows,
+}) {
   const { formatMessage, locale } = useIntl();
   const dispatch = useDispatch();
   const [nameField, nameMeta, nameHelper] = useField('name');
@@ -39,7 +61,7 @@ export function WorkflowAttributes({ canUpdate, contentTypes: { collectionTypes,
       </GridItem>
 
       <GridItem col={6}>
-        <MultiSelectNested
+        <MultiSelect
           {...contentTypesField}
           customizeContent={(value) =>
             formatMessage(
@@ -62,7 +84,12 @@ export function WorkflowAttributes({ canUpdate, contentTypes: { collectionTypes,
             dispatch(updateWorkflow({ contentTypes: values }));
             contentTypesHelper.setValue(values);
           }}
-          options={[
+          placeholder={formatMessage({
+            id: 'Settings.review-workflows.workflow.contentTypes.placeholder',
+            defaultMessage: 'Select',
+          })}
+        >
+          {[
             ...(collectionTypes.length > 0
               ? [
                   {
@@ -94,12 +121,53 @@ export function WorkflowAttributes({ canUpdate, contentTypes: { collectionTypes,
                   },
                 ]
               : []),
-          ]}
-          placeholder={formatMessage({
-            id: 'Settings.review-workflows.workflow.contentTypes.placeholder',
-            defaultMessage: 'Select',
+          ].map((opt) => {
+            if ('children' in opt) {
+              return (
+                <MultiSelectGroup
+                  key={opt.label}
+                  label={opt.label}
+                  values={opt.children.map((child) => child.value.toString())}
+                >
+                  {opt.children.map((child) => {
+                    const { name: assignedWorkflowName } =
+                      workflows.find(
+                        (workflow) =>
+                          ((currentWorkflow && workflow.id !== currentWorkflow.id) ||
+                            !currentWorkflow) &&
+                          workflow.contentTypes.includes(child.value)
+                      ) ?? {};
+
+                    return (
+                      <NestedOption key={child.value} value={child.value}>
+                        {formatMessage(
+                          {
+                            id: 'Settings.review-workflows.workflow.contentTypes.assigned.notice',
+                            defaultMessage:
+                              '{label} {name, select, undefined {} other {<i>(assigned to {name} workflow)</i>}}',
+                          },
+                          {
+                            label: child.label,
+                            name: assignedWorkflowName,
+                            i: (...children) => (
+                              <ContentTypeTakeNotice>{children}</ContentTypeTakeNotice>
+                            ),
+                          }
+                        )}
+                      </NestedOption>
+                    );
+                  })}
+                </MultiSelectGroup>
+              );
+            }
+
+            return (
+              <MultiSelectOption key={opt.value} value={opt.value}>
+                {opt.label}
+              </MultiSelectOption>
+            );
           })}
-        />
+        </MultiSelect>
       </GridItem>
     </Grid>
   );
@@ -114,6 +182,7 @@ const ContentTypeType = PropTypes.shape({
 
 WorkflowAttributes.defaultProps = {
   canUpdate: true,
+  currentWorkflow: undefined,
 };
 
 WorkflowAttributes.propTypes = {
@@ -122,4 +191,6 @@ WorkflowAttributes.propTypes = {
     collectionTypes: PropTypes.arrayOf(ContentTypeType).isRequired,
     singleTypes: PropTypes.arrayOf(ContentTypeType).isRequired,
   }).isRequired,
+  currentWorkflow: PropTypes.object,
+  workflows: PropTypes.array.isRequired,
 };

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/WorkflowAttributes/tests/WorkflowAttributes.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/WorkflowAttributes/tests/WorkflowAttributes.test.js
@@ -33,6 +33,26 @@ const CONTENT_TYPES_FIXTURE = {
   ],
 };
 
+const WORKFLOWS_FIXTURE = [
+  {
+    id: 1,
+    name: 'Default',
+    contentTypes: ['uid1'],
+    stages: [],
+  },
+
+  {
+    id: 2,
+    name: 'Workflow 1',
+    contentTypes: [],
+    stages: [],
+  },
+];
+
+const CURRENT_WORKFLOW_FIXTURE = {
+  ...WORKFLOWS_FIXTURE[0],
+};
+
 const ComponentFixture = (props) => {
   const store = configureStore([], [reducer]);
 
@@ -51,7 +71,12 @@ const ComponentFixture = (props) => {
         <FormikProvider value={formik}>
           <IntlProvider locale="en" messages={{}}>
             <ThemeProvider theme={lightTheme}>
-              <WorkflowAttributes contentTypes={CONTENT_TYPES_FIXTURE} {...props} />
+              <WorkflowAttributes
+                contentTypes={CONTENT_TYPES_FIXTURE}
+                currentWorkflow={CURRENT_WORKFLOW_FIXTURE}
+                workflows={WORKFLOWS_FIXTURE}
+                {...props}
+              />
             </ThemeProvider>
           </IntlProvider>
         </FormikProvider>
@@ -152,6 +177,46 @@ describe('Admin | Settings | Review Workflow | WorkflowAttributes', () => {
     await waitFor(() => {
       expect(getByRole('textbox')).toHaveAttribute('disabled');
       expect(getByRole('combobox', { name: /associated to/i })).toHaveAttribute('data-disabled');
+    });
+  });
+
+  it('should not render assigned content-types to the current workflow', async () => {
+    const { getByRole, queryByText, user } = setup();
+
+    const contentTypesSelect = getByRole('combobox', { name: /associated to/i });
+
+    await user.click(contentTypesSelect);
+
+    await waitFor(() => {
+      expect(queryByText(/\(assigned to default workflow\)/i)).not.toBeInTheDocument();
+    });
+  });
+
+  it('should render assigned content-types to the other workflows', async () => {
+    const { getByRole, getByText, user } = setup({
+      currentWorkflow: { ...WORKFLOWS_FIXTURE[1] },
+    });
+
+    const contentTypesSelect = getByRole('combobox', { name: /associated to/i });
+
+    await user.click(contentTypesSelect);
+
+    await waitFor(() => {
+      expect(getByText(/\(assigned to default workflow\)/i)).toBeInTheDocument();
+    });
+  });
+
+  it('should render assigned content-types to the other workflows, when currentWorkflow is not passed', async () => {
+    const { getByRole, getByText, user } = setup({
+      currentWorkflow: undefined,
+    });
+
+    const contentTypesSelect = getByRole('combobox', { name: /associated to/i });
+
+    await user.click(contentTypesSelect);
+
+    await waitFor(() => {
+      expect(getByText(/\(assigned to default workflow\)/i)).toBeInTheDocument();
     });
   });
 });

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/index.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/index.js
@@ -73,7 +73,7 @@ export function reducer(state = initialState, action) {
 
         if (!currentWorkflow.hasDeletedServerStages) {
           draft.clientState.currentWorkflow.hasDeletedServerStages = !!(
-            state.serverState.currentWorkflow?.stages ?? []
+            state.serverState.workflow?.stages ?? []
           ).find((stage) => stage.id === stageId);
         }
 

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/tests/index.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/tests/index.test.js
@@ -104,7 +104,7 @@ describe('Admin | Settings | Review Workflows | reducer', () => {
     state = {
       status: expect.any(String),
       serverState: {
-        currentWorkflow: WORKFLOW_FIXTURE,
+        workflow: WORKFLOW_FIXTURE,
       },
       clientState: {
         currentWorkflow: {
@@ -172,7 +172,7 @@ describe('Admin | Settings | Review Workflows | reducer', () => {
     state = {
       status: expect.any(String),
       serverState: {
-        currentWorkflow: WORKFLOW_FIXTURE,
+        workflow: WORKFLOW_FIXTURE,
       },
       clientState: {
         currentWorkflow: {

--- a/packages/core/helper-plugin/src/components/ConfirmDialog/index.js
+++ b/packages/core/helper-plugin/src/components/ConfirmDialog/index.js
@@ -1,18 +1,25 @@
 import React from 'react';
 
-import { Button, Dialog, DialogBody, DialogFooter, Flex, Typography } from '@strapi/design-system';
+import {
+  Button,
+  Box,
+  Dialog,
+  DialogBody,
+  DialogFooter,
+  Flex,
+  Typography,
+} from '@strapi/design-system';
 import { ExclamationMarkCircle, Trash } from '@strapi/icons';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 
-const ConfirmDialog = ({
-  bodyText,
+export const Root = ({
+  children,
   iconRightButton,
-  iconBody,
   isConfirmButtonLoading,
   leftButtonText,
-  onToggleDialog,
   onConfirm,
+  onToggleDialog,
   rightButtonText,
   title,
   variantRightButton,
@@ -31,43 +38,162 @@ const ConfirmDialog = ({
       describedBy="confirm-description"
       {...props}
     >
-      <DialogBody icon={iconBody}>
-        <Flex direction="column" alignItems="stretch" gap={2}>
-          <Flex justifyContent="center">
-            <Typography variant="omega" id="confirm-description">
-              {formatMessage({
-                id: bodyText.id,
-                defaultMessage: bodyText.defaultMessage,
-              })}
-            </Typography>
-          </Flex>
-        </Flex>
-      </DialogBody>
-      <DialogFooter
-        startAction={
-          <Button onClick={onToggleDialog} variant="tertiary">
-            {formatMessage({
-              id: leftButtonText.id,
-              defaultMessage: leftButtonText.defaultMessage,
-            })}
-          </Button>
-        }
-        endAction={
-          <Button
-            onClick={onConfirm}
-            variant={variantRightButton}
-            startIcon={iconRightButton}
-            id="confirm-delete"
-            loading={isConfirmButtonLoading}
-          >
-            {formatMessage({
-              id: rightButtonText.id,
-              defaultMessage: rightButtonText.defaultMessage,
-            })}
-          </Button>
-        }
+      <Box id="confirm-description">{children}</Box>
+
+      <Footer
+        iconRightButton={iconRightButton}
+        isConfirmButtonLoading={isConfirmButtonLoading}
+        leftButtonText={leftButtonText}
+        onConfirm={onConfirm}
+        onToggleDialog={onToggleDialog}
+        rightButtonText={rightButtonText}
+        variantRightButton={variantRightButton}
       />
     </Dialog>
+  );
+};
+
+Root.defaultProps = {
+  iconBody: <ExclamationMarkCircle />,
+  iconRightButton: <Trash />,
+  isConfirmButtonLoading: false,
+  leftButtonText: {
+    id: 'app.components.Button.cancel',
+    defaultMessage: 'Cancel',
+  },
+  rightButtonText: {
+    id: 'app.components.Button.confirm',
+    defaultMessage: 'Confirm',
+  },
+  title: {
+    id: 'app.components.ConfirmDialog.title',
+    defaultMessage: 'Confirmation',
+  },
+  variantRightButton: 'danger-light',
+};
+
+Root.propTypes = {
+  children: PropTypes.node.isRequired,
+  iconBody: PropTypes.node,
+  iconRightButton: PropTypes.node,
+  isConfirmButtonLoading: PropTypes.bool,
+  onConfirm: PropTypes.func.isRequired,
+  onToggleDialog: PropTypes.func.isRequired,
+  leftButtonText: PropTypes.shape({
+    id: PropTypes.string,
+    defaultMessage: PropTypes.string,
+  }),
+  rightButtonText: PropTypes.shape({
+    id: PropTypes.string,
+    defaultMessage: PropTypes.string,
+  }),
+  title: PropTypes.shape({
+    id: PropTypes.string,
+    defaultMessage: PropTypes.string,
+  }),
+  variantRightButton: PropTypes.string,
+};
+
+export const Body = ({ iconBody, children }) => {
+  return (
+    <DialogBody icon={iconBody}>
+      <Flex direction="column" alignItems="stretch" gap={2}>
+        <Flex justifyContent="center">{children}</Flex>
+      </Flex>
+    </DialogBody>
+  );
+};
+
+Body.defaultProps = {
+  iconBody: <ExclamationMarkCircle />,
+};
+
+Body.propTypes = {
+  children: PropTypes.node.isRequired,
+  iconBody: PropTypes.node,
+};
+
+const Footer = ({
+  iconRightButton,
+  isConfirmButtonLoading,
+  leftButtonText,
+  onConfirm,
+  onToggleDialog,
+  rightButtonText,
+  variantRightButton,
+}) => {
+  const { formatMessage } = useIntl();
+
+  return (
+    <DialogFooter
+      startAction={
+        <Button onClick={onToggleDialog} variant="tertiary">
+          {formatMessage({
+            id: leftButtonText.id,
+            defaultMessage: leftButtonText.defaultMessage,
+          })}
+        </Button>
+      }
+      endAction={
+        <Button
+          onClick={onConfirm}
+          variant={variantRightButton}
+          startIcon={iconRightButton}
+          id="confirm-delete"
+          loading={isConfirmButtonLoading}
+        >
+          {formatMessage({
+            id: rightButtonText.id,
+            defaultMessage: rightButtonText.defaultMessage,
+          })}
+        </Button>
+      }
+    />
+  );
+};
+
+Footer.propTypes = {
+  iconRightButton: PropTypes.node.isRequired,
+  isConfirmButtonLoading: PropTypes.bool.isRequired,
+  onConfirm: PropTypes.func.isRequired,
+  onToggleDialog: PropTypes.func.isRequired,
+  leftButtonText: PropTypes.shape({
+    id: PropTypes.string,
+    defaultMessage: PropTypes.string,
+  }).isRequired,
+  rightButtonText: PropTypes.shape({
+    id: PropTypes.string,
+    defaultMessage: PropTypes.string,
+  }).isRequired,
+  variantRightButton: PropTypes.string.isRequired,
+};
+
+const ConfirmDialog = ({
+  bodyText,
+  iconRightButton,
+  iconBody,
+  isConfirmButtonLoading,
+  leftButtonText,
+  onToggleDialog,
+  onConfirm,
+  rightButtonText,
+  title,
+  variantRightButton,
+  ...props
+}) => {
+  const { formatMessage } = useIntl();
+
+  return (
+    <Root onConfirm={onConfirm} onToggleDialog={onToggleDialog} title={title} {...props}>
+      <Body>
+        <Typography variant="omega">
+          {formatMessage({
+            id: bodyText.id,
+            defaultMessage: bodyText.defaultMessage,
+          })}
+        </Typography>
+      </Body>
+    </Root>
   );
 };
 
@@ -119,4 +245,7 @@ ConfirmDialog.propTypes = {
   variantRightButton: PropTypes.string,
 };
 
-export default ConfirmDialog;
+ConfirmDialog.Root = Root;
+ConfirmDialog.Body = Body;
+
+export { ConfirmDialog };

--- a/packages/core/helper-plugin/src/components/ConfirmDialog/tests/index.test.js
+++ b/packages/core/helper-plugin/src/components/ConfirmDialog/tests/index.test.js
@@ -4,7 +4,7 @@ import { lightTheme, ThemeProvider } from '@strapi/design-system';
 import { render, screen, waitFor } from '@testing-library/react';
 import { IntlProvider } from 'react-intl';
 
-import ConfirmDialog from '../index';
+import { ConfirmDialog } from '../index';
 
 const App = (
   <ThemeProvider theme={lightTheme}>

--- a/packages/core/helper-plugin/src/components/DynamicTable/index.js
+++ b/packages/core/helper-plugin/src/components/DynamicTable/index.js
@@ -7,7 +7,7 @@ import { useIntl } from 'react-intl';
 
 import { useTracking } from '../../features/Tracking';
 import useQueryParams from '../../hooks/useQueryParams';
-import ConfirmDialog from '../ConfirmDialog';
+import { ConfirmDialog } from '../ConfirmDialog';
 import EmptyBodyTable from '../EmptyBodyTable';
 
 import TableHead from './TableHead';

--- a/packages/core/helper-plugin/src/components/Table/index.js
+++ b/packages/core/helper-plugin/src/components/Table/index.js
@@ -23,7 +23,7 @@ import { useIntl } from 'react-intl';
 
 import useQueryParams from '../../hooks/useQueryParams';
 import SortIcon from '../../icons/SortIcon';
-import ConfirmDialog from '../ConfirmDialog';
+import { ConfirmDialog } from '../ConfirmDialog';
 import EmptyStateLayout from '../EmptyStateLayout';
 
 /* -------------------------------------------------------------------------------------------------

--- a/packages/core/helper-plugin/src/index.js
+++ b/packages/core/helper-plugin/src/index.js
@@ -7,7 +7,7 @@ import { getOtherInfos, getType } from './content-manager/utils/getAttributeInfo
 export { default as AnErrorOccurred } from './components/AnErrorOccurred';
 export { default as CheckPagePermissions } from './components/CheckPagePermissions';
 export { default as CheckPermissions } from './components/CheckPermissions';
-export { default as ConfirmDialog } from './components/ConfirmDialog';
+export * from './components/ConfirmDialog';
 export { default as ContentBox } from './components/ContentBox';
 export { default as DateTimePicker } from './components/DateTimePicker';
 export { default as DynamicTable } from './components/DynamicTable';

--- a/packages/core/upload/admin/src/components/EditAssetDialog/tests/__snapshots__/RemoveAssetDialog.test.js.snap
+++ b/packages/core/upload/admin/src/components/EditAssetDialog/tests/__snapshots__/RemoveAssetDialog.test.js.snap
@@ -398,40 +398,44 @@ exports[`RemoveAssetDialog snapshots the component 1`] = `
               class=""
             >
               <div
-                class="c12"
+                class=""
+                id="confirm-description"
               >
                 <div
-                  class="c13 c14"
+                  class="c12"
                 >
                   <div
-                    class="c8"
+                    class="c13 c14"
                   >
-                    <svg
-                      fill="none"
-                      height="1rem"
-                      viewBox="0 0 24 24"
-                      width="1rem"
-                      xmlns="http://www.w3.org/2000/svg"
+                    <div
+                      class="c8"
                     >
-                      <path
-                        d="M12 0C5.383 0 0 5.383 0 12s5.383 12 12 12 12-5.383 12-12S18.617 0 12 0Zm1.154 18.456h-2.308V16.15h2.308v2.307Zm-.23-3.687h-1.847l-.346-9.23h2.538l-.346 9.23Z"
-                        fill="#212134"
-                      />
-                    </svg>
+                      <svg
+                        fill="none"
+                        height="1rem"
+                        viewBox="0 0 24 24"
+                        width="1rem"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M12 0C5.383 0 0 5.383 0 12s5.383 12 12 12 12-5.383 12-12S18.617 0 12 0Zm1.154 18.456h-2.308V16.15h2.308v2.307Zm-.23-3.687h-1.847l-.346-9.23h2.538l-.346 9.23Z"
+                          fill="#212134"
+                        />
+                      </svg>
+                    </div>
                   </div>
-                </div>
-                <div
-                  class="c1"
-                >
                   <div
-                    class="c8"
+                    class="c1"
                   >
-                    <span
-                      class="c10 c15"
-                      id="confirm-description"
+                    <div
+                      class="c8"
                     >
-                      Are you sure you want to delete this?
-                    </span>
+                      <span
+                        class="c10 c15"
+                      >
+                        Are you sure you want to delete this?
+                      </span>
+                    </div>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
### What does it do?

1. Adds a new prompt that is displayed if assigning a content-type to a workflow would 'steal' this content-type from another workflow
2. Display a notice about which workflows are already assigned in the content-types select
3. Combine the above prompt with the existing prompt of deleted server stages
4. Refactor the `ConfirmDialog` component to be more composable

### Why is it needed?

This will make sure users understand the impact of selecting a specific content-type for a workflow.

### How to test it?

1. Create 2 workflows
5. Assign an already assigned content-type to the other workflow: expect a prompt to be displayed when saving
6. Delete an already existing stage: expect a prompt to be displayed when saving, which contains two questions

### Related issue(s)/PR(s)

- Alternative for https://github.com/strapi/strapi/pull/17392
- Closes https://github.com/strapi/strapi/pull/17392
