### PR TITLE
fix(lifecycles): improve typings

### DIFF
--- a/packages/core/database/lib/lifecycles/index.d.ts
+++ b/packages/core/database/lib/lifecycles/index.d.ts
@@ -2,25 +2,29 @@ import { Database } from '../';
 import { Model } from '../schema';
 import { Subscriber } from './subscribers';
 
-export type Action =
+export type BeforeAction =
   | 'beforeCreate'
-  | 'afterCreate'
   | 'beforeFindOne'
-  | 'afterFindOne'
   | 'beforeFindMany'
-  | 'afterFindMany'
   | 'beforeCount'
-  | 'afterCount'
   | 'beforeCreateMany'
-  | 'afterCreateMany'
   | 'beforeUpdate'
-  | 'afterUpdate'
   | 'beforeUpdateMany'
-  | 'afterUpdateMany'
   | 'beforeDelete'
+  | 'beforeDeleteMany';
+
+export type AfterAction =
+  | 'afterCreate'
+  | 'afterFindOne'
+  | 'afterFindMany'
+  | 'afterCount'
+  | 'afterCreateMany'
+  | 'afterUpdate'
+  | 'afterUpdateMany'
   | 'afterDelete'
-  | 'beforeDeleteMany'
   | 'afterDeleteMany';
+
+export type Action = BeforeAction | AfterAction;
 
 export interface Params {
   select?: any;
@@ -34,11 +38,23 @@ export interface Params {
   data?: any;
 }
 
-export interface Event {
+export interface BaseEvent {
   action: Action;
   model: Model;
   params: Params;
+  state: Record<string, any>;
 }
+
+export interface BeforeEvent extends BaseEvent {
+  action: BeforeAction;
+}
+
+export interface AfterEvent extends BaseEvent {
+  action: AfterAction;
+  result: Record<string, any>;
+}
+
+export type Event = BeforeEvent | AfterEvent;
 
 export interface LifecycleProvider {
   subscribe(subscriber: Subscriber): () => void;

--- a/packages/core/database/lib/lifecycles/subscribers/index.d.ts
+++ b/packages/core/database/lib/lifecycles/subscribers/index.d.ts
@@ -1,9 +1,11 @@
-import { Event, Action } from '../';
+import { Event, BeforeEvent, AfterEvent, BeforeAction, AfterAction } from '../';
 
-type SubscriberFn = (event: Event) => Promise<void> | void;
+type SubscriberFn<T> = (event: T) => Promise<void> | void;
 
-type SubscriberMap = {
-  [k in Action]: SubscriberFn;
-};
+type BaseSubscriberMap = { models?: string[] };
+type BeforeSubscriberMap = { [k in BeforeAction]?: SubscriberFn<BeforeEvent> };
+type AfterSubscriberMap = { [k in AfterAction]?: SubscriberFn<AfterEvent> };
 
-export type Subscriber = SubscriberFn | SubscriberMap;
+type SubscriberMap = BaseSubscriberMap & BeforeSubscriberMap & AfterSubscriberMap;
+
+export type Subscriber = SubscriberFn<Event> | SubscriberMap;


### PR DESCRIPTION
### What does it do?
Improves the typings for the lifecycles function.

### Why is it needed?
The typing were incompatible with the actual (and [documented](https://docs.strapi.io/dev-docs/backend-customization/models#lifecycle-hooks)) structure.

#### Fixes the following issues
- Reduce the restriction to have all lifecycle methods implemented for `SubscriberMap` format. Changes all of them to be optional. As far as I understand none of them are required.
- Add the missing optional `models` property for `SubscriberMap` format.
- Add the missing `state` property type to `Event`.
- Add the missing `result` property type to the `Event` structure for `afterXXX` events.

#### Notes
- For the`state` and `result` properties I went with the more permissive `Record<string, any>` over `Record<string, unknown>` as I was not sure what the preference was here for `Strapi`.
- I have refactored the typings to seperate between the `before` and `after` action/event structures for easier readability.

### How to test it?
- Clone this PR branch
- Build strapi
- Attempt to use the properties outlined above as missing
- Observe that they are now typed correctly.

#### Notes
I was not able to find any documentation on steps for easily testing type change PR reviews. If their is a better (or documented way) feel free to let me know and I will update the steps above. 

### Related issue(s)/PR(s)

I could not find any existings issue for this, so N/A.
