### PR TITLE
[blocks]: Quote option added

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/index.js
@@ -11,6 +11,7 @@ import {
   Code,
   BulletList,
   NumberList,
+  Quote,
   /**
    * TODO: add the rest of the icons when the DS will be released
    Paragraph,
@@ -319,6 +320,14 @@ const blockItems = {
     value: {
       type: 'heading',
       level: 6,
+    },
+  },
+  quote: {
+    name: 'quote',
+    icon: Quote,
+    label: { id: 'components.Blocks.blocks.quote', defaultMessage: 'Quote' },
+    value: {
+      type: 'quote',
     },
   },
 };

--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/tests/index.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/tests/index.test.js
@@ -13,7 +13,12 @@ import { BlocksToolbar } from '..';
 const initialValue = [
   {
     type: 'paragraph',
-    children: [{ text: 'A line of text in a paragraph.' }],
+    children: [
+      {
+        type: 'text',
+        text: 'A line of text in a paragraph.',
+      },
+    ],
   },
 ];
 
@@ -77,14 +82,17 @@ describe('BlocksEditor toolbar', () => {
         type: 'paragraph',
         children: [
           {
+            type: 'text',
             text: 'A ',
           },
           {
+            type: 'text',
             text: 'line of text',
             bold: true,
             italic: true,
           },
           {
+            type: 'text',
             text: ' in a paragraph.',
           },
         ],
@@ -134,6 +142,7 @@ describe('BlocksEditor toolbar', () => {
             type: 'list-item',
             children: [
               {
+                type: 'text',
                 text: 'A line of text in a paragraph.',
               },
             ],
@@ -161,6 +170,7 @@ describe('BlocksEditor toolbar', () => {
         level: 1,
         children: [
           {
+            type: 'text',
             text: 'A line of text in a paragraph.',
           },
         ],
@@ -176,6 +186,7 @@ describe('BlocksEditor toolbar', () => {
         type: 'paragraph',
         children: [
           {
+            type: 'text',
             text: 'A line of text in a paragraph.',
           },
         ],
@@ -201,6 +212,7 @@ describe('BlocksEditor toolbar', () => {
         type: 'quote',
         children: [
           {
+            type: 'text',
             text: 'A line of text in a paragraph.',
           },
         ],
@@ -216,6 +228,7 @@ describe('BlocksEditor toolbar', () => {
         type: 'paragraph',
         children: [
           {
+            type: 'text',
             text: 'A line of text in a paragraph.',
           },
         ],

--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/tests/index.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/tests/index.test.js
@@ -182,4 +182,44 @@ describe('BlocksEditor toolbar', () => {
       },
     ]);
   });
+
+  it('transforms the selection to a quote when selected and trasforms it back to text when selected again', async () => {
+    setup();
+
+    const headingsDropdown = screen.getByRole('combobox', { name: /Select a block/i });
+
+    Transforms.setSelection(baseEditor, {
+      anchor: { path: [0, 0], offset: 0 },
+    });
+
+    await user.click(headingsDropdown);
+
+    await user.click(screen.getByRole('option', { name: 'Quote' }));
+
+    expect(baseEditor.children).toEqual([
+      {
+        type: 'quote',
+        children: [
+          {
+            text: 'A line of text in a paragraph.',
+          },
+        ],
+      },
+    ]);
+
+    await user.click(headingsDropdown);
+
+    await user.click(screen.getByRole('option', { name: 'Text' }));
+
+    expect(baseEditor.children).toEqual([
+      {
+        type: 'paragraph',
+        children: [
+          {
+            text: 'A line of text in a paragraph.',
+          },
+        ],
+      },
+    ]);
+  });
 });

--- a/packages/core/admin/admin/src/translations/en.json
+++ b/packages/core/admin/admin/src/translations/en.json
@@ -634,6 +634,7 @@
   "components.Blocks.blocks.heading4": "Heading 4",
   "components.Blocks.blocks.heading5": "Heading 5",
   "components.Blocks.blocks.heading6": "Heading 6",
+  "components.Blocks.blocks.quote": "Quote",
   "components.Blocks.blocks.unorderedList": "Unordered list",
   "components.Blocks.blocks.orderedList": "Ordered list",
   "components.Wysiwyg.ToggleMode.markdown-mode": "Markdown mode",


### PR DESCRIPTION
### What does it do?

Quote option added with test case

### How to test it?

User should be able to select a quote option from the dropdown to convert text to block quote

