### PR TITLE
Fix circular dependency caused by Attribute.UID in Attribute.Any

### DIFF
--- a/packages/core/strapi/lib/types/core/attributes/common.d.ts
+++ b/packages/core/strapi/lib/types/core/attributes/common.d.ts
@@ -72,13 +72,3 @@ export type Any =
   | Attribute.Time
   | Attribute.Timestamp
   | Attribute.UID<Common.UID.Schema>;
-
-export type PopulatableKind = Extract<
-  Attribute.Kind,
-  'relation' | 'component' | 'dynamiczone' | 'media'
->;
-
-export type NonPopulatableKind = Exclude<
-  Attribute.Kind,
-  'relation' | 'component' | 'dynamiczone' | 'media'
->;

--- a/packages/core/strapi/lib/types/core/attributes/common.d.ts
+++ b/packages/core/strapi/lib/types/core/attributes/common.d.ts
@@ -71,4 +71,14 @@ export type Any =
   | Attribute.Text
   | Attribute.Time
   | Attribute.Timestamp
-  | Attribute.UID<Common.UID.Schema | undefined>;
+  | Attribute.UID<Common.UID.Schema>;
+
+export type PopulatableKind = Extract<
+  Attribute.Kind,
+  'relation' | 'component' | 'dynamiczone' | 'media'
+>;
+
+export type NonPopulatableKind = Exclude<
+  Attribute.Kind,
+  'relation' | 'component' | 'dynamiczone' | 'media'
+>;

--- a/packages/core/strapi/lib/types/core/attributes/uid.d.ts
+++ b/packages/core/strapi/lib/types/core/attributes/uid.d.ts
@@ -16,9 +16,6 @@ export interface UIDProperties<
   options: UIDOptions & TOptions;
 }
 
-/**
- * @param {Common.UID.Schema} [_TOrigin]
- */
 export type UID<
   // TODO: V5:
   // The TOrigin was used to narrow down the list of possible target attribute for a

--- a/packages/core/strapi/lib/types/core/attributes/uid.d.ts
+++ b/packages/core/strapi/lib/types/core/attributes/uid.d.ts
@@ -9,39 +9,32 @@ export interface UIDOptions {
 }
 
 export interface UIDProperties<
-  TOrigin extends Common.UID.Schema,
-  TTargetAttribute extends AllowedTargetAttributes<TOrigin>,
+  TTargetAttribute extends string = string,
   TOptions extends UIDOptions = UIDOptions
 > {
   targetField: TTargetAttribute;
   options: UIDOptions & TOptions;
 }
 
-export interface GenericUIDProperties<TOptions extends UIDOptions = UIDOptions> {
-  targetField?: string;
-  options: TOptions & UIDOptions;
-}
-
+/**
+ * @param {Common.UID.Schema} [_TOrigin]
+ */
 export type UID<
-  TOrigin extends Common.UID.Schema | undefined = undefined,
-  TTargetAttribute extends AllowedTargetAttributes<TOrigin> = AllowedTargetAttributes<TOrigin>,
+  // TODO: V5:
+  // The TOrigin was used to narrow down the list of possible target attribute for a
+  // UID, but was removed due to circular dependency issues and will be removed in V5
+  _TOrigin extends Common.UID.Schema = never,
+  TTargetAttribute extends string = string,
   TOptions extends UIDOptions = UIDOptions
 > = Attribute.OfType<'uid'> &
   // Properties
-  (TOrigin extends Common.UID.Schema
-    ? UIDProperties<TOrigin, TTargetAttribute, TOptions>
-    : GenericUIDProperties<TOptions>) &
+  UIDProperties<TTargetAttribute, TOptions> &
   // Options
   Attribute.ConfigurableOption &
   Attribute.DefaultOption<UIDValue> &
   Attribute.MinMaxLengthOption &
   Attribute.PrivateOption &
   Attribute.RequiredOption;
-
-type AllowedTargetAttributes<TOrigin extends Common.UID.Schema | undefined> =
-  TOrigin extends Common.UID.Schema
-    ? Utils.Guard.Never<Attribute.GetKeysByType<TOrigin, 'string' | 'text'>, string>
-    : never;
 
 export type UIDValue = string;
 

