### PR TITLE
[Types] Fix entity-service's parameters inference for generic mapped types with deep literal intersections

### DIFF
--- a/packages/core/types/src/modules/entity-service/params/attributes/index.ts
+++ b/packages/core/types/src/modules/entity-service/params/attributes/index.ts
@@ -53,7 +53,10 @@ export type GetValues<TSchemaUID extends Common.UID.Schema> = {
  *
  * Fallback to unknown if never is found
  */
-export type GetValue<TAttribute extends Attribute.Attribute> = Utils.Expression.If<
+export type GetValue<
+  TAttribute extends Attribute.Attribute,
+  TGuard = unknown
+> = Utils.Expression.If<
   Utils.Expression.IsNotNever<TAttribute>,
   Utils.Expression.MatchFirst<
     [
@@ -112,7 +115,7 @@ export type GetValue<TAttribute extends Attribute.Attribute> = Utils.Expression.
       ],
       // Fallback
       // If none of the above attribute type, fallback to the original Attribute.GetValue (while making sure it's an attribute)
-      [Utils.Expression.True, Attribute.GetValue<TAttribute, unknown>]
+      [Utils.Expression.True, Attribute.GetValue<TAttribute, TGuard>]
     ],
     unknown
   >,

--- a/packages/core/types/src/modules/entity-service/params/filters/index.ts
+++ b/packages/core/types/src/modules/entity-service/params/filters/index.ts
@@ -58,23 +58,19 @@ export type AttributesFiltering<TSchemaUID extends Common.UID.Schema> = Utils.Gu
  * Definition of scalar attribute filtering for a given schema UID.
  * @template TSchemaUID - The UID of the schema.
  */
-export type ScalarAttributesFiltering<TSchemaUID extends Common.UID.Schema> =
-  AttributeUtils.GetScalarKeys<TSchemaUID> extends infer TKeys
-    ? TKeys extends AttributeUtils.GetScalarKeys<TSchemaUID>
-      ? IDFiltering & { [TKey in TKeys]?: AttributeCondition<TSchemaUID, TKey> }
-      : never
-    : never;
+export type ScalarAttributesFiltering<TSchemaUID extends Common.UID.Schema> = IDFiltering & {
+  [TKey in AttributeUtils.GetScalarKeys<TSchemaUID>]?: AttributeCondition<TSchemaUID, TKey>;
+};
 
 /**
  * Filters object for nested schema attributes.
  * @template TSchemaUID - The UID of the schema to perform filtering on.
  */
-export type NestedAttributeFiltering<TSchemaUID extends Common.UID.Schema> =
-  AttributeUtils.GetNestedKeys<TSchemaUID> extends infer TKeys
-    ? TKeys extends AttributeUtils.GetNestedKeys<TSchemaUID>
-      ? { [TKey in TKeys]?: ObjectNotation<Attribute.GetTarget<TSchemaUID, TKey>> }
-      : never
-    : never;
+export type NestedAttributeFiltering<TSchemaUID extends Common.UID.Schema> = {
+  [TKey in AttributeUtils.GetNestedKeys<TSchemaUID>]?: ObjectNotation<
+    Attribute.GetTarget<TSchemaUID, TKey>
+  >;
+};
 
 type IDFiltering = { id?: AttributeCondition<never, IDKey> };
 

--- a/packages/core/types/src/modules/entity-service/params/filters/index.ts
+++ b/packages/core/types/src/modules/entity-service/params/filters/index.ts
@@ -21,7 +21,13 @@ export type Any<TSchemaUID extends Common.UID.Schema> = ObjectNotation<TSchemaUI
  * @template TSchemaUID The UID of the schema defining the object notation.
  */
 export type ObjectNotation<TSchemaUID extends Common.UID.Schema> =
