### PR TITLE
feat: check if a typo has been made in the filename

### DIFF
--- a/packages/core/strapi/lib/core/loaders/plugins/get-user-plugins-config.js
+++ b/packages/core/strapi/lib/core/loaders/plugins/get-user-plugins-config.js
@@ -13,6 +13,9 @@ const loadConfigFile = require('../../app-configuration/load-config-file');
  */
 const getUserPluginsConfig = async () => {
   const globalUserConfigPath = join(strapi.dirs.dist.config, 'plugins.js');
+  // Check if the user has a `plugin.js` or `plugin.ts` file instead of the correct `plugins.js` or `plugins.ts` filename
+  const incorrectGlobalUserConfigPath =
+    join(strapi.dirs.dist.config, 'plugin.js') ?? join(strapi.dirs.dist.config, 'plugin.ts');
   const currentEnvUserConfigPath = join(
     strapi.dirs.dist.config,
     'env',
@@ -20,6 +23,12 @@ const getUserPluginsConfig = async () => {
     'plugins.js'
   );
   let config = {};
+
+  if (await fse.pathExists(incorrectGlobalUserConfigPath)) {
+    console.warn(
+      `Warning: Detected 'plugin.js' or 'plugin.ts' file in your config folder. Please rename it to 'plugins.js' or 'plugins.ts'`
+    );
+  }
 
   // assign global user config if exists
   if (await fse.pathExists(globalUserConfigPath)) {


### PR DESCRIPTION
### What does it do?

Simple check for the plugins' config file to avoid having plugin.ts/js instead of plugins.js/ts.

### Why is it needed?

Warn the user if there's a typo in the filename.

### How to test it?

Create plugin.ts or plugin.js instead of plugins.js or ts.

### Related issue(s)/PR(s)

Related to issue : https://github.com/strapi/strapi/issues/17868
