### PR TITLE
fix: content manager action buttons not triggering and checkbox causing scroll

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ The Strapi core team will review your pull request and either merge it, request 
   - `yarn test:unit`
   - `yarn test:front`
   - `yarn test:e2e --setup --concurrency=1`
-    - you ***may*** need to install Playwright browsers first: `yarn playwright install`
+    - you **_may_** need to install Playwright browsers first: `yarn playwright install`
 - Make sure your code lints by running `yarn lint`.
 - If your contribution fixes an existing issue, please make sure to link it in your pull request.
 

--- a/packages/core/admin/admin/src/content-manager/pages/ListView/components/Body/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/ListView/components/Body/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { BaseCheckbox, IconButton, Td, Flex } from '@strapi/design-system';
+import { BaseCheckbox, IconButton, Flex } from '@strapi/design-system';
 import { useTracking, useTableContext, Table } from '@strapi/helper-plugin';
 import { Trash, Duplicate, Pencil } from '@strapi/icons';
 import PropTypes from 'prop-types';
@@ -29,15 +29,14 @@ const CheckboxDataCell = ({ rowId, index }) => {
   );
 
   return (
-    <Td onClick={stopPropagation}>
       <BaseCheckbox
         aria-label={ariaLabel}
         checked={isChecked}
+        onClick={stopPropagation}
         onChange={() => {
           onSelectRow({ name: rowId, value: !isChecked });
         }}
       />
-    </Td>
   );
 };
 

--- a/packages/core/admin/admin/src/content-manager/pages/ListView/components/Body/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/ListView/components/Body/index.js
@@ -75,7 +75,6 @@ const EntityActionsDataCell = ({
   );
 
   return (
-    <Td>
       <Flex gap={1} justifyContent="end" onClick={stopPropagation}>
         <IconButton
           forwardedAs={Link}
@@ -129,7 +128,6 @@ const EntityActionsDataCell = ({
           </IconButton>
         )}
       </Flex>
-    </Td>
   );
 };
 

--- a/packages/core/admin/admin/src/content-manager/pages/ListView/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/ListView/index.js
@@ -731,7 +731,7 @@ function ListView({
                 >
                   {data.map((rowData, index) => {
                     return (
-                      <Tr cursor="pointer" key={data.id} onClick={handleRowClick(rowData.id)}>
+                      <Tr cursor="pointer" key={rowData.id} onClick={handleRowClick(rowData.id)}>
                         {/* Bulk action row checkbox */}
                         <Td>
                           <Body.CheckboxDataCell rowId={rowData.id} index={index} />

--- a/packages/core/admin/admin/src/content-manager/pages/ListView/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/ListView/index.js
@@ -832,14 +832,16 @@ function ListView({
                         })}
                         {/* Actions: edit, duplicate, delete */}
                         {(canDelete || canPublish) && isBulkable && (
-                          <Body.EntityActionsDataCell
-                            rowId={rowData.id}
-                            index={index}
-                            setIsConfirmDeleteRowOpen={setIsConfirmDeleteRowOpen}
-                            canCreate={canCreate}
-                            canDelete={canDelete}
-                            handleCloneClick={handleCloneClick}
-                          />
+                          <Td>
+                            <Body.EntityActionsDataCell
+                              rowId={rowData.id}
+                              index={index}
+                              setIsConfirmDeleteRowOpen={setIsConfirmDeleteRowOpen}
+                              canCreate={canCreate}
+                              canDelete={canDelete}
+                              handleCloneClick={handleCloneClick}
+                            />
+                          </Td>
                         )}
                       </Tr>
                     );

--- a/packages/core/admin/admin/src/content-manager/pages/ListView/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/ListView/index.js
@@ -733,7 +733,9 @@ function ListView({
                     return (
                       <Tr cursor="pointer" key={data.id} onClick={handleRowClick(rowData.id)}>
                         {/* Bulk action row checkbox */}
-                        <Body.CheckboxDataCell rowId={rowData.id} index={index} />
+                        <Td>
+                          <Body.CheckboxDataCell rowId={rowData.id} index={index} />
+                        </Td>
                         {/* Field data */}
                         {tableHeaders.map(({ key, name, cellFormatter, ...rest }) => {
                           if (hasDraftAndPublish && name === 'publishedAt') {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

1. Wraps Checkbox and  Action Buttons components in a direct `<Td>` to correctly handle click events, seems that's the direct nesting it expects. 
3. Fixes incorrect `key` for mapped component (was displaying warning)

### Why is it needed?

To solve bugs reported in https://github.com/strapi/strapi/issues/17880, https://github.com/strapi/strapi/issues/17942

### How to test it?

1. In Content Manager, add a collection type that will cause horizontal scroll in Listing table
1. Attempt to delete or duplicate an entry by clicking the corresponding action buttons it should duplicate or prompt delete when corresponding buttons are clicked on

1. In Content Manager, Add enough items (maybe 10) or resize window to be short in height, scroll to bottom
2. Attempt to add a check to an item of the bottom, it should not scroll to top

### Related issue(s)/PR(s)

Fixes https://github.com/strapi/strapi/issues/17880, fixes https://github.com/strapi/strapi/issues/17942
