### PR TITLE
fix(ee): condition for displaying edit view info box

### DIFF
--- a/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/InformationBoxEE.js
+++ b/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/InformationBoxEE.js
@@ -6,17 +6,14 @@ import { Information } from '../../../../../../admin/src/content-manager/pages/E
 
 import { AssigneeSelect } from './components/AssigneeSelect';
 import { StageSelect } from './components/StageSelect';
-import { STAGE_ATTRIBUTE_NAME } from './constants';
 
 export function InformationBoxEE() {
-  const { initialData, isCreatingEntry } = useCMEditViewDataManager();
-  // it is possible to rely on initialData here, because it always will
-  // be updated at the same time when modifiedData is updated, otherwise
-  // the entity is flagged as modified
-  const hasReviewWorkflowsEnabled = Object.prototype.hasOwnProperty.call(
-    initialData,
-    STAGE_ATTRIBUTE_NAME
-  );
+  const {
+    isCreatingEntry,
+    layout: { options },
+  } = useCMEditViewDataManager();
+
+  const hasReviewWorkflowsEnabled = options?.reviewWorkflows ?? false;
 
   return (
     <Information.Root>

--- a/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/tests/InformationBoxEE.test.js
+++ b/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/tests/InformationBoxEE.test.js
@@ -91,7 +91,11 @@ describe('EE | Content Manager | EditView | InformationBox', () => {
     useCMEditViewDataManager.mockReturnValue({
       initialData: {},
       isCreatingEntry: true,
-      layout: { uid: 'api::articles:articles' },
+      layout: {
+        options: {
+          reviewWorkflows: false,
+        },
+      },
     });
 
     const { getByText } = setup();
@@ -103,7 +107,11 @@ describe('EE | Content Manager | EditView | InformationBox', () => {
   it('renders neither stage nor assignee select inputs, if no nothing is returned for an entity', () => {
     useCMEditViewDataManager.mockReturnValue({
       initialData: {},
-      layout: { uid: 'api::articles:articles' },
+      layout: {
+        options: {
+          reviewWorkflows: false,
+        },
+      },
     });
 
     const { queryByRole } = setup();
@@ -127,7 +135,12 @@ describe('EE | Content Manager | EditView | InformationBox', () => {
           lastname: 'Lastname',
         },
       },
-      layout: { uid: 'api::articles:articles' },
+      layout: {
+        uid: 'api::articles:articles',
+        options: {
+          reviewWorkflows: true,
+        },
+      },
     });
 
     const { queryAllByRole } = setup();


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Changes the condition we use to determine whether the edit view EE info box should be displayed

### Why is it needed?

Previously it was being displayed even for content types without review workflows enabled. e.g. 

https://github.com/strapi/strapi/assets/48524071/6eee873c-2f24-46ce-8644-08e8a04d5d5b

### How to test it?

Updated tests

