### PR TITLE
DB configuration type

### DIFF
--- a/packages/core/strapi/lib/types/core/config/database.d.ts
+++ b/packages/core/strapi/lib/types/core/config/database.d.ts
@@ -1,6 +1,6 @@
 import { Utils } from '../..';
 
-type Client = 'mysql' | 'postgres' | 'sqlite';
+type ClientKind = 'mysql' | 'postgres' | 'sqlite';
 
 type SSLConfig = {
   rejectUnauthorized?: boolean;
@@ -24,7 +24,7 @@ type PoolConfig = {
   afterCreate?: (conn: any, done: (err?: Error, conn?: any) => void) => void;
 };
 
-type Connection<TClient extends Client> = {
+type Connection<TClient extends ClientKind> = {
   database: string;
   user: string;
   password: string;
@@ -35,18 +35,19 @@ type Connection<TClient extends Client> = {
   timezone?: string;
 } & { [key: string]: unknown } & Utils.Expression.MatchFirst<
     [[Utils.Expression.StrictEqual<TClient, 'postgres'>, { schema?: string }]],
-    {}
+    unknown
   >;
 
 type SqliteConnection = {
   filename: string;
 } & { [key: string]: unknown };
 
-export interface DBConfig<TClient extends Client> {
+export interface DBConfig<TClient extends ClientKind> {
   connection: {
     client: TClient;
-    connection: Utils.Expression.MatchFirst<
-      [[Utils.Expression.StrictEqual<TClient, 'sqlite'>, SqliteConnection]],
+    connection: Utils.Expression.If<
+      Utils.Expression.StrictEqual<TClient, 'sqlite'>,
+      SqliteConnection,
       Connection<TClient>
     >;
     debug?: boolean;
@@ -54,7 +55,7 @@ export interface DBConfig<TClient extends Client> {
     acquireConnectionTimeout?: number;
   } & { [key: string]: unknown } & Utils.Expression.MatchFirst<
       [[Utils.Expression.StrictEqual<TClient, 'sqlite'>, { useNullAsDefault?: boolean }]],
-      {}
+      unknown
     >;
   settings?: {
     forceMigration?: boolean;

--- a/packages/core/strapi/lib/types/core/config/database.d.ts
+++ b/packages/core/strapi/lib/types/core/config/database.d.ts
@@ -1,0 +1,63 @@
+import { Utils } from '../..';
+
+type Client = 'mysql' | 'postgres' | 'sqlite';
+
+type SSLConfig = {
+  rejectUnauthorized?: boolean;
+  key?: string;
+  cert?: string;
+  ca?: string;
+  capath?: string;
+  cipher?: string;
+};
+
+type PoolConfig = {
+  min?: number;
+  max?: number;
+  acquireTimeoutMillis?: number;
+  createTimeoutMillis?: number;
+  destroyTimeoutMillis?: number;
+  idleTimeoutMillis?: number;
+  reapIntervalMillis?: number;
+  createRetryIntervalMillis?: number;
+  // Todo: add types for these callbacks
+  afterCreate?: (conn: any, done: (err?: Error, conn?: any) => void) => void;
+};
+
+type Connection<TClient extends Client> = {
+  database: string;
+  user: string;
+  password: string;
+  port: number;
+  host: string;
+  ssl?: SSLConfig | boolean;
+  connectionString?: string;
+  timezone?: string;
+} & { [key: string]: unknown } & Utils.Expression.MatchFirst<
+    [[Utils.Expression.StrictEqual<TClient, 'postgres'>, { schema?: string }]],
+    {}
+  >;
+
+type SqliteConnection = {
+  filename: string;
+} & { [key: string]: unknown };
+
+export interface DBConfig<TClient extends Client> {
+  connection: {
+    client: TClient;
+    connection: Utils.Expression.MatchFirst<
+      [[Utils.Expression.StrictEqual<TClient, 'sqlite'>, SqliteConnection]],
+      Connection<TClient>
+    >;
+    debug?: boolean;
+    pool?: PoolConfig;
+    acquireConnectionTimeout?: number;
+  } & { [key: string]: unknown } & Utils.Expression.MatchFirst<
+      [[Utils.Expression.StrictEqual<TClient, 'sqlite'>, { useNullAsDefault?: boolean }]],
+      {}
+    >;
+  settings?: {
+    forceMigration?: boolean;
+    runMigrations?: boolean;
+  };
+}

--- a/packages/core/strapi/lib/types/core/config/index.d.ts
+++ b/packages/core/strapi/lib/types/core/config/index.d.ts
@@ -1,2 +1,3 @@
 export { Server } from './server.js';
 export { Admin } from './admin.js';
+export type { DBConfig } from './database';


### PR DESCRIPTION


### What does it do?

Adds Database configuration type

### How to test it?

in kitchensink-ts DB config you can add the following and play around

```
import { DBConfig } from '@strapi/strapi/lib/types/core/config';

export default ({ env }) =>
  ({
    connection: {
      client: 'postgres',
      connection: {
        database: env('DATABASE_NAME', 'strapi'),
        password: env('DATABASE_PASSWORD', 'strapi'),
        host: env('DATABASE_HOST', 'localhost'),
        user: env('DATABASE_USERNAME', 'strapi'),
        port: env('DATABASE_PORT', 5432),
        ssl: true,
      },
      acquireConnectionTimeout: 10000,
    },
  } as DBConfig<'postgres'>);
```
