### PR TITLE
Allow for AWS optional session token.

### DIFF
--- a/packages/providers/upload-aws-s3/src/utils.ts
+++ b/packages/providers/upload-aws-s3/src/utils.ts
@@ -112,6 +112,7 @@ export const extractCredentials = (options: InitOptions): AwsCredentialIdentity 
     return {
       accessKeyId: options.s3Options.credentials.accessKeyId,
       secretAccessKey: options.s3Options.credentials.secretAccessKey,
+      sessionToken: options.s3Options.credentials?.sessionToken,
     };
   }
   return null;


### PR DESCRIPTION
### What does it do?

Added support for AWS session token

### Why is it needed?

AWS IAM can generate multiple types of credentials. This adds support for credentials where the access key, secret key, and session token are all required.
