### PR TITLE
fix: undefined error for relation type filter field

### DIFF
--- a/packages/core/admin/admin/src/content-manager/pages/ListView/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/ListView/index.js
@@ -185,6 +185,7 @@ function ListView({
       };
 
       filter.fieldSchema.mainField = {
+        ...mainField,
         name: 'id',
       };
     }


### PR DESCRIPTION
### What does it do?

The changes fix the issue faced when selecting a 'relation' type field.

The issue: 

![Screenshot from 2023-10-04 18-50-51](https://github.com/strapi/strapi/assets/58825865/49deab85-4bd3-4229-b312-e1e379c381b3)


### Describe the technical changes you did.

In the following code:
![image](https://github.com/strapi/strapi/assets/58825865/f7ac5bf4-0b36-4a24-ba81-5611d8ba9f41)

We are overwriting the mainfield object, with single property and are not preserving any other previously held properties that we are accessing here:
![Screenshot from 2023-10-04 18-54-14](https://github.com/strapi/strapi/assets/58825865/1d132b1a-5ebd-4af3-847a-3ad8cc4bbd72)

I added a single line to preserve the object's previous property, while adding a new property.

### Why is it needed?

The users are not able to use the relation type filter.

### How to test it?

- Go to Content Manager > Choose any collection
- Click on Filters button
- Choose createdBy/ or any other relation field
- See error in console

### Related issue(s)/PR(s)
closes #18174