### PR TITLE
[TS] Add basic type definition for remaining entity-service methods

### DIFF
--- a/packages/core/strapi/lib/services/entity-service/types/index.d.ts
+++ b/packages/core/strapi/lib/services/entity-service/types/index.d.ts
@@ -81,7 +81,7 @@ export interface EntityService {
 
   deleteMany<TContentTypeUID extends Common.UID.ContentType>(
     uid: TContentTypeUID,
-    params: Params.Pick<TContentTypeUID, 'populate'>
+    params: Params.Pick<TContentTypeUID, 'filters' | 'populate'>
   ): Promise<{ count: number }>;
 
   // TODO: What difference with findMany?? Not returning count by default

--- a/packages/core/strapi/lib/services/entity-service/types/index.d.ts
+++ b/packages/core/strapi/lib/services/entity-service/types/index.d.ts
@@ -24,7 +24,7 @@ export interface EntityService {
 
   emitEvent<TContentTypeUID extends Common.UID.ContentType>(
     uid: TContentTypeUID,
-    event: Event,
+    event: string,
     entity: Attribute.GetValues<TContentTypeUID> // double check
   ): Promise<void>;
 
@@ -105,7 +105,7 @@ export interface EntityService {
       TContentTypeUID,
       'fields' | 'populate' | 'sort' | 'filters' | 'plugin' | 'pagination' | 'publicationState'
     >
-  ): PaginatedResult<TContentTypeUID>;
+  ): Promise<PaginatedResult<TContentTypeUID>>;
 
   count<TContentTypeUID extends Common.UID.ContentType>(
     uid: TContentTypeUID,

--- a/packages/core/strapi/lib/services/entity-service/types/index.d.ts
+++ b/packages/core/strapi/lib/services/entity-service/types/index.d.ts
@@ -1,14 +1,36 @@
-import type { Attribute, Common, EntityService } from '@strapi/strapi';
+import type { Attribute, Common, Utils } from '@strapi/strapi';
+import type { Result, PaginatedResult } from './result';
+
+import type * as Params from './params';
 
 // TODO: Move params to @strapi/utils (related to convert-query-params)
 export * as Params from './params';
 
+export * from './result';
 export * from './plugin';
 
+type WrapAction = Omit<keyof EntityService, 'wrapParams' | 'wrapResult' | 'emitEvent'>;
+
 export interface EntityService {
+  wrapParams<TContentTypeUID extends Common.UID.ContentType, TParams extends object>(
+    params?: TParams,
+    options?: { uid: TContentTypeUID; action: WrapAction }
+  ): unknown;
+
+  wrapResult<TContentTypeUID extends Common.UID.ContentType>(
+    result: any,
+    options?: { uid: TContentTypeUID; action: WrapAction }
+  ): any;
+
+  emitEvent<TContentTypeUID extends Common.UID.ContentType>(
+    uid: TContentTypeUID,
+    event: Event,
+    entity: Attribute.GetValues<TContentTypeUID> // double check
+  ): Promise<void>;
+
   findMany<TContentTypeUID extends Common.UID.ContentType>(
     uid: TContentTypeUID,
-    params?: EntityService.Params.Pick<
+    params?: Params.Pick<
       TContentTypeUID,
       | 'fields'
       | 'filters'
@@ -18,24 +40,118 @@ export interface EntityService {
       | 'publicationState'
       | 'plugin'
     >
-  ): Promise<Attribute.GetValues<TContentTypeUID>[]>;
+  ): Promise<Result<TContentTypeUID>[]>;
+
   findOne<TContentTypeUID extends Common.UID.ContentType>(
     uid: TContentTypeUID,
     entityId: number,
-    params?: EntityService.Params.Pick<TContentTypeUID, 'fields' | 'populate'>
-  ): Promise<Attribute.GetValues<TContentTypeUID> | null>;
+    params?: Params.Pick<TContentTypeUID, 'fields' | 'populate'>
+  ): Promise<Result<TContentTypeUID> | null>;
+
   delete<TContentTypeUID extends Common.UID.ContentType>(
     uid: TContentTypeUID,
     entityId: number,
-    params?: EntityService.Params.Pick<TContentTypeUID, 'fields' | 'populate'>
-  ): Promise<Attribute.GetValues<TContentTypeUID> | null>;
+    params?: Params.Pick<TContentTypeUID, 'fields' | 'populate'>
+  ): Promise<Result<TContentTypeUID> | null>;
+
   create<TContentTypeUID extends Common.UID.ContentType>(
     uid: TContentTypeUID,
-    params?: EntityService.Params.Pick<TContentTypeUID, 'data' | 'files' | 'fields' | 'populate'>
-  ): Promise<Attribute.GetValues<TContentTypeUID>>;
+    params?: Params.Pick<TContentTypeUID, 'data' | 'files' | 'fields' | 'populate'>
+  ): Promise<Result<TContentTypeUID>>;
+
   update<TContentTypeUID extends Common.UID.ContentType>(
     uid: TContentTypeUID,
     entityId: number,
-    params?: EntityService.Params.Pick<TContentTypeUID, 'data' | 'files' | 'fields' | 'populate'>
-  ): Promise<Attribute.GetValues<TContentTypeUID>>;
+    params?: Params.Pick<TContentTypeUID, 'data' | 'files' | 'fields' | 'populate'>
+  ): Promise<Result<TContentTypeUID>>;
+
+  findPage<TContentTypeUID extends Common.UID.ContentType>(
+    uid: TContentTypeUID,
+    params?: Params.Pick<
+      TContentTypeUID,
+      'fields' | 'filters' | 'pagination' | 'sort' | 'populate' | 'publicationState' | 'plugin'
+    >
+  ): Promise<PaginatedResult<TContentTypeUID>>;
+
+  clone<TContentTypeUID extends Common.UID.ContentType>(
+    uid: TContentTypeUID,
+    cloneId: number,
+    params?: Params.Pick<TContentTypeUID, 'fields' | 'populate' | 'data' | 'files'>
+  ): Promise<Result<TContentTypeUID> | null>;
+
+  deleteMany<TContentTypeUID extends Common.UID.ContentType>(
+    uid: TContentTypeUID,
+    params: Params.Pick<TContentTypeUID, 'populate'>
+  ): Promise<{ count: number }>;
+
+  // TODO: What difference with findMany?? Not returning count by default
+  findWithRelationCounts<TContentTypeUID extends Common.UID.Schema>(
+    uid: TContentTypeUID,
+    params?: Params.Pick<
+      TContentTypeUID,
+      | 'fields'
+      | 'populate'
+      | 'sort'
+      | 'filters'
+      | 'plugin'
+      | 'pagination:offset'
+      | 'publicationState'
+    >
+  ): Promise<Result<TContentTypeUID>[]>;
+
+  findWithRelationCountsPage<TContentTypeUID extends Common.UID.Schema>(
+    uid: TContentTypeUID,
+    params?: Params.Pick<
+      TContentTypeUID,
+      'fields' | 'populate' | 'sort' | 'filters' | 'plugin' | 'pagination' | 'publicationState'
+    >
+  ): PaginatedResult<TContentTypeUID>;
+
+  count<TContentTypeUID extends Common.UID.ContentType>(
+    uid: TContentTypeUID,
+    params?: Params.Pick<
+      TContentTypeUID,
+      'fields' | 'populate' | 'sort' | 'filters' | 'plugin' | 'pagination' | 'publicationState'
+    >
+  ): Promise<number>;
+
+  load<
+    TContentTypeUID extends Common.UID.ContentType,
+    TField extends Attribute.GetPopulatableKeys<TContentTypeUID>
+  >(
+    uid: TContentTypeUID,
+    entity: Attribute.GetValues<TContentTypeUID>,
+    field: Utils.Guard.Never<TField, string>,
+    params?: GetPopulatableFieldParams<TContentTypeUID, TField>
+  ): Promise<Result<TContentTypeUID>>;
+
+  loadPages<
+    TContentTypeUID extends Common.UID.ContentType,
+    TField extends Attribute.GetPopulatableKeys<TContentTypeUID>
+  >(
+    uid: TContentTypeUID,
+    entity: Attribute.GetValues<TContentTypeUID>,
+    field: Utils.Guard.Never<TField, string>,
+    params?: GetPopulatableFieldParams<TContentTypeUID, TField>
+  ): Promise<PaginatedResult<TContentTypeUID>>;
 }
