### PR TITLE
[Bugfix] Bulk publish/unpublish for non-default locale entities

### DIFF
--- a/packages/core/admin/admin/src/content-manager/pages/ListView/components/BulkActionButtons/ConfirmBulkActionDialog/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/ListView/components/BulkActionButtons/ConfirmBulkActionDialog/index.js
@@ -6,6 +6,7 @@ import {
   useFetchClient,
   useNotification,
   useAPIErrorHandler,
+  useQueryParams,
 } from '@strapi/helper-plugin';
 import { Check, ExclamationMarkCircle } from '@strapi/icons';
 import PropTypes from 'prop-types';
@@ -82,6 +83,15 @@ const ConfirmDialogPublishAll = ({ isOpen, onToggleDialog, isConfirmButtonLoadin
   const {
     contentType: { uid: slug },
   } = useSelector(listViewDomain());
+  const [
+    {
+      query: {
+        plugins: {
+          i18n: { locale },
+        },
+      },
+    },
+  ] = useQueryParams();
 
   const {
     data: countDraftRelations,
@@ -97,6 +107,7 @@ const ConfirmDialogPublishAll = ({ isOpen, onToggleDialog, isConfirmButtonLoadin
         {
           params: {
             ids: selectedEntries,
+            locale,
           },
         }
       );

--- a/packages/core/admin/admin/src/content-manager/pages/ListView/components/BulkActionButtons/ConfirmBulkActionDialog/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/ListView/components/BulkActionButtons/ConfirmBulkActionDialog/index.js
@@ -83,15 +83,7 @@ const ConfirmDialogPublishAll = ({ isOpen, onToggleDialog, isConfirmButtonLoadin
   const {
     contentType: { uid: slug },
   } = useSelector(listViewDomain());
-  const [
-    {
-      query: {
-        plugins: {
-          i18n: { locale },
-        },
-      },
-    },
-  ] = useQueryParams();
+  const [{ query }] = useQueryParams();
 
   const {
     data: countDraftRelations,
@@ -107,7 +99,7 @@ const ConfirmDialogPublishAll = ({ isOpen, onToggleDialog, isConfirmButtonLoadin
         {
           params: {
             ids: selectedEntries,
-            locale,
+            locale: query?.plugins?.i18n?.locale,
           },
         }
       );

--- a/packages/core/admin/admin/src/content-manager/pages/ListView/components/BulkActionButtons/ConfirmBulkActionDialog/tests/index.test.js
+++ b/packages/core/admin/admin/src/content-manager/pages/ListView/components/BulkActionButtons/ConfirmBulkActionDialog/tests/index.test.js
@@ -34,6 +34,17 @@ jest.mock('@strapi/helper-plugin', () => ({
   useNotification: jest.fn(() => {
     return toggleNotification;
   }),
+  useQueryParams: jest.fn(() => [
+    {
+      query: {
+        plugins: {
+          i18n: {
+            locale: 'en',
+          },
+        },
+      },
+    },
+  ]),
 }));
 
 const handlers = [

--- a/packages/core/admin/admin/src/content-manager/pages/ListView/components/BulkActionButtons/SelectedEntriesModal/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/ListView/components/BulkActionButtons/SelectedEntriesModal/index.js
@@ -445,12 +445,7 @@ const SelectedEntriesModal = ({ onToggle }) => {
   // We want to keep the selected entries order same as the list view
   const [
     {
-      query: {
-        sort,
-        plugins: {
-          i18n: { locale },
-        },
-      },
+      query: { sort, plugins },
     },
   ] = useQueryParams();
 
@@ -463,7 +458,7 @@ const SelectedEntriesModal = ({ onToggle }) => {
         $in: entriesToFetch,
       },
     },
-    locale,
+    locale: plugins?.i18n?.locale,
   };
 
   const { get } = useFetchClient();

--- a/packages/core/admin/admin/src/content-manager/pages/ListView/components/BulkActionButtons/SelectedEntriesModal/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/ListView/components/BulkActionButtons/SelectedEntriesModal/index.js
@@ -445,7 +445,12 @@ const SelectedEntriesModal = ({ onToggle }) => {
   // We want to keep the selected entries order same as the list view
   const [
     {
-      query: { sort },
+      query: {
+        sort,
+        plugins: {
+          i18n: { locale },
+        },
+      },
     },
   ] = useQueryParams();
 
@@ -458,6 +463,7 @@ const SelectedEntriesModal = ({ onToggle }) => {
         $in: entriesToFetch,
       },
     },
+    locale,
   };
 
   const { get } = useFetchClient();

--- a/packages/core/admin/admin/src/content-manager/pages/ListView/components/BulkActionButtons/SelectedEntriesModal/tests/index.test.js
+++ b/packages/core/admin/admin/src/content-manager/pages/ListView/components/BulkActionButtons/SelectedEntriesModal/tests/index.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { lightTheme, ThemeProvider } from '@strapi/design-system';
-import { Table } from '@strapi/helper-plugin';
+import { Table, useQueryParams } from '@strapi/helper-plugin';
 import {
   render as renderRTL,
   screen,
@@ -149,6 +149,32 @@ describe('Bulk publish selected entries modal', () => {
   });
 
   it('renders the selected items in the modal', async () => {
+    const { queryByText } = render(
+      <Table.Root defaultSelectedEntries={[1, 2, 3]} colCount={4}>
+        <SelectedEntriesModal onToggle={jest.fn()} />
+      </Table.Root>
+    );
+
+    await waitForElementToBeRemoved(() => queryByText('Loading content'));
+
+    expect(screen.getByText(/publish entries/i)).toBeInTheDocument();
+
+    // Nested table should render the selected items from the parent table
+    expect(screen.queryByText('Entry 1')).toBeInTheDocument();
+    expect(screen.queryByText('Entry 4')).not.toBeInTheDocument();
+  });
+
+  it('renders the selected items in the modal even if the locale param is not passed', async () => {
+    useQueryParams.mockImplementation(() => [
+      {
+        query: {
+          page: 1,
+          pageSize: 10,
+          sort: 'name:DESC',
+        },
+      },
+    ]);
+
     const { queryByText } = render(
       <Table.Root defaultSelectedEntries={[1, 2, 3]} colCount={4}>
         <SelectedEntriesModal onToggle={jest.fn()} />

--- a/packages/core/admin/admin/src/content-manager/pages/ListView/components/BulkActionButtons/SelectedEntriesModal/tests/index.test.js
+++ b/packages/core/admin/admin/src/content-manager/pages/ListView/components/BulkActionButtons/SelectedEntriesModal/tests/index.test.js
@@ -31,6 +31,11 @@ jest.mock('@strapi/helper-plugin', () => ({
     {
       query: {
         sort: 'name:DESC',
+        plugins: {
+          i18n: {
+            locale: 'en',
+          },
+        },
       },
     },
   ]),

--- a/packages/core/content-manager/server/controllers/collection-types.js
+++ b/packages/core/content-manager/server/controllers/collection-types.js
@@ -445,6 +445,7 @@ module.exports = {
   async countManyEntriesDraftRelations(ctx) {
     const { userAbility } = ctx.state;
     const ids = ctx.request.query.ids;
+    const locale = ctx.request.query.locale;
     const { model } = ctx.params;
 
     const entityManager = getService('entity-manager');
@@ -454,13 +455,13 @@ module.exports = {
       return ctx.forbidden();
     }
 
-    const entities = await entityManager.find(ids, model);
+    const entities = await entityManager.find({ ids, locale }, model);
 
     if (!entities) {
       return ctx.notFound();
     }
 
-    const number = await entityManager.countManyEntriesDraftRelations(ids, model);
+    const number = await entityManager.countManyEntriesDraftRelations(ids, model, locale);
 
     return {
       data: number,

--- a/packages/core/content-manager/server/services/entity-manager.d.ts
+++ b/packages/core/content-manager/server/services/entity-manager.d.ts
@@ -11,7 +11,7 @@ interface EntityManager {
   publish(): any;
   unpublish(): any;
   countDraftRelations(id: string, uid: string): number;
-  countManyEntriesDraftRelations(ids: number[], uid: string): number;
+  countManyEntriesDraftRelations(ids: number[], uid: string, locale?: string): number;
 }
 
 export default function (opts: { strapi: Strapi }): EntityManager;

--- a/packages/core/content-manager/server/services/entity-manager.js
+++ b/packages/core/content-manager/server/services/entity-manager.js
@@ -301,7 +301,7 @@ module.exports = ({ strapi }) => ({
     return sumDraftCounts(entity, uid);
   },
 
-  async countManyEntriesDraftRelations(ids, uid) {
+  async countManyEntriesDraftRelations(ids, uid, locale = 'en') {
     const { populate, hasRelations } = getDeepPopulateDraftCount(uid);
 
     if (!hasRelations) {
@@ -311,6 +311,7 @@ module.exports = ({ strapi }) => ({
     const entities = await strapi.entityService.findMany(uid, {
       populate,
       filters: { id: { $in: ids } },
+      locale,
     });
 
     const totalNumberDraftRelations = entities.reduce(


### PR DESCRIPTION
### What does it do?

It fixes our bug when we try to publish/unpublish entities with a locale that is not the default one. Now the locale is passed as param

### Why is it needed?

Because otherwise we had a problem when we called the API to publish the entities

### How to test it?

- Go to Settings > Internationalization .
- Create additional locale e.g. Italian. Make sure it's not default locale.
- Confirm that the content type has enabled "Draft & Publish" feature.
- Create an item for the content type in locale Italian. It should be in Draft status.
- Go to the content type list view
- Select the item using checkbox, then click "Publish" button.
- You need to see the item in the list.
- Click "Publish" on the modal shows with success.

you can also test if it works with the draft and publish relations, you had to create a entity with a Relation and try to publish it

### Related issue(s)/PR(s)
This ticket solve this issue https://github.com/strapi/strapi/issues/17790 
