### PR TITLE
[DTS] Fix inclusion logic between links and files

### DIFF
--- a/packages/core/data-transfer/src/__tests__/test-utils.ts
+++ b/packages/core/data-transfer/src/__tests__/test-utils.ts
@@ -171,6 +171,27 @@ export const extendExpectForDataTransferTests = () => {
         message: () => 'Expected source provider not to have all stages called',
       };
     },
+    toHaveDestinationStageCalledTimes(
+      provider: IDestinationProvider,
+      stages: (keyof IDestinationProvider)[],
+      times = 1
+    ) {
+      try {
+        stages.forEach((stage) => {
+          expect(provider[stage as string].mock.results.length).toEqual(times);
+        });
+        return {
+          pass: true,
+          message: () => 'Expected destination provider not to have all stages called',
+        };
+      } catch (e) {
+        return {
+          pass: false,
+          message: () =>
+            `Expected destination provider to have stages ${stages} called ${times} times`,
+        };
+      }
+    },
     toHaveDestinationStagesCalledTimes(provider: IDestinationProvider, times: number) {
       const missing = destinationStages.filter((stage) => {
         if (provider[stage]) {

--- a/packages/core/data-transfer/src/__tests__/test-utils.ts
+++ b/packages/core/data-transfer/src/__tests__/test-utils.ts
@@ -144,7 +144,28 @@ export const extendExpectForDataTransferTests = () => {
         message: () => 'Expected engine not to be valid',
       };
     },
-    toHaveSourceStagesCalledTimes(provider: ISourceProvider, times: number) {
+    toHaveSourceStagesCalledTimes(
+      provider: ISourceProvider,
+      stages: (keyof ISourceProvider)[],
+      times: number
+    ) {
+      try {
+        stages.forEach((stage) => {
+          expect(provider[stage as string].mock.results.length).toEqual(times);
+        });
+        return {
+          pass: true,
+          message: () => 'Expected source provider not to have all stages called',
+        };
+      } catch (e) {
+        return {
+          pass: false,
+          message: () =>
+            `Expected destination sources to have stages ${stages} called ${times} times`,
+        };
+      }
+    },
+    toHaveAllSourceStagesCalledTimes(provider: ISourceProvider, times: number) {
       const missing = sourceStages.filter((stage) => {
         if (provider[stage]) {
           try {
@@ -171,7 +192,7 @@ export const extendExpectForDataTransferTests = () => {
         message: () => 'Expected source provider not to have all stages called',
       };
     },
-    toHaveDestinationStageCalledTimes(
+    toHaveDestinationStagesCalledTimes(
       provider: IDestinationProvider,
       stages: (keyof IDestinationProvider)[],
       times = 1
@@ -192,7 +213,7 @@ export const extendExpectForDataTransferTests = () => {
         };
       }
     },
-    toHaveDestinationStagesCalledTimes(provider: IDestinationProvider, times: number) {
+    toHaveAllDestinationStagesCalledTimes(provider: IDestinationProvider, times: number) {
       const missing = destinationStages.filter((stage) => {
         if (provider[stage]) {
           try {

--- a/packages/core/data-transfer/src/engine/__tests__/engine.test.ts
+++ b/packages/core/data-transfer/src/engine/__tests__/engine.test.ts
@@ -457,8 +457,36 @@ describe('Transfer engine', () => {
 
     test.each<
       // (givenStages, mustBeCalled, mustNotBeCalled)
-      [TransferFilterPreset[], (keyof IDestinationProvider)[], (keyof IDestinationProvider)[]]
+      [
+        TransferFilterPreset[] | undefined,
+        (keyof IDestinationProvider)[],
+        (keyof IDestinationProvider)[]
+      ]
     >([
+      [
+        undefined,
+        [
+          'bootstrap',
+          'createSchemasWriteStream',
+          'createLinksWriteStream',
+          'createEntitiesWriteStream',
+          'createConfigurationWriteStream',
+          'createAssetsWriteStream',
+        ],
+        [],
+      ],
+      [
+        [],
+        [
+          'bootstrap',
+          'createSchemasWriteStream',
+          'createLinksWriteStream',
+          'createEntitiesWriteStream',
+          'createConfigurationWriteStream',
+          'createAssetsWriteStream',
+        ],
+        [],
+      ],
       [
         ['files'],
         [

--- a/packages/core/data-transfer/src/engine/__tests__/engine.test.ts
+++ b/packages/core/data-transfer/src/engine/__tests__/engine.test.ts
@@ -424,7 +424,7 @@ describe('Transfer engine', () => {
       const engine = createTransferEngine(minimalSource, minimalDestination, defaultOptions);
       expect(engine).toBeValidTransferEngine();
       await engine.transfer();
-      expect(minimalSource).toHaveSourceStagesCalledTimes(1);
+      expect(minimalSource).toHaveAllSourceStagesCalledTimes(1);
     });
 
     test('bootstraps all providers with a bootstrap', async () => {
@@ -440,19 +440,19 @@ describe('Transfer engine', () => {
       expect(engine).toBeValidTransferEngine();
       await engine.transfer();
 
-      expect(minimalSource).toHaveSourceStagesCalledTimes(1);
+      expect(minimalSource).toHaveAllSourceStagesCalledTimes(1);
     });
   });
 
   describe('transfer', () => {
     test('calls all provider stages', async () => {
       const engine = createTransferEngine(completeSource, completeDestination, defaultOptions);
-      expect(completeSource).toHaveSourceStagesCalledTimes(0);
-      expect(completeDestination).toHaveDestinationStagesCalledTimes(0);
+      expect(completeSource).toHaveAllSourceStagesCalledTimes(0);
+      expect(completeDestination).toHaveAllDestinationStagesCalledTimes(0);
       await engine.transfer();
 
-      expect(completeSource).toHaveSourceStagesCalledTimes(1);
-      expect(completeDestination).toHaveDestinationStagesCalledTimes(1);
+      expect(completeSource).toHaveAllSourceStagesCalledTimes(1);
+      expect(completeDestination).toHaveAllDestinationStagesCalledTimes(1);
     });
 
     test.each<
@@ -528,12 +528,10 @@ describe('Transfer engine', () => {
           exclude: excludeStages,
         });
 
-        expect(completeSource).toHaveSourceStagesCalledTimes(0);
-        expect(completeDestination).toHaveDestinationStagesCalledTimes(0);
         await engine.transfer();
 
-        expect(completeDestination).toHaveDestinationStageCalledTimes(mustBeCalled, 1);
-        expect(completeDestination).toHaveDestinationStageCalledTimes(mustNotBeCalled, 0);
+        expect(completeDestination).toHaveDestinationStagesCalledTimes(mustBeCalled, 1);
+        expect(completeDestination).toHaveDestinationStagesCalledTimes(mustNotBeCalled, 0);
       }
     );
 
@@ -612,12 +610,10 @@ describe('Transfer engine', () => {
           only: onlyStages,
         });
 
-        expect(completeSource).toHaveSourceStagesCalledTimes(0);
-        expect(completeDestination).toHaveDestinationStagesCalledTimes(0);
         await engine.transfer();
 
-        expect(completeDestination).toHaveDestinationStageCalledTimes(mustBeCalled, 1);
-        expect(completeDestination).toHaveDestinationStageCalledTimes(mustNotBeCalled, 0);
+        expect(completeDestination).toHaveDestinationStagesCalledTimes(mustBeCalled, 1);
+        expect(completeDestination).toHaveDestinationStagesCalledTimes(mustNotBeCalled, 0);
       }
     );
 

--- a/packages/core/data-transfer/src/engine/index.ts
+++ b/packages/core/data-transfer/src/engine/index.ts
@@ -74,7 +74,6 @@ export const TransferGroupPresets: TransferGroupFilter = {
   },
   files: {
     assets: true,
-    links: true,
   },
   config: {
     configuration: true,

--- a/packages/core/data-transfer/src/engine/index.ts
+++ b/packages/core/data-transfer/src/engine/index.ts
@@ -792,6 +792,9 @@ class TransferEngine<
 
   async transferSchemas(): Promise<void> {
     const stage: TransferStage = 'schemas';
+    if (this.shouldSkipStage(stage)) {
+      return;
+    }
 
     const source = await this.sourceProvider.createSchemasReadStream?.();
     const destination = await this.destinationProvider.createSchemasWriteStream?.();
@@ -806,6 +809,9 @@ class TransferEngine<
 
   async transferEntities(): Promise<void> {
     const stage: TransferStage = 'entities';
+    if (this.shouldSkipStage(stage)) {
+      return;
+    }
 
     const source = await this.sourceProvider.createEntitiesReadStream?.();
     const destination = await this.destinationProvider.createEntitiesWriteStream?.();
@@ -849,6 +855,9 @@ class TransferEngine<
 
   async transferLinks(): Promise<void> {
     const stage: TransferStage = 'links';
+    if (this.shouldSkipStage(stage)) {
+      return;
+    }
 
     const source = await this.sourceProvider.createLinksReadStream?.();
     const destination = await this.destinationProvider.createLinksWriteStream?.();
@@ -902,6 +911,9 @@ class TransferEngine<
 
   async transferConfiguration(): Promise<void> {
     const stage: TransferStage = 'configuration';
+    if (this.shouldSkipStage(stage)) {
+      return;
+    }
 
     const source = await this.sourceProvider.createConfigurationReadStream?.();
     const destination = await this.destinationProvider.createConfigurationWriteStream?.();


### PR DESCRIPTION
### What does it do?

- Fix an error in the exclude/only logic that made `--exclude files` also exclude links, and `--only files` include also links.
- Add full stage skipping for entities, links, configuration, and schema

### Why is it needed?

links/files inclusion logic was working the opposite as intended.

### How to test it?

Use export with --exclude files and links should be included; --only files and links should be excluded

Test the same thing on transfer.

Tests have been added for both `only` and `exclude`

### Related issue(s)/PR(s)

I believe this is half of the solution for https://github.com/strapi/strapi/issues/17572 ; we also still need to improve exclude/only to not restore those files.
