### PR TITLE
Chore/ts migrate helper plugin linkbutton

### DIFF
--- a/packages/core/helper-plugin/src/components/LinkButton.jsx
+++ b/packages/core/helper-plugin/src/components/LinkButton.jsx
@@ -1,8 +1,0 @@
-import React from 'react';
-
-import { LinkButton as DSLinkButton } from '@strapi/design-system/v2';
-import { NavLink } from 'react-router-dom';
-
-const LinkButton = (props) => <DSLinkButton {...props} as={NavLink} />;
-
-export { LinkButton };

--- a/packages/core/helper-plugin/src/components/LinkButton.tsx
+++ b/packages/core/helper-plugin/src/components/LinkButton.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+import {
+  LinkButton as DSLinkButton,
+  LinkButtonProps as DSLinkButtonProps,
+} from '@strapi/design-system/v2';
+import { NavLink } from 'react-router-dom';
+
+/**
+ * @preserve
+ *
+ * @deprecated Use @strapi/design-system LinkButton instead.
+ */
+const LinkButton = (props: DSLinkButtonProps) => <DSLinkButton {...props} as={NavLink} />;
+
+export { LinkButton };


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Updated the Helper Plugin LinkButton Component from JavaScript to TypeScript

### Why is it needed?

Part of work for https://github.com/strapi/strapi/issues/17690 to transition the helper plugin to TS.

### How to test it?

* Check that existing tests are all still passing.
* Check that VS code is able to infer all the right types for function arguments and return values.

### Related issue(s)/PR(s)

Tracking issue: https://github.com/strapi/strapi/issues/17690
