### PR TITLE
fix(pack-up): ensure we pass the tsconfig file name, not a path to it

### DIFF
--- a/docs/docs/docs/01-core/strapi/commands/plugin/00-overview.md
+++ b/docs/docs/docs/01-core/strapi/commands/plugin/00-overview.md
@@ -32,14 +32,14 @@ side output we recommend doing the following:
   "version": "1.0.0",
   "exports": {
     "./strapi-admin": {
-      "types": "./dist/admin/index.d.ts",
+      "types": "./dist/admin/src/index.d.ts",
       "source": "./admin/src/index.ts",
       "import": "./dist/admin/index.mjs",
       "require": "./dist/admin/index.js",
       "default": "./dist/admin/index.js"
     },
     "./strapi-server": {
-      "types": "./dist/server/index.d.ts",
+      "types": "./dist/server/src/index.d.ts",
       "source": "./server/src/index.ts",
       "import": "./dist/server/index.mjs",
       "require": "./dist/server/index.js",

--- a/packages/core/admin/_internal/node/createBuildContext.ts
+++ b/packages/core/admin/_internal/node/createBuildContext.ts
@@ -94,7 +94,7 @@ const createBuildContext = async ({
   tsconfig,
   strapi,
   options = {},
-}: CreateBuildContextArgs) => {
+}: CreateBuildContextArgs): Promise<BuildContext> => {
   /**
    * If you make a new strapi instance when one already exists,
    * you will overwrite the global and the app will _most likely_

--- a/packages/core/admin/admin/custom.d.ts
+++ b/packages/core/admin/admin/custom.d.ts
@@ -36,7 +36,6 @@ declare global {
       flags: {
         promoteEE?: boolean;
         nps?: boolean;
-        promoteEE: boolean;
       };
       projectType: 'Community' | 'Enterprise';
       telemetryDisabled: boolean;

--- a/packages/core/admin/admin/src/pages/Settings/pages/Roles/hooks/tests/useAdminRolePermissions.test.ts
+++ b/packages/core/admin/admin/src/pages/Settings/pages/Roles/hooks/tests/useAdminRolePermissions.test.ts
@@ -1,9 +1,10 @@
 import { renderHook, waitFor } from '@tests/utils';
-import { UseQueryOptions } from 'react-query';
 
-import { useAdminRolePermissions, APIRolePermissionsQueryParams } from '../useAdminRolePermissions';
+import { useAdminRolePermissions } from '../useAdminRolePermissions';
 
-const setup = (params?: APIRolePermissionsQueryParams, options?: UseQueryOptions) =>
+type HookArguments = Parameters<typeof useAdminRolePermissions>;
+
+const setup = (params?: HookArguments[0], options?: HookArguments[1]) =>
   renderHook(() => useAdminRolePermissions(params, options));
 
 describe('useAdminRolePermissions', () => {

--- a/packages/core/admin/admin/src/pages/Settings/pages/Users/ListPage.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/Users/ListPage.tsx
@@ -26,7 +26,7 @@ import {
   TableHeader,
 } from '@strapi/helper-plugin';
 import { AxiosError, AxiosResponse } from 'axios';
-import qs from 'qs';
+import * as qs from 'qs';
 import { IntlShape, MessageDescriptor, useIntl } from 'react-intl';
 import { useMutation, useQueryClient } from 'react-query';
 import { useSelector } from 'react-redux';

--- a/packages/core/admin/admin/tests/server.ts
+++ b/packages/core/admin/admin/tests/server.ts
@@ -1,10 +1,10 @@
 import { rest } from 'msw';
-import { SetupServer, setupServer } from 'msw/node';
+import { setupServer } from 'msw/node';
 import * as qs from 'qs';
 
 import { MockData, mockData } from './mockData';
 
-export const server: SetupServer = setupServer(
+export const server = setupServer(
   ...[
     /**
      *

--- a/packages/core/admin/admin/tests/server.ts
+++ b/packages/core/admin/admin/tests/server.ts
@@ -1,10 +1,10 @@
 import { rest } from 'msw';
-import { setupServer } from 'msw/node';
+import { SetupServer, setupServer } from 'msw/node';
 import * as qs from 'qs';
 
 import { MockData, mockData } from './mockData';
 
-export const server = setupServer(
+export const server: SetupServer = setupServer(
   ...[
     /**
      *

--- a/packages/core/admin/admin/tsconfig.build.json
+++ b/packages/core/admin/admin/tsconfig.build.json
@@ -1,9 +1,23 @@
 {
-  "extends": "./admin/tsconfig.json",
-  "include": ["./admin/src/*", "./admin/custom.d.ts", "./shared/*", "./admin/module.d.ts"],
-  "exclude": ["tests/*", "**/*.test.*"],
+  "extends": "tsconfig/client.json",
   "compilerOptions": {
-    "rootDir": ".",
+    "rootDir": "../",
+    "baseUrl": ".",
     "outDir": "./dist"
-  }
+  },
+  "include": [
+    "./src",
+    "./custom.d.ts",
+    "../shared",
+    "./module.d.ts",
+    "../ee/admin",
+    "../package.json"
+  ],
+  "exclude": [
+    "./tests",
+    "**/__mocks__",
+    "**/*.test.*",
+    "../ee/admin/**/*.test.*",
+    "../ee/admin/**/__mocks__"
+  ]
 }

