### PR TITLE
[Rich Text Editor] Add type blocks to server

### DIFF
--- a/examples/getstarted/src/api/kitchensink/content-types/kitchensink/schema.json
+++ b/examples/getstarted/src/api/kitchensink/content-types/kitchensink/schema.json
@@ -22,6 +22,9 @@
     "rich_text": {
       "type": "richtext"
     },
+    "blocks": {
+      "type": "blocks"
+    },
     "integer": {
       "type": "integer"
     },

--- a/packages/core/content-manager/server/services/field-sizes.js
+++ b/packages/core/content-manager/server/services/field-sizes.js
@@ -23,6 +23,7 @@ const fieldSizes = {
   component: needsFullSize,
   json: needsFullSize,
   richtext: needsFullSize,
+  blocks: needsFullSize,
   // Small and resizable
   checkbox: smallSize,
   boolean: smallSize,

--- a/packages/core/content-type-builder/server/controllers/validation/types.js
+++ b/packages/core/content-type-builder/server/controllers/validation/types.js
@@ -107,7 +107,8 @@ const getTypeShape = (attribute, { modelType, attributes } = {}) => {
         regex: yup.string().test(isValidRegExpPattern),
       };
     }
-    case 'richtext': {
+    case 'richtext':
+    case 'blocks': {
       return {
         default: yup.string(),
         required: validators.required,

--- a/packages/core/content-type-builder/server/controllers/validation/types.js
+++ b/packages/core/content-type-builder/server/controllers/validation/types.js
@@ -107,13 +107,17 @@ const getTypeShape = (attribute, { modelType, attributes } = {}) => {
         regex: yup.string().test(isValidRegExpPattern),
       };
     }
-    case 'richtext':
-    case 'blocks': {
+    case 'richtext': {
       return {
         default: yup.string(),
         required: validators.required,
         minLength: validators.minLength,
         maxLength: validators.maxLength,
+      };
+    }
+    case 'blocks': {
+      return {
+        required: validators.required,
       };
     }
     case 'json': {

--- a/packages/core/content-type-builder/server/services/constants.js
+++ b/packages/core/content-type-builder/server/services/constants.js
@@ -14,6 +14,7 @@ const DEFAULT_TYPES = [
   'string',
   'text',
   'richtext',
+  'blocks',
   'json',
   'enumeration',
   'password',

--- a/packages/plugins/documentation/server/services/helpers/utils/clean-schema-attributes.js
+++ b/packages/plugins/documentation/server/services/helpers/utils/clean-schema-attributes.js
@@ -84,7 +84,8 @@ const cleanSchemaAttributes = (
         attributesCopy[prop] = { type: 'string', pattern: '^\\d*$', example: '123456789' };
         break;
       }
-      case 'json': {
+      case 'json':
+      case 'blocks': {
         attributesCopy[prop] = {};
         break;
       }


### PR DESCRIPTION
### What does it do?

Adds the type "blocks" to the CM and CTB server

### Why is it needed?

So the CM and CTB are aware of the type "blocks"

### How to test it?

- The server should start with {"type": "blocks"} in a schema.json
- The content manager should display "not supported" for the input
- The CTB should save a newly added blocks type and write to the schema.json for that content-type

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/pull/17877
