### PR TITLE
[Blocks editor] Fix - Hide the label of the Delete Button label in the link modal

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/hooks/useBlocksStore.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/hooks/useBlocksStore.js
@@ -369,9 +369,8 @@ const Link = React.forwardRef(({ element, children, ...attributes }, forwardedRe
                 <IconButton
                   icon={<Trash />}
                   size="L"
-                  variant="danger"
                   onClick={() => removeLink(editor)}
-                  label={formatMessage({
+                  aria-label={formatMessage({
                     id: 'components.Blocks.popover.delete',
                     defaultMessage: 'Delete',
                   })}
@@ -380,7 +379,7 @@ const Link = React.forwardRef(({ element, children, ...attributes }, forwardedRe
                   icon={<Pencil />}
                   size="L"
                   onClick={() => setIsEditing(true)}
-                  label={formatMessage({
+                  aria-label={formatMessage({
                     id: 'components.Blocks.popover.edit',
                     defaultMessage: 'Edit',
                   })}


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Hide the Delete button label inside the Link Modal which is shown in the wrong position when clicking the link inside the Editor

### Why is it needed?

Because otherwise we have a strange label shown at the top left of the window 
As you can see in the image 
<img width="537" alt="Screenshot 2023-10-05 at 15 33 42" src="https://github.com/strapi/strapi/assets/2589748/6d660ad8-6a73-4ec0-a77a-2472841a79c5">


### How to test it?
Create a link in the Blocks Rich Text Editor and click the Link, when the modal appears the Delete button label is not shown