### PR TITLE
[BUGFIX]-#17536

### DIFF
--- a/examples/kitchensink/config/server.js
+++ b/examples/kitchensink/config/server.js
@@ -1,7 +1,11 @@
 module.exports = ({ env }) => ({
   host: env('HOST', '0.0.0.0'),
   port: env.int('PORT', 1337),
+  url: env('PUBLIC_URL', 'http://localhost:1337'),
   app: {
-    keys: env.array('APP_KEYS', ['toBeModified1', 'toBeModified2']),
+    keys: env.array('APP_KEYS'),
+  },
+  webhooks: {
+    populateRelations: env.bool('WEBHOOKS_POPULATE_RELATIONS', false),
   },
 });


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Fixed changes as per suggestion 
server.js

`module.exports = ({ env }) => ({
  host: env('HOST', '0.0.0.0'),
  port: env.int('PORT', 1337),
  url: env('PUBLIC_URL', 'http://localhost:1337'),
  app: {
    keys: env.array('APP_KEYS'),
  },
  webhooks: {
    populateRelations: env.bool('WEBHOOKS_POPULATE_RELATIONS', false),
  },
});`

- As per suggestion Added "PUBLIC_URL" and removed "/" from url endpoint 

### Why is it needed?

The issue being addressed is related to the incorrect construction of URLs during redirection when using AWS Cognito authentication. The original code added "https" twice in the URL, causing redirection problems.

### How to test it?

- Ensure you have the specified system information, Node.js version, NPM version, Strapi version, etc., set up.

- Use the provided URL to log in to AWS Cognito: http://localhost:1337/api/connect/cognito/

- Observe the redirection behavior and verify that the URL constructed is correct and doesn't have duplicated "https".

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
I closed on open PR due to complications and opened this new one.
