### PR TITLE
[fix] usage of server url

### DIFF
--- a/packages/core/strapi/src/core/bootstrap.ts
+++ b/packages/core/strapi/src/core/bootstrap.ts
@@ -6,10 +6,11 @@ export default async function bootstrap({ strapi }: { strapi: Strapi }) {
   strapi.config.port = strapi.config.get('server.port') || strapi.config.port;
   strapi.config.host = strapi.config.get('server.host') || strapi.config.host;
 
-  const { serverUrl, adminUrl, adminPath } = getConfigUrls(strapi.config);
+  const { serverUrl, serverPath, adminUrl, adminPath } = getConfigUrls(strapi.config);
 
   strapi.config.server = strapi.config.server || {};
   strapi.config.server.url = serverUrl;
+  strapi.config.server.path = serverPath;
   strapi.config.admin.url = adminUrl;
   strapi.config.admin.path = adminPath;
 

--- a/packages/core/strapi/src/services/server/api.ts
+++ b/packages/core/strapi/src/services/server/api.ts
@@ -1,4 +1,5 @@
 import Router from '@koa/router';
+import { getConfigUrls } from '@strapi/utils';
 import type { Strapi, Common } from '@strapi/types';
 
 import { createRouteManager } from './routing';
@@ -10,8 +11,9 @@ interface Options {
 
 const createAPI = (strapi: Strapi, opts: Options = {}) => {
   const { prefix, type } = opts;
+  const { serverPath } = getConfigUrls(strapi.config);
 
-  const api = new Router({ prefix });
+  const api = new Router({ prefix: `${serverPath}${prefix}` });
 
   const routeManager = createRouteManager(strapi, { type });
 

--- a/packages/core/strapi/src/services/server/index.ts
+++ b/packages/core/strapi/src/services/server/index.ts
@@ -1,4 +1,5 @@
 import Router from '@koa/router';
+import { getConfigUrls } from '@strapi/utils';
 import type { Strapi, Common, Server } from '@strapi/types';
 
 import { createHTTPServer } from './http-server';
@@ -20,6 +21,7 @@ const createServer = (strapi: Strapi): Server => {
     proxy: strapi.config.get('server.proxy'),
     keys: strapi.config.get('server.app.keys'),
   });
+  const { serverPath } = getConfigUrls(strapi.config);
 
   app.use((ctx, next) => requestCtx.run(ctx, () => next()));
 
@@ -35,7 +37,7 @@ const createServer = (strapi: Strapi): Server => {
   };
 
   // init health check
-  router.all('/_health', healthCheck);
+  router.all(`${serverPath}/_health`, healthCheck);
 
   const state = {
     mounted: false,

--- a/packages/core/utils/src/config.ts
+++ b/packages/core/utils/src/config.ts
@@ -28,6 +28,12 @@ export const getConfigUrls = (config: Config, forAdminBuild = false) => {
     serverUrl = `/${serverUrl}`;
   }
 
+  // Defines serverPath value
+  let serverPath = serverUrl;
+  if (serverUrl.startsWith('http')) {
+    serverPath = new URL(serverUrl).pathname;
+  }
+
   // Defines adminUrl value
   let adminUrl = _.get(adminConfig, 'url', '/admin');
   adminUrl = _.trim(adminUrl, '/ ');
@@ -60,6 +66,7 @@ export const getConfigUrls = (config: Config, forAdminBuild = false) => {
 
   return {
     serverUrl,
+    serverPath,
     adminUrl,
     adminPath,
   };


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

This PR fixes usage of `server.url` config value. Currently setting url for server will broke strapi admin dashboard

### How to test it?

1. Create new project via `npx create-strapi-app@latest test-project`
2. Change server url in file: `config/server.js` like: `url: '/test',`
3. Build and start strapi server: `yarn build && yarn develop`