### PR TITLE
fix(upload): Use native fetch over API client for downloadFile

### DIFF
--- a/packages/core/upload/admin/src/utils/downloadFile.js
+++ b/packages/core/upload/admin/src/utils/downloadFile.js
@@ -1,9 +1,6 @@
-import { getFetchClient } from '@strapi/helper-plugin';
-
 export const downloadFile = async (url, fileName) => {
-  const { get } = getFetchClient();
-  const response = await get(url, { responseType: 'blob' });
-  const urlDownload = window.URL.createObjectURL(new Blob([response.data]));
+  const fileBlob = await fetch(url).then((res) => res.blob());
+  const urlDownload = window.URL.createObjectURL(fileBlob);
   const link = document.createElement('a');
 
   link.href = urlDownload;

--- a/packages/core/upload/admin/src/utils/tests/downloadFile.test.js
+++ b/packages/core/upload/admin/src/utils/tests/downloadFile.test.js
@@ -1,0 +1,48 @@
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+
+import { downloadFile } from '../downloadFile';
+
+const server = setupServer(
+  rest.get('*/some/file', async (req, res, ctx) => {
+    const file = new File([new Blob(['1'.repeat(1024 * 1024 + 1)])], 'image.png', {
+      type: 'image/png',
+    });
+    const buffer = await new Response(file).arrayBuffer();
+
+    return res(ctx.set('Content-Type', 'image/png'), ctx.body(buffer));
+  })
+);
+
+describe('Upload | utils | downloadFile', () => {
+  beforeAll(() => {
+    server.listen();
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
+  test('Download target as blob', async () => {
+    const setAttributeSpy = jest.fn();
+    const clickSpy = jest.fn();
+    const hrefSpy = jest.fn();
+
+    const documentSpy = jest.spyOn(document, 'createElement');
+
+    documentSpy.mockReturnValue({
+      click: clickSpy,
+      set href(val) {
+        hrefSpy(val);
+      },
+      setAttribute: setAttributeSpy,
+    });
+
+    await downloadFile('/some/file', 'my-filename');
+
+    expect(documentSpy).toHaveBeenCalledWith('a');
+    expect(clickSpy).toHaveBeenCalled();
+    expect(setAttributeSpy).toHaveBeenCalledWith('download', 'my-filename');
+    expect(hrefSpy).toHaveBeenCalledWith(expect.stringContaining('http://localhost:4000/assets'));
+  });
+});


### PR DESCRIPTION
### What does it do?

Uses native `fetch` API over the API client.

### Why is it needed?

Fixes https://github.com/strapi/strapi/issues/17454

### How to test it?

The automated tests covers at least a part of it. It would be nice if e.g. @Marc-Roig could test this on an actual S3 setup.
