### PR TITLE
feat: add priority to middlewares

### DIFF
--- a/api-tests/core/strapi/document-service/create.test.api.ts
+++ b/api-tests/core/strapi/document-service/create.test.api.ts
@@ -1,8 +1,8 @@
 import { LoadedStrapi } from '@strapi/types';
-import './resources/types/components.js';
-import './resources/types/contentTypes.js';
+import './resources/types/components.d.ts';
+import './resources/types/contentTypes.d.ts';
 import resources from './resources/index';
-import { createTestSetup, destroyTestSetup } from '../../../utils/builder-helper.js';
+import { createTestSetup, destroyTestSetup } from '../../../utils/builder-helper';
 import { testInTransaction } from '../../../utils/index';
 
 const ARTICLE_UID = 'api::article.article';
@@ -29,7 +29,7 @@ describe('Document Service', () => {
   });
 
   describe('Creates', () => {
-    it.todo(
+    it(
       'can create a document',
       testInTransaction(async () => {
         const article = await strapi.documents(ARTICLE_UID).create({
@@ -43,16 +43,18 @@ describe('Document Service', () => {
           publishedAt: null, // should be a draft
         });
 
-        // TODO: Check a published document was not created
+        // @ts-expect-error - TODO: doc service entry type should contain documentId
+        const articles = await findArticlesDb({ documentId: article.documentId });
+        // Only one article should have been created
+        expect(articles).toHaveLength(1);
       })
     );
 
-    it.todo(
+    it(
       'can create an article in french',
       testInTransaction(async () => {
         const article = await strapi.documents(ARTICLE_UID).create({
           locale: 'fr',
-          status: 'published',
           data: { title: 'Article' },
         });
 
@@ -65,7 +67,7 @@ describe('Document Service', () => {
       })
     );
 
-    it.todo(
+    it(
       'can not directly create a published document',
       testInTransaction(async () => {
         const articlePromise = strapi.documents(ARTICLE_UID).create({
@@ -79,7 +81,7 @@ describe('Document Service', () => {
     );
 
     // TODO: Make publishedAt not editable
-    it.todo(
+    it(
       'publishedAt attribute is ignored when creating document',
       testInTransaction(async () => {
         const article = await strapi.documents(ARTICLE_UID).create({

--- a/api-tests/core/strapi/document-service/delete.test.api.ts
+++ b/api-tests/core/strapi/document-service/delete.test.api.ts
@@ -29,11 +29,11 @@ describe('Document Service', () => {
   });
 
   describe('Delete', () => {
-    it.todo(
+    it(
       'delete an entire document',
       testInTransaction(async () => {
-        const articleDb = await findArticleDb({ name: 'Article1' });
-        const article = await strapi.documents(ARTICLE_UID).delete(articleDb.documentId);
+        const articleDb = await findArticleDb({ title: 'Article1-Draft-EN' });
+        await strapi.documents(ARTICLE_UID).delete(articleDb.documentId);
 
         const articles = await findArticlesDb({ documentId: articleDb.documentId });
 
@@ -41,11 +41,11 @@ describe('Document Service', () => {
       })
     );
 
-    it.todo(
+    it(
       'delete a document locale',
       testInTransaction(async () => {
-        const articleDb = await findArticleDb({ name: 'Article1-Draft-FR' });
-        const article = await strapi.documents(ARTICLE_UID).delete(articleDb.documentId, {
+        const articleDb = await findArticleDb({ title: 'Article1-Draft-FR' });
+        await strapi.documents(ARTICLE_UID).delete(articleDb.documentId, {
           locale: 'fr',
         });
 
@@ -59,25 +59,23 @@ describe('Document Service', () => {
       })
     );
 
-    it.todo(
-      'deleting a draft removes the published version too',
+    it(
+      'cannot delete a draft directly',
       testInTransaction(async () => {
-        const articleDb = await findArticleDb({ name: 'Article2-Draft-EN' });
-        const article = await strapi.documents(ARTICLE_UID).delete(articleDb.documentId, {
+        const articleDb = await findArticleDb({ title: 'Article2-Draft-EN' });
+        const articlePromise = strapi.documents(ARTICLE_UID).delete(articleDb.documentId, {
           status: 'draft',
         });
 
-        const articles = await findArticlesDb({ documentId: articleDb.documentId });
-
-        expect(articles.length).toBe(0);
+        await expect(articlePromise).rejects.toThrow('Cannot delete a draft document');
       })
     );
 
-    it.todo(
+    it(
       'deleting a published version keeps the draft version',
       testInTransaction(async () => {
-        const articleDb = await findArticleDb({ name: 'Article2-Draft-EN' });
-        const article = await strapi.documents(ARTICLE_UID).delete(articleDb.documentId, {
+        const articleDb = await findArticleDb({ title: 'Article2-Draft-EN' });
+        await strapi.documents(ARTICLE_UID).delete(articleDb.documentId, {
           status: 'published',
         });
 

--- a/api-tests/core/strapi/document-service/find-first.test.api.ts
+++ b/api-tests/core/strapi/document-service/find-first.test.api.ts
@@ -1,8 +1,8 @@
 import { LoadedStrapi } from '@strapi/types';
-import './resources/types/components.js';
-import './resources/types/contentTypes.js';
+import './resources/types/components.d.ts';
+import './resources/types/contentTypes.d.ts';
 import resources from './resources/index';
-import { createTestSetup, destroyTestSetup } from '../../../utils/builder-helper.js';
+import { createTestSetup, destroyTestSetup } from '../../../utils/builder-helper';
 import { testInTransaction } from '../../../utils/index';
 
 const ARTICLE_UID = 'api::article.article';
@@ -29,10 +29,10 @@ describe('Document Service', () => {
   });
 
   describe('FindFirst', () => {
-    it.todo(
+    it(
       'find first document with defaults',
       testInTransaction(async () => {
-        const articleDb = await findArticleDb({ name: 'Article1-Draft-EN' });
+        const articleDb = await findArticleDb({ title: 'Article1-Draft-EN' });
 
         const article = await strapi.documents(ARTICLE_UID).findFirst({});
 
@@ -41,13 +41,13 @@ describe('Document Service', () => {
       })
     );
 
-    it.todo(
+    it(
       'find first document in french',
       testInTransaction(async () => {
-        const articleDb = await findArticleDb({ name: 'Article1-Draft-FR' });
+        const articleDb = await findArticleDb({ title: 'Article1-Draft-FR' });
 
         const article = await strapi.documents(ARTICLE_UID).findFirst({
-          locale: 'fr'
+          locale: 'fr',
           filters: {
             title: { $startsWith: 'Article1' },
           },
@@ -57,27 +57,23 @@ describe('Document Service', () => {
       })
     );
 
-    it.todo(
+    it(
       'find one published document',
       testInTransaction(async () => {
-        const articleDb = await findArticleDb({ name: 'Article1-Published-EN' });
-
-        const article = await strapi.documents(ARTICLE_UID).findOne({
+        const article = await strapi.documents(ARTICLE_UID).findFirst({
           status: 'published',
         });
 
         expect(article).toMatchObject({
-          publishedAt: expect.any(Date),
+          publishedAt: expect.any(String),
         });
       })
     );
 
-    it.todo(
+    it(
       'find first draft document',
       testInTransaction(async () => {
-        const articleDb = await findArticleDb({ name: 'Article1-Draft-EN' });
-
-        const article = await strapi.documents(ARTICLE_UID).findOne({
+        const article = await strapi.documents(ARTICLE_UID).findFirst({
           status: 'draft',
         });
 

--- a/api-tests/core/strapi/document-service/find-many.test.api.ts
+++ b/api-tests/core/strapi/document-service/find-many.test.api.ts
@@ -29,7 +29,18 @@ describe('Document Service', () => {
   });
 
   describe('FindMany', () => {
-    it.todo(
+    it(
+      'find many documents should only return drafts by default',
+      testInTransaction(async () => {
+        const articles = await strapi.documents('api::article.article').findMany({});
+
+        articles.forEach((article) => {
+          expect(article.publishedAt).toBe(null);
+        });
+      })
+    );
+
+    it(
       'find documents by name returns default locale and draft version',
       testInTransaction(async () => {
         const articlesDb = await findArticlesDb({ title: 'Article1-Draft-EN' });
@@ -44,14 +55,14 @@ describe('Document Service', () => {
       })
     );
 
-    it.todo(
+    it(
       'find documents by name and locale',
       testInTransaction(async () => {
         // There should not be a fr article called Article1-Draft-EN
         const articles = await strapi.documents('api::article.article').findMany({
           locale: 'fr',
           // Locale will also be allowed in filters but not recommended or documented
-          filters: { title: 'Article1-Draft-EN' },
+          filters: { title: 'Article1-Draft-FR' },
         });
 
         // Should return french locale and draft version
@@ -59,7 +70,7 @@ describe('Document Service', () => {
       })
     );
 
-    it.todo(
+    it(
       'find french documents',
       testInTransaction(async () => {
         const articlesDb = await findArticlesDb({ title: 'Article1-Draft-EN' });
@@ -74,11 +85,12 @@ describe('Document Service', () => {
         // All articles should be in french
         articles.forEach((article) => {
           expect(article.locale).toBe('fr');
+          expect(article.publishedAt).toBe(null);
         });
       })
     );
 
-    it.todo(
+    it(
       'find published documents',
       testInTransaction(async () => {
         const articles = await strapi.documents('api::article.article').findMany({
@@ -94,7 +106,7 @@ describe('Document Service', () => {
       })
     );
 
-    it.todo(
+    it(
       'find draft documents',
       testInTransaction(async () => {
         const articles = await strapi.documents('api::article.article').findMany({

--- a/api-tests/core/strapi/document-service/find-one.test.api.ts
+++ b/api-tests/core/strapi/document-service/find-one.test.api.ts
@@ -29,10 +29,10 @@ describe('Document Service', () => {
   });
 
   describe('FindOne', () => {
-    it.todo(
+    it(
       'find one document returns defaults',
       testInTransaction(async () => {
-        const articleDb = await findArticleDb({ name: 'Article1-Draft-EN' });
+        const articleDb = await findArticleDb({ title: 'Article1-Draft-EN' });
 
         const article = await strapi.documents(ARTICLE_UID).findOne(articleDb.documentId, {});
 
@@ -40,10 +40,10 @@ describe('Document Service', () => {
       })
     );
 
-    it.todo(
+    it(
       'find one document in english',
       testInTransaction(async () => {
-        const articleDb = await findArticleDb({ name: 'Article1-Draft-EN' });
+        const articleDb = await findArticleDb({ title: 'Article1-Draft-EN' });
 
         const article = await strapi.documents(ARTICLE_UID).findOne(articleDb.documentId, {
           locale: 'en',
@@ -53,10 +53,10 @@ describe('Document Service', () => {
       })
     );
 
-    it.todo(
+    it(
       'find one published document',
       testInTransaction(async () => {
-        const articleDb = await findArticleDb({ name: 'Article1-Published-EN' });
+        const articleDb = await findArticleDb({ title: 'Article2-Published-EN' });
 
         const article = await strapi.documents(ARTICLE_UID).findOne(articleDb.documentId, {
           status: 'published',
@@ -66,10 +66,10 @@ describe('Document Service', () => {
       })
     );
 
-    it.todo(
+    it(
       'find one draft document',
       testInTransaction(async () => {
-        const articleDb = await findArticleDb({ name: 'Article1-Draft-EN' });
+        const articleDb = await findArticleDb({ title: 'Article1-Draft-EN' });
 
         const article = await strapi.documents(ARTICLE_UID).findOne(articleDb.documentId, {
           status: 'draft',

--- a/api-tests/core/strapi/document-service/middlewares.test.api.ts
+++ b/api-tests/core/strapi/document-service/middlewares.test.api.ts
@@ -30,6 +30,7 @@ describe('Document Service', () => {
   describe('Middlewares', () => {
     it('Add filters', async () => {
       strapi.documents.use('findMany', (ctx, next) => {
+        // @ts-expect-error - this is using a generic ContentType.UID , so article attributes are not typed
         ctx.params.filters = { title: 'Article1-Draft-EN' };
         return next(ctx);
       });

--- a/api-tests/core/strapi/document-service/middlewares.test.api.ts
+++ b/api-tests/core/strapi/document-service/middlewares.test.api.ts
@@ -50,4 +50,35 @@ describe('Document Service', () => {
       expect(articles).toHaveLength(1);
     });
   });
+
+  describe('Middleware priority', () => {
+    it('Add middlewares with different priority', async () => {
+      const ARTICLE_1 = 'Article1-Draft-EN';
+      const ARTICLE_2 = 'Article2-Draft-EN';
+
+      strapi.documents(ARTICLE_UID).use(
+        'findMany',
+        (ctx, next) => {
+          ctx.params.filters = { title: ARTICLE_1 };
+          return next(ctx);
+        },
+        { priority: strapi.documents.middlewares.priority.LAST }
+      );
+
+      strapi.documents(ARTICLE_UID).use(
+        'findMany',
+        (ctx, next) => {
+          ctx.params.filters = { title: ARTICLE_2 };
+          return next(ctx);
+        },
+        { priority: strapi.documents.middlewares.priority.FIRST }
+      );
+
+      // Higher priority middleware should be called first, even if it's added after
+      const articles = await strapi.documents(ARTICLE_UID).findMany({});
+
+      expect(articles).toHaveLength(1);
+      expect(articles[0].title).toEqual(ARTICLE_1);
+    });
+  });
 });

--- a/api-tests/core/strapi/document-service/middlewares.test.api.ts
+++ b/api-tests/core/strapi/document-service/middlewares.test.api.ts
@@ -63,7 +63,7 @@ describe('Document Service', () => {
           ctx.params.filters = { title: ARTICLE_1 };
           return next(ctx);
         },
-        { priority: strapi.documents.middlewares.priority.LAST }
+        { priority: strapi.documents.middlewares.priority.LOW }
       );
 
       strapi.documents(ARTICLE_UID).use(
@@ -72,7 +72,7 @@ describe('Document Service', () => {
           ctx.params.filters = { title: ARTICLE_2 };
           return next(ctx);
         },
-        { priority: strapi.documents.middlewares.priority.FIRST }
+        { priority: strapi.documents.middlewares.priority.HIGH }
       );
 
       // Higher priority middleware should be called first, even if it's added after

--- a/api-tests/core/strapi/document-service/update.test.api.ts
+++ b/api-tests/core/strapi/document-service/update.test.api.ts
@@ -29,10 +29,10 @@ describe('Document Service', () => {
   });
 
   describe('Update', () => {
-    it.todo(
-      'update a document',
+    it(
+      'update a document with defaults',
       testInTransaction(async () => {
-        const articleDb = await findArticleDb({ title: '3 Document A' });
+        const articleDb = await findArticleDb({ title: 'Article1-Draft-EN' });
         const newName = 'Updated Document';
 
         const article = await strapi.documents(ARTICLE_UID).update(articleDb.documentId, {
@@ -56,7 +56,7 @@ describe('Document Service', () => {
       })
     );
 
-    it.todo(
+    it(
       'update a document locale',
       testInTransaction(async () => {
         const articleDb = await findArticleDb({ title: 'Article1-Draft-FR' });
@@ -78,21 +78,22 @@ describe('Document Service', () => {
         // verify it was updated in the database
         const updatedArticleDb = await findArticleDb({ title: newName });
         expect(updatedArticleDb).toMatchObject({
-          ...articleDb,
+          id: articleDb.id,
+          locale: 'fr',
           title: newName,
           updatedAt: article.updatedAt,
         });
 
         // verity others locales are not updated
-        const enLocale = await findArticleDb({ title: 'Article1' });
+        const enLocale = await findArticleDb({ title: 'Article1-Draft-EN' });
         expect(enLocale).toBeDefined();
       })
     );
 
-    it.todo(
+    it(
       'create a new localization for an existing document',
       testInTransaction(async () => {
-        const articleDb = await findArticleDb({ title: 'Article1' });
+        const articleDb = await findArticleDb({ title: 'Article1-Draft-EN' });
         const newName = 'updated document';
 
         // Create a new article in spanish
@@ -103,18 +104,15 @@ describe('Document Service', () => {
 
         // verify that the returned document was updated
         expect(article).toMatchObject({
-          ...articleDb,
+          documentId: articleDb.documentId,
+          locale: 'es',
           title: newName,
           updatedAt: article.updatedAt,
         });
 
         // verify it was updated in the database
         const updatedArticleDb = await findArticleDb({ title: newName });
-        expect(updatedArticleDb).toMatchObject({
-          ...articleDb,
-          title: newName,
-          updatedAt: article.updatedAt,
-        });
+        expect(updatedArticleDb).toMatchObject(article);
 
         // verity others locales are not updated
         const enLocale = await findArticleDb({ title: 'Article1' });
@@ -122,24 +120,24 @@ describe('Document Service', () => {
       })
     );
 
-    it.todo(
+    it(
       'can not update published document',
       testInTransaction(async () => {
         const articleDb = await findArticleDb({ title: 'Article1-Draft-FR' });
         const newName = 'updated document';
 
         const updatePromise = strapi.documents(ARTICLE_UID).update(articleDb.documentId, {
-          status: 'published'
+          status: 'published',
           data: { title: newName },
         });
 
         await expect(updatePromise).rejects.toThrow(
-          `You cannot update a document published version`
+          'Cannot update a published document. Use the publish method instead.'
         );
       })
     );
 
-    it.todo(
+    it(
       'document to update does not exist',
       testInTransaction(async () => {
         const article = await strapi.documents(ARTICLE_UID).update('does-not-exist', {

--- a/packages/core/strapi/src/services/document-service/document-repository.ts
+++ b/packages/core/strapi/src/services/document-service/document-repository.ts
@@ -1,6 +1,7 @@
 import { Strapi, Common, Documents } from '@strapi/types';
 import createDocumentService from '.';
 import createMiddlewareManager from './middlewares';
+import { loadDefaultMiddlewares } from './middlewares/defaults';
 
 /**
  * TODO:
@@ -26,7 +27,9 @@ export const createDocumentRepository = (
   { defaults = {} }: { defaults?: any } = {}
 ): Documents.Repository => {
   const documents = createDocumentService({ strapi, db: strapi.db! });
+
   const middlewareManager = createMiddlewareManager();
+  loadDefaultMiddlewares(middlewareManager);
 
   function create<TContentTypeUID extends Common.UID.ContentType>(
     uid: TContentTypeUID

--- a/packages/core/strapi/src/services/document-service/document-repository.ts
+++ b/packages/core/strapi/src/services/document-service/document-repository.ts
@@ -107,24 +107,26 @@ export const createDocumentRepository = (
         );
       },
 
+      // @ts-expect-error - TODO: Fix this
       with(params: object) {
         return createDocumentRepository(strapi, {
           defaults: { ...defaults, ...params },
         })(uid);
       },
 
-      use(action, cb) {
-        middlewareManager.add(uid, action, cb);
+      use(action, cb, opts) {
+        middlewareManager.add(uid, action, cb, opts);
         return this;
       },
     };
   }
 
   Object.assign(create, {
-    use(action: any, cb: any) {
-      middlewareManager.add('allUIDs', action, cb);
+    use(action: any, cb: any, opts?: any) {
+      middlewareManager.add('allUIDs', action, cb, opts);
       return create;
     },
+    middlewares: middlewareManager,
     // NOTE : We should do this in a different way, where lifecycles are executed for the different methods
     ...documents,
   });

--- a/packages/core/strapi/src/services/document-service/index.ts
+++ b/packages/core/strapi/src/services/document-service/index.ts
@@ -21,7 +21,6 @@ const { transformParamsToQuery } = convertQueryParams;
 
 /**
  * TODO: TESTS - In progress
- * TODO: Components - In progress
  * TODO: Entity Validation
  * TODO: Lifecycles - In progress
  *        Plugin extensions
@@ -80,10 +79,6 @@ const createDocumentService = ({
     return db.query(uid).findOne({ ...query, where: { ...query.where, documentId } });
   },
 
-  // NOTE: What happens if user doesn't provide specific publications state and locale to delete?
-  // By default delete will remove all versions of the document
-  // You need to specify the locale and publication state to delete a specific version
-  // Should forbid deleting a draft version without deleting the published version
   async delete(uid, documentId, params) {
     const query = transformParamsToQuery(uid, params || ({} as any));
 
@@ -210,7 +205,6 @@ const createDocumentService = ({
 
   // TODO: Handle relations so they target the published version
   async publish(uid, documentId, params) {
-    // @ts-expect-error - TODO: Add typings
     const { filters } = params || {};
 
     // Clone every draft version to be published
@@ -229,7 +223,6 @@ const createDocumentService = ({
   },
 
   async unpublish(uid, documentId, params) {
-    // @ts-expect-error - TODO: Add typings
     const { filters } = params || {};
 
     this.delete(uid, documentId, {

--- a/packages/core/strapi/src/services/document-service/middlewares.ts
+++ b/packages/core/strapi/src/services/document-service/middlewares.ts
@@ -1,9 +1,11 @@
 import { Documents } from '@strapi/types';
 
 export const priority = {
-  LAST: 1,
+  LOWEST: 1,
+  LOW: 10,
   DEFAULT: 100,
-  FIRST: 1000,
+  HIGH: 1_000,
+  HIGHEST: 10_000,
 } as const;
 
 const createMiddlewareManager = (): Documents.Middleware.Manager => {

--- a/packages/core/strapi/src/services/document-service/middlewares/defaults/draft-and-publish.ts
+++ b/packages/core/strapi/src/services/document-service/middlewares/defaults/draft-and-publish.ts
@@ -1,0 +1,66 @@
+import { Documents } from '@strapi/types';
+
+type Middleware = Documents.Middleware.Middleware<any, any>;
+
+/**
+ * Adds a default status of `draft` to the params
+ */
+export const defaultToDraft: Middleware = async (ctx, next) => {
+  if (!ctx.params) ctx.params = {};
+
+  // Default to draft if no status is provided or it's invalid
+  if (!ctx.params.status || ctx.params.status !== 'published') {
+    ctx.params.status = 'draft';
+  }
+
+  return next(ctx);
+};
+
+/**
+ * Add status lookup query to the params
+ */
+export const lookUpDocumentStatus: Middleware = async (ctx, next) => {
+  if (!ctx.params) ctx.params = {};
+
+  const lookup = ctx.params.lookup || {};
+
+  switch (ctx.params?.status) {
+    case 'published':
+      lookup.publishedAt = { $notNull: true };
+      break;
+    case 'draft':
+      lookup.publishedAt = { $null: true };
+      break;
+    default:
+      break;
+  }
+
+  ctx.params.lookup = lookup;
+
+  return next(ctx);
+};
+
+/**
+ * Translate publication status parameter into the data that will be saved
+ */
+export const statusToData: Middleware = async (ctx, next) => {
+  if (!ctx.params) ctx.params = {};
+
+  // Ignore publishedAt attribute. TODO: Make publishedAt not editable
+  const { publishedAt, ...data } = ctx.params.data || {};
+
+  switch (ctx.params?.status) {
+    case 'published':
+      data.publishedAt = new Date();
+      break;
+    case 'draft':
+      data.publishedAt = null;
+      break;
+    default:
+      break;
+  }
+
+  ctx.params.data = data;
+
+  return next(ctx);
+};

--- a/packages/core/strapi/src/services/document-service/middlewares/defaults/index.ts
+++ b/packages/core/strapi/src/services/document-service/middlewares/defaults/index.ts
@@ -1,0 +1,65 @@
+import { Documents } from '@strapi/types';
+import { defaultToDraft, lookUpDocumentStatus, statusToData } from './draft-and-publish';
+import { defaultLocale, lookUpDocumentLocale, localeToData } from './locales';
+
+export const loadDefaultMiddlewares = (manager: Documents.Middleware.Manager) => {
+  // Find Many
+  manager.add(
+    'allUIDs',
+    'findMany',
+    [defaultToDraft, lookUpDocumentStatus, defaultLocale, lookUpDocumentLocale],
+    {}
+  );
+
+  // Find One
+  manager.add(
+    'allUIDs',
+    'findOne',
+    [defaultToDraft, lookUpDocumentStatus, defaultLocale, lookUpDocumentLocale],
+    {}
+  );
+
+  // Find First
+  manager.add(
+    'allUIDs',
+    'findFirst',
+    [defaultToDraft, lookUpDocumentStatus, defaultLocale, lookUpDocumentLocale],
+    {}
+  );
+
+  // Delete
+  manager.add('allUIDs', 'delete', [lookUpDocumentStatus, lookUpDocumentLocale], {});
+
+  // Delete Many - TODO
+  // manager.add('allUIDs', 'deleteMany', [], {});
+
+  // Create
+  manager.add('allUIDs', 'create', [defaultToDraft, statusToData, defaultLocale, localeToData], {});
+
+  // Update
+  manager.add(
+    'allUIDs',
+    'update',
+    [
+      defaultToDraft,
+      lookUpDocumentStatus,
+      statusToData,
+      defaultLocale,
+      // lookUpDocumentLocale,
+      localeToData,
+    ],
+    {}
+  );
+
+  // Count
+  manager.add('allUIDs', 'count', [defaultToDraft, defaultLocale], {});
+
+  // Clone
+  manager.add('allUIDs', 'clone', defaultToDraft, {});
+
+  // Publish
+  manager.add('allUIDs', 'publish', defaultToDraft, {});
+
+  // Unpublish
+  manager.add('allUIDs', 'unpublish', defaultToDraft, {});
+};

--- a/packages/core/strapi/src/services/document-service/middlewares/defaults/locales.ts
+++ b/packages/core/strapi/src/services/document-service/middlewares/defaults/locales.ts
@@ -1,0 +1,48 @@
+// TODO: Move to i18n
+import { Documents } from '@strapi/types';
+
+type Middleware = Documents.Middleware.Middleware<any, any>;
+
+export const defaultLocale: Middleware = async (ctx, next) => {
+  if (!ctx.params) ctx.params = {};
+
+  // Default to en (TODO: Load default locale from db in i18n)
+  if (!ctx.params.locale) {
+    ctx.params.locale = 'en';
+  }
+
+  return next(ctx);
+};
+
+/**
+ * Add locale lookup query to the params
+ */
+export const lookUpDocumentLocale: Middleware = async (ctx, next) => {
+  if (!ctx.params) ctx.params = {};
+
+  const lookup = ctx.params.lookup || {};
+
+  if (ctx.params.locale) {
+    lookup.locale = ctx.params.locale;
+    ctx.params.lookup = lookup;
+  }
+
+  return next(ctx);
+};
+
+/**
+ * Translate locale status parameter into the data that will be saved
+ */
+export const localeToData: Middleware = async (ctx, next) => {
+  if (!ctx.params) ctx.params = {};
+
+  const data = ctx.params.data || {};
+
+  if (ctx.params.locale) {
+    data.locale = ctx.params.locale;
+  }
+
+  ctx.params.data = data;
+
+  return next(ctx);
+};

--- a/packages/core/strapi/src/services/document-service/middlewares/index.ts
+++ b/packages/core/strapi/src/services/document-service/middlewares/index.ts
@@ -41,9 +41,12 @@ const createMiddlewareManager = (): Documents.Middleware.Manager => {
         this.middlewares[uid][action] = [];
       }
 
-      this.middlewares[uid][action].push({
-        middleware,
-        priority: opts?.priority ?? priority.DEFAULT,
+      const middlewareList = Array.isArray(middleware) ? middleware : [middleware];
+      middlewareList.forEach((middleware) => {
+        this.middlewares[uid][action].push({
+          middleware,
+          priority: opts?.priority ?? priority.DEFAULT,
+        });
       });
 
       return this;

--- a/packages/core/types/src/modules/documents/index.ts
+++ b/packages/core/types/src/modules/documents/index.ts
@@ -73,7 +73,8 @@ export type RepositoryInstance<
     action: TAction,
     // QUESTION: How do we type the result type of next?
     //           Should we send params + document id attribute?
-    cb: Middleware.Middleware<TAction>
+    cb: Middleware.Middleware<TAction>,
+    opts?: Middleware.Options
   ) => ThisType<RepositoryInstance<TContentTypeUID>>;
 
   /**
@@ -110,6 +111,9 @@ export type Repository = {
     action: TAction,
     // QUESTION: How do we type the result type of next?
     //           Should we send params + document id attribute?
-    cb: Middleware.Middleware<TAction>
+    cb: Middleware.Middleware<TAction>,
+    opts?: Middleware.Options
   ) => Repository;
+
+  middlewares: Middleware.Manager;
 } & DocumentService;

--- a/packages/core/types/src/modules/documents/index.ts
+++ b/packages/core/types/src/modules/documents/index.ts
@@ -10,8 +10,6 @@ export * as Params from './params';
 export * from './plugin';
 export * from './result';
 
-type A = Middleware.Middleware<'findMany'>;
-
 export type RepositoryInstance<
   TContentTypeUID extends Common.UID.ContentType = Common.UID.ContentType
 > = {
@@ -75,7 +73,9 @@ export type RepositoryInstance<
     action: TAction,
     // QUESTION: How do we type the result type of next?
     //           Should we send params + document id attribute?
-    cb: Middleware.Middleware<TContentTypeUID, TAction>,
+    cb:
+      | Middleware.Middleware<Common.UID.ContentType, TAction>
+      | Middleware.Middleware<Common.UID.ContentType, TAction>[],
     opts?: Middleware.Options
   ) => ThisType<RepositoryInstance<TContentTypeUID>>;
 
@@ -111,7 +111,9 @@ export type Repository = {
    */
   use: <TAction extends keyof DocumentService>(
     action: TAction,
-    cb: Middleware.Middleware<Common.UID.ContentType, TAction>,
+    cb:
+      | Middleware.Middleware<Common.UID.ContentType, TAction>
+      | Middleware.Middleware<Common.UID.ContentType, TAction>[],
     opts?: Middleware.Options
   ) => Repository;
 

--- a/packages/core/types/src/modules/documents/index.ts
+++ b/packages/core/types/src/modules/documents/index.ts
@@ -10,6 +10,8 @@ export * as Params from './params';
 export * from './plugin';
 export * from './result';
 
+type A = Middleware.Middleware<'findMany'>;
+
 export type RepositoryInstance<
   TContentTypeUID extends Common.UID.ContentType = Common.UID.ContentType
 > = {
@@ -73,7 +75,7 @@ export type RepositoryInstance<
     action: TAction,
     // QUESTION: How do we type the result type of next?
     //           Should we send params + document id attribute?
-    cb: Middleware.Middleware<TAction>,
+    cb: Middleware.Middleware<TContentTypeUID, TAction>,
     opts?: Middleware.Options
   ) => ThisType<RepositoryInstance<TContentTypeUID>>;
 
@@ -109,9 +111,7 @@ export type Repository = {
    */
   use: <TAction extends keyof DocumentService>(
     action: TAction,
-    // QUESTION: How do we type the result type of next?
-    //           Should we send params + document id attribute?
-    cb: Middleware.Middleware<TAction>,
+    cb: Middleware.Middleware<Common.UID.ContentType, TAction>,
     opts?: Middleware.Options
   ) => Repository;
 

--- a/packages/core/types/src/modules/documents/middleware.ts
+++ b/packages/core/types/src/modules/documents/middleware.ts
@@ -76,9 +76,11 @@ export interface Manager {
    * handy to define a middleware that should be executed first or last
    */
   priority: {
-    LAST: number;
-    FIRST: number;
+    LOWEST: number;
+    LOW: number;
     DEFAULT: number;
+    HIGH: number;
+    HIGHEST: number;
   };
 
   /**

--- a/packages/core/types/src/modules/documents/middleware.ts
+++ b/packages/core/types/src/modules/documents/middleware.ts
@@ -19,10 +19,11 @@ export type ParamsMap<TContentTypeUID extends Common.UID.ContentType = Common.UI
 
 export interface Context<
   TContentTypeUID extends Common.UID.ContentType = Common.UID.ContentType,
-  TAction extends keyof ParamsMap<TContentTypeUID> = keyof ParamsMap<TContentTypeUID>
+  TAction extends keyof DocumentService = keyof DocumentService
 > {
   uid: TContentTypeUID;
   action: TAction;
+  // @ts-expect-error - TODO: Fix this with a proper type from the DocumentService
   params: ParamsMap<TContentTypeUID>[TAction];
   options: object;
   trx?: any;
@@ -36,9 +37,12 @@ export interface Options {
   priority?: number;
 }
 
-export type Middleware<TAction extends keyof DocumentService> = (
-  ctx: Context,
-  next: (ctx: Context) => ReturnType<DocumentService[TAction]>
+export type Middleware<
+  TContentTypeUID extends Common.UID.ContentType,
+  TAction extends keyof DocumentService
+> = (
+  ctx: Context<TContentTypeUID, TAction>,
+  next: (ctx: Context<TContentTypeUID, TAction>) => ReturnType<DocumentService[TAction]>
 ) => ReturnType<DocumentService[TAction]>;
 
 /**
@@ -64,7 +68,7 @@ export interface Manager {
     // Specify uid or 'all' to apply to all uid's
     Common.UID.ContentType | 'allUIDs',
     // Specify action or 'all' to apply to all actions (e.g. findMany, create, ...)
-    Record<string | 'allActions', { priority: number; middleware: Middleware<any> }[]>
+    Record<string | 'allActions', { priority: number; middleware: Middleware<any, any> }[]>
   >;
 
   /**
@@ -80,7 +84,7 @@ export interface Manager {
   /**
    * Get list of middlewares for a specific uid and action
    */
-  get(uid: Common.UID.ContentType, action: string): Middleware<any>[];
+  get(uid: Common.UID.ContentType, action: string): Middleware<any, any>[];
 
   /**
    * Add a middleware for a specific uid and action
@@ -88,7 +92,7 @@ export interface Manager {
   add(
     uid: Common.UID.ContentType | 'allUIDs',
     action: string | 'allActions',
-    middleware: Middleware<any>,
+    middleware: Middleware<any, any>,
     opts?: Options
   ): ThisType<Manager>;
 

--- a/packages/core/types/src/modules/documents/middleware.ts
+++ b/packages/core/types/src/modules/documents/middleware.ts
@@ -94,7 +94,7 @@ export interface Manager {
   add(
     uid: Common.UID.ContentType | 'allUIDs',
     action: string | 'allActions',
-    middleware: Middleware<any, any>,
+    middleware: Middleware<any, any> | Middleware<any, any>[],
     opts?: Options
   ): ThisType<Manager>;
 

--- a/packages/core/types/src/modules/documents/params/document-service.ts
+++ b/packages/core/types/src/modules/documents/params/document-service.ts
@@ -17,21 +17,22 @@ export type FindMany<TContentTypeUID extends Common.UID.ContentType> = Pick<
   | 'status'
   | 'locale'
   | 'plugin'
+  | 'lookup'
 >;
 
 export type FindFirst<TContentTypeUID extends Common.UID.ContentType> = Pick<
   TContentTypeUID,
-  'fields' | 'filters' | '_q' | 'sort' | 'populate' | 'status' | 'locale' | 'plugin'
+  'fields' | 'filters' | '_q' | 'sort' | 'populate' | 'status' | 'locale' | 'plugin' | 'lookup'
 >;
 
 export type FindOne<TContentTypeUID extends Common.UID.ContentType> = Pick<
   TContentTypeUID,
-  'fields' | 'populate' | 'filters' | 'status' | 'locale' | 'sort'
+  'fields' | 'populate' | 'filters' | 'status' | 'locale' | 'sort' | 'lookup'
 >;
 
 export type Delete<TContentTypeUID extends Common.UID.ContentType> = Pick<
   TContentTypeUID,
-  'fields' | 'populate' | 'filters' | 'status' | 'locale'
+  'fields' | 'populate' | 'filters' | 'status' | 'locale' | 'lookup'
 >;
 
 export type DeleteMany<TContentTypeUID extends Common.UID.ContentType> = Pick<
@@ -45,21 +46,22 @@ export type DeleteMany<TContentTypeUID extends Common.UID.ContentType> = Pick<
   | 'status'
   | 'locale'
   | 'plugin'
+  | 'lookup'
 >;
 
 export type Create<TContentTypeUID extends Common.UID.ContentType> = Pick<
   TContentTypeUID,
-  'data' | 'files' | 'fields' | 'populate' | 'status' | 'locale'
+  'data' | 'files' | 'fields' | 'populate' | 'status' | 'locale' | 'lookup'
 >;
 
 export type Clone<TContentTypeUID extends Common.UID.ContentType> = Pick<
   TContentTypeUID,
-  'data' | 'files' | 'fields' | 'populate' | 'status' | 'locale'
+  'data' | 'files' | 'fields' | 'populate' | 'status' | 'locale' | 'lookup'
 >;
 
 export type Update<TContentTypeUID extends Common.UID.ContentType> = Pick<
   TContentTypeUID,
-  'data:partial' | 'files' | 'fields' | 'populate' | 'status' | 'locale'
+  'data:partial' | 'files' | 'fields' | 'populate' | 'status' | 'locale' | 'lookup'
 >;
 
 export type Count<TContentTypeUID extends Common.UID.ContentType> = Pick<
@@ -73,18 +75,19 @@ export type Count<TContentTypeUID extends Common.UID.ContentType> = Pick<
   | 'status'
   | 'locale'
   | 'plugin'
+  | 'lookup'
 >;
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export type Publish<TContentTypeUID extends Common.UID.ContentType> = Pick<
   TContentTypeUID,
-  'filters' | 'status' | 'locale'
+  'filters' | 'status' | 'locale' | 'lookup'
 >;
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export type Unpublish<TContentTypeUID extends Common.UID.ContentType> = Pick<
   TContentTypeUID,
-  'filters' | 'status' | 'locale'
+  'filters' | 'status' | 'locale' | 'lookup'
 >;
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -101,4 +104,5 @@ export type With<TContentTypeUID extends Common.UID.ContentType> = Pick<
   | 'status'
   | 'locale'
   | 'plugin'
+  | 'lookup'
 >;

--- a/packages/core/types/src/modules/documents/params/index.ts
+++ b/packages/core/types/src/modules/documents/params/index.ts
@@ -51,7 +51,9 @@ export type Pick<
     // Files
     [HasMember<TKind, 'files'>, { files?: Record<string, unknown> }], // TODO
     // Search
-    [HasMember<TKind, '_q'>, { _q?: Search.Q }]
+    [HasMember<TKind, '_q'>, { _q?: Search.Q }],
+    // Look Up - For internal use only
+    [HasMember<TKind, 'lookup'>, { lookup?: Record<string, unknown> }]
   ]
 >;
 
@@ -77,7 +79,8 @@ export type Kind =
   | 'data'
   | 'data:partial'
   | 'files'
-  | '_q';
+  | '_q'
+  | 'lookup';
 
 type HasMember<TValue extends Kind, TTest extends Kind> = Utils.Expression.Extends<TTest, TValue>;
 

--- a/packages/core/types/src/modules/documents/params/populate.ts
+++ b/packages/core/types/src/modules/documents/params/populate.ts
@@ -121,6 +121,7 @@ export type ObjectNotation<TSchemaUID extends Common.UID.Schema> = [
 
 export type NestedParams<TSchemaUID extends Common.UID.Schema> = Params.Pick<
   TSchemaUID,
+  // @ts-expect-error - remove publicationState from the list of keys
   'fields' | 'filters' | 'populate' | 'sort' | 'plugin' | 'publicationState'
 >;
 


### PR DESCRIPTION
Run doc service middlewares with a priority, the higher the number the earlier it will be executed.

```ts
strapi.documents(ARTICLE_UID).use(
  'findMany',
  (ctx, next) => { },
  // Runs last
  { priority: strapi.documents.middlewares.priority.LAST }
);

strapi.documents(ARTICLE_UID).use(
  'findMany',
  (ctx, next) => {},
  // Runs first
  { priority: strapi.documents.middlewares.priority.FIRST }
);
```