### PR TITLE
Enhancement: Add RW assignee as default sort option

### DIFF
--- a/packages/core/admin/admin/src/content-manager/pages/ListSettingsView/components/Settings.js
+++ b/packages/core/admin/admin/src/content-manager/pages/ListSettingsView/components/Settings.js
@@ -17,7 +17,12 @@ import { useIntl } from 'react-intl';
 import { useEnterprise } from '../../../../hooks/useEnterprise';
 import { getTrad } from '../../../utils';
 
-export const Settings = ({ contentTypeOptions, modifiedData, onChange, sortOptions: sortOptionsCE }) => {
+export const Settings = ({
+  contentTypeOptions,
+  modifiedData,
+  onChange,
+  sortOptions: sortOptionsCE,
+}) => {
   const { formatMessage, locale } = useIntl();
   const formatter = useCollator(locale, {
     sensitivity: 'base',
@@ -26,10 +31,13 @@ export const Settings = ({ contentTypeOptions, modifiedData, onChange, sortOptio
     sortOptionsCE,
     async () =>
       (await import('../../../../../../ee/admin/content-manager/pages/ListSettingsView/constants'))
-        .REVIEW_WORKFLOW_STAGE_SORT_OPTION_NAME,
+        .REVIEW_WORKFLOW_ASSIGNEE_SORT_OPTIONS,
     {
-      combine(ceOptions, eeOption) {
-        return [...ceOptions, { ...eeOption, label: formatMessage(eeOption.label) }];
+      combine(ceOptions, eeOptions) {
+        return [
+          ...ceOptions,
+          ...eeOptions.map((eeOption) => ({ ...eeOption, label: formatMessage(eeOption.label) })),
+        ];
       },
 
       defaultValue: sortOptionsCE,

--- a/packages/core/admin/admin/src/content-manager/pages/ListView/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/ListView/index.js
@@ -633,9 +633,7 @@ function ListView({
                                 <Td key={key}>
                                   {rowData.strapi_assignee ? (
                                     <ReviewWorkflowsColumns.ReviewWorkflowsAssigneeEE
-                                      firstname={rowData.strapi_assignee.firstname}
-                                      lastname={rowData?.strapi_assignee?.lastname}
-                                      displayname={rowData?.strapi_assignee?.username}
+                                      user={rowData.strapi_assignee}
                                     />
                                   ) : (
                                     <Typography textColor="neutral800">-</Typography>

--- a/packages/core/admin/ee/admin/content-manager/pages/ListSettingsView/constants.js
+++ b/packages/core/admin/ee/admin/content-manager/pages/ListSettingsView/constants.js
@@ -1,7 +1,17 @@
-export const REVIEW_WORKFLOW_STAGE_SORT_OPTION_NAME = {
-  value: 'strapi_stage[name]',
-  label: {
-    id: 'settings.defaultSortOrder.reviewWorkflows.label',
-    defaultMessage: 'Review Stage',
+export const REVIEW_WORKFLOW_ASSIGNEE_SORT_OPTIONS = [
+  {
+    value: 'strapi_stage[name]',
+    label: {
+      id: 'settings.defaultSortOrder.reviewWorkflows.stage.label',
+      defaultMessage: 'Review Stage',
+    },
   },
-};
+
+  {
+    value: 'strapi_assignee[name]',
+    label: {
+      id: 'settings.defaultSortOrder.reviewWorkflows.assignee.label',
+      defaultMessage: 'Assignee',
+    },
+  },
+];

--- a/packages/core/admin/ee/admin/content-manager/pages/ListView/ReviewWorkflowsColumn/ReviewWorkflowsAssigneeEE.js
+++ b/packages/core/admin/ee/admin/content-manager/pages/ListView/ReviewWorkflowsColumn/ReviewWorkflowsAssigneeEE.js
@@ -4,48 +4,22 @@ import { Typography } from '@strapi/design-system';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 
-import getTrad from '../../../../../../admin/src/content-manager/utils/getTrad';
+import { getDisplayName } from '../../../../../../admin/src/content-manager/utils';
 
-export function ReviewWorkflowsAssigneeEE({ firstname, lastname, displayname }) {
+export function ReviewWorkflowsAssigneeEE({ user }) {
   const { formatMessage } = useIntl();
 
-  // TODO align with changes from this PR, using the getDisplayName util
-  // https://github.com/strapi/strapi/pull/17043/
-  if (displayname) {
-    return (
-      <Typography textColor="neutral800">
-        {formatMessage(
-          {
-            id: getTrad(`containers.ListPage.reviewWorkflows.assignee`),
-            defaultMessage: '{displayname}',
-          },
-          { displayname }
-        )}
-      </Typography>
-    );
-  }
-
-  return (
-    <Typography textColor="neutral800">
-      {formatMessage(
-        {
-          id: getTrad(`containers.ListPage.reviewWorkflows.assignee`),
-          defaultMessage: '{firstname} {lastname}',
-        },
-        { firstname, lastname }
-      )}
-    </Typography>
-  );
+  return <Typography textColor="neutral800">{getDisplayName(user, formatMessage)}</Typography>;
 }
 
 ReviewWorkflowsAssigneeEE.defaultProps = {
-  firstname: '',
-  lastname: '',
-  displayname: '',
+  user: { lastname: '', username: '' },
 };
 
 ReviewWorkflowsAssigneeEE.propTypes = {
-  firstname: PropTypes.string,
-  lastname: PropTypes.string,
-  displayname: PropTypes.string,
+  user: PropTypes.shape({
+    firstname: PropTypes.string.isRequired,
+    lastname: PropTypes.string,
+    username: PropTypes.string,
+  }),
 };

--- a/packages/core/admin/ee/admin/content-manager/pages/ListView/ReviewWorkflowsColumn/tests/ReviewWorkflowsAssignee.test.js
+++ b/packages/core/admin/ee/admin/content-manager/pages/ListView/ReviewWorkflowsColumn/tests/ReviewWorkflowsAssignee.test.js
@@ -6,25 +6,28 @@ import { IntlProvider } from 'react-intl';
 
 import { ReviewWorkflowsAssigneeEE } from '..';
 
-const ComponentFixture = (props) => (
-  <ThemeProvider theme={lightTheme}>
-    <IntlProvider locale="en" messages={{}}>
-      <ReviewWorkflowsAssigneeEE {...props} />
-    </IntlProvider>
-  </ThemeProvider>
-);
-
-const setup = (props) => render(<ComponentFixture {...props} />);
-
-describe('DynamicTable | ReviewWorkflowsAssignee', () => {
-  test('will use displayname over first and last name', () => {
-    const displayname = 'Display Name';
-    const { getByText } = setup({ displayname });
-
-    expect(getByText(displayname)).toBeInTheDocument();
+const setup = (props) =>
+  render(<ReviewWorkflowsAssigneeEE {...props} />, {
+    wrapper({ children }) {
+      return (
+        <ThemeProvider theme={lightTheme}>
+          <IntlProvider locale="en" messages={{}}>
+            {children}
+          </IntlProvider>
+        </ThemeProvider>
+      );
+    },
   });
+
+describe('Content-Manager | List View | ReviewWorkflowsAssignee', () => {
+  test('will use displayname over first and last name', () => {
+    const { getByText } = setup({ user: { firstname: 'Kai', username: 'Display Name' } });
+
+    expect(getByText('Display Name')).toBeInTheDocument();
+  });
+
   test('render assignee name', () => {
-    const { getByText } = setup({ firstname: 'Kai', lastname: 'Doe' });
+    const { getByText } = setup({ user: { firstname: 'Kai', lastname: 'Doe' } });
 
     expect(getByText('Kai Doe')).toBeInTheDocument();
   });


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Replaces RW stage sort with assignee as that is what is relevant to this branch

I thought it was best to replace the stage stuff rather than add to it so we keep the branches separate during development. wdyt?

This PR is FE only

### Why is it needed?

Adding default sort ability on RW assignee
