### PR TITLE
Add blocks to namespace mapper

### DIFF
--- a/packages/utils/typescript/lib/generators/common/models/mappers.js
+++ b/packages/utils/typescript/lib/generators/common/models/mappers.js
@@ -87,6 +87,9 @@ module.exports = {
   json() {
     return [withAttributeNamespace('JSON')];
   },
+  blocks() {
+    return [withAttributeNamespace('Blocks')];
+  },
   media() {
     return [withAttributeNamespace('Media')];
   },


### PR DESCRIPTION
### What does it do?

Add blocks to the TypeScript namespace mapper

### Why is it needed?

Otherwise it throws a warning/error in the console:

`"blocks" attribute from "api::kitchensink.kitchensink" has an invalid type: "blocks"`

### How to test it?

Go to the getstarted start the app and you should see no warning in the console

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/pull/18166
