### PR TITLE
Fix issues with case sensitive email addresses sent by some SSO providers

### DIFF
--- a/packages/core/admin/server/services/__tests__/user.test.js
+++ b/packages/core/admin/server/services/__tests__/user.test.js
@@ -489,6 +489,21 @@ describe('User', () => {
 
       expect(res).toBeNull();
     });
+
+    test('Using findOneByEmail should make a case insensitive lookup', async () => {
+      const findOne = jest.fn();
+      const fakeEmail = 'admin@admin.com';
+
+      global.strapi = { query: () => ({ findOne }) };
+
+      await userService.findOneByEmail(fakeEmail);
+
+      expect(findOne).toHaveBeenCalledWith({
+        where: { email: { $eqi: fakeEmail } },
+        //                  ^ Case Insensitive $eq
+        populate: [],
+      });
+    });
   });
 
   describe('findRegistrationInfo', () => {

--- a/packages/core/admin/server/services/user.js
+++ b/packages/core/admin/server/services/user.js
@@ -199,10 +199,7 @@ const findOne = async (id, populate = ['roles']) => {
  * @returns
  */
 const findOneByEmail = async (email, populate = []) => {
-  return strapi.query('admin::user').findOne({
-    where: { email },
-    populate,
-  });
+  return strapi.query('admin::user').findOne({ where: { email: { $eqi: email } }, populate });
 };
 
 /** Find many users (paginated)


### PR DESCRIPTION
### What does it do?

Use a case-insensitive lookup for admin users in the findOneByEmail method of the user service.

### Why is it needed?

See #16982

### How to test it?

- Manually by executing `yarn strapi console` and then making a manual query to the admin user service.
- Or just by running the unit tests

### Related issue(s)/PR(s)

fix https://github.com/strapi/strapi/issues/16982