-  RootLevelOperatorFiltering<TSchemaUID> & AttributesFiltering<TSchemaUID>;
+  TSchemaUID extends infer TUIDs extends Common.UID.Schema
+    ? // The intermediary mapping step below allows TypeScript's generic inference to correctly distribute the
+      // TSchemaUID union into the individual keys of AttributesFiltering and RootLevelOperatorFiltering types
+      {
+        [TUID in TUIDs]: RootLevelOperatorFiltering<TUID> & AttributesFiltering<TUID>;
+      }[TSchemaUID]
+    : never;
 
 /**
  * Object for root level operator filtering.

--- a/packages/core/types/src/modules/entity-service/params/filters/index.ts
+++ b/packages/core/types/src/modules/entity-service/params/filters/index.ts
@@ -9,34 +9,78 @@ export { Operator };
 type IDKey = 'id';
 
 /**
- * Filter representation for nested attributes
+ * Generic object notation for filters.
+ * @template TSchemaUID The type of the schema UID for the object notation.
  */
-type NestedAttributeCondition<
-  TSchemaUID extends Common.UID.Schema,
-  TAttributeName extends Attribute.GetKeys<TSchemaUID>
-> = ObjectNotation<
-  Utils.Guard.Never<Attribute.GetTarget<TSchemaUID, TAttributeName>, Common.UID.Schema>
+export type Any<TSchemaUID extends Common.UID.Schema> = ObjectNotation<TSchemaUID>;
+
+/**
+ * Type that unites root-level operators and attributes filtering for a specific schema query.
+ *
+ * It is used to define the structure of filters objects in a specific schema.
+ * @template TSchemaUID The UID of the schema defining the object notation.
+ */
+export type ObjectNotation<TSchemaUID extends Common.UID.Schema> =
+  RootLevelOperatorFiltering<TSchemaUID> & AttributesFiltering<TSchemaUID>;
+
+/**
+ * Object for root level operator filtering.
+ * @template TSchemaUID - The type of the schema UID.
+ */
+export type RootLevelOperatorFiltering<TSchemaUID extends Common.UID.Schema> = {
+  [TIter in Operator.Group]?: ObjectNotation<TSchemaUID>[];
+} & {
+  [TIter in Operator.Logical]?: ObjectNotation<TSchemaUID>;
+};
+
+/**
+ * Represents a type for filtering on attributes based on a given schema.
+ *  @template TSchemaUID - The UID of the schema.
+ */
+export type AttributesFiltering<TSchemaUID extends Common.UID.Schema> = Utils.Guard.Never<
+  // Combines filtering for scalar and nested attributes based on schema UID
+  ScalarAttributesFiltering<TSchemaUID> & NestedAttributeFiltering<TSchemaUID>,
+  // Abstract representation of the filter object tree in case we don't have access to the attributes' list
+  {
+    [TKey in string]?:
+      | AttributeCondition<TSchemaUID, never>
+      | NestedAttributeCondition<TSchemaUID, never>;
+  }
 >;
 
 /**
- * Filter representation for scalar attributes
+ * Definition of scalar attribute filtering for a given schema UID.
+ * @template TSchemaUID - The UID of the schema.
+ */
+export type ScalarAttributesFiltering<TSchemaUID extends Common.UID.Schema> =
+  AttributeUtils.GetScalarKeys<TSchemaUID> extends infer TKeys
+    ? TKeys extends AttributeUtils.GetScalarKeys<TSchemaUID>
+      ? IDFiltering & { [TKey in TKeys]?: AttributeCondition<TSchemaUID, TKey> }
+      : never
+    : never;
+
+/**
+ * Filters object for nested schema attributes.
+ * @template TSchemaUID - The UID of the schema to perform filtering on.
+ */
+export type NestedAttributeFiltering<TSchemaUID extends Common.UID.Schema> =
+  AttributeUtils.GetNestedKeys<TSchemaUID> extends infer TKeys
+    ? TKeys extends AttributeUtils.GetNestedKeys<TSchemaUID>
+      ? { [TKey in TKeys]?: ObjectNotation<Attribute.GetTarget<TSchemaUID, TKey>> }
+      : never
+    : never;
+
+type IDFiltering = { id?: AttributeCondition<never, IDKey> };
+
+/**
+ * Filter condition for scalar attributes.
+ * @template TSchemaUID - The unique identifier of the schema.
+ * @template TAttributeName - The name of the attribute.
  */
 type AttributeCondition<
   TSchemaUID extends Common.UID.Schema,
