### PR TITLE
fix(content-manager): add memoization to params object to stop recursion

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/SingleTypeFormWrapper.tsx
+++ b/packages/core/admin/admin/src/content-manager/components/SingleTypeFormWrapper.tsx
@@ -82,7 +82,10 @@ const SingleTypeFormWrapper = ({ children, slug }: SingleTypeFormWrapperProps) =
   const { setCurrentStep } = useGuidedTour();
   const [isCreatingEntry, setIsCreatingEntry] = React.useState(true);
   const [{ query, rawQuery }] = useQueryParams();
-  const params = buildValidGetParams(query);
+  /**
+   * If you don't memoize this, the entire form dies in recursion.
+   */
+  const params = React.useMemo(() => buildValidGetParams(query), [query]);
   const toggleNotification = useNotification();
   const dispatch = useTypedDispatch();
   const { formatAPIError } = useAPIErrorHandler(getTranslation);


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* memoizes the params passed to the fetch data call for SingleTypes

### Why is it needed?

* Because we "just" fetch in a `useEffect` hook we get recursion from not memoizing

### How to test it?

* the current build on develop is broken if there's no single type entry already created
