### PR TITLE
[DTS] Add detail to ws upgrade error

### DIFF
--- a/packages/core/data-transfer/src/strapi/remote/handlers/utils.ts
+++ b/packages/core/data-transfer/src/strapi/remote/handlers/utils.ts
@@ -28,7 +28,12 @@ export const assertValidHeader = (ctx: Context) => {
   const upgradeHeader = transformUpgradeHeader(ctx.headers.upgrade);
 
   if (!upgradeHeader.includes('websocket')) {
-    throw new Error('Invalid Header');
+    const logSafeUpgradeHeader = ctx.headers.upgrade
+      ?.replace(/[^a-z0-9\s.,|]/gi, '')
+      .substring(0, 50);
+    throw new Error(
+      `Transfer Upgrade header expected 'websocket', found '${logSafeUpgradeHeader}'. Please ensure that your server or proxy is not modifying the Upgrade header.`
+    );
   }
 };
 

--- a/packages/core/data-transfer/src/strapi/remote/handlers/utils.ts
+++ b/packages/core/data-transfer/src/strapi/remote/handlers/utils.ts
@@ -25,14 +25,27 @@ export const transformUpgradeHeader = (header = '') => {
  * Make sure that the upgrade header is a valid websocket one
  */
 export const assertValidHeader = (ctx: Context) => {
-  const upgradeHeader = transformUpgradeHeader(ctx.headers.upgrade);
+  if (ctx.headers.upgrade !== 'websocket') {
+    const upgradeHeader = transformUpgradeHeader(ctx.headers.upgrade);
 
-  if (!upgradeHeader.includes('websocket')) {
-    const logSafeUpgradeHeader = ctx.headers.upgrade
+    // Sanitize user input before writing it to our logs
+    const logSafeUpgradeHeader = JSON.stringify(ctx.headers.upgrade)
       ?.replace(/[^a-z0-9\s.,|]/gi, '')
       .substring(0, 50);
-    throw new Error(
-      `Transfer Upgrade header expected 'websocket', found '${logSafeUpgradeHeader}'. Please ensure that your server or proxy is not modifying the Upgrade header.`
+
+    if (!upgradeHeader.includes('websocket')) {
+      throw new Error(
+        `Transfer Upgrade header expected 'websocket', found '${logSafeUpgradeHeader}'. Please ensure that your server or proxy is not modifying the Upgrade header.`
+      );
+    }
+
+    /**
+     * If there's more than expected but it still includes websocket, in theory it could still work
+     * and could be necessary for their certain configurations, so we'll allow it to proceed but
+     * log the unexpected behaviour in case it helps debug an issue
+     * */
+    strapi.log.info(
+      `Transfer Upgrade header expected only 'websocket', found unexpected values: ${logSafeUpgradeHeader}`
     );
   }
 };

--- a/packages/core/data-transfer/src/strapi/remote/handlers/utils.ts
+++ b/packages/core/data-transfer/src/strapi/remote/handlers/utils.ts
@@ -25,29 +25,33 @@ export const transformUpgradeHeader = (header = '') => {
  * Make sure that the upgrade header is a valid websocket one
  */
 export const assertValidHeader = (ctx: Context) => {
-  if (ctx.headers.upgrade !== 'websocket') {
-    const upgradeHeader = transformUpgradeHeader(ctx.headers.upgrade);
+  // if it's exactly what we expect, it's fine
+  if (ctx.headers.upgrade === 'websocket') {
+    return;
+  }
 
-    // Sanitize user input before writing it to our logs
-    const logSafeUpgradeHeader = JSON.stringify(ctx.headers.upgrade)
-      ?.replace(/[^a-z0-9\s.,|]/gi, '')
-      .substring(0, 50);
+  // check if it could be an array that still includes websocket
+  const upgradeHeader = transformUpgradeHeader(ctx.headers.upgrade);
 
-    if (!upgradeHeader.includes('websocket')) {
-      throw new Error(
-        `Transfer Upgrade header expected 'websocket', found '${logSafeUpgradeHeader}'. Please ensure that your server or proxy is not modifying the Upgrade header.`
-      );
-    }
+  // Sanitize user input before writing it to our logs
+  const logSafeUpgradeHeader = JSON.stringify(ctx.headers.upgrade)
+    ?.replace(/[^a-z0-9\s.,|]/gi, '')
+    .substring(0, 50);
 
-    /**
-     * If there's more than expected but it still includes websocket, in theory it could still work
-     * and could be necessary for their certain configurations, so we'll allow it to proceed but
-     * log the unexpected behaviour in case it helps debug an issue
-     * */
-    strapi.log.info(
-      `Transfer Upgrade header expected only 'websocket', found unexpected values: ${logSafeUpgradeHeader}`
+  if (!upgradeHeader.includes('websocket')) {
+    throw new Error(
+      `Transfer Upgrade header expected 'websocket', found '${logSafeUpgradeHeader}'. Please ensure that your server or proxy is not modifying the Upgrade header.`
     );
   }
+
+  /**
+   * If there's more than expected but it still includes websocket, in theory it could still work
+   * and could be necessary for their certain configurations, so we'll allow it to proceed but
+   * log the unexpected behaviour in case it helps debug an issue
+   * */
+  strapi.log.info(
+    `Transfer Upgrade header expected only 'websocket', found unexpected values: ${logSafeUpgradeHeader}`
+  );
 };
 
 export const isDataTransferMessage = (message: unknown): message is Protocol.Client.Message => {


### PR DESCRIPTION
### What does it do?

Adds more detail to the error when invalid Upgrade headers are sent

### Why is it needed?

Some users have proxies modifying their headers (such as to prevent websocket connections) but we do not provide adequate error messaging for them to debug the problem.

### How to test it?

Try to connect to the transfer websocket server without a 'websocket' Upgrade header and there is now a server log detailing the problem.

### Related issue(s)/PR(s)

Relates to the `500` response in [this issue](https://github.com/strapi/strapi/issues/16296)
