### PR TITLE
fix(admin): use appropriate loader between jsx and tsx

### DIFF
--- a/packages/core/admin/_internal/node/webpack/config.ts
+++ b/packages/core/admin/_internal/node/webpack/config.ts
@@ -33,12 +33,23 @@ const resolveBaseConfig = async (ctx: BuildContext) => {
     module: {
       rules: [
         {
-          test: /\.(t|j)sx?$/,
+          test: /\.(ts|tsx)$/,
           loader: require.resolve('esbuild-loader'),
           options: {
             loader: 'tsx',
-            jsx: 'automatic',
             target,
+            jsx: 'automatic',
+          },
+        },
+        {
+          test: /\.(js|jsx|mjs)$/,
+          use: {
+            loader: require.resolve('esbuild-loader'),
+            options: {
+              loader: 'jsx',
+              target,
+              jsx: 'automatic',
+            },
           },
         },
         {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* set up webpack config to separately handle tsx & jsx code

### Why is it needed?

* CKEditor custom field plugin doesn't work without it
