### PR TITLE
chore(@​strapi/typescript-utils): add repository info to package.json

### DIFF
--- a/packages/utils/typescript/package.json
+++ b/packages/utils/typescript/package.json
@@ -2,6 +2,11 @@
   "name": "@strapi/typescript-utils",
   "version": "4.12.1",
   "description": "Typescript support for Strapi",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/strapi/strapi.git",
+    "directory": "packages/utils/typescript"
+  },
   "keywords": [
     "strapi",
     "generators"


### PR DESCRIPTION
### What does it do?

Adding repository info in `package.json`.

### Why is it needed?

Helps bots like renovate to group update prs

### How to test it?

Check out https://www.npmjs.com/package/@strapi/typescript-utils after publishing a new package.
