### PR TITLE
Fixed Issue #18443 where timestamp got auto appended hence breaking the signed URL

### DIFF
--- a/packages/core/upload/admin/src/utils/appendSearchParamsToUrl.js
+++ b/packages/core/upload/admin/src/utils/appendSearchParamsToUrl.js
@@ -13,7 +13,8 @@ const appendSearchParamsToUrl = ({ url, params }) => {
   const urlObj = new URL(url, window.strapi.backendURL);
 
   Object.entries(params).forEach(([key, value]) => {
-    if (value !== undefined) {
+    
+    if (value !== undefined && key !== "updatedAt") {
       urlObj.searchParams.append(key, value);
     }
   });


### PR DESCRIPTION
**Fixed Issue #18443**

<!--
Hello 👋 Thank you for submitting a pull request.

**Fixed Issue #18443**

### What does it do?

I excluded the "updatedAt" key from the searchParams specifically so it doesn't get appended in image URL but serve it function elsewhere

### Why is it needed?

Original Image's Signed URL was invalid because timestamp was getting auto appended
