### PR TITLE
feat: strongly type document repository and add status and locale params

### DIFF
--- a/packages/core/types/src/modules/documents/document-service.ts
+++ b/packages/core/types/src/modules/documents/document-service.ts
@@ -1,8 +1,6 @@
-import type { Common, Utils } from '../../types';
-import type { Result } from './result';
-import type * as Params from './params';
-
-export type CountResult = { count: number };
+import type { Common } from '../../types';
+import type * as Params from './params/document-service';
+import type * as Result from './result/document-service';
 
 export type ID = string;
 
@@ -15,23 +13,13 @@ export type UploadFile = (
 export interface DocumentService {
   uploadFiles: UploadFile;
 
-  // TODO: Split in 2 different signatures for both single types & collection types
   findMany<
     TContentTypeUID extends Common.UID.ContentType,
     TParams extends Params.FindMany<TContentTypeUID>
   >(
     uid: TContentTypeUID,
     params?: TParams
-  ): Promise<
-    Utils.Expression.MatchFirst<
-      [
-        [Common.UID.IsCollectionType<TContentTypeUID>, Result<TContentTypeUID, TParams>[]],
-        // Is this true for documents?
-        [Common.UID.IsSingleType<TContentTypeUID>, Result<TContentTypeUID, TParams> | null]
-      ],
-      (Result<TContentTypeUID, TParams> | null) | Result<TContentTypeUID, TParams>[]
-    >
-  >;
+  ): Result.FindMany<TContentTypeUID, TParams>;
 
   findFirst<
     TContentTypeUID extends Common.UID.ContentType,
@@ -39,7 +27,7 @@ export interface DocumentService {
   >(
     uid: TContentTypeUID,
     params?: TParams
-  ): Promise<Result<TContentTypeUID, TParams> | null>;
+  ): Result.FindFirst<TContentTypeUID, TParams>;
 
   findOne<
     TContentTypeUID extends Common.UID.ContentType,
@@ -48,7 +36,7 @@ export interface DocumentService {
     uid: TContentTypeUID,
     documentId: ID,
     params?: TParams
-  ): Promise<Result<TContentTypeUID, TParams> | null>;
+  ): Result.FindOne<TContentTypeUID, TParams>;
 
   delete<
     TContentTypeUID extends Common.UID.ContentType,
@@ -57,7 +45,7 @@ export interface DocumentService {
     uid: TContentTypeUID,
     documentId: ID,
     params?: TParams
-  ): Promise<Result<TContentTypeUID, TParams> | null>;
+  ): Result.Delete<TContentTypeUID, TParams>;
 
   deleteMany<
     TContentTypeUID extends Common.UID.ContentType,
@@ -65,16 +53,15 @@ export interface DocumentService {
   >(
     uid: TContentTypeUID,
     params?: TParams
-  ): Promise<CountResult | null>;
+  ): Result.DeleteMany;
 
-  // TODO: Make data param required
   create<
     TContentTypeUID extends Common.UID.ContentType,
     TParams extends Params.Create<TContentTypeUID>
   >(
     uid: TContentTypeUID,
     params: TParams
-  ): Promise<Result<TContentTypeUID, TParams>>;
+  ): Result.Create<TContentTypeUID, TParams>;
 
   clone<
     TContentTypeUID extends Common.UID.ContentType,
@@ -83,7 +70,7 @@ export interface DocumentService {
     uid: TContentTypeUID,
     documentId: ID,
     params?: TParams
-  ): Promise<Result<TContentTypeUID, TParams>>;
+  ): Result.Clone<TContentTypeUID, TParams>;
 
   update<
     TContentTypeUID extends Common.UID.ContentType,
@@ -92,7 +79,7 @@ export interface DocumentService {
     uid: TContentTypeUID,
     documentId: ID,
     params?: TParams
-  ): Promise<Result<TContentTypeUID, TParams> | null>;
+  ): Result.Update<TContentTypeUID, TParams>;
 
   count<
     TContentTypeUID extends Common.UID.ContentType,
@@ -100,7 +87,7 @@ export interface DocumentService {
   >(
     uid: TContentTypeUID,
     params?: TParams
-  ): Promise<number | null>;
+  ): Result.Count;
 
   publish<
     TContentTypeUID extends Common.UID.ContentType,
@@ -109,7 +96,7 @@ export interface DocumentService {
     uid: TContentTypeUID,
     documentId: ID,
     params?: TParams
-  ): Promise<number | null>;
+  ): Result.Publish;
 
   unpublish<
     TContentTypeUID extends Common.UID.ContentType,
@@ -118,5 +105,5 @@ export interface DocumentService {
     uid: TContentTypeUID,
     documentId: ID,
     params?: TParams
-  ): Promise<number | null>;
+  ): Result.Unpublish;
 }

--- a/packages/core/types/src/modules/documents/index.ts
+++ b/packages/core/types/src/modules/documents/index.ts
@@ -1,22 +1,65 @@
 import { Common } from '../..';
 import { ID, type DocumentService } from './document-service';
-import type * as Params from './params';
+import type * as Params from './params/document-service';
+import type * as Result from './result/document-service';
 import type * as Middleware from './middleware';
