### PR TITLE
Fix analytics request waiting issue

### DIFF
--- a/packages/core/admin/admin/src/pages/App/index.js
+++ b/packages/core/admin/admin/src/pages/App/index.js
@@ -126,28 +126,30 @@ function App() {
 
           setTelemetryProperties(properties);
 
-          try {
-            const event = 'didInitializeAdministration';
-            post(
-              'https://analytics.strapi.io/api/v2/track',
-              {
-                // This event is anonymous
-                event,
-                userId: '',
-                deviceId,
-                eventPropeties: {},
-                userProperties: { environment: appInfo.currentEnvironment },
-                groupProperties: { ...properties, projectId: uuid },
+          const event = 'didInitializeAdministration';
+          post(
+            'https://analytics.strapi.io/api/v2/track',
+            {
+              // This event is anonymous
+              event,
+              userId: '',
+              deviceId,
+              eventPropeties: {},
+              userProperties: { environment: appInfo.currentEnvironment },
+              groupProperties: { ...properties, projectId: uuid },
+            },
+            {
+              headers: {
+                'X-Strapi-Event': event,
               },
-              {
-                headers: {
-                  'X-Strapi-Event': event,
-                },
-              }
-            );
-          } catch (e) {
-            // Silent.
-          }
+            }
+          )
+            .then(() => {
+              // Request was successful, do nothing here
+            })
+            .catch((e) => {
+              // Silent.
+            });
         }
 
         setState({ isLoading: false, hasAdmin, uuid, deviceId });

--- a/packages/core/admin/admin/src/pages/App/index.js
+++ b/packages/core/admin/admin/src/pages/App/index.js
@@ -128,7 +128,7 @@ function App() {
 
           try {
             const event = 'didInitializeAdministration';
-            await post(
+            post(
               'https://analytics.strapi.io/api/v2/track',
               {
                 // This event is anonymous

--- a/packages/core/helper-plugin/src/features/Tracking.tsx
+++ b/packages/core/helper-plugin/src/features/Tracking.tsx
@@ -283,7 +283,7 @@ const useTracking = (): UseTrackingReturn => {
     ) => {
       try {
         if (uuid && !window.strapi.telemetryDisabled) {
-          const res = await axios.post<string>(
+          const res = axios.post<string>(
             'https://analytics.strapi.io/api/v2/track',
             {
               event,

--- a/packages/core/helper-plugin/src/features/Tracking.tsx
+++ b/packages/core/helper-plugin/src/features/Tracking.tsx
@@ -283,7 +283,7 @@ const useTracking = (): UseTrackingReturn => {
     ) => {
       try {
         if (uuid && !window.strapi.telemetryDisabled) {
-          const res = axios.post<string>(
+          const res = await axios.post<string>(
             'https://analytics.strapi.io/api/v2/track',
             {
               event,

--- a/packages/core/strapi/src/commands/actions/telemetry/disable/action.ts
+++ b/packages/core/strapi/src/commands/actions/telemetry/disable/action.ts
@@ -32,7 +32,7 @@ const sendEvent = async (uuid: string) => {
   try {
     const event = 'didOptOutTelemetry';
 
-    await fetch('https://analytics.strapi.io/api/v2/track', {
+    fetch('https://analytics.strapi.io/api/v2/track', {
       method: 'POST',
       body: JSON.stringify({
         event,

--- a/packages/core/strapi/src/commands/actions/telemetry/enable/action.ts
+++ b/packages/core/strapi/src/commands/actions/telemetry/enable/action.ts
@@ -69,7 +69,7 @@ const sendEvent = async (uuid: string) => {
   try {
     const event = 'didOptInTelemetry';
 
-    await fetch('https://analytics.strapi.io/api/v2/track', {
+    fetch('https://analytics.strapi.io/api/v2/track', {
       method: 'POST',
       body: JSON.stringify({
         event,

--- a/packages/core/strapi/src/services/metrics/sender.ts
+++ b/packages/core/strapi/src/services/metrics/sender.ts
@@ -89,7 +89,7 @@ export default (strapi: Strapi): Sender => {
     };
 
     try {
-      const res = await strapi.fetch(`${ANALYTICS_URI}/api/v2/track`, reqParams);
+      const res = strapi.fetch(`${ANALYTICS_URI}/api/v2/track`, reqParams);
       return res.ok;
     } catch (err) {
       return false;


### PR DESCRIPTION
### What does it do?
This pull request makes technical changes to remove unnecessary await statements from analytics requests in multiple files. Specifically, it addresses the issue of slow loading in Strapi when the analytics server is under heavy load. The changes ensure that the application no longer waits for a response from the analytics server, which is not required for normal operation. 

### Why is it needed?

The issue being solved is that Strapi's performance is negatively impacted when the analytics server experiences high load. This happens because the application unnecessarily waits for responses from the analytics server, which can be slow during heavy traffic. Removing the await statements in analytics requests alleviates this issue and improves the loading performance.

### Related issue(s)/PR(s)

This pull request fixes #18441 

It addresses the problem described in the issue and provides a solution to mitigate the performance impact caused by waiting for analytics server responses.
