### PR TITLE
fix: save component's view configuration

### DIFF
--- a/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/index.js
@@ -133,7 +133,7 @@ const EditSettingsView = ({ mainLayout, components, isContentTypeView, slug, upd
       return put(
         isContentTypeView
           ? `/content-manager/content-types/${slug}/configuration`
-          : `components/${slug}/configuration`,
+          : `/content-manager/components/${slug}/configuration`,
         body
       );
     },


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Allows to save a view configuration for a component.

### Why is it needed?

Fixes a bug in the content-manager where a PUT request to save component's view configuration is sent to a wrong endpoint, resulting in a 405 HTTP error.

### How to test it?

1. In a Content Type Builder, create a component
1. Click on "Configure the view"
1. Change a title of any text field
1. Click "Save"

### Related issue(s)/PR(s)

Fixes #17575 , #17577 
