### PR TITLE
chore: pack-up admin-test-utils

### DIFF
--- a/packages/admin-test-utils/.eslintrc.js
+++ b/packages/admin-test-utils/.eslintrc.js
@@ -1,4 +1,7 @@
 module.exports = {
   root: true,
   extends: ['custom/back/typescript'],
+  parserOptions: {
+    project: ['./tsconfig.json'],
+  },
 };

--- a/packages/admin-test-utils/package.json
+++ b/packages/admin-test-utils/package.json
@@ -16,24 +16,54 @@
       "url": "https://strapi.io"
     }
   ],
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "require": "./dist/index.js"
+      "types": "./dist/index.d.ts",
+      "module": "./dist/index.mjs",
+      "require": "./dist/index.js",
+      "source": "./src/index.ts",
+      "default": "./dist/index.js"
     },
     "./after-env": {
-      "require": "./dist/after-env.js"
+      "types": "./dist/after-env.d.ts",
+      "module": "./dist/after-env.mjs",
+      "require": "./dist/after-env.js",
+      "source": "./src/after-env.ts",
+      "default": "./dist/after-env.js"
     },
     "./environment": {
-      "require": "./dist/environment.js"
+      "types": "./dist/environment.d.ts",
+      "module": "./dist/environment.mjs",
+      "require": "./dist/environment.js",
+      "source": "./src/environment.ts",
+      "default": "./dist/environment.js"
     },
     "./file-mock": {
-      "require": "./dist/file-mock.js"
+      "types": "./dist/file-mock.d.ts",
+      "module": "./dist/file-mock.mjs",
+      "require": "./dist/file-mock.js",
+      "source": "./src/file-mock.ts",
+      "default": "./dist/file-mock.js"
     },
     "./global-setup": {
-      "require": "./dist/global-setup.js"
-    }
+      "types": "./dist/global-setup.d.ts",
+      "module": "./dist/global-setup.mjs",
+      "require": "./dist/global-setup.js",
+      "source": "./src/global-setup.ts",
+      "default": "./dist/global-setup.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "source": "./src/index.ts",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "build": "pack-up build",
+    "clean": "run -T rimraf ./dist",
+    "lint": "run -T eslint .",
+    "test:ts": "run -T tsc --noEmit",
+    "watch": "pack-up watch"
   },
   "dependencies": {
     "@juggle/resize-observer": "3.4.0",
@@ -42,18 +72,13 @@
     "whatwg-fetch": "3.6.2"
   },
   "devDependencies": {
+    "@strapi/pack-up": "workspace:*",
     "eslint-config-custom": "4.14.3",
     "redux": "^4.2.1",
     "tsconfig": "4.14.3"
   },
   "peerDependencies": {
     "redux": "^4.2.1"
-  },
-  "scripts": {
-    "build": "run -T tsc",
-    "watch": "run -T tsc -w --preserveWatchOutput",
-    "clean": "run -T rimraf ./dist",
-    "lint": "run -T eslint ."
   },
   "engines": {
     "node": ">=16.0.0 <=20.x.x"

--- a/packages/admin-test-utils/src/fixtures/collection-types/index.ts
+++ b/packages/admin-test-utils/src/fixtures/collection-types/index.ts
@@ -1,3 +1,3 @@
-import { address, Address } from './address';
+import { address, type Address } from './address';
 
 export { Address, address };

--- a/packages/admin-test-utils/src/fixtures/meta-data/index.ts
+++ b/packages/admin-test-utils/src/fixtures/meta-data/index.ts
@@ -1,3 +1,3 @@
-import { address, Address } from './address';
+import { address, type Address } from './address';
 
 export { Address, address };

--- a/packages/admin-test-utils/src/fixtures/permissions/index.ts
+++ b/packages/admin-test-utils/src/fixtures/permissions/index.ts
@@ -4,10 +4,10 @@
  * from that package and use them here.
  */
 
-import { admin, Admin, app, App } from './admin-permissions';
-import { contentManager, ContentManager } from './content-manager-permissions';
-import { contentTypeBuilder, ContentTypeBuilder } from './content-type-builder-permissions';
-import { Documentation, documentation } from './documentation-permissions';
+import { admin, type Admin, app, type App } from './admin-permissions';
+import { contentManager, type ContentManager } from './content-manager-permissions';
+import { contentTypeBuilder, type ContentTypeBuilder } from './content-type-builder-permissions';
+import { type Documentation, documentation } from './documentation-permissions';
 
 // TODO: this should be called userPermissions
 const allPermissions = [...admin, ...contentManager, ...contentTypeBuilder, ...documentation];

--- a/packages/admin-test-utils/tsconfig.build.json
+++ b/packages/admin-test-utils/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src", "custom.d.ts"],
+  "exclude": ["**/__tests__/**"]
+}

--- a/packages/admin-test-utils/tsconfig.eslint.json
+++ b/packages/admin-test-utils/tsconfig.eslint.json
@@ -1,6 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "noEmit": true,
-  },
-}

--- a/packages/admin-test-utils/tsconfig.json
+++ b/packages/admin-test-utils/tsconfig.json
@@ -1,10 +1,5 @@
 {
   "extends": "tsconfig/client.json",
-  "compilerOptions": {
-    "declaration": true,
-    "noEmit": false,
-    "outDir": "dist"
-  },
   "include": ["src", "./custom.d.ts"],
-  "exclude": ["node_modules", "**/__tests__/**"]
+  "exclude": ["node_modules"]
 }

--- a/packages/core/helper-plugin/tests/utils.tsx
+++ b/packages/core/helper-plugin/tests/utils.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable check-file/filename-naming-convention */
 import * as React from 'react';
 
-// @ts-expect-error - the package is slightly broken, but will be fixed with https://github.com/strapi/strapi/pull/18233
 import { fixtures } from '@strapi/admin-test-utils';
 import { DesignSystemProvider } from '@strapi/design-system';
 import {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7399,6 +7399,7 @@ __metadata:
   resolution: "@strapi/admin-test-utils@workspace:packages/admin-test-utils"
   dependencies:
     "@juggle/resize-observer": 3.4.0
+    "@strapi/pack-up": "workspace:*"
     "@testing-library/jest-dom": 5.16.5
     eslint-config-custom: 4.14.3
     jest-styled-components: 7.1.1


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* converts admin test-utils to use pack-up

### Why is it needed?

* CJS / ESM & now we can export a universal test harness 👀 
