### PR TITLE
fix(review-workflows): update confirm button styles for apply all action

### DIFF
--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/Stages/Stage/Stage.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/Stages/Stage/Stage.js
@@ -503,6 +503,7 @@ export function Stage({
       )}
 
       <ConfirmDialog.Root
+        iconRightButton={null}
         isOpen={isApplyAllConfirmationOpen}
         onToggleDialog={() => setIsApplyAllConfirmationOpen(false)}
         onConfirm={() => {
@@ -516,6 +517,7 @@ export function Stage({
             }),
           });
         }}
+        variantRightButton="primary"
       >
         <ConfirmDialog.Body>
           <Typography textAlign="center" variant="omega">

--- a/packages/core/helper-plugin/src/components/ConfirmDialog.jsx
+++ b/packages/core/helper-plugin/src/components/ConfirmDialog.jsx
@@ -55,7 +55,6 @@ export const Root = ({
 
 Root.defaultProps = {
   iconBody: <ExclamationMarkCircle />,
-  iconRightButton: <Trash />,
   isConfirmButtonLoading: false,
   leftButtonText: {
     id: 'app.components.Button.cancel',
@@ -152,8 +151,12 @@ const Footer = ({
   );
 };
 
+Footer.defaultProps = {
+  iconRightButton: <Trash />,
+};
+
 Footer.propTypes = {
-  iconRightButton: PropTypes.node.isRequired,
+  iconRightButton: PropTypes.node,
   isConfirmButtonLoading: PropTypes.bool.isRequired,
   onConfirm: PropTypes.func.isRequired,
   onToggleDialog: PropTypes.func.isRequired,


### PR DESCRIPTION
### What does it do?

- Uses the `primary` variant for the confirm button
- Removes the default icon on the confirm button

### Why is it needed?

Came up during design-review during the blitz session.


