### PR TITLE
fix(admin): close webpack watch on reload

### DIFF
--- a/packages/core/admin/_internal/node/develop.ts
+++ b/packages/core/admin/_internal/node/develop.ts
@@ -85,7 +85,7 @@ const develop = async ({ cwd, polling, logger, tsconfig, ...options }: DevelopOp
 
     EE.init(cwd);
     await writeStaticClientFiles(ctx);
-    await watchWebpack(ctx);
+    const webpackWatcher = await watchWebpack(ctx);
 
     const adminDuration = timer.end('creatingAdmin');
     adminSpinner.text = `Creating admin (${adminDuration}ms)`;
@@ -165,6 +165,7 @@ const develop = async ({ cwd, polling, logger, tsconfig, ...options }: DevelopOp
           );
           await watcher.close();
           await strapiInstance.destroy();
+          webpackWatcher.close();
           process.send?.('killed');
           break;
         }


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* Closes webpack watcher on reloads

### Why is it needed?

* Avoid having background rebuild slowing down the app because the compiler / dev-middleware was not being terminated by the parent process

### Related issue(s)/PR(s)

* resolves CONTENT-2036
