### PR TITLE
added missing locales to i18n plugin ( Wolof and Xhosa languages)

### DIFF
--- a/packages/plugins/i18n/server/constants/iso-locales.json
+++ b/packages/plugins/i18n/server/constants/iso-locales.json
@@ -2368,6 +2368,14 @@
     "name":"Welsh (United Kingdom) (cy-GB)"
   },
   {
+    "code":"wo",
+    "name":"Wolof"
+  },
+  {
+    "code":"xh",
+    "name":"Xhosa"
+  },
+  {
     "code":"yav",
     "name":"Yangben (yav)"
   },

--- a/packages/plugins/i18n/server/services/__tests__/__snapshots__/iso-locales.test.js.snap
+++ b/packages/plugins/i18n/server/services/__tests__/__snapshots__/iso-locales.test.js.snap
@@ -2371,6 +2371,14 @@ exports[`ISO locales getIsoLocales 1`] = `
     "name": "Welsh (United Kingdom) (cy-GB)",
   },
   {
+    "code": "wo",
+    "name": "Wolof",
+  },
+  {
+    "code": "xh",
+    "name": "Xhosa",
+  },
+  {
     "code": "yav",
     "name": "Yangben (yav)",
   },


### PR DESCRIPTION


### What does it do?

Added additional locales for Wolof and Xhosa languages to the i18n plugin

### Why is it needed?

Our client requires i18n features in these languages.


