### PR TITLE
[Blocks editor] Fix disabled state

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/BlocksInput/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/BlocksInput/index.js
@@ -37,7 +37,7 @@ const baseRenderElement = (props, blocks) => {
   return block.renderElement(props);
 };
 
-const BlocksInput = ({ readOnly }) => {
+const BlocksInput = ({ disabled }) => {
   const theme = useTheme();
   const editor = useSlate();
 
@@ -71,7 +71,7 @@ const BlocksInput = ({ readOnly }) => {
 
   return (
     <Editable
-      readOnly={readOnly}
+      readOnly={disabled}
       style={getEditorStyle(theme)}
       renderElement={renderElement}
       renderLeaf={renderLeaf}
@@ -81,7 +81,7 @@ const BlocksInput = ({ readOnly }) => {
 };
 
 BlocksInput.propTypes = {
-  readOnly: PropTypes.bool.isRequired,
+  disabled: PropTypes.bool.isRequired,
 };
 
 export default BlocksInput;

--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/index.js
@@ -51,6 +51,8 @@ const ToolbarButton = ({ icon, name, label, isActive, disabled, handleClick }) =
   const { formatMessage } = useIntl();
   const labelMessage = formatMessage(label);
 
+  const enabledColor = isActive ? 'primary600' : 'neutral600';
+
   return (
     <Tooltip description={labelMessage}>
       <Toolbar.ToggleItem value={name} data-state={isActive ? 'on' : 'off'} asChild>
@@ -68,7 +70,7 @@ const ToolbarButton = ({ icon, name, label, isActive, disabled, handleClick }) =
           disabled={disabled}
           aria-label={labelMessage}
         >
-          <Icon width={3} height={3} as={icon} color={isActive ? 'primary600' : 'neutral600'} />
+          <Icon width={3} height={3} as={icon} color={disabled ? 'neutral300' : enabledColor} />
         </FlexButton>
       </Toolbar.ToggleItem>
     </Tooltip>

--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/index.js
@@ -8,17 +8,15 @@ import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 import { Editor, Transforms, Element as SlateElement } from 'slate';
 import { useSlate } from 'slate-react';
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 
 import { useBlocksStore } from '../hooks/useBlocksStore';
 import { useModifiersStore } from '../hooks/useModifiersStore';
 
 const ToolbarWrapper = styled(Flex)`
-  ${(props) =>
-    props.disabled &&
-    css`
-      cursor: not-allowed;
-    `}
+  &[aria-disabled='true'] {
+    cursor: not-allowed;
+  }
 `;
 
 const Separator = styled(Toolbar.Separator)`
@@ -28,23 +26,19 @@ const Separator = styled(Toolbar.Separator)`
 `;
 
 const FlexButton = styled(Flex).attrs({ as: 'button' })`
+  // Inherit the not-allowed cursor from ToolbarWrapper when disabled
   &[aria-disabled] {
-    display: none;
-    color: red;
-    opacity: 0.3;
+    cursor: inherit;
   }
-  ${(props) =>
-    props.disabled
-      ? css`
-          // Inherit the not-allowed cursor from ToolbarWrapper
-          cursor: inherit;
-        `
-      : css`
-          // Ignore hover effect when disabled
-          &:hover {
-            background: ${({ theme }) => theme.colors.primary100};
-          }
-        `}
+
+  &[aria-disabled='false'] {
+    cursor: pointer;
+
+    // Only apply hover styles if the button is enabled
+    &:hover {
+      background: ${({ theme }) => theme.colors.primary100};
+    }
+  }
 `;
 
 const ToolbarButton = ({ icon, name, label, isActive, disabled, handleClick }) => {
@@ -55,7 +49,18 @@ const ToolbarButton = ({ icon, name, label, isActive, disabled, handleClick }) =
 
   return (
     <Tooltip description={labelMessage}>
-      <Toolbar.ToggleItem value={name} data-state={isActive ? 'on' : 'off'} asChild>
+      <Toolbar.ToggleItem
+        value={name}
+        data-state={isActive ? 'on' : 'off'}
+        onMouseDown={(e) => {
+          e.preventDefault();
+          handleClick();
+        }}
+        aria-disabled={disabled}
+        disabled={disabled}
+        aria-label={labelMessage}
+        asChild
+      >
         <FlexButton
           background={isActive ? 'primary100' : ''}
           alignItems="center"
@@ -63,12 +68,6 @@ const ToolbarButton = ({ icon, name, label, isActive, disabled, handleClick }) =
           width={7}
           height={7}
           hasRadius
-          onMouseDown={(e) => {
-            e.preventDefault();
-            handleClick();
-          }}
-          disabled={disabled}
-          aria-label={labelMessage}
         >
           <Icon width={3} height={3} as={icon} color={disabled ? 'neutral300' : enabledColor} />
         </FlexButton>
@@ -457,9 +456,9 @@ const BlocksToolbar = ({ disabled }) => {
   const modifiers = useModifiersStore();
 
   return (
-    <Toolbar.Root asChild>
+    <Toolbar.Root aria-disabled={disabled} asChild>
       {/* Remove after the RTE Blocks Alpha release (paddingRight and width) */}
-      <ToolbarWrapper gap={1} padding={2} paddingRight={4} width="100%" disabled={disabled}>
+      <ToolbarWrapper gap={1} padding={2} paddingRight={4} width="100%">
         <BlocksDropdown disabled={disabled} />
         <Toolbar.ToggleGroup type="multiple" asChild>
           <Flex gap={1} marginLeft={1}>

--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/index.js
@@ -461,9 +461,8 @@ const BlocksToolbar = ({ disabled }) => {
       {/* Remove after the RTE Blocks Alpha release (paddingRight and width) */}
       <ToolbarWrapper gap={1} padding={2} paddingRight={4} width="100%" disabled={disabled}>
         <BlocksDropdown disabled={disabled} />
-        <Separator />
         <Toolbar.ToggleGroup type="multiple" asChild>
-          <Flex gap={1}>
+          <Flex gap={1} marginLeft={1}>
             {Object.entries(modifiers).map(([name, modifier]) => (
               <ToolbarButton
                 key={name}

--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/tests/index.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/tests/index.test.js
@@ -157,6 +157,7 @@ describe('BlocksEditor toolbar', () => {
       },
     ]);
   });
+
   it('transforms the selection to a heading when selected and trasforms it back to text when selected again', async () => {
     setup();
 

--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/tests/index.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/tests/index.test.js
@@ -51,7 +51,7 @@ Wrapper.propTypes = {
 };
 
 const setup = () =>
-  render(<BlocksToolbar />, {
+  render(<BlocksToolbar disabled={false} />, {
     wrapper: Wrapper,
   });
 
@@ -244,7 +244,7 @@ describe('BlocksEditor toolbar', () => {
   });
 
   it('when image is selected, it will set modal dialog open to select the images', async () => {
-    render(<BlocksDropdown />, {
+    render(<BlocksDropdown disabled={false} />, {
       wrapper: Wrapper,
     });
 
@@ -263,7 +263,7 @@ describe('BlocksEditor toolbar', () => {
   });
 
   it('when code option is selected and if its the last block in the editor then new empty block should be inserted below it', async () => {
-    render(<BlocksDropdown />, {
+    render(<BlocksDropdown disabled={false} />, {
       wrapper: Wrapper,
     });
 

--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/index.js
@@ -82,7 +82,7 @@ const BlocksEditor = React.forwardRef(
             onChange={handleSlateChange}
           >
             <InputWrapper direction="column" alignItems="flex-start">
-              <BlocksToolbar />
+              <BlocksToolbar disabled={disabled} />
               <EditorDivider width="100%" />
               <Wrapper>
                 <BlocksInput disabled={disabled} />

--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/index.js
@@ -32,7 +32,7 @@ const Wrapper = styled(Box)`
 `;
 
 const BlocksEditor = React.forwardRef(
-  ({ intlLabel, name, readOnly, required, error, value, onChange }, ref) => {
+  ({ intlLabel, name, disabled, required, error, value, onChange }, ref) => {
     const { formatMessage } = useIntl();
     const [editor] = React.useState(() => withReact(withHistory(createEditor())));
 
@@ -85,7 +85,7 @@ const BlocksEditor = React.forwardRef(
               <BlocksToolbar />
               <EditorDivider width="100%" />
               <Wrapper>
-                <BlocksInput readOnly={readOnly} />
+                <BlocksInput disabled={disabled} />
               </Wrapper>
             </InputWrapper>
           </Slate>
@@ -104,7 +104,6 @@ const BlocksEditor = React.forwardRef(
 
 BlocksEditor.defaultProps = {
   required: false,
-  readOnly: false,
   error: '',
   value: null,
 };
@@ -117,7 +116,7 @@ BlocksEditor.propTypes = {
   }).isRequired,
   name: PropTypes.string.isRequired,
   required: PropTypes.bool,
-  readOnly: PropTypes.bool,
+  disabled: PropTypes.bool.isRequired,
   error: PropTypes.string,
   onChange: PropTypes.func.isRequired,
   value: PropTypes.array,

--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/index.js
@@ -111,6 +111,7 @@ const BlocksEditor = React.forwardRef(
 
 BlocksEditor.defaultProps = {
   labelAction: null,
+  disabled: false,
   required: false,
   error: '',
   value: null,
@@ -125,7 +126,7 @@ BlocksEditor.propTypes = {
   labelAction: PropTypes.element,
   name: PropTypes.string.isRequired,
   required: PropTypes.bool,
-  disabled: PropTypes.bool.isRequired,
+  disabled: PropTypes.bool,
   error: PropTypes.string,
   onChange: PropTypes.func.isRequired,
   value: PropTypes.array,

--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/tests/index.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/tests/index.test.js
@@ -20,6 +20,7 @@ const setup = (props) =>
       name="blocks-editor"
       value={blocksData}
       onChange={jest.fn()}
+      disabled={false}
       {...props}
     />,
     {

--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/tests/index.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/tests/index.test.js
@@ -20,7 +20,6 @@ const setup = (props) =>
       name="blocks-editor"
       value={blocksData}
       onChange={jest.fn()}
-      disabled={false}
       {...props}
     />,
     {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Disables blocks fields when the user marked them as non editable in the configure the view page.

### Why is it needed?

Feature parity with other types of fields.

### How to test it?

Make a blocks field non-editable in the configure the view page. Go back to the edit view and try to edit things.