+
+type GetPopulatableFieldParams<
+  TContentTypeUID extends Common.UID.ContentType,
+  TField extends Attribute.GetPopulatableKeys<TContentTypeUID>
+> = Utils.Expression.MatchFirst<
+  [
+    [
+      Attribute.HasTarget<TContentTypeUID, TField>,
+      Params.Populate.NestedParams<Attribute.GetTarget<TContentTypeUID, TField>>
+    ],
+    [
+      Attribute.HasMorphTargets<TContentTypeUID, TField>,
+      (
+        | Params.Populate.Fragment<Attribute.GetMorphTargets<TContentTypeUID, TField>>
+        | Params.Populate.NestedParams<Common.UID.Schema>
+      )
+    ]
+  ],
+  Params.Populate.Fragment<Common.UID.Schema> | Params.Populate.NestedParams<Common.UID.Schema>
+>;

--- a/packages/core/strapi/lib/services/entity-service/types/params/index.d.ts
+++ b/packages/core/strapi/lib/services/entity-service/types/params/index.d.ts
@@ -7,13 +7,15 @@ import type * as Filters from './filters';
 import type * as Populate from './populate';
 import type * as PublicationState from './publication-state';
 import type * as Data from './data';
+import type * as Search from './search';
+
 // Utils
 import type * as Attribute from './attributes';
 
 export type Pick<
   TSchemaUID extends Common.UID.Schema,
