### PR TITLE
fix: Removed updatedAt param for non-local upload provider

### DIFF
--- a/packages/core/upload/admin/src/components/AssetCard/AssetCard.js
+++ b/packages/core/upload/admin/src/components/AssetCard/AssetCard.js
@@ -41,7 +41,7 @@ export const AssetCard = ({ asset, isSelected, onSelect, onEdit, onRemove, size,
         height={asset.height}
         thumbnail={prefixFileUrlWithBackendUrl(asset?.formats?.thumbnail?.url || asset.url)}
         width={asset.width}
-        updatedAt={asset.updatedAt}
+        updatedAt={asset.local ? asset.updatedAt : undefined}
       />
     );
   }


### PR DESCRIPTION
### What does it do?

Fixes #17938

Only includes the updatedAt URL param when the local upload plugin is being used.  I believe this was originally added to support cache-busting when image cropping, however the image cropper doesn't work with signed URL as this itself appends a 'timestamp' property.  This should probably be raised as a separate issue. 

### Why is it needed?

Currently the images are broken when using private upload providers, because an additional URL param is included.

Many services like AWS S3 etc are designed to be used with private, pre-signed URL.  The AWS URL itself is signed to prove that it is valid for a period of time.  Changing the URL in any way invalidates the hash, breaking the link/image.

### How to test it?

* When using the local upload plugin - the updatedAt param continues to be sent.
* When using a non-local upload plugin (like s3) - the updatedAt param is no longer sent.

### Related issue(s)/PR(s)

Fixes #17938
