### PR TITLE
Allow graphql queries with optional parameters that are not sent

### DIFF
--- a/api-tests/plugins/graphql/relations.test.api.js
+++ b/api-tests/plugins/graphql/relations.test.api.js
@@ -449,11 +449,52 @@ describe('Test Graphql Relations API End to End', () => {
       // assign for later use
       data.labels = res.body.data.labels.data;
     });
+
     test('Deep query', async () => {
       const res = await graphqlQuery({
         query: /* GraphQL */ `
           {
             documents(filters: { labels: { name: { contains: "label 1" } } }) {
+              data {
+                id
+                attributes {
+                  name
+                  labels {
+                    data {
+                      id
+                      attributes {
+                        name
+                        color {
+                          name
+                          red
+                          green
+                          blue
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        `,
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body).toMatchObject({
+        data: {
+          documents: {
+            data: expect.arrayContaining(data.documents),
+          },
+        },
+      });
+    });
+
+    test('Deep query with empty object param', async () => {
+      const res = await graphqlQuery({
+        query: /* GraphQL */ `
+          {
+            documents(filters: { labels: { name: {} } }) {
               data {
                 id
                 attributes {

--- a/packages/core/utils/src/validate/validators.ts
+++ b/packages/core/utils/src/validate/validators.ts
@@ -51,12 +51,6 @@ const defaultValidateFilters = curry((schema: Model, filters: unknown) => {
     // empty objects
     traverseQueryFilters(
       ({ key, value }) => {
-        // ID is not an attribute per se, so we need to make
-        // an extra check to ensure we're not removing it
-        if (key === 'id') {
-          return;
-        }
-
         if (isObject(value) && isEmpty(value)) {
           throwInvalidParam({ key });
         }

--- a/packages/core/utils/src/validate/validators.ts
+++ b/packages/core/utils/src/validate/validators.ts
@@ -51,6 +51,12 @@ const defaultValidateFilters = curry((schema: Model, filters: unknown) => {
     // empty objects
     traverseQueryFilters(
       ({ key, value }) => {
+        // ID is not an attribute per se, so we need to make
+        // an extra check to ensure we're not removing it
+        if (key === 'id') {
+          return;
+        }
+
         if (isObject(value) && isEmpty(value)) {
           throwInvalidParam({ key });
         }


### PR DESCRIPTION
### What does it do?

Allows graphql queries such as in https://github.com/strapi/strapi/issues/17995 where an optional parameter is not sent, resulting in the actual query parameters being an empty object such as `id: { }` by removing empty objects before converting to a Strapi query

NOTE: I'm not 100% convinced we should do this because it introduces a subtle difference between the rest api and the graphql api. That is, REST does not allow invalid query parameters, but graphql will now accept queries with missing inputs. I have added an [alternate solution](https://github.com/strapi/strapi/pull/18180) that I think is preferable to this one.

### Why is it needed?

Many users are sending queries with optional parameters that are broken now that the query validation disallows invalid query parameters such as empty objects.

### How to test it?

See the issue at https://github.com/strapi/strapi/issues/17995 ; it should now work

### Related issue(s)/PR(s)

Fixes https://github.com/strapi/strapi/issues/17995

Might be related to https://github.com/strapi/strapi/issues/17945 but need to confirm