### PR TITLE
fix(pack-up): set NODE_ENV if it's not already set

### DIFF
--- a/packages/utils/pack-up/src/node/build.ts
+++ b/packages/utils/pack-up/src/node/build.ts
@@ -33,6 +33,13 @@ interface BuildWithoutConfigFile extends BuildCLIOptions {
 type BuildOptions = BuildWithConfigFile | BuildWithoutConfigFile;
 
 const build = async (opts: BuildOptions = {}) => {
+  /**
+   * We always want to run in production mode when building and some packages
+   * use NODE_ENV to determin which type of package to import (looking at your react).
+   * Therefore for building, unless it's specifically set by the user, we'll set it to production.
+   */
+  process.env.NODE_ENV = process.env.NODE_ENV || 'production';
+
   const {
     silent,
     debug,

--- a/packages/utils/pack-up/src/node/build.ts
+++ b/packages/utils/pack-up/src/node/build.ts
@@ -35,7 +35,7 @@ type BuildOptions = BuildWithConfigFile | BuildWithoutConfigFile;
 const build = async (opts: BuildOptions = {}) => {
   /**
    * We always want to run in production mode when building and some packages
-   * use NODE_ENV to determin which type of package to import (looking at your react).
+   * use NODE_ENV to determine which type of package to import (looking at your react).
    * Therefore for building, unless it's specifically set by the user, we'll set it to production.
    */
   process.env.NODE_ENV = process.env.NODE_ENV || 'production';


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* pack-up now by default sets `NODE_ENV` to production _unless_ it's set already

### Why is it needed?

* vite doesn't set process.env.NODE_ENV, it does set values on `import.meta.env`, but `react` doesn't look at those 🙃 

### How to test it?

* build the color-picker without this PR and you'll see we're trying to import the dev jsx files
* with this pr we correctly import the non-dev jsx file

### Related issue(s)/PR(s)

* resolves #18575
