### PR TITLE
Feature: don't require update permissions to change stage

### DIFF
--- a/packages/core/admin/ee/server/routes/review-workflows.js
+++ b/packages/core/admin/ee/server/routes/review-workflows.js
@@ -131,15 +131,7 @@ module.exports = {
       handler: 'stages.updateEntity',
       config: {
         middlewares: [enableFeatureMiddleware('review-workflows')],
-        policies: [
-          'admin::isAuthenticatedAdmin',
-          {
-            name: 'admin::hasPermissions',
-            config: {
-              actions: ['admin::review-workflows.update'],
-            },
-          },
-        ],
+        policies: ['admin::isAuthenticatedAdmin'],
       },
     },
     {


### PR DESCRIPTION
### What does it do?

Allow users to update stage even if they don't have Review Workflow Settings update permissions. The permission is handled by the stage permission itself.

