### PR TITLE
chore(docs): initialize contributor docs for content releases

### DIFF
--- a/docs/docs/docs/01-core/content-releases/00-intro.md
+++ b/docs/docs/docs/01-core/content-releases/00-intro.md
@@ -1,0 +1,24 @@
+---
+title: Introduction
+tags:
+  - content-releases
+---
+
+# Content Releases
+
+A release contains various content entries, each capable of being assigned a specific action such as publish or unpublish. Within a release, entries may be in different locales or come from different content types. With a simple click of a button, a release can execute the designated action for each entry. Content Releases is an enterprise edition feature.
+
+### Architecture
+
+As opposed to other EE features built in the [EE folder](docs/docs/01-core/admin/01-ee/00-intro.md), Releases is built as a plugin. The plugin can be found in:
+
+```
+packages/core/content-releases
+```
+
+```mdx-code-block
+import DocCardList from '@theme/DocCardList';
+import { useCurrentSidebarCategory } from '@docusaurus/theme-common';
+
+<DocCardList items={useCurrentSidebarCategory().items} />
+```

--- a/docs/docs/docs/01-core/content-releases/01-backend.md
+++ b/docs/docs/docs/01-core/content-releases/01-backend.md
@@ -1,0 +1,75 @@
+---
+title: Backend Design
+description: Content Releases backend
+tags:
+  - content-releases
+  - tech design
+---
+
+All backend code can be found in:
+
+```
+ packages/core/content-releases/server
+```
+
+## Content-types
+
+The content-releases plugin creates two hidden content-types.
+
+### Release
+
+This content type stores all the information about a release and its associated Release Actions. It is saved in the database as `strapi_release`. The schema can be found in:
+
+```
+packages/core/content-releases/server/src/content-types/release/schema.ts
+```
+
+### Release Action
+
+This content type is associated with any entry from any content-type with draft and publish enable. It is also responsible for storing the action to perform for the associated entry. It is saved in the database as `strapi_release_actions`. The schema can be found in:
+
+```
+packages/core/content-releases/server/src/content-types/release-action/schema.ts
+```
+
+## Routes
+
+Release and Release Action routes are only accessible on the Admin API.
+
+### Release
+
+Release routes can be found in:
+
+```
+packages/core/content-releases/server/src/routes/release.ts
+```
+
+**Get all releases**:
+
+- method: `GET`
+- endpoint: `/content-releases/`
+
+**Create a release**:
+
+- method: `POST`
+- endpoint: `/content-releases/`
+
+## Controllers
+
+### Release
+
+Interacts with the Release content type
+
+```
+packages/core/content-releases/server/src/controllers/release.ts
+```
+
+## Services
+
+### Release
+
+Interacts with the database for Release CRUD actions.
+
+```
+packages/core/content-releases/server/src/services/release.ts
+```

--- a/docs/docs/docs/01-core/content-releases/01-backend.md
+++ b/docs/docs/docs/01-core/content-releases/01-backend.md
@@ -18,7 +18,7 @@ The content-releases plugin creates two hidden content-types.
 
 ### Release
 
-This content type stores all the information about a release and its associated Release Actions. It is saved in the database as `strapi_release`. The schema can be found in:
+The `Release` content type stores all the information about a release and its associated Release Actions. It is saved in the database as `strapi_releases`. The schema can be found in:
 
 ```
 packages/core/content-releases/server/src/content-types/release/schema.ts
@@ -26,7 +26,7 @@ packages/core/content-releases/server/src/content-types/release/schema.ts
 
 ### Release Action
 
-This content type is associated with any entry from any content-type with draft and publish enable. It is also responsible for storing the action to perform for the associated entry. It is saved in the database as `strapi_release_actions`. The schema can be found in:
+Th `Release Action` content type is associated with any entry from any content-type that has draft and publish enabled. It is responsible for storing the action to perform for an associated entry. It is saved in the database as `strapi_release_actions`. The schema can be found in:
 
 ```
 packages/core/content-releases/server/src/content-types/release-action/schema.ts
@@ -48,28 +48,71 @@ packages/core/content-releases/server/src/routes/release.ts
 
 - method: `GET`
 - endpoint: `/content-releases/`
+- params:
+  ```ts
+  {
+    page: number;
+    pageSize: number;
+  }
+  ```
 
 **Create a release**:
 
 - method: `POST`
 - endpoint: `/content-releases/`
+- body:
+  ```ts
+  {
+    name: string;
+  }
+  ```
+
+### Release Action
+
+**Create a release action**
+
+- method: `POST`
+- endpoint: `/content-releases/release-actions/`
+- body:
+  ```ts
+  {
+    releaseId: number,
+    entry: {
+      id: number,
+      contentType: string
+    }
+    type: 'publish' | 'unpublish'
+  }
+  ```
 
 ## Controllers
 
 ### Release
 
-Interacts with the Release content type
+Handles requests to interact with the Release content type
 
 ```
 packages/core/content-releases/server/src/controllers/release.ts
 ```
 
+### Release Action
+
+Handles requests to interact with the Release Action content type
+
 ## Services
 
 ### Release
 
-Interacts with the database for Release CRUD actions.
+Interacts with the database for Release and Release Action CRUD operations
 
 ```
 packages/core/content-releases/server/src/services/release.ts
+```
+
+### Release Validation
+
+Exposes validation functions to run before performing operations on a Release
+
+```
+packages/core/content-releases/server/src/services/validation.ts
 ```

--- a/docs/docs/docs/01-core/content-releases/_category_.json
+++ b/docs/docs/docs/01-core/content-releases/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Content Releases",
+  "collapsible": true,
+  "collapsed": true
+}


### PR DESCRIPTION
### What does it do?

Initialize the contributor documentation and documents everything for the backend currently on the feature branch

### Why is it needed?

So we can continue documenting the feature as we develop

### How to test it?

Just give it a read