### PR TITLE
Types - Only allow content types as relation target (cannot target component)

### DIFF
--- a/packages/core/types/src/types/core/attributes/common.ts
+++ b/packages/core/types/src/types/core/attributes/common.ts
@@ -67,7 +67,7 @@ export type Any =
   | Attribute.JSON
   | Attribute.Media<Attribute.MediaKind | undefined, boolean>
   | Attribute.Password
-  | Attribute.Relation<Common.UID.Schema, Attribute.RelationKind.Any, Common.UID.Schema>
+  | Attribute.Relation
   | Attribute.RichText
   | Attribute.String
   | Attribute.Text

--- a/packages/core/types/src/types/core/attributes/relation.ts
+++ b/packages/core/types/src/types/core/attributes/relation.ts
@@ -9,7 +9,7 @@ export type Relation<
   // It is kept to allow for future iterations without breaking the current type API
   _TOrigin extends Common.UID.Schema = Common.UID.Schema,
   TRelationKind extends RelationKind.Any = RelationKind.Any,
-  TTarget extends Common.UID.Schema = Common.UID.Schema
+  TTarget extends Common.UID.ContentType = Common.UID.ContentType
 > = Attribute.OfType<'relation'> &
   // Properties
   Utils.Guard.Never<RelationProperties<TRelationKind, TTarget>, AllRelationProperties<TTarget>> &
@@ -22,7 +22,7 @@ export type Relation<
 
 export type RelationProperties<
   TRelationKind extends RelationKind.Any,
-  TTarget extends Common.UID.Schema
+  TTarget extends Common.UID.ContentType
 > = Utils.Expression.MatchFirst<
   [
     [


### PR DESCRIPTION
### What does it do?

Replace the `Common.UID.Schema` constraint for `Attribute.Relation` target parameter with `Common.UID.ContentType`

### Why is it needed?

Relations' target can only be a content type (components' UID are not allowed)

