### PR TITLE
fix(upload): add folderPath arg (#18555, #18540)

### DIFF
--- a/packages/core/upload/admin/src/components/AssetDialog/index.js
+++ b/packages/core/upload/admin/src/components/AssetDialog/index.js
@@ -44,6 +44,7 @@ const LoadingBody = styled(Flex)`
 export const AssetDialog = ({
   allowedTypes,
   folderId,
+  folderPath,
   onClose,
   onAddAsset,
   onAddFolder,
@@ -75,7 +76,7 @@ export const AssetDialog = ({
       onChangeSearch,
       onChangeFolder: onChangeFolderParam,
     },
-  ] = useModalQueryParams({ folder: folderId });
+  ] = useModalQueryParams({ folder: folderId, folderPath });
 
   const {
     data: { pagination, results: assets } = {},
@@ -217,7 +218,7 @@ export const AssetDialog = ({
   };
 
   const handleFolderChange = (folderId, folderPath) => {
-    onChangeFolder(folderId);
+    onChangeFolder(folderId, folderPath);
     onChangeFolderParam(folderId, folderPath);
   };
 
@@ -322,6 +323,7 @@ export const AssetDialog = ({
 AssetDialog.defaultProps = {
   allowedTypes: [],
   folderId: null,
+  folderPath: undefined,
   initiallySelectedAssets: [],
   multiple: false,
   trackedLocation: undefined,
@@ -330,6 +332,7 @@ AssetDialog.defaultProps = {
 AssetDialog.propTypes = {
   allowedTypes: PropTypes.arrayOf(PropTypes.string),
   folderId: PropTypes.number,
+  folderPath: PropTypes.string,
   initiallySelectedAssets: PropTypes.arrayOf(AssetDefinition),
   multiple: PropTypes.bool,
   onAddAsset: PropTypes.func.isRequired,

--- a/packages/core/upload/admin/src/components/MediaLibraryDialog/index.js
+++ b/packages/core/upload/admin/src/components/MediaLibraryDialog/index.js
@@ -15,6 +15,7 @@ const STEPS = {
 export const MediaLibraryDialog = ({ onClose, onSelectAssets, allowedTypes }) => {
   const [step, setStep] = useState(STEPS.AssetSelect);
   const [folderId, setFolderId] = useState(null);
+  const [folderPath, setFolderPath] = useState(undefined);
 
   switch (step) {
     case STEPS.AssetSelect:
@@ -22,15 +23,20 @@ export const MediaLibraryDialog = ({ onClose, onSelectAssets, allowedTypes }) =>
         <AssetDialog
           allowedTypes={allowedTypes}
           folderId={folderId}
+          folderPath={folderPath}
           onClose={() => {
             setStep(undefined);
             setFolderId(null);
+            setFolderPath(undefined);
             onClose();
           }}
           onValidate={onSelectAssets}
           onAddAsset={() => setStep(STEPS.AssetUpload)}
           onAddFolder={() => setStep(STEPS.FolderCreate)}
-          onChangeFolder={(folderId) => setFolderId(folderId)}
+          onChangeFolder={(folderId, folderPath) => {
+            setFolderId(folderId);
+            setFolderPath(folderPath);
+          }}
           multiple
         />
       );


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Store the current `folderPath` in a state.

### Why is it needed?

Avoiding the problem of a component refreshing after a nested modal closes and the state is lost (reset), resulting in a lack of parameter passing and no data being found.

### How to test it?

Check out the video in the issue (https://github.com/strapi/strapi/issues/18555, https://github.com/strapi/strapi/issues/18540) and use the code snippet to reproduce it.

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/issues/18555

https://github.com/strapi/strapi/issues/18540
