### PR TITLE
fix: do not automatically grant permissions for required fields

### DIFF
--- a/packages/core/admin/server/services/content-type.js
+++ b/packages/core/admin/server/services/content-type.js
@@ -183,14 +183,7 @@ const cleanPermissionFields = (permissions, { nestingLevel } = {}) => {
       nestingLevel,
     });
 
-    const requiredFields = getNestedFields(strapi.contentTypes[subject], {
-      components: strapi.components,
-      requiredOnly: true,
-      nestingLevel,
-      existingFields: fields,
-    });
-
-    const badNestedFields = uniq([...intersection(fields, possibleFields), ...requiredFields]);
+    const badNestedFields = uniq([...intersection(fields, possibleFields)]);
 
     const newFields = badNestedFields.filter(
       (field) => !badNestedFields.some(startsWith(`${field}.`))


### PR DESCRIPTION
### What does it do?

RBAC permissions were reseted on required fields when restarting Strapi.

This seemed to be an intended behaviour, and this is a DRAFT removing it.
It still has to be discussed if we want to remove that behaviour, or prevent users removing permissions from required fields.


### Why is it needed?

Describe the issue you are solving.

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

Fixes https://github.com/strapi/strapi/issues/16890
