### PR TITLE
[DTS] check access permissions before attempting backup

### DIFF
--- a/packages/core/data-transfer/src/strapi/providers/local-destination/index.ts
+++ b/packages/core/data-transfer/src/strapi/providers/local-destination/index.ts
@@ -189,6 +189,15 @@ class LocalStrapiDestinationProvider implements IDestinationProvider {
       );
 
       try {
+        // Check access before attempting to do anything
+        await fse.access(
+          assetsDirectory,
+          // eslint-disable-next-line no-bitwise
+          fse.constants.W_OK | fse.constants.R_OK | fse.constants.F_OK
+        );
+        // eslint-disable-next-line no-bitwise
+        await fse.access(path.join(assetsDirectory, '..'), fse.constants.W_OK | fse.constants.R_OK);
+
         await fse.move(assetsDirectory, backupDirectory);
         await fse.mkdir(assetsDirectory);
         // Create a .gitkeep file to ensure the directory is not empty


### PR DESCRIPTION
### What does it do?

check access permissions before attempting backup

### Why is it needed?

reduce risk attempting file operations we can't perform

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
