### PR TITLE
[helper-plugin] migate `prefixPluginTranslations` on TypeScript

### DIFF
--- a/packages/core/helper-plugin/src/utils/prefixPluginTranslations.ts
+++ b/packages/core/helper-plugin/src/utils/prefixPluginTranslations.ts
@@ -1,9 +1,11 @@
-const prefixPluginTranslations = (trad, pluginId) => {
+type TradOptions = Record<string, string>;
+
+const prefixPluginTranslations = (trad: TradOptions, pluginId: string): TradOptions => {
   return Object.keys(trad).reduce((acc, current) => {
     acc[`${pluginId}.${current}`] = trad[current];
 
     return acc;
-  }, {});
+  }, {} as TradOptions);
 };
 
 export { prefixPluginTranslations };


### PR DESCRIPTION
### What does it do?
Migrates the `prefixPluginTranslations` method on TypeScript.

### Related issue(s)/PR(s)
https://github.com/strapi/strapi/issues/17690