### PR TITLE
Restore radix toolbar dependency

### DIFF
--- a/packages/core/admin/package.json
+++ b/packages/core/admin/package.json
@@ -42,6 +42,7 @@
   "dependencies": {
     "@casl/ability": "6.5.0",
     "@pmmmwh/react-refresh-webpack-plugin": "0.5.10",
+    "@radix-ui/react-toolbar": "1.0.4",
     "@strapi/data-transfer": "4.13.7",
     "@strapi/design-system": "1.11.0",
     "@strapi/helper-plugin": "4.13.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5850,7 +5850,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@radix-ui/react-toolbar@npm:^1.0.4":
+"@radix-ui/react-toolbar@npm:1.0.4, @radix-ui/react-toolbar@npm:^1.0.4":
   version: 1.0.4
   resolution: "@radix-ui/react-toolbar@npm:1.0.4"
   dependencies:
@@ -7167,6 +7167,7 @@ __metadata:
   dependencies:
     "@casl/ability": 6.5.0
     "@pmmmwh/react-refresh-webpack-plugin": 0.5.10
+    "@radix-ui/react-toolbar": 1.0.4
     "@strapi/data-transfer": 4.13.7
     "@strapi/design-system": 1.11.0
     "@strapi/helper-plugin": 4.13.7


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Restore @radix-ui/react-toolbar dependency
### Why is it needed?

Looks like it was deleted during a merge when resolving conflicts.

