### PR TITLE
fix: Content API partial update fails when not populating stage field 

### DIFF
--- a/packages/core/admin/ee/server/services/review-workflows/__tests__/entity-service-decorator.test.js
+++ b/packages/core/admin/ee/server/services/review-workflows/__tests__/entity-service-decorator.test.js
@@ -88,7 +88,7 @@ describe('Entity service decorator', () => {
         ...input,
         data: {
           ...input.data,
-          strapi_stage: 1,
+          [ENTITY_STAGE_ATTRIBUTE]: 1,
         },
       });
     });
@@ -160,7 +160,7 @@ describe('Entity service decorator', () => {
 
       const service = decorator(defaultService);
 
-      const input = { data: { title: 'title ', strapi_reviewWorkflows_stage: stageToId } };
+      const input = { data: { title: 'title ', [ENTITY_STAGE_ATTRIBUTE]: stageToId } };
       await service.update(uid, entityId, input);
 
       expect(defaultService.update).toHaveBeenCalledWith(uid, entityId, input);
@@ -197,13 +197,13 @@ describe('Entity service decorator', () => {
       const service = decorator(defaultService);
 
       const id = 1;
-      const input = { data: { title: 'title ', strapi_stage: null } };
+      const input = { data: { title: 'title ', [ENTITY_STAGE_ATTRIBUTE]: null } };
       await service.update(uid, id, input);
 
       expect(defaultService.update).toHaveBeenCalledWith(uid, id, {
         ...input,
         data: {
-          ...omit('strapi_stage', input.data),
+          ...omit(ENTITY_STAGE_ATTRIBUTE, input.data),
         },
       });
     });

--- a/packages/core/admin/ee/server/services/review-workflows/entity-service-decorator.js
+++ b/packages/core/admin/ee/server/services/review-workflows/entity-service-decorator.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { isNil, isNull } = require('lodash/fp');
+const { isNil } = require('lodash/fp');
 const { ENTITY_STAGE_ATTRIBUTE } = require('../../constants/workflows');
 const { WORKFLOW_UPDATE_STAGE } = require('../../constants/webhookEvents');
 const { getService } = require('../../utils');
@@ -56,7 +56,7 @@ const decorator = (service) => ({
   async update(uid, entityId, opts = {}) {
     // Prevents the stage from being set to null
     const data = { ...opts.data };
-    if (isNull(data[ENTITY_STAGE_ATTRIBUTE])) {
+    if (isNil(data[ENTITY_STAGE_ATTRIBUTE])) {
       delete data[ENTITY_STAGE_ATTRIBUTE];
       return service.update.call(this, uid, entityId, { ...opts, data });
     }
@@ -66,7 +66,8 @@ const decorator = (service) => ({
     const updatedEntity = await service.update.call(this, uid, entityId, { ...opts, data });
     const updatedStage = updatedEntity[ENTITY_STAGE_ATTRIBUTE];
 
-    if (previousStage?.id && previousStage.id !== updatedStage.id) {
+    // Stage might be null if field is not populated
+    if (updatedStage && previousStage?.id && previousStage.id !== updatedStage.id) {
       const model = strapi.getModel(uid);
 
       strapi.eventHub.emit(WORKFLOW_UPDATE_STAGE, {


### PR DESCRIPTION
### What does it do?

Partial Content API updates were broken if not populating `strapi_reviewWorkflow_stage` attribute.

### Why is it needed?

To prevent this error when doing partial updates in the content api:
![image](https://github.com/strapi/strapi/assets/20578351/9466c698-beb9-4561-8acf-d8d281e73ccf)