+
+export { ID, DocumentService as Service } from './document-service';
+export type * as Middleware from './middleware';
+export * as Params from './params';
+export * from './result';
+export * from './plugin';
 
 export type RepositoryInstance<
   TContentTypeUID extends Common.UID.ContentType = Common.UID.ContentType
 > = {
-  findOne: (id: ID, params?: Params.FindOne<TContentTypeUID>) => any;
-  findMany: (params?: Params.FindMany<TContentTypeUID>) => any;
-  findFirst: (params?: Params.FindFirst<TContentTypeUID>) => any;
-  delete: (documentId: ID, params: Params.Delete<TContentTypeUID>) => any;
-  deleteMany: (params: Params.DeleteMany<TContentTypeUID>) => any;
-  create: (params: Params.Create<TContentTypeUID>) => any;
-  clone: (documentId: ID, params: Params.Clone<TContentTypeUID>) => any;
-  update: (documentId: ID, params: Params.Update<TContentTypeUID>) => any;
-  count: (params: Params.Count<TContentTypeUID>) => any;
-  publish: (documentId: ID, params: Params.Publish<TContentTypeUID>) => any;
-  unpublish(documentId: ID, params: Params.Unpublish<TContentTypeUID>): any;
+  findMany: <TParams extends Params.FindMany<TContentTypeUID>>(
+    params?: TParams
+  ) => Result.FindMany<TContentTypeUID, TParams>;
+
+  findFirst: <TParams extends Params.FindFirst<TContentTypeUID>>(
+    params?: TParams
+  ) => Result.FindFirst<TContentTypeUID, TParams>;
+
+  findOne: <TParams extends Params.FindOne<TContentTypeUID>>(
+    id: ID,
+    params?: TParams
+  ) => Result.FindOne<TContentTypeUID, TParams>;
+
+  delete: <TParams extends Params.Delete<TContentTypeUID>>(
+    documentId: ID,
+    params: TParams
+  ) => Result.Delete<TContentTypeUID, TParams>;
+
+  deleteMany: <TParams extends Params.DeleteMany<TContentTypeUID>>(
+    params: TParams
+  ) => Result.DeleteMany;
+
+  create: <TParams extends Params.Create<TContentTypeUID>>(
+    params: TParams
+  ) => Result.Create<TContentTypeUID, TParams>;
+
+  clone: <TParams extends Params.Clone<TContentTypeUID>>(
+    documentId: ID,
+    params: TParams
+  ) => Result.Clone<TContentTypeUID, TParams>;
+
+  update: <TParams extends Params.Update<TContentTypeUID>>(
+    documentId: ID,
+    params: TParams
+  ) => Result.Update<TContentTypeUID, TParams>;
+
+  count: <TParams extends Params.Count<TContentTypeUID>>(params: TParams) => Result.Count;
+
+  publish: <TParams extends Params.Publish<TContentTypeUID>>(
+    documentId: ID,
+    params: TParams
+  ) => Result.Publish;
+
+  unpublish: <TParams extends Params.Unpublish<TContentTypeUID>>(
+    documentId: ID,
+    params: TParams
+  ) => Result.Unpublish;
 
   /** Add a middleware for a specific uid
    *  @example
@@ -68,6 +111,3 @@ export type Repository = {
     cb: Middleware.Middleware<TAction>
   ) => Repository;
 } & DocumentService;
-
-export { ID, DocumentService as Service } from './document-service';
-export type * as Middleware from './middleware';

--- a/packages/core/types/src/modules/documents/middleware.ts
+++ b/packages/core/types/src/modules/documents/middleware.ts
@@ -1,12 +1,11 @@
 // Utility type to reuse Param definition in MiddlewareContext
 import { Common } from '../..';
 import { DocumentService } from './document-service';
-import type * as Params from './params';
+import type * as Params from './params/document-service';
 
 export type ParamsMap<TContentTypeUID extends Common.UID.ContentType = Common.UID.ContentType> = {
   findOne: Params.FindOne<TContentTypeUID>;
   findMany: Params.FindMany<TContentTypeUID>;
-  findPage: Params.FindPage<TContentTypeUID>;
   findFirst: Params.FindFirst<TContentTypeUID>;
   delete: Params.Delete<TContentTypeUID>;
   deleteMany: Params.DeleteMany<TContentTypeUID>;

--- a/packages/core/types/src/modules/documents/params/attributes.ts
+++ b/packages/core/types/src/modules/documents/params/attributes.ts
@@ -1,0 +1,151 @@
+import type { Attribute, Common, Utils, Entity } from '../../../types';
+
+export type NonFilterableKind = Extract<Attribute.Kind, 'password' | 'dynamiczone'>;
+export type FilterableKind = Exclude<Attribute.Kind, NonFilterableKind>;
+
+export type GetNonFilterableKeys<TSchemaUID extends Common.UID.Schema> = Utils.Object.KeysBy<
+  Attribute.GetAll<TSchemaUID>,
+  Attribute.OfType<NonFilterableKind>,
+  string
+>;
+
+export type GetScalarKeys<TSchemaUID extends Common.UID.Schema> = Exclude<
+  Attribute.GetKeysByType<TSchemaUID, Attribute.NonPopulatableKind>,
+  GetNonFilterableKeys<TSchemaUID>
+>;
+
+export type GetNestedKeys<TSchemaUID extends Common.UID.Schema> = Exclude<
+  Attribute.GetKeysWithTarget<TSchemaUID>,
+  GetNonFilterableKeys<TSchemaUID>
+>;
+
+export type ID = Entity.ID;
+
+export type BooleanValue = boolean | 'true' | 'false' | 't' | 'f' | '1' | '0' | 1 | 0;
+
+export type NumberValue = string | number;
+
+export type DateValue = Attribute.DateValue | number;
+
+export type TimeValue = Attribute.TimeValue | number;
+
+export type DateTimeValue = Attribute.DateTimeValue | number;
+
+export type TimeStampValue = Attribute.TimestampValue;
+
+/**
+ * List of possible values for the scalar attributes
+ * Uses the local GetValue to benefit from the values' overrides
+ */
+export type ScalarValues = GetValue<
+  | Attribute.BigInteger
+  | Attribute.Boolean
+  | Attribute.DateTime
+  | Attribute.Date
+  | Attribute.Decimal
+  | Attribute.Email
+  | Attribute.Enumeration<string[]>
+  | Attribute.Float
+  | Attribute.Integer
+  | Attribute.Blocks
+  | Attribute.JSON
+  // /!\  Password attributes are NOT filterable and should NOT be part of this union type.
+  //      The member below has been commented on purpose to avoid adding it back without noticing.
+  // | Attribute.Password
+  | Attribute.RichText
+  | Attribute.String
+  | Attribute.Text
+  | Attribute.Time
+  | Attribute.Timestamp
+  | Attribute.UID<Common.UID.Schema>
+>;
+
+/**
+ * Attribute.GetValues override with extended values
+ */
+export type GetValues<TSchemaUID extends Common.UID.Schema> = {
+  id?: ID;
+} & OmitRelationWithoutTarget<
+  TSchemaUID,
+  {
+    [TKey in Attribute.GetOptionalKeys<TSchemaUID>]?: GetValue<Attribute.Get<TSchemaUID, TKey>>;
+  } & {
+    [TKey in Attribute.GetRequiredKeys<TSchemaUID>]-?: GetValue<Attribute.Get<TSchemaUID, TKey>>;
+  }
+>;
+
+export type OmitRelationWithoutTarget<TSchemaUID extends Common.UID.Schema, TValue> = Omit<
+  TValue,
+  Exclude<Attribute.GetKeysByType<TSchemaUID, 'relation'>, Attribute.GetKeysWithTarget<TSchemaUID>>
+>;
+
+/**
+ * Attribute.GetValue override with extended values
+ *
+ * Fallback to unknown if never is found
+ */
+export type GetValue<TAttribute extends Attribute.Attribute> = Utils.Expression.If<
+  Utils.Expression.IsNotNever<TAttribute>,
+  Utils.Expression.MatchFirst<
+    [
+      // Relation
+      [
+        Utils.Expression.Extends<TAttribute, Attribute.OfType<'relation'>>,
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        TAttribute extends Attribute.Relation<infer _TOrigin, infer TRelationKind, infer TTarget>
+          ? Utils.Expression.If<
+              Utils.Expression.IsNotNever<TTarget>,
+              Attribute.RelationPluralityModifier<TRelationKind, ID>
+            >
+          : never
+      ],
+      // DynamicZone
+      [
+        Utils.Expression.Extends<TAttribute, Attribute.OfType<'dynamiczone'>>,
+        TAttribute extends Attribute.DynamicZone<infer TComponentsUIDs>
+          ? Array<
+              // Extract tuple values to a component uid union type
+              Utils.Array.Values<TComponentsUIDs> extends infer TComponentUID
+                ? TComponentUID extends Common.UID.Component
+                  ? GetValues<TComponentUID> & { __component: TComponentUID }
+                  : never
+                : never
+            >
+          : never
+      ],
+      // Component
+      [
+        Utils.Expression.Extends<TAttribute, Attribute.OfType<'component'>>,
+        TAttribute extends Attribute.Component<infer TComponentUID, infer TRepeatable>
+          ? TComponentUID extends Common.UID.Component
+            ? GetValues<TComponentUID> extends infer TValues
+              ? Utils.Expression.If<TRepeatable, TValues[], TValues>
+              : never
+            : never
+          : never
+      ],
+      // Boolean
+      [Utils.Expression.Extends<TAttribute, Attribute.Boolean>, BooleanValue],
+      // Number
+      [
+        Utils.Expression.Extends<
+          TAttribute,
+          Attribute.Integer | Attribute.BigInteger | Attribute.Float | Attribute.Decimal
+        >,
+        NumberValue
+      ],
+      // Date / Time
+      [Utils.Expression.Extends<TAttribute, Attribute.Time>, TimeValue],
+      [Utils.Expression.Extends<TAttribute, Attribute.Date>, DateValue],
+      [
+        Utils.Expression.Extends<TAttribute, Attribute.Timestamp | Attribute.DateTime>,
+        DateTimeValue
+      ],
+      // Fallback
+      // If none of the above attribute type, fallback to the original Attribute.GetValue (while making sure it's an attribute)
+      [Utils.Expression.True, Attribute.GetValue<TAttribute, unknown>]
+    ],
+    unknown
+  >,
+  unknown
+>;

--- a/packages/core/types/src/modules/documents/params/data.ts
+++ b/packages/core/types/src/modules/documents/params/data.ts
@@ -1,0 +1,4 @@
+import type { Common } from '../../../types';
+import type * as AttributeUtils from './attributes';
+
+export type Input<TSchemaUID extends Common.UID.Schema> = AttributeUtils.GetValues<TSchemaUID>;

--- a/packages/core/types/src/modules/documents/params/document-service.ts
+++ b/packages/core/types/src/modules/documents/params/document-service.ts
@@ -1,0 +1,86 @@
+import { Common } from '../../..';
+import { Pick } from '.';
+
+/**
+ * Document Service specific method params
+ */
+export type FindMany<TContentTypeUID extends Common.UID.ContentType> = Pick<
+  TContentTypeUID,
+  | 'fields'
+  | 'filters'
+  | '_q'
+  | 'pagination:offset'
+  | 'sort'
+  | 'populate'
+  | 'status'
+  | 'locale'
+  | 'plugin'
+>;
+
+export type FindFirst<TContentTypeUID extends Common.UID.ContentType> = Pick<
+  TContentTypeUID,
+  'fields' | 'filters' | '_q' | 'sort' | 'populate' | 'status' | 'locale' | 'plugin'
+>;
+
+export type FindOne<TContentTypeUID extends Common.UID.ContentType> = Pick<
+  TContentTypeUID,
+  'fields' | 'populate' | 'filters' | 'status' | 'locale' | 'sort'
+>;
+
+export type Delete<TContentTypeUID extends Common.UID.ContentType> = Pick<
+  TContentTypeUID,
+  'fields' | 'populate' | 'filters' | 'status' | 'locale'
+>;
+
+export type DeleteMany<TContentTypeUID extends Common.UID.ContentType> = Pick<
+  TContentTypeUID,
+  | 'fields'
+  | 'filters'
+  | '_q'
+  | 'pagination:offset'
+  | 'sort'
+  | 'populate'
+  | 'status'
+  | 'locale'
+  | 'plugin'
+>;
+
+export type Create<TContentTypeUID extends Common.UID.ContentType> = Pick<
+  TContentTypeUID,
+  'data' | 'files' | 'fields' | 'populate' | 'status' | 'locale'
+>;
+
+export type Clone<TContentTypeUID extends Common.UID.ContentType> = Pick<
+  TContentTypeUID,
+  'data' | 'files' | 'fields' | 'populate' | 'status' | 'locale'
+>;
+
+export type Update<TContentTypeUID extends Common.UID.ContentType> = Pick<
+  TContentTypeUID,
+  'data:partial' | 'files' | 'fields' | 'populate' | 'status' | 'locale'
+>;
+
+export type Count<TContentTypeUID extends Common.UID.ContentType> = Pick<
+  TContentTypeUID,
+  | 'fields'
+  | 'filters'
+  | '_q'
+  | 'pagination:offset'
+  | 'sort'
+  | 'populate'
+  | 'status'
+  | 'locale'
+  | 'plugin'
+>;
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export type Publish<TContentTypeUID extends Common.UID.ContentType> = Pick<
+  TContentTypeUID,
+  'filters' | 'status' | 'locale'
+>;
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export type Unpublish<TContentTypeUID extends Common.UID.ContentType> = Pick<
+  TContentTypeUID,
+  'filters' | 'status' | 'locale'
+>;

--- a/packages/core/types/src/modules/documents/params/fields.ts
+++ b/packages/core/types/src/modules/documents/params/fields.ts
@@ -1,0 +1,74 @@
+import type { Attribute, Common, Utils } from '../../../types';
+
+/**
+ * Wildcard notation for the fields.
+ *
+ * When used, it represents every non-populatable field from the given schema
+ */
+export type WildcardNotation = '*';
+
+/**
+ * Single non-populatable attribute representation
+ *
+ * @example
+ * type A = 'title'; // ✅
+ * type B = 'description'; // ✅
+ * type C = 'populatableField'; // ❌
+ * type D = '<random_string>'; // ❌
+ */
+export type SingleAttribute<TSchemaUID extends Common.UID.Schema> =
+  | 'id'
+  | Utils.Guard.Never<Attribute.GetNonPopulatableKeys<TSchemaUID>, string>;
+
+/**
+ * Union of all possible string representation for fields
+ *
+ * @example
+ * type A = 'title'; // ✅
+ * type B = 'title,description'; // ✅
+ * type C = 'id'; // ✅
+ * type D = '*'; // ✅
+ * type E = 'populatableField'; // ❌
+ * type F = '<random_string>'; // ❌
+ */
+export type StringNotation<TSchemaUID extends Common.UID.Schema> =
+  | WildcardNotation
+  | SingleAttribute<TSchemaUID>
+  // TODO: Loose type checking to avoid circular dependencies & infinite recursion
+  | `${string},${string}`;
+
+/**
+ * Array notation for fields
+ *
+ * @example
+ * type A = ['title']; // ✅
+ * type B = ['title', 'description']; // ✅
+ * type C = ['id']; // ✅
+ * type E = ['*']; // ❌
+ * type F = ['populatableField']; // ❌
+ * type G = ['<random_string>']; // ❌
+ */
+export type ArrayNotation<TSchemaUID extends Common.UID.Schema> = Exclude<
+  StringNotation<TSchemaUID>,
+  WildcardNotation
+>[];
+
+/**
+ * Represents any notation for a sort (string, array, object)
+ *
+ * @example
+ * type A = '*'; // ✅
+ * type B = 'id'; // ✅
+ * type C = 'title'; // ✅
+ * type D = 'title,description'; // ✅
+ * type E = ['title', 'description']; // ✅
+ * type F = [id, 'title,description']; // ✅
+ * type G = ['*']; // ❌
+ * type H = ['populatableField']; // ❌
+ * type I = ['<random_string>']; // ❌
+ * type J = 'populatableField'; // ❌
+ * type K = '<random_string>'; // ❌
+ */
+export type Any<TSchemaUID extends Common.UID.Schema> =
+  | StringNotation<TSchemaUID>
+  | ArrayNotation<TSchemaUID>;

--- a/packages/core/types/src/modules/documents/params/filters/index.ts
+++ b/packages/core/types/src/modules/documents/params/filters/index.ts
@@ -1,0 +1,90 @@
+import type { Attribute, Common, Utils } from '../../../../types';
+
+import type * as Operator from './operators';
+import type * as AttributeUtils from '../attributes';
+import type * as Params from '..';
+
+export { Operator };
+
+type IDKey = 'id';
+
+/**
+ * Filter representation for nested attributes
+ */
+type NestedAttributeCondition<
+  TSchemaUID extends Common.UID.Schema,
+  TAttributeName extends Attribute.GetKeys<TSchemaUID>
+> = ObjectNotation<
+  Utils.Guard.Never<Attribute.GetTarget<TSchemaUID, TAttributeName>, Common.UID.Schema>
+>;
+
+/**
+ * Filter representation for scalar attributes
+ */
+type AttributeCondition<
+  TSchemaUID extends Common.UID.Schema,
+  TAttributeName extends IDKey | Attribute.GetKeys<TSchemaUID>
+> = Utils.Expression.MatchFirst<
+  [
+    // Special catch for manually added ID attributes
+    [Utils.Expression.StrictEqual<TAttributeName, IDKey>, Params.Attribute.ID],
+    [
+      Utils.Expression.IsNotNever<TAttributeName>,
+      // Get the filter attribute value for the given attribute
+      AttributeUtils.GetValue<Attribute.Get<TSchemaUID, Exclude<TAttributeName, IDKey>>>
+    ]
+  ],
+  // Fallback to the list of all possible scalar attributes' value if the attribute is not valid (never)
+  AttributeUtils.ScalarValues
+> extends infer TAttributeValue
+  ?
+      | TAttributeValue // Implicit $eq operator
+      | ({
+          [TIter in Operator.BooleanValue]?: boolean;
+        } & {
+          [TIter in Operator.DynamicValue]?: TAttributeValue;
+        } & {
+          [TIter in Operator.DynamicArrayValue]?: TAttributeValue[];
+        } & {
+          [TIter in Operator.DynamicBoundValue]?: [TAttributeValue, TAttributeValue];
+        } & {
+          [TIter in Operator.Logical]?: AttributeCondition<TSchemaUID, TAttributeName>;
+        } & {
+          [TIter in Operator.Group]?: AttributeCondition<TSchemaUID, TAttributeName>[];
+        })
+  : never;
+
+/**
+ * Tree representation of a Strapi filter for a given schema UID
+ */
+export type ObjectNotation<TSchemaUID extends Common.UID.Schema> = {
+  [TIter in Operator.Group]?: ObjectNotation<TSchemaUID>[];
+} & {
+  [TIter in Operator.Logical]?: ObjectNotation<TSchemaUID>;
+} & ([AttributeUtils.GetScalarKeys<TSchemaUID>, AttributeUtils.GetNestedKeys<TSchemaUID>] extends [
+    infer TScalarKeys extends AttributeUtils.GetScalarKeys<TSchemaUID>,
+    infer TNestedKeys extends AttributeUtils.GetNestedKeys<TSchemaUID>
+  ]
+    ? // If both the scalar and nested keys are resolved, then create a strongly
+      // typed filter object, else create a loose generic abstraction.
+      Utils.Expression.If<
+        Utils.Expression.And<
+          Utils.Expression.IsNotNever<TScalarKeys>,
+          Utils.Expression.IsNotNever<TNestedKeys>
+        >,
+        // Strongly typed representation of the filter object tree
+        {
+          [TIter in IDKey | TScalarKeys]?: AttributeCondition<TSchemaUID, TIter>;
+        } & {
+          [TIter in TNestedKeys]?: NestedAttributeCondition<TSchemaUID, TIter>;
+        },
+        // Generic representation of the filter object tree in case we don't have access to the attributes' list
+        {
+          [TKey in string]?:
+            | AttributeCondition<TSchemaUID, never>
+            | NestedAttributeCondition<TSchemaUID, never>;
+        }
+      >
+    : never);
+
+export type Any<TSchemaUID extends Common.UID.Schema> = ObjectNotation<TSchemaUID>;

--- a/packages/core/types/src/modules/documents/params/filters/operators.ts
+++ b/packages/core/types/src/modules/documents/params/filters/operators.ts
@@ -1,0 +1,31 @@
+export type Array = '$in' | '$notIn' | '$between';
+
+export type Group = '$and' | '$or';
+
+export type Logical = '$not';
+
+export type BooleanValue = '$null' | '$notNull';
+
+export type DynamicValue =
+  | '$eq'
+  | '$eqi'
+  | '$ne'
+  | '$nei'
+  | '$gt'
+  | '$gte'
+  | '$lt'
+  | '$lte'
+  | '$startsWith'
+  | '$endsWith'
+  | '$startsWithi'
+  | '$endsWithi'
+  | '$contains'
+  | '$notContains'
+  | '$containsi'
+  | '$notContainsi';
+
+export type DynamicArrayValue = '$in' | '$notIn';
+
+export type DynamicBoundValue = '$between';
+
+export type Where = BooleanValue | DynamicValue | DynamicArrayValue | DynamicBoundValue;

--- a/packages/core/types/src/modules/documents/params/index.ts
+++ b/packages/core/types/src/modules/documents/params/index.ts
@@ -1,77 +1,84 @@
-import { Common } from '../../..';
-import * as Params from '../../entity-service/params';
+import { Common, Utils } from '../../..';
+import type { GetPluginParams } from '..';
 
-// Export params list
-export * from '../../entity-service/params';
+// Params
+import type * as Sort from './sort';
+import type * as Pagination from './pagination';
+import type * as Fields from './fields';
+import type * as Filters from './filters';
+import type * as Populate from './populate';
+import type * as PublicationState from './status';
+import type * as Data from './data';
+import type * as Search from './search';
 
-export type FindMany<TContentTypeUID extends Common.UID.ContentType> = Params.Pick<
-  TContentTypeUID,
-  | 'fields'
-  | 'filters'
-  | '_q'
-  | 'pagination:offset'
+// Utils
+import type * as Attribute from './attributes';
+
+export type Pick<
+  TSchemaUID extends Common.UID.Schema,
+  TKind extends Kind
+> = Utils.Expression.MatchAllIntersect<
+  [
+    // Sort
+    [HasMember<TKind, 'sort'>, { sort?: Sort.Any<TSchemaUID> }],
+    [HasMember<TKind, 'sort:string'>, { sort?: Sort.StringNotation<TSchemaUID> }],
+    [HasMember<TKind, 'sort:array'>, { sort?: Sort.ArrayNotation<TSchemaUID> }],
+    [HasMember<TKind, 'sort:object'>, { sort?: Sort.ObjectNotation<TSchemaUID> }],
+    // Fields
+    [HasMember<TKind, 'fields'>, { fields?: Fields.Any<TSchemaUID> }],
+    [HasMember<TKind, 'fields:string'>, { fields?: Fields.StringNotation<TSchemaUID> }],
+    [HasMember<TKind, 'fields:array'>, { fields?: Fields.ArrayNotation<TSchemaUID> }],
+    // Filters
+    [HasMember<TKind, 'filters'>, { filters?: Filters.Any<TSchemaUID> }],
+    // Populate
+    [HasMember<TKind, 'populate'>, { populate?: Populate.Any<TSchemaUID> }],
+    [HasMember<TKind, 'populate:string'>, { populate?: Populate.StringNotation<TSchemaUID> }],
+    [HasMember<TKind, 'populate:array'>, { populate?: Populate.ArrayNotation<TSchemaUID> }],
+    [HasMember<TKind, 'populate:object'>, { populate?: Populate.ObjectNotation<TSchemaUID> }],
+    // Pagination
+    [HasMember<TKind, 'pagination'>, Pagination.Any],
+    [HasMember<TKind, 'pagination:offset'>, Pagination.OffsetNotation],
+    [HasMember<TKind, 'pagination:page'>, Pagination.PageNotation],
+    // Publication State
+    [HasMember<TKind, 'status'>, PublicationState.Param],
+    // Locale
+    [HasMember<TKind, 'locale'>, { locale?: string }],
+    // Plugin
+    [HasMember<TKind, 'plugin'>, GetPluginParams<TSchemaUID>],
+    // Data
+    [HasMember<TKind, 'data'>, { data?: Data.Input<TSchemaUID> }],
+    [HasMember<TKind, 'data:partial'>, { data?: Partial<Data.Input<TSchemaUID>> }],
+    // Files
+    [HasMember<TKind, 'files'>, { files?: Record<string, unknown> }], // TODO
+    // Search
+    [HasMember<TKind, '_q'>, { _q?: Search.Q }]
+  ]
+>;
+
+export type Kind =
   | 'sort'
-  | 'populate'
-  | 'publicationState'
-  | 'plugin'
->;
-
-export type FindFirst<TContentTypeUID extends Common.UID.ContentType> = Params.Pick<
-  TContentTypeUID,
-  'fields' | 'filters' | '_q' | 'sort' | 'populate' | 'publicationState' | 'plugin'
->;
-
-export type FindOne<TContentTypeUID extends Common.UID.ContentType> = Params.Pick<
-  TContentTypeUID,
-  'fields' | 'populate' | 'filters' | 'sort'
->;
-
-export type Delete<TContentTypeUID extends Common.UID.ContentType> = Params.Pick<
-  TContentTypeUID,
-  'fields' | 'populate' | 'filters'
->;
-
-export type DeleteMany<TContentTypeUID extends Common.UID.ContentType> = Params.Pick<
-  TContentTypeUID,
+  | 'sort:string'
+  | 'sort:array'
+  | 'sort:object'
   | 'fields'
+  | 'fields:string'
+  | 'fields:array'
   | 'filters'
-  | '_q'
-  | 'pagination:offset'
-  | 'sort'
   | 'populate'
-  | 'publicationState'
-  | 'plugin'
->;
-
-export type Create<TContentTypeUID extends Common.UID.ContentType> = Params.Pick<
-  TContentTypeUID,
-  'data' | 'files' | 'fields' | 'populate'
->;
-
-export type Clone<TContentTypeUID extends Common.UID.ContentType> = Params.Pick<
-  TContentTypeUID,
-  'data' | 'files' | 'fields' | 'populate'
->;
-
-export type Update<TContentTypeUID extends Common.UID.ContentType> = Params.Pick<
-  TContentTypeUID,
-  'data:partial' | 'files' | 'fields' | 'populate'
->;
-
-export type Count<TContentTypeUID extends Common.UID.ContentType> = Params.Pick<
-  TContentTypeUID,
-  | 'fields'
-  | 'filters'
-  | '_q'
+  | 'populate:string'
+  | 'populate:array'
+  | 'populate:object'
+  | 'pagination'
   | 'pagination:offset'
-  | 'sort'
-  | 'populate'
-  | 'publicationState'
+  | 'pagination:page'
+  | 'status'
+  | 'locale'
   | 'plugin'
->;
+  | 'data'
+  | 'data:partial'
+  | 'files'
+  | '_q';
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export type Publish<TContentTypeUID extends Common.UID.ContentType> = Record<string, any>;
+type HasMember<TValue extends Kind, TTest extends Kind> = Utils.Expression.Extends<TTest, TValue>;
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export type Unpublish<TContentTypeUID extends Common.UID.ContentType> = Record<string, any>;
+export type { Sort, Pagination, Fields, Filters, Populate, PublicationState, Data, Attribute };

--- a/packages/core/types/src/modules/documents/params/pagination.ts
+++ b/packages/core/types/src/modules/documents/params/pagination.ts
@@ -1,0 +1,13 @@
+import type { Utils } from '../../../types';
+
+export type PageNotation = {
+  page?: number;
+  pageSize?: number;
+};
+
+export type OffsetNotation = {
+  start?: number;
+  limit?: number;
+};
+
+export type Any = Utils.XOR<PageNotation, OffsetNotation>;

--- a/packages/core/types/src/modules/documents/params/populate.ts
+++ b/packages/core/types/src/modules/documents/params/populate.ts
@@ -1,0 +1,130 @@
+import type { Attribute, Common, Utils } from '../../../types';
+import type { Params } from '..';
+
+/**
+ * Wildcard notation for populate
+ *
+ * To populate all the root level relations
+ */
+export type WildcardNotation = '*';
+
+/**
+ * Union of all possible string representation for populate
+ *
+ * @example
+ * type A = 'image'; // ✅
+ * type B = 'image,component'; // ✅
+ * type c = '*'; // ✅
+ * type D = 'populatableField'; // ✅
+ * type E = '<random_string>'; // ❌
+ */
+export type StringNotation<TSchemaUID extends Common.UID.Schema> =
+  | WildcardNotation
+  // Populatable keys
+  | Utils.Guard.Never<Attribute.GetPopulatableKeys<TSchemaUID>, string>
+  // Other string notations
+  // Those are not computed as it would break the TS parser for schemas with lots of populatable attributes
+  | `${string},${string}`
+  | `${string}.${string}`;
+
+/**
+ * Array notation for populate
+ *
+ * @example
+ * type A = ['image']; // ✅
+ * type B = ['image', 'component']; // ✅
+ * type C = ['populatableField']; // ✅
+ * type D = ['<random_string>']; // ❌
+ * type E = ['*']; // ❌
+ */
+export type ArrayNotation<TSchemaUID extends Common.UID.Schema> = Exclude<
+  StringNotation<TSchemaUID>,
+  WildcardNotation
+>[];
+
+type GetPopulatableKeysWithTarget<TSchemaUID extends Common.UID.Schema> = Extract<
+  Attribute.GetPopulatableKeys<TSchemaUID>,
+  Attribute.GetKeysWithTarget<TSchemaUID>
+>;
+
+type GetPopulatableKeysWithoutTarget<TSchemaUID extends Common.UID.Schema> = Exclude<
+  Attribute.GetPopulatableKeys<TSchemaUID>,
+  GetPopulatableKeysWithTarget<TSchemaUID>
+>;
+
+/**
+ * Fragment populate notation for polymorphic attributes
+ */
+export type Fragment<TMaybeTargets extends Common.UID.Schema> = {
+  on?: { [TSchemaUID in TMaybeTargets]?: boolean | NestedParams<TSchemaUID> };
+};
+
+type PopulateClause<
+  TSchemaUID extends Common.UID.Schema,
+  TKeys extends Attribute.GetPopulatableKeys<TSchemaUID>
+> = {
+  [TKey in TKeys]?: boolean | NestedParams<Attribute.GetTarget<TSchemaUID, TKey>>;
+};
+
+/**
+ * Object notation for populate
+ *
+ * @example
+ * type A = { image: true }; // ✅
+ * type B = { image: { fields: ['url', 'provider'] } }; // ✅
+ * type C = { populatableField: { populate: { nestedPopulatableField: true } } }; // ✅
+ * type D = { dynamic_zone: { on: { comp_A: { fields: ['name', 'price_a'] }, comp_B: { fields: ['name', 'price_b'] } } } }; // ✅
+ */
+export type ObjectNotation<TSchemaUID extends Common.UID.Schema> = [
+  GetPopulatableKeysWithTarget<TSchemaUID>,
+  GetPopulatableKeysWithoutTarget<TSchemaUID>
+] extends [
+  infer TKeysWithTarget extends Attribute.GetPopulatableKeys<TSchemaUID>,
+  infer TKeysWithoutTarget extends Attribute.GetPopulatableKeys<TSchemaUID>
+]
+  ? Utils.Expression.If<
+      Utils.Expression.And<
+        Common.AreSchemaRegistriesExtended,
+        // If TSchemaUID === Common.UID.Schema, then ignore it and move to loose types
+        // Note: Currently, this only ignores TSchemaUID when it is equal to Common.UID.Schema, it won't work if Common.UID.(ContentType|Component) is passed as parameter
+        Utils.Expression.DoesNotExtends<Common.UID.Schema, TSchemaUID>
+      >,
+      // Populatable keys with a target
+      | Utils.Expression.If<
+          Utils.Expression.IsNotNever<TKeysWithTarget>,
+          PopulateClause<TSchemaUID, TKeysWithTarget>
+        >
+      // Populatable keys with either zero or multiple target(s)
+      | Utils.Expression.If<
+          Utils.Expression.IsNotNever<TKeysWithoutTarget>,
+          {
+            [TKey in TKeysWithoutTarget]?:
+              | boolean
+              | Fragment<
+                  Utils.Guard.Never<Attribute.GetMorphTargets<TSchemaUID, TKey>, Common.UID.Schema>
+                >
+              // TODO: V5: Remove root-level nested params for morph data structures and only allow fragments
+              | NestedParams<Common.UID.Schema>;
+          }
+        >,
+      // Loose fallback when registries are not extended
+      | { [TKey in string]?: boolean | NestedParams<Common.UID.Schema> }
+      | {
+          [TKey in string]?:
+            | boolean
+            | Fragment<Common.UID.Schema>
+            // TODO: V5: Remove root-level nested params for morph data structures and only allow fragments
+            | NestedParams<Common.UID.Schema>;
+        }
+    >
+  : never;
+
+export type NestedParams<TSchemaUID extends Common.UID.Schema> = Params.Pick<
+  TSchemaUID,
+  'fields' | 'filters' | 'populate' | 'sort' | 'plugin' | 'publicationState'
+>;
+
+export type Any<TSchemaUID extends Common.UID.Schema> =
+  | StringNotation<TSchemaUID>
+  | ArrayNotation<TSchemaUID>
+  | ObjectNotation<TSchemaUID>;

--- a/packages/core/types/src/modules/documents/params/search.ts
+++ b/packages/core/types/src/modules/documents/params/search.ts
@@ -1,0 +1,1 @@
+export type Q = string;

--- a/packages/core/types/src/modules/documents/params/sort.ts
+++ b/packages/core/types/src/modules/documents/params/sort.ts
@@ -1,0 +1,107 @@
+import type { Attribute, Common, Utils } from '../../../types';
+
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export namespace OrderKind {
+  export type Asc = 'asc';
+  export type Desc = 'desc';
+
+  export type Any = Asc | Desc;
+}
+
+/**
+ * Single non-populatable attribute representation
+ *
+ * @example
+ * type A = 'title'; // ✅
+ * type B = 'description'; // ✅
+ * type C = 'title:asc'; // ❌
+ * type D = 'title,description'; // ❌
+ */
+type SingleAttribute<TSchemaUID extends Common.UID.Schema> =
+  | 'id'
+  | Utils.Guard.Never<string & Attribute.GetNonPopulatableKeys<TSchemaUID>, string>;
+
+/**
+ * Ordered single non-populatable attribute representation
+ *
+ * @example
+ * type A = 'title:asc'; // ✅
+ * type B = 'description:desc'; // ✅
+ * type C = 'title'; // ❌
+ * type D = 'title,description'; // ❌
+ */
+type OrderedSingleAttribute<TSchemaUID extends Common.UID.Schema> =
+  `${SingleAttribute<TSchemaUID>}:${OrderKind.Any}`;
+
+/**
+ * Union of all possible string representation for a sort
+ *
+ * @example
+ * type A = 'title:asc'; // ✅
+ * type B = 'description:desc'; // ✅
+ * type C = 'title'; // ✅
+ * type D = 'title,description:asc'; // ✅
+ * type E = [42]; // ❌
+ * type F = { title: 'asc' }; // ❌
+ */
+export type StringNotation<TSchemaUID extends Common.UID.Schema> =
+  | SingleAttribute<TSchemaUID>
+  | OrderedSingleAttribute<TSchemaUID>
+  // TODO: Loose type checking to avoid circular dependencies & infinite recursion
+  | `${string},${string}`;
+
+/**
+ * Array notation for a sort
+ *
+ * @example
+ * type A = ['title:asc', 'description']; // ✅
+ * type B = ['title']; // ✅
+ * type C = ['count', 'title,description:asc']; // ✅
+ * type D = { title: 'asc' }; // ❌
+ * type E = [42]; // ❌
+ * type F = 'title'; // ❌
+ */
+export type ArrayNotation<TSchemaUID extends Common.UID.Schema> = Any<TSchemaUID>[];
+
+/**
+ * Object notation for a sort
+ *
+ * @example
+ * type A = { title: 'asc' }; // ✅
+ * type B = { title: 'asc', description: 'desc' }; // ✅
+ * type C = { title: 'asc', author: { name: 'asc' } }; // ✅
+ * type D = { author: { email: 'asc', role: { name: 'desc' } } }; // ✅
+ * type E = ['title']; // ❌
+ * type F = 'title'; // ❌
+ */
+export type ObjectNotation<TSchemaUID extends Common.UID.Schema> = {
+  // First level sort
+  [key in SingleAttribute<TSchemaUID>]?: OrderKind.Any;
+} & {
+  // Deep sort, only add populatable keys that have a
+  // target (remove dynamic zones and other polymorphic links)
+  [key in Attribute.GetKeysWithTarget<TSchemaUID>]?: ObjectNotation<
+    Attribute.GetTarget<TSchemaUID, key>
+  >;
+};
+
+/**
+ * Represents any notation for a sort (string, array, object)
+ *
+ * @example
+ * type A = 'title:asc'; // ✅
+ * type B = 'description:desc'; // ✅
+ * type C = 'title'; // ✅
+ * type D = 'title,description:asc'; // ✅
+ * type E = ['title:asc', 'description']; // ✅
+ * type F = ['title']; // ✅
+ * type G = ['count', 'title,description:asc']; // ✅
+ * type H = { title: 'asc' }; // ✅
+ * type I = { title: 'asc', description: 'desc' }; // ✅
+ * type J = { title: 'asc', author: { name: 'asc' } }; // ✅
+ * type K = { author: { email: 'asc', role: { name: 'desc' } } }; // ✅
+ */
+export type Any<TSchemaUID extends Common.UID.Schema> =
+  | StringNotation<TSchemaUID>
+  | ArrayNotation<TSchemaUID>
+  | ObjectNotation<TSchemaUID>;

--- a/packages/core/types/src/modules/documents/params/status.ts
+++ b/packages/core/types/src/modules/documents/params/status.ts
@@ -1,0 +1,3 @@
+export type Kind = 'draft' | 'published';
+
+export type Param = { status?: Kind };

--- a/packages/core/types/src/modules/documents/plugin.ts
+++ b/packages/core/types/src/modules/documents/plugin.ts
@@ -1,0 +1,11 @@
+import type { Common, Plugin, Utils, Shared } from '../../types';
+
+export type GetPluginParams<TSchemaUID extends Common.UID.Schema> = Utils.Guard.OfTypes<
+  [never, undefined],
+  Utils.Object.Values<{
+    [TPluginName in keyof Shared.DocumentServicePluginParams]: Shared.DocumentServicePluginParams[TPluginName] extends infer TParam
+      ? Utils.Expression.If<Plugin.IsEnabled<TPluginName, TSchemaUID>, TParam>
+      : never;
+  }>,
+  unknown
+>;

--- a/packages/core/types/src/modules/documents/result.ts
+++ b/packages/core/types/src/modules/documents/result.ts
@@ -1,8 +1,0 @@
-// TODO V5: Migrate every type from the entity-service to the document-service
-export {
-  Result,
-  Entity as Document,
-  PartialEntity as PartialDocument,
-  PaginatedResult,
-  GetValues,
-} from '../entity-service/result';

--- a/packages/core/types/src/modules/documents/result/document-service.ts
+++ b/packages/core/types/src/modules/documents/result/document-service.ts
@@ -1,0 +1,57 @@
+import { Common, Utils } from '../../..';
+import { Result } from '.';
+import * as Params from '../params/document-service';
+
+export type CountResult = { count: number };
+
+export type FindMany<
+  TContentTypeUID extends Common.UID.ContentType,
+  TParams extends Params.FindMany<TContentTypeUID>
+> = Promise<
+  Utils.Expression.MatchFirst<
+    [
+      [Common.UID.IsCollectionType<TContentTypeUID>, Result<TContentTypeUID, TParams>[]],
+      // Is this true for documents?
+      [Common.UID.IsSingleType<TContentTypeUID>, Result<TContentTypeUID, TParams> | null]
+    ],
+    (Result<TContentTypeUID, TParams> | null) | Result<TContentTypeUID, TParams>[]
+  >
+>;
+
+export type FindFirst<
+  TContentTypeUID extends Common.UID.ContentType,
+  TParams extends Params.FindFirst<TContentTypeUID>
+> = Promise<Result<TContentTypeUID, TParams> | null>;
+
+export type FindOne<
+  TContentTypeUID extends Common.UID.ContentType,
+  TParams extends Params.FindFirst<TContentTypeUID>
+> = Promise<Result<TContentTypeUID, TParams> | null>;
+
+export type Delete<
+  TContentTypeUID extends Common.UID.ContentType,
+  TParams extends Params.Delete<TContentTypeUID>
+> = Promise<Result<TContentTypeUID, TParams> | null>;
+
+export type DeleteMany = Promise<CountResult | null>;
+
+export type Create<
+  TContentTypeUID extends Common.UID.ContentType,
+  TParams extends Params.Create<TContentTypeUID>
+> = Promise<Result<TContentTypeUID, TParams>>;
+
+export type Clone<
+  TContentTypeUID extends Common.UID.ContentType,
+  TParams extends Params.Clone<TContentTypeUID>
+> = Promise<Result<TContentTypeUID, TParams>>;
+
+export type Update<
+  TContentTypeUID extends Common.UID.ContentType,
+  TParams extends Params.Update<TContentTypeUID>
+> = Promise<Result<TContentTypeUID, TParams> | null>;
+
+export type Count = Promise<number | null>;
+
+export type Publish = Promise<number | null>;
+
+export type Unpublish = Promise<number | null>;

--- a/packages/core/types/src/modules/documents/result/index.ts
+++ b/packages/core/types/src/modules/documents/result/index.ts
@@ -1,0 +1,205 @@
+import type { Attribute, Common, Utils } from '../../../types';
+import type { Params } from '../index';
+
+type Pagination = { page: number; pageSize: number; pageCount: number; total: number };
+
+type AnyDocument = { id: Params.Attribute.ID } & { [key: string]: any };
+
+export type Result<
+  TSchemaUID extends Common.UID.Schema,
+  TParams extends Params.Pick<TSchemaUID, 'fields' | 'populate'> = never
+> = Utils.Expression.If<
+  Common.AreSchemaRegistriesExtended,
+  GetValues<
+    TSchemaUID,
+    Utils.Guard.Never<
+      ExtractFields<TSchemaUID, TParams['fields']>,
+      Attribute.GetNonPopulatableKeys<TSchemaUID>
+    >,
+    ExtractPopulate<TSchemaUID, TParams['populate']>
+  >,
+  AnyDocument
+>;
+
+export type Document<
+  TSchemaUID extends Common.UID.Schema,
+  TParams extends Params.Pick<TSchemaUID, 'fields' | 'populate'> = never
+> = Utils.Expression.If<
+  Common.AreSchemaRegistriesExtended,
+  GetValues<
+    TSchemaUID,
+    Utils.Guard.Never<
+      ExtractFields<TSchemaUID, TParams['fields']>,
+      Attribute.GetNonPopulatableKeys<TSchemaUID>
+    >,
+    Utils.Guard.Never<
+      ExtractPopulate<TSchemaUID, TParams['populate']>,
+      Attribute.GetPopulatableKeys<TSchemaUID>
+    >
+  >,
+  AnyDocument
+>;
+
+export type PartialDocument<
+  TSchemaUID extends Common.UID.Schema,
+  TParams extends Params.Pick<TSchemaUID, 'fields' | 'populate'> = never
+> = Partial<Document<TSchemaUID, TParams>>;
+
+export type PaginatedResult<
+  TSchemaUID extends Common.UID.Schema,
+  TParams extends Params.Pick<TSchemaUID, 'fields' | 'populate'> = never
+> = {
+  results: Document<TSchemaUID, TParams>[];
+  pagination: Pagination;
+};
+
+/**
+ * Attribute.GetValues override with extended values
+ *
+ * TODO: Make it recursive for populatable fields
+ */
+export type GetValues<
+  TSchemaUID extends Common.UID.Schema,
+  TFields extends Attribute.GetKeys<TSchemaUID> = Attribute.GetNonPopulatableKeys<TSchemaUID>,
+  TPopulate extends Attribute.GetKeys<TSchemaUID> = Attribute.GetPopulatableKeys<TSchemaUID>
+> = Utils.Expression.If<
+  Common.AreSchemaRegistriesExtended,
+  Utils.Guard.Never<
+    TFields | TPopulate,
+    Attribute.GetKeys<TSchemaUID>
+  > extends infer TKeys extends Attribute.GetKeys<TSchemaUID>
+    ? Attribute.GetValues<TSchemaUID, TKeys>
+    : never,
+  AnyDocument
+>;
+
+type ExtractFields<
+  TSchemaUID extends Common.UID.Schema,
+  TFields extends Params.Fields.Any<TSchemaUID> | undefined
+> = Utils.Expression.MatchFirst<
+  [
+    // No fields provided
+    [
+      Utils.Expression.Or<
+        Utils.Expression.StrictEqual<TFields, Params.Fields.Any<TSchemaUID>>,
+        Utils.Expression.Or<
+          Utils.Expression.IsNever<TFields>,
+          Utils.Expression.StrictEqual<TFields, undefined>
+        >
+      >,
+      never
+    ],
+    // string
+    [
+      Utils.Expression.Extends<TFields, Params.Fields.StringNotation<TSchemaUID>>,
+      ParseStringFields<TSchemaUID, Utils.Cast<TFields, Params.Fields.StringNotation<TSchemaUID>>>
+    ],
+    // string array
+    [
+      Utils.Expression.Extends<TFields, Params.Fields.ArrayNotation<TSchemaUID>>,
+      ParseStringFields<
+        TSchemaUID,
+        Utils.Cast<
+          Utils.Array.Values<Utils.Cast<TFields, Params.Fields.ArrayNotation<TSchemaUID>>>,
+          Params.Fields.StringNotation<TSchemaUID>
+        >
+      >
+    ]
+  ]
+>;
+
+type ParseStringFields<
+  TSchemaUID extends Common.UID.Schema,
+  TFields extends Params.Fields.StringNotation<TSchemaUID>
+> = Utils.Expression.MatchFirst<
+  [
+    [
+      Utils.Expression.StrictEqual<TFields, Params.Fields.WildcardNotation>,
+      Attribute.GetNonPopulatableKeys<TSchemaUID>
+    ],
+    [Utils.Expression.Extends<TFields, Params.Fields.SingleAttribute<TSchemaUID>>, TFields],
+    [
+      Utils.Expression.Extends<TFields, `${string},${string}`>,
+      Utils.Array.Values<Utils.String.Split<Utils.Cast<TFields, string>, ','>>
+    ]
+  ]
+>;
+
+type ExtractPopulate<
+  TSchemaUID extends Common.UID.Schema,
+  TPopulate extends Params.Populate.Any<TSchemaUID> | undefined
+> = Utils.Expression.MatchFirst<
+  [
+    // No populate provided
+    [
+      Utils.Expression.Or<
+        Utils.Expression.StrictEqual<TPopulate, Params.Populate.Any<TSchemaUID>>,
+        Utils.Expression.IsNever<TPopulate>
+      >,
+      never
+    ],
+    // string notation
+    [
+      Utils.Expression.Extends<TPopulate, Params.Populate.StringNotation<TSchemaUID>>,
+      ParseStringPopulate<
+        TSchemaUID,
+        Utils.Cast<TPopulate, Params.Populate.StringNotation<TSchemaUID>>
+      >
+    ],
+    // Array notation
+    [
+      Utils.Expression.Extends<TPopulate, Params.Populate.ArrayNotation<TSchemaUID>>,
+      ParseStringPopulate<
+        TSchemaUID,
+        Utils.Cast<
+          Utils.Array.Values<Utils.Cast<TPopulate, Params.Populate.ArrayNotation<TSchemaUID>>>,
+          Params.Populate.StringNotation<TSchemaUID>
+        >
+      >
+    ],
+    // object notation
+    [
+      Utils.Expression.Extends<TPopulate, Params.Populate.ObjectNotation<TSchemaUID>>,
+      ParseStringPopulate<
+        TSchemaUID,
+        // TODO: Handle relations set to false in object notation
+        Utils.Cast<keyof TPopulate, Params.Populate.StringNotation<TSchemaUID>>
+      >
+    ]
+  ]
+>;
+
+type ParsePopulateDotNotation<
+  TSchemaUID extends Common.UID.Schema,
+  TPopulate extends Params.Populate.StringNotation<TSchemaUID>
+> = Utils.Cast<
+  Utils.String.Split<Utils.Cast<TPopulate, string>, '.'>[0],
+  Attribute.GetPopulatableKeys<TSchemaUID>
+>;
+
+type ParseStringPopulate<
+  TSchemaUID extends Common.UID.Schema,
+  TPopulate extends Params.Populate.StringNotation<TSchemaUID>
+> = Utils.Expression.MatchFirst<
+  [
+    [
+      Utils.Expression.StrictEqual<Params.Populate.WildcardNotation, TPopulate>,
+      Attribute.GetPopulatableKeys<TSchemaUID>
+    ],
+    [
+      Utils.Expression.Extends<TPopulate, `${string},${string}`>,
+      ParsePopulateDotNotation<
+        TSchemaUID,
+        Utils.Cast<
+          Utils.Array.Values<Utils.String.Split<Utils.Cast<TPopulate, string>, ','>>,
+          Params.Populate.StringNotation<TSchemaUID>
+        >
+      >
+    ],
+    [
+      Utils.Expression.Extends<TPopulate, `${string}.${string}`>,
+      ParsePopulateDotNotation<TSchemaUID, TPopulate>
+    ]
+  ],
+  TPopulate
+>;

--- a/packages/core/types/src/types/shared/document-service.d.ts
+++ b/packages/core/types/src/types/shared/document-service.d.ts
@@ -1,0 +1,1 @@
+export interface DocumentServicePluginParams {}

--- a/packages/core/types/src/types/shared/index.ts
+++ b/packages/core/types/src/types/shared/index.ts
@@ -1,3 +1,4 @@
 export * from './registries';
+export * from './document-service';
 export * from './entity-service';
 export * from './plugins';


### PR DESCRIPTION
Document Service types were mostly reused from the entity service before, we now need to add new parameters (locale and status) and so it became necessary to duplicate the typings and adapt them to work for the document service.

@innerdvations @Convly we will need to be careful if we refactor the entity service types, and make sure the changes are also reflected into the document service :)

TLDR: This PR allows the use of locale and status paraameters in all the strapi.documents methods:

```ts
strapi.documents(ARTICLE_UID).create({
          locale: 'fr',
          status: 'draft',
          data: { title: 'Article' },
        });
```

It also provides the return types of the document repository methods