### PR TITLE
Fix: Better align review workflows design and implementation of RBAC

### DIFF
--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/Stages/Stage/Stage.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/Stages/Stage/Stage.js
@@ -203,39 +203,42 @@ export function Stage({
             title={nameField.value}
             togglePosition="left"
             action={
-              <Flex>
-                {canDelete && (
-                  <IconButton
-                    background="transparent"
-                    icon={<Trash />}
-                    label={formatMessage({
-                      id: 'Settings.review-workflows.stage.delete',
-                      defaultMessage: 'Delete stage',
-                    })}
-                    noBorder
-                    onClick={() => dispatch(deleteStage(id))}
-                  />
-                )}
+              (canDelete || canUpdate) && (
+                <Flex>
+                  {canDelete && (
+                    <IconButton
+                      background="transparent"
+                      icon={<Trash />}
+                      label={formatMessage({
+                        id: 'Settings.review-workflows.stage.delete',
+                        defaultMessage: 'Delete stage',
+                      })}
+                      noBorder
+                      onClick={() => dispatch(deleteStage(id))}
+                    />
+                  )}
 
-                <IconButton
-                  background="transparent"
-                  disabled={!canUpdate}
-                  forwardedAs="div"
-                  role="button"
-                  noBorder
-                  tabIndex={0}
-                  data-handler-id={handlerId}
-                  ref={dragRef}
-                  label={formatMessage({
-                    id: 'Settings.review-workflows.stage.drag',
-                    defaultMessage: 'Drag',
-                  })}
-                  onClick={(e) => e.stopPropagation()}
-                  onKeyDown={handleKeyDown}
-                >
-                  <Drag />
-                </IconButton>
-              </Flex>
+                  {canUpdate && (
+                    <IconButton
+                      background="transparent"
+                      forwardedAs="div"
+                      role="button"
+                      noBorder
+                      tabIndex={0}
+                      data-handler-id={handlerId}
+                      ref={dragRef}
+                      label={formatMessage({
+                        id: 'Settings.review-workflows.stage.drag',
+                        defaultMessage: 'Drag',
+                      })}
+                      onClick={(e) => e.stopPropagation()}
+                      onKeyDown={handleKeyDown}
+                    >
+                      <Drag />
+                    </IconButton>
+                  )}
+                </Flex>
+              )
             }
           />
           <AccordionContent padding={6} background="neutral0" hasRadius>

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/Stages/Stage/tests/Stage.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/Stages/Stage/tests/Stage.test.js
@@ -91,12 +91,22 @@ describe('Admin | Settings | Review Workflow | Stage', () => {
     expect(queryByRole('textbox')).toBeInTheDocument();
   });
 
-  it('should not render delete button if canDelete=false', async () => {
+  it('should not render the delete button if canDelete=false', async () => {
     const { queryByRole } = setup({ isOpen: true, canDelete: false });
 
     expect(
       queryByRole('button', {
         name: /delete stage/i,
+      })
+    ).not.toBeInTheDocument();
+  });
+
+  it('should not render delete drag button if canUpdate=false', async () => {
+    const { queryByRole } = setup({ isOpen: true, canUpdate: false });
+
+    expect(
+      queryByRole('button', {
+        name: /drag/i,
       })
     ).not.toBeInTheDocument();
   });

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/CreateView/CreateView.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/CreateView/CreateView.js
@@ -6,7 +6,6 @@ import {
   useAPIErrorHandler,
   useFetchClient,
   useNotification,
-  useRBAC,
 } from '@strapi/helper-plugin';
 import { Check } from '@strapi/icons';
 import { useFormik, Form, FormikProvider } from 'formik';
@@ -18,7 +17,6 @@ import { useHistory } from 'react-router-dom';
 
 import { useContentTypes } from '../../../../../../../../admin/src/hooks/useContentTypes';
 import { useInjectReducer } from '../../../../../../../../admin/src/hooks/useInjectReducer';
-import { selectAdminPermissions } from '../../../../../../../../admin/src/pages/App/selectors';
 import { useLicenseLimits } from '../../../../../../hooks';
 import { addStage, resetWorkflow } from '../../actions';
 import * as Layout from '../../components/Layout';
@@ -40,7 +38,6 @@ export function ReviewWorkflowsCreateView() {
   const { push } = useHistory();
   const { formatAPIError } = useAPIErrorHandler();
   const dispatch = useDispatch();
-  const permissions = useSelector(selectAdminPermissions);
   const toggleNotification = useNotification();
   const { collectionTypes, singleTypes, isLoading: isLoadingModels } = useContentTypes();
   const { isLoading: isWorkflowLoading, meta, workflows } = useReviewWorkflows();
@@ -49,9 +46,6 @@ export function ReviewWorkflowsCreateView() {
       currentWorkflow: { data: currentWorkflow, isDirty: currentWorkflowIsDirty },
     },
   } = useSelector((state) => state?.[REDUX_NAMESPACE] ?? initialState);
-  const {
-    allowedActions: { canCreate },
-  } = useRBAC(permissions.settings['review-workflows']);
   const [showLimitModal, setShowLimitModal] = React.useState(false);
   const { isLoading: isLicenseLoading, getFeature } = useLicenseLimits();
   const [initialErrors, setInitialErrors] = React.useState(null);
@@ -230,7 +224,7 @@ export function ReviewWorkflowsCreateView() {
                 startIcon={<Check />}
                 type="submit"
                 size="M"
-                disabled={!currentWorkflowIsDirty || !canCreate}
+                disabled={!currentWorkflowIsDirty}
                 isLoading={isLoading}
               >
                 {formatMessage({

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/EditView/EditView.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/EditView/EditView.js
@@ -251,20 +251,22 @@ export function ReviewWorkflowsEditView() {
           <Layout.Header
             navigationAction={<Layout.Back href="/settings/review-workflows" />}
             primaryAction={
-              <Button
-                startIcon={<Check />}
-                type="submit"
-                size="M"
-                disabled={!currentWorkflowIsDirty || !canUpdate}
-                // if the confirm dialog is open the loading state is on
-                // the confirm button already
-                loading={!Object.keys(savePrompts).length > 0 && isLoading}
-              >
-                {formatMessage({
-                  id: 'global.save',
-                  defaultMessage: 'Save',
-                })}
-              </Button>
+              canUpdate && (
+                <Button
+                  startIcon={<Check />}
+                  type="submit"
+                  size="M"
+                  disabled={!currentWorkflowIsDirty}
+                  // if the confirm dialog is open the loading state is on
+                  // the confirm button already
+                  loading={!Object.keys(savePrompts).length > 0 && isLoading}
+                >
+                  {formatMessage({
+                    id: 'global.save',
+                    defaultMessage: 'Save',
+                  })}
+                </Button>
+              )
             }
             subtitle={
               currentWorkflow.stages.length > 0 &&

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/ListView/ListView.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/ListView/ListView.js
@@ -169,38 +169,39 @@ export function ReviewWorkflowsListView() {
     <>
       <Layout.Header
         primaryAction={
-          <LinkButton
-            disabled={!canCreate}
-            startIcon={<Plus />}
-            size="S"
-            to="/settings/review-workflows/create"
-            onClick={(event) => {
-              /**
-               * If the current license has a workflow limit:
-               * check if the total count of workflows exceeds that limit. If so,
-               * prevent the navigation and show the limits overlay.
-               *
-               * If the current license does not have a limit (e.g. offline license):
-               * allow the user to navigate to the create-view. In case they exceed the
-               * current hard-limit of 200 they will see an error thrown by the API.
-               */
+          canCreate && (
+            <LinkButton
+              startIcon={<Plus />}
+              size="S"
+              to="/settings/review-workflows/create"
+              onClick={(event) => {
+                /**
+                 * If the current license has a workflow limit:
+                 * check if the total count of workflows exceeds that limit. If so,
+                 * prevent the navigation and show the limits overlay.
+                 *
+                 * If the current license does not have a limit (e.g. offline license):
+                 * allow the user to navigate to the create-view. In case they exceed the
+                 * current hard-limit of 200 they will see an error thrown by the API.
+                 */
 
-              if (
-                limits?.[CHARGEBEE_WORKFLOW_ENTITLEMENT_NAME] &&
-                meta?.workflowCount >= parseInt(limits[CHARGEBEE_WORKFLOW_ENTITLEMENT_NAME], 10)
-              ) {
-                event.preventDefault();
-                setShowLimitModal(true);
-              } else {
-                trackUsage('willCreateWorkflow');
-              }
-            }}
-          >
-            {formatMessage({
-              id: 'Settings.review-workflows.list.page.create',
-              defaultMessage: 'Create new workflow',
-            })}
-          </LinkButton>
+                if (
+                  limits?.[CHARGEBEE_WORKFLOW_ENTITLEMENT_NAME] &&
+                  meta?.workflowCount >= parseInt(limits[CHARGEBEE_WORKFLOW_ENTITLEMENT_NAME], 10)
+                ) {
+                  event.preventDefault();
+                  setShowLimitModal(true);
+                } else {
+                  trackUsage('willCreateWorkflow');
+                }
+              }}
+            >
+              {formatMessage({
+                id: 'Settings.review-workflows.list.page.create',
+                defaultMessage: 'Create new workflow',
+              })}
+            </LinkButton>
+          )
         }
         subtitle={formatMessage({
           id: 'Settings.review-workflows.list.page.subtitle',


### PR DESCRIPTION
### What does it do?

Improves the alignment of design and implementation for RBAC on the settings pages:

- hide create button on the list-view instead of disabling
- hide drag button on a stage instead of disabling
- hide save button on the edit view instead of disabling

### Why is it needed?

Align design and implementation.
