### PR TITLE
Fix: Ensure fresh data for list and edit-views (api-tokens, users)

### DIFF
--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/ApiTokens/ListView/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/ApiTokens/ListView/index.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import * as React from 'react';
 
 import { Button, ContentLayout, HeaderLayout, Main } from '@strapi/design-system';
 import {
@@ -6,6 +6,7 @@ import {
   NoContent,
   NoPermissions,
   SettingsPageTitle,
+  useAPIErrorHandler,
   useFetchClient,
   useFocusWhenNavigate,
   useGuidedTour,
@@ -38,16 +39,17 @@ const ApiTokenListView = () => {
   const { push } = useHistory();
   const { trackUsage } = useTracking();
   const { startSection } = useGuidedTour();
-  const startSectionRef = useRef(startSection);
+  const startSectionRef = React.useRef(startSection);
   const { get, del } = useFetchClient();
+  const { formatAPIError } = useAPIErrorHandler();
 
-  useEffect(() => {
+  React.useEffect(() => {
     if (startSectionRef.current) {
       startSectionRef.current('apiTokens');
     }
   }, []);
 
-  useEffect(() => {
+  React.useEffect(() => {
     push({ search: qs.stringify({ sort: 'name:ASC' }, { encode: false }) });
   }, [push]);
 
@@ -59,16 +61,13 @@ const ApiTokenListView = () => {
     },
   }));
 
-  const {
-    data: apiTokens,
-    status,
-    isFetching,
-  } = useQuery(
+  const { data: apiTokens, isLoading: isLoadingTokens } = useQuery(
     ['api-tokens'],
     async () => {
       trackUsage('willAccessTokenList', {
         tokenType: API_TOKEN_TYPE,
       });
+
       const {
         data: { data },
       } = await get(`/admin/api-tokens`);
@@ -78,19 +77,18 @@ const ApiTokenListView = () => {
       return data;
     },
     {
+      cacheTime: 0,
       enabled: canRead,
-      onError() {
+      onError(error) {
         toggleNotification({
           type: 'warning',
-          message: { id: 'notification.error', defaultMessage: 'An error occured' },
+          message: formatAPIError(error),
         });
       },
     }
   );
 
-  const isLoading =
-    canRead &&
-    ((status !== 'success' && status !== 'error') || (status === 'success' && isFetching));
+  const isLoading = isLoadingTokens;
 
   const deleteMutation = useMutation(
     async (id) => {
@@ -101,15 +99,8 @@ const ApiTokenListView = () => {
         await queryClient.invalidateQueries(['api-tokens']);
         trackUsage('didDeleteToken');
       },
-      onError(err) {
-        if (err?.response?.data?.data) {
-          toggleNotification({ type: 'warning', message: err.response.data.data });
-        } else {
-          toggleNotification({
-            type: 'warning',
-            message: { id: 'notification.error', defaultMessage: 'An error occured' },
-          });
-        }
+      onError(error) {
+        toggleNotification({ type: 'warning', message: formatAPIError(error) });
       },
     }
   );
@@ -120,6 +111,7 @@ const ApiTokenListView = () => {
 
   return (
     <Main aria-busy={isLoading}>
+      {/* TODO: this needs to be translated */}
       <SettingsPageTitle name="API Tokens" />
       <HeaderLayout
         title={formatMessage({ id: 'Settings.apiTokens.title', defaultMessage: 'API Tokens' })}
@@ -128,7 +120,7 @@ const ApiTokenListView = () => {
           defaultMessage: 'List of generated tokens to consume the API',
         })}
         primaryAction={
-          canCreate ? (
+          canCreate && (
             <LinkButton
               data-testid="create-api-token-button"
               startIcon={<Plus />}
@@ -145,7 +137,7 @@ const ApiTokenListView = () => {
                 defaultMessage: 'Create new API Token',
               })}
             </LinkButton>
-          ) : undefined
+          )
         }
       />
       <ContentLayout>

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Users/EditPage/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Users/EditPage/index.js
@@ -71,6 +71,8 @@ const EditPage = ({ canUpdate }) => {
   } = useAdminUsers(
     { id },
     {
+      cacheTime: 0,
+
       onError(error) {
         const { status } = error.response;
 

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/Users/ListPage/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/Users/ListPage/index.js
@@ -52,6 +52,7 @@ export const UserListPageCE = () => {
     isLoading,
     refetch: refetchAdminUsers,
   } = useAdminUsers(qs.parse(search, { ignoreQueryPrefix: true }), {
+    cacheTime: 0,
     enabled: canRead,
   });
   const CreateAction = useEnterprise(


### PR DESCRIPTION
### What does it do?

Adds `cache-time: 0` for list and edit-views of API-tokens and users.

### Why is it needed?

As a user I never want to see stale data, but always the latest state. https://github.com/strapi/strapi/pull/17630 proposed to use `refetch`, but I think it is actually better to always fetch (e.g. because another user has updated something in the meantime) when accessing thes pages.

### Related issue(s)/PR(s)

- Closes https://github.com/strapi/strapi/pull/17630
- Fixes https://github.com/strapi/strapi/issues/17397
