### PR TITLE
[Data Transfer] Select http/https module based on protocol in local provider

### DIFF
--- a/packages/core/data-transfer/src/strapi/providers/local-source/assets.ts
+++ b/packages/core/data-transfer/src/strapi/providers/local-source/assets.ts
@@ -6,7 +6,7 @@ import { stat, createReadStream, ReadStream } from 'fs-extra';
 
 import type { IAsset } from '../../../../types';
 
-const httpMethod = (filepath: string) => {
+const protocolForPath = (filepath: string) => {
   return filepath?.startsWith('https') ? https : http;
 };
 
@@ -17,7 +17,7 @@ function getFileStream(filepath: string, isLocal = false): PassThrough | ReadStr
 
   const readableStream = new PassThrough();
 
-  httpMethod(filepath)
+  protocolForPath(filepath)
     .get(filepath, (res) => {
       if (res.statusCode !== 200) {
         readableStream.emit(
@@ -41,7 +41,7 @@ function getFileStats(filepath: string, isLocal = false): Promise<{ size: number
     return stat(filepath);
   }
   return new Promise((resolve, reject) => {
-    httpMethod(filepath)
+    protocolForPath(filepath)
       .get(filepath, (res) => {
         if (res.statusCode !== 200) {
           reject(new Error(`Request failed with status code ${res.statusCode}`));

--- a/packages/core/data-transfer/src/strapi/providers/local-source/assets.ts
+++ b/packages/core/data-transfer/src/strapi/providers/local-source/assets.ts
@@ -1,9 +1,14 @@
 import { join } from 'path';
 import https from 'https';
+import http from 'http';
 import { Duplex, PassThrough, Readable } from 'stream';
 import { stat, createReadStream, ReadStream } from 'fs-extra';
 
 import type { IAsset } from '../../../../types';
+
+const httpMethod = (filepath) => {
+  return filepath?.startsWith('https') ? https : http;
+};
 
 function getFileStream(filepath: string, isLocal = false): PassThrough | ReadStream {
   if (isLocal) {
@@ -12,7 +17,7 @@ function getFileStream(filepath: string, isLocal = false): PassThrough | ReadStr
 
   const readableStream = new PassThrough();
 
-  https
+  httpMethod(filepath)
     .get(filepath, (res) => {
       if (res.statusCode !== 200) {
         readableStream.emit(
@@ -36,7 +41,7 @@ function getFileStats(filepath: string, isLocal = false): Promise<{ size: number
     return stat(filepath);
   }
   return new Promise((resolve, reject) => {
-    https
+    httpMethod(filepath)
       .get(filepath, (res) => {
         if (res.statusCode !== 200) {
           reject(new Error(`Request failed with status code ${res.statusCode}`));

--- a/packages/core/data-transfer/src/strapi/providers/local-source/assets.ts
+++ b/packages/core/data-transfer/src/strapi/providers/local-source/assets.ts
@@ -6,7 +6,7 @@ import { stat, createReadStream, ReadStream } from 'fs-extra';
 
 import type { IAsset } from '../../../../types';
 
-const httpMethod = (filepath) => {
+const httpMethod = (filepath: string) => {
   return filepath?.startsWith('https') ? https : http;
 };
 


### PR DESCRIPTION
### What does it do?

Switches protocol based on url

### Why is it needed?

Currently export is broken in some cases (can't reproduce when) because the `https` module is throwing an error on urls that start with "http:"

### How to test it?

Run an export with files and it should work.

Note: I couldn't reproduce the original error, but the [reported issue](https://github.com/strapi/strapi/issues/17481) makes sense. So if someone can reproduce and then test that this PR fixes it, that would be great :)

### Related issue(s)/PR(s)

Fixes https://github.com/strapi/strapi/issues/17481