--- a/packages/core/admin/admin/tsconfig.json
+++ b/packages/core/admin/admin/tsconfig.json
@@ -1,12 +1,11 @@
 {
   "extends": "tsconfig/client.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "rootDir": "../",
+    "baseUrl": ".",
     "paths": {
       "@tests/*": ["./tests/*"]
     }
   },
-  "include": ["src/*", "../shared/*", "tests/*", "custom.d.ts", "module.d.ts"],
-  "exclude": ["node_modules"]
+  "include": ["../package.json", "./src", "../shared", "./tests", "./custom.d.ts", "./module.d.ts"]
 }

--- a/packages/core/admin/ee/admin/tsconfig.build.json
+++ b/packages/core/admin/ee/admin/tsconfig.build.json
@@ -1,7 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "outDir": "dist"
-  },
-  "exclude": ["tests", "**/*.test.*"]
-}

--- a/packages/core/admin/ee/admin/tsconfig.json
+++ b/packages/core/admin/ee/admin/tsconfig.json
@@ -1,11 +1,11 @@
 {
   "extends": "tsconfig/client.json",
   "compilerOptions": {
+    "rootDir": "../",
     "baseUrl": ".",
     "paths": {
       "@tests/*": ["../../admin/tests/*"]
     }
   },
-  "include": ["src", "tests", "custom.d.ts", "module.d.ts"],
-  "exclude": ["node_modules"]
+  "include": ["src", "tests", "custom.d.ts"]
 }

