### PR TITLE
Enable NPS feature by default

### DIFF
--- a/packages/core/admin/admin/src/components/NpsSurvey/index.js
+++ b/packages/core/admin/admin/src/components/NpsSurvey/index.js
@@ -79,8 +79,11 @@ const checkIfShouldShowSurvey = (settings) => {
   // Note that submitting a response resets the dismissal counts.
   // Checks 3 and 4 should not be reversed, since the first dismissal will also exist if the user has dismissed the survey twice or more before.
 
-  // User hasn't enabled NPS feature
-  if (!enabled) {
+  // For users who had created an account before the NPS feature was introduced,
+  // we assume that they would have enabled the NPS feature if they had the chance.
+
+  // User chose not to enable the NPS feature when signing up
+  if (enabled === false) {
     return false;
   }
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Displays the NPS modal when the STRAPI_NPS_SURVEY_SETTINGS storage key is not set.

### Why is it needed?

Admin users who registered on previous versions of Strapi do not have a STRAPI_NPS_SURVEY_SETTINGS key set, and were therefore excluded of the NPS survey. This created a bias in the responses.
### How to test it?

- Delete the STRAPI_NPS_SURVEY_SETTINGS key from your local storage
- Use the app for 5 minutes
- The NPS modal should show up
