### PR TITLE
Add missing blocks attribute types

### DIFF
--- a/examples/getstarted/types/generated/components.d.ts
+++ b/examples/getstarted/types/generated/components.d.ts
@@ -1,0 +1,154 @@
+import type { Schema, Attribute } from '@strapi/strapi';
+
+export interface BasicRelation extends Schema.Component {
+  collectionName: 'components_basic_relations';
+  info: {
+    displayName: 'Relation';
+  };
+  attributes: {
+    categories: Attribute.Relation<'basic.relation', 'oneToMany', 'api::category.category'>;
+  };
+}
+
+export interface BasicSimple extends Schema.Component {
+  collectionName: 'components_basic_simples';
+  info: {
+    displayName: 'simple';
+    icon: 'ambulance';
+    description: '';
+  };
+  attributes: {
+    name: Attribute.String & Attribute.Required;
+    test: Attribute.String;
+  };
+}
+
+export interface BlogTestComo extends Schema.Component {
+  collectionName: 'components_blog_test_comos';
+  info: {
+    displayName: 'test comp';
+    icon: 'air-freshener';
+    description: '';
+  };
+  attributes: {
+    name: Attribute.String & Attribute.DefaultTo<'toto'>;
+  };
+}
+
+export interface DefaultApple extends Schema.Component {
+  collectionName: 'components_default_apples';
+  info: {
+    displayName: 'apple';
+    icon: 'apple-alt';
+    description: '';
+  };
+  attributes: {
+    name: Attribute.String & Attribute.Required;
+  };
+}
+
+export interface DefaultCar extends Schema.Component {
+  collectionName: 'components_default_cars';
+  info: {
+    displayName: 'car';
+    icon: 'align-right';
+  };
+  attributes: {
+    name: Attribute.String;
+  };
+}
+
+export interface DefaultClosingperiod extends Schema.Component {
+  collectionName: 'components_closingperiods';
+  info: {
+    displayName: 'closingperiod';
+    description: '';
+    icon: 'angry';
+  };
+  attributes: {
+    label: Attribute.String & Attribute.DefaultTo<'toto'>;
+    start_date: Attribute.Date & Attribute.Required;
+    end_date: Attribute.Date & Attribute.Required;
+    media: Attribute.Media;
+    dish: Attribute.Component<'default.dish', true> &
+      Attribute.Required &
+      Attribute.SetMinMax<{
+        min: 2;
+      }>;
+  };
+}
+
+export interface DefaultDish extends Schema.Component {
+  collectionName: 'components_dishes';
+  info: {
+    displayName: 'dish';
+    description: '';
+    icon: 'address-book';
+  };
+  attributes: {
+    name: Attribute.String & Attribute.DefaultTo<'My super dish'>;
+    description: Attribute.Text;
+    price: Attribute.Float;
+    picture: Attribute.Media;
+    very_long_description: Attribute.RichText;
+    categories: Attribute.Relation<'default.dish', 'oneToOne', 'api::category.category'>;
+  };
+}
+
+export interface DefaultOpeningtimes extends Schema.Component {
+  collectionName: 'components_openingtimes';
+  info: {
+    displayName: 'openingtimes';
+    description: '';
+    icon: 'calendar';
+  };
+  attributes: {
+    label: Attribute.String & Attribute.Required & Attribute.DefaultTo<'something'>;
+    time: Attribute.String;
+    dishrep: Attribute.Component<'default.dish', true>;
+  };
+}
+
+export interface DefaultRestaurantservice extends Schema.Component {
+  collectionName: 'components_restaurantservices';
+  info: {
+    displayName: 'restaurantservice';
+    description: '';
+    icon: 'cannabis';
+  };
+  attributes: {
+    name: Attribute.String & Attribute.Required & Attribute.DefaultTo<'something'>;
+    media: Attribute.Media;
+    is_available: Attribute.Boolean & Attribute.Required & Attribute.DefaultTo<true>;
+  };
+}
+
+export interface DefaultTemp extends Schema.Component {
+  collectionName: 'components_default_temps';
+  info: {
+    displayName: 'temp';
+    icon: 'adjust';
+    description: '';
+  };
+  attributes: {
+    name: Attribute.String & Attribute.Required;
+    url: Attribute.String;
+  };
+}
+
+declare module '@strapi/types' {
+  export module Shared {
+    export interface Components {
+      'basic.relation': BasicRelation;
+      'basic.simple': BasicSimple;
+      'blog.test-como': BlogTestComo;
+      'default.apple': DefaultApple;
+      'default.car': DefaultCar;
+      'default.closingperiod': DefaultClosingperiod;
+      'default.dish': DefaultDish;
+      'default.openingtimes': DefaultOpeningtimes;
+      'default.restaurantservice': DefaultRestaurantservice;
+      'default.temp': DefaultTemp;
+    }
+  }
+}

