### PR TITLE
chore: update typescript module

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "rimraf": "3.0.2",
     "supertest": "6.3.3",
     "ts-jest": "29.1.0",
-    "typescript": "5.2.2",
+    "typescript": "5.3.2",
     "yargs": "17.7.2"
   },
   "packageManager": "yarn@4.0.1",

--- a/packages/core/admin/package.json
+++ b/packages/core/admin/package.json
@@ -164,7 +164,7 @@
     "slate-react": "0.98.3",
     "style-loader": "3.3.1",
     "styled-components": "5.3.3",
-    "typescript": "5.2.2",
+    "typescript": "5.3.2",
     "webpack": "^5.88.1",
     "webpack-bundle-analyzer": "^4.9.0",
     "webpack-dev-middleware": "6.1.1",

--- a/packages/core/helper-plugin/package.json
+++ b/packages/core/helper-plugin/package.json
@@ -86,7 +86,7 @@
     "rimraf": "3.0.2",
     "storybook": "7.5.3",
     "styled-components": "5.3.3",
-    "typescript": "5.2.2",
+    "typescript": "5.3.2",
     "vite": "4.4.9",
     "yup": "0.32.9"
   },

--- a/packages/core/strapi/package.json
+++ b/packages/core/strapi/package.json
@@ -158,7 +158,7 @@
     "qs": "6.11.1",
     "semver": "7.5.4",
     "statuses": "2.0.1",
-    "typescript": "5.2.2",
+    "typescript": "5.3.2",
     "undici": "5.27.2",
     "yup": "0.32.9"
   },

--- a/packages/core/types/package.json
+++ b/packages/core/types/package.json
@@ -64,7 +64,7 @@
     "@types/node-schedule": "2.1.0",
     "eslint-config-custom": "4.15.4",
     "tsconfig": "4.15.4",
-    "typescript": "5.2.2",
+    "typescript": "5.3.2",
     "undici": "5.27.2"
   },
   "engines": {

--- a/packages/utils/pack-up/package.json
+++ b/packages/utils/pack-up/package.json
@@ -79,7 +79,7 @@
     "prettier-plugin-packagejson": "2.4.5",
     "prompts": "2.4.2",
     "rxjs": "7.8.1",
-    "typescript": "5.2.2",
+    "typescript": "5.3.2",
     "vite": "4.4.9",
     "yup": "0.32.9"
   },


### PR DESCRIPTION
### What does it do?

- update typescript from 5.2.2 -> 5.3.2

[It includes breaking changes](https://devblogs.microsoft.com/typescript/announcing-typescript-5-3/#breaking-changes-and-correctness-improvements) but none that should affect us

### Why is it needed?

Updating packages in v5

### How to test it?

Test that ts:generate-types still works

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
