### PR TITLE
feat(content-releases): add endpoint to remove release action from release

### DIFF
--- a/docs/docs/docs/01-core/content-releases/01-backend.md
+++ b/docs/docs/docs/01-core/content-releases/01-backend.md
@@ -90,6 +90,7 @@ packages/core/content-releases/server/src/routes/release.ts
 - method: `POST`
 - endpoint: `/content-releases/:releaseId/actions`
 - body:
+
   ```ts
   {
     entry: {
@@ -110,6 +111,11 @@ packages/core/content-releases/server/src/routes/release.ts
     type: 'publish' | 'unpublish';
   }
   ```
+
+**Delete a release action**
+
+- method: `DELETE`
+- endpoint: `/content-releases/:releaseId/actions/:actionId`
 
 ## Controllers
 

--- a/packages/core/content-releases/server/src/constants.ts
+++ b/packages/core/content-releases/server/src/constants.ts
@@ -34,6 +34,12 @@ export const ACTIONS = [
   },
   {
     section: 'plugins',
+    displayName: 'Remove an action from a release',
+    uid: 'delete-action',
+    pluginName: 'content-releases',
+  },
+  {
+    section: 'plugins',
     displayName: 'Add an action to a release',
     uid: 'create-action',
     pluginName: 'content-releases',

--- a/packages/core/content-releases/server/src/controllers/release-action.ts
+++ b/packages/core/content-releases/server/src/controllers/release-action.ts
@@ -1,12 +1,16 @@
 import type Koa from 'koa';
 import { UID } from '@strapi/types';
 import { mapAsync } from '@strapi/utils';
-import { validateReleaseAction, validateReleaseActionUpdateSchema } from './validation/release-action';
+import {
+  validateReleaseAction,
+  validateReleaseActionUpdateSchema,
+} from './validation/release-action';
 import type {
   CreateReleaseAction,
   GetReleaseActions,
   ReleaseAction,
-  UpdateReleaseAction
+  UpdateReleaseAction,
+  DeleteReleaseAction,
 } from '../../../shared/contracts/release-actions';
 import { getAllowedContentTypes, getService, getPermissionsChecker } from '../utils';
 
@@ -106,10 +110,27 @@ const releaseActionController = {
     await validateReleaseActionUpdateSchema(releaseActionUpdateArgs);
 
     const releaseService = getService('release', { strapi });
-    const updatedAction = await releaseService.updateAction(actionId, releaseId, releaseActionUpdateArgs);
+    const updatedAction = await releaseService.updateAction(
+      actionId,
+      releaseId,
+      releaseActionUpdateArgs
+    );
 
     ctx.body = {
       data: updatedAction,
+    };
+  },
+  async delete(ctx: Koa.Context) {
+    const actionId: DeleteReleaseAction.Request['params']['actionId'] = ctx.params.actionId;
+    const releaseId: DeleteReleaseAction.Request['params']['releaseId'] = ctx.params.releaseId;
+
+    const deletedReleaseAction = await getService('release', { strapi }).deleteAction(
+      actionId,
+      releaseId
+    );
+
+    ctx.body = {
+      data: deletedReleaseAction,
     };
   },
 };

--- a/packages/core/content-releases/server/src/routes/release-action.ts
+++ b/packages/core/content-releases/server/src/routes/release-action.ts
@@ -49,5 +49,21 @@ export default {
         ],
       },
     },
+    {
+      method: 'DELETE',
+      path: '/:releaseId/actions/:actionId',
+      handler: 'release-action.delete',
+      config: {
+        policies: [
+          'admin::isAuthenticatedAdmin',
+          {
+            name: 'admin::hasPermissions',
+            config: {
+              actions: ['plugin::content-releases.delete-action'],
+            },
+          },
+        ],
+      },
+    },
   ],
 };

--- a/packages/core/content-releases/server/src/services/release.ts
+++ b/packages/core/content-releases/server/src/services/release.ts
@@ -12,6 +12,7 @@ import type {
   CreateReleaseAction,
   GetReleaseActions,
   UpdateReleaseAction,
+  DeleteReleaseAction,
 } from '../../../shared/contracts/release-actions';
 import type { UserInfo } from '../../../shared/types';
 import { getService } from '../utils';
@@ -181,6 +182,25 @@ const createReleaseService = ({ strapi }: { strapi: LoadedStrapi }) => ({
     }
 
     return updatedAction;
+  },
+  async deleteAction(
+    actionId: DeleteReleaseAction.Request['params']['actionId'],
+    releaseId: DeleteReleaseAction.Request['params']['releaseId']
+  ) {
+    const deletedAction = await strapi.db.query(RELEASE_ACTION_MODEL_UID).delete({
+      where: {
+        id: actionId,
+        release: releaseId,
+      },
+    });
+
+    if (!deletedAction) {
+      throw new errors.NotFoundError(
+        `Action with id ${actionId} not found in release with id ${releaseId}`
+      );
+    }
+
+    return deletedAction;
   },
 });
 

--- a/packages/core/content-releases/shared/contracts/release-actions.ts
+++ b/packages/core/content-releases/shared/contracts/release-actions.ts
@@ -18,7 +18,7 @@ export interface ReleaseAction extends Entity {
 }
 
 /**
- * POST /content-releases/:id/actions - Create a release action
+ * POST /content-releases/:releaseId/actions - Create a release action
  */
 export declare namespace CreateReleaseAction {
   export interface Request {
@@ -56,6 +56,22 @@ export declare namespace GetReleaseActions {
     meta: {
       pagination: Pagination;
     };
+  }
+}
+
+/*
+ * DELETE /content-releases/:releaseId/actions/:actionId - Delete a release action
+ */
+export declare namespace DeleteReleaseAction {
+  export interface Request {
+    params: {
+      actionId: ReleaseAction['id'];
+      releaseId: Release['id'];
+    };
+  }
+
+  export interface Response {
+    data: ReleaseAction;
     error?: errors.ApplicationError | errors.NotFoundError;
   }
 }


### PR DESCRIPTION
### What does it do?

- Add the endpoint to delete a release-action

### Why is it needed?

- To remove release actions from a release

### How to test it?

- Make sure you have a release with some release actions
- Make sure you have the id for the release and the action you want to delete
- Make a DELETE request to `/content-releases/:releaseId/actions/:actionId
- It should return the release action that was deleted
- Confirm it was deleted in the db
- Check a role that doesn't have permissions cannot make the request and that permissions can be given
