### PR TITLE
[helper-plugin] Migrate request util to TypeScript

### DIFF
--- a/packages/core/helper-plugin/src/utils/request.ts
+++ b/packages/core/helper-plugin/src/utils/request.ts
@@ -96,7 +96,7 @@ interface RequestOptions extends RequestInit {
  */
 export async function request<ResponseType = unknown>(
   url: string,
-  options = {} as RequestOptions,
+  options: RequestOptions = {},
   shouldWatchServerRestart?: boolean,
   stringify = true,
   { noAuth }: { noAuth?: boolean } = { noAuth: false }

--- a/packages/core/helper-plugin/src/utils/tests/request.test.ts
+++ b/packages/core/helper-plugin/src/utils/tests/request.test.ts
@@ -1,0 +1,80 @@
+import { server } from '@tests/utils';
+import { rest } from 'msw';
+
+import { request } from '../request';
+
+interface ExpectedError extends Error {
+  response: {
+    status: number;
+    payload: Record<string, unknown>;
+  };
+}
+
+describe('request', () => {
+  it('should return the response successful requests', async () => {
+    server.use(
+      rest.get('*/resource', (req, res, ctx) => {
+        return res(
+          ctx.json({
+            test: 'ok',
+          })
+        );
+      })
+    );
+
+    const response = await request('https://some-domain.com/resource');
+    expect(response).toEqual({ test: 'ok' });
+
+    server.restoreHandlers();
+  });
+
+  it('should throw errors on failed requests', async () => {
+    server.use(
+      rest.get('*/resource', (req, res, ctx) => {
+        return res(ctx.status(500), ctx.json({ error: 'some info about the error' }));
+      })
+    );
+
+    try {
+      await request('https://some-domain.com/resource');
+
+      // This line should not be reached, fail the test if it is
+      expect(true).toBe(false);
+    } catch (error) {
+      expect((error as ExpectedError).response.status).toBe(500);
+      expect((error as ExpectedError).response.payload).toEqual({
+        error: 'some info about the error',
+      });
+    }
+
+    server.restoreHandlers();
+  });
+
+  it('should watch server restart', async () => {
+    const fetchSpy = jest.spyOn(window, 'fetch');
+    server.use(
+      rest.get('*/resource', (req, res, ctx) => {
+        return res(
+          ctx.json({
+            test: 'ok',
+          })
+        );
+      }),
+      rest.head('*/_health', (req, res, ctx) => {
+        return res(ctx.status(200));
+      })
+    );
+
+    const response = await request('https://some-domain.com/resource', {}, true);
+    expect(response).toEqual({ test: 'ok' });
+
+    const lastCall = fetchSpy.mock.calls.at(-1);
+    expect(lastCall?.length).toBe(2);
+    expect(lastCall?.[0]).toBe('http://localhost:1337/_health');
+    expect(lastCall?.[1]?.method).toBe('HEAD');
+    expect(lastCall?.[1]?.mode).toBe('no-cors');
+    expect(lastCall?.[1]?.keepalive).toBe(false);
+
+    server.restoreHandlers();
+  });
+});


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Migrates the request util to TS.

I'm not super familiar with TS generics yet so I'd appreciate if you could look into how I implemented them here.

### Why is it needed?

Part of the helper plugin migration to TS: #17690

### Related issue(s)/PR(s)

#17690