### PR TITLE
fix: include strapi_assignee as a known feature in data transfer

### DIFF
--- a/packages/core/strapi/lib/commands/utils/data-transfer.js
+++ b/packages/core/strapi/lib/commands/utils/data-transfer.js
@@ -291,7 +291,8 @@ const getDiffHandler = (engine, { force, action }) => {
         if (
           uid === 'admin::workflow' ||
           uid === 'admin::workflow-stage' ||
-          endPath?.startsWith('strapi_stage')
+          endPath?.startsWith('strapi_stage') ||
+          endPath?.startsWith('strapi_assignee')
         ) {
           workflowsStatus = diff.kind;
         }


### PR DESCRIPTION
### What does it do?

Review workflow assignee (to be released next week) includes a new column into content types, `strapi_assignee`. In a similar fashion as what happened with `strapi_stage` , data transfer , when transfering from EE->CE (or the other way around) , notices there are different fields for content types.

This excludes the strapi_assignee field from the transfer schema check.


