### PR TITLE
chore: add precise types to blocks attribute

### DIFF
--- a/packages/core/types/src/types/core/attributes/blocks.ts
+++ b/packages/core/types/src/types/core/attributes/blocks.ts
@@ -8,6 +8,75 @@ export type Blocks = Attribute.OfType<'blocks'> &
   Attribute.WritableOption &
   Attribute.VisibleOption;
 
-export type BlocksValue<T extends object = object> = T;
+interface TextInlineNode {
+  type: 'text';
+  text: string;
+  bold?: boolean;
+  italic?: boolean;
+  underline?: boolean;
+  strikethrough?: boolean;
+  code?: boolean;
+}
+
+interface LinkInlineNode {
+  type: 'link';
+  url: string;
+  children: TextInlineNode[];
+}
+
+interface ListItemInlineNode {
+  type: 'list-item';
+  children: DefaultInlineNode[];
+}
+
+type DefaultInlineNode = TextInlineNode | LinkInlineNode;
+
+interface ParagraphBlockNode {
+  type: 'paragraph';
+  children: DefaultInlineNode[];
+}
+
+interface QuoteBlockNode {
+  type: 'quote';
+  children: DefaultInlineNode[];
+}
+
+interface CodeBlockNode {
+  type: 'code';
+  children: DefaultInlineNode[];
+}
+
+interface HeadingBlockNode {
+  type: 'heading';
+  level: 1 | 2 | 3 | 4 | 5 | 6;
+  children: DefaultInlineNode[];
+}
+
+interface ListBlockNode {
+  type: 'list';
+  format: 'ordered' | 'unordered';
+  children: (ListItemInlineNode | ListBlockNode)[];
+}
+
+interface ImageBlockNode {
+  type: 'image';
+  image: Attribute.GetValue<{
+    type: 'media';
+    allowedTypes: ['images'];
+    multiple: false;
+  }>;
+  children: [{ type: 'text'; text: '' }];
+}
+
+// Block node types
+type RootNode =
+  | ParagraphBlockNode
+  | QuoteBlockNode
+  | CodeBlockNode
+  | HeadingBlockNode
+  | ListBlockNode
+  | ImageBlockNode;
+
+export type BlocksValue = RootNode[];
 
 export type GetBlocksValue<T extends Attribute.Attribute> = T extends Blocks ? BlocksValue : never;

