### PR TITLE
Support cellformatter in ListView table

### DIFF
--- a/packages/core/admin/admin/src/content-manager/pages/ListView/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/ListView/index.js
@@ -575,7 +575,7 @@ function ListView({
                         {/* Bulk action row checkbox */}
                         <Body.CheckboxDataCell rowId={rowData.id} index={index} />
                         {/* Field data */}
-                        {tableHeaders.map(({ key, name, ...rest }) => {
+                        {tableHeaders.map(({ key, name, cellFormatter, ...rest }) => {
                           if (hasDraftAndPublish && name === 'publishedAt') {
                             return (
                               <Td key={key}>
@@ -619,6 +619,12 @@ function ListView({
                                   <Typography textColor="neutral800">-</Typography>
                                 )}
                               </Td>
+                            );
+                          }
+
+                          if (typeof cellFormatter === 'function') {
+                            return (
+                              <Td key={key}>{cellFormatter(rowData, { key, name, ...rest })}</Td>
                             );
                           }
 


### PR DESCRIPTION
### What does it do?

Adds the cellFormatter back (must have been removed in a messy merge)

### Why is it needed?

Even if internally in the content-manager we are moving away from this API we still need to support the cellFormatter since plugins like i18n use it: 

https://github.com/strapi/strapi/blob/489927e8e161dd5c3d48f0c97ab4efade802c3e3/packages/plugins/i18n/admin/src/index.js#L52

### How to test it?

Go to any content-type in the content manager that has i18n enabled. You should have the following column.

![Screenshot 2023-07-18 at 11 10 45](https://github.com/strapi/strapi/assets/26598053/be99f15b-dd78-4403-ad12-5454c234dff5)

### Related

https://github.com/strapi/strapi/pull/17347