### PR TITLE
Feature: Add "Duplicate stage" menu for stages

### DIFF
--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/actions/index.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/actions/index.js
@@ -1,5 +1,6 @@
 import {
   ACTION_ADD_STAGE,
+  ACTION_CLONE_STAGE,
   ACTION_DELETE_STAGE,
   ACTION_RESET_WORKFLOW,
   ACTION_SET_CONTENT_TYPES,
@@ -12,6 +13,13 @@ import {
   ACTION_UPDATE_STAGE_POSITION,
   ACTION_UPDATE_WORKFLOW,
 } from '../constants';
+
+export function cloneStage(id) {
+  return {
+    type: ACTION_CLONE_STAGE,
+    payload: { id },
+  };
+}
 
 export function setWorkflow({ workflow }) {
   return {

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/actions/tests/index.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/actions/tests/index.test.js
@@ -1,5 +1,6 @@
 import {
   addStage,
+  cloneStage,
   deleteStage,
   setWorkflow,
   setWorkflows,
@@ -16,6 +17,7 @@ import {
   ACTION_SET_WORKFLOW,
   ACTION_DELETE_STAGE,
   ACTION_ADD_STAGE,
+  ACTION_CLONE_STAGE,
   ACTION_UPDATE_STAGE,
   ACTION_UPDATE_STAGES,
   ACTION_SET_CONTENT_TYPES,
@@ -62,6 +64,15 @@ describe('Admin | Settings | Review Workflow | actions', () => {
     expect(addStage()).toStrictEqual({
       type: ACTION_ADD_STAGE,
       payload: {},
+    });
+  });
+
+  test('cloneStage()', () => {
+    expect(cloneStage(1)).toStrictEqual({
+      type: ACTION_CLONE_STAGE,
+      payload: {
+        id: 1,
+      },
     });
   });
 

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/Stages/Stage/Stage.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/Stages/Stage/Stage.js
@@ -19,8 +19,14 @@ import {
   Typography,
   VisuallyHidden,
 } from '@strapi/design-system';
-import { ConfirmDialog, useNotification, NotAllowedInput, useTracking } from '@strapi/helper-plugin';
-import { Drag, Trash } from '@strapi/icons';
+import { Menu, MenuItem } from '@strapi/design-system/v2';
+import {
+  ConfirmDialog,
+  useNotification,
+  NotAllowedInput,
+  useTracking,
+} from '@strapi/helper-plugin';
+import { Drag, More } from '@strapi/icons';
 import { useField } from 'formik';
 import PropTypes from 'prop-types';
 import { getEmptyImage } from 'react-dnd-html5-backend';
@@ -30,7 +36,13 @@ import styled from 'styled-components';
 
 import { useDragAndDrop } from '../../../../../../../../../admin/src/content-manager/hooks';
 import { composeRefs } from '../../../../../../../../../admin/src/content-manager/utils';
-import { deleteStage, updateStage, updateStagePosition, updateStages } from '../../../actions';
+import {
+  cloneStage,
+  deleteStage,
+  updateStage,
+  updateStagePosition,
+  updateStages,
+} from '../../../actions';
 import { DRAG_DROP_TYPES } from '../../../constants';
 import { selectRoles } from '../../../selectors';
 import { getAvailableStageColors, getStageColorByHex } from '../../../utils/colors';
@@ -231,18 +243,41 @@ export function Stage({
             action={
               (canDelete || canUpdate) && (
                 <Flex>
-                  {canDelete && (
-                    <IconButton
-                      background="transparent"
-                      icon={<Trash />}
-                      label={formatMessage({
-                        id: 'Settings.review-workflows.stage.delete',
-                        defaultMessage: 'Delete stage',
-                      })}
-                      noBorder
-                      onClick={() => dispatch(deleteStage(id))}
-                    />
-                  )}
+                  <Menu.Root>
+                    <Menu.Trigger size="S" endIcon={undefined} paddingLeft={2} paddingRight={2}>
+                      <More aria-hidden focusable={false} />
+                      <VisuallyHidden as="span">
+                        {formatMessage({
+                          id: '[tbdb].components.DynamicZone.more-actions',
+                          defaultMessage: 'More actions',
+                        })}
+                      </VisuallyHidden>
+                    </Menu.Trigger>
+                    {/* z-index needs to be as big as the one defined for the wrapper in Stages, otherwise the menu
+                     * disappears behind the accordion
+                     */}
+                    <Menu.Content zIndex={2}>
+                      <Menu.SubRoot>
+                        {canUpdate && (
+                          <MenuItem onClick={() => dispatch(cloneStage(id))}>
+                            {formatMessage({
+                              id: 'Settings.review-workflows.stage.delete',
+                              defaultMessage: 'Duplicate stage',
+                            })}
+                          </MenuItem>
+                        )}
+
+                        {canDelete && (
+                          <MenuItem onClick={() => dispatch(deleteStage(id))}>
+                            {formatMessage({
+                              id: 'Settings.review-workflows.stage.delete',
+                              defaultMessage: 'Delete',
+                            })}
+                          </MenuItem>
+                        )}
+                      </Menu.SubRoot>
+                    </Menu.Content>
+                  </Menu.Root>
 
                   {canUpdate && (
                     <IconButton
@@ -384,7 +419,9 @@ export function Stage({
                       })}
                       required
                       // The Select component expects strings for values
-                      value={(permissionsField.value ?? []).map((permission) => `${permission.role}`)}
+                      value={(permissionsField.value ?? []).map(
+                        (permission) => `${permission.role}`
+                      )}
                       withTags
                     >
                       {[
@@ -418,27 +455,27 @@ export function Stage({
                           );
                         }
 
-                      return (
-                        <MultiSelectOption key={role.value} value={role.value}>
-                          {role.label}
-                        </MultiSelectOption>
-                      );
-                    })}
-                  </MultiSelect>
+                        return (
+                          <MultiSelectOption key={role.value} value={role.value}>
+                            {role.label}
+                          </MultiSelectOption>
+                        );
+                      })}
+                    </MultiSelect>
 
-                  <Button
-                    disabled={!canUpdate}
-                    size="L"
-                    type="button"
-                    variant="secondary"
-                    onClick={() => handleApplyPermissionsToAllStages(permissionsField.value)}
-                  >
-                    {formatMessage({
-                      id: 'Settings.review-workflows.stage.permissions.apply.label',
-                      defaultMessage: 'Apply to all stages',
-                    })}
-                  </Button>
-                </Flex>
+                    <Button
+                      disabled={!canUpdate}
+                      size="L"
+                      type="button"
+                      variant="secondary"
+                      onClick={() => handleApplyPermissionsToAllStages(permissionsField.value)}
+                    >
+                      {formatMessage({
+                        id: 'Settings.review-workflows.stage.permissions.apply.label',
+                        defaultMessage: 'Apply to all stages',
+                      })}
+                    </Button>
+                  </Flex>
                 )}
               </GridItem>
             </Grid>

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/constants.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/constants.js
@@ -10,6 +10,7 @@ export const ACTION_SET_WORKFLOW = `Settings/Review_Workflows/SET_WORKFLOW`;
 export const ACTION_SET_WORKFLOWS = `Settings/Review_Workflows/SET_WORKFLOWS`;
 export const ACTION_DELETE_STAGE = `Settings/Review_Workflows/WORKFLOW_DELETE_STAGE`;
 export const ACTION_ADD_STAGE = `Settings/Review_Workflows/WORKFLOW_ADD_STAGE`;
+export const ACTION_CLONE_STAGE = `Settings/Review_Workflows/WORKFLOW_CLONE_STAGE`;
 export const ACTION_UPDATE_STAGE = `Settings/Review_Workflows/WORKFLOW_UPDATE_STAGE`;
 export const ACTION_UPDATE_STAGES = `Settings/Review_Workflows/WORKFLOW_UPDATE_STAGES`;
 export const ACTION_UPDATE_STAGE_POSITION = `Settings/Review_Workflows/WORKFLOW_UPDATE_STAGE_POSITION`;

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/index.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/index.js
@@ -2,6 +2,7 @@ import { produce } from 'immer';
 
 import {
   ACTION_ADD_STAGE,
+  ACTION_CLONE_STAGE,
   ACTION_DELETE_STAGE,
   ACTION_RESET_WORKFLOW,
   ACTION_SET_CONTENT_TYPES,
@@ -114,6 +115,22 @@ export function reducer(state = initialState, action) {
           ...payload,
           color: payload?.color ?? STAGE_COLOR_DEFAULT,
           __temp_key__: newTempKey,
+        });
+
+        break;
+      }
+
+      case ACTION_CLONE_STAGE: {
+        const { currentWorkflow } = state.clientState;
+        const { id } = payload;
+
+        const sourceStageIndex = currentWorkflow.data.stages.findIndex((stage) => stage.id === id);
+        const sourceStage = currentWorkflow.data.stages[sourceStageIndex];
+
+        draft.clientState.currentWorkflow.data.stages.splice(sourceStageIndex + 1, 0, {
+          ...sourceStage,
+          id: undefined,
+          __temp_key__: getMaxTempKey(draft.clientState.currentWorkflow.data.stages),
         });
 
         break;

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/tests/index.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/tests/index.test.js
@@ -1,6 +1,7 @@
 import { initialState, reducer } from '..';
 import {
   ACTION_ADD_STAGE,
+  ACTION_CLONE_STAGE,
   ACTION_DELETE_STAGE,
   ACTION_RESET_WORKFLOW,
   ACTION_SET_CONTENT_TYPES,
@@ -169,6 +170,47 @@ describe('Admin | Settings | Review Workflows | reducer', () => {
                   name: 'something',
                 },
               ]),
+            }),
+          }),
+        }),
+      })
+    );
+  });
+
+  test('ACTION_CLONE_STAGE', () => {
+    const action = {
+      type: ACTION_CLONE_STAGE,
+      payload: { id: 1 },
+    };
+
+    state = {
+      status: expect.any(String),
+      serverState: expect.any(Object),
+      clientState: {
+        currentWorkflow: { data: WORKFLOW_FIXTURE },
+      },
+    };
+
+    expect(reducer(state, action)).toStrictEqual(
+      expect.objectContaining({
+        clientState: expect.objectContaining({
+          currentWorkflow: expect.objectContaining({
+            data: expect.objectContaining({
+              stages: [
+                expect.objectContaining({
+                  id: 1,
+                }),
+
+                expect.objectContaining({
+                  id: undefined,
+                  __temp_key__: 3,
+                  name: 'stage-1',
+                }),
+
+                expect.objectContaining({
+                  id: 2,
+                }),
+              ],
             }),
           }),
         }),


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

- Moves stage delete into a menu
- Adds "Duplicate stage"

> **Note**
> Styling is currently broken - same as for dynamic zones. I will investigate in a follow-up design-system PR what broke.

### Why is it needed?

UX improvements.

