### PR TITLE
doc(pack-up): fix config file name in readme

### DIFF
--- a/packages/utils/pack-up/README.md
+++ b/packages/utils/pack-up/README.md
@@ -67,7 +67,7 @@ Creates a new package at the given path, by default uses the inbuilt template se
 
 ### `build`
 
-Builds your current package based on the configuration in your `package.json` and `package.config.ts` (if applicable).
+Builds your current package based on the configuration in your `package.json` and `packup.config.ts` (if applicable).
 
 - `--minify` – minifies the output (default `false`).
 - `--sourcemap` – generates sourcemaps for the output (default `true`).
@@ -82,10 +82,10 @@ Watches your current package for changes and rebuilds when necessary.
 
 ## Configuration
 
-`@strapi/pack-up` by default reads its configuration from your `package.json`. But sometimes you need more flexibility, to do this you can create a `package.config.ts` file in the root of your package.
+`@strapi/pack-up` by default reads its configuration from your `package.json`. But sometimes you need more flexibility, to do this you can create a `packup.config.ts` file in the root of your package.
 
 ```ts
-// package.config.ts
+// packup.config.ts
 import { defineConfig } from '@strapi/pack-up';
 
 export default defineConfig({


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Makes some changes to the pack-up readme about the name of the config file

### Why is it needed?

I think it was wrong. `packup.config.ts` is the file name used throughout the monorepo. And I tried on another repo using pack-up (the renderer), the config wasn't picked up unless I called it `packup.config.ts`

