### PR TITLE
[helper-plugin]: migrate OverlayBlocker.jsx to TypeScript #17690

### DIFF
--- a/packages/core/helper-plugin/src/features/OverlayBlocker.tsx
+++ b/packages/core/helper-plugin/src/features/OverlayBlocker.tsx
@@ -21,13 +21,17 @@ import styled from 'styled-components';
  * @preserve
  * @type {React.Context<OverlayBlockerContextValue>}
  */
-const OverlayBlockerContext = React.createContext();
+const OverlayBlockerContext = React.createContext({});
 
 /* -------------------------------------------------------------------------------------------------
  * Provider
  * -----------------------------------------------------------------------------------------------*/
 
-const OverlayBlockerProvider = ({ children }) => {
+interface OverlayBlockerProviderProps {
+  children: React.ReactNode;
+}
+
+const OverlayBlockerProvider = ({ children }: OverlayBlockerProviderProps) => {
   const [isOpen, setIsOpen] = React.useState(false);
 
   const lockApp = React.useCallback(() => {


### PR DESCRIPTION
 

### What does it do?

Migrate OverlayBlocker.jsx to TypeScript

### Related issue(s)/PR(s)

[#17690](https://github.com/strapi/strapi/issues/17690)

