### PR TITLE
types: add models property to lifecyles subscriber definition

### DIFF
--- a/packages/core/database/lib/lifecycles/subscribers/index.d.ts
+++ b/packages/core/database/lib/lifecycles/subscribers/index.d.ts
@@ -3,6 +3,7 @@ import { Event, Action } from '../';
 type SubscriberFn = (event: Event) => Promise<void> | void;
 
 type SubscriberMap = {
+  models?: string[],
   [k in Action]: SubscriberFn;
 };
 


### PR DESCRIPTION
### What does it do?

Adds the missing models property definition to the SubscriberMap type.

### Why is it needed?

As documented (here)[https://docs.strapi.io/dev-docs/backend-customization/models#declarative-and-programmatic-usage] lifecycle subscribers can include an optional models property that is an array of strings. This is missing from the Subscriber type, originally reported in #14165 and moved to the tracking issue #15225.

### How to test it?

Type errors reported when specifying the models property should disappear.

### Related issue(s)/PR(s)

n/a