### PR TITLE
Adds roles to user allowed fields

### DIFF
--- a/packages/core/admin/server/domain/user.js
+++ b/packages/core/admin/server/domain/user.js
@@ -19,7 +19,7 @@ const hasSuperAdminRole = (user) => {
   return user.roles.filter((role) => role.code === SUPER_ADMIN_CODE).length > 0;
 };
 
-const ADMIN_USER_ALLOWED_FIELDS = ['id', 'firstname', 'lastname', 'username'];
+const ADMIN_USER_ALLOWED_FIELDS = ['id', 'firstname', 'lastname', 'username', 'roles'];
 
 module.exports = {
   createUser,


### PR DESCRIPTION


<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

This added field 'roles' allows user's "Media Library" permissions to be validated, when "Same role as creator" is checked.

### Why is it needed?

When an admin user is acceding the Media Library section, with a role action that was previously marked with "Same role as creator", Strapi is throwing a { status: 400, name: "ValidationError", message: "Invalid parameter roles", … } error.

### How to test it?

Node.js version: v20.8.0
NPM version: 10.1.0
Strapi version: v4.14.4
Database: sqlite
Operating system: darwin-x64
Is your project Javascript or Typescript: Javascript

Steps to reproduce:
0. Using the getstarted example.
1. The Super-Admin has created some foldres and uploaded some files in the root folder.
2. Then create two roles: 'XReader' and 'XWritter' which can access (readonly read) and create(upload, update) in media library respectively with "same role as creator" checked.
3. Create 2 users, user 1 whose is roles are 'XWritter' and 'XReader', and user 2 whose is just 'XReader'.
4. Try to access to the Media Library with any of the user 1 or user 2
5. Strapi should display the error

### Related issue(s)/PR(s)

Issue #18297
