### PR TITLE
Fix: Registration - Send null for lastname instead of empty string

### DIFF
--- a/packages/core/admin/admin/src/pages/AuthPage/components/Register/index.js
+++ b/packages/core/admin/admin/src/pages/AuthPage/components/Register/index.js
@@ -98,6 +98,10 @@ const Register = ({ authType, fieldsToDisable, noSignin, onSubmit, schema }) => 
 
       if (!['password', 'confirmPassword'].includes(key) && typeof value === 'string') {
         normalizedvalue = normalizedvalue.trim();
+
+        if (key === 'lastname') {
+          normalizedvalue = normalizedvalue || null;
+        }
       }
 
       acc[key] = normalizedvalue;

--- a/packages/core/admin/admin/src/pages/AuthPage/components/Register/tests/index.test.js
+++ b/packages/core/admin/admin/src/pages/AuthPage/components/Register/tests/index.test.js
@@ -136,6 +136,61 @@ describe('ADMIN | PAGES | AUTH | Register', () => {
     );
   });
 
+  it('Validates optional Lastname value to be null', async () => {
+    const spy = jest.fn();
+    const { getByRole, getByLabelText, user } = setup({ onSubmit: spy });
+
+    await user.type(getByLabelText(/Firstname/i), 'First name');
+    await user.type(getByLabelText(/Email/i), 'test@strapi.io');
+    await user.type(getByLabelText(/^Password/i), 'secret');
+    await user.type(getByLabelText(/Confirm Password/i), 'secret');
+
+    fireEvent.click(getByRole('button', { name: /let's start/i }));
+
+    await waitFor(() =>
+      expect(spy).toHaveBeenCalledWith(
+        {
+          firstname: 'First name',
+          lastname: null,
+          email: 'test@strapi.io',
+          news: false,
+          registrationToken: undefined,
+          confirmPassword: 'secret',
+          password: 'secret',
+        },
+        expect.any(Object)
+      )
+    );
+  });
+
+  it('Validates optional Lastname value to be empty space', async () => {
+    const spy = jest.fn();
+    const { getByRole, getByLabelText, user } = setup({ onSubmit: spy });
+
+    await user.type(getByLabelText(/Firstname/i), 'First name');
+    await user.type(getByLabelText(/Lastname/i), ' ');
+    await user.type(getByLabelText(/Email/i), 'test@strapi.io');
+    await user.type(getByLabelText(/^Password/i), 'secret');
+    await user.type(getByLabelText(/Confirm Password/i), 'secret');
+
+    fireEvent.click(getByRole('button', { name: /let's start/i }));
+
+    await waitFor(() =>
+      expect(spy).toHaveBeenCalledWith(
+        {
+          firstname: 'First name',
+          lastname: null,
+          email: 'test@strapi.io',
+          news: false,
+          registrationToken: undefined,
+          confirmPassword: 'secret',
+          password: 'secret',
+        },
+        expect.any(Object)
+      )
+    );
+  });
+
   it('Disable fields', () => {
     const { getByLabelText } = setup({
       fieldsToDisable: ['email', 'firstname'],

--- a/packages/core/admin/admin/src/pages/AuthPage/components/Register/tests/index.test.js
+++ b/packages/core/admin/admin/src/pages/AuthPage/components/Register/tests/index.test.js
@@ -2,16 +2,18 @@ import React from 'react';
 
 import { lightTheme, ThemeProvider } from '@strapi/design-system';
 import { TrackingProvider, useNotification, useQuery } from '@strapi/helper-plugin';
-import { act, fireEvent, render, waitFor } from '@testing-library/react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { createMemoryHistory } from 'history';
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
 import { IntlProvider } from 'react-intl';
 import { Router } from 'react-router-dom';
-import * as yup from 'yup';
 
 import Register from '..';
+import { FORMS } from '../../../constants';
+
+const PASSWORD_VALID = '!Eight_8_characters!';
 
 jest.mock('../../../../../hooks/useConfigurations');
 jest.mock('../../../../../components/LocalesProvider/useLocalesProvider');
@@ -44,39 +46,40 @@ const server = setupServer(
   })
 );
 
-const ComponentFixture = (props) => {
-  const history = createMemoryHistory();
-
-  return (
-    <IntlProvider locale="en" messages={{}}>
-      <TrackingProvider>
-        <ThemeProvider theme={lightTheme}>
-          <Router history={history}>
-            <Register
-              authType="register-admin"
-              fieldsToDisable={[]}
-              noSignin
-              onSubmit={() => {}}
-              schema={yup.object()}
-              {...props}
-            />
-          </Router>
-        </ThemeProvider>
-      </TrackingProvider>
-    </IntlProvider>
-  );
-};
-
 const setup = (props) => {
   const user = userEvent.setup();
 
   return {
-    ...render(<ComponentFixture {...props} />),
+    ...render(
+      <Register
+        authType="register-admin"
+        fieldsToDisable={[]}
+        noSignin
+        onSubmit={() => {}}
+        schema={FORMS['register-admin'].schema}
+        {...props}
+      />,
+      {
+        wrapper({ children }) {
+          const history = createMemoryHistory();
+
+          return (
+            <IntlProvider locale="en" messages={{}}>
+              <TrackingProvider>
+                <ThemeProvider theme={lightTheme}>
+                  <Router history={history}>{children}</Router>
+                </ThemeProvider>
+              </TrackingProvider>
+            </IntlProvider>
+          );
+        },
+      }
+    ),
     user,
   };
 };
 
-describe('ADMIN | PAGES | AUTH | Register', () => {
+describe('ADMIN | PAGES | AUTH | Register Admin', () => {
   beforeAll(() => {
     server.listen();
   });
@@ -115,8 +118,8 @@ describe('ADMIN | PAGES | AUTH | Register', () => {
     await user.type(getByLabelText(/Firstname/i), ' First name ');
     await user.type(getByLabelText(/Lastname/i), ' Last name ');
     await user.type(getByLabelText(/Email/i), ' test@strapi.io ');
-    await user.type(getByLabelText(/^Password/i), ' secret ');
-    await user.type(getByLabelText(/Confirm Password/i), ' secret ');
+    await user.type(getByLabelText(/^Password/i), PASSWORD_VALID);
+    await user.type(getByLabelText(/Confirm Password/i), PASSWORD_VALID);
 
     fireEvent.click(getByRole('button', { name: /let's start/i }));
 
@@ -128,8 +131,8 @@ describe('ADMIN | PAGES | AUTH | Register', () => {
           email: 'test@strapi.io',
           news: false,
           registrationToken: undefined,
-          confirmPassword: ' secret ',
-          password: ' secret ',
+          confirmPassword: PASSWORD_VALID,
+          password: PASSWORD_VALID,
         },
         expect.any(Object)
       )
@@ -142,8 +145,8 @@ describe('ADMIN | PAGES | AUTH | Register', () => {
 
     await user.type(getByLabelText(/Firstname/i), 'First name');
     await user.type(getByLabelText(/Email/i), 'test@strapi.io');
-    await user.type(getByLabelText(/^Password/i), 'secret');
-    await user.type(getByLabelText(/Confirm Password/i), 'secret');
+    await user.type(getByLabelText(/^Password/i), PASSWORD_VALID);
+    await user.type(getByLabelText(/Confirm Password/i), PASSWORD_VALID);
 
     fireEvent.click(getByRole('button', { name: /let's start/i }));
 
@@ -155,8 +158,8 @@ describe('ADMIN | PAGES | AUTH | Register', () => {
           email: 'test@strapi.io',
           news: false,
           registrationToken: undefined,
-          confirmPassword: 'secret',
-          password: 'secret',
+          confirmPassword: PASSWORD_VALID,
+          password: PASSWORD_VALID,
         },
         expect.any(Object)
       )
@@ -170,8 +173,8 @@ describe('ADMIN | PAGES | AUTH | Register', () => {
     await user.type(getByLabelText(/Firstname/i), 'First name');
     await user.type(getByLabelText(/Lastname/i), ' ');
     await user.type(getByLabelText(/Email/i), 'test@strapi.io');
-    await user.type(getByLabelText(/^Password/i), 'secret');
-    await user.type(getByLabelText(/Confirm Password/i), 'secret');
+    await user.type(getByLabelText(/^Password/i), PASSWORD_VALID);
+    await user.type(getByLabelText(/Confirm Password/i), PASSWORD_VALID);
 
     fireEvent.click(getByRole('button', { name: /let's start/i }));
 
@@ -183,8 +186,8 @@ describe('ADMIN | PAGES | AUTH | Register', () => {
           email: 'test@strapi.io',
           news: false,
           registrationToken: undefined,
-          confirmPassword: 'secret',
-          password: 'secret',
+          confirmPassword: PASSWORD_VALID,
+          password: PASSWORD_VALID,
         },
         expect.any(Object)
       )
@@ -198,33 +201,6 @@ describe('ADMIN | PAGES | AUTH | Register', () => {
 
     expect(getByLabelText(/Firstname/i)).not.toHaveAttribute('disabled');
     expect(getByLabelText(/Email/i)).toHaveAttribute('disabled');
-  });
-
-  it('Set defaults if the registration token is set and omits it when submitting', async () => {
-    const spy = jest.fn();
-    const query = useQuery();
-    query.get.mockReturnValue('my-token');
-
-    const { getByLabelText, getByRole } = setup({ onSubmit: spy });
-
-    await waitFor(() => expect(getByLabelText(/Firstname/i)).toHaveValue('Token firstname'));
-
-    expect(getByLabelText(/Lastname/i)).toHaveValue('Token lastname');
-    expect(getByLabelText(/Email/i)).toHaveValue('test+register-token@strapi.io');
-
-    await act(async () => {
-      fireEvent.click(getByRole('button', { name: /let's start/i }));
-    });
-
-    expect(spy).toHaveBeenCalledWith(
-      {
-        registrationToken: 'my-token',
-        userInfo: expect.not.objectContaining({
-          registrationToken: expect.any(String),
-        }),
-      },
-      expect.any(Object)
-    );
   });
 
   it('Shows an error notification if the token does not exist', async () => {
@@ -241,26 +217,5 @@ describe('ADMIN | PAGES | AUTH | Register', () => {
       type: 'warning',
       message: expect.any(String),
     });
-  });
-
-  it('Violates the yup schema and displays error messages', async () => {
-    const { getByText, getByRole } = setup({
-      schema: yup.object().shape({
-        firstname: yup.string().trim().required(),
-        lastname: yup.string(),
-        password: yup.string().required(),
-        email: yup.string().required(),
-        confirmPassword: yup.string().required(),
-      }),
-    });
-
-    await act(async () => {
-      fireEvent.click(getByRole('button', { name: /let's start/i }));
-    });
-
-    expect(getByText(/firstname is a required field/i)).toBeInTheDocument();
-    expect(getByText(/email is a required field/i)).toBeInTheDocument();
-    expect(getByText(/^password is a required field/i)).toBeInTheDocument();
-    expect(getByText(/confirmpassword is a required field/i)).toBeInTheDocument();
   });
 });

--- a/packages/core/admin/admin/src/pages/AuthPage/constants.js
+++ b/packages/core/admin/admin/src/pages/AuthPage/constants.js
@@ -55,7 +55,7 @@ export const FORMS = {
     fieldsToOmit: ['userInfo.confirmPassword', 'userInfo.news', 'userInfo.email'],
     schema: yup.object().shape({
       firstname: yup.string().trim().required(translatedErrors.required),
-      lastname: yup.string(),
+      lastname: yup.string().nullable(),
       password: yup
         .string()
         .min(8, translatedErrors.minLength)
@@ -79,7 +79,7 @@ export const FORMS = {
     fieldsToOmit: ['confirmPassword', 'news'],
     schema: yup.object().shape({
       firstname: yup.string().trim().required(translatedErrors.required),
-      lastname: yup.string(),
+      lastname: yup.string().nullable(),
       password: yup
         .string()
         .min(8, translatedErrors.minLength)

--- a/packages/core/admin/server/validation/authentication/register.js
+++ b/packages/core/admin/server/validation/authentication/register.js
@@ -11,7 +11,7 @@ const registrationSchema = yup
       .object()
       .shape({
         firstname: validators.firstname.required(),
-        lastname: validators.lastname,
+        lastname: validators.lastname.nullable(),
         password: validators.password.required(),
       })
       .required()
@@ -32,7 +32,7 @@ const adminRegistrationSchema = yup
   .shape({
     email: validators.email.required(),
     firstname: validators.firstname.required(),
-    lastname: validators.lastname,
+    lastname: validators.lastname.nullable(),
     password: validators.password.required(),
   })
   .required()


### PR DESCRIPTION
### What does it do?

Make `lastname` field required for registrations AND admin registrations.

> **Note**
> The registration components need a bigger refactoring as well as more tests. I'll track this in follow-up tickets.

### Why is it needed?

The field is not required. The bug had been addressed in https://github.com/strapi/strapi/pull/17319, but new admin users with an empty lastname couldn't be registered any longer.

### How to test it?

1. Delete .tmp .cache build
2. Run `yarn build && yarn develop`
3. Register an admin user with an empty lastname

### Related issue(s)/PR(s)

This is an alternative to https://github.com/strapi/strapi/pull/17461 which reverts the previous PR.

Closes https://github.com/strapi/strapi/issues/17287
