### PR TITLE
feat: return affected documents on document service

### DIFF
--- a/api-tests/core/strapi/document-service/clone.test.api.ts
+++ b/api-tests/core/strapi/document-service/clone.test.api.ts
@@ -32,7 +32,7 @@ describe('Document Service', () => {
 
         expect(result).not.toBeNull();
 
-        const clonedArticlesDb = await findArticlesDb({ documentId: result.documentId });
+        const clonedArticlesDb = await findArticlesDb({ documentId: result.id });
 
         // all articles should be in draft, and only one should be english
         expect(clonedArticlesDb.length).toBe(1);
@@ -66,7 +66,7 @@ describe('Document Service', () => {
           documentId: articleDb.documentId,
           publishedAt: null,
         });
-        const clonedArticlesDb = await findArticlesDb({ documentId: result.documentId });
+        const clonedArticlesDb = await findArticlesDb({ documentId: result.id });
 
         // all articles should be in draft, and all locales should be cloned
         expect(clonedArticlesDb.length).toBe(originalArticlesDb.length);

--- a/api-tests/core/strapi/document-service/clone.test.api.ts
+++ b/api-tests/core/strapi/document-service/clone.test.api.ts
@@ -79,14 +79,6 @@ describe('Document Service', () => {
       })
     );
 
-    it('can not clone published documents', () => {
-      const resultPromise = strapi.documents(ARTICLE_UID).clone('1234', {
-        status: 'published',
-      });
-
-      expect(resultPromise).rejects.toThrowError('Cannot directly clone a published document');
-    });
-
     it('clone non existing document', () => {
       const resultPromise = strapi.documents(ARTICLE_UID).clone('1234', {
         data: {

--- a/api-tests/core/strapi/document-service/create.test.api.ts
+++ b/api-tests/core/strapi/document-service/create.test.api.ts
@@ -56,7 +56,8 @@ describe('Document Service', () => {
       })
     );
 
-    it(
+    // TODO
+    it.skip(
       'can not directly create a published document',
       testInTransaction(async () => {
         const articlePromise = strapi.documents(ARTICLE_UID).create({
@@ -64,8 +65,6 @@ describe('Document Service', () => {
           status: 'published',
           data: { title: 'Article' },
         });
-
-        await expect(articlePromise).rejects.toThrow('Cannot directly create a published document');
       })
     );
 

--- a/api-tests/core/strapi/document-service/discard-draft.test.api.ts
+++ b/api-tests/core/strapi/document-service/discard-draft.test.api.ts
@@ -1,0 +1,113 @@
+import { LoadedStrapi } from '@strapi/types';
+import { createTestSetup, destroyTestSetup } from '../../../utils/builder-helper';
+import { testInTransaction } from '../../../utils/index';
+import resources from './resources/index';
+import { ARTICLE_UID, findArticleDb, findArticlesDb } from './utils';
+
+describe('Document Service', () => {
+  let testUtils;
+  let strapi: LoadedStrapi;
+
+  beforeAll(async () => {
+    testUtils = await createTestSetup(resources);
+    strapi = testUtils.strapi;
+  });
+
+  afterAll(async () => {
+    await destroyTestSetup(testUtils);
+  });
+
+  describe('Discard Draft', () => {
+    it(
+      'Discard all locale drafts of a document',
+      testInTransaction(async () => {
+        const articleDb = await findArticleDb({ title: 'Article1-Draft-EN' });
+
+        // Publish every draft in every locale
+        await strapi.documents(ARTICLE_UID).publish(articleDb.documentId);
+
+        // Update drafts
+        await Promise.all(
+          ['es', 'fr', 'en'].map((locale) =>
+            strapi.documents(ARTICLE_UID).update(articleDb.documentId, {
+              locale,
+              data: { title: 'Draft Article' },
+            })
+          )
+        );
+
+        // Discard drafts
+        const result = await strapi.documents(ARTICLE_UID).discardDraft(articleDb.documentId);
+
+        const draftArticlesDb = await findArticlesDb({
+          documentId: articleDb.documentId,
+          publishedAt: { $null: true },
+        });
+
+        // All locales should have been discarded
+        expect(result.versions.length).toBe(3);
+        result.versions.forEach((version) => {
+          expect(version.publishedAt).toBeNull();
+          // The draft title should have been discarded
+          expect(version.title).not.toBe('Draft Article');
+        });
+
+        expect(draftArticlesDb.length).toBe(3);
+        draftArticlesDb.forEach((article) => {
+          expect(article.publishedAt).toBeNull();
+          // The draft title should have been discarded
+          expect(article.title).not.toBe('Draft Article');
+        });
+      })
+    );
+
+    it(
+      'Discard a single locale of a document',
+      testInTransaction(async () => {
+        const articleDb = await findArticleDb({ title: 'Article1-Draft-EN' });
+
+        // Publish every draft in every locale
+        await strapi.documents(ARTICLE_UID).publish(articleDb.documentId);
+
+        // Update drafts
+        await Promise.all(
+          ['es', 'fr', 'en'].map((locale) =>
+            strapi.documents(ARTICLE_UID).update(articleDb.documentId, {
+              locale,
+              data: { title: 'Draft Article' },
+            })
+          )
+        );
+
+        // Discard english draft
+        const result = await strapi
+          .documents(ARTICLE_UID)
+          .discardDraft(articleDb.documentId, { locale: 'en' });
+
+        const draftArticlesDb = await findArticlesDb({
+          documentId: articleDb.documentId,
+          publishedAt: { $null: true },
+        });
+
+        // Only english locale should have been discarded
+        expect(result.versions.length).toBe(1);
+        result.versions.forEach((version) => {
+          expect(version.locale).toBe('en');
+          expect(version.publishedAt).toBeNull();
+          // The draft title should have been discarded
+          expect(version.title).not.toBe('Draft Article');
+        });
+
+        // Rest of locales should not have been discarded
+        expect(draftArticlesDb.length).toBeGreaterThanOrEqual(3);
+        draftArticlesDb.forEach((article) => {
+          // The draft title should not have been discarded
+          // @ts-expect-error - FIX: 'StringAttribute' and 'string' have no overlap
+          if (['es', 'fr'].includes(article.locale)) {
+            expect(article.title).toBe('Draft Article');
+          }
+        });
+      })
+    );
+  });
+});

--- a/api-tests/core/strapi/document-service/update.test.api.ts
+++ b/api-tests/core/strapi/document-service/update.test.api.ts
@@ -109,7 +109,8 @@ describe('Document Service', () => {
       })
     );
 
-    it(
+    // TODO
+    it.skip(
       'can not update published document',
       testInTransaction(async () => {
         const articleDb = await findArticleDb({ title: 'Article1-Draft-FR' });
@@ -119,10 +120,6 @@ describe('Document Service', () => {
           status: 'published',
           data: { title: newName },
         });
-
-        await expect(updatePromise).rejects.toThrow(
-          'Cannot update a published document. Use the publish method instead.'
-        );
       })
     );
 

--- a/packages/core/strapi/src/services/document-service/document-repository.ts
+++ b/packages/core/strapi/src/services/document-service/document-repository.ts
@@ -121,6 +121,15 @@ export const createDocumentRepository = (
         );
       },
 
+      async discardDraft(id: string, params = {} as any) {
+        return strapi.db?.transaction?.(async () =>
+          middlewareManager.run(
+            { action: 'discardDraft', uid, params, options: { id } },
+            ({ params }) => documents.discardDraft(uid, id, params)
+          )
+        );
+      },
+
       // @ts-expect-error - TODO: Fix this
       with(params: object) {
         return createDocumentRepository(strapi, {

--- a/packages/core/strapi/src/services/document-service/index.ts
+++ b/packages/core/strapi/src/services/document-service/index.ts
@@ -104,7 +104,7 @@ const createDocumentService = ({
     });
 
     // TODO: Change return value to actual count
-    return { documents: entriesToDelete };
+    return { versions: entriesToDelete };
   },
 
   // TODO: should we provide two separate methods?
@@ -125,12 +125,6 @@ const createDocumentService = ({
     // TODO: Entity validator.
     // TODO: File upload - Probably in the lifecycles?
     const { data } = params;
-
-    if (params.status === 'published') {
-      throw new Error(
-        'Cannot directly create a published document. Use the publish method instead.'
-      );
-    }
 
     if (!data) {
       throw new Error('Create requires data attribute');
@@ -161,10 +155,6 @@ const createDocumentService = ({
     // TODO: File upload
     const { data } = params || {};
     const model = strapi.getModel(uid) as Shared.ContentTypes[Common.UID.ContentType];
-
-    if (params?.status === 'published') {
-      throw new Error('Cannot update a published document. Use the publish method instead.');
-    }
 
     const query = transformParamsToQuery(uid, pickSelectionParams(params || {}));
 
@@ -206,17 +196,13 @@ const createDocumentService = ({
     // TODO: Entity validator.
     const { data = {} as any } = params!;
 
-    if (params?.status === 'published') {
-      throw new Error('Cannot directly clone a published document');
-    }
-
     const model = strapi.getModel(uid);
     const query = transformParamsToQuery(uid, pickSelectionParams(params));
 
     // Find all locales of the document
     const entries = await db.query(uid).findMany({
       ...query,
-      where: { ...params?.lookup, ...query.where, documentId, publishedAt: null },
+      where: { ...params?.lookup, ...query.where, documentId },
     });
 
     // Document does not exist
@@ -226,7 +212,7 @@ const createDocumentService = ({
 
     const newDocumentId = createDocumentId();
 
-    const documents = await mapAsync(entries, async (entryToClone: any) => {
+    const versions = await mapAsync(entries, async (entryToClone: any) => {
       const isDraft = contentTypesUtils.isDraft(data);
       // Todo: Merge data with entry to clone
       const validData = await entityValidator.validateEntityUpdate(
@@ -251,15 +237,11 @@ const createDocumentService = ({
       });
     });
 
-    return { id: newDocumentId, documents };
+    return { id: newDocumentId, versions };
   },
 
   // TODO: Handle relations so they target the published version
   async publish(uid, documentId, params) {
-    if (params?.status === 'published') {
-      throw new Error('Cannot publish a document that is already published');
-    }
-
     // Delete already published versions that match the locales to be published
     await this.delete(uid, documentId, {
       ...params,
@@ -274,20 +256,40 @@ const createDocumentService = ({
     })) as any;
 
     // TODO: Return actual count
-    return { documents: clonedDocuments?.documents || [] };
+    return { versions: clonedDocuments?.versions || [] };
   },
 
   async unpublish(uid, documentId, params) {
-    if (params?.status === 'draft') {
-      throw new Error('Cannot unpublish a document that is already a draft');
-    }
-
-    // TODO: Discard draft
     // Delete all published versions
     return this.delete(uid, documentId, {
       ...params,
       lookup: { ...params?.lookup, publishedAt: { $ne: null } },
     }) as any;
+  },
+
+  /**
+   * Steps:
+   * - Delete the matching draft versions (publishedAt = null)
+   * - Clone the matching published versions into draft versions
+   */
+  async discardDraft(uid, documentId, params) {
+    // Delete draft versions, clone published versions into draft versions
+    await this.delete(uid, documentId, {
+      ...params,
+      // Delete all drafts that match query
+      lookup: { ...params?.lookup, publishedAt: null },
+    });
+
+    // Clone published versions into draft versions
+    const clonedDocuments = (await this.clone(uid, documentId, {
+      ...(params || {}),
+      // Clone only published versions
+      lookup: { ...params?.lookup, publishedAt: { $ne: null } },
+      // @ts-expect-error - Generic type does not have publishedAt attribute by default
+      data: { documentId, publishedAt: null },
+    })) as any;
+
+    return { versions: clonedDocuments?.versions || [] };
   },
 });
 

--- a/packages/core/strapi/src/services/document-service/middlewares/defaults/draft-and-publish.ts
+++ b/packages/core/strapi/src/services/document-service/middlewares/defaults/draft-and-publish.ts
@@ -3,6 +3,17 @@ import { Documents } from '@strapi/types';
 type Middleware = Documents.Middleware.Middleware<any, any>;
 
 /**
+ * Sets status to draft only
+ */
+export const setStatusToDraft: Middleware = async (ctx, next) => {
+  if (!ctx.params) ctx.params = {};
+
+  ctx.params.status = 'draft';
+
+  return next(ctx);
+};
+
+/**
  * Adds a default status of `draft` to the params
  */
 export const defaultToDraft: Middleware = async (ctx, next) => {
@@ -63,4 +74,11 @@ export const statusToData: Middleware = async (ctx, next) => {
   ctx.params.data = data;
 
   return next(ctx);
+};
+
+export default {
+  setStatusToDraft,
+  defaultToDraft,
+  statusToLookup,
+  statusToData,
 };

--- a/packages/core/strapi/src/services/document-service/middlewares/defaults/index.ts
+++ b/packages/core/strapi/src/services/document-service/middlewares/defaults/index.ts
@@ -1,13 +1,13 @@
 import { Documents } from '@strapi/types';
-import { defaultToDraft, statusToLookup, statusToData } from './draft-and-publish';
-import { defaultLocale, localeToLookup, localeToData } from './locales';
+import DP from './draft-and-publish';
+import i18n from './locales';
 
 export const loadDefaultMiddlewares = (manager: Documents.Middleware.Manager) => {
   // Find Many
   manager.add(
     '_all',
     'findMany',
-    [defaultToDraft, statusToLookup, defaultLocale, localeToLookup],
+    [DP.defaultToDraft, DP.statusToLookup, i18n.defaultLocale, i18n.localeToLookup],
     {}
   );
 
@@ -15,7 +15,7 @@ export const loadDefaultMiddlewares = (manager: Documents.Middleware.Manager) =>
   manager.add(
     '_all',
     'findOne',
-    [defaultToDraft, statusToLookup, defaultLocale, localeToLookup],
+    [DP.defaultToDraft, DP.statusToLookup, i18n.defaultLocale, i18n.localeToLookup],
     {}
   );
 
@@ -23,28 +23,57 @@ export const loadDefaultMiddlewares = (manager: Documents.Middleware.Manager) =>
   manager.add(
     '_all',
     'findFirst',
-    [defaultToDraft, statusToLookup, defaultLocale, localeToLookup],
+    [DP.defaultToDraft, DP.statusToLookup, i18n.defaultLocale, i18n.localeToLookup],
     {}
   );
 
   // Delete
-  manager.add('_all', 'delete', [statusToLookup, localeToLookup], {});
+  manager.add(
+    '_all',
+    'delete',
+    [
+      // Lookup for status and locale if provided
+      DP.statusToLookup,
+      i18n.localeToLookup,
+    ],
+    {}
+  );
 
   // Delete Many - TODO
   // manager.add('_all', 'deleteMany', [], {});
 
   // Create
-  manager.add('_all', 'create', [defaultToDraft, statusToData, defaultLocale, localeToData], {});
+  manager.add(
+    '_all',
+    'create',
+    [
+      // Only create drafts
+      DP.setStatusToDraft,
+      DP.statusToData,
+      i18n.defaultLocale,
+      i18n.localeToData,
+    ],
+    {}
+  );
 
   // Update
   manager.add(
     '_all',
     'update',
-    [defaultToDraft, statusToLookup, statusToData, defaultLocale, localeToLookup, localeToData],
+    [
+      // Only update drafts
+      DP.setStatusToDraft,
+      DP.statusToLookup,
+      DP.statusToData,
+      // Default locale will be set if not provided
+      i18n.defaultLocale,
+      i18n.localeToLookup,
+      i18n.localeToData,
+    ],
     {}
   );
 
-  // Upsert locale
+  // Upsert locale if doesn't exist on update
   manager.add('_all', 'update', async (ctx, next) => {
     // Try to update
     const res = await next(ctx);
@@ -67,14 +96,17 @@ export const loadDefaultMiddlewares = (manager: Documents.Middleware.Manager) =>
   });
 
   // Count
-  manager.add('_all', 'count', [defaultToDraft, defaultLocale], {});
+  manager.add('_all', 'count', [DP.defaultToDraft, i18n.defaultLocale], {});
 
   // Clone
-  manager.add('_all', 'clone', [localeToLookup], {});
+  manager.add('_all', 'clone', [i18n.localeToLookup], {});
 
   // Publish
-  manager.add('_all', 'publish', [localeToLookup], {});
+  manager.add('_all', 'publish', [i18n.localeToLookup], {});
 
   // Unpublish
-  manager.add('_all', 'unpublish', [localeToLookup], {});
+  manager.add('_all', 'unpublish', [i18n.localeToLookup], {});
+
+  // Discard Draft
+  manager.add('_all', 'discardDraft', [i18n.localeToLookup], {});
 };

--- a/packages/core/strapi/src/services/document-service/middlewares/defaults/locales.ts
+++ b/packages/core/strapi/src/services/document-service/middlewares/defaults/locales.ts
@@ -46,3 +46,9 @@ export const localeToData: Middleware = async (ctx, next) => {
 
   return next(ctx);
 };
+
+export default {
+  defaultLocale,
+  localeToLookup,
+  localeToData,
+};

--- a/packages/core/types/src/modules/documents/document-service.ts
+++ b/packages/core/types/src/modules/documents/document-service.ts
@@ -106,4 +106,13 @@ export interface DocumentService {
     documentId: ID,
     params?: TParams
   ): Result.Unpublish<TContentTypeUID, TParams>;
+
+  discardDraft<
+    TContentTypeUID extends Common.UID.ContentType,
+    TParams extends Params.DiscardDraft<TContentTypeUID>
+  >(
+    uid: TContentTypeUID,
+    documentId: ID,
+    params?: TParams
+  ): Result.DiscardDraft<TContentTypeUID, TParams>;
 }

--- a/packages/core/types/src/modules/documents/document-service.ts
+++ b/packages/core/types/src/modules/documents/document-service.ts
@@ -70,7 +70,7 @@ export interface DocumentService {
     uid: TContentTypeUID,
     documentId: ID,
     params?: TParams
-  ): Result.Clone;
+  ): Result.Clone<TContentTypeUID, TParams>;
 
   update<
     TContentTypeUID extends Common.UID.ContentType,
@@ -96,7 +96,7 @@ export interface DocumentService {
     uid: TContentTypeUID,
     documentId: ID,
     params?: TParams
-  ): Result.Publish;
+  ): Result.Publish<TContentTypeUID, TParams>;
 
   unpublish<
     TContentTypeUID extends Common.UID.ContentType,
@@ -105,5 +105,5 @@ export interface DocumentService {
     uid: TContentTypeUID,
     documentId: ID,
     params?: TParams
-  ): Result.Unpublish;
+  ): Result.Unpublish<TContentTypeUID, TParams>;
 }

--- a/packages/core/types/src/modules/documents/index.ts
+++ b/packages/core/types/src/modules/documents/index.ts
@@ -61,6 +61,11 @@ export type RepositoryInstance<
     params?: TParams
   ) => Result.Unpublish<TContentTypeUID, TParams>;
 
+  discardDraft: <TParams extends Params.DiscardDraft<TContentTypeUID>>(
+    documentId: ID,
+    params?: TParams
+  ) => Result.DiscardDraft<TContentTypeUID, TParams>;
+
   /** Add a middleware for a specific uid
    *  @example
    *  strapi.documents('api::article.article').use('findMany', async (ctx, next) => {

--- a/packages/core/types/src/modules/documents/index.ts
+++ b/packages/core/types/src/modules/documents/index.ts
@@ -42,7 +42,7 @@ export type RepositoryInstance<
   clone: <TParams extends Params.Clone<TContentTypeUID>>(
     documentId: ID,
     params: TParams
-  ) => Result.Clone;
+  ) => Result.Clone<TContentTypeUID, TParams>;
 
   update: <TParams extends Params.Update<TContentTypeUID>>(
     documentId: ID,
@@ -54,12 +54,12 @@ export type RepositoryInstance<
   publish: <TParams extends Params.Publish<TContentTypeUID>>(
     documentId: ID,
     params?: TParams
-  ) => Result.Publish;
+  ) => Result.Publish<TContentTypeUID, TParams>;
 
   unpublish: <TParams extends Params.Unpublish<TContentTypeUID>>(
     documentId: ID,
     params?: TParams
-  ) => Result.Unpublish;
+  ) => Result.Unpublish<TContentTypeUID, TParams>;
 
   /** Add a middleware for a specific uid
    *  @example

--- a/packages/core/types/src/modules/documents/middleware.ts
+++ b/packages/core/types/src/modules/documents/middleware.ts
@@ -15,6 +15,7 @@ export type ParamsMap<TContentTypeUID extends Common.UID.ContentType = Common.UI
   count: Params.Count<TContentTypeUID>;
   publish: Params.Publish<TContentTypeUID>;
   unpublish: Params.Unpublish<TContentTypeUID>;
+  discardDraft: Params.DiscardDraft<TContentTypeUID>;
 };
 
 export interface Context<

--- a/packages/core/types/src/modules/documents/params/document-service.ts
+++ b/packages/core/types/src/modules/documents/params/document-service.ts
@@ -53,7 +53,7 @@ export type DeleteMany<TContentTypeUID extends Common.UID.ContentType> = Pick<
 
 export type Create<TContentTypeUID extends Common.UID.ContentType> = Pick<
   TContentTypeUID,
-  'data' | 'files' | 'fields' | 'populate' | 'status' | 'locale' | 'lookup'
+  'data' | 'files' | 'fields' | 'populate' | 'locale' | 'lookup'
 >;
 
 export type Clone<TContentTypeUID extends Common.UID.ContentType> = Pick<
@@ -63,22 +63,24 @@ export type Clone<TContentTypeUID extends Common.UID.ContentType> = Pick<
 
 export type Update<TContentTypeUID extends Common.UID.ContentType> = Pick<
   TContentTypeUID,
-  'data:partial' | 'files' | 'fields' | 'populate' | 'status' | 'locale' | 'lookup'
+  'data:partial' | 'files' | 'fields' | 'populate' | 'locale' | 'lookup'
 >;
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export type Publish<TContentTypeUID extends Common.UID.ContentType> = Pick<
   TContentTypeUID,
-  'filters' | 'status' | 'locale' | 'lookup'
+  'filters' | 'locale' | 'lookup'
 >;
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export type Unpublish<TContentTypeUID extends Common.UID.ContentType> = Pick<
   TContentTypeUID,
-  'filters' | 'status' | 'locale' | 'lookup'
+  'filters' | 'locale' | 'lookup'
 >;
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export type DiscardDraft<TContentTypeUID extends Common.UID.ContentType> = Pick<
+  TContentTypeUID,
+  'filters' | 'locale' | 'lookup'
+>;
+
 export type With<TContentTypeUID extends Common.UID.ContentType> = Pick<
   TContentTypeUID,
   | 'filters'

--- a/packages/core/types/src/modules/documents/result/document-service.ts
+++ b/packages/core/types/src/modules/documents/result/document-service.ts
@@ -32,7 +32,7 @@ export type Delete<
   TContentTypeUID extends Common.UID.ContentType,
   TParams extends Params.Delete<TContentTypeUID>
 > = Promise<{
-  documents: Result<TContentTypeUID, TParams>[];
+  versions: Result<TContentTypeUID, TParams>[];
 } | null>;
 
 export type DeleteMany = Promise<CountResult | null>;
@@ -47,7 +47,7 @@ export type Clone<
   TParams extends Params.Clone<TContentTypeUID>
 > = Promise<{
   id: string;
-  documents: Result<TContentTypeUID, TParams>[];
+  versions: Result<TContentTypeUID, TParams>[];
 } | null>;
 
 export type Update<
@@ -61,12 +61,19 @@ export type Publish<
   TContentTypeUID extends Common.UID.ContentType,
   TParams extends Params.Publish<TContentTypeUID>
 > = Promise<{
-  documents: Result<TContentTypeUID, TParams>[];
+  versions: Result<TContentTypeUID, TParams>[];
 }>;
 
 export type Unpublish<
   TContentTypeUID extends Common.UID.ContentType,
   TParams extends Params.Unpublish<TContentTypeUID>
 > = Promise<{
-  documents: Result<TContentTypeUID, TParams>[];
+  versions: Result<TContentTypeUID, TParams>[];
+}>;
+
+export type DiscardDraft<
+  TContentTypeUID extends Common.UID.ContentType,
+  TParams extends Params.DiscardDraft<TContentTypeUID>
+> = Promise<{
+  versions: Result<TContentTypeUID, TParams>[];
 }>;

--- a/packages/core/types/src/modules/documents/result/document-service.ts
+++ b/packages/core/types/src/modules/documents/result/document-service.ts
@@ -31,7 +31,9 @@ export type FindOne<
 export type Delete<
   TContentTypeUID extends Common.UID.ContentType,
   TParams extends Params.Delete<TContentTypeUID>
-> = Promise<Result<TContentTypeUID, TParams> | null>;
+> = Promise<{
+  documents: Result<TContentTypeUID, TParams>[];
+} | null>;
 
 export type DeleteMany = Promise<CountResult | null>;
 
@@ -40,7 +42,13 @@ export type Create<
   TParams extends Params.Create<TContentTypeUID>
 > = Promise<Result<TContentTypeUID, TParams>>;
 
-export type Clone = Promise<{ documentId: string } | null>;
+export type Clone<
+  TContentTypeUID extends Common.UID.ContentType,
+  TParams extends Params.Clone<TContentTypeUID>
+> = Promise<{
+  id: string;
+  documents: Result<TContentTypeUID, TParams>[];
+} | null>;
 
 export type Update<
   TContentTypeUID extends Common.UID.ContentType,
@@ -49,6 +57,16 @@ export type Update<
 
 export type Count = Promise<number | null>;
 
-export type Publish = Promise<number | null>;
+export type Publish<
+  TContentTypeUID extends Common.UID.ContentType,
+  TParams extends Params.Publish<TContentTypeUID>
+> = Promise<{
+  documents: Result<TContentTypeUID, TParams>[];
+}>;
 
-export type Unpublish = Promise<number | null>;
+export type Unpublish<
+  TContentTypeUID extends Common.UID.ContentType,
+  TParams extends Params.Unpublish<TContentTypeUID>
+> = Promise<{
+  documents: Result<TContentTypeUID, TParams>[];
+}>;


### PR DESCRIPTION
### What does it do?
Return affected documents on clone/publish/unpublish


Created this in the meantime, we might want to discuss this more