### PR TITLE
fix: blocks static id removed

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/BlocksInput/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/BlocksInput/index.js
@@ -1,5 +1,6 @@
 import * as React from 'react';
 
+import { Box } from '@strapi/design-system';
 import PropTypes from 'prop-types';
 import { Editable, useSlate } from 'slate-react';
 import { useTheme } from 'styled-components';
@@ -41,6 +42,7 @@ const baseRenderElement = (props, blocks) => {
 const BlocksInput = ({ disabled, placeholder }) => {
   const theme = useTheme();
   const editor = useSlate();
+  const blocksRef = React.useRef();
 
   // Create renderLeaf function based on the modifiers store
   const modifiers = useModifiersStore();
@@ -90,13 +92,13 @@ const BlocksInput = ({ disabled, placeholder }) => {
    */
   const handleScrollSelectionIntoView = (_, domRange) => {
     const domRect = domRange.getBoundingClientRect();
-    const slateInput = document.getElementById('slate-input');
-    const editorRect = slateInput.parentElement.getBoundingClientRect(); // editorWrapper with overflow:auto
+    const blocksInput = blocksRef.current;
+    const editorRect = blocksInput.getBoundingClientRect();
 
     // Check if the selection is not fully within the visible area of the editor
     if (domRect.top < editorRect.top || domRect.bottom > editorRect.bottom) {
       // Scroll by one line to the bottom
-      slateInput.parentElement.scrollBy({
+      blocksInput.scrollBy({
         top: 28, // 20px is the line-height + 8px line gap
         behavior: 'smooth',
       });
@@ -104,16 +106,31 @@ const BlocksInput = ({ disabled, placeholder }) => {
   };
 
   return (
-    <Editable
-      id="slate-input"
-      readOnly={disabled}
-      placeholder={placeholder}
-      style={getEditorStyle(theme)}
-      renderElement={renderElement}
-      renderLeaf={renderLeaf}
-      onKeyDown={handleKeyDown}
-      scrollSelectionIntoView={handleScrollSelectionIntoView}
-    />
+    <Box
+      ref={blocksRef}
+      grow={1}
+      width="100%"
+      overflow="auto"
+      fontSize={2}
+      background="neutral0"
+      color="neutral800"
+      lineHeight={6}
+      hasRadius
+      paddingLeft={4}
+      paddingRight={4}
+      marginTop={3}
+      marginBottom={3}
+    >
+      <Editable
+        readOnly={disabled}
+        placeholder={placeholder}
+        style={getEditorStyle(theme)}
+        renderElement={renderElement}
+        renderLeaf={renderLeaf}
+        onKeyDown={handleKeyDown}
+        scrollSelectionIntoView={handleScrollSelectionIntoView}
+      />
+    </Box>
   );
 };
 

--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/index.js
@@ -28,18 +28,6 @@ const EditorDivider = styled(Divider)`
   background: ${({ theme }) => theme.colors.neutral200};
 `;
 
-const Wrapper = styled(Box)`
-  width: 100%;
-  overflow: auto;
-  padding: ${({ theme }) => `0 ${theme.spaces[4]}`};
-  margin: ${({ theme }) => `${theme.spaces[3]} 0`};
-  font-size: ${({ theme }) => theme.fontSizes[2]};
-  background-color: ${({ theme }) => theme.colors.neutral0};
-  color: ${({ theme }) => theme.colors.neutral800};
-  line-height: ${({ theme }) => theme.lineHeights[6]};
-  border-radius: ${({ theme }) => theme.borderRadius};
-`;
-
 /**
  * Images are void elements. They handle the rendering of their children instead of Slate.
  * See the Slate documentation for more information:
@@ -165,9 +153,7 @@ const BlocksEditor = React.forwardRef(
             <InputWrapper direction="column" alignItems="flex-start" height="512px">
               <BlocksToolbar disabled={disabled} />
               <EditorDivider width="100%" />
-              <Wrapper grow={1}>
-                <BlocksInput disabled={disabled} placeholder={formattedPlaceholder} />
-              </Wrapper>
+              <BlocksInput disabled={disabled} placeholder={formattedPlaceholder} />
             </InputWrapper>
           </Slate>
           <Hint hint={hint} name={name} error={error} />


### PR DESCRIPTION
### What does it do?

Blocks Static id removed, used ref instead on the wrapper

### How to test it?

When scrollbar activated inside blocks, pressing enter should not shift main layout.