### PR TITLE
fix(blocks): prevent creating images inside a list

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/index.js
@@ -6,7 +6,7 @@ import { pxToRem, prefixFileUrlWithBackendUrl, useLibrary } from '@strapi/helper
 import { Link } from '@strapi/icons';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
-import { Editor, Transforms, Element as SlateElement, Path } from 'slate';
+import { Editor, Transforms, Element as SlateElement } from 'slate';
 import { ReactEditor, useSlate } from 'slate-react';
 import styled from 'styled-components';
 

--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/index.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/index.js
@@ -193,7 +193,7 @@ const ImageDialog = ({ handleClose }) => {
       split: true,
     });
 
-    // Save the path of the node that is being replaced by an image to later insert the images there
+    // Save the path of the node that is being replaced by an image to insert the images there later
     // It's the closest full block node above the selection
     const [, pathToInsert] = Editor.above(editor, {
       match(node) {

--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/tests/index.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/tests/index.test.js
@@ -12,6 +12,36 @@ import { BlocksToolbar } from '..';
 
 const mockMediaLibraryTitle = 'dialog component';
 const mockMediaLibrarySubmitButton = 'upload images';
+const mockMediaLibraryImage = {
+  name: 'Screenshot 2023-10-18 at 15.03.11.png',
+  alternativeText: 'Screenshot 2023-10-18 at 15.03.11.png',
+  caption: null,
+  width: 437,
+  height: 420,
+  formats: {
+    thumbnail: {
+      name: 'thumbnail_Screenshot 2023-10-18 at 15.03.11.png',
+      hash: 'thumbnail_Screenshot_2023_10_18_at_15_03_11_c6d21f899b',
+      ext: '.png',
+      mime: 'image/png',
+      path: null,
+      width: 162,
+      height: 156,
+      size: 45.75,
+      url: '/uploads/thumbnail_Screenshot_2023_10_18_at_15_03_11_c6d21f899b.png',
+    },
+  },
+  hash: 'Screenshot_2023_10_18_at_15_03_11_c6d21f899b',
+  ext: '.png',
+  mime: 'image/png',
+  size: 47.67,
+  url: 'http://localhost:1337/uploads/Screenshot_2023_10_18_at_15_03_11_c6d21f899b.png',
+  previewUrl: null,
+  provider: 'local',
+  provider_metadata: null,
+  createdAt: '2023-10-18T15:54:33.504Z',
+  updatedAt: '2023-10-18T15:54:33.504Z',
+};
 
 jest.mock('@strapi/helper-plugin', () => ({
   ...jest.requireActual('@strapi/helper-plugin'),
@@ -20,43 +50,7 @@ jest.mock('@strapi/helper-plugin', () => ({
       'media-library': ({ onSelectAssets }) => (
         <div>
           <p>{mockMediaLibraryTitle}</p>
-          <button
-            type="button"
-            onClick={() =>
-              onSelectAssets([
-                {
-                  name: 'Screenshot 2023-10-18 at 15.03.11.png',
-                  alternativeText: 'Screenshot 2023-10-18 at 15.03.11.png',
-                  caption: null,
-                  width: 437,
-                  height: 420,
-                  formats: {
-                    thumbnail: {
-                      name: 'thumbnail_Screenshot 2023-10-18 at 15.03.11.png',
-                      hash: 'thumbnail_Screenshot_2023_10_18_at_15_03_11_c6d21f899b',
-                      ext: '.png',
-                      mime: 'image/png',
-                      path: null,
-                      width: 162,
-                      height: 156,
-                      size: 45.75,
-                      url: '/uploads/thumbnail_Screenshot_2023_10_18_at_15_03_11_c6d21f899b.png',
-                    },
-                  },
-                  hash: 'Screenshot_2023_10_18_at_15_03_11_c6d21f899b',
-                  ext: '.png',
-                  mime: 'image/png',
-                  size: 47.67,
-                  url: 'http://localhost:1337/uploads/Screenshot_2023_10_18_at_15_03_11_c6d21f899b.png',
-                  previewUrl: null,
-                  provider: 'local',
-                  provider_metadata: null,
-                  createdAt: '2023-10-18T15:54:33.504Z',
-                  updatedAt: '2023-10-18T15:54:33.504Z',
-                },
-              ])
-            }
-          >
+          <button type="button" onClick={() => onSelectAssets([mockMediaLibraryImage])}>
             {mockMediaLibrarySubmitButton}
           </button>
         </div>
@@ -868,36 +862,7 @@ describe('BlocksEditor toolbar', () => {
       },
       {
         type: 'image',
-        image: {
-          name: 'Screenshot 2023-10-18 at 15.03.11.png',
-          alternativeText: 'Screenshot 2023-10-18 at 15.03.11.png',
-          caption: null,
-          width: 437,
-          height: 420,
-          formats: {
-            thumbnail: {
-              name: 'thumbnail_Screenshot 2023-10-18 at 15.03.11.png',
-              hash: 'thumbnail_Screenshot_2023_10_18_at_15_03_11_c6d21f899b',
-              ext: '.png',
-              mime: 'image/png',
-              path: null,
-              width: 162,
-              height: 156,
-              size: 45.75,
-              url: '/uploads/thumbnail_Screenshot_2023_10_18_at_15_03_11_c6d21f899b.png',
-            },
-          },
-          hash: 'Screenshot_2023_10_18_at_15_03_11_c6d21f899b',
-          ext: '.png',
-          mime: 'image/png',
-          size: 47.67,
-          url: 'http://localhost:1337/uploads/Screenshot_2023_10_18_at_15_03_11_c6d21f899b.png',
-          previewUrl: null,
-          provider: 'local',
-          provider_metadata: null,
-          createdAt: '2023-10-18T15:54:33.504Z',
-          updatedAt: '2023-10-18T15:54:33.504Z',
-        },
+        image: mockMediaLibraryImage,
         children: [
           {
             type: 'text',

--- a/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/tests/index.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksEditor/Toolbar/tests/index.test.js
@@ -10,13 +10,57 @@ import { Slate, withReact, ReactEditor } from 'slate-react';
 
 import { BlocksToolbar } from '..';
 
-const title = 'dialog component';
+const mockMediaLibraryTitle = 'dialog component';
+const mockMediaLibrarySubmitButton = 'upload images';
 
 jest.mock('@strapi/helper-plugin', () => ({
   ...jest.requireActual('@strapi/helper-plugin'),
   useLibrary: jest.fn().mockImplementation(() => ({
     components: {
-      'media-library': () => <div>{title}</div>,
+      'media-library': ({ onSelectAssets }) => (
+        <div>
+          <p>{mockMediaLibraryTitle}</p>
+          <button
+            type="button"
+            onClick={() =>
+              onSelectAssets([
+                {
+                  name: 'Screenshot 2023-10-18 at 15.03.11.png',
+                  alternativeText: 'Screenshot 2023-10-18 at 15.03.11.png',
+                  caption: null,
+                  width: 437,
+                  height: 420,
+                  formats: {
+                    thumbnail: {
+                      name: 'thumbnail_Screenshot 2023-10-18 at 15.03.11.png',
+                      hash: 'thumbnail_Screenshot_2023_10_18_at_15_03_11_c6d21f899b',
+                      ext: '.png',
+                      mime: 'image/png',
+                      path: null,
+                      width: 162,
+                      height: 156,
+                      size: 45.75,
+                      url: '/uploads/thumbnail_Screenshot_2023_10_18_at_15_03_11_c6d21f899b.png',
+                    },
+                  },
+                  hash: 'Screenshot_2023_10_18_at_15_03_11_c6d21f899b',
+                  ext: '.png',
+                  mime: 'image/png',
+                  size: 47.67,
+                  url: 'http://localhost:1337/uploads/Screenshot_2023_10_18_at_15_03_11_c6d21f899b.png',
+                  previewUrl: null,
+                  provider: 'local',
+                  provider_metadata: null,
+                  createdAt: '2023-10-18T15:54:33.504Z',
+                  updatedAt: '2023-10-18T15:54:33.504Z',
+                },
+              ])
+            }
+          >
+            {mockMediaLibrarySubmitButton}
+          </button>
+        </div>
+      ),
     },
   })),
 }));
@@ -408,7 +452,7 @@ describe('BlocksEditor toolbar', () => {
     await user.click(blocksDropdown);
     await user.click(screen.getByRole('option', { name: 'Image' }));
 
-    expect(screen.getByText(title)).toBeInTheDocument();
+    expect(screen.getByText(mockMediaLibraryTitle)).toBeInTheDocument();
   });
 
   it('creates an empty paragraph below when a code block is created at the end of the editor', async () => {
@@ -788,5 +832,84 @@ describe('BlocksEditor toolbar', () => {
 
     const linkButton = screen.getByLabelText(/link/i);
     expect(linkButton).toBeDisabled();
+  });
+
+  it('splits a list in two when converting a list item to an image', async () => {
+    setup([
+      {
+        type: 'list',
+        format: 'ordered',
+        children: [
+          { type: 'list-item', children: [{ type: 'text', text: 'First list item' }] },
+          { type: 'list-item', children: [{ type: 'text', text: 'Second list item' }] },
+          { type: 'list-item', children: [{ type: 'text', text: 'Third list item' }] },
+        ],
+      },
+    ]);
+
+    // Select the item in the middle of the list
+    await select({
+      anchor: { path: [0, 1, 0], offset: 0 },
+      focus: { path: [0, 1, 0], offset: 0 },
+    });
+
+    // Convert it to an image
+    const blocksDropdown = screen.getByRole('combobox', { name: /Select a block/i });
+    await user.click(blocksDropdown);
+    await user.click(screen.getByRole('option', { name: 'Image' }));
+    await user.click(screen.getByText(mockMediaLibrarySubmitButton));
+
+    // The list should have been split in two
+    expect(baseEditor.children).toEqual([
+      {
+        type: 'list',
+        format: 'ordered',
+        children: [{ type: 'list-item', children: [{ type: 'text', text: 'First list item' }] }],
+      },
+      {
+        type: 'image',
+        image: {
+          name: 'Screenshot 2023-10-18 at 15.03.11.png',
+          alternativeText: 'Screenshot 2023-10-18 at 15.03.11.png',
+          caption: null,
+          width: 437,
+          height: 420,
+          formats: {
+            thumbnail: {
+              name: 'thumbnail_Screenshot 2023-10-18 at 15.03.11.png',
+              hash: 'thumbnail_Screenshot_2023_10_18_at_15_03_11_c6d21f899b',
+              ext: '.png',
+              mime: 'image/png',
+              path: null,
+              width: 162,
+              height: 156,
+              size: 45.75,
+              url: '/uploads/thumbnail_Screenshot_2023_10_18_at_15_03_11_c6d21f899b.png',
+            },
+          },
+          hash: 'Screenshot_2023_10_18_at_15_03_11_c6d21f899b',
+          ext: '.png',
+          mime: 'image/png',
+          size: 47.67,
+          url: 'http://localhost:1337/uploads/Screenshot_2023_10_18_at_15_03_11_c6d21f899b.png',
+          previewUrl: null,
+          provider: 'local',
+          provider_metadata: null,
+          createdAt: '2023-10-18T15:54:33.504Z',
+          updatedAt: '2023-10-18T15:54:33.504Z',
+        },
+        children: [
+          {
+            type: 'text',
+            text: '',
+          },
+        ],
+      },
+      {
+        type: 'list',
+        format: 'ordered',
+        children: [{ type: 'list-item', children: [{ type: 'text', text: 'Third list item' }] }],
+      },
+    ]);
   });
 });


### PR DESCRIPTION
### What does it do?

Fixes the conversion of a list item to an image. The list is now split in 2, and the image is created outside of the list.

### Why is it needed?

Images were created inside lists when converting list items. Therefore users could not save their content as the validations failed.

### How to test it?

- convert a list item to an image
- do it from the end or the middle of a list
- do it inside a list item with links and modifiers
- add several images at once
- click on cancel in the media library
