### PR TITLE
Use full model instead of base schemas for sanitization

### DIFF
--- a/packages/core/upload/server/controllers/content-api.js
+++ b/packages/core/upload/server/controllers/content-api.js
@@ -10,13 +10,13 @@ const { sanitize } = utils;
 const { ValidationError } = utils.errors;
 
 const sanitizeOutput = (data, ctx) => {
-  const schema = strapi.getModel(FILE_MODEL_UID);
+  const schema = strapi.contentType(FILE_MODEL_UID);
   const { auth } = ctx.state;
 
   return sanitize.contentAPI.output(data, schema, { auth });
 };
 const sanitizeQuery = (data, ctx) => {
-  const schema = strapi.getModel(FILE_MODEL_UID);
+  const schema = strapi.contentType(FILE_MODEL_UID);
   const { auth } = ctx.state;
 
   return sanitize.contentAPI.query(data, schema, { auth });

--- a/packages/plugins/users-permissions/server/controllers/user.js
+++ b/packages/plugins/users-permissions/server/controllers/user.js
@@ -15,14 +15,14 @@ const { sanitize } = utils;
 const { ApplicationError, ValidationError, NotFoundError } = utils.errors;
 
 const sanitizeOutput = async (user, ctx) => {
-  const schema = strapi.getModel('plugin::users-permissions.user');
+  const schema = strapi.contentType('plugin::users-permissions.user');
   const { auth } = ctx.state;
 
   return sanitize.contentAPI.output(user, schema, { auth });
 };
 
 const sanitizeQuery = async (query, ctx) => {
-  const schema = strapi.getModel('plugin::users-permissions.user');
+  const schema = strapi.contentType('plugin::users-permissions.user');
   const { auth } = ctx.state;
 
   return sanitize.contentAPI.query(query, schema, { auth });


### PR DESCRIPTION
### What does it do?

use strapi.contentType(uid) instead of strapi.getModel(uid) when sanitizing in controllers that were using it.

### Why is it needed?

strapi.getModel only returns the base model, not including fields that were added dynamically (such as creator fields, review workflows fields, etc)

### How to test it?

Everything should still work as before, except now fields that were updated after Strapi init will be recognized.

For example, if you create a content type with a public attribute, but then update it to private after Strapi init, it should now be kept in sanitization instead of removed (and vice versa).

### Related issue(s)/PR(s)

