### PR TITLE
fix(cm): add missing qs dependency

### DIFF
--- a/packages/core/content-manager/package.json
+++ b/packages/core/content-manager/package.json
@@ -27,7 +27,8 @@
   "dependencies": {
     "@sindresorhus/slugify": "1.1.0",
     "@strapi/utils": "4.12.7",
-    "lodash": "4.17.21"
+    "lodash": "4.17.21",
+    "qs": "6.11.1"
   },
   "engines": {
     "node": ">=16.0.0 <=20.x.x",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7311,6 +7311,7 @@ __metadata:
     "@sindresorhus/slugify": 1.1.0
     "@strapi/utils": 4.12.7
     lodash: 4.17.21
+    qs: 6.11.1
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
### What does it do?

Adds `qs` as dependency to the CM.

### Why is it needed?

Currently the CI is failing, because eslint found the problem.
