### PR TITLE
Enhancement: Emphasize workflow name

### DIFF
--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/WorkflowAttributes/WorkflowAttributes.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/WorkflowAttributes/WorkflowAttributes.js
@@ -144,11 +144,16 @@ export function WorkflowAttributes({
                           {
                             id: 'Settings.review-workflows.workflow.contentTypes.assigned.notice',
                             defaultMessage:
-                              '{label} {name, select, undefined {} other {<i>(assigned to {name} workflow)</i>}}',
+                              '{label} {name, select, undefined {} other {<i>(assigned to <em>{name}</em> workflow)</i>}}',
                           },
                           {
                             label: child.label,
                             name: assignedWorkflowName,
+                            em: (...children) => (
+                              <Typography as="em" fontWeight="bold">
+                                {children}
+                              </Typography>
+                            ),
                             i: (...children) => (
                               <ContentTypeTakeNotice>{children}</ContentTypeTakeNotice>
                             ),

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/WorkflowAttributes/tests/WorkflowAttributes.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/WorkflowAttributes/tests/WorkflowAttributes.test.js
@@ -85,6 +85,14 @@ const ComponentFixture = (props) => {
   );
 };
 
+const withMarkup = (query) => (text) =>
+  query((content, node) => {
+    const hasText = (node) => node.textContent === text;
+    const childrenDontHaveText = Array.from(node.children).every((child) => !hasText(child));
+
+    return hasText(node) && childrenDontHaveText;
+  });
+
 const setup = (props) => ({
   ...render(<ComponentFixture {...props} />),
   user: userEvent.setup(),
@@ -184,11 +192,12 @@ describe('Admin | Settings | Review Workflow | WorkflowAttributes', () => {
     const { getByRole, queryByText, user } = setup();
 
     const contentTypesSelect = getByRole('combobox', { name: /associated to/i });
+    const queryByTextWithMarkup = withMarkup(queryByText);
 
     await user.click(contentTypesSelect);
 
     await waitFor(() => {
-      expect(queryByText(/\(assigned to default workflow\)/i)).not.toBeInTheDocument();
+      expect(queryByTextWithMarkup('(assigned to Default workflow)')).not.toBeInTheDocument();
     });
   });
 
@@ -198,11 +207,12 @@ describe('Admin | Settings | Review Workflow | WorkflowAttributes', () => {
     });
 
     const contentTypesSelect = getByRole('combobox', { name: /associated to/i });
+    const getByTextWithMarkup = withMarkup(getByText);
 
     await user.click(contentTypesSelect);
 
     await waitFor(() => {
-      expect(getByText(/\(assigned to default workflow\)/i)).toBeInTheDocument();
+      expect(getByTextWithMarkup('(assigned to Default workflow)')).toBeInTheDocument();
     });
   });
 
@@ -212,11 +222,12 @@ describe('Admin | Settings | Review Workflow | WorkflowAttributes', () => {
     });
 
     const contentTypesSelect = getByRole('combobox', { name: /associated to/i });
+    const getByTextWithMarkup = withMarkup(getByText);
 
     await user.click(contentTypesSelect);
 
     await waitFor(() => {
-      expect(getByText(/\(assigned to default workflow\)/i)).toBeInTheDocument();
+      expect(getByTextWithMarkup('(assigned to Default workflow)')).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
### What does it do?

Emphasizes the workflow name in the workflow attributes content-type select.

### Why is it needed?

Differentiates the name visually from the other elements.