--- a/packages/core/admin/ee/server/tsconfig.build.json
+++ b/packages/core/admin/ee/server/tsconfig.build.json
@@ -1,7 +1,9 @@
 {
-  "extends": "./ee/server/tsconfig",
+  "extends": "./tsconfig",
   "compilerOptions": {
-    "outDir": "dist"
+    "rootDir": "../../",
+    "baseUrl": ".",
+    "outDir": "./dist"
   },
   "include": ["src"],
   "exclude": ["*.test.*"]

--- a/packages/core/admin/ee/server/tsconfig.json
+++ b/packages/core/admin/ee/server/tsconfig.json
@@ -1,9 +1,10 @@
 {
   "extends": "tsconfig/base.json",
   "include": ["src"],
-  "exclude": ["node_modules"],
   "compilerOptions": {
     "types": ["lodash", "jest"],
+    "rootDir": "../../",
+    "baseUrl": ".",
     "esModuleInterop": true,
     "allowJs": true
   }

--- a/packages/core/admin/index.d.ts
+++ b/packages/core/admin/index.d.ts
@@ -19,4 +19,4 @@ interface WatchAdminArgs {
 
 declare const watchAdmin: (args: WatchAdminArgs) => Promise<void>;
 
-export { build, BuildArgs, clean, CleanArg, watchAdmin, WatchAdminArgs };
+export { build, BuildArgs, clean, CleanArgs, watchAdmin, WatchAdminArgs };

--- a/packages/core/admin/package.json
+++ b/packages/core/admin/package.json
@@ -40,7 +40,6 @@
       "default": "./strapi-server.js"
     },
     "./cli": {
-      "types": "./dist/cli/index.d.ts",
       "source": "./_internal/index.ts",
       "import": "./dist/cli.mjs",
       "require": "./dist/cli.js",

--- a/packages/core/admin/server/src/controllers/permission.ts
+++ b/packages/core/admin/server/src/controllers/permission.ts
@@ -4,8 +4,8 @@ import { getService } from '../utils';
 import { formatConditions } from './formatters';
 import type { Action } from '../domain/action';
 import type { GetAll, Check } from '../../../shared/contracts/permissions';
-import { Permission } from '../domain/permission';
 import { Condition } from '../domain/condition';
+import { Permission } from '../../../shared/contracts/shared';
 
 export default {
   /**

--- a/packages/core/admin/server/src/domain/action/provider.ts
+++ b/packages/core/admin/server/src/domain/action/provider.ts
@@ -3,7 +3,7 @@ import { validateRegisterProviderAction } from '../../validation/action-provider
 
 import domain from './index';
 import type { Action, CreateActionPayload } from './index';
-import type { Permission } from '../permission';
+import type { Permission } from '../../../../shared/contracts/shared';
 
 type Options = Parameters<typeof providerFactory>['0'];
 

--- a/packages/core/admin/server/src/domain/permission/index.ts
+++ b/packages/core/admin/server/src/domain/permission/index.ts
@@ -1,5 +1,5 @@
 import { providerFactory } from '@strapi/utils';
-import { Utils, Entity } from '@strapi/types';
+import { Utils } from '@strapi/types';
 import {
   pipe,
   set,
@@ -14,24 +14,12 @@ import {
   curry,
   merge,
 } from 'lodash/fp';
-
-export type Permission = {
-  id: Entity.ID;
-  action: string;
-  actionParameters: object;
-  subject?: string | null;
-  properties: {
-    fields?: string[];
-    locales?: string[];
-    [key: string]: unknown;
-  };
-  conditions: string[]; // TODO: This should be a Condition interface
-  role?: string; // TODO: This should be AdminRole
-};
+import { Permission } from '../../../../shared/contracts/shared';
+import { SanitizedPermission } from '../../../../shared/contracts/roles';
 
 export type CreatePermissionPayload = Utils.Object.PartialBy<
   Permission,
-  'actionParameters' | 'conditions' | 'properties' | 'subject' | 'id'
+  'actionParameters' | 'conditions' | 'properties' | 'subject' | 'id' | 'createdAt' | 'updatedAt'
 >;
 
 type Provider = ReturnType<typeof providerFactory>;
@@ -53,8 +41,6 @@ export const sanitizedPermissionFields = [
   'properties',
   'conditions',
 ] as const;
-
-export type SanitizedPermission = Pick<Permission, (typeof sanitizedPermissionFields)[number]>;
 
 export const sanitizePermissionFields: (p: Permission) => SanitizedPermission =
   pick(sanitizedPermissionFields);

--- a/packages/core/admin/server/src/services/permission/engine.ts
+++ b/packages/core/admin/server/src/services/permission/engine.ts
@@ -1,10 +1,10 @@
 import { curry, isArray, isEmpty, difference } from 'lodash/fp';
 import permissions, { type engine } from '@strapi/permissions';
 import type { Ability } from '@casl/ability';
-import permissionDomain, { type Permission } from '../../domain/permission';
+import permissionDomain from '../../domain/permission';
 import { getService } from '../../utils';
 import { Action } from '../../domain/action';
-import type { AdminUser } from '../../../../shared/contracts/shared';
+import type { AdminUser, Permission } from '../../../../shared/contracts/shared';
 
 export default (params: { providers: engine.EngineParams['providers'] }) => {
   const { providers } = params;

--- a/packages/core/admin/server/src/services/permission/queries.ts
+++ b/packages/core/admin/server/src/services/permission/queries.ts
@@ -2,8 +2,8 @@ import { isNil, isArray, prop, xor, eq, map, differenceWith } from 'lodash/fp';
 import { Entity } from '@strapi/types';
 import pmap from 'p-map';
 import { getService } from '../../utils';
-import permissionDomain, { Permission, CreatePermissionPayload } from '../../domain/permission';
-import type { AdminUser } from '../../../../shared/contracts/shared';
+import permissionDomain, { CreatePermissionPayload } from '../../domain/permission';
+import type { AdminUser, Permission } from '../../../../shared/contracts/shared';
 import { Action } from '../../domain/action';
 
 type ID = Entity.ID;

--- a/packages/core/admin/server/src/services/role.ts
+++ b/packages/core/admin/server/src/services/role.ts
@@ -7,8 +7,8 @@ import deepEqual from 'fast-deep-equal';
 import { generateTimestampCode, stringIncludes, hooks as hooksUtils, errors } from '@strapi/utils';
 import { Entity } from '@strapi/types';
 
-import permissionDomain, { type Permission } from '../domain/permission';
-import type { AdminUser, AdminRole } from '../../../shared/contracts/shared';
+import permissionDomain from '../domain/permission';
+import type { AdminUser, AdminRole, Permission } from '../../../shared/contracts/shared';
 import type { Action } from '../domain/action';
 
 import { validatePermissionsExist } from '../validation/permission';

--- a/packages/core/admin/server/src/services/transfer/token.ts
+++ b/packages/core/admin/server/src/services/transfer/token.ts
@@ -5,35 +5,17 @@ import { errors } from '@strapi/utils';
 import '@strapi/types';
 import constants from '../constants';
 import { getService } from '../../utils';
+import {
+  SanitizedTransferToken,
+  TokenUpdatePayload,
+  TransferToken,
+  TransferTokenPermission,
+} from '../../../../shared/contracts/transfer';
 
 const { ValidationError, NotFoundError } = errors;
 
 const TRANSFER_TOKEN_UID = 'admin::transfer-token';
 const TRANSFER_TOKEN_PERMISSION_UID = 'admin::transfer-token-permission';
-
-export type TransferTokenPermission = {
-  id: number | string;
-  action: string;
-  token: TransferToken | number;
-};
-
-export type TransferToken = {
-  id: number | string;
-  name: string;
-  description: string;
-  accessKey: string;
-  lastUsedAt?: number;
-  lifespan: number;
-  expiresAt: number;
-  permissions: string[] | TransferTokenPermission[];
-};
-
-export type SanitizedTransferToken = Omit<TransferToken, 'accessKey'>;
-
-export type TokenUpdatePayload = Pick<
-  TransferToken,
-  'name' | 'description' | 'lastUsedAt' | 'permissions' | 'lifespan'
-> & { accessKey?: string };
 
 const SELECT_FIELDS = [
   'id',

--- a/packages/core/admin/server/src/tsconfig.build.json
+++ b/packages/core/admin/server/src/tsconfig.build.json
@@ -1,9 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "include": ["./src"],
-  "exclude": ["./src/**/*.test.ts"],
-  "compilerOptions": {
-    "rootDir": "./src",
-    "outDir": "./dist/server"
-  }
-}

--- a/packages/core/admin/server/tsconfig.build.json
+++ b/packages/core/admin/server/tsconfig.build.json
@@ -1,8 +1,10 @@
 {
-  "extends": "./server/tsconfig.json",
+  "extends": "./tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist"
+    "rootDir": "../",
+    "baseUrl": ".",
+    "outDir": "./dist"
   },
-  "include": ["src"],
+  "include": ["src", "../shared"],
   "exclude": ["*.test.*"]
 }

--- a/packages/core/admin/server/tsconfig.eslint.json
+++ b/packages/core/admin/server/tsconfig.eslint.json
@@ -1,5 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["src"],
-  "exclude": ["node_modules"]
+  "include": ["src"]
 }

--- a/packages/core/admin/server/tsconfig.json
+++ b/packages/core/admin/server/tsconfig.json
@@ -1,8 +1,9 @@
 {
   "extends": "tsconfig/base.json",
   "include": ["src"],
-  "exclude": ["node_modules"],
   "compilerOptions": {
+    "rootDir": "../",
+    "baseUrl": ".",
     "types": ["lodash", "jest"],
     "esModuleInterop": true
   }

--- a/packages/core/admin/shared/contracts/roles.ts
+++ b/packages/core/admin/shared/contracts/roles.ts
@@ -1,7 +1,11 @@
 import { EntityService } from '@strapi/types';
 import type { errors } from '@strapi/utils';
 import { AdminRole, Permission, SanitizedAdminRole } from './shared';
-import type { SanitizedPermission } from '../../server/src/domain/permission';
+
+export type SanitizedPermission = Pick<
+  Permission,
+  'id' | 'action' | 'actionParameters' | 'subject' | 'properties' | 'conditions'
+>;
 
 type SanitizedAdminRoleWithUsersCount = SanitizedAdminRole & { usersCount?: number };
 

--- a/packages/core/admin/shared/contracts/transfer.ts
+++ b/packages/core/admin/shared/contracts/transfer.ts
@@ -1,10 +1,28 @@
 import { errors } from '@strapi/utils';
 
-import type {
-  SanitizedTransferToken,
+export type TransferTokenPermission = {
+  id: number | string;
+  action: string;
+  token: TransferToken | number;
+};
+
+export type TransferToken = {
+  id: number | string;
+  name: string;
+  description: string;
+  accessKey: string;
+  lastUsedAt?: number;
+  lifespan: number;
+  expiresAt: number;
+  permissions: string[] | TransferTokenPermission[];
+};
+
+export type SanitizedTransferToken = Omit<TransferToken, 'accessKey'>;
+
+export type TokenUpdatePayload = Pick<
   TransferToken,
-  TokenUpdatePayload,
-} from '../../server/src/services/transfer/token';
+  'name' | 'description' | 'lastUsedAt' | 'permissions' | 'lifespan'
+> & { accessKey?: string };
 
 /**
  * GET /transfer/runner/push

--- a/packages/core/admin/shared/contracts/transfer.ts
+++ b/packages/core/admin/shared/contracts/transfer.ts
@@ -1,12 +1,12 @@
 import { errors } from '@strapi/utils';
 
-export type TransferTokenPermission = {
+export interface TransferTokenPermission {
   id: number | string;
   action: string;
   token: TransferToken | number;
-};
+}
 
-export type TransferToken = {
+export interface TransferToken {
   id: number | string;
   name: string;
   description: string;
@@ -15,7 +15,7 @@ export type TransferToken = {
   lifespan: number;
   expiresAt: number;
   permissions: string[] | TransferTokenPermission[];
-};
+}
 
 export type SanitizedTransferToken = Omit<TransferToken, 'accessKey'>;
 

--- a/packages/core/admin/tsconfig.build.json
+++ b/packages/core/admin/tsconfig.build.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/cli"
+    "outDir": "./dist"
   },
   "include": ["_internal"]
 }

--- a/packages/core/admin/tsconfig.json
+++ b/packages/core/admin/tsconfig.json
@@ -1,5 +1,7 @@
 {
   "extends": "tsconfig/client.json",
   "include": ["_internal", "packup.config.ts"],
-  "exclude": ["node_modules"]
+  "compilerOptions": {
+    "outDir": "./dist/cli"
+  }
 }

--- a/packages/core/content-type-builder/admin/tsconfig.build.json
+++ b/packages/core/content-type-builder/admin/tsconfig.build.json
@@ -1,9 +1,10 @@
 {
   "extends": "./tsconfig.json",
   "include": ["./src"],
-  "exclude": ["node_modules", "**/__tests__/**"],
+  "exclude": ["**/__tests__/**"],
   "compilerOptions": {
-    "rootDir": "./src",
-    "outDir": "./dist/admin"
+    "rootDir": "../",
+    "baseUrl": ".",
+    "outDir": "./dist"
   }
 }

--- a/packages/core/content-type-builder/admin/tsconfig.json
+++ b/packages/core/content-type-builder/admin/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "tsconfig/client.json",
   "include": ["src"],
-  "exclude": ["node_modules"]
+  "compilerOptions": {
+    "rootDir": "../",
+    "baseUrl": "."
+  }
 }

--- a/packages/core/content-type-builder/package.json
+++ b/packages/core/content-type-builder/package.json
@@ -21,7 +21,7 @@
   ],
   "exports": {
     "./strapi-admin": {
-      "types": "./dist/admin/index.d.ts",
+      "types": "./dist/admin/src/index.d.ts",
       "source": "./admin/src/index.ts",
       "import": "./dist/admin/index.mjs",
       "require": "./dist/admin/index.js",

--- a/packages/core/content-type-builder/packup.config.ts
+++ b/packages/core/content-type-builder/packup.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig, Config } from '@strapi/pack-up';
-import { transformWithEsbuild } from 'vite';
+
 const config: Config = defineConfig({
   bundles: [
     {
@@ -7,6 +7,7 @@ const config: Config = defineConfig({
       import: './dist/admin/index.mjs',
       require: './dist/admin/index.js',
       types: './dist/admin/src/index.d.ts',
+      tsconfig: './admin/tsconfig.build.json',
       runtime: 'web',
     },
     {
@@ -14,6 +15,7 @@ const config: Config = defineConfig({
       import: './dist/server/index.mjs',
       require: './dist/server/index.js',
       types: './dist/server/src/index.d.ts',
+      tsconfig: './server/tsconfig.build.json',
       runtime: 'node',
     },
   ],

--- a/packages/core/content-type-builder/server/tsconfig.build.json
+++ b/packages/core/content-type-builder/server/tsconfig.build.json
@@ -3,7 +3,8 @@
   "include": ["./src"],
   "exclude": ["node_modules", "**/__tests__/**"],
   "compilerOptions": {
-    "rootDir": "./src",
-    "outDir": "./dist/server"
+    "rootDir": "../",
+    "baseUrl": ".",
+    "outDir": "./dist"
   }
 }

--- a/packages/core/content-type-builder/server/tsconfig.json
+++ b/packages/core/content-type-builder/server/tsconfig.json
@@ -1,9 +1,10 @@
 {
   "extends": "tsconfig/base.json",
   "include": ["src"],
-  "exclude": ["node_modules"],
   "compilerOptions": {
     "types": ["lodash", "jest"],
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "rootDir": "../",
+    "baseUrl": "."
   }
 }

--- a/packages/core/email/admin/tsconfig.build.json
+++ b/packages/core/email/admin/tsconfig.build.json
@@ -1,9 +1,10 @@
 {
-  "extends": "./admin/tsconfig.json",
-  "include": ["./admin/src", "./shared"],
+  "extends": "./tsconfig.json",
+  "include": ["./src", "../shared"],
   "exclude": ["**/*.test.ts"],
   "compilerOptions": {
-    "rootDir": ".",
+    "rootDir": "../",
+    "baseUrl": ".",
     "outDir": "./dist"
   }
 }

--- a/packages/core/email/admin/tsconfig.json
+++ b/packages/core/email/admin/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "tsconfig/client.json",
-  "include": ["./src", "../shared/types.ts"],
+  "include": ["./src", "../shared"],
   "compilerOptions": {
-    "rootDir": "../"
+    "rootDir": "../",
+    "baseUrl": "."
   }
 }

