### PR TITLE
fix: bug in advance setting of date time picker

### DIFF
--- a/packages/core/helper-plugin/src/components/GenericInput.tsx
+++ b/packages/core/helper-plugin/src/components/GenericInput.tsx
@@ -312,7 +312,7 @@ const GenericInput = ({
           onClear={() => onChange({ target: { name, value: null, type } })}
           placeholder={formattedPlaceholder}
           required={required}
-          value={value}
+          value={value? value : undefined}
         />
       );
     }

--- a/packages/core/helper-plugin/src/components/GenericInput.tsx
+++ b/packages/core/helper-plugin/src/components/GenericInput.tsx
@@ -312,7 +312,7 @@ const GenericInput = ({
           onClear={() => onChange({ target: { name, value: null, type } })}
           placeholder={formattedPlaceholder}
           required={required}
-          value={value? value : undefined}
+          value={value ? new Date(value) : undefined}
         />
       );
     }


### PR DESCRIPTION
### What does it do?

The change fixes the error when we navigate to the advanced setting of the date (datetime) field.
![image](https://github.com/strapi/strapi/assets/58825865/b11aac9a-fd73-4e93-93e5-fae6a7f9de6c)

### Describe the technical changes you did.

We should not pass the empty to the dtp component. The fix was already added to the components except this one. The earlier commit for the fix - [fix](https://github.com/strapi/strapi/commit/8d6dc353e80908f8b3e7fcc1ff6e731d513ba030)

### Why is it needed?
After this fix, the user can edit/modify the advanced setting of datetime type date field.
![image](https://github.com/strapi/strapi/assets/58825865/b2a77ca5-d2f9-41ae-ad46-b851937301bc)

### How to test it?

- Go to 'Content type builder'
- Add a date field to any collection, if not already available
- Open the settings dialogue screen of any date field
- Click on 'advanced setting'
- See the error

### Related issue(s)/PR(s)
closes #18522 
