### PR TITLE
fix: don't deconstruct editor & wait a tick to check for ReactNode

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/hooks/useBlocksStore.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/hooks/useBlocksStore.js
@@ -31,6 +31,7 @@ import { Transforms, Editor } from 'slate';
 import { useSlateStatic, ReactEditor } from 'slate-react';
 import styled, { css } from 'styled-components';
 
+import { composeRefs } from '../../../utils';
 import { insertLink, removeLink } from '../utils/links';
 
 const H1 = styled(Typography).attrs({ as: 'h1' })`
@@ -180,7 +181,7 @@ Image.propTypes = {
   }).isRequired,
 };
 
-const Link = ({ element, children, ...attributes }) => {
+const Link = React.forwardRef(({ element, children, ...attributes }, forwardedRef) => {
   const { formatMessage } = useIntl();
   const editor = useSlateStatic();
   const { selection } = editor;
@@ -207,9 +208,16 @@ const Link = ({ element, children, ...attributes }) => {
     setPopoverOpen(false);
   };
 
+  const composedRefs = composeRefs(linkRef, forwardedRef);
+
   return (
     <>
-      <BaseLink {...attributes} ref={linkRef} href={element.url} onClick={handleOpenEditPopover}>
+      <BaseLink
+        {...attributes}
+        ref={composedRefs}
+        href={element.url}
+        onClick={handleOpenEditPopover}
+      >
         {children}
       </BaseLink>
       {popoverOpen && (
@@ -281,7 +289,7 @@ const Link = ({ element, children, ...attributes }) => {
       )}
     </>
   );
-};
+});
 
 Link.propTypes = {
   element: PropTypes.object.isRequired,

--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/utils/links.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/utils/links.js
@@ -8,37 +8,33 @@ const removeLink = (editor) => {
 };
 
 const insertLink = (editor, { url, text }) => {
-  const { selection } = editor;
-
   const linkElement = {
     type: 'link',
     url,
     children: [{ text }],
   };
 
-  ReactEditor.focus(editor);
-  const selectedText = Editor.string(editor, selection);
+  const selectedText = Editor.string(editor, editor.selection);
 
-  if (selection) {
-    const [parentNode] = Editor.parent(editor, selection.focus?.path);
+  if (editor.selection) {
+    const [parentNode] = Editor.parent(editor, editor.selection.focus?.path);
 
     // If we are creating a link inside another link, we remove the parent link
     if (parentNode.type === 'link') {
       removeLink(editor);
     }
 
-    if (Range.isCollapsed(selection)) {
-      Transforms.insertNodes(editor, linkElement, { select: true });
-    } else if (text !== selectedText) {
-      // If user changed the selected text, we need to remove the selection and created everything from scratch
-      // If not, we can wrap everything in a link node
+    // If user changed the selected text, we need to remove the editor.selection and created everything from scratch
+    if (Range.isCollapsed(editor.selection) || text !== selectedText) {
       Transforms.insertNodes(editor, linkElement, { select: true });
     } else {
+      // If not, we can wrap everything in a link node
       Transforms.wrapNodes(editor, { type: 'link', url }, { split: true });
     }
   } else {
     Transforms.insertNodes(editor, { type: 'paragraph', children: [linkElement] });
   }
+  ReactEditor.focus(editor);
 };
 
 export { insertLink, removeLink };


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* stops deconstructing editor because the values are cached prior to function scope.
* uses `setTimeout` to wait a single tick before trying to use the ReactEditor to find the domNode inserted by Editor
* Applies `forwardRef` to the link component because Slate needs to be able to give our elements refs if React is going to find them.

### Why is it needed?

* Allows the popover to be positioned next to the "new" element (in this case, our highlighted text)

### Related issue(s)/PR(s)

* helps #18118
