### PR TITLE
Move prettier and typescript to devDependencies

### DIFF
--- a/packages/utils/typescript/package.json
+++ b/packages/utils/typescript/package.json
@@ -38,7 +38,9 @@
     "chalk": "4.1.2",
     "cli-table3": "0.6.2",
     "fs-extra": "10.0.0",
-    "lodash": "4.17.21",
+    "lodash": "4.17.21"
+  },
+  "devDependencies": {
     "prettier": "2.8.4",
     "typescript": "5.2.2"
   },


### PR DESCRIPTION
### What does it do?

This PR makes changes to the `@strapi/typescript-utils` package's `package.json` file by moving "prettier" and "typescript" from the "dependencies" section to the "devDependencies" section.

### Why is it needed?

The issue being addressed is that both "prettier" and "typescript" are currently listed as production dependencies in `@strapi/typescript-utils`. This can lead to unnecessary pollution of consuming projects. By moving these dependencies to "devDependencies," we ensure that they are only installed when developing or testing the package, which is the expected behavior.

### Related issue(s)/PR(s)

Closes #17448
