### PR TITLE
feat: ts migrate admin permissions

### DIFF
--- a/packages/core/admin/package.json
+++ b/packages/core/admin/package.json
@@ -61,6 +61,8 @@
     "@strapi/types": "workspace:*",
     "@strapi/typescript-utils": "4.14.3",
     "@strapi/utils": "4.14.3",
+    "@types/koa-passport": "6.0.1",
+    "@types/passport-local": "1.0.36",
     "axios": "1.5.0",
     "bcryptjs": "2.4.3",
     "browserslist": "^4.22.1",

--- a/packages/core/admin/server/src/controllers/authentication.ts
+++ b/packages/core/admin/server/src/controllers/authentication.ts
@@ -1,4 +1,3 @@
-// @ts-expect-error
 import passport from 'koa-passport';
 import compose from 'koa-compose';
 import { errors } from '@strapi/utils';

--- a/packages/core/admin/server/src/controllers/permission.ts
+++ b/packages/core/admin/server/src/controllers/permission.ts
@@ -1,6 +1,7 @@
 import { validateCheckPermissionsInput } from '../validation/permission';
 import { getService } from '../utils';
 import { formatConditions } from './formatters';
+import type { Action } from '../domain/action';
 
 export default {
   /**
@@ -29,7 +30,7 @@ export default {
   async getAll(ctx: any) {
     const { sectionsBuilder, actionProvider, conditionProvider } = getService('permission');
 
-    const actions = actionProvider.values();
+    const actions = actionProvider.values() as Action[];
     const conditions = conditionProvider.values();
     const sections = await sectionsBuilder.build(actions);
 

--- a/packages/core/admin/server/src/domain/permission/index.ts
+++ b/packages/core/admin/server/src/domain/permission/index.ts
@@ -120,10 +120,11 @@ export const setProperty = (
  * Returns a new permission without the given property name set
  * @param property - The name of the property to delete
  * @param permission - The permission on which we want to remove the property
- * @return {Permission}
  */
-export const deleteProperty = (property: string, permission: Permission) =>
-  omit(`properties.${property}`, permission);
+export const deleteProperty = <TProperty extends string>(
+  property: TProperty,
+  permission: Permission
+) => omit(`properties.${property}`, permission) as Omit<Permission, TProperty>;
 
 /**
  * Creates a new {@link Permission} object from raw attributes. Set default values for certain fields

--- a/packages/core/admin/server/src/services/passport.ts
+++ b/packages/core/admin/server/src/services/passport.ts
@@ -1,5 +1,5 @@
-// @ts-expect-error
 import passport from 'koa-passport';
+import type { Strategy } from 'passport-local';
 import { isFunction } from 'lodash/fp';
 
 import createLocalStrategy from './passport/local-strategy';
@@ -9,22 +9,22 @@ const authEventsMapper = {
   onConnectionError: 'admin.auth.error',
 };
 
-const valueIsFunctionType = ([, value]: any) => isFunction(value);
+const valueIsFunctionType = ([, value]: [any, any]) => isFunction(value);
 const keyIsValidEventName = ([key]: any) => {
   return Object.keys(strapi.admin.services.passport.authEventsMapper).includes(key);
 };
 
-const getPassportStrategies = () => [createLocalStrategy(strapi)];
+const getPassportStrategies = () => [createLocalStrategy(strapi)] as Strategy[];
 
 const registerAuthEvents = () => {
-  const { events = {} } = strapi.config.get('admin.auth', {}) as any;
+  // @ts-expect-error - TODO: migrate auth service to TS
+  const { events = {} } = strapi.config.get('admin.auth', {});
   const { authEventsMapper } = strapi.admin.services.passport;
 
-  const eventList = Object.entries(events)
-    .filter(keyIsValidEventName)
-    .filter(valueIsFunctionType) as any;
+  const eventList = Object.entries(events).filter(keyIsValidEventName).filter(valueIsFunctionType);
 
   for (const [eventName, handler] of eventList) {
+    // @ts-expect-error
     strapi.eventHub.on(authEventsMapper[eventName], handler);
   }
 };
@@ -32,7 +32,7 @@ const registerAuthEvents = () => {
 const init = () => {
   strapi.admin.services.passport
     .getPassportStrategies()
-    .forEach((strategy: any) => passport.use(strategy));
+    .forEach((strategy: Strategy) => passport.use(strategy));
 
   registerAuthEvents();
 

--- a/packages/core/admin/server/src/services/passport/local-strategy.ts
+++ b/packages/core/admin/server/src/services/passport/local-strategy.ts
@@ -1,5 +1,4 @@
 import { toLower } from 'lodash/fp';
-// @ts-expect-error
 import { Strategy as LocalStrategy } from 'passport-local';
 import type { Strapi } from '@strapi/types';
 

--- a/packages/core/admin/server/src/services/permission/engine.ts
+++ b/packages/core/admin/server/src/services/permission/engine.ts
@@ -1,10 +1,12 @@
 import { curry, isArray, isEmpty, difference } from 'lodash/fp';
-import permissions from '@strapi/permissions';
-
-import permissionDomain from '../../domain/permission/index';
+import permissions, { type engine } from '@strapi/permissions';
+import type { Ability } from '@casl/ability';
+import permissionDomain, { type Permission } from '../../domain/permission';
 import { getService } from '../../utils';
+import { Action } from '../../domain/action';
+import { AdminUser } from '../../domain/user';
 
-export default (params: any) => {
+export default (params: { providers: engine.EngineParams['providers'] }) => {
   const { providers } = params;
 
   const engine = permissions.engine
@@ -27,19 +29,21 @@ export default (params: any) => {
     /**
      * Remove invalid properties from the permission based on the action (applyToProperties)
      */
-    .on('format.permission', (permission) => {
-      const action = providers.action.get(permission.action);
+    .on('format.permission', (permission: Permission) => {
+      const action = providers.action.get(permission.action) as Action;
       const properties = permission.properties || {};
 
       // Only keep the properties allowed by the action (action.applyToProperties)
       const propertiesName = Object.keys(properties);
       const invalidProperties = difference(
         propertiesName,
+        // @ts-expect-error - applyToProperties is defined inside the options of an action
         action.applyToProperties || propertiesName
       );
 
       const permissionWithSanitizedProperties = invalidProperties.reduce(
-        (property) => permissionDomain.deleteProperty(property, permission),
+        // @ts-expect-error - fix reduce, property should be a string but it's actually the permission object
+        (property) => permissionDomain.deleteProperty(property, permission) as Permission,
         permission
       );
 
@@ -65,9 +69,8 @@ export default (params: any) => {
     /**
      * Generate an ability based on the given user (using associated roles & permissions)
      * @param user
-     * @returns {Promise<Ability>}
      */
-    async generateUserAbility(user: any) {
+    async generateUserAbility(user: AdminUser): Promise<Ability> {
       const permissions = (await getService('permission').findUserPermissions(user)) as any;
 
       return engine.generateAbility(permissions, user);
@@ -76,10 +79,9 @@ export default (params: any) => {
     /**
      * Check many permissions based on an ability
      */
-    checkMany: curry((ability: any, permissions: any) => {
-      return permissions.map(({ action, subject, field }: any) =>
-        ability.can(action, subject, field)
-      );
+    checkMany: curry((ability: Ability, permissions: Permission[]) => {
+      // @ts-expect-error - Permissions does not contain any field property
+      return permissions.map(({ action, subject, field }) => ability.can(action, subject, field));
     }),
   };
 };

--- a/packages/core/admin/server/src/services/permission/sections-builder/builder.ts
+++ b/packages/core/admin/server/src/services/permission/sections-builder/builder.ts
@@ -1,4 +1,5 @@
-import createSection from './section';
+import { Action } from '../../../domain/action';
+import createSection, { SectionOptions } from './section';
 
 /**
  * Create a new section builder with its own sections registry
@@ -11,11 +12,10 @@ const createSectionBuilder = () => {
   return {
     /**
      * Create & add a section to the builder's registry
-     * @param {string} sectionName - The unique name of the section
-     * @param {SectionOptions} options - The options used to build a {@link Section}
-     * @return {this}
+     * @param sectionName - The unique name of the section
+     * @param options - The options used to build a {@link Section}
      */
-    createSection(sectionName: string, options: any) {
+    createSection(sectionName: string, options: SectionOptions) {
       const section = createSection(options);
 
       state.sections.set(sectionName, section);
@@ -25,8 +25,7 @@ const createSectionBuilder = () => {
 
     /**
      * Removes a section from the builder's registry using its unique name
-     * @param {string} sectionName - The name of the section to delete
-     * @return {this}
+     * @param sectionName - The name of the section to delete
      */
     deleteSection(sectionName: string) {
       // @ts-expect-error
@@ -37,9 +36,8 @@ const createSectionBuilder = () => {
 
     /**
      * Register a handler function for a given section
-     * @param {string} sectionName - The name of the section
-     * @param {Function} handler - The handler to register
-     * @return {this}
+     * @param  sectionName - The name of the section
+     * @param  handler - The handler to register
      */
     addHandler(sectionName: string, handler: () => unknown) {
       if (state.sections.has(sectionName)) {
@@ -51,9 +49,9 @@ const createSectionBuilder = () => {
 
     /**
      * Register a matcher function for a given section
-     * @param {string} sectionName - The name of the section
-     * @param {Function} matcher - The handler to register
-     * @return {this}
+     * @param sectionName - The name of the section
+     * @param matcher - The handler to register
+
      */
     addMatcher(sectionName: string, matcher: () => unknown) {
       if (state.sections.has(sectionName)) {
@@ -65,10 +63,9 @@ const createSectionBuilder = () => {
 
     /**
      * Build a section tree based on the registered actions and the given actions
-     * @param {Array<Action>} actions - The actions used to build each section
-     * @return {Promise<any>}
+     * @param actions - The actions used to build each section
      */
-    async build(actions = [] as any) {
+    async build(actions = [] as Action[]) {
       const sections = {} as any;
 
       for (const [sectionName, section] of state.sections.entries()) {

--- a/packages/core/admin/server/src/services/permission/sections-builder/section.ts
+++ b/packages/core/admin/server/src/services/permission/sections-builder/section.ts
@@ -1,24 +1,21 @@
 import { eq } from 'lodash/fp';
 import { hooks } from '@strapi/utils';
+import type { Action } from '../../../domain/action';
 
-/**
- * @typedef SectionOptions
- * @property {function():any} initialStateFactory - A factory function that returns the default shape of the section
- * @property {Array<Function>} handlers - An initial collection of handlers which will be registered in the handlers hook
- * @property {Array<Function>} matchers - An initial collection of matchers which will be registered in the matchers hook
- */
+export type SectionOptions = {
+  initialStateFactory?: (...args: any) => any; // A factory function that returns the default shape of the section
+  handlers?: ((...args: any) => any)[]; // An initial collection of handlers which will be registered in the handlers hook
+  matchers?: ((...args: any) => any)[]; // An initial collection of matchers which will be registered in the matchers hook
+};
 
 const emptyObjectFactory = () => ({});
 
 /**
  * Upon call, creates a new section object
- * @param {SectionOptions} options
  */
-const createSection = ({
-  initialStateFactory = emptyObjectFactory,
-  handlers = [],
-  matchers = [],
-} = {}) => {
+const createSection = (
+  { initialStateFactory = emptyObjectFactory, handlers = [], matchers = [] } = {} as SectionOptions
+) => {
   const state = {
     hooks: {
       handlers: hooks.createAsyncSeriesHook(),
@@ -36,10 +33,8 @@ const createSection = ({
     /**
      * Verifies if an action can be applied to the section by running the matchers hook.
      * If any of the registered matcher functions returns true, then the condition applies.
-     * @param {Action} action
-     * @return {Promise<boolean>}
      */
-    async appliesToAction(action: any) {
+    async appliesToAction(action: Action): Promise<boolean> {
       const results = await state.hooks.matchers.call(action);
 
       return results.some(eq(true));
@@ -47,10 +42,9 @@ const createSection = ({
 
     /**
      * Init, build and returns a section object based on the given actions
-     * @param {Array<Action>} actions - A list of actions used to populate the section
-     * @return {Promise<any>}
+     * @param  actions - A list of actions used to populate the section
      */
-    async build(actions = []) {
+    async build(actions = [] as Action[]) {
       const section = initialStateFactory();
 
       for (const action of actions) {

--- a/packages/core/admin/server/src/utils/index.d.ts
+++ b/packages/core/admin/server/src/utils/index.d.ts
@@ -1,5 +1,6 @@
 import * as role from '../services/role';
 import * as user from '../services/user';
+import * as passport from '../services/passport';
 import * as permission from '../services/permission';
 import * as contentType from '../services/content-type';
 import * as metrics from '../services/metrics';
@@ -12,6 +13,7 @@ import * as transfer from '../services/transfer';
 type S = {
   role: typeof role;
   user: typeof user;
+  passport: typeof passport;
   permission: typeof permission;
   'content-type': typeof contentType;
   token: typeof token;

--- a/packages/core/permissions/src/domain/permission/index.ts
+++ b/packages/core/permissions/src/domain/permission/index.ts
@@ -8,7 +8,7 @@ export interface Permission {
   action: string;
   actionParameters?: Record<string, unknown>;
   subject?: string | object | null;
-  properties?: object;
+  properties?: Record<string, any>;
   conditions?: string[];
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6383,7 +6383,9 @@ __metadata:
     "@testing-library/react": 14.0.0
     "@testing-library/user-event": 14.4.3
     "@types/jsonwebtoken": 9.0.3
+    "@types/koa-passport": 6.0.1
     "@types/lodash": ^4.14.191
+    "@types/passport-local": 1.0.36
     axios: 1.5.0
     bcryptjs: 2.4.3
     browserslist: ^4.22.1
@@ -8268,6 +8270,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/koa-passport@npm:6.0.1":
+  version: 6.0.1
+  resolution: "@types/koa-passport@npm:6.0.1"
+  dependencies:
+    "@types/koa": "*"
+    "@types/passport": "*"
+  checksum: b2f58c9018d0f4e1cfeb2c59f7b0bad580f5cda20bfe9e93d9bf858abbae1142f4fb6d9005da5d329c531be2cd1ec6df7d5c75096ea79e005f722ab658a62fdf
+  languageName: node
+  linkType: hard
+
 "@types/koa-send@npm:*":
   version: 4.1.4
   resolution: "@types/koa-send@npm:4.1.4"
@@ -8497,6 +8509,36 @@ __metadata:
   version: 4.0.0
   resolution: "@types/parse-json@npm:4.0.0"
   checksum: fd6bce2b674b6efc3db4c7c3d336bd70c90838e8439de639b909ce22f3720d21344f52427f1d9e57b265fcb7f6c018699b99e5e0c208a1a4823014269a6bf35b
+  languageName: node
+  linkType: hard
+
+"@types/passport-local@npm:1.0.36":
+  version: 1.0.36
+  resolution: "@types/passport-local@npm:1.0.36"
+  dependencies:
+    "@types/express": "*"
+    "@types/passport": "*"
+    "@types/passport-strategy": "*"
+  checksum: 32c9259053e659088527298c364ba2f05eac202412df89246506ad847d755107c08fe8452e50ebaca079cecedbb25acfd71fbb4565f109acc0557d1bf0db8386
+  languageName: node
+  linkType: hard
+
+"@types/passport-strategy@npm:*":
+  version: 0.2.36
+  resolution: "@types/passport-strategy@npm:0.2.36"
+  dependencies:
+    "@types/express": "*"
+    "@types/passport": "*"
+  checksum: 7f626eb6a12110c1ce64dd5d5181fc0795e77d60123872e33f6fa1c02a2a19451207eaf03543232241a1d70bfe0318f2ffeef88f6309d7cbaa43d2bf6ec1d1e8
+  languageName: node
+  linkType: hard
+
+"@types/passport@npm:*":
+  version: 1.0.13
+  resolution: "@types/passport@npm:1.0.13"
+  dependencies:
+    "@types/express": "*"
+  checksum: 84330bedb330302ffd92b009b9b88eb20d3c66b659b383badb9aa3035612b40b47052153858b2498a95d9979d668443bdee3182345819cb18635dfb7f24c109c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Migrates passport and permission service to typescript.

I have found many type inconsistencies in the permission service, I think for now is best to omit them and see if it's really important for the other packages to handle have all the type variations handled.
