### PR TITLE
Use custom field's sizes when restarting strapi to calculate edit layout

### DIFF
--- a/packages/core/content-manager/server/bootstrap.js
+++ b/packages/core/content-manager/server/bootstrap.js
@@ -8,8 +8,8 @@ module.exports = async () => {
     strapi.webhookStore.addAllowedEvent(key, value);
   });
 
+  getService('field-sizes').setCustomFieldInputSizes();
   await getService('components').syncConfigurations();
   await getService('content-types').syncConfigurations();
   await getService('permission').registerPermissions();
-  getService('field-sizes').setCustomFieldInputSizes();
 };

--- a/packages/core/content-manager/server/services/field-sizes.js
+++ b/packages/core/content-manager/server/services/field-sizes.js
@@ -52,6 +52,10 @@ const createFieldSizesService = ({ strapi }) => {
       return fieldSizes;
     },
 
+    hasFieldSize(type) {
+      return !!fieldSizes[type];
+    },
+
     getFieldSize(type) {
       if (!type) {
         throw new ApplicationError('The type is required');

--- a/packages/core/content-manager/server/services/utils/configuration/__tests__/layouts.test.js
+++ b/packages/core/content-manager/server/services/utils/configuration/__tests__/layouts.test.js
@@ -1,0 +1,88 @@
+'use strict';
+
+const { syncLayouts } = require('../layouts');
+
+jest.mock('../../../../utils', () => ({
+  getService: jest.fn().mockReturnValue({
+    getFieldSize: jest.fn().mockImplementation((type) => {
+      if (type === 'integer' || type === 'string') {
+        return { default: 6, isResizable: true };
+      }
+
+      if (type === 'json' || type === 'customField') {
+        return { default: 12, isResizable: false };
+      }
+    }),
+    hasFieldSize: jest.fn().mockImplementation((type) => {
+      return type === 'customField';
+    }),
+  }),
+}));
+
+const createMockSchema = ({ attributes = {} }) => ({
+  attributes: {
+    id: { type: 'integer' },
+    title: { type: 'string' },
+    nodes: { type: 'json' },
+    ...attributes,
+  },
+  config: {
+    attributes: {
+      title: {},
+      nodes: {},
+    },
+  },
+});
+
+describe('Layouts', () => {
+  it('should create default layouts with valid fields if no configuration is provided', async () => {
+    const configuration = { layouts: {} };
+
+    const layout = await syncLayouts(configuration, createMockSchema({}));
+
+    expect(layout.list).toEqual(['id', 'title']);
+    expect(layout.edit).toEqual([[{ name: 'title', size: 6 }], [{ name: 'nodes', size: 12 }]]);
+  });
+
+  it('should append new fields at the end of the layouts', async () => {
+    const configuration = {
+      layouts: {
+        list: ['id', 'title'],
+        edit: [[{ name: 'title', size: 6 }], [{ name: 'nodes', size: 12 }]],
+      },
+      metadatas: { id: {}, title: {}, nodes: {} },
+    };
+    const schema = createMockSchema({ attributes: { description: { type: 'string' } } });
+
+    const layout = await syncLayouts(configuration, schema);
+
+    expect(layout.list).toEqual(['id', 'title', 'description']);
+    expect(layout.edit).toEqual([
+      [{ name: 'title', size: 6 }],
+      [{ name: 'nodes', size: 12 }],
+      [{ name: 'description', size: 6 }],
+    ]);
+  });
+
+  it('should use the custom field size if the field is a custom field with custom size', async () => {
+    const configuration = {
+      layouts: {
+        list: ['id', 'title'],
+        edit: [[{ name: 'title', size: 6 }], [{ name: 'nodes', size: 12 }]],
+      },
+      metadatas: { id: {}, title: {}, nodes: {} },
+    };
+    const schema = createMockSchema({
+      attributes: { color: { type: 'string', customField: 'customField' } },
+    });
+
+    const layout = await syncLayouts(configuration, schema);
+
+    expect(layout.list).toEqual(['id', 'title', 'color']);
+    expect(layout.edit).toEqual([
+      [{ name: 'title', size: 6 }],
+      [{ name: 'nodes', size: 12 }],
+      [{ name: 'color', size: 12 }],
+    ]);
+  });
+});


### PR DESCRIPTION
### What does it do?

`isAllowedFieldSize` is used to verify whether a field has changed its type to one with a different size. With this PR, we check if the field is a custom field with its own custom size. Instead of employing the size associated with the data type, we use the user-defined custom size.

### Why is it needed?

This solve two different issues at the same time:
1. Users have the ability to create a custom field with a JSON type, while specifying a custom size such as 6 (the default size for a JSON type is 12). But, when restarting Strapi, the edit layout reverts to using the size of 12 instead of 6. (Additional context: Issue #16933)
2. During the development of a custom field, it is common for developers to adjust the default size of their custom fields to explore  different options. With this modification, the field now automatically adapts to its new size each time, eliminating the need for developers to manually adjust it in the configure the view page.

### How to test it?

1. Create a content type with a custom field with **NO** custom sizes set. You can create the custom field with the type you want.
2. Change the custom field and now set a custom size different to the type size and not resizable.
3. When restarting the app it should change the custom field size to the new one

### Related issue(s)/PR(s)

Closes #16933
