### PR TITLE
Update DynamicComponent.js

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/DynamicZone/components/DynamicComponent.js
+++ b/packages/core/admin/admin/src/content-manager/components/DynamicZone/components/DynamicComponent.js
@@ -37,7 +37,7 @@ export const DynamicComponent = ({
   dynamicComponentsByCategory,
   onAddComponent,
 }) => {
-  const [isOpen, setIsOpen] = useState(true);
+  const [isOpen, setIsOpen] = useState(false);
   const { formatMessage } = useIntl();
   const { getComponentLayout } = useContentTypeLayout();
   const { modifiedData } = useCMEditViewDataManager();


### PR DESCRIPTION
Address this feature request: https://feedback.strapi.io/customization/p/keep-dynamic-zone-accordions-closed-by-default


### What does it do?

This changes the default state of DynamicZones to be closed 

### Why is it needed?

With numerous dynamic zones, the admin panel can get very cluttered.

### How to test it?

Add a dynamic zone to a content type, when editing the content type, it should be closed by default

### Related issue(s)/PR(s)

https://feedback.strapi.io/customization/p/keep-dynamic-zone-accordions-closed-by-default
