### PR TITLE
Fix: website link containing a typo

### DIFF
--- a/packages/core/admin/admin/src/pages/SettingsPage/pages/ReviewWorkflows/SalesPage.js
+++ b/packages/core/admin/admin/src/pages/SettingsPage/pages/ReviewWorkflows/SalesPage.js
@@ -33,7 +33,7 @@ const SalesPage = () => {
               <LinkButton
                 variant="default"
                 endIcon={<ExternalLink />}
-                href="https://strp.cc/3tdNfJqe"
+                href="https://strp.cc/3tdNfJq"
                 isExternal
                 target="_blank"
               >


### PR DESCRIPTION
### What does it do?

Fix the link to our website pricing page which was incorrect due to an extra letter :/

### Why is it needed?

To make the link work as expected (redirecting to our pricing page instead of 404)

### How to test it?

Click on the link, it should redirect you to the pricing page of our website :)
