### PR TITLE
feat(email-amazon-ses): switch to AWS SDK v3 for sending e-mail

### DIFF
--- a/packages/providers/email-amazon-ses/README.md
+++ b/packages/providers/email-amazon-ses/README.md
@@ -26,7 +26,7 @@ npm install @strapi/provider-email-amazon-ses --save
 | Variable                | Type                    | Description                                                                                                                | Required | Default   |
 | ----------------------- | ----------------------- | -------------------------------------------------------------------------------------------------------------------------- | -------- | --------- |
 | provider                | string                  | The name of the provider you use                                                                                           | yes      |           |
-| providerOptions         | object                  | Will be directly given to `createClient` function. Please refer to [node-ses](https://www.npmjs.com/package/node-ses) doc. | yes      |           |
+| providerOptions         | object                  | Will be directly given to `SESClient` function. Please refer to [SESClient](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/ses/) doc. | yes      |           |
 | settings                | object                  | Settings                                                                                                                   | no       | {}        |
 | settings.defaultFrom    | string                  | Default sender mail address                                                                                                | no       | undefined |
 | settings.defaultReplyTo | string \| array<string> | Default address or addresses the receiver is asked to reply to                                                             | no       | undefined |
@@ -44,9 +44,12 @@ module.exports = ({ env }) => ({
     config: {
       provider: 'amazon-ses',
       providerOptions: {
-        key: env('AWS_SES_KEY'),
-        secret: env('AWS_SES_SECRET'),
-        amazon: 'https://email.us-east-1.amazonaws.com',
+        region: 'eu-west-1',
+        credentials: {
+          accessKeyId: env('AWS_ACCESS_KEY_ID'),
+          secretAccessKey: env('AWS_ACCESS_SECRET'),
+        }
+        // or any other SESClientConfig parameter
       },
       settings: {
         defaultFrom: 'myemail@protonmail.com',

--- a/packages/providers/email-amazon-ses/package.json
+++ b/packages/providers/email-amazon-ses/package.json
@@ -43,8 +43,8 @@
     "watch": "pack-up watch"
   },
   "dependencies": {
-    "@strapi/utils": "4.15.5",
-    "node-ses": "^3.0.3"
+    "@aws-sdk/client-ses": "^3.468.0",
+    "@strapi/utils": "4.15.5"
   },
   "devDependencies": {
     "@strapi/pack-up": "4.15.5",


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

The `email-amazon-ses` providers uses `node-ses` instead of the official AWS SDK (v3). 

### Why is it needed?

Switching to the SDK provides a lot more flexibility in configuration and does not use non-official packages anymore. 

### How to test it?

Send test e-mail from admin panel


```javascript
export default ({ env }) => ({
  email: {
    config: {
      provider: 'amazon-ses',
      providerOptions: {
        region: 'eu-west-1',
        credentials: {
          accessKeyId: env('AWS_ACCESS_KEY_ID'),
          secretAccessKey: env('AWS_ACCESS_SECRET'),
        }
      },
      settings: {
        defaultFrom: 'email@domain.com',
        defaultReplyTo: 'email@domain.com',
      },
    },
  },
}
})

```

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
