### PR TITLE
feat(content-releases): Delete a Release

### DIFF
--- a/packages/core/content-releases/server/src/controllers/release.ts
+++ b/packages/core/content-releases/server/src/controllers/release.ts
@@ -8,6 +8,7 @@ import type {
   PublishRelease,
   GetRelease,
   Release,
+  DeleteRelease,
 } from '../../../shared/contracts/releases';
 import type { UserInfo } from '../../../shared/types';
 import { getAllowedContentTypes, getService } from '../utils';
@@ -133,6 +134,17 @@ const releaseController = {
 
     ctx.body = {
       data: await permissionsManager.sanitizeOutput(release),
+    };
+  },
+
+  async delete(ctx: Koa.Context) {
+    const id: DeleteRelease.Request['params']['id'] = ctx.params.id;
+
+    const releaseService = getService('release', { strapi });
+    const release = await releaseService.delete(id);
+
+    ctx.body = {
+      data: release,
     };
   },
 

--- a/packages/core/content-releases/server/src/routes/release.ts
+++ b/packages/core/content-releases/server/src/routes/release.ts
@@ -66,6 +66,22 @@ export default {
       },
     },
     {
+      method: 'DELETE',
+      path: '/:id',
+      handler: 'release.delete',
+      config: {
+        policies: [
+          'admin::isAuthenticatedAdmin',
+          {
+            name: 'admin::hasPermissions',
+            config: {
+              actions: ['plugin::content-releases.delete'],
+            },
+          },
+        ],
+      },
+    },
+    {
       method: 'POST',
       path: '/:id/publish',
       handler: 'release.publish',

--- a/packages/core/content-releases/server/src/services/__tests__/release.test.ts
+++ b/packages/core/content-releases/server/src/services/__tests__/release.test.ts
@@ -148,4 +148,34 @@ describe('release service', () => {
       expect(mockUnpublishMany).toHaveBeenCalledWith([{ id: 2 }], 'contentType');
     });
   });
+
+  describe('delete', () => {
+    it('throws an error if the release does not exist', () => {
+      const strapiMock = {
+        ...baseStrapiMock,
+        entityService: {
+          findOne: jest.fn().mockReturnValue(null),
+        },
+      };
+
+      // @ts-expect-error Ignore missing properties
+      const releaseService = createReleaseService({ strapi: strapiMock });
+
+      expect(() => releaseService.delete(1)).rejects.toThrow('No release found for id 1');
+    });
+
+    it('throws an error if the release is already published', () => {
+      const strapiMock = {
+        ...baseStrapiMock,
+        entityService: {
+          findOne: jest.fn().mockReturnValue({ releasedAt: new Date() }),
+        },
+      };
+
+      // @ts-expect-error Ignore missing properties
+      const releaseService = createReleaseService({ strapi: strapiMock });
+
+      expect(() => releaseService.delete(1)).rejects.toThrow('Release already published');
+    });
+  });
 });

--- a/packages/core/content-releases/server/src/services/release.ts
+++ b/packages/core/content-releases/server/src/services/release.ts
@@ -247,13 +247,15 @@ const createReleaseService = ({ strapi }: { strapi: LoadedStrapi }) => ({
     })) as unknown as Release;
 
     // We delete each action related to the release
-    deletedRelease.actions.forEach((action) => {
-      strapi.db.query(RELEASE_ACTION_MODEL_UID).delete({
+    if (deletedRelease.actions) {
+      await strapi.db.query(RELEASE_ACTION_MODEL_UID).deleteMany({
         where: {
-          id: action.id,
+          id: {
+            $in: deletedRelease.actions.map(({ id }) => id),
+          },
         },
       });
-    });
+    }
 
     return deletedRelease;
   },

--- a/packages/core/content-releases/server/src/services/release.ts
+++ b/packages/core/content-releases/server/src/services/release.ts
@@ -177,7 +177,18 @@ const createReleaseService = ({ strapi }: { strapi: LoadedStrapi }) => ({
       throw new errors.ValidationError('Release already published');
     }
 
-    const deletedRelease = await strapi.entityService.delete(RELEASE_MODEL_UID, releaseId);
+    const deletedRelease = (await strapi.entityService.delete(RELEASE_MODEL_UID, releaseId, {
+      populate: { actions: { fields: ['id'] } },
+    })) as unknown as Release;
+
+    // We delete each action related to the release
+    deletedRelease.actions.forEach((action) => {
+      strapi.db.query(RELEASE_ACTION_MODEL_UID).delete({
+        where: {
+          id: action.id,
+        },
+      });
+    });
 
     return deletedRelease;
   },

--- a/packages/core/content-releases/shared/contracts/releases.ts
+++ b/packages/core/content-releases/shared/contracts/releases.ts
@@ -102,6 +102,25 @@ export declare namespace UpdateRelease {
 }
 
 /**
+ * DELETE /content-releases/:id - Delete a release
+ */
+export declare namespace DeleteRelease {
+  export interface Request {
+    state: {
+      user: UserInfo;
+    };
+    params: {
+      id: Release['id'];
+    };
+  }
+
+  export interface Response {
+    data: ReleaseDataResponse;
+    error?: errors.ApplicationError | errors.NotFoundError;
+  }
+}
+
+/**
  * POST /content-releases/:releaseId/publish - Publish a release
  */
 export declare namespace PublishRelease {

--- a/packages/core/content-releases/shared/contracts/releases.ts
+++ b/packages/core/content-releases/shared/contracts/releases.ts
@@ -2,7 +2,6 @@ import type { Entity } from '../types';
 import type { ReleaseAction } from './release-actions';
 import type { UserInfo } from '../types';
 import { errors } from '@strapi/utils';
-import { UID } from '@strapi/types';
 
 export interface Release extends Entity {
   name: string;


### PR DESCRIPTION
### What does it do?

Add a new `/content-releases/:id/` delete endpoint to delete a release.

### How to test it?

Make sure you have the content-releases feature enabled with a EE project.
1. Make a request to DELETE `/content-releases/:releaseId`
2. Release should exists, if not it should throw an error
3. Release should not be published, if not it should throw an error
4. If all good, it should return the details of the release

