### PR TITLE
Fix JSON type issue

### DIFF
--- a/packages/core/database/lib/dialects/postgresql/index.js
+++ b/packages/core/database/lib/dialects/postgresql/index.js
@@ -22,11 +22,16 @@ class PostgresDialect extends Dialect {
       'text',
       (v) => v
     );
-    // Don't parse JSONB automatically
     this.db.connection.client.driver.types.setTypeParser(
       this.db.connection.client.driver.types.builtins.JSONB,
       'text',
-      (v) => v
+      (v) => {
+        try {
+          return JSON.parse(v);
+        } catch (error) {
+          return v;
+        }
+      }
     );
     this.db.connection.client.driver.types.setTypeParser(
       this.db.connection.client.driver.types.builtins.NUMERIC,


### PR DESCRIPTION
Fix: https://github.com/strapi/strapi/issues/18073

### What does it do?

This PR introduces a crucial technical change aimed at resolving the issue with JSONB type columns being returned as strings instead of objects. The key modifications made in this PR include updating the code responsible for handling JSONB data conversion.

### Describe the technical changes you did.

The issue was identified when users observed that JSONB type columns were being returned as strings, causing unexpected behavior in their applications. This behavior was a result of the automatic conversion of JSONB data to text format.

In code modification, I have added a JSON parsing step to ensure that JSONB type columns are correctly converted into JavaScript objects when retrieved from the database. If any parsing errors occur, the original string value is returned to prevent potential issues.

### Let us know if this is related to any issue/pull request

This PR is directly related to the issue [#18073](https://github.com/strapi/strapi/issues/18073), which was reported by the community. It acknowledges and addresses this issue by implementing the described code changes.