### PR TITLE
[Blocks editor] Manage mixed blocks selection

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/index.js
@@ -262,6 +262,16 @@ export const BlocksDropdown = () => {
     }
   };
 
+  React.useEffect(() => {
+    const selectedBlocks = Object.keys(blocks).filter((key) => {
+      return isBlockActive(editor, blocks[key].matchNode);
+    });
+
+    if (selectedBlocks.length === 1) {
+      setBlockSelected(selectedBlocks[0]);
+    }
+  }, [blocks, editor, editor.selection]);
+
   return (
     <>
       <Select
@@ -280,8 +290,6 @@ export const BlocksDropdown = () => {
             value={key}
             label={blocks[key].label}
             icon={blocks[key].icon}
-            matchNode={blocks[key].matchNode}
-            handleSelection={setBlockSelected}
             blockSelected={blockSelected}
           />
         ))}
@@ -291,18 +299,10 @@ export const BlocksDropdown = () => {
   );
 };
 
-const BlockOption = ({ value, icon, label, handleSelection, blockSelected, matchNode }) => {
+const BlockOption = ({ value, icon, label, blockSelected }) => {
   const { formatMessage } = useIntl();
-  const editor = useSlate();
 
-  const isActive = isBlockActive(editor, matchNode);
   const isSelected = value === blockSelected;
-
-  React.useEffect(() => {
-    if (isActive && !isSelected) {
-      handleSelection(value);
-    }
-  }, [handleSelection, isActive, isSelected, value]);
 
   return (
     <Option
@@ -321,8 +321,6 @@ BlockOption.propTypes = {
     id: PropTypes.string.isRequired,
     defaultMessage: PropTypes.string.isRequired,
   }).isRequired,
-  matchNode: PropTypes.func.isRequired,
-  handleSelection: PropTypes.func.isRequired,
   blockSelected: PropTypes.string.isRequired,
 };
 

--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/index.js
@@ -316,7 +316,6 @@ export const BlocksDropdown = ({ disabled }) => {
 
       if (anchorNode) {
         const blockKey = findBlockKeyByTypeAndLevel(blocks, anchorNode.type, anchorNode?.level);
-        console.log('blockKey', blockKey);
 
         if (blockKey && blockKey !== blockSelected) {
           setBlockSelected(blockKey);

--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/index.js
@@ -241,23 +241,6 @@ const isLastBlockType = (editor, type) => {
   return false;
 };
 
-/**
- * Function that finds the corresponding block key in the blocks object based on the targetType and targetLevel (if present) provided.
- * @param {object} blocks - blocks object
- * @param {string} type - type of the target block
- * @param {number} level - level of the target block
- * @returns string|undefined - block key or null if no matching block is found
- */
-const getAnchorBlockKey = (blocks, { type, level = null }) => {
-  const anchorBlockKey = Object.keys(blocks).find((key) => {
-    const block = blocks[key];
-
-    return block.value.type === type && (level === null || block.value.level === level);
-  });
-
-  return anchorBlockKey;
-};
-
 const insertEmptyBlockAtLast = (editor) => {
   Transforms.insertNodes(
     editor,
@@ -309,12 +292,13 @@ export const BlocksDropdown = ({ disabled }) => {
   React.useEffect(() => {
     if (editor.selection) {
       const [anchorNode] = Editor.parent(editor, editor.selection.anchor); // Get the parent node of the anchor
+      const anchorBlockKey = Object.keys(blocks).find((blockKey) =>
+        blocks[blockKey].matchNode(anchorNode)
+      );
 
       if (anchorNode) {
-        const blockKey = getAnchorBlockKey(blocks, anchorNode);
-
-        if (blockKey && blockKey !== blockSelected) {
-          setBlockSelected(blockKey);
+        if (anchorBlockKey && anchorBlockKey !== blockSelected) {
+          setBlockSelected(anchorBlockKey);
         }
       }
     }

--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/index.js
@@ -244,22 +244,18 @@ const isLastBlockType = (editor, type) => {
 /**
  * Function that finds the corresponding block key in the blocks object based on the targetType and targetLevel (if present) provided.
  * @param {object} blocks - blocks object
- * @param {string} targetType - type of the target block
- * @param {number} targetLevel - level of the target block
- * @returns string|null - block key or null if no matching block is found
+ * @param {string} type - type of the target block
+ * @param {number} level - level of the target block
+ * @returns string|undefined - block key or null if no matching block is found
  */
-const findBlockKeyByTypeAndLevel = (blocks, targetType, targetLevel = null) => {
-  const blockKey = Object.keys(blocks).find((key) => {
+const getAnchorBlockKey = (blocks, { type, level = null }) => {
+  const anchorBlockKey = Object.keys(blocks).find((key) => {
     const block = blocks[key];
 
-    return (
-      block.value &&
-      block.value.type === targetType &&
-      (targetLevel === null || block.value.level === targetLevel)
-    );
+    return block.value.type === type && (level === null || block.value.level === level);
   });
 
-  return blockKey || null; // Return null if no matching block is found
+  return anchorBlockKey;
 };
 
 const insertEmptyBlockAtLast = (editor) => {
@@ -315,7 +311,7 @@ export const BlocksDropdown = ({ disabled }) => {
       const [anchorNode] = Editor.parent(editor, editor.selection.anchor); // Get the parent node of the anchor
 
       if (anchorNode) {
-        const blockKey = findBlockKeyByTypeAndLevel(blocks, anchorNode.type, anchorNode?.level);
+        const blockKey = getAnchorBlockKey(blocks, anchorNode);
 
         if (blockKey && blockKey !== blockSelected) {
           setBlockSelected(blockKey);

--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/index.js
@@ -289,17 +289,19 @@ export const BlocksDropdown = ({ disabled }) => {
     }
   };
 
+  // This useEffect tried to listen to the selection change and update the selected block in the dropdown
   React.useEffect(() => {
     if (editor.selection) {
-      const [anchorNode] = Editor.parent(editor, editor.selection.anchor); // Get the parent node of the anchor
+      // Get the parent node of the anchor
+      const [anchorNode] = Editor.parent(editor, editor.selection.anchor);
+      // Find the block key that matches the anchor node
       const anchorBlockKey = Object.keys(blocks).find((blockKey) =>
         blocks[blockKey].matchNode(anchorNode)
       );
 
-      if (anchorNode) {
-        if (anchorBlockKey && anchorBlockKey !== blockSelected) {
-          setBlockSelected(anchorBlockKey);
-        }
+      // change the value selected in the dropdown if it doesn't match the anchor block key
+      if (anchorBlockKey && anchorBlockKey !== blockSelected) {
+        setBlockSelected(anchorBlockKey);
       }
     }
   }, [editor.selection, editor, blocks, blockSelected]);

--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/index.js
@@ -187,7 +187,7 @@ const ImageDialog = ({ handleClose }) => {
 
   const handleSelectAssets = (images) => {
     const formattedImages = images.map((image) => {
-      // create an object with imageSchema defined and exclude unnecessary props coming from media library config
+      // Create an object with imageSchema defined and exclude unnecessary props coming from media library config
       const expectedImage = pick(image, IMAGE_SCHEMA_FIELDS);
 
       return {
@@ -200,7 +200,7 @@ const ImageDialog = ({ handleClose }) => {
     insertImages(formattedImages);
 
     if (isLastBlockType(editor, 'image')) {
-      // insert blank line to add new blocks below image block
+      // Insert blank line to add new blocks below image block
       insertEmptyBlockAtLast(editor);
     }
 
@@ -280,7 +280,7 @@ export const BlocksDropdown = ({ disabled }) => {
     setBlockSelected(optionKey);
 
     if (optionKey === 'code' && isLastBlockType(editor, 'code')) {
-      // insert blank line to add new blocks below code block
+      // Insert blank line to add new blocks below code block
       insertEmptyBlockAtLast(editor);
     }
 
@@ -289,7 +289,7 @@ export const BlocksDropdown = ({ disabled }) => {
     }
   };
 
-  // This useEffect tried to listen to the selection change and update the selected block in the dropdown
+  // Listen to the selection change and update the selected block in the dropdown
   React.useEffect(() => {
     if (editor.selection) {
       // Get the parent node of the anchor
@@ -299,7 +299,7 @@ export const BlocksDropdown = ({ disabled }) => {
         blocks[blockKey].matchNode(anchorNode)
       );
 
-      // change the value selected in the dropdown if it doesn't match the anchor block key
+      // Change the value selected in the dropdown if it doesn't match the anchor block key
       if (anchorBlockKey && anchorBlockKey !== blockSelected) {
         setBlockSelected(anchorBlockKey);
       }

--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/tests/index.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/tests/index.test.js
@@ -1,11 +1,11 @@
 import * as React from 'react';
 
 import { lightTheme, ThemeProvider } from '@strapi/design-system';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import PropTypes from 'prop-types';
 import { IntlProvider } from 'react-intl';
-import { createEditor, Transforms } from 'slate';
+import { createEditor, Transforms, Editor } from 'slate';
 import { Slate, withReact } from 'slate-react';
 
 import { BlocksToolbar, BlocksDropdown } from '..';
@@ -28,17 +28,34 @@ const initialValue = [
   },
 ];
 
+const mixedInitialValue = [
+  {
+    type: 'heading',
+    level: 1,
+    children: [{ type: 'text', text: 'A heading one' }],
+  },
+  {
+    type: 'paragraph',
+    children: [{ type: 'text', text: 'A line of text in a paragraph.' }],
+  },
+  {
+    type: 'heading',
+    level: 2,
+    children: [{ type: 'text', text: 'A heading two' }],
+  },
+];
+
 const user = userEvent.setup();
 
 const baseEditor = createEditor();
 
-const Wrapper = ({ children }) => {
+const Wrapper = ({ children, initialData }) => {
   const [editor] = React.useState(() => withReact(baseEditor));
 
   return (
     <ThemeProvider theme={lightTheme}>
       <IntlProvider messages={{}} locale="en">
-        <Slate initialValue={initialValue} editor={editor}>
+        <Slate initialValue={initialData} editor={editor}>
           {children}
         </Slate>
       </IntlProvider>
@@ -48,18 +65,20 @@ const Wrapper = ({ children }) => {
 
 Wrapper.propTypes = {
   children: PropTypes.node.isRequired,
+  initialData: PropTypes.array,
 };
 
-const setup = () =>
+Wrapper.defaultProps = {
+  initialData: initialValue,
+};
+
+const setup = (data) => {
   render(<BlocksToolbar />, {
-    wrapper: Wrapper,
+    wrapper: ({ children }) => <Wrapper initialData={data}>{children}</Wrapper>,
   });
+};
 
 describe('BlocksEditor toolbar', () => {
-  beforeEach(() => {
-    baseEditor.children = initialValue;
-  });
-
   it('should render the toolbar', () => {
     setup();
 
@@ -319,5 +338,34 @@ describe('BlocksEditor toolbar', () => {
         ],
       },
     ]);
+  });
+
+  it('check if a mixed selected content show only one option selected in the dropdown', async () => {
+    setup(mixedInitialValue);
+
+    const headingsDropdown = screen.getByRole('combobox', { name: /Select a block/i });
+
+    // Set the selection to cover the entire content
+    Transforms.setSelection(baseEditor, {
+      anchor: Editor.start(baseEditor, []),
+      focus: Editor.end(baseEditor, []),
+    });
+
+    // the dropdown should show only one option selected which is the block content in the first row
+    expect(within(headingsDropdown).getByText(/heading 1/i)).toBeInTheDocument();
+  });
+
+  it('check if a mixed selected content show only one option selected in the dropdown when you select only part of the content', async () => {
+    setup(mixedInitialValue);
+
+    const headingsDropdown = screen.getByRole('combobox', { name: /Select a block/i });
+
+    // Set the selection to cover the second and third row
+    Transforms.setSelection(baseEditor, {
+      anchor: { path: [1, 0], offset: 0 },
+    });
+
+    // the dropdown should show only one option selected which is the block content in the second row
+    expect(within(headingsDropdown).getByText(/text/i)).toBeInTheDocument();
   });
 });

--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/tests/index.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/tests/index.test.js
@@ -355,7 +355,8 @@ describe('BlocksEditor toolbar', () => {
     expect(within(headingsDropdown).getByText(/heading 1/i)).toBeInTheDocument();
   });
 
-  it('check if a mixed selected content show only one option selected in the dropdown when you select only part of the content', async () => {
+  // TODO: fix this test because after the Transforms the dropdown is not updated
+  it.skip('check if a mixed selected content show only one option selected in the dropdown when you select only part of the content', async () => {
     setup(mixedInitialValue);
 
     const headingsDropdown = screen.getByRole('combobox', { name: /Select a block/i });

--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/tests/index.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/tests/index.test.js
@@ -85,6 +85,20 @@ describe('BlocksEditor toolbar', () => {
     expect(screen.getByRole('toolbar')).toBeInTheDocument();
   });
 
+  it('check if a mixed selected content show only one option selected in the dropdown when you select only part of the content', async () => {
+    setup(mixedInitialValue);
+
+    const headingsDropdown = screen.getByRole('combobox', { name: /Select a block/i });
+
+    // Set the selection to cover the second and third row
+    Transforms.setSelection(baseEditor, {
+      anchor: { path: [1, 0], offset: 0 },
+    });
+
+    // the dropdown should show only one option selected which is the block content in the second row
+    expect(within(headingsDropdown).getByText(/text/i)).toBeInTheDocument();
+  });
+
   it('toggles the modifier on a selection', async () => {
     setup();
 
@@ -332,20 +346,5 @@ describe('BlocksEditor toolbar', () => {
 
     // the dropdown should show only one option selected which is the block content in the first row
     expect(within(headingsDropdown).getByText(/heading 1/i)).toBeInTheDocument();
-  });
-
-  // TODO: fix this test because after the Transforms the dropdown is not updated
-  it.skip('check if a mixed selected content show only one option selected in the dropdown when you select only part of the content', async () => {
-    setup(mixedInitialValue);
-
-    const headingsDropdown = screen.getByRole('combobox', { name: /Select a block/i });
-
-    // Set the selection to cover the second and third row
-    Transforms.setSelection(baseEditor, {
-      anchor: { path: [1, 0], offset: 0 },
-    });
-
-    // the dropdown should show only one option selected which is the block content in the second row
-    expect(within(headingsDropdown).getByText(/text/i)).toBeInTheDocument();
   });
 });

--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/tests/index.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/tests/index.test.js
@@ -85,7 +85,7 @@ describe('BlocksEditor toolbar', () => {
     expect(screen.getByRole('toolbar')).toBeInTheDocument();
   });
 
-  it('check if a mixed selected content show only one option selected in the dropdown when you select only part of the content', async () => {
+  it('checks if a mixed selected content shows only one option selected in the dropdown when you select only part of the content', async () => {
     setup(mixedInitialValue);
 
     const headingsDropdown = screen.getByRole('combobox', { name: /Select a block/i });
@@ -95,7 +95,7 @@ describe('BlocksEditor toolbar', () => {
       anchor: { path: [1, 0], offset: 0 },
     });
 
-    // the dropdown should show only one option selected which is the block content in the second row
+    // The dropdown should show only one option selected which is the block content in the second row
     expect(within(headingsDropdown).getByText(/text/i)).toBeInTheDocument();
   });
 
@@ -333,7 +333,7 @@ describe('BlocksEditor toolbar', () => {
     ]);
   });
 
-  it('check if a mixed selected content show only one option selected in the dropdown', async () => {
+  it('checks if a mixed selected content shows only one option selected in the dropdown', async () => {
     setup(mixedInitialValue);
 
     const headingsDropdown = screen.getByRole('combobox', { name: /Select a block/i });
@@ -344,7 +344,7 @@ describe('BlocksEditor toolbar', () => {
       focus: Editor.end(baseEditor, []),
     });
 
-    // the dropdown should show only one option selected which is the block content in the first row
+    // The dropdown should show only one option selected which is the block content in the first row
     expect(within(headingsDropdown).getByText(/heading 1/i)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

- Resolves the strange behavior we encountered when selecting content with mixed block types in the RTE block editor.

### Why is it needed?

Because the Blocks dropdown continuously changes its selected option between the block types in the selection.

### How to test it?

- Create a new blocks field inside a Collection.
- Create different content such as an h1, a paragraph, and a quote.
- Use the mouse to select all the created content.
- The option selected in the Dropdown will be the one related to the block type where you positioned the cursor to start the selection.

### Related PR
This PR is the new version of this Pr https://github.com/strapi/strapi/pull/18162 so we need to manage all the comments received in the old one (https://github.com/strapi/strapi/pull/18162#discussion_r1336740789)