### PR TITLE
[v5] ] Set default log level to 'info'

### DIFF
--- a/packages/core/strapi/src/Strapi.ts
+++ b/packages/core/strapi/src/Strapi.ts
@@ -212,7 +212,7 @@ class Strapi extends Container implements StrapiI {
     this.fs = createStrapiFs(this);
     this.eventHub = createEventHub();
     this.startupLogger = createStartupLogger(this);
-    this.log = createLogger(this.config.get('logger', {}));
+    this.log = createLogger(this.config.get('logger', { level: 'info' }));
     this.cron = createCronService();
     this.telemetry = createTelemetry(this);
     this.requestContext = requestContext;

--- a/packages/utils/logger/src/constants.ts
+++ b/packages/utils/logger/src/constants.ts
@@ -1,7 +1,7 @@
 import { config } from 'winston';
 
 const LEVELS = config.npm.levels;
-const LEVEL_LABEL = 'silly';
+const LEVEL_LABEL = 'info';
 const LEVEL = LEVELS[LEVEL_LABEL];
 
 export { LEVEL, LEVEL_LABEL, LEVELS };

--- a/packages/utils/logger/src/constants.ts
+++ b/packages/utils/logger/src/constants.ts
@@ -1,7 +1,7 @@
 import { config } from 'winston';
 
 const LEVELS = config.npm.levels;
-const LEVEL_LABEL = 'info';
+const LEVEL_LABEL = 'silly';
 const LEVEL = LEVELS[LEVEL_LABEL];
 
 export { LEVEL, LEVEL_LABEL, LEVELS };


### PR DESCRIPTION
### What does it do?

Sets the default log level for strapi.log to 'info'

### Why is it needed?

'info' is a more sensible default for logging; if someone wants to add debug info, they can still set the logger config parameter.

### TODO:

I can manage these as later tasks if we just want to merge and get the annoying logs out of the way.

- [ ] Check if logger.js is documented anywhere, since that's where the config value is being pulled from; we may want to move it as config/server.js { logger }  and document it
- [ ] change behavior of `--debug` option in `watch` + `develop` commands to pass through to the server log instead of just the build logs

### How to test it?

- debug logs should no longer appear in the server log by default
- debug logs should still be available if you create a config/logger.js that exports { level: 'debug' }

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
