### PR TITLE
fix(admin): load app custom with jsx and allow more extensions

### DIFF
--- a/examples/getstarted/jsconfig.json
+++ b/examples/getstarted/jsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "jsx": "react",
     "moduleResolution": "nodenext",
     "target": "ES2021",
     "checkJs": true,

--- a/examples/getstarted/src/admin/app.js
+++ b/examples/getstarted/src/admin/app.js
@@ -1,8 +1,18 @@
+import React from 'react';
+import { Button } from '@strapi/design-system';
+
 const config = {
   locales: ['it', 'es', 'en'],
 };
-const bootstrap = () => {
+const bootstrap = (app) => {
   console.log('I AM  BOOTSTRAPPED');
+
+  app.injectContentManagerComponent('editView', 'right-links', {
+    name: 'PreviewButton',
+    Component: () => (
+      <Button onClick={() => window.alert('Not here, The preview is.')}>Preview</Button>
+    ),
+  });
 };
 
 export default {

--- a/packages/core/admin/_internal/node/core/admin-customisations.ts
+++ b/packages/core/admin/_internal/node/core/admin-customisations.ts
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import { loadFile } from './files';
+import fs from 'node:fs';
 
 const ADMIN_APP_FILES = ['app.js', 'app.mjs', 'app.ts', 'app.jsx', 'app.tsx'];
 
@@ -12,16 +12,14 @@ interface AdminCustomisations {
 
 interface AppFile {
   path: string;
-  config: AdminCustomisations['config'];
 }
 
 const loadUserAppFile = async (appDir: string): Promise<AppFile | undefined> => {
   for (const file of ADMIN_APP_FILES) {
     const filePath = path.join(appDir, 'src', 'admin', file);
-    const configFile = await loadFile(filePath);
 
-    if (configFile) {
-      return { path: filePath, config: configFile };
+    if (fs.existsSync(filePath)) {
+      return { path: filePath };
     }
   }
 

--- a/packages/core/admin/_internal/node/core/files.ts
+++ b/packages/core/admin/_internal/node/core/files.ts
@@ -19,9 +19,7 @@ const pathExists = async (path: string) => {
 const loadFile = async (path: string): Promise<undefined | any> => {
   if (await pathExists(path)) {
     const esbuildOptions: Parameters<typeof register>[0] = {
-      extensions: ['.js', '.mjs', '.ts', '.jsx', '.tsx'],
-      jsx: 'automatic',
-      loader: 'jsx',
+      extensions: ['.js', '.mjs', '.ts'],
     };
 
     const { unregister } = register(esbuildOptions);

--- a/packages/core/admin/_internal/node/core/files.ts
+++ b/packages/core/admin/_internal/node/core/files.ts
@@ -18,7 +18,11 @@ const pathExists = async (path: string) => {
  */
 const loadFile = async (path: string): Promise<undefined | any> => {
   if (await pathExists(path)) {
-    const esbuildOptions = { extensions: ['.js', '.mjs', '.ts'] };
+    const esbuildOptions: Parameters<typeof register>[0] = {
+      extensions: ['.js', '.mjs', '.ts', '.jsx', '.tsx'],
+      jsx: 'automatic',
+      loader: 'jsx',
+    };
 
     const { unregister } = register(esbuildOptions);
 

--- a/packages/core/admin/_internal/node/staticFiles.ts
+++ b/packages/core/admin/_internal/node/staticFiles.ts
@@ -24,7 +24,7 @@ const getEntryModule = (ctx: BuildContext): string => {
          */
         ${pluginsImport}
         import { renderAdmin } from "@strapi/strapi/admin"
-        
+
         ${
           ctx.customisations?.path
             ? `import customisations from '${path.relative(
@@ -33,7 +33,7 @@ const getEntryModule = (ctx: BuildContext): string => {
               )}'`
             : ''
         }
-        
+
         renderAdmin(
           document.getElementById("strapi"),
           {


### PR DESCRIPTION
### What does it do?

Upgrade the laodFile util to support required feature.

### Why is it needed?

Fix an issue with custom app code

### How to test it?

create a src/admin/app.(ts|tsx|js|jsx) file with jsx code in it

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
