### PR TITLE
feat: remove helperCleanData function

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/utils/cleanData.js
+++ b/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/utils/cleanData.js
@@ -161,7 +161,7 @@ const cleanData = ({ browserState, serverState }, currentSchema, componentsSchem
           });
           break;
         default:
-          cleanedData = helperCleanData(value, 'id');
+          cleanedData = value;
       }
 
       acc[current] = cleanedData;
@@ -171,21 +171,6 @@ const cleanData = ({ browserState, serverState }, currentSchema, componentsSchem
   };
 
   return recursiveCleanData(browserState, serverState, currentSchema, '');
-};
-
-// TODO: check which parts are still needed: I suspect the
-// isArray part can go away, but I'm not sure what could send
-// an object; in case both can go away we might be able to get
-// rid of the whole helper
-export const helperCleanData = (value, key) => {
-  if (isArray(value)) {
-    return value.map((obj) => (obj[key] ? obj[key] : obj));
-  }
-  if (isObject(value)) {
-    return value[key];
-  }
-
-  return value;
 };
 
 export default cleanData;


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

It removes the `helperCleanData` function from the `EditViewDataManagerProvider`.

### Why is it needed?

I'm trying to send a nested object as the payload of the `put`/`post` request of the content manager edit view.
It is for a custom plugin I'm writing that alters the edit view and needs to send detailed data to the backend.

The function I removed is a fallback that is fired as the `default` of a `switch` case. It will sanitize any array or object you try to put in the payload and will alter it to be either a string, number or remove it completely.

### How to test it?

I'm not sure what other implications this might have and if I need to update or add any tests.
To test this we just have to make sure all the functionalities of the content manager edit view are still working. And we should test if we can add an object by manually adding it to the payload with something like this:

```
import { useCMEditViewDataManager } from "@strapi/helper-plugin";
// ...
const { onChange } = useCMEditViewDataManager();
// ...
onChange({ target: { name: `some_key`, value: {
  objectkey1: 'foo',
  objectkey2: 'bar',
} } });
```

### Related issue(s)/PR(s)

None that I know of.
