### PR TITLE
Fix RBAC provider single child expectation

### DIFF
--- a/packages/core/admin/admin/src/components/RBACProvider/index.js
+++ b/packages/core/admin/admin/src/components/RBACProvider/index.js
@@ -31,7 +31,7 @@ const RBACProvider = ({ children, permissions, refetchPermissions }) => {
 };
 
 RBACProvider.propTypes = {
-  children: PropTypes.element.isRequired,
+  children: PropTypes.node.isRequired,
   permissions: PropTypes.array.isRequired,
   refetchPermissions: PropTypes.func.isRequired,
 };


### PR DESCRIPTION
### What does it do?

Adds a fragment in the RBACProvider

### Why is it needed?

The provider expects a single child:

```
react.development.js:209 Warning: Failed prop type: Invalid prop `children` of type `array` supplied to `RBACProvider`, expected a single ReactElement.
    at RBACProvider
```

### How to test it?

- Go to a page like: /admin/settings/application-infos

There should be no error in the console for the invalid prop