--- a/packages/core/types/src/types/core/attributes/blocks.ts
+++ b/packages/core/types/src/types/core/attributes/blocks.ts
@@ -29,6 +29,7 @@ interface ListItemInlineNode extends BaseNode {
 type InlineNode = TextInlineNode | LinkInlineNode | ListItemInlineNode;
 
 type DefaultInlineNode = Exclude<InlineNode, ListItemInlineNode>;
+type NonTextInlineNode = Exclude<InlineNode, TextInlineNode>;
 
 interface ParagraphBlockNode extends BaseNode {
   type: 'paragraph';
@@ -89,5 +90,6 @@ export type BlocksValue = RootNode[];
 export type GetBlocksValue<T extends Attribute.Attribute> = T extends Blocks ? BlocksValue : never;
 
 // Type utils needed for the blocks renderer and the blocks editor
-export type BlocksNode = RootNode | Exclude<InlineNode, TextInlineNode>;
+export type BlocksNode = RootNode | NonTextInlineNode;
+export type BlocksInlineNode = NonTextInlineNode;
 export type BlocksTextNode = TextInlineNode;

--- a/packages/core/types/src/types/core/attributes/blocks.ts
+++ b/packages/core/types/src/types/core/attributes/blocks.ts
@@ -10,48 +10,54 @@ interface TextInlineNode {
   code?: boolean;
 }
 
-interface LinkInlineNode {
+interface BaseNode {
+  type: string;
+  children: unknown[];
+}
+
+interface LinkInlineNode extends BaseNode {
   type: 'link';
   url: string;
   children: TextInlineNode[];
 }
 
-interface ListItemInlineNode {
+interface ListItemInlineNode extends BaseNode {
   type: 'list-item';
   children: DefaultInlineNode[];
 }
 
-type DefaultInlineNode = TextInlineNode | LinkInlineNode;
-type NonTextInlineNode = Exclude<DefaultInlineNode | ListItemInlineNode, TextInlineNode>;
+type InlineNode = TextInlineNode | LinkInlineNode | ListItemInlineNode;
 
-interface ParagraphBlockNode {
+type DefaultInlineNode = Exclude<InlineNode, ListItemInlineNode>;
+
+interface ParagraphBlockNode extends BaseNode {
   type: 'paragraph';
   children: DefaultInlineNode[];
 }
 
-interface QuoteBlockNode {
+interface QuoteBlockNode extends BaseNode {
   type: 'quote';
   children: DefaultInlineNode[];
 }
 
-interface CodeBlockNode {
+interface CodeBlockNode extends BaseNode {
   type: 'code';
   children: DefaultInlineNode[];
 }
 
-interface HeadingBlockNode {
+interface HeadingBlockNode extends BaseNode {
   type: 'heading';
   level: 1 | 2 | 3 | 4 | 5 | 6;
   children: DefaultInlineNode[];
 }
 
-interface ListBlockNode {
+interface ListBlockNode extends BaseNode {
   type: 'list';
   format: 'ordered' | 'unordered';
   children: (ListItemInlineNode | ListBlockNode)[];
 }
 
-interface ImageBlockNode {
+interface ImageBlockNode extends BaseNode {
   type: 'image';
   image: Attribute.GetValue<{
     type: 'media';
@@ -80,13 +86,8 @@ export type Blocks = Attribute.OfType<'blocks'> &
 
 export type BlocksValue = RootNode[];
 
-// Type utils needed for the blocks renderer and the blocks editor (useBlocksStore)
-export type BlockNode<NodeKind extends 'root' | 'inline' | 'all'> = NodeKind extends 'root'
-  ? RootNode
-  : NodeKind extends 'inline'
-  ? NonTextInlineNode
-  : NodeKind extends 'all'
-  ? RootNode | NonTextInlineNode
-  : never;
-
 export type GetBlocksValue<T extends Attribute.Attribute> = T extends Blocks ? BlocksValue : never;
+
+// Type utils needed for the blocks renderer and the blocks editor
+export type BlocksNode = RootNode | Exclude<InlineNode, TextInlineNode>;
+export type BlocksTextNode = TextInlineNode;

--- a/packages/core/types/src/types/core/attributes/blocks.ts
+++ b/packages/core/types/src/types/core/attributes/blocks.ts
@@ -1,13 +1,5 @@
 import type { Attribute } from '..';
 
-export type Blocks = Attribute.OfType<'blocks'> &
-  // Options
-  Attribute.ConfigurableOption &
-  Attribute.PrivateOption &
-  Attribute.RequiredOption &
-  Attribute.WritableOption &
-  Attribute.VisibleOption;
-
 interface TextInlineNode {
   type: 'text';
   text: string;
@@ -30,6 +22,7 @@ interface ListItemInlineNode {
 }
 
 type DefaultInlineNode = TextInlineNode | LinkInlineNode;
+type NonTextInlineNode = Exclude<DefaultInlineNode | ListItemInlineNode, TextInlineNode>;
 
 interface ParagraphBlockNode {
   type: 'paragraph';
@@ -77,6 +70,23 @@ type RootNode =
   | ListBlockNode
   | ImageBlockNode;
 
+export type Blocks = Attribute.OfType<'blocks'> &
+  // Options
+  Attribute.ConfigurableOption &
+  Attribute.PrivateOption &
+  Attribute.RequiredOption &
+  Attribute.WritableOption &
+  Attribute.VisibleOption;
+
 export type BlocksValue = RootNode[];
+
+// Type utils needed for the blocks renderer and the blocks editor (useBlocksStore)
+export type BlockNode<NodeKind extends 'root' | 'inline' | 'all'> = NodeKind extends 'root'
+  ? RootNode
+  : NodeKind extends 'inline'
+  ? NonTextInlineNode
+  : NodeKind extends 'all'
+  ? RootNode | NonTextInlineNode
+  : never;
 
 export type GetBlocksValue<T extends Attribute.Attribute> = T extends Blocks ? BlocksValue : never;


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Provides precise types for blocks attributes, instead of just using the object type

### Why is it needed?

We'll need these types in 2 places:

- the blocks editor, as we're starting to convert it to TS
- the blocks renderer
