### PR TITLE
fix: fix wrong return value of pagination in useAdminUsers

### DIFF
--- a/packages/core/admin/admin/src/hooks/useAdminUsers.ts
+++ b/packages/core/admin/admin/src/hooks/useAdminUsers.ts
@@ -50,7 +50,7 @@ export function useAdminUsers(params: APIUsersQueryParams = {}, queryOptions = {
 
   return {
     users,
-    pagination: React.useMemo(() => (data && 'pagination' in data) ?? null, [data]),
+    pagination: React.useMemo(() => (data && data.pagination) ?? null, [data]),
     isLoading,
     isError,
     refetch,


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?
Fix issue [PaginationFooter not working in setting =>users page](https://github.com/strapi/strapi/issues/18931)

### Why is it needed?
Users can use the pagination function normally on the settings=>user page after upgrading to 4.14.5 or higher

