### PR TITLE
chore(actions): run checks workflow on develop branches

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -10,6 +10,7 @@ on:
       - unlabeled
     branches:
       - main
+      - develop
 
 jobs:
   check-pr-status:


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* sets up the checks workflow to run against `develop` branches

### Why is it needed?

* since this is our default working branch, i think we should continue to enforce the checks (which are still required in GH)
