### PR TITLE
[Blocks editor] Fix error message "This doesn't match the JSON format" when we click Save with an empty Block field

### DIFF
--- a/packages/core/admin/admin/src/content-manager/utils/schema.js
+++ b/packages/core/admin/admin/src/content-manager/utils/schema.js
@@ -228,8 +228,8 @@ const createYupSchemaAttribute = (type, validations, options) => {
         return true;
       }
 
-      // The backend validates the actual schema
-      if (!Array.isArray(value)) {
+      // The backend validates the actual schema, check if a value different than null is not an array
+      if (value && !Array.isArray(value)) {
         return false;
       }
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Fix the issue we had when we tried to save with empty Blocks field, we had the error : “This doesn't match the JSON format” 

### Why is it needed?

Because otherwise we can't save the entry

### How to test it?

Create new Blocks in CT, create new entry, try to save with empty Blocks field : “This doesn't match the JSON format” 