### PR TITLE
fix(review-workflows): fix cloning for temporary stages

### DIFF
--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/index.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/index.js
@@ -124,7 +124,9 @@ export function reducer(state = initialState, action) {
         const { currentWorkflow } = state.clientState;
         const { id } = payload;
 
-        const sourceStageIndex = currentWorkflow.data.stages.findIndex((stage) => stage.id === id);
+        const sourceStageIndex = currentWorkflow.data.stages.findIndex(
+          (stage) => (stage?.id ?? stage?.__temp_key__) === id
+        );
         const sourceStage = currentWorkflow.data.stages[sourceStageIndex];
 
         draft.clientState.currentWorkflow.data.stages.splice(sourceStageIndex + 1, 0, {

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/tests/index.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/tests/index.test.js
@@ -180,7 +180,7 @@ describe('Admin | Settings | Review Workflows | reducer', () => {
     );
   });
 
-  test('ACTION_CLONE_STAGE', () => {
+  test('ACTION_CLONE_STAGE - existing stages', () => {
     const action = {
       type: ACTION_CLONE_STAGE,
       payload: { id: 1 },
@@ -212,6 +212,54 @@ describe('Admin | Settings | Review Workflows | reducer', () => {
 
                 expect.objectContaining({
                   id: 2,
+                }),
+              ],
+            }),
+          }),
+        }),
+      })
+    );
+  });
+
+  test('ACTION_CLONE_STAGE - stages that haven not been saved yet', () => {
+    const action = {
+      type: ACTION_CLONE_STAGE,
+      payload: { id: 4 },
+    };
+
+    state = {
+      status: expect.any(String),
+      serverState: expect.any(Object),
+      clientState: {
+        currentWorkflow: {
+          data: {
+            ...WORKFLOW_FIXTURE,
+            stages: [
+              ...WORKFLOW_FIXTURE.stages,
+              {
+                __temp_key__: 4,
+                color: '#4945FF',
+                name: 'stage-temp',
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    expect(reducer(state, action)).toStrictEqual(
+      expect.objectContaining({
+        clientState: expect.objectContaining({
+          currentWorkflow: expect.objectContaining({
+            data: expect.objectContaining({
+              stages: [
+                expect.any(Object),
+                expect.any(Object),
+                expect.objectContaining({
+                  name: 'stage-temp',
+                }),
+                expect.objectContaining({
+                  name: 'stage-temp',
                 }),
               ],
             }),


### PR DESCRIPTION
### What does it do?

Also searches for stages via `__temp_key__` rather than `id` only when cloning a stage.

### Why is it needed?

Right now stages that don't have an id (because they weren't saved yet) couldn't be cloned. This PR fixes that.

### How to test it?

Automated tests.

