### PR TITLE
Increase work factor from 10 to 11 on password encryption

### DIFF
--- a/packages/core/admin/server/src/services/auth.ts
+++ b/packages/core/admin/server/src/services/auth.ts
@@ -12,7 +12,7 @@ const { ApplicationError } = errors;
  * @param password - password to hash
  * @returns hashed password
  */
-const hashPassword = (password: string) => bcrypt.hash(password, 10);
+const hashPassword = (password: string) => bcrypt.hash(password, 11);
 
 /**
  * Validate a password

--- a/packages/core/strapi/src/services/entity-service/attributes/transforms.ts
+++ b/packages/core/strapi/src/services/entity-service/attributes/transforms.ts
@@ -21,7 +21,7 @@ const transforms: Transforms = {
       return value;
     }
 
-    const rounds = toNumber(getOr(10, 'encryption.rounds', attribute));
+    const rounds = toNumber(getOr(11, 'encryption.rounds', attribute));
 
     return bcrypt.hashSync(value.toString(), rounds);
   },

--- a/packages/plugins/documentation/server/controllers/documentation.js
+++ b/packages/plugins/documentation/server/controllers/documentation.js
@@ -231,7 +231,7 @@ module.exports = {
         return ctx.badRequest('Please provide a password');
       }
 
-      config.password = await bcrypt.hash(password, 10);
+      config.password = await bcrypt.hash(password, 11);
     }
 
     await pluginStore.set({ key: 'config', value: config });


### PR DESCRIPTION
Changing the work factor in bcrypt from 10 to 11 will not directly affect the ability to compare existing hashed passwords because bcrypt stores the work factor within the hash itself, allowing the compare function to use the correct work factor for each hash.

New or updated passwords will simply have a higher work factor, thus requiring more computational resources to hash.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Increased the work factor from 10 to 11 for password hashes

### Why is it needed?

Some generally encryption mandates for financial service partnerships are requiring a work factor minimum of 11 for password encryption.  Some additional background information is avialable here https://github.com/strapi/strapi/issues/10802

### How to test it?

Login to an existing account with user/password.   Create a new account and login as well.

### Related issue(s)/PR(s)

[A hardcoded BCrypt cost factor of 10 is insecure by default](https://github.com/strapi/strapi/issues/10802)
