### PR TITLE
[TS][Entity Service] Add update types 

### DIFF
--- a/packages/core/strapi/lib/services/entity-service/types/index.d.ts
+++ b/packages/core/strapi/lib/services/entity-service/types/index.d.ts
@@ -36,6 +36,6 @@ export interface EntityService {
   update<TContentTypeUID extends Common.UID.ContentType>(
     uid: TContentTypeUID,
     entityId: number,
-    params?: EntityService.Params.Pick<TContentTypeUID, 'data' | 'fields' | 'populate'>
+    params?: EntityService.Params.Pick<TContentTypeUID, 'data' | 'files' | 'fields' | 'populate'>
   ): Promise<Attribute.GetValues<TContentTypeUID>>;
 }

--- a/packages/core/strapi/lib/services/entity-service/types/index.d.ts
+++ b/packages/core/strapi/lib/services/entity-service/types/index.d.ts
@@ -10,7 +10,13 @@ export interface EntityService {
     uid: TContentTypeUID,
     params?: EntityService.Params.Pick<
       TContentTypeUID,
-      'fields' | 'filters' | 'pagination:offset' | 'sort' | 'populate' | 'publicationState' | 'plugin'
+      | 'fields'
+      | 'filters'
+      | 'pagination:offset'
+      | 'sort'
+      | 'populate'
+      | 'publicationState'
+      | 'plugin'
     >
   ): Promise<Attribute.GetValues<TContentTypeUID>[]>;
   findOne<TContentTypeUID extends Common.UID.ContentType>(
@@ -26,5 +32,10 @@ export interface EntityService {
   create<TContentTypeUID extends Common.UID.ContentType>(
     uid: TContentTypeUID,
     params?: EntityService.Params.Pick<TContentTypeUID, 'data' | 'files' | 'fields' | 'populate'>
+  ): Promise<Attribute.GetValues<TContentTypeUID>>;
+  update<TContentTypeUID extends Common.UID.ContentType>(
+    uid: TContentTypeUID,
+    entityId: number,
+    params?: EntityService.Params.Pick<TContentTypeUID, 'data' | 'fields' | 'populate'>
   ): Promise<Attribute.GetValues<TContentTypeUID>>;
 }


### PR DESCRIPTION

### What does it do?

Adds types for the update method in the entity service.

### Why is it needed?

To help developers & improve type safeness.

### How to test it?

1. Go to [this file](https://github.com/strapi/strapi/blob/af8847e9441f15f426b6bca36e34c4391f3cc3d1/packages/core/strapi/lib/services/entity-service/types/index.d.ts) and rename it to index.ts.

2. Write the following code and play around with the `o.update` params
```
const o: EntityService = {
  update: (uid, id, params) => {
    return new Promise({});
  },
};

o.update('api::test.test', 2, {
  data: {
    name: 'John',
  },
  fields: ['*'],
  populate: 'user',
});
```

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
