### PR TITLE
feat: add Entity Id type

### DIFF
--- a/packages/core/strapi/src/core-api/service/collection-type.ts
+++ b/packages/core/strapi/src/core-api/service/collection-type.ts
@@ -1,6 +1,6 @@
 import { propOr } from 'lodash/fp';
 import { contentTypes } from '@strapi/utils';
-import type { CoreApi, Schema } from '@strapi/types';
+import type { CoreApi, Schema, Entity } from '@strapi/types';
 
 import {
   getPaginationInfo,
@@ -62,7 +62,7 @@ const createCollectionTypeService = ({
       };
     },
 
-    findOne(entityId: number | `${number}`, params = {}) {
+    findOne(entityId: Entity.ID, params = {}) {
       return strapi.entityService?.findOne(uid, entityId, this.getFetchParams(params));
     },
 
@@ -76,13 +76,13 @@ const createCollectionTypeService = ({
       return strapi.entityService?.create(uid, { ...params, data });
     },
 
-    update(entityId: number | `${number}`, params = { data: {} }) {
+    update(entityId: Entity.ID, params = { data: {} }) {
       const { data } = params;
 
       return strapi.entityService?.update(uid, entityId, { ...params, data });
     },
 
-    delete(entityId: number | `${number}`, params = {}) {
+    delete(entityId: Entity.ID, params = {}) {
       return strapi.entityService?.delete(uid, entityId, params);
     },
   };

--- a/packages/core/types/src/modules/entity-service/params/attributes.ts
+++ b/packages/core/types/src/modules/entity-service/params/attributes.ts
@@ -1,4 +1,4 @@
-import type { Attribute, Common, Utils } from '../../../types';
+import type { Attribute, Common, Utils, Entity } from '../../../types';
 
 export type NonFilterableKind = Extract<Attribute.Kind, 'password' | 'dynamiczone'>;
 export type FilterableKind = Exclude<Attribute.Kind, NonFilterableKind>;
@@ -19,7 +19,7 @@ export type GetNestedKeys<TSchemaUID extends Common.UID.Schema> = Exclude<
   GetNonFilterableKeys<TSchemaUID>
 >;
 
-export type ID = `${number}` | number;
+export type ID = Entity.ID;
 
 export type BooleanValue = boolean | 'true' | 'false' | 't' | 'f' | '1' | '0' | 1 | 0;
 

--- a/packages/core/types/src/types/core-api/service.ts
+++ b/packages/core/types/src/types/core-api/service.ts
@@ -1,4 +1,4 @@
-import type { Common, Utils } from '..';
+import type { Common, Utils, Entity } from '..';
 
 // TODO Use actual entities instead of regular object
 type Entity = { id: string | number } & Record<string, unknown>;
@@ -41,13 +41,13 @@ export type Generic = {
  */
 export interface CollectionType extends Base {
   find(params: object): Promise<PaginatedEntiies>;
-  findOne(entityId: number | `${number}`, params: object): Promise<Entity | null>;
+  findOne(entityId: Entity.ID, params: object): Promise<Entity | null>;
   create(params: { data: Data; [key: string]: unknown }): Promise<Entity>;
   update(
-    entityId: number | `${number}`,
+    entityId: Entity.ID,
     params: { data: Data; [key: string]: unknown }
   ): Promise<Entity> | Entity;
-  delete(entityId: number | `${number}`, params: object): Promise<Entity> | Entity;
+  delete(entityId: Entity.ID, params: object): Promise<Entity> | Entity;
 }
 
 /**

--- a/packages/core/types/src/types/core-api/service.ts
+++ b/packages/core/types/src/types/core-api/service.ts
@@ -1,9 +1,11 @@
-import type { Common, Utils, Entity } from '..';
+import type { Common, Utils, Entity as E } from '..';
+
+type EntityID = E.ID;
 
 // TODO Use actual entities instead of regular object
-type Entity = { id: string | number } & Record<string, unknown>;
+type Entity = { id: EntityID } & Record<string, unknown>;
 
-type PaginatedEntiies = {
+type PaginatedEntities = {
   results: Entity[];
   pagination:
     | {
@@ -40,14 +42,14 @@ export type Generic = {
  * Core-API collection type service
  */
 export interface CollectionType extends Base {
-  find(params: object): Promise<PaginatedEntiies>;
-  findOne(entityId: Entity.ID, params: object): Promise<Entity | null>;
+  find(params: object): Promise<PaginatedEntities>;
+  findOne(entityId: EntityID, params: object): Promise<Entity | null>;
   create(params: { data: Data; [key: string]: unknown }): Promise<Entity>;
   update(
-    entityId: Entity.ID,
+    entityId: EntityID,
     params: { data: Data; [key: string]: unknown }
   ): Promise<Entity> | Entity;
-  delete(entityId: Entity.ID, params: object): Promise<Entity> | Entity;
+  delete(entityId: EntityID, params: object): Promise<Entity> | Entity;
 }
 
 /**

--- a/packages/core/types/src/types/core/attributes/utils.ts
+++ b/packages/core/types/src/types/core/attributes/utils.ts
@@ -101,7 +101,7 @@ export type GetValueByKey<
 export type GetValues<
   TSchemaUID extends Common.UID.Schema,
   TKey extends GetKeys<TSchemaUID> = GetKeys<TSchemaUID>
-> = Entity.ID & {
+> = { id: Entity.ID } & {
   // Handle required attributes
   [key in GetRequiredKeys<TSchemaUID> as key extends TKey ? key : never]-?: GetValueByKey<
     TSchemaUID,

--- a/packages/core/types/src/types/core/attributes/utils.ts
+++ b/packages/core/types/src/types/core/attributes/utils.ts
@@ -1,4 +1,4 @@
-import type { Attribute, Common } from '..';
+import type { Attribute, Common, Entity } from '..';
 import type { Utils } from '../..';
 
 export type GetKeysByType<
@@ -101,7 +101,7 @@ export type GetValueByKey<
 export type GetValues<
   TSchemaUID extends Common.UID.Schema,
   TKey extends GetKeys<TSchemaUID> = GetKeys<TSchemaUID>
-> = { id: number | `${number}` } & {
+> = Entity.ID & {
   // Handle required attributes
   [key in GetRequiredKeys<TSchemaUID> as key extends TKey ? key : never]-?: GetValueByKey<
     TSchemaUID,

--- a/packages/core/types/src/types/core/entity/index.ts
+++ b/packages/core/types/src/types/core/entity/index.ts
@@ -1,0 +1,1 @@
+export type ID = number | string;

--- a/packages/core/types/src/types/core/entity/index.ts
+++ b/packages/core/types/src/types/core/entity/index.ts
@@ -1,1 +1,2 @@
+// TODO: v5: Rename this folder to `document`
 export type ID = number | string;

--- a/packages/core/types/src/types/core/index.ts
+++ b/packages/core/types/src/types/core/index.ts
@@ -11,6 +11,7 @@
 export * as Attribute from './attributes';
 export * as Schema from './schemas';
 export * as Plugin from './plugins';
+export * as Entity from './entity';
 export * from './strapi';
 
 export * as Common from './common';

--- a/packages/core/utils/src/types.ts
+++ b/packages/core/utils/src/types.ts
@@ -1,7 +1,7 @@
 import type * as Koa from 'koa';
 import type {} from 'koa-body';
 
-type ID = number | `${number}`;
+type ID = number | string;
 
 export type Data = {
   id?: ID;


### PR DESCRIPTION
### What does it do?

Add an Entity ID type, so it can be reused everywhere


```ts
import { Entity } from '@strapi/types'

type ID = Entity.ID
```


