### PR TITLE
[CM]: Add basic blocks(Slate) editor input 

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/index.js
@@ -1,0 +1,82 @@
+import * as React from 'react';
+
+import { Flex, Typography } from '@strapi/design-system';
+import { pxToRem } from '@strapi/helper-plugin';
+import PropTypes from 'prop-types';
+import { useIntl } from 'react-intl';
+import { createEditor } from 'slate';
+import { Slate, Editable, withReact, ReactEditor } from 'slate-react';
+import styled from 'styled-components';
+
+const TypographyAsterisk = styled(Typography)`
+  line-height: 0;
+`;
+
+const style = {
+  fontSize: pxToRem(14),
+};
+
+const initialValue = [
+  {
+    type: 'paragraph',
+    children: [{ text: 'A line of text in a paragraph.' }],
+  },
+];
+
+const BlocksEditor = React.forwardRef(({ intlLabel, name, readOnly, required }, ref) => {
+  const { formatMessage } = useIntl();
+  const [editor] = React.useState(() => withReact(createEditor()));
+
+  const label = intlLabel.id
+    ? formatMessage(
+        { id: intlLabel.id, defaultMessage: intlLabel.defaultMessage },
+        { ...intlLabel.values }
+      )
+    : name;
+
+  /** Editable is not able to hold the ref, https://github.com/ianstormtaylor/slate/issues/4082
+   *  so with "useImperativeHandle" we can use ReactEditor methods to expose to the parent above
+   */
+  React.useImperativeHandle(
+    ref,
+    () => ({
+      focus() {
+        ReactEditor.focus(editor);
+      },
+    }),
+    [editor]
+  );
+
+  return (
+    <Flex direction="column" alignItems="stretch" gap={1}>
+      <Flex gap={1}>
+        <Typography variant="pi" fontWeight="bold" textColor="neutral800">
+          {label}
+          {required && <TypographyAsterisk textColor="danger600">*</TypographyAsterisk>}
+        </Typography>
+      </Flex>
+
+      <Slate editor={editor} initialValue={initialValue}>
+        <Editable readOnly={readOnly} style={style} />
+      </Slate>
+    </Flex>
+  );
+});
+
+BlocksEditor.defaultProps = {
+  required: false,
+  readOnly: false,
+};
+
+BlocksEditor.propTypes = {
+  intlLabel: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    defaultMessage: PropTypes.string.isRequired,
+    values: PropTypes.object,
+  }).isRequired,
+  name: PropTypes.string.isRequired,
+  required: PropTypes.bool,
+  readOnly: PropTypes.bool,
+};
+
+export default BlocksEditor;

--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { Flex, Typography } from '@strapi/design-system';
+import { Box, Flex, Typography } from '@strapi/design-system';
 import { pxToRem } from '@strapi/helper-plugin';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
@@ -23,7 +23,7 @@ const initialValue = [
   },
 ];
 
