### PR TITLE
Include React on UnauthenticatedLogo to resolve React not found error

### DIFF
--- a/packages/core/admin/admin/src/components/GuidedTour/Homepage.tsx
+++ b/packages/core/admin/admin/src/components/GuidedTour/Homepage.tsx
@@ -1,3 +1,5 @@
+import * as React from 'react';
+
 import { Box, Button, Flex, Typography } from '@strapi/design-system';
 import { LinkButton } from '@strapi/design-system/v2';
 import { GuidedTourContextValue, pxToRem, useGuidedTour, useTracking } from '@strapi/helper-plugin';

--- a/packages/core/admin/admin/src/components/GuidedTour/Ornaments.tsx
+++ b/packages/core/admin/admin/src/components/GuidedTour/Ornaments.tsx
@@ -1,3 +1,5 @@
+import * as React from 'react';
+
 import { Box, BoxProps, Flex, FlexProps, Typography } from '@strapi/design-system';
 import { pxToRem } from '@strapi/helper-plugin';
 import { Check } from '@strapi/icons';

--- a/packages/core/admin/admin/src/components/UnauthenticatedLogo.tsx
+++ b/packages/core/admin/admin/src/components/UnauthenticatedLogo.tsx
@@ -1,3 +1,5 @@
+import * as React from 'react';
+
 import styled from 'styled-components';
 
 import { useConfiguration } from '../hooks/useConfiguration';


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Added import * as React from 'react'; to top of UnauthenticatedLogo.tsx like other components to prevent React not found error

### Why is it needed?

When in development using an unauthenticated account that triggers the guided tour the error will present itself.

### How to test it?

Provide information about the environment and the path to verify the behaviour.
Strapi v4.15.0
Node v20.8.1
NPM v10.1.0

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
