### PR TITLE
fix: pick color attribute on create workflow

### DIFF
--- a/api-tests/core/admin/ee/review-workflows.test.api.js
+++ b/api-tests/core/admin/ee/review-workflows.test.api.js
@@ -198,7 +198,10 @@ describeOnCondition(edition === 'EE')('Review workflows', () => {
         body: {
           data: {
             name: 'createdWorkflow',
-            stages: [{ name: 'Stage 1' }, { name: 'Stage 2' }],
+            stages: [
+              { name: 'Stage 1', color: '#343434' },
+              { name: 'Stage 2', color: '#141414' },
+            ],
           },
         },
       });
@@ -207,7 +210,10 @@ describeOnCondition(edition === 'EE')('Review workflows', () => {
         expect(res.status).toBe(200);
         expect(res.body.data).toMatchObject({
           name: 'createdWorkflow',
-          stages: [{ name: 'Stage 1' }, { name: 'Stage 2' }],
+          stages: [
+            { name: 'Stage 1', color: '#343434' },
+            { name: 'Stage 2', color: '#141414' },
+          ],
         });
       } else {
         expect(res.status).toBe(404);

--- a/packages/core/admin/ee/server/services/review-workflows/stages.js
+++ b/packages/core/admin/ee/server/services/review-workflows/stages.js
@@ -10,7 +10,7 @@ const { map, pick, isEqual } = require('lodash/fp');
 const { STAGE_MODEL_UID, ENTITY_STAGE_ATTRIBUTE, ERRORS } = require('../../constants/workflows');
 const { getService } = require('../../utils');
 
-const sanitizedStageFields = ['id', 'name', 'workflow'];
+const sanitizedStageFields = ['id', 'name', 'workflow', 'color'];
 const sanitizeStageFields = pick(sanitizedStageFields);
 
 module.exports = ({ strapi }) => {


### PR DESCRIPTION
### What does it do?
When creating a workflow, stage color attribute was ignored.

