### PR TITLE
chore(blocks): handle block conversion logic in the blocks store

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/BlocksInput/Blocks/Heading.tsx
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksInput/Blocks/Heading.tsx
@@ -9,9 +9,11 @@ import {
   HeadingThree,
   HeadingTwo,
 } from '@strapi/icons';
+import { Editor, Transforms } from 'slate';
 import styled from 'styled-components';
 
 import { type BlocksStore } from '../BlocksEditor';
+import { type Block } from '../utils/types';
 
 const H1 = styled(Typography).attrs({ as: 'h1' })`
   font-size: ${42 / 16}rem;
@@ -43,6 +45,34 @@ const H6 = styled(Typography).attrs({ as: 'h6' })`
   line-height: ${({ theme }) => theme.lineHeights[1]};
 `;
 
+/**
+ * Common handler for converting a node to a heading
+ */
+const handleConvertToHeading = (editor: Editor, level: Block<'heading'>['level']) => {
+  const entry = Editor.above(editor, {
+    match: (node) => !Editor.isEditor(node) && node.type !== 'text',
+  });
+
+  if (!entry || Editor.isEditor(entry[0])) {
+    return;
+  }
+
+  const { type: _type, children: _children, ...extra } = entry[0];
+
+  // Explicitly setting non-needed attributes to null so that Slate deletes them.
+  // For example, from heading to paragraph, remove the `leve` attribute.
+  const attributesToClear: Record<string, null> = {};
+  Object.keys(extra).forEach((key) => {
+    attributesToClear[key] = null;
+  });
+
+  Transforms.setNodes(editor, {
+    ...attributesToClear,
+    type: 'heading',
+    level,
+  });
+};
+
 const headingBlocks: Pick<
   BlocksStore,
   'heading-one' | 'heading-two' | 'heading-three' | 'heading-four' | 'heading-five' | 'heading-six'
@@ -54,10 +84,7 @@ const headingBlocks: Pick<
       id: 'components.Blocks.blocks.heading1',
       defaultMessage: 'Heading 1',
     },
-    value: {
-      type: 'heading',
-      level: 1,
-    },
+    handleConvert: (editor) => handleConvertToHeading(editor, 1),
     matchNode: (node) => node.type === 'heading' && node.level === 1,
     isInBlocksSelector: true,
   },
@@ -68,10 +95,7 @@ const headingBlocks: Pick<
       id: 'components.Blocks.blocks.heading2',
       defaultMessage: 'Heading 2',
     },
-    value: {
-      type: 'heading',
-      level: 2,
-    },
+    handleConvert: (editor) => handleConvertToHeading(editor, 2),
     matchNode: (node) => node.type === 'heading' && node.level === 2,
     isInBlocksSelector: true,
   },
@@ -82,10 +106,7 @@ const headingBlocks: Pick<
       id: 'components.Blocks.blocks.heading3',
       defaultMessage: 'Heading 3',
     },
-    value: {
-      type: 'heading',
-      level: 3,
-    },
+    handleConvert: (editor) => handleConvertToHeading(editor, 3),
     matchNode: (node) => node.type === 'heading' && node.level === 3,
     isInBlocksSelector: true,
   },
@@ -96,10 +117,7 @@ const headingBlocks: Pick<
       id: 'components.Blocks.blocks.heading4',
       defaultMessage: 'Heading 4',
     },
-    value: {
-      type: 'heading',
-      level: 4,
-    },
+    handleConvert: (editor) => handleConvertToHeading(editor, 4),
     matchNode: (node) => node.type === 'heading' && node.level === 4,
     isInBlocksSelector: true,
   },
@@ -110,10 +128,7 @@ const headingBlocks: Pick<
       id: 'components.Blocks.blocks.heading5',
       defaultMessage: 'Heading 5',
     },
-    value: {
-      type: 'heading',
-      level: 5,
-    },
+    handleConvert: (editor) => handleConvertToHeading(editor, 5),
     matchNode: (node) => node.type === 'heading' && node.level === 5,
     isInBlocksSelector: true,
   },
@@ -124,10 +139,7 @@ const headingBlocks: Pick<
       id: 'components.Blocks.blocks.heading6',
       defaultMessage: 'Heading 6',
     },
-    value: {
-      type: 'heading',
-      level: 6,
-    },
+    handleConvert: (editor) => handleConvertToHeading(editor, 6),
     matchNode: (node) => node.type === 'heading' && node.level === 6,
     isInBlocksSelector: true,
   },

--- a/packages/core/admin/admin/src/content-manager/components/BlocksInput/Blocks/Heading.tsx
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksInput/Blocks/Heading.tsx
@@ -13,6 +13,7 @@ import { Editor, Transforms } from 'slate';
 import styled from 'styled-components';
 
 import { type BlocksStore } from '../BlocksEditor';
+import { prepareHandleConvert } from '../utils/conversions';
 import { type Block } from '../utils/types';
 
 const H1 = styled(Typography).attrs({ as: 'h1' })`
