### PR TITLE
[Blocks] Disable link button when editor is disabled

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/index.js
@@ -489,7 +489,7 @@ ListButton.propTypes = {
   disabled: PropTypes.bool.isRequired,
 };
 
-const LinkButton = () => {
+const LinkButton = ({ disabled }) => {
   const editor = useSlate();
 
   const isLinkActive = () => {
@@ -522,9 +522,13 @@ const LinkButton = () => {
       }}
       isActive={isLinkActive()}
       handleClick={addLink}
-      disabled={false}
+      disabled={disabled}
     />
   );
+};
+
+LinkButton.propTypes = {
+  disabled: PropTypes.bool.isRequired,
 };
 
 // TODO: Remove after the RTE Blocks Beta release
@@ -558,7 +562,7 @@ const BlocksToolbar = ({ disabled }) => {
                 disabled={disabled}
               />
             ))}
-            <LinkButton />
+            <LinkButton disabled={disabled} />
           </Flex>
         </Toolbar.ToggleGroup>
         <Separator />


### PR DESCRIPTION


### What does it do?

Disables the toolbar's link button when the whole editor is disabled

### How to test it?

Disable the editor in configure the view, then try to click the link button
