### PR TITLE
core(content-releases): add env flag to include plugin

### DIFF
--- a/packages/core/admin/scripts/build.js
+++ b/packages/core/admin/scripts/build.js
@@ -23,7 +23,7 @@ const buildAdmin = async () => {
    */
   const plugins = getPlugins([
     '@strapi/plugin-content-type-builder',
-    '@strapi/content-releases',
+    process.env.FEATURE_FLAG_CONTENT_RELEASES && '@strapi/content-releases',
     '@strapi/plugin-email',
     '@strapi/plugin-upload',
     '@strapi/plugin-i18n',

--- a/packages/core/content-releases/package.json
+++ b/packages/core/content-releases/package.json
@@ -41,21 +41,14 @@
     "./dist",
     "strapi-server.js"
   ],
-  "strapi": {
-    "name": "releases",
-    "description": "Organize and release content",
-    "kind": "plugin",
-    "displayName": "Releases",
-    "required": true
-  },
   "scripts": {
     "build": "pack-up build",
     "clean": "run -T rimraf ./dist",
     "lint": "run -T eslint .",
     "prepublishOnly": "yarn clean && yarn build",
     "test:front": "run -T cross-env IS_EE=true jest --config ./jest.config.front.js",
-    "test:front:watch": "run -T cross-env IS_EE=true jest --config ./jest.config.front.js --watchAll",
     "test:front:ce": "run -T cross-env IS_EE=false jest --config ./jest.config.front.js",
+    "test:front:watch": "run -T cross-env IS_EE=true jest --config ./jest.config.front.js --watchAll",
     "test:front:watch:ce": "run -T cross-env IS_EE=false jest --config ./jest.config.front.js --watchAll",
     "test:ts:front": "run -T tsc -p admin/tsconfig.json",
     "test:unit": "run -T jest",
@@ -70,6 +63,7 @@
   },
   "devDependencies": {
     "@strapi/pack-up": "workspace:*",
+    "@strapi/strapi": "4.14.4",
     "@testing-library/react": "14.0.0",
     "@testing-library/user-event": "14.4.3",
     "@types/styled-components": "5.1.26",
@@ -94,5 +88,12 @@
     "implicitDependencies": [
       "!@strapi/strapi"
     ]
+  },
+  "strapi": {
+    "name": "releases",
+    "description": "Organize and release content",
+    "kind": "plugin",
+    "displayName": "Releases",
+    "required": true
   }
 }

--- a/packages/core/strapi/src/core/loaders/plugins/get-enabled-plugins.ts
+++ b/packages/core/strapi/src/core/loaders/plugins/get-enabled-plugins.ts
@@ -31,8 +31,8 @@ const INTERNAL_PLUGINS = [
   '@strapi/plugin-content-type-builder',
   '@strapi/plugin-email',
   '@strapi/plugin-upload',
-  '@strapi/content-releases',
-];
+  process.env.FEATURE_FLAG_CONTENT_RELEASES && '@strapi/content-releases',
+].filter(Boolean);
 
 const isStrapiPlugin = (info: PluginInfo) => get('strapi.kind', info) === 'plugin';
 
@@ -80,6 +80,9 @@ const toDetailedDeclaration = (declaration: boolean | PluginDeclaration) => {
 export const getEnabledPlugins = async (strapi: Strapi, { client } = { client: false }) => {
   const internalPlugins: PluginMetas = {};
   for (const dep of INTERNAL_PLUGINS) {
+    // eslint-disable-next-line no-continue
+    if (!dep) continue;
+
     const packagePath = join(dep, 'package.json');
     const packageInfo = require(packagePath);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7529,6 +7529,7 @@ __metadata:
     "@strapi/helper-plugin": 4.14.4
     "@strapi/icons": 1.12.0
     "@strapi/pack-up": "workspace:*"
+    "@strapi/strapi": 4.14.4
     "@testing-library/react": 14.0.0
     "@testing-library/user-event": 14.4.3
     "@types/styled-components": 5.1.26


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* uses an ENV flag in node to decide whether or not it should include the plugin
* includes `@strapi/strapi` as a devDep because it's a peer dep

### Why is it needed?

* allows us to merge into main without it affecting users

### Notes

* I think in the future it would be great if we had a global `strapi.config` because you could just add a flag that way which is a bit nicer, but for now i think this works, I tried to keep the name clear and basic af, I think the format for most things could just be `FEATURE_FLAG_XXX` 🤷🏼‍♀️ but I mean we're not going to document this so I don't think it matters _too_ much.
