### PR TITLE
Allows users to disable NPS in strapi config.

### DIFF
--- a/examples/getstarted/config/admin.js
+++ b/examples/getstarted/config/admin.js
@@ -14,4 +14,5 @@ module.exports = ({ env }) => ({
       salt: env('TRANSFER_TOKEN_SALT', 'example-salt'),
     },
   },
+  isNpsEnabled: env('IS_NPS_ENABLED', true),
 });

--- a/examples/getstarted/config/admin.js
+++ b/examples/getstarted/config/admin.js
@@ -14,5 +14,7 @@ module.exports = ({ env }) => ({
       salt: env('TRANSFER_TOKEN_SALT', 'example-salt'),
     },
   },
-  npsEnabled: env.bool('NPS_ENABLED', true),
+  flags: {
+    nps: env.bool('FLAG_NPS', true),
+  },
 });

--- a/examples/getstarted/config/admin.js
+++ b/examples/getstarted/config/admin.js
@@ -14,5 +14,5 @@ module.exports = ({ env }) => ({
       salt: env('TRANSFER_TOKEN_SALT', 'example-salt'),
     },
   },
-  isNpsEnabled: env('IS_NPS_ENABLED', true),
+  npsEnabled: env.bool('NPS_ENABLED', true),
 });

--- a/examples/kitchensink-ts/config/admin.ts
+++ b/examples/kitchensink-ts/config/admin.ts
@@ -11,6 +11,6 @@ export default ({ env }) => ({
     },
   },
   flags: {
-    ps: env.bool('FLAG_NPS', true),
+    nps: env.bool('FLAG_NPS', true),
   },
 });

--- a/examples/kitchensink-ts/config/admin.ts
+++ b/examples/kitchensink-ts/config/admin.ts
@@ -10,4 +10,5 @@ export default ({ env }) => ({
       salt: env('TRANSFER_TOKEN_SALT', 'example-salt'),
     },
   },
+  isNpsEnabled: env('IS_NPS_ENABLED', true),
 });

--- a/examples/kitchensink-ts/config/admin.ts
+++ b/examples/kitchensink-ts/config/admin.ts
@@ -10,5 +10,5 @@ export default ({ env }) => ({
       salt: env('TRANSFER_TOKEN_SALT', 'example-salt'),
     },
   },
-  isNpsEnabled: env('IS_NPS_ENABLED', true),
+  npsEnabled: env.bool('NPS_ENABLED', true),
 });

--- a/examples/kitchensink-ts/config/admin.ts
+++ b/examples/kitchensink-ts/config/admin.ts
@@ -10,5 +10,7 @@ export default ({ env }) => ({
       salt: env('TRANSFER_TOKEN_SALT', 'example-salt'),
     },
   },
-  npsEnabled: env.bool('NPS_ENABLED', true),
+  flags: {
+    ps: env.bool('FLAG_NPS', true),
+  },
 });

--- a/examples/kitchensink/config/admin.js
+++ b/examples/kitchensink/config/admin.js
@@ -11,5 +11,7 @@ module.exports = ({ env }) => ({
       salt: env('TRANSFER_TOKEN_SALT', 'example-salt'),
     },
   },
-  npsEnabled: env.bool('NPS_ENABLED', true),
+  flags: {
+    nps: env.bool('FLAG_NPS', true),
+  },
 });

--- a/examples/kitchensink/config/admin.js
+++ b/examples/kitchensink/config/admin.js
@@ -11,4 +11,5 @@ module.exports = ({ env }) => ({
       salt: env('TRANSFER_TOKEN_SALT', 'example-salt'),
     },
   },
+  isNpsEnabled: env('IS_NPS_ENABLED', true),
 });

--- a/examples/kitchensink/config/admin.js
+++ b/examples/kitchensink/config/admin.js
@@ -11,5 +11,5 @@ module.exports = ({ env }) => ({
       salt: env('TRANSFER_TOKEN_SALT', 'example-salt'),
     },
   },
-  isNpsEnabled: env('IS_NPS_ENABLED', true),
+  npsEnabled: env.bool('NPS_ENABLED', true),
 });

--- a/packages/admin-test-utils/custom.d.ts
+++ b/packages/admin-test-utils/custom.d.ts
@@ -1,4 +1,4 @@
-export {};
+export { };
 
 declare global {
   interface Window {
@@ -11,6 +11,9 @@ declare global {
       };
       projectType: string;
       telemetryDisabled: boolean;
+      flags: {
+        nps: boolean
+      }
     };
   }
 }

