### PR TITLE
[TS] Fix the EntityService Params Pick

### DIFF
--- a/packages/core/strapi/lib/services/entity-service/types/params/index.d.ts
+++ b/packages/core/strapi/lib/services/entity-service/types/params/index.d.ts
@@ -15,7 +15,7 @@ import type * as Attribute from './attributes';
 export type Pick<
   TSchemaUID extends Common.UID.Schema,
   TKind extends Kind
-> = Utils.Expression.MatchAll<
+> = Utils.Expression.MatchAllIntersect<
   [
     // Sort
     [HasMember<TKind, 'sort'>, { sort?: Sort.Any<TSchemaUID> }],

--- a/packages/core/strapi/lib/types/utils/expression.d.ts
+++ b/packages/core/strapi/lib/types/utils/expression.d.ts
@@ -39,17 +39,29 @@ export type MatchFirst<TTests extends Test[], TDefault = never> = TTests extends
     : never
   : never;
 
-export type MatchAll<TTests extends Test[], TDefault = never> = TTests extends [
+export type MatchAllUnion<TTests extends Test[], TDefault = never> = TTests extends [
   infer THead extends Test,
   ...infer TTail extends Test[]
 ]
   ? THead extends Test<infer TExpression, infer TValue>
     ? Utils.Guard.Never<
-        If<TExpression, TValue> | If<Utils.Array.IsNotEmpty<TTail>, MatchAll<TTail, TDefault>>,
+        If<TExpression, TValue> | If<Utils.Array.IsNotEmpty<TTail>, MatchAllUnion<TTail, TDefault>>,
         TDefault
       >
     : never
   : never;
+
+export type MatchAllIntersect<TTests extends Test[], TDefault = unknown> = TTests extends [
+  infer THead extends Test,
+  ...infer TTail extends Test[]
+]
+  ? THead extends Test<infer TExpression, infer TValue>
+    ? // Actual test case evaluation
+      If<TExpression, TValue, TDefault> &
+        // Recursion / End of recursion
+        If<Utils.Array.IsNotEmpty<TTail>, MatchAllIntersect<TTail, TDefault>, TDefault>
+    : TDefault
+  : TDefault;
 
 export type Test<TExpression extends BooleanValue = BooleanValue, TValue = unknown> = [
   TExpression,


### PR DESCRIPTION

### What does it do?

- Replace `MatchAll` by `MatchAllUnion` and `MatchAllIntersect` in `utils/expression`
- Use MatchAllIntersect in the EntityService Params Pick

### Why is it needed?

- Using a match all union-like for the params pick was creating a union of possible object with single params props thus creating a wrong representation of the final params object.
- On top of that, having a union meant that we were introducing an infinite recursion when using the params (eg. when using entity service methods)

