### PR TITLE
Add: promoting EE features in CE projects by default

### DIFF
--- a/packages/core/admin/admin/src/hooks/useSettingsMenu/constants.js
+++ b/packages/core/admin/admin/src/hooks/useSettingsMenu/constants.js
@@ -21,6 +21,33 @@ export const LINKS_CE = {
       to: '/settings/transfer-tokens?sort=name:ASC',
       id: 'transfer-tokens',
     },
+    ...((!window.strapi.features.isEnabled(
+      window.strapi.features.SSO) && window.strapi.promoteEnterpriseFeatures
+    )
+      ? [
+          {
+            intlLabel: { id: 'Settings.sso.title', defaultMessage: 'Single Sign-On' },
+            to: '/settings/purchase-single-sign-on',
+            id: 'sso',
+            tag: true,
+          },
+        ]
+      : []),
+    ...((!window.strapi.features.isEnabled(
+      window.strapi.features.REVIEW_WORKFLOWS) && window.strapi.promoteEnterpriseFeatures
+    )
+      ? [
+          {
+            intlLabel: {
+              id: 'Settings.review-workflows.page.title',
+              defaultMessage: 'Review Workflows',
+            },
+            to: '/settings/purchase-review-workflows',
+            id: 'review-workflows',
+            tag: true,
+          },
+        ]
+      : []),
   ],
 
   admin: [
@@ -35,5 +62,17 @@ export const LINKS_CE = {
       to: '/settings/users?pageSize=10&page=1&sort=firstname',
       id: 'users',
     },
+    ...((!window.strapi.features.isEnabled(
+      window.strapi.features.AUDIT_LOGS) && window.strapi.promoteEnterpriseFeatures
+    )
+      ? [
+          {
+            intlLabel: { id: 'global.auditLogs', defaultMessage: 'Audit Logs' },
+            to: '/settings/purchase-audit-logs',
+            id: 'auditLogs',
+            tag: true,
+          },
+        ]
+      : []),
   ],
 };

--- a/packages/core/admin/admin/src/index.js
+++ b/packages/core/admin/admin/src/index.js
@@ -22,6 +22,7 @@ window.strapi = {
     AUDIT_LOGS: 'audit-logs',
     REVIEW_WORKFLOWS: 'review-workflows',
   },
+  promoteEnterpriseFeatures: true,
   projectType: 'Community',
 };
 
@@ -41,11 +42,12 @@ const run = async () => {
   try {
     const {
       data: {
-        data: { isEE, features },
+        data: { isEE, features, promoteEnterpriseFeatures },
       },
     } = await get('/admin/project-type');
 
     window.strapi.isEE = isEE;
+    window.strapi.promoteEnterpriseFeatures = promoteEnterpriseFeatures;
     window.strapi.features = {
       ...window.strapi.features,
       isEnabled: (featureName) => features.some((feature) => feature.name === featureName),

--- a/packages/core/admin/admin/src/pages/SettingsPage/components/SettingsNav/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/components/SettingsNav/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { Badge } from '@strapi/design-system';
 import {
   SubNav,
   SubNavHeader,
@@ -60,6 +61,11 @@ const SettingsNav = ({ menu }) => {
                   key={link.id}
                 >
                   {formatMessage(link.intlLabel)}
+                  {link?.tag && (
+                    <Badge marginLeft={1} active>
+                      EE
+                    </Badge>
+                  )}
                 </SubNavLink>
               );
             })}

--- a/packages/core/admin/server/controllers/admin.js
+++ b/packages/core/admin/server/controllers/admin.js
@@ -26,11 +26,24 @@ module.exports = {
   // When removing this we need to update the /admin/src/index.js file
   // where we set the strapi.window.isEE value
   async getProjectType() {
+    const promoteEnterpriseFeatures = strapi.config.get('admin.promoteEnterpriseFeatures', true);
     // FIXME
     try {
-      return { data: { isEE: strapi.EE, features: ee.features.list() } };
+      return {
+        data: {
+          isEE: strapi.EE,
+          features: ee.features.list(),
+          promoteEnterpriseFeatures,
+        },
+      };
     } catch (err) {
-      return { data: { isEE: false, features: [] } };
+      return {
+        data: {
+          isEE: false,
+          features: [],
+          promoteEnterpriseFeatures,
+        },
+      };
     }
   },
 


### PR DESCRIPTION
### What does it do?

Promoting Enterprise features to CE projects by default. It will display the EE features on the settings page menu even if you are running a CE project. However, they will be highlighted with a badge/tag and they will open a page redirecting to our website pricing page.

**Important**, this is possible to disable it within the admin config file. See more on how to test it below

![Capture d’écran 2023-09-27 à 11 48 48](https://github.com/strapi/strapi/assets/17828745/ee947555-e9c7-42fd-9e8a-7f5e64de7301)

For now, only the features display is included in this PR and the goal is to validate if the config key is the right option to disable it or not. I intend to work on the pages later.

### Why is it needed?

Give more visibility to our Enterprise features.

### How to test it?


- Run the `getstarted` project without a license and without the config key to disable this behavior: On the settings page, you **should** see EE features opening to a blank page.
- Run the `getstarted` project with a license and with/without the config key to disable this behavior: On the settings page, you **should** see EE features like usual on an Enterprise project opening to the specific features page.
- Run the `getstarted` project without a license and with the config key to disable this behavior: On the settings page, you **should not** see EE features.


This is how you can disable this behavior:
`./config/admin.js`

```js
module.exports = ({ env }) => ({
  // autoOpen: false,
  auth: {
    secret: env('ADMIN_JWT_SECRET', 'example-token'),
  },
  apiToken: {
    salt: env('API_TOKEN_SALT', 'example-salt'),
  },
  auditLogs: {
    enabled: env.bool('AUDIT_LOGS_ENABLED', true),
  },
  transfer: {
    token: {
      salt: env('TRANSFER_TOKEN_SALT', 'example-salt'),
    },
  },
  promoteEnterpriseFeatures: false,
});
```
