### PR TITLE
chore: remove ee direct imports

### DIFF
--- a/api-tests/core/admin/admin-permission.test.api.js
+++ b/api-tests/core/admin/admin-permission.test.api.js
@@ -33,9 +33,7 @@ describe('Role CRUD End to End', () => {
     });
     sortedData.conditions = sortedData.conditions.sort();
 
-    // eslint-disable-next-line node/no-extraneous-require
-    const { features } = require('@strapi/strapi/dist/utils/ee');
-    const hasSSO = features.isEnabled('sso');
+    const hasSSO = strapi.ee.features.isEnabled('sso');
 
     if (hasSSO) {
       expect(sortedData).toMatchInlineSnapshot(`

--- a/api-tests/core/admin/ee/provider-login.test.api.js
+++ b/api-tests/core/admin/ee/provider-login.test.api.js
@@ -54,7 +54,7 @@ describeOnCondition(edition === 'EE')('Provider Login', () => {
     strapi = await createStrapiInstance();
     utils = createUtils(strapi);
     // eslint-disable-next-line node/no-extraneous-require
-    hasSSO = require('@strapi/strapi/dist/utils/ee').features.isEnabled('sso');
+    hasSSO = strapi.ee.features.isEnabled('sso');
 
     await createFixtures();
 

--- a/api-tests/core/admin/ee/provider-options.test.api.js
+++ b/api-tests/core/admin/ee/provider-options.test.api.js
@@ -53,8 +53,7 @@ describeOnCondition(edition === 'EE')('SSO Provider Options', () => {
   beforeAll(async () => {
     strapi = await createStrapiInstance();
     utils = createUtils(strapi);
-    // eslint-disable-next-line node/no-extraneous-require
-    hasSSO = require('@strapi/strapi/dist/utils/ee').features.isEnabled('sso');
+    hasSSO = strapi.ee.features.isEnabled('sso');
 
     await createFixtures();
 

--- a/api-tests/core/admin/ee/review-workflows.test.api.ts
+++ b/api-tests/core/admin/ee/review-workflows.test.api.ts
@@ -99,11 +99,12 @@ describeOnCondition(edition === 'EE')('Review workflows', () => {
 
   beforeAll(async () => {
     await builder.addContentTypes([model]).build();
-    // eslint-disable-next-line node/no-extraneous-require
-    hasRW = require('@strapi/strapi/dist/utils/ee').features.isEnabled('review-workflows');
 
     // @ts-expect-error - We don't have the type for this
     strapi = await createStrapiInstance({ bypassAuth: false });
+
+    hasRW = strapi.ee.features.isEnabled('review-workflows');
+
     requests.admin = await createAuthRequest({ strapi });
     // @ts-expect-error - We don't have the type for this
     requests.public = createRequest({ strapi }).setToken(await getFullAccessToken());

--- a/packages/core/admin/_internal/node/build.ts
+++ b/packages/core/admin/_internal/node/build.ts
@@ -4,7 +4,7 @@ import { writeStaticClientFiles } from './staticFiles';
 import { build as buildWebpack } from './webpack/build';
 import { createBuildContext } from './createBuildContext';
 
-import EE from '@strapi/strapi/dist/utils/ee';
+// import EE from '@strapi/strapi/dist/utils/ee';
 import { getTimer } from './core/timer';
 
 import type { CLIContext } from '@strapi/strapi';
@@ -79,8 +79,6 @@ const build = async ({ logger, cwd, tsconfig, ignorePrompts, ...options }: Build
   console.log('');
 
   try {
-    EE.init(cwd);
-
     await writeStaticClientFiles(ctx);
     await buildWebpack(ctx);
 

--- a/packages/core/admin/_internal/node/develop.ts
+++ b/packages/core/admin/_internal/node/develop.ts
@@ -10,7 +10,7 @@ import { createBuildContext } from './createBuildContext';
 import { WebpackWatcher, watch as watchWebpack } from './webpack/watch';
 import { build as buildWebpack } from './webpack/build';
 
-import EE from '@strapi/strapi/dist/utils/ee';
+// import EE from '@strapi/strapi/dist/utils/ee';
 import { writeStaticClientFiles } from './staticFiles';
 import strapiFactory from '@strapi/strapi';
 
@@ -70,7 +70,6 @@ const develop = async ({
       timer.start('creatingAdmin');
       const adminSpinner = logger.spinner(`Creating admin`).start();
 
-      EE.init(cwd);
       await writeStaticClientFiles(ctx);
       await buildWebpack(ctx);
 
@@ -147,7 +146,6 @@ const develop = async ({
       timer.start('creatingAdmin');
       const adminSpinner = logger.spinner(`Creating admin`).start();
 
-      EE.init(cwd);
       await writeStaticClientFiles(ctx);
       webpackWatcher = await watchWebpack(ctx);
 

--- a/packages/core/admin/ee/server/src/bootstrap.ts
+++ b/packages/core/admin/ee/server/src/bootstrap.ts
@@ -1,4 +1,3 @@
-import EE from '@strapi/strapi/dist/utils/ee';
 import executeCEBootstrap from '../../../server/src/bootstrap';
 import { getService } from '../../server/src/utils';
 import actions from './config/admin-actions';
@@ -6,14 +5,14 @@ import { persistTablesWithPrefix } from './utils/persisted-tables';
 
 export default async (args: any) => {
   const { actionProvider } = getService('permission');
-  if (EE.features.isEnabled('sso')) {
+  if (strapi.ee.features.isEnabled('sso')) {
     await actionProvider.registerMany(actions.sso);
   }
-  if (EE.features.isEnabled('audit-logs')) {
+  if (strapi.ee.features.isEnabled('audit-logs')) {
     await persistTablesWithPrefix('strapi_audit_logs');
     await actionProvider.registerMany(actions.auditLogs);
   }
-  if (EE.features.isEnabled('review-workflows')) {
+  if (strapi.ee.features.isEnabled('review-workflows')) {
     await persistTablesWithPrefix('strapi_workflows');
     const { bootstrap: rwBootstrap } = getService('review-workflows');
     await rwBootstrap();

--- a/packages/core/admin/ee/server/src/controllers/admin.ts
+++ b/packages/core/admin/ee/server/src/controllers/admin.ts
@@ -1,5 +1,4 @@
 import { isNil } from 'lodash/fp';
-import ee from '@strapi/strapi/dist/utils/ee';
 import { env } from '@strapi/utils';
 import { getService } from '../utils';
 
@@ -8,14 +7,14 @@ export default {
   async getProjectType() {
     const flags = strapi.config.get('admin.flags', {});
     try {
-      return { data: { isEE: strapi.EE, features: ee.features.list(), flags } };
+      return { data: { isEE: strapi.EE, features: strapi.ee.features.list(), flags } };
     } catch (err) {
       return { data: { isEE: false, features: [], flags } };
     }
   },
 
   async licenseLimitInformation() {
-    const permittedSeats = ee.seats;
+    const permittedSeats = strapi.ee.seats;
 
     let shouldNotify = false;
     let licenseLimitStatus = null;
@@ -49,7 +48,7 @@ export default {
       shouldStopCreate: isNil(permittedSeats) ? false : currentActiveUserCount >= permittedSeats,
       licenseLimitStatus,
       isHostedOnStrapiCloud: env('STRAPI_HOSTING', null) === 'strapi.cloud',
-      features: ee.features.list() ?? [],
+      features: strapi.ee.features.list() ?? [],
     };
 
     return { data };

--- a/packages/core/admin/ee/server/src/controllers/user.ts
+++ b/packages/core/admin/ee/server/src/controllers/user.ts
@@ -1,6 +1,5 @@
 import type { Context } from 'koa';
 
-import ee from '@strapi/strapi/dist/utils/ee';
 import _ from 'lodash';
 import { pick, isNil } from 'lodash/fp';
 import { errors } from '@strapi/utils';
@@ -18,7 +17,7 @@ const hasAdminSeatsAvaialble = async () => {
     return true;
   }
 
-  const permittedSeats = ee.seats as any;
+  const permittedSeats = strapi.ee.seats as any;
   if (isNil(permittedSeats)) {
     return true;
   }

--- a/packages/core/admin/ee/server/src/destroy.ts
+++ b/packages/core/admin/ee/server/src/destroy.ts
@@ -1,9 +1,8 @@
 import { Strapi } from '@strapi/types';
-import EE from '@strapi/strapi/dist/utils/ee';
 import executeCEDestroy from '../../../server/src/destroy';
 
 export default async ({ strapi }: { strapi: Strapi }) => {
-  if (EE.features.isEnabled('audit-logs')) {
+  if (strapi.ee.features.isEnabled('audit-logs')) {
     strapi.get('audit-logs').destroy();
   }
 

--- a/packages/core/admin/ee/server/src/register.ts
+++ b/packages/core/admin/ee/server/src/register.ts
@@ -1,5 +1,4 @@
 import { LoadedStrapi as Strapi } from '@strapi/types';
-import EE from '@strapi/strapi/dist/utils/ee';
 import executeCERegister from '../../../server/src/register';
 import migrateAuditLogsTable from './migrations/audit-logs-table';
 import migrateReviewWorkflowStagesColor from './migrations/review-workflows-stages-color';
@@ -21,7 +20,7 @@ export default async ({ strapi }: { strapi: Strapi }) => {
     strapi.add('audit-logs', auditLogsService);
     await auditLogsService.register();
   }
-  if (EE.features.isEnabled('review-workflows')) {
+  if (strapi.ee.features.isEnabled('review-workflows')) {
     strapi.hook('strapi::content-types.beforeSync').register(migrateStageAttribute);
     strapi
       .hook('strapi::content-types.afterSync')
@@ -33,7 +32,7 @@ export default async ({ strapi }: { strapi: Strapi }) => {
     const reviewWorkflowService = getService('review-workflows');
 
     reviewWorkflowsMiddlewares.contentTypeMiddleware(strapi);
-    await reviewWorkflowService.register(EE.features.get('review-workflows'));
+    await reviewWorkflowService.register(strapi.ee.features.get('review-workflows'));
   }
   await executeCERegister({ strapi });
 };

--- a/packages/core/admin/ee/server/src/routes/utils.ts
+++ b/packages/core/admin/ee/server/src/routes/utils.ts
@@ -1,9 +1,8 @@
-import EE from '@strapi/strapi/dist/utils/ee';
 import { Common } from '@strapi/types';
 
 export const enableFeatureMiddleware: Common.MiddlewareFactory =
   (featureName: string) => (ctx, next) => {
-    if (EE.features.isEnabled(featureName)) {
+    if (strapi.ee.features.isEnabled(featureName)) {
       return next();
     }
 

--- a/packages/core/admin/ee/server/src/services/__tests__/assignees.test.ts
+++ b/packages/core/admin/ee/server/src/services/__tests__/assignees.test.ts
@@ -1,20 +1,3 @@
-jest.mock('@strapi/strapi/dist/utils/ee', () => {
-  const eeModule = () => true;
-
-  Object.assign(eeModule, {
-    features: {
-      isEnabled() {
-        return true;
-      },
-      getEnabled() {
-        return ['review-workflows'];
-      },
-    },
-  });
-
-  return eeModule;
-});
-
 import { ENTITY_ASSIGNEE_ATTRIBUTE } from '../../constants/workflows';
 import assigneeFactory from '../review-workflows/assignees';
 
@@ -44,6 +27,17 @@ const strapiMock = {
   service: jest.fn((serviceName) => {
     return servicesMock[serviceName];
   }),
+  EE: true,
+  ee: {
+    features: {
+      isEnabled() {
+        return true;
+      },
+      getEnabled() {
+        return ['review-workflows'];
+      },
+    },
+  },
 };
 
 // @ts-expect-error - use strapi mock

--- a/packages/core/admin/ee/server/src/services/__tests__/passport.test.ts
+++ b/packages/core/admin/ee/server/src/services/__tests__/passport.test.ts
@@ -6,12 +6,6 @@ jest.mock('koa-passport', () => ({
 import passport from 'koa-passport';
 
 let ssoEnabled = true;
-jest.mock('@strapi/strapi/dist/utils/ee', () => ({
-  features: {
-    // Disable the SSO feature
-    isEnabled: () => ssoEnabled,
-  },
-}));
 
 import passportService from '../../../../../server/src/services/passport';
 import eePassportService from '../passport';
@@ -19,6 +13,18 @@ import eePassportService from '../passport';
 const { init } = passportService;
 
 describe('Passport', () => {
+  beforeAll(() => {
+    global.strapi = {
+      ee: {
+        features: {
+          isEnabled: jest.fn(() => {
+            return ssoEnabled;
+          }),
+        },
+      },
+    } as any;
+  });
+
   afterEach(() => {
     // Reset the mock on passport.use.toHaveBeenCalledTimes
     jest.clearAllMocks();
@@ -36,6 +42,7 @@ describe('Passport', () => {
       const { getPassportStrategies } = eePassportService;
 
       global.strapi = {
+        ...global.strapi,
         admin: {
           services: {
             passport: { getPassportStrategies },
@@ -69,6 +76,7 @@ describe('Passport', () => {
       const { getPassportStrategies } = eePassportService;
 
       global.strapi = {
+        ...global.strapi,
         admin: {
           services: {
             passport: { getPassportStrategies },

--- a/packages/core/admin/ee/server/src/services/__tests__/review-workflows-validation.test.ts
+++ b/packages/core/admin/ee/server/src/services/__tests__/review-workflows-validation.test.ts
@@ -1,20 +1,3 @@
-jest.mock('@strapi/strapi/dist/utils/ee', () => {
-  const eeModule = () => true;
-
-  Object.assign(eeModule, {
-    features: {
-      isEnabled() {
-        return true;
-      },
-      getEnabled() {
-        return ['review-workflows'];
-      },
-    },
-  });
-
-  return eeModule;
-});
-
 jest.mock('../review-workflows/workflows/content-types', () => {
   return jest.fn(() => ({
     migrate: jest.fn(),
@@ -35,6 +18,17 @@ const servicesMock: Record<string, any> = {
 
 const strapiMock = {
   service: jest.fn((serviceName) => servicesMock[serviceName]),
+  EE: true,
+  ee: {
+    features: {
+      isEnabled() {
+        return true;
+      },
+      getEnabled() {
+        return ['review-workflows'];
+      },
+    },
+  },
 } as unknown as LoadedStrapi;
 
 let validationService: any;

--- a/packages/core/admin/ee/server/src/services/__tests__/sso.test.ts
+++ b/packages/core/admin/ee/server/src/services/__tests__/sso.test.ts
@@ -1,14 +1,3 @@
-jest.mock('@strapi/strapi/dist/utils/ee', () => ({
-  features: {
-    isEnabled() {
-      return true;
-    },
-    list() {
-      return [{ name: 'sso' }];
-    },
-  },
-}));
-
 import {
   syncProviderRegistryWithConfig,
   getStrategyCallbackURL,
@@ -17,6 +6,21 @@ import {
 import createProviderRegistry from '../passport/provider-registry';
 
 describe('SSO', () => {
+  beforeEach(() => {
+    global.strapi = {
+      ee: {
+        features: {
+          isEnabled() {
+            return true;
+          },
+          list() {
+            return [{ name: 'sso' }];
+          },
+        },
+      },
+    } as any;
+  });
+
   afterEach(() => {
     providerRegistry.clear();
   });
@@ -27,6 +31,7 @@ describe('SSO', () => {
   describe('Sync Provider Registry with Config', () => {
     test('The provider registry should match the auth config', async () => {
       global.strapi = {
+        ...global.strapi,
         config: {
           get: () => ({
             providers: [{ uid: 'foo' }, { uid: 'bar' }],
@@ -58,7 +63,7 @@ describe('SSO', () => {
     const barProvider = { uid: 'bar', createStrategy: jest.fn() };
 
     beforeEach(() => {
-      global.strapi = { isLoaded: false } as any;
+      global.strapi = { ...global.strapi, isLoaded: false } as any;
     });
 
     afterEach(() => {
@@ -67,7 +72,7 @@ describe('SSO', () => {
     });
 
     test('Cannot register after bootstrap', () => {
-      global.strapi = { isLoaded: true } as any;
+      global.strapi = { ...global.strapi, isLoaded: true } as any;
 
       const fn = () => registry.register(fooProvider);
 

--- a/packages/core/admin/ee/server/src/services/__tests__/stages.test.ts
+++ b/packages/core/admin/ee/server/src/services/__tests__/stages.test.ts
@@ -1,20 +1,3 @@
-jest.mock('@strapi/strapi/dist/utils/ee', () => {
-  const eeModule = () => true;
-
-  Object.assign(eeModule, {
-    features: {
-      isEnabled() {
-        return true;
-      },
-      getEnabled() {
-        return ['review-workflows'];
-      },
-    },
-  });
-
-  return eeModule;
-});
-
 import { LoadedStrapi } from '@strapi/types';
 import { cloneDeep } from 'lodash/fp';
 import stageFactory from '../review-workflows/stages';
@@ -87,6 +70,17 @@ const servicesMock: Record<string, any> = {
 const queryUpdateMock = jest.fn(() => Promise.resolve());
 
 const strapiMock = {
+  EE: true,
+  ee: {
+    features: {
+      isEnabled() {
+        return true;
+      },
+      getEnabled() {
+        return ['review-workflows'];
+      },
+    },
+  },
   query: jest.fn(() => ({
     findOne: jest.fn(() => workflowMock),
   })),

--- a/packages/core/admin/ee/server/src/services/__tests__/workflows.test.ts
+++ b/packages/core/admin/ee/server/src/services/__tests__/workflows.test.ts
@@ -1,20 +1,3 @@
-jest.mock('@strapi/strapi/dist/utils/ee', () => {
-  const eeModule = () => true;
-
-  Object.assign(eeModule, {
-    features: {
-      isEnabled() {
-        return true;
-      },
-      getEnabled() {
-        return ['review-workflows'];
-      },
-    },
-  });
-
-  return eeModule;
-});
-
 jest.mock('../review-workflows/workflows/content-types', () => {
   return jest.fn(() => ({
     migrate: jest.fn(),
@@ -79,6 +62,17 @@ const servicesMock: Record<string, any> = {
 };
 
 const strapiMock = {
+  EE: true,
+  ee: {
+    features: {
+      isEnabled() {
+        return true;
+      },
+      getEnabled() {
+        return ['review-workflows'];
+      },
+    },
+  },
   entityService: entityServiceMock,
   plugin: jest.fn((name) => pluginsMock[name]),
   service: jest.fn((serviceName) => servicesMock[serviceName]),

--- a/packages/core/admin/ee/server/src/services/audit-logs.ts
+++ b/packages/core/admin/ee/server/src/services/audit-logs.ts
@@ -1,7 +1,6 @@
 import { LoadedStrapi } from '@strapi/types';
 import localProvider from '@strapi/provider-audit-logs-local';
 import { scheduleJob } from 'node-schedule';
-import EE from '@strapi/strapi/dist/utils/ee';
 
 const DEFAULT_RETENTION_DAYS = 90;
 
@@ -63,8 +62,7 @@ const getEventMap = (defaultEvents: any) => {
 };
 
 const getRetentionDays = (strapi: LoadedStrapi) => {
-  // @ts-expect-error - options is not typed into features
-  const licenseRetentionDays = EE.features.get('audit-logs')?.options.retentionDays;
+  const licenseRetentionDays = strapi.ee.features.get('audit-logs')?.options.retentionDays;
   const userRetentionDays = strapi.config.get('admin.auditLogs.retentionDays');
 
   // For enterprise plans, use 90 days by default, but allow users to override it
@@ -166,7 +164,7 @@ const createAuditLogsService = (strapi: LoadedStrapi) => {
       state.provider = await localProvider.register({ strapi });
 
       // Check current state of license
-      if (!EE.features.isEnabled('audit-logs')) {
+      if (!strapi.ee.features.isEnabled('audit-logs')) {
         return this;
       }
 

--- a/packages/core/admin/ee/server/src/services/passport.ts
+++ b/packages/core/admin/ee/server/src/services/passport.ts
@@ -1,5 +1,3 @@
-import EE from '@strapi/strapi/dist/utils/ee';
-
 import { errors } from '@strapi/utils';
 import createLocalStrategy from '../../../../server/src/services/passport/local-strategy';
 import sso from './passport/sso';
@@ -23,7 +21,7 @@ const localStrategyMiddleware = async ([error, user, message]: any, done: any) =
 };
 
 const getPassportStrategies = () => {
-  if (!EE.features.isEnabled('sso')) {
+  if (!strapi.ee.features.isEnabled('sso')) {
     return [createLocalStrategy(strapi)];
   }
 

--- a/packages/core/admin/ee/server/src/services/passport/sso.ts
+++ b/packages/core/admin/ee/server/src/services/passport/sso.ts
@@ -1,5 +1,4 @@
 import '@strapi/types';
-import EE from '@strapi/strapi/dist/utils/ee';
 import passport from '../../../../../server/src/services/passport';
 import createProviderRegistry from './provider-registry';
 
@@ -7,7 +6,7 @@ export const providerRegistry = createProviderRegistry();
 const errorMessage = 'SSO is disabled. Its functionnalities cannot be accessed.';
 
 export const getStrategyCallbackURL = (providerName: string) => {
-  if (!EE.features.isEnabled('sso')) {
+  if (!strapi.ee.features.isEnabled('sso')) {
     throw new Error(errorMessage);
   }
 
@@ -15,7 +14,7 @@ export const getStrategyCallbackURL = (providerName: string) => {
 };
 
 export const syncProviderRegistryWithConfig = () => {
-  if (!EE.features.isEnabled('sso')) {
+  if (!strapi.ee.features.isEnabled('sso')) {
     throw new Error(errorMessage);
   }
 

--- a/packages/core/admin/ee/server/src/services/seat-enforcement.ts
+++ b/packages/core/admin/ee/server/src/services/seat-enforcement.ts
@@ -1,5 +1,3 @@
-// eslint-disable-next-line node/no-extraneous-require
-import ee from '@strapi/strapi/dist/utils/ee';
 import { take, drop, map, prop, pick, reverse, isNil } from 'lodash/fp';
 import { getService } from '../utils';
 import constants from '../../../../server/src/services/constants';
@@ -89,7 +87,7 @@ const syncDisabledUserRecords = async () => {
 };
 
 const seatEnforcementWorkflow = async () => {
-  const adminSeats = ee.seats;
+  const adminSeats = strapi.ee.seats;
   if (isNil(adminSeats)) {
     return;
   }

--- a/packages/core/admin/ee/server/src/utils/__tests__/sso-lock.test.ts
+++ b/packages/core/admin/ee/server/src/utils/__tests__/sso-lock.test.ts
@@ -3,16 +3,6 @@ import { isSsoLocked } from '../sso-lock';
 // allow toggling the feature within tests
 let ssoEnabled = true;
 
-jest.mock('@strapi/strapi/dist/utils/ee', () => {
-  return {
-    features: {
-      isEnabled() {
-        return ssoEnabled;
-      },
-    },
-  };
-});
-
 describe('isSsoLocked', () => {
   const lockedRoles = ['1', '2'];
 
@@ -53,6 +43,13 @@ describe('isSsoLocked', () => {
         }),
       };
     }),
+    ee: {
+      features: {
+        isEnabled() {
+          return ssoEnabled;
+        },
+      },
+    },
   } as any;
 
   afterEach(() => {

--- a/packages/core/admin/ee/server/src/utils/sso-lock.ts
+++ b/packages/core/admin/ee/server/src/utils/sso-lock.ts
@@ -1,8 +1,7 @@
-import EE from '@strapi/strapi/dist/utils/ee';
 import { isEmpty } from 'lodash/fp';
 
 export const isSsoLocked = async (user: any) => {
-  if (!EE.features.isEnabled('sso')) {
+  if (!strapi.ee.features.isEnabled('sso')) {
     return false;
   }
 

--- a/packages/core/admin/ee/server/src/validation/role.ts
+++ b/packages/core/admin/ee/server/src/validation/role.ts
@@ -1,5 +1,4 @@
 import { yup, validateYupSchema } from '@strapi/utils';
-import EE from '@strapi/strapi/dist/utils/ee';
 
 const roleCreateSchema = yup
   .object()
@@ -24,7 +23,7 @@ const rolesDeleteSchema = yup
           try {
             await strapi.admin.services.role.checkRolesIdForDeletion(ids);
 
-            if (EE.features.isEnabled('sso')) {
+            if (strapi.ee.features.isEnabled('sso')) {
               await strapi.admin.services.role.ssoCheckRolesIdForDeletion(ids);
             }
           } catch (e: any) {
@@ -47,7 +46,7 @@ const roleDeleteSchema = yup
       try {
         await strapi.admin.services.role.checkRolesIdForDeletion([id]);
 
-        if (EE.features.isEnabled('sso')) {
+        if (strapi.ee.features.isEnabled('sso')) {
           await strapi.admin.services.role.ssoCheckRolesIdForDeletion([id]);
         }
       } catch (e: any) {

--- a/packages/core/admin/ee/server/src/validation/user.ts
+++ b/packages/core/admin/ee/server/src/validation/user.ts
@@ -1,5 +1,4 @@
 import { yup, validateYupSchema } from '@strapi/utils';
-import EE from '@strapi/strapi/dist/utils/ee';
 import { schemas } from '../../../../server/src/validation/user';
 
 const ssoUserCreationInputExtension = yup
@@ -12,7 +11,7 @@ const ssoUserCreationInputExtension = yup
 export const validateUserCreationInput = (data: any) => {
   let schema = schemas.userCreationSchema;
 
-  if (EE.features.isEnabled('sso')) {
+  if (strapi.ee.features.isEnabled('sso')) {
     schema = schema.concat(ssoUserCreationInputExtension);
   }
 

--- a/packages/core/admin/server/src/controllers/__tests__/admin.test.ts
+++ b/packages/core/admin/server/src/controllers/__tests__/admin.test.ts
@@ -1,26 +1,19 @@
 import adminController from '../admin';
 
-jest.mock('@strapi/strapi/dist/utils/ee', () => {
-  const eeModule = () => false;
-
-  Object.assign(eeModule, {
-    features: {
-      isEnabled() {
-        return false;
-      },
-      list() {
-        return [];
-      },
-    },
-  });
-
-  return eeModule;
-});
-
 describe('Admin Controller', () => {
   describe('init', () => {
     beforeAll(() => {
       global.strapi = {
+        ee: {
+          features: {
+            isEnabled() {
+              return false;
+            },
+            list() {
+              return [];
+            },
+          },
+        },
         config: {
           get: jest.fn(() => 'foo'),
         },

--- a/packages/core/content-type-builder/server/src/controllers/content-types.ts
+++ b/packages/core/content-type-builder/server/src/controllers/content-types.ts
@@ -9,7 +9,6 @@ import {
   validateKind,
 } from './validation/content-type';
 
-
 export default {
   async getContentTypes(ctx: Context) {
     const { kind } = ctx.query;

--- a/packages/core/strapi/package.json
+++ b/packages/core/strapi/package.json
@@ -72,13 +72,6 @@
       "require": "./dist/index.js",
       "default": "./dist/index.js"
     },
-    "./dist/utils/ee": {
-      "types": "./dist/utils/ee.d.ts",
-      "source": "./src/utils/ee.ts",
-      "import": "./dist/utils/ee.mjs",
-      "require": "./dist/utils/ee.js",
-      "default": "./dist/utils/ee.js"
-    },
     "./admin": {
       "types": "./dist/admin.d.ts",
       "source": "./src/admin.ts",

--- a/packages/core/strapi/src/Strapi.ts
+++ b/packages/core/strapi/src/Strapi.ts
@@ -228,6 +228,11 @@ class Strapi extends Container implements StrapiI {
       },
       configurable: false,
     });
+
+    Object.defineProperty<Strapi>(this, 'ee', {
+      get: () => ee,
+      configurable: false,
+    });
   }
 
   get config() {

--- a/packages/core/types/src/index.ts
+++ b/packages/core/types/src/index.ts
@@ -109,6 +109,15 @@ export interface Strapi extends Container {
   db?: Database;
   app: any;
   EE?: boolean;
+  ee: {
+    seats: number | null | undefined;
+    isEE: boolean;
+    features: {
+      isEnabled: (feature: string) => boolean;
+      list: () => { name: string; [key: string]: any }[];
+      get: (feature: string) => { name: string; [key: string]: any };
+    };
+  };
   components: Shared.Components;
   reload: Reloader;
   config: ConfigProvider;


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Replaces ee direct imports by strapi.ee. I'm keeping the old strapi.EE as is for now but will probably refactor later to merged into a single EE thing. 

Side note: as we are considering feature flag we could find a unified way to managed features that are enabled/disabled between flas & ee potentialy cc @Feranchz =)

### Why is it needed?

Removing dependencies to `@strapi/strapi`

### How to test it?

Verify the EE features are still toggled & working fine 

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
