### PR TITLE
fix(core): Revert plugin property on CustomFieldServerOptions

### DIFF
--- a/packages/core/strapi/lib/types/core/strapi/index.d.ts
+++ b/packages/core/strapi/lib/types/core/strapi/index.d.ts
@@ -11,7 +11,7 @@ interface CustomFieldServerOptions {
   /**
    * The name of the plugin creating the custom field
    */
-  pluginId?: string;
+  plugin?: string;
 
   /**
    * The existing Strapi data type the custom field uses


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

PR #17747 renamed the property `plugin` to `pluginId` on `CustomFieldServerOptions` types on the core lib.

https://github.com/strapi/strapi/blob/9756cafa000a3cb2e15702b1f73ccaf1af22bf82/packages/core/strapi/lib/types/core/strapi/index.d.ts#L5-L15

While `strapi.customFields.register(...)` on `server/register.ts` still expects the property `plugin`.

https://github.com/strapi/strapi/blob/41e2d2ccf25f13d47b90c2f8a0cd3b1bd8930b22/packages/core/strapi/lib/core/registries/custom-fields.js#L47

### Why is it needed?

This causes the build of typescript plugins to fail if it still has the `plugin` property

![Screen reading that plugin property is not assignable to parameter of type CustomFieldServerOptions](https://github.com/strapi/strapi/assets/22895284/bb34a370-2201-4985-9dae-7c5b7dd8e99e)

If it's being replaced to `pluginId` typescript will accept it and build it.

![Screenshot 2023-09-19 at 14 07 36](https://github.com/strapi/strapi/assets/22895284/772a9abe-c370-48e0-b6bb-a0294773f1bf)

But after building the Strapi app and running `strapi develop`, the plugin will fail the registration due to missing `plugin` prop.

```
Error: Could not find Custom Field: plugin::commercetools.ProductGrid
```

### How to test it?

1. Create typescript plugin
2. Register custom field in `server/register.ts` using the `plugin` property
3. Build the plugin
4. Build the Strapi app
5. Run the Strapi app and use the custom field

### Related issue(s)/PR(s)

I know this has been confusing for a long time because the `customFields.register(...)` in the admin app take `pluginId` and the server takes `plugin`. But if these two props should have the same name I think it's a different issue/conversation but I am +1 for changing both of them to `pluginId`.
