### PR TITLE
Remove check for excluding non-local providers

### DIFF
--- a/packages/core/data-transfer/src/strapi/providers/local-destination/index.ts
+++ b/packages/core/data-transfer/src/strapi/providers/local-destination/index.ts
@@ -62,17 +62,6 @@ class LocalStrapiDestinationProvider implements IDestinationProvider {
       throw new ProviderInitializationError('Could not access local strapi');
     }
 
-    // uploading to a non-local file provider without included entities is useless (and potentially problematic) because we don't have the links, so don't allow it
-    if (
-      this.strapi.config.get('plugin.upload').provider !== 'local' &&
-      this.#areAssetsIncluded() &&
-      !this.#isContentTypeIncluded('plugin::upload.file')
-    ) {
-      throw new ProviderValidationError(
-        'When using a non-local upload provider, files may not be transferred without also transferring content.'
-      );
-    }
-
     this.transaction = utils.transaction.createTransaction(this.strapi);
   }
 

--- a/packages/core/strapi/lib/commands/actions/import/action.js
+++ b/packages/core/strapi/lib/commands/actions/import/action.js
@@ -86,7 +86,7 @@ module.exports = async (opts) => {
     exclude: opts.exclude,
     only: opts.only,
     throttle: opts.throttle,
-    rules: {
+    transforms: {
       links: [
         {
           filter(link) {


### PR DESCRIPTION
### What does it do?

The assets metadata holds the URLs for the assets, so this check doesn't make sense for any provider.

### Why is it needed?

To be more permissive in the data transfer.

### How to test it?

Run an import with different `--exclude` and `--only` options that only contain assets, or the content, or the links.

### Related issue(s)/PR(s)
#17730
