### PR TITLE
fix: add missing type TS prop to RouterConfig

### DIFF
--- a/packages/core/types/src/types/core-api/router.ts
+++ b/packages/core/types/src/types/core-api/router.ts
@@ -41,6 +41,7 @@ export interface CollectionTypeRouterConfig extends Generic {
 }
 
 export type RouterConfig<TContentTypeUID extends Common.UID.ContentType> = {
+  type?: 'content-api' | 'admin';
   prefix?: string;
   // TODO Refactor when we have a controller registry
   only?: string[];


### PR DESCRIPTION
### What does it do?

Add missing `type` TS prop to `RouterConfig` used by `createCoreRouter` factory.

### Why is it needed?

The plugin docs show the usage of the type property ([see docs](https://docs.strapi.io/dev-docs/api/plugins/server-api#routes)).
The `'content-api'` value for example allows plugin routes to be shown as permissions in the U&P plugin config.

### How to test it?

1. Generate a typescript plugin with `yarn strapi generate`
2. Add a plugin content-type
3. Add core services and controller for content-type
4. Add core routes for content-type and add `type` prop
5. RESULT: no TS errors.

```ts
path: ./src/plugins/my-plugin/server/routes/content-api.ts

import { factories } from '@strapi/strapi';

export default factories.createCoreRouter('plugin::content-type.content-type',
{
  type: 'content-api',
  only: ['find'],
  config: {
    find: {}
  }
});
```

### Open end (docs)

The `type` prop is only shown in examples in the [Plugin routes docs](https://docs.strapi.io/dev-docs/api/plugins/server-api#routes), the question is:
Is there any clear info about it's working/usage and I guess this should also be included in the [Core router config docs](https://docs.strapi.io/dev-docs/backend-customization/routes#configuring-core-routers) for backend customizations.
If any pointers could be given, I'm happy to open a PR on for the missing documentations.