### PR TITLE
Fix required JSON field validation in Bulk Publish modal

### DIFF
--- a/packages/core/admin/admin/src/content-manager/pages/ListView/components/BulkActionButtons/SelectedEntriesModal/tests/index.test.js
+++ b/packages/core/admin/admin/src/content-manager/pages/ListView/components/BulkActionButtons/SelectedEntriesModal/tests/index.test.js
@@ -49,16 +49,25 @@ const handlers = [
           {
             id: 1,
             name: 'Entry 1',
+            metadata: {
+              sample: 'meta',
+            },
             publishedAt: null,
           },
           {
             id: 2,
             name: 'Entry 2',
+            metadata: {
+              sample: 'meta',
+            },
             publishedAt: null,
           },
           {
             id: 3,
             name: 'Entry 3',
+            metadata: {
+              sample: 'meta',
+            },
             publishedAt: null,
           },
         ],
@@ -100,6 +109,7 @@ const store = createStore(rootReducer, {
       attributes: {
         id: { type: 'integer' },
         name: { type: 'string', required: true },
+        metadata: { type: 'json', required: true },
       },
     },
     components: [],
@@ -250,14 +260,20 @@ describe('Bulk publish selected entries modal', () => {
               {
                 id: 1,
                 name: 'Entry 1',
+                metadata: {
+                  sample: 'meta',
+                },
               },
               {
                 id: 2,
                 name: 'Entry 2',
+                metadata: {
+                  sample: 'meta',
+                },
               },
               {
                 id: 3,
-                name: '',
+                name: 'Entry 3',
               },
             ],
           })
@@ -305,14 +321,20 @@ describe('Bulk publish selected entries modal', () => {
               {
                 id: 1,
                 name: 'Entry 1',
+                metadata: {
+                  sample: 'meta',
+                },
               },
               {
                 id: 2,
                 name: 'Entry 2',
+                metadata: {
+                  sample: 'meta',
+                },
               },
               {
                 id: 3,
-                name: '',
+                name: 'Entry 3',
               },
             ],
           })
@@ -356,14 +378,27 @@ describe('Bulk publish selected entries modal', () => {
                 id: 1,
                 name: 'Entry 1',
                 publishedAt: '2023-08-03T08:14:08.324Z',
+                metadata: {
+                  sample: 'meta',
+                },
               },
               {
                 id: 2,
                 name: 'Entry 2',
+                metadata: {
+                  sample: 'meta',
+                },
               },
               {
                 id: 3,
                 name: '',
+                metadata: {
+                  sample: 'meta',
+                },
+              },
+              {
+                id: 4,
+                name: 'Entry 4',
               },
             ],
           })
@@ -372,7 +407,7 @@ describe('Bulk publish selected entries modal', () => {
     );
 
     const { queryByText } = render(
-      <Table.Root defaultSelectedEntries={[1, 2, 3]} colCount={4}>
+      <Table.Root defaultSelectedEntries={[1, 2, 3, 4]} colCount={4}>
         <SelectedEntriesModal onToggle={jest.fn()} />
       </Table.Root>
     );
@@ -392,9 +427,9 @@ describe('Bulk publish selected entries modal', () => {
 
     expect(countReadyToBePublished).toHaveTextContent('1 entry ready to publish');
     // Should show a message with the entries with errors to fix
-    const countWithErrors = await screen.findByText('entry waiting for action', {
+    const countWithErrors = await screen.findByText('entries waiting for action', {
       exact: false,
     });
-    expect(countWithErrors).toHaveTextContent('1 entry waiting for action');
+    expect(countWithErrors).toHaveTextContent('2 entries waiting for action');
   });
 });

--- a/packages/core/admin/admin/src/content-manager/utils/schema.js
+++ b/packages/core/admin/admin/src/content-manager/utils/schema.js
@@ -229,11 +229,17 @@ const createYupSchemaAttribute = (type, validations, options) => {
       })
       .nullable()
       .test('required', errorsTrads.required, (value) => {
-        if (validations.required && (!value || !value.length)) {
-          return false;
+        if (!validations.required) return true;
+
+        if (typeof value === "string" && value.length) {
+          return true;
         }
 
-        return true;
+        if (typeof value === "object" && value !== null) {
+          return true;
+        }
+
+        return false;
       });
   }
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

In Content Manager, a function that validates `required` JSON field now correctly processes both `string` and `object` inputs.

### Why is it needed?

Fixes a bug when bulk publish modal always throws a "required" error for a JSON field, , even though the field is not empty.

### How to test it?

Apart from automated tests,
1. In Content Type Builder, create a collection type with Draft & Publish feature and a required JSON field.
1. Create a sample entry with arbitrary data in the JSON field and save it as a draft.
1. Select created entry from a list and publish it using Bulk Publish.
1. Publish the entry successfully

### Related issue(s)/PR(s)

Fixes #17598 
