### PR TITLE
upload-aws-s3: Add file url building function

### DIFF
--- a/packages/providers/upload-aws-s3/README.md
+++ b/packages/providers/upload-aws-s3/README.md
@@ -30,7 +30,7 @@ npm install @strapi/provider-upload-aws-s3 --save
   - `signedUrlExpires` is the number of seconds before a signed URL expires. (See [how signed URLs work](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-signed-urls.html)). Defaults to 15 minutes and URLs are only signed when ACL is set to `private`.
   - `Bucket` is the name of the bucket to upload to.
 - `actionOptions` is passed directly to the parameters to each method respectively. You can find the complete list of [upload/ uploadStream options](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#upload-property) and [delete options](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#deleteObject-property)
-- `buildFileUrl` optionally pass this function to define custom logic for building file url. This is provided as a way to handle the many different s3 provider options.
+- `mapFileDataToUrl` optionally pass this function to define custom logic for building file url. This is provided as a way to handle the many different s3 provider options.
 
 See the [documentation about using a provider](https://docs.strapi.io/developer-docs/latest/plugins/upload.html#using-a-provider) for information on installing and using a provider. To understand how environment variables are used in Strapi, please refer to the [documentation about environment variables](https://docs.strapi.io/developer-docs/latest/setup-deployment-guides/configurations/optional/environment.html#environment-variables).
 
@@ -59,7 +59,7 @@ module.exports = ({ env }) => ({
             Bucket: env('AWS_BUCKET'),
           },
         },
-        buildFileUrl: () => 'BUILD_CUSTOM_FILE_URL',
+        mapFileDataToUrl: () => 'BUILD_CUSTOM_FILE_URL',
       },
       actionOptions: {
         upload: {},

--- a/packages/providers/upload-aws-s3/README.md
+++ b/packages/providers/upload-aws-s3/README.md
@@ -30,6 +30,7 @@ npm install @strapi/provider-upload-aws-s3 --save
   - `signedUrlExpires` is the number of seconds before a signed URL expires. (See [how signed URLs work](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-signed-urls.html)). Defaults to 15 minutes and URLs are only signed when ACL is set to `private`.
   - `Bucket` is the name of the bucket to upload to.
 - `actionOptions` is passed directly to the parameters to each method respectively. You can find the complete list of [upload/ uploadStream options](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#upload-property) and [delete options](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#deleteObject-property)
+- `buildFileUrl` optionally pass this function to define custom logic for building file url. This is provided as a way to handle the many different s3 provider options.
 
 See the [documentation about using a provider](https://docs.strapi.io/developer-docs/latest/plugins/upload.html#using-a-provider) for information on installing and using a provider. To understand how environment variables are used in Strapi, please refer to the [documentation about environment variables](https://docs.strapi.io/developer-docs/latest/setup-deployment-guides/configurations/optional/environment.html#environment-variables).
 
@@ -58,6 +59,7 @@ module.exports = ({ env }) => ({
             Bucket: env('AWS_BUCKET'),
           },
         },
+        buildFileUrl: () => 'BUILD_CUSTOM_FILE_URL',
       },
       actionOptions: {
         upload: {},

--- a/packages/providers/upload-aws-s3/src/__tests__/upload-aws-s3.test.ts
+++ b/packages/providers/upload-aws-s3/src/__tests__/upload-aws-s3.test.ts
@@ -151,7 +151,7 @@ describe('AWS-S3 provider', () => {
           params: {
             Bucket: 'test',
           },
-          buildFileUrl: (data) => `https://buildFileUrl.test/${data.Location}`,
+          mapFileDataToUrl: (data) => `https://mapFileDataToUrl.test/${data.Location}`,
         },
       });
 
@@ -174,7 +174,7 @@ describe('AWS-S3 provider', () => {
 
       expect(S3InstanceMock.upload).toBeCalled();
       expect(file.url).toBeDefined();
-      expect(file.url).toEqual(`https://buildFileUrl.test/validurl.test`);
+      expect(file.url).toEqual(`https://mapFileDataToUrl.test/validurl.test`);
     });
   });
 

--- a/packages/providers/upload-aws-s3/src/__tests__/upload-aws-s3.test.ts
+++ b/packages/providers/upload-aws-s3/src/__tests__/upload-aws-s3.test.ts
@@ -142,6 +142,40 @@ describe('AWS-S3 provider', () => {
       expect(file.url).toBeDefined();
       expect(file.url).toEqual('https://cdn.test/dir/dir2/tmp/test/test.json');
     });
+
+    test('Should use the function for custom url building if provided', async () => {
+      const providerInstance = awsProvider.init({
+        baseUrl: 'https://cdn.test',
+        rootPath: 'dir/dir2',
+        s3Options: {
+          params: {
+            Bucket: 'test',
+          },
+          buildFileUrl: (data) => `https://buildFileUrl.test/${data.Location}`,
+        },
+      });
+
+      S3InstanceMock.upload.mockImplementationOnce((params, callback) =>
+        callback(null, { Location: 'validurl.test' })
+      );
+
+      const file: File = {
+        name: 'test',
+        size: 100,
+        url: '',
+        path: 'tmp/test',
+        hash: 'test',
+        ext: '.json',
+        mime: 'application/json',
+        buffer: Buffer.from(''),
+      };
+
+      await providerInstance.upload(file);
+
+      expect(S3InstanceMock.upload).toBeCalled();
+      expect(file.url).toBeDefined();
+      expect(file.url).toEqual(`https://buildFileUrl.test/validurl.test`);
+    });
   });
 
   describe('isPrivate', () => {

--- a/packages/providers/upload-aws-s3/src/index.ts
+++ b/packages/providers/upload-aws-s3/src/index.ts
@@ -41,6 +41,7 @@ interface InitOptions extends Partial<AWS.S3.ClientConfiguration> {
       ACL?: string;
       signedUrlExpires?: string;
     };
+    buildFileUrl?: (data: AWS.S3.ManagedUpload.SendData) => string;
   };
 }
 
@@ -93,7 +94,10 @@ export default {
           }
 
           // set the bucket file url
-          if (baseUrl) {
+          if (config.buildFileUrl) {
+            // Use the custom config function to build the file url
+            file.url = config.buildFileUrl(data);
+          } else if (baseUrl) {
             // Construct the url with the baseUrl
             file.url = `${baseUrl}/${fileKey}`;
           } else {

--- a/packages/providers/upload-aws-s3/src/index.ts
+++ b/packages/providers/upload-aws-s3/src/index.ts
@@ -41,7 +41,7 @@ interface InitOptions extends Partial<AWS.S3.ClientConfiguration> {
       ACL?: string;
       signedUrlExpires?: string;
     };
-    buildFileUrl?: (data: AWS.S3.ManagedUpload.SendData) => string;
+    mapFileDataToUrl?: (data: AWS.S3.ManagedUpload.SendData) => string;
   };
 }
 
@@ -94,9 +94,9 @@ export default {
           }
 
           // set the bucket file url
-          if (config.buildFileUrl) {
+          if (config.mapFileDataToUrl) {
             // Use the custom config function to build the file url
-            file.url = config.buildFileUrl(data);
+            file.url = config.mapFileDataToUrl(data);
           } else if (baseUrl) {
             // Construct the url with the baseUrl
             file.url = `${baseUrl}/${fileKey}`;


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Adds optional config to the aws s3 provider so users can build file urls with custom logic

### Why is it needed?

To solve needs such as https://github.com/strapi/strapi/pull/17495 without adding more edge cases to the if else statement

### How to test it?

Added a unit test
Set up and use the aws s3 provider