-  TKind extends ParamKind
-> = Utils.Expression.MatchAll<
+  TKind extends Kind
+> = Utils.Expression.MatchAllIntersect<
   [
     // Sort
     [HasMember<TKind, 'sort'>, { sort?: Sort.Any<TSchemaUID> }],
@@ -42,11 +44,13 @@ export type Pick<
     // Data
     [HasMember<TKind, 'data'>, { data?: Data.Input<TSchemaUID> }],
     // Files
-    [HasMember<TKind, 'files'>, { files?: unknown }] // TODO
+    [HasMember<TKind, 'files'>, { files?: unknown }], // TODO
+    // Search
+    [HasMember<TKind, '_q'>, { _q?: Search.Q }]
   ]
 >;
 
-type ParamKind =
+export type Kind =
   | 'sort'
   | 'sort:string'
   | 'sort:array'
@@ -65,11 +69,9 @@ type ParamKind =
   | 'publicationState'
   | 'plugin'
   | 'data'
-  | 'files';
+  | 'files'
+  | '_q';
 
-type HasMember<TValue extends ParamKind, TTest extends ParamKind> = Utils.Expression.Extends<
-  TTest,
-  TValue
->;
+type HasMember<TValue extends Kind, TTest extends Kind> = Utils.Expression.Extends<TTest, TValue>;
 
 export type { Sort, Pagination, Fields, Filters, Populate, PublicationState, Data, Attribute };

--- a/packages/core/strapi/lib/services/entity-service/types/params/populate.d.ts
+++ b/packages/core/strapi/lib/services/entity-service/types/params/populate.d.ts
@@ -51,7 +51,7 @@ type GetPopulatableKeysWithoutTarget<TSchemaUID extends Common.UID.Schema> = Exc
 /**
  * Fragment populate notation for polymorphic attributes
  */
