### PR TITLE
chore(plugin-upload) - update sharp to 0.32.6

### DIFF
--- a/packages/core/upload/package.json
+++ b/packages/core/upload/package.json
@@ -49,7 +49,7 @@
     "react-query": "3.39.3",
     "react-redux": "8.1.1",
     "react-select": "5.7.0",
-    "sharp": "0.32.0",
+    "sharp": "0.32.6",
     "yup": "0.32.9"
   },
   "devDependencies": {


### PR DESCRIPTION

Bumping Sharp dependency of plugin-upload from 0.32.0 to 0.32.6

There is critical vulnerability reported - https://security.snyk.io/vuln/SNYK-JS-SHARP-5922108
