### PR TITLE
Add NpsSurvey back to AuthenticatedApp

### DIFF
--- a/packages/core/admin/admin/src/components/AuthenticatedApp/index.js
+++ b/packages/core/admin/admin/src/components/AuthenticatedApp/index.js
@@ -14,6 +14,7 @@ import { useQueries } from 'react-query';
 import packageJSON from '../../../../package.json';
 import { useConfigurations } from '../../hooks';
 import { getFullName, hashAdminUserEmail } from '../../utils';
+import NpsSurvey from '../NpsSurvey';
 import PluginsInitializer from '../PluginsInitializer';
 import RBACProvider from '../RBACProvider';
 
@@ -109,6 +110,7 @@ const AuthenticatedApp = () => {
       userDisplayName={userDisplayName}
     >
       <RBACProvider permissions={permissions} refetchPermissions={refetch}>
+        <NpsSurvey />
         <PluginsInitializer />
       </RBACProvider>
     </AppInfoProvider>


### PR DESCRIPTION
### What does it do?

It adds the NpsSurvey back to the CMS

### Why is it needed?

It was removed on accident.

### How to test it?

Build and start the app, wait 5 minutes, the survey should appear.

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/commit/bc6c5b005869dd00db37a3942c0e30f9e955be3d#diff-dbb33815cda57c3b4c530539db1260835457b6ed58d033a1ef02a288586fb568L222
