### PR TITLE
chore: force dependabot to do semantic style commits

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -54,6 +54,9 @@ updates:
           - 'webpack-cli'
           - 'webpack-dev-server'
 
+    commit_message:
+      prefix: 'chore'
+      include_scope: true
     schedule:
       interval: weekly
       day: sunday
@@ -78,6 +81,9 @@ updates:
   - package-ecosystem: github-actions
     open-pull-requests-limit: 10
     directory: /
+    commit_message:
+      prefix: 'chore'
+      include_scope: true
     schedule:
       interval: weekly
       day: sunday


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* adds `commit_message` settings to dependabot

### Why is it needed?

* semantic commits are easier to scan a codebase for
