### PR TITLE
feat: add exports to pack-up config

### DIFF
--- a/packages/utils/pack-up/README.md
+++ b/packages/utils/pack-up/README.md
@@ -110,6 +110,12 @@ be exported by the package, e.g. CLI scripts or Node.js workers.
 
 The path to the directory to which the bundled files should be written.
 
+#### `exports`
+
+- Type: `Record<string, Export>`
+
+Overwrite or amend the parsed exports from your `package.json`.
+
 #### `externals`
 
 - Type: `string[]`

--- a/packages/utils/pack-up/package.json
+++ b/packages/utils/pack-up/package.json
@@ -30,7 +30,6 @@
       "url": "https://strapi.io"
     }
   ],
-  "bin": "./bin/pack-up.js",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -41,6 +40,11 @@
     },
     "./package.json": "./package.json"
   },
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "source": "./src/index.ts",
+  "types": "./dist/index.d.ts",
+  "bin": "./bin/pack-up.js",
   "files": [
     "bin",
     "dist"
@@ -52,8 +56,8 @@
     "lint": "run -T eslint .",
     "prepublishOnly": "yarn clean && yarn build",
     "test": "test:ts && test:unit",
-    "test:unit": "run -T jest",
     "test:ts": "run -T tsc --noEmit",
+    "test:unit": "run -T jest",
     "watch": "node -r esbuild-register scripts/watch"
   },
   "dependencies": {

--- a/packages/utils/pack-up/src/node/core/config.ts
+++ b/packages/utils/pack-up/src/node/core/config.ts
@@ -70,6 +70,7 @@ interface ConfigBundle {
   import?: string;
   require?: string;
   runtime?: Runtime;
+  types?: string;
 }
 
 interface ConfigOptions {

--- a/packages/utils/pack-up/src/node/core/config.ts
+++ b/packages/utils/pack-up/src/node/core/config.ts
@@ -4,9 +4,10 @@ import os from 'os';
 import * as path from 'path';
 import pkgUp from 'pkg-up';
 
-import { Runtime } from '../createBuildContext';
-
 import { Logger } from './logger';
+
+import type { Export } from './exports';
+import type { Runtime } from '../createBuildContext';
 
 interface LoadConfigOptions {
   cwd: string;
@@ -78,6 +79,10 @@ interface ConfigOptions {
    */
   dist?: string;
   /**
+   * @description Overwrite the default exports.
+   */
+  exports?: ConfigProperty<Record<string, Export>>;
+  /**
    * @description a list of external dependencies to exclude from the bundle.
    * We already collect the dependencies & peerDeps from the package.json.
    */
@@ -95,6 +100,23 @@ interface ConfigOptions {
 const defineConfig = (configOptions: ConfigOptions): ConfigOptions => configOptions;
 
 type Config = ConfigOptions;
+
+type ConfigPropertyResolver<T> = (currentValue: T) => T;
+
+type ConfigProperty<T> = T | ConfigPropertyResolver<T>;
+
+/** @internal */
+export function resolveConfigProperty<T>(prop: ConfigProperty<T> | undefined, initialValue: T): T {
+  if (!prop) {
+    return initialValue;
+  }
+
+  if (typeof prop === 'function') {
+    return (prop as ConfigPropertyResolver<T>)(initialValue);
+  }
+
+  return prop;
+}
 
 export { loadConfig, defineConfig, CONFIG_FILE_NAMES };
 export type { Config };

--- a/packages/utils/pack-up/src/node/createBuildContext.ts
+++ b/packages/utils/pack-up/src/node/createBuildContext.ts
@@ -1,6 +1,7 @@
 import browserslistToEsbuild from 'browserslist-to-esbuild';
 import path from 'path';
 
+import { resolveConfigProperty } from './core/config';
 import { parseExports, ExtMap, Export } from './core/exports';
 import { loadTsConfig } from './core/tsconfig';
 
@@ -74,11 +75,13 @@ const createBuildContext = async ({
     web: ['esnext'],
   };
 
-  const exports = parseExports({ extMap, pkg }).reduce((acc, x) => {
+  const parsedExports = parseExports({ extMap, pkg }).reduce((acc, x) => {
     const { _path: exportPath, ...exportEntry } = x;
 
     return { ...acc, [exportPath]: exportEntry };
   }, {} as Record<string, Export>);
+
+  const exports = resolveConfigProperty(config.exports, parsedExports);
 
   const parsedExternals = [
     ...(pkg.dependencies ? Object.keys(pkg.dependencies) : []),

--- a/packages/utils/pack-up/src/node/createTasks.ts
+++ b/packages/utils/pack-up/src/node/createTasks.ts
@@ -134,6 +134,17 @@ const createTasks =
           output: bundle.import,
         });
       }
+
+      if (bundle.types) {
+        const importId = path.join(ctx.pkg.name, bundle.source);
+
+        dtsTask.entries.push({
+          importId,
+          exportPath: bundle.source,
+          sourcePath: bundle.source,
+          targetPath: bundle.types,
+        });
+      }
     }
 
     if (dtsTask.entries.length) {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* adds `exports` property to `pack-up` config
* adds `types` to a bundle config

### Why is it needed?

* with a plugin like `email` we have a server & client package and each one needs their own runtime, we don't want to use the exports in the package.json instead we want to just use the bundles we've specified
