### PR TITLE
[RTE] Make images truly void

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/index.js
@@ -37,10 +37,20 @@ const Wrapper = styled(Box)`
   border-radius: ${({ theme }) => theme.borderRadius};
 `;
 
+const withImages = (editor) => {
+  const { isVoid } = editor;
+
+  editor.isVoid = (element) => {
+    return element.type === 'image' ? true : isVoid(element);
+  };
+
+  return editor;
+};
+
 const BlocksEditor = React.forwardRef(
   ({ intlLabel, labelAction, name, readOnly, required, error, value, onChange }, ref) => {
     const { formatMessage } = useIntl();
-    const [editor] = React.useState(() => withReact(withHistory(createEditor())));
+    const [editor] = React.useState(() => withReact(withImages(withHistory(createEditor()))));
 
     const label = intlLabel.id
       ? formatMessage(

--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/index.js
@@ -37,6 +37,14 @@ const Wrapper = styled(Box)`
   border-radius: ${({ theme }) => theme.borderRadius};
 `;
 
+/**
+ * Images are void elements. They handle the rendering of their children instead of Slate.
+ * See the Slate documentation for more information:
+ * - https://docs.slatejs.org/api/nodes/element#void-vs-not-void
+ * - https://docs.slatejs.org/api/nodes/element#rendering-void-elements
+ *
+ * @param {import('slate').Editor} editor
+ */
 const withImages = (editor) => {
   const { isVoid } = editor;
 


### PR DESCRIPTION
### What does it do?

Add a withImages plugin to Slate so images are truly void elements

### Why is it needed?

- Currently you can edit the text on an image element. It also means if your cursor is above the image and you select a new block it will delete the image

### How to test it?

- Add an image
- Put your cursor above the image and start typing, it should be whatever block you have selected
- Change the block and the image should stay
- Hit enter and you should be on a new line under the image
