### PR TITLE
fix(admin): restore current password input on profile page

### DIFF
--- a/packages/core/admin/admin/src/pages/ProfilePage.tsx
+++ b/packages/core/admin/admin/src/pages/ProfilePage.tsx
@@ -120,7 +120,7 @@ const ProfilePage = () => {
 
   const isLoading = isLoadingUser || isLoadingSSO;
 
-  type UpdateUsersMeBody = Omit<UpdateMe.Request['body'], 'currentPassword'> & {
+  type UpdateUsersMeBody = UpdateMe.Request['body'] & {
     confirmPassword: string;
     currentTheme: ThemeName;
   };
@@ -132,6 +132,11 @@ const ProfilePage = () => {
   >(
     async (body) => {
       const { confirmPassword: _confirmPassword, currentTheme, ...dataToSend } = body;
+
+      if (dataToSend.password === '') {
+        delete dataToSend.password;
+      }
+
       const { data } = await put<UpdateMe.Response>('/admin/users/me', dataToSend);
 
       return { ...data.data, currentTheme };
@@ -321,9 +326,10 @@ const ProfilePage = () => {
  * -----------------------------------------------------------------------------------------------*/
 
 interface PasswordSectionProps {
-  errors: { password?: string; confirmPassword?: string };
+  errors: { currentPassword?: string; password?: string; confirmPassword?: string };
   onChange: React.ChangeEventHandler<HTMLInputElement>;
   values: {
+    currentPassword?: string;
     password?: string;
     confirmPassword?: string;
   };
@@ -331,6 +337,7 @@ interface PasswordSectionProps {
 
 const PasswordSection = ({ errors, onChange, values }: PasswordSectionProps) => {
   const { formatMessage } = useIntl();
+  const [currentPasswordShown, setCurrentPasswordShown] = React.useState(false);
   const [passwordShown, setPasswordShown] = React.useState(false);
   const [passwordConfirmShown, setPasswordConfirmShown] = React.useState(false);
 
@@ -351,6 +358,49 @@ const PasswordSection = ({ errors, onChange, values }: PasswordSectionProps) => 
             defaultMessage: 'Change password',
           })}
         </Typography>
+        <Grid gap={5}>
+          <GridItem s={12} col={6}>
+            <TextInput
+              error={
+                errors.currentPassword
+                  ? formatMessage({
+                      id: errors.currentPassword,
+                      defaultMessage: errors.currentPassword,
+                    })
+                  : ''
+              }
+              onChange={onChange}
+              value={values.currentPassword}
+              label={formatMessage({
+                id: 'Auth.form.currentPassword.label',
+                defaultMessage: 'Current Password',
+              })}
+              name="currentPassword"
+              type={currentPasswordShown ? 'text' : 'password'}
+              endAction={
+                <FieldActionWrapper
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setCurrentPasswordShown((prev) => !prev);
+                  }}
+                  label={formatMessage(
+                    currentPasswordShown
+                      ? {
+                          id: 'Auth.form.password.show-password',
+                          defaultMessage: 'Show password',
+                        }
+                      : {
+                          id: 'Auth.form.password.hide-password',
+                          defaultMessage: 'Hide password',
+                        }
+                  )}
+                >
+                  {currentPasswordShown ? <Eye /> : <EyeStriked />}
+                </FieldActionWrapper>
+              }
+            />
+          </GridItem>
+        </Grid>
         <Grid gap={5}>
           <GridItem s={12} col={6}>
             <PasswordInput

--- a/packages/core/admin/admin/src/pages/ProfilePage.tsx
+++ b/packages/core/admin/admin/src/pages/ProfilePage.tsx
@@ -458,7 +458,7 @@ const PasswordSection = ({ errors, onChange, values }: PasswordSectionProps) => 
               value={values.confirmPassword}
               label={formatMessage({
                 id: 'Auth.form.confirmPassword.label',
-                defaultMessage: 'Password confirmation',
+                defaultMessage: 'Confirm Password',
               })}
               name="confirmPassword"
               type={passwordConfirmShown ? 'text' : 'password'}

--- a/packages/core/admin/admin/src/pages/tests/ProfilePage.test.tsx
+++ b/packages/core/admin/admin/src/pages/tests/ProfilePage.test.tsx
@@ -28,7 +28,7 @@ describe('Profile page', () => {
     jest.clearAllMocks();
   });
 
-  it('renders and show the Interface Language section', async () => {
+  it('renders and shows the Interface Language section', async () => {
     const { getByText } = render(<ProfilePage />);
     await waitFor(() => {
       expect(getByText('Interface language')).toBeInTheDocument();
@@ -54,10 +54,9 @@ describe('Profile page', () => {
         name: 'Change password',
       })
     ).toBeInTheDocument();
-
-    expect(getByLabelText('Password')).toBeInTheDocument();
-
-    expect(getByLabelText('Password confirmation')).toBeInTheDocument();
+    expect(getByLabelText(/current password/i)).toBeInTheDocument();
+    expect(getByLabelText(/^password$/i)).toBeInTheDocument();
+    expect(getByLabelText(/confirm password/i)).toBeInTheDocument();
   });
 
   it('should not display the change password section and all the fields if the user role is Locked', async () => {
@@ -84,9 +83,8 @@ describe('Profile page', () => {
     });
 
     expect(changePasswordHeading).not.toBeInTheDocument();
-
-    expect(queryByLabelText('Password')).not.toBeInTheDocument();
-
-    expect(queryByLabelText('Password confirmation')).not.toBeInTheDocument();
+    expect(queryByLabelText(/current password/i)).not.toBeInTheDocument();
+    expect(queryByLabelText(/^password$/)).not.toBeInTheDocument();
+    expect(queryByLabelText(/confirm password/i)).not.toBeInTheDocument();
   });
 });

--- a/packages/core/admin/shared/contracts/users.ts
+++ b/packages/core/admin/shared/contracts/users.ts
@@ -20,17 +20,22 @@ export declare namespace GetMe {
  * PUT /users/me - Update the current admin user
  */
 export declare namespace UpdateMe {
+  export interface BaseRequestBody {
+    email?: string;
+    firstname?: string;
+    lastname?: string;
+    username?: string;
+    preferedLanguage?: string;
+  }
+
+  export interface PasswordRequestBody extends BaseRequestBody {
+    currentPassword: string;
+    password: string;
+  }
+
   export interface Request {
     query: {};
-    body: {
-      email?: string;
-      firstname?: string;
-      lastname?: string;
-      username?: string;
-      password?: string;
-      currentPassword?: string;
-      preferedLanguage?: string;
-    };
+    body: BaseRequestBody | PasswordRequestBody;
   }
 
   export interface Response {


### PR DESCRIPTION
### What does it do?

Changes on the profile page:

- restores the current password input, as it it needed by the backend to change password
- avoids passing an empty password string if the user didn't touch the password input. This is what prevented users from saving

### Why is it needed?

To allow users to save their changes on the profile page.

### How to test it?

Go to the profile page, make changes (both with and without password changes), then try to save.

### Related issue(s)/PR(s)

fixes #18678