### PR TITLE
Feature: Allow review workflow stage column as default sort option

### DIFF
--- a/packages/core/admin/admin/src/content-manager/pages/ListSettingsView/components/Settings.js
+++ b/packages/core/admin/admin/src/content-manager/pages/ListSettingsView/components/Settings.js
@@ -10,14 +10,36 @@ import {
   ToggleInput,
   Typography,
 } from '@strapi/design-system';
+import { useCollator } from '@strapi/helper-plugin';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 
+import { useEnterprise } from '../../../../hooks/useEnterprise';
 import { getTrad } from '../../../utils';
 
-export const Settings = ({ modifiedData, onChange, sortOptions }) => {
-  const { formatMessage } = useIntl();
-  const { settings, metadatas } = modifiedData;
+export const Settings = ({ contentTypeOptions, modifiedData, onChange, sortOptions: sortOptionsCE }) => {
+  const { formatMessage, locale } = useIntl();
+  const formatter = useCollator(locale, {
+    sensitivity: 'base',
+  });
+  const sortOptions = useEnterprise(
+    sortOptionsCE,
+    async () =>
+      (await import('../../../../../../ee/admin/content-manager/pages/ListSettingsView/constants'))
+        .REVIEW_WORKFLOW_STAGE_SORT_OPTION_NAME,
+    {
+      combine(ceOptions, eeOption) {
+        return [...ceOptions, { ...eeOption, label: formatMessage(eeOption.label) }];
+      },
+
+      defaultValue: sortOptionsCE,
+
+      enabled: !!contentTypeOptions?.reviewWorkflows,
+    }
+  );
+
+  const sortOptionsSorted = sortOptions.sort((a, b) => formatter.compare(a.label, b.label));
+  const { settings } = modifiedData;
 
   return (
     <Flex direction="column" alignItems="stretch" gap={4}>
@@ -129,9 +151,9 @@ export const Settings = ({ modifiedData, onChange, sortOptions }) => {
             name="settings.defaultSortBy"
             value={modifiedData.settings.defaultSortBy || ''}
           >
-            {sortOptions.map((sortBy) => (
-              <Option key={sortBy} value={sortBy}>
-                {metadatas[sortBy].list.label || sortBy}
+            {sortOptionsSorted.map(({ value, label }) => (
+              <Option key={value} value={value}>
+                {label}
               </Option>
             ))}
           </Select>
@@ -164,7 +186,13 @@ Settings.defaultProps = {
 };
 
 Settings.propTypes = {
+  contentTypeOptions: PropTypes.object.isRequired,
   modifiedData: PropTypes.object,
   onChange: PropTypes.func.isRequired,
-  sortOptions: PropTypes.array,
+  sortOptions: PropTypes.arrayOf(
+    PropTypes.shape({
+      value: PropTypes.string,
+      label: PropTypes.string,
+    }).isRequired
+  ),
 };

--- a/packages/core/admin/admin/src/content-manager/pages/ListSettingsView/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/ListSettingsView/index.js
@@ -55,7 +55,7 @@ const ListSettingsView = ({ layout, slug }) => {
 
   const isModalFormOpen = Object.keys(fieldForm).length !== 0;
 
-  const { attributes } = layout;
+  const { attributes, options } = layout;
   const displayedFields = modifiedData.layouts.list;
 
   const goBackUrl = () => {
@@ -179,7 +179,10 @@ const ListSettingsView = ({ layout, slug }) => {
 
   const sortOptions = Object.entries(attributes)
     .filter(([, attribute]) => !EXCLUDED_SORT_ATTRIBUTE_TYPES.includes(attribute.type))
-    .map(([name]) => name);
+    .map(([name]) => ({
+      value: name,
+      label: layout.metadatas[name].list.label,
+    }));
 
   const move = (originalIndex, atIndex) => {
     dispatch({
@@ -235,6 +238,7 @@ const ListSettingsView = ({ layout, slug }) => {
               paddingRight={7}
             >
               <Settings
+                contentTypeOptions={options}
                 modifiedData={modifiedData}
                 onChange={handleChange}
                 sortOptions={sortOptions}

--- a/packages/core/admin/ee/admin/content-manager/pages/ListSettingsView/constants.js
+++ b/packages/core/admin/ee/admin/content-manager/pages/ListSettingsView/constants.js
@@ -1,0 +1,7 @@
+export const REVIEW_WORKFLOW_STAGE_SORT_OPTION_NAME = {
+  value: 'strapi_stage[name]',
+  label: {
+    id: 'settings.defaultSortOrder.reviewWorkflows.label',
+    defaultMessage: 'Review Stage',
+  },
+};


### PR DESCRIPTION
### What does it do?

Add the review workflow stage column as default sort option in configure the view.

### Why is it needed?

Will allow users to use the stage column with a default sorting.

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

- Needs https://github.com/strapi/strapi/pull/17438
- Needs https://github.com/strapi/strapi/pull/17440
- Needs https://github.com/strapi/strapi/pull/17205
- Needs https://github.com/strapi/strapi/pull/17444
