### PR TITLE
[Blocks Editor] Updated modifiers style

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/hooks/useModifiersStore.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/hooks/useModifiersStore.js
@@ -4,27 +4,29 @@ import { Typography } from '@strapi/design-system';
 import { Bold, Italic, Underline, StrikeThrough, Code } from '@strapi/icons';
 import { Editor } from 'slate';
 import { useSlate } from 'slate-react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
-const BoldText = styled(Typography).attrs({ fontWeight: 'bold' })`
+const stylesToInherit = css`
   font-size: inherit;
   color: inherit;
+  line-height: inherit;
+`;
+
+const BoldText = styled(Typography).attrs({ fontWeight: 'bold' })`
+  ${stylesToInherit}
 `;
 
 const ItalicText = styled(Typography)`
   font-style: italic;
-  font-size: inherit;
-  color: inherit;
+  ${stylesToInherit}
 `;
 
 const UnderlineText = styled(Typography).attrs({ textDecoration: 'underline' })`
-  font-size: inherit;
-  color: inherit;
+  ${stylesToInherit}
 `;
 
 const StrikeThroughText = styled(Typography).attrs({ textDecoration: 'line-through' })`
-  font-size: inherit;
-  color: inherit;
+  ${stylesToInherit}
 `;
 
 const InlineCode = styled.code`


### PR DESCRIPTION
### What does it do?

Updated modifiers style 

### Why is it needed?

Modifiers is using typography element which has its  own styling which gets applied, its overriding required styles

### How to test it?

If selected block is heading and user tries to apply bold/italic/underline/strikethrough, no line height changes should be observed.
