### PR TITLE
Fix admin lint script

### DIFF
--- a/packages/core/admin/.eslintignore
+++ b/packages/core/admin/.eslintignore
@@ -1,1 +1,2 @@
 dist
+build


### PR DESCRIPTION

### What does it do?

Added the "build" directory to the .eslintignore admin file

### Why is it needed?

Prevent the admin lint script from reporting problems from the built

### How to test it?

yarn lint should run without issues
