### PR TITLE
fix: typo causing action button to not show in empty list

### DIFF
--- a/e2e/tests/content-manager/listview.spec.js
+++ b/e2e/tests/content-manager/listview.spec.js
@@ -19,6 +19,6 @@ test.describe('List View', () => {
 
     await expect(page).toHaveTitle('Content Manager');
     await expect(page.getByRole('heading', { name: 'testing' })).toBeVisible();
-    await expect(page.getByRole('link', { name: /Create new entry/ })).toBeVisible();
+    await expect(page.getByRole('link', { name: /Create new entry/ }).first()).toBeVisible();
   });
 });

--- a/packages/core/admin/admin/src/content-manager/pages/ListView/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/ListView/index.js
@@ -720,7 +720,7 @@ function ListView({
                 {/* Empty content */}
                 <Table.EmptyBody
                   contentType={headerLayoutTitle}
-                  aciton={getCreateAction({ variant: 'secondary' })}
+                  action={getCreateAction({ variant: 'secondary' })}
                 />
                 {/* Content */}
                 <Body.Root


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Fixes #18251, by fixing a typo

### Why is it needed?

To fix action button from not showing in empty lists

### How to test it?

1. Go to 'Content Manager'
1. Click on a Collection that current has **0 entries**
1. Scroll down to List View
1. Action button should now be visible

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
