### PR TITLE
fix(ctb): Refactor data-fetching to use react-query

### DIFF
--- a/packages/core/admin/admin/src/components/RBACProvider/index.js
+++ b/packages/core/admin/admin/src/components/RBACProvider/index.js
@@ -31,7 +31,7 @@ const RBACProvider = ({ children, permissions, refetchPermissions }) => {
 };
 
 RBACProvider.propTypes = {
-  children: PropTypes.element.isRequired,
+  children: PropTypes.node.isRequired,
   permissions: PropTypes.array.isRequired,
   refetchPermissions: PropTypes.func.isRequired,
 };

--- a/packages/core/content-type-builder/admin/src/components/DataManagerProvider/index.js
+++ b/packages/core/content-type-builder/admin/src/components/DataManagerProvider/index.js
@@ -184,6 +184,7 @@ const DataManagerProvider = ({ children }) => {
     {
       async onSuccess() {
         await refetch();
+        unlockAppWithAutoreload();
       },
 
       onError(error) {
@@ -200,6 +201,7 @@ const DataManagerProvider = ({ children }) => {
     {
       async onSuccess() {
         await refetch();
+        unlockAppWithAutoreload();
       },
 
       onError(error) {
@@ -258,6 +260,8 @@ const DataManagerProvider = ({ children }) => {
 
         // Update the app's permissions
         await updatePermissions();
+
+        unlockAppWithAutoreload();
       },
     }
   );
@@ -268,6 +272,7 @@ const DataManagerProvider = ({ children }) => {
     {
       async onSuccess() {
         await refetch();
+        unlockAppWithAutoreload();
       },
 
       onError(error) {

--- a/packages/core/content-type-builder/admin/src/components/DataManagerProvider/reducer.js
+++ b/packages/core/content-type-builder/admin/src/components/DataManagerProvider/reducer.js
@@ -17,7 +17,6 @@ const initialState = {
   modifiedData: {},
   reservedNames: {},
   isLoading: true,
-  isLoadingForDataToBeSet: true,
 };
 
 const ONE_SIDE_RELATIONS = ['oneWay', 'manyWay'];
@@ -616,7 +615,6 @@ const reducer = (state = initialState, action) =>
         break;
       }
       case actions.SET_MODIFIED_DATA: {
-        draftState.isLoadingForDataToBeSet = false;
         draftState.initialData = action.schemaToSet;
         draftState.modifiedData = action.schemaToSet;
 

--- a/packages/core/content-type-builder/admin/src/components/DataManagerProvider/selectors.js
+++ b/packages/core/content-type-builder/admin/src/components/DataManagerProvider/selectors.js
@@ -18,10 +18,8 @@ const dataManagerProviderDomain = () => (state) =>
  * Default selector used by dataManagerProvider
  */
 
-const makeSelectDataManagerProvider = () =>
-  createSelector(dataManagerProviderDomain(), (substate) => {
-    return substate;
-  });
+export const selectDataManagerProvider = createSelector(dataManagerProviderDomain(), (substate) => {
+  return substate;
+});
 
-export default makeSelectDataManagerProvider;
 export { dataManagerProviderDomain };

--- a/packages/core/content-type-builder/admin/src/components/DataManagerProvider/tests/reducer_basic_actions.test.js
+++ b/packages/core/content-type-builder/admin/src/components/DataManagerProvider/tests/reducer_basic_actions.test.js
@@ -659,14 +659,12 @@ describe('CTB | components | DataManagerProvider | reducer | basics actions ', (
         ...initialState,
         modifiedData: null,
         initialData: null,
-        isLoadingForDataToBeSet: true,
       };
 
       const expected = {
         ...initialState,
         modifiedData: schemaToSet,
         initialData: schemaToSet,
-        isLoadingForDataToBeSet: false,
       };
 
       expect(
@@ -701,7 +699,6 @@ describe('CTB | components | DataManagerProvider | reducer | basics actions ', (
         contentTypes: { ok: false },
         initialData: schemaToSet,
         modifiedData: schemaToSet,
-        isLoadingForDataToBeSet: false,
       };
 
       expect(

--- a/packages/core/content-type-builder/admin/src/components/FormModal/index.js
+++ b/packages/core/content-type-builder/admin/src/components/FormModal/index.js
@@ -35,7 +35,6 @@ import useFormModalNavigation from '../../hooks/useFormModalNavigation';
 import pluginId from '../../pluginId';
 import { getTrad, isAllowedContentTypesForRelations } from '../../utils';
 import findAttribute from '../../utils/findAttribute';
-// New compos
 import AllowedTypesSelect from '../AllowedTypesSelect';
 import AttributeOptions from '../AttributeOptions';
 import BooleanDefaultValueSelect from '../BooleanDefaultValueSelect';
@@ -75,9 +74,6 @@ import forms from './forms';
 import makeSelectFormModal from './selectors';
 import { canEditContentType, getAttributesToDisplay, getFormInputNames } from './utils';
 import { createComponentUid, createUid } from './utils/createUid';
-
-/* eslint-disable indent */
-/* eslint-disable react/no-array-index-key */
 
 const FormModal = () => {
   const {

--- a/packages/core/content-type-builder/package.json
+++ b/packages/core/content-type-builder/package.json
@@ -43,6 +43,7 @@
     "qs": "6.11.1",
     "react-helmet": "^6.1.0",
     "react-intl": "6.4.1",
+    "react-query": "3.39.3",
     "react-redux": "8.1.1",
     "redux": "^4.2.1",
     "reselect": "4.1.7",

--- a/packages/core/helper-plugin/src/hooks/useAPIErrorHandler.js
+++ b/packages/core/helper-plugin/src/hooks/useAPIErrorHandler.js
@@ -1,3 +1,5 @@
+import * as React from 'react';
+
 import { AxiosError } from 'axios';
 import { useIntl } from 'react-intl';
 
@@ -15,21 +17,24 @@ import { normalizeAPIError } from '../utils/normalizeAPIError';
 export function useAPIErrorHandler(intlMessagePrefixCallback) {
   const { formatMessage } = useIntl();
 
-  return {
-    formatAPIError(error) {
-      // Try to normalize the passed error first. This will fail for e.g. network
-      // errors which are thrown by Axios directly.
-      try {
-        return formatAPIError(error, { intlMessagePrefixCallback, formatMessage });
-      } catch (_) {
-        if (error instanceof AxiosError) {
-          return formatAxiosError(error, { intlMessagePrefixCallback, formatMessage });
-        }
+  return React.useMemo(
+    () => ({
+      formatAPIError(error) {
+        // Try to normalize the passed error first. This will fail for e.g. network
+        // errors which are thrown by Axios directly.
+        try {
+          return formatAPIError(error, { intlMessagePrefixCallback, formatMessage });
+        } catch (_) {
+          if (error instanceof AxiosError) {
+            return formatAxiosError(error, { intlMessagePrefixCallback, formatMessage });
+          }
 
-        throw new Error('formatAPIError: Unknown error:', error);
-      }
-    },
-  };
+          throw new Error('formatAPIError: Unknown error:', error);
+        }
+      },
+    }),
+    [formatMessage, intlMessagePrefixCallback]
+  );
 }
 
 function formatAxiosError(error, { intlMessagePrefixCallback, formatMessage }) {

--- a/packages/plugins/i18n/admin/src/components/Initializer/index.js
+++ b/packages/plugins/i18n/admin/src/components/Initializer/index.js
@@ -12,16 +12,16 @@ import useLocales from '../../hooks/useLocales';
 import pluginId from '../../pluginId';
 
 const Initializer = ({ setPlugin }) => {
-  const { isLoading, locales } = useLocales();
+  const { isLoading, locales, error } = useLocales();
   const ref = useRef();
 
   ref.current = setPlugin;
 
   useEffect(() => {
-    if (!isLoading && locales.length > 0) {
+    if ((!isLoading && locales?.length > 0) || error) {
       ref.current(pluginId);
     }
-  }, [isLoading, locales]);
+  }, [isLoading, locales, error]);
 
   return null;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -7339,6 +7339,7 @@ __metadata:
     react-dom: ^18.2.0
     react-helmet: ^6.1.0
     react-intl: 6.4.1
+    react-query: 3.39.3
     react-redux: 8.1.1
     react-router-dom: 5.3.4
     redux: ^4.2.1


### PR DESCRIPTION
### What does it do?

Refactors the data-fetching logic in the CTB data manager provider to use react-query. It also makes `formatAPIError` a stable reference.

### Why is it needed?

Fixes a bug outlined in https://github.com/strapi/strapi/issues/17812. It seems that now we aren't unmounting pages as often anymore, which leads to stable references and therefore stale data.

### How to test it?

- Create / Delete / Update content-types (single + multiple)
- Create / Delete / Update components (new + existing categories)

### Related issue(s)/PR(s)

- Fixes https://github.com/strapi/strapi/issues/17812