--- a/packages/core/email/server/tsconfig.build.json
+++ b/packages/core/email/server/tsconfig.build.json
@@ -1,9 +1,10 @@
 {
   "extends": "./server/tsconfig.json",
-  "include": ["./server/src"],
+  "include": ["./src", "../shared"],
   "exclude": ["./server/src/**/*.test.ts"],
   "compilerOptions": {
-    "rootDir": ".",
+    "rootDir": "../",
+    "baseUrl": ".",
     "outDir": "./dist"
   }
 }

--- a/packages/core/email/server/tsconfig.json
+++ b/packages/core/email/server/tsconfig.json
@@ -1,8 +1,9 @@
 {
   "extends": "tsconfig/base.json",
-  "include": ["src"],
-  "exclude": ["node_modules"],
+  "include": ["./src", "../shared"],
   "compilerOptions": {
+    "rootDir": "../",
+    "baseUrl": ".",
     "esModuleInterop": true
   }
 }

--- a/packages/core/types/src/types/core/attributes/json.ts
+++ b/packages/core/types/src/types/core/attributes/json.ts
@@ -13,7 +13,7 @@ type JSONValue = string | number | boolean | null | JSONObject | JSONArray;
 
 type JSONArray = Array<JSONValue>;
 
-interface JSONObject {
+export interface JSONObject {
   [key: string]: JSONValue;
 }
 

--- a/packages/plugins/cloud/admin/tsconfig.build.json
+++ b/packages/plugins/cloud/admin/tsconfig.build.json
@@ -1,9 +1,10 @@
 {
-  "extends": "./admin/tsconfig.json",
-  "include": ["./admin/src", "./admin/*.d.ts"],
+  "extends": "./tsconfig.json",
+  "include": ["./src", "*.d.ts"],
   "exclude": ["**/*.test.tsx"],
   "compilerOptions": {
-    "rootDir": "./admin/src",
-    "outDir": "./dist/admin"
+    "rootDir": "../",
+    "baseUrl": ".",
+    "outDir": "./dist"
   }
 }

--- a/packages/plugins/cloud/admin/tsconfig.json
+++ b/packages/plugins/cloud/admin/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "tsconfig/client.json",
-  "include": ["src", "global.d.ts", "module.d.ts"],
-  "exclude": ["node_modules"]
+  "include": ["./src", "*.d.ts"],
+  "compilerOptions": {
+    "rootDir": "../",
+    "baseUrl": "."
+  }
 }

