### PR TITLE
Chore: Update review workflows copy

### DIFF
--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/ListView/ListView.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/ListView/ListView.js
@@ -204,8 +204,7 @@ export function ReviewWorkflowsListView() {
         }
         subtitle={formatMessage({
           id: 'Settings.review-workflows.list.page.subtitle',
-          defaultMessage:
-            'Manage content review stages and collaborate during content creation from draft to publication',
+          defaultMessage: 'Manage your content review process',
         })}
         title={formatMessage({
           id: 'Settings.review-workflows.list.page.title',


### PR DESCRIPTION
### What does it do?

Updates the copy for the review workflows settings page.

### Why is it needed?

Requested by design.
