### PR TITLE
feat: Content manager document metadata

### DIFF
--- a/packages/core/content-manager/server/src/controllers/collection-types.ts
+++ b/packages/core/content-manager/server/src/controllers/collection-types.ts
@@ -47,6 +47,7 @@ export default {
     const { model, id } = ctx.params;
 
     const entityManager = getService('entity-manager');
+    const documentMetadata = getService('document-metadata');
     const permissionChecker = getService('permission-checker').create({ userAbility, model });
 
     if (permissionChecker.cannot.read()) {
@@ -73,8 +74,15 @@ export default {
     }
 
     // TODO: Count populated relations by permissions
-
     ctx.body = await permissionChecker.sanitizeOutput(entity);
+
+    // TODO: Return { data, meta } format when UI is ready
+    // TODO: Sanitize output
+    if (ctx.body)
+      ctx.body.__meta__ = await documentMetadata.getMetadata(entity.id, model, {
+        locale: entity.locale,
+        status: 'draft',
+      });
   },
 
   async create(ctx: any) {
@@ -112,6 +120,14 @@ export default {
         eventProperties: { model },
       });
     }
+
+    // TODO: Return { data, meta } format when UI is ready
+    if (ctx.body)
+      // Document was just created, so there are no other locales or statuses
+      ctx.body.__meta__ = {
+        availableLocales: [],
+        availableStatus: [],
+      };
   },
 
   async update(ctx: any) {
@@ -120,6 +136,7 @@ export default {
     const { body } = ctx.request;
 
     const entityManager = getService('entity-manager');
+    const documentMetadata = getService('document-metadata');
     const permissionChecker = getService('permission-checker').create({ userAbility, model });
 
     if (permissionChecker.cannot.update()) {
@@ -150,6 +167,14 @@ export default {
     const updatedEntity = await entityManager.update(entity, sanitizedBody, model);
 
     ctx.body = await permissionChecker.sanitizeOutput(updatedEntity);
+
+    // TODO: Return { data, meta } format when UI is ready
+    // TODO: Sanitize output
+    if (ctx.body)
+      ctx.body.__meta__ = await documentMetadata.getMetadata(entity.id, model, {
+        locale: entity.locale,
+        status: 'draft',
+      });
   },
 
   async clone(ctx: any) {
@@ -187,6 +212,15 @@ export default {
     const clonedEntity = await entityManager.clone(entity, sanitizedBody, model);
 
     ctx.body = await permissionChecker.sanitizeOutput(clonedEntity);
+
+    // TODO: Return { data, meta } format when UI is ready
+    // TODO: Sanitize output
+    if (ctx.body)
+      // Document version was just cloned, so there are no other locales or statuses
+      ctx.body.__meta__ = {
+        availableLocales: [],
+        availableStatus: [],
+      };
   },
 
   async autoClone(ctx: any) {
@@ -240,6 +274,7 @@ export default {
     const { id, model } = ctx.params;
 
     const entityManager = getService('entity-manager');
+    const documentMetadata = getService('document-metadata');
     const permissionChecker = getService('permission-checker').create({ userAbility, model });
 
     if (permissionChecker.cannot.publish()) {
@@ -271,6 +306,14 @@ export default {
     );
 
     ctx.body = await permissionChecker.sanitizeOutput(result);
+
+    // TODO: Return { data, meta } format when UI is ready
+    // TODO: Sanitize output
+    if (ctx.body)
+      ctx.body.__meta__ = await documentMetadata.getMetadata(entity.id, model, {
+        locale: entity.locale,
+        status: 'draft',
+      });
   },
 
   async bulkPublish(ctx: any) {
@@ -356,6 +399,7 @@ export default {
     const { id, model } = ctx.params;
 
     const entityManager = getService('entity-manager');
+    const documentMetadata = getService('document-metadata');
     const permissionChecker = getService('permission-checker').create({ userAbility, model });
 
     if (permissionChecker.cannot.unpublish()) {
@@ -385,6 +429,14 @@ export default {
     );
 
     ctx.body = await permissionChecker.sanitizeOutput(result);
+
+    // TODO: Return { data, meta } format when UI is ready
+    // TODO: Sanitize output
+    if (ctx.body)
+      ctx.body.__meta__ = await documentMetadata.getMetadata(entity.id, model, {
+        locale: entity.locale,
+        status: 'draft',
+      });
   },
 
   async bulkDelete(ctx: any) {

--- a/packages/core/content-manager/server/src/services/document-metadata.ts
+++ b/packages/core/content-manager/server/src/services/document-metadata.ts
@@ -1,0 +1,62 @@
+import type { LoadedStrapi as Strapi, Common } from '@strapi/types';
+
+export default ({ strapi }: { strapi: Strapi }) => ({
+  async getAvailableLocales(
+    id: string,
+    uid: Common.UID.ContentType,
+    opts: { locale: string; status: string }
+  ) {
+    if (!opts.locale) return [];
+
+    // TODO: Use document service instead of query engine
+    // Find other locales of the document in the same status
+    return strapi.db.query(uid).findMany({
+      where: {
+        documentId: id,
+        // Omit current one
+        locale: { $ne: opts.locale },
+        // Find locales of the same status
+        publishedAt: opts.status === 'published' ? { $ne: null } : null,
+      },
+      select: ['id', 'locale', 'updatedAt', 'createdAt', 'publishedAt'],
+    });
+  },
+
+  async getAvailableStatus(
+    id: string,
+    uid: Common.UID.ContentType,
+    opts: { locale: string; status: string }
+  ) {
+    if (!opts.locale) return null;
+
+    // Find if the other status of the document is available
+    const otherStatus = opts.status === 'published' ? 'draft' : 'published';
+
+    return strapi.documents(uid).findOne(id, {
+      locale: opts.locale,
+      status: otherStatus,
+      fields: ['id', 'updatedAt', 'createdAt', 'publishedAt'],
+    });
+  },
+
+  /**
+   * Returns associated metadata of a document:
+   * - Available locales of the document for the current status
+   * - Available status of the document for the current locale
+   */
+  async getMetadata(
+    id: string,
+    uid: Common.UID.ContentType,
+    opts: { locale: string; status: string }
+  ) {
+    const [availableLocales, availableStatus] = await Promise.all([
+      this.getAvailableLocales(id, uid, opts),
+      this.getAvailableStatus(id, uid, opts),
+    ]);
+
+    return {
+      availableLocales,
+      availableStatus: availableStatus ? [availableStatus] : [],
+    };
+  },
+});

--- a/packages/core/content-manager/server/src/services/document-metadata.ts
+++ b/packages/core/content-manager/server/src/services/document-metadata.ts
@@ -1,6 +1,25 @@
 import type { LoadedStrapi as Strapi, Common } from '@strapi/types';
 
+interface DocumentMetadata {
+  availableLocales: {
+    id: string;
+    locale: string;
+    updatedAt: string;
+    createdAt: string;
+    publishedAt: string;
+  }[];
+  availableStatus: {
+    id: string;
+    updatedAt: string;
+    createdAt: string;
+    publishedAt: string;
+  }[];
+}
+
 export default ({ strapi }: { strapi: Strapi }) => ({
+  /**
+   * Returns available locales of a document for the current status
+   */
   async getAvailableLocales(
     id: string,
     uid: Common.UID.ContentType,
@@ -19,7 +38,7 @@ export default ({ strapi }: { strapi: Strapi }) => ({
         publishedAt: opts.status === 'published' ? { $ne: null } : null,
       },
       select: ['id', 'locale', 'updatedAt', 'createdAt', 'publishedAt'],
-    });
+    }) as unknown as DocumentMetadata['availableLocales'];
   },
 
   async getAvailableStatus(
@@ -36,7 +55,7 @@ export default ({ strapi }: { strapi: Strapi }) => ({
       locale: opts.locale,
       status: otherStatus,
       fields: ['id', 'updatedAt', 'createdAt', 'publishedAt'],
-    });
+    }) as unknown as DocumentMetadata['availableStatus'][0] | null;
   },
 
   /**

--- a/packages/core/content-manager/server/src/services/index.ts
+++ b/packages/core/content-manager/server/src/services/index.ts
@@ -8,11 +8,13 @@ import permissionChecker from './permission-checker';
 import permission from './permission';
 import populateBuilder from './populate-builder';
 import uid from './uid';
+import documentMetadata from './document-metadata';
 
 export default {
   components,
   'content-types': contentTypes,
   'data-mapper': dataMapper,
+  'document-metadata': documentMetadata,
   'entity-manager': entityManager,
   'field-sizes': fieldSizes,
   metrics,


### PR DESCRIPTION
### What does it do?

Returns metadata information as described in our admin [API contracts](https://github.com/strapi/strapi/blob/v5/draft-and-publish/packages/core/content-manager/shared/contracts/single-types.ts).

To not break the content-manager, instead of returning 
```ts
type Response =  {
	data: Document,
	meta: DocumentMetadata
}
```

I am returning

```ts
type Response =   Document & { __meta__:  DocumentMetadata}
```

I will remove this once @joshuaellis starts working on the ui.

