### PR TITLE
chore: use yarn resolution for design-system

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Run build:ts
         run: yarn nx run-many --target=build:ts --nx-ignore-cycles --skip-nx-cache
       - name: Run build
-        run: yarn nx run-many --target=build --nx-ignore-cycles --skip-nx-cache
+        run: DTS=true yarn nx run-many --target=build --nx-ignore-cycles --skip-nx-cache
       - name: TSC for packages
         run: yarn nx affected --target=test:ts --nx-ignore-cycles
       - name: TSC for back

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "watch": "nx run-many --target=watch --nx-ignore-cycles"
   },
   "resolutions": {
+    "@strapi/design-system": "1.12.0-typescript.1",
     "@types/koa": "2.13.4"
   },
   "devDependencies": {

--- a/packages/admin-test-utils/package.json
+++ b/packages/admin-test-utils/package.json
@@ -51,7 +51,6 @@
   },
   "scripts": {
     "build": "run -T tsc",
-    "build:ts": "run -T tsc",
     "watch": "run -T tsc -w --preserveWatchOutput",
     "clean": "run -T rimraf ./dist",
     "lint": "run -T eslint ."

--- a/packages/admin-test-utils/tsconfig.json
+++ b/packages/admin-test-utils/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "extends": "tsconfig/client.json",
   "compilerOptions": {
+    "declaration": true,
     "noEmit": false,
-    "noImplicitAny": true,
-    "outDir": "dist",
+    "outDir": "dist"
   },
   "include": ["src", "./custom.d.ts"],
   "exclude": ["node_modules", "**/__tests__/**"]

--- a/packages/core/admin/package.json
+++ b/packages/core/admin/package.json
@@ -66,7 +66,7 @@
     "execa": "5.1.1",
     "fast-deep-equal": "3.1.3",
     "find-root": "1.1.0",
-    "fork-ts-checker-webpack-plugin": "7.3.0",
+    "fork-ts-checker-webpack-plugin": "8.0.0",
     "formik": "2.4.0",
     "fractional-indexing": "3.2.0",
     "fs-extra": "10.0.0",

--- a/packages/core/helper-plugin/.eslintrc.js
+++ b/packages/core/helper-plugin/.eslintrc.js
@@ -1,8 +1,12 @@
 module.exports = {
   root: true,
   extends: ['custom/front/typescript', 'plugin:storybook/recommended'],
-  parserOptions: {
-    project: ['./tsconfig.eslint.json'],
+  settings: {
+    'import/resolver': {
+      typescript: {
+        project: './tsconfig.eslint.json',
+      },
+    },
   },
   rules: {
     'import/no-unresolved': [
@@ -13,13 +17,6 @@ module.exports = {
         ignore: ['@strapi/design-system/v2'],
       },
     ],
-  },
-  settings: {
-    'import/resolver': {
-      typescript: {
-        project: './tsconfig.eslint.json',
-      },
-    },
   },
   overrides: [
     {

--- a/packages/core/helper-plugin/.eslintrc.js
+++ b/packages/core/helper-plugin/.eslintrc.js
@@ -1,13 +1,6 @@
 module.exports = {
   root: true,
   extends: ['custom/front/typescript', 'plugin:storybook/recommended'],
-  settings: {
-    'import/resolver': {
-      typescript: {
-        project: './tsconfig.eslint.json',
-      },
-    },
-  },
   rules: {
     'import/no-unresolved': [
       'error',

--- a/packages/core/helper-plugin/package.json
+++ b/packages/core/helper-plugin/package.json
@@ -22,11 +22,14 @@
   ],
   "main": "build/helper-plugin.js",
   "module": "build/helper-plugin.esm.js",
+  "types": "build/index.d.ts",
   "exports": {
     ".": {
+      "types": "./build/index.d.ts",
       "require": "./build/helper-plugin.js",
       "import": "./build/helper-plugin.esm.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "files": [
     "build"
@@ -40,6 +43,7 @@
     "test:front": "run -T jest --config ./jest.config.front.js",
     "test:front:cov": "run -T jest --config ./jest.config.front.js --coverage",
     "test:front:watch": "run -T jest --config ./jest.config.front.js --watchAll",
+    "test:ts": "run -T tsc --noEmit",
     "watch": "cross-env NODE_ENV=development webpack-cli -w",
     "lint": "run -T eslint . --ext .js,.jsx,.tsx,.ts"
   },
@@ -79,7 +83,7 @@
     "esbuild-loader": "^2.21.0",
     "eslint-config-custom": "4.14.0",
     "eslint-plugin-storybook": "0.6.14",
-    "fork-ts-checker-webpack-plugin": "7.3.0",
+    "fork-ts-checker-webpack-plugin": "8.0.0",
     "msw": "1.3.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/packages/core/helper-plugin/src/content-manager/utils/tests/contentManagementUtilRemoveFieldsFromData.test.ts
+++ b/packages/core/helper-plugin/src/content-manager/utils/tests/contentManagementUtilRemoveFieldsFromData.test.ts
@@ -54,7 +54,11 @@ describe('STRAPI_HELPER_PLUGIN | utils', () => {
         },
         modelType: 'contentType',
         kind: 'collectionType',
+        modelName: 'test.test',
+        globalId: 'Test.Test',
         info: {
+          singularName: 'test',
+          pluralName: 'tests',
           displayName: 'Test',
         },
       };

--- a/packages/core/helper-plugin/src/content-manager/utils/tests/formatContentTypeData.test.ts
+++ b/packages/core/helper-plugin/src/content-manager/utils/tests/formatContentTypeData.test.ts
@@ -83,6 +83,8 @@ describe('STRAPI_HELPER_PLUGIN | utils | formatContentTypeData', () => {
   it('should stringify json fields', () => {
     const contentType: Schema.ContentType = {
       uid: 'api::test.test',
+      modelName: 'test.test',
+      globalId: 'Test.Test',
       attributes: {
         id: { type: 'integer' },
         name: { type: 'string' },
@@ -94,16 +96,19 @@ describe('STRAPI_HELPER_PLUGIN | utils | formatContentTypeData', () => {
       modelType: 'contentType',
       kind: 'collectionType',
       info: {
+        singularName: 'test',
+        pluralName: 'tests',
         displayName: 'Test',
       },
     };
 
     const components: Record<string, Schema.Component> = {
       'compos.sub-compo': {
+        uid: 'api::compos.sub-compo',
+        modelName: 'compos.sub-compo',
+        category: 'component',
+        globalId: 'Compos.SubCompo',
         modelType: 'component',
-        info: {
-          displayName: 'Test',
-        },
         attributes: {
           id: { type: 'integer' },
           name: { type: 'string' },

--- a/packages/core/helper-plugin/src/content-manager/utils/tests/testData.ts
+++ b/packages/core/helper-plugin/src/content-manager/utils/tests/testData.ts
@@ -18,24 +18,32 @@ const contentType: Schema.ContentType = {
   },
   modelType: 'contentType',
   kind: 'collectionType',
+  modelName: 'test',
+  globalId: 'Test',
   info: {
-    displayName: 'Test',
+    singularName: 'test',
+    pluralName: 'tests',
+    displayName: 'test',
   },
 };
 
 const components: Record<string, Schema.Component> = {
   'compos.sub-compo': {
+    category: 'default',
+    modelName: 'sub-compo',
+    globalId: 'SubCompo',
     attributes: {
       id: { type: 'integer' },
       name: { type: 'string' },
       password: { type: 'password' },
     },
     modelType: 'component',
-    info: {
-      displayName: 'Test',
-    },
+    uid: 'compos.sub-compo',
   },
   'compos.test-compo': {
+    category: 'default',
+    modelName: 'test-compo',
+    globalId: 'TestCompo',
     attributes: {
       id: { type: 'integer' },
       name: { type: 'string' },
@@ -52,9 +60,7 @@ const components: Record<string, Schema.Component> = {
       },
     },
     modelType: 'component',
-    info: {
-      displayName: 'Test',
-    },
+    uid: 'compos.test-compo',
   },
 };
 

--- a/packages/core/helper-plugin/src/utils/request.ts
+++ b/packages/core/helper-plugin/src/utils/request.ts
@@ -85,6 +85,7 @@ async function serverRestartWatcher<ResponseType>(response: ResponseType): Promi
 
 const warnOnce = once(console.warn);
 
+// eslint-disable-next-line no-undef
 interface RequestOptions extends RequestInit {
   params?: Record<string, string>;
 }

--- a/packages/core/helper-plugin/tests/utils.tsx
+++ b/packages/core/helper-plugin/tests/utils.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable check-file/filename-naming-convention */
 import * as React from 'react';
 
+// @ts-expect-error - the package is slightly broken, but will be fixed with https://github.com/strapi/strapi/pull/18233
 import { fixtures } from '@strapi/admin-test-utils';
 import { DesignSystemProvider } from '@strapi/design-system';
 import {

--- a/packages/core/helper-plugin/tsconfig.build.json
+++ b/packages/core/helper-plugin/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["declarations", "src"],
+  "exclude": ["**/*.test.tsx", "**/*.test.ts"],
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./build"
+  }
+}

--- a/packages/core/helper-plugin/tsconfig.eslint.json
+++ b/packages/core/helper-plugin/tsconfig.eslint.json
@@ -1,6 +1,5 @@
 {
   "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "noEmit": true
-  }
+  "include": ["declarations", "src"],
+  "exclude": ["node_modules"]
 }

--- a/packages/core/helper-plugin/tsconfig.json
+++ b/packages/core/helper-plugin/tsconfig.json
@@ -2,14 +2,12 @@
   "extends": "tsconfig/client.json",
   "compilerOptions": {
     "baseUrl": ".",
-    "moduleResolution": "Node16",
     "paths": {
       // workaround because @strapi/utils does not export types correctly.
       "*": ["src/*", "declarations/*"],
       "@tests/*": ["./tests/*"]
     }
   },
-  "include": ["declarations", "src", "tests", "jest.config.front.js", "webpack.config.js"],
-  "exclude": ["node_modules"],
-  "noImplicitAny": false,
+  "include": ["declarations", "src"],
+  "exclude": ["node_modules"]
 }

--- a/packages/core/helper-plugin/webpack.config.js
+++ b/packages/core/helper-plugin/webpack.config.js
@@ -74,7 +74,16 @@ const config = [
     experiments: {
       outputModule: true,
     },
-    plugins: [process.env.DTS ? new ForkTsCheckerPlugin() : undefined].filter((v) => v),
+    plugins: [
+      process.env.DTS
+        ? new ForkTsCheckerPlugin({
+            typescript: {
+              mode: 'write-dts',
+              configFile: `${__dirname}/tsconfig.build.json`,
+            },
+          })
+        : undefined,
+    ].filter((v) => v),
   },
   {
     ...baseConfig,

--- a/packages/plugins/color-picker/admin/.eslintrc.js
+++ b/packages/plugins/color-picker/admin/.eslintrc.js
@@ -1,7 +1,4 @@
 module.exports = {
   root: true,
   extends: ['custom/front/typescript'],
-  parserOptions: {
-    project: ['./admin/tsconfig.eslint.json'],
-  },
 };

--- a/packages/plugins/color-picker/admin/src/components/ColorPickerInput.tsx
+++ b/packages/plugins/color-picker/admin/src/components/ColorPickerInput.tsx
@@ -94,7 +94,7 @@ interface ColorPickerInputProps {
   value?: string;
 }
 
-export const ColorPickerInput = React.forwardRef<HTMLDivElement, ColorPickerInputProps>(
+export const ColorPickerInput = React.forwardRef<HTMLButtonElement, ColorPickerInputProps>(
   (
     {
       attribute,
@@ -111,10 +111,9 @@ export const ColorPickerInput = React.forwardRef<HTMLDivElement, ColorPickerInpu
     forwardedRef
   ) => {
     const [showColorPicker, setShowColorPicker] = React.useState(false);
-    const colorPickerButtonRef = React.useRef();
+    const colorPickerButtonRef = React.useRef<HTMLButtonElement>(null!);
     const { formatMessage } = useIntl();
     const color = value || '#000000';
-    const styleUppercase = { textTransform: 'uppercase' };
 
     const handleBlur: React.FocusEventHandler<HTMLDivElement> = (e) => {
       e.preventDefault();
@@ -153,8 +152,8 @@ export const ColorPickerInput = React.forwardRef<HTMLDivElement, ColorPickerInpu
             <Flex>
               <ColorPreview color={color} />
               <Typography
-                style={styleUppercase}
-                textColor={value ? null : 'neutral600'}
+                style={{ textTransform: 'uppercase' }}
+                textColor={value ? undefined : 'neutral600'}
                 variant="omega"
               >
                 {color}
@@ -191,7 +190,7 @@ export const ColorPickerInput = React.forwardRef<HTMLDivElement, ColorPickerInpu
                       id: getTrad('color-picker.input.aria-label'),
                       defaultMessage: 'Color picker input',
                     })}
-                    style={styleUppercase}
+                    style={{ textTransform: 'uppercase' }}
                     value={value}
                     placeholder="#000000"
                     onChange={onChange}

--- a/packages/plugins/color-picker/admin/src/global.d.ts
+++ b/packages/plugins/color-picker/admin/src/global.d.ts
@@ -1,3 +1,0 @@
-declare module '@strapi/helper-plugin';
-declare module '@strapi/design-system';
-declare module '@strapi/icons';

--- a/packages/utils/tsconfig/client.json
+++ b/packages/utils/tsconfig/client.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "target": "ESNext",
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "Bundler",
     "useDefineForClassFields": true,
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "allowJs": false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7268,7 +7268,7 @@ __metadata:
     execa: 5.1.1
     fast-deep-equal: 3.1.3
     find-root: 1.1.0
-    fork-ts-checker-webpack-plugin: 7.3.0
+    fork-ts-checker-webpack-plugin: 8.0.0
     formik: 2.4.0
     fractional-indexing: 3.2.0
     fs-extra: 10.0.0
@@ -7517,7 +7517,7 @@ __metadata:
     esbuild-loader: ^2.21.0
     eslint-config-custom: 4.14.0
     eslint-plugin-storybook: 0.6.14
-    fork-ts-checker-webpack-plugin: 7.3.0
+    fork-ts-checker-webpack-plugin: 8.0.0
     formik: 2.4.0
     immer: 9.0.19
     lodash: 4.17.21
@@ -16821,9 +16821,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fork-ts-checker-webpack-plugin@npm:7.3.0":
-  version: 7.3.0
-  resolution: "fork-ts-checker-webpack-plugin@npm:7.3.0"
+"fork-ts-checker-webpack-plugin@npm:8.0.0":
+  version: 8.0.0
+  resolution: "fork-ts-checker-webpack-plugin@npm:8.0.0"
   dependencies:
     "@babel/code-frame": ^7.16.7
     chalk: ^4.1.2
@@ -16839,12 +16839,8 @@ __metadata:
     tapable: ^2.2.1
   peerDependencies:
     typescript: ">3.6.0"
-    vue-template-compiler: "*"
     webpack: ^5.11.0
-  peerDependenciesMeta:
-    vue-template-compiler:
-      optional: true
-  checksum: 49c2af801e264349a3fdf0afe4ad33065960c43bd7e56c8351a5e0d32c8c54146cc89d6a0b70b1e0f810de96787bd0c7fd275cc8727a9aea1a077c53de99659a
+  checksum: aad4cbc5b802e6281a2700a379837697c93ad95288468f9595219d91d9c26674736d37852bb4c4341e9122f26181e9e05fc1a362e8d029fdd88e99de7816037b
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7399,9 +7399,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@strapi/design-system@npm:1.12.0":
-  version: 1.12.0
-  resolution: "@strapi/design-system@npm:1.12.0"
+"@strapi/design-system@npm:1.12.0-typescript.1":
+  version: 1.12.0-typescript.1
+  resolution: "@strapi/design-system@npm:1.12.0-typescript.1"
   dependencies:
     "@codemirror/lang-json": ^6.0.1
     "@floating-ui/react-dom": ^2.0.2
@@ -7410,19 +7410,19 @@ __metadata:
     "@radix-ui/react-dismissable-layer": ^1.0.5
     "@radix-ui/react-dropdown-menu": ^2.0.6
     "@radix-ui/react-focus-scope": 1.0.4
-    "@strapi/ui-primitives": ^1.12.0
+    "@strapi/ui-primitives": 1.12.0-typescript.1
     "@uiw/react-codemirror": ^4.21.18
     aria-hidden: ^1.2.3
     compute-scroll-into-view: ^3.1.0
     prop-types: ^15.8.1
     react-remove-scroll: ^2.5.6
   peerDependencies:
-    "@strapi/icons": ^1.5.0
+    "@strapi/icons": 1.12.0-typescript.1
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
     react-router-dom: ^5.2.0
     styled-components: ^5.2.1
-  checksum: a98bf689307337a5fc311beb040b09acd8479941af4e5c883bec24e1c15283fdaf9d95828411d560a771360da7158240ee5d4d13d8eb640f8b3efe9f5d426c60
+  checksum: cf966142378314ff3c7853e46244f6d85ceb064e9b95dde01e305f1a970412b5c9a5db35afec891e2ffd31592d3fb6745899f11846fc9f9e43f354a6d2564431
   languageName: node
   linkType: hard
 
@@ -8145,9 +8145,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@strapi/ui-primitives@npm:^1.12.0":
-  version: 1.12.0
-  resolution: "@strapi/ui-primitives@npm:1.12.0"
+"@strapi/ui-primitives@npm:1.12.0-typescript.1":
+  version: 1.12.0-typescript.1
+  resolution: "@strapi/ui-primitives@npm:1.12.0-typescript.1"
   dependencies:
     "@radix-ui/number": ^1.0.1
     "@radix-ui/primitive": ^1.0.1
@@ -8173,7 +8173,7 @@ __metadata:
   peerDependencies:
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
-  checksum: cf0af10a631da76daa0ef931a413789a3f29235b019a3827c940e707b518860612848101910415a7ea918e4c617203c3ebaddf13f44e17db393731b65b54f77c
+  checksum: 80dd3cb4286b2322e6f156ff06d51be82d59d288a291c850af3fc6b34a0c3f3d7be59f006bf11d8ab35ef24eb95af2f59d902510aca84cbdf0c39fd0df15b150
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* uses a yarn alias at the monorepo root to always install the TS version of the DS
* fixes the helper-plugin types & adds `test:ts` command so we can ensure the package types don't break
* Uses `Bundler` as the default client config because all conversions with admin code should be using a bundler
* fixes color-picker types & removes the global dts to override the libs that did not previously have types
* ensures we build packages with DTS=true (for the helper-plugin) in the CI 
* Updates `ForkTsCheckerPlugin`

### Why is it needed?

* We keep breaking the helper-plugin types
* We need the DS types so we can work faster
