### PR TITLE
fix: ListView in ApiTokens and TransferTokens shows empty content table

### DIFF
--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/ApiTokens/ListView/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/ApiTokens/ListView/index.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from 'react';
 
-import { Button, ContentLayout, HeaderLayout, Main } from '@strapi/design-system';
+import { ContentLayout, HeaderLayout, Main } from '@strapi/design-system';
 import {
   LinkButton,
   NoContent,
@@ -114,9 +114,10 @@ const ApiTokenListView = () => {
     }
   );
 
-  const shouldDisplayDynamicTable = canRead && apiTokens;
-  const shouldDisplayNoContent = canRead && !apiTokens && !canCreate;
-  const shouldDisplayNoContentWithCreationButton = canRead && !apiTokens && canCreate;
+  const hasApiTokens = apiTokens && apiTokens.length > 0;
+  const shouldDisplayDynamicTable = canRead && hasApiTokens;
+  const shouldDisplayNoContent = canRead && !hasApiTokens && !canCreate;
+  const shouldDisplayNoContentWithCreationButton = canRead && !hasApiTokens && canCreate;
 
   return (
     <Main aria-busy={isLoading}>
@@ -169,12 +170,12 @@ const ApiTokenListView = () => {
               defaultMessage: 'Add your first API Token',
             }}
             action={
-              <Button variant="secondary" startIcon={<Plus />}>
+              <LinkButton variant="secondary" startIcon={<Plus />} to="/settings/api-tokens/create">
                 {formatMessage({
                   id: 'Settings.apiTokens.addNewToken',
                   defaultMessage: 'Add new API Token',
                 })}
-              </Button>
+              </LinkButton>
             }
           />
         )}

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/TransferTokens/ListView/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/TransferTokens/ListView/index.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from 'react';
 
-import { Button, ContentLayout, HeaderLayout, Main } from '@strapi/design-system';
+import { ContentLayout, HeaderLayout, Main } from '@strapi/design-system';
 import {
   LinkButton,
   NoContent,
@@ -136,9 +136,10 @@ const TransferTokenListView = () => {
     }
   );
 
-  const shouldDisplayDynamicTable = canRead && transferTokens;
-  const shouldDisplayNoContent = canRead && !transferTokens && !canCreate;
-  const shouldDisplayNoContentWithCreationButton = canRead && !transferTokens && canCreate;
+  const hasTransferTokens = transferTokens && transferTokens?.length > 0;
+  const shouldDisplayDynamicTable = canRead && hasTransferTokens;
+  const shouldDisplayNoContent = canRead && !hasTransferTokens && !canCreate;
+  const shouldDisplayNoContentWithCreationButton = canRead && !hasTransferTokens && canCreate;
 
   return (
     <Main aria-busy={isLoading}>
@@ -194,12 +195,16 @@ const TransferTokenListView = () => {
               defaultMessage: 'Add your first Transfer Token',
             }}
             action={
-              <Button variant="secondary" startIcon={<Plus />}>
+              <LinkButton
+                variant="secondary"
+                startIcon={<Plus />}
+                to="/settings/transfer-tokens/create"
+              >
                 {formatMessage({
                   id: 'Settings.transferTokens.addNewToken',
                   defaultMessage: 'Add new Transfer Token',
                 })}
-              </Button>
+              </LinkButton>
             }
           />
         )}


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Updated the `ContentLayout` in both `ApiTokens` and `TransferTokens` to show `NoContent` and Call to action button in case the data fetch returns an empty list of tokens.  

### Why is it needed?

There is a bug if the data fetching returns an empty list of tokens, the page will render an empty table, instead of the `NoContent` component with the CTA to create a first token. 

Since the data fetching will return an empty list of there is no token, `apiTokens` will always be boolean true (i.e. `!apiTokens` or `!!apiTokens`), so added an extra boolean to check if the list exists and if the list is empty.

![Screenshot 2023-08-08 at 16 23 56](https://github.com/strapi/strapi/assets/22895284/87ffd37e-a67c-4fd1-b434-e4baf4fcbc7b)

![Screenshot 2023-08-08 at 16 23 45](https://github.com/strapi/strapi/assets/22895284/149f58d4-67e7-4841-be3d-ce6bb6af511e)

### How to test it?

Didn't find related tests and I wasn't sure if I should create some. 

### Related issue(s)/PR(s)

n/a
