### PR TITLE
fix: re add deleted afterSync hook

### DIFF
--- a/packages/core/strapi/src/Strapi.ts
+++ b/packages/core/strapi/src/Strapi.ts
@@ -441,6 +441,7 @@ class Strapi extends Container implements StrapiI {
 
   registerInternalHooks() {
     this.get('hooks').set('strapi::content-types.beforeSync', hooks.createAsyncParallelHook());
+    this.get('hooks').set('strapi::content-types.afterSync', hooks.createAsyncParallelHook());
   }
 
   async register() {


### PR DESCRIPTION
### What does it do?
Reintroduced deleted strapi.hooks ( content-types.afterSync )   that was removed during a merge conflict.

