### PR TITLE
Fix Upload API according to Open API3 standard

### DIFF
--- a/packages/core/upload/documentation/content-api.json
+++ b/packages/core/upload/documentation/content-api.json
@@ -63,7 +63,7 @@
         }
       }
     },
-    "/upload?id={id}": {
+    "/upload/info/{id}": {
       "post": {
         "parameters": [
           {


### PR DESCRIPTION
## What does it do?

**Technical Changes:**  
In this PR, we made the following technical changes:

- Modified the route `/upload?id={id}` in the Upload plugin to adhere to the OpenAPI3 standard.
- Updated the route to use the format `/upload/info/{id}`.

## Why is it needed?

**Issue Description:**  
This PR addresses issue #18130, which reported that the API `/upload?id={id}` within the Upload plugin  doesn't respect OpenAPI3 standard. Specifically, the issue was related to the declaration of the path parameter "id" not being defined as a path parameter at either the path or operation level. This non-compliance with OpenAPI3 standard not only affects validation but also impacts code generation tools.

**Related Issue:**  
This PR is related to the following issue: #18130
