### PR TITLE
Fix #17875 - Missing schema in validateQuery after upgrading to v4.13.1

### DIFF
--- a/packages/plugins/graphql/server/services/builders/resolvers/association.js
+++ b/packages/plugins/graphql/server/services/builders/resolvers/association.js
@@ -28,7 +28,7 @@ module.exports = ({ strapi }) => {
       const isMediaAttribute = isMedia(attribute);
       const isMorphAttribute = isMorphRelation(attribute);
 
-      const targetUID = isMediaAttribute ? 'plugins::upload.file' : attribute.target;
+      const targetUID = isMediaAttribute ? 'plugin::upload.file' : attribute.target;
       const isToMany = isMediaAttribute ? attribute.multiple : attribute.relation.endsWith('Many');
 
       const targetContentType = strapi.getModel(targetUID);


### PR DESCRIPTION
### What does it do?

There's a typo, causing validateQuery to fail for queries containing media file references.

### Why is it needed?

Fix the error `Missing schema in validateQuery`.

### How to test it?

Query for any entity that has a media file relation field and include the file in the attributes.

### Related issue(s)/PR(s)

fixes #17875 
