### PR TITLE
Chore: Cleanup configure the view styles

### DIFF
--- a/packages/core/admin/admin/src/content-manager/pages/ListSettingsView/components/EditFieldForm.js
+++ b/packages/core/admin/admin/src/content-manager/pages/ListSettingsView/components/EditFieldForm.js
@@ -29,7 +29,7 @@ const HeaderContainer = styled(Flex)`
   }
 `;
 
-const EditFieldForm = ({
+export const EditFieldForm = ({
   attributes,
   fieldForm,
   fieldToEdit,
@@ -142,5 +142,3 @@ EditFieldForm.propTypes = {
   onSubmit: PropTypes.func.isRequired,
   type: PropTypes.string.isRequired,
 };
-
-export default EditFieldForm;

--- a/packages/core/admin/admin/src/content-manager/pages/ListSettingsView/components/Settings.js
+++ b/packages/core/admin/admin/src/content-manager/pages/ListSettingsView/components/Settings.js
@@ -15,7 +15,7 @@ import { useIntl } from 'react-intl';
 
 import { getTrad } from '../../../utils';
 
-const Settings = ({ modifiedData, onChange, sortOptions }) => {
+export const Settings = ({ modifiedData, onChange, sortOptions }) => {
   const { formatMessage } = useIntl();
   const { settings, metadatas } = modifiedData;
 
@@ -168,5 +168,3 @@ Settings.propTypes = {
   onChange: PropTypes.func.isRequired,
   sortOptions: PropTypes.array,
 };
-
-export default Settings;

--- a/packages/core/admin/admin/src/content-manager/pages/ListSettingsView/components/SortDisplayedFields.js
+++ b/packages/core/admin/admin/src/content-manager/pages/ListSettingsView/components/SortDisplayedFields.js
@@ -5,19 +5,12 @@ import { Menu } from '@strapi/design-system/v2';
 import { Plus } from '@strapi/icons';
 import { PropTypes } from 'prop-types';
 import { useIntl } from 'react-intl';
-import styled from 'styled-components';
 
 import { getTrad } from '../../../utils';
 
 import DraggableCard from './DraggableCard';
 
-const ScrollableContainer = styled(Box)`
-  flex: ${({ size }) => size};
-  overflow-x: scroll;
-  overflow-y: hidden;
-`;
-
-const SortDisplayedFields = ({
+export const SortDisplayedFields = ({
   displayedFields,
   listRemainingFields,
   metadatas,
@@ -48,25 +41,16 @@ const SortDisplayedFields = ({
   }, [displayedFields, lastAction]);
 
   return (
-    <>
-      <Box paddingBottom={4}>
-        <Typography variant="delta" as="h2">
-          {formatMessage({
-            id: getTrad('containers.SettingPage.view'),
-            defaultMessage: 'View',
-          })}
-        </Typography>
-      </Box>
-      <Flex
-        paddingTop={4}
-        paddingLeft={4}
-        paddingRight={4}
-        borderColor="neutral300"
-        borderStyle="dashed"
-        borderWidth="1px"
-        hasRadius
-      >
-        <ScrollableContainer size="1" paddingBottom={4} ref={scrollableContainerRef}>
+    <Flex alignItems="stretch" direction="column" gap={4}>
+      <Typography variant="delta" as="h2">
+        {formatMessage({
+          id: getTrad('containers.SettingPage.view'),
+          defaultMessage: 'View',
+        })}
+      </Typography>
+
+      <Flex padding={4} borderColor="neutral300" borderStyle="dashed" borderWidth="1px" hasRadius>
+        <Box flex="1" overflow="scroll hidden" ref={scrollableContainerRef}>
           <Flex gap={3}>
             {displayedFields.map((field, index) => (
               <DraggableCard
@@ -82,7 +66,8 @@ const SortDisplayedFields = ({
               />
             ))}
           </Flex>
-        </ScrollableContainer>
+        </Box>
+
         <Menu.Root>
           <Menu.Trigger
             paddingLeft={2}
@@ -90,7 +75,6 @@ const SortDisplayedFields = ({
             justifyContent="center"
             endIcon={null}
             disabled={listRemainingFields.length <= 0}
-            marginBottom={4}
             variant="tertiary"
           >
             <VisuallyHidden as="span">
@@ -110,7 +94,7 @@ const SortDisplayedFields = ({
           </Menu.Content>
         </Menu.Root>
       </Flex>
-    </>
+    </Flex>
   );
 };
 
@@ -129,5 +113,3 @@ SortDisplayedFields.propTypes = {
   onMoveField: PropTypes.func.isRequired,
   onRemoveField: PropTypes.func.isRequired,
 };
-
-export default SortDisplayedFields;

--- a/packages/core/admin/admin/src/content-manager/pages/ListSettingsView/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/ListSettingsView/index.js
@@ -1,10 +1,10 @@
-import React, { memo, useContext, useReducer, useState } from 'react';
+import React, { useContext, useReducer, useState } from 'react';
 
 import {
-  Box,
   Button,
   ContentLayout,
   Divider,
+  Flex,
   HeaderLayout,
   Layout,
   Main,
@@ -31,9 +31,9 @@ import ModelsContext from '../../contexts/ModelsContext';
 import { usePluginsQueryParams } from '../../hooks';
 import { checkIfAttributeIsDisplayable, getTrad } from '../../utils';
 
-import EditFieldForm from './components/EditFieldForm';
-import Settings from './components/Settings';
-import SortDisplayedFields from './components/SortDisplayedFields';
+import { EditFieldForm } from './components/EditFieldForm';
+import { Settings } from './components/Settings';
+import { SortDisplayedFields } from './components/SortDisplayedFields';
 import { EXCLUDED_SORT_ATTRIBUTE_TYPES } from './constants';
 import init from './init';
 import reducer, { initialState } from './reducer';
@@ -217,8 +217,11 @@ const ListSettingsView = ({ layout, slug }) => {
             )}
           />
           <ContentLayout>
-            <Box
+            <Flex
+              alignItems="stretch"
               background="neutral0"
+              direction="column"
+              gap={6}
               hasRadius
               shadow="tableShadow"
               paddingTop={6}
@@ -231,9 +234,9 @@ const ListSettingsView = ({ layout, slug }) => {
                 onChange={handleChange}
                 sortOptions={sortOptions}
               />
-              <Box paddingTop={6} paddingBottom={6}>
-                <Divider />
-              </Box>
+
+              <Divider />
+
               <SortDisplayedFields
                 listRemainingFields={listRemainingFields}
                 displayedFields={displayedFields}
@@ -243,8 +246,9 @@ const ListSettingsView = ({ layout, slug }) => {
                 onRemoveField={handleRemoveField}
                 metadatas={modifiedData.metadatas}
               />
-            </Box>
+            </Flex>
           </ContentLayout>
+
           <ConfirmDialog
             bodyText={{
               id: getTrad('popUpWarning.warning.updateAllSettings'),
@@ -258,6 +262,7 @@ const ListSettingsView = ({ layout, slug }) => {
             variantRightButton="success-light"
           />
         </form>
+
         {isModalFormOpen && (
           <EditFieldForm
             attributes={attributes}
@@ -296,4 +301,4 @@ ListSettingsView.propTypes = {
   slug: PropTypes.string.isRequired,
 };
 
-export default memo(ListSettingsView);
+export default ListSettingsView;


### PR DESCRIPTION
### What does it do?

- Use `Flex` over paddings
- Use named exports

### Why is it needed?

Makes the DOM structure lighter and the component easier to extend.

