### PR TITLE
chore: build strapi permissions with pack-up

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -121,7 +121,7 @@ jobs:
       - uses: nrwl/nx-set-shas@v3
       - name: Monorepo install
         uses: ./.github/actions/yarn-nm-install
-      - name: Run build for admin-test-utils
+      - name: Run build:ts for admin-test-utils & helper-plugin
         run: yarn build --projects=@strapi/admin-test-utils,@strapi/helper-plugin --skip-nx-cache
       - name: Run test
         run: yarn nx affected --target=test:front --nx-ignore-cycles

--- a/packages/core/helper-plugin/declarations/@strapi/permissions.d.ts
+++ b/packages/core/helper-plugin/declarations/@strapi/permissions.d.ts
@@ -1,6 +1,0 @@
-export interface Permission {
-  action: string;
-  subject?: string | object | null;
-  properties?: object;
-  conditions?: string[];
-}

--- a/packages/core/helper-plugin/src/components/CheckPagePermissions.tsx
+++ b/packages/core/helper-plugin/src/components/CheckPagePermissions.tsx
@@ -8,7 +8,9 @@ import { hasPermissions } from '../utils/hasPermissions';
 
 import { LoadingIndicatorPage } from './LoadingIndicatorPage';
 
-import type { Permission } from '@strapi/permissions';
+import type { domain } from '@strapi/permissions';
+
+type Permission = domain.permission.Permission;
 
 export interface CheckPagePermissions {
   children: React.ReactNode;

--- a/packages/core/helper-plugin/src/components/CheckPermissions.tsx
+++ b/packages/core/helper-plugin/src/components/CheckPermissions.tsx
@@ -4,7 +4,9 @@ import { useNotification } from '../features/Notifications';
 import { useRBACProvider } from '../features/RBAC';
 import { hasPermissions } from '../utils/hasPermissions';
 
-import type { Permission } from '@strapi/permissions';
+import type { domain } from '@strapi/permissions';
+
+type Permission = domain.permission.Permission;
 
 // NOTE: this component is very similar to the CheckPagePermissions
 // except that it does not handle redirections nor loading state

--- a/packages/core/helper-plugin/src/features/RBAC.tsx
+++ b/packages/core/helper-plugin/src/features/RBAC.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react';
 
-import type { Permission } from '@strapi/permissions';
+import type { domain } from '@strapi/permissions';
 import type { QueryObserverBaseResult } from 'react-query';
+
+type Permission = domain.permission.Permission;
 
 /* -------------------------------------------------------------------------------------------------
  * Context

--- a/packages/core/helper-plugin/src/features/StrapiApp.tsx
+++ b/packages/core/helper-plugin/src/features/StrapiApp.tsx
@@ -2,7 +2,9 @@ import * as React from 'react';
 
 import { TranslationMessage } from '../types';
 
-import type { Permission } from '@strapi/permissions';
+import type { domain } from '@strapi/permissions';
+
+type Permission = domain.permission.Permission;
 
 interface MenuItem {
   to: string;

--- a/packages/core/helper-plugin/src/hooks/useQueryParams.ts
+++ b/packages/core/helper-plugin/src/hooks/useQueryParams.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from 'react';
 
-import { parse, ParsedQs, stringify } from 'qs';
+import { parse, stringify } from 'qs';
 import { useHistory, useLocation } from 'react-router-dom';
 
 const useQueryParams = <TQuery extends Record<string, unknown>>(initialParams?: TQuery) => {

--- a/packages/core/helper-plugin/src/hooks/useRBAC.ts
+++ b/packages/core/helper-plugin/src/hooks/useRBAC.ts
@@ -6,8 +6,10 @@ import { useRBACProvider } from '../features/RBAC';
 
 import { useFetchClient } from './useFetchClient';
 
-import type { Permission } from '@strapi/permissions';
+import type { domain } from '@strapi/permissions';
 import type { AxiosResponse } from 'axios';
+
+type Permission = domain.permission.Permission;
 
 type AllowedActions = Record<string, boolean>;
 

--- a/packages/core/helper-plugin/src/utils/hasPermissions.ts
+++ b/packages/core/helper-plugin/src/utils/hasPermissions.ts
@@ -1,7 +1,9 @@
 import { getFetchClient } from './getFetchClient';
 
-import type { Permission } from '@strapi/permissions';
+import type { domain } from '@strapi/permissions';
 import type { GenericAbortSignal } from 'axios';
+
+type Permission = domain.permission.Permission;
 
 const findMatchingPermissions = (userPermissions: Permission[], permissions: Permission[]) =>
   userPermissions.reduce<Permission[]>((acc, curr) => {

--- a/packages/core/helper-plugin/src/utils/tests/hasPermissions.test.ts
+++ b/packages/core/helper-plugin/src/utils/tests/hasPermissions.test.ts
@@ -1,11 +1,13 @@
-import { Permission } from '@strapi/permissions';
-
 import {
   hasPermissions,
   findMatchingPermissions,
   formatPermissionsForRequest,
   shouldCheckPermissions,
 } from '../hasPermissions';
+
+import type { domain } from '@strapi/permissions';
+
+type Permission = domain.permission.Permission;
 
 const hasPermissionsTestData: Record<string, Record<string, Permission[]>> = {
   userPermissions: {

--- a/packages/core/permissions/package.json
+++ b/packages/core/permissions/package.json
@@ -19,20 +19,21 @@
       "url": "https://strapi.io"
     }
   ],
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "source": "./src/index.ts",
+  "types": "./dist/index.d.ts",
   "files": [
     "./dist"
   ],
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
   "scripts": {
-    "build": "run -T tsc",
-    "build:ts": "run build",
-    "watch": "run -T tsc -w --preserveWatchOutput",
+    "build": "pack-up build",
     "clean": "run -T rimraf ./dist",
+    "lint": "run -T eslint .",
     "prepublishOnly": "yarn clean && yarn build",
     "test:unit": "run -T jest",
     "test:unit:watch": "run -T jest --watch",
-    "lint": "run -T eslint ."
+    "watch": "pack-up watch"
   },
   "dependencies": {
     "@casl/ability": "6.5.0",
@@ -42,6 +43,7 @@
     "sift": "16.0.1"
   },
   "devDependencies": {
+    "@strapi/pack-up": "workspace:*",
     "eslint-config-custom": "4.14.3",
     "tsconfig": "4.14.3"
   },

--- a/packages/core/permissions/package.json
+++ b/packages/core/permissions/package.json
@@ -31,6 +31,7 @@
     "clean": "run -T rimraf ./dist",
     "lint": "run -T eslint .",
     "prepublishOnly": "yarn clean && yarn build",
+    "test:ts": "run -T tsc --noEmit",
     "test:unit": "run -T jest",
     "test:unit:watch": "run -T jest --watch",
     "watch": "pack-up watch"

--- a/packages/core/permissions/packup.config.ts
+++ b/packages/core/permissions/packup.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from '@strapi/pack-up';
+
+export default defineConfig({
+  runtime: 'node',
+});

--- a/packages/core/permissions/packup.config.ts
+++ b/packages/core/permissions/packup.config.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { defineConfig } from '@strapi/pack-up';
 
 export default defineConfig({

--- a/packages/core/permissions/src/__tests__/permissions.engine.test.ts
+++ b/packages/core/permissions/src/__tests__/permissions.engine.test.ts
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import { subject } from '@casl/ability';
 import { providerFactory } from '@strapi/utils';
-import permissions from '..';
+import * as permissions from '../index';
 import type { HookName } from '../engine/hooks';
 import type { Permission } from '../domain/permission';
 

--- a/packages/core/permissions/src/index.ts
+++ b/packages/core/permissions/src/index.ts
@@ -1,7 +1,4 @@
 import * as domain from './domain';
 import * as engine from './engine';
 
-export = {
-  domain,
-  engine,
-};
+export { domain, engine };

--- a/packages/core/permissions/tsconfig.build.json
+++ b/packages/core/permissions/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "include": ["src"],
+  "exclude": ["**/__tests__/**"]
+}

--- a/packages/core/permissions/tsconfig.eslint.json
+++ b/packages/core/permissions/tsconfig.eslint.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "noEmit": true
   },
-  "include": ["src"],
+  "include": ["src", "packup.config.ts"],
   "exclude": ["node_modules"]
 }

--- a/packages/core/utils/package.json
+++ b/packages/core/utils/package.json
@@ -39,6 +39,7 @@
     "clean": "run -T rimraf ./dist",
     "lint": "run -T eslint .",
     "prepublishOnly": "yarn clean && yarn build",
+    "test:ts": "run -T tsc --noEmit",
     "test:unit": "run -T jest",
     "test:unit:watch": "run -T jest --watch",
     "watch": "run -T pack-up watch"

--- a/packages/core/utils/packup.config.ts
+++ b/packages/core/utils/packup.config.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { defineConfig } from '@strapi/pack-up';
 
 export default defineConfig({

--- a/yarn.lock
+++ b/yarn.lock
@@ -7817,6 +7817,7 @@ __metadata:
   resolution: "@strapi/permissions@workspace:packages/core/permissions"
   dependencies:
     "@casl/ability": 6.5.0
+    "@strapi/pack-up": "workspace:*"
     "@strapi/utils": 4.14.3
     eslint-config-custom: 4.14.3
     lodash: 4.17.21


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* uses `pack-up` to bundle `@strapi/permissions`
* remove `build:ts` from workflow because everytime we call build straight after which is the same command.

### Why is it needed?

* makes it ESM / CJS and fixes the type exports 🥳

### How to test it?

* automated testing should all pass still as we mix CJS & ESM already