### PR TITLE
fix(content-manager): search relations with contains not startsWith

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/Relations/RelationInput.tsx
+++ b/packages/core/admin/admin/src/content-manager/components/Relations/RelationInput.tsx
@@ -189,7 +189,7 @@ const RelationInput = ({
 
   const handleMenuOpen = (isOpen?: boolean) => {
     if (isOpen) {
-      onSearch();
+      onSearch(textValue);
     }
   };
 
@@ -241,7 +241,7 @@ const RelationInput = ({
         <ComboboxWrapper marginRight="auto" maxWidth={size <= 6 ? '100%' : '70%'} width="100%">
           <Combobox
             ref={fieldRef}
-            autocomplete="list"
+            autocomplete="none"
             error={error}
             name={name}
             hint={description}

--- a/packages/core/admin/admin/src/content-manager/components/Relations/tests/__snapshots__/RelationInput.test.tsx.snap
+++ b/packages/core/admin/admin/src/content-manager/components/Relations/tests/__snapshots__/RelationInput.test.tsx.snap
@@ -688,7 +688,7 @@ exports[`Content-Manager || RelationInput should render and match snapshot 1`] =
                 class="c10 c11"
               >
                 <input
-                  aria-autocomplete="list"
+                  aria-autocomplete="none"
                   aria-controls="radix-:r4:"
                   aria-describedby="1-hint 1-error"
                   aria-disabled="false"

--- a/packages/core/admin/admin/src/content-manager/components/Relations/tests/useRelation.test.tsx
+++ b/packages/core/admin/admin/src/content-manager/components/Relations/tests/useRelation.test.tsx
@@ -261,7 +261,7 @@ describe('useRelation', () => {
     });
 
     expect(spy).toBeCalledWith('/', {
-      params: { _q: 'something', _filter: '$startsWithi', limit: 10, page: 1 },
+      params: { _q: 'something', _filter: '$containsi', limit: 10, page: 1 },
     });
   });
 
@@ -289,7 +289,7 @@ describe('useRelation', () => {
     expect(spy).toBeCalledWith(expect.any(String), {
       params: {
         _q: 'something',
-        _filter: '$startsWithi',
+        _filter: '$containsi',
         limit: 5,
         page: expect.any(Number),
       },
@@ -321,7 +321,7 @@ describe('useRelation', () => {
     expect(spy).toHaveBeenNthCalledWith(1, expect.any(String), {
       params: {
         _q: 'something',
-        _filter: '$startsWithi',
+        _filter: '$containsi',
         limit: expect.any(Number),
         page: 1,
       },
@@ -329,7 +329,7 @@ describe('useRelation', () => {
     expect(spy).toHaveBeenNthCalledWith(2, expect.any(String), {
       params: {
         _q: 'something',
-        _filter: '$startsWithi',
+        _filter: '$containsi',
         limit: expect.any(Number),
         page: 2,
       },

--- a/packages/core/admin/admin/src/content-manager/components/Relations/useRelation.ts
+++ b/packages/core/admin/admin/src/content-manager/components/Relations/useRelation.ts
@@ -165,7 +165,7 @@ const useRelation = (cacheKey: any[] = [], { relation, search }: UseRelationArgs
     setSearchParams({
       ...options,
       _q: term,
-      _filter: '$startsWithi',
+      _filter: '$containsi',
     });
   };
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

This PR addresses and fixes two specific issues: #17391 and #18257. The main focus is on resolving the problem related to searching within a relational input. 
The changes include using `"none"` for autocomplete and updating the filter logic to `_filter: '$containsi'`
Additionally, it enhances the functionality by passing the `textValue` to the `onSearch` function in the `handleMenuOpen` handler, ensuring proper search results when the menu is opened with typing.




### Why is it needed?

The issues #17391 and #18257 highlighted a problem with searching in a relational input. This PR aims to solve this issue by making necessary changes and further improves the user experience by passing the text value to the `onSearch` function.


### How to test it?

To verify the behavior of this fix, follow these steps:

1. Set up the environment with the changes from this PR.
2. Navigate to the relational input that was problematic (context of the mentioned issues).
3. Perform a search operation and observe the behavior.
4. Confirm that the autocomplete on the combobox now uses "none," the filter logic is changed to "_filter: '$containsi'," and proper search results are displayed when the menu is opened with typing.


### Related issue(s)/PR(s)

This PR is related to the following issues:
- Fixes #17391
- Fixes #18257

**Note to Reviewer @joshuaellis :** 
- This PR is based on the develop branch.
- The title now provides a clear description of the changes made.
- This PR addresses the menu open when typing issue mentioned in your previous comment ("the TLDR; is the filter list is not being updated correctly"). The changes made aim to resolve this issue, and I appreciate your patience in reviewing these updates.