-  TAttributeName extends IDKey | Attribute.GetKeys<TSchemaUID>
-> = Utils.Expression.MatchFirst<
-  [
-    // Special catch for manually added ID attributes
-    [Utils.Expression.StrictEqual<TAttributeName, IDKey>, Params.Attribute.ID],
-    [
-      Utils.Expression.IsNotNever<TAttributeName>,
-      // Get the filter attribute value for the given attribute
-      AttributeUtils.GetValue<Attribute.Get<TSchemaUID, Exclude<TAttributeName, IDKey>>>
-    ]
-  ],
-  // Fallback to the list of all possible scalar attributes' value if the attribute is not valid (never)
-  AttributeUtils.ScalarValues
-> extends infer TAttributeValue
+  TAttributeName extends IDKey | AttributeUtils.GetScalarKeys<TSchemaUID>
+> = GetScalarAttributeValue<TSchemaUID, TAttributeName> extends infer TAttributeValue
   ?
       | TAttributeValue // Implicit $eq operator
       | ({
@@ -55,36 +99,43 @@ type AttributeCondition<
   : never;
 
 /**
- * Tree representation of a Strapi filter for a given schema UID
+ * Utility type that retrieves the value of a scalar attribute in a schema.
+ * @template TSchemaUID The UID type of the schema.
+ * @template TAttributeName The name of the attribute.
  */
-export type ObjectNotation<TSchemaUID extends Common.UID.Schema> = {
-  [TIter in Operator.Group]?: ObjectNotation<TSchemaUID>[];
-} & {
-  [TIter in Operator.Logical]?: ObjectNotation<TSchemaUID>;
-} & ([AttributeUtils.GetScalarKeys<TSchemaUID>, AttributeUtils.GetNestedKeys<TSchemaUID>] extends [
-    infer TScalarKeys extends AttributeUtils.GetScalarKeys<TSchemaUID>,
-    infer TNestedKeys extends AttributeUtils.GetNestedKeys<TSchemaUID>
-  ]
-    ? // If both the scalar and nested keys are resolved, then create a strongly
-      // typed filter object, else create a loose generic abstraction.
-      Utils.Expression.If<
-        Utils.Expression.And<
-          Utils.Expression.IsNotNever<TScalarKeys>,
-          Utils.Expression.IsNotNever<TNestedKeys>
-        >,
-        // Strongly typed representation of the filter object tree
-        {
-          [TIter in IDKey | TScalarKeys]?: AttributeCondition<TSchemaUID, TIter>;
-        } & {
-          [TIter in TNestedKeys]?: NestedAttributeCondition<TSchemaUID, TIter>;
-        },
-        // Generic representation of the filter object tree in case we don't have access to the attributes' list
-        {
-          [TKey in string]?:
-            | AttributeCondition<TSchemaUID, never>
-            | NestedAttributeCondition<TSchemaUID, never>;
-        }
+type GetScalarAttributeValue<
+  TSchemaUID extends Common.UID.Schema,
+  TAttributeName extends IDKey | AttributeUtils.GetScalarKeys<TSchemaUID>
+> = Utils.Expression.MatchFirst<
+  [
+    // Checks and captures for manually added ID attributes
+    [Utils.Expression.StrictEqual<TAttributeName, IDKey>, Params.Attribute.ID],
+    [
+      // Ensure attribute name isn't 'never'
+      Utils.Expression.IsNotNever<TAttributeName>,
+      // Get value of specific attribute in the schema
+      AttributeUtils.GetValue<
+        Attribute.Get<
+          TSchemaUID,
+          // Cast attribute name to a scalar key if possible
+          Utils.Cast<TAttributeName, AttributeUtils.GetScalarKeys<TSchemaUID>>
+        >
       >
-    : never);
+    ]
+  ],
+  // Fallback to the list of all possible scalar attributes' value if the attribute is not valid (never)
+  AttributeUtils.ScalarValues
+>;
 
-export type Any<TSchemaUID extends Common.UID.Schema> = ObjectNotation<TSchemaUID>;
+/**
+ * Nested filter condition based on the given schema and attribute name
+ * @template TSchemaUID - The (literal) UID of the schema.
+ * @template TAttributeName - The attribute name in the schema.
+ */
+type NestedAttributeCondition<
+  TSchemaUID extends Common.UID.Schema,
+  TAttributeName extends Attribute.GetKeys<TSchemaUID>
+> = ObjectNotation<
+  // Ensure the resolved target isn't `never`, else, fallback to Common.UID.Schema
+  Utils.Guard.Never<Attribute.GetTarget<TSchemaUID, TAttributeName>, Common.UID.Schema>
+>;

--- a/packages/core/types/src/modules/entity-service/params/sort.ts
+++ b/packages/core/types/src/modules/entity-service/params/sort.ts
@@ -78,8 +78,10 @@ export type ObjectNotation<TSchemaUID extends Common.UID.Schema> = {
   [TKey in ObjectNotationKeys<TSchemaUID>]?: TKey extends SingleAttribute<TSchemaUID>
     ? // First level sort (scalar attributes, id, ...)
       OrderKind.Any
-    : // Deep sort (relations with a target, components, media, ...)
-      ObjectNotation<Attribute.GetTarget<TSchemaUID, TKey>>;
+    : TKey extends Attribute.GetKeysWithTarget<TSchemaUID>
+    ? // Deep sort (relations with a target, components, media, ...)
+      ObjectNotation<Attribute.GetTarget<TSchemaUID, TKey>>
+    : never;
 };
 
 /**

--- a/packages/core/types/src/modules/entity-service/params/sort.ts
+++ b/packages/core/types/src/modules/entity-service/params/sort.ts
@@ -75,11 +75,11 @@ export type ArrayNotation<TSchemaUID extends Common.UID.Schema> = Any<TSchemaUID
  * type F = 'title'; // ❌
  */
 export type ObjectNotation<TSchemaUID extends Common.UID.Schema> = {
-  [key in ObjectNotationKeys<TSchemaUID>]?: key extends SingleAttribute<TSchemaUID>
+  [TKey in ObjectNotationKeys<TSchemaUID>]?: TKey extends SingleAttribute<TSchemaUID>
     ? // First level sort (scalar attributes, id, ...)
       OrderKind.Any
     : // Deep sort (relations with a target, components, media, ...)
-      ObjectNotation<Attribute.GetTarget<TSchemaUID, key>>;
+      ObjectNotation<Attribute.GetTarget<TSchemaUID, TKey>>;
 };
 
 /**

--- a/packages/core/types/src/modules/entity-service/params/sort.ts
+++ b/packages/core/types/src/modules/entity-service/params/sort.ts
@@ -75,15 +75,23 @@ export type ArrayNotation<TSchemaUID extends Common.UID.Schema> = Any<TSchemaUID
  * type F = 'title'; // ❌
  */
 export type ObjectNotation<TSchemaUID extends Common.UID.Schema> = {
-  // First level sort
-  [key in SingleAttribute<TSchemaUID>]?: OrderKind.Any;
-} & {
-  // Deep sort, only add populatable keys that have a
-  // target (remove dynamic zones and other polymorphic links)
-  [key in Attribute.GetKeysWithTarget<TSchemaUID>]?: ObjectNotation<
-    Attribute.GetTarget<TSchemaUID, key>
-  >;
+  [key in ObjectNotationKeys<TSchemaUID>]?: key extends SingleAttribute<TSchemaUID>
+    ? // First level sort (scalar attributes, id, ...)
+      OrderKind.Any
+    : // Deep sort (relations with a target, components, media, ...)
+      ObjectNotation<Attribute.GetTarget<TSchemaUID, key>>;
 };
+
+/**
+ * Represents the keys of an object notation for a sort
+ * - SingleAttribute<TSchemaUID> represents a union of every non-populatable attribute based on the passed schema UID
+ * - Attribute.GetKeysWithTarget<TSchemaUID> provides keys with a target from the passed schema UID.
+ *
+ * This means that every member of ObjectNotationKeys can represent either a single non-populatable attribute or an attribute with a target.
+ */
+type ObjectNotationKeys<TSchemaUID extends Common.UID.Schema> =
+  | SingleAttribute<TSchemaUID>
+  | Attribute.GetKeysWithTarget<TSchemaUID>;
 
 /**
  * Represents any notation for a sort (string, array, object)

--- a/packages/core/types/src/types/utils/array.ts
+++ b/packages/core/types/src/types/utils/array.ts
@@ -1,7 +1,7 @@
 import type { Utils } from '..';
 
 /**
- * Extract the array values into an union type
+ * Extract the array values into a union type
  */
 export type Values<TCollection extends Array<unknown>> = TCollection extends Array<infer TValues>
   ? TValues

--- a/packages/core/utils/package.json
+++ b/packages/core/utils/package.json
@@ -42,7 +42,7 @@
     "test:ts": "run -T tsc --noEmit",
     "test:unit": "run -T jest",
     "test:unit:watch": "run -T jest --watch",
-    "watch": "run -T pack-up watch"
+    "watch": "pack-up watch"
   },
   "dependencies": {
     "@sindresorhus/slugify": "1.1.0",


### PR DESCRIPTION
## What does it do?

### Summary
Fixed the `sort` and `filters` object notations for the entity service causing invalid inference, thus breaking the resulting types.

### Original Issue
[ #18263 - Populate generated types doesn't work with filter on entityService](https://github.com/strapi/strapi/issues/18263)

## What's happening?

### Context
`findMany` in the entity-service is defined as (simplified version):
```ts
findMany<
    TContentTypeUID extends Common.UID.ContentType,
    TParams extends Params.Pick<
      TContentTypeUID,
      | 'filters'
      | 'sort'
      | 'populate'
	  // | etc...
    >
  >(uid: TContentTypeUID, params?: TParams): Promise<Result<TContentTypeUID, TParams>[]>
```

### Sort (object notation only)

#### TL;DR
**When using the entity-service's `findMany` method with a `sort` object notation, it breaks the parameters type inference.
This is caused by the usage of generics (inferred upon usage) in mapped types with loose index signatures conflicting with each other.**

**Before**
```ts
export type ObjectNotation<TSchemaUID extends Common.UID.Schema> = {
  // First level sort
  [key in SingleAttribute<TSchemaUID>]?: OrderKind.Any;
} & {
  // Deep sort, only add populatable keys that have a
  // target (remove dynamic zones and other polymorphic links)
  [key in Attribute.GetKeysWithTarget<TSchemaUID>]?: ObjectNotation<
    Attribute.GetTarget<TSchemaUID, key>
  >;
};
```

#### Details
- `TParams` (`findMany`) is using a `TContentTypeUID` generic which will be inferred upon usage. (as opposed to using a hard-coded literal string like `api::restaurant.restaurant`)
- The `TContentTypeUID` generic is then used across different types in `TParams`, including inside the `sort` `ObjectNotation`
- `ObjectNotation` makes an intersection between two mapped types whose index signatures are built using the given `TSchemaUID` generic (== `TContentTypeUID` from `TParams<TContentTypeUID>`)

  > Note:  When using hard-coded literals instead of generics in the `findMany`, it'll limit the breadth of possible types and make it easier for TypeScript to infer the types down the line, which is not the case when it has to infer it from usage.
- All of this results in `ObjectNotation` creating an intersection of two mapped types whose index signatures end up being too loose and conflict with each other. It creates an errored type's intersection and breaks the inference up to `TParams`.
- With `TParams` being broken, it defaults to the abstract representation with a generic `Common.UID.Schema` being passed instead of the UID inferred from usage.
- Finally, since `TParams` is abstract, `Result` can't infer the `fields` and `populate` params anymore, and defaults to every scalar field + no populatable fields, breaking the final type and causing the initial error reported by users.

#### Proposed Solution

To solve this issue, I've decided to remove the faulty intersection, using a single mapped type and deferring the type narrowing to every value inside the map.

- This removes the conflicting index signatures. It now uses a single index built from the union of the 2 old ones.
- The type narrowing is done inside each key/value pair, allowing TypeScript to infer the correct type.
- Ultimately, this fixes the `TParams` inference, hence allowing `Result` to use the correct `fields` and `populate` params

**After**
```ts
export type ObjectNotation<TSchemaUID extends Common.UID.Schema> = {
  [TKey in ObjectNotationKeys<TSchemaUID>]?: TKey extends SingleAttribute<TSchemaUID>
    ? // First level sort (scalar attributes, id, ...)
      OrderKind.Any
    : // Deep sort (relations with a target, components, media, ...)
      ObjectNotation<Attribute.GetTarget<TSchemaUID, TKey>>;
};

type ObjectNotationKeys<TSchemaUID extends Common.UID.Schema> =
  | SingleAttribute<TSchemaUID>
  | Attribute.GetKeysWithTarget<TSchemaUID>;

```

### Filters (with enum fields only)

#### TL;DR
**When using the entity-service's `findMany` method with a `filters` object notation that contains literal filters (enums), it breaks the parameters type inference.
This is caused by the usage of generics (inferred upon usage) in mapped types with incorrect inference, creating impossible situations.**

**Before**
```ts
export type ObjectNotation<TSchemaUID extends Common.UID.Schema> = {
  [TIter in Operator.Group]?: ObjectNotation<TSchemaUID>[];
} & {
  [TIter in Operator.Logical]?: ObjectNotation<TSchemaUID>;
} & ([AttributeUtils.GetScalarKeys<TSchemaUID>, AttributeUtils.GetNestedKeys<TSchemaUID>] extends [
    infer TScalarKeys extends AttributeUtils.GetScalarKeys<TSchemaUID>,
    infer TNestedKeys extends AttributeUtils.GetNestedKeys<TSchemaUID>
  ]
  ? // If both the scalar and nested keys are resolved, then create a strongly
  // typed filter object, else create a loose generic abstraction.
  Utils.Expression.If<
    Utils.Expression.And<
      Utils.Expression.IsNotNever<TScalarKeys>,
      Utils.Expression.IsNotNever<TNestedKeys>
    >,
    // Strongly typed representation of the filter object tree
    {
      [TIter in IDKey | TScalarKeys]?: AttributeCondition<TSchemaUID, TIter>;
    } & {
    [TIter in TNestedKeys]?: NestedAttributeCondition<TSchemaUID, TIter>;
  },
    // Generic representation of the filter object tree in case we don't have access to the attributes' list
    {
      [TKey in string]?:
      | AttributeCondition<TSchemaUID, never>
      | NestedAttributeCondition<TSchemaUID, never>;
    }
  >
  : never);
```

#### Details
- `TParams` (`findMany`) is using a `TContentTypeUID` generic which will be inferred upon usage. (as opposed to using a hard-coded literal string like `api::restaurant.restaurant`)
- The `TContentTypeUID` generic is then used across different types in `TParams`, including inside the `filters` `ObjectNotation`
- `ObjectNotation` infers union types (from the given Schema keys) as variables (`TScalarKeys`, `TNestedKeys`)
  ```ts
    ([AttributeUtils.GetScalarKeys<TSchemaUID>, AttributeUtils.GetNestedKeys<TSchemaUID>] extends [
        infer TScalarKeys extends AttributeUtils.GetScalarKeys<TSchemaUID>,
        infer TNestedKeys extends AttributeUtils.GetNestedKeys<TSchemaUID>
    ]
    ```
- The mapped types built using those keys as indexes have values defined as unions and intersections of types resolved from both the given Schema and `keys` (e.g. for `email` fields, it'll return `string | ({ $eq?: string } & { ... })`).
- When this happens, if the resolved type for a given generic Schema and attribute name (`key`) is a literal value (e.g. enum fields), it then creates unions/intersection of a literal with object types.
   > Note:  When using hard-coded literals instead of generics in the `findMany`, it'll limit the breadth of possible types and make it easier for TypeScript to infer the types down the line, which is not the case when it has to infer it from usage.
- Based on last points, what is likely happening is that `TScalarKeys` is inferred incorrectly upon usage, which ends up creating intersections of mapped types (based on every key), and fail to intersect literal with loose types (such as `objects` or scalars like `number`)
- With `TParams` being broken, it defaults to the abstract representation with a generic `Common.UID.Schema` being passed instead of the UID inferred from usage.
- Finally, since `TParams` is abstract, `Result` can't infer the `fields` and `populate` params anymore, and defaults to every scalar field + no populatable fields, breaking the final type and causing the initial error reported by users.

#### Proposed Solution

To solve this issue, I've simplified the code, then used a two-steps inference.

Basically, the fix is going from:

`X infer TX extends X ? ... : never`

to:

`X infer TX ? TX extends X ? ... : never : never`

Which apparently forces TypeScript to better infer types (even using generic defined upon usage).

I've tried to make some research in order to understand the difference between both, but couldn't find much. Any additional information would be greatly appreciated

**After**
```ts
export type ObjectNotation<TSchemaUID extends Common.UID.Schema> =
  RootLevelOperatorFiltering<TSchemaUID> & AttributesFiltering<TSchemaUID>;

export type AttributesFiltering<TSchemaUID extends Common.UID.Schema> = Utils.Guard.Never<
  // Combines filtering for scalar and nested attributes based on schema UID
  ScalarAttributesFiltering<TSchemaUID> & NestedAttributeFiltering<TSchemaUID>,
  // Abstract representation of the filter object tree in case we don't have access to the attributes' list
  {
    [TKey in string]?:
        | AttributeCondition<TSchemaUID, never>
        | NestedAttributeCondition<TSchemaUID, never>;
  }
>;

export type ScalarAttributesFiltering<TSchemaUID extends Common.UID.Schema> =
  AttributeUtils.GetScalarKeys<TSchemaUID> extends infer TKeys // <--|
    ? TKeys extends AttributeUtils.GetScalarKeys<TSchemaUID> //   <--| Two steps inference to force the correct narrowing 
      ? IDFiltering & { [TKey in TKeys]?: AttributeCondition<TSchemaUID, TKey> }
      : never
    : never;

export type NestedAttributeFiltering<TSchemaUID extends Common.UID.Schema> =
  AttributeUtils.GetNestedKeys<TSchemaUID> extends infer TKeys // <--|
    ? TKeys extends AttributeUtils.GetNestedKeys<TSchemaUID> //   <--| Two steps inference to force the correct narrowing
      ? { [TKey in TKeys]?: ObjectNotation<Attribute.GetTarget<TSchemaUID, TKey>> }
      : never
    : never;

export type RootLevelOperatorFiltering<TSchemaUID extends Common.UID.Schema> = {
  [TIter in Operator.Group]?: ObjectNotation<TSchemaUID>[];
} & {
  [TIter in Operator.Logical]?: ObjectNotation<TSchemaUID>;
};
```

### Why is it needed?

Issues are being reported indicating that using sort or certain filters alongside populate breaks the entity service's types.
It aims at fixing those faulty behaviors.

### How to test it?

- Go in the `getstarted` project, make sure types are generated
- Copy the `types/` folder inside the `examples/kitchensink-ts` directory
- Open the `kitchensink-ts/src/index.ts` file and heads to any method inside, make it async
- Use the following query as a base for future tests
  ```ts
  const result = await strapi.findMany('api::restaurant.restaurant', { populate: ['menu'] });
  
  console.log(result[0].menu) // this is where the error was in the issue 
  ```
- To test the `sort` fix, add a `sort` property to the params (it was failing only on object notations)
  - Whatever `sort` you're adding, `result[0].menu` must not fail anymore
- To Test the `filters` fix, add a `filters` property to the params (it was failing only on enum filters)
  - `result[0].menu` must not fail anymore. Even when using filters such as `{ priceRange: 'cheap' }`
- Feel free to play with the overall params object in order to find additional issues

### Related issue(s)/PR(s)

improve #19082
fix #18263 

---
_oh, and it also fixes the core/utils package's watch script, because why not_
