### PR TITLE
feat: D&P Admin contracts with metadata

### DIFF
--- a/packages/core/content-manager/shared/contracts/collection-types.ts
+++ b/packages/core/content-manager/shared/contracts/collection-types.ts
@@ -1,15 +1,13 @@
 import { errors } from '@strapi/utils';
 import { Schema, Common, Documents } from '@strapi/types';
 
-// Admin document response follows the same format as the document service
-type Document = Documents.Result<Common.UID.Schema>;
 type PaginatedDocuments = Documents.PaginatedResult<Common.UID.Schema>;
-
 type PaginationQuery = Documents.Params.Pagination.PageNotation;
 type SortQuery = Documents.Params.Sort.StringNotation<Common.UID.Schema> & string;
-
 type PublicationState = Documents.Params.PublicationState.Kind;
 
+// Admin document response follows the same format as the document service
+type Document = Documents.Result<Common.UID.Schema>;
 type DocumentMetadata = {
   availableStatus: PublicationState[];
   availableLocales: string[];

--- a/packages/core/content-manager/shared/contracts/collection-types.ts
+++ b/packages/core/content-manager/shared/contracts/collection-types.ts
@@ -6,12 +6,13 @@ type PaginationQuery = Documents.Params.Pagination.PageNotation;
 type SortQuery = Documents.Params.Sort.StringNotation<Common.UID.Schema> & string;
 
 // Admin document response follows the same format as the document service
-type Document = Documents.Result<Common.UID.Schema>;
+type Document = Documents.Document<any>;
+type AT_FIELDS = 'updatedAt' | 'createdAt' | 'publishedAt';
 type DocumentMetadata = {
   // All status of the returned locale
-  availableStatus: Document[];
+  availableStatus: Pick<Document, 'id' | AT_FIELDS | 'status'>[];
   // Available locales within the same status of the returned document
-  availableLocales: Document[];
+  availableLocales: Pick<Document, 'id' | 'locale' | AT_FIELDS | 'status'>[];
 };
 
 /**

--- a/packages/core/content-manager/shared/contracts/collection-types.ts
+++ b/packages/core/content-manager/shared/contracts/collection-types.ts
@@ -4,13 +4,14 @@ import { Schema, Common, Documents } from '@strapi/types';
 type PaginatedDocuments = Documents.PaginatedResult<Common.UID.Schema>;
 type PaginationQuery = Documents.Params.Pagination.PageNotation;
 type SortQuery = Documents.Params.Sort.StringNotation<Common.UID.Schema> & string;
-type PublicationState = Documents.Params.PublicationState.Kind;
 
 // Admin document response follows the same format as the document service
 type Document = Documents.Result<Common.UID.Schema>;
 type DocumentMetadata = {
-  availableStatus: PublicationState[];
-  availableLocales: string[];
+  // All status of the returned locale
+  availableStatus: Document[];
+  // Available locales within the same status of the returned document
+  availableLocales: Document[];
 };
 
 /**

--- a/packages/core/content-manager/shared/contracts/collection-types.ts
+++ b/packages/core/content-manager/shared/contracts/collection-types.ts
@@ -1,12 +1,14 @@
 import { errors } from '@strapi/utils';
-import { Schema, Common, EntityService } from '@strapi/types';
+import { Schema, Common, EntityService, Documents } from '@strapi/types';
 
 // Admin entity response follows the same format as the entity service
-type Entity = EntityService.Result<Common.UID.Schema>;
-type PaginatedEntities = EntityService.PaginatedResult<Common.UID.Schema>;
+type Document = Documents.Result<Common.UID.Schema>;
+type PaginatedDocuments = Documents.PaginatedResult<Common.UID.Schema>;
 
-type PaginationQuery = EntityService.Params.Pagination.PageNotation;
-type SortQuery = EntityService.Params.Sort.StringNotation<Common.UID.Schema> & string;
+type PaginationQuery = Documents.Params.Pagination.PageNotation;
+type SortQuery = Documents.Params.Sort.StringNotation<Common.UID.Schema> & string;
+
+type PublicationState = Documents.Params.PublicationState.Kind;
 
 /**
  * GET /collection-types/:model
@@ -27,7 +29,7 @@ export declare namespace Find {
 
   export interface Response {
     data: {
-      results: PaginatedEntities;
+      results: PaginatedDocuments;
       pagination: {
         page: PaginationQuery['page'];
         pageSize: PaginationQuery['pageSize'];
@@ -54,7 +56,11 @@ export declare namespace FindOne {
   }
 
   export interface Response {
-    data: Entity;
+    data: Document;
+    meta: {
+      availableStatus: PublicationState[];
+      availableLocales: string[];
+    };
     error?: errors.ApplicationError;
   }
 }
@@ -73,7 +79,11 @@ export declare namespace Create {
   }
 
   export interface Response {
-    data: Entity;
+    data: Document;
+    meta: {
+      availableStatus: PublicationState[];
+      availableLocales: string[];
+    };
     error?: errors.ApplicationError;
   }
 }
@@ -93,7 +103,11 @@ export declare namespace AutoClone {
   }
 
   export interface Response {
-    data: Entity;
+    data: Document;
+    meta: {
+      availableStatus: PublicationState[];
+      availableLocales: string[];
+    };
     error?: errors.ApplicationError;
   }
 }
@@ -113,7 +127,11 @@ export declare namespace Clone {
   }
 
   export interface Response {
-    data: Entity;
+    data: Document;
+    meta: {
+      availableStatus: PublicationState[];
+      availableLocales: string[];
+    };
     error?: errors.ApplicationError;
   }
 }
@@ -123,7 +141,7 @@ export declare namespace Clone {
  */
 export declare namespace Update {
   export interface Request {
-    body: Entity;
+    body: Document;
     query: {};
   }
 
@@ -133,7 +151,11 @@ export declare namespace Update {
   }
 
   export interface Response {
-    data: Entity;
+    data: Document;
+    meta: {
+      availableStatus: PublicationState[];
+      availableLocales: string[];
+    };
     error?: errors.ApplicationError;
   }
 }
@@ -153,7 +175,11 @@ export declare namespace Delete {
   }
 
   export interface Response {
-    data: Entity;
+    data: Document;
+    meta: {
+      availableStatus: PublicationState[];
+      availableLocales: string[];
+    };
     error?: errors.ApplicationError;
   }
 }
