### PR TITLE
chore(review-workflow): enable assignee test-suite

### DIFF
--- a/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/components/AssigneeSelect/AssigneeSelect.js
+++ b/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/components/AssigneeSelect/AssigneeSelect.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { Combobox, ComboboxOption, Field, Flex, Loader, Typography } from '@strapi/design-system';
+import { Combobox, ComboboxOption, Field, Flex } from '@strapi/design-system';
 import {
   useCMEditViewDataManager,
   useAPIErrorHandler,
@@ -31,13 +31,14 @@ export function AssigneeSelect() {
   const { put } = useFetchClient();
   const {
     allowedActions: { canReadUsers },
+    isLoading: isLoadingPermissions,
   } = useRBAC({
     readUsers: permissions.settings.users.read,
   });
   const { users, isLoading, isError } = useAdminUsers(
     {},
     {
-      enabled: canReadUsers,
+      enabled: !isLoadingPermissions && canReadUsers,
     }
   );
 
@@ -102,7 +103,7 @@ export function AssigneeSelect() {
               })) ||
             (mutation.error && formatAPIError(mutation.error))
           }
-          disabled={!isLoading && users.length === 0}
+          disabled={!isLoadingPermissions && !isLoading && users.length === 0}
           name={ASSIGNEE_ATTRIBUTE_NAME}
           id={ASSIGNEE_ATTRIBUTE_NAME}
           value={currentAssignee ? currentAssignee.id : null}
@@ -116,18 +117,7 @@ export function AssigneeSelect() {
             id: 'content-manager.reviewWorkflows.assignee.label',
             defaultMessage: 'Assignee',
           })}
-          // eslint-disable-next-line react/no-unstable-nested-components
-          customizeContent={() => (
-            <Flex as="span" justifyContent="space-between" alignItems="center" width="100%">
-              <Typography textColor="neutral800" ellipsis>
-                {currentAssignee ? getDisplayName(currentAssignee, formatMessage) : null}
-              </Typography>
-
-              {isLoading || mutation.isLoading ? (
-                <Loader small style={{ display: 'flex' }} />
-              ) : null}
-            </Flex>
-          )}
+          loading={isLoading || isLoadingPermissions || mutation.isLoading}
         >
           {users.map((user) => {
             return (

--- a/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/components/StageSelect/tests/StageSelect.test.js
+++ b/packages/core/admin/ee/admin/content-manager/pages/EditView/InformationBox/components/StageSelect/tests/StageSelect.test.js
@@ -44,6 +44,14 @@ const server = setupServer(
         ],
       })
     )
+  ),
+
+  rest.get('*/license-limit-information', (req, res, ctx) =>
+    res(
+      ctx.json({
+        data: {},
+      })
+    )
   )
 );
 
@@ -92,7 +100,7 @@ describe('EE | Content Manager | EditView | InformationBox | StageSelect', () =>
     server.close();
   });
 
-  it('renders an enabled select input, if the entity is edited', () => {
+  it('renders an enabled select input, if the entity is edited', async () => {
     useCMEditViewDataManager.mockReturnValue({
       initialData: {
         [STAGE_ATTRIBUTE_NAME]: null,
@@ -102,9 +110,8 @@ describe('EE | Content Manager | EditView | InformationBox | StageSelect', () =>
     });
 
     const { queryByRole } = setup();
-    const select = queryByRole('combobox');
 
-    expect(select).toBeInTheDocument();
+    await waitFor(() => expect(queryByRole('combobox')).toBeInTheDocument());
   });
 
   it('renders a select input, if a workflow stage is assigned to the entity', async () => {
@@ -120,12 +127,10 @@ describe('EE | Content Manager | EditView | InformationBox | StageSelect', () =>
 
     await waitFor(() => expect(queryByTestId('loader')).not.toBeInTheDocument());
 
-    const select = queryByRole('combobox');
+    await waitFor(() => expect(getByText('Stage 1')).toBeInTheDocument());
 
-    expect(getByText('Stage 1')).toBeInTheDocument();
+    await user.click(queryByRole('combobox'));
 
-    await user.click(select);
-
-    expect(getByText('Stage 2')).toBeInTheDocument();
+    await waitFor(() => expect(getByText('Stage 2')).toBeInTheDocument());
   });
 });


### PR DESCRIPTION
### What does it do?

Enables the test-suite for review-workflow assignees again and fixes the outstanding problems. The main issue was, which has been an oversight during review, is that `Combobox` doesn't receive a `customizeContent` callback. Instead is has a `loading` prop and stores the selected value instead of customizing how it is being displayed.

Loading states between stages and assignee is not consistent anymore; the loading state for assignee is displayed in the popover. Are we ok with that?

The tests for `StageSelect` and `InformationBox` keep throwing `act()` errors, but I can't figure out why. Would appreciate of someone has an idea on how to fix them.


### Why is it needed?

Enables FE tests for these three components.
