### PR TITLE
fix(blocks): add modifiers to test provider

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/BlocksInput/Blocks/tests/Wrapper.tsx
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksInput/Blocks/tests/Wrapper.tsx
@@ -7,6 +7,7 @@ import { Slate, withReact } from 'slate-react';
 import { ThemeProvider } from 'styled-components';
 
 import { type BlocksStore, BlocksEditorProvider } from '../../BlocksEditor';
+import { modifiers } from '../../Modifiers';
 import { codeBlocks } from '../Code';
 import { headingBlocks } from '../Heading';
 import { imageBlocks } from '../Image';
@@ -38,7 +39,7 @@ const Wrapper = ({ children }: WrapperProps) => {
     <ThemeProvider theme={lightTheme}>
       <IntlProvider messages={{}} locale="en">
         <Slate initialValue={[]} editor={editor}>
-          <BlocksEditorProvider blocks={blocks} disabled={false}>
+          <BlocksEditorProvider modifiers={modifiers} blocks={blocks} disabled={false}>
             {children}
           </BlocksEditorProvider>
         </Slate>


### PR DESCRIPTION
### What does it do?

Puts modifiers on the Blocks context in a Wrapper component 

### Why is it needed?

To fix the build

### How to test it?

CI should pass

### Related issue(s)/PR(s)

No idea why this didn't make #18802 fail