### PR TITLE
Forbid access to workflow getters when user doesnt have content type permissions

### DIFF
--- a/packages/core/admin/ee/server/controllers/workflows/__tests__/workflows.test.js
+++ b/packages/core/admin/ee/server/controllers/workflows/__tests__/workflows.test.js
@@ -1,0 +1,43 @@
+'use strict';
+
+const workflowController = require('..');
+
+describe('Workflows controller', () => {
+  describe('checkWorkflowContentTypesPermissions', () => {
+    const disallowedContentTypes = 'test';
+    global.strapi = {
+      plugins: {
+        'content-manager': {
+          services: {
+            'permission-checker': {
+              create: jest.fn(({ model }) => ({
+                cannot: {
+                  read: jest.fn(() => model === disallowedContentTypes),
+                },
+              })),
+            },
+          },
+        },
+      },
+    };
+
+    test('returns true if the user has permissions to read a content type', async () => {
+      const res = workflowController.checkWorkflowContentTypesPermissions({}, [
+        { contentTypes: ['UID'] },
+        { contentTypes: ['UID1'] },
+      ]);
+
+      expect(res).toBeTruthy();
+    });
+
+    test('returns false if the user does not have permissions to read a content type', async () => {
+      const res = workflowController.checkWorkflowContentTypesPermissions({}, [
+        { contentTypes: [disallowedContentTypes] },
+        { contentTypes: ['UID'] },
+        { contentTypes: ['UID1'] },
+      ]);
+
+      expect(res).toBeFalsy();
+    });
+  });
+});

--- a/packages/core/admin/ee/server/routes/review-workflows.js
+++ b/packages/core/admin/ee/server/routes/review-workflows.js
@@ -63,15 +63,7 @@ module.exports = {
       handler: 'workflows.find',
       config: {
         middlewares: [enableFeatureMiddleware('review-workflows')],
-        policies: [
-          'admin::isAuthenticatedAdmin',
-          {
-            name: 'admin::hasPermissions',
-            config: {
-              actions: ['admin::review-workflows.read'],
-            },
-          },
-        ],
+        policies: ['admin::isAuthenticatedAdmin'],
       },
     },
     {
@@ -80,15 +72,7 @@ module.exports = {
       handler: 'workflows.findById',
       config: {
         middlewares: [enableFeatureMiddleware('review-workflows')],
-        policies: [
-          'admin::isAuthenticatedAdmin',
-          {
-            name: 'admin::hasPermissions',
-            config: {
-              actions: ['admin::review-workflows.read'],
-            },
-          },
-        ],
+        policies: ['admin::isAuthenticatedAdmin'],
       },
     },
     {

--- a/packages/core/admin/server/controllers/role.js
+++ b/packages/core/admin/server/controllers/role.js
@@ -45,7 +45,7 @@ module.exports = {
   },
 
   /**
-   * Returns every roles
+   * Returns every role
    * @param {KoaContext} ctx - koa context
    */
   async findAll(ctx) {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Checks that the user has access to all related content types of the workflows returned from workflow GET endpoints

### Why is it needed?

To base the display of the stage select component on content type permissions rather than the permission to see the review workflow settings page

### How to test it?

Through calling the endpoints as a user with insufficient permissions
Unit test

### Related issue(s)/PR(s)

CONTENT-1831