--- a/packages/plugins/cloud/package.json
+++ b/packages/plugins/cloud/package.json
@@ -17,7 +17,7 @@
   ],
   "exports": {
     "./strapi-admin": {
-      "types": "./dist/admin/index.d.ts",
+      "types": "./dist/admin/src/index.d.ts",
       "source": "./admin/src/index.ts",
       "import": "./dist/admin/index.mjs",
       "require": "./dist/admin/index.js",

--- a/packages/plugins/color-picker/admin/tsconfig.build.json
+++ b/packages/plugins/color-picker/admin/tsconfig.build.json
@@ -1,8 +1,10 @@
 {
-  "extends": "./admin/tsconfig.json",
-  "include": ["./admin/src"],
+  "extends": "./tsconfig.json",
+  "include": ["./src"],
   "exclude": ["**/*.test.tsx"],
   "compilerOptions": {
-    "outDir": "./dist/admin"
+    "rootDir": "../",
+    "baseUrl": ".",
+    "outDir": "./dist"
   }
 }

--- a/packages/plugins/color-picker/admin/tsconfig.json
+++ b/packages/plugins/color-picker/admin/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "tsconfig/client.json",
   "include": ["./src"],
-  "exclude": ["node_modules"]
+  "compilerOptions": {
+    "rootDir": "../",
+    "baseUrl": "."
+  }
 }

--- a/packages/plugins/color-picker/package.json
+++ b/packages/plugins/color-picker/package.json
@@ -22,14 +22,14 @@
   ],
   "exports": {
     "./strapi-admin": {
-      "types": "./dist/admin/index.d.ts",
+      "types": "./dist/admin/src/index.d.ts",
       "source": "./admin/src/index.ts",
       "import": "./dist/admin/index.mjs",
       "require": "./dist/admin/index.js",
       "default": "./dist/admin/index.js"
     },
     "./strapi-server": {
-      "types": "./dist/server/index.d.ts",
+      "types": "./dist/server/src/index.d.ts",
       "source": "./server/src/index.ts",
       "import": "./dist/server/index.mjs",
       "require": "./dist/server/index.js",

--- a/packages/plugins/color-picker/server/tsconfig.build.json
+++ b/packages/plugins/color-picker/server/tsconfig.build.json
@@ -1,8 +1,10 @@
 {
-  "extends": "./server/tsconfig.json",
-  "include": ["./server/src"],
+  "extends": "./tsconfig.json",
+  "include": ["./src"],
   "exclude": ["**/*.test.ts"],
   "compilerOptions": {
-    "outDir": "./dist/server"
+    "rootDir": "../",
+    "baseUrl": ".",
+    "outDir": "./dist"
   }
 }

--- a/packages/plugins/color-picker/server/tsconfig.json
+++ b/packages/plugins/color-picker/server/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "tsconfig/base.json",
   "include": ["./src"],
-  "exclude": ["node_modules"]
+  "compilerOptions": {
+    "rootDir": "../",
+    "baseUrl": "."
+  }
 }

--- a/packages/plugins/graphql/admin/tsconfig.build.json
+++ b/packages/plugins/graphql/admin/tsconfig.build.json
@@ -1,8 +1,10 @@
 {
-  "extends": "./admin/tsconfig.json",
-  "include": ["./admin/src"],
+  "extends": "./tsconfig.json",
+  "include": ["./src"],
   "exclude": ["**/*.test.tsx"],
   "compilerOptions": {
-    "outDir": "./dist/admin"
+    "rootDir": "../",
+    "baseUrl": ".",
+    "outDir": "./dist"
   }
 }

--- a/packages/plugins/graphql/admin/tsconfig.json
+++ b/packages/plugins/graphql/admin/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "tsconfig/client.json",
   "include": ["./src"],
-  "exclude": ["node_modules"]
+  "compilerOptions": {
+    "rootDir": "../",
+    "baseUrl": "."
+  }
 }

