### PR TITLE
Bulk publish: fix, enable countManyEntriesDraftRelations API only when you have selected entries in the modal

### DIFF
--- a/packages/core/admin/admin/src/content-manager/pages/ListView/components/BulkActionButtons/ConfirmBulkActionDialog/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/ListView/components/BulkActionButtons/ConfirmBulkActionDialog/index.js
@@ -104,6 +104,8 @@ const ConfirmDialogPublishAll = ({ isOpen, onToggleDialog, isConfirmButtonLoadin
       return data;
     },
     {
+      // The API is called everytime you select/deselect an entry, this check avoids us sending a query with bad data
+      enabled: selectedEntries.length > 0,
       onError(error) {
         toggleNotification({ type: 'warning', message: formatAPIError(error) });
       },


### PR DESCRIPTION
What does it do?
It fixes the problem we had inside the Confirm Publish All Modal when you deselect all the entries, because every time we pick or unpick one entry the countManyEntriesDraftRelations was called

Why is it needed?
Because otherwise we call the API with no ids, which gives an error (also a Warning with the "Internal server error" in the CMS)

How to test it?
Go to a Collection and select some entries in the content manager and click Publish, then inside the Modal try to deselect all the entries, you don't have to see a Warning popup and you can check in the Network if the countManyEntriesDraftRelations will be called or not

Related issue(s)/PR(s)
CX-128