### PR TITLE
Update fields in query-params.js

### DIFF
--- a/packages/plugins/documentation/server/services/helpers/utils/query-params.js
+++ b/packages/plugins/documentation/server/services/helpers/utils/query-params.js
@@ -68,7 +68,10 @@ module.exports = [
     deprecated: false,
     required: false,
     schema: {
-      type: 'string',
+      type: 'array',
+      items: {
+        type: 'string'
+      }
     },
   },
   {


### PR DESCRIPTION
### What does it do?

Fields schema doesn't match the current way of using fields when you generate the documentation.json. We expect an array of strings and not a string

### Why is it needed?

Because if you generate a Swagger or you try to use the OpenAPI spec generated it will be wrong.

### How to test it?

Install documentation plugin and generate the documentation.json. You will see that now we are ending up with this schema

```json
{
  "name": "fields",
  "in": "query",
  "description": "Fields to return (ex: ['title','author'])",
  "deprecated": false,
  "required": false,
  "schema": {
    "type": "array",
    "items": {
      "type": "string"
    }
  }
}
```
