### PR TITLE
Remove side effects and warnings in Blocks editor tests

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/index.js
@@ -272,7 +272,7 @@ const insertEmptyBlockAtLast = (editor) => {
   );
 };
 
-export const BlocksDropdown = ({ disabled }) => {
+const BlocksDropdown = ({ disabled }) => {
   const editor = useSlate();
   const { formatMessage } = useIntl();
   const [isMediaLibraryVisible, setIsMediaLibraryVisible] = React.useState(false);

--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/tests/index.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/tests/index.test.js
@@ -47,7 +47,8 @@ const mixedInitialValue = [
 
 const user = userEvent.setup();
 
-const baseEditor = createEditor();
+// Create editor outside of the component to have direct access to it from the tests
+let baseEditor;
 
 const Wrapper = ({ children, initialData }) => {
   const [editor] = React.useState(() => withReact(baseEditor));
@@ -87,6 +88,10 @@ const select = async (location) => {
  * @param {import('slate').Descendant[]} data
  */
 const setup = (data) => {
+  // Create a fresh instance of a Slate editor
+  // so that we have no side effects due to the previous selection or children
+  baseEditor = createEditor();
+
   render(<BlocksToolbar disabled={false} />, {
     wrapper: ({ children }) => <Wrapper initialData={data}>{children}</Wrapper>,
   });
@@ -94,7 +99,6 @@ const setup = (data) => {
 
 describe('BlocksEditor toolbar', () => {
   beforeEach(() => {
-    baseEditor.children = initialValue;
     /**
      * TODO: Find a way to use the actual implementation
      * Currently the editor throws an error as if the editor argument is missing:

--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/tests/index.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/tests/index.test.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { lightTheme, ThemeProvider } from '@strapi/design-system';
-import { render, screen, within } from '@testing-library/react';
+import { act, render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import PropTypes from 'prop-types';
 import { IntlProvider } from 'react-intl';
@@ -72,6 +72,20 @@ Wrapper.defaultProps = {
   initialData: initialValue,
 };
 
+/**
+ * Selects the given location without triggering warnings
+ * act is required because we're making an update outside of React that React needs to sync with
+ * And it only works if act is awaited
+ * @param {import('slate').Location} selection
+ */
+const select = async (location) => {
+  await act(async () => Transforms.select(baseEditor, location));
+};
+
+/**
+ * Render the toolbar inside the required context providers
+ * @param {import('slate').Descendant[]} data
+ */
 const setup = (data) => {
   render(<BlocksToolbar disabled={false} />, {
     wrapper: ({ children }) => <Wrapper initialData={data}>{children}</Wrapper>,
@@ -101,7 +115,7 @@ describe('BlocksEditor toolbar', () => {
     const headingsDropdown = screen.getByRole('combobox', { name: /Select a block/i });
 
     // Set the selection to cover the second and third row
-    Transforms.setSelection(baseEditor, {
+    await select({
       anchor: { path: [1, 0], offset: 0 },
       focus: { path: [2, 0], offset: 0 },
     });
@@ -117,7 +131,7 @@ describe('BlocksEditor toolbar', () => {
     const italicButton = screen.getByLabelText(/italic/i);
 
     // Simulate a selection of part of the editor
-    Transforms.select(baseEditor, {
+    await select({
       anchor: { path: [0, 0], offset: 2 },
       focus: { path: [0, 0], offset: 14 },
     });
@@ -172,8 +186,9 @@ describe('BlocksEditor toolbar', () => {
     const unorderedListButton = screen.getByLabelText(/bulleted list/i);
     const orderedListButton = screen.getByLabelText(/^numbered list/i);
 
-    Transforms.setSelection(baseEditor, {
+    await select({
       anchor: { path: [0, 0], offset: 2 },
+      focus: { path: [0, 0], offset: 2 },
     });
 
     await user.click(unorderedListButton);
@@ -209,8 +224,9 @@ describe('BlocksEditor toolbar', () => {
 
     const headingsDropdown = screen.getByRole('combobox', { name: /Select a block/i });
 
-    Transforms.setSelection(baseEditor, {
+    await select({
       anchor: { path: [0, 0], offset: 2 },
+      focus: { path: [0, 0], offset: 2 },
     });
 
     await user.click(headingsDropdown);
@@ -253,8 +269,9 @@ describe('BlocksEditor toolbar', () => {
 
     const headingsDropdown = screen.getByRole('combobox', { name: /Select a block/i });
 
-    Transforms.setSelection(baseEditor, {
+    await select({
       anchor: { path: [0, 0], offset: 2 },
+      focus: { path: [0, 0], offset: 2 },
     });
 
     await user.click(headingsDropdown);
@@ -307,8 +324,9 @@ describe('BlocksEditor toolbar', () => {
 
     const headingsDropdown = screen.getByRole('combobox', { name: /Select a block/i });
 
-    Transforms.setSelection(baseEditor, {
+    await select({
       anchor: { path: [0, 0], offset: 0 },
+      focus: { path: [0, 0], offset: 0 },
     });
 
     await user.click(headingsDropdown);
@@ -350,7 +368,7 @@ describe('BlocksEditor toolbar', () => {
       wrapper: Wrapper,
     });
 
-    Transforms.select(baseEditor, {
+    await select({
       anchor: { path: [0, 0], offset: 0 },
       focus: { path: [0, 0], offset: 0 },
     });
@@ -369,7 +387,7 @@ describe('BlocksEditor toolbar', () => {
       wrapper: Wrapper,
     });
 
-    Transforms.select(baseEditor, {
+    await select({
       anchor: { path: [0, 0], offset: 0 },
       focus: { path: [0, 0], offset: 0 },
     });
@@ -408,9 +426,10 @@ describe('BlocksEditor toolbar', () => {
 
     const headingsDropdown = screen.getByRole('combobox', { name: /Select a block/i });
 
-    // Set the selection to cover the second and third row
-    Transforms.setSelection(baseEditor, {
-      anchor: { path: [1, 0], offset: 0 },
+    // Set the selection to cover the first and second
+    await select({
+      anchor: { path: [0, 0], offset: 0 },
+      focus: { path: [1, 0], offset: 0 },
     });
 
     // The dropdown should show only one option selected which is the block content in the first row

--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/tests/index.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/tests/index.test.js
@@ -21,7 +21,7 @@ jest.mock('@strapi/helper-plugin', () => ({
   })),
 }));
 
-const initialValue = [
+const defaultInitialValue = [
   {
     type: 'paragraph',
     children: [{ type: 'text', text: 'A line of text in a paragraph.' }],
@@ -50,13 +50,13 @@ const user = userEvent.setup();
 // Create editor outside of the component to have direct access to it from the tests
 let baseEditor;
 
-const Wrapper = ({ children, initialData }) => {
+const Wrapper = ({ children, initialValue }) => {
   const [editor] = React.useState(() => withReact(baseEditor));
 
   return (
     <ThemeProvider theme={lightTheme}>
       <IntlProvider messages={{}} locale="en">
-        <Slate initialValue={initialData} editor={editor}>
+        <Slate initialValue={initialValue} editor={editor}>
           {children}
         </Slate>
       </IntlProvider>
@@ -66,11 +66,7 @@ const Wrapper = ({ children, initialData }) => {
 
 Wrapper.propTypes = {
   children: PropTypes.node.isRequired,
-  initialData: PropTypes.array,
-};
-
-Wrapper.defaultProps = {
-  initialData: initialValue,
+  initialValue: PropTypes.array.isRequired,
 };
 
 /**
@@ -87,13 +83,13 @@ const select = async (location) => {
  * Render the toolbar inside the required context providers
  * @param {import('slate').Descendant[]} data
  */
-const setup = (data) => {
+const setup = (data = defaultInitialValue) => {
   // Create a fresh instance of a Slate editor
   // so that we have no side effects due to the previous selection or children
   baseEditor = createEditor();
 
   render(<BlocksToolbar disabled={false} />, {
-    wrapper: ({ children }) => <Wrapper initialData={data}>{children}</Wrapper>,
+    wrapper: ({ children }) => <Wrapper initialValue={data}>{children}</Wrapper>,
   });
 };
 
@@ -176,7 +172,7 @@ describe('BlocksEditor toolbar', () => {
     await user.click(italicButton);
 
     // The selection should be back a single node
-    expect(baseEditor.children).toEqual(initialValue);
+    expect(baseEditor.children).toEqual(defaultInitialValue);
 
     // The bold and italic buttons should have the inactive state
     expect(boldButton).toHaveAttribute('data-state', 'off');

--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/tests/index.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/tests/index.test.js
@@ -8,7 +8,7 @@ import { IntlProvider } from 'react-intl';
 import { createEditor, Transforms } from 'slate';
 import { Slate, withReact, ReactEditor } from 'slate-react';
 
-import { BlocksDropdown, BlocksToolbar } from '..';
+import { BlocksToolbar } from '..';
 
 const title = 'dialog component';
 
@@ -368,9 +368,7 @@ describe('BlocksEditor toolbar', () => {
   });
 
   it('when image is selected, it will set modal dialog open to select the images', async () => {
-    render(<BlocksDropdown disabled={false} />, {
-      wrapper: Wrapper,
-    });
+    setup();
 
     await select({
       anchor: { path: [0, 0], offset: 0 },
@@ -387,9 +385,7 @@ describe('BlocksEditor toolbar', () => {
   });
 
   it('when code option is selected and if its the last block in the editor then new empty block should be inserted below it', async () => {
-    render(<BlocksDropdown disabled={false} />, {
-      wrapper: Wrapper,
-    });
+    setup();
 
     await select({
       anchor: { path: [0, 0], offset: 0 },

--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/tests/index.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/tests/index.test.js
@@ -112,8 +112,6 @@ describe('BlocksEditor toolbar', () => {
   it('checks if a mixed selected content shows only one option selected in the dropdown when you select only part of the content', async () => {
     setup(mixedInitialValue);
 
-    const headingsDropdown = screen.getByRole('combobox', { name: /Select a block/i });
-
     // Set the selection to cover the second and third row
     await select({
       anchor: { path: [1, 0], offset: 0 },
@@ -121,20 +119,23 @@ describe('BlocksEditor toolbar', () => {
     });
 
     // The dropdown should show only one option selected which is the block content in the second row
-    expect(within(headingsDropdown).getByText(/text/i)).toBeInTheDocument();
+    const blocksDropdown = screen.getByRole('combobox', { name: /Select a block/i });
+    expect(within(blocksDropdown).getByText(/text/i)).toBeInTheDocument();
+    expect(within(blocksDropdown).queryByText(/heading/i)).not.toBeInTheDocument();
   });
 
-  it('toggles the modifier on a selection', async () => {
+  it('toggles the modifiers on a selection', async () => {
     setup();
-
-    const boldButton = screen.getByLabelText(/bold/i);
-    const italicButton = screen.getByLabelText(/italic/i);
 
     // Simulate a selection of part of the editor
     await select({
       anchor: { path: [0, 0], offset: 2 },
       focus: { path: [0, 0], offset: 14 },
     });
+
+    // Get modifier buttons
+    const boldButton = screen.getByLabelText(/bold/i);
+    const italicButton = screen.getByLabelText(/italic/i);
 
     // We make that selection bold and italic
     await user.click(boldButton);
@@ -183,18 +184,21 @@ describe('BlocksEditor toolbar', () => {
   it('transforms the selection to a list and toggles the format', async () => {
     setup();
 
-    const unorderedListButton = screen.getByLabelText(/bulleted list/i);
-    const orderedListButton = screen.getByLabelText(/^numbered list/i);
-
     await select({
       anchor: { path: [0, 0], offset: 2 },
       focus: { path: [0, 0], offset: 2 },
     });
 
+    // Get modifier buttons
+    const unorderedListButton = screen.getByLabelText(/bulleted list/i);
+    const orderedListButton = screen.getByLabelText(/^numbered list/i);
+
+    // Convert the selection to an unordered list
     await user.click(unorderedListButton);
     expect(unorderedListButton).toHaveAttribute('data-state', 'on');
     expect(orderedListButton).toHaveAttribute('data-state', 'off');
 
+    // Convert the selection to an ordered list
     await user.click(orderedListButton);
     expect(unorderedListButton).toHaveAttribute('data-state', 'off');
     expect(orderedListButton).toHaveAttribute('data-state', 'on');
@@ -216,21 +220,21 @@ describe('BlocksEditor toolbar', () => {
         ],
       },
     ]);
+
     expect(ReactEditor.focus).toHaveBeenCalledTimes(2);
   });
 
-  it('transforms the selection to a heading when selected and trasforms it back to text when selected again', async () => {
+  it('transforms the selection to a heading and transforms it back to text when selected again', async () => {
     setup();
-
-    const headingsDropdown = screen.getByRole('combobox', { name: /Select a block/i });
 
     await select({
       anchor: { path: [0, 0], offset: 2 },
       focus: { path: [0, 0], offset: 2 },
     });
 
-    await user.click(headingsDropdown);
-
+    // Convert selection to a heading
+    const blocksDropdown = screen.getByRole('combobox', { name: /Select a block/i });
+    await user.click(blocksDropdown);
     await user.click(screen.getByRole('option', { name: 'Heading 1' }));
 
     expect(baseEditor.children).toEqual([
@@ -246,8 +250,8 @@ describe('BlocksEditor toolbar', () => {
       },
     ]);
 
-    await user.click(headingsDropdown);
-
+    // Convert selection to a paragraph
+    await user.click(blocksDropdown);
     await user.click(screen.getByRole('option', { name: 'Text' }));
 
     expect(baseEditor.children).toEqual([
@@ -261,21 +265,21 @@ describe('BlocksEditor toolbar', () => {
         ],
       },
     ]);
+
     expect(ReactEditor.focus).toHaveBeenCalledTimes(2);
   });
 
-  it('transforms the selection to an ordered list and to an unordered list when selected', async () => {
+  it('transforms the selection to an ordered list and to an unordered list', async () => {
     setup();
-
-    const headingsDropdown = screen.getByRole('combobox', { name: /Select a block/i });
 
     await select({
       anchor: { path: [0, 0], offset: 2 },
       focus: { path: [0, 0], offset: 2 },
     });
 
-    await user.click(headingsDropdown);
-
+    // Convert selection to an ordered list
+    const blocksDropdown = screen.getByRole('combobox', { name: /Select a block/i });
+    await user.click(blocksDropdown);
     await user.click(screen.getByRole('option', { name: 'Numbered list' }));
 
     expect(baseEditor.children).toEqual([
@@ -296,8 +300,8 @@ describe('BlocksEditor toolbar', () => {
       },
     ]);
 
-    await user.click(headingsDropdown);
-
+    // Convert selection to an unordered list
+    await user.click(blocksDropdown);
     await user.click(screen.getByRole('option', { name: 'Bulleted list' }));
 
     expect(baseEditor.children).toEqual([
@@ -319,18 +323,17 @@ describe('BlocksEditor toolbar', () => {
     ]);
   });
 
-  it('transforms the selection to a quote when selected and trasforms it back to text when selected again', async () => {
+  it('transforms the selection to a quote when selected and transforms it back to text', async () => {
     setup();
-
-    const headingsDropdown = screen.getByRole('combobox', { name: /Select a block/i });
 
     await select({
       anchor: { path: [0, 0], offset: 0 },
       focus: { path: [0, 0], offset: 0 },
     });
 
-    await user.click(headingsDropdown);
-
+    // Convert selection to a quote
+    const blocksDropdown = screen.getByRole('combobox', { name: /Select a block/i });
+    await user.click(blocksDropdown);
     await user.click(screen.getByRole('option', { name: 'Quote' }));
 
     expect(baseEditor.children).toEqual([
@@ -345,8 +348,8 @@ describe('BlocksEditor toolbar', () => {
       },
     ]);
 
-    await user.click(headingsDropdown);
-
+    // Convert selection to a paragraph
+    await user.click(blocksDropdown);
     await user.click(screen.getByRole('option', { name: 'Text' }));
 
     expect(baseEditor.children).toEqual([
@@ -360,10 +363,11 @@ describe('BlocksEditor toolbar', () => {
         ],
       },
     ]);
+
     expect(ReactEditor.focus).toHaveBeenCalledTimes(2);
   });
 
-  it('when image is selected, it will set modal dialog open to select the images', async () => {
+  it('opens the media library when image is selected', async () => {
     setup();
 
     await select({
@@ -371,16 +375,15 @@ describe('BlocksEditor toolbar', () => {
       focus: { path: [0, 0], offset: 0 },
     });
 
-    const headingsDropdown = screen.getByRole('combobox', { name: /Select a block/i });
-
-    await user.click(headingsDropdown);
-
+    // Convert selection to an image
+    const blocksDropdown = screen.getByRole('combobox', { name: /Select a block/i });
+    await user.click(blocksDropdown);
     await user.click(screen.getByRole('option', { name: 'Image' }));
 
     expect(screen.getByText(title)).toBeInTheDocument();
   });
 
-  it('when code option is selected and if its the last block in the editor then new empty block should be inserted below it', async () => {
+  it('creates an empty paragraph below when a code block is created at the end of the editor', async () => {
     setup();
 
     await select({
@@ -388,10 +391,9 @@ describe('BlocksEditor toolbar', () => {
       focus: { path: [0, 0], offset: 0 },
     });
 
-    const selectDropdown = screen.getByRole('combobox', { name: /Select a block/i });
-
-    await user.click(selectDropdown);
-
+    // Convert selection to a code block
+    const blocksDropdown = screen.getByRole('combobox', { name: /Select a block/i });
+    await user.click(blocksDropdown);
     await user.click(screen.getByRole('option', { name: 'Code' }));
 
     expect(baseEditor.children).toEqual([
@@ -414,13 +416,12 @@ describe('BlocksEditor toolbar', () => {
         ],
       },
     ]);
+
     expect(ReactEditor.focus).toHaveBeenCalledTimes(1);
   });
 
-  it('checks if a mixed selected content shows only one option selected in the dropdown', async () => {
+  it('only shows one option selected in the dropdown when mixed content is selected', async () => {
     setup(mixedInitialValue);
-
-    const headingsDropdown = screen.getByRole('combobox', { name: /Select a block/i });
 
     // Set the selection to cover the first and second
     await select({
@@ -429,6 +430,7 @@ describe('BlocksEditor toolbar', () => {
     });
 
     // The dropdown should show only one option selected which is the block content in the first row
-    expect(within(headingsDropdown).getByText(/heading 1/i)).toBeInTheDocument();
+    const blocksDropdown = screen.getByRole('combobox', { name: /Select a block/i });
+    expect(within(blocksDropdown).getByText(/heading 1/i)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## What does it do?

A few things to fix the issues with tests and make them easier to maintain. I think it's easier to review if you review the PR commit per commit. The first 3 are the most important:

### creates a helper for all selection transforms

Before we used a mix of `Transforms.select` and `Transforms.setSelection`. They're not exactly the same though, as [setSelection can only merge an update to an existing selection](https://docs.slatejs.org/api/transforms#transforms.setselection-editor-editor-props-partial-less-than-range-greater-than). It doesn't work if there wasn't a selection before, so it used to only work thanks to the side effects. `Transforms.select` works regardless of what is in other tests, so it's the one we should be using.

Note that `Transforms.select` requires _both_ the anchor and focus points every time (most of the time they're the same), which is something we probably should have been doing already.

Setting the selection also triggered warnings about updates to Slate not wrapped in act(). I think we didn't catch this before because the warnings only exist when we don't do things that already wrap act afterwards, like clicking on a button. But for consistency I made a little helper function that makes sure we never forget the act. It wouldn't work unless I awaited it though, I'm not sure why.

### Recreate editor on every test

Before we would just reset `baseEditor.children` in the beforeEach. This had issues though:

- it didn't stop all side effects. The selection still carried over from previous tests for example, and potentially other things
- for the tests with mixed content as the initial value, the `baseEditor.children` didn't match the initialValue passed to the Slate component, creating issues

Instead I'm now creating a fresh editor instance for every test.

### Don't test BlocksDropdown in isolation

2 tests were not rendering the BlocksToolbar component, but instead BlocksDropdown directly. I found that rewriting them to test the dropdown as part of the toolbar didn't create issues, so I modified it. Now all tests in the suite are consistent and call setup. We also avoid having to export BlocksDropdown.

## Why is it needed?

We had ⚠️ side effects ⚠️ in our tests. Some of them would pass when you only ran them, but then failed if they after another one.

And we had tons of warnings about updates not wrapped in act() that were polluting the console.
