### PR TITLE
[Fix] Image preview not refreshing automatically - strapi admin

### DIFF
--- a/packages/core/upload/admin/src/components/AssetCard/AssetCard.js
+++ b/packages/core/upload/admin/src/components/AssetCard/AssetCard.js
@@ -41,6 +41,7 @@ export const AssetCard = ({ asset, isSelected, onSelect, onEdit, onRemove, size,
         height={asset.height}
         thumbnail={prefixFileUrlWithBackendUrl(asset?.formats?.thumbnail?.url || asset.url)}
         width={asset.width}
+        updatedAt={asset.updatedAt}
       />
     );
   }


### PR DESCRIPTION
## What does it do?
Addresses https://github.com/strapi/strapi/issues/17283

## Why is it needed?
To fix a bug

## How to test it?

### Repro steps:

1. Go to Media Library
2. Upload an image
3. Replace image with a different image
4. Note that the image preview is not updated

### Expected behavior
By adding the updatedAt prop, thumbnail image src will be different when replacing with a new image, the image preview should show the newly updated preview as soon as the image is updated. 

This is due to this line of code in `packages/core/upload/admin/src/components/AssetCard/imageAssetCard.js` with the urlWithCacheBusting

```js
export const ImageAssetCard = ({ height, width, thumbnail, size, alt, ...props }) => {
  // Prevents the browser from caching the URL for all sizes and allow react-query to make a smooth update
  // instead of a full refresh
  const urlWithCacheBusting = props.updatedAt ? `${thumbnail}?${props.updatedAt}` : thumbnail;

  return (
    <AssetCardBase {...props} subtitle={height && width && ` - ${width}✕${height}`} variant="Image">
      <CardAsset src={urlWithCacheBusting} size={size} alt={alt} />
    </AssetCardBase>
  );
};
```

## Related issue(s)/PR(s)
https://github.com/strapi/strapi/issues/17283