@@ -49,13 +50,9 @@ const H6 = styled(Typography).attrs({ as: 'h6' })`
  * Common handler for converting a node to a heading
  */
 const handleConvertToHeading = (editor: Editor, level: Block<'heading'>['level']) => {
-  const entry = Editor.above(editor, {
-    match: (node) => !Editor.isEditor(node) && node.type !== 'text',
-  });
-
-  if (!entry || Editor.isEditor(entry[0])) {
-    return;
-  }
+  // Get the element to convert
+  const entry = prepareHandleConvert(editor);
+  if (!entry) return;
 
   const { type: _type, children: _children, ...extra } = entry[0];
 

--- a/packages/core/admin/admin/src/content-manager/components/BlocksInput/Blocks/Image.tsx
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksInput/Blocks/Image.tsx
@@ -1,12 +1,16 @@
 import * as React from 'react';
 
 import { Box, Flex } from '@strapi/design-system';
+import { prefixFileUrlWithBackendUrl, useLibrary } from '@strapi/helper-plugin';
 import { Picture } from '@strapi/icons';
-import { type Element } from 'slate';
+import { type Attribute } from '@strapi/types';
+import { Transforms, type Element } from 'slate';
+import { Editor } from 'slate';
 import { type RenderElementProps } from 'slate-react';
 import styled from 'styled-components';
 
-import { type BlocksStore } from '../BlocksEditor';
+import { useBlocksEditorContext, type BlocksStore } from '../BlocksEditor';
+import { insertEmptyBlockAtLast, isLastBlockType } from '../utils/conversions';
 import { type Block } from '../utils/types';
 
 // The max-height is decided with the design team, the 56px is the height of the toolbar
@@ -15,6 +19,30 @@ const Img = styled.img`
   max-width: 100%;
   object-fit: contain;
 `;
+
+const IMAGE_SCHEMA_FIELDS = [
+  'name',
+  'alternativeText',
+  'url',
+  'caption',
+  'width',
+  'height',
+  'formats',
+  'hash',
+  'ext',
+  'mime',
+  'size',
+  'previewUrl',
+  'provider',
+  'provider_metadata',
+  'createdAt',
+  'updatedAt',
+];
+
+const pick = <T extends object, K extends keyof T>(object: T, keys: K[]): Pick<T, K> => {
+  const entries = keys.map((key) => [key, object[key]]);
+  return Object.fromEntries(entries);
+};
 
 // Type guard to force TypeScript to narrow the type of the element in Blocks component
 const isImage = (element: Element): element is Block<'image'> => {
@@ -38,6 +66,92 @@ const Image = ({ attributes, children, element }: RenderElementProps) => {
   );
 };
 
+const ImageDialog = () => {
+  const [isOpen, setIsOpen] = React.useState(true);
+  const { editor } = useBlocksEditorContext('ImageDialog');
+  const { components } = useLibrary();
+
+  if (!components || !isOpen) return null;
+
+  const MediaLibraryDialog = components['media-library'] as React.ComponentType<{
+    allowedTypes: Attribute.MediaKind[];
+    onClose: () => void;
+    onSelectAssets: (_images: Attribute.MediaValue<true>) => void;
+  }>;
+
+  const insertImages = (images: Block<'image'>['image'][]) => {
+    // If the selection is inside a list, split the list so that the modified block is outside of it
+    Transforms.unwrapNodes(editor, {
+      match: (node) => !Editor.isEditor(node) && node.type === 'list',
+      split: true,
+    });
+
+    // Save the path of the node that is being replaced by an image to insert the images there later
+    // It's the closest full block node above the selection
+    const nodeEntryBeingReplaced = Editor.above(editor, {
+      match(node) {
+        if (Editor.isEditor(node)) return false;
+
+        const isInlineNode = ['text', 'link'].includes(node.type);
+
+        return !isInlineNode;
+      },
+    });
+
+    if (!nodeEntryBeingReplaced) return;
+    const [, pathToInsert] = nodeEntryBeingReplaced;
+
+    // Remove the previous node that is being replaced by an image
+    Transforms.removeNodes(editor);
+
+    // Convert images to nodes and insert them
+    const nodesToInsert = images.map((image) => {
+      const imageNode: Block<'image'> = {
+        type: 'image',
+        image,
+        children: [{ type: 'text', text: '' }],
+      };
+      return imageNode;
+    });
+    Transforms.insertNodes(editor, nodesToInsert, { at: pathToInsert });
+
+    // Set the selection on the image since it was cleared by calling removeNodes
+    Transforms.select(editor, pathToInsert);
+  };
+
+  const handleSelectAssets = (images: Attribute.MediaValue<true>) => {
+    const formattedImages = images.map((image) => {
+      // Create an object with imageSchema defined and exclude unnecessary props coming from media library config
+      const expectedImage = pick(image, IMAGE_SCHEMA_FIELDS);
+
+      const nodeImage: Block<'image'>['image'] = {
+        ...expectedImage,
+        alternativeText: expectedImage.alternativeText || expectedImage.name,
+        url: prefixFileUrlWithBackendUrl(image.url),
+      };
+
+      return nodeImage;
+    });
+
+    insertImages(formattedImages);
+
+    if (isLastBlockType(editor, 'image')) {
+      // Insert blank line to add new blocks below image block
+      insertEmptyBlockAtLast(editor);
+    }
+
+    setIsOpen(false);
+  };
+
+  return (
+    <MediaLibraryDialog
+      allowedTypes={['images']}
+      onClose={() => setIsOpen(false)}
+      onSelectAssets={handleSelectAssets}
+    />
+  );
+};
+
 const imageBlocks: Pick<BlocksStore, 'image'> = {
   image: {
     renderElement: (props) => <Image {...props} />,
@@ -46,11 +160,14 @@ const imageBlocks: Pick<BlocksStore, 'image'> = {
       id: 'components.Blocks.blocks.image',
       defaultMessage: 'Image',
     },
-    value: {
-      type: 'image',
-    },
     matchNode: (node) => node.type === 'image',
     isInBlocksSelector: true,
+    handleConvert: () => {
+      // All the logic is managed inside the ImageDialog component,
+      // because the blocks are only created when the user selects images in the modal and submits
+      // and if he closes the modal, then no changes are made to the editor
+      return () => <ImageDialog />;
+    },
   },
 };
 

--- a/packages/core/admin/admin/src/content-manager/components/BlocksInput/Blocks/Link.tsx
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksInput/Blocks/Link.tsx
@@ -241,8 +241,8 @@ const linkBlocks: Pick<BlocksStore, 'link'> = {
         {props.children}
       </Link>
     ),
-    value: {
-      type: 'link',
+    handleConvert() {
+      // No-op, links are created via the link button in the toolbar
     },
     matchNode: (node) => node.type === 'link',
     isInBlocksSelector: false,

--- a/packages/core/admin/admin/src/content-manager/components/BlocksInput/Blocks/Paragraph.tsx
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksInput/Blocks/Paragraph.tsx
@@ -5,6 +5,7 @@ import { Paragraph } from '@strapi/icons';
 import { type Text, Editor, Transforms } from 'slate';
 
 import { type BlocksStore } from '../BlocksEditor';
+import { prepareHandleConvert } from '../utils/conversions';
 
 const paragraphBlocks: Pick<BlocksStore, 'paragraph'> = {
   paragraph: {
@@ -18,11 +19,30 @@ const paragraphBlocks: Pick<BlocksStore, 'paragraph'> = {
       id: 'components.Blocks.blocks.text',
       defaultMessage: 'Text',
     },
-    value: {
-      type: 'paragraph',
-    },
     matchNode: (node) => node.type === 'paragraph',
     isInBlocksSelector: true,
+    handleConvert(editor) {
+      // Get the element to convert
+      const entry = prepareHandleConvert(editor);
+      if (!entry) return;
+      const [element, elementPath] = entry;
+
+      // Explicitly set non-needed attributes to null so that Slate deletes them
+      const { type: _type, children: _children, ...extra } = element;
+      const attributesToClear: Record<string, null> = {};
+      Object.keys(extra).forEach((key) => {
+        attributesToClear[key] = null;
+      });
+
+      Transforms.setNodes(
+        editor,
+        {
+          ...attributesToClear,
+          type: 'paragraph',
+        },
+        { at: elementPath }
+      );
+    },
     handleEnterKey(editor) {
       if (!editor.selection) {
         return;

--- a/packages/core/admin/admin/src/content-manager/components/BlocksInput/Blocks/Quote.tsx
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksInput/Blocks/Quote.tsx
@@ -5,6 +5,7 @@ import { type Text, Editor, Node, Transforms } from 'slate';
 import styled from 'styled-components';
 
 import { type BlocksStore } from '../BlocksEditor';
+import { prepareHandleConvert } from '../utils/conversions';
 
 const Blockquote = styled.blockquote.attrs({ role: 'blockquote' })`
   margin: ${({ theme }) => `${theme.spaces[4]} 0`};