--- a/packages/core/strapi/lib/types/utils/expression.d.ts
+++ b/packages/core/strapi/lib/types/utils/expression.d.ts
@@ -4,7 +4,7 @@ export type True = true;
 export type False = false;
 export type BooleanValue = True | False;
 
-export type IsNever<TValue> = [TValue] extends [never] ? True : False;
+export type IsNever<TValue> = StrictEqual<TValue, never>;
 
 export type IsNotNever<TValue> = Not<IsNever<TValue>>;
 
@@ -68,11 +68,10 @@ export type Every<TExpressions extends BooleanValue[]> = TExpressions extends [
   ? If<Utils.Array.IsNotEmpty<TTail>, And<THead, Every<TTail>>, And<THead, True>>
   : never;
 
-export type And<TLeft extends BooleanValue, TRight extends BooleanValue> = Extends<
-  Extends<TLeft, True> | Extends<TRight, True>,
-  True
+export type And<TLeft extends BooleanValue, TRight extends BooleanValue> = IsTrue<
+  IsTrue<TLeft> | IsTrue<TRight>
 >;
 
 export type Or<TLeft extends BooleanValue, TRight extends BooleanValue> = Not<
-  Extends<Extends<TLeft, True> | Extends<TRight, True>, False>
+  IsFalse<IsTrue<TLeft> | IsTrue<TRight>>
 >;

--- a/packages/core/strapi/lib/types/utils/expression.d.ts
+++ b/packages/core/strapi/lib/types/utils/expression.d.ts
@@ -4,6 +4,16 @@ export type True = true;
 export type False = false;
 export type BooleanValue = True | False;
 
+export type IsNever<TValue> = [TValue] extends [never] ? True : False;
+
+export type IsNotNever<TValue> = Not<IsNever<TValue>>;
+
+export type IsTrue<TValue> = [TValue] extends [True] ? True : False;
+
+export type IsFalse<TValue> = [TValue] extends [False] ? True : False;
+
+export type StrictEqual<TValue, TMatch> = And<Extends<TValue, TMatch>, Extends<TMatch, TValue>>;
+
 export type Extends<TLeft, TRight> = [TLeft] extends [TRight] ? True : False;
 
 export type Not<TExpression extends BooleanValue> = If<TExpression, False, True>;

--- a/packages/core/strapi/lib/types/utils/guard.d.ts
+++ b/packages/core/strapi/lib/types/utils/guard.d.ts
@@ -1,3 +1,5 @@
+import type { Utils } from '@strapi/strapi';
+
 /**
  * Assign a default value `TDefault` to `TValue` if `TValue` is of type `never`
  *
@@ -11,4 +13,15 @@
  * type X = Never<never, string>
  * // string
  */
-export type Never<TValue, TDefault = unknown> = [TValue] extends [never] ? TDefault : TValue;
+export type Never<TValue, TFallback = unknown> = OfTypes<[never], TValue, TFallback>;
+
+export type OfTypes<TTypes extends unknown[], TValue, TFallback = unknown> = TTypes extends [
+  infer THead extends unknown,
+  ...infer TTail extends unknown[]
+]
+  ? Utils.Expression.If<
+      Utils.Expression.StrictEqual<TValue, THead>,
+      TFallback,
+      Utils.Expression.If<Utils.Array.IsNotEmpty<TTail>, OfTypes<TTail, TValue, TFallback>, TValue>
+    >
+  : never;


### PR DESCRIPTION
### What does it do?

- Remove the type narrowing made in `Attribute.UID` to get a list of possible string-like attribute for `targetField`

### Why is it needed?

- Having such narrowing meant that in the case of application types not being available (e.g. not generated), the narrowing was done on `Common.UID.Schema`. Which caused a circular dependency when looking at its keys.
	- `Attribute.Any `=> `Attribute.UID<Common.UID.Schema>` => `KeysByType<Common.UID.Schema>` => `GetAll<Common.UID.Schema>` => `Shared.ContentTypes[Common.UID.ContentTypes]` => `Attribute.Any `

### How to test it?

- Don't generate types & try to use `Attribute.Any`. Autocomplete should be available

