### PR TITLE
[Blocks editor] Fix - When a code block is selected we want to disable the modifier buttons and the link button

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/index.js
@@ -613,7 +613,7 @@ const BlocksToolbar = ({ disabled }) => {
 
     const selectedNode = editor.children[editor.selection.anchor.path[0]];
 
-    if (selectedNode.type === 'image' || selectedNode.type === 'code') {
+    if (['image', 'code'].includes(selectedNode.type)) {
       return true;
     }
 

--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/index.js
@@ -613,7 +613,7 @@ const BlocksToolbar = ({ disabled }) => {
 
     const selectedNode = editor.children[editor.selection.anchor.path[0]];
 
-    if (selectedNode.type === 'image') {
+    if (selectedNode.type === 'image' || selectedNode.type === 'code') {
       return true;
     }
 

--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/tests/index.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/tests/index.test.js
@@ -759,23 +759,59 @@ describe('BlocksEditor toolbar', () => {
     const blocksDropdown = screen.getByRole('combobox', { name: /Select a block/i });
     expect(within(blocksDropdown).getByText(/image/i)).toBeInTheDocument();
 
-    const boldButton = screen.getByLabelText(/bold/i);
-    const italicButton = screen.getByLabelText(/italic/i);
-    expect(boldButton).toBeDisabled();
-    expect(italicButton).toBeDisabled();
+    const linkButton = screen.getByLabelText(/link/i);
+    expect(linkButton).toBeDisabled();
   });
 
-  it('should disable the link button when the selection is inside an image', async () => {
-    setup(imageInitialValue);
+  it('should disable the modifiers buttons when the selection is inside a code block', async () => {
+    setup([
+      {
+        type: 'code',
+        children: [
+          {
+            type: 'text',
+            text: 'A line of text in a paragraph.',
+          },
+        ],
+      },
+    ]);
 
     await select({
       anchor: { path: [0, 0], offset: 0 },
       focus: { path: [0, 0], offset: 0 },
     });
 
-    // The dropdown should show only one option selected which is the image
+    // The dropdown should show only one option selected which is the code block
     const blocksDropdown = screen.getByRole('combobox', { name: /Select a block/i });
-    expect(within(blocksDropdown).getByText(/image/i)).toBeInTheDocument();
+    expect(within(blocksDropdown).getByText(/code/i)).toBeInTheDocument();
+
+    const boldButton = screen.getByLabelText(/bold/i);
+    const italicButton = screen.getByLabelText(/italic/i);
+    expect(boldButton).toBeDisabled();
+    expect(italicButton).toBeDisabled();
+  });
+
+  it('should disable the link button when the selection is inside a code block', async () => {
+    setup([
+      {
+        type: 'code',
+        children: [
+          {
+            type: 'text',
+            text: 'A line of text in a paragraph.',
+          },
+        ],
+      },
+    ]);
+
+    await select({
+      anchor: { path: [0, 0], offset: 0 },
+      focus: { path: [0, 0], offset: 0 },
+    });
+
+    // The dropdown should show only one option selected which is the code block
+    const blocksDropdown = screen.getByRole('combobox', { name: /Select a block/i });
+    expect(within(blocksDropdown).getByText(/code/i)).toBeInTheDocument();
 
     const linkButton = screen.getByLabelText(/link/i);
     expect(linkButton).toBeDisabled();

--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/tests/index.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/tests/index.test.js
@@ -763,14 +763,14 @@ describe('BlocksEditor toolbar', () => {
     expect(linkButton).toBeDisabled();
   });
 
-  it('should disable the modifiers buttons when the selection is inside a code block', async () => {
+  it('should disable the modifiers buttons and the link button when the selection is inside a code block', async () => {
     setup([
       {
         type: 'code',
         children: [
           {
             type: 'text',
-            text: 'A line of text in a paragraph.',
+            text: 'A line of code.',
           },
         ],
       },
@@ -780,38 +780,11 @@ describe('BlocksEditor toolbar', () => {
       anchor: { path: [0, 0], offset: 0 },
       focus: { path: [0, 0], offset: 0 },
     });
-
-    // The dropdown should show only one option selected which is the code block
-    const blocksDropdown = screen.getByRole('combobox', { name: /Select a block/i });
-    expect(within(blocksDropdown).getByText(/code/i)).toBeInTheDocument();
 
     const boldButton = screen.getByLabelText(/bold/i);
     const italicButton = screen.getByLabelText(/italic/i);
     expect(boldButton).toBeDisabled();
     expect(italicButton).toBeDisabled();
-  });
-
-  it('should disable the link button when the selection is inside a code block', async () => {
-    setup([
-      {
-        type: 'code',
-        children: [
-          {
-            type: 'text',
-            text: 'A line of text in a paragraph.',
-          },
-        ],
-      },
-    ]);
-
-    await select({
-      anchor: { path: [0, 0], offset: 0 },
-      focus: { path: [0, 0], offset: 0 },
-    });
-
-    // The dropdown should show only one option selected which is the code block
-    const blocksDropdown = screen.getByRole('combobox', { name: /Select a block/i });
-    expect(within(blocksDropdown).getByText(/code/i)).toBeInTheDocument();
 
     const linkButton = screen.getByLabelText(/link/i);
     expect(linkButton).toBeDisabled();


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Disable the modifier buttons and the link button when a code block is selected.

### Why is it needed?

Because bold, italic, underline and other styles are not needed for code blocks and also the code block can't be a link.

### How to test it?

Create a code block in the Block Rich Text Editor and select it, the bold, underline, strikethrough, italic and link buttons need to be disabled