### PR TITLE
fix: set a fallback where we define `window.strapi.backendURL`

### DIFF
--- a/packages/core/admin/admin/src/index.js
+++ b/packages/core/admin/admin/src/index.js
@@ -8,7 +8,13 @@ import plugins from './plugins';
 import appReducers from './reducers';
 
 window.strapi = {
-  backendURL: process.env.STRAPI_ADMIN_BACKEND_URL,
+  /**
+   * This ENV variable is passed from the strapi instance, by default no url is set
+   * in the config and therefore the instance returns you an empty string so URLs are relative.
+   *
+   * To ensure that the backendURL is always set, we use the window.location.origin as a fallback.
+   */
+  backendURL: process.env.STRAPI_ADMIN_BACKEND_URL || window.location.origin,
   isEE: false,
   telemetryDisabled: process.env.STRAPI_TELEMETRY_DISABLED ?? false,
   features: {

--- a/packages/core/upload/admin/src/utils/appendSearchParamsToUrl.js
+++ b/packages/core/upload/admin/src/utils/appendSearchParamsToUrl.js
@@ -10,7 +10,7 @@ const appendSearchParamsToUrl = ({ url, params }) => {
     return url;
   }
 
-  const urlObj = new URL(url, window.strapi.backendURL ?? window.location.origin);
+  const urlObj = new URL(url, window.strapi.backendURL);
 
   Object.entries(params).forEach(([key, value]) => {
     if (value !== undefined) {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* Sets the fallback for `backendURL` at the very top where it's defined.

### Why is it needed?

The env key `STRAPI_ADMIN_BACKEND_URL` is passed as an `option` to the building script, typically this comes from the strapi instance `serverURL` from it's `sever` config, if none is set we default to an empty string to support relative URLs  – I assume, there's no documentation and the [PR](https://github.com/strapi/strapi/pull/5833) is lacking any information:
https://github.com/strapi/strapi/blob/c03a0a4a281f64796eba9ffaad88ad2bad154492/packages/core/utils/src/config.ts#L14 This is then still passed to the admin panel build (even though to support relative URLs you'd expect `undefined`).

Passing `undefined` only however then breaks `prefixFileUrlWithBackendUrl` because we "just use string concatenation" so realistically to preserve functionality we should set this higher up – where we define `window.strapi`.

This would never have shown up in local development because *surprise* the option is hardcoded and changing that to `undefined` breaks the entire admin panel because we then start trying to fetch from `localhost:4000` – which is not where our server is.

### How to test it?

* use the examples & ensure there is no `url` in `config/server` because that's how we deliver starter projects with `create-strapi-app`
