### PR TITLE
fix(content-manager): add optional chaining because listRef may not have a node attached

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/RelationInput/RelationInput.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInput/RelationInput.js
@@ -196,13 +196,13 @@ const RelationInput = ({
       updatedRelationsWith.current === 'onChange' &&
       relations.length !== previewRelationsLength
     ) {
-      listRef.current.scrollToItem(relations.length, 'end');
+      listRef.current?.scrollToItem(relations.length, 'end');
       updatedRelationsWith.current = undefined;
     } else if (
       updatedRelationsWith.current === 'loadMore' &&
       relations.length !== previewRelationsLength
     ) {
-      listRef.current.scrollToItem(0, 'start');
+      listRef.current?.scrollToItem(0, 'start');
       updatedRelationsWith.current = undefined;
     }
   }, [previewRelationsLength, relations]);


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* adds optional chaining to `listRef.current` because the ref will not always have a node attached.

### Why is it needed?

* avoids accessing a function on `undefined | null`

### Related issue(s)/PR(s)

* resolves #18025
