### PR TITLE
fix: reorder rw permissions so they appear as CRUD

### DIFF
--- a/packages/core/admin/ee/server/config/admin-actions.js
+++ b/packages/core/admin/ee/server/config/admin-actions.js
@@ -39,6 +39,14 @@ module.exports = {
       subCategory: 'options',
     },
     {
+      uid: 'review-workflows.read',
+      displayName: 'Read',
+      pluginName: 'admin',
+      section: 'settings',
+      category: 'review workflows',
+      subCategory: 'options',
+    },
+    {
       uid: 'review-workflows.update',
       displayName: 'Update',
       pluginName: 'admin',
@@ -49,14 +57,6 @@ module.exports = {
     {
       uid: 'review-workflows.delete',
       displayName: 'Delete',
-      pluginName: 'admin',
-      section: 'settings',
-      category: 'review workflows',
-      subCategory: 'options',
-    },
-    {
-      uid: 'review-workflows.read',
-      displayName: 'Read',
       pluginName: 'admin',
       section: 'settings',
       category: 'review workflows',


### PR DESCRIPTION
### What does it do?

Review workflows settings page were showing in the incorrect order:

Before:
![image](https://github.com/strapi/strapi/assets/20578351/8f2811da-13e8-4664-a37f-82352a92b13d)

After:
![image](https://github.com/strapi/strapi/assets/20578351/be70328b-efb7-46a5-b377-cf505b817118)


