### PR TITLE
fix: inaccurate floating point in averagePrice.

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
     "test:unit:watch": "run test:unit --watch",
     "test:api": "node test/scripts/run-api-tests.js",
     "test:generate-app": "yarn build:ts && node test/scripts/generate-test-app.js",
-    "doc:api": "node scripts/open-api/serve.js"
+    "doc:api": "node scripts/open-api/serve.js",
+    "postinstall": "patch-package" //to load the design-system patch in patches 
   },
   "devDependencies": {
     "@babel/core": "^7.20.12",

--- a/patches/@strapi+design-system+1.10.1.patch
+++ b/patches/@strapi+design-system+1.10.1.patch
@@ -1,0 +1,38 @@
+diff --git a/node_modules/@strapi/design-system/dist/NumberInput/NumberInput.js b/node_modules/@strapi/design-system/dist/NumberInput/NumberInput.js
+index 74f7fa1..62bee50 100644
+--- a/node_modules/@strapi/design-system/dist/NumberInput/NumberInput.js
++++ b/node_modules/@strapi/design-system/dist/NumberInput/NumberInput.js
+@@ -72,7 +72,9 @@ const NumberInput = React__default.default.forwardRef(({ size = 'M', startAction
+      * if the former then it'll be converted to a string.
+      */
+     const formatNumberAndSetInput = (value) => {
+-        setInputValue(String(value));
++        //Convert and round the input value to two decimal places before setting it as the new inputValue.
++        const roundedValueTwoDecimals = parseFloat(value).toFixed(2);
++        setInputValue(String(roundedValueTwoDecimals));
+     };
+     const handelInputChange = ({ target: { value } }) => {
+         if (numberParserRef.current.isValidPartialNumber(value)) {
+@@ -86,6 +88,7 @@ const NumberInput = React__default.default.forwardRef(({ size = 'M', startAction
+         }
+         const parsedValue = numberParserRef.current.parse(inputValue);
+         const newValue = isNaN(parsedValue) ? step : parsedValue + step;
++
+         formatNumberAndSetInput(numberFormaterRef.current.format(newValue));
+     };
+     const decrement = () => {
+diff --git a/node_modules/@strapi/design-system/dist/NumberInput/NumberInput.mjs b/node_modules/@strapi/design-system/dist/NumberInput/NumberInput.mjs
+index 300d673..49522e0 100644
+--- a/node_modules/@strapi/design-system/dist/NumberInput/NumberInput.mjs
++++ b/node_modules/@strapi/design-system/dist/NumberInput/NumberInput.mjs
+@@ -63,7 +63,9 @@ const NumberInput = React__default.forwardRef(({ size = 'M', startAction, name,
+      * if the former then it'll be converted to a string.
+      */
+     const formatNumberAndSetInput = (value) => {
+-        setInputValue(String(value));
++        //Convert and round the input value to two decimal places before setting it as the new inputValue.
++        const roundedValueTwoDecimals = parseFloat(value).toFixed(2);
++        setInputValue(String(roundedValueTwoDecimals));
+     };
+     const handelInputChange = ({ target: { value } }) => {
+         if (numberParserRef.current.isValidPartialNumber(value)) {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

I patched the problem in the function in the increment function in node_modules/@strapi/design-system/dist/NumberInput/NumberInput.js. This function adds a 0.01 to a value but because of the floating-point problems in javascript, it does not return an accurate floating-point. Instead of returning 0.06, it returns 0.060000000005 and so on.
What I did is I used .toFixed(2) to the value of type float directly before setting the new value.
![image](https://github.com/strapi/strapi/assets/68505433/e78949b2-247a-4768-bd62-4da5d100c840)


### Why is it needed?
In Content Manager and while creating a restaurant. 
If I used the arrows to set the averagePrice it gets missed because of the floating point problem.

### How to test it?

1 - Go to 'Content Manager'
2 - From the 'Content' menu Click on 'Restaurant'
3 - Click on 'Create new entry' in the top right.
4 - Scroll down to 'averagePrice'
5 - Using the arrow button increase the value until 0.06.
6 - The error is fixed (check the issue#18138 to see the problem).

### Related issue(s)/PR(s)

I do not know if the patching is correct because it's my first time, but I believe it solves the problem.

Fix #18138 
