### PR TITLE
[Blocks editor] Remove default value input from advanced CTB form

### DIFF
--- a/packages/core/content-type-builder/admin/src/components/FormModal/attributes/advancedForm.js
+++ b/packages/core/content-type-builder/admin/src/components/FormModal/attributes/advancedForm.js
@@ -1,6 +1,3 @@
-// import React from 'react';
-// import { FormattedMessage } from 'react-intl';
-// import isEmpty from 'lodash/isEmpty';
 import getTrad from '../../../utils/getTrad';
 import { componentForm } from '../component';
 
@@ -51,7 +48,6 @@ const advancedForm = {
                   metadatas: { intlLabel: { id: 'false', defaultMessage: 'false' } },
                 },
               ],
-              // validations: {},
             },
           ],
         },

--- a/packages/core/content-type-builder/admin/src/components/FormModal/attributes/advancedForm.js
+++ b/packages/core/content-type-builder/admin/src/components/FormModal/attributes/advancedForm.js
@@ -7,6 +7,19 @@ import { componentForm } from '../component';
 import options from './attributeOptions';
 
 const advancedForm = {
+  blocks() {
+    return {
+      sections: [
+        {
+          sectionTitle: {
+            id: 'global.settings',
+            defaultMessage: 'Settings',
+          },
+          items: [options.required, options.private],
+        },
+      ],
+    };
+  },
   boolean() {
     return {
       sections: [
@@ -326,20 +339,6 @@ const advancedForm = {
             defaultMessage: 'Settings',
           },
           items: [options.required, options.maxLength, options.minLength, options.private],
-        },
-      ],
-    };
-  },
-  blocks() {
-    return {
-      sections: [
-        { sectionTitle: null, items: [options.default] },
-        {
-          sectionTitle: {
-            id: 'global.settings',
-            defaultMessage: 'Settings',
-          },
-          items: [options.required, options.private],
         },
       ],
     };

--- a/packages/core/content-type-builder/admin/src/components/FormModal/attributes/baseForm.js
+++ b/packages/core/content-type-builder/admin/src/components/FormModal/attributes/baseForm.js
@@ -1,5 +1,3 @@
-// import React, { Fragment } from 'react';
-// import { FormattedMessage } from 'react-intl';
 import getTrad from '../../../utils/getTrad';
 import { componentField, componentForm } from '../component';
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

- Removes the default input
- Moves the blocks method to the file to respect alphabetical order
- Remove commented code from 2 years ago

### Why is it needed?

A plain text default value doesn't make sense for JSON content. It created errors when it was provided.

### How to test it?

Create a new blocks attribute.
