### PR TITLE
Fix #17876: create exclude plugin path in full path format

### DIFF
--- a/packages/core/admin/utils/create-plugins-exclude-path.js
+++ b/packages/core/admin/utils/create-plugins-exclude-path.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const path = require('path');
+
 const NODE_MODULES = 'node_modules';
 /**
  * @param {string[]} pluginsPath – an array of paths to the plugins from the user's directory
@@ -14,7 +16,7 @@ const createPluginsExcludePath = (pluginsPath = []) => {
     return /node_modules/;
   }
 
-  return new RegExp(`${NODE_MODULES}/(?!(${pluginsPath.join('|')}))`);
+  return new RegExp(`${path.resolve(__dirname, NODE_MODULES)}/(?!(${pluginsPath.join('|')}))`);
 };
 
 module.exports = { createPluginsExcludePath };


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

To enhance versatility, compatible with pnpm.

The current regular expression cannot cover the case of using pnpm.

https://github.com/strapi/strapi/blob/b31c3c3f6d934ebbb3d64cbf9722d8f50efc0391/packages/core/admin/utils/create-plugins-exclude-path.js#L17C1-L18C1
```
return new RegExp(`${NODE_MODULES}/(?!(${pluginsPath.join('|')}))`);
```
Using full path of modules to fix this issue

### Why is it needed?

Fix issue when build with pnpm:

```
...
[
  {
    moduleIdentifier: '/home/alex/Dev/strapi-app/node_modules/.pnpm/@strapi+plugin-content-type-builder@4.13.1_@babel+runtime@7.22.11_@codemirror+autocomplete@6._q2t3abadqxla6mm3iqr3n4fyoy/node_modules/@strapi/plugin-content-type-builder/admin/src/components/PluginIcon/index.js',
    moduleName: './node_modules/.pnpm/@strapi+plugin-content-type-builder@4.13.1_@babel+runtime@7.22.11_@codemirror+autocomplete@6._q2t3abadqxla6mm3iqr3n4fyoy/node_modules/@strapi/plugin-content-type-builder/admin/src/components/PluginIcon/index.js',
    loc: '11:25',
    message: 'Module parse failed: Unexpected token (11:25)\n' +
      'You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders\n' +
      "| import { Layout } from '@strapi/icons';\n" +
      '| \n' +
      '> const PluginIcon = () => <Layout />;\n' +
      '| \n' +
      '| export default PluginIcon;',
    moduleId: 80256,
    moduleTrace: [ [Object], [Object], [Object], [Object] ],
    details: undefined,
    stack: 'ModuleParseError: Module parse failed: Unexpected token (11:25)\n' +
      'You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders\n' +
      "| import { Layout } from '@strapi/icons';\n" +
      '| \n' +
      '> const PluginIcon = () => <Layout />;\n' +
      '| \n' +
...
```

### How to test it?

pnpm strapi build

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/issues/17876