### PR TITLE
CMS_HOST.js

### DIFF
--- a/CMS_HOST.js
+++ b/CMS_HOST.js
@@ -1,0 +1,21 @@
+
+const oldCMSHost = 'old-cms-host.com';
+const newIPAddress = 'new-ip-address.com'; // or 'new-domain.com'
+
+// Function to update image URLs in the rich text field content
+function updateImageUrls(richTextFieldContent) {
+  // Use regular expressions to find and replace old CMS_HOST with new IP address or domain
+  const updatedContent = richTextFieldContent.replace(
+    new RegExp(oldCMSHost, 'g'), // 'g' flag for global replacement
+    newIPAddress
+  );
+
+  return updatedContent;
+}
+
+// Example usage:
+const originalRichTextFieldContent = "Here is some content with an image <img src='http://old-cms-host.com/image.jpg' />.";
+const updatedRichTextFieldContent = updateImageUrls(originalRichTextFieldContent);
+
+// Print the updated content to check if the image URLs are modified
+console.log(updatedRichTextFieldContent);


### PR DESCRIPTION
This script defines the old CMS_HOST and the new IP address (or domain) and provides a function (updateImageUrls) that replaces all instances of the old CMS_HOST with the new IP address or domain in the rich text field content. You can use this function to preprocess your data before importing it into the CMS running on the new IP address or domain.

Make sure to adjust the oldCMSHost and newIPAddress variables according to your specific URLs. This script assumes that you have access to the rich text field content as a string and can apply this transformation before importing the data into your CMS.

Thanks Regards
Police Akshith Reddy
