### PR TITLE
fix(ctb): update attribute picker spacings

### DIFF
--- a/packages/core/content-type-builder/admin/src/components/AttributeOptions/AttributeList/index.js
+++ b/packages/core/content-type-builder/admin/src/components/AttributeOptions/AttributeList/index.js
@@ -1,10 +1,9 @@
 import React from 'react';
 
-import { Box, Flex, Grid, GridItem, KeyboardNavigable } from '@strapi/design-system';
+import { Flex, Grid, GridItem, KeyboardNavigable } from '@strapi/design-system';
 import PropTypes from 'prop-types';
 
 import AttributeOption from '../AttributeOption';
-import getPadding from '../utils/getPadding';
 
 const AttributeList = ({ attributes }) => (
   <KeyboardNavigable tagName="button">
@@ -12,23 +11,12 @@ const AttributeList = ({ attributes }) => (
       {attributes.map((attributeRow, index) => {
         return (
           // eslint-disable-next-line react/no-array-index-key
-          <Grid key={index} gap={0}>
-            {attributeRow.map((attribute, index) => {
-              const { paddingLeft, paddingRight } = getPadding(index);
-
-              return (
-                <GridItem key={attribute} col={6}>
-                  <Box
-                    paddingLeft={paddingLeft}
-                    paddingRight={paddingRight}
-                    paddingBottom={1}
-                    style={{ height: '100%' }}
-                  >
-                    <AttributeOption type={attribute} />
-                  </Box>
-                </GridItem>
-              );
-            })}
+          <Grid key={index} gap={3}>
+            {attributeRow.map((attribute) => (
+              <GridItem key={attribute} col={6}>
+                <AttributeOption type={attribute} />
+              </GridItem>
+            ))}
           </Grid>
         );
       })}

--- a/packages/core/content-type-builder/admin/src/components/AttributeOptions/CustomFieldsList/index.js
+++ b/packages/core/content-type-builder/admin/src/components/AttributeOptions/CustomFieldsList/index.js
@@ -1,13 +1,12 @@
 import React from 'react';
 
-import { Box, Flex, Grid, GridItem, KeyboardNavigable, Link } from '@strapi/design-system';
+import { Flex, Grid, GridItem, KeyboardNavigable, Link } from '@strapi/design-system';
 import { useCustomFields } from '@strapi/helper-plugin';
 import { useIntl } from 'react-intl';
 
 import { getTrad } from '../../../utils';
 import CustomFieldOption from '../CustomFieldOption';
 import EmptyAttributes from '../EmptyAttributes';
-import getPadding from '../utils/getPadding';
 
 const CustomFieldsList = () => {
   const { formatMessage } = useIntl();
@@ -26,23 +25,12 @@ const CustomFieldsList = () => {
   return (
     <KeyboardNavigable tagName="button">
       <Flex direction="column" alignItems="stretch" gap={3}>
-        <Grid gap={0}>
-          {sortedCustomFields.map(([uid, customField], index) => {
-            const { paddingLeft, paddingRight } = getPadding(index);
-
-            return (
-              <GridItem key={uid} col={6} style={{ height: '100%' }}>
-                <Box
-                  paddingLeft={paddingLeft}
-                  paddingRight={paddingRight}
-                  paddingBottom={1}
-                  style={{ height: '100%' }}
-                >
-                  <CustomFieldOption key={uid} customFieldUid={uid} customField={customField} />
-                </Box>
-              </GridItem>
-            );
-          })}
+        <Grid gap={3}>
+          {sortedCustomFields.map(([uid, customField]) => (
+            <GridItem key={uid} col={6}>
+              <CustomFieldOption key={uid} customFieldUid={uid} customField={customField} />
+            </GridItem>
+          ))}
         </Grid>
         <Link
           href="https://docs.strapi.io/developer-docs/latest/development/custom-fields.html"

--- a/packages/core/content-type-builder/admin/src/components/AttributeOptions/index.js
+++ b/packages/core/content-type-builder/admin/src/components/AttributeOptions/index.js
@@ -36,7 +36,7 @@ const AttributeOptions = ({ attributes, forTarget, kind }) => {
   const titleId = getTrad(`modalForm.sub-header.chooseAttribute.${titleIdSuffix}`);
 
   return (
-    <ModalBody padding={6}>
+    <ModalBody padding={7}>
       <TabGroup
         label={formatMessage({
           id: getTrad('modalForm.tabs.label'),

--- a/packages/core/content-type-builder/admin/src/components/AttributeOptions/tests/__snapshots__/index.test.js.snap
+++ b/packages/core/content-type-builder/admin/src/components/AttributeOptions/tests/__snapshots__/index.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<AttributeOptions /> renders and matches the snapshot 1`] = `
-.c26 {
+.c24 {
   border: 0;
   -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
@@ -36,21 +36,21 @@ exports[`<AttributeOptions /> renders and matches the snapshot 1`] = `
   color: #666687;
 }
 
-.c23 {
+.c22 {
   font-size: 0.875rem;
   line-height: 1.43;
   font-weight: 600;
   color: #32324d;
 }
 
-.c24 {
+.c23 {
   font-size: 0.75rem;
   line-height: 1.33;
   color: #666687;
 }
 
 .c0 {
-  padding: 24px;
+  padding: 32px;
 }
 
 .c5 {
@@ -66,16 +66,11 @@ exports[`<AttributeOptions /> renders and matches the snapshot 1`] = `
 }
 
 .c16 {
-  padding-right: 8px;
-  padding-bottom: 4px;
-}
-
-.c17 {
   padding: 16px;
   border-radius: 4px;
 }
 
-.c20 {
+.c19 {
   width: 2rem;
   height: 1.5rem;
   -webkit-flex-shrink: 0;
@@ -83,14 +78,9 @@ exports[`<AttributeOptions /> renders and matches the snapshot 1`] = `
   flex-shrink: 0;
 }
 
-.c22 {
+.c21 {
   padding-left: 16px;
   width: 100%;
-}
-
-.c25 {
-  padding-bottom: 4px;
-  padding-left: 8px;
 }
 
 .c2 {
@@ -126,7 +116,7 @@ exports[`<AttributeOptions /> renders and matches the snapshot 1`] = `
   gap: 40px;
 }
 
-.c19 {
+.c18 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -152,6 +142,7 @@ exports[`<AttributeOptions /> renders and matches the snapshot 1`] = `
 .c14 {
   display: grid;
   grid-template-columns: repeat(12,1fr);
+  gap: 12px;
 }
 
 .c15 {
@@ -176,19 +167,19 @@ exports[`<AttributeOptions /> renders and matches the snapshot 1`] = `
   cursor: not-allowed;
 }
 
-.c21 svg {
+.c20 svg {
   height: 100%;
   width: 100%;
 }
 
-.c18 {
+.c17 {
   width: 100%;
   height: 100%;
   border: 1px solid #dcdce4;
   text-align: left;
 }
 
-.c18:hover {
+.c17:hover {
   background: #f0f0ff;
   border: 1px solid #d9d8ff;
 }
@@ -289,802 +280,742 @@ exports[`<AttributeOptions /> renders and matches the snapshot 1`] = `
                 <div
                   class="c15"
                 >
-                  <div
-                    class="c16"
-                    style="height: 100%;"
+                  <button
+                    class="c16 c17"
+                    type="button"
                   >
-                    <button
-                      class="c17 c18"
-                      type="button"
+                    <div
+                      class="c18"
                     >
                       <div
-                        class="c19"
+                        aria-hidden="true"
+                        class="c19 c20"
+                      >
+                        <svg
+                          class=""
+                          fill="none"
+                          height="1rem"
+                          viewBox="0 0 32 24"
+                          width="1rem"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <rect
+                            fill="#EAFBE7"
+                            height="23"
+                            rx="2.5"
+                            stroke="#C6F0C2"
+                            width="31"
+                            x="0.5"
+                            y="0.5"
+                          />
+                          <path
+                            d="M8.62 16h1.857l.627-2.05h2.982l.627 2.05h1.863l-2.941-8.455h-2.08L8.619 16Zm3.925-6.768h.105l1.032 3.393h-2.174l1.037-3.393ZM21.65 16.1c1.612 0 2.62-1.26 2.62-3.323v-.011c0-2.075-.985-3.323-2.62-3.323-.884 0-1.605.434-1.933 1.137h-.106V7.082h-1.71V16h1.71v-1.002h.106c.334.697 1.02 1.102 1.933 1.102Zm-.585-1.418c-.903 0-1.471-.715-1.471-1.899v-.011c0-1.184.574-1.91 1.47-1.91.903 0 1.465.726 1.465 1.904v.011c0 1.19-.556 1.905-1.465 1.905Z"
+                            fill="#328048"
+                          />
+                        </svg>
+                      </div>
+                      <div
+                        class="c21"
                       >
                         <div
-                          aria-hidden="true"
-                          class="c20 c21"
+                          class="c2"
                         >
-                          <svg
-                            class=""
-                            fill="none"
-                            height="1rem"
-                            viewBox="0 0 32 24"
-                            width="1rem"
-                            xmlns="http://www.w3.org/2000/svg"
+                          <span
+                            class="c22"
                           >
-                            <rect
-                              fill="#EAFBE7"
-                              height="23"
-                              rx="2.5"
-                              stroke="#C6F0C2"
-                              width="31"
-                              x="0.5"
-                              y="0.5"
-                            />
-                            <path
-                              d="M8.62 16h1.857l.627-2.05h2.982l.627 2.05h1.863l-2.941-8.455h-2.08L8.619 16Zm3.925-6.768h.105l1.032 3.393h-2.174l1.037-3.393ZM21.65 16.1c1.612 0 2.62-1.26 2.62-3.323v-.011c0-2.075-.985-3.323-2.62-3.323-.884 0-1.605.434-1.933 1.137h-.106V7.082h-1.71V16h1.71v-1.002h.106c.334.697 1.02 1.102 1.933 1.102Zm-.585-1.418c-.903 0-1.471-.715-1.471-1.899v-.011c0-1.184.574-1.91 1.47-1.91.903 0 1.465.726 1.465 1.904v.011c0 1.19-.556 1.905-1.465 1.905Z"
-                              fill="#328048"
-                            />
-                          </svg>
+                            text
+                          </span>
                         </div>
                         <div
-                          class="c22"
+                          class="c18"
                         >
-                          <div
-                            class="c2"
+                          <span
+                            class="c23"
                           >
-                            <span
-                              class="c23"
-                            >
-                              text
-                            </span>
-                          </div>
-                          <div
-                            class="c19"
-                          >
-                            <span
-                              class="c24"
-                            >
-                              A type for modeling data
-                            </span>
-                          </div>
+                            A type for modeling data
+                          </span>
                         </div>
                       </div>
-                    </button>
-                  </div>
+                    </div>
+                  </button>
                 </div>
                 <div
                   class="c15"
                 >
-                  <div
-                    class="c25"
-                    style="height: 100%;"
+                  <button
+                    class="c16 c17"
+                    type="button"
                   >
-                    <button
-                      class="c17 c18"
-                      type="button"
+                    <div
+                      class="c18"
                     >
                       <div
-                        class="c19"
+                        aria-hidden="true"
+                        class="c19 c20"
+                      >
+                        <svg
+                          class=""
+                          fill="none"
+                          height="1rem"
+                          viewBox="0 0 32 24"
+                          width="1rem"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <rect
+                            fill="#FCECEA"
+                            height="23"
+                            rx="2.5"
+                            stroke="#F5C0B8"
+                            width="31"
+                            x="0.5"
+                            y="0.5"
+                          />
+                          <path
+                            d="M16.767 17.49c.724 0 1.428-.089 1.962-.253v-1.093c-.383.143-1.128.239-1.86.239-2.905 0-4.744-1.764-4.744-4.546v-.014c0-2.734 1.839-4.641 4.484-4.641 2.598 0 4.307 1.62 4.307 4.088v.013c0 1.402-.444 2.304-1.135 2.304-.417 0-.656-.287-.656-.772V9.157h-1.38v.82h-.124c-.273-.608-.868-.97-1.6-.97-1.367 0-2.296 1.135-2.296 2.789v.014c0 1.73.943 2.884 2.365 2.884.793 0 1.353-.362 1.64-1.052h.123l.007.04c.158.636.78 1.033 1.62 1.033 1.655 0 2.687-1.367 2.687-3.534v-.014c0-3.008-2.242-5.072-5.517-5.072-3.418 0-5.776 2.324-5.776 5.694v.014c0 3.431 2.331 5.687 5.893 5.687Zm-.342-4.053c-.718 0-1.149-.602-1.149-1.586v-.014c0-.991.431-1.586 1.156-1.586.724 0 1.182.608 1.182 1.586v.014c0 .977-.458 1.585-1.19 1.585Z"
+                            fill="#D02B20"
+                          />
+                        </svg>
+                      </div>
+                      <div
+                        class="c21"
                       >
                         <div
-                          aria-hidden="true"
-                          class="c20 c21"
+                          class="c2"
                         >
-                          <svg
-                            class=""
-                            fill="none"
-                            height="1rem"
-                            viewBox="0 0 32 24"
-                            width="1rem"
-                            xmlns="http://www.w3.org/2000/svg"
+                          <span
+                            class="c22"
                           >
-                            <rect
-                              fill="#FCECEA"
-                              height="23"
-                              rx="2.5"
-                              stroke="#F5C0B8"
-                              width="31"
-                              x="0.5"
-                              y="0.5"
-                            />
-                            <path
-                              d="M16.767 17.49c.724 0 1.428-.089 1.962-.253v-1.093c-.383.143-1.128.239-1.86.239-2.905 0-4.744-1.764-4.744-4.546v-.014c0-2.734 1.839-4.641 4.484-4.641 2.598 0 4.307 1.62 4.307 4.088v.013c0 1.402-.444 2.304-1.135 2.304-.417 0-.656-.287-.656-.772V9.157h-1.38v.82h-.124c-.273-.608-.868-.97-1.6-.97-1.367 0-2.296 1.135-2.296 2.789v.014c0 1.73.943 2.884 2.365 2.884.793 0 1.353-.362 1.64-1.052h.123l.007.04c.158.636.78 1.033 1.62 1.033 1.655 0 2.687-1.367 2.687-3.534v-.014c0-3.008-2.242-5.072-5.517-5.072-3.418 0-5.776 2.324-5.776 5.694v.014c0 3.431 2.331 5.687 5.893 5.687Zm-.342-4.053c-.718 0-1.149-.602-1.149-1.586v-.014c0-.991.431-1.586 1.156-1.586.724 0 1.182.608 1.182 1.586v.014c0 .977-.458 1.585-1.19 1.585Z"
-                              fill="#D02B20"
-                            />
-                          </svg>
+                            email
+                          </span>
                         </div>
                         <div
-                          class="c22"
+                          class="c18"
                         >
-                          <div
-                            class="c2"
+                          <span
+                            class="c23"
                           >
-                            <span
-                              class="c23"
-                            >
-                              email
-                            </span>
-                          </div>
-                          <div
-                            class="c19"
-                          >
-                            <span
-                              class="c24"
-                            >
-                              A type for modeling data
-                            </span>
-                          </div>
+                            A type for modeling data
+                          </span>
                         </div>
                       </div>
-                    </button>
-                  </div>
+                    </div>
+                  </button>
                 </div>
                 <div
                   class="c15"
                 >
-                  <div
-                    class="c16"
-                    style="height: 100%;"
+                  <button
+                    class="c16 c17"
+                    type="button"
                   >
-                    <button
-                      class="c17 c18"
-                      type="button"
+                    <div
+                      class="c18"
                     >
                       <div
-                        class="c19"
+                        aria-hidden="true"
+                        class="c19 c20"
+                      >
+                        <svg
+                          class=""
+                          fill="none"
+                          height="1rem"
+                          viewBox="0 0 32 24"
+                          width="1rem"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <rect
+                            fill="#EAF5FF"
+                            height="23"
+                            rx="2.5"
+                            stroke="#B8E1FF"
+                            width="31"
+                            x="0.5"
+                            y="0.5"
+                          />
+                          <path
+                            clip-rule="evenodd"
+                            d="M19.286 9.286v-.857a.397.397 0 0 0-.138-.302A.465.465 0 0 0 18.82 8h-8.357a.465.465 0 0 0-.326.127.397.397 0 0 0-.138.302v.857c0 .116.046.216.138.301.092.085.2.127.326.127h8.357a.465.465 0 0 0 .327-.127.397.397 0 0 0 .138-.301Zm2.785 2.713v.857a.397.397 0 0 1-.137.301.465.465 0 0 1-.327.128H10.464a.465.465 0 0 1-.326-.128.397.397 0 0 1-.138-.301v-.857c0-.116.046-.217.138-.302a.465.465 0 0 1 .326-.127h11.143c.126 0 .235.043.327.127a.397.397 0 0 1 .137.302Zm-1.857 3.574v.857a.397.397 0 0 1-.137.302.465.465 0 0 1-.327.127h-9.286a.465.465 0 0 1-.326-.127.397.397 0 0 1-.138-.302v-.857c0-.116.046-.216.138-.301a.465.465 0 0 1 .326-.127h9.286c.126 0 .235.042.326.127a.397.397 0 0 1 .138.301Z"
+                            fill="#0C75AF"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                      <div
+                        class="c21"
                       >
                         <div
-                          aria-hidden="true"
-                          class="c20 c21"
+                          class="c2"
                         >
-                          <svg
-                            class=""
-                            fill="none"
-                            height="1rem"
-                            viewBox="0 0 32 24"
-                            width="1rem"
-                            xmlns="http://www.w3.org/2000/svg"
+                          <span
+                            class="c22"
                           >
-                            <rect
-                              fill="#EAF5FF"
-                              height="23"
-                              rx="2.5"
-                              stroke="#B8E1FF"
-                              width="31"
-                              x="0.5"
-                              y="0.5"
-                            />
-                            <path
-                              clip-rule="evenodd"
-                              d="M19.286 9.286v-.857a.397.397 0 0 0-.138-.302A.465.465 0 0 0 18.82 8h-8.357a.465.465 0 0 0-.326.127.397.397 0 0 0-.138.302v.857c0 .116.046.216.138.301.092.085.2.127.326.127h8.357a.465.465 0 0 0 .327-.127.397.397 0 0 0 .138-.301Zm2.785 2.713v.857a.397.397 0 0 1-.137.301.465.465 0 0 1-.327.128H10.464a.465.465 0 0 1-.326-.128.397.397 0 0 1-.138-.301v-.857c0-.116.046-.217.138-.302a.465.465 0 0 1 .326-.127h11.143c.126 0 .235.043.327.127a.397.397 0 0 1 .137.302Zm-1.857 3.574v.857a.397.397 0 0 1-.137.302.465.465 0 0 1-.327.127h-9.286a.465.465 0 0 1-.326-.127.397.397 0 0 1-.138-.302v-.857c0-.116.046-.216.138-.301a.465.465 0 0 1 .326-.127h9.286c.126 0 .235.042.326.127a.397.397 0 0 1 .138.301Z"
-                              fill="#0C75AF"
-                              fill-rule="evenodd"
-                            />
-                          </svg>
+                            richtext
+                          </span>
                         </div>
                         <div
-                          class="c22"
+                          class="c18"
                         >
-                          <div
-                            class="c2"
+                          <span
+                            class="c23"
                           >
-                            <span
-                              class="c23"
-                            >
-                              richtext
-                            </span>
-                          </div>
-                          <div
-                            class="c19"
-                          >
-                            <span
-                              class="c24"
-                            >
-                              A type for modeling data
-                            </span>
-                          </div>
+                            A type for modeling data
+                          </span>
                         </div>
                       </div>
-                    </button>
-                  </div>
+                    </div>
+                  </button>
                 </div>
                 <div
                   class="c15"
                 >
-                  <div
-                    class="c25"
-                    style="height: 100%;"
+                  <button
+                    class="c16 c17"
+                    type="button"
                   >
-                    <button
-                      class="c17 c18"
-                      type="button"
+                    <div
+                      class="c18"
                     >
                       <div
-                        class="c19"
+                        aria-hidden="true"
+                        class="c19 c20"
+                      >
+                        <svg
+                          class=""
+                          fill="none"
+                          height="1rem"
+                          viewBox="0 0 32 24"
+                          width="1rem"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M.5 3A2.5 2.5 0 0 1 3 .5h26A2.5 2.5 0 0 1 31.5 3v18a2.5 2.5 0 0 1-2.5 2.5H3A2.5 2.5 0 0 1 .5 21V3Z"
+                            fill="#FDF4DC"
+                            stroke="#FAE7B9"
+                          />
+                          <path
+                            d="M20.158 11.995c0-.591-.463-1.073-1.045-1.11H13.53V9.245a2.05 2.05 0 0 1 2.046-2.049c1.13 0 2.048.784 2.049 1.913 0 .24.194.433.433.433h.33a.433.433 0 0 0 .433-.433C18.82 7.32 17.365 5.999 15.577 6a3.246 3.246 0 0 0-3.241 3.244v1.642h-.223c-.615 0-1.113.499-1.113 1.114v4.887c.001.615.5 1.113 1.115 1.113l6.93-.003c.616 0 1.114-.5 1.114-1.115l-.001-4.887Z"
+                            fill="#D9822F"
+                          />
+                        </svg>
+                      </div>
+                      <div
+                        class="c21"
                       >
                         <div
-                          aria-hidden="true"
-                          class="c20 c21"
+                          class="c2"
                         >
-                          <svg
-                            class=""
-                            fill="none"
-                            height="1rem"
-                            viewBox="0 0 32 24"
-                            width="1rem"
-                            xmlns="http://www.w3.org/2000/svg"
+                          <span
+                            class="c22"
                           >
-                            <path
-                              d="M.5 3A2.5 2.5 0 0 1 3 .5h26A2.5 2.5 0 0 1 31.5 3v18a2.5 2.5 0 0 1-2.5 2.5H3A2.5 2.5 0 0 1 .5 21V3Z"
-                              fill="#FDF4DC"
-                              stroke="#FAE7B9"
-                            />
-                            <path
-                              d="M20.158 11.995c0-.591-.463-1.073-1.045-1.11H13.53V9.245a2.05 2.05 0 0 1 2.046-2.049c1.13 0 2.048.784 2.049 1.913 0 .24.194.433.433.433h.33a.433.433 0 0 0 .433-.433C18.82 7.32 17.365 5.999 15.577 6a3.246 3.246 0 0 0-3.241 3.244v1.642h-.223c-.615 0-1.113.499-1.113 1.114v4.887c.001.615.5 1.113 1.115 1.113l6.93-.003c.616 0 1.114-.5 1.114-1.115l-.001-4.887Z"
-                              fill="#D9822F"
-                            />
-                          </svg>
+                            password
+                          </span>
                         </div>
                         <div
-                          class="c22"
+                          class="c18"
                         >
-                          <div
-                            class="c2"
+                          <span
+                            class="c23"
                           >
-                            <span
-                              class="c23"
-                            >
-                              password
-                            </span>
-                          </div>
-                          <div
-                            class="c19"
-                          >
-                            <span
-                              class="c24"
-                            >
-                              A type for modeling data
-                            </span>
-                          </div>
+                            A type for modeling data
+                          </span>
                         </div>
                       </div>
-                    </button>
-                  </div>
+                    </div>
+                  </button>
                 </div>
                 <div
                   class="c15"
                 >
-                  <div
-                    class="c16"
-                    style="height: 100%;"
+                  <button
+                    class="c16 c17"
+                    type="button"
                   >
-                    <button
-                      class="c17 c18"
-                      type="button"
+                    <div
+                      class="c18"
                     >
                       <div
-                        class="c19"
+                        aria-hidden="true"
+                        class="c19 c20"
+                      >
+                        <svg
+                          class=""
+                          fill="none"
+                          height="1rem"
+                          viewBox="0 0 32 24"
+                          width="1rem"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <rect
+                            fill="#FCECEA"
+                            height="23"
+                            rx="2.5"
+                            stroke="#F5C0B8"
+                            width="31"
+                            x="0.5"
+                            y="0.5"
+                          />
+                          <path
+                            d="M9.815 16h1.475V8.954H9.82L8 10.22v1.328l1.729-1.201h.087V16Zm3.394 0h5.083v-1.187h-3.106v-.112l1.304-1.216c1.284-1.186 1.7-1.85 1.7-2.651v-.015c0-1.215-1.016-2.046-2.466-2.046-1.543 0-2.598.928-2.598 2.28l.005.02h1.362v-.024c0-.67.474-1.128 1.162-1.128.674 0 1.084.42 1.084 1.02v.015c0 .493-.268.85-1.26 1.812l-2.27 2.24V16Zm9.067.156c1.646 0 2.744-.864 2.744-2.143v-.01c0-.957-.683-1.563-1.733-1.66v-.03c.825-.17 1.47-.742 1.47-1.62v-.01c0-1.123-.977-1.885-2.49-1.885-1.48 0-2.471.82-2.574 2.08l-.005.059h1.358l.005-.044c.058-.586.522-.962 1.216-.962.693 0 1.098.361 1.098.947v.01c0 .571-.478.962-1.22.962h-.787v1.05h.806c.855 0 1.357.37 1.357 1.044v.01c0 .596-.493 1.016-1.245 1.016-.761 0-1.264-.39-1.328-.938l-.005-.053h-1.41l.004.063c.098 1.26 1.148 2.114 2.74 2.114Z"
+                            fill="#D02B20"
+                          />
+                        </svg>
+                      </div>
+                      <div
+                        class="c21"
                       >
                         <div
-                          aria-hidden="true"
-                          class="c20 c21"
+                          class="c2"
                         >
-                          <svg
-                            class=""
-                            fill="none"
-                            height="1rem"
-                            viewBox="0 0 32 24"
-                            width="1rem"
-                            xmlns="http://www.w3.org/2000/svg"
+                          <span
+                            class="c22"
                           >
-                            <rect
-                              fill="#FCECEA"
-                              height="23"
-                              rx="2.5"
-                              stroke="#F5C0B8"
-                              width="31"
-                              x="0.5"
-                              y="0.5"
-                            />
-                            <path
-                              d="M9.815 16h1.475V8.954H9.82L8 10.22v1.328l1.729-1.201h.087V16Zm3.394 0h5.083v-1.187h-3.106v-.112l1.304-1.216c1.284-1.186 1.7-1.85 1.7-2.651v-.015c0-1.215-1.016-2.046-2.466-2.046-1.543 0-2.598.928-2.598 2.28l.005.02h1.362v-.024c0-.67.474-1.128 1.162-1.128.674 0 1.084.42 1.084 1.02v.015c0 .493-.268.85-1.26 1.812l-2.27 2.24V16Zm9.067.156c1.646 0 2.744-.864 2.744-2.143v-.01c0-.957-.683-1.563-1.733-1.66v-.03c.825-.17 1.47-.742 1.47-1.62v-.01c0-1.123-.977-1.885-2.49-1.885-1.48 0-2.471.82-2.574 2.08l-.005.059h1.358l.005-.044c.058-.586.522-.962 1.216-.962.693 0 1.098.361 1.098.947v.01c0 .571-.478.962-1.22.962h-.787v1.05h.806c.855 0 1.357.37 1.357 1.044v.01c0 .596-.493 1.016-1.245 1.016-.761 0-1.264-.39-1.328-.938l-.005-.053h-1.41l.004.063c.098 1.26 1.148 2.114 2.74 2.114Z"
-                              fill="#D02B20"
-                            />
-                          </svg>
+                            number
+                          </span>
                         </div>
                         <div
-                          class="c22"
+                          class="c18"
                         >
-                          <div
-                            class="c2"
+                          <span
+                            class="c23"
                           >
-                            <span
-                              class="c23"
-                            >
-                              number
-                            </span>
-                          </div>
-                          <div
-                            class="c19"
-                          >
-                            <span
-                              class="c24"
-                            >
-                              A type for modeling data
-                            </span>
-                          </div>
+                            A type for modeling data
+                          </span>
                         </div>
                       </div>
-                    </button>
-                  </div>
+                    </div>
+                  </button>
                 </div>
                 <div
                   class="c15"
                 >
-                  <div
-                    class="c25"
-                    style="height: 100%;"
+                  <button
+                    class="c16 c17"
+                    type="button"
                   >
-                    <button
-                      class="c17 c18"
-                      type="button"
+                    <div
+                      class="c18"
                     >
                       <div
-                        class="c19"
+                        aria-hidden="true"
+                        class="c19 c20"
+                      >
+                        <svg
+                          class=""
+                          fill="none"
+                          height="1rem"
+                          viewBox="0 0 32 24"
+                          width="1rem"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <rect
+                            fill="#F6ECFC"
+                            height="23"
+                            rx="2.5"
+                            stroke="#E0C1F4"
+                            width="31"
+                            x="0.5"
+                            y="0.5"
+                          />
+                          <path
+                            clip-rule="evenodd"
+                            d="M10.167 7a1.167 1.167 0 1 0 0 2.333 1.167 1.167 0 0 0 0-2.333Zm0 4.03a1.167 1.167 0 1 0 0 2.334 1.167 1.167 0 0 0 0-2.334ZM9 16.23a1.167 1.167 0 1 1 2.333 0 1.167 1.167 0 0 1-2.333 0Zm4.005-9.02a.4.4 0 0 0-.4.4v1.11c0 .22.18.4.4.4H22.6a.4.4 0 0 0 .4-.4V7.61a.4.4 0 0 0-.4-.4h-9.594Zm-.399 4.432a.4.4 0 0 1 .4-.4H22.6c.22 0 .4.18.4.4v1.11a.4.4 0 0 1-.4.4h-9.594a.4.4 0 0 1-.4-.4v-1.11Zm.4 3.63a.4.4 0 0 0-.4.4v1.11c0 .22.18.4.4.4H22.6a.4.4 0 0 0 .4-.4v-1.11a.4.4 0 0 0-.4-.4h-9.594Z"
+                            fill="#9736E8"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                      <div
+                        class="c21"
                       >
                         <div
-                          aria-hidden="true"
-                          class="c20 c21"
+                          class="c2"
                         >
-                          <svg
-                            class=""
-                            fill="none"
-                            height="1rem"
-                            viewBox="0 0 32 24"
-                            width="1rem"
-                            xmlns="http://www.w3.org/2000/svg"
+                          <span
+                            class="c22"
                           >
-                            <rect
-                              fill="#F6ECFC"
-                              height="23"
-                              rx="2.5"
-                              stroke="#E0C1F4"
-                              width="31"
-                              x="0.5"
-                              y="0.5"
-                            />
-                            <path
-                              clip-rule="evenodd"
-                              d="M10.167 7a1.167 1.167 0 1 0 0 2.333 1.167 1.167 0 0 0 0-2.333Zm0 4.03a1.167 1.167 0 1 0 0 2.334 1.167 1.167 0 0 0 0-2.334ZM9 16.23a1.167 1.167 0 1 1 2.333 0 1.167 1.167 0 0 1-2.333 0Zm4.005-9.02a.4.4 0 0 0-.4.4v1.11c0 .22.18.4.4.4H22.6a.4.4 0 0 0 .4-.4V7.61a.4.4 0 0 0-.4-.4h-9.594Zm-.399 4.432a.4.4 0 0 1 .4-.4H22.6c.22 0 .4.18.4.4v1.11a.4.4 0 0 1-.4.4h-9.594a.4.4 0 0 1-.4-.4v-1.11Zm.4 3.63a.4.4 0 0 0-.4.4v1.11c0 .22.18.4.4.4H22.6a.4.4 0 0 0 .4-.4v-1.11a.4.4 0 0 0-.4-.4h-9.594Z"
-                              fill="#9736E8"
-                              fill-rule="evenodd"
-                            />
-                          </svg>
+                            enumeration
+                          </span>
                         </div>
                         <div
-                          class="c22"
+                          class="c18"
                         >
-                          <div
-                            class="c2"
+                          <span
+                            class="c23"
                           >
-                            <span
-                              class="c23"
-                            >
-                              enumeration
-                            </span>
-                          </div>
-                          <div
-                            class="c19"
-                          >
-                            <span
-                              class="c24"
-                            >
-                              A type for modeling data
-                            </span>
-                          </div>
+                            A type for modeling data
+                          </span>
                         </div>
                       </div>
-                    </button>
-                  </div>
+                    </div>
+                  </button>
                 </div>
                 <div
                   class="c15"
                 >
-                  <div
-                    class="c16"
-                    style="height: 100%;"
+                  <button
+                    class="c16 c17"
+                    type="button"
                   >
-                    <button
-                      class="c17 c18"
-                      type="button"
+                    <div
+                      class="c18"
                     >
                       <div
-                        class="c19"
+                        aria-hidden="true"
+                        class="c19 c20"
+                      >
+                        <svg
+                          class=""
+                          fill="none"
+                          height="1rem"
+                          viewBox="0 0 32 24"
+                          width="1rem"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M.5 3A2.5 2.5 0 0 1 3 .5h26A2.5 2.5 0 0 1 31.5 3v18a2.5 2.5 0 0 1-2.5 2.5H3A2.5 2.5 0 0 1 .5 21V3Z"
+                            fill="#FDF4DC"
+                            stroke="#FAE7B9"
+                          />
+                          <path
+                            clip-rule="evenodd"
+                            d="M11.934 7.495V6h1.45v1.495h5.232V6h1.45v1.495h.314c1.385 0 1.602.249 1.62 1.463V16.5c0 1.062-.096 1.5-1.4 1.5h-9.19c-1.306 0-1.41-.318-1.41-1.607V9.105c.018-1.025.117-1.61 1.5-1.61h.434Zm-.774 8.687c0 .406.123.433.388.433h8.953c.265 0 .34-.007.34-.413v-6.087c-.008-.314-.11-.369-.316-.369h-9.072c-.206 0-.296.045-.293.287v6.15Z"
+                            fill="#D9822F"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                      <div
+                        class="c21"
                       >
                         <div
-                          aria-hidden="true"
-                          class="c20 c21"
+                          class="c2"
                         >
-                          <svg
-                            class=""
-                            fill="none"
-                            height="1rem"
-                            viewBox="0 0 32 24"
-                            width="1rem"
-                            xmlns="http://www.w3.org/2000/svg"
+                          <span
+                            class="c22"
                           >
-                            <path
-                              d="M.5 3A2.5 2.5 0 0 1 3 .5h26A2.5 2.5 0 0 1 31.5 3v18a2.5 2.5 0 0 1-2.5 2.5H3A2.5 2.5 0 0 1 .5 21V3Z"
-                              fill="#FDF4DC"
-                              stroke="#FAE7B9"
-                            />
-                            <path
-                              clip-rule="evenodd"
-                              d="M11.934 7.495V6h1.45v1.495h5.232V6h1.45v1.495h.314c1.385 0 1.602.249 1.62 1.463V16.5c0 1.062-.096 1.5-1.4 1.5h-9.19c-1.306 0-1.41-.318-1.41-1.607V9.105c.018-1.025.117-1.61 1.5-1.61h.434Zm-.774 8.687c0 .406.123.433.388.433h8.953c.265 0 .34-.007.34-.413v-6.087c-.008-.314-.11-.369-.316-.369h-9.072c-.206 0-.296.045-.293.287v6.15Z"
-                              fill="#D9822F"
-                              fill-rule="evenodd"
-                            />
-                          </svg>
+                            date
+                          </span>
                         </div>
                         <div
-                          class="c22"
+                          class="c18"
                         >
-                          <div
-                            class="c2"
+                          <span
+                            class="c23"
                           >
-                            <span
-                              class="c23"
-                            >
-                              date
-                            </span>
-                          </div>
-                          <div
-                            class="c19"
-                          >
-                            <span
-                              class="c24"
-                            >
-                              A type for modeling data
-                            </span>
-                          </div>
+                            A type for modeling data
+                          </span>
                         </div>
                       </div>
-                    </button>
-                  </div>
+                    </div>
+                  </button>
                 </div>
                 <div
                   class="c15"
                 >
-                  <div
-                    class="c25"
-                    style="height: 100%;"
+                  <button
+                    class="c16 c17"
+                    type="button"
                   >
-                    <button
-                      class="c17 c18"
-                      type="button"
+                    <div
+                      class="c18"
                     >
                       <div
-                        class="c19"
+                        aria-hidden="true"
+                        class="c19 c20"
+                      >
+                        <svg
+                          class=""
+                          fill="none"
+                          height="1rem"
+                          viewBox="0 0 32 24"
+                          width="1rem"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <rect
+                            fill="#F6ECFC"
+                            height="23"
+                            rx="2.5"
+                            stroke="#E0C1F4"
+                            width="31"
+                            x="0.5"
+                            y="0.5"
+                          />
+                          <path
+                            clip-rule="evenodd"
+                            d="M22 8.759a2 2 0 0 0-2-2h-8c-1.105 0-2 .902-2 2.006v6.068a2 2 0 0 0 .985 1.724l3.66-3.74 3.31 3.381 1.471-1.502 1.731 1.769c.51-.363.843-.958.843-1.632V8.76ZM18.5 9c-.84 0-1.5.66-1.5 1.5s.66 1.5 1.5 1.5 1.5-.66 1.5-1.5S19.34 9 18.5 9Z"
+                            fill="#9736E8"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                      <div
+                        class="c21"
                       >
                         <div
-                          aria-hidden="true"
-                          class="c20 c21"
+                          class="c2"
                         >
-                          <svg
-                            class=""
-                            fill="none"
-                            height="1rem"
-                            viewBox="0 0 32 24"
-                            width="1rem"
-                            xmlns="http://www.w3.org/2000/svg"
+                          <span
+                            class="c22"
                           >
-                            <rect
-                              fill="#F6ECFC"
-                              height="23"
-                              rx="2.5"
-                              stroke="#E0C1F4"
-                              width="31"
-                              x="0.5"
-                              y="0.5"
-                            />
-                            <path
-                              clip-rule="evenodd"
-                              d="M22 8.759a2 2 0 0 0-2-2h-8c-1.105 0-2 .902-2 2.006v6.068a2 2 0 0 0 .985 1.724l3.66-3.74 3.31 3.381 1.471-1.502 1.731 1.769c.51-.363.843-.958.843-1.632V8.76ZM18.5 9c-.84 0-1.5.66-1.5 1.5s.66 1.5 1.5 1.5 1.5-.66 1.5-1.5S19.34 9 18.5 9Z"
-                              fill="#9736E8"
-                              fill-rule="evenodd"
-                            />
-                          </svg>
+                            media
+                          </span>
                         </div>
                         <div
-                          class="c22"
+                          class="c18"
                         >
-                          <div
-                            class="c2"
+                          <span
+                            class="c23"
                           >
-                            <span
-                              class="c23"
-                            >
-                              media
-                            </span>
-                          </div>
-                          <div
-                            class="c19"
-                          >
-                            <span
-                              class="c24"
-                            >
-                              A type for modeling data
-                            </span>
-                          </div>
+                            A type for modeling data
+                          </span>
                         </div>
                       </div>
-                    </button>
-                  </div>
+                    </div>
+                  </button>
                 </div>
                 <div
                   class="c15"
                 >
-                  <div
-                    class="c16"
-                    style="height: 100%;"
+                  <button
+                    class="c16 c17"
+                    type="button"
                   >
-                    <button
-                      class="c17 c18"
-                      type="button"
+                    <div
+                      class="c18"
                     >
                       <div
-                        class="c19"
+                        aria-hidden="true"
+                        class="c19 c20"
+                      >
+                        <svg
+                          class=""
+                          fill="none"
+                          height="1rem"
+                          viewBox="0 0 32 24"
+                          width="1rem"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <rect
+                            fill="#EAFBE7"
+                            height="23"
+                            rx="2.5"
+                            stroke="#C6F0C2"
+                            width="31"
+                            x="0.5"
+                            y="0.5"
+                          />
+                          <path
+                            d="M19.5 7h-7A4.505 4.505 0 0 0 8 11.5c0 2.481 2.019 4.5 4.5 4.5h7c2.481 0 4.5-2.019 4.5-4.5S21.981 7 19.5 7Zm0 8a3.5 3.5 0 1 1 0-7 3.5 3.5 0 0 1 0 7Z"
+                            fill="#328048"
+                          />
+                        </svg>
+                      </div>
+                      <div
+                        class="c21"
                       >
                         <div
-                          aria-hidden="true"
-                          class="c20 c21"
+                          class="c2"
                         >
-                          <svg
-                            class=""
-                            fill="none"
-                            height="1rem"
-                            viewBox="0 0 32 24"
-                            width="1rem"
-                            xmlns="http://www.w3.org/2000/svg"
+                          <span
+                            class="c22"
                           >
-                            <rect
-                              fill="#EAFBE7"
-                              height="23"
-                              rx="2.5"
-                              stroke="#C6F0C2"
-                              width="31"
-                              x="0.5"
-                              y="0.5"
-                            />
-                            <path
-                              d="M19.5 7h-7A4.505 4.505 0 0 0 8 11.5c0 2.481 2.019 4.5 4.5 4.5h7c2.481 0 4.5-2.019 4.5-4.5S21.981 7 19.5 7Zm0 8a3.5 3.5 0 1 1 0-7 3.5 3.5 0 0 1 0 7Z"
-                              fill="#328048"
-                            />
-                          </svg>
+                            boolean
+                          </span>
                         </div>
                         <div
-                          class="c22"
+                          class="c18"
                         >
-                          <div
-                            class="c2"
+                          <span
+                            class="c23"
                           >
-                            <span
-                              class="c23"
-                            >
-                              boolean
-                            </span>
-                          </div>
-                          <div
-                            class="c19"
-                          >
-                            <span
-                              class="c24"
-                            >
-                              A type for modeling data
-                            </span>
-                          </div>
+                            A type for modeling data
+                          </span>
                         </div>
                       </div>
-                    </button>
-                  </div>
+                    </div>
+                  </button>
                 </div>
                 <div
                   class="c15"
                 >
-                  <div
-                    class="c25"
-                    style="height: 100%;"
+                  <button
+                    class="c16 c17"
+                    type="button"
                   >
-                    <button
-                      class="c17 c18"
-                      type="button"
+                    <div
+                      class="c18"
                     >
                       <div
-                        class="c19"
+                        aria-hidden="true"
+                        class="c19 c20"
+                      >
+                        <svg
+                          class=""
+                          fill="none"
+                          height="1rem"
+                          viewBox="0 0 32 24"
+                          width="1rem"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <rect
+                            fill="#EAF5FF"
+                            height="23"
+                            rx="2.5"
+                            stroke="#B8E1FF"
+                            width="31"
+                            x="0.5"
+                            y="0.5"
+                          />
+                          <path
+                            clip-rule="evenodd"
+                            d="M8.243 11.907v.157c.835.093 1.287.516 1.287 1.223V14.5c0 .693.236.959.855.959h.216V16.5h-.364c-1.459 0-2.078-.56-2.078-1.857v-.973c0-.722-.314-.992-1.159-1.002v-1.366c.84-.005 1.16-.275 1.16-1.002v-.968c0-1.282.618-1.832 2.077-1.832h.364v1.041h-.216c-.624 0-.855.266-.855.958v1.184c0 .713-.452 1.135-1.287 1.224Zm15.804.181v-.157c-.835-.088-1.287-.51-1.287-1.223V9.495c0-.693-.236-.954-.855-.954h-.216V7.5h.363c1.454 0 2.073.56 2.073 1.852v.973c0 .722.32.997 1.165 1.002v1.366c-.845.005-1.165.28-1.165 1.002v.973c0 1.282-.613 1.832-2.073 1.832h-.363v-1.046h.216c.619 0 .855-.26.855-.954v-1.188c0-.708.452-1.13 1.287-1.224ZM13.15 13a1 1 0 1 0 0-2 1 1 0 0 0 0 2Zm4-1a1 1 0 1 1-2 0 1 1 0 0 1 2 0Zm2 1a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z"
+                            fill="#0C75AF"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                      <div
+                        class="c21"
                       >
                         <div
-                          aria-hidden="true"
-                          class="c20 c21"
+                          class="c2"
                         >
-                          <svg
-                            class=""
-                            fill="none"
-                            height="1rem"
-                            viewBox="0 0 32 24"
-                            width="1rem"
-                            xmlns="http://www.w3.org/2000/svg"
+                          <span
+                            class="c22"
                           >
-                            <rect
-                              fill="#EAF5FF"
-                              height="23"
-                              rx="2.5"
-                              stroke="#B8E1FF"
-                              width="31"
-                              x="0.5"
-                              y="0.5"
-                            />
-                            <path
-                              clip-rule="evenodd"
-                              d="M8.243 11.907v.157c.835.093 1.287.516 1.287 1.223V14.5c0 .693.236.959.855.959h.216V16.5h-.364c-1.459 0-2.078-.56-2.078-1.857v-.973c0-.722-.314-.992-1.159-1.002v-1.366c.84-.005 1.16-.275 1.16-1.002v-.968c0-1.282.618-1.832 2.077-1.832h.364v1.041h-.216c-.624 0-.855.266-.855.958v1.184c0 .713-.452 1.135-1.287 1.224Zm15.804.181v-.157c-.835-.088-1.287-.51-1.287-1.223V9.495c0-.693-.236-.954-.855-.954h-.216V7.5h.363c1.454 0 2.073.56 2.073 1.852v.973c0 .722.32.997 1.165 1.002v1.366c-.845.005-1.165.28-1.165 1.002v.973c0 1.282-.613 1.832-2.073 1.832h-.363v-1.046h.216c.619 0 .855-.26.855-.954v-1.188c0-.708.452-1.13 1.287-1.224ZM13.15 13a1 1 0 1 0 0-2 1 1 0 0 0 0 2Zm4-1a1 1 0 1 1-2 0 1 1 0 0 1 2 0Zm2 1a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z"
-                              fill="#0C75AF"
-                              fill-rule="evenodd"
-                            />
-                          </svg>
+                            json
+                          </span>
                         </div>
                         <div
-                          class="c22"
+                          class="c18"
                         >
-                          <div
-                            class="c2"
+                          <span
+                            class="c23"
                           >
-                            <span
-                              class="c23"
-                            >
-                              json
-                            </span>
-                          </div>
-                          <div
-                            class="c19"
-                          >
-                            <span
-                              class="c24"
-                            >
-                              A type for modeling data
-                            </span>
-                          </div>
+                            A type for modeling data
+                          </span>
                         </div>
                       </div>
-                    </button>
-                  </div>
+                    </div>
+                  </button>
                 </div>
                 <div
                   class="c15"
                 >
-                  <div
-                    class="c16"
-                    style="height: 100%;"
+                  <button
+                    class="c16 c17"
+                    type="button"
                   >
-                    <button
-                      class="c17 c18"
-                      type="button"
+                    <div
+                      class="c18"
                     >
                       <div
-                        class="c19"
+                        aria-hidden="true"
+                        class="c19 c20"
+                      >
+                        <svg
+                          class=""
+                          fill="none"
+                          height="1rem"
+                          viewBox="0 0 32 24"
+                          width="1rem"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M.5 3A2.5 2.5 0 0 1 3 .5h26A2.5 2.5 0 0 1 31.5 3v18a2.5 2.5 0 0 1-2.5 2.5H3A2.5 2.5 0 0 1 .5 21V3Z"
+                            fill="#F0F0FF"
+                            stroke="#D9D8FF"
+                          />
+                          <path
+                            clip-rule="evenodd"
+                            d="M21.375 16.316c.417-.407.625-.904.625-1.492 0-.589-.206-1.089-.618-1.5l-1.53-1.53a2.042 2.042 0 0 0-1.5-.617 2.06 2.06 0 0 0-1.529.646l-.646-.646c.43-.422.646-.934.646-1.537a2.03 2.03 0 0 0-.61-1.493l-1.515-1.522a2.014 2.014 0 0 0-1.5-.625 2.03 2.03 0 0 0-1.492.61l-1.081 1.074A2.006 2.006 0 0 0 10 9.176c0 .589.206 1.089.618 1.5l1.53 1.53c.41.412.91.617 1.5.617a2.06 2.06 0 0 0 1.529-.646l.646.646a2.069 2.069 0 0 0-.646 1.537c0 .588.203 1.086.61 1.493l1.514 1.522c.407.417.907.625 1.5.625a2.03 2.03 0 0 0 1.493-.61l1.081-1.074Zm-5.956-6.678a.68.68 0 0 0-.205-.5l-1.515-1.522a.68.68 0 0 0-.5-.206.71.71 0 0 0-.5.199l-1.081 1.073a.672.672 0 0 0-.206.493.68.68 0 0 0 .206.5l1.53 1.53a.678.678 0 0 0 .5.198.71.71 0 0 0 .529-.228l-.14-.136a4.46 4.46 0 0 1-.158-.158 1.756 1.756 0 0 1-.11-.14.593.593 0 0 1-.122-.39.68.68 0 0 1 .206-.5.68.68 0 0 1 .5-.206.59.59 0 0 1 .39.121c.064.047.11.084.14.111.03.027.082.08.158.158l.136.14a.713.713 0 0 0 .242-.537Zm5.168 5.187a.68.68 0 0 0-.206-.5l-1.529-1.53a.68.68 0 0 0-.5-.205.7.7 0 0 0-.53.235l.14.136c.079.076.132.129.159.158.027.03.063.076.11.14a.591.591 0 0 1 .121.39.681.681 0 0 1-.206.5.681.681 0 0 1-.5.206.591.591 0 0 1-.39-.121 1.746 1.746 0 0 1-.14-.111 4.395 4.395 0 0 1-.157-.158 20.642 20.642 0 0 0-.136-.14.714.714 0 0 0-.037 1.037l1.515 1.522a.678.678 0 0 0 .5.198.708.708 0 0 0 .5-.19l1.08-1.074a.672.672 0 0 0 .206-.493Z"
+                            fill="#4945FF"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                      <div
+                        class="c21"
                       >
                         <div
-                          aria-hidden="true"
-                          class="c20 c21"
+                          class="c2"
                         >
-                          <svg
-                            class=""
-                            fill="none"
-                            height="1rem"
-                            viewBox="0 0 32 24"
-                            width="1rem"
-                            xmlns="http://www.w3.org/2000/svg"
+                          <span
+                            class="c22"
                           >
-                            <path
-                              d="M.5 3A2.5 2.5 0 0 1 3 .5h26A2.5 2.5 0 0 1 31.5 3v18a2.5 2.5 0 0 1-2.5 2.5H3A2.5 2.5 0 0 1 .5 21V3Z"
-                              fill="#F0F0FF"
-                              stroke="#D9D8FF"
-                            />
-                            <path
-                              clip-rule="evenodd"
-                              d="M21.375 16.316c.417-.407.625-.904.625-1.492 0-.589-.206-1.089-.618-1.5l-1.53-1.53a2.042 2.042 0 0 0-1.5-.617 2.06 2.06 0 0 0-1.529.646l-.646-.646c.43-.422.646-.934.646-1.537a2.03 2.03 0 0 0-.61-1.493l-1.515-1.522a2.014 2.014 0 0 0-1.5-.625 2.03 2.03 0 0 0-1.492.61l-1.081 1.074A2.006 2.006 0 0 0 10 9.176c0 .589.206 1.089.618 1.5l1.53 1.53c.41.412.91.617 1.5.617a2.06 2.06 0 0 0 1.529-.646l.646.646a2.069 2.069 0 0 0-.646 1.537c0 .588.203 1.086.61 1.493l1.514 1.522c.407.417.907.625 1.5.625a2.03 2.03 0 0 0 1.493-.61l1.081-1.074Zm-5.956-6.678a.68.68 0 0 0-.205-.5l-1.515-1.522a.68.68 0 0 0-.5-.206.71.71 0 0 0-.5.199l-1.081 1.073a.672.672 0 0 0-.206.493.68.68 0 0 0 .206.5l1.53 1.53a.678.678 0 0 0 .5.198.71.71 0 0 0 .529-.228l-.14-.136a4.46 4.46 0 0 1-.158-.158 1.756 1.756 0 0 1-.11-.14.593.593 0 0 1-.122-.39.68.68 0 0 1 .206-.5.68.68 0 0 1 .5-.206.59.59 0 0 1 .39.121c.064.047.11.084.14.111.03.027.082.08.158.158l.136.14a.713.713 0 0 0 .242-.537Zm5.168 5.187a.68.68 0 0 0-.206-.5l-1.529-1.53a.68.68 0 0 0-.5-.205.7.7 0 0 0-.53.235l.14.136c.079.076.132.129.159.158.027.03.063.076.11.14a.591.591 0 0 1 .121.39.681.681 0 0 1-.206.5.681.681 0 0 1-.5.206.591.591 0 0 1-.39-.121 1.746 1.746 0 0 1-.14-.111 4.395 4.395 0 0 1-.157-.158 20.642 20.642 0 0 0-.136-.14.714.714 0 0 0-.037 1.037l1.515 1.522a.678.678 0 0 0 .5.198.708.708 0 0 0 .5-.19l1.08-1.074a.672.672 0 0 0 .206-.493Z"
-                              fill="#4945FF"
-                              fill-rule="evenodd"
-                            />
-                          </svg>
+                            relation
+                          </span>
                         </div>
                         <div
-                          class="c22"
+                          class="c18"
                         >
-                          <div
-                            class="c2"
+                          <span
+                            class="c23"
                           >
-                            <span
-                              class="c23"
-                            >
-                              relation
-                            </span>
-                          </div>
-                          <div
-                            class="c19"
-                          >
-                            <span
-                              class="c24"
-                            >
-                              A type for modeling data
-                            </span>
-                          </div>
+                            A type for modeling data
+                          </span>
                         </div>
                       </div>
-                    </button>
-                  </div>
+                    </div>
+                  </button>
                 </div>
                 <div
                   class="c15"
                 >
-                  <div
-                    class="c25"
-                    style="height: 100%;"
+                  <button
+                    class="c16 c17"
+                    type="button"
                   >
-                    <button
-                      class="c17 c18"
-                      type="button"
+                    <div
+                      class="c18"
                     >
                       <div
-                        class="c19"
+                        aria-hidden="true"
+                        class="c19 c20"
+                      >
+                        <svg
+                          class=""
+                          fill="none"
+                          height="1rem"
+                          viewBox="0 0 32 24"
+                          width="1rem"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M.5 3A2.5 2.5 0 0 1 3 .5h26A2.5 2.5 0 0 1 31.5 3v18a2.5 2.5 0 0 1-2.5 2.5H3A2.5 2.5 0 0 1 .5 21V3Z"
+                            fill="#F0F0FF"
+                            stroke="#D9D8FF"
+                          />
+                          <path
+                            d="M14.907 9.438c0 .375 0 .738.118 1.078-1.243 1.46-4.526 5.317-4.832 5.611a.582.582 0 0 0-.193.433c0 .245.15.481.277.614.19.2 1.004.952 1.154.808.444-.433.533-.548.715-.727.274-.268-.029-.816.066-1.039.096-.222.197-.265.361-.3.165-.034.456.084.684.087.24.003.369-.098.548-.265.144-.133.248-.257.25-.45.007-.26-.368-.603-.089-.877.28-.274.684.178.981.144.297-.035.658-.447.695-.623.038-.176-.337-.629-.28-.886.02-.086.197-.288.33-.317.132-.029.72.199.853.17.162-.034.35-.205.502-.3.447.193.854.271 1.376.271C20.4 12.87 22 11.33 22 9.432 22 7.534 20.399 6 18.423 6s-3.516 1.54-3.516 3.438Zm5.247-.669a.923.923 0 1 1-1.847 0 .923.923 0 0 1 1.847 0Z"
+                            fill="#4945FF"
+                          />
+                        </svg>
+                      </div>
+                      <div
+                        class="c21"
                       >
                         <div
-                          aria-hidden="true"
-                          class="c20 c21"
+                          class="c2"
                         >
-                          <svg
-                            class=""
-                            fill="none"
-                            height="1rem"
-                            viewBox="0 0 32 24"
-                            width="1rem"
-                            xmlns="http://www.w3.org/2000/svg"
+                          <span
+                            class="c22"
                           >
-                            <path
-                              d="M.5 3A2.5 2.5 0 0 1 3 .5h26A2.5 2.5 0 0 1 31.5 3v18a2.5 2.5 0 0 1-2.5 2.5H3A2.5 2.5 0 0 1 .5 21V3Z"
-                              fill="#F0F0FF"
-                              stroke="#D9D8FF"
-                            />
-                            <path
-                              d="M14.907 9.438c0 .375 0 .738.118 1.078-1.243 1.46-4.526 5.317-4.832 5.611a.582.582 0 0 0-.193.433c0 .245.15.481.277.614.19.2 1.004.952 1.154.808.444-.433.533-.548.715-.727.274-.268-.029-.816.066-1.039.096-.222.197-.265.361-.3.165-.034.456.084.684.087.24.003.369-.098.548-.265.144-.133.248-.257.25-.45.007-.26-.368-.603-.089-.877.28-.274.684.178.981.144.297-.035.658-.447.695-.623.038-.176-.337-.629-.28-.886.02-.086.197-.288.33-.317.132-.029.72.199.853.17.162-.034.35-.205.502-.3.447.193.854.271 1.376.271C20.4 12.87 22 11.33 22 9.432 22 7.534 20.399 6 18.423 6s-3.516 1.54-3.516 3.438Zm5.247-.669a.923.923 0 1 1-1.847 0 .923.923 0 0 1 1.847 0Z"
-                              fill="#4945FF"
-                            />
-                          </svg>
+                            uid
+                          </span>
                         </div>
                         <div
-                          class="c22"
+                          class="c18"
                         >
-                          <div
-                            class="c2"
+                          <span
+                            class="c23"
                           >
-                            <span
-                              class="c23"
-                            >
-                              uid
-                            </span>
-                          </div>
-                          <div
-                            class="c19"
-                          >
-                            <span
-                              class="c24"
-                            >
-                              A type for modeling data
-                            </span>
-                          </div>
+                            A type for modeling data
+                          </span>
                         </div>
                       </div>
-                    </button>
-                  </div>
+                    </div>
+                  </button>
                 </div>
               </div>
               <div
@@ -1093,142 +1024,132 @@ exports[`<AttributeOptions /> renders and matches the snapshot 1`] = `
                 <div
                   class="c15"
                 >
-                  <div
-                    class="c16"
-                    style="height: 100%;"
+                  <button
+                    class="c16 c17"
+                    type="button"
                   >
-                    <button
-                      class="c17 c18"
-                      type="button"
+                    <div
+                      class="c18"
                     >
                       <div
-                        class="c19"
+                        aria-hidden="true"
+                        class="c19 c20"
+                      >
+                        <svg
+                          class=""
+                          fill="none"
+                          height="1rem"
+                          viewBox="0 0 32 24"
+                          width="1rem"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <rect
+                            fill="#F6F6F9"
+                            height="23"
+                            rx="2.5"
+                            stroke="#DCDCE4"
+                            width="31"
+                            x="0.5"
+                            y="0.5"
+                          />
+                          <path
+                            clip-rule="evenodd"
+                            d="M13.535 8.768c0 .116-.011.229-.032.339l3.013 1.776 2.985-1.76a1.768 1.768 0 1 1 .519.93l-2.982 1.757v2.477a1.768 1.768 0 1 1-1.048-.044v-2.435l-2.997-1.767a1.768 1.768 0 1 1 .542-1.274Z"
+                            fill="#666687"
+                            fill-rule="evenodd"
+                          />
+                          <path
+                            d="m13.503 9.107-.05-.01-.006.035.03.018.026-.043Zm3.013 1.776-.025.043.025.014.025-.014-.025-.043Zm2.985-1.76.025.044.031-.018-.007-.035-.05.01Zm.518.93.035-.036-.027-.026-.033.02.026.042Zm-2.98 1.757-.026-.043-.025.014v.029h.05Zm0 2.477h-.05v.035l.032.012.017-.047Zm-1.049-.044.013.048.037-.01v-.038h-.05Zm0-2.435h.05v-.029l-.024-.014-.026.043Zm-2.997-1.767.025-.043-.033-.019-.027.027.035.035Zm.559-.925c.022-.113.033-.23.033-.348h-.1c0 .112-.01.223-.031.33l.098.018Zm2.99 1.723-3.014-1.775-.05.086 3.013 1.775.05-.086Zm2.933-1.758-2.984 1.758.05.086 2.985-1.758-.05-.086Zm-.06-.313c0 .125.013.247.037.366l.098-.02a1.723 1.723 0 0 1-.035-.346h-.1Zm1.818-1.818a1.818 1.818 0 0 0-1.818 1.818h.1c0-.949.769-1.718 1.718-1.718v-.1Zm1.817 1.818a1.818 1.818 0 0 0-1.817-1.818v.1c.948 0 1.717.769 1.717 1.718h.1Zm-1.817 1.817a1.818 1.818 0 0 0 1.817-1.817h-.1c0 .948-.769 1.717-1.717 1.717v.1Zm-1.248-.495c.326.307.765.495 1.248.495v-.1c-.457 0-.872-.178-1.18-.468l-.068.073Zm-2.921 1.763 2.98-1.757-.05-.086-2.981 1.757.05.086Zm.024 2.434V11.81h-.1v2.477h.1Zm-.067.047a1.718 1.718 0 0 1 1.14 1.618h.1c0-.79-.503-1.46-1.206-1.712l-.034.094Zm1.14 1.618c0 .948-.77 1.717-1.718 1.717v.1a1.817 1.817 0 0 0 1.817-1.817h-.1Zm-1.718 1.717a1.718 1.718 0 0 1-1.718-1.717h-.1c0 1.004.814 1.817 1.818 1.817v-.1Zm-1.718-1.717c0-.797.543-1.467 1.278-1.66l-.026-.098a1.818 1.818 0 0 0-1.352 1.758h.1Zm1.215-4.144v2.435h.1v-2.435h-.1Zm-2.973-1.723 2.998 1.766.05-.086-2.997-1.767-.05.087Zm-1.2.5c.49 0 .934-.193 1.26-.507l-.069-.072c-.309.296-.728.48-1.19.48v.1ZM9.95 8.768c0 1.003.814 1.817 1.818 1.817v-.1a1.718 1.718 0 0 1-1.718-1.717h-.1Zm1.818-1.818A1.818 1.818 0 0 0 9.95 8.768h.1c0-.949.769-1.718 1.717-1.718v-.1Zm1.817 1.818a1.818 1.818 0 0 0-1.818-1.818v.1c.95 0 1.718.769 1.718 1.718h.1Z"
+                            fill="#666687"
+                          />
+                        </svg>
+                      </div>
+                      <div
+                        class="c21"
                       >
                         <div
-                          aria-hidden="true"
-                          class="c20 c21"
+                          class="c2"
                         >
-                          <svg
-                            class=""
-                            fill="none"
-                            height="1rem"
-                            viewBox="0 0 32 24"
-                            width="1rem"
-                            xmlns="http://www.w3.org/2000/svg"
+                          <span
+                            class="c22"
                           >
-                            <rect
-                              fill="#F6F6F9"
-                              height="23"
-                              rx="2.5"
-                              stroke="#DCDCE4"
-                              width="31"
-                              x="0.5"
-                              y="0.5"
-                            />
-                            <path
-                              clip-rule="evenodd"
-                              d="M13.535 8.768c0 .116-.011.229-.032.339l3.013 1.776 2.985-1.76a1.768 1.768 0 1 1 .519.93l-2.982 1.757v2.477a1.768 1.768 0 1 1-1.048-.044v-2.435l-2.997-1.767a1.768 1.768 0 1 1 .542-1.274Z"
-                              fill="#666687"
-                              fill-rule="evenodd"
-                            />
-                            <path
-                              d="m13.503 9.107-.05-.01-.006.035.03.018.026-.043Zm3.013 1.776-.025.043.025.014.025-.014-.025-.043Zm2.985-1.76.025.044.031-.018-.007-.035-.05.01Zm.518.93.035-.036-.027-.026-.033.02.026.042Zm-2.98 1.757-.026-.043-.025.014v.029h.05Zm0 2.477h-.05v.035l.032.012.017-.047Zm-1.049-.044.013.048.037-.01v-.038h-.05Zm0-2.435h.05v-.029l-.024-.014-.026.043Zm-2.997-1.767.025-.043-.033-.019-.027.027.035.035Zm.559-.925c.022-.113.033-.23.033-.348h-.1c0 .112-.01.223-.031.33l.098.018Zm2.99 1.723-3.014-1.775-.05.086 3.013 1.775.05-.086Zm2.933-1.758-2.984 1.758.05.086 2.985-1.758-.05-.086Zm-.06-.313c0 .125.013.247.037.366l.098-.02a1.723 1.723 0 0 1-.035-.346h-.1Zm1.818-1.818a1.818 1.818 0 0 0-1.818 1.818h.1c0-.949.769-1.718 1.718-1.718v-.1Zm1.817 1.818a1.818 1.818 0 0 0-1.817-1.818v.1c.948 0 1.717.769 1.717 1.718h.1Zm-1.817 1.817a1.818 1.818 0 0 0 1.817-1.817h-.1c0 .948-.769 1.717-1.717 1.717v.1Zm-1.248-.495c.326.307.765.495 1.248.495v-.1c-.457 0-.872-.178-1.18-.468l-.068.073Zm-2.921 1.763 2.98-1.757-.05-.086-2.981 1.757.05.086Zm.024 2.434V11.81h-.1v2.477h.1Zm-.067.047a1.718 1.718 0 0 1 1.14 1.618h.1c0-.79-.503-1.46-1.206-1.712l-.034.094Zm1.14 1.618c0 .948-.77 1.717-1.718 1.717v.1a1.817 1.817 0 0 0 1.817-1.817h-.1Zm-1.718 1.717a1.718 1.718 0 0 1-1.718-1.717h-.1c0 1.004.814 1.817 1.818 1.817v-.1Zm-1.718-1.717c0-.797.543-1.467 1.278-1.66l-.026-.098a1.818 1.818 0 0 0-1.352 1.758h.1Zm1.215-4.144v2.435h.1v-2.435h-.1Zm-2.973-1.723 2.998 1.766.05-.086-2.997-1.767-.05.087Zm-1.2.5c.49 0 .934-.193 1.26-.507l-.069-.072c-.309.296-.728.48-1.19.48v.1ZM9.95 8.768c0 1.003.814 1.817 1.818 1.817v-.1a1.718 1.718 0 0 1-1.718-1.717h-.1Zm1.818-1.818A1.818 1.818 0 0 0 9.95 8.768h.1c0-.949.769-1.718 1.717-1.718v-.1Zm1.817 1.818a1.818 1.818 0 0 0-1.818-1.818v.1c.95 0 1.718.769 1.718 1.718h.1Z"
-                              fill="#666687"
-                            />
-                          </svg>
+                            component
+                          </span>
                         </div>
                         <div
-                          class="c22"
+                          class="c18"
                         >
-                          <div
-                            class="c2"
+                          <span
+                            class="c23"
                           >
-                            <span
-                              class="c23"
-                            >
-                              component
-                            </span>
-                          </div>
-                          <div
-                            class="c19"
-                          >
-                            <span
-                              class="c24"
-                            >
-                              A type for modeling data
-                            </span>
-                          </div>
+                            A type for modeling data
+                          </span>
                         </div>
                       </div>
-                    </button>
-                  </div>
+                    </div>
+                  </button>
                 </div>
                 <div
                   class="c15"
                 >
-                  <div
-                    class="c25"
-                    style="height: 100%;"
+                  <button
+                    class="c16 c17"
+                    type="button"
                   >
-                    <button
-                      class="c17 c18"
-                      type="button"
+                    <div
+                      class="c18"
                     >
                       <div
-                        class="c19"
+                        aria-hidden="true"
+                        class="c19 c20"
+                      >
+                        <svg
+                          class=""
+                          fill="none"
+                          height="1rem"
+                          viewBox="0 0 32 24"
+                          width="1rem"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <rect
+                            fill="#F6F6F9"
+                            height="23"
+                            rx="2.5"
+                            stroke="#DCDCE4"
+                            width="31"
+                            x="0.5"
+                            y="0.5"
+                          />
+                          <path
+                            d="M20.573 8c-1.484 0-2.666.745-3.397 1.37l-.026.023-.416.452.919 1.51.68-.682c.711-.6 1.506-.93 2.24-.93 1.48 0 2.685 1.171 2.685 2.612 0 1.44-1.205 2.613-2.685 2.613-2.25 0-3.78-2.974-3.795-3.004C16.69 11.784 14.75 8 11.428 8 8.985 8 7 9.954 7 12.355c0 2.401 1.986 4.355 4.427 4.355 1.196 0 2.373-.476 3.404-1.376l.022-.02.413-.45-.919-1.51-.683.686c-.712.616-1.465.928-2.237.928-1.48 0-2.685-1.172-2.685-2.613 0-1.44 1.205-2.613 2.685-2.613 2.25 0 3.78 2.974 3.795 3.004.088.18 2.028 3.964 5.35 3.964 2.442 0 4.428-1.954 4.428-4.355C25 9.954 23.014 8 20.573 8Z"
+                            fill="#666687"
+                          />
+                        </svg>
+                      </div>
+                      <div
+                        class="c21"
                       >
                         <div
-                          aria-hidden="true"
-                          class="c20 c21"
+                          class="c2"
                         >
-                          <svg
-                            class=""
-                            fill="none"
-                            height="1rem"
-                            viewBox="0 0 32 24"
-                            width="1rem"
-                            xmlns="http://www.w3.org/2000/svg"
+                          <span
+                            class="c22"
                           >
-                            <rect
-                              fill="#F6F6F9"
-                              height="23"
-                              rx="2.5"
-                              stroke="#DCDCE4"
-                              width="31"
-                              x="0.5"
-                              y="0.5"
-                            />
-                            <path
-                              d="M20.573 8c-1.484 0-2.666.745-3.397 1.37l-.026.023-.416.452.919 1.51.68-.682c.711-.6 1.506-.93 2.24-.93 1.48 0 2.685 1.171 2.685 2.612 0 1.44-1.205 2.613-2.685 2.613-2.25 0-3.78-2.974-3.795-3.004C16.69 11.784 14.75 8 11.428 8 8.985 8 7 9.954 7 12.355c0 2.401 1.986 4.355 4.427 4.355 1.196 0 2.373-.476 3.404-1.376l.022-.02.413-.45-.919-1.51-.683.686c-.712.616-1.465.928-2.237.928-1.48 0-2.685-1.172-2.685-2.613 0-1.44 1.205-2.613 2.685-2.613 2.25 0 3.78 2.974 3.795 3.004.088.18 2.028 3.964 5.35 3.964 2.442 0 4.428-1.954 4.428-4.355C25 9.954 23.014 8 20.573 8Z"
-                              fill="#666687"
-                            />
-                          </svg>
+                            dynamiczone
+                          </span>
                         </div>
                         <div
-                          class="c22"
+                          class="c18"
                         >
-                          <div
-                            class="c2"
+                          <span
+                            class="c23"
                           >
-                            <span
-                              class="c23"
-                            >
-                              dynamiczone
-                            </span>
-                          </div>
-                          <div
-                            class="c19"
-                          >
-                            <span
-                              class="c24"
-                            >
-                              A type for modeling data
-                            </span>
-                          </div>
+                            A type for modeling data
+                          </span>
                         </div>
                       </div>
-                    </button>
-                  </div>
+                    </div>
+                  </button>
                 </div>
               </div>
             </div>
@@ -1238,7 +1159,7 @@ exports[`<AttributeOptions /> renders and matches the snapshot 1`] = `
     </div>
   </div>
   <div
-    class="c26"
+    class="c24"
   >
     <p
       aria-live="polite"

--- a/packages/core/content-type-builder/admin/src/components/AttributeOptions/utils/getPadding.js
+++ b/packages/core/content-type-builder/admin/src/components/AttributeOptions/utils/getPadding.js
@@ -1,9 +1,0 @@
-const getPadding = (index) => {
-  const isOdd = index % 2 === 1;
-  const paddingLeft = isOdd ? 2 : 0;
-  const paddingRight = isOdd ? 0 : 2;
-
-  return { paddingLeft, paddingRight };
-};
-
-export default getPadding;

--- a/packages/core/content-type-builder/admin/src/components/FormModal/utils/getAttributesToDisplay.js
+++ b/packages/core/content-type-builder/admin/src/components/FormModal/utils/getAttributesToDisplay.js
@@ -1,17 +1,17 @@
 const getAttributes = (dataTarget = '', targetUid, nestedComponents) => {
   const defaultAttributes = [
     'text',
-    'email',
-    'richtext',
-    'password',
-    'blocks',
-    'number',
-    'enumeration',
-    'date',
-    'media',
     'boolean',
+    'blocks',
     'json',
+    'number',
+    'email',
+    'date',
+    'password',
+    'media',
+    'enumeration',
     'relation',
+    'richtext',
   ];
 
   const isPickingAttributeForAContentType = dataTarget === 'contentType';
@@ -21,7 +21,7 @@ const getAttributes = (dataTarget = '', targetUid, nestedComponents) => {
 
   if (isPickingAttributeForAContentType) {
     return [
-      [...defaultAttributes, 'uid'],
+      [...defaultAttributes.slice(0, -1), 'uid', ...defaultAttributes.slice(-1)],
       ['component', 'dynamiczone'],
     ];
   }

--- a/packages/core/content-type-builder/admin/src/components/FormModal/utils/getAttributesToDisplay.js
+++ b/packages/core/content-type-builder/admin/src/components/FormModal/utils/getAttributesToDisplay.js
@@ -21,6 +21,7 @@ const getAttributes = (dataTarget = '', targetUid, nestedComponents) => {
 
   if (isPickingAttributeForAContentType) {
     return [
+      // Insert UID before the last item (richtext)
       [...defaultAttributes.slice(0, -1), 'uid', ...defaultAttributes.slice(-1)],
       ['component', 'dynamiczone'],
     ];


### PR DESCRIPTION
### What does it do?

2 design changes on the CTB attribute type picker modal:

- **Harmonize the grid spacings**. The current/previous version makes the items very close vertically, and far apart horizontally. It doesn't look balanced, and looks like the grid is meant to be read by columns instead of read row by row.
- **Change attributes order**. The live version didn't match the designs before, which were organized to have icons of the same color on the same rows. The markdown field is also moved to the last item as it will be deprecated in v5 and the blocks field is now stable.

All the changes were checked by @lucasboilly ([see figma file](https://www.figma.com/file/PICiE8O4NLrHO1lhJftLdE/Strapi-CMS---UI-Kit-%F0%9F%A7%A9?type=design&node-id=16466%3A34126&mode=design&t=e7hjzGC9UY1iJo12-1))
### Why is it needed?

Users creating an app open this modal tons of times in a row, polishing it has an impact on the onboarding experience.

### How to test it?

Pretend you're creating a field. Check both default and custom tabs.