@@ -173,7 +199,11 @@ export declare namespace Publish {
   }
 
   export interface Response {
-    data: Entity;
+    data: Document;
+    meta: {
+      availableStatus: PublicationState[];
+      availableLocales: string[];
+    };
     error?: errors.ApplicationError;
   }
 }
@@ -193,7 +223,11 @@ export declare namespace Unpublish {
   }
 
   export interface Response {
-    data: Entity;
+    data: Document;
+    meta: {
+      availableStatus: PublicationState[];
+      availableLocales: string[];
+    };
     error?: errors.ApplicationError;
   }
 }

--- a/packages/core/content-manager/shared/contracts/collection-types.ts
+++ b/packages/core/content-manager/shared/contracts/collection-types.ts
@@ -1,7 +1,7 @@
 import { errors } from '@strapi/utils';
-import { Schema, Common, EntityService, Documents } from '@strapi/types';
+import { Schema, Common, Documents } from '@strapi/types';
 
-// Admin entity response follows the same format as the entity service
+// Admin document response follows the same format as the document service
 type Document = Documents.Result<Common.UID.Schema>;
 type PaginatedDocuments = Documents.PaginatedResult<Common.UID.Schema>;
 
@@ -9,6 +9,11 @@ type PaginationQuery = Documents.Params.Pagination.PageNotation;
 type SortQuery = Documents.Params.Sort.StringNotation<Common.UID.Schema> & string;
 
 type PublicationState = Documents.Params.PublicationState.Kind;
