### PR TITLE
cache yarn build

### DIFF
--- a/.github/actions/run-api-tests/script.sh
+++ b/.github/actions/run-api-tests/script.sh
@@ -10,6 +10,5 @@ export JWT_SECRET="aSecret"
 
 opts=($DB_OPTIONS)
 
-yarn nx run-many --target=build --nx-ignore-cycles --skip-nx-cache
 yarn run test:generate-app --appPath=test-apps/api "${opts[@]}"
 yarn run test:api --no-generate-app

--- a/.github/actions/run-api-tests/script.sh
+++ b/.github/actions/run-api-tests/script.sh
@@ -10,5 +10,5 @@ export JWT_SECRET="aSecret"
 
 opts=($DB_OPTIONS)
 
-yarn run test:generate-app --appPath=test-apps/api "${opts[@]}"
+yarn run test:generate-app:no:build --appPath=test-apps/api "${opts[@]}"
 yarn run test:api --no-generate-app

--- a/.github/actions/run-build/action.yml
+++ b/.github/actions/run-build/action.yml
@@ -12,7 +12,7 @@ runs:
       with:
         path: packages/**/dist
         key: yarn-build-cache-${{ github.sha }}
-
-    - name: 📥 Run build
+    - if: ${{ steps.yarn-build-cache.outputs.cache-hit != 'true' }}
+      name: 📥 Run build
       shell: bash
       run: yarn nx run-many --target=build --nx-ignore-cycles --skip-nx-cache

--- a/.github/actions/run-build/action.yml
+++ b/.github/actions/run-build/action.yml
@@ -1,0 +1,18 @@
+name: 'Monorepo build (yarn)'
+description: 'Run yarn build with cache enabled'
+
+runs:
+  using: 'composite'
+
+  steps:
+
+    - name: ♻️ Restore build cache
+      uses: actions/cache@v3
+      id: yarn-build-cache
+      with:
+        path: packages/**/dist
+        key: yarn-build-cache-${{ github.sha }}
+
+    - name: 📥 Run build
+      shell: bash
+      run: yarn nx run-many --target=build --nx-ignore-cycles --skip-nx-cache

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -70,8 +70,8 @@ jobs:
       - uses: nrwl/nx-set-shas@v3
       - name: Monorepo install
         uses: ./.github/actions/yarn-nm-install
-      - name: Run build
-        run: yarn nx run-many --target=build --nx-ignore-cycles --skip-nx-cache
+      - name: Monorepo build
+        uses: ./.github/actions/run-build
       - name: TSC for packages
         run: yarn nx affected --target=test:ts --nx-ignore-cycles
       - name: TSC for back

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,14 +51,14 @@ jobs:
       - uses: nrwl/nx-set-shas@v3
       - name: Monorepo install
         uses: ./.github/actions/yarn-nm-install
-      - name: Run build
-        run: yarn nx run-many --target=build --nx-ignore-cycles --skip-nx-cache
+      - name: Monorepo build
+        uses: ./.github/actions/run-build
       - name: Run lint
         run: yarn nx affected --target=lint --parallel --nx-ignore-cycles
 
   typescript:
     name: 'typescript'
-    needs: [changes]
+    needs: [changes, lint]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -81,7 +81,7 @@ jobs:
 
   unit_back:
     name: 'unit_back (node: ${{ matrix.node }})'
-    needs: [changes, lint, typescript]
+    needs: [changes, lint]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -96,14 +96,14 @@ jobs:
       - uses: nrwl/nx-set-shas@v3
       - name: Monorepo install
         uses: ./.github/actions/yarn-nm-install
-      - name: Run build
-        run: yarn build --skip-nx-cache
+      - name: Monorepo build
+        uses: ./.github/actions/run-build
       - name: Run tests
         run: yarn nx affected --target=test:unit --nx-ignore-cycles
 
   unit_front:
     name: 'unit_front (node: ${{ matrix.node }})'
-    needs: [changes, lint, typescript]
+    needs: [changes, lint]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -118,8 +118,8 @@ jobs:
       - uses: nrwl/nx-set-shas@v3
       - name: Monorepo install
         uses: ./.github/actions/yarn-nm-install
-      - name: Run build:ts for admin-test-utils & helper-plugin
-        run: yarn build --projects=@strapi/admin-test-utils,@strapi/helper-plugin --skip-nx-cache
+      - name: Monorepo build
+        uses: ./.github/actions/run-build
       - name: Run test
         run: yarn nx affected --target=test:front --nx-ignore-cycles
 
