### PR TITLE
chore: add missing populate-builder type

### DIFF
--- a/packages/core/content-manager/server/utils/index.d.ts
+++ b/packages/core/content-manager/server/utils/index.d.ts
@@ -7,6 +7,7 @@ import * as fieldSizes from '../services/field-sizes';
 import * as metris from '../services/metris';
 import * as permissionChecker from '../services/permission-checker';
 import * as permission from '../services/permission';
+import * as populateBuilder from "../services/populate-builder";
 import * as uid from '../services/uid';
 
 type S = {
@@ -14,6 +15,7 @@ type S = {
   ['data-mapper']: typeof dataMapper;
   ['entity-manager']: typeof entityManager;
   ['permission-checker']: typeof permissionChecker;
+  ['populate-builder']: typeof populateBuilder;
   components: typeof components;
   configuration: typeof configuration;
   ['field-sizes']: typeof fieldSizes;


### PR DESCRIPTION
### What does it do?
Imports and add type for `content-manager/server/services/populate-builder`.

```ts
// content-manager/server/utils/index.d.ts
import * as populateBuilder from "../services/populate-builder";

type S = {
  ..
  ['populate-builder']: typeof populateBuilder;
  ..
};
```

### Why is it needed?
Not a big issue, but it does improve developer experience a bit as `'populate-builder'` becomes a valid parameter. Else, the customer will have to do something like this as a workaround:

```ts
import * as populateBuilder from "@strapi/plugin-content-manager/server/services/populate-builder.js";

const populate = await getService<typeof populateBuilder>("populate-builder")(model)
  .populateDeep(1)
  .countRelations({ toOne: false, toMany: true })
  .build();
```

### How to test it?
There should be no TS complaints and `populate-builder` shows up on the tooltip as valid parameter for `getService`.
