### PR TITLE
[Blocks Editor] Link popover save button disabled state

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/hooks/tests/useBlocksStore.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/hooks/tests/useBlocksStore.test.js
@@ -311,7 +311,7 @@ describe('useBlocksStore', () => {
     const editButton = screen.queryByLabelText(/Edit/i, { selector: 'button' });
     await user.click(editButton);
 
-    const linkTextInput = screen.getByPlaceholderText('This text is the text of the link');
+    const linkTextInput = screen.getByPlaceholderText('Enter link text');
     const SaveButton = screen.getAllByRole('button', { type: 'submit' });
     expect(SaveButton[1]).toHaveAttribute('aria-disabled', 'false'); // SaveButton[1] is a popover save button
 

--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/hooks/tests/useBlocksStore.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/hooks/tests/useBlocksStore.test.js
@@ -293,6 +293,33 @@ describe('useBlocksStore', () => {
     expect(screen.queryByLabelText(/Edit/i, { selector: 'button' })).toBeInTheDocument();
   });
 
+  it('renders link fields to edit when user clicks the edit option and check save button disabled state', async () => {
+    const { result } = renderHook(useBlocksStore, { wrapper: Wrapper });
+
+    render(
+      result.current.link.renderElement({
+        children: 'Some link',
+        element: { url: 'https://example.com', children: [{ text: 'Some' }, { text: ' link' }] },
+        attributes: {},
+      }),
+      {
+        wrapper: Wrapper,
+      }
+    );
+    const link = screen.getByRole('link', 'Some link');
+    await user.click(link);
+    const editButton = screen.queryByLabelText(/Edit/i, { selector: 'button' });
+    await user.click(editButton);
+
+    const linkTextInput = screen.getByPlaceholderText('This text is the text of the link');
+    const SaveButton = screen.getAllByRole('button', { type: 'submit' });
+    expect(SaveButton[1]).toHaveAttribute('aria-disabled', 'false'); // SaveButton[1] is a popover save button
+
+    // Remove link text and check if save button is disabled
+    userEvent.clear(linkTextInput);
+    expect(SaveButton[1]).toHaveAttribute('aria-disabled', 'true');
+  });
+
   it('renders a code block properly', () => {
     const { result } = renderHook(useBlocksStore, { wrapper: Wrapper });
 

--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/hooks/tests/useBlocksStore.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/hooks/tests/useBlocksStore.test.js
@@ -313,11 +313,11 @@ describe('useBlocksStore', () => {
 
     const linkTextInput = screen.getByPlaceholderText('Enter link text');
     const SaveButton = screen.getAllByRole('button', { type: 'submit' });
-    expect(SaveButton[1]).toHaveAttribute('aria-disabled', 'false'); // SaveButton[1] is a popover save button
+    expect(SaveButton[1]).not.toBeDisabled(); // SaveButton[1] is a popover save button
 
     // Remove link text and check if save button is disabled
     userEvent.clear(linkTextInput);
-    expect(SaveButton[1]).toHaveAttribute('aria-disabled', 'true');
+    expect(SaveButton[1]).toBeDisabled();
   });
 
   it('renders a code block properly', () => {

--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/hooks/useBlocksStore.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/hooks/useBlocksStore.js
@@ -353,7 +353,7 @@ const Link = React.forwardRef(({ element, children, ...attributes }, forwardedRe
                   name="text"
                   placeholder={formatMessage({
                     id: 'components.Blocks.popover.text.placeholder',
-                    defaultMessage: 'This text is the text of the link',
+                    defaultMessage: 'Enter link text',
                   })}
                   value={formData.text}
                   onChange={handleFormDataChange}

--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/hooks/useBlocksStore.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/hooks/useBlocksStore.js
@@ -271,8 +271,18 @@ const Link = React.forwardRef(({ element, children, ...attributes }, forwardedRe
   );
   const [isEditing, setIsEditing] = React.useState(element.url === '');
   const linkRef = React.useRef(null);
-
   const elementText = element.children.map((child) => child.text).join('');
+  const [formData, setFormData] = React.useState({
+    text: elementText,
+    url: element.url,
+  });
+
+  const handleFormDataChange = (e) => {
+    setFormData({
+      ...formData,
+      [e.target.name]: e.target.value,
+    });
+  };
 
   const handleOpenEditPopover = (e) => {
     e.preventDefault();
@@ -281,9 +291,8 @@ const Link = React.forwardRef(({ element, children, ...attributes }, forwardedRe
 
   const handleSave = (e) => {
     e.stopPropagation();
-    const data = new FormData(e.target);
 
-    if (data.get('url') === '') {
+    if (formData.url === '') {
       removeLink(editor);
       setIsEditing(false);
       setPopoverOpen(false);
@@ -294,7 +303,7 @@ const Link = React.forwardRef(({ element, children, ...attributes }, forwardedRe
         Transforms.select(editor, parentPath);
       }
 
-      editLink(editor, { url: data.get('url'), text: data.get('text') });
+      editLink(editor, { url: formData.url, text: formData.text });
       setIsEditing(false);
     }
   };
@@ -346,7 +355,8 @@ const Link = React.forwardRef(({ element, children, ...attributes }, forwardedRe
                     id: 'components.Blocks.popover.text.placeholder',
                     defaultMessage: 'This text is the text of the link',
                   })}
-                  defaultValue={elementText}
+                  value={formData.text}
+                  onChange={handleFormDataChange}
                 />
               </Field>
               <Field width="300px">
@@ -356,7 +366,12 @@ const Link = React.forwardRef(({ element, children, ...attributes }, forwardedRe
                     defaultMessage: 'Link',
                   })}
                 </FieldLabel>
-                <FieldInput name="url" placeholder="https://strapi.io" defaultValue={element.url} />
+                <FieldInput
+                  name="url"
+                  placeholder="https://strapi.io"
+                  value={formData.url}
+                  onChange={handleFormDataChange}
+                />
               </Field>
               <Flex justifyContent="end" width="100%" gap={2}>
                 <Button variant="tertiary" onClick={handleCancel}>
@@ -365,7 +380,7 @@ const Link = React.forwardRef(({ element, children, ...attributes }, forwardedRe
                     defaultMessage: 'Cancel',
                   })}
                 </Button>
-                <Button type="submit">
+                <Button type="submit" disabled={!formData.text || !formData.url}>
                   {formatMessage({
                     id: 'components.Blocks.popover.save',
                     defaultMessage: 'Save',

--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/hooks/useBlocksStore.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/hooks/useBlocksStore.js
@@ -292,20 +292,14 @@ const Link = React.forwardRef(({ element, children, ...attributes }, forwardedRe
   const handleSave = (e) => {
     e.stopPropagation();
 
-    if (formData.url === '') {
-      removeLink(editor);
-      setIsEditing(false);
-      setPopoverOpen(false);
-    } else {
-      // If the selection is collapsed, we select the parent node because we want all the link to be replaced
-      if (Range.isCollapsed(editor.selection)) {
-        const [, parentPath] = Editor.parent(editor, editor.selection.focus?.path);
-        Transforms.select(editor, parentPath);
-      }
-
-      editLink(editor, { url: formData.url, text: formData.text });
-      setIsEditing(false);
+    // If the selection is collapsed, we select the parent node because we want all the link to be replaced
+    if (Range.isCollapsed(editor.selection)) {
+      const [, parentPath] = Editor.parent(editor, editor.selection.focus?.path);
+      Transforms.select(editor, parentPath);
     }
+
+    editLink(editor, { url: formData.url, text: formData.text });
+    setIsEditing(false);
   };
 
   const handleCancel = () => {

--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/hooks/useBlocksStore.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/hooks/useBlocksStore.js
@@ -272,17 +272,8 @@ const Link = React.forwardRef(({ element, children, ...attributes }, forwardedRe
   const [isEditing, setIsEditing] = React.useState(element.url === '');
   const linkRef = React.useRef(null);
   const elementText = element.children.map((child) => child.text).join('');
-  const [formData, setFormData] = React.useState({
-    text: elementText,
-    url: element.url,
-  });
-
-  const handleFormDataChange = (e) => {
-    setFormData({
-      ...formData,
-      [e.target.name]: e.target.value,
-    });
-  };
+  const [linkText, setLinkText] = React.useState(elementText);
+  const [linkUrl, setLinkUrl] = React.useState(element.url);
 
   const handleOpenEditPopover = (e) => {
     e.preventDefault();
@@ -298,7 +289,7 @@ const Link = React.forwardRef(({ element, children, ...attributes }, forwardedRe
       Transforms.select(editor, parentPath);
     }
 
-    editLink(editor, { url: formData.url, text: formData.text });
+    editLink(editor, { url: linkUrl, text: linkText });
     setIsEditing(false);
   };
 
@@ -349,8 +340,8 @@ const Link = React.forwardRef(({ element, children, ...attributes }, forwardedRe
                     id: 'components.Blocks.popover.text.placeholder',
                     defaultMessage: 'Enter link text',
                   })}
-                  value={formData.text}
-                  onChange={handleFormDataChange}
+                  value={linkText}
+                  onChange={(e) => setLinkText(e.target.value)}
                 />
               </Field>
               <Field width="300px">
@@ -363,8 +354,8 @@ const Link = React.forwardRef(({ element, children, ...attributes }, forwardedRe
                 <FieldInput
                   name="url"
                   placeholder="https://strapi.io"
-                  value={formData.url}
-                  onChange={handleFormDataChange}
+                  value={linkUrl}
+                  onChange={(e) => setLinkUrl(e.target.value)}
                 />
               </Field>
               <Flex justifyContent="end" width="100%" gap={2}>
@@ -374,7 +365,7 @@ const Link = React.forwardRef(({ element, children, ...attributes }, forwardedRe
                     defaultMessage: 'Cancel',
                   })}
                 </Button>
-                <Button type="submit" disabled={!formData.text || !formData.url}>
+                <Button type="submit" disabled={!linkText || !linkUrl}>
                   {formatMessage({
                     id: 'components.Blocks.popover.save',
                     defaultMessage: 'Save',

--- a/packages/core/admin/admin/src/translations/en.json
+++ b/packages/core/admin/admin/src/translations/en.json
@@ -628,7 +628,7 @@
   "components.Blocks.modifiers.code": "Code",
   "components.Blocks.link": "Link",
   "components.Blocks.popover.text": "Text",
-  "components.Blocks.popover.text.placeholder": "This text is the text of the link",
+  "components.Blocks.popover.text.placeholder": "Enter link text",
   "components.Blocks.popover.link": "Link",
   "components.Blocks.popover.save": "Save",
   "components.Blocks.popover.cancel": "Cancel",


### PR DESCRIPTION
### What does it do?

- Added Link popover save button disabled state
- Updated link text field placeholder after discussing with UX(Lucas)

### Why is it needed?

There was no validation for empty state of link text and url fields, so save button disabled state added

### How to test it?

When user do not enter link text or url in links popover, save button should be disabled.
