### PR TITLE
feat: allow passing http serverOptions from config

### DIFF
--- a/examples/getstarted/config/server.js
+++ b/examples/getstarted/config/server.js
@@ -23,7 +23,7 @@ module.exports = ({ env }) => ({
   globalProxy: env('http_proxy'),
   http: {
     serverOptions: {
-      requestTimeout: 60 * 10, // set request timeout to 10 minutes instead of default 5
+      requestTimeout: 1000 * 60 * 10, // set request timeout to 600000ms (10 minutes)
     },
   },
 });

--- a/examples/getstarted/config/server.js
+++ b/examples/getstarted/config/server.js
@@ -21,4 +21,9 @@ module.exports = ({ env }) => ({
   },
   // ℹ️ http_proxy is the env var used by system to set proxy globally
   globalProxy: env('http_proxy'),
+  http: {
+    serverOptions: {
+      requestTimeout: 60 * 10, // set request timeout to 10 minutes instead of default 5
+    },
+  },
 });

--- a/packages/core/strapi/src/services/server/http-server.ts
+++ b/packages/core/strapi/src/services/server/http-server.ts
@@ -20,7 +20,12 @@ const createHTTPServer = (strapi: Strapi, koaApp: Koa): Server => {
     return handler(req, res);
   };
 
-  const server: http.Server = http.createServer(listener);
+  const options = strapi.config.get<Record<string, unknown>>(
+    'server.http.server.options',
+    {}
+  ) as http.ServerOptions;
+
+  const server: http.Server = http.createServer(options, listener);
 
   server.on('connection', (connection) => {
     connections.add(connection);

--- a/packages/core/strapi/src/services/server/http-server.ts
+++ b/packages/core/strapi/src/services/server/http-server.ts
@@ -20,10 +20,7 @@ const createHTTPServer = (strapi: Strapi, koaApp: Koa): Server => {
     return handler(req, res);
   };
 
-  const options = strapi.config.get<Record<string, unknown>>(
-    'server.http.serverOptions',
-    {}
-  ) as http.ServerOptions;
+  const options = strapi.config.get<http.ServerOptions>('server.http.serverOptions', {});
 
   const server: http.Server = http.createServer(options, listener);
 

--- a/packages/core/strapi/src/services/server/http-server.ts
+++ b/packages/core/strapi/src/services/server/http-server.ts
@@ -21,7 +21,7 @@ const createHTTPServer = (strapi: Strapi, koaApp: Koa): Server => {
   };
 
   const options = strapi.config.get<Record<string, unknown>>(
-    'server.http.server.options',
+    'server.http.serverOptions',
     {}
   ) as http.ServerOptions;
 


### PR DESCRIPTION
### What does it do?

Allows user to set http server configuration options


### Why is it needed?

The specific issue is that Strapi can no longer accept any file uploads that take longer than the default Node 18+ http server requestTimeout, which is 5 minutes.

This allows users to configure that setting to be whatever value they wish.

In addition to that, users will now be able to configure any option available in http.ServerOptions

### How to test it?

Try setting some values in config/server.ts http.serverOptions and see that they are passed through to the http.createServer

### Related issue(s)/PR(s)

Fixes https://github.com/strapi/strapi/issues/18543

[Documentation PR](https://github.com/strapi/documentation/pull/1903)