### PR TITLE
Create types for Api Config

### DIFF
--- a/packages/core/strapi/lib/types/core/config/api.d.ts
+++ b/packages/core/strapi/lib/types/core/config/api.d.ts
@@ -1,0 +1,16 @@
+export interface ResponsesProp {
+  privateAttributes: string[];
+}
+
+export interface RestProp {
+  prefix: string;
+  port?: number;
+  defaultLimit: number;
+  maxLimit: number;
+  withCount: boolean;
+}
+
+export interface Api {
+  responses?: ResponsesProp;
+  rest: RestProp;
+}

--- a/packages/core/strapi/lib/types/core/config/index.d.ts
+++ b/packages/core/strapi/lib/types/core/config/index.d.ts
@@ -1,2 +1,3 @@
-export { Server } from './server.js';
-export { Admin } from './admin.js';
+export { Server } from './server';
+export { Admin } from './admin';
+export { Api } from './api';


### PR DESCRIPTION
### What does it do?

Adds types for the API configuration file.

### Why is it needed?

To simplify users' lifes

### How to test it?
Go to the `kitchensink-ts` example project and in the `config/api.js` write:
```
import { Api } from '@strapi/strapi/lib/types/core/config';

export default {
  rest: {
    defaultLimit: 3,
    maxLimit: 10,
    withCount: true,
    prefix: '/api',
    port: 1337,
  },
  responses: {
    privateAttributes: ['createdBy', 'updatedBy'],
  },
} as Api;

```
### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
