### PR TITLE
[Types] Fix the sort's object notation (entity service)

### DIFF
--- a/packages/core/types/src/modules/entity-service/params/sort.ts
+++ b/packages/core/types/src/modules/entity-service/params/sort.ts
@@ -75,15 +75,23 @@ export type ArrayNotation<TSchemaUID extends Common.UID.Schema> = Any<TSchemaUID
  * type F = 'title'; // ❌
  */
 export type ObjectNotation<TSchemaUID extends Common.UID.Schema> = {
-  // First level sort
-  [key in SingleAttribute<TSchemaUID>]?: OrderKind.Any;
-} & {
-  // Deep sort, only add populatable keys that have a
-  // target (remove dynamic zones and other polymorphic links)
-  [key in Attribute.GetKeysWithTarget<TSchemaUID>]?: ObjectNotation<
-    Attribute.GetTarget<TSchemaUID, key>
-  >;
+  [key in ObjectNotationKeys<TSchemaUID>]?: key extends SingleAttribute<TSchemaUID>
+    ? // First level sort (scalar attributes, id, ...)
+      OrderKind.Any
+    : // Deep sort (relations with a target, components, media, ...)
+      ObjectNotation<Attribute.GetTarget<TSchemaUID, key>>;
 };
+
+/**
+ * Represents the keys of an object notation for a sort
+ * - SingleAttribute<TSchemaUID> represents a union of every non-populatable attribute based on the passed schema UID
+ * - Attribute.GetKeysWithTarget<TSchemaUID> provides keys with a target from the passed schema UID.
+ *
+ * This means that every member of ObjectNotationKeys can represent either a single non-populatable attribute or an attribute with a target.
+ */
+type ObjectNotationKeys<TSchemaUID extends Common.UID.Schema> =
+  | SingleAttribute<TSchemaUID>
+  | Attribute.GetKeysWithTarget<TSchemaUID>;
 
 /**
  * Represents any notation for a sort (string, array, object)

--- a/packages/core/utils/package.json
+++ b/packages/core/utils/package.json
@@ -42,7 +42,7 @@
     "test:ts": "run -T tsc --noEmit",
     "test:unit": "run -T jest",
     "test:unit:watch": "run -T jest --watch",
-    "watch": "run -T pack-up watch"
+    "watch": "pack-up watch"
   },
   "dependencies": {
     "@sindresorhus/slugify": "1.1.0",


### PR DESCRIPTION
### What does it do?

**tl;dr: Refactored the sort's object notation to fix inference and index signatures conflicts**

- Moved away from an intersection of mapped types (with different values) as their respective index signatures were conflicting.
- Used a single mapped type
	- It uses a union of every sortable key (populatable and non-populatable) as index
	- The value type is assigned directly based on the key type (using conditionals)

### Why is it needed?

Currently, it is not possible to use a combination of `fields`/`populate` and `sort` params (using the sort's object notation), as it'll break the params inference.

This results in undesired behavior in users' code (e.g. #18263)

### How to test it?

Using any Strapi project with generated types
- Go into a file that has access to both generated types and the `strapi` global object
- Write an `entityService.findMany` query for a collection-type.
- Add a populate attribute to hand-pick some relations or component
- The `findMany`'s result should propose only the populatable fields that have been selected
- Now, add a sort param using the object notation, and sort on any field available
- **The `findMany` result should still propose populated fields** 

### Related issue(s)/PR(s)

fix #18263

___

_also, fixed the watch script for the core/utils package_
