### PR TITLE
[POC] Types for configuration files

### DIFF
--- a/packages/core/strapi/lib/types/core/config/admin.d.ts
+++ b/packages/core/strapi/lib/types/core/config/admin.d.ts
@@ -1,3 +1,5 @@
+import type { ConfigFunction } from './shared.d.ts';
+
 export type ApiTokenProp = {
   salt: string;
 };
@@ -35,7 +37,7 @@ export type TransferProp = {
   token: TransferTokenProp;
 };
 
-export type Admin = {
+export type AdminConfiguration = {
   // required
   apiToken: ApiTokenProp;
   transfer: TransferProp;
@@ -46,3 +48,6 @@ export type Admin = {
   forgotPassword?: ForgotPasswordProp;
   rateLimit?: RateLimitProp;
 };
+
+// TODO: can this just be an object rather than a function?
+export type Admin = ConfigFunction<AdminConfiguration>;

--- a/packages/core/strapi/lib/types/core/config/admin.d.ts
+++ b/packages/core/strapi/lib/types/core/config/admin.d.ts
@@ -1,0 +1,48 @@
+export type ApiTokenProp = {
+  salt: string;
+};
+
+export type AuthProp = {
+  secret: string;
+};
+
+export type TransferTokenProp = {
+  salt: string;
+};
+
+export type AuditLogsProp = {
+  retentionDays?: number;
+};
+
+export type ForgotPasswordProp = {
+  emailTemplate?: string;
+  from?: string;
+  replyTo?: string;
+};
+
+export type RateLimitProp = {
+  enabled?: boolean;
+  interval?: number;
+  max?: number;
+  delayAfter?: number;
+  timeWait?: number;
+  prefixKey?: number;
+  whietlist?: string;
+  store?: string;
+};
+
+export type TransferProp = {
+  token: TransferTokenProp;
+};
+
+export type Admin = {
+  // required
+  apiToken: ApiTokenProp;
+  transfer: TransferProp;
+  auth: AuthProp;
+  // optional
+  auditLogs?: AuditLogsProp;
+  url?: string;
+  forgotPassword?: ForgotPasswordProp;
+  rateLimit?: RateLimitProp;
+};

--- a/packages/core/strapi/lib/types/core/config/index.d.ts
+++ b/packages/core/strapi/lib/types/core/config/index.d.ts
@@ -1,0 +1,2 @@
+export { Server } from './server.js';
+export { Admin } from './admin.js';

--- a/packages/core/strapi/lib/types/core/config/server.d.ts
+++ b/packages/core/strapi/lib/types/core/config/server.d.ts
@@ -1,3 +1,5 @@
+import type { ConfigFunction } from './shared.d.ts';
+
 export type AppProp = {
   keys: string[];
 };
@@ -15,7 +17,7 @@ export type WebhooksProp = {
   populateRelations?: boolean;
 };
 
-export type Server = {
+export type ServerConfiguration = {
   // required
   host: string;
   post: number;
@@ -31,3 +33,6 @@ export type Server = {
   dirs?: DirsProp;
   webhooks?: WebhooksProp;
 };
+
+// TODO: can this just be an object rather than a function?
+export type Server = ConfigFunction<ServerConfiguration>;

--- a/packages/core/strapi/lib/types/core/config/server.d.ts
+++ b/packages/core/strapi/lib/types/core/config/server.d.ts
@@ -1,0 +1,33 @@
+export type AppProp = {
+  keys: string[];
+};
+
+export type CronProp = {
+  enabled?: boolean;
+  tasks?: object; // TODO: does strapi crash if cron is enabled but tasks is empty?
+};
+
+export type DirsProp = {
+  public?: string;
+};
+
+export type WebhooksProp = {
+  populateRelations?: boolean;
+};
+
+export type Server = {
+  // required
+  host: string;
+  post: number;
+  app: AppProp;
+
+  // optional
+  socket?: string | number;
+  emitErrors?: boolean;
+  url?: string;
+  proxy?: boolean;
+  globalProxy?: string;
+  cron?: CronProp;
+  dirs?: DirsProp;
+  webhooks?: WebhooksProp;
+};

--- a/packages/core/strapi/lib/types/core/config/shared.d.ts
+++ b/packages/core/strapi/lib/types/core/config/shared.d.ts
@@ -1,0 +1,2 @@
+// TODO: can this be async?
+type ConfigFunction<TConfigObject> = ({ env }) => TConfigObject;

--- a/packages/core/strapi/lib/types/core/index.d.ts
+++ b/packages/core/strapi/lib/types/core/index.d.ts
@@ -1,5 +1,6 @@
 export * as Attribute from './attributes';
 export * as Schema from './schemas';
+export * as Config from './config';
 export * from './strapi';
 
 export * as Common from './common';


### PR DESCRIPTION
NOTE: This is an initial concept for us to discuss this week

### What does it do?

Adds a base for configuration typings as well as admin and server config file typings.

### Why is it needed?

To assist typescript users in the creation of configuration files

### How to test it?

Give your configuration a type Config.Admin or Config.Server and see that you now have typings enforced in your config.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
