### PR TITLE
Throw error on missing schema in sanitization

### DIFF
--- a/packages/core/utils/src/sanitize/index.ts
+++ b/packages/core/utils/src/sanitize/index.ts
@@ -26,6 +26,9 @@ export interface SanitizeFunc {
 
 const createContentAPISanitizers = () => {
   const sanitizeInput: SanitizeFunc = (data: unknown, schema: Model, { auth } = {}) => {
+    if (!schema) {
+      throw new Error('Missing schema in sanitizeInput');
+    }
     if (isArray(data)) {
       return Promise.all(data.map((entry) => sanitizeInput(entry, schema, { auth })));
     }
@@ -51,6 +54,9 @@ const createContentAPISanitizers = () => {
   };
 
   const sanitizeOutput: SanitizeFunc = async (data, schema: Model, { auth } = {}) => {
+    if (!schema) {
+      throw new Error('Missing schema in sanitizeOutput');
+    }
     if (isArray(data)) {
       const res = new Array(data.length);
       for (let i = 0; i < data.length; i += 1) {
@@ -78,6 +84,9 @@ const createContentAPISanitizers = () => {
     schema: Model,
     { auth }: Options = {}
   ) => {
+    if (!schema) {
+      throw new Error('Missing schema in sanitizeQuery');
+    }
     const { filters, sort, fields, populate } = query;
 
     const sanitizedQuery = cloneDeep(query);
@@ -102,6 +111,9 @@ const createContentAPISanitizers = () => {
   };
 
   const sanitizeFilters: SanitizeFunc = (filters, schema: Model, { auth } = {}) => {
+    if (!schema) {
+      throw new Error('Missing schema in sanitizeFilters');
+    }
     if (isArray(filters)) {
       return Promise.all(filters.map((filter) => sanitizeFilters(filter, schema, { auth })));
     }
@@ -116,6 +128,9 @@ const createContentAPISanitizers = () => {
   };
 
   const sanitizeSort: SanitizeFunc = (sort, schema: Model, { auth } = {}) => {
+    if (!schema) {
+      throw new Error('Missing schema in sanitizeSort');
+    }
     const transforms = [sanitizers.defaultSanitizeSort(schema)];
 
     if (auth) {
@@ -126,12 +141,18 @@ const createContentAPISanitizers = () => {
   };
 
   const sanitizeFields: SanitizeFunc = (fields, schema: Model) => {
+    if (!schema) {
+      throw new Error('Missing schema in sanitizeFields');
+    }
     const transforms = [sanitizers.defaultSanitizeFields(schema)];
 
     return pipeAsync(...transforms)(fields);
   };
 
   const sanitizePopulate: SanitizeFunc = (populate, schema: Model, { auth } = {}) => {
+    if (!schema) {
+      throw new Error('Missing schema in sanitizePopulate');
+    }
     const transforms = [sanitizers.defaultSanitizePopulate(schema)];
 
     if (auth) {

--- a/packages/core/utils/src/validate/index.ts
+++ b/packages/core/utils/src/validate/index.ts
@@ -57,6 +57,9 @@ const createContentAPIValidators = () => {
     schema: Model,
     { auth }: Options = {}
   ) => {
+    if (!schema) {
+      throw new Error('Missing schema in validateQuery');
+    }
     const { filters, sort, fields } = query;
 
     if (filters) {
@@ -75,6 +78,9 @@ const createContentAPIValidators = () => {
   };
 
   const validateFilters: ValidateFunc = async (filters, schema: Model, { auth } = {}) => {
+    if (!schema) {
+      throw new Error('Missing schema in validateFilters');
+    }
     if (isArray(filters)) {
       await Promise.all(filters.map((filter) => validateFilters(filter, schema, { auth })));
       return;
@@ -90,6 +96,9 @@ const createContentAPIValidators = () => {
   };
 
   const validateSort: ValidateFunc = async (sort, schema: Model, { auth } = {}) => {
+    if (!schema) {
+      throw new Error('Missing schema in validateSort');
+    }
     const transforms = [validators.defaultValidateSort(schema)];
 
     if (auth) {


### PR DESCRIPTION
### What does it do?

Throws an error when sanitize and validate utils are called without a schema. 

I would like to have opinions on this; it is potentially a breaking change, but it is for user security. Almost anywhere it causes breaking, it's almost certainly because of user error that needs to be corrected. But there are potentially some use-cases, however unlikely, where it is intentionally called without a schema.

### Why is it needed?

Without a schema, the methods do almost nothing at all, which gives users who are using it incorrectly a false sense of security.

### How to test it?

Try using the sanitize/validate utils without a schema and now there should be an error instead of silently proceeding.

### Related issue(s)/PR(s)

I branched from and targeted my validate PR because I didn't want to complicate that one any more and wanted to discuss this issue independently from that.