### PR TITLE
[RTE] remove screen debug

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/tests/index.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/tests/index.test.js
@@ -261,8 +261,6 @@ describe('BlocksEditor toolbar', () => {
 
     await user.click(screen.getByRole('option', { name: 'Numbered list' }));
 
-    screen.debug(headingsDropdown);
-
     expect(baseEditor.children).toEqual([
       {
         type: 'list',


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Remove a screen debug inside a unit test

### Why is it needed?

Because it is not needed, I forgot about it during the unit test implementation.
