### PR TITLE
test(content-manager): fix console pollution in tests

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/RelationInput/components/tests/Option.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInput/components/tests/Option.test.js
@@ -14,7 +14,7 @@ const setup = (props) => ({
       <IntlProvider locale="en" messages={{}}>
         <Combobox>
           {props.options.map((opt) => (
-            <Option {...opt} />
+            <Option key={opt.mainField} {...opt} />
           ))}
         </Combobox>
       </IntlProvider>

--- a/packages/core/admin/admin/src/content-manager/hooks/useRelation/tests/useRelation.test.js
+++ b/packages/core/admin/admin/src/content-manager/hooks/useRelation/tests/useRelation.test.js
@@ -29,48 +29,41 @@ const client = new QueryClient({
   },
 });
 
-// eslint-disable-next-line react/prop-types
-const ComponentFixture = ({ children }) => (
-  <QueryClientProvider client={client}>{children}</QueryClientProvider>
-);
-
 const cacheKey = ['useRelation-cache-key'];
 function setup(args) {
-  return new Promise((resolve) => {
-    act(() => {
-      resolve(
-        renderHook(
-          () =>
-            useRelation(cacheKey, {
-              relation: {
-                enabled: true,
-                endpoint: '/',
-                pageParams: {
-                  limit: 10,
-                  ...(args?.relation?.pageParams ?? {}),
-                },
-                normalizeArguments: {
-                  mainFieldName: 'name',
-                  shouldAddLink: false,
-                  targetModel: 'api::tag.tag',
-                },
-                ...(args?.relation ?? {}),
-              },
+  return renderHook(
+    () =>
+      useRelation(cacheKey, {
+        relation: {
+          enabled: true,
+          endpoint: '/',
+          pageParams: {
+            limit: 10,
+            ...(args?.relation?.pageParams ?? {}),
+          },
+          normalizeArguments: {
+            mainFieldName: 'name',
+            shouldAddLink: false,
+            targetModel: 'api::tag.tag',
+          },
+          ...(args?.relation ?? {}),
+        },
 
-              search: {
-                endpoint: '/',
-                pageParams: {
-                  limit: 10,
-                  ...(args?.search?.pageParams ?? {}),
-                },
-                ...(args?.search ?? {}),
-              },
-            }),
-          { wrapper: ComponentFixture }
-        )
-      );
-    });
-  });
+        search: {
+          endpoint: '/',
+          pageParams: {
+            limit: 10,
+            ...(args?.search?.pageParams ?? {}),
+          },
+          ...(args?.search ?? {}),
+        },
+      }),
+    {
+      wrapper({ children }) {
+        return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+      },
+    }
+  );
 }
 
 describe('useRelation', () => {
@@ -80,7 +73,7 @@ describe('useRelation', () => {
 
   test('fetch relations and calls onLoadRelationsCallback', async () => {
     const onLoadMock = jest.fn();
-    await setup({
+    setup({
       relation: {
         onLoad: onLoadMock,
       },
@@ -119,7 +112,7 @@ describe('useRelation', () => {
       },
     });
 
-    const { result } = await setup({
+    const { result } = setup({
       relation: {
         onLoad: onLoadMock,
       },
@@ -131,7 +124,7 @@ describe('useRelation', () => {
   });
 
   test('fetch relations with different limit', async () => {
-    await setup({
+    setup({
       relation: { pageParams: { limit: 5 } },
     });
 
@@ -148,14 +141,14 @@ describe('useRelation', () => {
   });
 
   test('does not fetch relations if it was not enabled', async () => {
-    await setup({ relation: { enabled: false } });
+    setup({ relation: { enabled: false } });
     const { get } = useFetchClient();
 
     expect(get).not.toBeCalled();
   });
 
   test('fetch relations', async () => {
-    const { result } = await setup();
+    const { result } = setup();
 
     await waitFor(() => {
       expect(result.current.relations.isSuccess).toBe(true);
@@ -186,7 +179,7 @@ describe('useRelation', () => {
 
     const { get } = useFetchClient();
 
-    const { result } = await setup();
+    const { result } = setup();
 
     await waitFor(() => expect(result.current.relations.isLoading).toBe(false));
 
@@ -207,6 +200,8 @@ describe('useRelation', () => {
         page: 2,
       },
     });
+
+    await waitFor(() => expect(result.current.relations.isLoading).toBe(false));
   });
 
   test("does not fetch relations next page, if there isn't one", async () => {
@@ -222,7 +217,7 @@ describe('useRelation', () => {
 
     const { get } = useFetchClient();
 
-    const { result } = await setup();
+    const { result } = setup();
 
     await waitFor(() => {
       expect(get).toBeCalledTimes(1);
@@ -236,7 +231,7 @@ describe('useRelation', () => {
   });
 
   test('does not fetch search by default', async () => {
-    const { result } = await setup();
+    const { result } = setup();
 
     await waitFor(() => {
       expect(result.current.search.isLoading).toBe(false);
@@ -244,7 +239,7 @@ describe('useRelation', () => {
   });
 
   test('does fetch search results once a term was provided', async () => {
-    const { result } = await setup();
+    const { result } = setup();
 
     await waitFor(() => expect(result.current).toBeTruthy());
 
@@ -265,7 +260,7 @@ describe('useRelation', () => {
   });
 
   test('does fetch search results with a different limit', async () => {
-    const { result } = await setup({
+    const { result } = setup({
       search: { pageParams: { limit: 5 } },
     });
 
@@ -294,7 +289,7 @@ describe('useRelation', () => {
   });
 
   test('fetch search next page, if there is one', async () => {
-    const { result } = await setup();
+    const { result } = setup();
 
     const spy = jest
       .fn()
@@ -332,7 +327,7 @@ describe('useRelation', () => {
   });
 
   test("does not fetch search next page, if there isn't one", async () => {
-    const { result } = await setup();
+    const { result } = setup();
 
     const spy = jest.fn().mockResolvedValueOnce({
       data: { results: [], pagination: { page: 1, pageCount: 1 } },

--- a/packages/core/admin/admin/src/content-manager/hooks/useRelation/useRelation.js
+++ b/packages/core/admin/admin/src/content-manager/hooks/useRelation/useRelation.js
@@ -9,100 +9,84 @@ export const useRelation = (cacheKey, { relation, search }) => {
   const [searchParams, setSearchParams] = useState({});
   const [currentPage, setCurrentPage] = useState(0);
   const { get } = useFetchClient();
-  /**
-   * This runs in `useInfiniteQuery` to actually fetch the data
-   */
-  const fetchRelations = async ({ pageParam = 1 }) => {
-    try {
-      const { data } = await get(relation?.endpoint, {
-        params: {
-          ...(relation.pageParams ?? {}),
-          page: pageParam,
-        },
-      });
-
-      setCurrentPage(pageParam);
-
-      return data;
-    } catch (err) {
-      return null;
-    }
-  };
-
-  const fetchSearch = async ({ pageParam = 1 }) => {
-    try {
-      const { data } = await get(search.endpoint, {
-        params: {
-          ...(search.pageParams ?? {}),
-          ...searchParams,
-          page: pageParam,
-        },
-      });
-
-      return data;
-    } catch (err) {
-      return null;
-    }
-  };
 
   const { onLoad: onLoadRelations, normalizeArguments = {} } = relation;
 
-  const relationsRes = useInfiniteQuery(['relation', ...cacheKey], fetchRelations, {
-    cacheTime: 0,
-    enabled: relation.enabled,
-    /**
-     * @type {(lastPage:
-     * | { data: null }
-     * | { results: any[],
-     *     pagination: {
-     *      page: number,
-     *      pageCount: number,
-     *      pageSize: number,
-     *      total: number
-     *     }
-     *   }
-     * ) => number}
-     */
-    getNextPageParam(lastPage) {
-      const isXToOneRelation = !lastPage?.pagination;
+  const relationsRes = useInfiniteQuery(
+    ['relation', ...cacheKey],
+    async ({ pageParam = 1 }) => {
+      try {
+        const { data } = await get(relation?.endpoint, {
+          params: {
+            ...(relation.pageParams ?? {}),
+            page: pageParam,
+          },
+        });
 
-      if (
-        !lastPage || // the API may send an empty 204 response
-        isXToOneRelation || // xToOne relations do not have a pagination
-        lastPage?.pagination.page >= lastPage?.pagination.pageCount
-      ) {
-        return undefined;
+        setCurrentPage(pageParam);
+
+        return data;
+      } catch (err) {
+        return null;
       }
-
-      // eslint-disable-next-line consistent-return
-      return lastPage.pagination.page + 1;
     },
-    select: (data) => ({
-      ...data,
-      pages: data.pages.map((page) => {
-        if (!page) {
-          return page;
+    {
+      cacheTime: 0,
+      enabled: relation.enabled,
+      /**
+       * @type {(lastPage:
+       * | { data: null }
+       * | { results: any[],
+       *     pagination: {
+       *      page: number,
+       *      pageCount: number,
+       *      pageSize: number,
+       *      total: number
+       *     }
+       *   }
+       * ) => number}
+       */
+      getNextPageParam(lastPage) {
+        const isXToOneRelation = !lastPage?.pagination;
+
+        if (
+          !lastPage || // the API may send an empty 204 response
+          isXToOneRelation || // xToOne relations do not have a pagination
+          lastPage?.pagination.page >= lastPage?.pagination.pageCount
+        ) {
+          return undefined;
         }
 
-        const { data, results, pagination } = page;
-        const isXToOneRelation = !!data;
-        let normalizedResults = [];
+        // eslint-disable-next-line consistent-return
+        return lastPage.pagination.page + 1;
+      },
+      select: (data) => ({
+        ...data,
+        pages: data.pages.map((page) => {
+          if (!page) {
+            return page;
+          }
 
-        // xToOne relations return an object, which we normalize so that relations
-        // always have the same shape
-        if (isXToOneRelation) {
-          normalizedResults = [data];
-        } else if (results) {
-          normalizedResults = [...results].reverse();
-        }
+          const { data, results, pagination } = page;
+          const isXToOneRelation = !!data;
+          let normalizedResults = [];
 
-        return {
-          pagination,
-          results: normalizedResults,
-        };
+          // xToOne relations return an object, which we normalize so that relations
+          // always have the same shape
+          if (isXToOneRelation) {
+            normalizedResults = [data];
+          } else if (results) {
+            normalizedResults = [...results].reverse();
+          }
+
+          return {
+            pagination,
+            results: normalizedResults,
+          };
+        }),
       }),
-    }),
-  });
+    }
+  );
 
   const { pageGoal } = relation;
 
@@ -137,7 +121,21 @@ export const useRelation = (cacheKey, { relation, search }) => {
 
   const searchRes = useInfiniteQuery(
     ['relation', ...cacheKey, 'search', JSON.stringify(searchParams)],
-    fetchSearch,
+    async ({ pageParam = 1 }) => {
+      try {
+        const { data } = await get(search.endpoint, {
+          params: {
+            ...(search.pageParams ?? {}),
+            ...searchParams,
+            page: pageParam,
+          },
+        });
+
+        return data;
+      } catch (err) {
+        return null;
+      }
+    },
     {
       enabled: Object.keys(searchParams).length > 0,
       /**

--- a/packages/core/helper-plugin/src/components/tests/DateTimePicker.test.tsx
+++ b/packages/core/helper-plugin/src/components/tests/DateTimePicker.test.tsx
@@ -5,6 +5,14 @@ import { render as renderRTL } from '@testing-library/react';
 
 import { DateTimePicker } from '../DateTimePicker';
 
+/**
+ * DateTimePicker is deprecated and as such will fire a warning when rendered,
+ * we therefore mock the console so we don't pollute the test output with warnings.
+ */
+jest.mock('../../utils/once', () => ({
+  once: jest.fn(() => jest.fn()),
+}));
+
 const render = (props: Partial<DateTimePickerProps>) =>
   renderRTL(<DateTimePicker label="Date time picker" {...props} />, {
     wrapper: ({ children }) => (

--- a/packages/core/helper-plugin/src/utils/tests/request.test.ts
+++ b/packages/core/helper-plugin/src/utils/tests/request.test.ts
@@ -10,6 +10,14 @@ interface ExpectedError extends Error {
   };
 }
 
+/**
+ * request is deprecated and as such will fire a warning when rendered,
+ * we therefore mock the console so we don't pollute the test output with warnings.
+ */
+jest.mock('../../utils/once', () => ({
+  once: jest.fn(() => jest.fn()),
+}));
+
 describe('request', () => {
   it('should return the response successful requests', async () => {
     server.use(


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* mocks `once` in helper-plugin tests for `DateTimePicker` & `request`
* fixes `act` warnings in `useLazyComponents`, `useRelation` and `InputUID`
* fixes `keys` warning in `Options`

### Why is it needed?

* Stops erroneous console messages in FE tests

### How to test it?

* automated testing

### Related issue(s)/PR(s)

* part of #17924
