### PR TITLE
Migrate stages into RBAC versions

### DIFF
--- a/packages/core/admin/ee/server/migrations/review-workflows-stages-roles.js
+++ b/packages/core/admin/ee/server/migrations/review-workflows-stages-roles.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const { STAGE_TRANSITION_UID, STAGE_MODEL_UID } = require('../constants/workflows');
+const { getService } = require('../utils');
+
+async function migrateReviewWorkflowStagesRoles({ oldContentTypes, contentTypes }) {
+  const stageUID = 'admin::workflow-stage';
+  const hadRolePermissions = !!oldContentTypes?.[stageUID]?.attributes?.permissions;
+  const hasRolePermissions = !!contentTypes?.[stageUID]?.attributes?.permissions;
+
+  // If the stage content type did not have permissions in the previous version
+  // then we set the permissions of every stage to be every current role in the app.
+  // This ensures consistent behaviour when upgrading to a strapi version with review workflows RBAC.
+  if (!hadRolePermissions && hasRolePermissions) {
+    const stagePermissionsService = getService('stage-permissions');
+
+    const stages = await strapi.query(stageUID).findMany();
+    const roles = await strapi.query('admin::role').findMany();
+
+    // Collect the permissions to add and group them by stage id.
+    const groupedPermissions = {};
+    roles
+      .map((role) => role.id)
+      .forEach((id) => {
+        stages
+          .map((stage) => stage.id)
+          .forEach((stageId) => {
+            if (!groupedPermissions[stageId]) {
+              groupedPermissions[stageId] = [];
+            }
+
+            groupedPermissions[stageId].push({
+              roleId: id,
+              fromStage: stageId,
+              action: STAGE_TRANSITION_UID,
+            });
+          });
+      });
+
+    for (const [stageId, permissions] of Object.entries(groupedPermissions)) {
+      // Register the permissions for this stage
+      const stagePermissions = await stagePermissionsService.registerMany(permissions);
+
+      // Update the stage with its new permissions
+      await strapi.entityService.update(STAGE_MODEL_UID, Number(stageId), {
+        data: {
+          permissions: stagePermissions.flat().map((p) => p.id),
+        },
+      });
+    }
+  }
+}
+
+module.exports = migrateReviewWorkflowStagesRoles;

--- a/packages/core/admin/ee/server/register.js
+++ b/packages/core/admin/ee/server/register.js
@@ -4,6 +4,7 @@ const { features } = require('@strapi/strapi/lib/utils/ee');
 const executeCERegister = require('../../server/register');
 const migrateAuditLogsTable = require('./migrations/audit-logs-table');
 const migrateReviewWorkflowStagesColor = require('./migrations/review-workflows-stages-color');
+const migrateReviewWorkflowStagesRoles = require('./migrations/review-workflows-stages-roles');
 const migrateReviewWorkflowName = require('./migrations/review-workflows-workflow-name');
 const migrateWorkflowsContentTypes = require('./migrations/review-workflows-content-types');
 const migrateStageAttribute = require('./migrations/review-workflows-stage-attribute');
@@ -26,6 +27,7 @@ module.exports = async ({ strapi }) => {
     strapi
       .hook('strapi::content-types.afterSync')
       .register(migrateReviewWorkflowStagesColor)
+      .register(migrateReviewWorkflowStagesRoles)
       .register(migrateReviewWorkflowName)
       .register(migrateWorkflowsContentTypes)
       .register(migrateDeletedCTInWorkflows);

--- a/packages/core/admin/ee/server/services/review-workflows/stage-permissions.js
+++ b/packages/core/admin/ee/server/services/review-workflows/stage-permissions.js
@@ -15,7 +15,7 @@ module.exports = ({ strapi }) => {
   const permissionService = getService('permission');
 
   return {
-    async register(roleId, action, fromStage) {
+    async register({ roleId, action, fromStage }) {
       if (!validActions.includes(action)) {
         throw new ApplicationError(`Invalid action ${action}`);
       }

--- a/packages/core/admin/ee/server/services/review-workflows/stages.js
+++ b/packages/core/admin/ee/server/services/review-workflows/stages.js
@@ -61,7 +61,11 @@ module.exports = ({ strapi }) => {
           stagePermissions,
           // Register each stage permission
           (permission) =>
-            stagePermissionsService.register(permission.role, permission.action, stageId)
+            stagePermissionsService.register({
+              roleId: permission.role,
+              action: permission.action,
+              fromStage: stageId,
+            })
         );
 
         // Update stage with the new permissions
@@ -85,7 +89,11 @@ module.exports = ({ strapi }) => {
         await this.deleteStagePermissions([srcStage]);
 
         const permissions = await mapAsync(destStage.permissions, (permission) =>
-          stagePermissionsService.register(permission.role, permission.action, stageId)
+          stagePermissionsService.register({
+            roleId: permission.role,
+            action: permission.action,
+            fromStage: stageId,
+          })
         );
         stagePermissions = permissions.flat().map((p) => p.id);
       }


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Adds a migration that migrates all existing review workflow stages to have RBAC permissions for all admin roles.

### Why is it needed?

So that if you're coming from a version before RBAC for review workflow stages the apps behaviour is consistent. e.g. any role can still update any stage of any workflow.

### How to test it?

- Roll back to a version pre RW RBAC stages (e.g. currently `main`)
- Build and run the app
- Set up some workflows and stages etc
- Roll forward to this branch
- Build and run the app
- Verify that the migration is run (see logs) and that all stages of every workflow in the UI have every role applied to their RBAC permissions

e.g.
<img width="1098" alt="image" src="https://github.com/strapi/strapi/assets/48524071/fbdc0bb5-08b5-4d85-a98a-24d44af32cc1">

### Related issue(s)/PR(s)

CONTENT-1856
