### PR TITLE
fix: user settings requires two renders to be shown in Admin UI

### DIFF
--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Users/EditPage/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Users/EditPage/index.js
@@ -68,6 +68,7 @@ const EditPage = ({ canUpdate }) => {
   const {
     users: [user],
     isLoading: isLoadingAdminUsers,
+    refetch,
   } = useAdminUsers(
     { id },
     {
@@ -117,6 +118,7 @@ const EditPage = ({ canUpdate }) => {
         setUserDisplayName(userDisplayName);
       }
       actions.setValues(pick(body, fieldsToPick));
+      await refetch();
     } catch (err) {
       // FIXME when API errors are ready
       const errors = formatAPIErrors(err.response.data);


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Used the `refetch`(react-query) method from `useAdminUsers()` when submitting to get the user data from the server and invalidate the cached data from react-query

The issue is that when getting back to the user settings page, react query uses the last successfully fetched data (old), but internally it was already there the new data. Then react query invalidates this on the second render.

That is why we need to explicitly call refetch when submitting.

### Why is it needed?

In the settings page, when editing a user after saving, it requires two renders to be shown in Admin UI
Here is the video example:

[](https://user-images.githubusercontent.com/137342269/254974473-d02e527d-fe1f-444f-b00a-6c259a80293c.webm)

### How to test it?

Didn't find related tests and I wasn't sure if I should create some.

### Related issue(s)/PR(s)

Fix #17397
