### PR TITLE
chore(repo): Add Change Freeze workflow

### DIFF
--- a/.github/workflows/changeFreeze.yml
+++ b/.github/workflows/changeFreeze.yml
@@ -1,0 +1,34 @@
+name: Check Change Freeze
+
+on:
+  pull_request:
+    types: [opened]
+
+permissions: read-all
+
+jobs:
+  check-ownership:
+    name: "Check if PR was created by a Strapi Team Member"
+    runs-on: ubuntu-latest
+    outputs:
+      isTeamMember: ${{ steps.get-user-teams-membership.outputs.isTeamMember }}
+    steps:
+      - uses: tspascoal/get-user-teams-membership@v3
+        id: get-user-teams-membership
+        with:
+          GITHUB_TOKEN: ${{ secrets.CHECK_OWNERSHIP_TOKEN }}
+          team: team
+          username: ${{ github.actor }}
+  send-response:
+    name: "Alert user to change freeze"
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    needs: [check-ownership]
+    if: ${{ needs.check-ownership.outputs.isTeamMember == 'false' && vars.CHANGE_FREEZE_ENABLED == 'true' }}
+    steps:
+      - uses: thollander/actions-comment-pull-request@v2
+        with:
+          message: |
+            This repo is currently under a community change freeze. Please see any pinned issues for more information.
+            If you believe this PR should be merged, please respond with the reason why else we will close all PRs until after the change freeze is lifted.


### PR DESCRIPTION
### What does it do?

Adds a workflow that checks all PR authors to see if they belong to the `@strapi/team` org team, if they aren't it will post a message on the PR asking for the reason why this should be merged before we close it.

### Why is it needed?

Change Freeze for v5 but coded so that we can simply turn it on or off using a repo variable

### How to test it?

Need to create the following:

- a PAT under repo secrets called `CHECK_OWNERSHIP_TOKEN` with at minimum the admin:org -> read:org permission (to read the team membership since not everyone on our team has public membership enabled)
![image](https://github.com/strapi/strapi/assets/8593673/f84be537-55cf-437e-ac2e-07da076671e8)

- a repo var called: `CHANGE_FREEZE_ENABLED` set to `true`
![image](https://github.com/strapi/strapi/assets/8593673/d1a05208-3d2f-4442-8ccd-9f4e4c6e6504)


### Related issue(s)/PR(s)

#18618
