### PR TITLE
Plugin i18n related entry relation fix

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/RelationInputDataManager.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/RelationInputDataManager.js
@@ -24,6 +24,7 @@ export const RelationInputDataManager = ({
   description,
   intlLabel,
   isCreatingEntry,
+  isRelatedEntry,
   isCloningEntry,
   isFieldAllowed,
   isFieldReadable,
@@ -61,21 +62,36 @@ export const RelationInputDataManager = ({
     [slug, initialDataPath.join('.'), modifiedData.id, defaultParams],
     {
       relation: {
-        enabled: !!endpoints.relation,
+        enabled: !!endpoints.relation || !!endpoints.relatedRelation,
+        relatedEndpoint: endpoints.relatedRelation,
         endpoint: endpoints.relation,
         pageGoal: currentLastPage,
+        isRelatedEntry,
         pageParams: {
           ...defaultParams,
           pageSize: RELATIONS_TO_DISPLAY,
         },
         onLoad(value) {
-          relationLoad({
-            target: {
-              initialDataPath: ['initialData', ...initialDataPath],
-              modifiedDataPath: ['modifiedData', ...nameSplit],
-              value,
-            },
-          });
+          if (isRelatedEntry) {
+            relationLoad({
+              target: {
+                initialDataPath: ['initialData', ...initialDataPath],
+                modifiedDataPath: ['modifiedData', ...nameSplit],
+                value: [],
+              },
+            });
+            value.forEach((relation) => {
+              handleRelationConnect(relation);
+            });
+          } else {
+            relationLoad({
+              target: {
+                initialDataPath: ['initialData', ...initialDataPath],
+                modifiedDataPath: ['modifiedData', ...nameSplit],
+                value,
+              },
+            });
+          }
         },
         normalizeArguments: {
           mainFieldName: mainField.name,

--- a/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/RelationInputDataManager.js
+++ b/packages/core/admin/admin/src/content-manager/components/RelationInputDataManager/RelationInputDataManager.js
@@ -62,8 +62,7 @@ export const RelationInputDataManager = ({
     [slug, initialDataPath.join('.'), modifiedData.id, defaultParams],
     {
       relation: {
-        enabled: !!endpoints.relation || !!endpoints.relatedRelation,
-        relatedEndpoint: endpoints.relatedRelation,
+        enabled: !!endpoints.relation || !!isRelatedEntry,
         endpoint: endpoints.relation,
         pageGoal: currentLastPage,
         isRelatedEntry,

--- a/packages/core/content-manager/server/controllers/relations.js
+++ b/packages/core/content-manager/server/controllers/relations.js
@@ -238,6 +238,7 @@ module.exports = {
 
     const queryParams = {
       fields: fieldsToSelect,
+      ...ctx.request.query,
     };
 
     if (isAnyToMany(attribute)) {


### PR DESCRIPTION
### What does it do?
Fetch relation fields from original entry (by relatedEntityId) with populating "localizations" field, and get data for current locale. 

### Why is it needed?
When user tries to add new localization, relations fields always stay empty, even if they have value for chosen locale.

### How to test it?
Add second locale through admin settings. Create 2 entities "Article" and "Category" with localization and connect them to each other with relation field. Create category in both languages. Create article with category. Change locale, category field must be filled in with the appropriate localization. 

### Related issue(s)/PR(s)
https://github.com/strapi/strapi/issues/12538