### PR TITLE
[v5] Replace fast-deep-equal with lodash/fp isEqual

### DIFF
--- a/examples/getstarted/config/admin.js
+++ b/examples/getstarted/config/admin.js
@@ -11,7 +11,7 @@ module.exports = ({ env }) => ({
   },
   transfer: {
     token: {
-      salt: env('TRANSFER_TOKEN_SALT', 'example-salt'),
+      // salt: env('TRANSFER_TOKEN_SALT', 'example-salt'),
     },
   },
   flags: {

--- a/examples/getstarted/config/admin.js
+++ b/examples/getstarted/config/admin.js
@@ -11,7 +11,7 @@ module.exports = ({ env }) => ({
   },
   transfer: {
     token: {
-      // salt: env('TRANSFER_TOKEN_SALT', 'example-salt'),
+      salt: env('TRANSFER_TOKEN_SALT', 'example-salt'),
     },
   },
   flags: {

--- a/packages/core/admin/server/services/role.js
+++ b/packages/core/admin/server/services/role.js
@@ -1,8 +1,17 @@
 'use strict';
 
 const _ = require('lodash');
-const { set, omit, pick, prop, isArray, differenceWith, differenceBy } = require('lodash/fp');
-const deepEqual = require('fast-deep-equal');
+const {
+  set,
+  omit,
+  pick,
+  prop,
+  isArray,
+  differenceWith,
+  differenceBy,
+  isEqual,
+} = require('lodash/fp');
+
 const {
   generateTimestampCode,
   stringIncludes,
@@ -37,7 +46,7 @@ const jsonClean = (data) => JSON.parse(JSON.stringify(data));
  */
 const arePermissionsEqual = (p1, p2) => {
   if (p1.action === p2.action) {
-    return deepEqual(jsonClean(pickComparableFields(p1)), jsonClean(pickComparableFields(p2)));
+    return isEqual(jsonClean(pickComparableFields(p1)), jsonClean(pickComparableFields(p2)));
   }
 
   return false;


### PR DESCRIPTION
### What does it do?

Replace fast-deep-equal with lodash/fp isEqual

### Why is it needed?

fast-deep-equal isn't needed

### How to test it?

RBAC permissions updates (adding/removing permissions) should still work exactly as before

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
