### PR TITLE
[Telemetry] Custom Controllers Count

### DIFF
--- a/packages/core/strapi/src/Strapi.ts
+++ b/packages/core/strapi/src/Strapi.ts
@@ -372,18 +372,23 @@ class Strapi implements StrapiI {
     // Emit started event.
     // do not await to avoid slower startup
     // This event is anonymous
-    this.telemetry.send('didStartServer', {
-      groupProperties: {
-        database: this.config.get('database.connection.client'),
-        plugins: Object.keys(this.plugins),
-        numberOfAllContentTypes: _.size(this.contentTypes), // TODO: V5: This event should be renamed numberOfContentTypes in V5 as the name is already taken to describe the number of content types using i18n.
-        numberOfComponents: _.size(this.components),
-        numberOfDynamicZones: getNumberOfDynamicZones(),
-        environment: this.config.environment,
-        // TODO: to add back
-        // providers: this.config.installedProviders,
-      },
-    });
+    this.telemetry
+      .send('didStartServer', {
+        groupProperties: {
+          database: this.config.get('database.connection.client'),
+          plugins: Object.keys(this.plugins),
+          numberOfAllContentTypes: _.size(this.contentTypes), // TODO: V5: This event should be renamed numberOfContentTypes in V5 as the name is already taken to describe the number of content types using i18n.
+          numberOfComponents: _.size(this.components),
+          numberOfDynamicZones: getNumberOfDynamicZones(),
+          numberOfCustomControllers: Object.values<Common.Controller>(this.controllers).filter(
+            factories.isCustomController
+          ).length,
+          environment: this.config.environment,
+          // TODO: to add back
+          // providers: this.config.installedProviders,
+        },
+      })
+      .catch(this.log.error);
   }
 
   async openAdmin({ isInitialized }: { isInitialized: boolean }) {

--- a/packages/core/strapi/src/factories.ts
+++ b/packages/core/strapi/src/factories.ts
@@ -5,6 +5,10 @@ import { createController } from './core-api/controller';
 import { createService } from './core-api/service';
 import { createRoutes } from './core-api/routes';
 
+const symbols = {
+  CustomController: Symbol('StrapiCustomCoreController'),
+} as const;
+
 type WithStrapiCallback<T> = T | (<S extends { strapi: Strapi }>(params: S) => T);
 
 // Content type is proxied to allow for dynamic content type updates
@@ -38,6 +42,16 @@ const createCoreController = <
     }
 
     Object.setPrototypeOf(userCtrl, baseController);
+
+    const isCustomController = typeof cfg !== 'undefined';
+    if (isCustomController) {
+      Object.defineProperty(userCtrl, symbols.CustomController, {
+        writable: false,
+        configurable: false,
+        enumerable: false,
+      });
+    }
+
     return userCtrl;
   };
 };
@@ -101,4 +115,8 @@ function createCoreRouter<T extends Common.UID.ContentType>(
   };
 }
 
-export { createCoreController, createCoreService, createCoreRouter };
+const isCustomController = <T extends Common.Controller>(controller: T): boolean => {
+  return symbols.CustomController in controller;
+};
+
+export { createCoreController, createCoreService, createCoreRouter, isCustomController };


### PR DESCRIPTION
### What does it do?

Flag custom core controller to keep track of them
Update the sent telemetry group properties on server's start to include the number of custom controllers

### How to test it?
Customize the controller of an API endpoint (adding the second parameter to the createCoreController() function)
Check that the number of customized controllers passed to didStartServer is increased by one unit

### Related issue(s)/PR(s)
close https://github.com/strapi/strapi/pull/17640