### PR TITLE
fix(rw): hide endIcon on stage context menu

### DIFF
--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/Stages/Stage/Stage.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/Stages/Stage/Stage.js
@@ -244,7 +244,7 @@ export function Stage({
               (canDelete || canUpdate) && (
                 <Flex>
                   <Menu.Root>
-                    <Menu.Trigger size="S" endIcon={undefined} paddingLeft={2} paddingRight={2}>
+                    <Menu.Trigger size="S" endIcon={null} paddingLeft={2} paddingRight={2}>
                       <More aria-hidden focusable={false} />
                       <VisuallyHidden as="span">
                         {formatMessage({


### PR DESCRIPTION
### What does it do?

Hides the chevron down icon on the stage context menu.

### Why is it needed?

To properly overwrite the icon we need to pass in `null` over `undefined`.

