### PR TITLE
Enable WAL mode by default for SQLite

### DIFF
--- a/packages/core/database/lib/dialects/sqlite/index.js
+++ b/packages/core/database/lib/dialects/sqlite/index.js
@@ -32,7 +32,7 @@ class SqliteDialect extends Dialect {
 
   async initialize() {
     await this.db.connection.raw('pragma foreign_keys = on');
-    await this.db.pragma('journal_mode = WAL');
+    await this.db.connection.raw('pragma journal_mode = WAL');
     await this.db.connection.raw('pragma synchronous = normal');
   }
 

--- a/packages/core/database/lib/dialects/sqlite/index.js
+++ b/packages/core/database/lib/dialects/sqlite/index.js
@@ -33,6 +33,7 @@ class SqliteDialect extends Dialect {
   async initialize() {
     await this.db.connection.raw('pragma foreign_keys = on');
     await this.db.pragma('journal_mode = WAL');
+    await this.db.pragma('synchronous = normal');
   }
 
   canAlterConstraints() {

--- a/packages/core/database/lib/dialects/sqlite/index.js
+++ b/packages/core/database/lib/dialects/sqlite/index.js
@@ -33,7 +33,7 @@ class SqliteDialect extends Dialect {
   async initialize() {
     await this.db.connection.raw('pragma foreign_keys = on');
     await this.db.pragma('journal_mode = WAL');
-    await this.db.pragma('synchronous = normal');
+    await this.db.connection.raw('pragma synchronous = normal');
   }
 
   canAlterConstraints() {

--- a/packages/core/database/lib/dialects/sqlite/index.js
+++ b/packages/core/database/lib/dialects/sqlite/index.js
@@ -32,6 +32,7 @@ class SqliteDialect extends Dialect {
 
   async initialize() {
     await this.db.connection.raw('pragma foreign_keys = on');
+    await this.db.pragma('journal_mode = WAL');
   }
 
   canAlterConstraints() {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Enabled the following during initialization of SQLite dialect-
Enable WAL mode
Set synchronous to normal

### Why is it needed?

according to feature request #17625 it will increase the performance of SQLite

### How to test it?

tested on localhost while using sqlite as dialect

### Related issue(s)/PR(s)

fixes #17625 
