### PR TITLE
[Blocks] Fix code blocks shrinking

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/hooks/useBlocksStore.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/hooks/useBlocksStore.js
@@ -100,6 +100,7 @@ const CodeBlock = styled.pre.attrs({ role: 'code' })`
   max-width: 100%;
   overflow: auto;
   padding: ${({ theme }) => `${theme.spaces[3]} ${theme.spaces[4]}`};
+  flex-shrink: 0;
   & > code {
     font-family: 'SF Mono', SFMono-Regular, ui-monospace, 'DejaVu Sans Mono', Menlo, Consolas,
       monospace;


### PR DESCRIPTION
### What does it do?

Prevents code blocks from shrinking when there's a lot of content

### How to test it?

Create a multi-line code block.

Add lots of empty lines below.

The code block should not be scrollable, it should retain its height
