### PR TITLE
fix(helper-plugin): notifications should not have a default for "success"

### DIFF
--- a/packages/core/helper-plugin/src/features/Notifications.tsx
+++ b/packages/core/helper-plugin/src/features/Notifications.tsx
@@ -133,7 +133,7 @@ const Notification = ({
   },
   onClose,
   timeout = 2500,
-  title = 'success',
+  title,
   type,
 }: NotificationProps) => {
   const { formatMessage } = useIntl();


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* removes the default value for `title` from `Notification`

### Why is it needed?

* _all_ messages no matter what said "success" which is a lie

### Related issue(s)/PR(s)

* reported on Discord
