### PR TITLE
[DTS] Use schema names in custom queries

### DIFF
--- a/packages/core/data-transfer/src/strapi/queries/link.ts
+++ b/packages/core/data-transfer/src/strapi/queries/link.ts
@@ -198,7 +198,7 @@ export const createLinkQuery = (strapi: Strapi.Strapi, trx?: Knex.Transaction) =
       if (attribute.joinColumn) {
         const joinColumnName = attribute.joinColumn.name;
 
-        // Note: this addSchema may not be necessary, but it can't hurt
+        // Note: this addSchema may not be necessary, but is added for safety
         const qb = connection(addSchema(metadata.tableName))
           .where('id', left.ref)
           .update({ [joinColumnName]: right.ref });

--- a/packages/core/data-transfer/src/strapi/queries/link.ts
+++ b/packages/core/data-transfer/src/strapi/queries/link.ts
@@ -197,7 +197,9 @@ export const createLinkQuery = (strapi: Strapi.Strapi, trx?: Knex.Transaction) =
 
       if (attribute.joinColumn) {
         const joinColumnName = attribute.joinColumn.name;
-        const qb = connection(metadata.tableName)
+
+        // Note: this addSchema may not be necessary, but it can't hurt
+        const qb = connection(addSchema(metadata.tableName))
           .where('id', left.ref)
           .update({ [joinColumnName]: right.ref });
         if (trx) {

--- a/packages/core/data-transfer/src/strapi/queries/link.ts
+++ b/packages/core/data-transfer/src/strapi/queries/link.ts
@@ -8,6 +8,12 @@ export const createLinkQuery = (strapi: Strapi.Strapi, trx?: Knex.Transaction) =
   const query = () => {
     const { connection } = strapi.db;
 
+    // TODO: Export utils from database and use the addSchema that is already written
+    const addSchema = (tableName: string) => {
+      const schemaName = connection.client.connectionSettings.schema;
+      return schemaName ? `${schemaName}.${tableName}` : tableName;
+    };
+
     async function* generateAllForAttribute(uid: string, fieldName: string): AsyncGenerator<ILink> {
       const metadata = strapi.db.metadata.get(uid);
 
@@ -31,7 +37,10 @@ export const createLinkQuery = (strapi: Strapi.Strapi, trx?: Knex.Transaction) =
       if (attribute.joinColumn) {
         const joinColumnName: string = attribute.joinColumn.name;
 
-        const qb = connection.queryBuilder().select('id', joinColumnName).from(metadata.tableName);
+        const qb = connection
+          .queryBuilder()
+          .select('id', joinColumnName)
+          .from(addSchema(metadata.tableName));
 
         if (trx) {
           qb.transacting(trx);
@@ -65,7 +74,7 @@ export const createLinkQuery = (strapi: Strapi.Strapi, trx?: Knex.Transaction) =
           inverseOrderColumnName,
         } = attribute.joinTable;
 
-        const qb = connection.queryBuilder().from(name);
+        const qb = connection.queryBuilder().from(addSchema(name));
 
         type Columns = {
           left: { ref: string | null; order?: string };
@@ -253,7 +262,7 @@ export const createLinkQuery = (strapi: Strapi.Strapi, trx?: Knex.Transaction) =
 
         assignOrderColumns();
 
-        const qb = connection.insert(payload).into(name);
+        const qb = connection.insert(payload).into(addSchema(name));
         if (trx) {
           qb.transacting(trx);
         }


### PR DESCRIPTION
### What does it do?

Uses schema names for custom queries in DTS

### Why is it needed?

Using a postgres db with a custom schema and deleted 'public' schema:
- without this PR: import, export, and transfer all fail due to invalid schema reference

### How to test it?

Using a postgres db with a custom schema and deleted 'public' schema:
- with this PR: import, export, and transfer should now all work normally

Using any other database:
- with this PR: import, export, and transfer should still all work normally

### Related issue(s)/PR(s)

Fixes #16836
Specific alternate solution to the more general #18042