### PR TITLE
Fix plugin load order

### DIFF
--- a/packages/core/strapi/src/core/loaders/plugins/get-enabled-plugins.ts
+++ b/packages/core/strapi/src/core/loaders/plugins/get-enabled-plugins.ts
@@ -149,8 +149,8 @@ export const getEnabledPlugins = async (strapi: Strapi, { client } = { client: f
   );
 
   const enabledPlugins = pipe(
-    defaultsDeep(declaredPlugins),
     defaultsDeep(installedPluginsNotAlreadyUsed),
+    defaultsDeep(declaredPlugins),
     pickBy((p: PluginMeta) => p.enabled)
   )(internalPlugins);
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Change plugins load order.

### Why is it needed?

Because when I was developing the plugin, Found the `bootstrap` lifecycle call order is not system plugin first.

e.g., my plugin name is `my-plugin`, system plugins is `users-permissions`, `i18n`. The `bootstrap` call order should be:
1. users-permissions
2. i18n
3. my-plugin

But current call order is:
1. my-plugin
2. users-permissions
3. i18n


### How to test it?

Create an plugin, Extend `Content-Type` or `Field` in `bootstrap` method, Open `Content-Type Builder` and create or edit model,  You can see the customized plugin extended attribute show before the `i18n` attribute.

### Related issue(s)/PR(s)

Nop.
