### PR TITLE
chore(generator): add runtime dir to gitignore

### DIFF
--- a/packages/generators/app/src/resources/dot-files/common/gitignore
+++ b/packages/generators/app/src/resources/dot-files/common/gitignore
@@ -108,7 +108,7 @@ coverage
 .env
 license.txt
 exports
-*.cache
+.strapi
 dist
 build
 .strapi-updater.json


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* adds the runtime directory for strapi apps to the generated gitignore

### Why is it needed?

* nicer DX – they don't need to commit this

### Related issue(s)/PR(s)

* raised on slack
