### PR TITLE
Allow priority sorting on relational fields

### DIFF
--- a/packages/core/admin/admin/src/content-manager/pages/ListView/components/BulkActionButtons/SelectedEntriesModal/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/ListView/components/BulkActionButtons/SelectedEntriesModal/index.js
@@ -146,11 +146,11 @@ const SelectedEntriesTableContent = ({
     <Table.Content>
       <Table.Head>
         <Table.HeaderCheckboxCell />
-        <Table.HeaderCell fieldSchemaType="number" label="id" name="id" />
+        <Table.HeaderCell fieldSchemaType="number" metadatas={{ label: 'id' }} name="id" />
         {shouldDisplayMainField && (
-          <Table.HeaderCell fieldSchemaType="string" label="name" name="name" />
+          <Table.HeaderCell fieldSchemaType="string" metadatas={{ label: 'name' }} name="name" />
         )}
-        <Table.HeaderCell fieldSchemaType="string" label="status" name="status" />
+        <Table.HeaderCell fieldSchemaType="string" metadatas={{ label: 'status' }} name="status" />
       </Table.Head>
       <Table.LoadingBody />
       <Table.Body>

--- a/packages/core/admin/admin/src/content-manager/pages/ListView/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/ListView/index.js
@@ -554,9 +554,7 @@ function ListView({
                       key={key}
                       name={name}
                       fieldSchemaType={fieldSchema.type}
-                      relationFieldName={metadatas.mainField?.name}
-                      isSortable={metadatas.sortable}
-                      label={metadatas.label}
+                      metadatas={metadatas}
                     />
                   ))}
                   {/* Visually hidden header for actions */}

--- a/packages/core/admin/ee/admin/content-manager/pages/ListView/ReviewWorkflowsColumn/constants.js
+++ b/packages/core/admin/ee/admin/content-manager/pages/ListView/ReviewWorkflowsColumn/constants.js
@@ -40,12 +40,28 @@ export const REVIEW_WORKFLOW_COLUMNS_EE = [
       },
       searchable: false,
       sortable: true,
-      mainField: {
-        name: 'firstname',
-        schema: {
-          type: 'string',
+      mainField: [
+        {
+          name: 'username',
+          schema: {
+            type: 'string',
+          },
         },
-      },
+
+        {
+          name: 'lastname',
+          schema: {
+            type: 'string',
+          },
+        },
+
+        {
+          name: 'firstname',
+          schema: {
+            type: 'string',
+          },
+        },
+      ],
     },
   },
 ];

--- a/packages/core/helper-plugin/src/hooks/useQueryParams/index.js
+++ b/packages/core/helper-plugin/src/hooks/useQueryParams/index.js
@@ -18,7 +18,7 @@ const useQueryParams = (initialParams) => {
   }, [search, initialParams]);
 
   const setQuery = useCallback(
-    (nextParams, method = 'push') => {
+    (nextParams, method = 'push', arrayFormat = 'indices') => {
       let nextQuery = { ...query };
 
       if (method === 'remove') {
@@ -29,7 +29,7 @@ const useQueryParams = (initialParams) => {
         nextQuery = { ...query, ...nextParams };
       }
 
-      push({ search: stringify(nextQuery, { encode: false }) });
+      push({ search: stringify(nextQuery, { encode: false, arrayFormat }) });
     },
     [push, query]
   );


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Allows priority sorting in the CM list view on relational fields

### Why is it needed?

Sorting of users can then be done on multiple fields e.g. [username, firstname, lastname]

Previously we would have to pick one mainField to sort by and for users this field may not always be displayed

### How to test it?

Test provided

### Related issue(s)/PR(s)

CONTENT-1124
