### PR TITLE
[TS] Add types for strapi compile

### DIFF
--- a/packages/core/strapi/lib/compile.d.ts
+++ b/packages/core/strapi/lib/compile.d.ts
@@ -1,0 +1,8 @@
+interface CompileResult {
+  appDir: string;
+  distDir: string;
+}
+
+type CompileFunction = (dir?: string) => Promise<CompileResult>;
+
+export const compile: CompileFunction;

--- a/packages/core/strapi/lib/index.d.ts
+++ b/packages/core/strapi/lib/index.d.ts
@@ -2,5 +2,6 @@ import './global';
 
 export * from './types';
 export * as factories from './factories';
+export * as compile from './compile';
 
 export default function (opts): Strapi.Strapi;


### PR DESCRIPTION
### What does it do?

Adds types for strapi.compile

### Why is it needed?

Types for strapi.compile didn't exist 

### How to test it?

### Related issue(s)/PR(s)

Fixes https://github.com/strapi/strapi/issues/17962
