### PR TITLE
Add timeout to marketplace notification on prod

### DIFF
--- a/packages/core/admin/admin/src/pages/MarketplacePage/index.js
+++ b/packages/core/admin/admin/src/pages/MarketplacePage/index.js
@@ -70,7 +70,6 @@ const MarketPlacePage = () => {
           id: 'admin.pages.MarketPlacePage.production',
           defaultMessage: 'Manage plugins from the development environment',
         },
-        blockTransition: true,
       });
     }
   }, [toggleNotification, isInDevelopmentMode]);

--- a/packages/core/admin/admin/src/pages/MarketplacePage/tests/index.test.js
+++ b/packages/core/admin/admin/src/pages/MarketplacePage/tests/index.test.js
@@ -175,7 +175,6 @@ describe('Marketplace page - layout', () => {
         id: 'admin.pages.MarketPlacePage.production',
         defaultMessage: 'Manage plugins from the development environment',
       },
-      blockTransition: true,
     });
     expect(toggleNotification).toHaveBeenCalledTimes(1);
     // Should not show install buttons


### PR DESCRIPTION
### What does it do?

Remove the blockTransition from notification on marketplace so it would remove after a time

### How to test it?

1. Run Strapi on production mode
2. Go to the marketplace
3. The notification appears and should be remove after a time

### Related issue(s)/PR(s)

Closes #14939 
