### PR TITLE
chore(docs): extend contributor docs by RBAC for stages

### DIFF
--- a/docs/docs/docs/01-core/admin/01-ee/01-review-workflows.md
+++ b/docs/docs/docs/01-core/admin/01-ee/01-review-workflows.md
@@ -113,6 +113,10 @@ This route updates the stages associated with a specific workflow identified by 
 
 This route updates the stage of a specific entity identified by the id parameter and belonging to a specific collection identified by the model_uid parameter. The new stage value is passed in the request body.
 
+#### GET `/content-manager/(collection|single)-types/:model_uid/:id/stages`
+
+Returns a list of stages that a user has permission to transition into (based on the permission settings of a stage).
+
 ### Services
 
 The Review Workflow feature of the Enterprise Edition includes several services to manipulate workflows and stages. Here is a list of those services:

--- a/docs/docs/docs/01-core/admin/01-ee/01-review-workflows.md
+++ b/docs/docs/docs/01-core/admin/01-ee/01-review-workflows.md
@@ -29,6 +29,7 @@ This code is separated into several elements:
 - Controllers
   - _workflows_: `packages/core/admin/ee/server/controllers/workflows/index.js`
   - _stages_: `packages/core/admin/ee/server/controllers/workflows/stages/index.js`
+  - _assignees_: `packages/core/admin/ee/server/controllers/workflows/assignees/index.js`
 - Middlewares
   - [_DEPRECATED_] _contentTypeMiddleware_: `packages/core/admin/ee/server/middlewares/review-workflows.js`
 - Routes
@@ -38,7 +39,10 @@ This code is separated into several elements:
   - _workflows_: `packages/core/admin/ee/server/services/review-workflows/workflows.js`
   - _stages_: `packages/core/admin/ee/server/services/review-workflows/stages.js`
   - _metrics_: `packages/core/admin/ee/server/services/review-workflows/metrics.js`
+  - _weekly-metrics_: `packages/core/admin/ee/server/services/review-workflows/weekly-metrics.js`
   - _validation_: `packages/core/admin/ee/server/services/review-workflows/validation.js`
+  - _assignees_: `packages/core/admin/ee/server/services/review-workflows/assignees.js`
+  - _stage-permissions_: `packages/core/admin/ee/server/services/review-workflows/stage-permissions.js`
 - Decorators
   - _EntityService_ decorator: `packages/core/admin/ee/server/services/review-workflows/entity-service-decorator.js`
 - Utils file
@@ -66,6 +70,10 @@ Used to interact with the `strapi_workflows` content-type.
 #### stages
 
 Used to interact with the `strapi_workflows_stages` content-type.
+
+#### assignees
+
+Used to interact with the `admin_users` content-type entities related to review workflow enabled content types.
 
 ### Middlewares
 
@@ -117,6 +125,10 @@ This route updates the stage of a specific entity identified by the id parameter
 
 Returns a list of stages that a user has permission to transition into (based on the permission settings of a stage).
 
+#### PUT `/content-manager/(collection|single)-types/:model_uid/:id/assignee`
+
+This route updates the assignee of the entity identified by the model_uid and id parameters. The updated entity is passed to the request body.
+
 ### Services
 
 The Review Workflow feature of the Enterprise Edition includes several services to manipulate workflows and stages. Here is a list of those services:
@@ -136,6 +148,18 @@ This service is used to manipulate the stages entities and to update stages on o
 #### metrics
 
 This is the telemetry service used to gather information on the usage of this feature. It provides information on the number of workflows and stages created, as well as the frequency of stage updates on entities.
+
+#### weekly-metrics
+
+Once a week we report on review workflows usage statistic. This service is used to set up the cron job responsible for gathering and sending statistics on: number of active workflows, average number of stages in a workflow, maximum number of stages across all workflows and the content types on which review workflows is activated.
+
+#### assignees
+
+This service is used to interact with admin user assignee relations on review workflow enabled content types. It provides the ability to: find the Id of an entity assignee, update and delete (unassign) the assignee on an entity.
+
+#### stage-permissions
+
+This service is used to enable RBAC functionality for review workflow stages. Each entry of the `strapi_workflows_stages` has a manyToMany relation with `admin_permissions`. The permissions held in this relation indicate which roles can change the review stage of an entry in this stage. The service provides the ability to: register and unregister new stage permissions based on stage and role Ids and to find out whether a role can transition from a given stage.
 
 #### validation
 

