### PR TITLE
feat: Upgrade the strapi dependencies in project's package.json

### DIFF
--- a/packages/cli/create-strapi-starter/src/utils/child-process.ts
+++ b/packages/cli/create-strapi-starter/src/utils/child-process.ts
@@ -3,6 +3,7 @@ import execa from 'execa';
 import logger from './logger';
 import type { Options } from '../types';
 
+// TODO: Refactor run install, use the methods available in @strapi/utils instead
 export function runInstall(path: string, { useYarn }: Options = {}) {
   return execa(useYarn ? 'yarn' : 'npm', ['install'], {
     cwd: path,

--- a/packages/core/utils/package.json
+++ b/packages/core/utils/package.json
@@ -42,14 +42,16 @@
     "test:ts": "run -T tsc --noEmit",
     "test:unit": "run -T jest",
     "test:unit:watch": "run -T jest --watch",
-    "watch": "run -T pack-up watch"
+    "watch": "pack-up watch"
   },
   "dependencies": {
     "@sindresorhus/slugify": "1.1.0",
     "date-fns": "2.30.0",
+    "execa": "5.1.1",
     "http-errors": "1.8.1",
     "lodash": "4.17.21",
     "p-map": "4.0.0",
+    "preferred-pm": "3.1.2",
     "yup": "0.32.9"
   },
   "devDependencies": {

--- a/packages/core/utils/src/index.ts
+++ b/packages/core/utils/src/index.ts
@@ -44,6 +44,7 @@ import * as file from './file';
 import * as traverse from './traverse';
 import webhook from './webhook';
 import { isOperator, isOperatorOfType } from './operators';
+import * as packageManager from './package-manager';
 
 export {
   parseMultipartData,
@@ -95,4 +96,5 @@ export {
   webhook,
   isOperator,
   isOperatorOfType,
+  packageManager,
 };

--- a/packages/core/utils/src/package-manager.ts
+++ b/packages/core/utils/src/package-manager.ts
@@ -1,0 +1,37 @@
+import execa from 'execa';
+import preferredPM from 'preferred-pm';
+
+import type { Options as ProcessOptions } from 'execa';
+
+const SUPPORTED_PACKAGE_MANAGERS = ['npm', 'yarn'];
+const DEFAULT_PACKAGE_MANAGER = 'npm' as const;
+
+type SupportedPackageManagerName = 'npm' | 'yarn';
+
+export const getPreferred = async (pkgPath: string): Promise<SupportedPackageManagerName> => {
+  const pm = await preferredPM(pkgPath);
+
+  const hasPackageManager = pm !== undefined;
+  if (!hasPackageManager) {
+    throw new Error(`Couldn't find a package manager in your project.`);
+  }
+
+  const isPackageManagerSupported = SUPPORTED_PACKAGE_MANAGERS.includes(pm.name);
+  if (!isPackageManagerSupported) {
+    process.emitWarning(
+      `We detected your package manager (${pm.name} v${pm.version}), but it's not officially supported by Strapi yet. Defaulting to npm instead.`
+    );
+
+    return DEFAULT_PACKAGE_MANAGER;
+  }
+
+  return pm.name as SupportedPackageManagerName;
+};
+
+export const installDependencies = (
+  path: string,
+  packageManager: SupportedPackageManagerName,
+  options: ProcessOptions<string> = {}
+) => {
+  return execa(packageManager, ['install'], { ...options, cwd: path, stdin: 'ignore' });
+};

--- a/packages/utils/upgrade/package.json
+++ b/packages/utils/upgrade/package.json
@@ -59,6 +59,7 @@
     "watch": "pack-up watch"
   },
   "dependencies": {
+    "@strapi/utils": "4.15.5",
     "chalk": "4.1.2",
     "cli-table3": "0.6.2",
     "commander": "8.3.0",

--- a/packages/utils/upgrade/src/modules/logger/logger.ts
+++ b/packages/utils/upgrade/src/modules/logger/logger.ts
@@ -1,4 +1,5 @@
 import chalk from 'chalk';
+import { Readable } from 'node:stream';
 
 import type { Logger as LoggerInterface, LoggerOptions } from './types';
 
@@ -31,6 +32,14 @@ export class Logger implements LoggerInterface {
 
   get warnings(): number {
     return this.nbWarningsCalls;
+  }
+
+  get stdout(): (NodeJS.WriteStream & { fd: 1 }) | undefined {
+    return this.isSilent ? undefined : process.stdout;
+  }
+
+  get stderr(): (NodeJS.WriteStream & { fd: 2 }) | undefined {
+    return this.isSilent ? undefined : process.stderr;
   }
 
   setDebug(debug: boolean): this {

--- a/packages/utils/upgrade/src/modules/logger/types.ts
+++ b/packages/utils/upgrade/src/modules/logger/types.ts
@@ -13,6 +13,9 @@ export interface Logger {
   get warnings(): number;
   get errors(): number;
 
+  get stdout(): (NodeJS.WriteStream & { fd: 1 }) | undefined;
+  get stderr(): (NodeJS.WriteStream & { fd: 2 }) | undefined;
+
   debug(...args: unknown[]): this;
   info(...args: unknown[]): this;
   warn(...args: unknown[]): this;

--- a/packages/utils/upgrade/src/modules/upgrader/upgrader.ts
+++ b/packages/utils/upgrade/src/modules/upgrader/upgrader.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert';
+import { packageManager } from '@strapi/utils';
 
 import {
   codemodRepositoryFactory,
@@ -89,6 +90,7 @@ export class Upgrader implements UpgraderInterface {
       });
 
       await this.updateDependencies();
+      await this.installDependencies();
 
       await this.runCodemods(range);
     } catch (e) {
@@ -185,7 +187,18 @@ export class Upgrader implements UpgraderInterface {
     return strapiDependencies;
   }
 
-  private async runCodemods(range: Version.Range) {
+  private async installDependencies(): Promise<void> {
+    const projectPath = this.project.cwd;
+
+    const packageManagerName = await packageManager.getPreferred(projectPath);
+
+    await packageManager.installDependencies(projectPath, packageManagerName, {
+      stdout: this.logger?.stdout,
+      stderr: this.logger?.stderr,
+    });
+  }
+
+  private async runCodemods(range: Version.Range): Promise<void> {
     const repository = codemodRepositoryFactory(
       codemodRepositoryConstants.INTERNAL_CODEMODS_DIRECTORY
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -9971,6 +9971,7 @@ __metadata:
   dependencies:
     "@strapi/pack-up": "workspace:*"
     "@strapi/types": "npm:4.15.5"
+    "@strapi/utils": "npm:4.15.5"
     "@types/jscodeshift": "npm:0.11.10"
     chalk: "npm:4.1.2"
     cli-table3: "npm:0.6.2"
@@ -10002,11 +10003,13 @@ __metadata:
     "@types/node": "npm:18.18.4"
     date-fns: "npm:2.30.0"
     eslint-config-custom: "npm:4.15.5"
+    execa: "npm:5.1.1"
     http-errors: "npm:1.8.1"
     koa: "npm:2.13.4"
     koa-body: "npm:4.2.0"
     lodash: "npm:4.17.21"
     p-map: "npm:4.0.0"
+    preferred-pm: "npm:3.1.2"
     tsconfig: "npm:4.15.5"
     yup: "npm:0.32.9"
   languageName: unknown
@@ -18478,6 +18481,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"find-yarn-workspace-root2@npm:1.2.16":
+  version: 1.2.16
+  resolution: "find-yarn-workspace-root2@npm:1.2.16"
+  dependencies:
+    micromatch: "npm:^4.0.2"
+    pkg-dir: "npm:^4.2.0"
+  checksum: 398aa473ac245d9c9e9af5a75806b5a6828bd9a759f138faf4666f00c5fcb78af679d43f5cfbe73fe667cf6ec3ef6c9e157b09400181e5b9edc3adc47080e9bb
+  languageName: node
+  linkType: hard
+
 "findup-sync@npm:^2.0.0":
   version: 2.0.0
   resolution: "findup-sync@npm:2.0.0"
@@ -19514,6 +19527,13 @@ __metadata:
   version: 4.2.10
   resolution: "graceful-fs@npm:4.2.10"
   checksum: 0c83c52b62c68a944dcfb9d66b0f9f10f7d6e3d081e8067b9bfdc9e5f3a8896584d576036f82915773189eec1eba599397fc620e75c03c0610fb3d67c6713c1a
+  languageName: node
+  linkType: hard
+
+"graceful-fs@npm:^4.1.5":
+  version: 4.2.11
+  resolution: "graceful-fs@npm:4.2.11"
+  checksum: bf152d0ed1dc159239db1ba1f74fdbc40cb02f626770dcd5815c427ce0688c2635a06ed69af364396da4636d0408fcf7d4afdf7881724c3307e46aff30ca49e2
   languageName: node
   linkType: hard
 
@@ -22041,7 +22061,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:^3.10.0, js-yaml@npm:^3.13.1":
+"js-yaml@npm:^3.10.0, js-yaml@npm:^3.13.0, js-yaml@npm:^3.13.1":
   version: 3.14.1
   resolution: "js-yaml@npm:3.14.1"
   dependencies:
@@ -23069,6 +23089,18 @@ __metadata:
     pify: "npm:^3.0.0"
     strip-bom: "npm:^3.0.0"
   checksum: 8f5d6d93ba64a9620445ee9bde4d98b1eac32cf6c8c2d20d44abfa41a6945e7969456ab5f1ca2fb06ee32e206c9769a20eec7002fe290de462e8c884b6b8b356
+  languageName: node
+  linkType: hard
+
+"load-yaml-file@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "load-yaml-file@npm:0.2.0"
+  dependencies:
+    graceful-fs: "npm:^4.1.5"
+    js-yaml: "npm:^3.13.0"
+    pify: "npm:^4.0.1"
+    strip-bom: "npm:^3.0.0"
+  checksum: b1bfa7e80114933e43ccc1cf3772582b7e13c8a71dc8d560de2aeecdabf545014daf8a5afabe634c1e9f71c75f6f8528bbd944c9cbbbdf2ab8c927118bd48fd2
   languageName: node
   linkType: hard
 
@@ -24315,7 +24347,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"micromatch@npm:4.0.5, micromatch@npm:^4.0.4, micromatch@npm:^4.0.5":
+"micromatch@npm:4.0.5, micromatch@npm:^4.0.2, micromatch@npm:^4.0.4, micromatch@npm:^4.0.5":
   version: 4.0.5
   resolution: "micromatch@npm:4.0.5"
   dependencies:
@@ -27055,6 +27087,18 @@ __metadata:
   bin:
     prebuild-install: bin.js
   checksum: 6c70a2f82fbda8903497c560a761b000d861a3e772322c8bed012be0f0a084b5aaca4438a3fad1bd3a24210765f4fae06ddd89ea04dc4c034dde693cc0d9d5f4
+  languageName: node
+  linkType: hard
+
+"preferred-pm@npm:3.1.2":
+  version: 3.1.2
+  resolution: "preferred-pm@npm:3.1.2"
+  dependencies:
+    find-up: "npm:^5.0.0"
+    find-yarn-workspace-root2: "npm:1.2.16"
+    path-exists: "npm:^4.0.0"
+    which-pm: "npm:2.0.0"
+  checksum: d66019f36765c4e241197cd34e2718c03d7eff953b94dacb278df9326767ccc2744d4e0bcab265fd9bb036f704ed5f3909d02594cd5663bd640a160fe4c1446c
   languageName: node
   linkType: hard
 
@@ -32582,6 +32626,16 @@ __metadata:
     is-weakmap: "npm:^2.0.1"
     is-weakset: "npm:^2.0.1"
   checksum: 85c95fcf92df7972ce66bed879e53d9dc752a30ef08e1ca4696df56bcf1c302e3b9965a39b04a20fa280a997fad6c170eb0b4d62435569b7f6c0bc7be910572b
+  languageName: node
+  linkType: hard
+
+"which-pm@npm:2.0.0":
+  version: 2.0.0
+  resolution: "which-pm@npm:2.0.0"
+  dependencies:
+    load-yaml-file: "npm:^0.2.0"
+    path-exists: "npm:^4.0.0"
+  checksum: 8f9dc47ab1302d536458a3d28b891907540d67e18b95d8cf0a41ba768b679c2bc7b64c17d9b80c85443c4b300a3e2d5c29ae1e9c7c6ad2833760070fbdbd3b6f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
ℹ️ The following work is based on https://github.com/strapi/strapi/pull/18989 by @innerdvations with some modifications

### What does it do?

Runs the detected preferred package manager for the project after the package.json update stage

### Why is it needed?

To automatically install packages for users

### How to test it?

Run the upgrade tool and see that packages are installed after being updated

Tests will be added before the final feature is merged
