### PR TITLE
chore(releases): setup releases plugin (#18401)

### DIFF
--- a/docs/docs/docs/01-core/content-releases/01-backend.md
+++ b/docs/docs/docs/01-core/content-releases/01-backend.md
@@ -100,6 +100,17 @@ packages/core/content-releases/server/src/routes/release.ts
   }
   ```
 
+**Update a release action**
+
+- method: `PUT`
+- endpoint: `/content-releases/:releaseId/actions/:actionId`
+- body:
+  ```ts
+  {
+    type: 'publish' | 'unpublish';
+  }
+  ```
+
 ## Controllers
 
 ### Release

--- a/packages/core/content-releases/server/src/constants.ts
+++ b/packages/core/content-releases/server/src/constants.ts
@@ -28,14 +28,20 @@ export const ACTIONS = [
   },
   {
     section: 'plugins',
-    displayName: 'Add entry to release',
+    displayName: 'Publish',
+    uid: 'publish',
+    pluginName: 'content-releases',
+  },
+  {
+    section: 'plugins',
+    displayName: 'Add an action to a release',
     uid: 'create-action',
     pluginName: 'content-releases',
   },
   {
     section: 'plugins',
-    displayName: 'Publish',
-    uid: 'publish',
+    displayName: 'Update an action in a release',
+    uid: 'update-action',
     pluginName: 'content-releases',
   },
 ];

--- a/packages/core/content-releases/server/src/controllers/__tests__/release-action.test.ts
+++ b/packages/core/content-releases/server/src/controllers/__tests__/release-action.test.ts
@@ -22,8 +22,6 @@ describe('Release Action controller', () => {
     });
 
     it('throws an error given bad request arguments', () => {
-      // Mock permitted user
-      global.strapi.admin.services.role.hasSuperAdminRole.mockReturnValue(true);
       // Mock content type
       global.strapi.contentType = jest.fn().mockReturnValue({
         options: {
@@ -64,6 +62,26 @@ describe('Release Action controller', () => {
 
       // @ts-expect-error Ignore missing properties
       expect(() => releaseActionController.create(ctx)).rejects.toThrow('type is a required field');
+    });
+  });
+  describe('update', () => {
+    it('throws an error given bad request arguments', () => {
+      const ctx = {
+        params: {
+          actionId: 1,
+        },
+        request: {
+          // Mock missing type property
+          body: {
+            type: 'ffff',
+          },
+        },
+      };
+
+      // @ts-expect-error Ignore missing properties
+      expect(() => releaseActionController.update(ctx)).rejects.toThrow(
+        'type must be one of the following values: publish, unpublish'
+      );
     });
   });
 });

--- a/packages/core/content-releases/server/src/controllers/release-action.ts
+++ b/packages/core/content-releases/server/src/controllers/release-action.ts
@@ -1,6 +1,12 @@
 import type Koa from 'koa';
-import { validateReleaseActionCreateSchema } from './validation/release-action';
-import type { CreateReleaseAction } from '../../../shared/contracts/release-actions';
+import {
+  validateReleaseActionCreateSchema,
+  validateReleaseActionUpdateSchema,
+} from './validation/release-action';
+import type {
+  CreateReleaseAction,
+  UpdateReleaseAction,
+} from '../../../shared/contracts/release-actions';
 import { getService } from '../utils';
 
 const releaseActionController = {
@@ -15,6 +21,19 @@ const releaseActionController = {
 
     ctx.body = {
       data: releaseAction,
+    };
+  },
+  async update(ctx: Koa.Context) {
+    const actionId: UpdateReleaseAction.Request['params']['actionId'] = ctx.params.actionId;
+    const releaseActionUpdateArgs: UpdateReleaseAction.Request['body'] = ctx.request.body;
+
+    await validateReleaseActionUpdateSchema(releaseActionUpdateArgs);
+
+    const releaseService = getService('release', { strapi });
+    const updatedAction = await releaseService.updateAction(actionId, releaseActionUpdateArgs);
+
+    ctx.body = {
+      data: updatedAction,
     };
   },
 };

--- a/packages/core/content-releases/server/src/controllers/validation/release-action.ts
+++ b/packages/core/content-releases/server/src/controllers/validation/release-action.ts
@@ -1,6 +1,6 @@
 import { yup, validateYupSchema } from '@strapi/utils';
 
-const releaseActionCreateSchema = yup.object().shape({
+const RELEASE_ACTION_SCHEMA = yup.object().shape({
   entry: yup
     .object()
     .shape({
@@ -11,4 +11,9 @@ const releaseActionCreateSchema = yup.object().shape({
   type: yup.string().oneOf(['publish', 'unpublish']).required(),
 });
 
-export const validateReleaseActionCreateSchema = validateYupSchema(releaseActionCreateSchema);
+const RELEASE_ACTION_UPDATE_SCHEMA = yup.object().shape({
+  type: yup.string().oneOf(['publish', 'unpublish']).required(),
+});
+
+export const validateReleaseActionCreateSchema = validateYupSchema(RELEASE_ACTION_SCHEMA);
+export const validateReleaseActionUpdateSchema = validateYupSchema(RELEASE_ACTION_UPDATE_SCHEMA);

--- a/packages/core/content-releases/server/src/routes/release-action.ts
+++ b/packages/core/content-releases/server/src/routes/release-action.ts
@@ -17,5 +17,21 @@ export default {
         ],
       },
     },
+    {
+      method: 'PUT',
+      path: '/:releaseId/actions/:actionId',
+      handler: 'release-action.update',
+      config: {
+        policies: [
+          'admin::isAuthenticatedAdmin',
+          {
+            name: 'admin::hasPermissions',
+            config: {
+              actions: ['plugin::content-releases.update-action'],
+            },
+          },
+        ],
+      },
+    },
   ],
 };

--- a/packages/core/content-releases/shared/contracts/release-actions.ts
+++ b/packages/core/content-releases/shared/contracts/release-actions.ts
@@ -3,13 +3,14 @@ import type { Release } from './releases';
 import type { Entity } from '../types';
 
 import type { errors } from '@strapi/utils';
+import { UserInfo } from '@strapi/helper-plugin';
 
 type ReleaseActionEntry = Entity & {
   // Entity attributes
   [key: string]: Attribute.Any;
 };
 
-export interface ReleaseAction {
+export interface ReleaseAction extends Entity {
   type: 'publish' | 'unpublish';
   entry: ReleaseActionEntry;
   contentType: Common.UID.ContentType;
@@ -30,6 +31,25 @@ export declare namespace CreateReleaseAction {
         id: ReleaseActionEntry['id'];
         contentType: Common.UID.ContentType;
       };
+    };
+  }
+
+  export interface Response {
+    data: ReleaseAction;
+    error?: errors.ApplicationError | errors.ValidationError | errors.NotFoundError;
+  }
+}
+
+/**
+ * PUT /content-releases/:releaseId/actions/:actionId - Update a release action
+ */
+export declare namespace UpdateReleaseAction {
+  export interface Request {
+    params: {
+      actionId: ReleaseAction['id'];
+    };
+    body: {
+      type: ReleaseAction['type'];
     };
   }
 


### PR DESCRIPTION
### What does it do?

- Add endpoint to update a release action

### Why is it needed?

- To change the type of an action already in a release

### How to test it?

- Make sure you have a release with some release actions
- Make sure you have the id for the release and the action you want to delete
- Make a PUT request to `/content-releases/:releaseId/actions/:actionId
```
{ type: 'publish' | 'unpublish'}
```
- Confirm it was updated in the db
- Try to send something that isn't publish or unpublish
- Check a role that doesn't have permissions cannot make the request and that permissions can be given

