### PR TITLE
fix: webpack dev server wants false not undefined for a non-enabled plugins

### DIFF
--- a/packages/core/admin/webpack.config.dev.js
+++ b/packages/core/admin/webpack.config.dev.js
@@ -67,7 +67,7 @@ module.exports = () => {
 
     plugins: [
       ...config.plugins,
-      analyzeBundle && new BundleAnalyzerPlugin(),
+      analyzeBundle === 'true' && new BundleAnalyzerPlugin(),
       analyzeDuplicateDependencies === 'true' && new DuplicateReporterPlugin(),
     ],
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* fixes the webpack dev server check of a plugin

### Why is it needed?

* the webpack dev server can't accept undefined in replacement of a plugin but it can accept `false`

### How to test it?

* run `yarn develop` in the admin package

