### PR TITLE
test(pack-up): fix unit tests by using a global-teardown

### DIFF
--- a/packages/utils/pack-up/jest.config.js
+++ b/packages/utils/pack-up/jest.config.js
@@ -1,5 +1,11 @@
-module.exports = {
+/**
+ * @type {import('jest').Config}
+ */
+const config = {
   preset: '../../../jest-preset.unit.js',
   displayName: 'Pack up',
   collectCoverageFrom: ['src/**/*.ts'],
+  globalTeardown: '<rootDir>/tests/teardown.ts',
 };
+
+module.exports = config;

--- a/packages/utils/pack-up/src/__tests__/cli.test.ts
+++ b/packages/utils/pack-up/src/__tests__/cli.test.ts
@@ -1,14 +1,9 @@
 import { spawn } from '../../tests/spawn';
-import { cleanupWorkspaces } from '../../tests/workspaces';
 
 /**
  * This has issues running in the CI due to how yarn3 works.
  */
 describe('cli', () => {
-  afterAll(async () => {
-    await cleanupWorkspaces();
-  });
-
   const timeout = 1000 * 120;
 
   describe('build & check', () => {

--- a/packages/utils/pack-up/src/__tests__/node.test.ts
+++ b/packages/utils/pack-up/src/__tests__/node.test.ts
@@ -1,5 +1,5 @@
 import { stripColor } from '../../tests/console';
-import { cleanupWorkspaces, createWorkspace } from '../../tests/workspaces';
+import { createWorkspace } from '../../tests/workspaces';
 import { init } from '../node/init';
 import { defaultTemplate } from '../node/templates/internal/default';
 import { Template, TemplateOrTemplateResolver, TemplateResolver } from '../node/templates/types';
@@ -12,10 +12,6 @@ const loggerMock = {
 };
 
 describe('node', () => {
-  afterAll(async () => {
-    await cleanupWorkspaces();
-  });
-
   /**
    * @note You can't use the default template because it has prompts and we can't
    * interact with the terminal when using the node-api. Instead we just pass a small

--- a/packages/utils/pack-up/tests/teardown.ts
+++ b/packages/utils/pack-up/tests/teardown.ts
@@ -1,0 +1,5 @@
+import { cleanupWorkspaces } from './workspaces';
+
+export default async () => {
+  await cleanupWorkspaces();
+};


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* uses a global teardown to clean up `tmp` instead of `afterAll`

### Why is it needed?

* it was cleaning up the entire `tmp` folder even if a test was running if `node` and `cli` started at the same time but finished at different times.

### How to test it?

* unit tests should work at the same time

### Related issue(s)/PR(s)

* reported on slack
