### PR TITLE
fix(rw): allow subtractive partial updates

### DIFF
--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/Stages/Stage/Stage.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/Stages/Stage/Stage.js
@@ -234,7 +234,7 @@ export function Stage({
           }}
           expanded={isOpen}
           shadow="tableShadow"
-          error={nameMeta.error ?? colorMeta?.error ?? false}
+          error={nameMeta.error ?? colorMeta?.error ?? permissionsMeta?.error ?? false}
           hasErrorMessage={false}
         >
           <AccordionToggle

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/EditView/EditView.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/pages/EditView/EditView.js
@@ -115,16 +115,21 @@ export function ReviewWorkflowsEditView() {
           // changed; this enables partial updates e.g. for users who don't have
           // permissions to see roles
           stages: workflow.stages.map((stage) => {
-            const hasUpdatedPermissions =
-              stage?.permissions?.length > 0
-                ? stage.permissions.some(
-                    ({ role }) =>
-                      !serverState.workflow.stages.find(
-                        (stage) =>
-                          !!(stage.permissions ?? []).find((permission) => permission.role === role)
-                      )
-                  )
-                : false;
+            let hasUpdatedPermissions = true;
+            const serverStage = serverState.workflow.stages.find(
+              (serverStage) => serverStage.id === stage?.id
+            );
+
+            if (serverStage) {
+              hasUpdatedPermissions =
+                serverStage.permissions?.length !== stage.permission?.length ||
+                !serverStage.permissions.every(
+                  (serverPermission) =>
+                    !!stage.permissions.find(
+                      (permission) => permission.role === serverPermission.role
+                    )
+                );
+            }
 
             return {
               ...stage,

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/utils/tests/validateWorkflow.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/utils/tests/validateWorkflow.test.js
@@ -167,27 +167,6 @@ describe('Settings | Review Workflows | validateWorkflow()', () => {
           {
             name: 'stage-1',
             color: '#ffffff',
-            permissions: [],
-          },
-        ],
-      })
-    ).toMatchInlineSnapshot(`
-      {
-        "stages": [
-          {
-            "permissions": "Must be either an array or undefined",
-          },
-        ],
-      }
-    `);
-
-    expect(
-      await setup({
-        name: 'name',
-        stages: [
-          {
-            name: 'stage-1',
-            color: '#ffffff',
             permissions: { role: '1', action: 'admin::review-workflow.stage.transition' },
           },
         ],

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/utils/validateWorkflow.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/utils/validateWorkflow.js
@@ -76,14 +76,7 @@ export async function validateWorkflow({ values, formatMessage }) {
                 }),
               })
             )
-            .strict()
-            .min(
-              1,
-              formatMessage({
-                id: 'Settings.review-workflows.validation.stage.permissions',
-                defaultMessage: 'Must be either an array or undefined',
-              })
-            ),
+            .strict(),
         })
       )
       .min(1),


### PR DESCRIPTION
### What does it do?

- Display error message around each stage also if an error occurred for stage permissions
- Allow empty arrays to be sent
- Fixes a case where removing a role would send `undefined`, because so far only additive updates worked

### Why is it needed?

Fixes the issues above.

