### PR TITLE
fix(pack-up): redefine `external` to work better with presereModules and omit changing the fileName

### DIFF
--- a/packages/core/admin/admin/src/components/GuidedTour/Homepage/tests/index.test.js
+++ b/packages/core/admin/admin/src/components/GuidedTour/Homepage/tests/index.test.js
@@ -72,18 +72,18 @@ describe('GuidedTour Homepage', () => {
         color: #32324d;
       }
 
-      .c22 {
-        font-size: 0.875rem;
-        line-height: 1.43;
-        font-weight: 500;
-        color: #666687;
-      }
-
-      .c29 {
+      .c18 {
         font-size: 0.75rem;
         line-height: 1.33;
         font-weight: 600;
         color: #ffffff;
+      }
+
+      .c20 {
+        font-size: 0.875rem;
+        line-height: 1.43;
+        font-weight: 500;
+        color: #666687;
       }
 
       .c0 {
@@ -128,7 +128,18 @@ describe('GuidedTour Homepage', () => {
         margin-top: 8px;
       }
 
-      .c21 {
+      .c14 {
+        background: #4945ff;
+        padding-top: 8px;
+        padding-right: 16px;
+        padding-bottom: 8px;
+        padding-left: 16px;
+        border-radius: 4px;
+        border-color: #4945ff;
+        border: 1px solid #4945ff;
+      }
+
+      .c19 {
         padding: 8px;
         border-radius: 50%;
         border-style: solid;
@@ -138,7 +149,7 @@ describe('GuidedTour Homepage', () => {
         height: 1.875rem;
       }
 
-      .c23 {
+      .c21 {
         background: #c0c0cf;
         border-radius: 4px;
         width: 0.125rem;
@@ -146,7 +157,7 @@ describe('GuidedTour Homepage', () => {
         min-height: 4.0625rem;
       }
 
-      .c25 {
+      .c23 {
         background: #4945ff;
         padding: 8px;
         padding-right: 16px;
@@ -218,7 +229,22 @@ describe('GuidedTour Homepage', () => {
         flex-direction: row;
       }
 
-      .c24 {
+      .c15 {
+        -webkit-align-items: center;
+        -webkit-box-align: center;
+        -ms-flex-align: center;
+        align-items: center;
+        display: -webkit-inline-box;
+        display: -webkit-inline-flex;
+        display: -ms-inline-flexbox;
+        display: inline-flex;
+        -webkit-flex-direction: row;
+        -ms-flex-direction: row;
+        flex-direction: row;
+        gap: 8px;
+      }
+
+      .c22 {
         -webkit-align-items: center;
         -webkit-box-align: center;
         -ms-flex-align: center;
@@ -236,7 +262,7 @@ describe('GuidedTour Homepage', () => {
         justify-content: flex-end;
       }
 
-      .c26 {
+      .c24 {
         -webkit-align-items: center;
         -webkit-box-align: center;
         -ms-flex-align: center;
@@ -249,158 +275,6 @@ describe('GuidedTour Homepage', () => {
         -ms-flex-direction: row;
         flex-direction: row;
         gap: 8px;
-      }
-
-      .c27 {
-        position: relative;
-        outline: none;
-      }
-
-      .c27 > svg {
-        height: 12px;
-        width: 12px;
-      }
-
-      .c27 > svg > g,
-      .c27 > svg path {
-        fill: #ffffff;
-      }
-
-      .c27[aria-disabled='true'] {
-        pointer-events: none;
-      }
-
-      .c27:after {
-        -webkit-transition-property: all;
-        transition-property: all;
-        -webkit-transition-duration: 0.2s;
-        transition-duration: 0.2s;
-        border-radius: 8px;
-        content: '';
-        position: absolute;
-        top: -4px;
-        bottom: -4px;
-        left: -4px;
-        right: -4px;
-        border: 2px solid transparent;
-      }
-
-      .c27:focus-visible {
-        outline: none;
-      }
-
-      .c27:focus-visible:after {
-        border-radius: 8px;
-        content: '';
-        position: absolute;
-        top: -5px;
-        bottom: -5px;
-        left: -5px;
-        right: -5px;
-        border: 2px solid #4945ff;
-      }
-
-      .c28 {
-        height: 2rem;
-        border: 1px solid #dcdce4;
-        background: #ffffff;
-      }
-
-      .c28 svg {
-        height: 0.75rem;
-        width: auto;
-      }
-
-      .c28[aria-disabled='true'] {
-        border: 1px solid #dcdce4;
-        background: #eaeaef;
-      }
-
-      .c28[aria-disabled='true'] .c2 {
-        color: #666687;
-      }
-
-      .c28[aria-disabled='true'] svg > g,
-      .c28[aria-disabled='true'] svg path {
-        fill: #666687;
-      }
-
-      .c28[aria-disabled='true']:active {
-        border: 1px solid #dcdce4;
-        background: #eaeaef;
-      }
-
-      .c28[aria-disabled='true']:active .c2 {
-        color: #666687;
-      }
-
-      .c28[aria-disabled='true']:active svg > g,
-      .c28[aria-disabled='true']:active svg path {
-        fill: #666687;
-      }
-
-      .c28:hover {
-        background-color: #f6f6f9;
-      }
-
-      .c28:active {
-        background-color: #eaeaef;
-      }
-
-      .c28 .c2 {
-        color: #32324d;
-      }
-
-      .c28 svg > g,
-      .c28 svg path {
-        fill: #32324d;
-      }
-
-      .c14 {
-        background: #4945ff;
-        padding-top: 8px;
-        padding-right: 16px;
-        padding-bottom: 8px;
-        padding-left: 16px;
-        border-radius: 4px;
-        border-color: #4945ff;
-        border: 1px solid #4945ff;
-      }
-
-      .c19 {
-        font-size: 0.75rem;
-        line-height: 1.33;
-        font-weight: 600;
-        color: #ffffff;
-      }
-
-      .c15 {
-        -webkit-align-items: center;
-        -webkit-box-align: center;
-        -ms-flex-align: center;
-        align-items: center;
-        display: -webkit-inline-box;
-        display: -webkit-inline-flex;
-        display: -ms-inline-flexbox;
-        display: inline-flex;
-        -webkit-flex-direction: row;
-        -ms-flex-direction: row;
-        flex-direction: row;
-        gap: 8px;
-      }
-
-      .c20 {
-        -webkit-align-items: center;
-        -webkit-box-align: center;
-        -ms-flex-align: center;
-        align-items: center;
-        display: -webkit-box;
-        display: -webkit-flex;
-        display: -ms-flexbox;
-        display: flex;
-        -webkit-flex-direction: row;
-        -ms-flex-direction: row;
-        flex-direction: row;
       }
 
       .c16 {
@@ -452,6 +326,62 @@ describe('GuidedTour Homepage', () => {
         border: 2px solid #4945ff;
       }
 
+      .c25 {
+        height: 2rem;
+        border: 1px solid #dcdce4;
+        background: #ffffff;
+      }
+
+      .c25 svg {
+        height: 0.75rem;
+        width: auto;
+      }
+
+      .c25[aria-disabled='true'] {
+        border: 1px solid #dcdce4;
+        background: #eaeaef;
+      }
+
+      .c25[aria-disabled='true'] .c2 {
+        color: #666687;
+      }
+
+      .c25[aria-disabled='true'] svg > g,
+      .c25[aria-disabled='true'] svg path {
+        fill: #666687;
+      }
+
+      .c25[aria-disabled='true']:active {
+        border: 1px solid #dcdce4;
+        background: #eaeaef;
+      }
+
+      .c25[aria-disabled='true']:active .c2 {
+        color: #666687;
+      }
+
+      .c25[aria-disabled='true']:active svg > g,
+      .c25[aria-disabled='true']:active svg path {
+        fill: #666687;
+      }
+
+      .c25:hover {
+        background-color: #f6f6f9;
+      }
+
+      .c25:active {
+        background-color: #eaeaef;
+      }
+
+      .c25 .c2 {
+        color: #32324d;
+      }
+
+      .c25 svg > g,
+      .c25 svg path {
+        fill: #32324d;
+      }
+
       .c17 {
         -webkit-text-decoration: none;
         text-decoration: none;
@@ -462,7 +392,7 @@ describe('GuidedTour Homepage', () => {
         background: #eaeaef;
       }
 
-      .c17[aria-disabled='true'] .c18 {
+      .c17[aria-disabled='true'] .c2 {
         color: #666687;
       }
 
@@ -476,7 +406,7 @@ describe('GuidedTour Homepage', () => {
         background: #eaeaef;
       }
 
-      .c17[aria-disabled='true']:active .c18 {
+      .c17[aria-disabled='true']:active .c2 {
         color: #666687;
       }
 
@@ -558,13 +488,13 @@ describe('GuidedTour Homepage', () => {
                     href="/plugins/content-type-builder"
                   >
                     <span
-                      class="c18 c19"
+                      class="c2 c18"
                     >
                       Go to the Content type Builder
                     </span>
                     <div
                       aria-hidden="true"
-                      class="c20"
+                      class="c4"
                     >
                       <svg
                         fill="none"
@@ -593,10 +523,10 @@ describe('GuidedTour Homepage', () => {
                   class="c5"
                 >
                   <div
-                    class="c21 c7"
+                    class="c19 c7"
                   >
                     <span
-                      class="c2 c22"
+                      class="c2 c20"
                     >
                       2
                     </span>
@@ -615,7 +545,7 @@ describe('GuidedTour Homepage', () => {
                   class="c11 c7"
                 >
                   <div
-                    class="c23"
+                    class="c21"
                   />
                 </div>
                 <div
@@ -633,10 +563,10 @@ describe('GuidedTour Homepage', () => {
                   class="c5"
                 >
                   <div
-                    class="c21 c7"
+                    class="c19 c7"
                   >
                     <span
-                      class="c2 c22"
+                      class="c2 c20"
                     >
                       3
                     </span>
@@ -662,15 +592,15 @@ describe('GuidedTour Homepage', () => {
           </div>
         </div>
         <div
-          class="c24"
+          class="c22"
         >
           <button
             aria-disabled="false"
-            class="c25 c26 c27 c28"
+            class="c23 c24 c16 c25"
             type="button"
           >
             <span
-              class="c2 c29"
+              class="c2 c18"
             >
               Skip the tour
             </span>

--- a/packages/core/admin/admin/src/content-manager/pages/EditView/Header/tests/index.test.js
+++ b/packages/core/admin/admin/src/content-manager/pages/EditView/Header/tests/index.test.js
@@ -56,6 +56,12 @@ describe('CONTENT MANAGER | EditView | Header', () => {
     } = render(makeApp());
 
     expect(firstChild).toMatchInlineSnapshot(`
+      .c4 {
+        font-size: 0.875rem;
+        line-height: 1.43;
+        color: #4945ff;
+      }
+
       .c8 {
         font-weight: 600;
         font-size: 2rem;
@@ -88,7 +94,7 @@ describe('CONTENT MANAGER | EditView | Header', () => {
         padding-bottom: 8px;
       }
 
-      .c5 {
+      .c6 {
         min-width: 0;
       }
 
@@ -103,7 +109,7 @@ describe('CONTENT MANAGER | EditView | Header', () => {
         cursor: pointer;
       }
 
-      .c4 {
+      .c5 {
         -webkit-align-items: center;
         -webkit-box-align: center;
         -ms-flex-align: center;
@@ -121,7 +127,7 @@ describe('CONTENT MANAGER | EditView | Header', () => {
         justify-content: space-between;
       }
 
-      .c6 {
+      .c7 {
         -webkit-align-items: center;
         -webkit-box-align: center;
         -ms-flex-align: center;
@@ -213,7 +219,7 @@ describe('CONTENT MANAGER | EditView | Header', () => {
         background: #eaeaef;
       }
 
-      .c12[aria-disabled='true'] .c7 {
+      .c12[aria-disabled='true'] .c3 {
         color: #666687;
       }
 
@@ -227,7 +233,7 @@ describe('CONTENT MANAGER | EditView | Header', () => {
         background: #eaeaef;
       }
 
-      .c12[aria-disabled='true']:active .c7 {
+      .c12[aria-disabled='true']:active .c3 {
         color: #666687;
       }
 
@@ -249,12 +255,6 @@ describe('CONTENT MANAGER | EditView | Header', () => {
       .c12 svg > g,
       .c12 svg path {
         fill: #ffffff;
-      }
-
-      .c3 {
-        font-size: 0.875rem;
-        line-height: 1.43;
-        color: #4945ff;
       }
 
       .c2 {
@@ -347,20 +347,20 @@ describe('CONTENT MANAGER | EditView | Header', () => {
                 />
               </svg>
               <span
-                class="c3"
+                class="c3 c4"
               >
                 Back
               </span>
             </a>
           </div>
           <div
-            class="c4"
+            class="c5"
           >
             <div
-              class="c5 c6"
+              class="c6 c7"
             >
               <h1
-                class="c7 c8"
+                class="c3 c8"
               >
                 Create an entry
               </h1>
@@ -375,7 +375,7 @@ describe('CONTENT MANAGER | EditView | Header', () => {
                 type="submit"
               >
                 <span
-                  class="c7 c13"
+                  class="c3 c13"
                 >
                   Save
                 </span>
@@ -383,7 +383,7 @@ describe('CONTENT MANAGER | EditView | Header', () => {
             </div>
           </div>
           <p
-            class="c7 c14"
+            class="c3 c14"
           >
             API ID  : restaurant
           </p>

--- a/packages/core/admin/admin/src/content-manager/pages/NoContentType/tests/index.test.js
+++ b/packages/core/admin/admin/src/content-manager/pages/NoContentType/tests/index.test.js
@@ -32,19 +32,26 @@ describe('CONTENT MANAGER | pages | NoContentType', () => {
     );
 
     expect(firstChild).toMatchInlineSnapshot(`
-      .c5 {
+      .c6 {
         font-weight: 600;
         font-size: 2rem;
         line-height: 1.25;
         color: #32324d;
       }
 
-      .c12 {
+      .c13 {
         font-weight: 500;
         font-size: 1rem;
         line-height: 1.25;
         color: #666687;
         text-align: center;
+      }
+
+      .c18 {
+        font-size: 0.75rem;
+        line-height: 1.33;
+        font-weight: 600;
+        color: #ffffff;
       }
 
       .c1 {
@@ -59,24 +66,35 @@ describe('CONTENT MANAGER | pages | NoContentType', () => {
         min-width: 0;
       }
 
-      .c6 {
+      .c7 {
         padding-right: 56px;
         padding-left: 56px;
       }
 
-      .c7 {
+      .c8 {
         background: #ffffff;
         padding: 64px;
         border-radius: 4px;
         box-shadow: 0px 1px 4px rgba(33,33,52,0.1);
       }
 
-      .c9 {
+      .c10 {
         padding-bottom: 24px;
       }
 
-      .c11 {
+      .c12 {
         padding-bottom: 16px;
+      }
+
+      .c14 {
+        background: #4945ff;
+        padding-top: 8px;
+        padding-right: 16px;
+        padding-bottom: 8px;
+        padding-left: 16px;
+        border-radius: 4px;
+        border-color: #4945ff;
+        border: 1px solid #4945ff;
       }
 
       .c2 {
@@ -111,7 +129,7 @@ describe('CONTENT MANAGER | pages | NoContentType', () => {
         flex-direction: row;
       }
 
-      .c8 {
+      .c9 {
         -webkit-align-items: center;
         -webkit-box-align: center;
         -ms-flex-align: center;
@@ -125,33 +143,7 @@ describe('CONTENT MANAGER | pages | NoContentType', () => {
         flex-direction: column;
       }
 
-      .c10 svg {
-        height: 5.5rem;
-      }
-
-      .c0:focus-visible {
-        outline: none;
-      }
-
-      .c13 {
-        background: #4945ff;
-        padding-top: 8px;
-        padding-right: 16px;
-        padding-bottom: 8px;
-        padding-left: 16px;
-        border-radius: 4px;
-        border-color: #4945ff;
-        border: 1px solid #4945ff;
-      }
-
-      .c19 {
-        font-size: 0.75rem;
-        line-height: 1.33;
-        font-weight: 600;
-        color: #ffffff;
-      }
-
-      .c14 {
+      .c15 {
         -webkit-align-items: center;
         -webkit-box-align: center;
         -ms-flex-align: center;
@@ -166,40 +158,26 @@ describe('CONTENT MANAGER | pages | NoContentType', () => {
         gap: 8px;
       }
 
-      .c17 {
-        -webkit-align-items: center;
-        -webkit-box-align: center;
-        -ms-flex-align: center;
-        align-items: center;
-        display: -webkit-box;
-        display: -webkit-flex;
-        display: -ms-flexbox;
-        display: flex;
-        -webkit-flex-direction: row;
-        -ms-flex-direction: row;
-        flex-direction: row;
-      }
-
-      .c15 {
+      .c16 {
         position: relative;
         outline: none;
       }
 
-      .c15 > svg {
+      .c16 > svg {
         height: 12px;
         width: 12px;
       }
 
-      .c15 > svg > g,
-      .c15 > svg path {
+      .c16 > svg > g,
+      .c16 > svg path {
         fill: #ffffff;
       }
 
-      .c15[aria-disabled='true'] {
+      .c16[aria-disabled='true'] {
         pointer-events: none;
       }
 
-      .c15:after {
+      .c16:after {
         -webkit-transition-property: all;
         transition-property: all;
         -webkit-transition-duration: 0.2s;
@@ -214,11 +192,11 @@ describe('CONTENT MANAGER | pages | NoContentType', () => {
         border: 2px solid transparent;
       }
 
-      .c15:focus-visible {
+      .c16:focus-visible {
         outline: none;
       }
 
-      .c15:focus-visible:after {
+      .c16:focus-visible:after {
         border-radius: 8px;
         content: '';
         position: absolute;
@@ -229,65 +207,73 @@ describe('CONTENT MANAGER | pages | NoContentType', () => {
         border: 2px solid #4945ff;
       }
 
-      .c16 {
+      .c11 svg {
+        height: 5.5rem;
+      }
+
+      .c0:focus-visible {
+        outline: none;
+      }
+
+      .c17 {
         -webkit-text-decoration: none;
         text-decoration: none;
         border: 1px solid #d9d8ff;
         background: #f0f0ff;
       }
 
-      .c16[aria-disabled='true'] {
+      .c17[aria-disabled='true'] {
         border: 1px solid #dcdce4;
         background: #eaeaef;
       }
 
-      .c16[aria-disabled='true'] .c18 {
+      .c17[aria-disabled='true'] .c5 {
         color: #666687;
       }
 
-      .c16[aria-disabled='true'] svg > g,
-      .c16[aria-disabled='true'] svg path {
+      .c17[aria-disabled='true'] svg > g,
+      .c17[aria-disabled='true'] svg path {
         fill: #666687;
       }
 
-      .c16[aria-disabled='true']:active {
+      .c17[aria-disabled='true']:active {
         border: 1px solid #dcdce4;
         background: #eaeaef;
       }
 
-      .c16[aria-disabled='true']:active .c18 {
+      .c17[aria-disabled='true']:active .c5 {
         color: #666687;
       }
 
-      .c16[aria-disabled='true']:active svg > g,
-      .c16[aria-disabled='true']:active svg path {
+      .c17[aria-disabled='true']:active svg > g,
+      .c17[aria-disabled='true']:active svg path {
         fill: #666687;
       }
 
-      .c16:hover {
+      .c17:hover {
         background-color: #ffffff;
       }
 
-      .c16:active {
+      .c17:active {
         background-color: #ffffff;
         border: 1px solid #4945ff;
       }
 
-      .c16:active .c18 {
+      .c17:active .c5 {
         color: #4945ff;
       }
 
-      .c16:active svg > g,
-      .c16:active svg path {
+      .c17:active svg > g,
+      .c17:active svg path {
         fill: #4945ff;
       }
 
-      .c16 .c18 {
+      .c17 .c5 {
         color: #271fe0;
       }
 
-      .c16 svg > g,
-      .c16 svg path {
+      .c17 svg > g,
+      .c17 svg path {
         fill: #271fe0;
       }
 
@@ -311,7 +297,7 @@ describe('CONTENT MANAGER | pages | NoContentType', () => {
                 class="c3 c4"
               >
                 <h1
-                  class="c5"
+                  class="c5 c6"
                 >
                   Content
                 </h1>
@@ -320,14 +306,14 @@ describe('CONTENT MANAGER | pages | NoContentType', () => {
           </div>
         </div>
         <div
-          class="c6"
+          class="c7"
         >
           <div
-            class="c7 c8"
+            class="c8 c9"
           >
             <div
               aria-hidden="true"
-              class="c9 c10"
+              class="c10 c11"
             >
               <svg
                 fill="none"
@@ -393,22 +379,22 @@ describe('CONTENT MANAGER | pages | NoContentType', () => {
               </svg>
             </div>
             <div
-              class="c11"
+              class="c12"
             >
               <p
-                class="c12"
+                class="c5 c13"
               >
                 You don't have any content yet, we recommend you to create your first Content-Type.
               </p>
             </div>
             <a
               aria-disabled="false"
-              class="c13 c14 c15 c16"
+              class="c14 c15 c16 c17"
               href="/plugins/content-type-builder/content-types/create-content-type"
             >
               <div
                 aria-hidden="true"
-                class="c17"
+                class="c4"
               >
                 <svg
                   fill="none"
@@ -424,7 +410,7 @@ describe('CONTENT MANAGER | pages | NoContentType', () => {
                 </svg>
               </div>
               <span
-                class="c18 c19"
+                class="c5 c18"
               >
                 Create your first Content-type
               </span>

--- a/packages/core/admin/admin/src/pages/AuthPage/components/Login/tests/BaseLogin.test.js
+++ b/packages/core/admin/admin/src/pages/AuthPage/components/Login/tests/BaseLogin.test.js
@@ -82,6 +82,12 @@ describe('ADMIN | PAGES | AUTH | BaseLogin', () => {
         color: #ffffff;
       }
 
+      .c40 {
+        font-size: 0.875rem;
+        line-height: 1.43;
+        color: #4945ff;
+      }
+
       .c1 {
         background: #ffffff;
         padding-top: 48px;
@@ -561,12 +567,6 @@ describe('ADMIN | PAGES | AUTH | BaseLogin', () => {
         outline: none;
       }
 
-      .c40 {
-        font-size: 0.875rem;
-        line-height: 1.43;
-        color: #4945ff;
-      }
-
       .c39 {
         display: -webkit-inline-box;
         display: -webkit-inline-flex;
@@ -852,7 +852,7 @@ describe('ADMIN | PAGES | AUTH | BaseLogin', () => {
               href="/auth/forgot-password"
             >
               <span
-                class="c40"
+                class="c7 c40"
               >
                 Forgot your password?
               </span>

--- a/packages/core/admin/admin/src/pages/AuthPage/components/Oops/tests/index.test.js
+++ b/packages/core/admin/admin/src/pages/AuthPage/components/Oops/tests/index.test.js
@@ -57,6 +57,12 @@ describe('ADMIN | PAGES | AUTH | Oops', () => {
         color: #32324d;
       }
 
+      .c26 {
+        font-size: 0.875rem;
+        line-height: 1.43;
+        color: #4945ff;
+      }
+
       .c1 {
         padding-top: 24px;
         padding-right: 40px;
@@ -260,12 +266,6 @@ describe('ADMIN | PAGES | AUTH | Oops', () => {
         outline: none;
       }
 
-      .c26 {
-        font-size: 0.875rem;
-        line-height: 1.43;
-        color: #4945ff;
-      }
-
       .c25 {
         display: -webkit-inline-box;
         display: -webkit-inline-flex;
@@ -467,7 +467,7 @@ describe('ADMIN | PAGES | AUTH | Oops', () => {
                   href="/auth/login"
                 >
                   <span
-                    class="c26"
+                    class="c8 c26"
                   >
                     Sign in
                   </span>

--- a/packages/core/admin/admin/src/pages/AuthPage/components/ResetPassword/tests/index.test.js
+++ b/packages/core/admin/admin/src/pages/AuthPage/components/ResetPassword/tests/index.test.js
@@ -95,6 +95,12 @@ describe('ADMIN | PAGES | AUTH | ResetPassword', () => {
         color: #ffffff;
       }
 
+      .c46 {
+        font-size: 0.875rem;
+        line-height: 1.43;
+        color: #4945ff;
+      }
+
       .c1 {
         padding-top: 24px;
         padding-right: 40px;
@@ -567,12 +573,6 @@ describe('ADMIN | PAGES | AUTH | ResetPassword', () => {
         outline: none;
       }
 
-      .c46 {
-        font-size: 0.875rem;
-        line-height: 1.43;
-        color: #4945ff;
-      }
-
       .c45 {
         display: -webkit-inline-box;
         display: -webkit-inline-flex;
@@ -926,7 +926,7 @@ describe('ADMIN | PAGES | AUTH | ResetPassword', () => {
                   href="/auth/login"
                 >
                   <span
-                    class="c46"
+                    class="c8 c46"
                   >
                     Ready to sign in?
                   </span>

--- a/packages/core/admin/admin/src/pages/InternalErrorPage/tests/index.test.js
+++ b/packages/core/admin/admin/src/pages/InternalErrorPage/tests/index.test.js
@@ -27,19 +27,26 @@ describe('InternalErrorPage', () => {
     } = render(App);
 
     expect(firstChild).toMatchInlineSnapshot(`
-      .c5 {
+      .c6 {
         font-weight: 600;
         font-size: 2rem;
         line-height: 1.25;
         color: #32324d;
       }
 
-      .c12 {
+      .c13 {
         font-weight: 500;
         font-size: 1rem;
         line-height: 1.25;
         color: #666687;
         text-align: center;
+      }
+
+      .c18 {
+        font-size: 0.75rem;
+        line-height: 1.33;
+        font-weight: 600;
+        color: #ffffff;
       }
 
       .c1 {
@@ -54,24 +61,35 @@ describe('InternalErrorPage', () => {
         min-width: 0;
       }
 
-      .c6 {
+      .c7 {
         padding-right: 56px;
         padding-left: 56px;
       }
 
-      .c7 {
+      .c8 {
         background: #ffffff;
         padding: 64px;
         border-radius: 4px;
         box-shadow: 0px 1px 4px rgba(33,33,52,0.1);
       }
 
-      .c9 {
+      .c10 {
         padding-bottom: 24px;
       }
 
-      .c11 {
+      .c12 {
         padding-bottom: 16px;
+      }
+
+      .c14 {
+        background: #4945ff;
+        padding-top: 8px;
+        padding-right: 16px;
+        padding-bottom: 8px;
+        padding-left: 16px;
+        border-radius: 4px;
+        border-color: #4945ff;
+        border: 1px solid #4945ff;
       }
 
       .c2 {
@@ -106,7 +124,7 @@ describe('InternalErrorPage', () => {
         flex-direction: row;
       }
 
-      .c8 {
+      .c9 {
         -webkit-align-items: center;
         -webkit-box-align: center;
         -ms-flex-align: center;
@@ -120,33 +138,7 @@ describe('InternalErrorPage', () => {
         flex-direction: column;
       }
 
-      .c10 svg {
-        height: 5.5rem;
-      }
-
-      .c0:focus-visible {
-        outline: none;
-      }
-
-      .c13 {
-        background: #4945ff;
-        padding-top: 8px;
-        padding-right: 16px;
-        padding-bottom: 8px;
-        padding-left: 16px;
-        border-radius: 4px;
-        border-color: #4945ff;
-        border: 1px solid #4945ff;
-      }
-
-      .c18 {
-        font-size: 0.75rem;
-        line-height: 1.33;
-        font-weight: 600;
-        color: #ffffff;
-      }
-
-      .c14 {
+      .c15 {
         -webkit-align-items: center;
         -webkit-box-align: center;
         -ms-flex-align: center;
@@ -161,40 +153,26 @@ describe('InternalErrorPage', () => {
         gap: 8px;
       }
 
-      .c19 {
-        -webkit-align-items: center;
-        -webkit-box-align: center;
-        -ms-flex-align: center;
-        align-items: center;
-        display: -webkit-box;
-        display: -webkit-flex;
-        display: -ms-flexbox;
-        display: flex;
-        -webkit-flex-direction: row;
-        -ms-flex-direction: row;
-        flex-direction: row;
-      }
-
-      .c15 {
+      .c16 {
         position: relative;
         outline: none;
       }
 
-      .c15 > svg {
+      .c16 > svg {
         height: 12px;
         width: 12px;
       }
 
-      .c15 > svg > g,
-      .c15 > svg path {
+      .c16 > svg > g,
+      .c16 > svg path {
         fill: #ffffff;
       }
 
-      .c15[aria-disabled='true'] {
+      .c16[aria-disabled='true'] {
         pointer-events: none;
       }
 
-      .c15:after {
+      .c16:after {
         -webkit-transition-property: all;
         transition-property: all;
         -webkit-transition-duration: 0.2s;
@@ -209,11 +187,11 @@ describe('InternalErrorPage', () => {
         border: 2px solid transparent;
       }
 
-      .c15:focus-visible {
+      .c16:focus-visible {
         outline: none;
       }
 
-      .c15:focus-visible:after {
+      .c16:focus-visible:after {
         border-radius: 8px;
         content: '';
         position: absolute;
@@ -224,65 +202,73 @@ describe('InternalErrorPage', () => {
         border: 2px solid #4945ff;
       }
 
-      .c16 {
+      .c11 svg {
+        height: 5.5rem;
+      }
+
+      .c0:focus-visible {
+        outline: none;
+      }
+
+      .c17 {
         -webkit-text-decoration: none;
         text-decoration: none;
         border: 1px solid #d9d8ff;
         background: #f0f0ff;
       }
 
-      .c16[aria-disabled='true'] {
+      .c17[aria-disabled='true'] {
         border: 1px solid #dcdce4;
         background: #eaeaef;
       }
 
-      .c16[aria-disabled='true'] .c17 {
+      .c17[aria-disabled='true'] .c5 {
         color: #666687;
       }
 
-      .c16[aria-disabled='true'] svg > g,
-      .c16[aria-disabled='true'] svg path {
+      .c17[aria-disabled='true'] svg > g,
+      .c17[aria-disabled='true'] svg path {
         fill: #666687;
       }
 
-      .c16[aria-disabled='true']:active {
+      .c17[aria-disabled='true']:active {
         border: 1px solid #dcdce4;
         background: #eaeaef;
       }
 
-      .c16[aria-disabled='true']:active .c17 {
+      .c17[aria-disabled='true']:active .c5 {
         color: #666687;
       }
 
-      .c16[aria-disabled='true']:active svg > g,
-      .c16[aria-disabled='true']:active svg path {
+      .c17[aria-disabled='true']:active svg > g,
+      .c17[aria-disabled='true']:active svg path {
         fill: #666687;
       }
 
-      .c16:hover {
+      .c17:hover {
         background-color: #ffffff;
       }
 
-      .c16:active {
+      .c17:active {
         background-color: #ffffff;
         border: 1px solid #4945ff;
       }
 
-      .c16:active .c17 {
+      .c17:active .c5 {
         color: #4945ff;
       }
 
-      .c16:active svg > g,
-      .c16:active svg path {
+      .c17:active svg > g,
+      .c17:active svg path {
         fill: #4945ff;
       }
 
-      .c16 .c17 {
+      .c17 .c5 {
         color: #271fe0;
       }
 
-      .c16 svg > g,
-      .c16 svg path {
+      .c17 svg > g,
+      .c17 svg path {
         fill: #271fe0;
       }
 
@@ -306,7 +292,7 @@ describe('InternalErrorPage', () => {
                 class="c3 c4"
               >
                 <h1
-                  class="c5"
+                  class="c5 c6"
                   id="title"
                 >
                   Page not found
@@ -316,14 +302,14 @@ describe('InternalErrorPage', () => {
           </div>
         </div>
         <div
-          class="c6"
+          class="c7"
         >
           <div
-            class="c7 c8"
+            class="c8 c9"
           >
             <div
               aria-hidden="true"
-              class="c9 c10"
+              class="c10 c11"
             >
               <svg
                 fill="none"
@@ -402,10 +388,10 @@ describe('InternalErrorPage', () => {
               </svg>
             </div>
             <div
-              class="c11"
+              class="c12"
             >
               <p
-                class="c12"
+                class="c5 c13"
               >
                 An error occured
               </p>
@@ -413,17 +399,17 @@ describe('InternalErrorPage', () => {
             <a
               aria-current="page"
               aria-disabled="false"
-              class="c13 c14 c15 c16 active"
+              class="c14 c15 c16 c17 active"
               href="/"
             >
               <span
-                class="c17 c18"
+                class="c5 c18"
               >
                 Back to homepage
               </span>
               <div
                 aria-hidden="true"
-                class="c19"
+                class="c4"
               >
                 <svg
                   fill="none"

--- a/packages/core/admin/admin/src/pages/NotFoundPage/tests/index.test.js
+++ b/packages/core/admin/admin/src/pages/NotFoundPage/tests/index.test.js
@@ -27,19 +27,26 @@ describe('NotFoundPage', () => {
     } = render(App);
 
     expect(firstChild).toMatchInlineSnapshot(`
-      .c5 {
+      .c6 {
         font-weight: 600;
         font-size: 2rem;
         line-height: 1.25;
         color: #32324d;
       }
 
-      .c12 {
+      .c13 {
         font-weight: 500;
         font-size: 1rem;
         line-height: 1.25;
         color: #666687;
         text-align: center;
+      }
+
+      .c18 {
+        font-size: 0.75rem;
+        line-height: 1.33;
+        font-weight: 600;
+        color: #ffffff;
       }
 
       .c1 {
@@ -54,24 +61,35 @@ describe('NotFoundPage', () => {
         min-width: 0;
       }
 
-      .c6 {
+      .c7 {
         padding-right: 56px;
         padding-left: 56px;
       }
 
-      .c7 {
+      .c8 {
         background: #ffffff;
         padding: 64px;
         border-radius: 4px;
         box-shadow: 0px 1px 4px rgba(33,33,52,0.1);
       }
 
-      .c9 {
+      .c10 {
         padding-bottom: 24px;
       }
 
-      .c11 {
+      .c12 {
         padding-bottom: 16px;
+      }
+
+      .c14 {
+        background: #4945ff;
+        padding-top: 8px;
+        padding-right: 16px;
+        padding-bottom: 8px;
+        padding-left: 16px;
+        border-radius: 4px;
+        border-color: #4945ff;
+        border: 1px solid #4945ff;
       }
 
       .c2 {
@@ -106,7 +124,7 @@ describe('NotFoundPage', () => {
         flex-direction: row;
       }
 
-      .c8 {
+      .c9 {
         -webkit-align-items: center;
         -webkit-box-align: center;
         -ms-flex-align: center;
@@ -120,33 +138,7 @@ describe('NotFoundPage', () => {
         flex-direction: column;
       }
 
-      .c10 svg {
-        height: 5.5rem;
-      }
-
-      .c0:focus-visible {
-        outline: none;
-      }
-
-      .c13 {
-        background: #4945ff;
-        padding-top: 8px;
-        padding-right: 16px;
-        padding-bottom: 8px;
-        padding-left: 16px;
-        border-radius: 4px;
-        border-color: #4945ff;
-        border: 1px solid #4945ff;
-      }
-
-      .c18 {
-        font-size: 0.75rem;
-        line-height: 1.33;
-        font-weight: 600;
-        color: #ffffff;
-      }
-
-      .c14 {
+      .c15 {
         -webkit-align-items: center;
         -webkit-box-align: center;
         -ms-flex-align: center;
@@ -161,40 +153,26 @@ describe('NotFoundPage', () => {
         gap: 8px;
       }
 
-      .c19 {
-        -webkit-align-items: center;
-        -webkit-box-align: center;
-        -ms-flex-align: center;
-        align-items: center;
-        display: -webkit-box;
-        display: -webkit-flex;
-        display: -ms-flexbox;
-        display: flex;
-        -webkit-flex-direction: row;
-        -ms-flex-direction: row;
-        flex-direction: row;
-      }
-
-      .c15 {
+      .c16 {
         position: relative;
         outline: none;
       }
 
-      .c15 > svg {
+      .c16 > svg {
         height: 12px;
         width: 12px;
       }
 
-      .c15 > svg > g,
-      .c15 > svg path {
+      .c16 > svg > g,
+      .c16 > svg path {
         fill: #ffffff;
       }
 
-      .c15[aria-disabled='true'] {
+      .c16[aria-disabled='true'] {
         pointer-events: none;
       }
 
-      .c15:after {
+      .c16:after {
         -webkit-transition-property: all;
         transition-property: all;
         -webkit-transition-duration: 0.2s;
@@ -209,11 +187,11 @@ describe('NotFoundPage', () => {
         border: 2px solid transparent;
       }
 
-      .c15:focus-visible {
+      .c16:focus-visible {
         outline: none;
       }
 
-      .c15:focus-visible:after {
+      .c16:focus-visible:after {
         border-radius: 8px;
         content: '';
         position: absolute;
@@ -224,65 +202,73 @@ describe('NotFoundPage', () => {
         border: 2px solid #4945ff;
       }
 
-      .c16 {
+      .c11 svg {
+        height: 5.5rem;
+      }
+
+      .c0:focus-visible {
+        outline: none;
+      }
+
+      .c17 {
         -webkit-text-decoration: none;
         text-decoration: none;
         border: 1px solid #d9d8ff;
         background: #f0f0ff;
       }
 
-      .c16[aria-disabled='true'] {
+      .c17[aria-disabled='true'] {
         border: 1px solid #dcdce4;
         background: #eaeaef;
       }
 
-      .c16[aria-disabled='true'] .c17 {
+      .c17[aria-disabled='true'] .c5 {
         color: #666687;
       }
 
-      .c16[aria-disabled='true'] svg > g,
-      .c16[aria-disabled='true'] svg path {
+      .c17[aria-disabled='true'] svg > g,
+      .c17[aria-disabled='true'] svg path {
         fill: #666687;
       }
 
-      .c16[aria-disabled='true']:active {
+      .c17[aria-disabled='true']:active {
         border: 1px solid #dcdce4;
         background: #eaeaef;
       }
 
-      .c16[aria-disabled='true']:active .c17 {
+      .c17[aria-disabled='true']:active .c5 {
         color: #666687;
       }
 
-      .c16[aria-disabled='true']:active svg > g,
-      .c16[aria-disabled='true']:active svg path {
+      .c17[aria-disabled='true']:active svg > g,
+      .c17[aria-disabled='true']:active svg path {
         fill: #666687;
       }
 
-      .c16:hover {
+      .c17:hover {
         background-color: #ffffff;
       }
 
-      .c16:active {
+      .c17:active {
         background-color: #ffffff;
         border: 1px solid #4945ff;
       }
 
-      .c16:active .c17 {
+      .c17:active .c5 {
         color: #4945ff;
       }
 
-      .c16:active svg > g,
-      .c16:active svg path {
+      .c17:active svg > g,
+      .c17:active svg path {
         fill: #4945ff;
       }
 
-      .c16 .c17 {
+      .c17 .c5 {
         color: #271fe0;
       }
 
-      .c16 svg > g,
-      .c16 svg path {
+      .c17 svg > g,
+      .c17 svg path {
         fill: #271fe0;
       }
 
@@ -306,7 +292,7 @@ describe('NotFoundPage', () => {
                 class="c3 c4"
               >
                 <h1
-                  class="c5"
+                  class="c5 c6"
                   id="title"
                 >
                   Page not found
@@ -316,14 +302,14 @@ describe('NotFoundPage', () => {
           </div>
         </div>
         <div
-          class="c6"
+          class="c7"
         >
           <div
-            class="c7 c8"
+            class="c8 c9"
           >
             <div
               aria-hidden="true"
-              class="c9 c10"
+              class="c10 c11"
             >
               <svg
                 fill="none"
@@ -402,10 +388,10 @@ describe('NotFoundPage', () => {
               </svg>
             </div>
             <div
-              class="c11"
+              class="c12"
             >
               <p
-                class="c12"
+                class="c5 c13"
               >
                 Oops! We can't seem to find the page you're looging for...
               </p>
@@ -413,17 +399,17 @@ describe('NotFoundPage', () => {
             <a
               aria-current="page"
               aria-disabled="false"
-              class="c13 c14 c15 c16 active"
+              class="c14 c15 c16 c17 active"
               href="/"
             >
               <span
-                class="c17 c18"
+                class="c5 c18"
               >
                 Back to homepage
               </span>
               <div
                 aria-hidden="true"
-                class="c19"
+                class="c4"
               >
                 <svg
                   fill="none"

--- a/packages/core/content-type-builder/admin/src/pages/ListView/tests/__snapshots__/index.test.js.snap
+++ b/packages/core/content-type-builder/admin/src/pages/ListView/tests/__snapshots__/index.test.js.snap
@@ -13,6 +13,12 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
   width: 1px;
 }
 
+.c4 {
+  font-size: 0.875rem;
+  line-height: 1.43;
+  color: #4945ff;
+}
+
 .c8 {
   font-weight: 600;
   font-size: 2rem;
@@ -91,7 +97,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
   padding-bottom: 8px;
 }
 
-.c5 {
+.c6 {
   min-width: 0;
 }
 
@@ -216,7 +222,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
   padding: 20px;
 }
 
-.c4 {
+.c5 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -234,7 +240,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
   justify-content: space-between;
 }
 
-.c6 {
+.c7 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -449,7 +455,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
   background: #eaeaef;
 }
 
-.c13[aria-disabled='true'] .c7 {
+.c13[aria-disabled='true'] .c3 {
   color: #666687;
 }
 
@@ -463,7 +469,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
   background: #eaeaef;
 }
 
-.c13[aria-disabled='true']:active .c7 {
+.c13[aria-disabled='true']:active .c3 {
   color: #666687;
 }
 
@@ -480,7 +486,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
   background-color: #eaeaef;
 }
 
-.c13 .c7 {
+.c13 .c3 {
   color: #32324d;
 }
 
@@ -505,7 +511,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
   background: #eaeaef;
 }
 
-.c15[aria-disabled='true'] .c7 {
+.c15[aria-disabled='true'] .c3 {
   color: #666687;
 }
 
@@ -519,7 +525,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
   background: #eaeaef;
 }
 
-.c15[aria-disabled='true']:active .c7 {
+.c15[aria-disabled='true']:active .c3 {
   color: #666687;
 }
 
@@ -537,7 +543,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
   border: 1px solid #4945ff;
 }
 
-.c15:active .c7 {
+.c15:active .c3 {
   color: #4945ff;
 }
 
@@ -546,7 +552,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
   fill: #4945ff;
 }
 
-.c15 .c7 {
+.c15 .c3 {
   color: #271fe0;
 }
 
@@ -569,7 +575,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
   background: #eaeaef;
 }
 
-.c16[aria-disabled='true'] .c7 {
+.c16[aria-disabled='true'] .c3 {
   color: #666687;
 }
 
@@ -583,7 +589,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
   background: #eaeaef;
 }
 
-.c16[aria-disabled='true']:active .c7 {
+.c16[aria-disabled='true']:active .c3 {
   color: #666687;
 }
 
@@ -670,12 +676,6 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
   display: block;
   width: 100%;
   border: none;
-}
-
-.c3 {
-  font-size: 0.875rem;
-  line-height: 1.43;
-  color: #4945ff;
 }
 
 .c2 {
@@ -845,9 +845,9 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
   display: block;
 }
 
-.c57.active .c7,
-.c57:focus .c7,
-.c57:hover .c7 {
+.c57.active .c3,
+.c57:focus .c3,
+.c57:hover .c3 {
   color: #4945ff;
 }
 
@@ -1085,20 +1085,20 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
             />
           </svg>
           <span
-            class="c3"
+            class="c3 c4"
           >
             Back
           </span>
         </a>
       </div>
       <div
-        class="c4"
+        class="c5"
       >
         <div
-          class="c5 c6"
+          class="c6 c7"
         >
           <h1
-            class="c7 c8"
+            class="c3 c8"
             id="title"
           />
           <div
@@ -1129,7 +1129,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                 </svg>
               </div>
               <span
-                class="c7 c14"
+                class="c3 c14"
               >
                 Edit
               </span>
@@ -1162,7 +1162,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
               </svg>
             </div>
             <span
-              class="c7 c14"
+              class="c3 c14"
             >
               Add another field
             </span>
@@ -1191,7 +1191,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
               </svg>
             </div>
             <span
-              class="c7 c14"
+              class="c3 c14"
             >
               Save
             </span>
@@ -1199,7 +1199,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
         </div>
       </div>
       <p
-        class="c7 c17"
+        class="c3 c17"
       >
         Build the data architecture of your content
       </p>
@@ -1241,7 +1241,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                 </svg>
               </div>
               <span
-                class="c7 c14"
+                class="c3 c14"
               >
                 Configure the view
               </span>
@@ -1264,7 +1264,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                 <tr>
                   <th>
                     <span
-                      class="c7 c24"
+                      class="c3 c24"
                     >
                       Name
                     </span>
@@ -1273,7 +1273,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                     colspan="2"
                   >
                     <span
-                      class="c7 c24"
+                      class="c3 c24"
                     >
                       Type
                     </span>
@@ -1319,7 +1319,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                         </svg>
                       </div>
                       <span
-                        class="c7 c30"
+                        class="c3 c30"
                       >
                         postal_code
                       </span>
@@ -1327,7 +1327,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                   </td>
                   <td>
                     <span
-                      class="c7 c31"
+                      class="c3 c31"
                     >
                       string
                        
@@ -1442,7 +1442,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                         </svg>
                       </div>
                       <span
-                        class="c7 c30"
+                        class="c3 c30"
                       >
                         categories
                       </span>
@@ -1450,7 +1450,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                   </td>
                   <td>
                     <span
-                      class="c7 c31"
+                      class="c3 c31"
                     >
                       Relation with
                        
@@ -1574,7 +1574,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                         </svg>
                       </div>
                       <span
-                        class="c7 c30"
+                        class="c3 c30"
                       >
                         cover
                       </span>
@@ -1582,7 +1582,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                   </td>
                   <td>
                     <span
-                      class="c7 c31"
+                      class="c3 c31"
                     >
                       media
                        
@@ -1701,7 +1701,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                         </svg>
                       </div>
                       <span
-                        class="c7 c30"
+                        class="c3 c30"
                       >
                         images
                       </span>
@@ -1709,7 +1709,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                   </td>
                   <td>
                     <span
-                      class="c7 c31"
+                      class="c3 c31"
                     >
                       media
                        
@@ -1826,7 +1826,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                         </svg>
                       </div>
                       <span
-                        class="c7 c30"
+                        class="c3 c30"
                       >
                         city
                       </span>
@@ -1834,7 +1834,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                   </td>
                   <td>
                     <span
-                      class="c7 c31"
+                      class="c3 c31"
                     >
                       string
                        
@@ -1953,7 +1953,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                         </svg>
                       </div>
                       <span
-                        class="c7 c30"
+                        class="c3 c30"
                       >
                         json
                       </span>
@@ -1961,7 +1961,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                   </td>
                   <td>
                     <span
-                      class="c7 c31"
+                      class="c3 c31"
                     >
                       json
                        
@@ -2074,7 +2074,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                         </svg>
                       </div>
                       <span
-                        class="c7 c30"
+                        class="c3 c30"
                       >
                         slug
                       </span>
@@ -2082,7 +2082,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                   </td>
                   <td>
                     <span
-                      class="c7 c31"
+                      class="c3 c31"
                     >
                       uid
                        
@@ -2205,7 +2205,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                         </svg>
                       </div>
                       <span
-                        class="c7 c30"
+                        class="c3 c30"
                       >
                         notrepeat_req
                       </span>
@@ -2213,7 +2213,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                   </td>
                   <td>
                     <span
-                      class="c7 c31"
+                      class="c3 c31"
                     >
                       component
                        
@@ -2363,7 +2363,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                     </svg>
                                   </div>
                                   <span
-                                    class="c7 c30"
+                                    class="c3 c30"
                                   >
                                     name
                                   </span>
@@ -2371,7 +2371,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                               </td>
                               <td>
                                 <span
-                                  class="c7 c31"
+                                  class="c3 c31"
                                 >
                                   string
                                    
@@ -2507,7 +2507,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                     </svg>
                                   </div>
                                   <span
-                                    class="c7 c30"
+                                    class="c3 c30"
                                   >
                                     popo
                                   </span>
@@ -2515,7 +2515,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                               </td>
                               <td>
                                 <span
-                                  class="c7 c31"
+                                  class="c3 c31"
                                 >
                                   string
                                    
@@ -2651,7 +2651,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                     </svg>
                                   </div>
                                   <span
-                                    class="c7 c30"
+                                    class="c3 c30"
                                   >
                                     poq
                                   </span>
@@ -2659,7 +2659,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                               </td>
                               <td>
                                 <span
-                                  class="c7 c31"
+                                  class="c3 c31"
                                 >
                                   string
                                    
@@ -2746,7 +2746,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                         type="button"
                       >
                         <div
-                          class="c6"
+                          class="c7"
                         >
                           <div
                             aria-hidden="true"
@@ -2769,7 +2769,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                             class="c45"
                           >
                             <span
-                              class="c7 c46"
+                              class="c3 c46"
                             >
                               Add another field
                             </span>
@@ -2823,7 +2823,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                         </svg>
                       </div>
                       <span
-                        class="c7 c30"
+                        class="c3 c30"
                       >
                         Compopo
                       </span>
@@ -2831,7 +2831,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                   </td>
                   <td>
                     <span
-                      class="c7 c31"
+                      class="c3 c31"
                     >
                       component
                        
@@ -2981,7 +2981,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                     </svg>
                                   </div>
                                   <span
-                                    class="c7 c30"
+                                    class="c3 c30"
                                   >
                                     dede
                                   </span>
@@ -2989,7 +2989,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                               </td>
                               <td>
                                 <span
-                                  class="c7 c31"
+                                  class="c3 c31"
                                 >
                                   string
                                    
@@ -3125,7 +3125,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                     </svg>
                                   </div>
                                   <span
-                                    class="c7 c30"
+                                    class="c3 c30"
                                   >
                                     dada
                                   </span>
@@ -3133,7 +3133,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                               </td>
                               <td>
                                 <span
-                                  class="c7 c31"
+                                  class="c3 c31"
                                 >
                                   string
                                    
@@ -3269,7 +3269,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                     </svg>
                                   </div>
                                   <span
-                                    class="c7 c30"
+                                    class="c3 c30"
                                   >
                                     papi
                                   </span>
@@ -3277,7 +3277,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                               </td>
                               <td>
                                 <span
-                                  class="c7 c31"
+                                  class="c3 c31"
                                 >
                                   string
                                    
@@ -3364,7 +3364,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                         type="button"
                       >
                         <div
-                          class="c6"
+                          class="c7"
                         >
                           <div
                             aria-hidden="true"
@@ -3387,7 +3387,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                             class="c45"
                           >
                             <span
-                              class="c7 c46"
+                              class="c3 c46"
                             >
                               Add another field
                             </span>
@@ -3435,7 +3435,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                         </svg>
                       </div>
                       <span
-                        class="c7 c30"
+                        class="c3 c30"
                       >
                         DynamicZone
                       </span>
@@ -3443,7 +3443,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                   </td>
                   <td>
                     <span
-                      class="c7 c31"
+                      class="c3 c31"
                     >
                       dynamiczone
                        
@@ -3554,7 +3554,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                               />
                             </svg>
                             <span
-                              class="c7 c54"
+                              class="c3 c54"
                             >
                               Add a component
                             </span>
@@ -3592,7 +3592,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                               class="c61"
                             >
                               <span
-                                class="c7 c62"
+                                class="c3 c62"
                               />
                             </div>
                             <button
@@ -3640,7 +3640,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                               class="c61"
                             >
                               <span
-                                class="c7 c62"
+                                class="c3 c62"
                               />
                             </div>
                             <button
@@ -3691,7 +3691,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                               class="c61"
                             >
                               <span
-                                class="c7 c62"
+                                class="c3 c62"
                               />
                             </div>
                             <button
@@ -3739,7 +3739,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                               class="c61"
                             >
                               <span
-                                class="c7 c62"
+                                class="c3 c62"
                               />
                             </div>
                             <button
@@ -3845,7 +3845,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                 </svg>
                                               </div>
                                               <span
-                                                class="c7 c30"
+                                                class="c3 c30"
                                               >
                                                 name
                                               </span>
@@ -3853,7 +3853,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                           </td>
                                           <td>
                                             <span
-                                              class="c7 c31"
+                                              class="c3 c31"
                                             >
                                               string
                                                
@@ -3989,7 +3989,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                 </svg>
                                               </div>
                                               <span
-                                                class="c7 c30"
+                                                class="c3 c30"
                                               >
                                                 mail
                                               </span>
@@ -3997,7 +3997,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                           </td>
                                           <td>
                                             <span
-                                              class="c7 c31"
+                                              class="c3 c31"
                                             >
                                               email
                                                
@@ -4133,7 +4133,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                 </svg>
                                               </div>
                                               <span
-                                                class="c7 c30"
+                                                class="c3 c30"
                                               >
                                                 phone
                                               </span>
@@ -4141,7 +4141,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                           </td>
                                           <td>
                                             <span
-                                              class="c7 c31"
+                                              class="c3 c31"
                                             >
                                               integer
                                                
@@ -4228,7 +4228,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                     type="button"
                                   >
                                     <div
-                                      class="c6"
+                                      class="c7"
                                     >
                                       <div
                                         aria-hidden="true"
@@ -4251,7 +4251,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                         class="c45"
                                       >
                                         <span
-                                          class="c7 c54"
+                                          class="c3 c54"
                                         >
                                           Add another field
                                         </span>
@@ -4344,7 +4344,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                 </svg>
                                               </div>
                                               <span
-                                                class="c7 c30"
+                                                class="c3 c30"
                                               >
                                                 name
                                               </span>
@@ -4352,7 +4352,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                           </td>
                                           <td>
                                             <span
-                                              class="c7 c31"
+                                              class="c3 c31"
                                             >
                                               string
                                                
@@ -4488,7 +4488,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                 </svg>
                                               </div>
                                               <span
-                                                class="c7 c30"
+                                                class="c3 c30"
                                               >
                                                 description
                                               </span>
@@ -4496,7 +4496,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                           </td>
                                           <td>
                                             <span
-                                              class="c7 c31"
+                                              class="c3 c31"
                                             >
                                               text
                                                
@@ -4632,7 +4632,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                 </svg>
                                               </div>
                                               <span
-                                                class="c7 c30"
+                                                class="c3 c30"
                                               >
                                                 price
                                               </span>
@@ -4640,7 +4640,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                           </td>
                                           <td>
                                             <span
-                                              class="c7 c31"
+                                              class="c3 c31"
                                             >
                                               float
                                                
@@ -4778,7 +4778,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                 </svg>
                                               </div>
                                               <span
-                                                class="c7 c30"
+                                                class="c3 c30"
                                               >
                                                 picture
                                               </span>
@@ -4786,7 +4786,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                           </td>
                                           <td>
                                             <span
-                                              class="c7 c31"
+                                              class="c3 c31"
                                             >
                                               media
                                                
@@ -4924,7 +4924,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                 </svg>
                                               </div>
                                               <span
-                                                class="c7 c30"
+                                                class="c3 c30"
                                               >
                                                 very_long_description
                                               </span>
@@ -4932,7 +4932,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                           </td>
                                           <td>
                                             <span
-                                              class="c7 c31"
+                                              class="c3 c31"
                                             >
                                               richtext
                                                
@@ -5066,7 +5066,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                 </svg>
                                               </div>
                                               <span
-                                                class="c7 c30"
+                                                class="c3 c30"
                                               >
                                                 categories
                                               </span>
@@ -5074,7 +5074,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                           </td>
                                           <td>
                                             <span
-                                              class="c7 c31"
+                                              class="c3 c31"
                                             >
                                               Relation with
                                                
@@ -5166,7 +5166,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                     type="button"
                                   >
                                     <div
-                                      class="c6"
+                                      class="c7"
                                     >
                                       <div
                                         aria-hidden="true"
@@ -5189,7 +5189,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                         class="c45"
                                       >
                                         <span
-                                          class="c7 c54"
+                                          class="c3 c54"
                                         >
                                           Add another field
                                         </span>
@@ -5282,7 +5282,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                 </svg>
                                               </div>
                                               <span
-                                                class="c7 c30"
+                                                class="c3 c30"
                                               >
                                                 label
                                               </span>
@@ -5290,7 +5290,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                           </td>
                                           <td>
                                             <span
-                                              class="c7 c31"
+                                              class="c3 c31"
                                             >
                                               string
                                                
@@ -5426,7 +5426,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                 </svg>
                                               </div>
                                               <span
-                                                class="c7 c30"
+                                                class="c3 c30"
                                               >
                                                 time
                                               </span>
@@ -5434,7 +5434,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                           </td>
                                           <td>
                                             <span
-                                              class="c7 c31"
+                                              class="c3 c31"
                                             >
                                               string
                                                
@@ -5576,7 +5576,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                 </svg>
                                               </div>
                                               <span
-                                                class="c7 c30"
+                                                class="c3 c30"
                                               >
                                                 dishrep
                                               </span>
@@ -5584,7 +5584,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                           </td>
                                           <td>
                                             <span
-                                              class="c7 c31"
+                                              class="c3 c31"
                                             >
                                               component
                                                
@@ -5735,7 +5735,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                             </svg>
                                                           </div>
                                                           <span
-                                                            class="c7 c30"
+                                                            class="c3 c30"
                                                           >
                                                             name
                                                           </span>
@@ -5743,7 +5743,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                       </td>
                                                       <td>
                                                         <span
-                                                          class="c7 c31"
+                                                          class="c3 c31"
                                                         >
                                                           string
                                                            
@@ -5879,7 +5879,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                             </svg>
                                                           </div>
                                                           <span
-                                                            class="c7 c30"
+                                                            class="c3 c30"
                                                           >
                                                             description
                                                           </span>
@@ -5887,7 +5887,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                       </td>
                                                       <td>
                                                         <span
-                                                          class="c7 c31"
+                                                          class="c3 c31"
                                                         >
                                                           text
                                                            
@@ -6023,7 +6023,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                             </svg>
                                                           </div>
                                                           <span
-                                                            class="c7 c30"
+                                                            class="c3 c30"
                                                           >
                                                             price
                                                           </span>
@@ -6031,7 +6031,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                       </td>
                                                       <td>
                                                         <span
-                                                          class="c7 c31"
+                                                          class="c3 c31"
                                                         >
                                                           float
                                                            
@@ -6169,7 +6169,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                             </svg>
                                                           </div>
                                                           <span
-                                                            class="c7 c30"
+                                                            class="c3 c30"
                                                           >
                                                             picture
                                                           </span>
@@ -6177,7 +6177,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                       </td>
                                                       <td>
                                                         <span
-                                                          class="c7 c31"
+                                                          class="c3 c31"
                                                         >
                                                           media
                                                            
@@ -6315,7 +6315,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                             </svg>
                                                           </div>
                                                           <span
-                                                            class="c7 c30"
+                                                            class="c3 c30"
                                                           >
                                                             very_long_description
                                                           </span>
@@ -6323,7 +6323,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                       </td>
                                                       <td>
                                                         <span
-                                                          class="c7 c31"
+                                                          class="c3 c31"
                                                         >
                                                           richtext
                                                            
@@ -6457,7 +6457,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                             </svg>
                                                           </div>
                                                           <span
-                                                            class="c7 c30"
+                                                            class="c3 c30"
                                                           >
                                                             categories
                                                           </span>
@@ -6465,7 +6465,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                       </td>
                                                       <td>
                                                         <span
-                                                          class="c7 c31"
+                                                          class="c3 c31"
                                                         >
                                                           Relation with
                                                            
@@ -6557,7 +6557,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                 type="button"
                                               >
                                                 <div
-                                                  class="c6"
+                                                  class="c7"
                                                 >
                                                   <div
                                                     aria-hidden="true"
@@ -6580,7 +6580,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                     class="c45"
                                                   >
                                                     <span
-                                                      class="c7 c46"
+                                                      class="c3 c46"
                                                     >
                                                       Add another field
                                                     </span>
@@ -6598,7 +6598,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                     type="button"
                                   >
                                     <div
-                                      class="c6"
+                                      class="c7"
                                     >
                                       <div
                                         aria-hidden="true"
@@ -6621,7 +6621,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                         class="c45"
                                       >
                                         <span
-                                          class="c7 c54"
+                                          class="c3 c54"
                                         >
                                           Add another field
                                         </span>
@@ -6714,7 +6714,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                 </svg>
                                               </div>
                                               <span
-                                                class="c7 c30"
+                                                class="c3 c30"
                                               >
                                                 name
                                               </span>
@@ -6722,7 +6722,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                           </td>
                                           <td>
                                             <span
-                                              class="c7 c31"
+                                              class="c3 c31"
                                             >
                                               string
                                                
@@ -6860,7 +6860,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                 </svg>
                                               </div>
                                               <span
-                                                class="c7 c30"
+                                                class="c3 c30"
                                               >
                                                 media
                                               </span>
@@ -6868,7 +6868,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                           </td>
                                           <td>
                                             <span
-                                              class="c7 c31"
+                                              class="c3 c31"
                                             >
                                               media
                                                
@@ -7004,7 +7004,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                                 </svg>
                                               </div>
                                               <span
-                                                class="c7 c30"
+                                                class="c3 c30"
                                               >
                                                 is_available
                                               </span>
@@ -7012,7 +7012,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                           </td>
                                           <td>
                                             <span
-                                              class="c7 c31"
+                                              class="c3 c31"
                                             >
                                               boolean
                                                
@@ -7099,7 +7099,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                     type="button"
                                   >
                                     <div
-                                      class="c6"
+                                      class="c7"
                                     >
                                       <div
                                         aria-hidden="true"
@@ -7122,7 +7122,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                                         class="c45"
                                       >
                                         <span
-                                          class="c7 c54"
+                                          class="c3 c54"
                                         >
                                           Add another field
                                         </span>
@@ -7149,7 +7149,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
               class="c72 c73"
             >
               <div
-                class="c6"
+                class="c7"
               >
                 <div
                   aria-hidden="true"
@@ -7172,7 +7172,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
                   class="c45"
                 >
                   <span
-                    class="c7 c54"
+                    class="c3 c54"
                   >
                     Add another field
                   </span>

--- a/packages/core/upload/admin/src/pages/App/ConfigureTheView/tests/__snapshots__/ConfigureTheView.test.js.snap
+++ b/packages/core/upload/admin/src/pages/App/ConfigureTheView/tests/__snapshots__/ConfigureTheView.test.js.snap
@@ -13,6 +13,12 @@ exports[`Upload - Configure initial render renders and matches the snapshot 1`] 
   width: 1px;
 }
 
+.c8 {
+  font-size: 0.875rem;
+  line-height: 1.43;
+  color: #4945ff;
+}
+
 .c12 {
   font-weight: 600;
   font-size: 2rem;
@@ -72,7 +78,7 @@ exports[`Upload - Configure initial render renders and matches the snapshot 1`] 
   padding-bottom: 8px;
 }
 
-.c9 {
+.c10 {
   min-width: 0;
 }
 
@@ -119,7 +125,7 @@ exports[`Upload - Configure initial render renders and matches the snapshot 1`] 
   flex: 1;
 }
 
-.c8 {
+.c9 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -137,7 +143,7 @@ exports[`Upload - Configure initial render renders and matches the snapshot 1`] 
   justify-content: space-between;
 }
 
-.c10 {
+.c11 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -278,7 +284,7 @@ exports[`Upload - Configure initial render renders and matches the snapshot 1`] 
   background: #eaeaef;
 }
 
-.c16[aria-disabled='true'] .c11 {
+.c16[aria-disabled='true'] .c7 {
   color: #666687;
 }
 
@@ -292,7 +298,7 @@ exports[`Upload - Configure initial render renders and matches the snapshot 1`] 
   background: #eaeaef;
 }
 
-.c16[aria-disabled='true']:active .c11 {
+.c16[aria-disabled='true']:active .c7 {
   color: #666687;
 }
 
@@ -376,7 +382,7 @@ exports[`Upload - Configure initial render renders and matches the snapshot 1`] 
   flex-wrap: wrap;
 }
 
-.c37[data-state='checked'] .c11 {
+.c37[data-state='checked'] .c7 {
   font-weight: bold;
   color: #4945ff;
 }
@@ -403,12 +409,6 @@ exports[`Upload - Configure initial render renders and matches the snapshot 1`] 
 
 .c3:focus-visible {
   outline: none;
-}
-
-.c7 {
-  font-size: 0.875rem;
-  line-height: 1.43;
-  color: #4945ff;
 }
 
 .c6 {
@@ -527,20 +527,20 @@ exports[`Upload - Configure initial render renders and matches the snapshot 1`] 
                     />
                   </svg>
                   <span
-                    class="c7"
+                    class="c7 c8"
                   >
                     Back
                   </span>
                 </a>
               </div>
               <div
-                class="c8"
+                class="c9"
               >
                 <div
-                  class="c9 c10"
+                  class="c10 c11"
                 >
                   <h1
-                    class="c11 c12"
+                    class="c7 c12"
                   >
                     Configure the view - Media Library
                   </h1>
@@ -569,14 +569,14 @@ exports[`Upload - Configure initial render renders and matches the snapshot 1`] 
                     </svg>
                   </div>
                   <span
-                    class="c11 c17"
+                    class="c7 c17"
                   >
                     Save
                   </span>
                 </button>
               </div>
               <p
-                class="c11 c18"
+                class="c7 c18"
               >
                 Define the view settings of the media library.
               </p>
@@ -601,7 +601,7 @@ exports[`Upload - Configure initial render renders and matches the snapshot 1`] 
                       class="c23"
                     >
                       <label
-                        class="c11 c24 c25"
+                        class="c7 c24 c25"
                         for=":r0:"
                       >
                         Entries per page
@@ -624,7 +624,7 @@ exports[`Upload - Configure initial render renders and matches the snapshot 1`] 
                           class="c29 c30"
                         >
                           <span
-                            class="c11 c31 c32"
+                            class="c7 c31 c32"
                           >
                             <span
                               class="c33"
@@ -658,7 +658,7 @@ exports[`Upload - Configure initial render renders and matches the snapshot 1`] 
                         </span>
                       </div>
                       <p
-                        class="c11 c35"
+                        class="c7 c35"
                         id=":r0:-hint"
                       >
                         Number of assets displayed by default in the Media Library
@@ -676,7 +676,7 @@ exports[`Upload - Configure initial render renders and matches the snapshot 1`] 
                       class="c23"
                     >
                       <label
-                        class="c11 c24 c25"
+                        class="c7 c24 c25"
                         for=":r4:"
                       >
                         Default sort order
@@ -699,7 +699,7 @@ exports[`Upload - Configure initial render renders and matches the snapshot 1`] 
                           class="c29 c30"
                         >
                           <span
-                            class="c11 c31 c32"
+                            class="c7 c31 c32"
                           >
                             <span
                               class="c33"
@@ -733,7 +733,7 @@ exports[`Upload - Configure initial render renders and matches the snapshot 1`] 
                         </span>
                       </div>
                       <p
-                        class="c11 c35"
+                        class="c7 c35"
                         id=":r4:-hint"
                       >
                         Note: You can override this value in the media library.

--- a/packages/utils/pack-up/src/node/tasks/vite/config.ts
+++ b/packages/utils/pack-up/src/node/tasks/vite/config.ts
@@ -11,7 +11,7 @@ import type { BuildContext } from '../../createBuildContext';
  * @internal
  */
 const resolveViteConfig = (ctx: BuildContext, task: ViteBaseTask) => {
-  const { cwd, distPath, targets, external, extMap, pkg } = ctx;
+  const { cwd, distPath, targets, external, extMap, pkg, exports: exportMap } = ctx;
   const { entries, format, output, runtime } = task;
   const outputExt = extMap[pkg.type || 'commonjs'][format];
   const outDir = path.relative(cwd, distPath);
@@ -21,6 +21,9 @@ const resolveViteConfig = (ctx: BuildContext, task: ViteBaseTask) => {
   customLogger.warnOnce = (msg) => ctx.logger.warn(msg);
   customLogger.error = (msg) => ctx.logger.error(msg);
   customLogger.info = () => {};
+
+  const exportIds = Object.keys(exportMap).map((exportPath) => path.join(pkg.name, exportPath));
+  const sourcePaths = Object.values(exportMap).map((exp) => path.resolve(cwd, exp.source));
 
   const config = {
     configFile: false,
@@ -43,14 +46,48 @@ const resolveViteConfig = (ctx: BuildContext, task: ViteBaseTask) => {
         formats: [format],
         /**
          * this enforces the file name to match what the output we've
-         * determined from the package.json exports.
+         * determined from the package.json exports. However, when preserving modules
+         * we want to let Rollup handle the file names.
          */
-        fileName() {
-          return `${path.relative(outDir, output).replace(/\.[^/.]+$/, '')}${outputExt}`;
-        },
+        fileName: resolveConfigProperty(ctx.config.preserveModules, false)
+          ? undefined
+          : () => {
+              return `${path.relative(outDir, output).replace(/\.[^/.]+$/, '')}${outputExt}`;
+            },
       },
       rollupOptions: {
-        external,
+        external(id, importer) {
+          // Check if the id is a self-referencing import
+          if (exportIds?.includes(id)) {
+            return true;
+          }
+
+          // Check if the id is a file path that points to an exported source file
+          if (importer && (id.startsWith('.') || id.startsWith('/'))) {
+            const idPath = path.resolve(path.dirname(importer), id);
+
+            if (sourcePaths?.includes(idPath)) {
+              ctx.logger.warn(
+                `detected self-referencing import – treating as external: ${path.relative(
+                  cwd,
+                  idPath
+                )}`
+              );
+
+              return true;
+            }
+          }
+
+          const idParts = id.split('/');
+
+          const name = idParts[0].startsWith('@') ? `${idParts[0]}/${idParts[1]}` : idParts[0];
+
+          if (name && external.includes(name)) {
+            return true;
+          }
+
+          return false;
+        },
         output: {
           preserveModules: resolveConfigProperty(ctx.config.preserveModules, false),
           /**


### PR DESCRIPTION


<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* changes the `external` property in the vite config from a passed array to a function so it works better with `preserveModules`
* doesn't override `fileName` when we use `preserveModules` because that breaks the point of the config option.

### Why is it needed?

* preserveModules either renamed everything to `indexXX` or had the folders nested according to where you called the command from

### Related issue(s)/PR(s)

* unblocks #18341 
* unblocks #18339
