### PR TITLE
[U&P] Add allowedFields configuration option

### DIFF
--- a/packages/plugins/users-permissions/server/bootstrap/index.js
+++ b/packages/plugins/users-permissions/server/bootstrap/index.js
@@ -10,10 +10,12 @@
 const crypto = require('crypto');
 const _ = require('lodash');
 const urljoin = require('url-join');
+const { isArray } = require('lodash/fp');
 const { getService } = require('../utils');
 const getGrantConfig = require('./grant-config');
 
 const usersPermissionsActions = require('./users-permissions-actions');
+const userSchema = require('../content-types/user');
 
 const initGrant = async (pluginStore) => {
   const apiPrefix = strapi.config.get('api.rest.prefix');
@@ -97,6 +99,26 @@ const initAdvancedOptions = async (pluginStore) => {
   }
 };
 
+const userSchemaAdditions = () => {
+  const defaultSchema = Object.keys(userSchema.attributes);
+  const currentSchema = Object.keys(
+    strapi.contentTypes['plugin::users-permissions.user'].attributes
+  );
+
+  // Some dynamic fields may not have been initialized yet, so we need to ignore them
+  // TODO: we should have a global method for finding these
+  const ignoreDiffs = [
+    'createdBy',
+    'createdAt',
+    'updatedBy',
+    'updatedAt',
+    'publishedAt',
+    'strapi_reviewWorkflows_stage',
+  ];
+
+  return currentSchema.filter((key) => !(ignoreDiffs.includes(key) || defaultSchema.includes(key)));
+};
+
 module.exports = async ({ strapi }) => {
   const pluginStore = strapi.store({ type: 'plugin', name: 'users-permissions' });
 
@@ -127,6 +149,19 @@ For security reasons, prefer storing the secret in an environment variable and r
       strapi.fs.appendFile(envPath, `JWT_SECRET=${jwtSecret}\n`);
       strapi.log.info(
         `The Users & Permissions plugin automatically generated a jwt secret and stored it in ${envPath} under the name JWT_SECRET.`
+      );
+    }
+  }
+
+  // TODO v5: Remove this block of code and default allowedFields to empty array
+  if (!isArray(strapi.config.get('plugin.users-permissions.register.allowedFields'))) {
+    const modifications = userSchemaAdditions();
+    if (modifications.length > 0) {
+      // if there is a potential vulnerability, show a warning
+      strapi.log.warn(
+        `Users-permissions registration has defaulted to accepting the following additional user fields during registration: ${modifications.join(
+          ','
+        )}`
       );
     }
   }

--- a/packages/plugins/users-permissions/server/controllers/auth.js
+++ b/packages/plugins/users-permissions/server/controllers/auth.js
@@ -9,7 +9,11 @@
 /* eslint-disable no-useless-escape */
 const crypto = require('crypto');
 const _ = require('lodash');
+const { concat, compact, isArray } = require('lodash/fp');
 const utils = require('@strapi/utils');
+const {
+  contentTypes: { getNonWritableAttributes },
+} = require('@strapi/utils');
 const { getService } = require('../utils');
 const {
   validateCallbackBody,
@@ -273,20 +277,49 @@ module.exports = {
       throw new ApplicationError('Register action is currently disabled');
     }
 
+    const { register } = strapi.config.get('plugin.users-permissions');
+    const alwaysAllowedKeys = ['username', 'password', 'email'];
+    const userModel = strapi.contentTypes['plugin::users-permissions.user'];
+    const { attributes } = userModel;
+
+    const nonWritable = getNonWritableAttributes(userModel);
+
+    const allowedKeys = compact(
+      concat(
+        alwaysAllowedKeys,
+        isArray(register?.allowedFields)
+          ? // Note that we do not filter allowedFields in case a user explicitly chooses to allow a private or otherwise omitted field on registration
+            register.allowedFields // if null or undefined, compact will remove it
+          : // to prevent breaking changes, if allowedFields is not set in config, we only remove private and known dangerous user schema fields
+            // TODO V5: allowedFields defaults to [] when undefined and remove this case
+            Object.keys(attributes).filter(
+              (key) =>
+                !nonWritable.includes(key) &&
+                !attributes[key].private &&
+                ![
+                  // many of these are included in nonWritable, but we'll list them again to be safe and since we're removing this code in v5 anyway
+                  // Strapi user schema fields
+                  'confirmed',
+                  'blocked',
+                  'confirmationToken',
+                  'resetPasswordToken',
+                  'provider',
+                  'id',
+                  'role',
+                  // other Strapi fields that might be added
+                  'createdAt',
+                  'updatedAt',
+                  'createdBy',
+                  'updatedBy',
+                  'publishedAt', // d&p
+                  'strapi_reviewWorkflows_stage', // review workflows
+                ].includes(key)
+            )
+      )
+    );
+
     const params = {
-      ..._.omit(ctx.request.body, [
-        'confirmed',
-        'blocked',
-        'confirmationToken',
-        'resetPasswordToken',
-        'provider',
-        'id',
-        'createdAt',
-        'updatedAt',
-        'createdBy',
-        'updatedBy',
-        'role',
-      ]),
+      ..._.pick(ctx.request.body, allowedKeys),
       provider: 'local',
     };
 


### PR DESCRIPTION
### What does it do?

Adds the allowedFields feature that [was previously stalled](https://github.com/strapi/strapi/pull/16333) for being a breaking change

### Why is it needed?

To allow users to choose which fields are accepted or not during user registration

### How to test it?

- Add a field called 'newField' (for example) to your u&p user schema
- Configure the plugin like the following:

```js
// path: ./config/plugins.js

module.exports = {
  'users-permissions': {
    config: {
      register: {
        allowedFields: [ 'newField' ]
      }
    }
  }
}
```

- newField should be accepted on registration
- 
- Configure the plugin like the following:

```js
// path: ./config/plugins.js

module.exports = {
  'users-permissions': {
    config: {
      register: {
        allowedFields: [  ]
      }
    }
  }
}
```
- newFIeld should no longer be accepted on registration

### Related issue(s)/PR(s)

[Documentation PR](https://github.com/strapi/documentation/pull/1833)