--- a/examples/getstarted/types/generated/contentTypes.d.ts
+++ b/examples/getstarted/types/generated/contentTypes.d.ts
@@ -1,0 +1,1313 @@
+import type { Schema, Attribute } from '@strapi/strapi';
+
+export interface AdminPermission extends Schema.CollectionType {
+  collectionName: 'admin_permissions';
+  info: {
+    name: 'Permission';
+    description: '';
+    singularName: 'permission';
+    pluralName: 'permissions';
+    displayName: 'Permission';
+  };
+  pluginOptions: {
+    'content-manager': {
+      visible: false;
+    };
+    'content-type-builder': {
+      visible: false;
+    };
+  };
+  attributes: {
+    action: Attribute.String &
+      Attribute.Required &
+      Attribute.SetMinMaxLength<{
+        minLength: 1;
+      }>;
+    actionParameters: Attribute.JSON & Attribute.DefaultTo<{}>;
+    subject: Attribute.String &
+      Attribute.SetMinMaxLength<{
+        minLength: 1;
+      }>;
+    properties: Attribute.JSON & Attribute.DefaultTo<{}>;
+    conditions: Attribute.JSON & Attribute.DefaultTo<[]>;
+    role: Attribute.Relation<'admin::permission', 'manyToOne', 'admin::role'>;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<'admin::permission', 'oneToOne', 'admin::user'> &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<'admin::permission', 'oneToOne', 'admin::user'> &
+      Attribute.Private;
+  };
+}
+
+export interface AdminUser extends Schema.CollectionType {
+  collectionName: 'admin_users';
+  info: {
+    name: 'User';
+    description: '';
+    singularName: 'user';
+    pluralName: 'users';
+    displayName: 'User';
+  };
+  pluginOptions: {
+    'content-manager': {
+      visible: false;
+    };
+    'content-type-builder': {
+      visible: false;
+    };
+  };
+  attributes: {
+    firstname: Attribute.String &
+      Attribute.SetMinMaxLength<{
+        minLength: 1;
+      }>;
+    lastname: Attribute.String &
+      Attribute.SetMinMaxLength<{
+        minLength: 1;
+      }>;
+    username: Attribute.String;
+    email: Attribute.Email &
+      Attribute.Required &
+      Attribute.Private &
+      Attribute.Unique &
+      Attribute.SetMinMaxLength<{
+        minLength: 6;
+      }>;
+    password: Attribute.Password &
+      Attribute.Private &
+      Attribute.SetMinMaxLength<{
+        minLength: 6;
+      }>;
+    resetPasswordToken: Attribute.String & Attribute.Private;
+    registrationToken: Attribute.String & Attribute.Private;
+    isActive: Attribute.Boolean & Attribute.Private & Attribute.DefaultTo<false>;
+    roles: Attribute.Relation<'admin::user', 'manyToMany', 'admin::role'> & Attribute.Private;
+    blocked: Attribute.Boolean & Attribute.Private & Attribute.DefaultTo<false>;
+    preferedLanguage: Attribute.String;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<'admin::user', 'oneToOne', 'admin::user'> & Attribute.Private;
+    updatedBy: Attribute.Relation<'admin::user', 'oneToOne', 'admin::user'> & Attribute.Private;
+  };
+}
+
+export interface AdminRole extends Schema.CollectionType {
+  collectionName: 'admin_roles';
+  info: {
+    name: 'Role';
+    description: '';
+    singularName: 'role';
+    pluralName: 'roles';
+    displayName: 'Role';
+  };
+  pluginOptions: {
+    'content-manager': {
+      visible: false;
+    };
+    'content-type-builder': {
+      visible: false;
+    };
+  };
+  attributes: {
+    name: Attribute.String &
+      Attribute.Required &
+      Attribute.Unique &
+      Attribute.SetMinMaxLength<{
+        minLength: 1;
+      }>;
+    code: Attribute.String &
+      Attribute.Required &
+      Attribute.Unique &
+      Attribute.SetMinMaxLength<{
+        minLength: 1;
+      }>;
+    description: Attribute.String;
+    users: Attribute.Relation<'admin::role', 'manyToMany', 'admin::user'>;
+    permissions: Attribute.Relation<'admin::role', 'oneToMany', 'admin::permission'>;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<'admin::role', 'oneToOne', 'admin::user'> & Attribute.Private;
+    updatedBy: Attribute.Relation<'admin::role', 'oneToOne', 'admin::user'> & Attribute.Private;
+  };
+}
+
+export interface AdminApiToken extends Schema.CollectionType {
+  collectionName: 'strapi_api_tokens';
+  info: {
+    name: 'Api Token';
+    singularName: 'api-token';
+    pluralName: 'api-tokens';
+    displayName: 'Api Token';
+    description: '';
+  };
+  pluginOptions: {
+    'content-manager': {
+      visible: false;
+    };
+    'content-type-builder': {
+      visible: false;
+    };
+  };
+  attributes: {
+    name: Attribute.String &
+      Attribute.Required &
+      Attribute.Unique &
+      Attribute.SetMinMaxLength<{
+        minLength: 1;
+      }>;
+    description: Attribute.String &
+      Attribute.SetMinMaxLength<{
+        minLength: 1;
+      }> &
+      Attribute.DefaultTo<''>;
+    type: Attribute.Enumeration<['read-only', 'full-access', 'custom']> &
+      Attribute.Required &
+      Attribute.DefaultTo<'read-only'>;
+    accessKey: Attribute.String &
+      Attribute.Required &
+      Attribute.SetMinMaxLength<{
+        minLength: 1;
+      }>;
+    lastUsedAt: Attribute.DateTime;
+    permissions: Attribute.Relation<'admin::api-token', 'oneToMany', 'admin::api-token-permission'>;
+    expiresAt: Attribute.DateTime;
+    lifespan: Attribute.BigInteger;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<'admin::api-token', 'oneToOne', 'admin::user'> &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<'admin::api-token', 'oneToOne', 'admin::user'> &
+      Attribute.Private;
+  };
+}
+
+export interface AdminApiTokenPermission extends Schema.CollectionType {
+  collectionName: 'strapi_api_token_permissions';
+  info: {
+    name: 'API Token Permission';
+    description: '';
+    singularName: 'api-token-permission';
+    pluralName: 'api-token-permissions';
+    displayName: 'API Token Permission';
+  };
+  pluginOptions: {
+    'content-manager': {
+      visible: false;
+    };
+    'content-type-builder': {
+      visible: false;
+    };
+  };
+  attributes: {
+    action: Attribute.String &
+      Attribute.Required &
+      Attribute.SetMinMaxLength<{
+        minLength: 1;
+      }>;
+    token: Attribute.Relation<'admin::api-token-permission', 'manyToOne', 'admin::api-token'>;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<'admin::api-token-permission', 'oneToOne', 'admin::user'> &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<'admin::api-token-permission', 'oneToOne', 'admin::user'> &
+      Attribute.Private;
+  };
+}
+
+export interface AdminTransferToken extends Schema.CollectionType {
+  collectionName: 'strapi_transfer_tokens';
+  info: {
+    name: 'Transfer Token';
+    singularName: 'transfer-token';
+    pluralName: 'transfer-tokens';
+    displayName: 'Transfer Token';
+    description: '';
+  };
+  pluginOptions: {
+    'content-manager': {
+      visible: false;
+    };
+    'content-type-builder': {
+      visible: false;
+    };
+  };
+  attributes: {
+    name: Attribute.String &
+      Attribute.Required &
+      Attribute.Unique &
+      Attribute.SetMinMaxLength<{
+        minLength: 1;
+      }>;
+    description: Attribute.String &
+      Attribute.SetMinMaxLength<{
+        minLength: 1;
+      }> &
+      Attribute.DefaultTo<''>;
+    accessKey: Attribute.String &
+      Attribute.Required &
+      Attribute.SetMinMaxLength<{
+        minLength: 1;
+      }>;
+    lastUsedAt: Attribute.DateTime;
+    permissions: Attribute.Relation<
+      'admin::transfer-token',
+      'oneToMany',
+      'admin::transfer-token-permission'
+    >;
+    expiresAt: Attribute.DateTime;
+    lifespan: Attribute.BigInteger;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<'admin::transfer-token', 'oneToOne', 'admin::user'> &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<'admin::transfer-token', 'oneToOne', 'admin::user'> &
+      Attribute.Private;
+  };
+}
+
+export interface AdminTransferTokenPermission extends Schema.CollectionType {
+  collectionName: 'strapi_transfer_token_permissions';
+  info: {
+    name: 'Transfer Token Permission';
+    description: '';
+    singularName: 'transfer-token-permission';
+    pluralName: 'transfer-token-permissions';
+    displayName: 'Transfer Token Permission';
+  };
+  pluginOptions: {
+    'content-manager': {
+      visible: false;
+    };
+    'content-type-builder': {
+      visible: false;
+    };
+  };
+  attributes: {
+    action: Attribute.String &
+      Attribute.Required &
+      Attribute.SetMinMaxLength<{
+        minLength: 1;
+      }>;
+    token: Attribute.Relation<
+      'admin::transfer-token-permission',
+      'manyToOne',
+      'admin::transfer-token'
+    >;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<'admin::transfer-token-permission', 'oneToOne', 'admin::user'> &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<'admin::transfer-token-permission', 'oneToOne', 'admin::user'> &
+      Attribute.Private;
+  };
+}
+
+export interface PluginUploadFile extends Schema.CollectionType {
+  collectionName: 'files';
+  info: {
+    singularName: 'file';
+    pluralName: 'files';
+    displayName: 'File';
+    description: '';
+  };
+  pluginOptions: {
+    'content-manager': {
+      visible: false;
+    };
+    'content-type-builder': {
+      visible: false;
+    };
+  };
+  attributes: {
+    name: Attribute.String & Attribute.Required;
+    alternativeText: Attribute.String;
+    caption: Attribute.String;
+    width: Attribute.Integer;
+    height: Attribute.Integer;
+    formats: Attribute.JSON;
+    hash: Attribute.String & Attribute.Required;
+    ext: Attribute.String;
+    mime: Attribute.String & Attribute.Required;
+    size: Attribute.Decimal & Attribute.Required;
+    url: Attribute.String & Attribute.Required;
+    previewUrl: Attribute.String;
+    provider: Attribute.String & Attribute.Required;
+    provider_metadata: Attribute.JSON;
+    related: Attribute.Relation<'plugin::upload.file', 'morphToMany'>;
+    folder: Attribute.Relation<'plugin::upload.file', 'manyToOne', 'plugin::upload.folder'> &
+      Attribute.Private;
+    folderPath: Attribute.String &
+      Attribute.Required &
+      Attribute.Private &
+      Attribute.SetMinMax<{
+        min: 1;
+      }>;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<'plugin::upload.file', 'oneToOne', 'admin::user'> &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<'plugin::upload.file', 'oneToOne', 'admin::user'> &
+      Attribute.Private;
+  };
+}
+
+export interface PluginUploadFolder extends Schema.CollectionType {
+  collectionName: 'upload_folders';
+  info: {
+    singularName: 'folder';
+    pluralName: 'folders';
+    displayName: 'Folder';
+  };
+  pluginOptions: {
+    'content-manager': {
+      visible: false;
+    };
+    'content-type-builder': {
+      visible: false;
+    };
+  };
+  attributes: {
+    name: Attribute.String &
+      Attribute.Required &
+      Attribute.SetMinMax<{
+        min: 1;
+      }>;
+    pathId: Attribute.Integer & Attribute.Required & Attribute.Unique;
+    parent: Attribute.Relation<'plugin::upload.folder', 'manyToOne', 'plugin::upload.folder'>;
+    children: Attribute.Relation<'plugin::upload.folder', 'oneToMany', 'plugin::upload.folder'>;
+    files: Attribute.Relation<'plugin::upload.folder', 'oneToMany', 'plugin::upload.file'>;
+    path: Attribute.String &
+      Attribute.Required &
+      Attribute.SetMinMax<{
+        min: 1;
+      }>;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<'plugin::upload.folder', 'oneToOne', 'admin::user'> &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<'plugin::upload.folder', 'oneToOne', 'admin::user'> &
+      Attribute.Private;
+  };
+}
+
+export interface PluginMypluginTest extends Schema.CollectionType {
+  collectionName: 'myplugin_test';
+  info: {
+    displayName: 'Test';
+    singularName: 'test';
+    pluralName: 'tests';
+    description: '';
+  };
+  options: {
+    draftAndPublish: false;
+  };
+  pluginOptions: {
+    i18n: {
+      localized: true;
+    };
+  };
+  attributes: {
+    type: Attribute.String &
+      Attribute.Required &
+      Attribute.Unique &
+      Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<'plugin::myplugin.test', 'oneToOne', 'admin::user'> &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<'plugin::myplugin.test', 'oneToOne', 'admin::user'> &
+      Attribute.Private;
+    localizations: Attribute.Relation<
+      'plugin::myplugin.test',
+      'oneToMany',
+      'plugin::myplugin.test'
+    >;
+    locale: Attribute.String;
+  };
+}
+
+export interface PluginI18NLocale extends Schema.CollectionType {
+  collectionName: 'i18n_locale';
+  info: {
+    singularName: 'locale';
+    pluralName: 'locales';
+    collectionName: 'locales';
+    displayName: 'Locale';
+    description: '';
+  };
+  options: {
+    draftAndPublish: false;
+  };
+  pluginOptions: {
+    'content-manager': {
+      visible: false;
+    };
+    'content-type-builder': {
+      visible: false;
+    };
+  };
+  attributes: {
+    name: Attribute.String &
+      Attribute.SetMinMax<{
+        min: 1;
+        max: 50;
+      }>;
+    code: Attribute.String & Attribute.Unique;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<'plugin::i18n.locale', 'oneToOne', 'admin::user'> &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<'plugin::i18n.locale', 'oneToOne', 'admin::user'> &
+      Attribute.Private;
+  };
+}
+
+export interface PluginUsersPermissionsPermission extends Schema.CollectionType {
+  collectionName: 'up_permissions';
+  info: {
+    name: 'permission';
+    description: '';
+    singularName: 'permission';
+    pluralName: 'permissions';
+    displayName: 'Permission';
+  };
+  pluginOptions: {
+    'content-manager': {
+      visible: false;
+    };
+    'content-type-builder': {
+      visible: false;
+    };
+  };
+  attributes: {
+    action: Attribute.String & Attribute.Required;
+    role: Attribute.Relation<
+      'plugin::users-permissions.permission',
+      'manyToOne',
+      'plugin::users-permissions.role'
+    >;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'plugin::users-permissions.permission',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'plugin::users-permissions.permission',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
+export interface PluginUsersPermissionsRole extends Schema.CollectionType {
+  collectionName: 'up_roles';
+  info: {
+    name: 'role';
+    description: '';
+    singularName: 'role';
+    pluralName: 'roles';
+    displayName: 'Role';
+  };
+  pluginOptions: {
+    'content-manager': {
+      visible: false;
+    };
+    'content-type-builder': {
+      visible: false;
+    };
+  };
+  attributes: {
+    name: Attribute.String &
+      Attribute.Required &
+      Attribute.SetMinMaxLength<{
+        minLength: 3;
+      }>;
+    description: Attribute.String;
+    type: Attribute.String & Attribute.Unique;
+    permissions: Attribute.Relation<
+      'plugin::users-permissions.role',
+      'oneToMany',
+      'plugin::users-permissions.permission'
+    >;
+    users: Attribute.Relation<
+      'plugin::users-permissions.role',
+      'oneToMany',
+      'plugin::users-permissions.user'
+    >;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<'plugin::users-permissions.role', 'oneToOne', 'admin::user'> &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<'plugin::users-permissions.role', 'oneToOne', 'admin::user'> &
+      Attribute.Private;
+  };
+}
+
+export interface PluginUsersPermissionsUser extends Schema.CollectionType {
+  collectionName: 'up_users';
+  info: {
+    name: 'User';
+    description: '';
+    singularName: 'user';
+    pluralName: 'users';
+    displayName: 'User';
+  };
+  options: {
+    draftAndPublish: false;
+  };
+  attributes: {
+    username: Attribute.String &
+      Attribute.Required &
+      Attribute.Unique &
+      Attribute.SetMinMaxLength<{
+        minLength: 3;
+      }>;
+    email: Attribute.Email &
+      Attribute.Required &
+      Attribute.SetMinMaxLength<{
+        minLength: 6;
+      }>;
+    provider: Attribute.String;
+    password: Attribute.Password &
+      Attribute.Private &
+      Attribute.SetMinMaxLength<{
+        minLength: 6;
+      }>;
+    resetPasswordToken: Attribute.String & Attribute.Private;
+    confirmationToken: Attribute.String & Attribute.Private;
+    confirmed: Attribute.Boolean & Attribute.DefaultTo<false>;
+    blocked: Attribute.Boolean & Attribute.DefaultTo<false>;
+    role: Attribute.Relation<
+      'plugin::users-permissions.user',
+      'manyToOne',
+      'plugin::users-permissions.role'
+    >;
+    picture: Attribute.Media;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<'plugin::users-permissions.user', 'oneToOne', 'admin::user'> &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<'plugin::users-permissions.user', 'oneToOne', 'admin::user'> &
+      Attribute.Private;
+  };
+}
+
+export interface ApiAddressAddress extends Schema.CollectionType {
+  collectionName: 'addresses';
+  info: {
+    displayName: 'Address';
+    singularName: 'address';
+    pluralName: 'addresses';
+    description: '';
+    name: 'Address';
+  };
+  options: {
+    reviewWorkflows: true;
+    draftAndPublish: false;
+  };
+  attributes: {
+    postal_code: Attribute.String &
+      Attribute.SetMinMaxLength<{
+        maxLength: 2;
+      }>;
+    categories: Attribute.Relation<'api::address.address', 'manyToMany', 'api::category.category'>;
+    cover: Attribute.Media;
+    images: Attribute.Media;
+    city: Attribute.String &
+      Attribute.Required &
+      Attribute.SetMinMaxLength<{
+        maxLength: 200;
+      }>;
+    json: Attribute.JSON;
+    slug: Attribute.UID;
+    notrepeat_req: Attribute.Component<'blog.test-como'> & Attribute.Required;
+    repeat_req: Attribute.Component<'blog.test-como', true> & Attribute.Required;
+    repeat_req_min: Attribute.Component<'blog.test-como', true> &
+      Attribute.SetMinMax<{
+        min: 2;
+      }>;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<'api::address.address', 'oneToOne', 'admin::user'> &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<'api::address.address', 'oneToOne', 'admin::user'> &
+      Attribute.Private;
+  };
+}
+
+export interface ApiCategoryCategory extends Schema.CollectionType {
+  collectionName: 'categories';
+  info: {
+    displayName: 'Category';
+    singularName: 'category';
+    pluralName: 'categories';
+    description: '';
+    name: 'Category';
+  };
+  options: {
+    reviewWorkflows: true;
+    draftAndPublish: true;
+  };
+  pluginOptions: {
+    i18n: {
+      localized: true;
+    };
+  };
+  attributes: {
+    name: Attribute.String &
+      Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
+    addresses: Attribute.Relation<'api::category.category', 'manyToMany', 'api::address.address'>;
+    temps: Attribute.Relation<'api::category.category', 'manyToMany', 'api::temp.temp'>;
+    datetime: Attribute.DateTime &
+      Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
+    date: Attribute.Date &
+      Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
+    relation_locales: Attribute.Relation<
+      'api::category.category',
+      'manyToMany',
+      'api::relation-locale.relation-locale'
+    >;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<'api::category.category', 'oneToOne', 'admin::user'> &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<'api::category.category', 'oneToOne', 'admin::user'> &
+      Attribute.Private;
+    localizations: Attribute.Relation<
+      'api::category.category',
+      'oneToMany',
+      'api::category.category'
+    >;
+    locale: Attribute.String;
+  };
+}
+
+export interface ApiCountryCountry extends Schema.CollectionType {
+  collectionName: 'countries';
+  info: {
+    displayName: 'Country';
+    singularName: 'country';
+    pluralName: 'countries';
+    description: '';
+    name: 'Country';
+  };
+  options: {
+    draftAndPublish: false;
+    comment: '';
+  };
+  pluginOptions: {
+    i18n: {
+      localized: true;
+    };
+  };
+  attributes: {
+    name: Attribute.String &
+      Attribute.Required &
+      Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }> &
+      Attribute.SetMinMaxLength<{
+        minLength: 3;
+      }>;
+    code: Attribute.String &
+      Attribute.Unique &
+      Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }> &
+      Attribute.SetMinMaxLength<{
+        minLength: 2;
+        maxLength: 3;
+      }>;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<'api::country.country', 'oneToOne', 'admin::user'> &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<'api::country.country', 'oneToOne', 'admin::user'> &
+      Attribute.Private;
+    localizations: Attribute.Relation<'api::country.country', 'oneToMany', 'api::country.country'>;
+    locale: Attribute.String;
+  };
+}
+
+export interface ApiHomepageHomepage extends Schema.SingleType {
+  collectionName: 'homepages';
+  info: {
+    displayName: 'Homepage';
+    singularName: 'homepage';
+    pluralName: 'homepages';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  pluginOptions: {
+    i18n: {
+      localized: true;
+    };
+  };
+  attributes: {
+    title: Attribute.String &
+      Attribute.Required &
+      Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
+    slug: Attribute.UID<'api::homepage.homepage', 'title'> &
+      Attribute.Required &
+      Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
+    single: Attribute.Media;
+    multiple: Attribute.Media;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<'api::homepage.homepage', 'oneToOne', 'admin::user'> &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<'api::homepage.homepage', 'oneToOne', 'admin::user'> &
+      Attribute.Private;
+    localizations: Attribute.Relation<
+      'api::homepage.homepage',
+      'oneToMany',
+      'api::homepage.homepage'
+    >;
+    locale: Attribute.String;
+  };
+}
+
+export interface ApiKitchensinkKitchensink extends Schema.CollectionType {
+  collectionName: 'kitchensinks';
+  info: {
+    displayName: 'Kitchen Sink';
+    singularName: 'kitchensink';
+    pluralName: 'kitchensinks';
+    description: '';
+    name: 'Kitchen Sink';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    short_text: Attribute.String;
+    long_text: Attribute.Text;
+    rich_text: Attribute.RichText;
+    blocks: Attribute.Blocks;
+    integer: Attribute.Integer;
+    biginteger: Attribute.BigInteger;
+    decimal: Attribute.Decimal;
+    float: Attribute.Float;
+    date: Attribute.Date;
+    datetime: Attribute.DateTime;
+    time: Attribute.Time;
+    timestamp: Attribute.Timestamp;
+    boolean: Attribute.Boolean;
+    email: Attribute.Email;
+    password: Attribute.Password;
+    enumeration: Attribute.Enumeration<['A', 'B', 'C', 'D', 'E']>;
+    single_media: Attribute.Media;
+    multiple_media: Attribute.Media;
+    json: Attribute.JSON;
+    single_compo: Attribute.Component<'basic.simple'>;
+    repeatable_compo: Attribute.Component<'basic.simple', true>;
+    dynamiczone: Attribute.DynamicZone<['basic.simple', 'blog.test-como']>;
+    one_way_tag: Attribute.Relation<'api::kitchensink.kitchensink', 'oneToOne', 'api::tag.tag'>;
+    one_to_one_tag: Attribute.Relation<'api::kitchensink.kitchensink', 'oneToOne', 'api::tag.tag'> &
+      Attribute.Private;
+    one_to_many_tags: Attribute.Relation<
+      'api::kitchensink.kitchensink',
+      'oneToMany',
+      'api::tag.tag'
+    >;
+    many_to_one_tag: Attribute.Relation<
+      'api::kitchensink.kitchensink',
+      'manyToOne',
+      'api::tag.tag'
+    >;
+    many_to_many_tags: Attribute.Relation<
+      'api::kitchensink.kitchensink',
+      'manyToMany',
+      'api::tag.tag'
+    >;
+    many_way_tags: Attribute.Relation<'api::kitchensink.kitchensink', 'oneToMany', 'api::tag.tag'>;
+    morph_to_one: Attribute.Relation<'api::kitchensink.kitchensink', 'morphToOne'>;
+    morph_to_many: Attribute.Relation<'api::kitchensink.kitchensink', 'morphToMany'>;
+    custom_field: Attribute.String & Attribute.CustomField<'plugin::color-picker.color'>;
+    custom_field_with_default_options: Attribute.String &
+      Attribute.CustomField<'plugin::color-picker.color'>;
+    cats: Attribute.DynamicZone<['basic.relation', 'basic.simple']>;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<'api::kitchensink.kitchensink', 'oneToOne', 'admin::user'> &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<'api::kitchensink.kitchensink', 'oneToOne', 'admin::user'> &
+      Attribute.Private;
+  };
+}
+
+export interface ApiLikeLike extends Schema.CollectionType {
+  collectionName: 'likes';
+  info: {
+    displayName: 'Like';
+    singularName: 'like';
+    pluralName: 'likes';
+    description: '';
+  };
+  options: {
+    draftAndPublish: false;
+    comment: '';
+  };
+  attributes: {
+    author: Attribute.Relation<'api::like.like', 'oneToOne', 'plugin::users-permissions.user'>;
+    review: Attribute.Relation<'api::like.like', 'manyToOne', 'api::review.review'>;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<'api::like.like', 'oneToOne', 'admin::user'> & Attribute.Private;
+    updatedBy: Attribute.Relation<'api::like.like', 'oneToOne', 'admin::user'> & Attribute.Private;
+  };
+}
+
+export interface ApiMenuMenu extends Schema.CollectionType {
+  collectionName: 'menus';
+  info: {
+    description: '';
+    displayName: 'Menu';
+    singularName: 'menu';
+    pluralName: 'menus';
+  };
+  options: {
+    draftAndPublish: false;
+    comment: '';
+  };
+  attributes: {
+    description: Attribute.Text;
+    menusections: Attribute.Relation<'api::menu.menu', 'oneToMany', 'api::menusection.menusection'>;
+    restaurant: Attribute.Relation<'api::menu.menu', 'oneToOne', 'api::restaurant.restaurant'>;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<'api::menu.menu', 'oneToOne', 'admin::user'> & Attribute.Private;
+    updatedBy: Attribute.Relation<'api::menu.menu', 'oneToOne', 'admin::user'> & Attribute.Private;
+  };
+}
+
+export interface ApiMenusectionMenusection extends Schema.CollectionType {
+  collectionName: 'menusections';
+  info: {
+    displayName: 'Menu Section';
+    singularName: 'menusection';
+    pluralName: 'menusections';
+    description: '';
+  };
+  options: {
+    draftAndPublish: false;
+    comment: '';
+  };
+  attributes: {
+    name: Attribute.String &
+      Attribute.Required &
+      Attribute.SetMinMaxLength<{
+        minLength: 6;
+      }>;
+    dishes: Attribute.Component<'default.dish', true> & Attribute.Required;
+    menu: Attribute.Relation<'api::menusection.menusection', 'manyToOne', 'api::menu.menu'>;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<'api::menusection.menusection', 'oneToOne', 'admin::user'> &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<'api::menusection.menusection', 'oneToOne', 'admin::user'> &
+      Attribute.Private;
+  };
+}
+
+export interface ApiRelationLocaleRelationLocale extends Schema.CollectionType {
+  collectionName: 'relation_locales';
+  info: {
+    singularName: 'relation-locale';
+    pluralName: 'relation-locales';
+    displayName: 'Relations';
+    description: '';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  pluginOptions: {
+    i18n: {
+      localized: true;
+    };
+  };
+  attributes: {
+    categories: Attribute.Relation<
+      'api::relation-locale.relation-locale',
+      'manyToMany',
+      'api::category.category'
+    >;
+    title: Attribute.String &
+      Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
+    repeatable_relations: Attribute.Component<'basic.relation', true> &
+      Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
+    dynamic_relations: Attribute.DynamicZone<['basic.relation', 'basic.simple']> &
+      Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
+    single_relation: Attribute.Component<'basic.relation'> &
+      Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
+    require_single_relation: Attribute.Component<'basic.relation'> &
+      Attribute.Required &
+      Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::relation-locale.relation-locale',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::relation-locale.relation-locale',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    localizations: Attribute.Relation<
+      'api::relation-locale.relation-locale',
+      'oneToMany',
+      'api::relation-locale.relation-locale'
+    >;
+    locale: Attribute.String;
+  };
+}
+
+export interface ApiRestaurantRestaurant extends Schema.CollectionType {
+  collectionName: 'restaurants';
+  info: {
+    displayName: 'Restaurant';
+    singularName: 'restaurant';
+    pluralName: 'restaurants';
+    description: '';
+    name: 'Restaurant';
+  };
+  options: {
+    draftAndPublish: true;
+    populateCreatorFields: true;
+    comment: '';
+  };
+  pluginOptions: {
+    i18n: {
+      localized: true;
+    };
+  };
+  attributes: {
+    name: Attribute.String &
+      Attribute.Required &
+      Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }> &
+      Attribute.SetMinMaxLength<{
+        minLength: 5;
+        maxLength: 50;
+      }>;
+    slug: Attribute.UID<'api::restaurant.restaurant', 'name'>;
+    priceRange: Attribute.Enumeration<
+      ['very_cheap', 'cheap', 'average', 'expensive', 'very_expensive']
+    > &
+      Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
+    closingPeriod: Attribute.Component<'default.closingperiod'> &
+      Attribute.Required &
+      Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
+    contactEmail: Attribute.Email &
+      Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
+    stars: Attribute.Integer &
+      Attribute.Required &
+      Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }> &
+      Attribute.SetMinMax<{
+        min: 0;
+        max: 3;
+      }>;
+    averagePrice: Attribute.Float &
+      Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }> &
+      Attribute.SetMinMax<{
+        min: 0;
+        max: 35.12;
+      }>;
+    address: Attribute.Relation<'api::restaurant.restaurant', 'oneToOne', 'api::address.address'>;
+    cover: Attribute.Media &
+      Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
+    timestamp: Attribute.Timestamp;
+    images: Attribute.Media &
+      Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
+    shortDescription: Attribute.Text &
+      Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
+    since: Attribute.Date &
+      Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
+    categories: Attribute.Relation<
+      'api::restaurant.restaurant',
+      'oneToMany',
+      'api::category.category'
+    >;
+    description: Attribute.RichText &
+      Attribute.Required &
+      Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }> &
+      Attribute.SetMinMaxLength<{
+        minLength: 10;
+      }>;
+    services: Attribute.Component<'default.restaurantservice', true> &
+      Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }> &
+      Attribute.SetMinMax<{
+        max: 1;
+      }>;
+    menu: Attribute.Relation<'api::restaurant.restaurant', 'oneToOne', 'api::menu.menu'>;
+    openingTimes: Attribute.Component<'default.openingtimes', true> &
+      Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }> &
+      Attribute.SetMinMax<{
+        min: 1;
+        max: 10;
+      }>;
+    dz: Attribute.DynamicZone<
+      ['default.openingtimes', 'default.restaurantservice', 'default.closingperiod', 'default.dish']
+    > &
+      Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<'api::restaurant.restaurant', 'oneToOne', 'admin::user'>;
+    updatedBy: Attribute.Relation<'api::restaurant.restaurant', 'oneToOne', 'admin::user'>;
+    localizations: Attribute.Relation<
+      'api::restaurant.restaurant',
+      'oneToMany',
+      'api::restaurant.restaurant'
+    >;
+    locale: Attribute.String;
+  };
+}
+
+export interface ApiReviewReview extends Schema.CollectionType {
+  collectionName: 'reviews';
+  info: {
+    displayName: 'Review';
+    singularName: 'review';
+    pluralName: 'reviews';
+    description: '';
+  };
+  options: {
+    draftAndPublish: false;
+    comment: '';
+  };
+  attributes: {
+    comment: Attribute.Text & Attribute.Required;
+    rating: Attribute.Integer &
+      Attribute.Required &
+      Attribute.SetMinMax<{
+        min: 1;
+        max: 5;
+      }>;
+    likes: Attribute.Relation<'api::review.review', 'oneToMany', 'api::like.like'>;
+    author: Attribute.Relation<'api::review.review', 'oneToOne', 'plugin::users-permissions.user'>;
+    restaurant: Attribute.Relation<'api::review.review', 'oneToOne', 'api::restaurant.restaurant'>;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<'api::review.review', 'oneToOne', 'admin::user'> &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<'api::review.review', 'oneToOne', 'admin::user'> &
+      Attribute.Private;
+  };
+}
+
+export interface ApiTagTag extends Schema.CollectionType {
+  collectionName: 'tags';
+  info: {
+    displayName: 'Tag';
+    singularName: 'tag';
+    pluralName: 'tags';
+    description: '';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    name: Attribute.String;
+    many_to_one_kitchensink: Attribute.Relation<
+      'api::tag.tag',
+      'manyToOne',
+      'api::kitchensink.kitchensink'
+    >;
+    one_to_many_kitchensinks: Attribute.Relation<
+      'api::tag.tag',
+      'oneToMany',
+      'api::kitchensink.kitchensink'
+    >;
+    many_to_many_kitchensinks: Attribute.Relation<
+      'api::tag.tag',
+      'manyToMany',
+      'api::kitchensink.kitchensink'
+    >;
+    one_to_one_kitchensink: Attribute.Relation<
+      'api::tag.tag',
+      'oneToOne',
+      'api::kitchensink.kitchensink'
+    >;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<'api::tag.tag', 'oneToOne', 'admin::user'> & Attribute.Private;
+    updatedBy: Attribute.Relation<'api::tag.tag', 'oneToOne', 'admin::user'> & Attribute.Private;
+  };
+}
+
+export interface ApiTempTemp extends Schema.CollectionType {
+  collectionName: 'temps';
+  info: {
+    singularName: 'temp';
+    pluralName: 'temps';
+    displayName: 'temp';
+    name: 'temp';
+    description: '';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    name: Attribute.String;
+    category: Attribute.Relation<'api::temp.temp', 'oneToOne', 'api::category.category'>;
+    categories: Attribute.Relation<'api::temp.temp', 'manyToMany', 'api::category.category'>;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<'api::temp.temp', 'oneToOne', 'admin::user'> & Attribute.Private;
+    updatedBy: Attribute.Relation<'api::temp.temp', 'oneToOne', 'admin::user'> & Attribute.Private;
+  };
+}
+
+declare module '@strapi/types' {
+  export module Shared {
+    export interface ContentTypes {
+      'admin::permission': AdminPermission;
+      'admin::user': AdminUser;
+      'admin::role': AdminRole;
+      'admin::api-token': AdminApiToken;
+      'admin::api-token-permission': AdminApiTokenPermission;
+      'admin::transfer-token': AdminTransferToken;
+      'admin::transfer-token-permission': AdminTransferTokenPermission;
+      'plugin::upload.file': PluginUploadFile;
+      'plugin::upload.folder': PluginUploadFolder;
+      'plugin::myplugin.test': PluginMypluginTest;
+      'plugin::i18n.locale': PluginI18NLocale;
+      'plugin::users-permissions.permission': PluginUsersPermissionsPermission;
+      'plugin::users-permissions.role': PluginUsersPermissionsRole;
+      'plugin::users-permissions.user': PluginUsersPermissionsUser;
+      'api::address.address': ApiAddressAddress;
+      'api::category.category': ApiCategoryCategory;
+      'api::country.country': ApiCountryCountry;
+      'api::homepage.homepage': ApiHomepageHomepage;
+      'api::kitchensink.kitchensink': ApiKitchensinkKitchensink;
+      'api::like.like': ApiLikeLike;
+      'api::menu.menu': ApiMenuMenu;
+      'api::menusection.menusection': ApiMenusectionMenusection;
+      'api::relation-locale.relation-locale': ApiRelationLocaleRelationLocale;
+      'api::restaurant.restaurant': ApiRestaurantRestaurant;
+      'api::review.review': ApiReviewReview;
+      'api::tag.tag': ApiTagTag;
+      'api::temp.temp': ApiTempTemp;
+    }
+  }
+}

