### PR TITLE
[Content manager] Refactor useContentManagerInitData to remove ModelsContext

### DIFF
--- a/packages/core/admin/admin/src/content-manager/contexts/models.ts
+++ b/packages/core/admin/admin/src/content-manager/contexts/models.ts
@@ -1,9 +1,0 @@
-import * as React from 'react';
-
-const ModelsContext = React.createContext<{
-  refetchData: () => Promise<void>;
-}>({
-  refetchData: () => Promise.resolve(),
-});
-
-export { ModelsContext };

--- a/packages/core/admin/admin/src/content-manager/hooks/useContentManagerInitData.ts
+++ b/packages/core/admin/admin/src/content-manager/hooks/useContentManagerInitData.ts
@@ -18,7 +18,7 @@ import { useQuery } from 'react-query';
 
 import { HOOKS } from '../../constants';
 import { useTypedDispatch, useTypedSelector } from '../../core/store/hooks';
-import { SET_INIT_DATA, RESET_INIT_DATA, GET_INIT_DATA } from '../pages/App';
+import { SET_INIT_DATA } from '../pages/App';
 import { getTranslation } from '../utils/translations';
 
 const { MUTATE_COLLECTION_TYPES_LINKS, MUTATE_SINGLE_TYPES_LINKS } = HOOKS;
@@ -163,44 +163,26 @@ const useContentManagerInitData = () => {
 
     dispatch({
       type: SET_INIT_DATA,
-      data: {
-        authorizedCollectionTypeLinks: ctLinks,
-        authorizedSingleTypeLinks: stLinks,
-        contentTypeSchemas: contentTypes,
-        components,
-        fieldSizes,
-      },
+      authorizedCollectionTypeLinks: ctLinks,
+      authorizedSingleTypeLinks: stLinks,
+      contentTypeSchemas: contentTypes,
+      components,
+      fieldSizes,
     });
   };
 
   const isLoading = initialDataQuery.isLoading || contentTypeSettingsQuery.isLoading;
 
   useEffect(() => {
-    const formatAndSetData = async () => {
-      if (!isLoading && initialDataQuery.data && contentTypeSettingsQuery.data) {
-        await formatData(
-          initialDataQuery.data.components,
-          initialDataQuery.data.contentTypes,
-          initialDataQuery.data.fieldSizes,
-          contentTypeSettingsQuery.data
-        );
-      }
-    };
-
-    formatAndSetData();
+    if (!isLoading && initialDataQuery.data && contentTypeSettingsQuery.data) {
+      formatData(
+        initialDataQuery.data.components,
+        initialDataQuery.data.contentTypes,
+        initialDataQuery.data.fieldSizes,
+        contentTypeSettingsQuery.data
+      );
+    }
   }, [isLoading, initialDataQuery.data, contentTypeSettingsQuery.data]);
-
-  useEffect(() => {
-    dispatch({
-      type: GET_INIT_DATA,
-    });
-
-    return () => {
-      dispatch({
-        type: RESET_INIT_DATA,
-      });
-    };
-  }, [dispatch]);
 
   return { ...state, isLoading };
 };

--- a/packages/core/admin/admin/src/content-manager/hooks/useContentManagerInitData.ts
+++ b/packages/core/admin/admin/src/content-manager/hooks/useContentManagerInitData.ts
@@ -18,7 +18,7 @@ import { useQuery } from 'react-query';
 
 import { HOOKS } from '../../constants';
 import { useTypedDispatch, useTypedSelector } from '../../core/store/hooks';
-import { SET_INIT_DATA, RESET_INIT_DATA } from '../pages/App';
+import { SET_INIT_DATA, RESET_INIT_DATA, GET_INIT_DATA } from '../pages/App';
 import { getTranslation } from '../utils/translations';
 
 const { MUTATE_COLLECTION_TYPES_LINKS, MUTATE_SINGLE_TYPES_LINKS } = HOOKS;
