### PR TITLE
fix(ctb): advanced settings DatePickers crash with empty string

### DIFF
--- a/packages/core/content-type-builder/admin/src/components/TabForm/index.js
+++ b/packages/core/content-type-builder/admin/src/components/TabForm/index.js
@@ -35,7 +35,10 @@ const TabForm = ({ form, formErrors, genericInputProps, modifiedData, onChange }
           {section.items.map((input, i) => {
             const key = `${sectionIndex}.${i}`;
 
-            const value = get(modifiedData, input.name, '');
+            /**
+             * Use undefined as the default value because not every input wants a string e.g. Date pickers
+             */
+            const value = get(modifiedData, input.name, undefined);
 
             // When extending the yup schema of an existing field (like in https://github.com/strapi/strapi/blob/293ff3b8f9559236609d123a2774e3be05ce8274/packages/strapi-plugin-i18n/admin/src/index.js#L52)
             // and triggering a yup validation error in the UI (missing a required field for example)


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* replaces the default get with explicitly undefined not an empty string

### Why is it needed?

* not every input wants a string
* AdvancedSettings in the CTB for DatePicker crashes because it receives an empty string

### How to test it?

* Go to the CTB
* Edit a DateTimePicker field
* Click on advanced settings
* App should not crash

### Related issue(s)/PR(s)

* resolves #18123
* resolves CONTENT-2000
