### PR TITLE
[bulk publish] Move edit icon to the right in the Modal

### DIFF
--- a/packages/core/admin/admin/src/content-manager/pages/ListView/components/BulkActionButtons/SelectedEntriesModal/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/ListView/components/BulkActionButtons/SelectedEntriesModal/index.js
@@ -188,6 +188,7 @@ const SelectedEntriesTableContent = ({ isPublishing, rowsToDisplay, entriesToPub
                 )}
                 noBorder
                 target="_blank"
+                style={{ marginLeft: 'auto' }}
               >
                 <Pencil />
               </IconButton>


### PR DESCRIPTION
### What does it do?

- It moves the Edit icon (Pencil) to the right inside the Selected Entries modal

### Why is it needed?

- because in this modal we could have just this button inside the cell

### How to test it?

- Select a bunch of entries in the ListView
- click Publish
- you can now see the icon to the right of the last column

Bug related CS-126