### PR TITLE
[Blocks editor] Handle enter key behavior in lists

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/hooks/tests/useBlocksStore.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/hooks/tests/useBlocksStore.test.js
@@ -426,4 +426,133 @@ describe('useBlocksStore', () => {
       },
     ]);
   });
+
+  it('handles enter key on a list item with text', () => {
+    // Don't use Wrapper since we don't test any React logic or rendering
+    // Wrapper cause issues about updates not wrapped in act()
+    const { result } = renderHook(useBlocksStore);
+
+    baseEditor.children = [
+      {
+        type: 'list',
+        format: 'unordered',
+        children: [
+          {
+            type: 'list-item',
+            children: [
+              {
+                type: 'text',
+                text: 'Line of text',
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    // Set the cursor at the end of the first list item
+    Transforms.select(baseEditor, {
+      anchor: Editor.end(baseEditor, []),
+      focus: Editor.end(baseEditor, []),
+    });
+
+    // Simulate the enter key
+    result.current['list-unordered'].handleEnterKey(baseEditor);
+
+    // Should insert a new list item
+    expect(baseEditor.children).toEqual([
+      {
+        type: 'list',
+        format: 'unordered',
+        children: [
+          {
+            type: 'list-item',
+            children: [
+              {
+                type: 'text',
+                text: 'Line of text',
+              },
+            ],
+          },
+          {
+            type: 'list-item',
+            children: [
+              {
+                type: 'text',
+                text: '',
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('handles enter key on a list item without text', () => {
+    const { result } = renderHook(useBlocksStore);
+
+    baseEditor.children = [
+      {
+        type: 'list',
+        format: 'unordered',
+        children: [
+          {
+            type: 'list-item',
+            children: [
+              {
+                type: 'text',
+                text: 'First list item',
+              },
+            ],
+          },
+          {
+            type: 'list-item',
+            children: [
+              {
+                type: 'text',
+                text: '',
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    // Set the cursor at the end of the last list item
+    Transforms.select(baseEditor, {
+      anchor: Editor.end(baseEditor, [0, 1]),
+      focus: Editor.end(baseEditor, [0, 1]),
+    });
+
+    // Simulate the enter key
+    result.current['list-unordered'].handleEnterKey(baseEditor);
+
+    // Should remove the empty list item and create a paragraph after the list
+    expect(baseEditor.children).toEqual([
+      {
+        type: 'list',
+        format: 'unordered',
+        children: [
+          {
+            type: 'list-item',
+            children: [
+              {
+                type: 'text',
+                text: 'First list item',
+              },
+            ],
+          },
+        ],
+      },
+      {
+        type: 'paragraph',
+        children: [
+          {
+            type: 'text',
+            text: '',
+          },
+        ],
+      },
+    ]);
+  });
 });

--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/hooks/useBlocksStore.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/hooks/useBlocksStore.js
@@ -12,7 +12,7 @@ import {
   HeadingFive,
   HeadingSix,
 } from '@strapi/icons';
-import PropTypes, { node } from 'prop-types';
+import PropTypes from 'prop-types';
 import { Editor, Path, Transforms } from 'slate';
 import styled, { css } from 'styled-components';
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

When hitting the enter key inside a list:

- If the currently selected list item is not empty, create a list item below
- If the currently selected list item is empty, create a paragraph block below outside of the list

The behavior should be the same for both ordered and unordered lists.

Known issue: if you have an empty list item that is not the last one and you hit enter, the paragraph will be created, but the list items after your cursor will be deleted.

### Related issue(s)/PR(s)

Follow-up to #18112