### PR TITLE
Suspend dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -61,7 +61,7 @@ updates:
       interval: weekly
       day: sunday
       time: '22:00'
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 0
     versioning-strategy: increase
     ignore:
       # Only allow patch as minor babel versions need to be upgraded all together
@@ -78,8 +78,9 @@ updates:
     labels:
       - 'source: dependencies'
       - 'pr: chore'
+
   - package-ecosystem: github-actions
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 0
     directory: /
     commit-message:
       prefix: 'chore'


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Suspend dependabot PR opening for the time being. 

> ⚠️ This only disables dependabot opening update PRs. It does not disable dependabot security alerts.

### Why is it needed?

- In order to slow down on v4 and reach maintenance in a few months we can start freezing version upgrades and focus on security fixes when needed.  
- To reduce code conflicts with v5 work is starting that will make many dependency upgrades/changes

### How to test it?

/

### Related issue(s)/PR(s)

/