### PR TITLE
Refactor useContentManagerInitData to use react query 

### DIFF
--- a/packages/core/admin/admin/src/content-manager/contexts/ModelsContext.jsx
+++ b/packages/core/admin/admin/src/content-manager/contexts/ModelsContext.jsx
@@ -1,5 +1,0 @@
-import { createContext } from 'react';
-
-const ModelsContext = createContext();
-
-export default ModelsContext;

--- a/packages/core/admin/admin/src/content-manager/pages/App/actions.js
+++ b/packages/core/admin/admin/src/content-manager/pages/App/actions.js
@@ -1,10 +1,8 @@
-import { GET_INIT_DATA, RESET_INIT_DATA, SET_INIT_DATA } from './constants';
+import { GET_INIT_DATA, SET_INIT_DATA } from './constants';
 
 export const getInitData = () => ({
   type: GET_INIT_DATA,
 });
-
-export const resetInitData = () => ({ type: RESET_INIT_DATA });
 
 export const setInitData = ({
   authorizedCollectionTypeLinks,

--- a/packages/core/admin/admin/src/content-manager/pages/App/constants.js
+++ b/packages/core/admin/admin/src/content-manager/pages/App/constants.js
@@ -1,3 +1,2 @@
 export const GET_INIT_DATA = 'ContentManager/App/GET_INIT_DATA';
-export const RESET_INIT_DATA = 'ContentManager/App/RESET_INIT_DATA';
 export const SET_INIT_DATA = 'ContentManager/App/SET_INIT_DATA';

--- a/packages/core/admin/admin/src/content-manager/pages/App/index.jsx
+++ b/packages/core/admin/admin/src/content-manager/pages/App/index.jsx
@@ -15,7 +15,6 @@ import { Redirect, Route, Switch, useLocation, useRouteMatch } from 'react-route
 
 import { DragLayer } from '../../../components/DragLayer';
 import { selectAdminPermissions } from '../../../selectors';
-import ModelsContext from '../../contexts/ModelsContext';
 import getTrad from '../../utils/getTrad';
 import ItemTypes from '../../utils/ItemTypes';
 import CollectionTypeRecursivePath from '../CollectionTypeRecursivePath';
@@ -63,8 +62,8 @@ function renderDraglayerItem({ type, item }) {
 
 const App = () => {
   const contentTypeMatch = useRouteMatch(`/content-manager/:kind/:uid`);
-  const { status, collectionTypeLinks, singleTypeLinks, models, refetchData } =
-    useContentManagerInitData();
+  const { status, collectionTypeLinks, singleTypeLinks, models } = useContentManagerInitData();
+
   const authorisedModels = sortBy([...collectionTypeLinks, ...singleTypeLinks], (model) =>
     model.title.toLowerCase()
   );
@@ -124,28 +123,26 @@ const App = () => {
   return (
     <Layout sideNav={<LeftMenu />}>
       <DragLayer renderItem={renderDraglayerItem} />
-      <ModelsContext.Provider value={{ refetchData }}>
-        <Switch>
-          <Route path="/content-manager/components/:uid/configurations/edit">
-            <CheckPagePermissions permissions={permissions.contentManager.componentsConfigurations}>
-              <ComponentSettingsView />
-            </CheckPagePermissions>
-          </Route>
-          <Route
-            path="/content-manager/collectionType/:slug"
-            component={CollectionTypeRecursivePath}
-          />
-          <Route path="/content-manager/singleType/:slug" component={SingleTypeRecursivePath} />
+      <Switch>
+        <Route path="/content-manager/components/:uid/configurations/edit">
+          <CheckPagePermissions permissions={permissions.contentManager.componentsConfigurations}>
+            <ComponentSettingsView />
+          </CheckPagePermissions>
+        </Route>
+        <Route
+          path="/content-manager/collectionType/:slug"
+          component={CollectionTypeRecursivePath}
+        />
+        <Route path="/content-manager/singleType/:slug" component={SingleTypeRecursivePath} />
 
-          <Route path="/content-manager/403">
-            <NoPermissions />
-          </Route>
-          <Route path="/content-manager/no-content-types">
-            <NoContentType />
-          </Route>
-          <Route path="" component={AnErrorOccurred} />
-        </Switch>
-      </ModelsContext.Provider>
+        <Route path="/content-manager/403">
+          <NoPermissions />
+        </Route>
+        <Route path="/content-manager/no-content-types">
+          <NoContentType />
+        </Route>
+        <Route path="" component={AnErrorOccurred} />
+      </Switch>
     </Layout>
   );
 };

--- a/packages/core/admin/admin/src/content-manager/pages/App/reducer.js
+++ b/packages/core/admin/admin/src/content-manager/pages/App/reducer.js
@@ -5,7 +5,7 @@
 /* eslint-disable consistent-return */
 import produce from 'immer';
 
-import { GET_INIT_DATA, RESET_INIT_DATA, SET_INIT_DATA } from './constants';
+import { GET_INIT_DATA, SET_INIT_DATA } from './constants';
 
 const initialState = {
   components: [],
@@ -25,9 +25,7 @@ const mainReducer = (state = initialState, action) =>
         draftState.status = 'loading';
         break;
       }
-      case RESET_INIT_DATA: {
-        return initialState;
-      }
+
       case SET_INIT_DATA: {
         draftState.collectionTypeLinks = action.data.authorizedCollectionTypeLinks.filter(
           ({ isDisplayed }) => isDisplayed

--- a/packages/core/admin/admin/src/content-manager/pages/App/tests/reducer.test.js
+++ b/packages/core/admin/admin/src/content-manager/pages/App/tests/reducer.test.js
@@ -1,6 +1,6 @@
 import produce from 'immer';
 
-import { getInitData, resetInitData, setInitData } from '../actions';
+import { getInitData, setInitData } from '../actions';
 import mainReducer from '../reducer';
 
 describe('Content Manager | App | reducer', () => {
@@ -82,17 +82,5 @@ describe('Content Manager | App | reducer', () => {
         })
       )
     ).toEqual(expected);
-  });
-
-  it('should handle the resetInitData action correctly', () => {
-    state = 'test';
-
-    expect(mainReducer(state, resetInitData())).toEqual({
-      components: [],
-      models: [],
-      collectionTypeLinks: [],
-      singleTypeLinks: [],
-      status: 'loading',
-    });
   });
 });

--- a/packages/core/admin/admin/src/content-manager/pages/App/useContentManagerInitData.js
+++ b/packages/core/admin/admin/src/content-manager/pages/App/useContentManagerInitData.js
@@ -1,5 +1,3 @@
-import { useEffect } from 'react';
-
 import { useNotifyAT } from '@strapi/design-system';
 import {
   useFetchClient,
@@ -15,7 +13,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { HOOKS } from '../../../constants';
 import { getTrad } from '../../utils';
 
-import { getInitData, resetInitData, setInitData } from './actions';
+import { getInitData, setInitData } from './actions';
 import { selectAppDomain } from './selectors';
 import getContentTypeLinks from './utils/getContentTypeLinks';
 
@@ -27,8 +25,6 @@ const useContentManagerInitData = () => {
   const state = useSelector(selectAppDomain());
   const { allPermissions } = useRBACProvider();
   const { runHookWaterfall } = useStrapiApp();
-  const CancelToken = axios.CancelToken;
-  const source = CancelToken.source();
   const { notifyStatus } = useNotifyAT();
   const { formatMessage } = useIntl();
   const { get } = useFetchClient();
@@ -93,13 +89,6 @@ const useContentManagerInitData = () => {
       },
     }
   );
-
-  useEffect(() => {
-    return () => {
-      source.cancel('Operation canceled by the user.');
-      dispatch(resetInitData());
-    };
-  }, [dispatch, source]);
 
   return { ...state };
 };

--- a/packages/core/admin/admin/src/content-manager/pages/ListSettingsView/index.jsx
+++ b/packages/core/admin/admin/src/content-manager/pages/ListSettingsView/index.jsx
@@ -16,9 +16,8 @@ import upperFirst from 'lodash/upperFirst';
 import PropTypes from 'prop-types';
 import { stringify } from 'qs';
 import { useIntl } from 'react-intl';
-import { useMutation } from 'react-query';
+import { useQueryClient, useMutation } from 'react-query';
 
-import ModelsContext from '../../contexts/ModelsContext';
 import { usePluginsQueryParams } from '../../hooks';
 import { checkIfAttributeIsDisplayable, getTrad } from '../../utils';
 
@@ -29,12 +28,12 @@ import { EXCLUDED_SORT_ATTRIBUTE_TYPES } from './constants';
 import reducer, { initialState } from './reducer';
 
 export const ListSettingsView = ({ layout, slug }) => {
+  const queryClient = useQueryClient();
   const { put } = useFetchClient();
   const { formatMessage } = useIntl();
   const { trackUsage } = useTracking();
   const pluginsQueryParams = usePluginsQueryParams();
   const toggleNotification = useNotification();
-  const { refetchData } = React.useContext(ModelsContext);
   const [{ fieldToEdit, fieldForm, initialData, modifiedData }, dispatch] = React.useReducer(
     reducer,
     initialState,
@@ -82,7 +81,7 @@ export const ListSettingsView = ({ layout, slug }) => {
     {
       onSuccess() {
         trackUsage('didEditListSettings');
-        refetchData();
+        queryClient.invalidateQueries(['content-manager', 'initData']);
       },
       onError() {
         toggleNotification({

--- a/packages/core/admin/admin/tests/utils.tsx
+++ b/packages/core/admin/admin/tests/utils.tsx
@@ -24,8 +24,6 @@ import { MemoryRouter, MemoryRouterProps } from 'react-router-dom';
 
 import { LanguageProvider } from '../src/components/LanguageProvider';
 import { ThemeToggleProvider } from '../src/components/ThemeToggleProvider';
-// @ts-expect-error – no types yet.
-import ModelsContext from '../src/content-manager/contexts/ModelsContext';
 import { AdminContextProvider } from '../src/contexts/admin';
 import { ConfigurationContextProvider } from '../src/contexts/configuration';
 
@@ -93,21 +91,19 @@ const Providers = ({ children, initialEntries }: ProvidersProps) => {
                         ] as Permission[],
                       }}
                     >
-                      <ModelsContext.Provider value={{ refetchData: jest.fn() }}>
-                        <AdminContextProvider getAdminInjectedComponents={jest.fn()}>
-                          <ConfigurationContextProvider
-                            showReleaseNotification={false}
-                            showTutorials={false}
-                            updateProjectSettings={jest.fn()}
-                            logos={{
-                              auth: { default: '' },
-                              menu: { default: '' },
-                            }}
-                          >
-                            {children}
-                          </ConfigurationContextProvider>
-                        </AdminContextProvider>
-                      </ModelsContext.Provider>
+                      <AdminContextProvider getAdminInjectedComponents={jest.fn()}>
+                        <ConfigurationContextProvider
+                          showReleaseNotification={false}
+                          showTutorials={false}
+                          updateProjectSettings={jest.fn()}
+                          logos={{
+                            auth: { default: '' },
+                            menu: { default: '' },
+                          }}
+                        >
+                          {children}
+                        </ConfigurationContextProvider>
+                      </AdminContextProvider>
                     </RBACContext.Provider>
                   </NotificationsProvider>
                 </LanguageProvider>


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Refactors useContentManagerInitData to use react query and removes the ModelsContext used for refetching this data

### Why is it needed?

Describe the issue you are solving.	

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
