### PR TITLE
Added missing `models` key to `SubscriberMap` and made actions optional.

### DIFF
--- a/packages/core/database/lib/lifecycles/subscribers/index.d.ts
+++ b/packages/core/database/lib/lifecycles/subscribers/index.d.ts
@@ -3,7 +3,7 @@ import { Event, Action } from '../';
 type SubscriberFn = (event: Event) => Promise<void> | void;
 
 type SubscriberMap = {
-  models?: string[],
+  models?: string[];
 } & {
   [k in Action]?: SubscriberFn;
 };

--- a/packages/core/database/lib/lifecycles/subscribers/index.d.ts
+++ b/packages/core/database/lib/lifecycles/subscribers/index.d.ts
@@ -3,7 +3,9 @@ import { Event, Action } from '../';
 type SubscriberFn = (event: Event) => Promise<void> | void;
 
 type SubscriberMap = {
-  [k in Action]: SubscriberFn;
+  models?: string[],
+} & {
+  [k in Action]?: SubscriberFn;
 };
 
 export type Subscriber = SubscriberFn | SubscriberMap;


### PR DESCRIPTION
The `Subscriber` union type of which `SubscriberMap` is a component was missing the optional `models` parameter document here at [#declarative-and-programmatic-usage](https://docs.strapi.io/dev-docs/backend-customization/models#declarative-and-programmatic-usage).

I added the optional field by intersecting it with the original type formulation, and also made the `Action` keys optional, since not all of the 18 individual actions should necessarily be specified when making a `SubscriberMap`.

---

This is just a simple fix to one of the types conflicting with how it's used in the official documentation.