### PR TITLE
chore(content-releases): update permissions wording

### DIFF
--- a/packages/core/content-releases/server/src/constants.ts
+++ b/packages/core/content-releases/server/src/constants.ts
@@ -34,13 +34,13 @@ export const ACTIONS = [
   },
   {
     section: 'plugins',
-    displayName: 'Remove an action from a release',
+    displayName: 'Remove an entry from a release',
     uid: 'delete-action',
     pluginName: 'content-releases',
   },
   {
     section: 'plugins',
-    displayName: 'Add an action to a release',
+    displayName: 'Add an entry to a release',
     uid: 'create-action',
     pluginName: 'content-releases',
   },


### PR DESCRIPTION
### What does it do?

Change permissions wording to use "entry" instead of "action"

### Why is it needed?

It's confusing

### How to test it?

Test the permissions work the same. Give read and add entry to release to an Editor for example 
