### PR TITLE
Feat/update admin content links on location change

### DIFF
--- a/packages/core/admin/admin/src/content-manager/pages/App/LeftMenu/index.js
+++ b/packages/core/admin/admin/src/content-manager/pages/App/LeftMenu/index.js
@@ -20,12 +20,14 @@ import { NavLink } from 'react-router-dom';
 
 import getTrad from '../../../utils/getTrad';
 import { makeSelectModelLinks } from '../selectors';
+import useUpdateContentManagerLinks from '../useUpdateContentManagerLinks';
 
 const LeftMenu = () => {
   const [search, setSearch] = useState('');
   const { formatMessage, locale } = useIntl();
   const modelLinksSelector = useMemo(makeSelectModelLinks, []);
   const { collectionTypeLinks, singleTypeLinks } = useSelector(modelLinksSelector, shallowEqual);
+  useUpdateContentManagerLinks();
 
   const { startsWith } = useFilter(locale, {
     sensitivity: 'base',

--- a/packages/core/admin/admin/src/content-manager/pages/App/actions.js
+++ b/packages/core/admin/admin/src/content-manager/pages/App/actions.js
@@ -1,4 +1,4 @@
-import { GET_INIT_DATA, RESET_INIT_DATA, SET_INIT_DATA } from './constants';
+import { UPDATE_LINKS, GET_INIT_DATA, RESET_INIT_DATA, SET_INIT_DATA } from './constants';
 
 export const getInitData = () => ({
   type: GET_INIT_DATA,
@@ -20,5 +20,16 @@ export const setInitData = ({
     components,
     contentTypeSchemas,
     fieldSizes,
+  },
+});
+
+export const updateLinksAction = ({
+  authorizedCollectionTypeLinks,
+  authorizedSingleTypeLinks,
+}) => ({
+  type: UPDATE_LINKS,
+  data: {
+    authorizedCollectionTypeLinks,
+    authorizedSingleTypeLinks,
   },
 });

--- a/packages/core/admin/admin/src/content-manager/pages/App/constants.js
+++ b/packages/core/admin/admin/src/content-manager/pages/App/constants.js
@@ -1,3 +1,4 @@
 export const GET_INIT_DATA = 'ContentManager/App/GET_INIT_DATA';
 export const RESET_INIT_DATA = 'ContentManager/App/RESET_INIT_DATA';
 export const SET_INIT_DATA = 'ContentManager/App/SET_INIT_DATA';
+export const UPDATE_LINKS = 'ContentManager/App/UPDATE_LINKS';

--- a/packages/core/admin/admin/src/content-manager/pages/App/reducer.js
+++ b/packages/core/admin/admin/src/content-manager/pages/App/reducer.js
@@ -5,7 +5,7 @@
 /* eslint-disable consistent-return */
 import produce from 'immer';
 
-import { GET_INIT_DATA, RESET_INIT_DATA, SET_INIT_DATA } from './constants';
+import { UPDATE_LINKS, GET_INIT_DATA, RESET_INIT_DATA, SET_INIT_DATA } from './constants';
 
 const initialState = {
   components: [],
@@ -39,6 +39,15 @@ const mainReducer = (state = initialState, action) =>
         draftState.models = action.data.contentTypeSchemas;
         draftState.fieldSizes = action.data.fieldSizes;
         draftState.status = 'resolved';
+        break;
+      }
+      case UPDATE_LINKS: {
+        draftState.collectionTypeLinks = action.data.authorizedCollectionTypeLinks.filter(
+          ({ isDisplayed }) => isDisplayed
+        );
+        draftState.singleTypeLinks = action.data.authorizedSingleTypeLinks.filter(
+          ({ isDisplayed }) => isDisplayed
+        );
         break;
       }
       default:

--- a/packages/core/admin/admin/src/content-manager/pages/App/useUpdateContentManagerLinks.js
+++ b/packages/core/admin/admin/src/content-manager/pages/App/useUpdateContentManagerLinks.js
@@ -1,0 +1,53 @@
+import { useEffect } from 'react';
+
+import { useNotification, useStrapiApp } from '@strapi/helper-plugin';
+import { useDispatch, useSelector } from 'react-redux';
+import { useLocation } from 'react-router-dom';
+
+import { HOOKS } from '../../../constants';
+
+import { updateLinksAction } from './actions';
+import { selectAppDomain } from './selectors';
+
+const { MUTATE_COLLECTION_TYPES_LINKS, MUTATE_SINGLE_TYPES_LINKS } = HOOKS;
+
+const useUpdateContentManagerLinks = () => {
+  const dispatch = useDispatch();
+  const toggleNotification = useNotification();
+  const location = useLocation();
+  const state = useSelector(selectAppDomain());
+  const { runHookWaterfall } = useStrapiApp();
+
+  const updateLinks = () => {
+    try {
+      const { ctLinks: authorizedCollectionTypeLinks } = runHookWaterfall(
+        MUTATE_COLLECTION_TYPES_LINKS,
+        {
+          ctLinks: state.collectionTypeLinks,
+          models: state.models,
+        }
+      );
+      const { stLinks: authorizedSingleTypeLinks } = runHookWaterfall(MUTATE_SINGLE_TYPES_LINKS, {
+        stLinks: state.singleTypeLinks,
+        models: state.models,
+      });
+
+      const actionToDispatch = updateLinksAction({
+        authorizedCollectionTypeLinks,
+        authorizedSingleTypeLinks,
+      });
+
+      dispatch(actionToDispatch);
+    } catch (err) {
+      console.error(err);
+      toggleNotification({ type: 'warning', message: { id: 'notification.error' } });
+    }
+  };
+
+  useEffect(() => {
+    updateLinks();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dispatch, location]);
+};
+
+export default useUpdateContentManagerLinks;

--- a/packages/plugins/i18n/admin/src/contentManagerHooks/utils/addLocaleToLinksSearch.js
+++ b/packages/plugins/i18n/admin/src/contentManagerHooks/utils/addLocaleToLinksSearch.js
@@ -2,6 +2,7 @@ import get from 'lodash/get';
 import { parse, stringify } from 'qs';
 
 import getDefaultLocale from '../../utils/getDefaultLocale';
+import getLocaleFromQuery from '../../utils/getLocaleFromQuery';
 
 const addLocaleToLinksSearch = (links, kind, contentTypeSchemas, locales, permissions) => {
   return links.map((link) => {
@@ -36,7 +37,10 @@ const addLocaleToLinksSearch = (links, kind, contentTypeSchemas, locales, permis
       {}
     );
 
+    const currentSearchQuery = parse(window.location.search.slice(1)); // skip `?` in search string
+    const currentLocale = getLocaleFromQuery(currentSearchQuery);
     const defaultLocale = getDefaultLocale(contentTypeNeededPermissions, locales);
+    const newLinkLocale = currentLocale || defaultLocale;
 
     if (!defaultLocale) {
       return { ...link, isDisplayed: false };
@@ -45,8 +49,8 @@ const addLocaleToLinksSearch = (links, kind, contentTypeSchemas, locales, permis
     const linkParams = link.search ? parse(link.search) : {};
 
     const params = linkParams
-      ? { ...linkParams, plugins: { ...linkParams.plugins, i18n: { locale: defaultLocale } } }
-      : { plugins: { i18n: { locale: defaultLocale } } };
+      ? { ...linkParams, plugins: { ...linkParams.plugins, i18n: { locale: newLinkLocale } } }
+      : { plugins: { i18n: { locale: newLinkLocale } } };
 
     const search = stringify(params, { encode: false });
 

--- a/packages/plugins/i18n/admin/src/contentManagerHooks/utils/tests/addLocaleToLinksSearch.test.js
+++ b/packages/plugins/i18n/admin/src/contentManagerHooks/utils/tests/addLocaleToLinksSearch.test.js
@@ -134,4 +134,79 @@ describe('i18n | contentManagerHooks | utils | addLocaleToLinksSearch', () => {
       expected
     );
   });
+
+  it('should add the current locale to a link search', () => {
+    const links = [
+      {
+        uid: 'foo',
+        to: 'cm/collectionType/foo',
+        isDisplayed: true,
+        search: 'page=1',
+      },
+      { uid: 'bar', to: 'cm/collectionType/bar', isDisplayed: true },
+    ];
+    const schemas = [
+      { uid: 'foo', pluginOptions: { i18n: { localized: true } } },
+      { uid: 'bar', pluginOptions: { i18n: { localized: true } } },
+    ];
+    const permissions = {
+      foo: {
+        'plugin::content-manager.explorer.create': [
+          {
+            properties: {
+              fields: ['name'],
+              locales: ['fr'],
+            },
+          },
+        ],
+        'plugin::content-manager.explorer.read': [
+          {
+            properties: {
+              fields: ['name'],
+              locales: ['en'],
+            },
+          },
+        ],
+      },
+      bar: {
+        'plugin::content-manager.explorer.create': [
+          {
+            properties: {
+              fields: ['name'],
+              locales: ['fr'],
+            },
+          },
+        ],
+        'plugin::content-manager.explorer.read': [
+          {
+            properties: {
+              fields: ['name'],
+              locales: ['en'],
+            },
+          },
+        ],
+      },
+    };
+    const expected = [
+      {
+        uid: 'foo',
+        to: 'cm/collectionType/foo',
+        isDisplayed: true,
+        search: 'page=1&plugins[i18n][locale]=fr',
+      },
+      {
+        uid: 'bar',
+        to: 'cm/collectionType/bar',
+        isDisplayed: true,
+        search: 'plugins[i18n][locale]=fr',
+      },
+    ];
+    const locales = [{ code: 'en', isDefault: true }, { code: 'fr' }];
+    delete window.location;
+    window.location = { search: '?plugins[i18n][locale]=fr' };
+
+    expect(addLocaleToLinksSearch(links, 'collectionType', schemas, locales, permissions)).toEqual(
+      expected
+    );
+  });
 });


### PR DESCRIPTION

### What does it do?

This addition improves the content editing experience when working with non-default locales. It will reuse the "current locale" if available (from i18n URL parameters) so it is tab specific to render Collection and Single type links in Content Manager Navigation Menu.

I tried to make the changes as small as possible, as I believe v5 is already in progress, and better invest the effort on it. I hope this will make it to v4. 

### Why is it needed?

When working with a non-default locale, currently, editors need to constantly use the Locale Selectors in the page to change to the Locale they are working with. Navigating back to a list, or to another content type, bumps you back to the default locale.

### How to test it?

Given a user has access to two locales, EN (default locale), and FR:
- User navigates to collection listing with i18n enabled, and selects `FR` from locale selector. The URL now should include `plugins[i18n][locale]=fr`,
- User navigates to another i18n-enabled single/collection type, he should remain in `FR` locale.

### Related issue(s)/PR(s)

There were two attempts to add this feature:
- #17218: I was hoping this one will be merged as it introduced `preferd locale`, but seems it includes a lot of changes and using local storage may not be ideal (restructuring i18n state).
- #16952: small change, but reloading the whole app isn't a pleasant experience and costly.