### PR TITLE
Chore/ts migrate helper plugin notallowedinput

### DIFF
--- a/packages/core/helper-plugin/src/components/NotAllowedInput.tsx
+++ b/packages/core/helper-plugin/src/components/NotAllowedInput.tsx
@@ -1,33 +1,34 @@
-/**
- *
- * NotAllowedInput
- *
- */
-
 import React from 'react';
 
-import { TextInput } from '@strapi/design-system';
+import { TextInput, TextInputProps } from '@strapi/design-system';
 import { EyeStriked } from '@strapi/icons';
-import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 import styled from 'styled-components';
 
-const StyledIcon = styled(EyeStriked)`
-  > path {
-    fill: ${({ theme }) => theme.colors.neutral600};
-  }
-`;
+import { TranslationMessage } from '../types';
 
-const NotAllowedInput = ({ description, intlLabel, labelAction, error, name }) => {
+interface NotAllowedInputProps extends Pick<TextInputProps, 'labelAction' | 'name'> {
+  description?: TranslationMessage;
+  error?: string;
+  intlLabel: TranslationMessage;
+}
+
+const NotAllowedInput = ({
+  description,
+  error,
+  intlLabel,
+  labelAction,
+  name,
+}: NotAllowedInputProps) => {
   const { formatMessage } = useIntl();
-  const label = intlLabel.id
+  const label = intlLabel?.id
     ? formatMessage(
         { id: intlLabel.id, defaultMessage: intlLabel.defaultMessage },
         { ...intlLabel.values }
       )
     : name;
 
-  const hint = description
+  const hint = description?.id
     ? formatMessage(
         { id: description.id, defaultMessage: description.defaultMessage },
         { ...description.values }
@@ -58,26 +59,10 @@ const NotAllowedInput = ({ description, intlLabel, labelAction, error, name }) =
   );
 };
 
-NotAllowedInput.defaultProps = {
-  description: null,
-  error: '',
-  labelAction: undefined,
-};
-
-NotAllowedInput.propTypes = {
-  description: PropTypes.shape({
-    id: PropTypes.string.isRequired,
-    defaultMessage: PropTypes.string.isRequired,
-    values: PropTypes.object,
-  }),
-  error: PropTypes.string,
-  intlLabel: PropTypes.shape({
-    id: PropTypes.string.isRequired,
-    defaultMessage: PropTypes.string.isRequired,
-    values: PropTypes.object,
-  }).isRequired,
-  labelAction: PropTypes.element,
-  name: PropTypes.string.isRequired,
-};
+const StyledIcon = styled(EyeStriked)`
+  & > path {
+    fill: ${({ theme }) => theme.colors.neutral600};
+  }
+`;
 
 export { NotAllowedInput };

--- a/packages/core/helper-plugin/src/components/tests/NotAllowedInput.test.tsx
+++ b/packages/core/helper-plugin/src/components/tests/NotAllowedInput.test.tsx
@@ -20,13 +20,15 @@ describe('<NotAllowedInput />', () => {
   it('renders and matches the snapshot', () => {
     const {
       container: { firstChild },
-    } = render(
-      <ThemeProvider theme={lightTheme}>
-        <IntlProvider locale="en" messages={messages} defaultLocale="en">
-          <NotAllowedInput name="test" intlLabel={{ id: 'test', defaultMessage: 'test' }} />
-        </IntlProvider>
-      </ThemeProvider>
-    );
+    } = render(<NotAllowedInput name="test" intlLabel={{ id: 'test', defaultMessage: 'test' }} />, {
+      wrapper: ({ children }) => (
+        <ThemeProvider theme={lightTheme}>
+          <IntlProvider locale="en" messages={messages} defaultLocale="en">
+            <>{children}</>
+          </IntlProvider>
+        </ThemeProvider>
+      ),
+    });
 
     expect(firstChild).toMatchInlineSnapshot(`
       .c1 {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Updated the Helper Plugin NotAllowedInput Component from JavaScript to TypeScript

### Why is it needed?

Part of work for https://github.com/strapi/strapi/issues/17690 to transition the helper plugin to TS.

### How to test it?

* Check that existing tests are all still passing.
* Check that VS code is able to infer all the right types for function arguments and return values.

### Related issue(s)/PR(s)

Tracking issue: https://github.com/strapi/strapi/issues/17690
