### PR TITLE
fix(documentation): use correct localization schema

### DIFF
--- a/packages/plugins/documentation/server/services/helpers/utils/clean-schema-attributes.js
+++ b/packages/plugins/documentation/server/services/helpers/utils/clean-schema-attributes.js
@@ -202,7 +202,7 @@ const cleanSchemaAttributes = (
             properties: {
               data: {
                 type: 'array',
-                items: componentSchemaRefName.length ? { $ref: componentSchemaRefName } : {},
+                items: componentSchemaRefName.length ? { $ref: componentSchemaRefName + "ListResponseDataItemLocalized"} : {},
               },
             },
           };

--- a/packages/plugins/documentation/server/services/helpers/utils/clean-schema-attributes.js
+++ b/packages/plugins/documentation/server/services/helpers/utils/clean-schema-attributes.js
@@ -202,7 +202,7 @@ const cleanSchemaAttributes = (
             properties: {
               data: {
                 type: 'array',
-                items: componentSchemaRefName.length ? { $ref: componentSchemaRefName + "ListResponseDataItemLocalized"} : {},
+                items: componentSchemaRefName.length ? { $ref: `${componentSchemaRefName}ListResponseDataItemLocalized`} : {},
               },
             },
           };


### PR DESCRIPTION
### What does it do?

The generated `full_documentation.json` contains an error in the `localizations` property. The `localizations` property only shows up when [strapi-plugin-populate-deep](https://www.npmjs.com/package/strapi-plugin-populate-deep) is also installed, but the issue is in the documentation plugin, not [strapi-plugin-populate-deep](https://www.npmjs.com/package/strapi-plugin-populate-deep).

The edited line is only hit once in the debugger and patching it seems to do exactly what I want and nothing else. It's used in production at our company.

### Why is it needed?

Without this, the localization field in the schema doesn't match the actual api response. The api response contains an id & attributes, which then contain the actual data. The schema makes it seem like the localization field already contains the data.

Api response via Postman:
![CleanShot 2023-10-26 at 07 54 51@2x](https://github.com/strapi/strapi/assets/16866223/0d7e6da5-98df-4ef7-96ff-b08a9a676ed4)

### How to test it?

1. Clone this: https://github.com/ciriousjoker/demo_strapi_localization_field
2. Check out first, second and third commit in order
3. Notice that by switching to the forked version that matches this PR, the schema now matches the api response

### Related issue(s)/PR(s)

- Fixes #18577
- This pr seems to be related, although I can't figure out if it actually caused this issue: https://github.com/strapi/strapi/pull/13458

### Context

We had a pretty scuffed `package-lock.json` at some point, which for whatever reason produced a correct `full_documentation.json` schema. However, I couldn't reproduce this correct behavior when deleting the `package-lock.json` & the `node_modules` folder. In the working `full_documentation.json`, it used this name: `ArticleListResponseDataItemLocalized`, so when I had the option of choosing the suffix, I chose the one that most closely resembled the (I assume) original, correct behavior.