### PR TITLE
Fix: Upload assets from url

### DIFF
--- a/packages/core/upload/admin/src/components/UploadAssetDialog/tests/UploadAssetDialog.test.js
+++ b/packages/core/upload/admin/src/components/UploadAssetDialog/tests/UploadAssetDialog.test.js
@@ -145,7 +145,7 @@ describe('UploadAssetDialog', () => {
       fireEvent.change(screen.getByLabelText('URL'), { target: { value: urls } });
       fireEvent.click(screen.getByText('Next'));
 
-      await waitFor(() => expect(screen.getByText('Network Error')).toBeInTheDocument());
+      await waitFor(() => expect(screen.getByText('Failed to fetch')).toBeInTheDocument());
     });
 
     it('snapshots the component with 4 URLs: 3 valid and one in failure', async () => {

--- a/packages/core/upload/admin/src/components/UploadAssetDialog/tests/server.js
+++ b/packages/core/upload/admin/src/components/UploadAssetDialog/tests/server.js
@@ -14,5 +14,5 @@ export const server = setupServer(
     res(ctx.set('Content-Type', 'video/mp4'), ctx.body())
   ),
   rest.get('*/not-working-like-cors.lutin', (req, res, ctx) => res(ctx.json({}))),
-  rest.get('*/some-where-not-existing.jpg', (req, res) => res.networkError())
+  rest.get('*/some-where-not-existing.jpg', (req, res) => res.networkError('Failed to fetch'))
 );

--- a/packages/core/upload/admin/src/utils/urlsToAssets.js
+++ b/packages/core/upload/admin/src/utils/urlsToAssets.js
@@ -1,5 +1,3 @@
-import { getFetchClient } from '@strapi/helper-plugin';
-
 import { AssetSource } from '../constants';
 
 import { typeFromMime } from './typeFromMime';
@@ -9,20 +7,18 @@ function getFilenameFromURL(url) {
 }
 
 export const urlsToAssets = async (urls) => {
-  const { get } = getFetchClient();
   const assetPromises = urls.map((url) =>
-    get(url, {
-      responseType: 'blob',
-      timeout: 60000,
-    }).then((res) => {
-      const loadedFile = new File([res.data], getFilenameFromURL(res.config.url), {
-        type: res.headers['content-type'],
+    fetch(url).then(async (res) => {
+      const blob = await res.blob();
+
+      const loadedFile = new File([blob], getFilenameFromURL(res.url), {
+        type: res.headers.get('content-type'),
       });
 
       return {
         name: loadedFile.name,
-        url: res.config.url,
-        mime: res.headers['content-type'],
+        url: res.url,
+        mime: res.headers.get('content-type'),
         rawFile: loadedFile,
       };
     })


### PR DESCRIPTION
### What does it do?

We changed all the old axios requests to start using the `getFetchClient` util. This util adds an authorization token to all requests. In the "Upload asset from URL" case we don't need that token (bc they are external requests) and have that token in the headers cause CORS problems in some cases

### How to test it?

1. Go to the Media Library
2. Try to upload an image from a random public URL
3. It should upload the image without problems

