### PR TITLE
[features/types/config-base] Add configuration middlewares config

### DIFF
--- a/packages/core/strapi/src/services/server/middleware.ts
+++ b/packages/core/strapi/src/services/server/middleware.ts
@@ -36,15 +36,7 @@ const dummyMiddleware: Common.MiddlewareHandler = (_, next) => next();
  * Initialize every configured middlewares
  */
 const resolveMiddlewares = (
-  config: Array<
-    | string
-    | {
-        name?: string;
-        resolve?: string;
-        config?: unknown;
-      }
-    | Common.MiddlewareHandler
-  >,
+  config: Array<Common.MiddlewareUID | Common.MiddlewareConfig | Common.MiddlewareHandler>,
   strapi: Strapi
 ) => {
   const middlewares: {

--- a/packages/core/types/src/types/config/index.ts
+++ b/packages/core/types/src/types/config/index.ts
@@ -3,3 +3,4 @@ export type { Admin } from './admin';
 export type { Api } from './api';
 export type { Plugin } from './plugin';
 export type { Database } from './database';
+export type { Middlewares } from './middlewares';

--- a/packages/core/types/src/types/config/middlewares.ts
+++ b/packages/core/types/src/types/config/middlewares.ts
@@ -1,0 +1,3 @@
+import { MiddlewareConfig, MiddlewareName } from '../core/common';
+
+export type Middlewares = Array<MiddlewareName | MiddlewareConfig>;

--- a/packages/core/types/src/types/core/common/middleware.ts
+++ b/packages/core/types/src/types/core/common/middleware.ts
@@ -6,6 +6,14 @@ export type MiddlewareFactory<T = any> = (
   ctx: { strapi: Strapi }
 ) => MiddlewareHandler | void;
 
+export type MiddlewareName = string;
+
+export type MiddlewareConfig = {
+  name?: string;
+  resolve?: string;
+  config?: unknown;
+};
+
 export type MiddlewareHandler = Koa.Middleware;
 
 export type Middleware = MiddlewareHandler | MiddlewareFactory;


### PR DESCRIPTION
### What does it do?

Adds types for Middlewares configuration values to strapi Common types and uses them to add types for the config/middlewares export value.

