### PR TITLE
Update semver to remove audit warnings

### DIFF
--- a/packages/core/admin/package.json
+++ b/packages/core/admin/package.json
@@ -117,7 +117,7 @@
     "reselect": "^4.1.7",
     "rimraf": "3.0.2",
     "sanitize-html": "2.11.0",
-    "semver": "7.5.2",
+    "semver": "7.5.4",
     "sift": "16.0.1",
     "style-loader": "3.3.1",
     "styled-components": "5.3.3",

--- a/packages/core/data-transfer/package.json
+++ b/packages/core/data-transfer/package.json
@@ -45,7 +45,7 @@
     "chalk": "4.1.2",
     "fs-extra": "10.0.0",
     "lodash": "4.17.21",
-    "semver": "7.5.2",
+    "semver": "7.5.4",
     "stream-chain": "2.2.5",
     "stream-json": "1.8.0",
     "tar": "6.1.13",

--- a/packages/core/database/package.json
+++ b/packages/core/database/package.json
@@ -39,7 +39,7 @@
     "fs-extra": "10.0.0",
     "knex": "2.5.0",
     "lodash": "4.17.21",
-    "semver": "7.5.2",
+    "semver": "7.5.4",
     "umzug": "3.2.1"
   },
   "engines": {

--- a/packages/core/strapi/package.json
+++ b/packages/core/strapi/package.json
@@ -131,7 +131,7 @@
     "package-json": "7.0.0",
     "qs": "6.11.1",
     "resolve-cwd": "3.0.0",
-    "semver": "7.5.2",
+    "semver": "7.5.4",
     "statuses": "2.0.1"
   },
   "devDependencies": {

--- a/packages/generators/app/package.json
+++ b/packages/generators/app/package.json
@@ -52,7 +52,7 @@
     "node-fetch": "^2.6.9",
     "node-machine-id": "^1.1.10",
     "ora": "^5.4.1",
-    "semver": "7.5.2",
+    "semver": "7.5.4",
     "tar": "6.1.13"
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7622,7 +7622,7 @@ __metadata:
     reselect: ^4.1.7
     rimraf: 3.0.2
     sanitize-html: 2.11.0
-    semver: 7.5.2
+    semver: 7.5.4
     sift: 16.0.1
     speed-measure-webpack-plugin: 1.5.0
     style-loader: 3.3.1
@@ -7662,7 +7662,7 @@ __metadata:
     koa: 2.13.4
     lodash: 4.17.21
     rimraf: 3.0.2
-    semver: 7.5.2
+    semver: 7.5.4
     stream-chain: 2.2.5
     stream-json: 1.8.0
     tar: 6.1.13
@@ -7682,7 +7682,7 @@ __metadata:
     fs-extra: 10.0.0
     knex: 2.5.0
     lodash: 4.17.21
-    semver: 7.5.2
+    semver: 7.5.4
     umzug: 3.2.1
   languageName: unknown
   linkType: soft
@@ -7754,7 +7754,7 @@ __metadata:
     node-fetch: ^2.6.9
     node-machine-id: ^1.1.10
     ora: ^5.4.1
-    semver: 7.5.2
+    semver: 7.5.4
     tar: 6.1.13
   languageName: unknown
   linkType: soft
@@ -8334,7 +8334,7 @@ __metadata:
     package-json: 7.0.0
     qs: 6.11.1
     resolve-cwd: 3.0.0
-    semver: 7.5.2
+    semver: 7.5.4
     statuses: 2.0.1
     supertest: 6.3.3
     typescript: 5.1.3
@@ -29143,17 +29143,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:7.5.2":
-  version: 7.5.2
-  resolution: "semver@npm:7.5.2"
-  dependencies:
-    lru-cache: ^6.0.0
-  bin:
-    semver: bin/semver.js
-  checksum: 3fdf5d1e6f170fe8bcc41669e31787649af91af7f54f05c71d0865bb7aa27e8b92f68b3e6b582483e2c1c648008bc84249d2cd86301771fe5cbf7621d1fe5375
-  languageName: node
-  linkType: hard
-
 "semver@npm:7.5.3, semver@npm:^7.5.3":
   version: 7.5.3
   resolution: "semver@npm:7.5.3"
@@ -29162,6 +29151,17 @@ __metadata:
   bin:
     semver: bin/semver.js
   checksum: 9d58db16525e9f749ad0a696a1f27deabaa51f66e91d2fa2b0db3de3e9644e8677de3b7d7a03f4c15bc81521e0c3916d7369e0572dbde250d9bedf5194e2a8a7
+  languageName: node
+  linkType: hard
+
+"semver@npm:7.5.4":
+  version: 7.5.4
+  resolution: "semver@npm:7.5.4"
+  dependencies:
+    lru-cache: ^6.0.0
+  bin:
+    semver: bin/semver.js
+  checksum: 12d8ad952fa353b0995bf180cdac205a4068b759a140e5d3c608317098b3575ac2f1e09182206bf2eb26120e1c0ed8fb92c48c592f6099680de56bb071423ca3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What does it do?

Upgrade `semver` from 7.5.2 to 7.5.4 due to https://github.com/advisories/GHSA-c2qf-rxjj-qqgw

### Why is it needed?

Fixing and audit warning, Strapi itself is not vulnerable to this issue

### How to test it?

Run `yarn npm audit` and see that the audit warnings have disappeared

### Related issue(s)/PR(s)

N/A
