### PR TITLE
Upgrade mysql2 client to 3.6.0 for CI

### DIFF
--- a/examples/getstarted/package.json
+++ b/examples/getstarted/package.json
@@ -26,7 +26,7 @@
     "better-sqlite3": "8.5.0",
     "lodash": "4.17.21",
     "mysql": "2.18.1",
-    "mysql2": "3.5.1",
+    "mysql2": "3.6.0",
     "passport-google-oauth2": "0.2.0",
     "pg": "8.11.1",
     "react": "^18.2.0",

--- a/examples/kitchensink/package.json
+++ b/examples/kitchensink/package.json
@@ -18,6 +18,7 @@
     "@strapi/strapi": "4.12.1",
     "lodash": "4.17.21",
     "mysql": "2.18.1",
+    "mysql2": "3.6.0",
     "passport-google-oauth2": "0.2.0",
     "pg": "8.11.1",
     "react": "^18.2.0",

--- a/packages/generators/app/src/utils/db-client-dependencies.ts
+++ b/packages/generators/app/src/utils/db-client-dependencies.ts
@@ -2,7 +2,7 @@ import type { ClientName } from '../types';
 
 const sqlClientModule = {
   mysql: { mysql: '2.18.1' },
-  mysql2: { mysql2: '3.2.0' },
+  mysql2: { mysql2: '3.6.0' },
   postgres: { pg: '8.8.0' },
   sqlite: { 'better-sqlite3': '8.5.0' },
   'sqlite-legacy': { sqlite3: '5.1.2' },

--- a/yarn.lock
+++ b/yarn.lock
@@ -18295,7 +18295,7 @@ __metadata:
     better-sqlite3: 8.5.0
     lodash: 4.17.21
     mysql: 2.18.1
-    mysql2: 3.5.1
+    mysql2: 3.6.0
     passport-google-oauth2: 0.2.0
     pg: 8.11.1
     react: ^18.2.0
@@ -22207,6 +22207,7 @@ __metadata:
     "@strapi/strapi": 4.12.1
     lodash: 4.17.21
     mysql: 2.18.1
+    mysql2: 3.6.0
     passport-google-oauth2: 0.2.0
     pg: 8.11.1
     react: ^18.2.0
@@ -24276,9 +24277,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mysql2@npm:3.5.1":
-  version: 3.5.1
-  resolution: "mysql2@npm:3.5.1"
+"mysql2@npm:3.6.0":
+  version: 3.6.0
+  resolution: "mysql2@npm:3.6.0"
   dependencies:
     denque: ^2.1.0
     generate-function: ^2.3.1
@@ -24288,7 +24289,7 @@ __metadata:
     named-placeholders: ^1.1.3
     seq-queue: ^0.0.5
     sqlstring: ^2.3.2
-  checksum: 93c88c88ae374504dc07e5ac1370e74f86f560962d41f7e674a933110167d01023e02947199f6d0be06e75a234c3c19bc9ada8db449a9ebddd928e11357891d3
+  checksum: 3c0f6102ce76314b3a0789626bf49beccf4e51cba72dc8509e631ccd47f12d23020832468b6e30db513e73bd2ed72b6e0e6b118a7ad808f9e32f2e3dc744ffc8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What does it do?

- Upgrade mysql2 client version from 3.5.1 -> 3.6.0 for CI
- Upgrade mysql2 client from 3.2.0 -> 3.6.0 for generated api and e2e test apps


### Why is it needed?

It's not, but we should at least be generating projects with our recommended and tested version

### How to test it?

- All CI tests should pass
- Strapi projects should work with mysql2 3.6.0 

Note: I thought that we could generate mysql2 projects with create-strapi-app but it only generates with the mysql client, so nothing to test there.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
