### PR TITLE
[Blocks editor] Fix - When a image is selected we want to disable the modifier buttons

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/index.js
@@ -579,7 +579,7 @@ const BlocksToolbar = ({ disabled }) => {
    * The modifier buttons are disabled when an image is selected.
    */
 
-  const isToolbarButtonDisabled = () => {
+  const checkButtonDisabled = () => {
     // Always disabled when the whole editor is disabled
     if (disabled) {
       return true;
@@ -598,6 +598,8 @@ const BlocksToolbar = ({ disabled }) => {
     return false;
   };
 
+  const isButtonDisabled = checkButtonDisabled();
+
   return (
     <Toolbar.Root aria-disabled={disabled} asChild>
       {/* Remove after the RTE Blocks Beta release (paddingRight and width) */}
@@ -613,10 +615,10 @@ const BlocksToolbar = ({ disabled }) => {
                 label={modifier.label}
                 isActive={modifier.checkIsActive()}
                 handleClick={modifier.handleToggle}
-                disabled={isToolbarButtonDisabled()}
+                disabled={isButtonDisabled}
               />
             ))}
-            <LinkButton disabled={disabled} />
+            <LinkButton disabled={isButtonDisabled} />
           </Flex>
         </Toolbar.ToggleGroup>
         <Separator />

--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/index.js
@@ -573,6 +573,30 @@ const BetaTag = styled(Box)`
 const BlocksToolbar = ({ disabled }) => {
   const modifiers = useModifiersStore();
   const blocks = useBlocksStore();
+  const editor = useSlate();
+
+  /**
+   * The modifier buttons are disabled when an image is selected.
+   */
+
+  const isToolbarButtonDisabled = () => {
+    // Always disabled when the whole editor is disabled
+    if (disabled) {
+      return true;
+    }
+
+    if (!editor.selection) {
+      return false;
+    }
+
+    const selectedNode = editor.children[editor.selection.anchor.path[0]];
+
+    if (selectedNode.type === 'image') {
+      return true;
+    }
+
+    return false;
+  };
 
   return (
     <Toolbar.Root aria-disabled={disabled} asChild>
@@ -589,7 +613,7 @@ const BlocksToolbar = ({ disabled }) => {
                 label={modifier.label}
                 isActive={modifier.checkIsActive()}
                 handleClick={modifier.handleToggle}
-                disabled={disabled}
+                disabled={isToolbarButtonDisabled()}
               />
             ))}
             <LinkButton disabled={disabled} />

--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/tests/index.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/tests/index.test.js
@@ -48,6 +48,31 @@ const mixedInitialValue = [
   },
 ];
 
+const imageInitialValue = [
+  {
+    type: 'image',
+    url: 'test.photos/200/300',
+    children: [{ text: '', type: 'text' }],
+    image: {
+      name: 'test.jpg',
+      alternativeText: 'test',
+      caption: null,
+      createdAt: '2021-08-31T14:00:00.000Z',
+      ext: '.jpg',
+      formats: {},
+      hash: 'test',
+      height: 300,
+      mime: 'image/jpeg',
+      previewUrl: null,
+      provider: 'local',
+      size: 100,
+      updatedAt: '2021-08-31T14:00:00.000Z',
+      url: '/uploads/test.jpg',
+      width: 200,
+    },
+  },
+];
+
 const user = userEvent.setup();
 
 // Create editor outside of the component to have direct access to it from the tests
@@ -551,30 +576,7 @@ describe('BlocksEditor toolbar', () => {
   });
 
   it('should disable the modifiers buttons when the selection is inside an image', async () => {
-    setup([
-      {
-        type: 'image',
-        url: 'test.photos/200/300',
-        children: [{ text: '', type: 'text' }],
-        image: {
-          name: 'test.jpg',
-          alternativeText: 'test',
-          caption: null,
-          createdAt: '2021-08-31T14:00:00.000Z',
-          ext: '.jpg',
-          formats: {},
-          hash: 'test',
-          height: 300,
-          mime: 'image/jpeg',
-          previewUrl: null,
-          provider: 'local',
-          size: 100,
-          updatedAt: '2021-08-31T14:00:00.000Z',
-          url: '/uploads/test.jpg',
-          width: 200,
-        },
-      },
-    ]);
+    setup(imageInitialValue);
 
     await select({
       anchor: { path: [0, 0], offset: 0 },
@@ -589,5 +591,21 @@ describe('BlocksEditor toolbar', () => {
     const italicButton = screen.getByLabelText(/italic/i);
     expect(boldButton).toBeDisabled();
     expect(italicButton).toBeDisabled();
+  });
+
+  it('should disable the link button when the selection is inside an image', async () => {
+    setup(imageInitialValue);
+
+    await select({
+      anchor: { path: [0, 0], offset: 0 },
+      focus: { path: [0, 0], offset: 0 },
+    });
+
+    // The dropdown should show only one option selected which is the image
+    const blocksDropdown = screen.getByRole('combobox', { name: /Select a block/i });
+    expect(within(blocksDropdown).getByText(/image/i)).toBeInTheDocument();
+
+    const linkButton = screen.getByLabelText(/link/i);
+    expect(linkButton).toBeDisabled();
   });
 });

--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/tests/index.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/tests/index.test.js
@@ -549,4 +549,45 @@ describe('BlocksEditor toolbar', () => {
 
     expect(linkButton).not.toBeDisabled();
   });
+
+  it('should disable the modifiers buttons when the selection is inside an image', async () => {
+    setup([
+      {
+        type: 'image',
+        url: 'test.photos/200/300',
+        children: [{ text: '', type: 'text' }],
+        image: {
+          name: 'test.jpg',
+          alternativeText: 'test',
+          caption: null,
+          createdAt: '2021-08-31T14:00:00.000Z',
+          ext: '.jpg',
+          formats: {},
+          hash: 'test',
+          height: 300,
+          mime: 'image/jpeg',
+          previewUrl: null,
+          provider: 'local',
+          size: 100,
+          updatedAt: '2021-08-31T14:00:00.000Z',
+          url: '/uploads/test.jpg',
+          width: 200,
+        },
+      },
+    ]);
+
+    await select({
+      anchor: { path: [0, 0], offset: 0 },
+      focus: { path: [0, 0], offset: 0 },
+    });
+
+    // The dropdown should show only one option selected which is the image
+    const blocksDropdown = screen.getByRole('combobox', { name: /Select a block/i });
+    expect(within(blocksDropdown).getByText(/image/i)).toBeInTheDocument();
+
+    const boldButton = screen.getByLabelText(/bold/i);
+    const italicButton = screen.getByLabelText(/italic/i);
+    expect(boldButton).toBeDisabled();
+    expect(italicButton).toBeDisabled();
+  });
 });


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Disable the modifier buttons when an image is selected and also the Link button.

### Why is it needed?

Because bold, italic, underline and other styles are not needed for images and also the image can't be a link.

### How to test it?

Create an image in the Block Rich Text Editor and select it, the bold, underline, strikethrough, italic buttons need to be disabled