### PR TITLE
feature(admin): sync theme with system theme

### DIFF
--- a/packages/core/admin/admin/src/components/Theme.tsx
+++ b/packages/core/admin/admin/src/components/Theme.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 
 import { DesignSystemProvider } from '@strapi/design-system';
 import { useIntl } from 'react-intl';
-import { ThemeName } from 'src/contexts/themeToggle';
 import { createGlobalStyle } from 'styled-components';
 
 import { useThemeToggle } from '../hooks/useThemeToggle';
@@ -11,27 +10,9 @@ interface ThemeProps {
   children: React.ReactNode;
 }
 
-type NonSystemThemeName = Exclude<ThemeName, 'system'>;
-
 const Theme = ({ children }: ThemeProps) => {
-  const { currentTheme, themes } = useThemeToggle();
+  const { currentTheme, themes, systemTheme } = useThemeToggle();
   const { locale } = useIntl();
-  const [systemTheme, setSystemTheme] = React.useState<NonSystemThemeName>();
-
-  // Listen to changes in the system theme
-  React.useEffect(() => {
-    const themeWatcher = window.matchMedia('(prefers-color-scheme: dark)');
-    setSystemTheme(themeWatcher.matches ? 'dark' : 'light');
-
-    themeWatcher.addEventListener('change', (event) => {
-      setSystemTheme(event.matches ? 'dark' : 'light');
-    });
-
-    // Cleanup on unmount
-    return () => {
-      themeWatcher.removeEventListener('change', () => {});
-    };
-  }, []);
 
   const computedThemeName = currentTheme === 'system' ? systemTheme : currentTheme;
 

--- a/packages/core/admin/admin/src/components/ThemeToggleProvider.tsx
+++ b/packages/core/admin/admin/src/components/ThemeToggleProvider.tsx
@@ -7,14 +7,9 @@ import { ThemeToggleContext, ThemeName } from '../contexts/themeToggle';
 const THEME_KEY = 'STRAPI_THEME';
 
 const getDefaultTheme = () => {
-  const browserTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
   const persistedTheme = localStorage.getItem(THEME_KEY) as ThemeName | null;
 
-  if (!persistedTheme) {
-    localStorage.setItem(THEME_KEY, browserTheme);
-  }
-
-  return persistedTheme || browserTheme;
+  return persistedTheme || 'system';
 };
 
 interface ThemeToggleProviderProps {
@@ -26,7 +21,7 @@ interface ThemeToggleProviderProps {
 }
 
 const ThemeToggleProvider = ({ children, themes }: ThemeToggleProviderProps) => {
-  const [currentTheme, setCurrentTheme] = React.useState(getDefaultTheme());
+  const [currentTheme, setCurrentTheme] = React.useState<ThemeName>(getDefaultTheme());
 
   const handleChangeTheme = React.useCallback(
     (nextTheme: ThemeName) => {

--- a/packages/core/admin/admin/src/contexts/themeToggle.ts
+++ b/packages/core/admin/admin/src/contexts/themeToggle.ts
@@ -3,6 +3,7 @@ import { createContext } from 'react';
 import { DefaultTheme } from 'styled-components';
 
 export type ThemeName = 'light' | 'dark' | 'system';
+export type NonSystemThemeName = Exclude<ThemeName, 'system'>;
 
 interface ThemeToggleContextContextValue {
   currentTheme?: ThemeName;
@@ -11,6 +12,7 @@ interface ThemeToggleContextContextValue {
     dark: DefaultTheme;
     light: DefaultTheme;
   };
+  systemTheme?: NonSystemThemeName;
 }
 
 export const ThemeToggleContext = createContext<ThemeToggleContextContextValue>({});

--- a/packages/core/admin/admin/src/contexts/themeToggle.ts
+++ b/packages/core/admin/admin/src/contexts/themeToggle.ts
@@ -2,7 +2,7 @@ import { createContext } from 'react';
 
 import { DefaultTheme } from 'styled-components';
 
-export type ThemeName = 'light' | 'dark';
+export type ThemeName = 'light' | 'dark' | 'system';
 
 interface ThemeToggleContextContextValue {
   currentTheme?: ThemeName;

--- a/packages/core/admin/admin/src/pages/ProfilePage/components/Preferences/index.js
+++ b/packages/core/admin/admin/src/pages/ProfilePage/components/Preferences/index.js
@@ -1,6 +1,14 @@
 import React from 'react';
 
-import { Box, Flex, Grid, GridItem, Option, Select, Typography } from '@strapi/design-system';
+import {
+  Box,
+  Flex,
+  Grid,
+  GridItem,
+  SingleSelect,
+  SingleSelectOption,
+  Typography,
+} from '@strapi/design-system';
 import upperFirst from 'lodash/upperFirst';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
@@ -58,7 +66,7 @@ const Preferences = ({ onChange, values, localeNames, allApplicationThemes }) =>
         </Flex>
         <Grid gap={5}>
           <GridItem s={12} col={6}>
-            <Select
+            <SingleSelect
               label={formatMessage({
                 id: 'Settings.profile.form.section.experience.interfaceLanguage',
                 defaultMessage: 'Interface language',
@@ -88,14 +96,14 @@ const Preferences = ({ onChange, values, localeNames, allApplicationThemes }) =>
               }}
             >
               {Object.entries(localeNames).map(([language, langName]) => (
-                <Option value={language} key={language}>
+                <SingleSelectOption value={language} key={language}>
                   {langName}
-                </Option>
+                </SingleSelectOption>
               ))}
-            </Select>
+            </SingleSelect>
           </GridItem>
           <GridItem s={12} col={6}>
-            <Select
+            <SingleSelect
               label={formatMessage({
                 id: 'Settings.profile.form.section.experience.mode.label',
                 defaultMessage: 'Interface mode',
@@ -116,7 +124,7 @@ const Preferences = ({ onChange, values, localeNames, allApplicationThemes }) =>
               }}
             >
               {themesToDisplay.map((theme) => (
-                <Option value={theme} key={theme}>
+                <SingleSelectOption value={theme} key={theme}>
                   {formatMessage(
                     {
                       id: 'Settings.profile.form.section.experience.mode.option-label',
@@ -129,15 +137,15 @@ const Preferences = ({ onChange, values, localeNames, allApplicationThemes }) =>
                       }),
                     }
                   )}
-                </Option>
+                </SingleSelectOption>
               ))}
-              <Option value="system">
+              <SingleSelectOption value="system">
                 {formatMessage({
                   id: 'Settings.profile.form.section.experience.mode.option-system-label',
                   defaultMessage: 'Use system settings',
                 })}
-              </Option>
-            </Select>
+              </SingleSelectOption>
+            </SingleSelect>
           </GridItem>
         </Grid>
       </Flex>

--- a/packages/core/admin/admin/src/pages/ProfilePage/components/Preferences/index.js
+++ b/packages/core/admin/admin/src/pages/ProfilePage/components/Preferences/index.js
@@ -122,6 +122,12 @@ const Preferences = ({ onChange, values, localeNames, allApplicationThemes }) =>
                 });
               }}
             >
+              <SingleSelectOption value="system">
+                {formatMessage({
+                  id: 'Settings.profile.form.section.experience.mode.option-system-label',
+                  defaultMessage: 'Use system settings',
+                })}
+              </SingleSelectOption>
               {themesToDisplay.map((theme) => (
                 <SingleSelectOption value={theme} key={theme}>
                   {formatMessage(
@@ -138,12 +144,6 @@ const Preferences = ({ onChange, values, localeNames, allApplicationThemes }) =>
                   )}
                 </SingleSelectOption>
               ))}
-              <SingleSelectOption value="system">
-                {formatMessage({
-                  id: 'Settings.profile.form.section.experience.mode.option-system-label',
-                  defaultMessage: 'Use system settings',
-                })}
-              </SingleSelectOption>
             </SingleSelect>
           </GridItem>
         </Grid>

--- a/packages/core/admin/admin/src/pages/ProfilePage/components/Preferences/index.js
+++ b/packages/core/admin/admin/src/pages/ProfilePage/components/Preferences/index.js
@@ -18,7 +18,6 @@ const Preferences = ({ onChange, values, localeNames, allApplicationThemes }) =>
   const themesToDisplay = Object.keys(allApplicationThemes).filter(
     (themeName) => allApplicationThemes[themeName]
   );
-  console.log({ allApplicationThemes, themesToDisplay });
 
   return (
     <Box

--- a/packages/core/admin/admin/src/pages/ProfilePage/components/Preferences/index.js
+++ b/packages/core/admin/admin/src/pages/ProfilePage/components/Preferences/index.js
@@ -10,6 +10,7 @@ const Preferences = ({ onChange, values, localeNames, allApplicationThemes }) =>
   const themesToDisplay = Object.keys(allApplicationThemes).filter(
     (themeName) => allApplicationThemes[themeName]
   );
+  console.log({ allApplicationThemes, themesToDisplay });
 
   return (
     <Box
@@ -130,6 +131,12 @@ const Preferences = ({ onChange, values, localeNames, allApplicationThemes }) =>
                   )}
                 </Option>
               ))}
