### PR TITLE
fix: use ts-expect-error on admin test mock

### DIFF
--- a/packages/admin-test-utils/src/environment.ts
+++ b/packages/admin-test-utils/src/environment.ts
@@ -116,6 +116,7 @@ window.URL.createObjectURL = jest
 
 document.createRange = () => {
   const range = new Range();
+  // @ts-expect-error we don't need to implement all the methods
   range.getClientRects = jest.fn(() => ({
     item: () => null,
     length: 0,

--- a/packages/admin-test-utils/tsconfig.json
+++ b/packages/admin-test-utils/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "tsconfig/base.json",
+  "extends": "tsconfig/client.json",
   "compilerOptions": {
     "outDir": "dist"
   },


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* adds `@ts-expect-error` to the mock for `range.getClientRects` because we don't need to mock all the methods i.e. the fact it is iterable

### Why is it needed?

* fixes build:ts
