### PR TITLE
[bulk publish] Remove sorting from the bulk publish modal

### DIFF
--- a/packages/core/helper-plugin/src/components/Table/index.js
+++ b/packages/core/helper-plugin/src/components/Table/index.js
@@ -241,7 +241,8 @@ const HeaderCell = ({ fieldSchemaType, name, relationFieldName, isSortable, labe
     <Th
       key={name}
       action={
-        isSorted && (
+        isSorted &&
+        isSortable && (
           <IconButton
             label={sortLabel}
             onClick={handleClickSort}


### PR DESCRIPTION
### What does it do?

- remove the sorting icon from the Name column

### Why is it needed?

- because we have the sorting icon that doesn't work and we don't want to sort the rows in the modal

### How to test it?

- Select a bunch of entries in the ListView
- click Publish
- you can now see the bulk publish modal without sorting in the Name column

Bug related CS-124