### PR TITLE
Feature: Add review workflow assignee to CM filter options

### DIFF
--- a/packages/core/admin/admin/src/content-manager/pages/ListView/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/ListView/index.js
@@ -17,6 +17,7 @@ import {
   lightTheme,
 } from '@strapi/design-system';
 import {
+  findMatchingPermissions,
   NoPermissions,
   CheckPermissions,
   SearchURLQuery,
@@ -76,6 +77,7 @@ const REVIEW_WORKFLOW_COLUMNS_CE = null;
 const REVIEW_WORKFLOW_COLUMNS_CELL_CE = () => null;
 const REVIEW_WORKFLOW_FILTER_CE = [];
 const CREATOR_ATTRIBUTES = ['createdBy', 'updatedBy'];
+const USER_FILTER_ATTRIBUTES = [...CREATOR_ATTRIBUTES, 'strapi_assignee'];
 
 function ListView({
   canCreate,
@@ -101,7 +103,7 @@ function ListView({
   const [isConfirmDeleteRowOpen, setIsConfirmDeleteRowOpen] = React.useState(false);
   const toggleNotification = useNotification();
   const { trackUsage } = useTracking();
-  const { refetchPermissions } = useRBACProvider();
+  const { allPermissions, refetchPermissions } = useRBACProvider();
   const trackUsageRef = React.useRef(trackUsage);
   const fetchPermissionsRef = React.useRef(refetchPermissions);
   const { notifyStatus } = useNotifyAT();
@@ -122,7 +124,9 @@ function ListView({
       const [key, value] = Object.entries(filter)[0];
       const id = value.id?.$eq || value.id?.$ne;
 
-      if (CREATOR_ATTRIBUTES.includes(key) && !acc.includes(id)) {
+      // TODO: strapi_assignee should not be in here and rather defined
+      // in the ee directory.
+      if (USER_FILTER_ATTRIBUTES.includes(key) && !acc.includes(id)) {
         acc.push(id);
       }
 
@@ -132,7 +136,16 @@ function ListView({
   const { users, isLoading: isLoadingAdminUsers } = useAdminUsers(
     { filter: { id: { in: selectedUserIds } } },
     {
-      enabled: selectedUserIds.length > 0,
+      // fetch the list of admin users only if the filter contains users and the
+      // current user has permissions to display users
+      enabled:
+        selectedUserIds.length > 0 &&
+        findMatchingPermissions(allPermissions, [
+          {
+            action: 'admin::users.read',
+            subject: null,
+          },
+        ]).length > 0,
     }
   );
 
@@ -225,24 +238,58 @@ function ListView({
         await import(
           '../../../../../ee/admin/content-manager/components/Filter/CustomInputs/ReviewWorkflows/constants'
         )
-      ).REVIEW_WORKFLOW_STAGE_FILTER,
+      ).REVIEW_WORKFLOW_FILTERS,
     {
-      combine(ceFilters, eeFilter) {
+      combine(ceFilters, eeFilters) {
         return [
           ...ceFilters,
-          {
-            ...eeFilter,
-            metadatas: {
-              ...eeFilter.metadatas,
-              label: formatMessage(eeFilter.metadatas.label),
-              uid: contentType.uid,
-            },
-          },
+          ...eeFilters
+            .filter((eeFilter) => {
+              // do not display the filter at all, if the current user does
+              // not have permissions to read admin users
+              if (eeFilter.name === 'strapi_assignee') {
+                return (
+                  findMatchingPermissions(allPermissions, [
+                    {
+                      action: 'admin::users.read',
+                      subject: null,
+                    },
+                  ]).length > 0
+                );
+              }
+
+              return true;
+            })
+            .map((eeFilter) => ({
+              ...eeFilter,
+              metadatas: {
+                ...eeFilter.metadatas,
+                // the stage filter needs the current content-type uid to fetch
+                // the list of stages that can be assigned to this content-type
+                ...(eeFilter.name === 'strapi_stage' ? { uid: contentType.uid } : {}),
+
+                // translate the filter label
+                label: formatMessage(eeFilter.metadatas.label),
+
+                // `options` allows the filter-tag to render the displayname
+                // of a user over a plain id
+                options:
+                  eeFilter.name === 'strapi_assignee' &&
+                  users.map((user) => ({
+                    label: getDisplayName(user, formatMessage),
+                    customValue: user.id.toString(),
+                  })),
+              },
+            })),
         ];
       },
 
       defaultValue: [],
-      enabled: hasReviewWorkflows,
+
+      // we have to wait for admin users to be fully loaded, because otherwise
+      // combine is called to early and does not contain the latest state of
+      // the users array
+      enabled: hasReviewWorkflows && !isLoadingAdminUsers,
     }
   );
 

--- a/packages/core/admin/ee/admin/content-manager/components/Filter/CustomInputs/ReviewWorkflows/AssigneeFilter.js
+++ b/packages/core/admin/ee/admin/content-manager/components/Filter/CustomInputs/ReviewWorkflows/AssigneeFilter.js
@@ -4,10 +4,10 @@ import { Combobox, ComboboxOption } from '@strapi/design-system';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 
-import { useAdminUsers } from '../../../../hooks/useAdminUsers';
-import { getDisplayName } from '../../../utils';
+import { getDisplayName } from '../../../../../../../admin/src/content-manager/utils/getDisplayName';
+import { useAdminUsers } from '../../../../../../../admin/src/hooks/useAdminUsers';
 
-export const AdminUsersFilter = ({ value, onChange }) => {
+export const AssigneeFilter = ({ value, onChange }) => {
   const { formatMessage } = useIntl();
   const { users, isLoading } = useAdminUsers();
 
@@ -32,11 +32,11 @@ export const AdminUsersFilter = ({ value, onChange }) => {
   );
 };
 
-AdminUsersFilter.propTypes = {
+AssigneeFilter.propTypes = {
   onChange: PropTypes.func.isRequired,
   value: PropTypes.string,
 };
 
-AdminUsersFilter.defaultProps = {
+AssigneeFilter.defaultProps = {
   value: '',
 };

--- a/packages/core/admin/ee/admin/content-manager/components/Filter/CustomInputs/ReviewWorkflows/StageFilter.js
+++ b/packages/core/admin/ee/admin/content-manager/components/Filter/CustomInputs/ReviewWorkflows/StageFilter.js
@@ -7,7 +7,7 @@ import { useIntl } from 'react-intl';
 import { useReviewWorkflows } from '../../../../../pages/SettingsPage/pages/ReviewWorkflows/hooks/useReviewWorkflows';
 import { getStageColorByHex } from '../../../../../pages/SettingsPage/pages/ReviewWorkflows/utils/colors';
 
-export const ReviewWorkflowsFilter = ({ value, onChange, uid }) => {
+export const StageFilter = ({ value, onChange, uid }) => {
   const { formatMessage } = useIntl();
   const {
     workflows: [workflow],
@@ -59,11 +59,11 @@ export const ReviewWorkflowsFilter = ({ value, onChange, uid }) => {
   );
 };
 
-ReviewWorkflowsFilter.defaultProps = {
+StageFilter.defaultProps = {
   value: '',
 };
 
-ReviewWorkflowsFilter.propTypes = {
+StageFilter.propTypes = {
   onChange: PropTypes.func.isRequired,
   uid: PropTypes.string.isRequired,
   value: PropTypes.string,

--- a/packages/core/admin/ee/admin/content-manager/components/Filter/CustomInputs/ReviewWorkflows/constants.js
+++ b/packages/core/admin/ee/admin/content-manager/components/Filter/CustomInputs/ReviewWorkflows/constants.js
@@ -1,27 +1,71 @@
 import { getTrad } from '../../../../../../../admin/src/content-manager/utils';
 
-import { ReviewWorkflowsFilter } from './ReviewWorkflowsFilter';
+import { AssigneeFilter } from './AssigneeFilter';
+import { StageFilter } from './StageFilter';
 
-export const REVIEW_WORKFLOW_STAGE_FILTER = {
-  fieldSchema: {
-    type: 'relation',
-    mainField: {
-      name: 'name',
+export const REVIEW_WORKFLOW_FILTERS = [
+  {
+    fieldSchema: {
+      type: 'relation',
+      mainField: {
+        name: 'name',
 
-      schema: {
-        type: 'string',
+        schema: {
+          type: 'string',
+        },
       },
     },
-  },
 
-  metadatas: {
-    customInput: ReviewWorkflowsFilter,
+    metadatas: {
+      customInput: StageFilter,
 
-    label: {
-      id: getTrad(`containers.ListPage.table-headers.reviewWorkflows.stage`),
-      defaultMessage: 'Review stage',
+      label: {
+        id: getTrad(`containers.ListPage.table-headers.reviewWorkflows.stage`),
+        defaultMessage: 'Review stage',
+      },
     },
+
+    name: 'strapi_stage',
   },
 
-  name: 'strapi_stage',
-};
+  {
+    fieldSchema: {
+      type: 'relation',
+      mainField: {
+        name: 'id',
+
+        schema: {
+          type: 'int',
+        },
+      },
+    },
+
+    metadatas: {
+      customInput: AssigneeFilter,
+
+      customOperators: [
+        {
+          intlLabel: {
+            id: 'components.FilterOptions.FILTER_TYPES.$eq',
+            defaultMessage: 'is',
+          },
+          value: '$eq',
+        },
+        {
+          intlLabel: {
+            id: 'components.FilterOptions.FILTER_TYPES.$ne',
+            defaultMessage: 'is not',
+          },
+          value: '$ne',
+        },
+      ],
+
+      label: {
+        id: getTrad(`containers.ListPage.table-headers.reviewWorkflows.assignee.label`),
+        defaultMessage: 'Assignee',
+      },
+    },
+
+    name: 'strapi_assignee',
+  },
+];

--- a/packages/core/admin/ee/admin/content-manager/components/Filter/CustomInputs/ReviewWorkflows/tests/StageFilter.test.js
+++ b/packages/core/admin/ee/admin/content-manager/components/Filter/CustomInputs/ReviewWorkflows/tests/StageFilter.test.js
@@ -1,0 +1,83 @@
+import React from 'react';
+
+import { ThemeProvider, lightTheme } from '@strapi/design-system';
+import { render, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import { IntlProvider } from 'react-intl';
+import { QueryClientProvider, QueryClient } from 'react-query';
+
+import { StageFilter } from '../StageFilter';
+
+const server = setupServer(
+  rest.get('*/admin/review-workflows/workflows', (req, res, ctx) => {
+    return res(
+      ctx.json({
+        data: [
+          {
+            id: 1,
+            stages: [
+              {
+                id: 1,
+                name: 'To Review',
+                color: '#FFFFFF',
+              },
+            ],
+          },
+        ],
+      })
+    );
+  })
+);
+
+const queryClient = new QueryClient();
+
+const setup = (props) => {
+  return {
+    ...render(<StageFilter uid="api::address.address" onChange={() => {}} {...props} />, {
+      wrapper: ({ children }) => (
+        <ThemeProvider theme={lightTheme}>
+          <QueryClientProvider client={queryClient}>
+            <IntlProvider locale="en" messages={{}} defaultLocale="en">
+              {children}
+            </IntlProvider>
+          </QueryClientProvider>
+        </ThemeProvider>
+      ),
+    }),
+    user: userEvent.setup(),
+  };
+};
+
+describe('Content-Manger | List View | Filter | StageFilter', () => {
+  beforeAll(() => {
+    server.listen();
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
+  it('should display stages', async () => {
+    const { getByText, user, getByRole } = setup();
+
+    await user.click(getByRole('combobox'));
+
+    await waitFor(() => {
+      expect(getByText('To Review')).toBeInTheDocument();
+    });
+  });
+
+  it('should use the stage name as filter value', async () => {
+    const spy = jest.fn();
+    const { getByText, user, getByRole } = setup({ onChange: spy });
+
+    await user.click(getByRole('combobox'));
+    await user.click(getByText('To Review'));
+
+    await waitFor(() => {
+      expect(spy).toHaveBeenCalledWith('To Review');
+    });
+  });
+});


### PR DESCRIPTION
### What does it do?

Adds review workflow assignees to the list of filters in the CM filter view.

### Why is it needed?

Support more use-cases for users who want to use advanced filtering.

