### PR TITLE
fix: empty url will break the admin with not an url

### DIFF
--- a/packages/core/upload/admin/src/utils/appendSearchParamsToUrl.js
+++ b/packages/core/upload/admin/src/utils/appendSearchParamsToUrl.js
@@ -10,7 +10,7 @@ const appendSearchParamsToUrl = ({ url, params }) => {
     return url;
   }
 
-  const urlObj = new URL(url, window.strapi.backendURL ?? window.location.origin);
+  const urlObj = new URL(url, window.strapi.backendURL || window.location.origin);
 
   Object.entries(params).forEach(([key, value]) => {
     if (value !== undefined) {

--- a/packages/core/upload/admin/src/utils/tests/appendSearchParamsToUrl.test.js
+++ b/packages/core/upload/admin/src/utils/tests/appendSearchParamsToUrl.test.js
@@ -103,9 +103,9 @@ describe('appendSearchParamsToUrl', () => {
       );
     });
 
-    test("if there's no window.strapi.backendURL, it uses window.location.origin", () => {
+    test.each([undefined, ''])("if there's no window.strapi.backendURL, it uses window.location.origin", (backendUrl) => {
       const oldBackendURL = window.strapi.backendURL;
-      window.strapi.backendURL = undefined;
+      window.strapi.backendURL = backendUrl;
 
       expect(
         appendSearchParamsToUrl({ url, params: { updatedAt: updateTime } })


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Fixes
- https://github.com/strapi/strapi/issues/17975
- Based on https://github.com/strapi/strapi/pull/17982
- See comment https://github.com/strapi/strapi/pull/17982/files#r1321995512

### Why is it needed?

Latest version 4.13.4 doesn't fix the disapearring admin (media library) in production (develop works)

I suspect webpack replaces empty env vars by an empty string (in development it's well undefined which was covered already). `new URL('')` is not valid.

Just replaces the `??` by `||`. Another way could be `typeof string + length check` but I feel if the linter is okay... why not

### How to test it?

```
yarn build
yarn start
```

Go to the admin an open the media library

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/issues/17975
