### PR TITLE
[Blocks] Disable link button when multiple blocks are selected

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/index.js
@@ -508,17 +508,17 @@ const LinkButton = ({ disabled }) => {
   };
 
   const isLinkDisabled = () => {
-    // Always disable the whole editor is disabled
+    // Always disabled when the whole editor is disabled
     if (disabled) {
       return true;
     }
 
-    // Always enable when there's no selection
+    // Always enabled when there's no selection
     if (!editor.selection) {
       return false;
     }
 
-    // Get the block nodes closest to the anchor and focus
+    // Get the block node closest to the anchor and focus
     const anchorNodeEntry = Editor.above(editor, {
       at: editor.selection.anchor,
       match: (node) => node.type !== 'text',
@@ -528,7 +528,7 @@ const LinkButton = ({ disabled }) => {
       match: (node) => node.type !== 'text',
     });
 
-    // Disable if the anchor and focus are not in the same block
+    // Disabled if the anchor and focus are not in the same block
     return anchorNodeEntry[0] !== focusNodeEntry[0];
   };
 

--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/index.js
@@ -507,6 +507,31 @@ const LinkButton = ({ disabled }) => {
     return Boolean(match);
   };
 
+  const isLinkDisabled = () => {
+    // Always disable the whole editor is disabled
+    if (disabled) {
+      return true;
+    }
+
+    // Always enable when there's no selection
+    if (!editor.selection) {
+      return false;
+    }
+
+    // Get the block nodes closest to the anchor and focus
+    const anchorNodeEntry = Editor.above(editor, {
+      at: editor.selection.anchor,
+      match: (node) => node.type !== 'text',
+    });
+    const focusNodeEntry = Editor.above(editor, {
+      at: editor.selection.focus,
+      match: (node) => node.type !== 'text',
+    });
+
+    // Disable if the anchor and focus are not in the same block
+    return anchorNodeEntry[0] !== focusNodeEntry[0];
+  };
+
   const addLink = () => {
     // We insert an empty anchor, so we split the DOM to have a element we can use as reference for the popover
     insertLink(editor, { url: '' });
@@ -522,7 +547,7 @@ const LinkButton = ({ disabled }) => {
       }}
       isActive={isLinkActive()}
       handleClick={addLink}
-      disabled={disabled}
+      disabled={isLinkDisabled()}
     />
   );
 };

--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/tests/index.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/tests/index.test.js
@@ -32,7 +32,10 @@ const mixedInitialValue = [
   {
     type: 'heading',
     level: 1,
-    children: [{ type: 'text', text: 'A heading one' }],
+    children: [
+      { type: 'text', text: 'A heading one' },
+      { type: 'text', text: ' with modifiers', bold: true },
+    ],
   },
   {
     type: 'paragraph',
@@ -443,15 +446,15 @@ describe('BlocksEditor toolbar', () => {
       focus: { path: [1, 0], offset: 0 },
     });
 
-    const linksButton = screen.getByLabelText(/link/i);
-    expect(linksButton).toBeDisabled();
+    const linkButton = screen.getByLabelText(/link/i);
+    expect(linkButton).toBeDisabled();
 
-    // Set the selection to a single point, not a range
+    // Set the selection to a range inside the same block node
     await select({
       anchor: { path: [0, 0], offset: 0 },
-      focus: { path: [0, 0], offset: 0 },
+      focus: { path: [0, 1], offset: 2 },
     });
 
-    expect(screen.getByLabelText(/link/i)).not.toBeDisabled();
+    expect(linkButton).not.toBeDisabled();
   });
 });

--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/tests/index.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/tests/index.test.js
@@ -433,4 +433,25 @@ describe('BlocksEditor toolbar', () => {
     const blocksDropdown = screen.getByRole('combobox', { name: /Select a block/i });
     expect(within(blocksDropdown).getByText(/heading 1/i)).toBeInTheDocument();
   });
+
+  it('should disable the link button when multiple blocks are selected', async () => {
+    setup(mixedInitialValue);
+
+    // Set the selection to cover the first and second
+    await select({
+      anchor: { path: [0, 0], offset: 0 },
+      focus: { path: [1, 0], offset: 0 },
+    });
+
+    const linksButton = screen.getByLabelText(/link/i);
+    expect(linksButton).toBeDisabled();
+
+    // Set the selection to a single point, not a range
+    await select({
+      anchor: { path: [0, 0], offset: 0 },
+      focus: { path: [0, 0], offset: 0 },
+    });
+
+    expect(screen.getByLabelText(/link/i)).not.toBeDisabled();
+  });
 });


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Disables the link button when multiple block nodes are selected
### Why is it needed?

Creating a link that spanned over multiple blocks created issues

### How to test it?

Select mulitple blocks, the link button should be disabled

Keep your selection within the same block, the link button should be enabled
