### PR TITLE
test(pack-up): add ENV to allow immutable installs in yarn 4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -93,8 +93,6 @@ jobs:
     name: 'unit_back (node: ${{ matrix.node }})'
     needs: [changes, build]
     runs-on: ubuntu-latest
-    env:
-      YARN_ENABLE_IMMUTABLE_INSTALLS: false
     strategy:
       matrix:
         node: [18, 20]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -93,6 +93,8 @@ jobs:
     name: 'unit_back (node: ${{ matrix.node }})'
     needs: [changes, build]
     runs-on: ubuntu-latest
+    env:
+      YARN_ENABLE_IMMUTABLE_INSTALLS: false
     strategy:
       matrix:
         node: [18, 20]

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "typescript": "5.2.2",
     "yargs": "17.7.2"
   },
-  "packageManager": "yarn@4.0.1",
+  "packageManager": "yarn@4.0.0",
   "engines": {
     "node": ">=18.0.0 <=20.x.x",
     "npm": ">=6.0.0"

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "typescript": "5.2.2",
     "yargs": "17.7.2"
   },
-  "packageManager": "yarn@4.0.0",
+  "packageManager": "yarn@4.0.1",
   "engines": {
     "node": ">=18.0.0 <=20.x.x",
     "npm": ">=6.0.0"

--- a/packages/utils/pack-up/tests/spawn.ts
+++ b/packages/utils/pack-up/tests/spawn.ts
@@ -100,7 +100,7 @@ const spawn = async (projectName: string): Promise<Project> => {
 
   return {
     cwd: tmpPath,
-    install: () => execute('yarn install --no-immutable'),
+    install: () => execute('YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn install --no-immutable'),
     remove: tmpRemove,
     run: (cmd: string) => execute(`yarn run ${cmd}`),
   };

--- a/packages/utils/pack-up/tests/spawn.ts
+++ b/packages/utils/pack-up/tests/spawn.ts
@@ -100,7 +100,7 @@ const spawn = async (projectName: string): Promise<Project> => {
 
   return {
     cwd: tmpPath,
-    install: () => execute('yarn install --no-immutable'),
+    install: () => execute('yarn install'),
     remove: tmpRemove,
     run: (cmd: string) => execute(`yarn run ${cmd}`),
   };

--- a/packages/utils/pack-up/tests/spawn.ts
+++ b/packages/utils/pack-up/tests/spawn.ts
@@ -100,7 +100,7 @@ const spawn = async (projectName: string): Promise<Project> => {
 
   return {
     cwd: tmpPath,
-    install: () => execute('YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn install --no-immutable'),
+    install: () => execute('yarn install --no-immutable'),
     remove: tmpRemove,
     run: (cmd: string) => execute(`yarn run ${cmd}`),
   };

--- a/packages/utils/pack-up/tests/spawn.ts
+++ b/packages/utils/pack-up/tests/spawn.ts
@@ -57,33 +57,27 @@ export class ExecError extends Error {
   }
 }
 
-const runExec =
-  (cwd: string) =>
-  async (
-    cmd: string,
-    { env: providedEnv, ...execOpts }: Omit<child_process.ExecOptions, 'cwd'> = {}
-  ) => {
-    try {
-      const env = {
-        ...process.env,
-        PATH: `${process.env.PATH}:${path.resolve(__dirname, '../../bin')}`,
-        ...providedEnv,
-      };
+const runExec = (cwd: string) => async (cmd: string) => {
+  try {
+    const env = {
+      ...process.env,
+      PATH: `${process.env.PATH}:${path.resolve(__dirname, '../../bin')}`,
+    };
 
-      const res = await exec(cmd, { cwd, env, ...execOpts });
+    const res = await exec(cmd, { cwd, env });
 
-      return res;
-    } catch (execErr) {
-      if (execErr instanceof ExecError) {
-        console.log(execErr.stdout);
-        console.error(execErr.stderr);
+    return res;
+  } catch (execErr) {
+    if (execErr instanceof ExecError) {
+      console.log(execErr.stdout);
+      console.error(execErr.stderr);
 
-        return execErr;
-      }
-
-      throw execErr;
+      return execErr;
     }
-  };
+
+    throw execErr;
+  }
+};
 
 interface Project {
   cwd: string;
@@ -106,12 +100,7 @@ const spawn = async (projectName: string): Promise<Project> => {
 
   return {
     cwd: tmpPath,
-    install: () =>
-      execute('yarn install', {
-        env: {
-          YARN_ENABLE_IMMUTABLE_INSTALLS: 'false',
-        },
-      }),
+    install: () => execute('yarn install'),
     remove: tmpRemove,
     run: (cmd: string) => execute(`yarn run ${cmd}`),
   };


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* adds `YARN_ENABLE_IMMUTABLE_INSTALLS` to env of workflow under `test:unit` – NOTE, including it here will ensure it's still caught for unintended issues e.g. in the build step

### Why is it needed?

* lets pack-up tests run correctly