@@ -26,11 +27,30 @@ const quoteBlocks: Pick<BlocksStore, 'quote'> = {
       id: 'components.Blocks.blocks.quote',
       defaultMessage: 'Quote',
     },
-    value: {
-      type: 'quote',
-    },
     matchNode: (node) => node.type === 'quote',
     isInBlocksSelector: true,
+    handleConvert(editor) {
+      // Get the element to convert
+      const entry = prepareHandleConvert(editor);
+      if (!entry) return;
+      const [element, elementPath] = entry;
+
+      // Explicitly set non-needed attributes to null so that Slate deletes them
+      const { type: _type, children: _children, ...extra } = element;
+      const attributesToClear: Record<string, null> = {};
+      Object.keys(extra).forEach((key) => {
+        attributesToClear[key] = null;
+      });
+
+      Transforms.setNodes(
+        editor,
+        {
+          ...attributesToClear,
+          type: 'quote',
+        },
+        { at: elementPath }
+      );
+    },
     handleEnterKey(editor) {
       /**
        * To determine if we should break out of the quote node, check 2 things:

--- a/packages/core/admin/admin/src/content-manager/components/BlocksInput/Blocks/tests/Code.test.tsx
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksInput/Blocks/tests/Code.test.tsx
@@ -68,4 +68,96 @@ describe('Code', () => {
       },
     ]);
   });
+
+  it('converts a quote block to a code block', () => {
+    const baseEditor = createEditor();
+    baseEditor.children = [
+      {
+        type: 'quote',
+        children: [
+          {
+            type: 'text',
+            text: 'Some quote',
+          },
+        ],
+      },
+    ];
+
+    Transforms.select(baseEditor, {
+      anchor: { path: [0, 0], offset: 0 },
+      focus: { path: [0, 0], offset: 0 },
+    });
+
+    codeBlocks.code.handleConvert(baseEditor);
+
+    expect(baseEditor.children).toEqual([
+      {
+        type: 'code',
+        children: [
+          {
+            type: 'text',
+            text: 'Some quote',
+          },
+        ],
+      },
+      // Should insert a new paragraph as it was the last block
+      {
+        type: 'paragraph',
+        children: [{ type: 'text', text: '' }],
+      },
+    ]);
+  });
+
+  it('should not insert an empty block below if the converted block is not the last one', () => {
+    const baseEditor = createEditor();
+    baseEditor.children = [
+      {
+        type: 'quote',
+        children: [
+          {
+            type: 'text',
+            text: 'Some quote',
+          },
+        ],
+      },
+      {
+        type: 'paragraph',
+        children: [
+          {
+            type: 'text',
+            text: 'Some paragraph',
+          },
+        ],
+      },
+    ];
+
+    Transforms.select(baseEditor, {
+      anchor: { path: [0, 0], offset: 0 },
+      focus: { path: [0, 0], offset: 0 },
+    });
+
+    codeBlocks.code.handleConvert(baseEditor);
+
+    expect(baseEditor.children).toEqual([
+      {
+        type: 'code',
+        children: [
+          {
+            type: 'text',
+            text: 'Some quote',
+          },
+        ],
+      },
+      {
+        type: 'paragraph',
+        children: [
+          {
+            type: 'text',
+            text: 'Some paragraph',
+          },
+        ],
+      },
+      // Nothing should be inserted here
+    ]);
+  });
 });

--- a/packages/core/admin/admin/src/content-manager/components/BlocksInput/Blocks/tests/Heading.test.tsx
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksInput/Blocks/tests/Heading.test.tsx
@@ -47,4 +47,63 @@ describe('Heading', () => {
 
     headingBlocks['heading-six'].handleConvert(baseEditor);
   });
+
+  it('splits a list when converting a list item to a heading', () => {
+    const baseEditor = createEditor();
+    baseEditor.children = [
+      {
+        type: 'list',
+        format: 'ordered',
+        children: [
+          {
+            type: 'list-item',
+            children: [{ type: 'text', text: 'List item 1' }],
+          },
+          {
+            type: 'list-item',
+            children: [{ type: 'text', text: 'List item 2' }],
+          },
+          {
+            type: 'list-item',
+            children: [{ type: 'text', text: 'List item 3' }],
+          },
+        ],
+      },
+    ];
+
+    Transforms.select(baseEditor, {
+      anchor: { path: [0, 1, 0], offset: 0 },
+      focus: { path: [0, 1, 0], offset: 0 },
+    });
+
+    headingBlocks['heading-one'].handleConvert(baseEditor);
+
+    expect(baseEditor.children).toEqual([
+      {
+        type: 'list',
+        format: 'ordered',
+        children: [
+          {
+            type: 'list-item',
+            children: [{ type: 'text', text: 'List item 1' }],
+          },
+        ],
+      },
+      {
+        type: 'heading',
+        level: 1,
+        children: [{ type: 'text', text: 'List item 2' }],
+      },
+      {
+        type: 'list',
+        format: 'ordered',
+        children: [
+          {
+            type: 'list-item',
+            children: [{ type: 'text', text: 'List item 3' }],
+          },
+        ],
+      },
+    ]);
+  });
 });

--- a/packages/core/admin/admin/src/content-manager/components/BlocksInput/Blocks/tests/Heading.test.tsx
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksInput/Blocks/tests/Heading.test.tsx
@@ -1,4 +1,6 @@
+/* eslint-disable testing-library/no-node-access */
 import { render, screen } from '@testing-library/react';
+import { Transforms, createEditor } from 'slate';
 
 import { headingBlocks } from '../Heading';
 
@@ -22,5 +24,27 @@ describe('Heading', () => {
 
     const heading = screen.getByRole('heading', { level: 2, name: 'Some heading' });
     expect(heading).toBeInTheDocument();
+  });
+
+  it('converts a code block to a heading', () => {
+    const baseEditor = createEditor();
+    baseEditor.children = [
+      {
+        type: 'code',
+        children: [
+          {
+            type: 'text',
+            text: 'Line of code',
+          },
+        ],
+      },
+    ];
+
+    Transforms.select(baseEditor, {
+      anchor: { path: [0, 0], offset: 0 },
+      focus: { path: [0, 0], offset: 0 },
+    });
+
+    headingBlocks['heading-six'].handleConvert(baseEditor);
   });
 });

--- a/packages/core/admin/admin/src/content-manager/components/BlocksInput/Blocks/tests/Image.test.tsx
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksInput/Blocks/tests/Image.test.tsx
@@ -1,8 +1,69 @@
-import { render, screen } from '@testing-library/react';
+/* eslint-disable testing-library/no-node-access */
+
+import React from 'react';
+
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Transforms, createEditor } from 'slate';
 
 import { imageBlocks } from '../Image';
 
 import { Wrapper } from './Wrapper';
