### PR TITLE
Fix params pick

### DIFF
--- a/packages/core/strapi/lib/services/entity-service/types/params/index.d.ts
+++ b/packages/core/strapi/lib/services/entity-service/types/params/index.d.ts
@@ -15,7 +15,7 @@ import type * as Attribute from './attributes';
 export type Pick<
   TSchemaUID extends Common.UID.Schema,
   TKind extends Kind
-> = Utils.Expression.MatchAllIntersect<
+> = Utils.Expression.MatchAll<
   [
     // Sort
     [HasMember<TKind, 'sort'>, { sort?: Sort.Any<TSchemaUID> }],


### PR DESCRIPTION
### What does it do?

Change MatchAlIntersect to MatchAll, cause the former doesn't exist

### Why is it needed ?

Param typings are not working 

### How to test it?

make sure that the params are typing of entityService methods are working properly