--- a/packages/core/types/src/modules/entity-service/params/attributes.ts
+++ b/packages/core/types/src/modules/entity-service/params/attributes.ts
@@ -47,6 +47,7 @@ export type ScalarValues = GetValue<
   | Attribute.Enumeration<string[]>
   | Attribute.Float
   | Attribute.Integer
+  | Attribute.Blocks
   | Attribute.JSON
   // /!\  Password attributes are NOT filterable and should NOT be part of this union type.
   //      The member below has been commented on purpose to avoid adding it back without noticing.

--- a/packages/core/types/src/types/core/attributes/base.ts
+++ b/packages/core/types/src/types/core/attributes/base.ts
@@ -22,7 +22,8 @@ export type Kind =
   | 'media'
   | 'relation'
   | 'component'
-  | 'dynamiczone';
+  | 'dynamiczone'
+  | 'blocks';
 
 /**
  * Most basic shape of a schema attribute

--- a/packages/core/types/src/types/core/attributes/blocks.ts
+++ b/packages/core/types/src/types/core/attributes/blocks.ts
@@ -1,0 +1,17 @@
+import type { Attribute } from '..';
+
+type BlocksAttribute = Attribute.OfType<'blocks'> &
+  // Options
+  Attribute.ConfigurableOption &
+  Attribute.PrivateOption &
+  Attribute.RequiredOption &
+  Attribute.WritableOption &
+  Attribute.VisibleOption;
+
+export type BlocksValue<T extends object = object> = T;
+
+export type GetBlocksValue<T extends Attribute.Attribute> = T extends BlocksAttribute
+  ? BlocksValue
+  : never;
+
+export type Blocks = BlocksAttribute;

--- a/packages/core/types/src/types/core/attributes/blocks.ts
+++ b/packages/core/types/src/types/core/attributes/blocks.ts
@@ -1,6 +1,6 @@
 import type { Attribute } from '..';
 
-type BlocksAttribute = Attribute.OfType<'blocks'> &
+export type Blocks = Attribute.OfType<'blocks'> &
   // Options
   Attribute.ConfigurableOption &
   Attribute.PrivateOption &
@@ -10,8 +10,4 @@ type BlocksAttribute = Attribute.OfType<'blocks'> &
 
 export type BlocksValue<T extends object = object> = T;
 
-export type GetBlocksValue<T extends Attribute.Attribute> = T extends BlocksAttribute
-  ? BlocksValue
-  : never;
-
-export type Blocks = BlocksAttribute;
+export type GetBlocksValue<T extends Attribute.Attribute> = T extends Blocks ? BlocksValue : never;

--- a/packages/core/types/src/types/core/attributes/common.ts
+++ b/packages/core/types/src/types/core/attributes/common.ts
@@ -54,6 +54,7 @@ export type DefaultTo<T> = { default: T };
 export type Any =
   | Attribute.BigInteger
   | Attribute.Boolean
+  | Attribute.Blocks
   | Attribute.Component<Common.UID.Component, boolean>
   | Attribute.DateTime
   | Attribute.Date

--- a/packages/core/types/src/types/core/attributes/index.ts
+++ b/packages/core/types/src/types/core/attributes/index.ts
@@ -2,6 +2,7 @@ export * from './base';
 
 export * from './biginteger';
 export * from './boolean';
+export * from './blocks';
 export * from './component';
 export * from './decimal';
 export * from './dynamic-zone';

--- a/packages/core/types/src/types/core/attributes/utils.ts
+++ b/packages/core/types/src/types/core/attributes/utils.ts
@@ -68,6 +68,7 @@ export type GetKeysWithTarget<TSchemaUID extends Common.UID.Schema> = keyof {
 export type GetValue<TAttribute extends Attribute.Attribute, TGuard = unknown> = Utils.Guard.Never<
   | Attribute.GetBigIntegerValue<TAttribute>
   | Attribute.GetBooleanValue<TAttribute>
+  | Attribute.GetBlocksValue<TAttribute>
   | Attribute.GetComponentValue<TAttribute>
   | Attribute.GetDecimalValue<TAttribute>
   | Attribute.GetDynamicZoneValue<TAttribute>

--- a/packages/core/types/src/types/core/common/schema.ts
+++ b/packages/core/types/src/types/core/common/schema.ts
@@ -1,3 +1,3 @@
-import type { Shared } from '../..';
+import type { ContentTypes, Components } from '../../shared';
 
-export type Schemas = Shared.ContentTypes & Shared.Components;
+export type Schemas = ContentTypes & Components;

--- a/packages/core/utils/src/types.ts
+++ b/packages/core/utils/src/types.ts
@@ -52,6 +52,7 @@ export interface ScalarAttribute extends Attribute {
     | 'enumeration'
     | 'boolean'
     | 'json'
+    | 'blocks'
     | 'uid'
     | 'password'
     | 'email'


### PR DESCRIPTION
### What does it do?
- Add the `blocks` attribute type and its related definition
- Fix the Common.Schemas type (fix the broken link to dynamic type registries)
