### PR TITLE
[Blocks editor] Setup toolbar container

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/index.js
@@ -1,0 +1,30 @@
+import * as React from 'react';
+
+import { Flex } from '@strapi/design-system';
+import styled from 'styled-components';
+
+const Root = ({ children }) => {
+  return (
+    <Flex paddingTop={2} paddingBottom={2} gap={2} paddingLeft={2} paddingRight={2}>
+      {children}
+    </Flex>
+  );
+};
+
+const SectionWrapper = styled(Flex)`
+  &:not(:last-child) {
+    padding-right: ${({ theme }) => theme.spaces[2]};
+    border-right: 1px solid ${({ theme }) => theme.colors.neutral200};
+  }
+`;
+
+const Section = ({ children }) => {
+  return <SectionWrapper gap={1}>{children}</SectionWrapper>;
+};
+
+const Toolbar = {
+  Root,
+  Section,
+};
+
+export default Toolbar;

--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/index.js
@@ -1,47 +1,36 @@
 import * as React from 'react';
 
+import * as Toolbar from '@radix-ui/react-toolbar';
 import { Flex } from '@strapi/design-system';
-import PropTypes from 'prop-types';
+import { pxToRem } from '@strapi/helper-plugin';
 import styled from 'styled-components';
 
-const Root = ({ children }) => {
-  return (
-    <Flex paddingTop={2} paddingBottom={2} gap={2} paddingLeft={2} paddingRight={2} role="toolbar">
-      {children}
-    </Flex>
-  );
-};
-
-Root.propTypes = {
-  children: PropTypes.node.isRequired,
-};
-
-const SectionWrapper = styled(Flex)`
-  &:not(:last-child) {
-    padding-right: ${({ theme }) => theme.spaces[2]};
-    border-right: 1px solid ${({ theme }) => theme.colors.neutral200};
-  }
+const Separator = styled(Toolbar.Separator)`
+  background: ${({ theme }) => theme.colors.neutral150};
+  width: 1px;
+  height: ${pxToRem(24)};
 `;
 
-const Section = ({ children }) => {
-  return <SectionWrapper gap={1}>{children}</SectionWrapper>;
-};
-
-Section.propTypes = {
-  children: PropTypes.node.isRequired,
-};
-
-const Toolbar = () => {
+const BlocksToolbar = () => {
   return (
-    <Root>
-      <Section>
-        <div>item</div>
-      </Section>
-      <Section>
-        <div>item</div>
-      </Section>
-    </Root>
+    <Toolbar.Root asChild>
+      <Flex gap={1} padding={2}>
+        <Toolbar.ToggleGroup type="multiple" asChild>
+          <Flex gap={1}>
+            <Toolbar.ToggleItem value="test">test</Toolbar.ToggleItem>
+            <Toolbar.ToggleItem value="test2">test</Toolbar.ToggleItem>
+          </Flex>
+        </Toolbar.ToggleGroup>
+        <Separator />
+        <Toolbar.ToggleGroup type="multiple" asChild>
+          <Flex gap={1}>
+            <Toolbar.ToggleItem value="test">test</Toolbar.ToggleItem>
+            <Toolbar.ToggleItem value="test2">test</Toolbar.ToggleItem>
+          </Flex>
+        </Toolbar.ToggleGroup>
+      </Flex>
+    </Toolbar.Root>
   );
 };
 
-export default Toolbar;
+export { BlocksToolbar };

--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/index.js
@@ -1,14 +1,19 @@
 import * as React from 'react';
 
 import { Flex } from '@strapi/design-system';
+import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
 const Root = ({ children }) => {
   return (
-    <Flex paddingTop={2} paddingBottom={2} gap={2} paddingLeft={2} paddingRight={2}>
+    <Flex paddingTop={2} paddingBottom={2} gap={2} paddingLeft={2} paddingRight={2} role="toolbar">
       {children}
     </Flex>
   );
+};
+
+Root.propTypes = {
+  children: PropTypes.node.isRequired,
 };
 
 const SectionWrapper = styled(Flex)`
@@ -22,9 +27,21 @@ const Section = ({ children }) => {
   return <SectionWrapper gap={1}>{children}</SectionWrapper>;
 };
 
