### PR TITLE
Fix: Strapi wont start after editing schema

### DIFF
--- a/packages/core/database/lib/dialects/mysql/schema-inspector.js
+++ b/packages/core/database/lib/dialects/mysql/schema-inspector.js
@@ -174,7 +174,7 @@ class MysqlSchemaInspector {
         ret[index.Key_name] = {
           columns: [index.Column_name],
           name: index.Key_name,
-          type: !index.Non_unique ? 'unique' : null,
+          type: index.Non_unique === '0' ? 'unique' : null,
         };
       } else {
         ret[index.Key_name].columns.push(index.Column_name);

--- a/packages/core/database/lib/dialects/sqlite/index.js
+++ b/packages/core/database/lib/dialects/sqlite/index.js
@@ -32,6 +32,7 @@ class SqliteDialect extends Dialect {
 
   async initialize() {
     await this.db.connection.raw('pragma foreign_keys = on');
+    await this.db.pragma('journal_mode = WAL',)
   }
 
   canAlterConstraints() {

--- a/packages/core/database/lib/dialects/sqlite/index.js
+++ b/packages/core/database/lib/dialects/sqlite/index.js
@@ -32,7 +32,8 @@ class SqliteDialect extends Dialect {
 
   async initialize() {
     await this.db.connection.raw('pragma foreign_keys = on');
-    await this.db.pragma('journal_mode = WAL',)
+    await this.db.connection.raw('pragma journal_mode = WAL');
+    await this.db.connection.raw('pragma synchronous = normal');
   }
 
   canAlterConstraints() {

--- a/packages/core/database/lib/dialects/sqlite/index.js
+++ b/packages/core/database/lib/dialects/sqlite/index.js
@@ -32,8 +32,6 @@ class SqliteDialect extends Dialect {
 
   async initialize() {
     await this.db.connection.raw('pragma foreign_keys = on');
-    await this.db.connection.raw('pragma journal_mode = WAL');
-    await this.db.connection.raw('pragma synchronous = normal');
   }
 
   canAlterConstraints() {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?
It solves the issue of not being able to start schema after editing schema by changing `type:  index.Non_unique === '0' ? 'unique' : null,`

### Why is it needed?
When starting up strapi after a schema change (adding a field to an entity) strapi won't start up

### How to test it?
This can be tested by running it locally and updating the schema to know its further challenges if come up

Feel Free to contact me.

Abhinav Gupta
Email:- guptaabhinav103@gmail.com