### PR TITLE
chore: i18n content manager locale param

### DIFF
--- a/packages/plugins/i18n/server/src/controllers/validate-locale-creation.ts
+++ b/packages/plugins/i18n/server/src/controllers/validate-locale-creation.ts
@@ -23,7 +23,7 @@ const validateLocaleCreation: Common.MiddlewareHandler = async (ctx, next) => {
     return next();
   }
 
-  const locale = get('locale', query) ?? get('locale', body);
+  const locale = get('locale', query) || get('locale', body);
   const relatedEntityId = get('plugins.i18n.relatedEntityId', query);
   // cleanup to avoid creating duplicates in singletypes
   ctx.request.query = {};

--- a/packages/plugins/i18n/server/src/controllers/validate-locale-creation.ts
+++ b/packages/plugins/i18n/server/src/controllers/validate-locale-creation.ts
@@ -23,7 +23,7 @@ const validateLocaleCreation: Common.MiddlewareHandler = async (ctx, next) => {
     return next();
   }
 
-  const locale = get('plugins.i18n.locale', query);
+  const locale = get('locale', query) ?? get('locale', body);
   const relatedEntityId = get('plugins.i18n.relatedEntityId', query);
   // cleanup to avoid creating duplicates in singletypes
   ctx.request.query = {};

--- a/packages/plugins/i18n/server/src/controllers/validate-locale-creation.ts
+++ b/packages/plugins/i18n/server/src/controllers/validate-locale-creation.ts
@@ -23,7 +23,8 @@ const validateLocaleCreation: Common.MiddlewareHandler = async (ctx, next) => {
     return next();
   }
 
-  const locale = get('locale', query) || get('locale', body);
+  // Prevent empty string locale
+  const locale = get('locale', query) || get('locale', body) || undefined;
   const relatedEntityId = get('plugins.i18n.relatedEntityId', query);
   // cleanup to avoid creating duplicates in singletypes
   ctx.request.query = {};


### PR DESCRIPTION
### What does it do?

Content Manager was sending the following param when accessing a locale:
```
plugins[i18n][locale]=en
```

As i18n will be a core package, this is now changed to be

```
locale=en
```

