### PR TITLE
feat(pack-up): enable config via nodeAPI & allow bundles to have own tsconfig

### DIFF
--- a/packages/cli/create-strapi-app/packup.config.ts
+++ b/packages/cli/create-strapi-app/packup.config.ts
@@ -10,6 +10,5 @@ export default defineConfig({
     },
   ],
   dist: './dist',
-  externals: ['node:fs', 'node:path'],
   runtime: 'node',
 });

--- a/packages/cli/create-strapi-starter/packup.config.ts
+++ b/packages/cli/create-strapi-starter/packup.config.ts
@@ -10,6 +10,5 @@ export default defineConfig({
     },
   ],
   dist: './dist',
-  externals: ['child_process', 'node:fs', 'node:path', 'os', 'path'],
   runtime: 'node',
 });

--- a/packages/core/data-transfer/packup.config.ts
+++ b/packages/core/data-transfer/packup.config.ts
@@ -3,5 +3,4 @@ import { defineConfig } from '@strapi/pack-up';
 
 export default defineConfig({
   runtime: 'node',
-  externals: ['crypto', 'http', 'https', 'os', 'path', 'stream', 'zlib'],
 });

--- a/packages/core/database/packup.config.ts
+++ b/packages/core/database/packup.config.ts
@@ -3,13 +3,6 @@ import { defineConfig } from '@strapi/pack-up';
 
 export default defineConfig({
   externals: [
-    'crypto',
-    'node:async_hooks',
-    'node:path',
-    'path',
-    'stream',
-    'timers',
-    'tty',
     /**
      * Knex dependencies, if we don't mark these as external
      * they will be included in the bundle which means they

--- a/packages/core/utils/packup.config.ts
+++ b/packages/core/utils/packup.config.ts
@@ -2,6 +2,5 @@
 import { defineConfig } from '@strapi/pack-up';
 
 export default defineConfig({
-  externals: ['node:stream'],
   runtime: 'node',
 });

--- a/packages/generators/app/packup.config.ts
+++ b/packages/generators/app/packup.config.ts
@@ -2,7 +2,6 @@
 import { defineConfig } from '@strapi/pack-up';
 
 export default defineConfig({
-  externals: ['crypto', 'fs', 'node:fs', 'node:os', 'node:path', 'node:readline', 'os', 'path'],
   preserveModules: true,
   runtime: 'node',
 });

--- a/packages/generators/generators/packup.config.ts
+++ b/packages/generators/generators/packup.config.ts
@@ -9,6 +9,5 @@ export default defineConfig({
       import: './dist/plopfile.mjs',
     },
   ],
-  externals: ['node:path', 'path'],
   runtime: 'node',
 });

--- a/packages/providers/upload-local/packup.config.ts
+++ b/packages/providers/upload-local/packup.config.ts
@@ -2,6 +2,5 @@
 import { defineConfig } from '@strapi/pack-up';
 
 export default defineConfig({
-  externals: ['stream', 'fs', 'path'],
   runtime: 'node',
 });

--- a/packages/utils/pack-up/packup.config.ts
+++ b/packages/utils/pack-up/packup.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
       require: './dist/cli.js',
     },
   ],
-  externals: ['fs', 'path', 'child_process', 'fs/promises', 'module', 'os'],
+  externals: ['node:module'],
   runtime: 'node',
   minify: false,
   sourcemap: true,

--- a/packages/utils/pack-up/src/cli/commands/build.ts
+++ b/packages/utils/pack-up/src/cli/commands/build.ts
@@ -1,7 +1,7 @@
-import { build as nodeBuild, BuildOptions } from '../../node/build';
+import { build as nodeBuild, BuildCLIOptions } from '../../node/build';
 import { handleError } from '../errors';
 
-export const build = async (options: Omit<BuildOptions, 'cwd'>) => {
+export const build = async (options: BuildCLIOptions) => {
   try {
     await nodeBuild(options);
   } catch (err) {

--- a/packages/utils/pack-up/src/cli/commands/watch.ts
+++ b/packages/utils/pack-up/src/cli/commands/watch.ts
@@ -1,7 +1,7 @@
-import { WatchOptions, watch as nodeWatch } from '../../node/watch';
+import { WatchCLIOptions, watch as nodeWatch } from '../../node/watch';
 import { handleError } from '../errors';
 
-export const watch = async (options: WatchOptions) => {
+export const watch = async (options: WatchCLIOptions) => {
   try {
     await nodeWatch(options);
   } catch (err) {

--- a/packages/utils/pack-up/src/index.ts
+++ b/packages/utils/pack-up/src/index.ts
@@ -4,7 +4,13 @@ export * from './node/check';
 export * from './node/init';
 
 export { defineConfig } from './node/core/config';
-export type { Config } from './node/core/config';
+export type {
+  Config,
+  ConfigBundle,
+  ConfigOptions,
+  ConfigProperty,
+  ConfigPropertyResolver,
+} from './node/core/config';
 
 export { defineTemplate, definePackageFeature, definePackageOption } from './node/templates/create';
 export type {

--- a/packages/utils/pack-up/src/node/core/config.ts
+++ b/packages/utils/pack-up/src/node/core/config.ts
@@ -70,6 +70,7 @@ interface ConfigBundle {
   import?: string;
   require?: string;
   runtime?: Runtime;
+  tsconfig?: string;
   types?: string;
 }
 
@@ -99,6 +100,12 @@ interface ConfigOptions {
   preserveModules?: boolean;
   sourcemap?: boolean;
   runtime?: Runtime;
+  /**
+   * @description path to the tsconfig file to use for the bundle.
+   *
+   * @default tsconfig.build.json
+   */
+  tsconfig?: string;
 }
 
 /**
@@ -128,4 +135,4 @@ export function resolveConfigProperty<T>(prop: ConfigProperty<T> | undefined, in
 }
 
 export { loadConfig, defineConfig, CONFIG_FILE_NAMES };
-export type { Config };
+export type { Config, ConfigOptions, ConfigBundle, ConfigPropertyResolver, ConfigProperty };

--- a/packages/utils/pack-up/src/node/createBuildContext.ts
+++ b/packages/utils/pack-up/src/node/createBuildContext.ts
@@ -65,7 +65,7 @@ const createBuildContext = async ({
 }: BuildContextArgs): Promise<BuildContext> => {
   const tsConfig = loadTsConfig({
     cwd,
-    path: 'tsconfig.build.json',
+    path: resolveConfigProperty(config.tsconfig, 'tsconfig.build.json'),
     logger,
   });
 

--- a/packages/utils/pack-up/src/node/createTasks.ts
+++ b/packages/utils/pack-up/src/node/createTasks.ts
@@ -143,6 +143,7 @@ const createTasks =
           exportPath: bundle.source,
           sourcePath: bundle.source,
           targetPath: bundle.types,
+          tsconfig: bundle.tsconfig,
         });
       }
     }

--- a/packages/utils/pack-up/src/node/tasks/dts/types.ts
+++ b/packages/utils/pack-up/src/node/tasks/dts/types.ts
@@ -3,6 +3,12 @@ interface DtsTaskEntry {
   exportPath: string;
   sourcePath: string;
   targetPath: string;
+  /**
+   * Allow a particular task to have it's own tsconfig
+   * great for when you're creating a server & web bundle
+   * package.
+   */
+  tsconfig?: string;
 }
 
 interface DtsBaseTask {

--- a/packages/utils/pack-up/src/node/tasks/dts/watch.ts
+++ b/packages/utils/pack-up/src/node/tasks/dts/watch.ts
@@ -4,6 +4,7 @@ import { Observable } from 'rxjs';
 import ts from 'typescript';
 
 import { isError } from '../../core/errors';
+import { loadTsConfig } from '../../core/tsconfig';
 
 import { printDiagnostic } from './diagnostic';
 import { DtsBaseTask } from './types';
@@ -36,7 +37,18 @@ const dtsWatchTask: TaskHandler<DtsWatchTask, ts.Diagnostic> = {
     return new Observable((subscriber) => {
       Promise.all(
         task.entries.map(async (entry) => {
-          if (!ctx.ts) {
+          /**
+           * Entry level tsconfig's take precedence
+           */
+          const tsconfig = entry.tsconfig
+            ? loadTsConfig({
+                cwd: ctx.cwd,
+                path: entry.tsconfig,
+                logger: ctx.logger,
+              })
+            : ctx.ts;
+
+          if (!tsconfig) {
             ctx.logger.warn(
               `You've added a types entry but no tsconfig.json was found for ${entry.targetPath}. Skipping...`
             );
@@ -46,7 +58,7 @@ const dtsWatchTask: TaskHandler<DtsWatchTask, ts.Diagnostic> = {
 
           const compilerHost = ts.createWatchCompilerHost(
             'tsconfig.build.json',
-            ctx.ts.config.options,
+            tsconfig.config.options,
             ts.sys,
             ts.createEmitAndSemanticDiagnosticsBuilderProgram,
             (diagnostic) => {

--- a/packages/utils/pack-up/src/node/tasks/vite/config.ts
+++ b/packages/utils/pack-up/src/node/tasks/vite/config.ts
@@ -1,4 +1,5 @@
 import react from '@vitejs/plugin-react';
+import { builtinModules } from 'node:module';
 import path from 'path';
 import { InlineConfig, createLogger } from 'vite';
 
@@ -82,7 +83,15 @@ const resolveViteConfig = (ctx: BuildContext, task: ViteBaseTask) => {
 
           const name = idParts[0].startsWith('@') ? `${idParts[0]}/${idParts[1]}` : idParts[0];
 
-          if (name && external.includes(name)) {
+          const builtinModulesWithNodePrefix = [
+            ...builtinModules,
+            ...builtinModules.map((modName) => `node:${modName}`),
+          ];
+
+          if (
+            (name && external.includes(name)) ||
+            (name && builtinModulesWithNodePrefix.includes(name))
+          ) {
             return true;
           }
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* lets you pass configs via the node APIs only if you flag `configFile: false`
* allows bundles to declare their own tsconfig & the root config can change the default tsconfig
* uses node builtins so we don't have to do it ourselves incl. `node:XXX` << @alexandrebodin 

### Why is it needed?

* allows the `plugin:build` command to not require a pack-up config to run
* you shouldn't really have to set `externals` anymore unless you _really_ need to

### Related issue(s)/PR(s)

* slack requests lol