-const BlocksEditor = React.forwardRef(({ intlLabel, name, readOnly, required }, ref) => {
+const BlocksEditor = React.forwardRef(({ intlLabel, name, readOnly, required, error }, ref) => {
   const { formatMessage } = useIntl();
   const [editor] = React.useState(() => withReact(createEditor()));
 
@@ -36,6 +36,7 @@ const BlocksEditor = React.forwardRef(({ intlLabel, name, readOnly, required }, 
 
   /** Editable is not able to hold the ref, https://github.com/ianstormtaylor/slate/issues/4082
    *  so with "useImperativeHandle" we can use ReactEditor methods to expose to the parent above
+   *  also not passing forwarded ref here, gives console warning.
    */
   React.useImperativeHandle(
     ref,
@@ -48,24 +49,34 @@ const BlocksEditor = React.forwardRef(({ intlLabel, name, readOnly, required }, 
   );
 
   return (
-    <Flex direction="column" alignItems="stretch" gap={1}>
-      <Flex gap={1}>
-        <Typography variant="pi" fontWeight="bold" textColor="neutral800">
-          {label}
-          {required && <TypographyAsterisk textColor="danger600">*</TypographyAsterisk>}
-        </Typography>
-      </Flex>
+    <>
+      <Flex direction="column" alignItems="stretch" gap={1}>
+        <Flex gap={1}>
+          <Typography variant="pi" fontWeight="bold" textColor="neutral800">
+            {label}
+            {required && <TypographyAsterisk textColor="danger600">*</TypographyAsterisk>}
+          </Typography>
+        </Flex>
 
-      <Slate editor={editor} initialValue={initialValue}>
-        <Editable readOnly={readOnly} style={style} />
-      </Slate>
-    </Flex>
+        <Slate editor={editor} initialValue={initialValue}>
+          <Editable readOnly={readOnly} style={style} />
+        </Slate>
+      </Flex>
+      {error && (
+        <Box paddingTop={1}>
+          <Typography variant="pi" textColor="danger600" data-strapi-field-error>
+            {error}
+          </Typography>
+        </Box>
+      )}
+    </>
   );
 });
 
 BlocksEditor.defaultProps = {
   required: false,
   readOnly: false,
+  error: '',
 };
 
 BlocksEditor.propTypes = {
@@ -77,6 +88,7 @@ BlocksEditor.propTypes = {
   name: PropTypes.string.isRequired,
   required: PropTypes.bool,
   readOnly: PropTypes.bool,
+  error: PropTypes.string,
 };
 
 export default BlocksEditor;

--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/tests/index.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/tests/index.test.js
@@ -25,14 +25,14 @@ const setup = (props) =>
   );
 
 describe('BlocksEditor', () => {
-  it('should render blocks without error', async () => {
+  it('should render blocks without error', () => {
     setup();
 
     expect(screen.getByText('blocks type')).toBeInTheDocument();
     expect(screen.getByText(/A line of text in a paragraph./));
   });
 
-  it('should render blocks with error', async () => {
+  it('should render blocks with error', () => {
     setup({ error: 'field is required' });
 
     expect(screen.getByText(/field is required/));

--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/tests/index.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/tests/index.test.js
@@ -1,0 +1,40 @@
+import * as React from 'react';
+
+import { lightTheme, ThemeProvider } from '@strapi/design-system';
+import { render, screen } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
+
+import Blocks from '../index';
+
+const setup = (props) =>
+  render(
+    <Blocks
+      intlLabel={{ id: 'blocks', defaultMessage: 'blocks type' }}
+      name="blocks-editor"
+      {...props}
+    />,
+    {
+      wrapper: ({ children }) => (
+        <ThemeProvider theme={lightTheme}>
+          <IntlProvider messages={{}} locale="en">
+            {children}
+          </IntlProvider>
+        </ThemeProvider>
+      ),
+    }
+  );
+
+describe('BlocksEditor', () => {
+  it('should render blocks without error', async () => {
+    setup();
+
+    expect(screen.getByText('blocks type')).toBeInTheDocument();
+    expect(screen.getByText(/A line of text in a paragraph./));
+  });
+
+  it('should render blocks with error', async () => {
+    setup({ error: 'field is required' });
+
+    expect(screen.getByText(/field is required/));
+  });
+});

--- a/packages/core/admin/admin/src/content-manager/components/Inputs/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/Inputs/index.js
@@ -10,6 +10,7 @@ import { useIntl } from 'react-intl';
 
 import { useContentTypeLayout } from '../../hooks';
 import { getFieldName } from '../../utils';
+import Blocks from '../BlocksEditor';
 import InputUID from '../InputUID';
 import { RelationInputDataManager } from '../RelationInputDataManager';
 import Wysiwyg from '../Wysiwyg';
@@ -207,6 +208,7 @@ function Inputs({
     uid: InputUID,
     media: fields.media,
     wysiwyg: Wysiwyg,
+    blocks: Blocks,
     ...fields,
     ...customFieldInputs,
   };

--- a/packages/core/admin/admin/src/content-manager/components/Inputs/utils/getInputType.js
+++ b/packages/core/admin/admin/src/content-manager/components/Inputs/utils/getInputType.js
@@ -2,6 +2,8 @@ import toLower from 'lodash/toLower';
 
 const getInputType = (type = '') => {
   switch (toLower(type)) {
+    case 'blocks':
+      return 'blocks';
     case 'boolean':
       return 'bool';
     case 'biginteger':

--- a/packages/core/admin/admin/src/content-manager/utils/schema.js
+++ b/packages/core/admin/admin/src/content-manager/utils/schema.js
@@ -211,6 +211,32 @@ const createYupSchemaAttribute = (type, validations, options) => {
     schema = yup.string();
   }
 
+  if (type === 'blocks') {
+    schema = yup
+      .mixed(errorsTrads.json)
+      .test('isJSONObject', errorsTrads.json, (value) => {
+        try {
+          const parsedValue = JSON.parse(value);
+
+          if (typeof parsedValue === 'object' && parsedValue !== null) {
+            return true;
+          }
+        } catch (err) {
+          return false;
+        }
+
+        return false;
+      })
+      .nullable()
+      .test('required', errorsTrads.required, (value) => {
+        if (validations.required && (!value || !value.length)) {
+          return false;
+        }
+
+        return true;
+      });
+  }
+
   if (type === 'json') {
     schema = yup
       .mixed(errorsTrads.json)

--- a/packages/core/admin/admin/src/content-manager/utils/schema.js
+++ b/packages/core/admin/admin/src/content-manager/utils/schema.js
@@ -207,7 +207,11 @@ const createYupSchema = (
 const createYupSchemaAttribute = (type, validations, options) => {
   let schema = yup.mixed();
 
-  if (['string', 'uid', 'text', 'richtext', 'email', 'password', 'enumeration'].includes(type)) {
+  if (
+    ['string', 'uid', 'text', 'richtext', 'blocks', 'email', 'password', 'enumeration'].includes(
+      type
+    )
+  ) {
     schema = yup.string();
   }
 

--- a/packages/core/admin/admin/src/content-manager/utils/schema.js
+++ b/packages/core/admin/admin/src/content-manager/utils/schema.js
@@ -207,11 +207,7 @@ const createYupSchema = (
 const createYupSchemaAttribute = (type, validations, options) => {
   let schema = yup.mixed();
 
-  if (
-    ['string', 'uid', 'text', 'richtext', 'blocks', 'email', 'password', 'enumeration'].includes(
-      type
-    )
-  ) {
+  if (['string', 'uid', 'text', 'richtext', 'email', 'password', 'enumeration'].includes(type)) {
     schema = yup.string();
   }
 

--- a/packages/core/admin/package.json
+++ b/packages/core/admin/package.json
@@ -119,6 +119,8 @@
     "sanitize-html": "2.11.0",
     "semver": "7.5.4",
     "sift": "16.0.1",
+    "slate": "0.94.1",
+    "slate-react": "0.98.3",
     "style-loader": "3.3.1",
     "styled-components": "5.3.3",
     "typescript": "5.1.3",

--- a/packages/core/content-type-builder/admin/src/components/AttributeIcon/index.js
+++ b/packages/core/content-type-builder/admin/src/components/AttributeIcon/index.js
@@ -55,6 +55,7 @@ const iconByTypes = {
   time: Date,
   timestamp: Date,
   uid: Uid,
+  blocks: Blocks,
 };
 
 const IconBox = styled(Box)`

--- a/packages/core/content-type-builder/admin/src/components/AttributeIcon/index.js
+++ b/packages/core/content-type-builder/admin/src/components/AttributeIcon/index.js
@@ -55,7 +55,6 @@ const iconByTypes = {
   time: Date,
   timestamp: Date,
   uid: Uid,
-  blocks: Blocks,
 };
 
 const IconBox = styled(Box)`

--- a/packages/core/content-type-builder/admin/src/components/FormModal/attributes/advancedForm.js
+++ b/packages/core/content-type-builder/admin/src/components/FormModal/attributes/advancedForm.js
@@ -339,7 +339,7 @@ const advancedForm = {
             id: 'global.settings',
             defaultMessage: 'Settings',
           },
-          items: [options.required, options.maxLength, options.private, options.minLength],
+          items: [options.required, options.private],
         },
       ],
     };

--- a/yarn.lock
+++ b/yarn.lock
@@ -4005,7 +4005,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@juggle/resize-observer@npm:3.4.0, @juggle/resize-observer@npm:^3.3.1":
+"@juggle/resize-observer@npm:3.4.0, @juggle/resize-observer@npm:^3.3.1, @juggle/resize-observer@npm:^3.4.0":
   version: 3.4.0
   resolution: "@juggle/resize-observer@npm:3.4.0"
   checksum: 2505028c05cc2e17639fcad06218b1c4b60f932a4ebb4b41ab546ef8c157031ae377e3f560903801f6d01706dbefd4943b6c4704bf19ed86dfa1c62f1473a570
@@ -7035,6 +7035,8 @@ __metadata:
     sanitize-html: 2.11.0
     semver: 7.5.4
     sift: 16.0.1
+    slate: 0.94.1
+    slate-react: 0.98.3
     speed-measure-webpack-plugin: 1.5.0
     style-loader: 3.3.1
     styled-components: 5.3.3
@@ -8547,6 +8549,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/is-hotkey@npm:^0.1.1":
+  version: 0.1.7
+  resolution: "@types/is-hotkey@npm:0.1.7"
+  checksum: bce7c8874b30f346f20cf6cfcf4a10372962924f0e1b1a925a279004faeb276242ebfbfee47bd48df57e1021f2e3078c34e25837e226960c418d5f78f83dacea
+  languageName: node
+  linkType: hard
+
 "@types/istanbul-lib-coverage@npm:*, @types/istanbul-lib-coverage@npm:^2.0.0, @types/istanbul-lib-coverage@npm:^2.0.1":
   version: 2.0.4
   resolution: "@types/istanbul-lib-coverage@npm:2.0.4"
@@ -8714,6 +8723,13 @@ __metadata:
     "@types/interpret": "*"
     "@types/node": "*"
   checksum: 3d411a234a911d0464f5f77e8cb63ad88e1115fadb1138cfa12b02b67fb93d365966a0af5e1cc4a9f92c8d8d369727021cb638df4f9756d953fa37f3a3d6ba46
+  languageName: node
+  linkType: hard
+
+"@types/lodash@npm:^4.14.149":
+  version: 4.14.197
+  resolution: "@types/lodash@npm:4.14.197"
+  checksum: 53d7567d1704de76cf33266c78062e0fd722d4b846e5b1417d0b6ef0ee41c0d9c451b92bc34f73d5f1fcc45c7d36511e92f6f47a9279b48157ba60a92ddaa078
   languageName: node
   linkType: hard
 
@@ -12586,6 +12602,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"compute-scroll-into-view@npm:^1.0.20":
+  version: 1.0.20
+  resolution: "compute-scroll-into-view@npm:1.0.20"
+  checksum: f15fab29221953620735393ac1866541aab0d27d28078bedbba071a291ee9c8cc1a72bee302cf0bc06ed83c5e55afb74ebcbd634a63671ba33cf1fb1c51d3308
+  languageName: node
+  linkType: hard
+
 "compute-scroll-into-view@npm:^3.0.3":
   version: 3.0.3
   resolution: "compute-scroll-into-view@npm:3.0.3"
@@ -13730,6 +13753,15 @@ __metadata:
   dependencies:
     path-type: ^4.0.0
   checksum: fa05e18324510d7283f55862f3161c6759a3f2f8dbce491a2fc14c8324c498286c54282c1f0e933cb930da8419b30679389499b919122952a4f8592362ef4615
+  languageName: node
+  linkType: hard
+
+"direction@npm:^1.0.3":
+  version: 1.0.4
+  resolution: "direction@npm:1.0.4"
+  bin:
+    direction: cli.js
+  checksum: 572ac399093d7c9f2181c96828d252922e2a962b8f31a7fc118e3f7619592c566cc2ed313baf7703f17b2be00cd3c1402550140d0c3f4f70362976376a08b095
   languageName: node
   linkType: hard
 
@@ -17877,6 +17909,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"immer@npm:^9.0.6":
+  version: 9.0.21
+  resolution: "immer@npm:9.0.21"
+  checksum: 70e3c274165995352f6936695f0ef4723c52c92c92dd0e9afdfe008175af39fa28e76aafb3a2ca9d57d1fb8f796efc4dd1e1cc36f18d33fa5b74f3dfb0375432
+  languageName: node
+  linkType: hard
+
 "import-fresh@npm:^3.2.1":
   version: 3.3.0
   resolution: "import-fresh@npm:3.3.0"
@@ -18478,6 +18517,13 @@ __metadata:
   version: 1.0.0
   resolution: "is-gzip@npm:1.0.0"
   checksum: 0d28931c1f445fa29c900cf9f48e06e9d1d477a3bf7bd7332e7ce68f1333ccd8cb381de2f0f62a9a262d9c0912608a9a71b4a40e788e201b3dbd67072bb20d86
+  languageName: node
+  linkType: hard
+
+"is-hotkey@npm:^0.1.6":
+  version: 0.1.8
+  resolution: "is-hotkey@npm:0.1.8"
+  checksum: 793d0cccaf804583d8f4b835e040d4b6a74cb3f8d4094cb8188ed7cc86e6edf8f650fc80fabd4309e6c29938f5b0e9a17b45504b29dbf92735ef8d780d613aa0
   languageName: node
   linkType: hard
 
@@ -20919,7 +20965,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:4.17.21, lodash@npm:^4.17.11, lodash@npm:^4.17.15, lodash@npm:^4.17.19, lodash@npm:^4.17.20, lodash@npm:^4.17.21":
+"lodash@npm:4.17.21, lodash@npm:^4.17.11, lodash@npm:^4.17.15, lodash@npm:^4.17.19, lodash@npm:^4.17.20, lodash@npm:^4.17.21, lodash@npm:^4.17.4":
   version: 4.17.21
   resolution: "lodash@npm:4.17.21"
   checksum: eb835a2e51d381e561e508ce932ea50a8e5a68f4ebdd771ea240d3048244a8d13658acbd502cd4829768c56f2e16bdd4340b9ea141297d472517b83868e677f7
@@ -27037,6 +27083,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"scroll-into-view-if-needed@npm:^2.2.20":
+  version: 2.2.31
+  resolution: "scroll-into-view-if-needed@npm:2.2.31"
+  dependencies:
+    compute-scroll-into-view: ^1.0.20
+  checksum: 93b28f3723a462245b40d4120c40c542c8449473e2b157a5f8e18f04d95d66cd35249d96c625e8a440a56891f7d8905b1d026c690bdda07fcfb4f1a48d643ad1
+  languageName: node
+  linkType: hard
+
 "select-hose@npm:^2.0.0":
   version: 2.0.0
   resolution: "select-hose@npm:2.0.0"
@@ -27471,6 +27526,38 @@ __metadata:
   version: 5.0.0
   resolution: "slash@npm:5.0.0"
   checksum: 1fa799ee165f7eacf0122ea4252bcf44290db402eb9d3058624ff1d421b8dfe262100dffb0b2cc23f36858666bf661476e2a4c40ebaf3e7b61107cad55a1de88
+  languageName: node
+  linkType: hard
+
+"slate-react@npm:0.98.3":
+  version: 0.98.3
+  resolution: "slate-react@npm:0.98.3"
+  dependencies:
+    "@juggle/resize-observer": ^3.4.0
+    "@types/is-hotkey": ^0.1.1
+    "@types/lodash": ^4.14.149
+    direction: ^1.0.3
+    is-hotkey: ^0.1.6
+    is-plain-object: ^5.0.0
+    lodash: ^4.17.4
+    scroll-into-view-if-needed: ^2.2.20
+    tiny-invariant: 1.0.6
+  peerDependencies:
+    react: ">=16.8.0"
+    react-dom: ">=16.8.0"
+    slate: ">=0.65.3"
+  checksum: 52c08b7d149e5b0b9bda5b77368f884a38e5ce772916da11f23e5b1af089c0e26ef223bca234e3b1c5394dfecaf8c73918ba383f0a6803df3e2da91dcd024bab
+  languageName: node
+  linkType: hard
+
+"slate@npm:0.94.1":
+  version: 0.94.1
+  resolution: "slate@npm:0.94.1"
+  dependencies:
+    immer: ^9.0.6
+    is-plain-object: ^5.0.0
+    tiny-warning: ^1.0.3
+  checksum: 07666fe3373e59aaa19261366fd3cf1df546edfc0162fb88d675d71f158ebd1bf0630fd00ecc9152ab6547080f3e90c9f6d1504e09c25b3bf980cceb9b15c3c1
   languageName: node
   linkType: hard
 
@@ -28949,6 +29036,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tiny-invariant@npm:1.0.6":
+  version: 1.0.6
+  resolution: "tiny-invariant@npm:1.0.6"
+  checksum: c90b34beea3cb10c49531e754afb0999033a2d7edffef6602922de27678d8a96dcbc0e8f0a959bc272859281b0cd1305b711e25d5edfb1da5fc7135e2a992961
+  languageName: node
+  linkType: hard
+
 "tiny-invariant@npm:^1.0.2":
   version: 1.2.0
   resolution: "tiny-invariant@npm:1.2.0"
@@ -28963,7 +29057,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tiny-warning@npm:^1.0.0, tiny-warning@npm:^1.0.2":
+"tiny-warning@npm:^1.0.0, tiny-warning@npm:^1.0.2, tiny-warning@npm:^1.0.3":
   version: 1.0.3
   resolution: "tiny-warning@npm:1.0.3"
   checksum: da62c4acac565902f0624b123eed6dd3509bc9a8d30c06e017104bedcf5d35810da8ff72864400ad19c5c7806fc0a8323c68baf3e326af7cb7d969f846100d71


### PR DESCRIPTION
### What does it do?

Render basic Blocks input with Slate. 

- Added basic blocks editor(using Slate)
https://strapi-inc.atlassian.net/browse/CS-190

### How to test it?

1. Go to CTB, add new field "Blocks" and save it.
2. Go to CM for respective collection type, you should be able to see newly added Blocks type with default value.

For now there are no event handlers or renderers added it the block input.