### PR TITLE
fix: add missing prepublish script

### DIFF
--- a/packages/admin-test-utils/package.json
+++ b/packages/admin-test-utils/package.json
@@ -63,6 +63,7 @@
     "clean": "run -T rimraf ./dist",
     "lint": "run -T eslint .",
     "test:ts": "run -T tsc --noEmit",
+    "prepublishOnly": "yarn clean && yarn build",
     "watch": "pack-up watch"
   },
   "dependencies": {

--- a/packages/core/content-type-builder/package.json
+++ b/packages/core/content-type-builder/package.json
@@ -43,6 +43,7 @@
     "test:front:watch:ce": "run -T cross-env IS_EE=false jest --config ./jest.config.front.js --watchAll",
     "test:unit": "run -T jest",
     "test:unit:watch": "run -T jest --watch",
+    "prepublishOnly": "yarn clean && yarn build",
     "watch": "pack-up watch"
   },
   "dependencies": {

--- a/packages/core/upload/package.json
+++ b/packages/core/upload/package.json
@@ -39,6 +39,7 @@
     "test:front:watch:ce": "run -T cross-env IS_EE=false jest --config ./jest.config.front.js --watchAll",
     "test:unit": "run -T jest",
     "test:unit:watch": "run -T jest --watch",
+    "prepublishOnly": "yarn clean && yarn build",
     "watch": "pack-up watch"
   },
   "dependencies": {

--- a/packages/plugins/documentation/package.json
+++ b/packages/plugins/documentation/package.json
@@ -42,6 +42,7 @@
     "test:front:watch": "run -T cross-env IS_EE=true jest --config ./jest.config.front.js --watchAll",
     "test:unit": "jest --verbose",
     "test:unit:watch": "run -T jest --watch",
+    "prepublishOnly": "yarn clean && yarn build",
     "watch": "pack-up watch"
   },
   "dependencies": {

--- a/packages/plugins/graphql/package.json
+++ b/packages/plugins/graphql/package.json
@@ -38,6 +38,7 @@
     "build": "pack-up build",
     "clean": "run -T rimraf dist",
     "lint": "run -T eslint .",
+    "prepublishOnly": "yarn clean && yarn build",
     "watch": "pack-up watch"
   },
   "dependencies": {

--- a/packages/plugins/i18n/package.json
+++ b/packages/plugins/i18n/package.json
@@ -44,6 +44,7 @@
     "test:front:watch:ce": "run -T cross-env IS_EE=false jest --config ./jest.config.front.js --watchAll",
     "test:unit": "run -T jest",
     "test:unit:watch": "run -T jest --watch",
+    "prepublishOnly": "yarn clean && yarn build",
     "watch": "pack-up watch"
   },
   "dependencies": {

--- a/packages/plugins/sentry/package.json
+++ b/packages/plugins/sentry/package.json
@@ -40,6 +40,7 @@
     "lint": "run -T eslint .",
     "test:unit": "run -T jest",
     "test:unit:watch": "run -T jest --watch",
+    "prepublishOnly": "yarn clean && yarn build",
     "watch": "pack-up watch"
   },
   "dependencies": {

--- a/packages/plugins/users-permissions/package.json
+++ b/packages/plugins/users-permissions/package.json
@@ -43,6 +43,7 @@
     "test:front:watch:ce": "run -T cross-env IS_EE=false jest --config ./jest.config.front.js --watchAll",
     "test:unit": "run -T jest",
     "test:unit:watch": "run -T jest --watch",
+    "prepublishOnly": "yarn clean && yarn build",
     "watch": "pack-up watch"
   },
   "dependencies": {


### PR DESCRIPTION
### What does it do?

Adds a missing prepublish script in some packages

### Why is it needed?

To publish experimental correctly

