### PR TITLE
feat(content-releases): Add action column to details view

### DIFF
--- a/packages/core/content-releases/admin/src/components/CMReleasesContainer.tsx
+++ b/packages/core/content-releases/admin/src/components/CMReleasesContainer.tsx
@@ -162,12 +162,11 @@ const AddActionToReleaseModal = ({
                       defaultMessage: 'What do you want to do with this entry?',
                     })}
                   </FieldLabel>
-                  <Flex>
-                    <ReleaseActionOptions
-                      selected={values.type}
-                      handleChange={(e) => setFieldValue('type', e.target.value)}
-                    />
-                  </Flex>
+                  <ReleaseActionOptions
+                    selected={values.type}
+                    handleChange={(e) => setFieldValue('type', e.target.value)}
+                    name="type"
+                  />
                 </Flex>
               </ModalBody>
               <ModalFooter

--- a/packages/core/content-releases/admin/src/components/ReleaseActionOptions.tsx
+++ b/packages/core/content-releases/admin/src/components/ReleaseActionOptions.tsx
@@ -5,6 +5,7 @@ import {
   FieldLabel,
   VisuallyHidden,
   Field,
+  Flex,
   type FieldProps,
 } from '@strapi/design-system';
 import styled from 'styled-components';
@@ -55,13 +56,14 @@ const FieldWrapper = styled(Field)<FieldWrapperProps>`
 interface ActionOptionProps {
   selected: 'publish' | 'unpublish';
   handleChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  name: string;
 }
 
 interface OptionProps extends ActionOptionProps {
   actionType: 'publish' | 'unpublish';
 }
 
-const ActionOption = ({ selected, actionType, handleChange }: OptionProps) => {
+const ActionOption = ({ selected, actionType, handleChange, name }: OptionProps) => {
   return (
     <FieldWrapper
       actionType={actionType}
@@ -72,12 +74,12 @@ const ActionOption = ({ selected, actionType, handleChange }: OptionProps) => {
       cursor="pointer"
       data-checked={selected === actionType}
     >
-      <FieldLabel htmlFor={`release-action-${actionType}`}>
+      <FieldLabel htmlFor={`${name}-${actionType}`}>
         <VisuallyHidden>
           <FieldInput
             type="radio"
-            id={`release-action-${actionType}`}
-            name="type"
+            id={`${name}-${actionType}`}
+            name={name}
             checked={selected === actionType}
             onChange={handleChange}
             value={actionType}
@@ -89,11 +91,21 @@ const ActionOption = ({ selected, actionType, handleChange }: OptionProps) => {
   );
 };
 
-export const ReleaseActionOptions = ({ selected, handleChange }: ActionOptionProps) => {
+export const ReleaseActionOptions = ({ selected, handleChange, name }: ActionOptionProps) => {
   return (
-    <>
-      <ActionOption actionType="publish" selected={selected} handleChange={handleChange} />
-      <ActionOption actionType="unpublish" selected={selected} handleChange={handleChange} />
-    </>
+    <Flex>
+      <ActionOption
+        actionType="publish"
+        selected={selected}
+        handleChange={handleChange}
+        name={name}
+      />
+      <ActionOption
+        actionType="unpublish"
+        selected={selected}
+        handleChange={handleChange}
+        name={name}
+      />
+    </Flex>
   );
 };

--- a/packages/core/content-releases/admin/src/components/tests/ReleasActionOptions.test.tsx
+++ b/packages/core/content-releases/admin/src/components/tests/ReleasActionOptions.test.tsx
@@ -6,7 +6,9 @@ import { ReleaseActionOptions } from '../ReleaseActionOptions';
 describe('ReleaseActionOptions', () => {
   it('should render the component', () => {
     const handleChange = jest.fn();
-    render(<ReleaseActionOptions selected="publish" handleChange={handleChange} />);
+    render(
+      <ReleaseActionOptions selected="publish" handleChange={handleChange} name="test-radio" />
+    );
 
     const publishOption = screen.getByRole('radio', { name: 'publish' });
     const unpublishOption = screen.getByRole('radio', { name: 'unpublish' });

--- a/packages/core/content-releases/admin/src/pages/ReleaseDetailsPage.tsx
+++ b/packages/core/content-releases/admin/src/pages/ReleaseDetailsPage.tsx
@@ -263,6 +263,8 @@ const ReleaseDetailsBody = () => {
   const { formatMessage } = useIntl();
   const { releaseId } = useParams<{ releaseId: string }>();
   const [{ query }] = useQueryParams<GetReleaseActionsQueryParams>();
+  const toggleNotification = useNotification();
+  const { formatAPIError } = useAPIErrorHandler();
 
   const { isLoading, isFetching, isError, data } = useGetReleaseActionsQuery({
     ...query,
@@ -271,11 +273,11 @@ const ReleaseDetailsBody = () => {
 
   const [updateReleaseAction] = useUpdateReleaseActionMutation();
 
-  const handleChangeType = (
+  const handleChangeType = async (
     e: React.ChangeEvent<HTMLInputElement>,
     actionId: ReleaseAction['id']
   ) => {
-    updateReleaseAction({
+    const response = await updateReleaseAction({
       params: {
         releaseId,
         actionId,
@@ -284,6 +286,22 @@ const ReleaseDetailsBody = () => {
         type: e.target.value as ReleaseAction['type'],
       },
     });
+
+    if ('error' in response) {
+      if (isAxiosError(response.error)) {
+        // When the response returns an object with 'error', handle axios error
+        toggleNotification({
+          type: 'warning',
+          message: formatAPIError(response.error),
+        });
+      } else {
+        // Otherwise, the response returns an object with 'error', handle a generic error
+        toggleNotification({
+          type: 'warning',
+          message: formatMessage({ id: 'notification.error', defaultMessage: 'An error occurred' }),
+        });
+      }
+    }
   };
 
   if (isLoading) {

--- a/packages/core/content-releases/admin/src/pages/ReleaseDetailsPage.tsx
+++ b/packages/core/content-releases/admin/src/pages/ReleaseDetailsPage.tsx
@@ -380,12 +380,11 @@ const ReleaseDetailsBody = () => {
                     <Typography>{entry.contentType.displayName || ''}</Typography>
                   </Td>
                   <Td>
-                    <Flex>
-                      <ReleaseActionOptions
-                        selected={type}
-                        handleChange={(e) => handleChangeType(e, id)}
-                      />
-                    </Flex>
+                    <ReleaseActionOptions
+                      selected={type}
+                      handleChange={(e) => handleChangeType(e, id)}
+                      name={`release-action-${id}-type`}
+                    />
                   </Td>
                 </Tr>
               ))}

--- a/packages/core/content-releases/admin/src/pages/ReleaseDetailsPage.tsx
+++ b/packages/core/content-releases/admin/src/pages/ReleaseDetailsPage.tsx
@@ -32,6 +32,7 @@ import { useIntl } from 'react-intl';
 import { useParams } from 'react-router-dom';
 import styled from 'styled-components';
 
+import { ReleaseActionOptions } from '../components/ReleaseActionOptions';
 import { ReleaseModal, FormValues } from '../components/ReleaseModal';
 import { PERMISSIONS } from '../constants';
 import { isAxiosError } from '../services/axios';
@@ -40,7 +41,10 @@ import {
   useGetReleaseActionsQuery,
   useGetReleaseQuery,
   useUpdateReleaseMutation,
+  useUpdateReleaseActionMutation,
 } from '../services/release';
+
+import type { ReleaseAction } from '../../../shared/contracts/release-actions';
 
 /* -------------------------------------------------------------------------------------------------
  * ReleaseDetailsLayout
@@ -265,6 +269,23 @@ const ReleaseDetailsBody = () => {
     releaseId,
   });
 
+  const [updateReleaseAction] = useUpdateReleaseActionMutation();
+
+  const handleChangeType = (
+    e: React.ChangeEvent<HTMLInputElement>,
+    actionId: ReleaseAction['id']
+  ) => {
+    updateReleaseAction({
+      params: {
+        releaseId,
+        actionId,
+      },
+      body: {
+        type: e.target.value as ReleaseAction['type'],
+      },
+    });
+  };
+
   if (isLoading) {
     return (
       <ContentLayout>
@@ -336,10 +357,18 @@ const ReleaseDetailsBody = () => {
                 })}
                 name="content-type"
               />
+              <Table.HeaderCell
+                fieldSchemaType="string"
+                label={formatMessage({
+                  id: 'content-releases.page.ReleaseDetails.table.header.label.action',
+                  defaultMessage: 'action',
+                })}
+                name="action"
+              />
             </Table.Head>
             <Table.LoadingBody />
             <Table.Body>
-              {releaseActions.map(({ id, entry }) => (
+              {releaseActions.map(({ id, type, entry }) => (
                 <Tr key={id}>
                   <Td>
                     <Typography>{`${entry.contentType.mainFieldValue || entry.id}`}</Typography>
@@ -349,6 +378,14 @@ const ReleaseDetailsBody = () => {
                   </Td>
                   <Td>
                     <Typography>{entry.contentType.displayName || ''}</Typography>
+                  </Td>
+                  <Td>
+                    <Flex>
+                      <ReleaseActionOptions
+                        selected={type}
+                        handleChange={(e) => handleChangeType(e, id)}
+                      />
+                    </Flex>
                   </Td>
                 </Tr>
               ))}

--- a/packages/core/content-releases/admin/src/pages/tests/ReleaseDetailsPage.test.tsx
+++ b/packages/core/content-releases/admin/src/pages/tests/ReleaseDetailsPage.test.tsx
@@ -8,7 +8,7 @@ import { mockReleaseDetailsPageData } from './mockReleaseDetailsPageData';
 jest.mock('@strapi/helper-plugin', () => ({
   ...jest.requireActual('@strapi/helper-plugin'),
   // eslint-disable-next-line
-  CheckPermissions: ({ children }: { children: JSX.Element}) => <div>{children}</div>
+  CheckPermissions: ({ children }: { children: JSX.Element }) => <div>{children}</div>,
 }));
 
 describe('Releases details page', () => {
@@ -104,6 +104,10 @@ describe('Releases details page', () => {
     expect(
       screen.getByText(mockReleaseDetailsPageData.withActionsBodyData.data[0].entry.locale.name)
     ).toBeInTheDocument();
+
+    // There is one column with actions and the right one is checked
+    expect(screen.getByRole('radio', { name: 'publish' })).toBeChecked();
+    expect(screen.getByRole('radio', { name: 'unpublish' })).not.toBeChecked();
 
     const paginationCombobox = screen.queryByRole('combobox', { name: /entries per page/i });
     expect(paginationCombobox).toBeInTheDocument();

--- a/packages/core/content-releases/admin/src/services/release.ts
+++ b/packages/core/content-releases/admin/src/services/release.ts
@@ -5,7 +5,10 @@ import { pluginId } from '../pluginId';
 
 import { axiosBaseQuery } from './axios';
 
-import type { GetReleaseActions } from '../../../shared/contracts/release-actions';
+import type {
+  GetReleaseActions,
+  UpdateReleaseAction,
+} from '../../../shared/contracts/release-actions';
 import type {
   CreateRelease,
   GetContentTypeEntryReleases,
@@ -176,6 +179,21 @@ const releaseApi = createApi({
         },
         invalidatesTags: [{ type: 'ReleaseAction', id: 'LIST' }],
       }),
+      updateReleaseAction: build.mutation<
+        UpdateReleaseAction.Response,
+        UpdateReleaseAction.Request
+      >({
+        query({ body, params }) {
+          return {
+            url: `/content-releases/${params.releaseId}/actions/${params.actionId}`,
+            method: 'PUT',
+            data: body,
+          };
+        },
+        invalidatesTags: (result, error, arg) => [
+          { type: 'ReleaseAction', id: arg.params.actionId },
+        ],
+      }),
     };
   },
 });
@@ -188,6 +206,7 @@ const {
   useCreateReleaseMutation,
   useCreateReleaseActionMutation,
   useUpdateReleaseMutation,
+  useUpdateReleaseActionMutation,
 } = releaseApi;
 
 export {
@@ -198,5 +217,6 @@ export {
   useCreateReleaseMutation,
   useCreateReleaseActionMutation,
   useUpdateReleaseMutation,
+  useUpdateReleaseActionMutation,
   releaseApi,
 };

--- a/packages/core/content-releases/admin/src/services/release.ts
+++ b/packages/core/content-releases/admin/src/services/release.ts
@@ -59,7 +59,12 @@ const releaseApi = createApi({
           };
         },
         providesTags: (result) =>
-          result ? [...result.data.map(({ id }) => ({ type: 'Release' as const, id }))] : [],
+          result
+            ? [
+                ...result.data.map(({ id }) => ({ type: 'Release' as const, id })),
+                { type: 'Release', id: 'LIST' },
+              ]
+            : [],
       }),
       getReleases: build.query<GetReleasesTabResponse, GetReleasesQueryParams | void>({
         query(
@@ -177,7 +182,10 @@ const releaseApi = createApi({
             data: body,
           };
         },
-        invalidatesTags: [{ type: 'ReleaseAction', id: 'LIST' }],
+        invalidatesTags: [
+          { type: 'Release', id: 'LIST' },
+          { type: 'ReleaseAction', id: 'LIST' },
+        ],
       }),
       updateReleaseAction: build.mutation<
         UpdateReleaseAction.Response,

--- a/packages/core/content-releases/admin/src/translations/en.json
+++ b/packages/core/content-releases/admin/src/translations/en.json
@@ -32,7 +32,6 @@
   "page.Releases.release-item.entries": "{number, plural, =0 {No entries} one {# entry} other {# entries}}",
   "page.ReleaseDetails.table.header.label.name": "name",
   "page.ReleaseDetails.table.header.label.locale": "locale",
-  "page.ReleaseDetails.table.header.label.content-type": "content-type"
-
-
+  "page.ReleaseDetails.table.header.label.content-type": "content-type",
+  "page.ReleaseDetails.table.header.label.action": "action"
 }


### PR DESCRIPTION
⚠️ Wait for Simone's PR to be merged first, and then we can merge his last updated work here and change this PR to point into feature branch

### What does it do?

This PR add the action column to the details view, in this column you can change the type of the action (publish or unpublish)

### How to test it?

You should have an EE license and the feature enabled by setting contentReleases as enabled on the feature file.
```
// myproject/config/features.js
module.exports = ({ env }) => ({
  future: {
    contentReleases: true
  },
});
```

1. Then go to a release with actions (Create one and assign actions to it)
2. You should see a new column with the action 
3. You can change the action and the change should be reflect on the UI

