### PR TITLE
Fix: Improve default value for useAuthProviders()

### DIFF
--- a/packages/core/admin/ee/admin/hooks/useAuthProviders.js
+++ b/packages/core/admin/ee/admin/hooks/useAuthProviders.js
@@ -1,3 +1,5 @@
+import * as React from 'react';
+
 import { useFetchClient } from '@strapi/helper-plugin';
 import { useQuery } from 'react-query';
 
@@ -14,5 +16,10 @@ export const useAuthProviders = (queryOptions = {}) => {
     queryOptions
   );
 
-  return { data, isLoading };
+  // the return value needs to be memoized, because a fresh
+  // instantiated array would cause an infinite rendering loop
+  // when used as an effect dependency
+  const providers = React.useMemo(() => data ?? [], [data]);
+
+  return { providers, isLoading };
 };

--- a/packages/core/admin/ee/admin/pages/AuthPage/components/Login/index.js
+++ b/packages/core/admin/ee/admin/pages/AuthPage/components/Login/index.js
@@ -16,7 +16,7 @@ const DividerFull = styled(Divider)`
 
 export const LoginEE = (loginProps) => {
   const { formatMessage } = useIntl();
-  const { isLoading, data: providers } = useAuthProviders({
+  const { isLoading, providers } = useAuthProviders({
     enabled: window.strapi.features.isEnabled(window.strapi.features.SSO),
   });
 

--- a/packages/core/admin/ee/admin/pages/AuthPage/components/Providers/index.js
+++ b/packages/core/admin/ee/admin/pages/AuthPage/components/Providers/index.js
@@ -22,7 +22,7 @@ const DividerFull = styled(Divider)`
 const Providers = () => {
   const { push } = useHistory();
   const { formatMessage } = useIntl();
-  const { isLoading, data: providers } = useAuthProviders({
+  const { isLoading, providers } = useAuthProviders({
     enabled: window.strapi.features.isEnabled(window.strapi.features.SSO),
   });
 


### PR DESCRIPTION
### What does it do?

Add an empty array as default value for providers returned by `useAuthProviders`

### Why is it needed?

Makes code dependent on it more bullet proof.

### Related issue(s)/PR(s)

Broke in https://github.com/strapi/strapi/pull/17673