--- a/packages/admin-test-utils/src/environment.ts
+++ b/packages/admin-test-utils/src/environment.ts
@@ -65,6 +65,9 @@ window.strapi = {
   },
   projectType: 'Community',
   telemetryDisabled: true,
+  flags: {
+    nps: true
+  }
 };
 
 /* -------------------------------------------------------------------------------------------------

--- a/packages/core/admin/admin/src/components/NpsSurvey/index.js
+++ b/packages/core/admin/admin/src/components/NpsSurvey/index.js
@@ -71,18 +71,22 @@ const checkIfShouldShowSurvey = (settings) => {
   const { enabled, lastResponseDate, firstDismissalDate, lastDismissalDate } = settings;
 
   // This function goes through all the cases where we'd want to not show the survey:
-  // 1. If the survey is disabled, abort mission, don't bother checking the other settings.
-  // 2. If the user has already responded to the survey, check if enough time has passed since the last response.
-  // 3. If the user has dismissed the survey twice or more before, check if enough time has passed since the last dismissal.
-  // 4. If the user has only dismissed the survey once before, check if enough time has passed since the first dismissal.
+  // 1. If the survey is disabled by strapi, abort mission, don't bother checking the other settings.
+  // 2. If the survey is disabled by user, abort mission, don't bother checking the other settings.
+  // 3. If the user has already responded to the survey, check if enough time has passed since the last response.
+  // 4. If the user has dismissed the survey twice or more before, check if enough time has passed since the last dismissal.
+  // 5. If the user has only dismissed the survey once before, check if enough time has passed since the first dismissal.
   // If none of these cases check out, then we show the survey.
   // Note that submitting a response resets the dismissal counts.
-  // Checks 3 and 4 should not be reversed, since the first dismissal will also exist if the user has dismissed the survey twice or more before.
+  // Checks 4 and 5 should not be reversed, since the first dismissal will also exist if the user has dismissed the survey twice or more before.
 
   // For users who had created an account before the NPS feature was introduced,
   // we assume that they would have enabled the NPS feature if they had the chance.
 
   // User chose not to enable the NPS feature when signing up
+  if(window.strapi.isNpsEnabled === false){
+    return false
+  }
   if (enabled === false) {
     return false;
   }

--- a/packages/core/admin/admin/src/components/NpsSurvey/index.js
+++ b/packages/core/admin/admin/src/components/NpsSurvey/index.js
@@ -84,7 +84,7 @@ const checkIfShouldShowSurvey = (settings) => {
   // we assume that they would have enabled the NPS feature if they had the chance.
 
   // Global strapi disable for NSP.
-  if (window?.strapi?.flags === undefined || window.strapi.flags.nps === false) {
+  if (window.strapi.flags.nps === false) {
     return false
   }
 

--- a/packages/core/admin/admin/src/components/NpsSurvey/index.js
+++ b/packages/core/admin/admin/src/components/NpsSurvey/index.js
@@ -84,7 +84,7 @@ const checkIfShouldShowSurvey = (settings) => {
   // we assume that they would have enabled the NPS feature if they had the chance.
 
   // Global strapi disable for NSP.
-  if(window.strapi.flags.nps === false){
+  if (window.strapi.flags.nps === false) {
     return false
   }
 

--- a/packages/core/admin/admin/src/components/NpsSurvey/index.js
+++ b/packages/core/admin/admin/src/components/NpsSurvey/index.js
@@ -84,7 +84,7 @@ const checkIfShouldShowSurvey = (settings) => {
   // we assume that they would have enabled the NPS feature if they had the chance.
 
   // Global strapi disable for NSP.
-  if(window.strapi.npsEnabled === false){
+  if(window.strapi.flags.nps === false){
     return false
   }
 

--- a/packages/core/admin/admin/src/components/NpsSurvey/index.js
+++ b/packages/core/admin/admin/src/components/NpsSurvey/index.js
@@ -84,7 +84,7 @@ const checkIfShouldShowSurvey = (settings) => {
   // we assume that they would have enabled the NPS feature if they had the chance.
 
   // Global strapi disable for NSP.
-  if (window.strapi.flags.nps === false) {
+  if (window?.strapi?.flags === undefined || window.strapi.flags.nps === false) {
     return false
   }
 

--- a/packages/core/admin/admin/src/components/NpsSurvey/index.js
+++ b/packages/core/admin/admin/src/components/NpsSurvey/index.js
@@ -83,10 +83,12 @@ const checkIfShouldShowSurvey = (settings) => {
   // For users who had created an account before the NPS feature was introduced,
   // we assume that they would have enabled the NPS feature if they had the chance.
 
-  // User chose not to enable the NPS feature when signing up
-  if(window.strapi.isNpsEnabled === false){
+  // Global strapi disable for NSP.
+  if(window.strapi.npsEnabled === false){
     return false
   }
+
+  // User chose not to enable the NPS feature when signing up
   if (enabled === false) {
     return false;
   }

--- a/packages/core/admin/admin/src/index.js
+++ b/packages/core/admin/admin/src/index.js
@@ -23,6 +23,7 @@ window.strapi = {
     REVIEW_WORKFLOWS: 'review-workflows',
   },
   projectType: 'Community',
+  isNpsEnabled: false
 };
 
 const customConfig = appCustomisations;
@@ -41,11 +42,12 @@ const run = async () => {
   try {
     const {
       data: {
-        data: { isEE, features },
+        data: { isEE, features, isNpsEnabled },
       },
     } = await get('/admin/project-type');
 
     window.strapi.isEE = isEE;
+    window.strapi.isNpsEnabled = isNpsEnabled
     window.strapi.features = {
       ...window.strapi.features,
       isEnabled: (featureName) => features.some((feature) => feature.name === featureName),

--- a/packages/core/admin/admin/src/index.js
+++ b/packages/core/admin/admin/src/index.js
@@ -23,7 +23,9 @@ window.strapi = {
     REVIEW_WORKFLOWS: 'review-workflows',
   },
   projectType: 'Community',
-  npsEnabled: false
+  flags: {
+    nps: false
+  },
 };
 
 const customConfig = appCustomisations;
@@ -42,17 +44,16 @@ const run = async () => {
   try {
     const {
       data: {
-        data: { isEE, features, npsEnabled },
+        data: { isEE, features, flags },
       },
     } = await get('/admin/project-type');
 
     window.strapi.isEE = isEE;
-    window.strapi.npsEnabled = npsEnabled
+    window.strapi.flags = flags;
     window.strapi.features = {
       ...window.strapi.features,
       isEnabled: (featureName) => features.some((feature) => feature.name === featureName),
     };
-
     window.strapi.projectType = isEE ? 'Enterprise' : 'Community';
   } catch (err) {
     console.error(err);

--- a/packages/core/admin/admin/src/index.js
+++ b/packages/core/admin/admin/src/index.js
@@ -23,7 +23,7 @@ window.strapi = {
     REVIEW_WORKFLOWS: 'review-workflows',
   },
   projectType: 'Community',
-  isNpsEnabled: false
+  npsEnabled: false
 };
 
 const customConfig = appCustomisations;
@@ -42,12 +42,12 @@ const run = async () => {
   try {
     const {
       data: {
-        data: { isEE, features, isNpsEnabled },
+        data: { isEE, features, npsEnabled },
       },
     } = await get('/admin/project-type');
 
     window.strapi.isEE = isEE;
-    window.strapi.isNpsEnabled = isNpsEnabled
+    window.strapi.npsEnabled = npsEnabled
     window.strapi.features = {
       ...window.strapi.features,
       isEnabled: (featureName) => features.some((feature) => feature.name === featureName),

--- a/packages/core/admin/server/controllers/admin.js
+++ b/packages/core/admin/server/controllers/admin.js
@@ -26,12 +26,12 @@ module.exports = {
   // When removing this we need to update the /admin/src/index.js file
   // where we set the strapi.window.isEE value
   async getProjectType() {
-    const isNpsEnabled = strapi.config.get('admin.isNpsEnabled', true);
+    const NpsEnabled = strapi.config.get('admin.npsEnabled', true);
     // FIXME
     try {
-      return { data: { isEE: strapi.EE, features: ee.features.list(), isNpsEnabled } };
+      return { data: { isEE: strapi.EE, features: ee.features.list(), NpsEnabled } };
     } catch (err) {
-      return { data: { isEE: false, features: [], isNpsEnabled } };
+      return { data: { isEE: false, features: [], NpsEnabled } };
     }
   },
 

--- a/packages/core/admin/server/controllers/admin.js
+++ b/packages/core/admin/server/controllers/admin.js
@@ -29,9 +29,9 @@ module.exports = {
     const NpsEnabled = strapi.config.get('admin.npsEnabled', true);
     // FIXME
     try {
-      return { data: { isEE: strapi.EE, features: ee.features.list(), NpsEnabled } };
+      return { data: { isEE: strapi.EE, features: ee.features.list(), npsEnabled } };
     } catch (err) {
-      return { data: { isEE: false, features: [], NpsEnabled } };
+      return { data: { isEE: false, features: [], npsEnabled } };
     }
   },
 

--- a/packages/core/admin/server/controllers/admin.js
+++ b/packages/core/admin/server/controllers/admin.js
@@ -26,11 +26,12 @@ module.exports = {
   // When removing this we need to update the /admin/src/index.js file
   // where we set the strapi.window.isEE value
   async getProjectType() {
+    const isNpsEnabled = strapi.config.get('admin.isNpsEnabled', true);
     // FIXME
     try {
-      return { data: { isEE: strapi.EE, features: ee.features.list() } };
+      return { data: { isEE: strapi.EE, features: ee.features.list(), isNpsEnabled } };
     } catch (err) {
-      return { data: { isEE: false, features: [] } };
+      return { data: { isEE: false, features: [], isNpsEnabled } };
     }
   },
 

--- a/packages/core/admin/server/controllers/admin.js
+++ b/packages/core/admin/server/controllers/admin.js
@@ -26,12 +26,12 @@ module.exports = {
   // When removing this we need to update the /admin/src/index.js file
   // where we set the strapi.window.isEE value
   async getProjectType() {
-    const NpsEnabled = strapi.config.get('admin.npsEnabled', true);
+    const flags = strapi.config.get('admin.flags', {});
     // FIXME
     try {
-      return { data: { isEE: strapi.EE, features: ee.features.list(), npsEnabled } };
+      return { data: { isEE: strapi.EE, features: ee.features.list(), flags } };
     } catch (err) {
-      return { data: { isEE: false, features: [], npsEnabled } };
+      return { data: { isEE: false, features: [], flags } };
     }
   },
 

--- a/packages/generators/app/src/resources/files/js/config/admin.js
+++ b/packages/generators/app/src/resources/files/js/config/admin.js
@@ -10,5 +10,7 @@ module.exports = ({ env }) => ({
       salt: env('TRANSFER_TOKEN_SALT'),
     },
   },
-  npsEnabled: env.bool('NPS_ENABLED', true),
+  flags: {
+    nps: env.bool('FLAG_NPS', true),
+  },
 });

--- a/packages/generators/app/src/resources/files/js/config/admin.js
+++ b/packages/generators/app/src/resources/files/js/config/admin.js
@@ -10,5 +10,5 @@ module.exports = ({ env }) => ({
       salt: env('TRANSFER_TOKEN_SALT'),
     },
   },
-  isNpsEnabled: env('IS_NPS_ENABLED', true),
+  npsEnabled: env.bool('NPS_ENABLED', true),
 });

--- a/packages/generators/app/src/resources/files/js/config/admin.js
+++ b/packages/generators/app/src/resources/files/js/config/admin.js
@@ -10,4 +10,5 @@ module.exports = ({ env }) => ({
       salt: env('TRANSFER_TOKEN_SALT'),
     },
   },
+  isNpsEnabled: env('IS_NPS_ENABLED', true),
 });

--- a/packages/generators/app/src/resources/files/ts/config/admin.ts
+++ b/packages/generators/app/src/resources/files/ts/config/admin.ts
@@ -10,5 +10,7 @@ export default ({ env }) => ({
       salt: env('TRANSFER_TOKEN_SALT'),
     },
   },
-  npsEnabled: env.bool('NPS_ENABLED', true),
+  flags: {
+    nps: env.bool('FLAG_NPS', true),
+  },
 });

--- a/packages/generators/app/src/resources/files/ts/config/admin.ts
+++ b/packages/generators/app/src/resources/files/ts/config/admin.ts
@@ -10,4 +10,5 @@ export default ({ env }) => ({
       salt: env('TRANSFER_TOKEN_SALT'),
     },
   },
+  isNpsEnabled: env('IS_NPS_ENABLED', true),
 });

--- a/packages/generators/app/src/resources/files/ts/config/admin.ts
+++ b/packages/generators/app/src/resources/files/ts/config/admin.ts
@@ -10,5 +10,5 @@ export default ({ env }) => ({
       salt: env('TRANSFER_TOKEN_SALT'),
     },
   },
-  isNpsEnabled: env('IS_NPS_ENABLED', true),
+  npsEnabled: env.bool('NPS_ENABLED', true),
 });


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

adds config option named *isNpsEnabled* what you can set to false what would disable it

### Why is it needed?

So people can disable NPS for the whole strapi instance and not just for 1 browser.

### How to test it?

Not having any config will make it pop up.
Having the config set to false will disable it.

### Related issue(s)/PR(s)

fixes https://github.com/strapi/strapi/issues/17978
