### PR TITLE
[bulk publish] Set page size to the number of selected entries

### DIFF
--- a/packages/core/admin/admin/src/content-manager/pages/ListView/components/BulkActionButtons/SelectedEntriesModal/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/ListView/components/BulkActionButtons/SelectedEntriesModal/index.js
@@ -397,14 +397,16 @@ const SelectedEntriesModal = ({ onToggle }) => {
   const { contentType, components } = useSelector(listViewDomain());
   // The child table will update this value based on the entries that were published
   const [entriesToFetch, setEntriesToFetch] = React.useState(selectedListViewEntries);
-
   // We want to keep the selected entries order same as the list view
   const [
     {
       query: { sort },
     },
   ] = useQueryParams();
+
   const queryParams = {
+    page: 1,
+    pageSize: entriesToFetch.length,
     sort,
     filters: {
       id: {


### PR DESCRIPTION
### What does it do?

Sets the page size to the length of the entries being fetched

### Why is it needed?

Currently if you select multiple entries across pages in the ListView or you select more than 10 from a single page in the list view only 10 will show up in the modal, however all will be published.

We need to support selecting as many entries as the user wants across multiple pages.

This is a fix but the ideal solution would include some sort of paginated list in the validation modal as well. It's a bit more complex and will likely need to handle it in a follow up PR to fix this issue before the release

### How to test it?

Go to a contentType where you have a lot of entries
Select more than 10 entries across several pages 
You should see all of your selected items in the validation modal
Publish, all the valid entries should publish

Go back to the list view and change the page size to something big like 100
Select more than 10 entries
You should see all of your selected items in the validation modal
Publish, all the valid entries should publish