--- a/packages/plugins/graphql/package.json
+++ b/packages/plugins/graphql/package.json
@@ -22,14 +22,14 @@
   ],
   "exports": {
     "./strapi-admin": {
-      "types": "./dist/admin/index.d.ts",
+      "types": "./dist/admin/src/index.d.ts",
       "source": "./admin/src/index.ts",
       "import": "./dist/admin/index.mjs",
       "require": "./dist/admin/index.js",
       "default": "./dist/admin/index.js"
     },
     "./strapi-server": {
-      "types": "./dist/server/index.d.ts",
+      "types": "./dist/server/src/index.d.ts",
       "source": "./server/src/index.ts",
       "import": "./dist/server/index.mjs",
       "require": "./dist/server/index.js",

--- a/packages/plugins/graphql/server/tsconfig.build.json
+++ b/packages/plugins/graphql/server/tsconfig.build.json
@@ -1,8 +1,10 @@
 {
-  "extends": "./server/tsconfig.json",
-  "include": ["./server/src"],
-  "exclude": ["node_modules", "**/*.test.ts"],
+  "extends": "./tsconfig.json",
+  "include": ["./src"],
+  "exclude": ["**/*.test.ts"],
   "compilerOptions": {
-    "outDir": "./dist/server"
+    "rootDir": "../",
+    "baseUrl": ".",
+    "outDir": "./dist"
   }
 }

--- a/packages/plugins/graphql/server/tsconfig.json
+++ b/packages/plugins/graphql/server/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "tsconfig/base.json",
   "include": ["./src"],
-  "exclude": ["node_modules"]
+  "compilerOptions": {
+    "rootDir": "../",
+    "baseUrl": "."
+  }
 }

--- a/packages/plugins/i18n/admin/tsconfig.build.json
+++ b/packages/plugins/i18n/admin/tsconfig.build.json
@@ -1,9 +1,10 @@
 {
-  "extends": "./admin/tsconfig.json",
-  "include": ["./admin/src", "./shared"],
+  "extends": "./tsconfig.json",
+  "include": ["./src", "../shared"],
   "exclude": ["tests", "**/*.test.*"],
   "compilerOptions": {
-    "rootDir": ".",
+    "rootDir": "../",
+    "baseUrl": ".",
     "outDir": "./dist"
   }
 }

--- a/packages/plugins/i18n/admin/tsconfig.json
+++ b/packages/plugins/i18n/admin/tsconfig.json
@@ -1,12 +1,11 @@
 {
   "extends": "tsconfig/client.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "rootDir": "../",
+    "baseUrl": ".",
     "paths": {
       "@tests/*": ["./tests/*"]
     }
   },
-  "include": ["src", "../shared", "tests"],
-  "exclude": ["node_modules"]
+  "include": ["src", "../shared", "tests"]
 }

