### PR TITLE
Revert 17319 fix/default admin lastname

### DIFF
--- a/packages/core/admin/admin/src/pages/AuthPage/components/Register/index.js
+++ b/packages/core/admin/admin/src/pages/AuthPage/components/Register/index.js
@@ -98,10 +98,6 @@ const Register = ({ authType, fieldsToDisable, noSignin, onSubmit, schema }) => 
 
       if (!['password', 'confirmPassword'].includes(key) && typeof value === 'string') {
         normalizedvalue = normalizedvalue.trim();
-
-        if (key === 'lastname') {
-          normalizedvalue = normalizedvalue || null;
-        }
       }
 
       acc[key] = normalizedvalue;

--- a/packages/core/admin/admin/src/pages/AuthPage/components/Register/tests/index.test.js
+++ b/packages/core/admin/admin/src/pages/AuthPage/components/Register/tests/index.test.js
@@ -136,61 +136,6 @@ describe('ADMIN | PAGES | AUTH | Register', () => {
     );
   });
 
-  it('Validates optional Lastname value to be null', async () => {
-    const spy = jest.fn();
-    const { getByRole, getByLabelText, user } = setup({ onSubmit: spy });
-
-    await user.type(getByLabelText(/Firstname/i), 'First name');
-    await user.type(getByLabelText(/Email/i), 'test@strapi.io');
-    await user.type(getByLabelText(/^Password/i), 'secret');
-    await user.type(getByLabelText(/Confirm Password/i), 'secret');
-
-    fireEvent.click(getByRole('button', { name: /let's start/i }));
-
-    await waitFor(() =>
-      expect(spy).toHaveBeenCalledWith(
-        {
-          firstname: 'First name',
-          lastname: null,
-          email: 'test@strapi.io',
-          news: false,
-          registrationToken: undefined,
-          confirmPassword: 'secret',
-          password: 'secret',
-        },
-        expect.any(Object)
-      )
-    );
-  });
-
-  it('Validates optional Lastname value to be empty space', async () => {
-    const spy = jest.fn();
-    const { getByRole, getByLabelText, user } = setup({ onSubmit: spy });
-
-    await user.type(getByLabelText(/Firstname/i), 'First name');
-    await user.type(getByLabelText(/Lastname/i), ' ');
-    await user.type(getByLabelText(/Email/i), 'test@strapi.io');
-    await user.type(getByLabelText(/^Password/i), 'secret');
-    await user.type(getByLabelText(/Confirm Password/i), 'secret');
-
-    fireEvent.click(getByRole('button', { name: /let's start/i }));
-
-    await waitFor(() =>
-      expect(spy).toHaveBeenCalledWith(
-        {
-          firstname: 'First name',
-          lastname: null,
-          email: 'test@strapi.io',
-          news: false,
-          registrationToken: undefined,
-          confirmPassword: 'secret',
-          password: 'secret',
-        },
-        expect.any(Object)
-      )
-    );
-  });
-
   it('Disable fields', () => {
     const { getByLabelText } = setup({
       fieldsToDisable: ['email', 'firstname'],


### PR DESCRIPTION
Reverts strapi/strapi#17319
Reopens https://github.com/strapi/strapi/issues/17287

This introduces a bug where new admin users can not be registered anymore.

