### PR TITLE
[helper-plugin] migrate `prefixFileUrlWithBackendUrl` on TS

### DIFF
--- a/packages/core/helper-plugin/src/utils/prefixFileUrlWithBackendUrl.ts
+++ b/packages/core/helper-plugin/src/utils/prefixFileUrlWithBackendUrl.ts
@@ -1,4 +1,4 @@
-const prefixFileUrlWithBackendUrl = (fileURL) => {
+const prefixFileUrlWithBackendUrl = (fileURL?: string): string | undefined => {
   return !!fileURL && fileURL.startsWith('/') ? `${window.strapi.backendURL}${fileURL}` : fileURL;
 };
 


### PR DESCRIPTION
### What does it do?
Migrates the `prefixFileUrlWithBackendUrl` method on TypeScript.

### Related issue(s)/PR(s)
https://github.com/strapi/strapi/issues/17690