### PR TITLE
fix(cm): remove chevron-down on context menus of dynamic-zone components

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/DynamicZone/components/DynamicComponent.js
+++ b/packages/core/admin/admin/src/content-manager/components/DynamicZone/components/DynamicComponent.js
@@ -134,7 +134,7 @@ export const DynamicComponent = ({
         <Drag />
       </IconButton>
       <Menu.Root>
-        <Menu.Trigger size="S" endIcon={undefined} paddingLeft={2} paddingRight={2}>
+        <Menu.Trigger size="S" endIcon={null} paddingLeft={2} paddingRight={2}>
           <More aria-hidden focusable={false} />
           <VisuallyHidden as="span">
             {formatMessage({


### PR DESCRIPTION
### What does it do?

Currently the context menu of a dynamic zone component renders the more icon and a huge chevron next to it. This PR removes the chevron.

### Why is it needed?

To properly overwrite the icon we need to pass in null over undefined.

### Related issue(s)/PR(s)

- Similar to https://github.com/strapi/strapi/pull/17863
