### PR TITLE
fix: fix local appending search params to url

### DIFF
--- a/packages/core/upload/admin/src/utils/appendSearchParamsToUrl.js
+++ b/packages/core/upload/admin/src/utils/appendSearchParamsToUrl.js
@@ -6,35 +6,30 @@
  * @returns {String} A string representing the URL with the search params appended
  */
 const appendSearchParamsToUrl = ({ url, params }) => {
-  if (
-    url === undefined ||
-    params === undefined ||
-    typeof params !== 'object' ||
-    Object.entries(params).length === 0
-  ) {
+  if (url === undefined || params === undefined || typeof params !== 'object') {
     return url;
   }
 
-  const placeholderUrl = 'https://placeholder.com';
-  let didUsePlaceholderUrl = false;
-  let urlObj;
-  try {
-    urlObj = new URL(url);
-  } catch (e) {
-    urlObj = new URL(`${placeholderUrl}${url}`);
-    didUsePlaceholderUrl = true;
+  const filteredParams = Object.fromEntries(
+    Object.entries(params).filter((entry) => entry[1] !== undefined)
+  );
+
+  if (Object.entries(filteredParams).length === 0) return url;
+
+  if (url.startsWith('/')) {
+    // relative url
+    const searchParams = new URLSearchParams(filteredParams).toString();
+
+    return `${url}${url.includes('?') ? '&' : '?'}${searchParams}`;
   }
 
-  const urlParams = urlObj.searchParams;
-  Object.entries(params).forEach(([key, value]) => {
-    if (value !== undefined) {
-      urlParams.append(key, value);
-    }
+  // absolute url
+  const urlObj = new URL(url);
+  Object.entries(filteredParams).forEach(([key, value]) => {
+    urlObj.searchParams.append(key, value);
   });
 
-  const result = urlObj.toString();
-
-  return didUsePlaceholderUrl ? result.replace(placeholderUrl, '') : result;
+  return urlObj.toString();
 };
 
 export { appendSearchParamsToUrl };

--- a/packages/core/upload/admin/src/utils/appendSearchParamsToUrl.js
+++ b/packages/core/upload/admin/src/utils/appendSearchParamsToUrl.js
@@ -6,11 +6,25 @@
  * @returns {String} A string representing the URL with the search params appended
  */
 const appendSearchParamsToUrl = ({ url, params }) => {
-  if (url === undefined || params === undefined || typeof params !== 'object' || Object.entries(params).length === 0) {
+  if (
+    url === undefined ||
+    params === undefined ||
+    typeof params !== 'object' ||
+    Object.entries(params).length === 0
+  ) {
     return url;
   }
 
-  const urlObj = new URL(url);
+  const placeholderUrl = 'https://placeholder.com';
+  let didUsePlaceholderUrl = false;
+  let urlObj;
+  try {
+    urlObj = new URL(url);
+  } catch (e) {
+    urlObj = new URL(`${placeholderUrl}${url}`);
+    didUsePlaceholderUrl = true;
+  }
+
   const urlParams = urlObj.searchParams;
   Object.entries(params).forEach(([key, value]) => {
     if (value !== undefined) {
@@ -18,7 +32,9 @@ const appendSearchParamsToUrl = ({ url, params }) => {
     }
   });
 
-  return urlObj.toString();
+  const result = urlObj.toString();
+
+  return didUsePlaceholderUrl ? result.replace(placeholderUrl, '') : result;
 };
 
 export { appendSearchParamsToUrl };

--- a/packages/core/upload/admin/src/utils/tests/appendSearchParamsToUrl.test.js
+++ b/packages/core/upload/admin/src/utils/tests/appendSearchParamsToUrl.test.js
@@ -1,38 +1,81 @@
 import { appendSearchParamsToUrl } from '..';
 
 describe('appendSearchParamsToUrl', () => {
-  const urlString = 'https://example.com/';
+  const absoluteUrlString = 'https://example.com/';
+  const relativeUrlString = '/uploads/image.jpg';
   const updateTime = '2023-07-19T03:00:00.000Z';
 
   test('returns undefined for undefined url string', () => {
     expect(appendSearchParamsToUrl({})).toBeUndefined();
-    expect(appendSearchParamsToUrl({ url: undefined, params: { updatedAt: updateTime }})).toBeUndefined();
+    expect(
+      appendSearchParamsToUrl({ url: undefined, params: { updatedAt: updateTime } })
+    ).toBeUndefined();
   });
 
   test('returns original string with no update time', () => {
-    expect(appendSearchParamsToUrl({ url: urlString, params: undefined })).toEqual(urlString);
-    expect(appendSearchParamsToUrl({ url: urlString, params: 'notAnObject' })).toEqual(urlString);
-    expect(appendSearchParamsToUrl({ url: urlString, params: { updatedAt: undefined } })).toEqual(urlString);
+    expect(appendSearchParamsToUrl({ url: absoluteUrlString, params: undefined })).toEqual(
+      absoluteUrlString
+    );
+    expect(appendSearchParamsToUrl({ url: relativeUrlString, params: undefined })).toEqual(
+      relativeUrlString
+    );
+    expect(appendSearchParamsToUrl({ url: absoluteUrlString, params: 'notAnObject' })).toEqual(
+      absoluteUrlString
+    );
+    expect(appendSearchParamsToUrl({ url: relativeUrlString, params: 'notAnObject' })).toEqual(
+      relativeUrlString
+    );
+    expect(
+      appendSearchParamsToUrl({ url: absoluteUrlString, params: { updatedAt: undefined } })
+    ).toEqual(absoluteUrlString);
+    expect(
+      appendSearchParamsToUrl({ url: relativeUrlString, params: { updatedAt: undefined } })
+    ).toEqual(relativeUrlString);
   });
 
   test('appends update time to string with no search params', () => {
-    const expected = `${urlString}?updatedAt=${updateTime.replaceAll(':', '%3A')}`;
+    const expectedAbsolute = `${absoluteUrlString}?updatedAt=${updateTime.replaceAll(':', '%3A')}`;
+    const expectedRelative = `${relativeUrlString}?updatedAt=${updateTime.replaceAll(':', '%3A')}`;
 
-    expect(appendSearchParamsToUrl({ url: urlString, params: { updatedAt: updateTime } })).toEqual(expected);
+    expect(
+      appendSearchParamsToUrl({ url: absoluteUrlString, params: { updatedAt: updateTime } })
+    ).toEqual(expectedAbsolute);
+    expect(
+      appendSearchParamsToUrl({ url: relativeUrlString, params: { updatedAt: updateTime } })
+    ).toEqual(expectedRelative);
   });
 
   test('appends update time to string with search params', () => {
-    const urlWithQuery = `${urlString}?query=test`;
-    const expected = `${urlWithQuery}&updatedAt=${updateTime.replaceAll(':', '%3A')}`;
+    const absoluteUrlWithQuery = `${absoluteUrlString}?query=test`;
+    const expectedAbsolute = `${absoluteUrlWithQuery}&updatedAt=${updateTime.replaceAll(
+      ':',
+      '%3A'
+    )}`;
+    const relativeUrlWithQuery = `${relativeUrlString}?query=test`;
+    const expectedRelative = `${relativeUrlWithQuery}&updatedAt=${updateTime.replaceAll(
+      ':',
+      '%3A'
+    )}`;
 
-    expect(appendSearchParamsToUrl({ url: urlWithQuery, params: { updatedAt: updateTime } })).toEqual(expected);
+    expect(
+      appendSearchParamsToUrl({ url: absoluteUrlWithQuery, params: { updatedAt: updateTime } })
+    ).toEqual(expectedAbsolute);
+    expect(
+      appendSearchParamsToUrl({ url: relativeUrlWithQuery, params: { updatedAt: updateTime } })
+    ).toEqual(expectedRelative);
   });
 
   test('appends multiple search params', () => {
     const param1 = 'example1';
     const param2 = 'example2';
-    const expected = `${urlString}?param1=${param1}&param2=${param2}`;
+    const expectedAbsolute = `${absoluteUrlString}?param1=${param1}&param2=${param2}`;
+    const expectedRelative = `${relativeUrlString}?param1=${param1}&param2=${param2}`;
 
-    expect(appendSearchParamsToUrl({ url: urlString, params: { param1, param2 } })).toEqual(expected);
+    expect(appendSearchParamsToUrl({ url: absoluteUrlString, params: { param1, param2 } })).toEqual(
+      expectedAbsolute
+    );
+    expect(appendSearchParamsToUrl({ url: relativeUrlString, params: { param1, param2 } })).toEqual(
+      expectedRelative
+    );
   });
 });


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?
Edited `appendSearchParamsToUrl` to support relative urls for local files as well as added tests to `appendSearchParamsToUrl.test.js`

### Why is it needed?
Fix #17931.
#17751 introduced the Url constructor to append params onto a url, but local files with relative urls are not valid urls which makes the Url constructor throw an error when passing a relative url.

### How to test it?
I added unit tests, but not sure how to test in a project. Would like someone to help if possible.

### Related issue(s)/PR(s)
Fix #17931
Introduced by #17751 
