### PR TITLE
fix(strapi/types): add missing customField to Kind type

### DIFF
--- a/packages/core/types/src/types/core/attributes/base.ts
+++ b/packages/core/types/src/types/core/attributes/base.ts
@@ -2,6 +2,7 @@
  * List of all the Strapi attribute types
  */
 export type Kind =
+  | 'customField'
   | 'string'
   | 'text'
   | 'richtext'


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Add missing attribute type: `customField`

### Why is it needed?

To be able to validate with TypeScript when having a custom field

<img width="858" alt="image" src="https://github.com/strapi/strapi/assets/1881266/1c9b9c62-eb49-40eb-8c58-729ae4909c00">

note: it seems that `<attributeName>.customField` is also missing from types (don't have time at the moment to fix it)