### PR TITLE
fix(admin): handle windows paths in plugins.js

### DIFF
--- a/packages/core/admin/utils/plugins.js
+++ b/packages/core/admin/utils/plugins.js
@@ -118,7 +118,7 @@ const filterPluginsByAdminEntry = (plugin) => {
         pathToPlugin = pathToPlugin.split(path.sep).join(path.posix.sep);
       }
 
-      const isModuleWithFE = require.resolve(`${packageName}/strapi-admin`);
+      const isModuleWithFE = require.resolve(`${pathToPlugin}/strapi-admin`);
 
       return isModuleWithFE;
     }


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Fixes plugin module paths on windows systems.

### Why is it needed?

Windows operating system uses \ as path separator. It is also escaped by \ making pathToPlugin something like `@strapi\\plugin-color-picker`

Using that path in module resolution fails when plugin is using "exports" package entry points in package.json.
"exports" entry points use posix style / separator.

Currently @strapi/plugin-color-picker doesn't work on Windows because it changed from using "strapi-admin.js" file to using exports entry points in package.json in 4.13.6.

See issue #18070 

### How to test it?

```
yarn create strapi-app colorpickertest --quickstart --ts --no-run
cd colorpickertest
yarn add @strapi/plugin-color-picker
yarn build
yarn develop
```

On Windows (without fix) .cache/admin/src/plugins.js won't have the plugins that use "exports" entry points in their package.json

### Related issue(s)/PR(s)

* resolves #18070
