### PR TITLE
chore(ncu): add convenience script for keeping deps updated

### DIFF
--- a/.ncurc.yml
+++ b/.ncurc.yml
@@ -1,0 +1,8 @@
+# npm-check-updates configuration used by yarn deps:check && yarn deps:update
+# @link https://github.com/raineorshine/npm-check-updates
+
+# Exclude those packages from default updates
+# the list should be set and maintained over time.
+reject: [
+
+]

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "build:size": "cd examples/getstarted && yarn build",
     "build:ts": "nx run-many --target=build:ts --nx-ignore-cycles",
     "clean": "nx run-many --target=clean --nx-ignore-cycles",
+    "deps:check": "npx npm-check-updates@latest --configFileName ncurc.yml --workspaces --root --mergeConfig",
+    "deps:update": "npx npm-check-updates@latest --configFileName ncurc.yml -u --workspaces --root --mergeConfig",
     "doc:api": "node scripts/open-api/serve.js",
     "format": "yarn format:code && yarn format:other",
     "format:code": "yarn prettier:code --write",


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Expose 2 top-level convenience scripts to list (identify) and/or update possible dependencies updates in the repo.

| Name                         | Description                                                                                                                          |
| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
| `yarn deps:check --dep dev`  | Will display the list of possible updates (follows [.ncurc.yml](.ncurc.yml)) |
| `yarn deps:update --dep dev` | Apply possible updates (run `yarn install && yarn dedupe` after)                                                                     |

It comes from a follow up of https://github.com/strapi/strapi/pull/16764#issuecomment-1552868977 about deduplication.

### Why is it needed?

In my experience I found it very useful to list, identify, update or populate backlog task from the cli. Bots like renovate, dependabot... can totally co-exists.

The top-level scripts are based on [npm-check-updates](https://github.com/raineorshine/npm-check-updates) a.k.a ncu
(see [options](https://github.com/raineorshine/npm-check-updates#options), i.e: `yarn check:deps -t minor`). Nowadays Yarn 4 has built-in commands to do almost the same thing, but I feel in a monorepo ncu still is very convenient (especially when you want to upgrade a package in all workspaces).


### How to test it?

N/A

### Future

This PR doesn't update anything.  In the future it might be interesting to

#### Setup exclusions

Identify and add exclusions in the ncurc.yml (deps that we want to ignore for now)

#### Align and update all minor devDeps

```bash
yarn check:deps -t minor -dep dev  # displays the list
yarn check:update -t minor -dep dev 
yarn dedupe
```

#### Align and update all minor production deps

```bash
yarn check:deps -t minor -dep prod  # displays the list
yarn check:update -t minor -dep prod 
yarn dedupe
```
