### PR TITLE
tests(user-permissions): add default messages for form errors

### DIFF
--- a/packages/plugins/users-permissions/admin/src/pages/Roles/pages/CreatePage.js
+++ b/packages/plugins/users-permissions/admin/src/pages/Roles/pages/CreatePage.js
@@ -145,7 +145,11 @@ export const CreatePage = () => {
                           id: 'global.name',
                           defaultMessage: 'Name',
                         })}
-                        error={errors?.name ? formatMessage({ id: errors.name }) : false}
+                        error={
+                          errors?.name
+                            ? formatMessage({ id: errors.name, defaultMessage: 'Name is required' })
+                            : false
+                        }
                         required
                       />
                     </GridItem>
@@ -159,7 +163,12 @@ export const CreatePage = () => {
                           defaultMessage: 'Description',
                         })}
                         error={
-                          errors?.description ? formatMessage({ id: errors.description }) : false
+                          errors?.description
+                            ? formatMessage({
+                                id: errors.description,
+                                defaultMessage: 'Description is required',
+                              })
+                            : false
                         }
                         required
                       />

--- a/packages/plugins/users-permissions/admin/src/pages/Roles/pages/EditPage.js
+++ b/packages/plugins/users-permissions/admin/src/pages/Roles/pages/EditPage.js
@@ -166,7 +166,11 @@ export const EditPage = () => {
                           id: 'global.name',
                           defaultMessage: 'Name',
                         })}
-                        error={errors?.name ? formatMessage({ id: errors.name }) : false}
+                        error={
+                          errors?.name
+                            ? formatMessage({ id: errors.name, defaultMessage: 'Name is required' })
+                            : false
+                        }
                         required
                       />
                     </GridItem>
@@ -180,7 +184,12 @@ export const EditPage = () => {
                           defaultMessage: 'Description',
                         })}
                         error={
-                          errors?.description ? formatMessage({ id: errors.description }) : false
+                          errors?.description
+                            ? formatMessage({
+                                id: errors.description,
+                                defaultMessage: 'Description is required',
+                              })
+                            : false
                         }
                         required
                       />


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* Adds default messages to the form errors.

### Why is it needed?

* We currently don't supply any messages to our IntlProvider in tests so when there's no defaultMessage it warns us the id will be used instead polluting the console.

### Related issue(s)/PR(s)

* part of #17924