@@ -191,6 +191,10 @@ const useContentManagerInitData = () => {
   }, [isLoading, initialDataQuery.data, contentTypeSettingsQuery.data]);
 
   useEffect(() => {
+    dispatch({
+      type: GET_INIT_DATA,
+    });
+
     return () => {
       dispatch({
         type: RESET_INIT_DATA,

--- a/packages/core/admin/admin/src/content-manager/hooks/useContentManagerInitData.ts
+++ b/packages/core/admin/admin/src/content-manager/hooks/useContentManagerInitData.ts
@@ -33,15 +33,13 @@ interface ContentManagerLink {
 
 const useContentManagerInitData = () => {
   const dispatch = useTypedDispatch();
-
   const toggleNotification = useNotification();
-  const state = useTypedSelector((state) => state['content-manager_app']);
-
   const { allPermissions } = useRBACProvider();
   const { runHookWaterfall } = useStrapiApp();
   const { notifyStatus } = useNotifyAT();
   const { formatMessage } = useIntl();
   const { get } = useFetchClient();
+  const state = useTypedSelector((state) => state['content-manager_app']);
 
   const fetchInitialData = async () => {
     const {
@@ -93,17 +91,8 @@ const useContentManagerInitData = () => {
   const formatData = async (
     components: Contracts.Components.Component[],
     contentTypes: Contracts.ContentTypes.ContentType[],
-    fieldSizes: Record<
-      string,
-      {
-        default: number;
-        isResizeable: boolean;
-      }
-    >,
-    contentTypeConfigurations: {
-      uid: string;
-      settings: Contracts.ContentTypes.Settings;
-    }[]
+    fieldSizes: Contracts.Init.GetInitData.Response['data']['fieldSizes'],
+    contentTypeConfigurations: Contracts.ContentTypes.FindContentTypesSettings.Response['data']
   ) => {
     /**
      * We group these by the two types we support. We do with an object because we can use default
@@ -133,6 +122,7 @@ const useContentManagerInitData = () => {
       contentTypeConfigurations
     );
     const singleTypeSectionLinks = generateLinks(singleTypeLinks, 'singleTypes');
+
     // Collection Types verifications
     const collectionTypeLinksPermissions = await Promise.all(
       collectionTypeSectionLinks.map(({ permissions }) =>
@@ -142,6 +132,7 @@ const useContentManagerInitData = () => {
     const authorizedCollectionTypeLinks = collectionTypeSectionLinks.filter(
       (_, index) => collectionTypeLinksPermissions[index]
     );
+
     // Single Types verifications
     const singleTypeLinksPermissions = await Promise.all(
       singleTypeSectionLinks.map(({ permissions }) => hasPermissions(allPermissions, permissions))

--- a/packages/core/admin/admin/src/content-manager/pages/App.tsx
+++ b/packages/core/admin/admin/src/content-manager/pages/App.tsx
@@ -235,6 +235,10 @@ const selectSchemas = createSelector(
 const reducer = (state: ContentManagerAppState = initialState, action: Action) =>
   produce(state, (draftState) => {
     switch (action.type) {
+      case GET_INIT_DATA: {
+        draftState.status = 'loading';
+        break;
+      }
       case RESET_INIT_DATA: {
         return initialState;
       }

--- a/packages/core/admin/admin/src/content-manager/pages/App.tsx
+++ b/packages/core/admin/admin/src/content-manager/pages/App.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { createSelector } from '@reduxjs/toolkit';
+import { AnyAction, createSelector } from '@reduxjs/toolkit';
 import { HeaderLayout, Layout, Main } from '@strapi/design-system';
 import {
   AnErrorOccurred,
@@ -182,30 +182,16 @@ function renderDraglayerItem({ type, item }: Parameters<DragLayerProps['renderIt
  * reducer
  * -----------------------------------------------------------------------------------------------*/
 
-export const GET_INIT_DATA = 'ContentManager/App/GET_INIT_DATA';
-export const RESET_INIT_DATA = 'ContentManager/App/RESET_INIT_DATA';
 export const SET_INIT_DATA = 'ContentManager/App/SET_INIT_DATA';
-
-interface GetInitDataAction {
-  type: typeof GET_INIT_DATA;
-}
-
-interface ResetInitDataAction {
-  type: typeof RESET_INIT_DATA;
-}
 
 interface SetInitDataAction {
   type: typeof SET_INIT_DATA;
-  data: {
-    authorizedCollectionTypeLinks: ContentManagerAppState['collectionTypeLinks'];
-    authorizedSingleTypeLinks: ContentManagerAppState['singleTypeLinks'];
-    components: ContentManagerAppState['components'];
-    contentTypeSchemas: ContentManagerAppState['models'];
-    fieldSizes: ContentManagerAppState['fieldSizes'];
-  };
+  authorizedCollectionTypeLinks: ContentManagerAppState['collectionTypeLinks'];
+  authorizedSingleTypeLinks: ContentManagerAppState['singleTypeLinks'];
+  components: ContentManagerAppState['components'];
+  contentTypeSchemas: ContentManagerAppState['models'];
+  fieldSizes: ContentManagerAppState['fieldSizes'];
 }
-
-type Action = GetInitDataAction | ResetInitDataAction | SetInitDataAction;
 
 interface ContentManagerAppState {
   collectionTypeLinks: ContentManagerLink[];
@@ -213,7 +199,6 @@ interface ContentManagerAppState {
   fieldSizes: Contracts.Init.GetInitData.Response['data']['fieldSizes'];
   models: Contracts.Init.GetInitData.Response['data']['contentTypes'];
   singleTypeLinks: ContentManagerLink[];
-  status: 'loading' | 'resolved' | 'error';
 }
 
 const initialState = {
@@ -222,7 +207,6 @@ const initialState = {
   fieldSizes: {},
   models: [],
   singleTypeLinks: [],
-  status: 'loading',
 } satisfies ContentManagerAppState;
 
 const selectSchemas = createSelector(
@@ -232,29 +216,22 @@ const selectSchemas = createSelector(
   }
 );
 
-const reducer = (state: ContentManagerAppState = initialState, action: Action) =>
+const reducer = (state: ContentManagerAppState = initialState, action: AnyAction) =>
   produce(state, (draftState) => {
     switch (action.type) {
-      case GET_INIT_DATA: {
-        draftState.status = 'loading';
-        break;
-      }
-      case RESET_INIT_DATA: {
-        return initialState;
-      }
       case SET_INIT_DATA: {
-        draftState.collectionTypeLinks = action.data.authorizedCollectionTypeLinks.filter(
+        const initDataAction = action as SetInitDataAction;
+        draftState.collectionTypeLinks = initDataAction.authorizedCollectionTypeLinks.filter(
           ({ isDisplayed }) => isDisplayed
         );
-        draftState.singleTypeLinks = action.data.authorizedSingleTypeLinks.filter(
+        draftState.singleTypeLinks = initDataAction.authorizedSingleTypeLinks.filter(
           ({ isDisplayed }) => isDisplayed
         );
         // @ts-expect-error – recursive types
-        draftState.components = action.data.components;
+        draftState.components = initDataAction.components;
         // @ts-expect-error – issues with immer types not working quite right....
-        draftState.models = action.data.contentTypeSchemas;
-        draftState.fieldSizes = action.data.fieldSizes;
-        draftState.status = 'resolved';
+        draftState.models = initDataAction.contentTypeSchemas;
+        draftState.fieldSizes = initDataAction.fieldSizes;
         break;
       }
       default:

--- a/packages/core/admin/admin/src/content-manager/pages/ListSettingsView/index.jsx
+++ b/packages/core/admin/admin/src/content-manager/pages/ListSettingsView/index.jsx
@@ -19,6 +19,7 @@ import { useIntl } from 'react-intl';
 import { useMutation, useQueryClient } from 'react-query';
 
 import { usePluginsQueryParams } from '../../hooks';
+import { queryKeyPrefix as initDataQueryKey } from '../../hooks/useContentManagerInitData';
 import { checkIfAttributeIsDisplayable } from '../../utils';
 import { getTranslation } from '../../utils/translations';
 
@@ -82,7 +83,7 @@ export const ListSettingsView = ({ layout, slug }) => {
     {
       onSuccess() {
         trackUsage('didEditListSettings');
-        queryClient.invalidateQueries(['contentManager', 'init']);
+        queryClient.invalidateQueries(initDataQueryKey);
       },
       onError() {
         toggleNotification({

--- a/packages/core/admin/admin/src/content-manager/pages/ListSettingsView/index.jsx
+++ b/packages/core/admin/admin/src/content-manager/pages/ListSettingsView/index.jsx
@@ -16,9 +16,8 @@ import upperFirst from 'lodash/upperFirst';
 import PropTypes from 'prop-types';
 import { stringify } from 'qs';
 import { useIntl } from 'react-intl';
-import { useMutation } from 'react-query';
+import { useMutation, useQueryClient } from 'react-query';
 
-import { ModelsContext } from '../../contexts/models';
 import { usePluginsQueryParams } from '../../hooks';
 import { checkIfAttributeIsDisplayable } from '../../utils';
 import { getTranslation } from '../../utils/translations';
@@ -30,12 +29,12 @@ import { EXCLUDED_SORT_ATTRIBUTE_TYPES } from './constants';
 import reducer, { initialState } from './reducer';
 
 export const ListSettingsView = ({ layout, slug }) => {
+  const queryClient = useQueryClient();
   const { put } = useFetchClient();
   const { formatMessage } = useIntl();
   const { trackUsage } = useTracking();
   const pluginsQueryParams = usePluginsQueryParams();
   const toggleNotification = useNotification();
-  const { refetchData } = React.useContext(ModelsContext);
   const [{ fieldToEdit, fieldForm, initialData, modifiedData }, dispatch] = React.useReducer(
     reducer,
     initialState,
@@ -83,7 +82,7 @@ export const ListSettingsView = ({ layout, slug }) => {
     {
       onSuccess() {
         trackUsage('didEditListSettings');
-        refetchData();
+        queryClient.invalidateQueries(['contentManager', 'init']);
       },
       onError() {
         toggleNotification({

--- a/packages/core/admin/admin/src/tests/StrapiApp.test.tsx
+++ b/packages/core/admin/admin/src/tests/StrapiApp.test.tsx
@@ -27,7 +27,6 @@ describe('ADMIN | new StrapiApp', () => {
           "fieldSizes": {},
           "models": [],
           "singleTypeLinks": [],
-          "status": "loading",
         },
         "content-manager_editViewCrudReducer": {
           "componentsDataStructure": {},

--- a/packages/core/admin/admin/src/tests/StrapiApp.test.tsx
+++ b/packages/core/admin/admin/src/tests/StrapiApp.test.tsx
@@ -27,6 +27,7 @@ describe('ADMIN | new StrapiApp', () => {
           "fieldSizes": {},
           "models": [],
           "singleTypeLinks": [],
+          "status": "loading",
         },
         "content-manager_editViewCrudReducer": {
           "componentsDataStructure": {},

--- a/packages/core/admin/admin/tests/utils.tsx
+++ b/packages/core/admin/admin/tests/utils.tsx
@@ -24,7 +24,6 @@ import { MemoryRouter, MemoryRouterProps } from 'react-router-dom';
 
 import { LanguageProvider } from '../src/components/LanguageProvider';
 import { ThemeToggleProvider } from '../src/components/ThemeToggleProvider';
-import { ModelsContext } from '../src/content-manager/contexts/models';
 import { AdminContextProvider } from '../src/contexts/admin';
 import { ConfigurationContextProvider } from '../src/contexts/configuration';
 
@@ -92,21 +91,19 @@ const Providers = ({ children, initialEntries }: ProvidersProps) => {
                         ] as Permission[],
                       }}
                     >
-                      <ModelsContext.Provider value={{ refetchData: jest.fn() }}>
-                        <AdminContextProvider getAdminInjectedComponents={jest.fn()}>
-                          <ConfigurationContextProvider
-                            showReleaseNotification={false}
-                            showTutorials={false}
-                            updateProjectSettings={jest.fn()}
-                            logos={{
-                              auth: { default: '' },
-                              menu: { default: '' },
-                            }}
-                          >
-                            {children}
-                          </ConfigurationContextProvider>
-                        </AdminContextProvider>
-                      </ModelsContext.Provider>
+                      <AdminContextProvider getAdminInjectedComponents={jest.fn()}>
+                        <ConfigurationContextProvider
+                          showReleaseNotification={false}
+                          showTutorials={false}
+                          updateProjectSettings={jest.fn()}
+                          logos={{
+                            auth: { default: '' },
+                            menu: { default: '' },
+                          }}
+                        >
+                          {children}
+                        </ConfigurationContextProvider>
+                      </AdminContextProvider>
                     </RBACContext.Provider>
                   </NotificationsProvider>
                 </LanguageProvider>


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Refactor useContentManagerInitData to use react query and remove ModelsContext

### Why is it needed?

Describe the issue you are solving.

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
