### PR TITLE
[Blocks] Fix links colors

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/hooks/useBlocksStore.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/hooks/useBlocksStore.js
@@ -326,6 +326,7 @@ const Link = React.forwardRef(({ element, children, ...attributes }, forwardedRe
         ref={composedRefs}
         href={element.url}
         onClick={handleOpenEditPopover}
+        color="primary600"
       >
         {children}
       </BaseLink>
@@ -376,7 +377,7 @@ const Link = React.forwardRef(({ element, children, ...attributes }, forwardedRe
           ) : (
             <Flex direction="column" gap={4} alignItems="start" width="400px">
               <Typography>{elementText}</Typography>
-              <BaseLink href={element.url} target="_blank">
+              <BaseLink href={element.url} target="_blank" color="primary600">
                 {element.url}
               </BaseLink>
               <Flex justifyContent="end" width="100%" gap={2}>

--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/hooks/useModifiersStore.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/hooks/useModifiersStore.js
@@ -8,19 +8,23 @@ import styled from 'styled-components';
 
 const BoldText = styled(Typography).attrs({ fontWeight: 'bold' })`
   font-size: inherit;
+  color: inherit;
 `;
 
 const ItalicText = styled(Typography)`
   font-style: italic;
   font-size: inherit;
+  color: inherit;
 `;
 
 const UnderlineText = styled(Typography).attrs({ textDecoration: 'underline' })`
   font-size: inherit;
+  color: inherit;
 `;
 
 const StrikeThroughText = styled(Typography).attrs({ textDecoration: 'line-through' })`
   font-size: inherit;
+  color: inherit;
 `;
 
 const InlineCode = styled.code`
@@ -29,6 +33,7 @@ const InlineCode = styled.code`
   padding: ${({ theme }) => `0 ${theme.spaces[2]}`};
   font-family: 'SF Mono', SFMono-Regular, ui-monospace, 'DejaVu Sans Mono', Menlo, Consolas,
     monospace;
+  color: inherit;
 `;
 
 /**


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

- Fixes the links relying on the browser's default color for <a> tags instead of using a value from the design system
- Fixes the blue color disappearing when using modifiers inside of a link

The new blue, even with modifiers inside:
<img width="208" alt="Screenshot 2023-10-05 at 19 40 25" src="https://github.com/strapi/strapi/assets/8087692/d0809652-6ea6-40be-a218-1df564153bdb">

