### PR TITLE
refactor(content-manager): convert InputUIDs data-fetching to use react-query

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/Inputs/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/Inputs/index.js
@@ -10,7 +10,7 @@ import { useIntl } from 'react-intl';
 
 import { useContentTypeLayout } from '../../hooks';
 import { getFieldName } from '../../utils';
-import InputUID from '../InputUID';
+import { InputUID } from '../InputUID';
 import { RelationInputDataManager } from '../RelationInputDataManager';
 import Wysiwyg from '../Wysiwyg';
 


### PR DESCRIPTION


<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* refactors `InputUID`'s data-fetching to stop using callback refs & use `react-query`
* tweaks to tests parallel to #18113 so they're in sync (it doesn't matter whos merged first)

### Why is it needed?

* It avoids as many confusing `useEffect` calls as there were
* refs for data-fetching links rendering to data-fetching, we know this is bad
* cleans up a lot of noise in the component

### How to test it?

* automated tests should pass 🪄 

### Related issue(s)/PR(s)

* nope, just irritated me
