### PR TITLE
feat(pack-up): add the ability to pass plugins via the config

### DIFF
--- a/docs/docs/docs/05-utils/pack-up/02-config.mdx
+++ b/docs/docs/docs/05-utils/pack-up/02-config.mdx
@@ -50,7 +50,7 @@ interface Config {
   /**
    * An array of Vite plugins to use when bundling.
    */
-  plugins?: PluginOption[];
+  plugins?: PluginOption[] | (({ runtime }: { runtime: Runtime }) => PluginOption[]);
   /**
    * @alpha
    *

--- a/docs/docs/docs/05-utils/pack-up/02-config.mdx
+++ b/docs/docs/docs/05-utils/pack-up/02-config.mdx
@@ -48,7 +48,13 @@ interface Config {
    */
   minify?: boolean;
   /**
-   * Instead of creating as few chunks as possible, this mode
+   * An array of Vite plugins to use when bundling.
+   */
+  plugins?: PluginOption[];
+  /**
+   * @alpha
+   *
+   * @description Instead of creating as few chunks as possible, this mode
    * will create separate chunks for all modules using the original module
    * names as file names
    */
@@ -63,7 +69,7 @@ interface Config {
    */
   runtime?: Runtime;
   /**
-   * path to the tsconfig file to use for the bundle.
+   * Path to the tsconfig file to use for the bundle.
    */
   tsconfig?: string;
 }

--- a/packages/utils/pack-up/README.md
+++ b/packages/utils/pack-up/README.md
@@ -128,6 +128,18 @@ An array of modules that should not be bundled but instead be resolved at runtim
 
 Whether to minify the output or not.
 
+#### `plugins`
+
+- Type: `PluginOption[]`
+
+An array of Vite plugins to use when bundling.
+
+#### `preserveModules`
+
+- Type: `boolean`
+
+Instead of creating as few chunks as possible, this mode will create separate chunks for all modules using the original module names as file names.
+
 #### `sourcemap`
 
 - Type: `boolean`
@@ -139,3 +151,9 @@ Whether to generate sourcemaps for the output or not.
 - Type: `Runtime`
 
 The transpilation target of the bundle. This is useful if you're bundling many different CLIs or Node.js workers and you want them to be transpiled for the node environment.
+
+#### `tsconfig`
+
+- Type: `string`
+
+Path to the tsconfig file to use for the bundle, defaults to `tsconfig.build.json`.

--- a/packages/utils/pack-up/README.md
+++ b/packages/utils/pack-up/README.md
@@ -130,9 +130,9 @@ Whether to minify the output or not.
 
 #### `plugins`
 
-- Type: `PluginOption[]`
+- Type: `PluginOption[] | (({ runtime }: { runtime: Runtime }) => PluginOption[]);`
 
-An array of Vite plugins to use when bundling.
+An array of Vite plugins to use when bundling, or optionally a function that returns an array of plugins based on the runtime.
 
 #### `preserveModules`
 

--- a/packages/utils/pack-up/src/node/core/config.ts
+++ b/packages/utils/pack-up/src/node/core/config.ts
@@ -8,6 +8,7 @@ import { Logger } from './logger';
 
 import type { Export } from './exports';
 import type { Runtime } from '../createBuildContext';
+import type { PluginOption } from 'vite';
 
 interface LoadConfigOptions {
   cwd: string;
@@ -90,6 +91,7 @@ interface ConfigOptions {
    */
   externals?: string[];
   minify?: boolean;
+  plugins?: PluginOption[];
   /**
    * @alpha
    *

--- a/packages/utils/pack-up/src/node/core/config.ts
+++ b/packages/utils/pack-up/src/node/core/config.ts
@@ -91,7 +91,7 @@ interface ConfigOptions {
    */
   externals?: string[];
   minify?: boolean;
-  plugins?: PluginOption[];
+  plugins?: PluginOption[] | (({ runtime }: { runtime: Runtime }) => PluginOption[]);
   /**
    * @alpha
    *

--- a/packages/utils/pack-up/src/node/createBuildContext.ts
+++ b/packages/utils/pack-up/src/node/createBuildContext.ts
@@ -9,7 +9,6 @@ import type { Config } from './core/config';
 import type { Logger } from './core/logger';
 import type { PackageJson } from './core/pkg';
 import type { ParsedCommandLine } from 'typescript';
-import type { PluginOption } from 'vite';
 
 interface BuildContextArgs {
   config: Config;
@@ -36,7 +35,6 @@ interface BuildContext {
   extMap: ExtMap;
   logger: Logger;
   pkg: PackageJson;
-  plugins: PluginOption[];
   runtime?: Runtime;
   targets: Targets;
   ts?: {
@@ -136,7 +134,6 @@ const createBuildContext = async ({
     external,
     extMap,
     logger,
-    plugins: resolveConfigProperty(config.plugins, []),
     pkg,
     runtime: config?.runtime,
     targets,

--- a/packages/utils/pack-up/src/node/createBuildContext.ts
+++ b/packages/utils/pack-up/src/node/createBuildContext.ts
@@ -9,6 +9,7 @@ import type { Config } from './core/config';
 import type { Logger } from './core/logger';
 import type { PackageJson } from './core/pkg';
 import type { ParsedCommandLine } from 'typescript';
+import type { PluginOption } from 'vite';
 
 interface BuildContextArgs {
   config: Config;
@@ -35,6 +36,7 @@ interface BuildContext {
   extMap: ExtMap;
   logger: Logger;
   pkg: PackageJson;
+  plugins: PluginOption[];
   runtime?: Runtime;
   targets: Targets;
   ts?: {
@@ -134,6 +136,7 @@ const createBuildContext = async ({
     external,
     extMap,
     logger,
+    plugins: resolveConfigProperty(config.plugins, []),
     pkg,
     runtime: config?.runtime,
     targets,

--- a/packages/utils/pack-up/src/node/tasks/vite/config.ts
+++ b/packages/utils/pack-up/src/node/tasks/vite/config.ts
@@ -26,6 +26,8 @@ const resolveViteConfig = (ctx: BuildContext, task: ViteBaseTask) => {
   const exportIds = Object.keys(exportMap).map((exportPath) => path.join(pkg.name, exportPath));
   const sourcePaths = Object.values(exportMap).map((exp) => path.resolve(cwd, exp.source));
 
+  const basePlugins = runtime === 'node' ? [] : [react()];
+
   const config = {
     configFile: false,
     root: cwd,
@@ -120,14 +122,7 @@ const resolveViteConfig = (ctx: BuildContext, task: ViteBaseTask) => {
         },
       },
     },
-    /**
-     * We _could_ omit this, but we'd need to introduce the
-     * concept of a custom config for the scripts straight away
-     *
-     * and since this is isolated to the Strapi CLI, we can make
-     * some assumptions and add some weight until we move it outside.
-     */
-    plugins: runtime === 'node' ? [] : [react()],
+    plugins: [...basePlugins, ...ctx.plugins],
   } satisfies InlineConfig;
 
   return config;

--- a/packages/utils/pack-up/src/node/tasks/vite/config.ts
+++ b/packages/utils/pack-up/src/node/tasks/vite/config.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-nested-ternary */
 import react from '@vitejs/plugin-react';
 import { builtinModules } from 'node:module';
 import path from 'path';
@@ -27,6 +28,12 @@ const resolveViteConfig = (ctx: BuildContext, task: ViteBaseTask) => {
   const sourcePaths = Object.values(exportMap).map((exp) => path.resolve(cwd, exp.source));
 
   const basePlugins = runtime === 'node' ? [] : [react()];
+
+  const plugins = ctx.config.plugins
+    ? typeof ctx.config.plugins === 'function'
+      ? ctx.config.plugins({ runtime })
+      : ctx.config.plugins
+    : [];
 
   const config = {
     configFile: false,
@@ -122,7 +129,7 @@ const resolveViteConfig = (ctx: BuildContext, task: ViteBaseTask) => {
         },
       },
     },
-    plugins: [...basePlugins, ...ctx.plugins],
+    plugins: [...basePlugins, ...plugins],
   } satisfies InlineConfig;
 
   return config;


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* adds `plugins` to pack-up config

### Why is it needed?

* for the admin package we're moving from JS -> TSX but esbuild doesn't recognise JSX in JS, a plugin solves this, but this is the problem of the admin package, not pack-up & therefore having the option to pass a plugin would solve this 👍🏼 
