### PR TITLE
chore: add tsc for packages and back to workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,8 +58,8 @@ jobs:
       - name: Run lint
         run: yarn nx affected --target=lint --parallel --nx-ignore-cycles
 
-  typescript_front:
-    name: 'typescript_front'
+  typescript:
+    name: 'typescript'
     needs: [changes, lint]
     runs-on: ubuntu-latest
     steps:
@@ -72,14 +72,20 @@ jobs:
       - uses: nrwl/nx-set-shas@v3
       - name: Monorepo install
         uses: ./.github/actions/yarn-nm-install
-      - name: Run build:ts for admin-test-utils & helper-plugin
-        run: yarn build --projects=@strapi/admin-test-utils,@strapi/helper-plugin --skip-nx-cache
-      - name: Run test
+      - name: Run build:ts
+        run: yarn nx run-many --target=build:ts --nx-ignore-cycles --skip-nx-cache
+      - name: Run build
+        run: yarn nx run-many --target=build --nx-ignore-cycles --skip-nx-cache
+      - name: TSC for packages
+        run: yarn nx affected --target=test:ts --nx-ignore-cycles
+      - name: TSC for back
+        run: yarn nx affected --target=test:ts:back --nx-ignore-cycles
+      - name: TSC for front
         run: yarn nx affected --target=test:ts:front --nx-ignore-cycles
 
   unit_back:
     name: 'unit_back (node: ${{ matrix.node }})'
-    needs: [changes, lint]
+    needs: [changes, lint, typescript]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -101,7 +107,7 @@ jobs:
 
   unit_front:
     name: 'unit_front (node: ${{ matrix.node }})'
-    needs: [changes, lint, typescript_front]
+    needs: [changes, lint, typescript]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -123,7 +129,7 @@ jobs:
 
   build:
     name: 'build (node: ${{ matrix.node }})'
-    needs: [changes, lint, typescript_front, unit_front]
+    needs: [changes, lint, typescript, unit_front]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -140,7 +146,7 @@ jobs:
 
   e2e:
     timeout-minutes: 60
-    needs: [changes, lint, typescript_front, unit_front, build]
+    needs: [changes, lint, typescript, unit_front, build]
     name: 'e2e (browser: ${{ matrix.project }})'
     runs-on: ubuntu-latest
     strategy:
@@ -175,7 +181,7 @@ jobs:
   api_ce_pg:
     if: needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
-    needs: [changes, lint, unit_back, unit_front]
+    needs: [changes, lint, typescript, unit_back, unit_front]
     name: '[CE] API Integration (postgres, node: ${{ matrix.node }})'
     strategy:
       matrix:
@@ -213,7 +219,7 @@ jobs:
   api_ce_mysql:
     if: needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
-    needs: [changes, lint, unit_back, unit_front]
+    needs: [changes, lint, typescript, unit_back, unit_front]
     name: '[CE] API Integration (mysql:latest, client: ${{ matrix.db_client }}, node: ${{ matrix.node }})'
     strategy:
       matrix:
@@ -250,7 +256,7 @@ jobs:
   api_ce_mysql_5:
     if: needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
-    needs: [changes, lint, unit_back, unit_front]
+    needs: [changes, lint, typescript, unit_back, unit_front]
     name: '[CE] API Integration (mysql:5, client: ${{ matrix.db_client }} , node: ${{ matrix.node }})'
     strategy:
       matrix:
@@ -286,7 +292,7 @@ jobs:
   api_ce_sqlite:
     if: needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
-    needs: [changes, lint, unit_back, unit_front]
+    needs: [changes, lint, typescript, unit_back, unit_front]
     name: '[CE] API Integration (sqlite, client: ${{ matrix.sqlite_pkg }}, node: ${{ matrix.node }})'
     strategy:
       matrix:
@@ -308,7 +314,7 @@ jobs:
   # EE
   api_ee_pg:
     runs-on: ubuntu-latest
-    needs: [changes, lint, unit_back, unit_front]
+    needs: [changes, lint, typescript, unit_back, unit_front]
     name: '[EE] API Integration (postgres, node: ${{ matrix.node }})'
     if: needs.changes.outputs.backend == 'true' && github.event.pull_request.head.repo.full_name == github.repository && !(github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]')
     env:
@@ -349,7 +355,7 @@ jobs:
 
   api_ee_mysql:
     runs-on: ubuntu-latest
-    needs: [changes, lint, unit_back, unit_front]
+    needs: [changes, lint, typescript, unit_back, unit_front]
     name: '[EE] API Integration (mysql:latest, client: ${{ matrix.db_client }}, node: ${{ matrix.node }})'
     if: needs.changes.outputs.backend == 'true' && github.event.pull_request.head.repo.full_name == github.repository && !(github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]')
     env:
@@ -389,7 +395,7 @@ jobs:
 
   api_ee_sqlite:
     runs-on: ubuntu-latest
-    needs: [changes, lint, unit_back, unit_front]
+    needs: [changes, lint, typescript, unit_back, unit_front]
     name: '[EE] API Integration (sqlite, client: ${{ matrix.sqlite_pkg }}, node: ${{ matrix.node }})'
     if: needs.changes.outputs.backend == 'true' && github.event.pull_request.head.repo.full_name == github.repository && !(github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]')
     env:

--- a/package.json
+++ b/package.json
@@ -29,42 +29,47 @@
     "scripts/*"
   ],
   "scripts": {
-    "prepare": "husky install",
-    "setup": "yarn && yarn clean && yarn build",
-    "clean": "nx run-many --target=clean --nx-ignore-cycles",
-    "watch": "nx run-many --target=watch --nx-ignore-cycles",
     "build": "nx run-many --target=build --nx-ignore-cycles",
     "build:ts": "nx run-many --target=build:ts --nx-ignore-cycles",
+    "clean": "nx run-many --target=clean --nx-ignore-cycles",
+    "doc:api": "node scripts/open-api/serve.js",
+    "format": "yarn format:code && yarn format:other",
+    "format:code": "yarn prettier:code --write",
+    "format:other": "yarn prettier:other --write",
     "generate": "plop --plopfile ./packages/generators/admin/plopfile.js",
     "lint": "nx run-many --target=lint --nx-ignore-cycles && yarn lint:css && yarn lint:other",
     "lint:css": "stylelint packages/**/admin/src/**/*.js",
     "lint:fix": "nx run-many --target=lint --nx-ignore-cycles -- --fix",
     "lint:other": "npm run prettier:other -- --check",
-    "format": "yarn format:code && yarn format:other",
-    "format:code": "yarn prettier:code --write",
-    "format:other": "yarn prettier:other --write",
+    "prepare": "husky install",
     "prettier:code": "prettier --cache --cache-strategy content \"**/*.{js,ts}\"",
     "prettier:other": "prettier --cache --cache-strategy content \"**/*.{md,css,scss,yaml,yml}\"",
+    "setup": "yarn && yarn clean && yarn build",
+    "test:api": "node test/scripts/run-api-tests.js",
     "test:clean": "rimraf ./coverage",
     "test:e2e": "node test/scripts/run-e2e-tests.js",
-    "test:e2e:debug": "node test/scripts/run-e2e-tests.js --debug",
     "test:e2e:clean": "node test/scripts/run-e2e-tests.js clean",
-    "test:front:all": "cross-env IS_EE=true nx run-many --target=test:front --nx-ignore-cycles",
+    "test:e2e:debug": "node test/scripts/run-e2e-tests.js --debug",
     "test:front": "cross-env IS_EE=true jest --config jest.config.front.js",
-    "test:front:watch": "cross-env IS_EE=true run test:front --watch",
-    "test:front:update": "run test:front -u",
+    "test:front:all": "cross-env IS_EE=true nx run-many --target=test:front --nx-ignore-cycles",
     "test:front:all:ce": "cross-env IS_EE=false nx run-many --target=test:front:ce --nx-ignore-cycles",
     "test:front:ce": "cross-env IS_EE=false run test:front",
-    "test:front:watch:ce": "cross-env IS_EE=false run test:front --watch",
+    "test:front:update": "run test:front -u",
     "test:front:update:ce": "yarn test:front:ce -u",
-    "test:ts": "yarn test:ts:front",
-    "test:ts:front": "nx run-many --target=test:ts:front --nx-ignore-cycles",
-    "test:unit:all": "nx run-many --target=test:unit --nx-ignore-cycles",
-    "test:unit": "jest --config jest.config.js",
-    "test:unit:watch": "run test:unit --watch",
-    "test:api": "node test/scripts/run-api-tests.js",
+    "test:front:watch": "cross-env IS_EE=true run test:front --watch",
+    "test:front:watch:ce": "cross-env IS_EE=false run test:front --watch",
     "test:generate-app": "yarn build:ts && node test/scripts/generate-test-app.js",
-    "doc:api": "node scripts/open-api/serve.js"
+    "test:ts": "yarn test:ts:packages && yarn test:ts:front && yarn test:ts:back",
+    "test:ts:back": "nx run-many --target=test:ts:back --nx-ignore-cycles",
+    "test:ts:front": "nx run-many --target=test:ts:front --nx-ignore-cycles",
+    "test:ts:packages": "nx run-many --target=test:ts --nx-ignore-cycles",
+    "test:unit": "jest --config jest.config.js",
+    "test:unit:all": "nx run-many --target=test:unit --nx-ignore-cycles",
+    "test:unit:watch": "run test:unit --watch",
+    "watch": "nx run-many --target=watch --nx-ignore-cycles"
+  },
+  "resolutions": {
+    "@types/koa": "2.13.4"
   },
   "devDependencies": {
     "@babel/core": "^7.20.12",
@@ -129,12 +134,9 @@
     "typescript": "5.2.2",
     "yargs": "17.7.2"
   },
-  "resolutions": {
-    "@types/koa": "2.13.4"
-  },
+  "packageManager": "yarn@3.6.1",
   "engines": {
     "node": ">=16.0.0 <=20.x.x",
     "npm": ">=6.0.0"
-  },
-  "packageManager": "yarn@3.6.1"
+  }
 }


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* updates workflow to run `yarn test:ts:packages` & `yarn test:ts:back` 

### Why is it needed?

* If you add a package e.g. `@strapi/helper-plugin` and include the script `yarn test:ts` then it will be caught under the `yarn test:ts:packages` command and we can check the types correctly – the helper-plugin is already broken due to #17960, where the CI was not checking it correctly.