--- a/packages/plugins/i18n/package.json
+++ b/packages/plugins/i18n/package.json
@@ -22,14 +22,14 @@
   ],
   "exports": {
     "./strapi-admin": {
-      "types": "./dist/admin/index.d.ts",
+      "types": "./dist/admin/src/index.d.ts",
       "source": "./admin/src/index.ts",
       "import": "./dist/admin/index.mjs",
       "require": "./dist/admin/index.js",
       "default": "./dist/admin/index.js"
     },
     "./strapi-server": {
-      "types": "./dist/server/index.d.ts",
+      "types": "./dist/server/src/index.d.ts",
       "source": "./server/src/index.ts",
       "import": "./dist/server/index.mjs",
       "require": "./dist/server/index.js",

--- a/packages/plugins/i18n/server/tsconfig.build.json
+++ b/packages/plugins/i18n/server/tsconfig.build.json
@@ -1,8 +1,10 @@
 {
-  "extends": "./server/tsconfig.json",
-  "include": ["./server/src"],
+  "extends": "./tsconfig.json",
+  "include": ["./src"],
   "exclude": ["node_modules", "**/*.test.ts"],
   "compilerOptions": {
-    "outDir": "./dist/server"
+    "rootDir": "../",
+    "baseUrl": ".",
+    "outDir": "./dist"
   }
 }

--- a/packages/plugins/i18n/server/tsconfig.json
+++ b/packages/plugins/i18n/server/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "tsconfig/base.json",
   "include": ["./src"],
-  "exclude": ["node_modules"]
+  "compilerOptions": {
+    "rootDir": "../",
+    "baseUrl": "."
+  }
 }

--- a/packages/utils/pack-up/src/node/core/tsconfig.ts
+++ b/packages/utils/pack-up/src/node/core/tsconfig.ts
@@ -1,4 +1,5 @@
 import os from 'os';
+import nodePath from 'path';
 import ts from 'typescript';
 
 import { Logger } from './logger';
@@ -23,7 +24,11 @@ const loadTsConfig = ({
       path: string;
     }
   | undefined => {
-  const configPath = ts.findConfigFile(cwd, ts.sys.fileExists, path);
+  const providedPath = path.split(nodePath.sep);
+  const [configFileName] = providedPath.slice(-1);
+  const pathToConfig = nodePath.join(cwd, providedPath.slice(0, -1).join(nodePath.sep));
+
+  const configPath = ts.findConfigFile(pathToConfig, ts.sys.fileExists, configFileName);
 
   if (!configPath) {
     return undefined;
@@ -31,7 +36,7 @@ const loadTsConfig = ({
 
   const configFile = ts.readConfigFile(configPath, ts.sys.readFile);
 
-  const parsedConfig = ts.parseJsonConfigFileContent(configFile.config, ts.sys, cwd);
+  const parsedConfig = ts.parseJsonConfigFileContent(configFile.config, ts.sys, pathToConfig);
 
   logger.debug(`Loaded user TS config:`, os.EOL, parsedConfig);
 

--- a/packages/utils/pack-up/tsconfig.build.json
+++ b/packages/utils/pack-up/tsconfig.build.json
@@ -5,5 +5,5 @@
     "outDir": "./dist"
   },
   "include": ["src"],
-  "exclude": ["tests", "**/__tests__/**", "**/cli/**", "./src/types.ts"]
+  "exclude": ["tests", "**/__tests__/**", "**/cli/**"]
 }


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* fixes pack-up build to correctly pass the config name & path correctly
* refactor the `tsconfig.build`'s of projects to reflect this change
* refactors `admin/permission` type hierarchy so the `shared` folder is "the bottom"

### Why is it needed?

* It was causing weird TS issues not picking up `custom.d.ts`
* There was a confusing mismatch in behaviour between the `build` and `watch` command
* the admin thought it should import server code – not nice

### How to test it?

* run build
* run watch
* they should behave the same

### Related issue(s)/PR(s)

* resolves CONTENT-2011
