### PR TITLE
Use schema on all table names in queryBuilder

### DIFF
--- a/packages/core/database/lib/query/query-builder.js
+++ b/packages/core/database/lib/query/query-builder.js
@@ -10,6 +10,7 @@ const { addSchema } = require('../utils/knex');
 const createQueryBuilder = (uid, db, initialState = {}) => {
   const meta = db.metadata.get(uid);
   const { tableName } = meta;
+  const tableNameWithSchema = addSchema(tableName);
 
   const state = _.defaults(
     {
@@ -297,7 +298,7 @@ const createQueryBuilder = (uid, db, initialState = {}) => {
 
       const nestedSubQuery = db.getConnection().select('id').from(subQB.as('subQuery'));
 
-      return db.getConnection(addSchema(tableName))[state.type]().whereIn('id', nestedSubQuery);
+      return db.getConnection(tableNameWithSchema)[state.type]().whereIn('id', nestedSubQuery);
     },
 
     processState() {
@@ -345,8 +346,8 @@ const createQueryBuilder = (uid, db, initialState = {}) => {
       }
 
       const aliasedTableName = this.mustUseAlias()
-        ? `${tableName} as ${this.alias}`
-        : addSchema(tableName);
+        ? `${tableNameWithSchema} as ${this.alias}`
+        : tableNameWithSchema;
 
       const qb = db.getConnection(aliasedTableName);
 

--- a/packages/core/database/lib/query/query-builder.js
+++ b/packages/core/database/lib/query/query-builder.js
@@ -9,8 +9,7 @@ const { addSchema } = require('../utils/knex');
 
 const createQueryBuilder = (uid, db, initialState = {}) => {
   const meta = db.metadata.get(uid);
-  const { tableName } = meta;
-  const tableNameWithSchema = addSchema(tableName);
+  const tableNameWithSchema = addSchema(meta.tableName);
 
   const state = _.defaults(
     {

--- a/packages/core/database/lib/query/query-builder.js
+++ b/packages/core/database/lib/query/query-builder.js
@@ -5,6 +5,7 @@ const _ = require('lodash/fp');
 const { DatabaseError } = require('../errors');
 const helpers = require('./helpers');
 const transactionCtx = require('../transaction-context');
+const { addSchema } = require('../utils/knex');
 
 const createQueryBuilder = (uid, db, initialState = {}) => {
   const meta = db.metadata.get(uid);
@@ -296,7 +297,7 @@ const createQueryBuilder = (uid, db, initialState = {}) => {
 
       const nestedSubQuery = db.getConnection().select('id').from(subQB.as('subQuery'));
 
-      return db.getConnection(tableName)[state.type]().whereIn('id', nestedSubQuery);
+      return db.getConnection(addSchema(tableName))[state.type]().whereIn('id', nestedSubQuery);
     },
 
     processState() {
@@ -343,7 +344,9 @@ const createQueryBuilder = (uid, db, initialState = {}) => {
         this.select('*');
       }
 
-      const aliasedTableName = this.mustUseAlias() ? `${tableName} as ${this.alias}` : tableName;
+      const aliasedTableName = this.mustUseAlias()
+        ? `${tableName} as ${this.alias}`
+        : addSchema(tableName);
 
       const qb = db.getConnection(aliasedTableName);
 


### PR DESCRIPTION
### What does it do?

Adds the schema name to table name before each knex query and subquery.

### Why is it needed?

WIthout it, anything using the query builder needs to be aware of the schema and manually add the schema name.

Alternative: export addSchema so it's at least easier 

### How to test it?

WIth a postgres database with a schema other than 'public' and the 'public' schema deleted:
- build and run a query that includes a join, such as `connection.queryBuilder().select('id', joinColumnName).from(tableName)`
- without this PR:  it will fail, because it is attempting to join the public schema (which doesn't exist)
- with the PR: it will work, because now the join is including the schema name

### Related issue(s)/PR(s)

General solution for #18042 which fixes only a specific instance of the issue

Fixes https://github.com/strapi/strapi/issues/16836

a couple other issues I've seen in the past that were fixed in place rather than at the source, but couldn't find
