### PR TITLE
Centers the welcome title for the AuthPage

### DIFF
--- a/packages/core/admin/admin/src/pages/AuthPage/components/Login/BaseLogin.js
+++ b/packages/core/admin/admin/src/pages/AuthPage/components/Login/BaseLogin.js
@@ -41,7 +41,7 @@ const Login = ({ onSubmit, schema, children }) => {
               <Column>
                 <Logo />
                 <Box paddingTop={6} paddingBottom={1}>
-                  <Typography variant="alpha" as="h1">
+                  <Typography variant="alpha" as="h1" text-align="center">
                     {formatMessage({
                       id: 'Auth.form.welcome.title',
                       defaultMessage: 'Welcome!',
@@ -49,7 +49,7 @@ const Login = ({ onSubmit, schema, children }) => {
                   </Typography>
                 </Box>
                 <Box paddingBottom={7}>
-                  <Typography variant="epsilon" textColor="neutral600">
+                  <Typography variant="epsilon" textColor="neutral600" text-align="center">
                     {formatMessage({
                       id: 'Auth.form.welcome.subtitle',
                       defaultMessage: 'Log in to your Strapi account',

--- a/packages/core/admin/admin/src/pages/AuthPage/components/Login/BaseLogin.js
+++ b/packages/core/admin/admin/src/pages/AuthPage/components/Login/BaseLogin.js
@@ -49,7 +49,7 @@ const Login = ({ onSubmit, schema, children }) => {
                   </Typography>
                 </Box>
                 <Box paddingBottom={7}>
-                  <Typography variant="epsilon" textColor="neutral600" text-align="center">
+                  <Typography variant="epsilon" textColor="neutral600">
                     {formatMessage({
                       id: 'Auth.form.welcome.subtitle',
                       defaultMessage: 'Log in to your Strapi account',


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Sets the `text-align` property for the title field in AuthPage to center.

### Why is it needed?

When overriding the title name, if the name is too long it doesn't center itself and is instead left aligned.

### How to test it?

Override `Auth.form.welcome.title` and open an example login page

### Related issue(s)/PR(s)

N/A
