### PR TITLE
Fix sanitizeQuery types

### DIFF
--- a/packages/core/strapi/lib/types/core-api/controller.d.ts
+++ b/packages/core/strapi/lib/types/core-api/controller.d.ts
@@ -11,7 +11,7 @@ export interface Base {
   transformResponse<TData, TResponse>(data: TData, meta: object): TResponse;
   sanitizeOutput<TData>(data: TData, ctx: ExtendableContext): Promise<TData>;
   sanitizeInput<TData>(data: TData, ctx: ExtendableContext): Promise<TData>;
-  sanitizeQuery<TData>(data: TData, ctx: ExtendableContext): Promise<TData>;
+  sanitizeQuery<TData>(ctx: ExtendableContext): Promise<TData>;
 }
 
 /**


### PR DESCRIPTION
### What does it do?

It fixes the `sanitizeQuery` function

### Why is it needed?

The `sanitizeQuery` function had two parameters in the types but it only requires one.

### How to test it?

Check the [sanitizeQuery function code](https://github.com/strapi/strapi/blob/c399af2056035901e4c172ec113f98d3e3e2d274/packages/core/strapi/lib/core-api/controller/index.js#L33) and you'll see that it only requires one parameter

### Related issue(s)/PR(s)

17539