+
+type DocumentMetadata = {
+  availableStatus: PublicationState[];
+  availableLocales: string[];
+};
 
 /**
  * GET /collection-types/:model
@@ -57,10 +62,7 @@ export declare namespace FindOne {
 
   export interface Response {
     data: Document;
-    meta: {
-      availableStatus: PublicationState[];
-      availableLocales: string[];
-    };
+    meta: DocumentMetadata;
     error?: errors.ApplicationError;
   }
 }
@@ -80,10 +82,7 @@ export declare namespace Create {
 
   export interface Response {
     data: Document;
-    meta: {
-      availableStatus: PublicationState[];
-      availableLocales: string[];
-    };
+    meta: DocumentMetadata;
     error?: errors.ApplicationError;
   }
 }
@@ -104,10 +103,7 @@ export declare namespace AutoClone {
 
   export interface Response {
     data: Document;
-    meta: {
-      availableStatus: PublicationState[];
-      availableLocales: string[];
-    };
+    meta: DocumentMetadata;
     error?: errors.ApplicationError;
   }
 }
@@ -128,10 +124,7 @@ export declare namespace Clone {
 
   export interface Response {
     data: Document;
-    meta: {
-      availableStatus: PublicationState[];
-      availableLocales: string[];
-    };
+    meta: DocumentMetadata;
     error?: errors.ApplicationError;
   }
 }
@@ -152,10 +145,7 @@ export declare namespace Update {
 
   export interface Response {
     data: Document;
-    meta: {
-      availableStatus: PublicationState[];
-      availableLocales: string[];
-    };
+    meta: DocumentMetadata;
     error?: errors.ApplicationError;
   }
 }
@@ -176,10 +166,7 @@ export declare namespace Delete {
 
   export interface Response {
     data: Document;
-    meta: {
-      availableStatus: PublicationState[];
-      availableLocales: string[];
-    };
+    meta: DocumentMetadata;
     error?: errors.ApplicationError;
   }
 }
@@ -200,10 +187,7 @@ export declare namespace Publish {
 
   export interface Response {
     data: Document;
-    meta: {
-      availableStatus: PublicationState[];
-      availableLocales: string[];
-    };
+    meta: DocumentMetadata;
     error?: errors.ApplicationError;
   }
 }
@@ -224,10 +208,7 @@ export declare namespace Unpublish {
 
   export interface Response {
     data: Document;
-    meta: {
-      availableStatus: PublicationState[];
-      availableLocales: string[];
-    };
+    meta: DocumentMetadata;
     error?: errors.ApplicationError;
   }
 }

--- a/packages/core/content-manager/shared/contracts/single-types.ts
+++ b/packages/core/content-manager/shared/contracts/single-types.ts
@@ -1,8 +1,14 @@
-import { EntityService, Common } from '@strapi/types';
+import { Documents, Common } from '@strapi/types';
 
 import { errors } from '@strapi/utils';
 
-type Entity = EntityService.Result<Common.UID.Schema>;
+type PublicationState = Documents.Params.PublicationState.Kind;
+
+type Document = Documents.Result<Common.UID.Schema>;
+type DocumentMetadata = {
+  availableStatus: PublicationState[];
+  availableLocales: string[];
+};
 
 /**
  * GET /single-types/:model
@@ -20,7 +26,8 @@ export declare namespace Find {
   }
 
   export interface Response {
-    data: Entity;
+    data: Document;
+    meta: DocumentMetadata;
     error?: errors.ApplicationError;
   }
 }
@@ -30,7 +37,7 @@ export declare namespace Find {
  */
 export declare namespace CreateOrUpdate {
   export interface Request {
-    body: Entity;
+    body: Document;
     query: {
       plugins: {
         i18n: {
@@ -41,7 +48,8 @@ export declare namespace CreateOrUpdate {
   }
 
   export interface Response {
-    data: Entity;
+    data: Document;
+    meta: DocumentMetadata;
     error?: errors.ApplicationError;
   }
 }
@@ -58,7 +66,8 @@ export declare namespace Delete {
   }
 
   export interface Response {
-    data: Entity;
+    data: Document;
+    meta: DocumentMetadata;
     error?: errors.ApplicationError;
   }
 }
@@ -75,7 +84,8 @@ export declare namespace Publish {
   }
 
   export interface Response {
-    data: Entity;
+    data: Document;
+    meta: DocumentMetadata;
     error?: errors.ApplicationError;
   }
 }
@@ -91,7 +101,8 @@ export declare namespace UnPublish {
     };
   }
   export interface Response {
-    data: Entity;
+    data: Document;
+    meta: DocumentMetadata;
     error?: errors.ApplicationError;
   }
 }

--- a/packages/core/content-manager/shared/contracts/single-types.ts
+++ b/packages/core/content-manager/shared/contracts/single-types.ts
@@ -2,8 +2,6 @@ import { Documents, Common } from '@strapi/types';
 
 import { errors } from '@strapi/utils';
 
-type PublicationState = Documents.Params.PublicationState.Kind;
-
 type Document = Documents.Result<Common.UID.Schema>;
 type DocumentMetadata = {
   // All status of the returned locale

--- a/packages/core/content-manager/shared/contracts/single-types.ts
+++ b/packages/core/content-manager/shared/contracts/single-types.ts
@@ -6,8 +6,10 @@ type PublicationState = Documents.Params.PublicationState.Kind;
 
 type Document = Documents.Result<Common.UID.Schema>;
 type DocumentMetadata = {
-  availableStatus: PublicationState[];
-  availableLocales: string[];
+  // All status of the returned locale
+  availableStatus: Document[];
+  // Available locales within the same status of the returned document
+  availableLocales: Document[];
 };
 
 /**

--- a/packages/core/content-manager/shared/contracts/single-types.ts
+++ b/packages/core/content-manager/shared/contracts/single-types.ts
@@ -2,12 +2,13 @@ import { Documents, Common } from '@strapi/types';
 
 import { errors } from '@strapi/utils';
 
-type Document = Documents.Result<Common.UID.Schema>;
+type Document = Documents.Document<any>;
+type AT_FIELDS = 'updatedAt' | 'createdAt' | 'publishedAt';
 type DocumentMetadata = {
   // All status of the returned locale
-  availableStatus: Document[];
+  availableStatus: Pick<Document, 'id' | 'status' | AT_FIELDS>[];
   // Available locales within the same status of the returned document
-  availableLocales: Document[];
+  availableLocales: Pick<Document, 'id' | 'locale' | 'status' | AT_FIELDS>[];
 };
 
 /**


### PR DESCRIPTION
### What does it do?
- Adds metadata type to the content manager collection-type & single types endpoints
- Change `Entity` response to `Document` response.

