### PR TITLE
#17841 edits in content-manager after saving is solved

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/utils/cleanData.js
+++ b/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/utils/cleanData.js
@@ -101,8 +101,8 @@ const cleanData = ({ browserState, serverState }, currentSchema, componentsSchem
            *  connectedRelations are the items that are in the browserState
            * array but not in the serverState
            */
-          const connectedRelations = value.reduce((acc, relation, currentIndex, array) => {
-            const relationOnServer = actualOldValue.find(
+          const connectedRelations = Object.keys(value).reduce((acc, relation, currentIndex, array) => {
+            const relationOnServer = Object.keys(actualOldValue).find(
               (oldRelation) => oldRelation.id === relation.id
             );
 
@@ -121,8 +121,8 @@ const cleanData = ({ browserState, serverState }, currentSchema, componentsSchem
            * disconnectedRelations are the items that are in the serverState but
            * are no longer in the browserState
            */
-          const disconnectedRelations = actualOldValue.reduce((acc, relation) => {
-            if (!value.find((newRelation) => newRelation.id === relation.id)) {
+          const disconnectedRelations = Object.keys(actualOldValue).reduce((acc, relation) => {
+            if (!Object.keys(value).find((newRelation) => newRelation.id === relation.id)) {
               return [...acc, { id: relation.id }];
             }
 


### PR DESCRIPTION
Fix #17841  

### What does it do?

So basically in
strapi\packages\core\admin\admin\src\content-manager\components\EditViewDataManagerProvider\utils\cleanData.js
There was usage of the reduce method , so it is required to give arrays as parameter but there was objects those were given to this method so I changed it.

value.reduce() to Object.keys(value).reduce 


### Why is it needed?

Describe the issue you are solving.

As issue suggests before the change when we click on the save button after the edits in content-manager... it was giving errors

Before:

https://github.com/strapi/strapi/assets/89585732/b46f365c-a7b1-4b79-b0fb-a93ba1c5d0f5

After:


https://github.com/strapi/strapi/assets/89585732/69c98881-0b90-4a93-af22-2dd1704b908f


Please review the changes carefully!
