### PR TITLE
fix(admin): build pipeline & deps

### DIFF
--- a/packages/core/admin/_internal/node/core/dependencies.ts
+++ b/packages/core/admin/_internal/node/core/dependencies.ts
@@ -15,8 +15,8 @@ import { getPackageManager } from './managers';
 const PEER_DEPS = {
   react: '^18.0.0',
   'react-dom': '^18.0.0',
-  'react-router-dom': '^5.0.0',
-  'styled-components': '^5.0.0',
+  'react-router-dom': '^5.2.0',
+  'styled-components': '^5.2.1',
 };
 
 interface CheckRequiredDependenciesResult {

--- a/packages/core/admin/_internal/node/core/plugins.ts
+++ b/packages/core/admin/_internal/node/core/plugins.ts
@@ -5,13 +5,6 @@ import { getModule, PackageJson } from './dependencies';
 import { loadFile } from './files';
 import { BuildContext, CreateBuildContextArgs } from '../createBuildContext';
 
-const CORE_PLUGINS = [
-  '@strapi/plugin-content-manager',
-  '@strapi/plugin-content-type-builder',
-  '@strapi/plugin-email',
-  '@strapi/plugin-upload',
-];
-
 interface PluginMeta {
   name: string;
   pathToPlugin: string;
@@ -45,24 +38,6 @@ export const getEnabledPlugins = async ({
   logger,
 }: Pick<BuildContext, 'cwd' | 'logger' | 'strapi'>) => {
   const plugins: Record<string, PluginMeta> = {};
-
-  logger.debug('Core plugins', os.EOL, CORE_PLUGINS);
-
-  for (const plugin of CORE_PLUGINS) {
-    const pkg = await getModule(plugin, cwd);
-
-    if (pkg && validatePackageIsPlugin(pkg)) {
-      /**
-       * We know there's a name because these are our packages.
-       */
-      const name = (pkg.strapi.name || pkg.name)!;
-
-      plugins[name] = {
-        name,
-        pathToPlugin: plugin,
-      };
-    }
-  }
 
   /**
    * This is the list of dependencies that are installed in the user's project.

--- a/packages/core/admin/_internal/node/staticFiles.ts
+++ b/packages/core/admin/_internal/node/staticFiles.ts
@@ -26,7 +26,7 @@ const getEntryModule = ({ plugins }: EntryModuleArgs): string => {
          * Any modifications made will be discarded.
          */
         ${pluginsImport}
-        import { renderAdmin } from "@strapi/admin/strapi-admin"
+        import { renderAdmin } from "@strapi/strapi/admin"
         
         renderAdmin(
           document.getElementById("strapi"),

--- a/packages/core/admin/package.json
+++ b/packages/core/admin/package.json
@@ -96,6 +96,7 @@
     "css-loader": "^6.8.1",
     "date-fns": "2.30.0",
     "dotenv": "14.2.0",
+    "esbuild": "0.19.2",
     "esbuild-loader": "^2.21.0",
     "esbuild-register": "3.5.0",
     "execa": "5.1.1",
@@ -185,7 +186,12 @@
     "vite": "4.4.9"
   },
   "peerDependencies": {
-    "@strapi/strapi": "^4.3.4"
+    "@strapi/data-transfer": "4.15.0",
+    "@strapi/strapi": "^4.3.4",
+    "react": "^17.0.0 || ^18.0.0",
+    "react-dom": "^17.0.0 || ^18.0.0",
+    "react-router-dom": "^5.2.0",
+    "styled-components": "^5.2.1"
   },
   "engines": {
     "node": ">=18.0.0 <=20.x.x",

--- a/packages/core/content-type-builder/package.json
+++ b/packages/core/content-type-builder/package.json
@@ -58,8 +58,8 @@
   "peerDependencies": {
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0",
-    "react-router-dom": "5.3.4",
-    "styled-components": "5.3.3"
+    "react-router-dom": "^5.2.0",
+    "styled-components": "^5.2.1"
   },
   "engines": {
     "node": ">=18.0.0 <=20.x.x",

--- a/packages/core/data-transfer/src/commands/data-transfer.ts
+++ b/packages/core/data-transfer/src/commands/data-transfer.ts
@@ -5,7 +5,7 @@ import { configs, createLogger } from '@strapi/logger';
 import strapiFactory from '@strapi/strapi';
 import ora from 'ora';
 import { merge } from 'lodash/fp';
-import type { LoadedStrapi } from '@strapi/types';
+import type { LoadedStrapi, Strapi } from '@strapi/types';
 
 import { readableBytes, exitWith } from './helpers';
 import { getParseListWithChoices, parseInteger, confirmMessage } from './commander';
@@ -148,7 +148,9 @@ const setSignalHandler = async (
   });
 };
 
-const createStrapiInstance = async (opts: { logLevel?: string } = {}) => {
+const createStrapiInstance = async (
+  opts: { logLevel?: string } = {}
+): Promise<Strapi & Required<Strapi>> => {
   try {
     const appContext = await strapiFactory.compile();
     const app = strapiFactory({ ...opts, ...appContext });

--- a/packages/core/email/package.json
+++ b/packages/core/email/package.json
@@ -81,8 +81,8 @@
     "koa": "2.13.4",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0",
-    "react-router-dom": "5.3.4",
-    "styled-components": "5.3.3"
+    "react-router-dom": "^5.2.0",
+    "styled-components": "^5.2.1"
   },
   "engines": {
     "node": ">=18.0.0 <=20.x.x",

--- a/packages/core/helper-plugin/package.json
+++ b/packages/core/helper-plugin/package.json
@@ -100,8 +100,8 @@
     "@strapi/icons": "1.13.0",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0",
-    "react-router-dom": "^5.3.4",
-    "styled-components": "^5.3.3"
+    "react-router-dom": "^5.2.0",
+    "styled-components": "^5.2.1"
   },
   "engines": {
     "node": ">=18.0.0 <=20.x.x",

--- a/packages/core/strapi/package.json
+++ b/packages/core/strapi/package.json
@@ -64,6 +64,30 @@
       "url": "https://strapi.io"
     }
   ],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "source": "./src/index.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./dist/utils/ee": {
+      "types": "./dist/utils/ee.d.ts",
+      "source": "./src/utils/ee.ts",
+      "import": "./dist/utils/ee.mjs",
+      "require": "./dist/utils/ee.js",
+      "default": "./dist/utils/ee.js"
+    },
+    "./admin": {
+      "types": "./dist/admin.d.ts",
+      "source": "./src/admin.ts",
+      "import": "./dist/admin.mjs",
+      "require": "./dist/admin.js",
+      "default": "./dist/admin.js"
+    },
+    "./package.json": "./package.json"
+  },
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "source": "./src/index.ts",

--- a/packages/core/strapi/packup.config.ts
+++ b/packages/core/strapi/packup.config.ts
@@ -5,12 +5,27 @@ import { builtinModules } from 'node:module';
 export default defineConfig({
   bundles: [
     {
+      source: './src/index.ts',
+      import: './dist/index.js',
+      require: './dist/index.js',
+      types: './dist/index.d.ts',
+      runtime: 'node',
+    },
+    {
       source: './src/cli.ts',
       require: './dist/cli.js',
       runtime: 'node',
     },
+    {
+      source: './src/admin.ts',
+      import: './dist/admin.js',
+      require: './dist/admin.js',
+      types: './dist/index.d.ts',
+      runtime: 'web',
+    },
   ],
+  exports: {},
+  dist: './dist',
   externals: [...builtinModules],
   preserveModules: true,
-  runtime: 'node',
 });

--- a/packages/core/strapi/src/admin.ts
+++ b/packages/core/strapi/src/admin.ts
@@ -1,0 +1,21 @@
+import { RenderAdminArgs, renderAdmin } from '@strapi/admin/strapi-admin';
+// @ts-expect-error – No types, yet.
+import contentTypeBuilder from '@strapi/plugin-content-type-builder/strapi-admin';
+import email from '@strapi/plugin-email/strapi-admin';
+// @ts-expect-error – No types, yet.
+import upload from '@strapi/plugin-upload/strapi-admin';
+
+const render = (mountNode: HTMLElement | null, { plugins }: RenderAdminArgs) => {
+  return renderAdmin(mountNode, {
+    plugins: {
+      'content-type-builder': contentTypeBuilder,
+      // @ts-expect-error – TODO: fix this
+      email,
+      upload,
+      ...plugins,
+    },
+  });
+};
+
+export { render as renderAdmin };
+export type { RenderAdminArgs };

--- a/packages/core/strapi/src/commands/actions/plugin/build-command/action.ts
+++ b/packages/core/strapi/src/commands/actions/plugin/build-command/action.ts
@@ -13,6 +13,10 @@ export default async ({ force, ...opts }: ActionOptions) => {
   const logger = createLogger({ debug: opts.debug, silent: opts.silent, timestamp: false });
   try {
     /**
+     * ALWAYS set production for using plugin build CLI.
+     */
+    process.env.NODE_ENV = 'production';
+    /**
      * Notify users this is an experimental command and get them to approve first
      * this can be opted out by setting the argument --yes
      */

--- a/packages/core/upload/package.json
+++ b/packages/core/upload/package.json
@@ -65,8 +65,8 @@
   "peerDependencies": {
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0",
-    "react-router-dom": "5.3.4",
-    "styled-components": "5.3.3"
+    "react-router-dom": "^5.2.0",
+    "styled-components": "^5.2.1"
   },
   "engines": {
     "node": ">=18.0.0 <=20.x.x",

--- a/packages/generators/generators/src/templates/js/plugin-package.json.hbs
+++ b/packages/generators/generators/src/templates/js/plugin-package.json.hbs
@@ -23,8 +23,8 @@
   "peerDependencies": {
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0",
-    "react-router-dom": "^5.3.4",
-    "styled-components": "^5.3.6"
+    "react-router-dom": "^5.2.0",
+    "styled-components": "^5.2.1"
   },
   "author": {
     "name": "A Strapi developer"

--- a/packages/generators/generators/src/templates/ts/plugin-package.json.hbs
+++ b/packages/generators/generators/src/templates/ts/plugin-package.json.hbs
@@ -28,8 +28,8 @@
   "peerDependencies": {
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0",
-    "react-router-dom": "^5.3.4",
-    "styled-components": "^5.3.6"
+    "react-router-dom": "^5.2.0",
+    "styled-components": "^5.2.1"
   },
   "author": {
     "name": "A Strapi developer"

--- a/packages/plugins/cloud/package.json
+++ b/packages/plugins/cloud/package.json
@@ -53,8 +53,8 @@
     "eslint-config-custom": "4.15.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^5.3.4",
-    "styled-components": "^5.3.3",
+    "react-router-dom": "5.3.4",
+    "styled-components": "5.3.3",
     "tsconfig": "4.15.1",
     "typescript": "5.2.2"
   },
@@ -62,8 +62,8 @@
     "@strapi/strapi": "^4.4.0",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0",
-    "react-router-dom": "^5.3.4",
-    "styled-components": "^5.3.6"
+    "react-router-dom": "^5.2.0",
+    "styled-components": "^5.2.1"
   },
   "engines": {
     "node": ">=18.0.0 <=20.x.x",

--- a/packages/plugins/color-picker/package.json
+++ b/packages/plugins/color-picker/package.json
@@ -79,8 +79,8 @@
     "@strapi/strapi": "^4.4.0",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0",
-    "react-router-dom": "5.3.4",
-    "styled-components": "5.3.3"
+    "react-router-dom": "^5.2.0",
+    "styled-components": "^5.2.1"
   },
   "engines": {
     "node": ">=18.0.0 <=20.x.x",

--- a/packages/plugins/documentation/package.json
+++ b/packages/plugins/documentation/package.json
@@ -61,8 +61,8 @@
     "@strapi/strapi": "^4.0.0",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0",
-    "react-router-dom": "5.3.4",
-    "styled-components": "5.3.3"
+    "react-router-dom": "^5.2.0",
+    "styled-components": "^5.2.1"
   },
   "engines": {
     "node": ">=18.0.0 <=20.x.x",

--- a/packages/plugins/graphql/package.json
+++ b/packages/plugins/graphql/package.json
@@ -54,8 +54,8 @@
     "@strapi/strapi": "^4.0.0",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0",
-    "react-router-dom": "5.3.4",
-    "styled-components": "5.3.3"
+    "react-router-dom": "^5.2.0",
+    "styled-components": "^5.2.1"
   },
   "engines": {
     "node": ">=18.0.0 <=20.x.x",

--- a/packages/plugins/i18n/package.json
+++ b/packages/plugins/i18n/package.json
@@ -56,8 +56,8 @@
   "peerDependencies": {
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0",
-    "react-router-dom": "5.3.4",
-    "styled-components": "5.3.3"
+    "react-router-dom": "^5.2.0",
+    "styled-components": "^5.2.1"
   },
   "engines": {
     "node": ">=18.0.0 <=20.x.x",

--- a/packages/plugins/sentry/package.json
+++ b/packages/plugins/sentry/package.json
@@ -41,8 +41,8 @@
     "@strapi/strapi": "^4.0.0",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0",
-    "react-router-dom": "5.3.4",
-    "styled-components": "5.3.3"
+    "react-router-dom": "^5.2.0",
+    "styled-components": "^5.2.1"
   },
   "engines": {
     "node": ">=18.0.0 <=20.x.x",

--- a/packages/plugins/users-permissions/package.json
+++ b/packages/plugins/users-permissions/package.json
@@ -63,8 +63,8 @@
   "peerDependencies": {
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0",
-    "react-router-dom": "5.3.4",
-    "styled-components": "5.3.3"
+    "react-router-dom": "^5.2.0",
+    "styled-components": "^5.2.1"
   },
   "engines": {
     "node": ">=18.0.0 <=20.x.x",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2814,15 +2814,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emotion/is-prop-valid@npm:^1.1.0":
-  version: 1.2.1
-  resolution: "@emotion/is-prop-valid@npm:1.2.1"
-  dependencies:
-    "@emotion/memoize": "npm:^0.8.1"
-  checksum: fe231c472d38b3bbe519bcc9a5585cd41c45604147f3a065e333caf0f695d668aa21bc4229e657c1b6ea7398e096899e6ad54662548c73f11f6ba594aebd76a1
-  languageName: node
-  linkType: hard
-
 "@emotion/memoize@npm:0.7.4":
   version: 0.7.4
   resolution: "@emotion/memoize@npm:0.7.4"
@@ -2834,13 +2825,6 @@ __metadata:
   version: 0.8.0
   resolution: "@emotion/memoize@npm:0.8.0"
   checksum: c87bb110b829edd8e1c13b90a6bc37cebc39af29c7599a1e66a48e06f9bec43e8e53495ba86278cc52e7589549492c8dfdc81d19f4fdec0cee6ba13d2ad2c928
-  languageName: node
-  linkType: hard
-
-"@emotion/memoize@npm:^0.8.1":
-  version: 0.8.1
-  resolution: "@emotion/memoize@npm:0.8.1"
-  checksum: a19cc01a29fcc97514948eaab4dc34d8272e934466ed87c07f157887406bc318000c69ae6f813a9001c6a225364df04249842a50e692ef7a9873335fbcc141b0
   languageName: node
   linkType: hard
 
@@ -7467,6 +7451,7 @@ __metadata:
     css-loader: "npm:^6.8.1"
     date-fns: "npm:2.30.0"
     dotenv: "npm:14.2.0"
+    esbuild: "npm:0.19.2"
     esbuild-loader: "npm:^2.21.0"
     esbuild-register: "npm:3.5.0"
     execa: "npm:5.1.1"
@@ -7543,7 +7528,12 @@ __metadata:
     webpack-hot-middleware: "npm:2.25.4"
     yup: "npm:0.32.9"
   peerDependencies:
+    "@strapi/data-transfer": 4.15.0
     "@strapi/strapi": ^4.3.4
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^5.2.0
+    styled-components: ^5.2.1
   languageName: unknown
   linkType: soft
 
@@ -7755,8 +7745,8 @@ __metadata:
     "@strapi/icons": 1.13.0
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
-    react-router-dom: ^5.3.4
-    styled-components: ^5.3.3
+    react-router-dom: ^5.2.0
+    styled-components: ^5.2.1
   languageName: unknown
   linkType: soft
 
@@ -7869,16 +7859,16 @@ __metadata:
     react: "npm:^18.2.0"
     react-dom: "npm:^18.2.0"
     react-intl: "npm:6.4.1"
-    react-router-dom: "npm:^5.3.4"
-    styled-components: "npm:^5.3.3"
+    react-router-dom: "npm:5.3.4"
+    styled-components: "npm:5.3.3"
     tsconfig: "npm:4.15.1"
     typescript: "npm:5.2.2"
   peerDependencies:
     "@strapi/strapi": ^4.4.0
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
-    react-router-dom: ^5.3.4
-    styled-components: ^5.3.6
+    react-router-dom: ^5.2.0
+    styled-components: ^5.2.1
   languageName: unknown
   linkType: soft
 
@@ -7905,8 +7895,8 @@ __metadata:
     "@strapi/strapi": ^4.4.0
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
-    react-router-dom: 5.3.4
-    styled-components: 5.3.3
+    react-router-dom: ^5.2.0
+    styled-components: ^5.2.1
   languageName: unknown
   linkType: soft
 
@@ -7951,8 +7941,8 @@ __metadata:
   peerDependencies:
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
-    react-router-dom: 5.3.4
-    styled-components: 5.3.3
+    react-router-dom: ^5.2.0
+    styled-components: ^5.2.1
   languageName: unknown
   linkType: soft
 
@@ -7990,8 +7980,8 @@ __metadata:
     "@strapi/strapi": ^4.0.0
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
-    react-router-dom: 5.3.4
-    styled-components: 5.3.3
+    react-router-dom: ^5.2.0
+    styled-components: ^5.2.1
   languageName: unknown
   linkType: soft
 
@@ -8024,8 +8014,8 @@ __metadata:
     koa: 2.13.4
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
-    react-router-dom: 5.3.4
-    styled-components: 5.3.3
+    react-router-dom: ^5.2.0
+    styled-components: ^5.2.1
   languageName: unknown
   linkType: soft
 
@@ -8060,8 +8050,8 @@ __metadata:
     "@strapi/strapi": ^4.0.0
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
-    react-router-dom: 5.3.4
-    styled-components: 5.3.3
+    react-router-dom: ^5.2.0
+    styled-components: ^5.2.1
   languageName: unknown
   linkType: soft
 
@@ -8092,8 +8082,8 @@ __metadata:
   peerDependencies:
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
-    react-router-dom: 5.3.4
-    styled-components: 5.3.3
+    react-router-dom: ^5.2.0
+    styled-components: ^5.2.1
   languageName: unknown
   linkType: soft
 
@@ -8113,8 +8103,8 @@ __metadata:
     "@strapi/strapi": ^4.0.0
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
-    react-router-dom: 5.3.4
-    styled-components: 5.3.3
+    react-router-dom: ^5.2.0
+    styled-components: ^5.2.1
   languageName: unknown
   linkType: soft
 
@@ -8159,8 +8149,8 @@ __metadata:
   peerDependencies:
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
-    react-router-dom: 5.3.4
-    styled-components: 5.3.3
+    react-router-dom: ^5.2.0
+    styled-components: ^5.2.1
   languageName: unknown
   linkType: soft
 
@@ -8199,8 +8189,8 @@ __metadata:
   peerDependencies:
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
-    react-router-dom: 5.3.4
-    styled-components: 5.3.3
+    react-router-dom: ^5.2.0
+    styled-components: ^5.2.1
   languageName: unknown
   linkType: soft
 
@@ -26849,7 +26839,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-router-dom@npm:5.3.4, react-router-dom@npm:^5.3.4":
+"react-router-dom@npm:5.3.4":
   version: 5.3.4
   resolution: "react-router-dom@npm:5.3.4"
   dependencies:
@@ -29523,28 +29513,6 @@ __metadata:
     react-dom: ">= 16.8.0"
     react-is: ">= 16.8.0"
   checksum: b242a805479bac5346d0fa2c860a5a95b78fb2883b859a5b508e8f03d26cf4aa4f80eef49a3c3b8eb11db904f0a9dbab1627674725475fa3d7c6d0eed5f2d3dc
-  languageName: node
-  linkType: hard
-
-"styled-components@npm:^5.3.3":
-  version: 5.3.11
-  resolution: "styled-components@npm:5.3.11"
-  dependencies:
-    "@babel/helper-module-imports": "npm:^7.0.0"
-    "@babel/traverse": "npm:^7.4.5"
-    "@emotion/is-prop-valid": "npm:^1.1.0"
-    "@emotion/stylis": "npm:^0.8.4"
-    "@emotion/unitless": "npm:^0.7.4"
-    babel-plugin-styled-components: "npm:>= 1.12.0"
-    css-to-react-native: "npm:^3.0.0"
-    hoist-non-react-statics: "npm:^3.0.0"
-    shallowequal: "npm:^1.1.0"
-    supports-color: "npm:^5.5.0"
-  peerDependencies:
-    react: ">= 16.8.0"
-    react-dom: ">= 16.8.0"
-    react-is: ">= 16.8.0"
-  checksum: 7e1baee0f7b4479fe1a4064e4ae87e40f1ba583030d04827cef73fa7b36d3a91ed552dc76164d319216039f906af42a5229648c023482280fa4b5f71f00eef2d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* adds `esbuild` as a dep to the `admin` package
* sets peerDeps to match the `design-system` which is lower than what we were targeting incl. on templates so all packages are aligned
* re-exports admin from the strapi package and no longer tries to include the core plugins on a user app level

### Why is it needed?

* upgrading projects couldn't resolve esbuild
* peer dep issues in npm projects
* it's NPM specific but the admin package is not at the same level in the node_modules so you can't import it. Because a user has `@strapi/strapi` declared, we might as well use that and re-export it. We can also import the core plugins there meaning we're another step closer to PNPM working.

### How to test it?

* install a project at `4.15.0`
* upgrade to experimental manually
* experimental build –> `0.0.0-experimental.1cec6226fe6c8ca4b8404f1ebac8076d5ee5b336`
* should build sucessfully

### Related issue(s)/PR(s)

* resolves #18656
* resolves #18652