+
+const mockMediaLibraryTitle = 'dialog component';
+const mockMediaLibrarySubmitButton = 'upload images';
+const mockMediaLibraryImage = {
+  name: 'Screenshot 2023-10-18 at 15.03.11.png',
+  alternativeText: 'Screenshot 2023-10-18 at 15.03.11.png',
+  caption: null,
+  width: 437,
+  height: 420,
+  formats: {
+    thumbnail: {
+      name: 'thumbnail_Screenshot 2023-10-18 at 15.03.11.png',
+      hash: 'thumbnail_Screenshot_2023_10_18_at_15_03_11_c6d21f899b',
+      ext: '.png',
+      mime: 'image/png',
+      path: null,
+      width: 162,
+      height: 156,
+      size: 45.75,
+      url: '/uploads/thumbnail_Screenshot_2023_10_18_at_15_03_11_c6d21f899b.png',
+    },
+  },
+  hash: 'Screenshot_2023_10_18_at_15_03_11_c6d21f899b',
+  ext: '.png',
+  mime: 'image/png',
+  size: 47.67,
+  url: 'http://localhost:1337/uploads/Screenshot_2023_10_18_at_15_03_11_c6d21f899b.png',
+  previewUrl: null,
+  provider: 'local',
+  provider_metadata: null,
+  createdAt: '2023-10-18T15:54:33.504Z',
+  updatedAt: '2023-10-18T15:54:33.504Z',
+};
+
+jest.mock('@strapi/helper-plugin', () => ({
+  ...jest.requireActual('@strapi/helper-plugin'),
+  useLibrary: jest.fn().mockImplementation(() => ({
+    components: {
+      'media-library': ({
+        onSelectAssets,
+      }: {
+        onSelectAssets: (images: (typeof mockMediaLibraryImage)[]) => void;
+      }) => (
+        <div>
+          <p>{mockMediaLibraryTitle}</p>
+          <button type="button" onClick={() => onSelectAssets([mockMediaLibraryImage])}>
+            {mockMediaLibrarySubmitButton}
+          </button>
+        </div>
+      ),
+    },
+  })),
+}));
+
+const user = userEvent.setup();
 
 describe('Image', () => {
   it('renders an image block properly', () => {
@@ -27,5 +88,118 @@ describe('Image', () => {
     const image = screen.getByRole('img', { name: 'Some image' });
     expect(image).toBeInTheDocument();
     expect(image).toHaveAttribute('src', 'https://example.com/image.png');
+  });
+
+  it('converts a paragraph block to an image', async () => {
+    const baseEditor = createEditor();
+    baseEditor.children = [{ type: 'paragraph', children: [{ type: 'text', text: '' }] }];
+
+    await act(async () =>
+      Transforms.select(baseEditor, {
+        anchor: { path: [0, 0], offset: 0 },
+        focus: { path: [0, 0], offset: 0 },
+      })
+    );
+
+    // Display the media library modal via handleConvert
+    const modalComponent = imageBlocks.image.handleConvert(baseEditor);
+    expect(modalComponent).toBeDefined();
+    const modalUi = modalComponent!();
+    render(modalUi, {
+      wrapper: ({ children }) => <Wrapper baseEditor={baseEditor}>{children}</Wrapper>,
+    });
+
+    // No changes should have been made to the editor yet
+    expect(baseEditor.children).toEqual([
+      { type: 'paragraph', children: [{ type: 'text', text: '' }] },
+    ]);
+
+    // Fake an image upload, then nodes should be created
+    expect(screen.getByText(mockMediaLibraryTitle)).toBeInTheDocument();
+    await user.click(screen.getByText(mockMediaLibrarySubmitButton));
+
+    expect(baseEditor.children).toEqual([
+      {
+        type: 'image',
+        image: mockMediaLibraryImage,
+        children: [{ type: 'text', text: '' }],
+      },
+      // An empty paragraph should have been created below the image since it was the last block
+      {
+        type: 'paragraph',
+        children: [{ type: 'text', text: '' }],
+      },
+    ]);
+  });
+
+  it('splits a list in two when converting a list item to an image', async () => {
+    const baseEditor = createEditor();
+    baseEditor.children = [
+      {
+        type: 'list',
+        format: 'ordered',
+        children: [
+          { type: 'list-item', children: [{ type: 'text', text: 'List item 1' }] },
+          { type: 'list-item', children: [{ type: 'text', text: 'List item 2' }] },
+          { type: 'list-item', children: [{ type: 'text', text: 'List item 3' }] },
+        ],
+      },
+    ];
+
+    await act(async () =>
+      Transforms.select(baseEditor, {
+        anchor: { path: [0, 1, 0], offset: 0 },
+        focus: { path: [0, 1, 0], offset: 0 },
+      })
+    );
+
+    // Display the media library modal via handleConvert
+    const modalComponent = imageBlocks.image.handleConvert(baseEditor);
+    expect(modalComponent).toBeDefined();
+    const modalUi = modalComponent!();
+    render(modalUi, {
+      wrapper: ({ children }) => <Wrapper baseEditor={baseEditor}>{children}</Wrapper>,
+    });
+
+    // Fake an image upload, then nodes should be created
+    expect(screen.getByText(mockMediaLibraryTitle)).toBeInTheDocument();
+    await user.click(screen.getByText(mockMediaLibrarySubmitButton));
+    expect(baseEditor.children).toEqual([
+      {
+        type: 'list',
+        format: 'ordered',
+        children: [
+          {
+            type: 'list-item',
+            children: [
+              {
+                type: 'text',
+                text: 'List item 1',
+              },
+            ],
+          },
+        ],
+      },
+      {
+        type: 'image',
+        image: mockMediaLibraryImage,
+        children: [{ type: 'text', text: '' }],
+      },
+      {
+        type: 'list',
+        format: 'ordered',
+        children: [
+          {
+            type: 'list-item',
+            children: [
+              {
+                type: 'text',
+                text: 'List item 3',
+              },
+            ],
+          },
+        ],
+      },
+    ]);
   });
 });

--- a/packages/core/admin/admin/src/content-manager/components/BlocksInput/Blocks/tests/List.test.tsx
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksInput/Blocks/tests/List.test.tsx
@@ -758,4 +758,103 @@ describe('List', () => {
       },
     ]);
   });