-const Toolbar = {
-  Root,
-  Section,
+Section.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+const Toolbar = () => {
+  return (
+    <Root>
+      <Section>
+        <div>item</div>
+      </Section>
+      <Section>
+        <div>item</div>
+      </Section>
+    </Root>
+  );
 };
 
 export default Toolbar;

--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/tests/index.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/tests/index.test.js
@@ -1,0 +1,26 @@
+import * as React from 'react';
+
+import { lightTheme, ThemeProvider } from '@strapi/design-system';
+import { render, screen } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
+
+import Toolbar from '..';
+
+const setup = () =>
+  render(<Toolbar />, {
+    wrapper: ({ children }) => (
+      <ThemeProvider theme={lightTheme}>
+        <IntlProvider messages={{}} locale="en">
+          {children}
+        </IntlProvider>
+      </ThemeProvider>
+    ),
+  });
+
+describe('BlocksEditor toolbar', () => {
+  it('should render the toolbar', () => {
+    setup();
+
+    expect(screen.getByRole('toolbar')).toBeInTheDocument();
+  });
+});

--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/tests/index.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/tests/index.test.js
@@ -4,10 +4,10 @@ import { lightTheme, ThemeProvider } from '@strapi/design-system';
 import { render, screen } from '@testing-library/react';
 import { IntlProvider } from 'react-intl';
 
-import Toolbar from '..';
+import { BlocksToolbar } from '..';
 
 const setup = () =>
-  render(<Toolbar />, {
+  render(<BlocksToolbar />, {
     wrapper: ({ children }) => (
       <ThemeProvider theme={lightTheme}>
         <IntlProvider messages={{}} locale="en">

--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/index.js
@@ -68,14 +68,7 @@ const BlocksEditor = React.forwardRef(({ intlLabel, name, readOnly, required, er
 
         <Slate editor={editor} initialValue={initialValue}>
           <InputWrapper direction="column" alignItems="flex-start">
-            <Toolbar.Root>
-              <Toolbar.Section>
-                <div>item</div>
-              </Toolbar.Section>
-              <Toolbar.Section>
-                <div>item</div>
-              </Toolbar.Section>
-            </Toolbar.Root>
+            <Toolbar />
             <EditorDivider width="100%" />
             <Editable readOnly={readOnly} style={style} />
           </InputWrapper>

--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { Box, Flex, Typography } from '@strapi/design-system';
+import { Box, Flex, Typography, InputWrapper, Divider } from '@strapi/design-system';
 import { pxToRem } from '@strapi/helper-plugin';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
@@ -8,12 +8,20 @@ import { createEditor } from 'slate';
 import { Slate, Editable, withReact, ReactEditor } from 'slate-react';
 import styled from 'styled-components';
 
+import Toolbar from './Toolbar';
+
 const TypographyAsterisk = styled(Typography)`
   line-height: 0;
 `;
 
+const EditorDivider = styled(Divider)`
+  background: ${({ theme }) => theme.colors.neutral200};
+`;
+
 const style = {
   fontSize: pxToRem(14),
+  // The outline style is set on the wrapper with :focus-within
+  outline: 'none',
 };
 
 const initialValue = [
@@ -59,7 +67,18 @@ const BlocksEditor = React.forwardRef(({ intlLabel, name, readOnly, required, er
         </Flex>
 
         <Slate editor={editor} initialValue={initialValue}>
-          <Editable readOnly={readOnly} style={style} />
+          <InputWrapper direction="column" alignItems="flex-start">
+            <Toolbar.Root>
+              <Toolbar.Section>
+                <div>item</div>
+              </Toolbar.Section>
+              <Toolbar.Section>
+                <div>item</div>
+              </Toolbar.Section>
+            </Toolbar.Root>
+            <EditorDivider width="100%" />
+            <Editable readOnly={readOnly} style={style} />
+          </InputWrapper>
         </Slate>
       </Flex>
       {error && (

--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/index.js
@@ -8,7 +8,7 @@ import { createEditor } from 'slate';
 import { Slate, Editable, withReact, ReactEditor } from 'slate-react';
 import styled from 'styled-components';
 
-import Toolbar from './Toolbar';
+import { BlocksToolbar } from './Toolbar';
 
 const TypographyAsterisk = styled(Typography)`
   line-height: 0;
@@ -68,7 +68,7 @@ const BlocksEditor = React.forwardRef(({ intlLabel, name, readOnly, required, er
 
         <Slate editor={editor} initialValue={initialValue}>
           <InputWrapper direction="column" alignItems="flex-start">
-            <Toolbar />
+            <BlocksToolbar />
             <EditorDivider width="100%" />
             <Editable readOnly={readOnly} style={style} />
           </InputWrapper>

--- a/packages/core/admin/package.json
+++ b/packages/core/admin/package.json
@@ -42,6 +42,7 @@
   "dependencies": {
     "@casl/ability": "^5.4.3",
     "@pmmmwh/react-refresh-webpack-plugin": "0.5.10",
+    "@radix-ui/react-toolbar": "1.0.4",
     "@strapi/data-transfer": "4.12.7",
     "@strapi/design-system": "1.9.0",
     "@strapi/helper-plugin": "4.12.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5627,7 +5627,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@radix-ui/react-toolbar@npm:^1.0.4":
+"@radix-ui/react-toolbar@npm:1.0.4, @radix-ui/react-toolbar@npm:^1.0.4":
   version: 1.0.4
   resolution: "@radix-ui/react-toolbar@npm:1.0.4"
   dependencies:
@@ -6952,6 +6952,7 @@ __metadata:
   dependencies:
     "@casl/ability": ^5.4.3
     "@pmmmwh/react-refresh-webpack-plugin": 0.5.10
+    "@radix-ui/react-toolbar": 1.0.4
     "@strapi/data-transfer": 4.12.7
     "@strapi/design-system": 1.9.0
     "@strapi/helper-plugin": 4.12.7


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Sets up the container of the new block editor's toolbar.

Also sets the global stylings for the blocks editor (everything excluding the Editable component which @madhurisandbhor is working on)

It's exported from its own component because it will likely be reused for the popover feature.

### Why is it needed?

It will allow us to start building the different sections in parallel.

