### PR TITLE
removed from email code - fixed issue #18267

### DIFF
--- a/packages/plugins/users-permissions/server/controllers/auth.js
+++ b/packages/plugins/users-permissions/server/controllers/auth.js
@@ -255,7 +255,7 @@ module.exports = {
       to: user.email,
       from:
         resetPasswordSettings.from.email || resetPasswordSettings.from.name
-          ? `${resetPasswordSettings.from.name} <${resetPasswordSettings.from.email}>`
+          ? `${resetPasswordSettings.from.name}`
           : undefined,
       replyTo: resetPasswordSettings.response_email,
       subject: emailObject,


### PR DESCRIPTION
Fixed #18267
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?
Removed the email address of the sender from email name

Describe the technical changes you did.
Requirement:
`const emailToSend = {
      to: user.email,
      from:
        resetPasswordSettings.from.email || resetPasswordSettings.from.name
          ? '${resetPasswordSettings.from.name} <${resetPasswordSettings.from.email}>' // <$reset...from.email> should be removed
          : undefined,
      replyTo: resetPasswordSettings.response_email,
      subject: emailObject,
      text: emailBody,
      html: emailBody,
    };`

Changes I did:
`const emailToSend = {
      to: user.email,
      from:
        resetPasswordSettings.from.email || resetPasswordSettings.from.name
          ? '${resetPasswordSettings.from.name}' // removed the extra code
          : undefined,
      replyTo: resetPasswordSettings.response_email,
      subject: emailObject,
      text: emailBody,
      html: emailBody,
    };`


### Why is it needed?
The email sent for a forgot password request has the email address of the sender also in the name of the email.
The code responsible for this put both the name of the email with also the email address of the sender.
This "duplicate" of the sender's address make it show up two time when opening an email (as email name and as email sender) .
In addition it makes the name of the email pointlessly longer.

Describe the issue you are solving.
Expected behavior
The name of the email should contain only the name of the email, not the email address of the sender


### How to test it?
Steps to reproduce the behavior
Request an email to reset a password that has been forgotten
Watch the email's name in the inbox having also an email address

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)
https://github.com/strapi/strapi/issues/18267


Let us know if this is related to any issue/pull request
yes #18267 