+
+  // TODO: test list conversion.
+  // check out the commented code in BlocksToolbar to see what we're missing
+  it('converts a paragraph to a list', () => {
+    const baseEditor = createEditor();
+    baseEditor.children = [
+      {
+        type: 'heading',
+        level: 1,
+        children: [
+          {
+            type: 'text',
+            text: 'Heading link',
+          },
+        ],
+      },
+    ];
+
+    // Set the cursor on the heading
+    Transforms.select(baseEditor, {
+      anchor: { path: [0, 0], offset: 0 },
+      focus: { path: [0, 0], offset: 0 },
+    });
+
+    listBlocks['list-ordered'].handleConvert(baseEditor);
+
+    // console.log(JSON.stringify(baseEditor.children, null, 2));
+    expect(baseEditor.children).toEqual([
+      {
+        type: 'list',
+        format: 'ordered',
+        children: [
+          {
+            type: 'list-item',
+            children: [
+              {
+                type: 'text',
+                text: 'Heading link',
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('converts a heading with a link to a list', () => {
+    const baseEditor = createEditor();
+    baseEditor.children = [
+      {
+        type: 'heading',
+        level: 1,
+        children: [
+          {
+            type: 'link',
+            url: 'https://strapi.io',
+            children: [
+              {
+                type: 'text',
+                text: 'Heading link',
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    // Set the cursor on the heading
+    Transforms.select(baseEditor, {
+      anchor: { path: [0, 0, 0], offset: 0 },
+      focus: { path: [0, 0, 0], offset: 0 },
+    });
+
+    listBlocks['list-ordered'].handleConvert(baseEditor);
+
+    expect(baseEditor.children).toEqual([
+      {
+        type: 'list',
+        format: 'ordered',
+        children: [
+          {
+            type: 'list-item',
+            children: [
+              {
+                type: 'link',
+                url: 'https://strapi.io',
+                children: [
+                  {
+                    type: 'text',
+                    text: 'Heading link',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+  });
 });

--- a/packages/core/admin/admin/src/content-manager/components/BlocksInput/Blocks/tests/Paragraph.test.tsx
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksInput/Blocks/tests/Paragraph.test.tsx
@@ -247,4 +247,81 @@ describe('Paragraph', () => {
       },
     ]);
   });
+
+  it('converts a list to a paragraph', () => {
+    const baseEditor = createEditor();
+    baseEditor.children = [
+      {
+        type: 'list',
+        format: 'unordered',
+        children: [
+          {
+            type: 'list-item',
+            children: [
+              {
+                type: 'text',
+                text: 'List item 1',
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    Transforms.select(baseEditor, {
+      anchor: { path: [0, 0, 0], offset: 0 },
+      focus: { path: [0, 0, 0], offset: 0 },
+    });
+
+    paragraphBlocks.paragraph.handleConvert(baseEditor);
+
+    expect(baseEditor.children).toEqual([
+      {
+        type: 'paragraph',
+        children: [
+          {
+            type: 'text',
+            text: 'List item 1',
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('converts a heading to a paragraph', () => {
+    const baseEditor = createEditor();
+    baseEditor.children = [
+      {
+        type: 'heading',
+        level: 1,
+        children: [
+          {
+            type: 'text',
+            italic: true,
+            text: 'Heading 1',
+          },
+        ],
+      },
+    ];
+
+    Transforms.select(baseEditor, {
+      anchor: { path: [0, 0], offset: 0 },
+      focus: { path: [0, 0], offset: 0 },
+    });
+
+    paragraphBlocks.paragraph.handleConvert(baseEditor);
+
+    expect(baseEditor.children).toEqual([
+      {
+        type: 'paragraph',
+        children: [
+          {
+            type: 'text',
+            italic: true,
+            text: 'Heading 1',
+          },
+        ],
+      },
+    ]);
+  });
 });

--- a/packages/core/admin/admin/src/content-manager/components/BlocksInput/Blocks/tests/Quote.test.tsx
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksInput/Blocks/tests/Quote.test.tsx
@@ -125,4 +125,41 @@ describe('Quote', () => {
     // Once on the new line, bold and italic should be disabled
     expect(Editor.marks(baseEditor)).toEqual({ type: 'text' });
   });
+
+  it('converts a heading to a quote', () => {
+    const baseEditor = createEditor();
+    baseEditor.children = [
+      {
+        type: 'heading',
+        level: 1,
+        children: [
+          {
+            type: 'text',
+            italic: true,
+            text: 'Heading 1',
+          },
+        ],
+      },
+    ];
+
+    Transforms.select(baseEditor, {
+      anchor: { path: [0, 0], offset: 0 },
+      focus: { path: [0, 0], offset: 0 },
+    });
+
+    quoteBlocks.quote.handleConvert(baseEditor);
+
+    expect(baseEditor.children).toEqual([
+      {
+        type: 'quote',
+        children: [
+          {
+            type: 'text',
+            italic: true,
+            text: 'Heading 1',
+          },
+        ],
+      },
+    ]);
+  });
 });

--- a/packages/core/admin/admin/src/content-manager/components/BlocksInput/Blocks/tests/Wrapper.tsx
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksInput/Blocks/tests/Wrapper.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import { lightTheme } from '@strapi/design-system';
 import { IntlProvider } from 'react-intl';
-import { createEditor } from 'slate';
+import { type Editor, createEditor } from 'slate';
 import { Slate, withReact } from 'slate-react';
 import { ThemeProvider } from 'styled-components';
 
@@ -15,13 +15,14 @@ import { listBlocks } from '../List';
 import { paragraphBlocks } from '../Paragraph';
 import { quoteBlocks } from '../Quote';
 
-const baseEditor = createEditor();
+const defaultBaseEditor = createEditor();
 
 interface WrapperProps {
   children: React.ReactNode;
+  baseEditor?: Editor;
 }
 
-const Wrapper = ({ children }: WrapperProps) => {
+const Wrapper = ({ children, baseEditor = defaultBaseEditor }: WrapperProps) => {
   const [editor] = React.useState(() => withReact(baseEditor));
 
   const blocks: BlocksStore = {
@@ -37,7 +38,7 @@ const Wrapper = ({ children }: WrapperProps) => {
   return (
     <ThemeProvider theme={lightTheme}>
       <IntlProvider messages={{}} locale="en">
-        <Slate initialValue={[]} editor={editor}>
+        <Slate initialValue={baseEditor.children} editor={editor}>
           <BlocksEditorProvider blocks={blocks} disabled={false}>
             {children}
           </BlocksEditorProvider>

--- a/packages/core/admin/admin/src/content-manager/components/BlocksInput/BlocksEditor.tsx
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksInput/BlocksEditor.tsx
@@ -27,9 +27,9 @@ import { withStrapiSchema } from './plugins/withStrapiSchema';
 
 interface NonSelectorBlock {
   renderElement: (props: RenderElementProps) => React.JSX.Element;
-  value: object;
   matchNode: (node: Attribute.BlocksNode) => boolean;
   isInBlocksSelector: false;
+  handleConvert: (editor: Editor) => void | (() => React.JSX.Element);
   handleEnterKey?: (editor: Editor) => void;
   handleBackspaceKey?: (editor: Editor, event: React.KeyboardEvent<HTMLElement>) => void;
 }

--- a/packages/core/admin/admin/src/content-manager/components/BlocksInput/BlocksToolbar.tsx
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksInput/BlocksToolbar.tsx
@@ -2,11 +2,10 @@ import * as React from 'react';
 
 import * as Toolbar from '@radix-ui/react-toolbar';
 import { Flex, Icon, Tooltip, SingleSelect, SingleSelectOption, Box } from '@strapi/design-system';
-import { pxToRem, prefixFileUrlWithBackendUrl, useLibrary } from '@strapi/helper-plugin';
+import { pxToRem } from '@strapi/helper-plugin';
 import { Link } from '@strapi/icons';
-import { Attribute } from '@strapi/types';
 import { MessageDescriptor, useIntl } from 'react-intl';
-import { type Text, Editor, Transforms, Element as SlateElement, Element, Node } from 'slate';
+import { Editor, Transforms, Element as SlateElement, Node } from 'slate';
 import { ReactEditor } from 'slate-react';
 import styled from 'styled-components';
 
@@ -134,202 +133,10 @@ const ToolbarButton = ({
   );
 };
 
-const toggleBlock = (editor: Editor, value: Partial<Element>) => {
-  if (!value.type) {
-    throw new Error('The block type is required');
-  }
-
-  // Set the selected block properties received from the useBlockStore
-  const blockProperties = {
-    type: value.type,
-    level: (value as Block<'heading'>).level || null,
-    format: (value as Block<'list'>).format || null,
-  };
-
-  if (editor.selection) {
-    // If the selection is inside a list, split the list so that the modified block is outside of it
-    Transforms.unwrapNodes(editor, {
-      match: (node) => !Editor.isEditor(node) && node.type === 'list',
-      split: true,
-    });
-
-    // When there is a selection, update the existing block in the tree
-    Transforms.setNodes(editor, blockProperties);
-  } else {
-    /**
-     * When there is no selection, we want to insert a new block just after
-     * the last node inserted and prevent the code to add an empty paragraph
-     * between them.
-     */
-    const [, lastNodePath] = Editor.last(editor, []);
-    const [parentNode] = Editor.parent(editor, lastNodePath);
-    Transforms.removeNodes(editor, {
-      voids: true,
-      hanging: true,
-      at: {
-        anchor: { path: lastNodePath, offset: 0 },
-        focus: { path: lastNodePath, offset: 0 },
-      },
-    });
-    Transforms.insertNodes(
-      editor,
-      {
-        ...blockProperties,
-        children: parentNode.children,
-      } as Node,
-      {
-        at: [lastNodePath[0]],
-        select: true,
-      }
-    );
-  }
-
-  // When the select is clicked it blurs the editor, restore the focus to the editor
-  ReactEditor.focus(editor);
-};
-
-const IMAGE_SCHEMA_FIELDS = [
-  'name',
-  'alternativeText',
-  'url',
-  'caption',
-  'width',
-  'height',
-  'formats',
-  'hash',
-  'ext',
-  'mime',
-  'size',
-  'previewUrl',
-  'provider',
-  'provider_metadata',
-  'createdAt',
-  'updatedAt',
-];
-
-const pick = <T extends object, K extends keyof T>(object: T, keys: K[]): Pick<T, K> => {
-  const entries = keys.map((key) => [key, object[key]]);
-  return Object.fromEntries(entries);
-};
-
-const ImageDialog = ({ handleClose }: { handleClose: () => void }) => {
-  const { editor } = useBlocksEditorContext('ImageDialog');
-  const { components } = useLibrary();
-
-  if (!components) return null;
-
-  const MediaLibraryDialog = components['media-library'] as React.ComponentType<{
-    allowedTypes: Attribute.MediaKind[];
-    onClose: () => void;
-    onSelectAssets: (_images: Attribute.MediaValue<true>) => void;
-  }>;
-
-  const insertImages = (images: Block<'image'>['image'][]) => {
-    // If the selection is inside a list, split the list so that the modified block is outside of it
-    Transforms.unwrapNodes(editor, {
-      match: (node) => !Editor.isEditor(node) && node.type === 'list',
-      split: true,
-    });
-
-    // Save the path of the node that is being replaced by an image to insert the images there later
-    // It's the closest full block node above the selection
-    const nodeEntryBeingReplaced = Editor.above(editor, {
-      match(node) {
-        if (Editor.isEditor(node)) return false;
-
-        const isInlineNode = ['text', 'link'].includes(node.type);
-
-        return !isInlineNode;
-      },
-    });
-
-    if (!nodeEntryBeingReplaced) return;
-    const [, pathToInsert] = nodeEntryBeingReplaced;
-
-    // Remove the previous node that is being replaced by an image
-    Transforms.removeNodes(editor);
-
-    // Convert images to nodes and insert them
-    const nodesToInsert = images.map((image) => {
-      const imageNode: Block<'image'> = {
-        type: 'image',
-        image,
-        children: [{ type: 'text', text: '' }],
-      };
-      return imageNode;
-    });
-    Transforms.insertNodes(editor, nodesToInsert, { at: pathToInsert });
-  };
-
-  const handleSelectAssets = (images: Attribute.MediaValue<true>) => {
-    const formattedImages = images.map((image) => {
-      // Create an object with imageSchema defined and exclude unnecessary props coming from media library config
-      const expectedImage = pick(image, IMAGE_SCHEMA_FIELDS);
-
-      const nodeImage: Block<'image'>['image'] = {
-        ...expectedImage,
-        alternativeText: expectedImage.alternativeText || expectedImage.name,
-        url: prefixFileUrlWithBackendUrl(image.url),
-      };
-
-      return nodeImage;
-    });
-
-    insertImages(formattedImages);
-
-    if (isLastBlockType(editor, 'image')) {
-      // Insert blank line to add new blocks below image block
-      insertEmptyBlockAtLast(editor);
-    }
-
-    handleClose();
-  };
-
-  return (
-    <MediaLibraryDialog
-      allowedTypes={['images']}
-      onClose={handleClose}
-      onSelectAssets={handleSelectAssets}
-    />
-  );
-};
-
-const isLastBlockType = (editor: Editor, type: Element['type']) => {
-  const { selection } = editor;
-
-  if (!selection) return false;
-
-  const [currentBlock] = Editor.nodes(editor, {
-    at: selection,
-    match: (node) => !Editor.isEditor(node) && node.type === type,
-  });
-
-  if (currentBlock) {
-    const [, currentNodePath] = currentBlock;
-
-    const isNodeAfter = Boolean(Editor.after(editor, currentNodePath));
-
-    return !isNodeAfter;
-  }
-
-  return false;
-};
-
-const insertEmptyBlockAtLast = (editor: Editor) => {
-  Transforms.insertNodes(
-    editor,
-    {
-      type: 'paragraph',
-      children: [{ type: 'text', text: '' }],
-    },
-    { at: [editor.children.length] }
-  );
-};
-
 const BlocksDropdown = () => {
   const { editor, blocks, disabled } = useBlocksEditorContext('BlocksDropdown');
   const { formatMessage } = useIntl();
-  const [isMediaLibraryVisible, setIsMediaLibraryVisible] = React.useState(false);
+  const [modalComponent, setModalComponent] = React.useState<React.JSX.Element | null>(null);
 
   const blockKeysToInclude: SelectorBlockKey[] = getEntries(blocks).reduce<
     ReturnType<typeof getEntries>
@@ -346,32 +153,35 @@ const BlocksDropdown = () => {
       return;
     }
 
-    if (['list-ordered', 'list-unordered'].includes(optionKey)) {
-      // retrieve the list format
-      const listFormat = (blocks[optionKey].value as { format: Block<'list'>['format'] })?.format;
-
-      // check if the list is already active
-      const isActive = isListActive(
+    if (!editor.selection) {
+      // When there is no selection, create an empty block at the end of the editor
+      // so that it can be converted to the selected block
+      Transforms.insertNodes(
         editor,
-        (node) => !Editor.isEditor(node) && !isText(node) && blocks[optionKey].matchNode(node)
+        {
+          type: 'quote',
+          children: [{ type: 'text', text: '' }],
+        },
+        {
+          select: true,
+          // Since there's no selection, Slate will automatically insert the node at the end
+        }
       );
-
-      // toggle the list
-      toggleList(editor, isActive, listFormat);
-    } else if (optionKey !== 'image') {
-      toggleBlock(editor, blocks[optionKey].value);
     }
 
-    setBlockSelected(optionKey as SelectorBlockKey);
+    // Let the block handle the Slate conversion logic
+    const maybeRenderModal = blocks[optionKey].handleConvert(editor);
 
-    if (optionKey === 'code' && isLastBlockType(editor, 'code')) {
-      // Insert blank line to add new blocks below code block
-      insertEmptyBlockAtLast(editor);
+    // Some blocks, like Image, require a modal. Check if there's one returned
+    if (maybeRenderModal) {
+      // Use cloneElement to apply a key because to create a new instance of the component
+      // Without the new key, the state is kept from previous times that option was picked
+      setModalComponent(React.cloneElement(maybeRenderModal(), { key: Date.now() }));
     }
 
-    if (optionKey === 'image') {
-      setIsMediaLibraryVisible(true);
-    }
+    setBlockSelected(optionKey);
+
+    ReactEditor.focus(editor);
   };
 
   /**
@@ -431,7 +241,7 @@ const BlocksDropdown = () => {
           ))}
         </SingleSelect>
       </SelectWrapper>
-      {isMediaLibraryVisible && <ImageDialog handleClose={() => setIsMediaLibraryVisible(false)} />}
+      {modalComponent}
     </>
   );
 };
@@ -456,10 +266,6 @@ const BlockOption = ({ value, icon, label, blockSelected }: BlockOptionProps) =>
       {formatMessage(label)}
     </SingleSelectOption>
   );
-};
-
-const isText = (node: unknown): node is Text => {
-  return Node.isNode(node) && !Editor.isEditor(node) && node.type === 'text';
 };
 
 const isListNode = (node: unknown): node is Block<'list'> => {
@@ -537,13 +343,13 @@ const toggleList = (editor: Editor, isActive: boolean, format: Block<'list'>['fo
 
 interface ListButtonProps {
   block: BlocksStore['list-ordered'] | BlocksStore['list-unordered'];
+  format: Block<'list'>['format'];
 }
 
-const ListButton = ({ block }: ListButtonProps) => {
+const ListButton = ({ block, format }: ListButtonProps) => {
   const { editor, disabled } = useBlocksEditorContext('ListButton');
 
-  const { icon, matchNode, value, label } = block;
-  const { format } = value as { format: Block<'list'>['format'] };
+  const { icon, matchNode, label } = block;
 
   const isActive = isListActive(
     editor,
@@ -681,8 +487,8 @@ const BlocksToolbar = () => {
         <Separator />
         <Toolbar.ToggleGroup type="single" asChild>
           <Flex gap={1}>
-            <ListButton block={blocks['list-unordered']} />
-            <ListButton block={blocks['list-ordered']} />
+            <ListButton block={blocks['list-unordered']} format="unordered" />
+            <ListButton block={blocks['list-ordered']} format="ordered" />
           </Flex>
         </Toolbar.ToggleGroup>
       </ToolbarWrapper>

--- a/packages/core/admin/admin/src/content-manager/components/BlocksInput/tests/BlocksToolbar.test.tsx
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksInput/tests/BlocksToolbar.test.tsx
@@ -20,59 +20,6 @@ import { quoteBlocks } from '../Blocks/Quote';
 import { type BlocksStore, BlocksEditorProvider } from '../BlocksEditor';
 import { BlocksToolbar } from '../BlocksToolbar';
 
-const mockMediaLibraryTitle = 'dialog component';
-const mockMediaLibrarySubmitButton = 'upload images';
-const mockMediaLibraryImage = {
-  name: 'Screenshot 2023-10-18 at 15.03.11.png',
-  alternativeText: 'Screenshot 2023-10-18 at 15.03.11.png',
-  caption: null,
-  width: 437,
-  height: 420,
-  formats: {
-    thumbnail: {
-      name: 'thumbnail_Screenshot 2023-10-18 at 15.03.11.png',
-      hash: 'thumbnail_Screenshot_2023_10_18_at_15_03_11_c6d21f899b',
-      ext: '.png',
-      mime: 'image/png',
-      path: null,
-      width: 162,
-      height: 156,
-      size: 45.75,
-      url: '/uploads/thumbnail_Screenshot_2023_10_18_at_15_03_11_c6d21f899b.png',
-    },
-  },
-  hash: 'Screenshot_2023_10_18_at_15_03_11_c6d21f899b',
-  ext: '.png',
-  mime: 'image/png',
-  size: 47.67,
-  url: 'http://localhost:1337/uploads/Screenshot_2023_10_18_at_15_03_11_c6d21f899b.png',
-  previewUrl: null,
-  provider: 'local',
-  provider_metadata: null,
-  createdAt: '2023-10-18T15:54:33.504Z',
-  updatedAt: '2023-10-18T15:54:33.504Z',
-};
-
-jest.mock('@strapi/helper-plugin', () => ({
-  ...jest.requireActual('@strapi/helper-plugin'),
-  useLibrary: jest.fn().mockImplementation(() => ({
-    components: {
-      'media-library': ({
-        onSelectAssets,
-      }: {
-        onSelectAssets: (images: (typeof mockMediaLibraryImage)[]) => void;
-      }) => (
-        <div>
-          <p>{mockMediaLibraryTitle}</p>
-          <button type="button" onClick={() => onSelectAssets([mockMediaLibraryImage])}>
-            {mockMediaLibrarySubmitButton}
-          </button>
-        </div>
-      ),
-    },
-  })),
-}));
-
 const defaultInitialValue: Descendant[] = [
   {
     type: 'paragraph',
@@ -457,59 +404,6 @@ describe('BlocksToolbar', () => {
     expect(ReactEditor.focus).toHaveBeenCalledTimes(2);
   });
 
-  it('opens the media library when image is selected', async () => {
-    setup();
-
-    await select({
-      anchor: { path: [0, 0], offset: 0 },
-      focus: { path: [0, 0], offset: 0 },
-    });
-
-    // Convert selection to an image
-    const blocksDropdown = screen.getByRole('combobox', { name: /Select a block/i });
-    await user.click(blocksDropdown);
-    await user.click(screen.getByRole('option', { name: 'Image' }));
-
-    expect(screen.getByText(mockMediaLibraryTitle)).toBeInTheDocument();
-  });
-
-  it('creates an empty paragraph below when a code block is created at the end of the editor', async () => {
-    setup();
-
-    await select({
-      anchor: { path: [0, 0], offset: 0 },
-      focus: { path: [0, 0], offset: 0 },
-    });
-
-    // Convert selection to a code block
-    const blocksDropdown = screen.getByRole('combobox', { name: /Select a block/i });
-    await user.click(blocksDropdown);
-    await user.click(screen.getByRole('option', { name: 'Code' }));
-
-    expect(baseEditor.children).toEqual([
-      {
-        type: 'code',
-        children: [
-          {
-            type: 'text',
-            text: 'A line of text in a paragraph.',
-          },
-        ],
-      },
-      {
-        type: 'paragraph',
-        children: [
-          {
-            type: 'text',
-            text: '',
-          },
-        ],
-      },
-    ]);
-
-    expect(ReactEditor.focus).toHaveBeenCalledTimes(1);
-  });
-
   it('only shows one option selected in the dropdown when mixed content is selected', async () => {
     setup(mixedInitialValue);
 
@@ -616,33 +510,31 @@ describe('BlocksToolbar', () => {
     ]);
   });
 
-  it('creates a new code block without empty lines before it when you select the option in a empty editor', async () => {
+  it('creates a new node when selecting a block if there is no selection', async () => {
     setup([
       {
         type: 'paragraph',
-        children: [{ type: 'text', text: '' }],
+        children: [{ type: 'text', text: 'Some paragraph' }],
       },
     ]);
 
     // Convert selection to a code block
     const blocksDropdown = screen.getByRole('combobox', { name: /Select a block/i });
     await user.click(blocksDropdown);
-    await user.click(screen.getByRole('option', { name: 'Code' }));
+    await user.click(screen.getByRole('option', { name: 'Quote' }));
 
     expect(baseEditor.children).toEqual([
       {
-        type: 'code',
-        format: null,
-        level: null,
+        type: 'paragraph',
         children: [
           {
             type: 'text',
-            text: '',
+            text: 'Some paragraph',
           },
         ],
       },
       {
-        type: 'paragraph',
+        type: 'quote',
         children: [
           {
             type: 'text',
@@ -775,6 +667,10 @@ describe('BlocksToolbar', () => {
     const blocksDropdown = screen.getByRole('combobox', { name: /Select a block/i });
 
     // Convert selection to an ordered list
+    await select({
+      anchor: { path: [2, 0], offset: 0 },
+      focus: { path: [2, 0], offset: 0 },
+    });
     await user.click(blocksDropdown);
     await user.click(screen.getByRole('option', { name: 'Numbered list' }));
 
@@ -850,55 +746,5 @@ describe('BlocksToolbar', () => {
 
     const linkButton = screen.getByLabelText(/link/i);
     expect(linkButton).toBeDisabled();
-  });
-
-  it('splits a list in two when converting a list item to an image', async () => {
-    setup([
-      {
-        type: 'list',
-        format: 'ordered',
-        children: [
-          { type: 'list-item', children: [{ type: 'text', text: 'First list item' }] },
-          { type: 'list-item', children: [{ type: 'text', text: 'Second list item' }] },
-          { type: 'list-item', children: [{ type: 'text', text: 'Third list item' }] },
-        ],
-      },
-    ]);
-
-    // Select the item in the middle of the list
-    await select({
-      anchor: { path: [0, 1, 0], offset: 0 },
-      focus: { path: [0, 1, 0], offset: 0 },
-    });
-
-    // Convert it to an image
-    const blocksDropdown = screen.getByRole('combobox', { name: /Select a block/i });
-    await user.click(blocksDropdown);
-    await user.click(screen.getByRole('option', { name: 'Image' }));
-    await user.click(screen.getByText(mockMediaLibrarySubmitButton));
-
-    // The list should have been split in two
-    expect(baseEditor.children).toEqual([
-      {
-        type: 'list',
-        format: 'ordered',
-        children: [{ type: 'list-item', children: [{ type: 'text', text: 'First list item' }] }],
-      },
-      {
-        type: 'image',
-        image: mockMediaLibraryImage,
-        children: [
-          {
-            type: 'text',
-            text: '',
-          },
-        ],
-      },
-      {
-        type: 'list',
-        format: 'ordered',
-        children: [{ type: 'list-item', children: [{ type: 'text', text: 'Third list item' }] }],
-      },
-    ]);
   });
 });

--- a/packages/core/admin/admin/src/content-manager/components/BlocksInput/utils/conversions.ts
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksInput/utils/conversions.ts
@@ -1,0 +1,54 @@
+import { type Element, Editor, Transforms } from 'slate';
+
+const prepareHandleConvert = (editor: Editor) => {
+  // If the selection is inside a list, split the list so that the modified block is outside of it
+  Transforms.unwrapNodes(editor, {
+    match: (node) => !Editor.isEditor(node) && node.type === 'list',
+    split: true,
+  });
+
+  const entry = Editor.above(editor, {
+    match: (node) => !Editor.isEditor(node) && node.type !== 'text' && node.type !== 'link',
+  });
+
+  if (!entry || Editor.isEditor(entry[0])) {
+    return;
+  }
+
+  // Can't return entry directly because TS isn't smart enough to understand it can't be an editor
+  return [entry[0], entry[1]] as const;
+};
+
+const isLastBlockType = (editor: Editor, type: Element['type']) => {
+  const { selection } = editor;
+
+  if (!selection) return false;
+
+  const [currentBlock] = Editor.nodes(editor, {
+    at: selection,
+    match: (node) => !Editor.isEditor(node) && node.type === type,
+  });
+
+  if (currentBlock) {
+    const [, currentNodePath] = currentBlock;
+
+    const isNodeAfter = Boolean(Editor.after(editor, currentNodePath));
+
+    return !isNodeAfter;
+  }
+
+  return false;
+};
+
+const insertEmptyBlockAtLast = (editor: Editor) => {
+  Transforms.insertNodes(
+    editor,
+    {
+      type: 'paragraph',
+      children: [{ type: 'text', text: '' }],
+    },
+    { at: [editor.children.length] }
+  );
+};
+
+export { prepareHandleConvert, isLastBlockType, insertEmptyBlockAtLast };


### PR DESCRIPTION
### What does it do?

Moves the blocks conversion logic to the store via a new `handleConvert` function. And add tests for each type of block to make sure other blocks can be converted to it.

The image was the trickiest case. To keep a block-agnostic approach, I allow the handleConvert component to return a React component, which lets us display the media library dialog while keeping the.

### Why is it needed?

Currently the blocks conversion can only be done via the toolbar. But that will soon change with the upcoming Blocks features like slash commands and markdown shortcuts. We now need to be able to convert blocks from anywhere in the BlocksEditor. So moving that logic to the store makes it easy to reuse.

It also has the benefit of making it easier to add a custom blocks feature if we wanted to do that.

### How to test it?

Convert a bunch of blocks to other blocks. Especially try converting list items and nodes with links (with the selection on the links) as they're the trickiest cases.

Also try the conversion to images in particular. And try to add several images in a row as that created issues.