+              <Option value="system">
+                {formatMessage({
+                  id: 'Settings.profile.form.section.experience.mode.option-system-label',
+                  defaultMessage: 'Use system settings',
+                })}
+              </Option>
             </Select>
           </GridItem>
         </Grid>

--- a/packages/core/admin/admin/src/translations/en.json
+++ b/packages/core/admin/admin/src/translations/en.json
@@ -218,6 +218,7 @@
   "Settings.profile.form.section.experience.mode.hint": "Displays your interface in the chosen mode.",
   "Settings.profile.form.section.experience.mode.label": "Interface mode",
   "Settings.profile.form.section.experience.mode.option-label": "{name} mode",
+  "Settings.profile.form.section.experience.mode.option-system-label": "Use system settings",
   "Settings.profile.form.section.experience.title": "Experience",
   "Settings.profile.form.section.helmet.title": "User profile",
   "Settings.profile.form.section.profile.page.title": "Profile page",


### PR DESCRIPTION
### What does it do?

Adds a third option to the theme picker, in addition to light and dark: "sync with system settings" (wording picked by @lucasboilly).

That option is picked by default, so the experience won't change for new Strapi users, except that if they later change their OS theme, they won't be stuck with the old one in Strapi.

It won't affect existing users, as they already have either light or dark in the localStorage. They have to go and save system settings on their profile page to get this functionality.

Demo time:

https://github.com/strapi/strapi/assets/8087692/6ebfedd8-b84a-46c7-b9fb-cef71e2699b2


### Why is it needed?

Syncing with system theme has become a standard feature for web apps (Notion, GitHub, Google... even Jira). It enables you to toggle the theme for all your apps and websites at the same time. This enables cool workflows like switching everything to dark theme at sunset, and back to light in the morning. Or just super fast theme switching with system preferences or Raycast like in the video above.

I also found switching themes in Strapi a bit hard. It's done in the profile page, which is hard to find, it also requires a lot of clicks and you have to leave the page you were working on to do it.

### How to test it?

- Set system theme as your theme in the profile page. Switch your OS theme. The admin UI should reflect the change without the need for a refresh
- Set light or dark as your theme. Switching your OS theme should have no impact on the admin UI
- Delete the STRAPI_THEME localStorage entry (or create a new app). It should sync with the system UI by default.

