### PR TITLE
[v5] Remove support for MySQL v5

### DIFF
--- a/.github/workflows/skipped_tests.yml
+++ b/.github/workflows/skipped_tests.yml
@@ -86,16 +86,6 @@ jobs:
     steps:
       - run: echo "Skipped"
 
-  api_ce_mysql_5:
-    runs-on: ubuntu-latest
-    needs: [lint, unit_back, unit_front]
-    name: '[CE] API Integration (mysql:5 , node: ${{ matrix.node }})'
-    strategy:
-      matrix:
-        node: [18, 20]
-    steps:
-      - run: echo "Skipped"
-
   api_ce_sqlite:
     runs-on: ubuntu-latest
     needs: [lint, unit_back, unit_front]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -253,46 +253,6 @@ jobs:
           dbOptions: '--dbclient=${{ matrix.db_client }} --dbhost=localhost --dbport=3306 --dbname=strapi_test --dbusername=strapi --dbpassword=strapi'
           jestOptions: '--shard=${{ matrix.shard }}'
 
-  api_ce_mysql_5:
-    if: needs.changes.outputs.backend == 'true'
-    runs-on: ubuntu-latest
-    needs: [changes, build, typescript, unit_back, unit_front]
-    name: '[CE] API Integration (mysql:5, client: ${{ matrix.db_client }} , node: ${{ matrix.node }}, shard: ${{ matrix.shard }})'
-    strategy:
-      matrix:
-        node: [18, 20]
-        db_client: ['mysql', 'mysql2']
-        shard: [1/5, 2/5, 3/5, 4/5, 5/5]
-    services:
-      mysql:
-        image: bitnami/mysql:5.7
-        env:
-          MYSQL_ROOT_PASSWORD: strapi
-          MYSQL_USER: strapi
-          MYSQL_PASSWORD: strapi
-          MYSQL_DATABASE: strapi_test
-        options: >-
-          --health-cmd="mysqladmin ping"
-          --health-interval=10s
-          --health-timeout=5s
-          --health-retries=3
-        ports:
-          # Maps tcp port 5432 on service container to the host
-          - 3306:3306
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
-        with:
-          node-version: ${{ matrix.node }}
-      - name: Monorepo install
-        uses: ./.github/actions/yarn-nm-install
-      - name: Monorepo build
-        uses: ./.github/actions/run-build
-      - uses: ./.github/actions/run-api-tests
-        with:
-          dbOptions: '--dbclient=${{ matrix.db_client }} --dbhost=localhost --dbport=3306 --dbname=strapi_test --dbusername=strapi --dbpassword=strapi'
-          jestOptions: '--shard=${{ matrix.shard }}'
-
   api_ce_sqlite:
     if: needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Strapi only supports maintenance and LTS versions of Node.js. Please refer to th
 
 | Strapi Version  | Recommended | Minimum |
 | --------------- | ----------- | ------- |
+| 5.0.0 and up    | 20.x        | 18.x    |
 | 4.14.5 and up   | 20.x        | 18.x    |
 | 4.11.0 and up   | 18.x        | 16.x    |
 | 4.3.9 to 4.10.x | 18.x        | 14.x    |
@@ -103,7 +104,7 @@ Strapi only supports maintenance and LTS versions of Node.js. Please refer to th
 
 | Database   | Recommended | Minimum |
 | ---------- | ----------- | ------- |
-| MySQL      | 8.0         | 5.7.8   |
+| MySQL      | 8.0         | 8.0     |
 | MariaDB    | 10.6        | 10.3    |
 | PostgreSQL | 14.0        | 11.0    |
 | SQLite     | 3           | 3       |

--- a/packages/core/database/src/dialects/dialect.ts
+++ b/packages/core/database/src/dialects/dialect.ts
@@ -41,10 +41,6 @@ export default class Dialect {
     return false;
   }
 
