### PR TITLE
Fix typos inside register generator

### DIFF
--- a/packages/generators/generators/src/files/js/plugin/server/register.js
+++ b/packages/generators/generators/src/files/js/plugin/server/register.js
@@ -1,5 +1,5 @@
 'use strict';
 
 module.exports = ({ strapi }) => {
-  // registeration phase
+  // registration phase
 };


### PR DESCRIPTION
### What does it do?
It fixes typo inside the repository.

### Why is it needed?
Even though this word is still conveying meaning it looks unprofessional.

### How to test it?
There are no changes that can affect the behaviour.
