### PR TITLE
Docs for AWS V3 SDK Update

### DIFF
--- a/packages/providers/upload-aws-s3/README.md
+++ b/packages/providers/upload-aws-s3/README.md
@@ -171,7 +171,7 @@ module.exports = [
 ];
 ```
 
-If you use dots in your bucket name, the url of the ressource is in directory style (`s3.yourRegion.amazonaws.com/your.bucket.name/image.jpg`) instead of `yourBucketName.s3.yourRegion.amazonaws.com/image.jpg`. Then only add `s3.yourRegion.amazonaws.com` to img-src and media-src directives.
+If you use dots in your bucket name, the url of the resource is in directory style (`s3.yourRegion.amazonaws.com/your.bucket.name/image.jpg`) instead of `yourBucketName.s3.yourRegion.amazonaws.com/image.jpg`. Then only add `s3.yourRegion.amazonaws.com` to img-src and media-src directives.
 
 ## Bucket CORS Configuration
 
@@ -202,3 +202,45 @@ These are the minimum amount of permissions needed for this provider to work.
   "s3:PutObjectAcl"
 ],
 ```
+
+## Update to AWS SDK V3 and URL Format Change
+
+In the recent update of the `@strapi/provider-upload-aws-s3` plugin, we have transitioned from AWS SDK V2 to AWS SDK V3. This significant update brings along a change in the format of the URLs used in Amazon S3 services.
+
+### Understanding the New URL Format
+
+AWS SDK V3 adopts the virtual-hosted–style URI format for S3 URLs. This format is recommended by AWS and is likely to become the standard in the near future, as the path-style URI is being deprecated. More details on this format can be found in the [AWS User Guide](https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html#virtual-hosted-style-access).
+
+### Why the Change?
+
+The move to virtual-hosted–style URIs aligns with AWS's recommendation and future-proofing strategies. For an in-depth understanding of AWS's decision behind this transition, you can refer to their detailed post [here](https://aws.amazon.com/es/blogs/aws/amazon-s3-path-deprecation-plan-the-rest-of-the-story/).
+
+### Configuring Your Strapi Application
+
+If you wish to continue using the plugin with Strapi 4.15.x versions or newer without changing your URL format, it's possible to specify your desired URL format directly in the plugin's configuration. Below is an example configuration highlighting the critical `baseUrl` property:
+
+```javascript
+upload: {
+  config: {
+    provider: 'aws-s3',
+    providerOptions: {
+      accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+      secretAccessKey: process.env.AWS_ACCESS_SECRET,
+      region: process.env.AWS_REGION,
+      baseUrl: `https://s3.${region}.amazonaws.com/${bucket}`, // CRITICAL LINE
+      params: {
+        ACL: process.env.AWS_ACL || 'public-read',
+        signedUrlExpires: process.env.AWS_SIGNED_URL_EXPIRES || 15 * 60,
+        Bucket: process.env.AWS_BUCKET,
+      },
+    },
+    actionOptions: {
+      upload: {},
+      uploadStream: {},
+      delete: {},
+    },
+  },
+}
+```
+
+This configuration ensures compatibility with the updated AWS SDK while providing flexibility in URL format selection, catering to various user needs.


### PR DESCRIPTION
### What does it do?

It adds a section in the `@strapi/provider-upload-aws-s3` plugin documentation to explain the new recent change in the `aws-sdk` updated from v2 to v3

### Why is it needed?

It's needed to be up to date with the aws sdk


### Related issue(s)/PR(s)
https://github.com/strapi/documentation/issues/1925
