### PR TITLE
Update media thumbnails on replace

### DIFF
--- a/packages/core/upload/admin/src/components/AssetCard/AssetCard.js
+++ b/packages/core/upload/admin/src/components/AssetCard/AssetCard.js
@@ -27,6 +27,7 @@ export const AssetCard = ({ asset, isSelected, onSelect, onEdit, onRemove, size,
     onRemove: onRemove ? () => onRemove(asset) : undefined,
     selected: isSelected,
     size,
+    updatedAt: asset.updatedAt,
   };
 
   if (asset.mime.includes(AssetType.Video)) {

--- a/packages/core/upload/admin/src/components/AssetCard/AssetCard.js
+++ b/packages/core/upload/admin/src/components/AssetCard/AssetCard.js
@@ -27,7 +27,6 @@ export const AssetCard = ({ asset, isSelected, onSelect, onEdit, onRemove, size,
     onRemove: onRemove ? () => onRemove(asset) : undefined,
     selected: isSelected,
     size,
-    updatedAt: asset.updatedAt,
   };
 
   if (asset.mime.includes(AssetType.Video)) {
@@ -42,6 +41,7 @@ export const AssetCard = ({ asset, isSelected, onSelect, onEdit, onRemove, size,
         height={asset.height}
         thumbnail={prefixFileUrlWithBackendUrl(asset?.formats?.thumbnail?.url || asset.url)}
         width={asset.width}
+        updatedAt={asset.updatedAt}
       />
     );
   }

--- a/packages/core/upload/admin/src/components/AssetGridList/tests/__snapshots__/AssetGridList.test.js.snap
+++ b/packages/core/upload/admin/src/components/AssetGridList/tests/__snapshots__/AssetGridList.test.js.snap
@@ -387,7 +387,7 @@ exports[`MediaLibrary / AssetList snapshots the asset list 1`] = `
                 alt="strapi-cover_1fabc982ce.png"
                 aria-hidden="true"
                 class="c14"
-                src="http://localhost:1337/uploads/thumbnail_strapi_cover_1fabc982ce_5b43615ed5.png"
+                src="http://localhost:1337/uploads/thumbnail_strapi_cover_1fabc982ce_5b43615ed5.png?2021-09-14T07:32:50.816Z"
               />
             </div>
           </div>


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

- Provides the `updatedAt` prop to ImageAssetCard
- This ensures that the FE gets the latest image when media is replaced using https://github.com/strapi/strapi/blob/0c20c6cea2c856b7725787549e1ba887d9a06afc/packages/core/upload/admin/src/components/AssetCard/ImageAssetCard.js#L11


### Related issue(s)/PR(s)

Fixes https://github.com/strapi/strapi/issues/17283
