### PR TITLE
Chore: Enforce build sourcemaps with an environment variable

### DIFF
--- a/packages/core/admin/index.js
+++ b/packages/core/admin/index.js
@@ -31,6 +31,7 @@ async function build({ appDir, buildDestDir, env, forceBuild, optimize, options,
   const dest = path.resolve(buildDestDir, 'build');
 
   const pluginsPath = Object.keys(plugins).map((pluginName) => plugins[pluginName].pathToPlugin);
+  const enforceSourceMaps = process.env.STRAPI_ENFORCE_SOURCEMAPS === 'true' ?? false;
 
   // Either use the tsconfig file from the generated app or the one inside the .cache folder
   // so we can develop plugins in TS while being in a JS app
@@ -42,6 +43,7 @@ async function build({ appDir, buildDestDir, env, forceBuild, optimize, options,
     appDir,
     cacheDir,
     dest,
+    enforceSourceMaps,
     entry,
     env,
     optimize,

--- a/packages/core/admin/scripts/build.js
+++ b/packages/core/admin/scripts/build.js
@@ -54,6 +54,7 @@ const buildAdmin = async () => {
       telemetryDisabled: process.env.STRAPI_TELEMETRY_DISABLED === 'true' ?? false,
     },
     tsConfigFilePath,
+    enforceSourceMaps: process.env.STRAPI_ENFORCE_SOURCEMAPS === 'true' ?? false,
   };
 
   const config =

--- a/packages/core/admin/webpack.config.js
+++ b/packages/core/admin/webpack.config.js
@@ -28,6 +28,7 @@ module.exports = ({
     features: [],
   },
   tsConfigFilePath,
+  enforceSourceMaps,
 }) => {
   const isProduction = env === 'production';
 
@@ -54,7 +55,7 @@ module.exports = ({
   return {
     mode: isProduction ? 'production' : 'development',
     bail: !!isProduction,
-    devtool: isProduction ? false : 'eval-source-map',
+    devtool: isProduction && !enforceSourceMaps ? false : 'source-map',
     experiments: {
       topLevelAwait: true,
     },


### PR DESCRIPTION
### What does it do?

This adds a new environment variable, which is read during the build step by webpack to enable source-maps: `STRAPI_ENFORCE_SOURCEMAPS`.

I have also changed to source map type from 'eval-source-map' to 'source-map' because the content security policy does not allow `eval`.

### Why is it needed?

We receive a lot of bug reports where users reference minified errors from the browser console. Because the admin app is always built in production mode these errors are cryptic and often not actionable unless users overwrite their webpack configuration, which is heavy, and there is a chance they are not changing it back. [Example](https://github.com/strapi/strapi/issues/17457#issuecomment-1651829759).

This will make it easier for us to get the information we need in order to fix these bugs.

This is an idea for now I'd like to get feedback on - once you agreed I'll documentation for it :)

Experimental release: `0.0.0-experimental.dd3ae14b0b01403328c0ae5914b7dae1424a11c3`
