### PR TITLE
fix: blocks toolbar gap

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/index.js
@@ -625,7 +625,7 @@ const BlocksToolbar = ({ disabled }) => {
   return (
     <Toolbar.Root aria-disabled={disabled} asChild>
       {/* Remove after the RTE Blocks Beta release (paddingRight and width) */}
-      <ToolbarWrapper gap={1} padding={2} paddingRight={4} width="100%">
+      <ToolbarWrapper gap={2} padding={2} paddingRight={4} width="100%">
         <BlocksDropdown disabled={disabled} />
         <Toolbar.ToggleGroup type="multiple" asChild>
           <Flex gap={1} marginLeft={1}>


### PR DESCRIPTION
### What does it do?

Updated blocks toolbar gap as per [design](https://www.figma.com/file/MWPKHNT98LLWHGRp3MyWqu/Rich-Text-(Blocks)?type=design&node-id=0-1&mode=design&t=9CpZHERQUrackDxE-0) 