### PR TITLE
feat: default sort by relational fields

### DIFF
--- a/api-tests/core/content-manager/content-manager/configuration.test.api.js
+++ b/api-tests/core/content-manager/content-manager/configuration.test.api.js
@@ -157,7 +157,7 @@ describe('Content Manager - Configuration', () => {
     expect(body.data.contentType.layouts.list).toStrictEqual(['id', 'title', 'author']);
   });
 
-  test('Update list non visible attribute as default sort', async () => {
+  test('Set non visible attribute as default sort', async () => {
     // Get current config
     const { body } = await rq({
       url: '/content-manager/content-types/api::article.article/configuration',
@@ -175,5 +175,25 @@ describe('Content Manager - Configuration', () => {
 
     expect(res.statusCode).toBe(200);
     expect(res.body.data.contentType.settings.defaultSortBy).toBe('nonVisible');
+  });
+
+  test('Set relational attribute as default sort', async () => {
+    // Get current config
+    const { body } = await rq({
+      url: '/content-manager/content-types/api::article.article/configuration',
+      method: 'GET',
+    });
+
+    // set default sort
+    const configuration = set('contentType.settings.defaultSortBy', 'author[username]', body.data);
+
+    const res = await rq({
+      url: '/content-manager/content-types/api::article.article/configuration',
+      method: 'PUT',
+      body: { settings: configuration.contentType.settings },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.data.contentType.settings.defaultSortBy).toBe('author[username]');
   });
 });

--- a/packages/core/content-manager/package.json
+++ b/packages/core/content-manager/package.json
@@ -27,7 +27,8 @@
   "dependencies": {
     "@sindresorhus/slugify": "1.1.0",
     "@strapi/utils": "4.11.7",
-    "lodash": "4.17.21"
+    "lodash": "4.17.21",
+    "qs": "6.11.1"
   },
   "engines": {
     "node": ">=16.0.0 <=20.x.x",

--- a/packages/core/content-manager/server/controllers/validation/model-configuration.js
+++ b/packages/core/content-manager/server/controllers/validation/model-configuration.js
@@ -61,6 +61,9 @@ const createSettingsSchema = (schema) => {
       defaultSortBy: yup
         .string()
         .test('is-valid-sort-attribute', '${path} is not a valid sort attribute', async (value) => {
+          // Does nested validation for relational attributes (e.g author[username])
+          const parsedValue = qs.parse(value);
+
           const omitNonSortableAttributes = ({ schema, key }, { remove }) => {
             const sortableAttributes = getSortableAttributes(schema);
             if (!sortableAttributes.includes(key)) {
@@ -68,7 +71,6 @@ const createSettingsSchema = (schema) => {
             }
           };
 
-          const parsedValue = qs.parse(value);
           const sanitizedValue = await traverse.traverseQuerySort(
             omitNonSortableAttributes,
             { schema },

--- a/packages/core/content-manager/server/services/utils/configuration/__tests__/settings.test.js
+++ b/packages/core/content-manager/server/services/utils/configuration/__tests__/settings.test.js
@@ -2,6 +2,13 @@
 
 const settingsService = require('../settings');
 
+jest.mock('@strapi/utils', () => ({
+  ...jest.requireActual('@strapi/utils'),
+  traverse: {
+    traverseQuerySort: jest.fn((a, b, c) => c),
+  },
+}));
+
 describe('Configuration settings service', () => {
   describe('createDefaultSettings', () => {
     test('Consistent defaults', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7890,6 +7890,7 @@ __metadata:
     "@sindresorhus/slugify": 1.1.0
     "@strapi/utils": 4.11.7
     lodash: 4.17.21
+    qs: 6.11.1
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
### What does it do?
We only allowed `defaultSort` attributes to be top level ones. But Strapi allows you to sort by relational fields and other nested structures.

This PR modifies the yup validation so we can set the default sort by `strapi_stage[name]` and `strapi_assignee[name]`.
