### PR TITLE
fix(admin): windows files paths do not make for module paths

### DIFF
--- a/packages/core/admin/_internal/node/core/admin-customisations.ts
+++ b/packages/core/admin/_internal/node/core/admin-customisations.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
-import fs from 'node:fs';
+import { convertSystemPathToModulePath, pathExists } from '../core/files';
+import { BuildContext } from '../createBuildContext';
 
 const ADMIN_APP_FILES = ['app.js', 'app.mjs', 'app.ts', 'app.jsx', 'app.tsx'];
 
@@ -11,15 +12,28 @@ interface AdminCustomisations {
 }
 
 interface AppFile {
+  /**
+   * The system path to the file
+   */
   path: string;
+  /**
+   * The module path to the file i.e. how you would import it
+   */
+  modulePath: string;
 }
 
-const loadUserAppFile = async (appDir: string): Promise<AppFile | undefined> => {
+const loadUserAppFile = async ({
+  runtimeDir,
+  appDir,
+}: Pick<BuildContext, 'appDir' | 'runtimeDir'>): Promise<AppFile | undefined> => {
   for (const file of ADMIN_APP_FILES) {
     const filePath = path.join(appDir, 'src', 'admin', file);
 
-    if (fs.existsSync(filePath)) {
-      return { path: filePath };
+    if (await pathExists(filePath)) {
+      return {
+        path: filePath,
+        modulePath: convertSystemPathToModulePath(path.relative(runtimeDir, filePath)),
+      };
     }
   }
 

--- a/packages/core/admin/_internal/node/core/files.ts
+++ b/packages/core/admin/_internal/node/core/files.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import { access } from 'node:fs/promises';
 import { register } from 'esbuild-register/dist/node';
 
@@ -40,4 +41,34 @@ const loadFile = async (path: string): Promise<undefined | any> => {
   return undefined;
 };
 
-export { pathExists, loadFile };
+/**
+ * @internal
+ *
+ * @description Converts a system path to a module path mainly for `Windows` systems.
+ * where the path separator is `\` instead of `/`, on linux systems the path separator
+ * is identical to the module path separator.
+ */
+const convertSystemPathToModulePath = (sysPath: string) => {
+  if (process.platform === 'win32') {
+    return sysPath.split(path.sep).join(path.posix.sep);
+  } else {
+    return sysPath;
+  }
+};
+
+/**
+ * @internal
+ *
+ * @description Converts a module path to a system path, again largely used for Windows systems.
+ * The original use case was plugins where the resolve path was in module format but we want to
+ * have it relative to the runtime directory.
+ */
+const convertModulePathToSystemPath = (modulePath: string) => {
+  if (process.platform === 'win32') {
+    return modulePath.split(path.posix.sep).join(path.sep);
+  } else {
+    return modulePath;
+  }
+};
+
+export { pathExists, loadFile, convertSystemPathToModulePath, convertModulePathToSystemPath };

--- a/packages/core/admin/_internal/node/core/plugins.ts
+++ b/packages/core/admin/_internal/node/core/plugins.ts
@@ -4,15 +4,50 @@ import fs from 'node:fs';
 import camelCase from 'lodash/camelCase';
 import { env } from '@strapi/utils';
 import { getModule, PackageJson } from './dependencies';
-import { loadFile } from './files';
+import { convertModulePathToSystemPath, convertSystemPathToModulePath, loadFile } from './files';
 import { BuildContext } from '../createBuildContext';
 import { isError } from './errors';
 
-interface PluginMeta {
+interface LocalPluginMeta {
   name: string;
-  pathToPlugin: string;
-  isLocal?: boolean;
+  /**
+   * camelCased version of the plugin name
+   */
+  importName: string;
+  /**
+   * The path to the plugin, relative to the app's root directory
+   * in system format
+   */
+  path: string;
+  /**
+   * The path to the plugin, relative to the runtime directory
+   * in module format (i.e. with forward slashes) because thats
+   * where it should be used as an import
+   */
+  modulePath: string;
+  type: 'local';
 }
+
+interface ModulePluginMeta {
+  name: string;
+  /**
+   * camelCased version of the plugin name
+   */
+  importName: string;
+  /**
+   * Modules don't have a path because we never resolve them to their node_modules
+   * because we simply do not require it.
+   */
+  path?: never;
+  /**
+   * The path to the plugin, relative to the app's root directory
+   * in module format (i.e. with forward slashes)
+   */
+  modulePath: string;
+  type: 'module';
+}
+
+type PluginMeta = LocalPluginMeta | ModulePluginMeta;
 
 interface StrapiPlugin extends PackageJson {
   strapi: {
@@ -36,10 +71,13 @@ const validatePackageIsPlugin = (pkg: PackageJson): pkg is StrapiPlugin =>
   validatePackageHasStrapi(pkg) && pkg.strapi.kind === 'plugin';
 
 const getEnabledPlugins = async ({
-  strapi,
   cwd,
   logger,
-}: Pick<BuildContext, 'cwd' | 'logger' | 'strapi'>): Promise<Record<string, PluginMeta>> => {
+  runtimeDir,
+  strapi,
+}: Pick<BuildContext, 'cwd' | 'logger' | 'strapi' | 'runtimeDir'>): Promise<
+  Record<string, PluginMeta>
+> => {
   const plugins: Record<string, PluginMeta> = {};
 
   /**
@@ -68,7 +106,9 @@ const getEnabledPlugins = async ({
 
       plugins[name] = {
         name,
-        pathToPlugin: dep,
+        importName: camelCase(name),
+        type: 'module',
+        modulePath: dep,
       };
     }
   }
@@ -79,14 +119,17 @@ const getEnabledPlugins = async ({
 
   for (const [userPluginName, userPluginConfig] of Object.entries(userPluginsFile)) {
     if (userPluginConfig.enabled && userPluginConfig.resolve) {
+      const sysPath = convertModulePathToSystemPath(userPluginConfig.resolve);
       plugins[userPluginName] = {
         name: userPluginName,
-        isLocal: true,
+        importName: camelCase(userPluginName),
+        type: 'local',
         /**
          * User plugin paths are resolved from the entry point
          * of the app, because that's how you import them.
          */
-        pathToPlugin: userPluginConfig.resolve,
+        modulePath: convertSystemPathToModulePath(path.relative(runtimeDir, sysPath)),
+        path: sysPath,
       };
     }
   }
@@ -114,10 +157,7 @@ const loadUserPluginsFile = async (root: string): Promise<UserPluginConfigFile> 
   return {};
 };
 
-const getMapOfPluginsWithAdmin = (
-  plugins: Record<string, PluginMeta>,
-  { runtimeDir }: { runtimeDir: string }
-) =>
+const getMapOfPluginsWithAdmin = (plugins: Record<string, PluginMeta>) =>
   Object.values(plugins)
     .filter((plugin) => {
       if (!plugin) {
@@ -128,7 +168,7 @@ const getMapOfPluginsWithAdmin = (
        * There are two ways a plugin should be imported, either it's local to the strapi app,
        * or it's an actual npm module that's installed and resolved via node_modules.
        *
-       * We first check if the plugin is local to the strapi app, using a regular `resolve` because
+       * We first check if the plugin is local to the strapi app, using a regular `fs.existsSync` because
        * the pathToPlugin will be relative i.e. `/Users/my-name/strapi-app/src/plugins/my-plugin`.
        *
        * If the file doesn't exist well then it's probably a node_module, so instead we use `require.resolve`
@@ -136,20 +176,11 @@ const getMapOfPluginsWithAdmin = (
        * then it doesn't have an admin part to the package.
        */
       try {
-        const isLocalPluginWithLegacyAdminFile = fs.existsSync(
-          //@ts-ignore
-          path.resolve(`${plugin.pathToPlugin}/strapi-admin.js`)
-        );
+        const isLocalPluginWithLegacyAdminFile =
+          plugin.path && fs.existsSync(path.join(plugin.path, 'strapi-admin.js'));
 
         if (!isLocalPluginWithLegacyAdminFile) {
-          //@ts-ignore
-          let pathToPlugin = plugin.pathToPlugin;
-
-          if (process.platform === 'win32') {
-            pathToPlugin = pathToPlugin.split(path.sep).join(path.posix.sep);
-          }
-
-          const isModuleWithFE = require.resolve(`${pathToPlugin}/strapi-admin`);
+          const isModuleWithFE = require.resolve(`${plugin.modulePath}/strapi-admin`);
 
           return isModuleWithFE;
         }
@@ -167,19 +198,10 @@ const getMapOfPluginsWithAdmin = (
         throw err;
       }
     })
-    .map((plugin) => {
-      const systemPath = plugin.isLocal
-        ? path.relative(runtimeDir, plugin.pathToPlugin.split('/').join(path.sep))
-        : undefined;
-      const modulePath = systemPath ? systemPath.split(path.sep).join('/') : undefined;
-
-      return {
-        path: !plugin.isLocal
-          ? `${plugin.pathToPlugin}/strapi-admin`
-          : `${modulePath}/strapi-admin`,
-        name: plugin.name,
-        importName: camelCase(plugin.name),
-      };
-    });
+    .map((plugin) => ({
+      ...plugin,
+      modulePath: `${plugin.modulePath}/strapi-admin`,
+    }));
 
 export { getEnabledPlugins, getMapOfPluginsWithAdmin };
+export type { PluginMeta, LocalPluginMeta, ModulePluginMeta };

--- a/packages/core/admin/_internal/node/staticFiles.ts
+++ b/packages/core/admin/_internal/node/staticFiles.ts
@@ -4,6 +4,7 @@ import outdent from 'outdent';
 import { format } from 'prettier';
 import { createElement } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
+import camelCase from 'lodash/camelCase';
 import { DefaultDocument as Document } from '../../admin/src/components/DefaultDocument';
 
 import type { BuildContext } from './createBuildContext';
@@ -14,7 +15,7 @@ const getEntryModule = (ctx: BuildContext): string => {
     .join(',\n');
 
   const pluginsImport = ctx.plugins
-    .map(({ importName, path }) => `import ${importName} from '${path}';`)
+    .map(({ importName, modulePath }) => `import ${importName} from '${modulePath}';`)
     .join('\n');
 
   return outdent`
@@ -26,18 +27,15 @@ const getEntryModule = (ctx: BuildContext): string => {
         import { renderAdmin } from "@strapi/strapi/admin"
 
         ${
-          ctx.customisations?.path
-            ? `import customisations from '${path.relative(
-                ctx.runtimeDir,
-                ctx.customisations.path
-              )}'`
+          ctx.customisations?.modulePath
+            ? `import customisations from '${ctx.customisations.modulePath}'`
             : ''
         }
 
         renderAdmin(
           document.getElementById("strapi"),
           {
-            ${ctx.customisations?.path ? 'customisations,' : ''}
+            ${ctx.customisations?.modulePath ? 'customisations,' : ''}
             plugins: {
         ${pluginsObject}
             }


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* creates some utility functions for handling windows system vs module paths since they need to be handled especially unlike macos/linux

### Why is it needed?

* on windows, the `app.js` file was not being imported correctly

### Related issue(s)/PR(s)

* closes #18795 