-type PopulateFragment<TMaybeTargets extends Common.UID.Schema> = {
+export type Fragment<TMaybeTargets extends Common.UID.Schema> = {
   on?: { [TSchemaUID in TMaybeTargets]?: boolean | NestedParams<TSchemaUID> };
 };
 
@@ -96,7 +96,7 @@ export type ObjectNotation<TSchemaUID extends Common.UID.Schema> = [
           {
             [TKey in TKeysWithoutTarget]?:
               | boolean
-              | PopulateFragment<
+              | Fragment<
                   Utils.Guard.Never<Attribute.GetMorphTargets<TSchemaUID, TKey>, Common.UID.Schema>
                 >
               // TODO: V5: Remove root-level nested params for morph data structures and only allow fragments
@@ -104,18 +104,18 @@ export type ObjectNotation<TSchemaUID extends Common.UID.Schema> = [
           }
         >,
       // Loose fallback when registries are not extended
-      | { [TKey in string]?: boolean | Params.Read<Common.UID.Schema> }
+      | { [TKey in string]?: boolean | NestedParams<Common.UID.Schema> }
       | {
           [TKey in string]?:
             | boolean
-            | PopulateFragment<Common.UID.Schema>
+            | Fragment<Common.UID.Schema>
             // TODO: V5: Remove root-level nested params for morph data structures and only allow fragments
             | NestedParams<Common.UID.Schema>;
         }
     >
   : never;
 
-type NestedParams<TSchemaUID extends Common.UID.Schema> = EntityService.Params.Pick<
+export type NestedParams<TSchemaUID extends Common.UID.Schema> = EntityService.Params.Pick<
   TSchemaUID,
   'fields' | 'filters' | 'populate' | 'sort' | 'plugin' | 'publicationState'
 >;

--- a/packages/core/strapi/lib/services/entity-service/types/params/search.d.ts
+++ b/packages/core/strapi/lib/services/entity-service/types/params/search.d.ts
@@ -1,0 +1,1 @@
+export type Q = string;

--- a/packages/core/strapi/lib/services/entity-service/types/result.d.ts
+++ b/packages/core/strapi/lib/services/entity-service/types/result.d.ts
@@ -1,10 +1,38 @@
-import type { Attribute, Common } from '@strapi/strapi';
+import type { Attribute, Common, EntityService, Utils } from '@strapi/strapi';
 
 type Pagination = { page: number; pageSize: number; pageCount: number; total: number };
 
-export type Result<TSchemaUID extends Common.UID.Schema> = Attribute.GetValues<TSchemaUID>;
+export type Entity<TSchemaUID extends Common.UID.Schema> = Utils.Object.DeepPartial<
+  GetValues<TSchemaUID>
+>;
 
 export type PaginatedResult<TSchemaUID extends Common.UID.Schema> = {
-  results: Result<TSchemaUID>[];
+  results: Entity<TSchemaUID>[];
   pagination: Pagination;
 };
+
+/**
+ * Attribute.GetValues override with extended values
+ */
+export type GetValues<TSchemaUID extends Common.UID.Schema> = {
+  [TKey in Attribute.GetKeys<TSchemaUID>]?: Utils.Guard.Never<
+    GetValue<Attribute.Get<TSchemaUID, TKey>>,
+    unknown
+  >;
+} & { id: EntityService.Params.Attribute.ID };
+
+type GetValue<TAttribute extends Attribute.Attribute> = Utils.Expression.If<
+  Utils.Expression.IsNotNever<TAttribute>,
+  // GetValue overrides
+  Utils.Expression.MatchFirst<
+    [
+      // Relation, media and components needs an id property
+      [
+        Utils.Expression.Extends<TAttribute, Attribute.OfType<'relation' | 'component' | 'media'>>,
+        { id: EntityService.Params.Attribute.ID } & Attribute.GetValue<TAttribute>
+      ]
+    ],
+    // Default GetValue fallback
+    Attribute.GetValue<TAttribute>
+  >
+>;

--- a/packages/core/strapi/lib/services/entity-service/types/result.d.ts
+++ b/packages/core/strapi/lib/services/entity-service/types/result.d.ts
@@ -1,0 +1,10 @@
+import type { Attribute, Common } from '@strapi/strapi';
+
+type Pagination = { page: number; pageSize: number; pageCount: number; total: number };
+
+export type Result<TSchemaUID extends Common.UID.Schema> = Attribute.GetValues<TSchemaUID>;
+
+export type PaginatedResult<TSchemaUID extends Common.UID.Schema> = {
+  results: Result<TSchemaUID>[];
+  pagination: Pagination;
+};

--- a/packages/core/strapi/lib/types/core/attributes/utils.d.ts
+++ b/packages/core/strapi/lib/types/core/attributes/utils.d.ts
@@ -121,3 +121,23 @@ export type GetOptionalKeys<TSchemaUID extends Common.UID.Schema> = Utils.Object
   GetAll<TSchemaUID>,
   Attribute.Required
 >;
+
+export type HasTarget<
+  TSchemaUID extends Common.UID.Schema,
+  TField extends Attribute.GetKeys<TSchemaUID>
+> = GetTarget<TSchemaUID, TField> extends infer TTarget
+  ? Utils.Expression.And<
+      Utils.Expression.IsNotNever<TTarget>,
+      Utils.Expression.Extends<TTarget, Common.UID.Schema>
+    >
+  : Utils.Expression.False;
+
+export type HasMorphTargets<
+  TSchemaUID extends Common.UID.Schema,
+  TField extends Attribute.GetKeys<TSchemaUID>
+> = GetMorphTargets<TSchemaUID, TField> extends infer TMaybeTargets
+  ? Utils.Expression.And<
+      Utils.Expression.IsNotNever<TMaybeTargets>,
+      Utils.Expression.Extends<TMaybeTargets, Common.UID.Schema>
+    >
+  : Utils.Expression.False;

--- a/packages/core/strapi/lib/types/utils/object.d.ts
+++ b/packages/core/strapi/lib/types/utils/object.d.ts
@@ -55,3 +55,9 @@ export type PickBy<TValue, TTest> = Pick<TValue, KeysBy<TValue, TTest>>;
  * // { x: 'foo' } | { x: 'bar' } | { x: '42' }
  */
 export type Values<TObject extends object> = TObject[keyof TObject];
+
+export type DeepPartial<TObject> = TObject extends object
+  ? {
+      [TKey in keyof TObject]?: DeepPartial<TObject[TKey]>;
+    }
+  : TObject;


### PR DESCRIPTION
### What does it do?

Add type definitions for:
- wrapParams
- wrapResult
- emitEvent
- findMany
- findPage
- findWithRelationCountsPage
- findWithRelationCounts
- findOne
- count
- create
- update
- delete
- clone
- deleteMany
- load
- loadPages

### QA

All methods QA'd by:
- @Convly 
- @innerdvations 
