### PR TITLE
[Blocks Editor]: Can’t create a block below an image or code block

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/index.js
@@ -202,7 +202,7 @@ ImageDialog.propTypes = {
   handleClose: PropTypes.func.isRequired,
 };
 
-const isLastBlockImageORCode = (editor) => {
+const isLastBlockImageOrCode = (editor) => {
   const { selection } = editor;
 
   if (!selection) return false;
@@ -215,9 +215,9 @@ const isLastBlockImageORCode = (editor) => {
   if (currentImageORCodeBlock) {
     const [, currentNodePath] = currentImageORCodeBlock;
 
-    const nodeAfter = Editor.after(editor, currentNodePath);
+    const isNodeAfter = Boolean(Editor.after(editor, currentNodePath));
 
-    return !nodeAfter;
+    return !isNodeAfter;
   }
 
   return false;
@@ -245,7 +245,7 @@ export const BlocksDropdown = () => {
 
     setBlockSelected(optionKey);
 
-    if (isLastBlockImageORCode(editor)) {
+    if (isLastBlockImageOrCode(editor)) {
       // insert blank line to add new blocks below code or image blocks
       Transforms.insertNodes(
         editor,

--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/tests/index.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/tests/index.test.js
@@ -259,4 +259,42 @@ describe('BlocksEditor toolbar', () => {
 
     expect(screen.getByText(title)).toBeInTheDocument();
   });
+
+  it('when code option is selected and if its the last block in the editor then new empty block should be inserted below it', async () => {
+    render(<BlocksDropdown />, {
+      wrapper: Wrapper,
+    });
+
+    Transforms.select(baseEditor, {
+      anchor: { path: [0, 0], offset: 0 },
+      focus: { path: [0, 0], offset: 0 },
+    });
+
+    const selectDropdown = screen.getByRole('combobox', { name: /Select a block/i });
+
+    await user.click(selectDropdown);
+
+    await user.click(screen.getByRole('option', { name: 'Code' }));
+
+    expect(baseEditor.children).toEqual([
+      {
+        type: 'code',
+        children: [
+          {
+            type: 'text',
+            text: 'A line of text in a paragraph.',
+          },
+        ],
+      },
+      {
+        type: 'paragraph',
+        children: [
+          {
+            type: 'text',
+            text: '',
+          },
+        ],
+      },
+    ]);
+  });
 });

--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/tests/index.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/tests/index.test.js
@@ -247,8 +247,9 @@ describe('BlocksEditor toolbar', () => {
       wrapper: Wrapper,
     });
 
-    Transforms.setSelection(baseEditor, {
+    Transforms.select(baseEditor, {
       anchor: { path: [0, 0], offset: 0 },
+      focus: { path: [0, 0], offset: 0 },
     });
 
     const headingsDropdown = screen.getByRole('combobox', { name: /Select a block/i });
@@ -258,6 +259,28 @@ describe('BlocksEditor toolbar', () => {
     await user.click(screen.getByRole('option', { name: 'Image' }));
 
     expect(screen.getByText(title)).toBeInTheDocument();
+
+    expect(baseEditor.children).toEqual([
+      {
+        type: 'image',
+        children: [
+          {
+            type: 'text',
+            text: 'A line of text in a paragraph.',
+          },
+        ],
+      },
+      // As its the last block in the editor new empty block is added below it
+      {
+        type: 'paragraph',
+        children: [
+          {
+            type: 'text',
+            text: '',
+          },
+        ],
+      },
+    ]);
   });
 
   it('when code option is selected and if its the last block in the editor then new empty block should be inserted below it', async () => {

--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/hooks/useBlocksStore.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/hooks/useBlocksStore.js
@@ -161,7 +161,7 @@ Image.propTypes = {
       alternativeText: PropTypes.string,
       width: PropTypes.number,
       height: PropTypes.number,
-    }).isRequired,
+    }),
   }).isRequired,
 };
 


### PR DESCRIPTION
### What does it do?

Adding a new line(Para) below end Code block or Image block

### Why is it needed?

Currently user is not able to type or add new block below code or image block, [Issue](https://strapi-inc.atlassian.net/browse/CS-261) 

### How to test it?

User can now add new block or type below the end code/image block.
