### PR TITLE
Make named and default exports live together with ts migration

### DIFF
--- a/packages/core/strapi/src/index.ts
+++ b/packages/core/strapi/src/index.ts
@@ -9,5 +9,5 @@ export * as factories from './factories';
 
 export default strapiFactory;
 
-// TODO: drop in v5
+// TODO: drop in v5 – see https://github.com/rollup/rollup/issues/1961 for more info on this decision
 module.exports = exports = strapiFactory;

--- a/packages/core/strapi/src/index.ts
+++ b/packages/core/strapi/src/index.ts
@@ -1,5 +1,13 @@
+/* eslint-disable no-multi-assign */
+/* eslint-disable node/exports-style */
+/* eslint-disable import/no-import-module-exports */
 import strapiFactory from './Strapi';
 
 export type * from '@strapi/types';
 
+export * as factories from './factories';
+
 export default strapiFactory;
+
+// TODO: drop in v5
+module.exports = exports = strapiFactory;


### PR DESCRIPTION


### What does it do?

enforce module.exports = exports = strapiFactory so pack-up build will mix named and default exports in a backward compatible manner.

### Why is it needed?

This is the only way to force the named and default exports to live together while using pack-up for now.  @joshuaellis if you have better I'll take it but search trough rollup issue I couldn't find an option for this.

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
