### PR TITLE
[TS][Entity Service] Add findMany types

### DIFF
--- a/packages/core/strapi/lib/services/entity-service/types/index.d.ts
+++ b/packages/core/strapi/lib/services/entity-service/types/index.d.ts
@@ -1,6 +1,16 @@
+import type { Attribute, Common, EntityService } from '@strapi/strapi';
+
 // TODO: Move params to @strapi/utils (related to convert-query-params)
 export * as Params from './params';
 
 export * from './plugin';
 
-export interface EntityService {}
+export interface EntityService {
+  findMany<TContentTypeUID extends Common.UID.ContentType>(
+    uid: TContentTypeUID,
+    params?: Omit<
+      EntityService.Params.Read<TContentTypeUID>,
+      keyof EntityService.Params.Pagination.PageNotation
+    >
+  ): Promise<Attribute.GetValues<TContentTypeUID>[]>;
+}

--- a/packages/core/strapi/lib/services/entity-service/types/index.d.ts
+++ b/packages/core/strapi/lib/services/entity-service/types/index.d.ts
@@ -10,7 +10,7 @@ export interface EntityService {
     uid: TContentTypeUID,
     params?: EntityService.Params.Pick<
       TContentTypeUID,
-      'fields' | 'filters' | 'pagination:offset' | 'sort' | 'populate' | 'publicationState'
+      'fields' | 'filters' | 'pagination:offset' | 'sort' | 'populate' | 'publicationState' | 'plugin'
     >
   ): Promise<Attribute.GetValues<TContentTypeUID>[]>;
   findOne<TContentTypeUID extends Common.UID.ContentType>(


### PR DESCRIPTION
### What does it do?

Adds the typings for the `findMany` method in the EntityService

### Why is it needed?

To help developers & improve type safetiness.

### How to test it?

1. Add the EntityService type here: https://github.com/strapi/strapi/blob/c41c3e715d9316fbf2d9179b8167cc845b7b028b/packages/core/strapi/lib/types/core/strapi/index.d.ts#L415

2. Generate types in one of the example projects with `yarn strapi ts:generate-types`
3. Play with the `strapi.entityService` in one of the controllers (for example):
```

import { factories } from '@strapi/strapi';

export default factories.createCoreController('admin::user', ({ strapi }) => ({
  async find(ctx) {
    console.log('findingMany');
    strapi.entityService.;
    const res = await strapi.entityService.findMany('api::test.test', {
      limit: 3,
      start: 1,
      populate: {
        createdBy: {
          fields: ['firstname'],
        },
      },
    });
    ctx.body = res;
  },
}));

```

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
