### PR TITLE
[Blocks] Set fixed height for the whole editor

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/BlocksInput/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/BlocksInput/index.js
@@ -13,6 +13,7 @@ const getEditorStyle = (theme) => ({
   display: 'flex',
   flexDirection: 'column',
   gap: theme.spaces[2],
+  height: '100%',
 });
 
 const baseRenderLeaf = (props, modifiers) => {

--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/index.js
@@ -28,7 +28,6 @@ const EditorDivider = styled(Divider)`
 
 const Wrapper = styled(Box)`
   width: 100%;
-  max-height: 512px;
   overflow: auto;
   padding: ${({ theme }) => `${theme.spaces[3]} ${theme.spaces[4]}`};
   font-size: ${({ theme }) => theme.fontSizes[2]};
@@ -109,10 +108,10 @@ const BlocksEditor = React.forwardRef(
             initialValue={value || [{ type: 'paragraph', children: [{ type: 'text', text: '' }] }]}
             onChange={handleSlateChange}
           >
-            <InputWrapper direction="column" alignItems="flex-start">
+            <InputWrapper direction="column" alignItems="flex-start" height="512px">
               <BlocksToolbar disabled={disabled} />
               <EditorDivider width="100%" />
-              <Wrapper>
+              <Wrapper grow={1}>
                 <BlocksInput disabled={disabled} />
               </Wrapper>
             </InputWrapper>


### PR DESCRIPTION
### What does it do?

Sets a fixed height of 512px for the whole editor (toolbar + content). It's both the min and max height.

In the current implementation 512px was only for the content and not the toolbar, and it was a max-height, so when you had no content the editor was tiny.

### Why is it needed?

It's what's in the designs
