### PR TITLE
[helper-plugin]: migrate use-persistent-state hook to typescript 

### DIFF
--- a/packages/core/helper-plugin/src/hooks/tests/usePersistentState.test.ts
+++ b/packages/core/helper-plugin/src/hooks/tests/usePersistentState.test.ts
@@ -1,0 +1,17 @@
+import { renderHook, act } from '@testing-library/react';
+
+import { usePersistentState } from '../usePersistentState';
+
+describe('usePersistentState', () => {
+  it('should return the value passed to set in the local storage', async () => {
+    const { result } = renderHook(() => usePersistentState('key', 0));
+    const [value, setValue] = result.current;
+    expect(value).toBe(0);
+
+    act(() => {
+      setValue(1);
+    });
+    const [updatedValue] = result.current;
+    expect(updatedValue).toBe(1);
+  });
+});

--- a/packages/core/helper-plugin/src/hooks/usePersistentState.ts
+++ b/packages/core/helper-plugin/src/hooks/usePersistentState.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
-const usePersistentState = (key, defaultValue) => {
-  const [value, setValue] = useState(() => {
+const usePersistentState = <T>(key: string, defaultValue: T) => {
+  const [value, setValue] = useState<T>(() => {
     const stickyValue = window.localStorage.getItem(key);
 
     if (stickyValue !== null) {
@@ -20,7 +20,7 @@ const usePersistentState = (key, defaultValue) => {
     window.localStorage.setItem(key, JSON.stringify(value));
   }, [key, value]);
 
-  return [value, setValue];
+  return [value, setValue] as const;
 };
 
 export { usePersistentState };


### PR DESCRIPTION
### What does it do?

Migrate helper-plugin/hooks/usePersistentState to typescript.
Added test case.

### How to test it?

You can check if any value in the local storage getting set properly or not, for eg: `key: navbar-condensed`(i.e. dashboard left menu)

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/issues/17690