### PR TITLE
refactor(content-releases): remove permission checks and update endpo…

### DIFF
--- a/packages/core/content-releases/server/src/controllers/__tests__/release-action.test.ts
+++ b/packages/core/content-releases/server/src/controllers/__tests__/release-action.test.ts
@@ -8,7 +8,7 @@ jest.mock('../../utils', () => ({
   getService: jest.fn(() => ({
     create: jest.fn(),
     findActions: mockFindActions,
-    getContentTypesMetaFromActions: jest.fn(() => ({
+    getContentTypesDataForActions: jest.fn(() => ({
       'api::contentTypeA.contentTypeA': {
         mainField: 'name',
         displayName: 'contentTypeA',
@@ -114,7 +114,7 @@ describe('Release Action controller', () => {
   });
 
   describe('findMany', () => {
-    it('should return the correct entry meta data', async () => {
+    it('should return the data for an entry', async () => {
       mockFindActions.mockResolvedValueOnce({
         results: [
           {
@@ -183,29 +183,25 @@ describe('Release Action controller', () => {
       // @ts-expect-error Ignore missing properties
       expect(ctx.body.data[0].entry).toEqual({
         id: 1,
-        meta: {
-          contentType: {
-            displayName: 'contentTypeA',
-            mainFieldValue: 'test 1',
-          },
-          locale: {
-            code: 'en',
-            name: 'English (en)',
-          },
+        contentType: {
+          displayName: 'contentTypeA',
+          mainFieldValue: 'test 1',
+        },
+        locale: {
+          code: 'en',
+          name: 'English (en)',
         },
       });
       // @ts-expect-error Ignore missing properties
       expect(ctx.body.data[1].entry).toEqual({
         id: 2,
-        meta: {
-          contentType: {
-            displayName: 'contentTypeB',
-            mainFieldValue: 'test 2',
-          },
-          locale: {
-            code: 'fr',
-            name: 'French (fr)',
-          },
+        contentType: {
+          displayName: 'contentTypeB',
+          mainFieldValue: 'test 2',
+        },
+        locale: {
+          code: 'fr',
+          name: 'French (fr)',
         },
       });
     });

--- a/packages/core/content-releases/server/src/controllers/__tests__/release-action.test.ts
+++ b/packages/core/content-releases/server/src/controllers/__tests__/release-action.test.ts
@@ -8,18 +8,17 @@ jest.mock('../../utils', () => ({
   getService: jest.fn(() => ({
     create: jest.fn(),
     findActions: mockFindActions,
-    findReleaseContentTypesMainFields: jest.fn(() => ({
+    getContentTypesMetaFromActions: jest.fn(() => ({
       'api::contentTypeA.contentTypeA': {
         mainField: 'name',
+        displayName: 'contentTypeA',
       },
       'api::contentTypeB.contentTypeB': {
         mainField: 'name',
+        displayName: 'contentTypeB',
       },
     })),
   })),
-  getAllowedContentTypes: jest
-    .fn()
-    .mockReturnValue(['api::contentTypeA.contentTypeA', 'api::contentTypeB.contentTypeB']),
   getPermissionsChecker: jest.fn(() => ({
     sanitizedQuery: {
       read: mockSanitizedQueryRead,
@@ -93,47 +92,6 @@ describe('Release Action controller', () => {
     });
   });
 
-  describe('findMany', () => {
-    const ctx = {
-      state: {
-        userAbility: {
-          can: jest.fn(),
-          cannot: jest.fn(),
-        },
-      },
-      params: {
-        releaseId: 1,
-      },
-    };
-
-    it('should call sanitizedQueryRead once for each contentType', async () => {
-      // @ts-expect-error Ignore missing properties
-      await releaseActionController.findMany(ctx);
-
-      expect(mockSanitizedQueryRead).toHaveBeenCalledTimes(2);
-    });
-
-    it('should call findActions with the right params', async () => {
-      // @ts-expect-error Ignore missing properties
-      await releaseActionController.findMany(ctx);
-
-      expect(mockFindActions).toHaveBeenCalledWith(
-        1,
-        ['api::contentTypeA.contentTypeA', 'api::contentTypeB.contentTypeB'],
-        {
-          populate: {
-            entry: {
-              on: {
-                'api::contentTypeA.contentTypeA': {},
-                'api::contentTypeB.contentTypeB': {},
-              },
-            },
-          },
-        }
-      );
-    });
-  });
-
   describe('update', () => {
     it('throws an error given bad request arguments', () => {
       const ctx = {
@@ -152,6 +110,104 @@ describe('Release Action controller', () => {
       expect(() => releaseActionController.update(ctx)).rejects.toThrow(
         'type must be one of the following values: publish, unpublish'
       );
+    });
+  });
+
+  describe('findMany', () => {
+    it('should return the correct entry meta data', async () => {
+      mockFindActions.mockResolvedValueOnce({
+        results: [
+          {
+            id: 1,
+            contentType: 'api::contentTypeA.contentTypeA',
+            entry: { id: 1, name: 'test 1', locale: 'en' },
+          },
+          {
+            id: 2,
+            contentType: 'api::contentTypeB.contentTypeB',
+            entry: { id: 2, name: 'test 2', locale: 'fr' },
+          },
+        ],
+        pagination: {},
+      });
+      global.strapi = {
+        plugins: {
+          // @ts-expect-error Ignore missing properties
+          i18n: {
+            services: {
+              locales: {
+                find: jest.fn().mockReturnValue([
+                  {
+                    id: 1,
+                    name: 'English (en)',
+                    code: 'en',
+                  },
+                  {
+                    id: 2,
+                    name: 'French (fr)',
+                    code: 'fr',
+                  },
+                ]),
+              },
+            },
+          },
+        },
+        // @ts-expect-error Ignore missing properties
+        admin: {
+          services: {
+            permission: {
+              createPermissionsManager: jest.fn(() => ({
+                ability: {
+                  can: jest.fn(),
+                },
+                validateQuery: jest.fn(),
+                sanitizeQuery: jest.fn(() => ctx.query),
+              })),
+            },
+          },
+        },
+      };
+
+      const ctx = {
+        state: {
+          userAbility: {},
+        },
+        params: {
+          releaseId: 1,
+        },
+        query: {},
+      };
+      // @ts-expect-error Ignore missing properties
+      await releaseActionController.findMany(ctx);
+
+      // @ts-expect-error Ignore missing properties
+      expect(ctx.body.data[0].entry).toEqual({
+        id: 1,
+        meta: {
+          contentType: {
+            displayName: 'contentTypeA',
+            mainFieldValue: 'test 1',
+          },
+          locale: {
+            code: 'en',
+            name: 'English (en)',
+          },
+        },
+      });
+      // @ts-expect-error Ignore missing properties
+      expect(ctx.body.data[1].entry).toEqual({
+        id: 2,
+        meta: {
+          contentType: {
+            displayName: 'contentTypeB',
+            mainFieldValue: 'test 2',
+          },
+          locale: {
+            code: 'fr',
+            name: 'French (fr)',
+          },
+        },
+      });
     });
   });
 });

--- a/packages/core/content-releases/server/src/controllers/__tests__/release.test.ts
+++ b/packages/core/content-releases/server/src/controllers/__tests__/release.test.ts
@@ -10,7 +10,7 @@ jest.mock('../../utils', () => ({
     findPage: mockFindPage,
     findManyForContentTypeEntry: mockFindManyForContentTypeEntry,
     countActions: mockCountActions,
-    getContentTypesMetaFromActions: jest.fn(),
+    getContentTypesDataForActions: jest.fn(),
   })),
   getAllowedContentTypes: jest.fn(() => ['contentTypeA', 'contentTypeB']),
 }));

--- a/packages/core/content-releases/server/src/controllers/release-action.ts
+++ b/packages/core/content-releases/server/src/controllers/release-action.ts
@@ -48,7 +48,7 @@ const releaseActionController = {
 
     const releaseService = getService('release', { strapi });
     const { results, pagination } = await releaseService.findActions(releaseId, query);
-    const allReleaseContentTypesDictionary = await releaseService.getContentTypesMetaFromActions(
+    const allReleaseContentTypesDictionary = await releaseService.getContentTypesDataForActions(
       releaseId
     );
 
@@ -66,13 +66,11 @@ const releaseActionController = {
         ...action,
         entry: {
           id: action.entry.id,
-          meta: {
-            contentType: {
-              displayName,
-              mainFieldValue: action.entry[mainField],
-            },
-            locale: allLocalesDictionary[action.entry.locale],
+          contentType: {
+            displayName,
+            mainFieldValue: action.entry[mainField],
           },
+          locale: allLocalesDictionary[action.entry.locale],
         },
       };
     });

--- a/packages/core/content-releases/server/src/services/release.ts
+++ b/packages/core/content-releases/server/src/services/release.ts
@@ -221,14 +221,14 @@ const createReleaseService = ({ strapi }: { strapi: LoadedStrapi }) => ({
     return contentTypesFromReleaseActions.map(({ contentType: contentTypeUid }) => contentTypeUid);
   },
 
-  async getContentTypesMetaFromActions(releaseId: Release['id']) {
+  async getContentTypesDataForActions(releaseId: Release['id']) {
     const contentTypesUids = await this.getAllContentTypeUids(releaseId);
 
     const contentManagerContentTypeService = strapi
       .plugin('content-manager')
       .service('content-types');
 
-    const contentTypesMetaData: Record<
+    const contentTypesData: Record<
       UID.ContentType,
       { mainField: string; displayName: string }
     > = {};
@@ -237,13 +237,13 @@ const createReleaseService = ({ strapi }: { strapi: LoadedStrapi }) => ({
         uid: contentTypeUid,
       });
 
-      contentTypesMetaData[contentTypeUid] = {
+      contentTypesData[contentTypeUid] = {
         mainField: contentTypeConfig.settings.mainField,
         displayName: strapi.getModel(contentTypeUid).info.displayName,
       };
     }
 
-    return contentTypesMetaData;
+    return contentTypesData;
   },
 
   async delete(releaseId: DeleteRelease.Request['params']['id']) {

--- a/packages/core/content-releases/server/src/utils/index.ts
+++ b/packages/core/content-releases/server/src/utils/index.ts
@@ -1,35 +1,6 @@
-import type { LoadedStrapi, UID } from '@strapi/types';
-
 export const getService = (
   name: 'release' | 'release-validation',
   { strapi } = { strapi: global.strapi }
 ) => {
   return strapi.plugin('content-releases').service(name);
-};
-
-/**
- * Gets the content types that have draft and publish enabled and that the user can read
- */
-export const getAllowedContentTypes = ({ strapi, userAbility }: { strapi: LoadedStrapi, userAbility: any }) => {
-  const { contentTypes } = strapi;
-  const contentTypesWithDraftAndPublish = (Object.keys(contentTypes) as UID.ContentType[]).filter(
-    (contentTypeUid) => contentTypes[contentTypeUid].options?.draftAndPublish
-  );
-  const allowedContentTypes = contentTypesWithDraftAndPublish.filter(
-    (contentTypeUid) => {
-      return userAbility.can('plugin::content-manager.explorer.read', contentTypeUid);
-    }
-  );
-
-  return allowedContentTypes;
-};
-
-/**
- * Gets the permissions checker for a given content type using the permission checker from content-manager
- */
-export const  getPermissionsChecker = ({ strapi, userAbility, model }: { strapi: LoadedStrapi, userAbility: any, model: UID.ContentType }) => {
-  return strapi
-    .plugin('content-manager')
-    .service('permission-checker')
-    .create({ userAbility, model });
 };

--- a/packages/core/content-releases/shared/contracts/release-actions.ts
+++ b/packages/core/content-releases/shared/contracts/release-actions.ts
@@ -3,11 +3,23 @@ import type { Release, Pagination } from './releases';
 import type { Entity } from '../types';
 
 import type { errors } from '@strapi/utils';
-import { UserInfo } from '@strapi/helper-plugin';
 
 type ReleaseActionEntry = Entity & {
   // Entity attributes
   [key: string]: Attribute.Any;
+} & {
+  locale: string;
+};
+
+type ReleaseActionEntryMeta = {
+  locale?: {
+    name: string;
+    code: string;
+  };
+  contentType: {
+    mainFieldValue?: string;
+    displayName: string;
+  };
 };
 
 export interface ReleaseAction extends Entity {
@@ -52,7 +64,8 @@ export declare namespace GetReleaseActions {
   }
 
   export interface Response {
-    data: ReleaseAction[];
+    data: ReleaseAction &
+      { entry: { id: ReleaseActionEntry['id']; meta: ReleaseActionEntryMeta } }[];
     meta: {
       pagination: Pagination;
     };
@@ -82,7 +95,7 @@ export declare namespace DeleteReleaseAction {
 export declare namespace UpdateReleaseAction {
   export interface Request {
     params: {
-      actionId: ReleaseAction['id']
+      actionId: ReleaseAction['id'];
       releaseId: ReleaseAction['id'];
     };
     body: {

--- a/packages/core/content-releases/shared/contracts/release-actions.ts
+++ b/packages/core/content-releases/shared/contracts/release-actions.ts
@@ -11,7 +11,7 @@ type ReleaseActionEntry = Entity & {
   locale: string;
 };
 
-type ReleaseActionEntryMeta = {
+type ReleaseActionEntryData = {
   locale?: {
     name: string;
     code: string;
@@ -64,8 +64,7 @@ export declare namespace GetReleaseActions {
   }
 
   export interface Response {
-    data: ReleaseAction &
-      { entry: { id: ReleaseActionEntry['id']; meta: ReleaseActionEntryMeta } }[];
+    data: ReleaseAction & { entry: ReleaseActionEntryData }[];
     meta: {
       pagination: Pagination;
     };


### PR DESCRIPTION
### What does it do?

Release Action
- Removes the permission checks on entry and filtering of entries that don't pass the permission check
- Reshapes the populated entry to use a meta entry meta data (content type display name, locale)
```json
//...release action stuff...//
"entry": {
    "contentType": {
        "mainFieldValue": "name",
        "displayName": "Restaurant"
    },
    "locale": {
        "name": "English (en)",
        "code": "en"
    }
}
```

Release findOne
- Forward the query from the controller to the service so the pagination works
- Update the findOne service to populate and sanitize creator fields
```json
// ... release stuff ... //
"createdBy": {
  "id": 1,
  "firstname": "George",
  "lastname": "Harrison",
  "username": "Thebestbeatle",
},
```


### Why is it needed?

- We decided for now to not check permissions on every single entry. We may re-introduce granular permission checks in the future.
- Gives the frontend all the data it needs for the Release page

### How to test it?

- Make a request for a single release: http://localhost:1337/content-releases/:id
- Check the data looks correct
- Make a request for a release's actions: http://localhost:1337/content-releases/3/actions?page=1&pageSize=20
- Check it is returning only the actions for the requested release, the pagination works, and the entry meta is as described above where applicable.
