### PR TITLE
Fix : Media Library List View navigation

### DIFF
--- a/packages/core/upload/admin/src/components/TableList/TableRows.js
+++ b/packages/core/upload/admin/src/components/TableList/TableRows.js
@@ -22,18 +22,18 @@ export const TableRows = ({
 }) => {
   const { formatMessage } = useIntl();
 
-  const handleRowClickFn = (element, elementType, id) => {
+  const handleRowClickFn = (element, elementType, id, path) => {
     if (elementType === 'asset') {
       onEditAsset(element);
     } else {
-      onChangeFolder(id);
+      onChangeFolder(id, path);
     }
   };
 
   return (
     <Tbody>
       {rows.map((element) => {
-        const { id, isSelectable, name, folderURL, type: contentType } = element;
+        const { path, id, isSelectable, name, folderURL, type: contentType } = element;
 
         const isSelected = !!selected.find(
           (currentRow) => currentRow.id === id && currentRow.type === contentType
@@ -43,7 +43,7 @@ export const TableRows = ({
           <Tr
             key={id}
             {...onRowClick({
-              fn: () => handleRowClickFn(element, contentType, id),
+              fn: () => handleRowClickFn(element, contentType, id, path),
             })}
           >
             <Td {...stopPropagation}>

--- a/packages/core/upload/admin/src/pages/App/MediaLibrary/index.js
+++ b/packages/core/upload/admin/src/pages/App/MediaLibrary/index.js
@@ -332,7 +332,9 @@ export const MediaLibrary = () => {
               folderCount={folderCount}
               indeterminate={indeterminateBulkSelect}
               onChangeSort={handleChangeSort}
-              onChangeFolder={(folderID) => push(getFolderURL(pathname, query, folderID))}
+              onChangeFolder={(folderID, folderPath) =>
+                push(getFolderURL(pathname, query, { folder: folderID, folderPath }))
+              }
               onEditAsset={setAssetToEdit}
               onEditFolder={handleEditFolder}
               onSelectOne={selectOne}


### PR DESCRIPTION

### What does it do?

The PR fix the issue of Folder links not working in the Media Library page , in the List view
The issue is related to issue number  #17564

### Why is it needed?

It is needed since we want to navigate to folders in List View also.


### How to test it?
To test the issue do the following things
1. Go to Media Library
2. Create a new Folder
3. Switch to List View
4. Click on any of the folder links

We are not be navigated to the target folder.



Fixes #17564
