### PR TITLE
[Blocks editor] Fix - Click on a Modifier when the editor selection is null crashes the app

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/index.js
@@ -97,49 +97,6 @@ ToolbarButton.propTypes = {
   handleClick: PropTypes.func.isRequired,
 };
 
-const ModifierButton = ({ icon, name, label, disabled }) => {
-  const editor = useSlate();
-
-  const isModifierActive = () => {
-    const modifiers = Editor.marks(editor);
-
-    if (!modifiers) return false;
-
-    return Boolean(modifiers[name]);
-  };
-
-  const isActive = isModifierActive();
-
-  const toggleModifier = () => {
-    if (isActive) {
-      Editor.removeMark(editor, name);
-    } else {
-      Editor.addMark(editor, name, true);
-    }
-  };
-
-  return (
-    <ToolbarButton
-      icon={icon}
-      name={name}
-      label={label}
-      isActive={isActive}
-      disabled={disabled}
-      handleClick={toggleModifier}
-    />
-  );
-};
-
-ModifierButton.propTypes = {
-  icon: PropTypes.elementType.isRequired,
-  name: PropTypes.string.isRequired,
-  label: PropTypes.shape({
-    id: PropTypes.string.isRequired,
-    defaultMessage: PropTypes.string.isRequired,
-  }).isRequired,
-  disabled: PropTypes.bool.isRequired,
-};
-
 const toggleBlock = (editor, value) => {
   const { type, level, format } = value;
 

--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/hooks/useModifiersStore.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/hooks/useModifiersStore.js
@@ -72,7 +72,7 @@ export function useModifiersStore() {
    * @param {string} name - The name of the modifier to toggle
    */
   const baseHandleToggle = (name) => {
-    if (modifiers && modifiers[name]) {
+    if (modifiers?.[name]) {
       Editor.removeMark(editor, name);
     } else {
       Editor.addMark(editor, name, true);

--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/hooks/useModifiersStore.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/hooks/useModifiersStore.js
@@ -72,7 +72,7 @@ export function useModifiersStore() {
    * @param {string} name - The name of the modifier to toggle
    */
   const baseHandleToggle = (name) => {
-    if (modifiers[name]) {
+    if (modifiers && modifiers[name]) {
       Editor.removeMark(editor, name);
     } else {
       Editor.addMark(editor, name, true);


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Fix the case when you click on a modifier at the first rendering of the edit view

### Why is it needed?

Because otherwise if you click directly one modifier button the app crashes

### How to test it?

Open a new instance of a collection and then click the Bold button, now the app doesn't crash
