### PR TITLE
feat(content-releases): list releases containing content type entry

### DIFF
--- a/packages/core/content-releases/admin/src/components/CMReleasesContainer.tsx
+++ b/packages/core/content-releases/admin/src/components/CMReleasesContainer.tsx
@@ -281,6 +281,7 @@ export const CMReleasesContainer = () => {
                 borderWidth="1px"
                 borderStyle="solid"
                 borderColor={getReleaseColorVariant(release.action.type, '200')}
+                overflow="hidden"
                 hasRadius
               >
                 <Box

--- a/packages/core/content-releases/admin/src/components/CMReleasesContainer.tsx
+++ b/packages/core/content-releases/admin/src/components/CMReleasesContainer.tsx
@@ -242,7 +242,7 @@ export const CMReleasesContainer = () => {
 
   const getReleaseColorVariant = (
     actionType: 'publish' | 'unpublish',
-    shade: '200' | '100' | '600'
+    shade: '100' | '200' | '600'
   ) => {
     if (actionType === 'unpublish') {
       return `secondary${shade}`;

--- a/packages/core/content-releases/admin/src/components/CMReleasesContainer.tsx
+++ b/packages/core/content-releases/admin/src/components/CMReleasesContainer.tsx
@@ -207,13 +207,12 @@ export const CMReleasesContainer = () => {
     isCreatingEntry,
     allLayoutData: { contentType },
   } = useCMEditViewDataManager();
-  const params = useParams<{ id?: string }>();
+  const params = useParams<{ id: string }>();
 
-  const canFetch = Boolean(params.id && contentType?.uid);
+  const canFetch = params?.id != null && contentType?.uid != null;
   const fetchParams = canFetch
     ? {
-        // TypeScript still thinks contentType could be undefined, assert that it is defined
-        contentTypeUid: contentType!.uid,
+        contentTypeUid: contentType.uid,
         entryId: params.id,
         hasEntryAttached: true,
       }
@@ -241,12 +240,15 @@ export const CMReleasesContainer = () => {
 
   const toggleAddActionToReleaseModal = () => setShowModal((prev) => !prev);
 
-  const getReleaseColorVariant = (actionType: 'publish' | 'unpublish') => {
+  const getReleaseColorVariant = (
+    actionType: 'publish' | 'unpublish',
+    shade: '200' | '100' | '600'
+  ) => {
     if (actionType === 'unpublish') {
-      return 'secondary';
+      return `secondary${shade}`;
     }
 
-    return 'success';
+    return `success${shade}`;
   };
 
   return (
@@ -267,7 +269,7 @@ export const CMReleasesContainer = () => {
           <Typography variant="sigma" textColor="neutral600" textTransform="uppercase">
             {formatMessage({
               id: 'content-releases.plugin.name',
-              defaultMessage: 'RELEASES',
+              defaultMessage: 'Releases',
             })}
           </Typography>
           {releases?.map((release) => {
@@ -278,7 +280,7 @@ export const CMReleasesContainer = () => {
                 alignItems="start"
                 borderWidth="1px"
                 borderStyle="solid"
-                borderColor={`${getReleaseColorVariant(release.action.type)}200`}
+                borderColor={getReleaseColorVariant(release.action.type, '200')}
                 hasRadius
               >
                 <Box
@@ -286,13 +288,13 @@ export const CMReleasesContainer = () => {
                   paddingBottom={3}
                   paddingLeft={4}
                   paddingRight={4}
-                  background={`${getReleaseColorVariant(release.action.type)}100`}
+                  background={getReleaseColorVariant(release.action.type, '100')}
                   width="100%"
                 >
                   <Typography
                     fontSize={1}
                     variant="pi"
-                    textColor={`${getReleaseColorVariant(release.action.type)}600`}
+                    textColor={getReleaseColorVariant(release.action.type, '600')}
                   >
                     {formatMessage(
                       {
@@ -332,10 +334,8 @@ export const CMReleasesContainer = () => {
         {showModal && (
           <AddActionToReleaseModal
             handleClose={toggleAddActionToReleaseModal}
-            // Assert contentType.uid is defined when canFetch is true
-            contentTypeUid={contentType.uid!}
-            // Assert params.id is defined when canFetch is true
-            entryId={params.id!}
+            contentTypeUid={contentType.uid}
+            entryId={params.id}
           />
         )}
       </Box>

--- a/packages/core/content-releases/admin/src/components/ReleaseActionOptions.tsx
+++ b/packages/core/content-releases/admin/src/components/ReleaseActionOptions.tsx
@@ -45,6 +45,11 @@ const FieldWrapper = styled(Field)<FieldWrapperProps>`
     background-color: ${({ theme }) => theme.colors.primary100};
     border-color: ${({ theme }) => theme.colors.primary700};
   }
+
+  &[data-checked='false'] {
+    border-left: ${({ actionType }) => actionType === 'unpublish' && 'none'};
+    border-right: ${({ actionType }) => actionType === 'publish' && 'none'};
+  }
 `;
 
 interface ActionOptionProps {

--- a/packages/core/content-releases/admin/src/components/tests/CMReleasesContainer.test.tsx
+++ b/packages/core/content-releases/admin/src/components/tests/CMReleasesContainer.test.tsx
@@ -1,5 +1,5 @@
 import { useCMEditViewDataManager } from '@strapi/helper-plugin';
-import { screen } from '@testing-library/react';
+import { screen, within } from '@testing-library/react';
 import { render, server } from '@tests/utils';
 import { rest } from 'msw';
 
@@ -28,7 +28,7 @@ jest.mock('react-router-dom', () => ({
 }));
 
 describe('CMReleasesContainer', () => {
-  it('should not render the injection zone when creating an entry', () => {
+  it('should not render the container when creating an entry', () => {
     // @ts-expect-error - Ignore error
     useCMEditViewDataManager.mockReturnValueOnce({
       isCreatingEntry: true,
@@ -47,7 +47,7 @@ describe('CMReleasesContainer', () => {
     expect(informationBox).not.toBeInTheDocument();
   });
 
-  it('should not render the injection zone without draft and publish enabled', () => {
+  it('should not render the container without draft and publish enabled', async () => {
     // @ts-expect-error - Ignore error
     useCMEditViewDataManager.mockReturnValueOnce({
       isCreatingEntry: false,
@@ -66,11 +66,11 @@ describe('CMReleasesContainer', () => {
     expect(informationBox).not.toBeInTheDocument();
   });
 
-  it('should render the injection zone', () => {
+  it('should render the container', async () => {
     render(<CMReleasesContainer />);
 
-    const addToReleaseButton = screen.getByRole('button', { name: 'Add to release' });
     const informationBox = screen.getByRole('complementary', { name: 'Releases' });
+    const addToReleaseButton = await screen.findByRole('button', { name: 'Add to release' });
     expect(informationBox).toBeInTheDocument();
     expect(addToReleaseButton).toBeInTheDocument();
   });
@@ -94,7 +94,7 @@ describe('CMReleasesContainer', () => {
       rest.get('/content-releases', (req, res, ctx) => {
         return res(
           ctx.json({
-            data: [{ name: 'release1', id: '1' }],
+            data: [{ name: 'release1', id: '1', action: { type: 'publish' } }],
           })
         );
       })
@@ -112,5 +112,27 @@ describe('CMReleasesContainer', () => {
 
     const submitButtom = screen.getByRole('button', { name: 'Continue' });
     expect(submitButtom).toBeEnabled();
+  });
+
+  it('should list releases', async () => {
+    // Mock the response from the server
+    server.use(
+      rest.get('/content-releases', (req, res, ctx) => {
+        return res(
+          ctx.json({
+            data: [
+              { name: 'release1', id: '1', action: { type: 'publish' } },
+              { name: 'release2', id: '2', action: { type: 'unpublish' } },
+            ],
+          })
+        );
+      })
+    );
+
+    render(<CMReleasesContainer />);
+
+    const informationBox = await screen.findByRole('complementary', { name: 'Releases' });
+    expect(within(informationBox).getByText('release1')).toBeInTheDocument();
+    expect(within(informationBox).getByText('release2')).toBeInTheDocument();
   });
 });

--- a/packages/core/content-releases/admin/src/services/release.ts
+++ b/packages/core/content-releases/admin/src/services/release.ts
@@ -37,7 +37,7 @@ const releaseApi = createApi({
     return {
       getReleasesForEntry: build.query<
         GetContentTypeEntryReleases.Response,
-        GetContentTypeEntryReleases.Request['query']
+        Partial<GetContentTypeEntryReleases.Request['query']>
       >({
         query(params) {
           return {

--- a/packages/core/content-releases/admin/src/translations/en.json
+++ b/packages/core/content-releases/admin/src/translations/en.json
@@ -6,6 +6,7 @@
   "content-manager-edit-view.add-to-release.continue-button": "Continue",
   "content-manager-edit-view.add-to-release": "Add to release",
   "content-manager-edit-view.add-to-release.notification.success": "Entry added to release",
+  "content-manager-edit-view.list-releases.title": "{isPublish, select, true {Will be published in} other {Will be unpublished in}}",
   "content-manager.notification.entry-error": "Failed to get entry data",
   "plugin.name": "Releases",
   "pages.Releases.title": "Releases",

--- a/packages/core/content-releases/server/src/services/release.ts
+++ b/packages/core/content-releases/server/src/services/release.ts
@@ -36,7 +36,6 @@ const createReleaseService = ({ strapi }: { strapi: LoadedStrapi }) => ({
       ...query,
       populate: {
         actions: {
-          // @ts-expect-error TS error on populate, is not considering count
           count: true,
         },
       },
@@ -301,7 +300,7 @@ const createReleaseService = ({ strapi }: { strapi: LoadedStrapi }) => ({
       }
     });
 
-		// When the transaction fails it throws an error, when it is successful proceed to updating the release
+    // When the transaction fails it throws an error, when it is successful proceed to updating the release
     const release = await strapi.entityService.update(RELEASE_MODEL_UID, releaseId, {
       data: {
         /*


### PR DESCRIPTION
### What does it do?

- Lists all Releases that have the content type entry

### Why is it needed?

- To see all the releases containing a specific entry

### How to test it?

- Go to the CM edit view with permissions to read releases
- Make sure you have multiple releases with the same entry attached (or use the add to release button)
- You should see the releases containing the entry to are on and it should say what type of action will be performed


