### PR TITLE
Fix/aws credentials

### DIFF
--- a/packages/providers/upload-aws-s3/src/__tests__/utils.test.ts
+++ b/packages/providers/upload-aws-s3/src/__tests__/utils.test.ts
@@ -16,7 +16,7 @@ const defaultOptions = {
 
 describe('Utils', () => {
   describe('Extract credentials for V4 different aws provider configurations', () => {
-    test('[Legacy] Credentials directly in the options', async () => {
+    test('[Legacy] Credentials directly in the options', () => {
       const options: InitOptions = {
         accessKeyId,
         secretAccessKey,
@@ -30,7 +30,7 @@ describe('Utils', () => {
       });
     });
 
-    test('[Legacy] credentials directly in s3Options', async () => {
+    test('[Legacy] credentials directly in s3Options', () => {
       const options: InitOptions = {
         s3Options: {
           accessKeyId,
@@ -46,7 +46,7 @@ describe('Utils', () => {
       });
     });
 
-    test('Credentials in credentials object inside s3Options', async () => {
+    test('Credentials in credentials object inside s3Options', () => {
       const options: InitOptions = {
         s3Options: {
           credentials: {
@@ -62,6 +62,16 @@ describe('Utils', () => {
         accessKeyId,
         secretAccessKey,
       });
+    });
+    test('Does not throw an error when credentials are not present', () => {
+      const options: InitOptions = {
+        s3Options: {
+          ...defaultOptions,
+        },
+      };
+      const credentials = extractCredentials(options);
+
+      expect(credentials).toEqual(null);
     });
   });
 });

--- a/packages/providers/upload-aws-s3/src/index.ts
+++ b/packages/providers/upload-aws-s3/src/index.ts
@@ -76,11 +76,11 @@ const getConfig = ({ baseUrl, rootPath, s3Options, ...legacyS3Options }: InitOpt
       "S3 configuration options passed at root level of the plugin's providerOptions is deprecated and will be removed in a future release. Please wrap them inside the 's3Options:{}' property."
     );
   }
-
+  const credentials = extractCredentials({ s3Options, ...legacyS3Options });
   const config = {
     ...s3Options,
     ...legacyS3Options,
-    credentials: extractCredentials({ s3Options, ...legacyS3Options }),
+    ...(credentials ? { credentials } : {}),
   };
 
   config.params.ACL = getOr(ObjectCannedACL.public_read, ['params', 'ACL'], config);

--- a/packages/providers/upload-aws-s3/src/utils.ts
+++ b/packages/providers/upload-aws-s3/src/utils.ts
@@ -89,7 +89,7 @@ function getBucketFromAwsUrl(fileUrl: string): BucketInfo {
 }
 
 // TODO Remove this in V5 since we will only support the new config structure
-export const extractCredentials = (options: InitOptions): AwsCredentialIdentity => {
+export const extractCredentials = (options: InitOptions): AwsCredentialIdentity | null => {
   // legacy
   if (options.accessKeyId && options.secretAccessKey) {
     return {
@@ -115,5 +115,5 @@ export const extractCredentials = (options: InitOptions): AwsCredentialIdentity 
     };
   }
 
-  throw new Error("Couldn't find AWS credentials.");
+  return null;
 };


### PR DESCRIPTION
### What does it do?
It makes the accessKeyId and secretKeyId optional in the AWS S3 provider because these credentials can be omitted when strapi is deployed on and EC2 instance or on another AWS service that supports IAM Profiles instead of accessKeyId and secretAccessKey.

### Why is it needed?

To support other types of authentication in the AWS provider

### How to test it?

Check that if you don't pass the credentials and have an EC2 instance with another type of authentication configured, the provider works as expected

### Related issue(s)/PR(s)
Closes https://github.com/strapi/strapi/issues/18718
Merged on main: https://github.com/strapi/strapi/pull/18733
Let us know if this is related to any issue/pull request


### What does it do?

Describe the technical changes you did.

### Why is it needed?

Describe the issue you are solving.

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)
https://github.com/strapi/strapi/pull/18800
