### PR TITLE
feat(content-releases): delete release action on release page

### DIFF
--- a/packages/core/content-releases/admin/src/components/ReleaseActionMenu.tsx
+++ b/packages/core/content-releases/admin/src/components/ReleaseActionMenu.tsx
@@ -12,7 +12,7 @@ import { useDeleteReleaseActionMutation } from '../services/release';
 
 const StyledMenuItem = styled(Menu.Item)`
   &:hover {
-    background: transparent;
+    background: ${({ theme }) => theme.colors.danger100};
   }
 
   svg {
@@ -100,11 +100,11 @@ export const ReleaseActionMenu = ({ releaseId, actionId }: ReleaseActionMenuProp
           // @ts-expect-error See above
           icon={<More />}
         />
-        {/* 
+        {/*
           TODO: Using Menu instead of SimpleMenu mainly because there is no positioning provided from the DS,
           Refactor this once fixed in the DS
          */}
-        <Menu.Content top={1}>
+        <Menu.Content top={1} popoverPlacement="bottom-end">
           <CheckPermissions permissions={PERMISSIONS.deleteAction}>
             <StyledMenuItem color="danger600" onSelect={handleDeleteAction}>
               <Flex gap={2}>

--- a/packages/core/content-releases/admin/src/pages/ReleaseDetailsPage.tsx
+++ b/packages/core/content-releases/admin/src/pages/ReleaseDetailsPage.tsx
@@ -33,6 +33,7 @@ import { useIntl } from 'react-intl';
 import { useParams, useHistory } from 'react-router-dom';
 import styled from 'styled-components';
 
+import { ReleaseActionMenu } from '../components/ReleaseActionMenu';
 import { ReleaseActionOptions } from '../components/ReleaseActionOptions';
 import { ReleaseModal, FormValues } from '../components/ReleaseModal';
 import { PERMISSIONS } from '../constants';
@@ -405,9 +406,9 @@ const ReleaseDetailsBody = () => {
     <ContentLayout>
       <Flex gap={4} direction="column" alignItems="stretch">
         <Table.Root
-          rows={releaseActions.map((item) => ({
-            ...item,
-            id: Number(item.entry.id),
+          rows={releaseActions.map((action) => ({
+            ...action,
+            id: Number(action.entry.id),
           }))}
           colCount={releaseActions.length}
           isLoading={isLoading}
@@ -447,6 +448,7 @@ const ReleaseDetailsBody = () => {
                 })}
                 name="action"
               />
+              <Table.HeaderHiddenActionsCell />
             </Table.Head>
             <Table.LoadingBody />
             <Table.Body>
@@ -485,6 +487,11 @@ const ReleaseDetailsBody = () => {
                         name={`release-action-${id}-type`}
                       />
                     )}
+                  </Td>
+                  <Td>
+                    <Flex justifyContent="flex-end">
+                      <ReleaseActionMenu releaseId={releaseId} actionId={id} />
+                    </Flex>
                   </Td>
                 </Tr>
               ))}


### PR DESCRIPTION
### What does it do?

- Adds the hover state for delete
- Adjusts the popover placement to match the designs
- Adds the menu to the Release page

### Why is it needed?

So it is easier to delete ReleaseActions

### How to test it?

Go to the release page
Click the 3 dots
Click delete


Originally I wanted to take care of CS-465 and refactor this component so we can use it for all our popover menus but I don't have the time before going on vacation. I should however be able to open a PR to fix the positioning in the DS for the Simple Menu.

I've also created CS-476 to handle this when I get back