### PR TITLE
refactor(admin): add watch-admin flag

### DIFF
--- a/packages/core/admin/_internal/cli/index.ts
+++ b/packages/core/admin/_internal/cli/index.ts
@@ -34,6 +34,7 @@ const develop: StrapiCommand = ({ command, ctx }) => {
     .option('--silent', "Don't log anything", false)
     .option('--ignore-prompts', 'Ignore all prompts', false)
     .option('--polling', 'Watch for file changes in network directories', false)
+    .option('--watch-admin', 'Watch the admin panel for hot changes', false)
     .option(
       '--no-build',
       '[deprecated]: there is middleware for the server, it is no longer a separate process'

--- a/packages/core/admin/_internal/node/webpack/watch.ts
+++ b/packages/core/admin/_internal/node/webpack/watch.ts
@@ -6,19 +6,19 @@ import webpackHotMiddleware from 'webpack-hot-middleware';
 import { webpack } from 'webpack';
 import type { BuildContext } from '../createBuildContext';
 import { mergeConfigWithUserConfig, resolveDevelopmentConfig } from './config';
-import { Common } from '@strapi/types';
+import { Common, Strapi } from '@strapi/types';
 
-interface Closer {
+interface WebpackWatcher {
   close(): Promise<void>;
 }
 
-const watch = async (ctx: BuildContext): Promise<Closer> => {
+const watch = async (ctx: BuildContext): Promise<WebpackWatcher> => {
   const config = await resolveDevelopmentConfig(ctx);
   const finalConfig = await mergeConfigWithUserConfig(config, ctx);
 
   ctx.logger.debug('Final webpack config:', os.EOL, finalConfig);
 
-  return new Promise<Closer>((res) => {
+  return new Promise<WebpackWatcher>((res) => {
     const compiler = webpack(finalConfig);
 
     const devMiddleware = webpackDevMiddleware(compiler);
@@ -110,3 +110,4 @@ const watch = async (ctx: BuildContext): Promise<Closer> => {
 };
 
 export { watch };
+export type { WebpackWatcher };


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* adds `watch-admin` flag to trigger the watching middleware attaching process

### Why is it needed?

* only lower powered machines the current reload set up is very slow due to webpack re-compiling, this is intended to be a patch until we solve the issue.
