### PR TITLE
fix: upload replaced media file

### DIFF
--- a/packages/core/upload/admin/src/hooks/useEditAsset.js
+++ b/packages/core/upload/admin/src/hooks/useEditAsset.js
@@ -32,6 +32,9 @@ const editAssetRequest = (asset, file, cancelToken, onProgress, post) => {
     onUploadProgress({ total, loaded }) {
       onProgress((loaded / total) * 100);
     },
+    headers: {
+      'Content-Type': 'multipart/form-data',
+    },
   }).then((res) => res.data);
 };
 


### PR DESCRIPTION
### What does it do?

When the user tries to replace the media file and upload, the file isn't updated because it isn't uploaded.

This PR fixes the issue.

### Why is it needed?

It is needed because when the user replaces their media file and uploads, it isn't uploading. 

### How to test it?

1. Go to the media library directory
2. Click on assets
3. Click replace
4. Click Finish

### Related issue(s)/PR(s)

Fixes #18250
