### PR TITLE
Await for `isSsoLocked` promise, fix #17409

### DIFF
--- a/packages/core/admin/ee/server/services/auth.js
+++ b/packages/core/admin/ee/server/services/auth.js
@@ -59,7 +59,7 @@ const resetPassword = async ({ resetPasswordToken, password } = {}) => {
     .query('admin::user')
     .findOne({ where: { resetPasswordToken, isActive: true } });
 
-  if (!matchingUser || isSsoLocked(matchingUser)) {
+  if (!matchingUser || (await isSsoLocked(matchingUser))) {
     throw new ApplicationError();
   }
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Awaits for the promise returned by the `isSsoLocked` function.

### Why is it needed?

Without `await`, the condition will always be true and an error will always be thrown when calling the `resetPassword` function.

### How to test it?

Just try resetting your password with an EE edition, it should work fine now.

### Related issue(s)/PR(s)

#17409 
