### PR TITLE
update(CONTRIBUTING.md): new pull requests should be based on the `develop` branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ The Strapi core team will review your pull request and either merge it, request 
 
 **Before submitting your pull request** make sure the following requirements are fulfilled:
 
-- Fork the repository and create your new branch from `main`.
+- Fork the repository and create your new branch from `develop`.
 - Run `yarn install` in the root of the repository.
 - Run `yarn setup` in the root of the repository.
 - If you've fixed a bug or added code that should be tested, please make sure to add tests


### PR DESCRIPTION
new pull requests should be based on the `develop` branch

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

This pull request switches the base branch for new pull requests from `main` to `develop` as discussed [here](https://github.com/strapi/strapi/pull/19034#issuecomment-1853660331).

### Why is it needed?

Maintain consistency with the project's development workflow.

### How to test it?

### Related issue(s)/PR(s)

