### PR TITLE
[helper-plugin]: migrate NoPermissions to TypeScript

### DIFF
--- a/packages/core/helper-plugin/src/components/NoPermissions.tsx
+++ b/packages/core/helper-plugin/src/components/NoPermissions.tsx
@@ -2,10 +2,13 @@ import React from 'react';
 
 import { EmptyStateLayout } from '@strapi/design-system';
 import { EmptyPermissions } from '@strapi/icons';
-import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 
-const NoPermissions = ({ action }) => {
+export type NoPermissionsProps = {
+  action?: React.ReactNode;
+};
+
+const NoPermissions = ({ action }: NoPermissionsProps) => {
   const { formatMessage } = useIntl();
 
   return (
@@ -18,14 +21,6 @@ const NoPermissions = ({ action }) => {
       action={action}
     />
   );
-};
-
-NoPermissions.defaultProps = {
-  action: undefined,
-};
-
-NoPermissions.propTypes = {
-  action: PropTypes.node,
 };
 
 export { NoPermissions };


### PR DESCRIPTION
### What does it do?

Migrates NoPermissions.jsx to TypeScript

### Related issue(s)/PR(s)

#17690 
