### PR TITLE
fix: protect undefined values on SelectComponents

### DIFF
--- a/packages/core/content-type-builder/admin/src/components/SelectComponents/index.js
+++ b/packages/core/content-type-builder/admin/src/components/SelectComponents/index.js
@@ -54,7 +54,7 @@ const SelectComponents = ({ dynamicZoneTarget, intlLabel, name, onChange, value 
       defaultMessage:
         '{number, plural, =0 {# components} one {# component} other {# components}} selected',
     },
-    { number: value.length }
+    { number: value?.length }
   );
 
   return (

--- a/packages/core/content-type-builder/admin/src/components/SelectComponents/index.js
+++ b/packages/core/content-type-builder/admin/src/components/SelectComponents/index.js
@@ -54,7 +54,7 @@ const SelectComponents = ({ dynamicZoneTarget, intlLabel, name, onChange, value 
       defaultMessage:
         '{number, plural, =0 {# components} one {# component} other {# components}} selected',
     },
-    { number: value?.length }
+    { number: value?.length ?? 0 }
   );
 
   return (


### PR DESCRIPTION
### What does it do?

It adds protection for possibly undefined values in SelectComponents since the default value given in [packages/core/content-type-builder/admin/src/components/TabForm/index.js](https://github.com/strapi/strapi/blob/44fafdc341f0100dd2c63261c252c0ecb67bc939/packages/core/content-type-builder/admin/src/components/TabForm/index.js#L38-L41):
```
/**
    * Use undefined as the default value because not every input wants a string e.g. Date pickers
*/
const value = get(modifiedData, input.name, undefined);
```

### Why is it needed?

Right now the CTB throws an error when creating a component inside a Dynamic Zone.

### How to test it?
Try to create a component inside a dynamic zone in the CTB.

### Related issue(s)/PR(s)

Closes https://github.com/strapi/strapi/issues/18633
Closes https://github.com/strapi/strapi/issues/18665