### PR TITLE
Fix unique validation on clone save

### DIFF
--- a/packages/core/strapi/src/services/entity-validator/validators.ts
+++ b/packages/core/strapi/src/services/entity-validator/validators.ts
@@ -153,16 +153,6 @@ const addUniqueValidator = <T extends strapiUtils.yup.AnySchema>(
       return true;
     }
 
-    /**
-     * If the attribute is unchanged we skip the unique verification. This will
-     * prevent the validator to be triggered in case the user activated the
-     * unique constraint after already creating multiple entries with
-     * the same attribute value for that field.
-     */
-    if (entity && updatedAttribute.value === entity[updatedAttribute.name]) {
-      return true;
-    }
-
     const whereParams = entity
       ? { $and: [{ [updatedAttribute.name]: value }, { $not: { id: entity.id } }] }
       : { [updatedAttribute.name]: value };


### PR DESCRIPTION
### What does it do?
It removes a condition that prevents validation when the value doesn't change.

Describe the technical changes you did.
I completely removed the check that skips the validation in case the values are the same, although it is probably better to skip it only if we are in clone flow.

### Why is it needed?
It is usually a great optimization, but in the case of clone, it skips the validation and can lead to invalid values being saved. This exact issue has already cause a lot of problems for us.

Describe the issue you are solving.
I am preventing invalid values from being saved when using clone.

### How to test it?
- Clone an entity with unique field. 
- Press save.
- Expect a validation error to happen.

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
