### PR TITLE
chore(admin): move LanguageProvider mock file to TS

### DIFF
--- a/packages/core/admin/admin/src/components/__mocks__/LanguageProvider.ts
+++ b/packages/core/admin/admin/src/components/__mocks__/LanguageProvider.ts
@@ -1,3 +1,5 @@
+/* eslint-disable check-file/filename-naming-convention */
+
 export function useLocalesProvider() {
   return {
     changeLocale() {},


### PR DESCRIPTION
### What does it do?

Converts a component conversion leftover to TS: `LanguageProvider` mock.

