### PR TITLE
Fix: Added test-results to file watcher ignore list

### DIFF
--- a/packages/core/strapi/src/commands/actions/develop/action.ts
+++ b/packages/core/strapi/src/commands/actions/develop/action.ts
@@ -232,6 +232,8 @@ function watchFileChanges({
       '**/exports/**',
       '**/dist/**',
       '**/*.d.ts',
+      '**/test-results',
+      '**/test-results/**',
       ...watchIgnoreFiles,
     ],
   });


### PR DESCRIPTION
### What does it do?

Added `test-results` folder to the list of ignored paths of file watcher.

### Why is it needed?

Fix: #18196
Users are facing issues while running E2E tests, as the server gets restarted during the tests.

### How to test it?

Go to `examples/getstarted`
Run `yarn develop`
Create a new file (e.g. test-results/something.txt)
The server restart does not happen as it was happenning before

### Related issue(s)/PR(s)

Issue: #18196
