### PR TITLE
fix: prevent workflow name to be reseted when CE -> EE

### DIFF
--- a/packages/core/admin/ee/server/migrations/review-workflows-workflow-name.js
+++ b/packages/core/admin/ee/server/migrations/review-workflows-workflow-name.js
@@ -3,6 +3,10 @@
 const { WORKFLOW_MODEL_UID } = require('../constants/workflows');
 const defaultWorkflow = require('../constants/default-workflow.json');
 
+/**
+ * Multiple workflows introduced the ability to name a workflow.
+ * This migration adds the default workflow name if the name attribute was added.
+ */
 async function migrateReviewWorkflowName({ oldContentTypes, contentTypes }) {
   // Look for RW name attribute
   const hadName = !!oldContentTypes?.[WORKFLOW_MODEL_UID]?.attributes?.name;
@@ -11,6 +15,9 @@ async function migrateReviewWorkflowName({ oldContentTypes, contentTypes }) {
   // Add the default workflow name if name attribute was added
   if (!hadName && hasName) {
     await strapi.query(WORKFLOW_MODEL_UID).updateMany({
+      where: {
+        name: { $null: true },
+      },
       data: {
         name: defaultWorkflow.name,
       },


### PR DESCRIPTION
Workflow name was reseted to 'Default' when upgrading to EE.

A migration file was setting the workflow names to 'Default. The workflow content type does not exist on CE , but the workflow data is persisted. So when updating to EE, the migration file always detected the new Workflow content type and so updated all workflow names to use the "Default" name.
