### PR TITLE
Added a maximum date to DatePicker and DateTimePicker

### DIFF
--- a/packages/core/helper-plugin/src/components/GenericInput.tsx
+++ b/packages/core/helper-plugin/src/components/GenericInput.tsx
@@ -77,6 +77,7 @@ interface GenericInputProps<TAttribute extends Attribute.Any = Attribute.Any> {
   value?: Attribute.GetValue<TAttribute>;
   isNullable?: boolean;
 }
+const MAX_DATE = new Date(2100, 0);
 
 const GenericInput = ({
   autoComplete,
@@ -303,6 +304,7 @@ const GenericInput = ({
           id={name}
           hint={hint}
           name={name}
+          maxDate={MAX_DATE}
           onChange={(date) => {
             // check if date is not null or undefined
             const formattedDate = date ? date.toISOString() : null;
@@ -327,6 +329,7 @@ const GenericInput = ({
           id={name}
           hint={hint}
           name={name}
+          maxDate={MAX_DATE}
           onChange={(date) => {
             onChange({
               target: {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Sets a maximum date for the DatePicker and the DateTimePicker.

### Why is it needed?

If no maximum date is provided to the DatePicker, it defaults to current_year + 15, and some people would like to pick a later date than that.

### How to test it?

I started up the getstarted example, made a type with date and datetime, and tried picking a date above 2038.

### Related issue(s)/PR(s)

[#18009](https://github.com/strapi/strapi/issues/18009)

### Notes

I made this PR a draft, because I'm not sure about 2 things:
  - I completely eyeballed the max year to 2100. I figured, it is high enough to be enough, but not too high, so the year picker dropdown doesn't have to unnecessarily render to many options.
  - You might want to put the max_date constant somewhere else, like a config or util file. I'm not very familiar with your codebase, this is my first PR.
