### PR TITLE
fix(content-releases): add a bottom border below tabs

### DIFF
--- a/packages/core/content-releases/admin/src/pages/ReleasesPage.tsx
+++ b/packages/core/content-releases/admin/src/pages/ReleasesPage.tsx
@@ -4,6 +4,7 @@ import {
   Box,
   Button,
   ContentLayout,
+  Divider,
   EmptyStateLayout,
   Flex,
   Grid,
@@ -277,6 +278,7 @@ const ReleasesPage = () => {
                   })}
                 </Tab>
               </Tabs>
+              <Divider />
             </Box>
             <TabPanels>
               {/* Pending releases */}


### PR DESCRIPTION
### What does it do?

Added a divider below the tabs 

### Why is it needed?

In the list of releases the bottom border is missing below the tabs

### How to test it?

Go to the Releases page and check below the tabs