### PR TITLE
[Email] define shared types for email package

### DIFF
--- a/packages/core/email/shared/types.ts
+++ b/packages/core/email/shared/types.ts
@@ -1,0 +1,41 @@
+export interface ApiResponse<T> {
+  data: T;
+  status: number;
+  statusText: string;
+  headers: Record<string, string>;
+  config: {
+    transitional: {
+      silentJSONParsing: boolean;
+      forcedJSONParsing: boolean;
+      clarifyTimeoutError: boolean;
+    };
+    adapter: string;
+    transformRequest: any[];
+    transformResponse: any[];
+    timeout: number;
+    xsrfCookieName: string;
+    xsrfHeaderName: string;
+    maxContentLength: number;
+    maxBodyLength: number;
+    env: Record<string, any>;
+    headers: Record<string, string>;
+    paramsSerializer: Record<string, any>;
+    baseURL: string;
+    signal: any;
+    method: string;
+    url: string;
+  };
+  request: any;
+}
+
+export interface EmailSettings {
+  config: ConfigSettings;
+}
+
+export interface ConfigSettings {
+  provider: string;
+  settings: {
+    defaultFrom: string;
+    defaultReplyTo: string;
+  };
+}

--- a/packages/core/email/shared/types.ts
+++ b/packages/core/email/shared/types.ts
@@ -1,9 +1,3 @@
-export interface ApiResponse<T> {
-  data: T;
-  status: number;
-  statusText: string;
-}
-
 export interface EmailSettings {
   config: ConfigSettings;
 }

--- a/packages/core/email/shared/types.ts
+++ b/packages/core/email/shared/types.ts
@@ -2,30 +2,6 @@ export interface ApiResponse<T> {
   data: T;
   status: number;
   statusText: string;
-  headers: Record<string, string>;
-  config: {
-    transitional: {
-      silentJSONParsing: boolean;
-      forcedJSONParsing: boolean;
-      clarifyTimeoutError: boolean;
-    };
-    adapter: string;
-    transformRequest: any[];
-    transformResponse: any[];
-    timeout: number;
-    xsrfCookieName: string;
-    xsrfHeaderName: string;
-    maxContentLength: number;
-    maxBodyLength: number;
-    env: Record<string, any>;
-    headers: Record<string, string>;
-    paramsSerializer: Record<string, any>;
-    baseURL: string;
-    signal: any;
-    method: string;
-    url: string;
-  };
-  request: any;
 }
 
 export interface EmailSettings {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Defines shared types to be used throughout the email package

### Why is it needed?

Type consistency across BE and FE of email package


Defined as per https://github.com/strapi/strapi/pull/18117#discussion_r1331915646

I plan to import and use these types where relevant in 
https://github.com/strapi/strapi/pull/18117 & https://github.com/strapi/strapi/pull/18127
