### PR TITLE
eslint front custom config also add jest global to ts/tsx test files

### DIFF
--- a/packages/utils/eslint-config-custom/front/typescript.js
+++ b/packages/utils/eslint-config-custom/front/typescript.js
@@ -3,7 +3,7 @@ module.exports = {
   extends: ['@strapi/eslint-config/front/typescript'],
   overrides: [
     {
-      files: ['**/*.test.js', '**/*.test.jsx', '**/__mocks__/**/*'],
+      files: ['**/*.test.[jt]s', '**/*.test.[jt]sx', '**/__mocks__/**/*'],
       env: {
         jest: true,
       },


### PR DESCRIPTION
### Why is it needed?

Because when changing the test files to `.ts(x)` they have lint errors because jest is not a global 

### Related issue(s)/PR(s)

#17690 
