### PR TITLE
Feature: Add an "apply to all stages" action for stage permissions

### DIFF
--- a/packages/core/admin/admin/src/hooks/useAdminUsers/useAdminUsers.js
+++ b/packages/core/admin/admin/src/hooks/useAdminUsers/useAdminUsers.js
@@ -29,7 +29,8 @@ export function useAdminUsers(params = {}, queryOptions = {}) {
   const users = React.useMemo(() => {
     if (id && data) {
       return [data];
-    } else if (Array.isArray(data?.results)) {
+    }
+    if (Array.isArray(data?.results)) {
       return data.results;
     }
 

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/actions/index.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/actions/index.js
@@ -8,6 +8,7 @@ import {
   ACTION_SET_WORKFLOW,
   ACTION_SET_WORKFLOWS,
   ACTION_UPDATE_STAGE,
+  ACTION_UPDATE_STAGES,
   ACTION_UPDATE_STAGE_POSITION,
   ACTION_UPDATE_WORKFLOW,
 } from '../constants';
@@ -49,6 +50,13 @@ export function updateStage(stageId, payload) {
       stageId,
       ...payload,
     },
+  };
+}
+
+export function updateStages(payload) {
+  return {
+    type: ACTION_UPDATE_STAGES,
+    payload,
   };
 }
 

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/actions/tests/index.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/actions/tests/index.test.js
@@ -4,6 +4,7 @@ import {
   setWorkflow,
   setWorkflows,
   updateStage,
+  updateStages,
   updateStagePosition,
   updateWorkflow,
   resetWorkflow,
@@ -16,6 +17,7 @@ import {
   ACTION_DELETE_STAGE,
   ACTION_ADD_STAGE,
   ACTION_UPDATE_STAGE,
+  ACTION_UPDATE_STAGES,
   ACTION_SET_CONTENT_TYPES,
   ACTION_SET_IS_LOADING,
   ACTION_SET_ROLES,
@@ -68,6 +70,15 @@ describe('Admin | Settings | Review Workflow | actions', () => {
       type: ACTION_UPDATE_STAGE,
       payload: {
         stageId: 1,
+        something: '',
+      },
+    });
+  });
+
+  test('updateStages()', () => {
+    expect(updateStages({ something: '' })).toStrictEqual({
+      type: ACTION_UPDATE_STAGES,
+      payload: {
         something: '',
       },
     });

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/constants.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/constants.js
@@ -11,6 +11,7 @@ export const ACTION_SET_WORKFLOWS = `Settings/Review_Workflows/SET_WORKFLOWS`;
 export const ACTION_DELETE_STAGE = `Settings/Review_Workflows/WORKFLOW_DELETE_STAGE`;
 export const ACTION_ADD_STAGE = `Settings/Review_Workflows/WORKFLOW_ADD_STAGE`;
 export const ACTION_UPDATE_STAGE = `Settings/Review_Workflows/WORKFLOW_UPDATE_STAGE`;
+export const ACTION_UPDATE_STAGES = `Settings/Review_Workflows/WORKFLOW_UPDATE_STAGES`;
 export const ACTION_UPDATE_STAGE_POSITION = `Settings/Review_Workflows/WORKFLOW_UPDATE_STAGE_POSITION`;
 export const ACTION_UPDATE_WORKFLOW = `Settings/Review_Workflows/WORKFLOW_UPDATE`;
 

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/hooks/useReviewWorkflows.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/hooks/useReviewWorkflows.js
@@ -30,7 +30,8 @@ export function useReviewWorkflows(params = {}) {
   const workflows = React.useMemo(() => {
     if (id && data?.data) {
       return [data.data];
-    } else if (Array.isArray(data?.data)) {
+    }
+    if (Array.isArray(data?.data)) {
       return data.data;
     }
 

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/index.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/index.js
@@ -10,6 +10,7 @@ import {
   ACTION_SET_WORKFLOW,
   ACTION_SET_WORKFLOWS,
   ACTION_UPDATE_STAGE,
+  ACTION_UPDATE_STAGES,
   ACTION_UPDATE_STAGE_POSITION,
   ACTION_UPDATE_WORKFLOW,
   STAGE_COLOR_DEFAULT,
@@ -129,6 +130,19 @@ export function reducer(state = initialState, action) {
                 ...modified,
               }
             : stage
+        );
+
+        break;
+      }
+
+      case ACTION_UPDATE_STAGES: {
+        const { currentWorkflow } = state.clientState;
+
+        draft.clientState.currentWorkflow.data.stages = currentWorkflow.data.stages.map(
+          (stage) => ({
+            ...stage,
+            ...payload,
+          })
         );
 
         break;

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/tests/index.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/tests/index.test.js
@@ -8,6 +8,7 @@ import {
   ACTION_SET_ROLES,
   ACTION_SET_WORKFLOW,
   ACTION_UPDATE_STAGE,
+  ACTION_UPDATE_STAGES,
   ACTION_UPDATE_STAGE_POSITION,
   ACTION_UPDATE_WORKFLOW,
 } from '../../constants';
@@ -281,6 +282,40 @@ describe('Admin | Settings | Review Workflows | reducer', () => {
                   color: '#4945FF',
                   name: 'stage-1-modified',
                 },
+              ]),
+            }),
+          }),
+        }),
+      })
+    );
+  });
+
+  test('ACTION_UPDATE_STAGES', () => {
+    const action = {
+      type: ACTION_UPDATE_STAGES,
+      payload: { permissions: [1, 2, 3] },
+    };
+
+    state = {
+      status: expect.any(String),
+      serverState: expect.any(Object),
+      clientState: {
+        currentWorkflow: { data: WORKFLOW_FIXTURE },
+      },
+    };
+
+    expect(reducer(state, action)).toStrictEqual(
+      expect.objectContaining({
+        clientState: expect.objectContaining({
+          currentWorkflow: expect.objectContaining({
+            data: expect.objectContaining({
+              stages: expect.arrayContaining([
+                expect.objectContaining({
+                  permissions: [1, 2, 3],
+                }),
+                expect.objectContaining({
+                  permissions: [1, 2, 3],
+                }),
               ]),
             }),
           }),


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Renders a new button for each stage: "Apply to all stages", which will copy the current set of permissions to all other stages.

### Why is it needed?

UX requiremet.
