### PR TITLE
[helper-plugin]: move useLockScroll.js to TypeScript

### DIFF
--- a/packages/core/helper-plugin/src/hooks/useLockScroll.ts
+++ b/packages/core/helper-plugin/src/hooks/useLockScroll.ts
@@ -1,7 +1,11 @@
-import { useEffect } from 'react';
+import React from 'react';
 
-const useLockScroll = (lockScroll) => {
-  useEffect(() => {
+interface LockScrollProps {
+  lockScroll: boolean;
+}
+
+const useLockScroll = ({ lockScroll }: LockScrollProps) => {
+  React.useEffect(() => {
     if (lockScroll) {
       document.body.classList.add('lock-body-scroll');
     }

--- a/packages/core/helper-plugin/src/hooks/useLockScroll.ts
+++ b/packages/core/helper-plugin/src/hooks/useLockScroll.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 interface LockScrollProps {
   lockScroll: boolean;


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Migrate useLockScroll from helper-plugin to typescript.

### Related issue(s)/PR(s)

Relates to [#17690](https://github.com/strapi/strapi/issues/17690)
