### PR TITLE
[TS] Fix the Attribute.Relation type

### DIFF
--- a/packages/core/strapi/lib/types/core/attributes/common.d.ts
+++ b/packages/core/strapi/lib/types/core/attributes/common.d.ts
@@ -58,11 +58,7 @@ export type Any =
   | Attribute.JSON
   | Attribute.Media<Attribute.MediaKind | undefined, boolean>
   | Attribute.Password
-  // Necessary to reference "any" relation
-  | (
-      | Attribute.Relation<Common.UID.Schema, Attribute.RelationKind.WithTarget, Common.UID.Schema>
-      | Attribute.Relation<Common.UID.Schema, Attribute.RelationKind.WithoutTarget>
-    )
+  | Attribute.Relation<Common.UID.Schema, Attribute.RelationKind.Any, Common.UID.Schema>
   | Attribute.RichText
   | Attribute.String
   | Attribute.Text

--- a/packages/core/strapi/lib/types/core/attributes/relation.d.ts
+++ b/packages/core/strapi/lib/types/core/attributes/relation.d.ts
@@ -1,59 +1,94 @@
 import type { Attribute, Common, Utils } from '@strapi/strapi';
 
 export type Relation<
-  // TODO: TOrigin was originally needed to infer precise attribute literal types by doing a reverse lookup
-  // on TTarget -> TOrigin relations. Due to errors because of Attribute.Any [relation] very generic
-  // representation, type mismatches were encountered and mappedBy/inversedBy are now regular strings.
-  // It is kept to allow for future iterations without breaking the current type API
   TOrigin extends Common.UID.Schema = Common.UID.Schema,
   TRelationKind extends RelationKind.Any = RelationKind.Any,
   TTarget extends Common.UID.Schema = never
 > = Attribute.OfType<'relation'> &
   // Properties
-  RelationProperties<TOrigin, TRelationKind, TTarget> &
+  Utils.Guard.Never<
+    RelationProperties<TOrigin, TRelationKind, TTarget>,
+    AllRelationProperties<TOrigin, TTarget>
+  > &
   // Options
   Attribute.ConfigurableOption &
   Attribute.PrivateOption;
 
 export type RelationProperties<
-  _TOrigin extends Common.UID.Schema,
+  TOrigin extends Common.UID.Schema,
   TRelationKind extends RelationKind.Any,
   TTarget extends Common.UID.Schema
 > = Utils.Expression.MatchFirst<
   [
     [
       Utils.Expression.Extends<TRelationKind, RelationKind.BiDirectional>,
-      {
-        relation: TRelationKind;
-        target: TTarget;
-      } & Utils.XOR<{ inversedBy?: string }, { mappedBy?: string }>
+      BiDirectionalProperties<
+        TOrigin,
+        Utils.Cast<TRelationKind, RelationKind.BiDirectional>,
+        TTarget
+      >
     ],
     [
       Utils.Expression.Extends<TRelationKind, RelationKind.XWay>,
-      {
-        relation: TRelationKind;
-        target: TTarget;
-      }
+      XWayProperties<Utils.Cast<TRelationKind, RelationKind.XWay>, TTarget>
     ],
     [
       Utils.Expression.Extends<TRelationKind, RelationKind.MorphReference>,
-      {
-        relation: TRelationKind;
-        target: TTarget;
-        morphBy?: Utils.Guard.Never<
-          Attribute.GetKeysByType<TTarget, 'relation', { relation: RelationKind.MorphOwner }>,
-          string
-        >;
-      }
+      MorphReferenceProperties<Utils.Cast<TRelationKind, RelationKind.MorphReference>, TTarget>
     ],
-    [Utils.Expression.Extends<TRelationKind, RelationKind.MorphOwner>, { relation: TRelationKind }]
+    [
+      Utils.Expression.Extends<TRelationKind, RelationKind.MorphOwner>,
+      MorphOwnerProperties<Utils.Cast<TRelationKind, RelationKind.MorphOwner>>
+    ]
   ]
 >;
+
+export type AllRelationProperties<
+  TOrigin extends Common.UID.Schema,
+  TTarget extends Common.UID.Schema
+> =
+  | BiDirectionalProperties<TOrigin, RelationKind.BiDirectional, TTarget>
+  | XWayProperties<RelationKind.XWay, TTarget>
+  | MorphReferenceProperties<RelationKind.MorphReference, TTarget>
+  | MorphOwnerProperties<RelationKind.MorphOwner>;
+
+type BiDirectionalProperties<
+  TOrigin extends Common.UID.Schema,
+  TRelationKind extends RelationKind.BiDirectional,
+  TTarget extends Common.UID.Schema
+> = {
+  relation: TRelationKind;
+  target: TTarget;
+} & Utils.XOR<
+  { inversedBy?: RelationsKeysFromTo<TTarget, TOrigin> },
+  { mappedBy?: RelationsKeysFromTo<TTarget, TOrigin> }
+>;
+
+type XWayProperties<TRelationKind extends RelationKind.XWay, TTarget extends Common.UID.Schema> = {
+  relation: TRelationKind;
+  target: TTarget;
+};
+
+type MorphReferenceProperties<
+  TRelationKind extends RelationKind.MorphReference,
+  TTarget extends Common.UID.Schema
+> = {
+  relation: TRelationKind;
+  target: TTarget;
+  morphBy?: Utils.Guard.Never<
+    Attribute.GetKeysByType<TTarget, 'relation', { relation: RelationKind.MorphOwner }>,
+    string
+  >;
+};
+
+type MorphOwnerProperties<TRelationKind extends RelationKind.MorphOwner> = {
+  relation: TRelationKind;
+};
 
 export type RelationsKeysFromTo<
   TTarget extends Common.UID.Schema,
   TOrigin extends Common.UID.Schema
-> = keyof PickRelationsFromTo<TTarget, TOrigin>;
+> = Utils.Guard.Never<keyof PickRelationsFromTo<TTarget, TOrigin>, string>;
 
 export type PickRelationsFromTo<
   TTarget extends Common.UID.Schema,

--- a/packages/core/strapi/lib/types/utils/index.d.ts
+++ b/packages/core/strapi/lib/types/utils/index.d.ts
@@ -23,3 +23,5 @@ export type Without<TLeft, TRight> = { [key in Exclude<keyof TLeft, keyof TRight
 export type XOR<TLeft, TRight> = TLeft | TRight extends object
   ? (Without<TLeft, TRight> & TRight) | (Without<TRight, TLeft> & TLeft)
   : TLeft | TRight;
+
+export type Cast<TValue, TType> = TValue extends TType ? TValue : never;


### PR DESCRIPTION
### What does it do?

- Add a fallback for the relation properties when the RelationKind is too loose (i.e. when it doesn't match any condition for the properties)
- The fallback is a union type of all possible loose representation of the properties (bi-directional, xway, morph(ref|owner)

### Why is it needed?

- Generated types contain errors (rename to .ts instead of .d.ts) and prevent the correct matching between generated schema types & parent types (CollectionType, SingleType) because of type incompatibility at the Attributes (map) level

### How to test it?

Errors should be gone in the generated type + the entity service findMany should be able to differentiate between array or single entity for generated types.

