### PR TITLE
[Fix] Fix the content Type Dialog problem with the Grid elements in Safari

### DIFF
--- a/packages/core/content-type-builder/admin/src/components/AttributeOptions/AttributeList/index.js
+++ b/packages/core/content-type-builder/admin/src/components/AttributeOptions/AttributeList/index.js
@@ -17,7 +17,7 @@ const AttributeList = ({ attributes }) => (
               const { paddingLeft, paddingRight } = getPadding(index);
 
               return (
-                <GridItem key={attribute} col={6} style={{ height: '100%' }}>
+                <GridItem key={attribute} col={6}>
                   <Box
                     paddingLeft={paddingLeft}
                     paddingRight={paddingRight}

--- a/packages/core/content-type-builder/admin/src/components/AttributeOptions/tests/__snapshots__/index.test.js.snap
+++ b/packages/core/content-type-builder/admin/src/components/AttributeOptions/tests/__snapshots__/index.test.js.snap
@@ -287,7 +287,6 @@ exports[`<AttributeOptions /> renders and matches the snapshot 1`] = `
               >
                 <div
                   class="c15"
-                  style="height: 100%;"
                 >
                   <div
                     class="c16"
@@ -355,7 +354,6 @@ exports[`<AttributeOptions /> renders and matches the snapshot 1`] = `
                 </div>
                 <div
                   class="c15"
-                  style="height: 100%;"
                 >
                   <div
                     class="c25"
@@ -423,7 +421,6 @@ exports[`<AttributeOptions /> renders and matches the snapshot 1`] = `
                 </div>
                 <div
                   class="c15"
-                  style="height: 100%;"
                 >
                   <div
                     class="c16"
@@ -493,7 +490,6 @@ exports[`<AttributeOptions /> renders and matches the snapshot 1`] = `
                 </div>
                 <div
                   class="c15"
-                  style="height: 100%;"
                 >
                   <div
                     class="c25"
@@ -557,7 +553,6 @@ exports[`<AttributeOptions /> renders and matches the snapshot 1`] = `
                 </div>
                 <div
                   class="c15"
-                  style="height: 100%;"
                 >
                   <div
                     class="c16"
@@ -625,7 +620,6 @@ exports[`<AttributeOptions /> renders and matches the snapshot 1`] = `
                 </div>
                 <div
                   class="c15"
-                  style="height: 100%;"
                 >
                   <div
                     class="c25"
@@ -695,7 +689,6 @@ exports[`<AttributeOptions /> renders and matches the snapshot 1`] = `
                 </div>
                 <div
                   class="c15"
-                  style="height: 100%;"
                 >
                   <div
                     class="c16"
@@ -761,7 +754,6 @@ exports[`<AttributeOptions /> renders and matches the snapshot 1`] = `
                 </div>
                 <div
                   class="c15"
-                  style="height: 100%;"
                 >
                   <div
                     class="c25"
@@ -831,7 +823,6 @@ exports[`<AttributeOptions /> renders and matches the snapshot 1`] = `
                 </div>
                 <div
                   class="c15"
-                  style="height: 100%;"
                 >
                   <div
                     class="c16"
@@ -899,7 +890,6 @@ exports[`<AttributeOptions /> renders and matches the snapshot 1`] = `
                 </div>
                 <div
                   class="c15"
-                  style="height: 100%;"
                 >
                   <div
                     class="c25"
@@ -969,7 +959,6 @@ exports[`<AttributeOptions /> renders and matches the snapshot 1`] = `
                 </div>
                 <div
                   class="c15"
-                  style="height: 100%;"
                 >
                   <div
                     class="c16"
@@ -1035,7 +1024,6 @@ exports[`<AttributeOptions /> renders and matches the snapshot 1`] = `
                 </div>
                 <div
                   class="c15"
-                  style="height: 100%;"
                 >
                   <div
                     class="c25"
@@ -1103,7 +1091,6 @@ exports[`<AttributeOptions /> renders and matches the snapshot 1`] = `
               >
                 <div
                   class="c15"
-                  style="height: 100%;"
                 >
                   <div
                     class="c16"
@@ -1177,7 +1164,6 @@ exports[`<AttributeOptions /> renders and matches the snapshot 1`] = `
                 </div>
                 <div
                   class="c15"
-                  style="height: 100%;"
                 >
                   <div
                     class="c25"


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

It removes an inline style that gave some problems in Safari, in the Dialog of the Content Type Builder.

### Why is it needed?

Because there is a wrong height of the last two grid elements in the grid as you can see in this picture
https://user-images.githubusercontent.com/9023312/258780045-09354681-e9be-49c2-a3e9-70f2e74fa994.png
And this cause a problem with the Relation and UID content type buttons, they are not clickable

### How to test it?

- Use Safari browser
- Go to Content Type Builder plugin
- Click on Add another field button of existing CT
- Scroll down to the end of the content type list
- Try to click on either Relation or UID

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/issues/17591