### PR TITLE
fix(review-workflows): make apply to all stages an iconbutton

### DIFF
--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/Stages/Stage/Stage.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/Stages/Stage/Stage.js
@@ -5,7 +5,6 @@ import {
   AccordionContent,
   AccordionToggle,
   Box,
-  Button,
   Flex,
   Grid,
   GridItem,
@@ -26,7 +25,7 @@ import {
   NotAllowedInput,
   useTracking,
 } from '@strapi/helper-plugin';
-import { Drag, More } from '@strapi/icons';
+import { Duplicate, Drag, More } from '@strapi/icons';
 import { useField } from 'formik';
 import PropTypes from 'prop-types';
 import { getEmptyImage } from 'react-dnd-html5-backend';
@@ -56,12 +55,6 @@ const PermissionWrapper = styled(Flex)`
   > * {
     flex-grow: 1;
   }
-`;
-
-// Make sure the apply to all stages button doesn't collapse, when the Select
-// contains more tags than it can fit into one line
-const ApplyToAllStages = styled(Button)`
-  flex-shrink: 0;
 `;
 
 const DeleteMenuItem = styled(MenuItem)`
@@ -482,18 +475,17 @@ export function Stage({
                       </MultiSelect>
                     </PermissionWrapper>
 
-                    <ApplyToAllStages
+                    <IconButton
                       disabled={!canUpdate}
-                      size="L"
-                      type="button"
-                      variant="secondary"
-                      onClick={() => handleApplyPermissionsToAllStages(permissionsField.value)}
-                    >
-                      {formatMessage({
+                      icon={<Duplicate />}
+                      label={formatMessage({
                         id: 'Settings.review-workflows.stage.permissions.apply.label',
                         defaultMessage: 'Apply to all stages',
                       })}
-                    </ApplyToAllStages>
+                      size="L"
+                      variant="secondary"
+                      onClick={() => handleApplyPermissionsToAllStages(permissionsField.value)}
+                    />
                   </Flex>
                 )}
               </GridItem>

--- a/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/Stages/Stage/tests/Stage.test.js
+++ b/packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/components/Stages/Stage/tests/Stage.test.js
@@ -272,7 +272,7 @@ describe('Admin | Settings | Review Workflow | Stage', () => {
       'data-disabled'
     );
 
-    expect(getByRole('button', { name: /apply to all stages/i })).toHaveAttribute('disabled');
+    expect(getByRole('button', { name: /apply to all stages/i })).toHaveAttribute('aria-disabled');
   });
 
   it('should render a list of all available roles (except super admins)', async () => {


### PR DESCRIPTION
### What does it do?

Replace the "Apply to all stages" button with an `IconButton`.

### Why is it needed?

Came up during the blitz-session design review. This is only possible since the DS@1.10.1 was released, which added support for `variant` props on `IconButton`s.

