### PR TITLE
chore(e2e): store test traces for failed tests as GH action artifacts

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -182,6 +182,7 @@ jobs:
         with:
           name: playwright-trace
           path: test-apps/e2e/**/test-results/**/trace.zip
+          retention-days: 1
 
   api_ce_pg:
     if: needs.changes.outputs.backend == 'true'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -177,6 +177,12 @@ jobs:
       - name: Run E2E tests
         run: yarn test:e2e --setup --concurrency=1 --project=${{ matrix.project }}
 
+      - uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: playwright-trace
+          path: test-apps/e2e/**/test-results/**/trace.zip
+
   api_ce_pg:
     if: needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest

--- a/playwright.base.config.js
+++ b/playwright.base.config.js
@@ -36,8 +36,8 @@ const createConfig = ({ port, testDir, appDir }) => ({
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
     actionTimeout: 0,
 
-    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-    trace: 'off',
+    /* Collect trace when a test failed. See https://playwright.dev/docs/trace-viewer */
+    trace: 'retain-on-failure',
   },
 
   /* Configure projects for major browsers */

--- a/playwright.base.config.js
+++ b/playwright.base.config.js
@@ -36,8 +36,11 @@ const createConfig = ({ port, testDir, appDir }) => ({
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
     actionTimeout: 0,
 
-    /* Collect trace when a test failed. See https://playwright.dev/docs/trace-viewer */
-    trace: 'retain-on-failure',
+    /* Collect trace when a test failed on the CI. See https://playwright.dev/docs/trace-viewer
+       Until https://github.com/strapi/strapi/issues/18196 is fixed we can't enable this locally,
+       because the Strapi server restarts every time a new file (trace) is created.
+    */
+    trace: process.env.CI ? 'retain-on-failure' : 'off',
   },
 
   /* Configure projects for major browsers */


### PR DESCRIPTION
### What does it do?

- Stores traces for failed e2e tests
- Uploads traces as GH Action artifact

### Why is it needed?

I am pretty lost why https://github.com/strapi/strapi/pull/18065 keeps failing and hope traces give me some hints.
