### PR TITLE
[DTS] Only delete types of data that are being transferred

### DIFF
--- a/packages/core/data-transfer/src/__tests__/test-utils.ts
+++ b/packages/core/data-transfer/src/__tests__/test-utils.ts
@@ -144,7 +144,28 @@ export const extendExpectForDataTransferTests = () => {
         message: () => 'Expected engine not to be valid',
       };
     },
-    toHaveSourceStagesCalledTimes(provider: ISourceProvider, times: number) {
+    toHaveSourceStagesCalledTimes(
+      provider: ISourceProvider,
+      stages: (keyof ISourceProvider)[],
+      times: number
+    ) {
+      try {
+        stages.forEach((stage) => {
+          expect(provider[stage as string].mock.results.length).toEqual(times);
+        });
+        return {
+          pass: true,
+          message: () => 'Expected source provider not to have all stages called',
+        };
+      } catch (e) {
+        return {
+          pass: false,
+          message: () =>
+            `Expected destination sources to have stages ${stages} called ${times} times`,
+        };
+      }
+    },
+    toHaveAllSourceStagesCalledTimes(provider: ISourceProvider, times: number) {
       const missing = sourceStages.filter((stage) => {
         if (provider[stage]) {
           try {
@@ -171,7 +192,28 @@ export const extendExpectForDataTransferTests = () => {
         message: () => 'Expected source provider not to have all stages called',
       };
     },
-    toHaveDestinationStagesCalledTimes(provider: IDestinationProvider, times: number) {
+    toHaveDestinationStagesCalledTimes(
+      provider: IDestinationProvider,
+      stages: (keyof IDestinationProvider)[],
+      times = 1
+    ) {
+      try {
+        stages.forEach((stage) => {
+          expect(provider[stage as string].mock.results.length).toEqual(times);
+        });
+        return {
+          pass: true,
+          message: () => 'Expected destination provider not to have all stages called',
+        };
+      } catch (e) {
+        return {
+          pass: false,
+          message: () =>
+            `Expected destination provider to have stages ${stages} called ${times} times`,
+        };
+      }
+    },
+    toHaveAllDestinationStagesCalledTimes(provider: IDestinationProvider, times: number) {
       const missing = destinationStages.filter((stage) => {
         if (provider[stage]) {
           try {

--- a/packages/core/data-transfer/src/__tests__/test-utils.ts
+++ b/packages/core/data-transfer/src/__tests__/test-utils.ts
@@ -29,7 +29,7 @@ export const getStrapiFactory =
   >(
     properties?: T
   ) =>
-  (additionalProperties?: T) => {
+  (additionalProperties?: Partial<T>) => {
     return { ...properties, ...additionalProperties } as Strapi.Strapi;
   };
 

--- a/packages/core/data-transfer/src/engine/index.ts
+++ b/packages/core/data-transfer/src/engine/index.ts
@@ -74,7 +74,6 @@ export const TransferGroupPresets: TransferGroupFilter = {
   },
   files: {
     assets: true,
-    links: true,
   },
   config: {
     configuration: true,

--- a/packages/core/data-transfer/src/engine/index.ts
+++ b/packages/core/data-transfer/src/engine/index.ts
@@ -792,6 +792,9 @@ class TransferEngine<
 
   async transferSchemas(): Promise<void> {
     const stage: TransferStage = 'schemas';
+    if (this.shouldSkipStage(stage)) {
+      return;
+    }
 
     const source = await this.sourceProvider.createSchemasReadStream?.();
     const destination = await this.destinationProvider.createSchemasWriteStream?.();
@@ -806,6 +809,9 @@ class TransferEngine<
 
   async transferEntities(): Promise<void> {
     const stage: TransferStage = 'entities';
+    if (this.shouldSkipStage(stage)) {
+      return;
+    }
 
     const source = await this.sourceProvider.createEntitiesReadStream?.();
     const destination = await this.destinationProvider.createEntitiesWriteStream?.();
@@ -849,6 +855,9 @@ class TransferEngine<
 
   async transferLinks(): Promise<void> {
     const stage: TransferStage = 'links';
+    if (this.shouldSkipStage(stage)) {
+      return;
+    }
 
     const source = await this.sourceProvider.createLinksReadStream?.();
     const destination = await this.destinationProvider.createLinksWriteStream?.();
@@ -902,6 +911,9 @@ class TransferEngine<
 
   async transferConfiguration(): Promise<void> {
     const stage: TransferStage = 'configuration';
+    if (this.shouldSkipStage(stage)) {
+      return;
+    }
 
     const source = await this.sourceProvider.createConfigurationReadStream?.();
     const destination = await this.destinationProvider.createConfigurationWriteStream?.();

--- a/packages/core/data-transfer/src/strapi/providers/local-destination/__tests__/assets.test.ts
+++ b/packages/core/data-transfer/src/strapi/providers/local-destination/__tests__/assets.test.ts
@@ -24,6 +24,25 @@ const transaction = jest.fn(async (cb) => {
   await cb({ trx, rollback });
 });
 
+const strapiFactory = getStrapiFactory({
+  dirs: {
+    static: {
+      public: 'static/public/assets',
+    },
+  },
+  db: { transaction },
+  config: {
+    get(service) {
+      if (service === 'plugin.upload') {
+        return {
+          provider: 'local',
+        };
+      }
+      return {};
+    },
+  },
+});
+
 describe('Local Strapi Destination Provider - Get Assets Stream', () => {
   test('Throws an error if the Strapi instance is not provided', async () => {
     /* @ts-ignore: disable-next-line */
@@ -35,23 +54,35 @@ describe('Local Strapi Destination Provider - Get Assets Stream', () => {
       'Not able to stream Assets. Strapi instance not found'
     );
   });
-  test('Returns a stream', async () => {
+
+  test('Returns a stream when assets restore is true', async () => {
     const provider = createLocalStrapiDestinationProvider({
-      getStrapi: getStrapiFactory({
-        dirs: {
-          static: {
-            public: 'static/public/assets',
-          },
-        },
-        db: { transaction },
-      }),
+      getStrapi: () => strapiFactory(),
       strategy: 'restore',
+      restore: {
+        assets: true,
+      },
     });
     await provider.bootstrap();
 
     const stream = await provider.createAssetsWriteStream();
 
     expect(stream instanceof Writable).toBeTruthy();
+  });
+
+  test('Throw an error if attempting to create stream while restore assets is false', async () => {
+    const provider = createLocalStrapiDestinationProvider({
+      getStrapi: () => strapiFactory(),
+      strategy: 'restore',
+      restore: {
+        assets: false,
+      },
+    });
+    await provider.bootstrap();
+
+    expect(async () => provider.createAssetsWriteStream()).rejects.toThrow(
+      'Attempting to transfer assets when they are not included'
+    );
   });
 
   test('Writes on the strapi assets path', async () => {
@@ -64,15 +95,18 @@ describe('Local Strapi Destination Provider - Get Assets Stream', () => {
       stream: Readable.from(['test', 'test-2']),
     };
     const provider = createLocalStrapiDestinationProvider({
-      getStrapi: getStrapiFactory({
-        dirs: {
-          static: {
-            public: assetsDirectory,
+      getStrapi: () =>
+        strapiFactory({
+          dirs: {
+            static: {
+              public: assetsDirectory,
+            },
           },
-        },
-        db: { transaction },
-      }),
+        }),
       strategy: 'restore',
+      restore: {
+        assets: true,
+      },
     });
 
     await provider.bootstrap();

--- a/packages/core/data-transfer/src/strapi/providers/local-destination/__tests__/index.test.ts
+++ b/packages/core/data-transfer/src/strapi/providers/local-destination/__tests__/index.test.ts
@@ -19,7 +19,11 @@ jest.mock('../strategies/restore', () => {
 
 const strapiCommonProperties = {
   config: {
-    get: jest.fn().mockReturnValue({ provider: 'aws-s3' }),
+    get(service) {
+      if (service === 'plugin.upload') {
+        return { provider: 'local' };
+      }
+    },
   },
   dirs: {
     static: {
@@ -44,6 +48,11 @@ describe('Local Strapi Source Destination', () => {
           ...strapiCommonProperties,
         }),
         strategy: 'restore',
+        restore: {
+          entities: {
+            exclude: [],
+          },
+        },
       });
 
       expect(provider.strapi).not.toBeDefined();
@@ -56,6 +65,11 @@ describe('Local Strapi Source Destination', () => {
           ...strapiCommonProperties,
         }),
         strategy: 'restore',
+        restore: {
+          entities: {
+            exclude: [],
+          },
+        },
       });
       await provider.bootstrap();
 
@@ -71,6 +85,11 @@ describe('Local Strapi Source Destination', () => {
           ...strapiCommonProperties,
         }),
         strategy: 'restore',
+        restore: {
+          entities: {
+            exclude: [],
+          },
+        },
       });
       await restoreProvider.bootstrap();
       expect(restoreProvider.strapi).toBeDefined();
@@ -89,7 +108,9 @@ describe('Local Strapi Source Destination', () => {
       ).rejects.toThrow();
     });
 
-    test('Should delete all entities if it is a restore', async () => {
+    test.todo('Should not delete entities that are not included');
+
+    test('Should delete all entities if it is a restore with only exclude property', async () => {
       const entities = [
         {
           entity: { id: 1, title: 'My first foo' },
@@ -161,6 +182,11 @@ describe('Local Strapi Source Destination', () => {
       const provider = createLocalStrapiDestinationProvider({
         getStrapi: () => strapi,
         strategy: 'restore',
+        restore: {
+          entities: {
+            exclude: [],
+          },
+        },
       });
       const deleteAllSpy = jest.spyOn(restoreApi, 'deleteRecords');
       await provider.bootstrap();

--- a/packages/core/data-transfer/src/strapi/providers/local-destination/index.ts
+++ b/packages/core/data-transfer/src/strapi/providers/local-destination/index.ts
@@ -27,7 +27,7 @@ export interface ILocalStrapiDestinationProviderOptions {
   getStrapi(): Strapi.Strapi | Promise<Strapi.Strapi>; // return an initialized instance of Strapi
 
   autoDestroy?: boolean; // shut down the instance returned by getStrapi() at the end of the transfer
-  restore?: restore.IRestoreOptions; // erase all data in strapi database before transfer
+  restore?: restore.IRestoreOptions; // erase data in strapi database before transfer; required if strategy is 'restore'
   strategy: 'restore'; // conflict management strategy; only the restore strategy is available at this time
 }
 

--- a/packages/core/data-transfer/src/strapi/providers/local-destination/index.ts
+++ b/packages/core/data-transfer/src/strapi/providers/local-destination/index.ts
@@ -294,7 +294,7 @@ class LocalStrapiDestinationProvider implements IDestinationProvider {
     }
 
     const removeAssetsBackup = this.#removeAssetsBackup.bind(this);
-    const thisStrapi = this.strapi;
+    const strapi = this.strapi;
     const transaction = this.transaction;
     const backupDirectory = this.uploadsBackupDirectoryName;
 
@@ -312,7 +312,7 @@ class LocalStrapiDestinationProvider implements IDestinationProvider {
           // TODO: Remove this logic in V5
           if (!chunk.metadata) {
             // If metadata does not exist is because it is an old backup file
-            const assetsDirectory = path.join(thisStrapi.dirs.static.public, 'uploads');
+            const assetsDirectory = path.join(strapi.dirs.static.public, 'uploads');
             const entryPath = path.join(assetsDirectory, chunk.filename);
             const writableStream = fse.createWriteStream(entryPath);
             chunk.stream
@@ -350,10 +350,10 @@ class LocalStrapiDestinationProvider implements IDestinationProvider {
             buffer: chunk?.buffer,
           };
 
-          const provider = thisStrapi.config.get('plugin.upload').provider;
+          const provider = strapi.config.get('plugin.upload').provider;
 
           try {
-            await thisStrapi.plugin('upload').provider.uploadStream(uploadData);
+            await strapi.plugin('upload').provider.uploadStream(uploadData);
 
             // if we're not supposed to transfer the associated entities, stop here
             if (!restoreMediaEntitiesContent) {
@@ -362,14 +362,14 @@ class LocalStrapiDestinationProvider implements IDestinationProvider {
 
             // Files formats are stored within the parent file entity
             if (uploadData?.type) {
-              const entry: IFile = await thisStrapi.db.query('plugin::upload.file').findOne({
+              const entry: IFile = await strapi.db.query('plugin::upload.file').findOne({
                 where: { hash: uploadData.mainHash },
               });
               const specificFormat = entry?.formats?.[uploadData.type];
               if (specificFormat) {
                 specificFormat.url = uploadData.url;
               }
-              await thisStrapi.db.query('plugin::upload.file').update({
+              await strapi.db.query('plugin::upload.file').update({
                 where: { hash: uploadData.mainHash },
                 data: {
                   formats: entry.formats,
@@ -378,11 +378,11 @@ class LocalStrapiDestinationProvider implements IDestinationProvider {
               });
               return callback();
             }
-            const entry: IFile = await thisStrapi.db.query('plugin::upload.file').findOne({
+            const entry: IFile = await strapi.db.query('plugin::upload.file').findOne({
               where: { hash: uploadData.hash },
             });
             entry.url = uploadData.url;
-            await thisStrapi.db.query('plugin::upload.file').update({
+            await strapi.db.query('plugin::upload.file').update({
               where: { hash: uploadData.hash },
               data: {
                 url: entry.url,

--- a/packages/core/data-transfer/src/strapi/providers/local-destination/index.ts
+++ b/packages/core/data-transfer/src/strapi/providers/local-destination/index.ts
@@ -129,7 +129,7 @@ class LocalStrapiDestinationProvider implements IDestinationProvider {
     assertValidStrapi(this.strapi);
 
     // if we're not restoring files, don't touch the files
-    if (!this.options.restore?.assets) {
+    if (!this.#areAssetsIncluded()) {
       return;
     }
 

--- a/packages/core/data-transfer/src/strapi/providers/local-destination/index.ts
+++ b/packages/core/data-transfer/src/strapi/providers/local-destination/index.ts
@@ -58,6 +58,7 @@ class LocalStrapiDestinationProvider implements IDestinationProvider {
     this.transaction = utils.transaction.createTransaction(this.strapi);
   }
 
+  // TODO: either move this to restore strategy, or restore strategy should given access to these instead of repeating the logic possibly in a different way
   #areAssetsIncluded = () => {
     return this.options.restore?.assets;
   };
@@ -295,7 +296,7 @@ class LocalStrapiDestinationProvider implements IDestinationProvider {
       objectMode: true,
       async final(next) {
         // Delete the backup folder
-        removeAssetsBackup();
+        await removeAssetsBackup();
         next();
       },
       async write(chunk: IAsset, _encoding, callback) {

--- a/packages/core/data-transfer/src/strapi/providers/local-destination/strategies/restore/index.ts
+++ b/packages/core/data-transfer/src/strapi/providers/local-destination/strategies/restore/index.ts
@@ -22,7 +22,7 @@ interface IDeleteResults {
 }
 
 export const deleteRecords = async (strapi: Strapi.Strapi, options?: IRestoreOptions) => {
-  const entities = await deleteEntitiesRecord(strapi, options);
+  const entities = await deleteEntitiesRecords(strapi, options);
   const configuration = await deleteConfigurationRecords(strapi, options);
 
   return {
@@ -32,7 +32,7 @@ export const deleteRecords = async (strapi: Strapi.Strapi, options?: IRestoreOpt
   };
 };
 
-const deleteEntitiesRecord = async (
+const deleteEntitiesRecords = async (
   strapi: Strapi.Strapi,
   options: IRestoreOptions = {}
 ): Promise<IDeleteResults> => {

--- a/packages/core/data-transfer/src/strapi/providers/local-destination/strategies/restore/index.ts
+++ b/packages/core/data-transfer/src/strapi/providers/local-destination/strategies/restore/index.ts
@@ -21,7 +21,7 @@ interface IDeleteResults {
   aggregate: { [uid: string]: { count: number } };
 }
 
-export const deleteRecords = async (strapi: Strapi.Strapi, options?: IRestoreOptions) => {
+export const deleteRecords = async (strapi: Strapi.Strapi, options: IRestoreOptions) => {
   const entities = await deleteEntitiesRecords(strapi, options);
   const configuration = await deleteConfigurationRecords(strapi, options);
 
@@ -43,12 +43,14 @@ const deleteEntitiesRecords = async (
   const contentTypesToClear = contentTypes.filter((contentType) => {
     let keep = true;
 
+    // include means "only include these types" so if it's not in here, it's not being included
     if (entities?.include) {
       keep = entities.include.includes(contentType.uid);
     }
 
-    if (entities?.exclude) {
-      keep = !entities.exclude.includes(contentType.uid);
+    // if something is excluded, remove it. But lack of being excluded doesn't mean it's kept
+    if (entities?.exclude && entities.exclude.includes(contentType.uid)) {
+      keep = false;
     }
 
     if (entities?.filters) {

--- a/packages/core/data-transfer/src/strapi/providers/local-destination/strategies/restore/index.ts
+++ b/packages/core/data-transfer/src/strapi/providers/local-destination/strategies/restore/index.ts
@@ -41,23 +41,23 @@ const deleteEntitiesRecords = async (
   const contentTypes = Object.values<Schema.ContentType>(strapi.contentTypes);
 
   const contentTypesToClear = contentTypes.filter((contentType) => {
-    let keep = true;
+    let removeThisContentType = true;
 
     // include means "only include these types" so if it's not in here, it's not being included
     if (entities?.include) {
-      keep = entities.include.includes(contentType.uid);
+      removeThisContentType = entities.include.includes(contentType.uid);
     }
 
     // if something is excluded, remove it. But lack of being excluded doesn't mean it's kept
     if (entities?.exclude && entities.exclude.includes(contentType.uid)) {
-      keep = false;
+      removeThisContentType = false;
     }
 
     if (entities?.filters) {
-      keep = entities.filters.every((filter) => filter(contentType));
+      removeThisContentType = entities.filters.every((filter) => filter(contentType));
     }
 
-    return keep;
+    return removeThisContentType;
   });
 
   const [results, updateResults] = useResults(

--- a/packages/core/strapi/lib/commands/actions/import/__tests__/import.test.js
+++ b/packages/core/strapi/lib/commands/actions/import/__tests__/import.test.js
@@ -37,6 +37,33 @@ const createTransferEngine = jest.fn(() => {
 });
 
 describe('Import', () => {
+  // mock command utils
+  jest.mock('../../../utils/data-transfer.js', () => {
+    return {
+      ...jest.requireActual('../../../utils/data-transfer.js'),
+      getTransferTelemetryPayload: jest.fn().mockReturnValue({}),
+      loadersFactory: jest.fn().mockReturnValue({ updateLoader: jest.fn() }),
+      formatDiagnostic: jest.fn(),
+      createStrapiInstance: jest.fn().mockReturnValue({
+        telemetry: {
+          send: jest.fn(),
+        },
+        destroy: jest.fn(),
+      }),
+      buildTransferTable: jest.fn(() => {
+        return {
+          toString() {
+            return 'table';
+          },
+        };
+      }),
+      exitMessageText: jest.fn(),
+      getDiffHandler: jest.fn(),
+      setSignalHandler: jest.fn(),
+    };
+  });
+
+  // mock @strapi/data-transfer
   const mockDataTransfer = {
     file: {
       providers: {
@@ -60,38 +87,7 @@ describe('Import', () => {
       createTransferEngine,
     },
   };
-
   jest.mock('@strapi/data-transfer', () => mockDataTransfer);
-
-  // command utils
-  const mockUtils = {
-    getTransferTelemetryPayload: jest.fn().mockReturnValue({}),
-    loadersFactory: jest.fn().mockReturnValue({ updateLoader: jest.fn() }),
-    formatDiagnostic: jest.fn(),
-    createStrapiInstance: jest.fn().mockReturnValue({
-      telemetry: {
-        send: jest.fn(),
-      },
-      destroy: jest.fn(),
-    }),
-    buildTransferTable: jest.fn(() => {
-      return {
-        toString() {
-          return 'table';
-        },
-      };
-    }),
-    exitMessageText: jest.fn(),
-    getDiffHandler: jest.fn(),
-    setSignalHandler: jest.fn(),
-  };
-  jest.mock(
-    '../../../utils/data-transfer.js',
-    () => {
-      return mockUtils;
-    },
-    { virtual: true }
-  );
 
   // console spies
   jest.spyOn(console, 'log').mockImplementation(() => {});

--- a/packages/core/strapi/lib/commands/actions/import/action.js
+++ b/packages/core/strapi/lib/commands/actions/import/action.js
@@ -23,6 +23,7 @@ const {
   getTransferTelemetryPayload,
   setSignalHandler,
   getDiffHandler,
+  parseRestoreFromOptions,
 } = require('../../utils/data-transfer');
 const { exitWith } = require('../../utils/helpers');
 
@@ -71,10 +72,9 @@ module.exports = async (opts) => {
     },
     autoDestroy: false,
     strategy: opts.conflictStrategy || DEFAULT_CONFLICT_STRATEGY,
-    restore: {
-      entities: { exclude: DEFAULT_IGNORED_CONTENT_TYPES },
-    },
+    restore: parseRestoreFromOptions(opts),
   };
+
   const destination = createLocalStrapiDestinationProvider(destinationOptions);
 
   /**

--- a/packages/core/strapi/lib/commands/actions/import/command.js
+++ b/packages/core/strapi/lib/commands/actions/import/command.js
@@ -89,7 +89,7 @@ module.exports = ({ command }) => {
     .hook(
       'preAction',
       getCommanderConfirmMessage(
-        'The import will delete all assets and data in your database. Are you sure you want to proceed?',
+        'The import will delete your existing data! Are you sure you want to proceed?',
         { failMessage: 'Import process aborted' }
       )
     )

--- a/packages/core/strapi/lib/commands/actions/transfer/__tests__/transfer.test.js
+++ b/packages/core/strapi/lib/commands/actions/transfer/__tests__/transfer.test.js
@@ -3,39 +3,36 @@
 const { expectExit } = require('../../../__tests__/commands.test.utils');
 
 describe('Transfer', () => {
-  // command utils
-  const mockUtils = {
-    getTransferTelemetryPayload: jest.fn().mockReturnValue({}),
-    loadersFactory: jest.fn().mockReturnValue({ updateLoader: jest.fn() }),
-    formatDiagnostic: jest.fn(),
-    createStrapiInstance() {
-      return {
-        telemetry: {
-          send: jest.fn(),
-        },
-      };
-    },
-    getDefaultExportName: jest.fn(() => 'default'),
-    buildTransferTable: jest.fn(() => {
-      return {
-        toString() {
-          return 'table';
-        },
-      };
-    }),
-    exitMessageText: jest.fn(),
-    getDiffHandler: jest.fn(),
-    getAssetsBackupHandler: jest.fn(),
-    setSignalHandler: jest.fn(),
-  };
-  jest.mock(
-    '../../../utils/data-transfer.js',
-    () => {
-      return mockUtils;
-    },
-    { virtual: true }
-  );
+  // mock command utils
+  jest.mock('../../../utils/data-transfer.js', () => {
+    return {
+      ...jest.requireActual('../../../utils/data-transfer.js'),
+      getTransferTelemetryPayload: jest.fn().mockReturnValue({}),
+      loadersFactory: jest.fn().mockReturnValue({ updateLoader: jest.fn() }),
+      formatDiagnostic: jest.fn(),
+      createStrapiInstance() {
+        return {
+          telemetry: {
+            send: jest.fn(),
+          },
+        };
+      },
+      getDefaultExportName: jest.fn(() => 'default'),
+      buildTransferTable: jest.fn(() => {
+        return {
+          toString() {
+            return 'table';
+          },
+        };
+      }),
+      exitMessageText: jest.fn(),
+      getDiffHandler: jest.fn(),
+      getAssetsBackupHandler: jest.fn(),
+      setSignalHandler: jest.fn(),
+    };
+  });
 
+  // mock data transfer
   const mockDataTransfer = {
     strapi: {
       providers: {
@@ -75,7 +72,6 @@ describe('Transfer', () => {
       },
     },
   };
-
   jest.mock('@strapi/data-transfer', () => mockDataTransfer);
 
   const transferAction = require('../action');

--- a/packages/core/strapi/lib/commands/actions/transfer/action.js
+++ b/packages/core/strapi/lib/commands/actions/transfer/action.js
@@ -25,6 +25,7 @@ const {
   setSignalHandler,
   getDiffHandler,
   getAssetsBackupHandler,
+  parseRestoreFromOptions,
 } = require('../../utils/data-transfer');
 const { exitWith } = require('../../utils/helpers');
 
@@ -88,9 +89,7 @@ module.exports = async (opts) => {
     destination = createLocalStrapiDestinationProvider({
       getStrapi: () => strapi,
       strategy: 'restore',
-      restore: {
-        entities: { exclude: DEFAULT_IGNORED_CONTENT_TYPES },
-      },
+      restore: parseRestoreFromOptions(opts),
     });
   }
   // if URL provided, set up a remote destination provider
@@ -106,9 +105,7 @@ module.exports = async (opts) => {
         token: opts.toToken,
       },
       strategy: 'restore',
-      restore: {
-        entities: { exclude: DEFAULT_IGNORED_CONTENT_TYPES },
-      },
+      restore: parseRestoreFromOptions(opts),
     });
   }
 

--- a/packages/core/strapi/lib/commands/actions/transfer/command.js
+++ b/packages/core/strapi/lib/commands/actions/transfer/command.js
@@ -105,7 +105,7 @@ module.exports = ({ command }) => {
           }
 
           await getCommanderConfirmMessage(
-            'The transfer will delete all the remote Strapi assets and its database. Are you sure you want to proceed?',
+            'The transfer will delete existing data from the remote Strapi! Are you sure you want to proceed?',
             { failMessage: 'Transfer process aborted' }
           )(thisCommand);
         }

--- a/packages/core/strapi/lib/commands/utils/data-transfer.js
+++ b/packages/core/strapi/lib/commands/utils/data-transfer.js
@@ -374,12 +374,13 @@ const shouldSkipStage = (opts, dataKind) => {
     return true;
   }
   if (opts.only) {
-    return opts.only.includes(dataKind);
+    return !opts.only.includes(dataKind);
   }
 
   return false;
 };
 
+// Based on exclude/only from options, create the restore object to match
 const parseRestoreFromOptions = (opts) => {
   const entitiesOptions = {
     exclude: DEFAULT_IGNORED_CONTENT_TYPES,

--- a/packages/core/strapi/lib/commands/utils/data-transfer.js
+++ b/packages/core/strapi/lib/commands/utils/data-transfer.js
@@ -369,6 +369,40 @@ const getAssetsBackupHandler = (engine, { force, action }) => {
   };
 };
 
+const shouldSkipStage = (opts, dataKind) => {
+  if (opts.exclude?.includes(dataKind)) {
+    return true;
+  }
+  if (opts.only) {
+    return opts.only.includes(dataKind);
+  }
+
+  return false;
+};
+
+const parseRestoreFromOptions = (opts) => {
+  const entitiesOptions = {
+    exclude: DEFAULT_IGNORED_CONTENT_TYPES,
+    include: undefined,
+  };
+
+  // if content is not included, send an empty array for include
+  if ((opts.only && !opts.only.includes('content')) || opts.exclude?.includes('content')) {
+    entitiesOptions.include = [];
+  }
+
+  const restoreConfig = {
+    entities: entitiesOptions,
+    assets: !shouldSkipStage(opts, 'files'),
+    configuration: {
+      webhooks: !shouldSkipStage(opts, 'config'),
+      coreStore: !shouldSkipStage(opts, 'config'),
+    },
+  };
+
+  return restoreConfig;
+};
+
 module.exports = {
   loadersFactory,
   buildTransferTable,
@@ -386,4 +420,6 @@ module.exports = {
   setSignalHandler,
   getDiffHandler,
   getAssetsBackupHandler,
+  shouldSkipStage,
+  parseRestoreFromOptions,
 };


### PR DESCRIPTION
### What does it do?

Update the import and transfer commands to generate the correct restore object

TODO:

- [ ] add more tests
- [ ] ~~refactor restore logic so it's modular and independent from local-source~~ I'm skipping this one because it would be a big structural change that might break things*

* I think we first need a discussion about if it would make more sense to make local-source a wrapper for a local-restore-source rather than local-source using strategies, since the strategies are/will be so tightly integrated it may be difficult to abstract them
 
### Why is it needed?

The initial functionality of the restore strategy causing a global reset of Strapi data caused too many users to be confused. 

The updated functionality of only touching data included in a transfer matches user expectations to not touch files that are excluded in a transfer or import.

### How to test it?

Using exclude or only with transfer or import should now only delete the files that are included in the process.

### Related issue(s)/PR(s)

Closes https://github.com/strapi/strapi/issues/17572

Completes DX-862, DX-863, DX-864