### PR TITLE
fix: display role names

### DIFF
--- a/api-tests/core/content-manager/api/relations-permissions.test.api.js
+++ b/api-tests/core/content-manager/api/relations-permissions.test.api.js
@@ -88,11 +88,6 @@ const createUserAndReq = async (userName, permissions) => {
   return rq;
 };
 
-// Create role?
-//  - Without permissions to read users
-//  - With permissions to read users
-//  - With permissions to read a specific model mainField
-//  - Without permissions to read a specific model mainField
 describe('Relations', () => {
   const builder = createTestBuilder();
 

--- a/api-tests/core/content-manager/api/relations-permissions.test.api.js
+++ b/api-tests/core/content-manager/api/relations-permissions.test.api.js
@@ -1,0 +1,199 @@
+'use strict';
+
+const { createTestBuilder } = require('api-tests/builder');
+const { createStrapiInstance } = require('api-tests/strapi');
+const { createAuthRequest } = require('api-tests/request');
+const { createUtils } = require('api-tests/utils');
+
+let strapi;
+let utils;
+// Requests
+let rq;
+let rqRestricted;
+let rqPermissive;
+// Entries
+let product;
+let shop;
+let user;
+
+const populateShop = ['products'];
+
+const productModel = {
+  attributes: {
+    name: {
+      type: 'string',
+    },
+  },
+  displayName: 'Product',
+  singularName: 'product',
+  pluralName: 'products',
+  description: '',
+  collectionName: '',
+};
+
+const shopModel = {
+  attributes: {
+    name: {
+      type: 'string',
+    },
+    products: {
+      type: 'relation',
+      relation: 'manyToMany',
+      target: 'api::product.product',
+      targetAttribute: 'shops',
+    },
+  },
+  displayName: 'Shop',
+  singularName: 'shop',
+  pluralName: 'shops',
+};
+
+const createEntry = async (model, data, populate) => {
+  const { body } = await rq({
+    method: 'POST',
+    url: `/content-manager/collection-types/${model}`,
+    body: data,
+    qs: { populate },
+  });
+  return body;
+};
+
+const getRelations = async (rq, uid, field, id) => {
+  const res = await rq({
+    method: 'GET',
+    url: `/content-manager/relations/${uid}/${id}/${field}`,
+  });
+
+  return res;
+};
+
+const createUserAndReq = async (userName, permissions) => {
+  const role = await utils.createRole({
+    name: `role-${userName}`,
+    description: `Role with restricted permissions for ${userName}`,
+  });
+
+  const rolePermissions = await utils.assignPermissionsToRole(role.id, permissions);
+  Object.assign(role, { permissions: rolePermissions });
+
+  const user = await utils.createUser({
+    firstname: userName,
+    lastname: 'User',
+    email: `${userName}.user@strapi.io`,
+    roles: [role.id],
+  });
+
+  const rq = await createAuthRequest({ strapi, userInfo: user });
+
+  return rq;
+};
+
+// Create role?
+//  - Without permissions to read users
+//  - With permissions to read users
+//  - With permissions to read a specific model mainField
+//  - Without permissions to read a specific model mainField
+describe('Relations', () => {
+  const builder = createTestBuilder();
+
+  const createFixtures = async () => {
+    rqRestricted = await createUserAndReq('restricted', [
+      // Can read shops but not products
+      {
+        action: 'plugin::content-manager.explorer.read',
+        subject: 'api::shop.shop',
+      },
+      {
+        action: 'plugin::content-manager.explorer.read',
+        subject: 'plugin::users-permissions.user',
+      },
+    ]);
+    rqPermissive = await createUserAndReq('permissive', [
+      // Can read shops and products
+      {
+        action: 'plugin::content-manager.explorer.read',
+        subject: 'api::shop.shop',
+      },
+      {
+        action: 'plugin::content-manager.explorer.read',
+        subject: 'api::product.product',
+      },
+      {
+        action: 'plugin::content-manager.explorer.read',
+        subject: 'plugin::users-permissions.user',
+      },
+    ]);
+  };
+
+  beforeAll(async () => {
+    await builder.addContentTypes([productModel, shopModel]).build();
+
+    strapi = await createStrapiInstance();
+    utils = createUtils(strapi);
+
+    rq = await createAuthRequest({ strapi });
+    await createFixtures();
+
+    product = await createEntry('api::product.product', { name: 'Skate' });
+    shop = await createEntry(
+      'api::shop.shop',
+      { name: 'Shop', products: [product.id] },
+      populateShop
+    );
+    user = await createEntry('plugin::users-permissions.user', {
+      username: 'Alice',
+      email: 'test@strapi.io',
+      password: '1234-never-gonna-hack-you-up',
+      role: 1,
+    });
+  });
+
+  afterAll(async () => {
+    await strapi.destroy();
+    await builder.cleanup();
+  });
+
+  test('Permissive user can read shop products mainField', async () => {
+    const { body: products } = await getRelations(
+      rqPermissive,
+      'api::shop.shop',
+      'products',
+      shop.id
+    );
+
+    // Main field should be in here
+    expect(products.results).toHaveLength(1);
+    // Main field should be visible
+    expect(products.results[0].name).toBe(product.name);
+  });
+
+  test('Restricted user cannot read shop products mainField', async () => {
+    const { body: products } = await getRelations(
+      rqRestricted,
+      'api::shop.shop',
+      'products',
+      shop.id
+    );
+
+    expect(products.results).toHaveLength(1);
+    // Main field should not be visible
+    expect(products.results[0].name).toBeUndefined();
+    expect(products.results[0].id).toBe(product.id);
+  });
+
+  /**
+   * Test hardcoded condition to populate the user role names
+   * if the user has the permission to read users
+   */
+  test('Restricted user can read user role names', async () => {
+    const { body: role } = await getRelations(
+      rqRestricted,
+      'plugin::users-permissions.user',
+      'role',
+      user.id
+    );
+
+    // Main field should be visible
+    expect(role.data?.name).toBe('Authenticated');
+  });
+});

--- a/api-tests/core/content-manager/api/relations-permissions.test.api.js
+++ b/api-tests/core/content-manager/api/relations-permissions.test.api.js
@@ -137,7 +137,7 @@ describe('Relations', () => {
     );
     user = await createEntry('plugin::users-permissions.user', {
       username: 'Alice',
-      email: 'test@strapi.io',
+      email: 'test-relations@strapi.io',
       password: '1234-never-gonna-hack-you-up',
       role: 1,
     });

--- a/packages/core/content-manager/server/controllers/relations.js
+++ b/packages/core/content-manager/server/controllers/relations.js
@@ -18,8 +18,6 @@ const addFiltersClause = (params, filtersClause) => {
   }
 };
 
-const MAIN_FIELD_READ_ALLOWED_MODELS = ['plugin::users-permissions.role'];
-
 const sanitizeMainField = (model, mainField, userAbility) => {
   const permissionChecker = getService('permission-checker').create({
     userAbility,
@@ -30,11 +28,19 @@ const sanitizeMainField = (model, mainField, userAbility) => {
     return 'id';
   }
 
-  if (MAIN_FIELD_READ_ALLOWED_MODELS.includes(model.uid)) {
-    return mainField;
-  }
-
   if (permissionChecker.cannot.read(null, mainField)) {
+    // Allow reading role name if user can read the user model
+    if (model.uid === 'plugin::users-permissions.role') {
+      const userPermissionChecker = getService('permission-checker').create({
+        userAbility,
+        model: 'plugin::users-permissions.user',
+      });
+
+      if (userPermissionChecker.can.read()) {
+        return 'name';
+      }
+    }
+
     return 'id';
   }
 


### PR DESCRIPTION
### What does it do?
Recently, we implemented a security fix that restricts users from visualizing a relation mainfield if they don't have permissions to read the targeted content type field.

For example, consider a relation `Address → Category`, where the main field of Category is `name`. The address relation should only display the category ID if the user doesn't have permission to read the category name.

This implementation has been successful so far. However, we have encountered an issue ([[see reported issue](https://github.com/strapi/strapi/issues/17561)](https://github.com/strapi/strapi/issues/17561)) where the User roles are always empty after this fix.

<table>
<tr>
 <td>BEFORE
 <td>AFTER
<tr>
 <td><img src="https://github.com/strapi/strapi/assets/20578351/b786126f-34c7-499d-9815-b27e5ddb8889" />
 <td><img src="https://github.com/strapi/strapi/assets/20578351/47fbfe9a-d020-40e0-8eb0-9484c042eec4" />
</table>


### How to test it?

TODO

### Related issue(s)/PR(s)

Fixes: https://github.com/strapi/strapi/issues/17561