### PR TITLE
fix: fallback to window.location.href if backendURL is not defined

### DIFF
--- a/packages/core/upload/admin/src/utils/appendSearchParamsToUrl.js
+++ b/packages/core/upload/admin/src/utils/appendSearchParamsToUrl.js
@@ -10,7 +10,7 @@ const appendSearchParamsToUrl = ({ url, params }) => {
     return url;
   }
 
-  const urlObj = new URL(url, window.strapi.backendURL);
+  const urlObj = new URL(url, window.strapi.backendURL ?? window.location.origin);
 
   Object.entries(params).forEach(([key, value]) => {
     if (value !== undefined) {

--- a/packages/core/upload/admin/src/utils/tests/appendSearchParamsToUrl.test.js
+++ b/packages/core/upload/admin/src/utils/tests/appendSearchParamsToUrl.test.js
@@ -103,7 +103,7 @@ describe('appendSearchParamsToUrl', () => {
       );
     });
 
-    test("if there's no window.strapi.backendURL, it uses window.location.href", () => {
+    test("if there's no window.strapi.backendURL, it uses window.location.origin", () => {
       const oldBackendURL = window.strapi.backendURL;
       window.strapi.backendURL = undefined;
 

--- a/packages/core/upload/admin/src/utils/tests/appendSearchParamsToUrl.test.js
+++ b/packages/core/upload/admin/src/utils/tests/appendSearchParamsToUrl.test.js
@@ -102,5 +102,18 @@ describe('appendSearchParamsToUrl', () => {
         `"https://appending-search-params.com/uploads/image.jpg?param1=example1&param2=example2"`
       );
     });
+
+    test("if there's no window.strapi.backendURL, it uses window.location.href", () => {
+      const oldBackendURL = window.strapi.backendURL;
+      window.strapi.backendURL = undefined;
+
+      expect(
+        appendSearchParamsToUrl({ url, params: { updatedAt: updateTime } })
+      ).toMatchInlineSnapshot(
+        `"http://localhost:1337/uploads/image.jpg?updatedAt=2023-07-19T03%3A00%3A00.000Z"`
+      );
+
+      window.strapi.backendURL = oldBackendURL;
+    });
   });
 });


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* uses a fallback if `window.strapi.backendURL` is not defined

### Why is it needed?

* if you don't provide it, the upload plugin still crashes

### How to test it?

* there's an automated test added

### Related issue(s)/PR(s)

* relates to #17975
