### PR TITLE
[Blocks editor] Add the list ordered and list unordered options in the block selector

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/index.js
@@ -424,7 +424,7 @@ const isListActive = (editor, matchNode) => {
   const [match] = Array.from(
     Editor.nodes(editor, {
       at: Editor.unhangRange(editor, selection),
-      match: (node) => isListNode(node) && matchNode(node),
+      match: matchNode,
     })
   );
 

--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/index.js
@@ -3,7 +3,7 @@ import * as React from 'react';
 import * as Toolbar from '@radix-ui/react-toolbar';
 import { Flex, Icon, Tooltip, Select, Option, Box, Typography } from '@strapi/design-system';
 import { pxToRem, prefixFileUrlWithBackendUrl, useLibrary } from '@strapi/helper-plugin';
-import { BulletList, NumberList, Link } from '@strapi/icons';
+import { Link } from '@strapi/icons';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 import { Editor, Transforms, Element as SlateElement } from 'slate';

--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/index.js
@@ -298,7 +298,7 @@ export const BlocksDropdown = ({ disabled }) => {
       const listFormat = blocks[optionKey].value.format;
 
       // check if the list is already active
-      const isActive = isListActive(editor, listFormat);
+      const isActive = isListActive(editor, blocks[optionKey].matchNode);
 
       // toggle the list
       toggleList(editor, isActive, listFormat);
@@ -416,7 +416,7 @@ const isListNode = (node) => {
   return !Editor.isEditor(node) && SlateElement.isElement(node) && node.type === 'list';
 };
 
-const isListActive = (editor, format) => {
+const isListActive = (editor, matchNode) => {
   const { selection } = editor;
 
   if (!selection) return false;
@@ -424,7 +424,7 @@ const isListActive = (editor, format) => {
   const [match] = Array.from(
     Editor.nodes(editor, {
       at: Editor.unhangRange(editor, selection),
-      match: (node) => isListNode(node) && node.format === format,
+      match: (node) => isListNode(node) && matchNode(node),
     })
   );
 
@@ -450,10 +450,17 @@ const toggleList = (editor, isActive, format) => {
   }
 };
 
-const ListButton = ({ icon, format, label, disabled }) => {
+const ListButton = ({ block, disabled }) => {
   const editor = useSlate();
 
-  const isActive = isListActive(editor, format);
+  const {
+    icon,
+    matchNode,
+    value: { format },
+    label,
+  } = block;
+
+  const isActive = isListActive(editor, matchNode);
 
   return (
     <ToolbarButton
@@ -468,11 +475,16 @@ const ListButton = ({ icon, format, label, disabled }) => {
 };
 
 ListButton.propTypes = {
-  icon: PropTypes.elementType.isRequired,
-  format: PropTypes.string.isRequired,
-  label: PropTypes.shape({
-    id: PropTypes.string.isRequired,
-    defaultMessage: PropTypes.string.isRequired,
+  block: PropTypes.shape({
+    icon: PropTypes.elementType.isRequired,
+    matchNode: PropTypes.func.isRequired,
+    value: PropTypes.shape({
+      format: PropTypes.string.isRequired,
+    }).isRequired,
+    label: PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      defaultMessage: PropTypes.string.isRequired,
+    }).isRequired,
   }).isRequired,
   disabled: PropTypes.bool.isRequired,
 };
@@ -552,18 +564,8 @@ const BlocksToolbar = ({ disabled }) => {
         <Separator />
         <Toolbar.ToggleGroup type="single" asChild>
           <Flex gap={1}>
-            <ListButton
-              label={blocks['list-unordered'].label}
-              format="unordered"
-              icon={blocks['list-unordered'].icon}
-              disabled={disabled}
-            />
-            <ListButton
-              label={blocks['list-ordered'].label}
-              format="ordered"
-              icon={blocks['list-ordered'].icon}
-              disabled={disabled}
-            />
+            <ListButton block={blocks['list-unordered']} disabled={disabled} />
+            <ListButton block={blocks['list-ordered']} disabled={disabled} />
           </Flex>
         </Toolbar.ToggleGroup>
         {/* TODO: Remove after the RTE Blocks Alpha release */}

--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/index.js
@@ -526,6 +526,7 @@ const AlphaTag = styled(Box)`
 
 const BlocksToolbar = ({ disabled }) => {
   const modifiers = useModifiersStore();
+  const blocks = useBlocksStore();
 
   return (
     <Toolbar.Root aria-disabled={disabled} asChild>
@@ -552,21 +553,15 @@ const BlocksToolbar = ({ disabled }) => {
         <Toolbar.ToggleGroup type="single" asChild>
           <Flex gap={1}>
             <ListButton
-              label={{
-                id: 'components.Blocks.blocks.unorderedList',
-                defaultMessage: 'Bulleted list',
-              }}
+              label={blocks['list-unordered'].label}
               format="unordered"
-              icon={BulletList}
+              icon={blocks['list-unordered'].icon}
               disabled={disabled}
             />
             <ListButton
-              label={{
-                id: 'components.Blocks.blocks.orderedList',
-                defaultMessage: 'Numbered list',
-              }}
+              label={blocks['list-ordered'].label}
               format="ordered"
-              icon={NumberList}
+              icon={blocks['list-ordered'].icon}
               disabled={disabled}
             />
           </Flex>

--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/tests/index.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/tests/index.test.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { lightTheme, ThemeProvider } from '@strapi/design-system';
-import { render, screen, waitFor, within } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import PropTypes from 'prop-types';
 import { IntlProvider } from 'react-intl';
@@ -103,6 +103,7 @@ describe('BlocksEditor toolbar', () => {
     // Set the selection to cover the second and third row
     Transforms.setSelection(baseEditor, {
       anchor: { path: [1, 0], offset: 0 },
+      focus: { path: [2, 0], offset: 0 },
     });
 
     // The dropdown should show only one option selected which is the block content in the second row

--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/hooks/useBlocksStore.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/hooks/useBlocksStore.js
@@ -25,6 +25,8 @@ import {
   HeadingSix,
   Trash,
   Pencil,
+  BulletList,
+  NumberList,
 } from '@strapi/icons';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
@@ -522,6 +524,48 @@ export function useBlocksStore() {
       matchNode: (node) => node.type === 'heading' && node.level === 6,
       isInBlocksSelector: true,
     },
+    'list-ordered': {
+      renderElement: (props) => <List {...props} />,
+      label: {
+        id: 'components.Blocks.blocks.orderedList',
+        defaultMessage: 'Numbered list',
+      },
+      value: {
+        type: 'list',
+        format: 'ordered',
+      },
+      icon: NumberList,
+      matchNode: (node) => node.type === 'list' && node.format === 'ordered',
+      isInBlocksSelector: true,
+      handleEnterKey: handleEnterKeyOnList,
+    },
+    'list-unordered': {
+      renderElement: (props) => <List {...props} />,
+      label: {
+        id: 'components.Blocks.blocks.unorderedList',
+        defaultMessage: 'Bulleted list',
+      },
+      value: {
+        type: 'list',
+        format: 'unordered',
+      },
+      icon: BulletList,
+      matchNode: (node) => node.type === 'list' && node.format === 'unordered',
+      isInBlocksSelector: true,
+      handleEnterKey: handleEnterKeyOnList,
+    },
+    'list-item': {
+      renderElement: (props) => (
+        <Typography as="li" {...props.attributes}>
+          {props.children}
+        </Typography>
+      ),
+      value: {
+        type: 'list-item',
+      },
+      matchNode: (node) => node.type === 'list-item',
+      isInBlocksSelector: false,
+    },
     link: {
       renderElement: (props) => (
         <Link element={props.element} {...props.attributes}>
@@ -534,26 +578,18 @@ export function useBlocksStore() {
       matchNode: (node) => node.type === 'link',
       isInBlocksSelector: false,
     },
-    code: {
-      renderElement: (props) => (
-        <CodeBlock {...props.attributes}>
-          <code>{props.children}</code>
-        </CodeBlock>
-      ),
-      icon: Code,
+    image: {
+      renderElement: (props) => <Image {...props} />,
+      icon: Picture,
       label: {
-        id: 'components.Blocks.blocks.code',
-        defaultMessage: 'Code',
+        id: 'components.Blocks.blocks.image',
+        defaultMessage: 'Image',
       },
       value: {
-        type: 'code',
+        type: 'image',
       },
-      matchNode: (node) => node.type === 'code',
+      matchNode: (node) => node.type === 'image',
       isInBlocksSelector: true,
-      handleEnterKey(editor) {
-        // Insert a new line within the block
-        Transforms.insertText(editor, '\n');
-      },
     },
     quote: {
       renderElement: (props) => <Blockquote {...props.attributes}>{props.children}</Blockquote>,
@@ -593,52 +629,26 @@ export function useBlocksStore() {
         }
       },
     },
-    'list-ordered': {
-      renderElement: (props) => <List {...props} />,
-      value: {
-        type: 'list',
-        format: 'ordered',
-      },
-      matchNode: (node) => node.type === 'list' && node.format === 'ordered',
-      // TODO add icon and label and set isInBlocksEditor to true
-      isInBlocksSelector: false,
-      handleEnterKey: handleEnterKeyOnList,
-    },
-    'list-unordered': {
-      renderElement: (props) => <List {...props} />,
-      value: {
-        type: 'list',
-        format: 'unordered',
-      },
-      matchNode: (node) => node.type === 'list' && node.format === 'unordered',
-      // TODO add icon and label and set isInBlocksEditor to true
-      isInBlocksSelector: false,
-      handleEnterKey: handleEnterKeyOnList,
-    },
-    'list-item': {
+    code: {
       renderElement: (props) => (
-        <Typography as="li" {...props.attributes}>
-          {props.children}
-        </Typography>
+        <CodeBlock {...props.attributes}>
+          <code>{props.children}</code>
+        </CodeBlock>
       ),
-      value: {
-        type: 'list-item',
-      },
-      matchNode: (node) => node.type === 'list-item',
-      isInBlocksSelector: false,
-    },
-    image: {
-      renderElement: (props) => <Image {...props} />,
-      icon: Picture,
+      icon: Code,
       label: {
-        id: 'components.Blocks.blocks.image',
-        defaultMessage: 'Image',
+        id: 'components.Blocks.blocks.code',
+        defaultMessage: 'Code',
       },
       value: {
-        type: 'image',
+        type: 'code',
       },
-      matchNode: (node) => node.type === 'image',
+      matchNode: (node) => node.type === 'code',
       isInBlocksSelector: true,
+      handleEnterKey(editor) {
+        // Insert a new line within the block
+        Transforms.insertText(editor, '\n');
+      },
     },
   };
 }


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

This PR adds the list ordered and list unordered options to the Dropdown, change the options order and fix a small issue we had when we selected a list with the cursor (the Dropdown remains empty)

### Why is it needed?

We need the list options in the dropdown because in future we want to show a popover when you selected a portion of text in the editor with all the options in the Dropdown plus the list options

### How to test it?

Create a new block field and try to create a new list from the dropdown
- the related modifier needs to be toggled and also the option in the dropdown needs to be selected
- when you select a list with the cursor in the list the related option in the dropdown needs to be selected