### PR TITLE
chore(tooling): lint needs build

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,6 +36,7 @@ jobs:
 
   lint:
     name: 'lint (node: 20)'
+    needs: [build]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION

### What does it do?

add needs: [build] to lint

### Why is it needed?

to not build 2 times

### How to test it?

run CI

### Related issue(s)/PR(s)
#18489
