### PR TITLE
chore(admin): convert useRegenerate to TS

### DIFF
--- a/packages/core/admin/admin/src/hooks/index.js
+++ b/packages/core/admin/admin/src/hooks/index.js
@@ -3,7 +3,6 @@ export { useContentTypes } from './useContentTypes';
 export { default as useLicenseLimitNotification } from './useLicenseLimitNotification';
 export { default as useMenu } from './useMenu';
 export { default as usePermissionsDataManager } from './usePermissionsDataManager';
-export { default as useRegenerate } from './useRegenerate';
 export { default as useReleaseNotification } from './useReleaseNotification';
 export { default as useSettingsForm } from './useSettingsForm';
 export { default as useSettingsMenu } from './useSettingsMenu';

--- a/packages/core/admin/admin/src/pages/SettingsPage/components/Tokens/Regenerate/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/components/Tokens/Regenerate/index.js
@@ -6,7 +6,7 @@ import { Refresh } from '@strapi/icons';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 
-import { useRegenerate } from '../../../../../hooks';
+import { useRegenerate } from '../../../hooks/useRegenerate';
 
 export const Regenerate = ({ onRegenerate, idToRegenerate, backUrl, onError }) => {
   const { formatMessage } = useIntl();

--- a/packages/core/admin/admin/src/pages/SettingsPage/hooks/tests/useRegenerate.test.tsx
+++ b/packages/core/admin/admin/src/pages/SettingsPage/hooks/tests/useRegenerate.test.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
+/* eslint-disable check-file/filename-naming-convention */
 
 import { renderHook } from '@testing-library/react';
 import { IntlProvider } from 'react-intl';
 
-import useRegenerate from '../index';
+import { useRegenerate } from '../useRegenerate';
 
 jest.mock('@strapi/helper-plugin', () => ({
   ...jest.requireActual('@strapi/helper-plugin'),
@@ -18,19 +18,17 @@ jest.mock('@strapi/helper-plugin', () => ({
     }),
   }),
 }));
-// eslint-disable-next-line react/prop-types
-function RegenerateWrapper({ children }) {
-  return (
-    <IntlProvider messages={{}} locale="en">
-      {children}
-    </IntlProvider>
-  );
-}
 
 describe('useRegenerate', () => {
   it('returns a function to regenerate the data and a boolean', () => {
     const { result } = renderHook(() => useRegenerate('/test', 1, (accessKey) => accessKey), {
-      wrapper: RegenerateWrapper,
+      wrapper({ children }) {
+        return (
+          <IntlProvider messages={{}} locale="en">
+            {children}
+          </IntlProvider>
+        );
+      },
     });
 
     expect(result.current).toEqual({

--- a/packages/core/admin/admin/src/pages/SettingsPage/hooks/useRegenerate.ts
+++ b/packages/core/admin/admin/src/pages/SettingsPage/hooks/useRegenerate.ts
@@ -1,8 +1,14 @@
 import { useState } from 'react';
 
 import { useAPIErrorHandler, useFetchClient, useNotification } from '@strapi/helper-plugin';
+import { AxiosError } from 'axios';
 
-const useRegenerate = (url, id, onRegenerate, onError) => {
+export const useRegenerate = (
+  url: string,
+  id: number | string,
+  onRegenerate: (accessKey: string) => void,
+  onError?: (error: unknown) => void
+): { isLoadingConfirmation: boolean; regenerateData: () => void } => {
   const [isLoadingConfirmation, setIsLoadingConfirmation] = useState(false);
   const toggleNotification = useNotification();
   const { post } = useFetchClient();
@@ -23,10 +29,12 @@ const useRegenerate = (url, id, onRegenerate, onError) => {
       if (onError) {
         onError(error);
       } else {
-        toggleNotification({
-          type: 'warning',
-          message: formatAPIError(error),
-        });
+        if (error instanceof AxiosError) {
+          toggleNotification({
+            type: 'warning',
+            message: formatAPIError(error),
+          });
+        }
       }
     }
   };
@@ -36,5 +44,3 @@ const useRegenerate = (url, id, onRegenerate, onError) => {
     isLoadingConfirmation,
   };
 };
-
-export default useRegenerate;

--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/ApiTokens/EditView/components/Regenerate/index.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/ApiTokens/EditView/components/Regenerate/index.js
@@ -6,7 +6,7 @@ import { Refresh } from '@strapi/icons';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 
-import { useRegenerate } from '../../../../../../../hooks';
+import { useRegenerate } from '../../../../../hooks/useRegenerate';
 
 export const Regenerate = ({ onRegenerate, idToRegenerate }) => {
   const { formatMessage } = useIntl();

--- a/packages/core/helper-plugin/src/features/Notifications.tsx
+++ b/packages/core/helper-plugin/src/features/Notifications.tsx
@@ -44,7 +44,9 @@ export interface NotificationsContextValue {
   toggleNotification: (config: NotificationConfig) => void;
 }
 
-const NotificationsContext = React.createContext<NotificationsContextValue | null>(null);
+const NotificationsContext = React.createContext<NotificationsContextValue>({
+  toggleNotification: () => {},
+});
 
 /* -------------------------------------------------------------------------------------------------
  * Provider
@@ -255,10 +257,10 @@ const Notification = ({
  * import { useNotification } from '@strapi/helper-plugin';
  *
  * const MyComponent = () => {
- *  const { toggleNotification } = useNotification();
+ *  const toggleNotification = useNotification();
  *
  *  return <button onClick={() => toggleNotification({ message: 'Hello world!' })}>Click me</button>;
  */
-const useNotification = () => React.useContext(NotificationsContext)?.toggleNotification;
+const useNotification = () => React.useContext(NotificationsContext).toggleNotification;
 
 export { NotificationsContext, NotificationsProvider, useNotification };


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Convert `useRegenerate` hook to TS. I've also moved the util from the global folder into the settings NS. In addition I had to update the return type of `useNotification`, because otherwise `toggleNotification` could be `undefined` and this would lead to a lot of unnecessary checks.

