### PR TITLE
fix(workflow): re-add build step for linting because it's required

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,6 +47,8 @@ jobs:
       - uses: nrwl/nx-set-shas@v3
       - name: Monorepo install
         uses: ./.github/actions/yarn-nm-install
+      - name: Monorepo build
+        uses: ./.github/actions/run-build
       - name: Run lint
         run: yarn nx affected --target=lint --parallel --nx-ignore-cycles
 
@@ -129,7 +131,7 @@ jobs:
         uses: ./.github/actions/run-build
       - name: Run test
         run: yarn nx affected --target=test:front --nx-ignore-cycles
-         
+
   e2e:
     timeout-minutes: 60
     needs: [changes, build, typescript, unit_front]


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* re-adds build step for linting because otherwise packages aren't built for those that it depends on

### Why is it needed?

* it wasn't caught on the CI because the CI only runs against "affected packages"

### Related issue(s)/PR(s)

* caused by #18383 
