### PR TITLE
Add `fields` and `populate` query params to schema for single entity `get` requests

### DIFF
--- a/packages/plugins/documentation/server/services/helpers/build-api-endpoint-path.js
+++ b/packages/plugins/documentation/server/services/helpers/build-api-endpoint-path.js
@@ -5,6 +5,7 @@ const pathToRegexp = require('path-to-regexp');
 
 const pascalCase = require('./utils/pascal-case');
 const queryParams = require('./utils/query-params');
+const queryGetEntityParams = require('./utils/query-get-entity-params');
 const loopContentTypeNames = require('./utils/loop-content-type-names');
 const getApiResponses = require('./utils/get-api-responses');
 const { hasFindMethod, isLocalizedPath } = require('./utils/routes');
@@ -115,6 +116,8 @@ const getPaths = ({ routeInfo, uniqueName, contentTypeInfo, kind }) => {
 
     if (isListOfEntities) {
       swaggerConfig.parameters.push(...queryParams);
+    } else if (methodVerb === 'get') {
+      swaggerConfig.parameters.push(...queryGetEntityParams);
     }
 
     if (hasPathParams) {

--- a/packages/plugins/documentation/server/services/helpers/utils/query-get-entity-params.js
+++ b/packages/plugins/documentation/server/services/helpers/utils/query-get-entity-params.js
@@ -1,0 +1,9 @@
+'use strict';
+
+const queryParams = require('./query-params');
+
+const singleEntityGetParams = ['fields', 'populate']
+
+module.exports = queryParams.filter(({ name }) => (
+	singleEntityGetParams.includes(name) === true
+));


### PR DESCRIPTION
### What does it do?

Adds `fields` and `populate` query params to generated schemas for single entity `get` requests.

### Why is it needed?

REST API supports those params and so does the schema must include them.

### How to test it?

Run `yarn develop` with `@strapi/plugin-documentation` installed and go to `http://localhost:1337/documentation/v1.0.0` and find a single entity get request, you will see added `fields` and `populate` query params. Or check it in generated schema: `/src/extensions/documentation/documentation/1.0.0/full_documentation.json`.

### Related issue(s)/PR(s)

None yet?

### Implementation details.

In `@strapi/plugin-documentation` created a new file `/server/services/helpers/utils/query-get-entity-params.js` that re-exports `populate` and `fields` query params from [/server/services/helpers/utils/query-params.js](https://github.com/strapi/strapi/blob/main/packages/plugins/documentation/server/services/helpers/utils/query-params.js).
Then in `/server/services/helpers/build-api-endpoint-path.js` in [getPaths](https://github.com/strapi/strapi/blob/main/packages/plugins/documentation/server/services/helpers/build-api-endpoint-path.js#L84) function inside of [contentTypeRoutes.reduce](https://github.com/strapi/strapi/blob/main/packages/plugins/documentation/server/services/helpers/build-api-endpoint-path.js#L93) loop, if [isListOfEntities](https://github.com/strapi/strapi/blob/main/packages/plugins/documentation/server/services/helpers/build-api-endpoint-path.js#L95) is falsish and route method [methodVerb](https://github.com/strapi/strapi/blob/main/packages/plugins/documentation/server/services/helpers/build-api-endpoint-path.js#L97) is `GET` push `...queryGetEntityParams` to `swaggerConfig.parameters`.
