### PR TITLE
Update Sentry usage in `@strapi/plugin-sentry`

### DIFF
--- a/packages/generators/app/package.json
+++ b/packages/generators/app/package.json
@@ -43,7 +43,7 @@
     "lint": "run -T eslint ."
   },
   "dependencies": {
-    "@sentry/node": "6.19.7",
+    "@sentry/node": "^7.60.0",
     "chalk": "^4.1.2",
     "execa": "5.1.1",
     "fs-extra": "10.0.0",

--- a/packages/generators/app/package.json
+++ b/packages/generators/app/package.json
@@ -43,7 +43,7 @@
     "lint": "run -T eslint ."
   },
   "dependencies": {
-    "@sentry/node": "^7.60.0",
+    "@sentry/node": "7.69.0",
     "chalk": "^4.1.2",
     "execa": "5.1.1",
     "fs-extra": "10.0.0",

--- a/packages/generators/app/src/index.ts
+++ b/packages/generators/app/src/index.ts
@@ -3,7 +3,7 @@ import { readFileSync } from 'node:fs';
 import os from 'node:os';
 import readline from 'node:readline';
 import crypto from 'crypto';
-import * as sentry from '@sentry/node';
+import * as Sentry from '@sentry/node';
 import hasYarn from './utils/has-yarn';
 import checkRequirements from './utils/check-requirements';
 import { trackError, captureException } from './utils/usage';
@@ -17,7 +17,7 @@ export { default as checkInstallPath } from './utils/check-install-path';
 const packageJson = JSON.parse(readFileSync(resolve(__dirname, '../package.json'), 'utf8'));
 
 export const generateNewApp = (projectDirectory: string, options: Partial<NewOptions>) => {
-  sentry.init({
+  Sentry.init({
     dsn: 'https://841d2b2c9b4d4b43a4cde92794cb705a@sentry.io/1762059',
   });
 
@@ -59,7 +59,7 @@ export const generateNewApp = (projectDirectory: string, options: Partial<NewOpt
     useTypescript: Boolean(options.typescript),
   };
 
-  sentry.configureScope(function configureScope(sentryScope) {
+  Sentry.configureScope(function configureScope(sentryScope) {
     const tags = {
       os: os.type(),
       osPlatform: os.platform(),

--- a/packages/generators/app/src/utils/usage.ts
+++ b/packages/generators/app/src/utils/usage.ts
@@ -1,7 +1,7 @@
 import os from 'os';
 import _ from 'lodash';
 import fetch from 'node-fetch';
-import sentry, { Severity } from '@sentry/node';
+import * as Sentry from '@sentry/node';
 import { Scope, StderrError, isStderrError } from '../types';
 
 type TrackError = Error | string | StderrError;
@@ -15,8 +15,8 @@ function addPackageJsonStrapiMetadata(metadata: Record<string, unknown>, scope: 
 
 export async function captureException(error: Error) {
   try {
-    sentry.captureException(error);
-    await sentry.flush();
+    Sentry.captureException(error);
+    await Sentry.flush();
   } catch (err) {
     /** ignore errors */
     return Promise.resolve();
@@ -25,8 +25,8 @@ export async function captureException(error: Error) {
 
 async function captureError(message: string) {
   try {
-    sentry.captureMessage(message, Severity.Error);
-    await sentry.flush();
+    Sentry.captureMessage(message, Sentry.Severity.Error);
+    await Sentry.flush();
   } catch (err) {
     /** ignore errors */
     return Promise.resolve();
@@ -39,10 +39,10 @@ export function captureStderr(name: string, error: unknown) {
       .trim()
       .split('\n')
       .forEach((line) => {
-        sentry.addBreadcrumb({
+        Sentry.addBreadcrumb({
           category: 'stderr',
           message: line,
-          level: Severity.Error,
+          level: Sentry.Severity.Error,
         });
       });
   }

--- a/packages/generators/app/src/utils/usage.ts
+++ b/packages/generators/app/src/utils/usage.ts
@@ -25,7 +25,7 @@ export async function captureException(error: Error) {
 
 async function captureError(message: string) {
   try {
-    Sentry.captureMessage(message, Sentry.Severity.Error);
+    Sentry.captureMessage(message, 'error');
     await Sentry.flush();
   } catch (err) {
     /** ignore errors */
@@ -42,7 +42,7 @@ export function captureStderr(name: string, error: unknown) {
         Sentry.addBreadcrumb({
           category: 'stderr',
           message: line,
-          level: Sentry.Severity.Error,
+          level: 'error',
         });
       });
   }

--- a/packages/plugins/sentry/README.md
+++ b/packages/plugins/sentry/README.md
@@ -23,12 +23,12 @@ npm install @strapi/plugin-sentry
 
 ## Configuration
 
-| property       | type (default)   | description                                                                                                                                                                              |
-| -------------- | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `dsn`          | string (`null`)  | Your Sentry data source name ([see Sentry docs](https://docs.sentry.io/product/sentry-basics/dsn-explainer/)).                                                                           |
-| `tracesSampleRate`          | number (`0.1`)  | The sample rate to use for performance monitoring. Set this to `0` to disable performance monitoring. `1` means all transactions are captured, `0.1` means 10% of transactions are captured.                                                                           |
-| `sendMetadata` | boolean (`true`) | Whether the plugin should attach additional information (like OS, browser, etc.) to the events sent to Sentry.                                                                           |
-| `init`         | object (`{}`)    | A config object that is passed directly to Sentry during the `Sentry.init()`. See all available options [on Sentry's docs](https://docs.sentry.io/platforms/node/configuration/options/) |
+| property           | type (default)   | description                                                                                                                                                                                  |
+| ------------------ | ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `dsn`              | string (`null`)  | Your Sentry data source name ([see Sentry docs](https://docs.sentry.io/product/sentry-basics/dsn-explainer/)).                                                                               |
+| `tracesSampleRate` | number (`0.1`)   | The sample rate to use for performance monitoring. Set this to `0` to disable performance monitoring. `1` means all transactions are captured, `0.1` means 10% of transactions are captured. |
+| `sendMetadata`     | boolean (`true`) | Whether the plugin should attach additional information (like OS, browser, etc.) to the events sent to Sentry.                                                                               |
+| `init`             | object (`{}`)    | A config object that is passed directly to Sentry during the `Sentry.init()`. See all available options [on Sentry's docs](https://docs.sentry.io/platforms/node/configuration/options/)     |
 
 **Example**
 

--- a/packages/plugins/sentry/README.md
+++ b/packages/plugins/sentry/README.md
@@ -26,6 +26,7 @@ npm install @strapi/plugin-sentry
 | property       | type (default)   | description                                                                                                                                                                              |
 | -------------- | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `dsn`          | string (`null`)  | Your Sentry data source name ([see Sentry docs](https://docs.sentry.io/product/sentry-basics/dsn-explainer/)).                                                                           |
+| `tracesSampleRate`          | number (`0.1`)  | The sample rate to use for performance monitoring. Set this to `0` to disable performance monitoring. `1` means all transactions are captured, `0.1` means 10% of transactions are captured.                                                                           |
 | `sendMetadata` | boolean (`true`) | Whether the plugin should attach additional information (like OS, browser, etc.) to the events sent to Sentry.                                                                           |
 | `init`         | object (`{}`)    | A config object that is passed directly to Sentry during the `Sentry.init()`. See all available options [on Sentry's docs](https://docs.sentry.io/platforms/node/configuration/options/) |
 
@@ -40,6 +41,7 @@ module.exports = ({ env }) => ({
     enabled: true,
     config: {
       dsn: env('SENTRY_DSN'),
+      tracesSampleRate: 0.1,
       sendMetadata: true,
     },
   },

--- a/packages/plugins/sentry/package.json
+++ b/packages/plugins/sentry/package.json
@@ -26,8 +26,8 @@
     "lint": "run -T eslint ."
   },
   "dependencies": {
-    "@sentry/node": "^7.60.0",
-    "@sentry/utils": "^7.60.0",
+    "@sentry/node": "7.69.0",
+    "@sentry/utils": "7.69.0",
     "@strapi/design-system": "1.10.1",
     "@strapi/helper-plugin": "4.13.5",
     "@strapi/icons": "1.10.1"

--- a/packages/plugins/sentry/package.json
+++ b/packages/plugins/sentry/package.json
@@ -26,7 +26,8 @@
     "lint": "run -T eslint ."
   },
   "dependencies": {
-    "@sentry/node": "6.19.7",
+    "@sentry/node": "^7.60.0",
+    "@sentry/utils": "^7.60.0",
     "@strapi/design-system": "1.10.1",
     "@strapi/helper-plugin": "4.13.5",
     "@strapi/icons": "1.10.1"

--- a/packages/plugins/sentry/server/bootstrap.js
+++ b/packages/plugins/sentry/server/bootstrap.js
@@ -1,8 +1,10 @@
 'use strict';
 
 const initSentryMiddleware = require('./middlewares/sentry');
+const initSentryPerformanceMiddleware = require('./middlewares/sentry-performance');
 
 module.exports = async ({ strapi }) => {
   // Initialize the Sentry service exposed by this plugin
   initSentryMiddleware({ strapi });
+  initSentryPerformanceMiddleware({ strapi });
 };

--- a/packages/plugins/sentry/server/config.js
+++ b/packages/plugins/sentry/server/config.js
@@ -4,6 +4,7 @@ module.exports = {
   default: {
     dsn: null,
     sendMetadata: true,
+    tracesSampleRate: 0.1,
     init: {},
   },
   validator() {},

--- a/packages/plugins/sentry/server/middlewares/sentry-performance.js
+++ b/packages/plugins/sentry/server/middlewares/sentry-performance.js
@@ -1,0 +1,84 @@
+'use strict';
+
+const { stripUrlQueryAndFragment } = require("@sentry/utils");
+
+/**
+ * Programmatic sentry-performance middleware. We do not want to expose it in the plugin
+ * @param {{ strapi: import('@strapi/strapi').Strapi }}
+ */
+module.exports = ({ strapi }) => {
+  const sentryService = strapi.plugin('sentry').service('sentry');
+  sentryService.init();
+  const Sentry = sentryService.getInstance();
+
+  if (!Sentry || !sentryService.hasTracingEnabled()) {
+    // initialization failed or tracing is not enabled
+    return;
+  }
+
+  strapi.server.use(async (ctx, next) => {
+    return new Promise((resolve, reject) => {
+      Sentry.runWithAsyncContext(async () => {
+        const hub = Sentry.getCurrentHub();
+        hub.configureScope((scope) =>
+          scope.addEventProcessor((event) =>
+            Sentry.addRequestDataToEvent(event, ctx.request, {
+              include: {
+                user: false,
+              },
+            })
+          )
+        );
+
+        try {
+          await next();
+        } catch (err) {
+          reject(err);
+        }
+        resolve();
+      });
+    });
+  });
+
+  // this tracing middleware creates a transaction per request
+  strapi.server.use(async (ctx, next) => {
+    const reqMethod = (ctx.method || "").toUpperCase();
+    const reqUrl = ctx.url && stripUrlQueryAndFragment(ctx.url);
+
+    // connect to trace of upstream app
+    let traceparentData;
+    if (ctx.request.get("sentry-trace")) {
+      traceparentData = Sentry.extractTraceparentData(
+        ctx.request.get("sentry-trace")
+      );
+    }
+
+    const transaction = Sentry.startTransaction({
+      name: `${reqMethod} ${reqUrl}`,
+      op: "http.server",
+      ...traceparentData,
+    });
+
+    ctx.__sentry_transaction = transaction;
+
+    // We put the transaction on the scope so users can attach children to it
+    Sentry.getCurrentHub().configureScope((scope) => {
+      scope.setSpan(transaction);
+    });
+
+    ctx.res.on("finish", () => {
+      // Push `transaction.finish` to the next event loop so open spans have a chance to finish before the transaction closes
+      setImmediate(() => {
+        // if using koa router, a nicer way to capture transaction using the matched route
+        if (ctx._matchedRoute) {
+          const mountPath = ctx.mountPath || "";
+          transaction.setName(`${reqMethod} ${mountPath}${ctx._matchedRoute}`);
+        }
+        transaction.setHttpStatus(ctx.status);
+        transaction.finish();
+      });
+    });
+
+    await next();
+  });
+};

--- a/packages/plugins/sentry/server/middlewares/sentry.js
+++ b/packages/plugins/sentry/server/middlewares/sentry.js
@@ -21,7 +21,7 @@ module.exports = ({ strapi }) => {
       sentryService.sendError(error, (scope, Sentry) => {
         scope.setSDKProcessingMetadata({ request: ctx.request });
         Sentry.captureException(error);
-   
+
         // Manually add Strapi version
         scope.setTag('strapi_version', strapi.config.info.strapi);
 

--- a/packages/plugins/sentry/server/services/sentry/index.js
+++ b/packages/plugins/sentry/server/services/sentry/index.js
@@ -27,10 +27,9 @@ const createSentryService = (strapi) => {
             dsn: settings.dsn,
             tracesSampleRate: settings.tracesSampleRate,
             environment: strapi.config.get('environment'),
-            integrations: settings.tracesSampleRate ? [
-              new Sentry.Integrations.Http({ tracing: true }),
-              new Sentry.Integrations.GraphQL(),
-            ] : undefined,
+            integrations: settings.tracesSampleRate
+              ? [new Sentry.Integrations.Http({ tracing: true }), new Sentry.Integrations.GraphQL()]
+              : undefined,
             ...settings.init,
           });
           // Store the successfully initialized Sentry instance
@@ -56,7 +55,7 @@ const createSentryService = (strapi) => {
 
     /** If tracing (performance monitoring) is enabled. */
     hasTracingEnabled() {
-      return !!settings.tracesSampleRate; 
+      return !!settings.tracesSampleRate;
     },
 
     /**

--- a/packages/plugins/sentry/server/services/sentry/index.js
+++ b/packages/plugins/sentry/server/services/sentry/index.js
@@ -1,7 +1,5 @@
 'use strict';
 
-// FIXME
-/* eslint-disable import/extensions */
 const Sentry = require('@sentry/node');
 
 const createSentryService = (strapi) => {
@@ -27,7 +25,12 @@ const createSentryService = (strapi) => {
         if (settings.dsn) {
           Sentry.init({
             dsn: settings.dsn,
+            tracesSampleRate: settings.tracesSampleRate,
             environment: strapi.config.get('environment'),
+            integrations: settings.tracesSampleRate ? [
+              new Sentry.Integrations.Http({ tracing: true }),
+              new Sentry.Integrations.GraphQL(),
+            ] : undefined,
             ...settings.init,
           });
           // Store the successfully initialized Sentry instance
@@ -49,6 +52,11 @@ const createSentryService = (strapi) => {
      */
     getInstance() {
       return instance;
+    },
+
+    /** If tracing (performance monitoring) is enabled. */
+    hasTracingEnabled() {
+      return !!settings.tracesSampleRate; 
     },
 
     /**

--- a/packages/plugins/sentry/server/services/sentry/index.js
+++ b/packages/plugins/sentry/server/services/sentry/index.js
@@ -23,6 +23,20 @@ const createSentryService = (strapi) => {
       try {
         // Don't init Sentry if no DSN was provided
         if (settings.dsn) {
+          const userConfig = settings.init || {};
+
+          // Handle v6 -> v7 changed config options
+          if (userConfig.whitelistUrls) {
+            userConfig.allowUrls = userConfig.whitelistUrls;
+            delete userConfig.whitelistUrls;
+            strapi.log.warn('Sentry: whitelistUrls is deprecated, use allowUrls instead');
+          }
+          if (userConfig.blacklistUrls) {
+            userConfig.denyUrls = userConfig.blacklistUrls;
+            delete userConfig.blacklistUrls;
+            strapi.log.warn('Sentry: blacklistUrls is deprecated, use denyUrls instead');
+          }
+
           Sentry.init({
             dsn: settings.dsn,
             tracesSampleRate: settings.tracesSampleRate,
@@ -30,7 +44,7 @@ const createSentryService = (strapi) => {
             integrations: settings.tracesSampleRate
               ? [new Sentry.Integrations.Http({ tracing: true }), new Sentry.Integrations.GraphQL()]
               : undefined,
-            ...settings.init,
+            ...userConfig,
           });
           // Store the successfully initialized Sentry instance
           instance = Sentry;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5937,59 +5937,59 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry-internal/tracing@npm:7.60.0":
-  version: 7.60.0
-  resolution: "@sentry-internal/tracing@npm:7.60.0"
+"@sentry-internal/tracing@npm:7.69.0":
+  version: 7.69.0
+  resolution: "@sentry-internal/tracing@npm:7.69.0"
   dependencies:
-    "@sentry/core": 7.60.0
-    "@sentry/types": 7.60.0
-    "@sentry/utils": 7.60.0
+    "@sentry/core": 7.69.0
+    "@sentry/types": 7.69.0
+    "@sentry/utils": 7.69.0
     tslib: ^2.4.1 || ^1.9.3
-  checksum: ebd60aea46ca4317303ddb6ee4d6d440fd1b6c936a7c30081944d6197406a13465c7211a1490f199f2b5c51c2de51e5e6471a082990891150fcbeedc28c6464e
+  checksum: 3ccb7e7d008dd39ed2bb9a02fcd7ae6161a8355451891db25020d8068357254a430e697c4f72c4d1d747754585ca0f610cea6798d51b6a791ae2c73ee399b58e
   languageName: node
   linkType: hard
 
-"@sentry/core@npm:7.60.0":
-  version: 7.60.0
-  resolution: "@sentry/core@npm:7.60.0"
+"@sentry/core@npm:7.69.0":
+  version: 7.69.0
+  resolution: "@sentry/core@npm:7.69.0"
   dependencies:
-    "@sentry/types": 7.60.0
-    "@sentry/utils": 7.60.0
+    "@sentry/types": 7.69.0
+    "@sentry/utils": 7.69.0
     tslib: ^2.4.1 || ^1.9.3
-  checksum: 33d5c69f9507a49ac22d36bfe772625b328cd75a4b5c9d64af8b2d8635b3e502e1e98e0eaab51458e4d8b55739daa1c34294aa4179eeb6fe4f285c03b08e6328
+  checksum: b24ec3121dd899dc53edaf1ca984f6df4fab3cd9dc1756b2037729c61e33df47ad4b94abb0dc24fc2dfb6099396a3e9df7f13d0e4673184c93e5932dcfb9a8e1
   languageName: node
   linkType: hard
 
-"@sentry/node@npm:^7.60.0":
-  version: 7.60.0
-  resolution: "@sentry/node@npm:7.60.0"
+"@sentry/node@npm:7.69.0":
+  version: 7.69.0
+  resolution: "@sentry/node@npm:7.69.0"
   dependencies:
-    "@sentry-internal/tracing": 7.60.0
-    "@sentry/core": 7.60.0
-    "@sentry/types": 7.60.0
-    "@sentry/utils": 7.60.0
+    "@sentry-internal/tracing": 7.69.0
+    "@sentry/core": 7.69.0
+    "@sentry/types": 7.69.0
+    "@sentry/utils": 7.69.0
     cookie: ^0.4.1
     https-proxy-agent: ^5.0.0
     lru_map: ^0.3.3
     tslib: ^2.4.1 || ^1.9.3
-  checksum: 3ec42ea5d95a204c5ad8ed360c4d2d6c1583780b4879e752856a418289889b8a9e18e6d1ebe721a141b2b0fd3275e22c7ca3661fb6db471e343067c2caf29218
+  checksum: 97210ced968a3d968fd9d93e67e1f3c9613b99b223f87fad944e6e94db40ebc10a7c339c848e0529c5ded69f94f1f689b4a6df1da4df1aad6663a752ac591d03
   languageName: node
   linkType: hard
 
-"@sentry/types@npm:7.60.0":
-  version: 7.60.0
-  resolution: "@sentry/types@npm:7.60.0"
-  checksum: c145704ef188121df0f19e195026b6be22840f56c92e914b54063a2c2241ab09e7c3863530efd70bbb6d1152237b3b99f22a3d9cded06ac25e089121c2890dd7
+"@sentry/types@npm:7.69.0":
+  version: 7.69.0
+  resolution: "@sentry/types@npm:7.69.0"
+  checksum: aaa40a43cab358e10c2566d62966eff61925fb2605c146967bf9eb8acb4a883d4ca7c8a5eee1915271da08f27ddf1ed7dc520a8617f229ce70c7d00557173cc4
   languageName: node
   linkType: hard
 
-"@sentry/utils@npm:7.60.0, @sentry/utils@npm:^7.60.0":
-  version: 7.60.0
-  resolution: "@sentry/utils@npm:7.60.0"
+"@sentry/utils@npm:7.69.0":
+  version: 7.69.0
+  resolution: "@sentry/utils@npm:7.69.0"
   dependencies:
-    "@sentry/types": 7.60.0
+    "@sentry/types": 7.69.0
     tslib: ^2.4.1 || ^1.9.3
-  checksum: 3dd3dd2d7c33e011db700032d1a81f8c7c95f6b212f9685fd614e976fae1ff259dd98340e5ccca52bf251387e7f02949850edb5879a35da842e1b71a1e975331
+  checksum: 8c18b6a1c5a869d608ff9cdb4534b29c5c85a06660647d8d8dfd67460be985d44a88f1ec4335174d40f147fecaa2e952b78747e83b6ed2f654e93248744fa291
   languageName: node
   linkType: hard
 
@@ -7186,7 +7186,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@strapi/generate-new@workspace:packages/generators/app"
   dependencies:
-    "@sentry/node": ^7.60.0
+    "@sentry/node": 7.69.0
     chalk: ^4.1.2
     copyfiles: 2.4.1
     execa: 5.1.1
@@ -7527,7 +7527,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@strapi/plugin-sentry@workspace:packages/plugins/sentry"
   dependencies:
-    "@sentry/node": 6.19.7
+    "@sentry/node": 7.69.0
+    "@sentry/utils": 7.69.0
     "@strapi/design-system": 1.10.1
     "@strapi/helper-plugin": 4.13.5
     "@strapi/icons": 1.10.1
@@ -29342,7 +29343,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"tslib@npm:^1.10.0, tslib@npm:^1.13.0, tslib@npm:^1.8.1, tslib@npm:^1.9.0, tslib@npm:^1.9.3":
+"tslib@npm:^1.10.0, tslib@npm:^1.13.0, tslib@npm:^1.8.1, tslib@npm:^1.9.0":
   version: 1.14.1
   resolution: "tslib@npm:1.14.1"
   checksum: dbe628ef87f66691d5d2959b3e41b9ca0045c3ee3c7c7b906cc1e328b39f199bb1ad9e671c39025bd56122ac57dfbf7385a94843b1cc07c60a4db74795829acd

--- a/yarn.lock
+++ b/yarn.lock
@@ -5937,71 +5937,59 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry/core@npm:6.19.7":
-  version: 6.19.7
-  resolution: "@sentry/core@npm:6.19.7"
+"@sentry-internal/tracing@npm:7.60.0":
+  version: 7.60.0
+  resolution: "@sentry-internal/tracing@npm:7.60.0"
   dependencies:
-    "@sentry/hub": 6.19.7
-    "@sentry/minimal": 6.19.7
-    "@sentry/types": 6.19.7
-    "@sentry/utils": 6.19.7
-    tslib: ^1.9.3
-  checksum: d212e8ef07114549de4a93b81f8bfa217ca1550ca7a5eeaa611e5629faef78ff72663ce561ffa2cff48f3dc556745ef65177044f9965cdd3cbccf617cf3bf675
+    "@sentry/core": 7.60.0
+    "@sentry/types": 7.60.0
+    "@sentry/utils": 7.60.0
+    tslib: ^2.4.1 || ^1.9.3
+  checksum: ebd60aea46ca4317303ddb6ee4d6d440fd1b6c936a7c30081944d6197406a13465c7211a1490f199f2b5c51c2de51e5e6471a082990891150fcbeedc28c6464e
   languageName: node
   linkType: hard
 
-"@sentry/hub@npm:6.19.7":
-  version: 6.19.7
-  resolution: "@sentry/hub@npm:6.19.7"
+"@sentry/core@npm:7.60.0":
+  version: 7.60.0
+  resolution: "@sentry/core@npm:7.60.0"
   dependencies:
-    "@sentry/types": 6.19.7
-    "@sentry/utils": 6.19.7
-    tslib: ^1.9.3
-  checksum: 10bb1c5cba1b0f1e27a3dd0a186c22f94aeaf11c4662890ab07b2774f46f46af78d61e3ba71d76edc750a7b45af86edd032f35efecdb4efa2eaf551080ccdcb1
+    "@sentry/types": 7.60.0
+    "@sentry/utils": 7.60.0
+    tslib: ^2.4.1 || ^1.9.3
+  checksum: 33d5c69f9507a49ac22d36bfe772625b328cd75a4b5c9d64af8b2d8635b3e502e1e98e0eaab51458e4d8b55739daa1c34294aa4179eeb6fe4f285c03b08e6328
   languageName: node
   linkType: hard
 
-"@sentry/minimal@npm:6.19.7":
-  version: 6.19.7
-  resolution: "@sentry/minimal@npm:6.19.7"
+"@sentry/node@npm:^7.60.0":
+  version: 7.60.0
+  resolution: "@sentry/node@npm:7.60.0"
   dependencies:
-    "@sentry/hub": 6.19.7
-    "@sentry/types": 6.19.7
-    tslib: ^1.9.3
-  checksum: 9153ac426ee056fc34c5be898f83d74ec08f559d69f544c5944ec05e584b62ed356b92d1a9b08993a7022ad42b5661c3d72881221adc19bee5fc1af3ad3864a8
-  languageName: node
-  linkType: hard
-
-"@sentry/node@npm:6.19.7":
-  version: 6.19.7
-  resolution: "@sentry/node@npm:6.19.7"
-  dependencies:
-    "@sentry/core": 6.19.7
-    "@sentry/hub": 6.19.7
-    "@sentry/types": 6.19.7
-    "@sentry/utils": 6.19.7
+    "@sentry-internal/tracing": 7.60.0
+    "@sentry/core": 7.60.0
+    "@sentry/types": 7.60.0
+    "@sentry/utils": 7.60.0
     cookie: ^0.4.1
     https-proxy-agent: ^5.0.0
     lru_map: ^0.3.3
-    tslib: ^1.9.3
-  checksum: 2293b0d1d1f9fac3a451eb94f820bc27721c8edddd1f373064666ddd6272f0a4c70dbe58c6c4b3d3ccaf4578aab8f466d71ee69f6f6ff93521bbb02dfe829ce5
+    tslib: ^2.4.1 || ^1.9.3
+  checksum: 3ec42ea5d95a204c5ad8ed360c4d2d6c1583780b4879e752856a418289889b8a9e18e6d1ebe721a141b2b0fd3275e22c7ca3661fb6db471e343067c2caf29218
   languageName: node
   linkType: hard
 
-"@sentry/types@npm:6.19.7":
-  version: 6.19.7
-  resolution: "@sentry/types@npm:6.19.7"
-  checksum: f46ef74a33376ad6ea9b128115515c58eb9369d89293c60aa67abca26b5d5d519aa4d0a736db56ae0d75ffd816643d62187018298523cbc2e6c2fb3a6b2a9035
+"@sentry/types@npm:7.60.0":
+  version: 7.60.0
+  resolution: "@sentry/types@npm:7.60.0"
+  checksum: c145704ef188121df0f19e195026b6be22840f56c92e914b54063a2c2241ab09e7c3863530efd70bbb6d1152237b3b99f22a3d9cded06ac25e089121c2890dd7
   languageName: node
   linkType: hard
 
-"@sentry/utils@npm:6.19.7":
-  version: 6.19.7
-  resolution: "@sentry/utils@npm:6.19.7"
+"@sentry/utils@npm:7.60.0, @sentry/utils@npm:^7.60.0":
+  version: 7.60.0
+  resolution: "@sentry/utils@npm:7.60.0"
   dependencies:
-    "@sentry/types": 6.19.7
-    tslib: ^1.9.3
-  checksum: a000223b9c646c64e3565e79cace1eeb75114342b768367c4dddd646476c215eb1bddfb70c63f05e2352d3bce2d7d415344e4757a001605d0e01ac74da5dd306
+    "@sentry/types": 7.60.0
+    tslib: ^2.4.1 || ^1.9.3
+  checksum: 3dd3dd2d7c33e011db700032d1a81f8c7c95f6b212f9685fd614e976fae1ff259dd98340e5ccca52bf251387e7f02949850edb5879a35da842e1b71a1e975331
   languageName: node
   linkType: hard
 
@@ -7198,7 +7186,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@strapi/generate-new@workspace:packages/generators/app"
   dependencies:
-    "@sentry/node": 6.19.7
+    "@sentry/node": ^7.60.0
     chalk: ^4.1.2
     copyfiles: 2.4.1
     execa: 5.1.1
@@ -29365,6 +29353,13 @@ __metadata:
   version: 2.4.1
   resolution: "tslib@npm:2.4.1"
   checksum: 19480d6e0313292bd6505d4efe096a6b31c70e21cf08b5febf4da62e95c265c8f571f7b36fcc3d1a17e068032f59c269fab3459d6cd3ed6949eafecf64315fca
+  languageName: node
+  linkType: hard
+
+"tslib@npm:^2.4.1 || ^1.9.3":
+  version: 2.6.1
+  resolution: "tslib@npm:2.6.1"
+  checksum: b0d176d176487905b66ae4d5856647df50e37beea7571c53b8d10ba9222c074b81f1410fb91da13debaf2cbc970663609068bdebafa844ea9d69b146527c38fe
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This updates the used Sentry version to the current latest (7.60.0), and also updates the middlewares based on https://docs.sentry.io/platforms/node/guides/koa/.

* Update `@sentry/node` to `^7.60.0` - I think it makes sense to allow the caret version here, as otherwise you do not get bugfixes etc. If you prefer to hard-pin this to `7.60.0`, let me know, then I can also do that.
* Add new option `tracesSampleRate` which defaults to 0.1. Based on this we can also instrument performance monitoring in Sentry for the user.
* Update middlewares based on current docs.

Fixes https://github.com/strapi/strapi/issues/17425