### PR TITLE
Fixing #18672: return message for unauthorized and forbidden

### DIFF
--- a/packages/core/strapi/src/services/server/compose-endpoint.ts
+++ b/packages/core/strapi/src/services/server/compose-endpoint.ts
@@ -40,11 +40,11 @@ const createAuthorizeMiddleware =
       return await next();
     } catch (error) {
       if (error instanceof errors.UnauthorizedError) {
-        return ctx.unauthorized();
+        return ctx.unauthorized(error.message, error.details);
       }
 
       if (error instanceof errors.ForbiddenError) {
-        return ctx.forbidden();
+        return ctx.forbidden(error.message, error.details);
       }
 
       throw error;


### PR DESCRIPTION
### What does it do?

This PR is fixing #18672 .

### How to test it?
1. run throw `new UnauthorizedError('detail message', 'detail info')` or `throw new ForbiddenError('detail message', 'detail info')`
2. check the response data if contains message and details