### PR TITLE
Fix Strapi dark and light mode images on readme

### DIFF
--- a/packages/core/strapi/README.md
+++ b/packages/core/strapi/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://strapi.io">
-    <picture width="318px">
+    <picture>
       <source
         srcset="https://strapi.io/assets/strapi-logo-dark.svg"
         media="(prefers-color-scheme: dark)"

--- a/packages/core/strapi/README.md
+++ b/packages/core/strapi/README.md
@@ -1,16 +1,18 @@
 <p align="center">
-  <picture width="318px">
-    <source
-      srcset="https://strapi.io/assets/strapi-logo-dark.svg"
-      media="(prefers-color-scheme: dark)"
-      width="318px"
-    />
-    <img
-      src="https://strapi.io/assets/strapi-logo-light.svg"
-      alt="Strapi logo"
-      width="318px"
-    />
-  </picture>
+  <a href="https://strapi.io">
+    <picture width="318px">
+      <source
+        srcset="https://strapi.io/assets/strapi-logo-dark.svg"
+        media="(prefers-color-scheme: dark)"
+        width="318px"
+      />
+      <img
+        src="https://strapi.io/assets/strapi-logo-light.svg"
+        alt="Strapi logo"
+        width="318px"
+      />
+    </picture>
+  </a>
 </p>
 
 <h3 align="center">API creation made simple, secure and fast.</h3>

--- a/packages/core/strapi/README.md
+++ b/packages/core/strapi/README.md
@@ -1,10 +1,16 @@
 <p align="center">
-  <a href="https://strapi.io/#gh-light-mode-only">
-    <img src="https://strapi.io/assets/strapi-logo-dark.svg" width="318px" alt="Strapi logo" />
-  </a>
-  <a href="https://strapi.io/#gh-dark-mode-only">
-    <img src="https://strapi.io/assets/strapi-logo-light.svg" width="318px" alt="Strapi logo" />
-  </a>
+  <picture width="318px">
+    <source
+      srcset="https://strapi.io/assets/strapi-logo-dark.svg"
+      media="(prefers-color-scheme: dark)"
+      width="318px"
+    />
+    <img
+      src="https://strapi.io/assets/strapi-logo-light.svg"
+      alt="Strapi logo"
+      width="318px"
+    />
+  </picture>
 </p>
 
 <h3 align="center">API creation made simple, secure and fast.</h3>


### PR DESCRIPTION
### What does it do?

use picture with a media selector rather than rely on github decorators

### Why is it needed?

fix the light/dark mode strapi logo

### How to test it?

see if it works on github by viewing the file directly

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
