### PR TITLE
fix(plugin-documentation): custom routes docgen

### DIFF
--- a/packages/plugins/documentation/server/services/__mocks__/mock-strapi-data.js
+++ b/packages/plugins/documentation/server/services/__mocks__/mock-strapi-data.js
@@ -137,6 +137,20 @@ module.exports = {
         kitchensink: contentTypes['api::kitchensink.kitchensink'],
       },
       routes: {
+        actions: {
+          routes: [
+            {
+              method: 'POST',
+              path: '/kitchensinks/:id/wash',
+              handler: 'api::kitchensink.actions.wash',
+            },
+            {
+              method: 'GET',
+              path: '/kitchensinks/empty',
+              handler: 'api::kitchensink.actions.empty',
+            }
+          ]
+        },
         kitchensink: {
           routes: [
             {

--- a/packages/plugins/documentation/server/services/__tests__/documentation.test.js
+++ b/packages/plugins/documentation/server/services/__tests__/documentation.test.js
@@ -129,6 +129,17 @@ describe('Documentation plugin | Documentation service', () => {
     expect(mockFinalDoc.paths['/kitchensinks/{id}'].put.responses['200']).toEqual(expectedOne);
   });
 
+  it('generates the correct response component schema for custom routes', async () => {
+    const docService = documentation({ strapi: global.strapi });
+    await docService.generateFullDoc();
+    const lastMockCall = fse.writeJson.mock.calls[fse.writeJson.mock.calls.length - 1];
+    const mockFinalDoc = lastMockCall[1];
+    expect(mockFinalDoc.paths['/kitchensinks/{id}/wash'].post.parameters.length).toEqual(1);
+    expect(mockFinalDoc.paths['/kitchensinks/{id}/wash'].post.responses).toBeDefined();
+    expect(mockFinalDoc.paths['/kitchensinks/empty'].get.responses).toBeDefined();
+
+  });
+
   describe('Determines the plugins that need documentation', () => {
     it('generates documentation for the default plugins if the user provided nothing in the config', async () => {
       const docService = documentation({ strapi: global.strapi });

--- a/packages/plugins/documentation/server/services/helpers/utils/get-api-responses.js
+++ b/packages/plugins/documentation/server/services/helpers/utils/get-api-responses.js
@@ -2,6 +2,58 @@
 
 const pascalCase = require('./pascal-case');
 
+const getApiErrorResponses = () => ({
+    400: {
+      description: 'Bad Request',
+      content: {
+        'application/json': {
+          schema: {
+            $ref: '#/components/schemas/Error',
+          },
+        },
+      },
+    },
+    401: {
+      description: 'Unauthorized',
+      content: {
+        'application/json': {
+          schema: {
+            $ref: '#/components/schemas/Error',
+          },
+        },
+      },
+    },
+    403: {
+      description: 'Forbidden',
+      content: {
+        'application/json': {
+          schema: {
+            $ref: '#/components/schemas/Error',
+          },
+        },
+      },
+    },
+    404: {
+      description: 'Not Found',
+      content: {
+        'application/json': {
+          schema: {
+            $ref: '#/components/schemas/Error',
+          },
+        },
+      },
+    },
+    500: {
+      description: 'Internal Server Error',
+      content: {
+        'application/json': {
+          schema: {
+            $ref: '#/components/schemas/Error',
+          },
+        },
+      },
+    },
+});
 /**
  * @description - Builds the Swagger response object for a given api
  *
@@ -11,7 +63,7 @@ const pascalCase = require('./pascal-case');
  *
  * @returns The Swagger responses
  */
-const getApiResponse = ({
+const getApiResponses = ({
   uniqueName,
   route,
   isListOfEntities = false,
@@ -48,58 +100,12 @@ const getApiResponse = ({
           },
         },
       },
-      400: {
-        description: 'Bad Request',
-        content: {
-          'application/json': {
-            schema: {
-              $ref: '#/components/schemas/Error',
-            },
-          },
-        },
-      },
-      401: {
-        description: 'Unauthorized',
-        content: {
-          'application/json': {
-            schema: {
-              $ref: '#/components/schemas/Error',
-            },
-          },
-        },
-      },
-      403: {
-        description: 'Forbidden',
-        content: {
-          'application/json': {
-            schema: {
-              $ref: '#/components/schemas/Error',
-            },
-          },
-        },
-      },
-      404: {
-        description: 'Not Found',
-        content: {
-          'application/json': {
-            schema: {
-              $ref: '#/components/schemas/Error',
-            },
-          },
-        },
-      },
-      500: {
-        description: 'Internal Server Error',
-        content: {
-          'application/json': {
-            schema: {
-              $ref: '#/components/schemas/Error',
-            },
-          },
-        },
-      },
-    },
+      ...getApiErrorResponses(),
+    }
   };
 };
 
-module.exports = getApiResponse;
+module.exports = {
+  getApiResponses,
+  getApiErrorResponses
+};


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Add the ability to generate openapi paths for custom routes using @strapi/plugin-documentation.

### How to test it?

1. Install strapi plugin-documentation
2. Add custom routes to your content-types in strapi. 
Example:
src/api/myEntity/routes/my-custom-routes.ts
src/api/myEntity/routes/myEntity.ts
3. `npm run develop`

Without this fix, the generated src\extensions\documentation\documentation\1.0.0\full_documentation.json will only include paths defined in src/api/myEntity/routes/myEntity.ts. 

### Related issue(s)/PR(s)

Fix [#844](https://github.com/strapi/documentation/issues/844) .
