### PR TITLE
fix: cannot clear date-field

### DIFF
--- a/packages/core/content-type-builder/admin/src/components/FormModal/utils/customFieldDefaultOptionsReducer.js
+++ b/packages/core/content-type-builder/admin/src/components/FormModal/utils/customFieldDefaultOptionsReducer.js
@@ -11,4 +11,4 @@ const customFieldDefaultOptionsReducer = (acc, option) => {
   return acc;
 };
 
-module.exports = { customFieldDefaultOptionsReducer };
+export { customFieldDefaultOptionsReducer };

--- a/packages/core/helper-plugin/src/components/GenericInput.jsx
+++ b/packages/core/helper-plugin/src/components/GenericInput.jsx
@@ -249,7 +249,11 @@ const GenericInput = ({
           name={name}
           onChange={(date) => {
             onChange({
-              target: { name, value: formatISO(date, { representation: 'date' }), type },
+              target: {
+                name,
+                value: date ? formatISO(date, { representation: 'date' }) : null,
+                type,
+              },
             });
           }}
           onClear={() => onChange({ target: { name, value: null, type } })}

--- a/packages/core/helper-plugin/src/components/tests/GenericInput.test.jsx
+++ b/packages/core/helper-plugin/src/components/tests/GenericInput.test.jsx
@@ -31,32 +31,6 @@ function setup(props) {
   };
 }
 
-function setupNumber(props) {
-  return setup({
-    type: 'number',
-    name: 'number',
-    placeholder: {
-      id: 'placeholder.test',
-      defaultMessage: 'Default placeholder',
-    },
-    hint: 'Hint message',
-    required: true,
-    ...props,
-  });
-}
-
-function setupDatetimePicker(props) {
-  return setup({
-    type: 'datetime',
-    name: 'datetime-picker',
-    intlLabel: {
-      id: 'label.test',
-      defaultMessage: 'datetime picker',
-    },
-    onClear: jest.fn(),
-    ...props,
-  });
-}
 /**
  * We extend the timeout of these tests because the DS
  * DateTimePicker has a slow rendering issue at the moment.
@@ -66,6 +40,20 @@ jest.setTimeout(50000);
 
 describe('GenericInput', () => {
   describe('number', () => {
+    const setupNumber = (props) => {
+      return setup({
+        type: 'number',
+        name: 'number',
+        placeholder: {
+          id: 'placeholder.test',
+          defaultMessage: 'Default placeholder',
+        },
+        hint: 'Hint message',
+        required: true,
+        ...props,
+      });
+    };
+
     test('renders and matches the snapshot', () => {
       const { container } = setupNumber();
       expect(container).toMatchSnapshot();
@@ -145,7 +133,51 @@ describe('GenericInput', () => {
     });
   });
 
+  describe('date', () => {
+    const setupDateField = (props) => {
+      return setup({
+        type: 'date',
+        name: 'date',
+        intlLabel: {
+          id: 'label.test',
+          defaultMessage: 'date',
+        },
+        onClear: jest.fn(),
+        ...props,
+      });
+    };
+
+    it('should allow the user to clear the field', async () => {
+      const onChange = jest.fn();
+
+      const { getByRole, user } = setupDateField({
+        value: new Date(),
+        onChange,
+      });
+
+      await user.click(getByRole('button', { name: 'Clear' }));
+
+      expect(getByRole('combobox', { name: 'date' })).toHaveValue('');
+      expect(onChange).toHaveBeenCalledWith({
+        target: { name: 'date', type: 'date', value: null },
+      });
+    });
+  });
+
   describe('datetime', () => {
+    const setupDatetimePicker = (props) => {
+      return setup({
+        type: 'datetime',
+        name: 'datetime-picker',
+        intlLabel: {
+          id: 'label.test',
+          defaultMessage: 'datetime picker',
+        },
+        onClear: jest.fn(),
+        ...props,
+      });
+    };
+
     test('renders the datetime picker with the correct value for date and time', async () => {
       const { getByRole, user } = setupDatetimePicker();
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

When a date field is cleared we pass `null` as the onChange value, however we weren't checking this before trying to use `formatISO`, we now do this. It also fixes a rogue `module.exports` declaration we have in the codebase.

### Why is it needed?

* Users were unable to clear date fields

### How to test it?

* Go to entry with date field & date time field
* clear the date
* see no errors

### Related issue(s)/PR(s)

* resolves #16493
* partially resolves CONTENT-1639