### PR TITLE
Fix `strapi import` failure caused by corrupted asset metadata

### DIFF
--- a/packages/core/data-transfer/src/file/providers/source/index.ts
+++ b/packages/core/data-transfer/src/file/providers/source/index.ts
@@ -286,8 +286,8 @@ class LocalFileSourceProvider implements ISourceProvider {
               const content = await entry.collect();
 
               try {
-                // Parse from buffer to string to JSON
-                const parsedContent = JSON.parse(content.toString());
+                // Parse from buffer array to string to JSON
+                const parsedContent = JSON.parse(Buffer.concat(content).toString());
 
                 // Resolve the Promise with the parsed content
                 resolve(parsedContent);


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Fixes a failure when running `strapi import` to import a`.tar.gz` backup file.

### Why is it needed?

When I ran `strapi import -f database/local/export_20230825142140.tar.gz`, it failed with the message:

```
error: [ERROR] Error while uploading asset featured_image_28dc07b76a.png TypeError: Cannot set properties of null (setting 'url')
```

I traced this to a mistake in `LocalFileSourceProvider` in the way it parsed asset metadata files; the `ReadEntry.collect()` method from the `tar` library returns `Buffer[]`, so if there is more than one Buffer in the array, the call to `[].toString()` inserts `,` characters in the string. In my case, this led to metadata containing this:

```json
"has,h": "featured_image_28dc07b76a",
```

Which caused a crash in `LocalStrapiDestinationProvider`:

https://github.com/strapi/strapi/blob/a2b1a1e72400fea121da3c3fb18f524b0c885ba8/packages/core/data-transfer/src/strapi/providers/local-destination/index.ts#L308-L311

Because `uploadData.hash` is undefined, so `entry` comes back from the db as `null`.

### How to test it?

In my case, `ReadEntry.collect()` returned the data in two chunks, the first Buffer being 1024 bytes long. But out of 127 assets in my backup, this (the 108th asset processed) was the only one affected; the others all have a single Buffer in the array, even when it's longer than 1024 bytes. Maybe it depends on the total size of the tar.gz file?

I've tested this fix by re-running the import with my export.tar.gz that caused the crash for me in the first place. I can't provide the entire export; hopefully this PR is small and obvious enough to be accepted as-is.

### Related issue(s)/PR(s)

N/A