-  supportsWindowFunctions() {
-    return true;
-  }
-
   supportsOperator(operator?: string): boolean;
   supportsOperator(): boolean {
     return true;

--- a/packages/core/database/src/dialects/mysql/index.ts
+++ b/packages/core/database/src/dialects/mysql/index.ts
@@ -82,14 +82,6 @@ export default class MysqlDialect extends Dialect {
   }
 
   supportsWindowFunctions() {
-    const isMysqlDB = !this.info?.database || this.info.database === MYSQL;
-    const isBeforeV8 =
-      !semver.valid(this.info?.version) || semver.lt(this.info?.version ?? '', '8.0.0');
-
-    if (isMysqlDB && isBeforeV8) {
-      return false;
-    }
-
     return true;
   }
 

--- a/packages/core/database/src/dialects/mysql/index.ts
+++ b/packages/core/database/src/dialects/mysql/index.ts
@@ -1,10 +1,8 @@
-import semver from 'semver';
 import type { Knex } from 'knex';
 
 import Dialect from '../dialect';
 import MysqlSchemaInspector from './schema-inspector';
 import MysqlDatabaseInspector from './database-inspector';
-import { MYSQL } from './constants';
 import type { Database } from '../..';
 
 import type { Information } from './database-inspector';
@@ -78,10 +76,6 @@ export default class MysqlDialect extends Dialect {
   }
 
   supportsUnsigned() {
-    return true;
-  }
-
-  supportsWindowFunctions() {
     return true;
   }
 

--- a/packages/core/database/src/entity-manager/regular-relations.ts
+++ b/packages/core/database/src/entity-manager/regular-relations.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-namespace */
-import { randomBytes } from 'crypto';
 import { map, isEmpty } from 'lodash/fp';
 import type { Knex } from 'knex';
 

--- a/packages/core/database/src/entity-manager/regular-relations.ts
+++ b/packages/core/database/src/entity-manager/regular-relations.ts
@@ -220,7 +220,7 @@ const cleanOrderColumns = async ({
     return;
   }
 
-  // Handle databases that don't support window function ROW_NUMBER (here it's MySQL 5)
+  // Handle databases that don't support window function ROW_NUMBER
   if (!strapi.db.dialect.supportsWindowFunctions()) {
     await cleanOrderColumnsForOldDatabases({ id, attribute, db, inverseRelIds, transaction: trx });
     return;
@@ -351,7 +351,7 @@ const cleanOrderColumns = async ({
 
 /*
  * Ensure that orders are following a 1, 2, 3 sequence, without gap.
- * The use of a session variable instead of a window function makes the query compatible with MySQL 5
+ * The use of a session variable instead of a window function makes the query compatible with databases without ROW_NUMBER
  */
 const cleanOrderColumnsForOldDatabases = async ({
   id,

--- a/packages/core/strapi/README.md
+++ b/packages/core/strapi/README.md
@@ -94,6 +94,7 @@ Strapi only supports maintenance and LTS versions of Node.js. Please refer to th
 
 | Strapi Version  | Recommended | Minimum |
 | --------------- | ----------- | ------- |
+| 5.0.0 and up    | 20.x        | 18.x    |
 | 4.14.5 and up   | 20.x        | 18.x    |
 | 4.11.0 and up   | 18.x        | 16.x    |
 | 4.3.9 to 4.10.x | 18.x        | 14.x    |
@@ -103,7 +104,7 @@ Strapi only supports maintenance and LTS versions of Node.js. Please refer to th
 
 | Database   | Recommended | Minimum |
 | ---------- | ----------- | ------- |
-| MySQL      | 8.0         | 5.7.8   |
+| MySQL      | 8.0         | 8.0     |
 | MariaDB    | 10.6        | 10.3    |
 | PostgreSQL | 14.0        | 11.0    |
 | SQLite     | 3           | 3       |

--- a/packages/core/strapi/src/Strapi.ts
+++ b/packages/core/strapi/src/Strapi.ts
@@ -60,7 +60,6 @@ import ee from './utils/ee';
 import bootstrap from './core/bootstrap';
 import { destroyOnSignal } from './utils/signals';
 import getNumberOfDynamicZones from './services/utils/dynamic-zones';
-
 import convertCustomFieldType from './utils/convert-custom-field-type';
 
 /**


### PR DESCRIPTION
### What does it do?

Removes support for mysql v5 in CI and documentation.

### Why is it needed?

Mysql v5 is EOL Oct 2023 and starting in Strapi v5 we will only support Mysql v8+

### How to test it?

The only code I changed was removing `supportsWindowFunctions` from the mysql dialect because it was just a check for mysql5. So test that mysql dialect didn't somehow break, but otherwise if tests pass I think it's good.

### Related issue(s)/PR(s)

Docs PR: https://github.com/strapi/documentation/pull/1887

