### PR TITLE
Add publicationState param to documentation

### DIFF
--- a/packages/plugins/documentation/server/services/helpers/utils/query-params.js
+++ b/packages/plugins/documentation/server/services/helpers/utils/query-params.js
@@ -102,4 +102,15 @@ module.exports = [
       type: 'string',
     },
   },
+  {
+    name: 'publicationState',
+    in: 'query',
+    description: 'Publication state (default: live)',
+    deprecated: false,
+    required: false,
+    schema: {
+      type: 'string',
+      enum: ['live', 'preview'],
+    },
+  },
 ];


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

I have added `publicationState` param to the collection of accepted query arguments for getting items of a collection. This parameter is already accepted by the API, but was never documented in the OpenAPI spec generated by the Documentation plugin.

This allows API clients following the generated documentation to request not only published (the current state), but also draft entities. This is achieved by passing `preview` as the value.

I have followed the way other parameters are documented, and did the same for the `publicationState`.

### Why is it needed?

The param was completely missing from the documentation. For people consuming the API for example through auto-generated client library (based on the OpenAPI JSON spec), a missing parameter from documentation means those clients can never access entities in the draft state.

### How to test it?

- Install the plugin
- `strapi develop`
- wait for `full_documentation.json` to be generated
- confirm that GET endpoints to list entities now support `publicationState` (the same way as they support `locale` parameter, for example)

### Related issue(s)/PR(s)

—