### PR TITLE
Fix dynamic zone id conflicts and editor re-rendering

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/tests/reducer.test.js
+++ b/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/tests/reducer.test.js
@@ -923,6 +923,88 @@ describe('CONTENT MANAGER | COMPONENTS | EditViewDataManagerProvider | reducer',
 
       expect(reducer(state, action)).toEqual(expected);
     });
+
+    it('should add a component with a __temp_key__ that is higher than the highest id to not get rendering conflicts', () => {
+      const components = {
+        'blog.simple': {
+          uid: 'blog.simple',
+          attributes: {
+            id: {
+              type: 'integer',
+            },
+            name: {
+              type: 'string',
+            },
+          },
+        },
+      };
+
+      const state = {
+        ...initialState,
+        componentsDataStructure: {
+          'blog.simple': { name: 'test' },
+        },
+        initialData: {
+          name: 'name',
+          dz: [
+            { name: 'test', __component: 'blog.simple', id: 1 },
+            { name: 'test', __component: 'blog.simple', id: 42 },
+          ],
+        },
+        modifiedData: {
+          name: 'name',
+          dz: [
+            { name: 'test', __component: 'blog.simple', id: 1 },
+            { name: 'test', __component: 'blog.simple', id: 42 },
+          ],
+        },
+      };
+
+      const expected = {
+        ...initialState,
+        componentsDataStructure: {
+          'blog.simple': { name: 'test' },
+        },
+        initialData: {
+          name: 'name',
+          dz: [
+            { name: 'test', __component: 'blog.simple', id: 1 },
+            { name: 'test', __component: 'blog.simple', id: 42 },
+          ],
+        },
+        modifiedData: {
+          name: 'name',
+          dz: [
+            { name: 'test', __component: 'blog.simple', __temp_key__: 43 },
+            { name: 'test', __component: 'blog.simple', id: 1 },
+            { name: 'test', __component: 'blog.simple', id: 42 },
+          ],
+        },
+        modifiedDZName: 'dz',
+        shouldCheckErrors: true,
+      };
+
+      const action = {
+        type: 'ADD_COMPONENT_TO_DYNAMIC_ZONE',
+        componentLayoutData: {
+          uid: 'blog.simple',
+          attributes: {
+            id: {
+              type: 'integer',
+            },
+            name: {
+              type: 'string',
+            },
+          },
+        },
+        allComponents: components,
+        keys: ['dz'],
+        shouldCheckErrors: true,
+        position: -1,
+      };
+
+      expect(reducer(state, action)).toEqual(expected);
+    });
   });
 
   describe('CONNECT_RELATION', () => {

--- a/packages/core/admin/admin/src/content-manager/components/Wysiwyg/Editor.js
+++ b/packages/core/admin/admin/src/content-manager/components/Wysiwyg/Editor.js
@@ -1,4 +1,4 @@
-import React, { forwardRef, useEffect, useImperativeHandle, useRef } from 'react';
+import { forwardRef, useEffect, useImperativeHandle, useRef } from 'react';
 
 import CodeMirror from 'codemirror5';
 import PropTypes from 'prop-types';
@@ -29,6 +29,11 @@ const Editor = forwardRef(
     const onChangeRef = useRef(onChange);
 
     useEffect(() => {
+      if (editorRef.current) {
+        // Ensure the editor and its wrapper are cleaned up whenever this view is re-rendered
+        // e.g. in case of re-ordering wysiwyg components in a DynamicZone
+        editorRef.current.toTextArea();
+      }
       editorRef.current = CodeMirror.fromTextArea(textareaRef.current, {
         lineWrapping: true,
         extraKeys: {

--- a/packages/core/admin/admin/src/content-manager/utils/getMaxTempKey.js
+++ b/packages/core/admin/admin/src/content-manager/utils/getMaxTempKey.js
@@ -3,9 +3,13 @@ const getMaxTempKey = (arr) => {
     return -1;
   }
 
+  /**
+   * We check if there are ids or __temp_key__ because you may add an object to a list of objects
+   * already in the DB.
+   */
   const maxTempKey = Math.max.apply(
     Math,
-    arr.map((o) => o.__temp_key__ ?? 0)
+    arr.map((o) => o.id ?? o.__temp_key__ ?? 0)
   );
 
   return Number.isNaN(maxTempKey) ? -1 : maxTempKey;


### PR DESCRIPTION
### What does it do?

It fixes the stability of editing rich text in components within a Dynamic Zone;
- Ensures id's of newly added components don't conflict with existing id's
- Ensures that the editor wrapper is not rendered twice after adding new components above it

### Why is it needed?

When adding a new component in the Dynamic Zone it is assigned a Temporary Key. This temporary key is also used as id and key within the rendering loop of the components leading to conflicts. These conflicts show up as duplicate content.

E.g. Before this PR if there were 9 components in a dynamic zone, a newly added component would get id 10 assigned as temporary key. If there was already a same component with that id from the backend in the list it would show up as duplicate of that tinstance (until saving/ refreshing the editor). Now it will be assigned an id that is higher than any of the id's included in the array, this logic has been inspired by the same logic for stages: packages/core/admin/ee/admin/pages/SettingsPage/pages/ReviewWorkflows/reducer/index.js:209

The second fix is ensuring that the wrapper of CodeMIrror is not rendered twice when the parent component is re-rendered by cleaning it up if it ahs been instantiated before.

Eg. Whenever a component was added in a Dynamic Zone above a component containing the rich text editor, the wrapper would show up twice.

### How to test it?

- set up a dynamic zone with a component containing a rich text editor 
- Add one above and see the wrapper duplication and id generation fail

### Related issue(s)/PR(s)

- Fixes #17858 (breaks before PR, doesn't break after)