--- a/docs/docs/docs/01-core/admin/03-settings/01-review-workflows.mdx
+++ b/docs/docs/docs/01-core/admin/03-settings/01-review-workflows.mdx
@@ -50,6 +50,12 @@ attribute will be re-ordered and not created.
 
 Stages without an `id` property will be created in the database on submission. Stages that existed already, but are not submitted again will be deleted on submission.
 
+When editing a workflow and the `permissions` of a stage have not been modified by a user, they are sent as `undefined`. This special case allows users to edit a workflow without having to have
+permissions to read `roles`, because the API won't update anything in the database.
+
+Users without read permissions for roles are able to create workflows, but they will not be able to define which roles can change a stage, so that stages of that workflow can only be changed
+by the super-admin unless the roles are set.
+
 ### Edit view
 
 Displays a license-limits modal in case the user is above the license limit on page load and upon form submission.
@@ -74,10 +80,28 @@ hooks returns a partial react-query result.
 
 ```ts
 useReviewWorkflows(queryParams: object): {
-  meta: { workflowCount: int }
+  meta: { workflowCount: number }
   workflows: Workflow[],
   isLoading: boolean,
   status: string,
+  refetch: () => Promise<void>,
+}
+```
+
+#### `useReviewWorkflowsStages({ id, layout }, reactQueryOptions)`
+
+This hook allows to fetch stages for a given workflow, that a user has permissions to transition to.
+
+```ts
+type ContentTypeLayout {
+  uid: string;
+  kind: 'collectionType' | 'singleType';
+}
+
+useReviewWorkflowsStages({ id: number, layout: ContentTypeLayout }, reactQueryOptions): {
+  meta: { workflowCount: number, stagesCount: number }
+  stages: Stage[],
+  isLoading: boolean,
   refetch: () => Promise<void>,
 }
 ```
@@ -89,6 +113,7 @@ type Stage {
     id: number;
     color: string; // hex code
     name: string; // max-length: 255 characters
+    permissions: Permission[];
     createdAt: Date;
     updatedAt: Date;
 }

--- a/docs/docs/docs/01-core/content-manager/02-review-workflows.mdx
+++ b/docs/docs/docs/01-core/content-manager/02-review-workflows.mdx
@@ -8,7 +8,7 @@ tags:
 
 ## Summary
 
-Review workflows are disabled for all content-types by default and have to be enabled for each of them individually. More about how to 
+Review workflows are disabled for all content-types by default and have to be enabled for each of them individually. More about how to
 [enable review-workflows for a content-type](/docs/settings/review-workflows#edit--create-view). The feature itself is visible in two places
 of the content-manager: list and edit view.
 
@@ -37,18 +37,17 @@ Please refer to the [type definitions](/settings/review-workflows) for more info
 **Note**: Downgrading from EE to CE won't delete the associated review workflow data and `http://localhost:1337/content-manager/content-types` still returns true. The admin app had to
 add an additional check if the feature toggle returned in `http://localhost:1337/admin/project-type` is enabled.
 
-
 ### Edit view
 
 If the feature is enabled on the current content-type, the selected stage will show up in the information sidebar next to the edit view. Users
-can select any other stage of the current workflow.
+can select any other stage of the current workflow provided they have the necessary permissions to change the current stage see [EE Review Workflows](../admin/01-ee/01-review-workflows.md).
 
 Stage assignments are decoupled from entities, meaning updating entity attributes won't set the selected stage at the same time. Instead the stage select
 component will trigger an atomic update on the admin API to assign/ update a stage to the current entity.
 
 Because of this decoupling, stages **can not be assigned on entity creation** and only after they have been created.
 
-The information which stage is currently assigned to an entity is send as part of the entity response payload in the attribute `strapi_stage`.
+Information about which stage is currently assigned to an entity is sent as part of the entity response payload in the attribute `strapi_stage`.
 Please refer to the [type definitions](/settings/review-workflows) for more information.
 
 ```ts


### PR DESCRIPTION
### What does it do?

Extends contributor docs by RBAC for stages.

### Why is it needed?

Having complete docs is good.

