### PR TITLE
feat(content-releases): Add sidebar link and routes to the ListView page and the detail page

### DIFF
--- a/packages/core/content-releases/admin/src/index.ts
+++ b/packages/core/content-releases/admin/src/index.ts
@@ -1,13 +1,36 @@
 import { prefixPluginTranslations } from '@strapi/helper-plugin';
+import { PaperPlane } from '@strapi/icons';
+
+import { pluginId } from './pluginId';
+
+import type { Plugin } from '@strapi/types';
 
 // eslint-disable-next-line import/no-default-export
-export default {
-  register() {
+const admin: Plugin.Config.AdminInput = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  register(app: any) {
     if (window.strapi.features.isEnabled('cms-content-releases')) {
       // EE Code would be here
       // For testing if the plugin is working, add a console.log
+      app.addMenuLink({
+        to: `/plugins/${pluginId}`,
+        icon: PaperPlane,
+        intlLabel: {
+          id: `${pluginId}.plugin.name`,
+          defaultMessage: 'Releases',
+        },
+        async Component() {
+          const { Releases } = await import(
+            /* webpackChunkName: "content-type-builder" */ './pages/Releases'
+          );
+          return Releases;
+        },
+        permissions: [], // array of permissions (object), allow a user to access a plugin depending on its permissions
+      });
     }
   },
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  bootstrap() {},
   async registerTrads({ locales }: { locales: string[] }) {
     const importedTrads = await Promise.all(
       locales.map((locale) => {
@@ -30,3 +53,6 @@ export default {
     return Promise.resolve(importedTrads);
   },
 };
+
+// eslint-disable-next-line import/no-default-export
+export default admin;

--- a/packages/core/content-releases/admin/src/index.ts
+++ b/packages/core/content-releases/admin/src/index.ts
@@ -23,24 +23,7 @@ const admin: Plugin.Config.AdminInput = {
           );
           return Releases;
         },
-        permissions: [
-          {
-            action: 'admin::users.read',
-            subject: null,
-          },
-          {
-            action: 'admin::users.create',
-            subject: null,
-          },
-          {
-            action: 'admin::users.delete',
-            subject: null,
-          },
-          {
-            action: 'admin::users.update',
-            subject: null,
-          },
-        ],
+        permissions: [],
       });
     }
   },

--- a/packages/core/content-releases/admin/src/index.ts
+++ b/packages/core/content-releases/admin/src/index.ts
@@ -23,7 +23,24 @@ const admin: Plugin.Config.AdminInput = {
           );
           return Releases;
         },
-        permissions: [], // array of permissions (object), allow a user to access a plugin depending on its permissions
+        permissions: [
+          {
+            action: 'admin::users.read',
+            subject: null,
+          },
+          {
+            action: 'admin::users.create',
+            subject: null,
+          },
+          {
+            action: 'admin::users.delete',
+            subject: null,
+          },
+          {
+            action: 'admin::users.update',
+            subject: null,
+          },
+        ],
       });
     }
   },

--- a/packages/core/content-releases/admin/src/index.ts
+++ b/packages/core/content-releases/admin/src/index.ts
@@ -44,8 +44,6 @@ const admin: Plugin.Config.AdminInput = {
       });
     }
   },
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  bootstrap() {},
   async registerTrads({ locales }: { locales: string[] }) {
     const importedTrads = await Promise.all(
       locales.map((locale) => {

--- a/packages/core/content-releases/admin/src/index.ts
+++ b/packages/core/content-releases/admin/src/index.ts
@@ -10,8 +10,6 @@ const admin: Plugin.Config.AdminInput = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   register(app: any) {
     if (window.strapi.features.isEnabled('cms-content-releases')) {
-      // EE Code would be here
-      // For testing if the plugin is working, add a console.log
       app.addMenuLink({
         to: `/plugins/${pluginId}`,
         icon: PaperPlane,

--- a/packages/core/content-releases/admin/src/pages/Releases.tsx
+++ b/packages/core/content-releases/admin/src/pages/Releases.tsx
@@ -1,0 +1,22 @@
+import { Main } from '@strapi/design-system';
+import { Route, Switch } from 'react-router-dom';
+
+import { pluginId } from '../pluginId';
+
+export const Releases = () => {
+  return (
+    <Main>
+      <Switch>
+        <Route
+          exact
+          path={`/plugins/${pluginId}`}
+          render={() => <div>TODO: This is the ListPage</div>}
+        />
+        <Route
+          path={`/plugins/${pluginId}/:releaseId`}
+          render={() => <div>TODO: This is the DetailsPage</div>}
+        />
+      </Switch>
+    </Main>
+  );
+};

--- a/packages/core/content-releases/admin/src/pluginId.ts
+++ b/packages/core/content-releases/admin/src/pluginId.ts
@@ -1,0 +1,3 @@
+import pluginPkg from '../../package.json';
+
+export const pluginId = pluginPkg.name.replace(/^@strapi\//i, '');

--- a/packages/core/content-releases/admin/src/pluginId.ts
+++ b/packages/core/content-releases/admin/src/pluginId.ts
@@ -1,3 +1,1 @@
-import pluginPkg from '../../package.json';
-
-export const pluginId = pluginPkg.name.replace(/^@strapi\//i, '');
+export const pluginId = 'content-releases';

--- a/packages/core/content-releases/admin/src/translations/en.json
+++ b/packages/core/content-releases/admin/src/translations/en.json
@@ -1,1 +1,3 @@
-{}
+{
+  "plugin.name": "Releases"
+}

--- a/packages/core/content-releases/admin/src/translations/tests/plural.test.ts
+++ b/packages/core/content-releases/admin/src/translations/tests/plural.test.ts
@@ -1,0 +1,23 @@
+import translations from '../en.json';
+
+const typedTranslations: Record<string, string> = translations;
+
+describe('translations', () => {
+  describe('plural syntax', () => {
+    it('should avoid .plural/.singular syntax', () => {
+      Object.keys(typedTranslations).forEach((translationKey) => {
+        const keyParts = translationKey.split('.');
+        const lastKeyPart = keyParts.pop();
+
+        // Skip if the key cannot be splitted
+        // Fail only if a PAIR of .singular/.plural keys is found
+        if (keyParts.length > 1 && lastKeyPart === 'singular') {
+          keyParts.push('plural');
+          const pluralKey = keyParts.join('.');
+
+          expect(typedTranslations[pluralKey]).toBeUndefined();
+        }
+      });
+    });
+  });
+});

--- a/packages/core/types/src/types/core/plugins/config/strapi-admin/index.ts
+++ b/packages/core/types/src/types/core/plugins/config/strapi-admin/index.ts
@@ -2,6 +2,6 @@
 // Interface for the plugin strapi-admin file
 export interface AdminInput {
   register: unknown;
-  bootstrap: unknown;
+  bootstrap?: unknown;
   registerTrads: ({ locales }: { locales: string[] }) => Promise<unknown>;
 }


### PR DESCRIPTION
### What does it do?

Create the Link in the Sidebar in the plugin section and also the two Routes to the
- /admin/plugins/content-releases the ListView page
- /admin/plugins/content-releases/:releaseId the Detail Page

### How to test it?

You need to have an Enterprise License
In the sidebar you can see in the Plugins section the "Releases" link that links to the admin/plugins/content-releases page
You can also navigate the two pages directly from the browser url

In the two different pages we want to show just the strings
TODO: This is the ListPage
TODO: This is the DetailsPage
