### PR TITLE
Migrate permission back eslint after color-picker changes. merge issues

### DIFF
--- a/packages/core/permissions/.eslintrc.js
+++ b/packages/core/permissions/.eslintrc.js
@@ -1,4 +1,4 @@
 module.exports = {
   root: true,
-  extends: ['custom/typescript'],
+  extends: ['custom/back/typescript'],
 };


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Fix eslint config for the permission package 

### Why is it needed?

the ts-color-picker change move the ts config to back/typescript but this PR was merge in between the changes.

### How to test it?

yarn lint should work

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