@@ -137,8 +137,8 @@ jobs:
           node-version: ${{ matrix.node }}
       - name: Monorepo install
         uses: ./.github/actions/yarn-nm-install
-      - name: Build
-        run: yarn build --projects=@strapi/admin,@strapi/helper-plugin
+      - name: Monorepo build
+        uses: ./.github/actions/run-build
 
   e2e:
     timeout-minutes: 60
@@ -211,6 +211,8 @@ jobs:
           node-version: ${{ matrix.node }}
       - name: Monorepo install
         uses: ./.github/actions/yarn-nm-install
+      - name: Monorepo build
+        uses: ./.github/actions/run-build
       - uses: ./.github/actions/run-api-tests
         with:
           dbOptions: '--dbclient=postgres --dbhost=localhost --dbport=5432 --dbname=strapi_test --dbusername=strapi --dbpassword=strapi'
@@ -248,6 +250,8 @@ jobs:
           node-version: ${{ matrix.node }}
       - name: Monorepo install
         uses: ./.github/actions/yarn-nm-install
+      - name: Monorepo build
+        uses: ./.github/actions/run-build
       - uses: ./.github/actions/run-api-tests
         with:
           dbOptions: '--dbclient=${{ matrix.db_client }} --dbhost=localhost --dbport=3306 --dbname=strapi_test --dbusername=strapi --dbpassword=strapi'
@@ -284,6 +288,8 @@ jobs:
           node-version: ${{ matrix.node }}
       - name: Monorepo install
         uses: ./.github/actions/yarn-nm-install
+      - name: Monorepo build
+        uses: ./.github/actions/run-build
       - uses: ./.github/actions/run-api-tests
         with:
           dbOptions: '--dbclient=${{ matrix.db_client }} --dbhost=localhost --dbport=3306 --dbname=strapi_test --dbusername=strapi --dbpassword=strapi'
@@ -304,6 +310,8 @@ jobs:
           node-version: ${{ matrix.node }}
       - name: Monorepo install
         uses: ./.github/actions/yarn-nm-install
+      - name: Monorepo build
+        uses: ./.github/actions/run-build
       - uses: ./.github/actions/run-api-tests
         env:
           SQLITE_PKG: ${{ matrix.sqlite_pkg }}
@@ -347,6 +355,8 @@ jobs:
           node-version: ${{ matrix.node }}
       - name: Monorepo install
         uses: ./.github/actions/yarn-nm-install
+      - name: Monorepo build
+        uses: ./.github/actions/run-build
       - uses: ./.github/actions/run-api-tests
         with:
           dbOptions: '--dbclient=postgres --dbhost=localhost --dbport=5432 --dbname=strapi_test --dbusername=strapi --dbpassword=strapi'
@@ -387,6 +397,8 @@ jobs:
           node-version: ${{ matrix.node }}
       - name: Monorepo install
         uses: ./.github/actions/yarn-nm-install
+      - name: Monorepo build
+        uses: ./.github/actions/run-build
       - uses: ./.github/actions/run-api-tests
         with:
           dbOptions: '--dbclient=${{ matrix.db_client }} --dbhost=localhost --dbport=3306 --dbname=strapi_test --dbusername=strapi --dbpassword=strapi'
@@ -410,6 +422,8 @@ jobs:
           node-version: ${{ matrix.node }}
       - name: Monorepo install
         uses: ./.github/actions/yarn-nm-install
+      - name: Monorepo build
+        uses: ./.github/actions/run-build
       - uses: ./.github/actions/run-api-tests
         env:
           SQLITE_PKG: ${{ matrix.sqlite_pkg }}

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "test:front:watch": "cross-env IS_EE=true run test:front --watch",
     "test:front:watch:ce": "cross-env IS_EE=false run test:front --watch",
     "test:generate-app": "yarn build:ts && node test/scripts/generate-test-app.js",
+    "test:generate-app:no:build": "node test/scripts/generate-test-app.js",
     "test:ts": "yarn test:ts:packages && yarn test:ts:front && yarn test:ts:back",
     "test:ts:back": "nx run-many --target=test:ts:back --nx-ignore-cycles",
     "test:ts:front": "nx run-many --target=test:ts:front --nx-ignore-cycles",


### PR DESCRIPTION

### What does it do?

cache yarn build dist folders

### Why is it needed?

to speed up CI

### How to test it?

That is caches the dist folders so the start up time of db tests becomes less.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
