### PR TITLE
chore(content-releases): group by UI for content releases

### DIFF
--- a/packages/core/content-releases/admin/src/pages/tests/ReleaseDetailsPage.test.tsx
+++ b/packages/core/content-releases/admin/src/pages/tests/ReleaseDetailsPage.test.tsx
@@ -94,16 +94,20 @@ describe('Releases details page', () => {
     // should show the entries
     expect(
       screen.getByText(
-        mockReleaseDetailsPageData.withActionsBodyData.data[0].entry.contentType.mainFieldValue
+        mockReleaseDetailsPageData.withActionsBodyData.data['Category'][0].entry.contentType
+          .mainFieldValue
       )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('gridcell', {
+        name: mockReleaseDetailsPageData.withActionsBodyData.data['Category'][0].entry.contentType
+          .displayName,
+      })
     ).toBeInTheDocument();
     expect(
       screen.getByText(
-        mockReleaseDetailsPageData.withActionsBodyData.data[0].entry.contentType.displayName
+        mockReleaseDetailsPageData.withActionsBodyData.data['Category'][0].entry.locale.name
       )
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(mockReleaseDetailsPageData.withActionsBodyData.data[0].entry.locale.name)
     ).toBeInTheDocument();
 
     // There is one column with actions and the right one is checked
@@ -143,5 +147,32 @@ describe('Releases details page', () => {
     expect(screen.queryByRole('radio', { name: 'publish' })).not.toBeInTheDocument();
     const container = screen.getByText(/This entry was/);
     expect(container.querySelector('span')).toHaveTextContent('published');
+  });
+
+  it('renders as many tables as there are in the response', async () => {
+    server.use(
+      rest.get('/content-releases/:releaseId', (req, res, ctx) =>
+        res(ctx.json(mockReleaseDetailsPageData.withActionsHeaderData))
+      )
+    );
+
+    server.use(
+      rest.get('/content-releases/:releaseId/actions', (req, res, ctx) =>
+        res(ctx.json(mockReleaseDetailsPageData.withMultipleActionsBodyData))
+      )
+    );
+
+    render(<ReleaseDetailsPage />, {
+      initialEntries: [{ pathname: `/content-releases/1` }],
+    });
+
+    const releaseTitle = await screen.findByText(
+      mockReleaseDetailsPageData.withActionsHeaderData.data.name
+    );
+    expect(releaseTitle).toBeInTheDocument();
+
+    const tables = screen.getAllByRole('grid');
+
+    expect(tables).toHaveLength(2);
   });
 });

--- a/packages/core/content-releases/admin/src/pages/tests/mockReleaseDetailsPageData.ts
+++ b/packages/core/content-releases/admin/src/pages/tests/mockReleaseDetailsPageData.ts
@@ -93,26 +93,102 @@ const PUBLISHED_RELEASE_WITH_ACTIONS_HEADER_MOCK_DATA = {
  * RELEASE_WITH_ACTIONS_BODY_MOCK_DATA
  * -----------------------------------------------------------------------------------------------*/
 const RELEASE_WITH_ACTIONS_BODY_MOCK_DATA = {
-  data: [
-    {
-      id: 3,
-      type: 'publish',
-      contentType: 'api::category.category',
-      createdAt: '2023-12-05T09:03:57.155Z',
-      updatedAt: '2023-12-05T09:03:57.155Z',
-      entry: {
-        id: 1,
-        contentType: {
-          displayName: 'Category',
-          mainFieldValue: 'cat1',
-        },
-        locale: {
-          name: 'English (en)',
-          code: 'en',
+  data: {
+    Category: [
+      {
+        id: 3,
+        type: 'publish',
+        contentType: 'api::category.category',
+        createdAt: '2023-12-05T09:03:57.155Z',
+        updatedAt: '2023-12-05T09:03:57.155Z',
+        entry: {
+          id: 1,
+          contentType: {
+            displayName: 'Category',
+            mainFieldValue: 'cat1',
+          },
+          locale: {
+            name: 'English (en)',
+            code: 'en',
+          },
         },
       },
+    ],
+  },
+  meta: {
+    pagination: {
+      page: 1,
+      pageSize: 10,
+      total: 1,
+      pageCount: 1,
     },
-  ],
+  },
+};
+
+/* -------------------------------------------------------------------------------------------------
+ * RELEASE_WITH_MULTIPLE_ACTIONS_BODY_MOCK_DATA
+ * -----------------------------------------------------------------------------------------------*/
+const RELEASE_WITH_MULTIPLE_ACTIONS_BODY_MOCK_DATA = {
+  data: {
+    Category: [
+      {
+        id: 3,
+        type: 'publish',
+        contentType: 'api::category.category',
+        createdAt: '2023-12-05T09:03:57.155Z',
+        updatedAt: '2023-12-05T09:03:57.155Z',
+        entry: {
+          id: 1,
+          contentType: {
+            displayName: 'Category',
+            mainFieldValue: 'cat1',
+          },
+          locale: {
+            name: 'English (en)',
+            code: 'en',
+          },
+        },
+      },
+      {
+        id: 4,
+        type: 'publish',
+        contentType: 'api::category.category',
+        createdAt: '2023-12-05T09:03:57.155Z',
+        updatedAt: '2023-12-05T09:03:57.155Z',
+        entry: {
+          id: 2,
+          contentType: {
+            displayName: 'Category',
+            mainFieldValue: 'cat1',
+          },
+          locale: {
+            name: 'English (en)',
+            code: 'en',
+          },
+        },
+      },
+    ],
+    Address: [
+      {
+        id: 5,
+        type: 'publish',
+        contentType: 'api::address.address',
+        createdAt: '2023-12-05T09:03:57.155Z',
+        updatedAt: '2023-12-05T09:03:57.155Z',
+        entry: {
+          id: 1,
+          contentType: {
+            displayName: 'Address',
+            mainFieldValue: 'add1',
+          },
+          locale: {
+            name: 'English (en)',
+            code: 'en',
+          },
+        },
+      },
+    ],
+  },
   meta: {
     pagination: {
       page: 1,
@@ -128,6 +204,7 @@ const mockReleaseDetailsPageData = {
   noActionsBodyData: RELEASE_NO_ACTIONS_BODY_MOCK_DATA,
   withActionsHeaderData: RELEASE_WITH_ACTIONS_HEADER_MOCK_DATA,
   withActionsBodyData: RELEASE_WITH_ACTIONS_BODY_MOCK_DATA,
+  withMultipleActionsBodyData: RELEASE_WITH_MULTIPLE_ACTIONS_BODY_MOCK_DATA,
   withActionsAndPublishedHeaderData: PUBLISHED_RELEASE_WITH_ACTIONS_HEADER_MOCK_DATA,
 } as const;
 

--- a/packages/core/content-releases/admin/src/services/release.ts
+++ b/packages/core/content-releases/admin/src/services/release.ts
@@ -36,6 +36,7 @@ export interface GetReleasesQueryParams {
 export interface GetReleaseActionsQueryParams {
   page?: number;
   pageSize?: number;
+  groupBy?: GetReleaseActions.Request['query']['groupBy'];
 }
 
 type GetReleasesTabResponse = GetReleases.Response & {
@@ -133,7 +134,7 @@ const releaseApi = createApi({
         GetReleaseActions.Response,
         GetReleaseActions.Request['params'] & GetReleaseActions.Request['query']
       >({
-        query({ releaseId, page, pageSize }) {
+        query({ releaseId, page, pageSize, groupBy }) {
           return {
             url: `/content-releases/${releaseId}/actions`,
             method: 'GET',
@@ -141,17 +142,12 @@ const releaseApi = createApi({
               params: {
                 page,
                 pageSize,
+                groupBy,
               },
             },
           };
         },
-        providesTags: (result, error, arg) =>
-          result
-            ? [
-                ...result.data.map(({ id }) => ({ type: 'ReleaseAction' as const, id })),
-                { type: 'ReleaseAction', id: 'LIST' },
-              ]
-            : [{ type: 'ReleaseAction', id: 'LIST' }],
+        providesTags: [{ type: 'ReleaseAction', id: 'LIST' }],
       }),
       createRelease: build.mutation<CreateRelease.Response, CreateRelease.Request['body']>({
         query(data) {
@@ -203,9 +199,7 @@ const releaseApi = createApi({
             data: body,
           };
         },
-        invalidatesTags: (result, error, arg) => [
-          { type: 'ReleaseAction', id: arg.params.actionId },
-        ],
+        invalidatesTags: () => [{ type: 'ReleaseAction', id: 'LIST' }],
       }),
       deleteReleaseAction: build.mutation<
         DeleteReleaseAction.Response,

--- a/packages/core/content-releases/admin/src/translations/en.json
+++ b/packages/core/content-releases/admin/src/translations/en.json
@@ -39,5 +39,6 @@
   "page.ReleaseDetails.table.header.label.action": "action",
   "page.ReleaseDetails.table.action-published": "This entry was <b>{isPublish, select, true {published} other {unpublished}}</b>.",
   "pages.ReleaseDetails.publish-notification-success": "Release was published successfully.",
+  "pages.ReleaseDetails.groupBy.label": "Group by {groupBy}",
   "dialog.confirmation-message": "Are you sure you want to delete this release?"
 }

--- a/packages/core/content-releases/server/src/controllers/release-action.ts
+++ b/packages/core/content-releases/server/src/controllers/release-action.ts
@@ -38,7 +38,7 @@ const releaseActionController = {
 
     const releaseService = getService('release', { strapi });
     const { results, pagination } = await releaseService.findActions(releaseId, {
-      sort: query.groupBy,
+      sort: query.groupBy === 'action' ? 'type' : query.groupBy,
       ...query,
     });
     const groupedData = await releaseService.groupActions(results, query.groupBy);

--- a/packages/core/content-releases/server/src/services/release.ts
+++ b/packages/core/content-releases/server/src/services/release.ts
@@ -41,7 +41,7 @@ const getGroupName = (queryValue?: ReleaseActionGroupBy) => {
     case 'action':
       return 'type';
     case 'locale':
-      return 'entry.locale.name';
+      return _.getOr('No locale', 'entry.locale.name');
     default:
       return 'entry.contentType.displayName';
   }

--- a/packages/core/content-releases/shared/contracts/release-actions.ts
+++ b/packages/core/content-releases/shared/contracts/release-actions.ts
@@ -65,8 +65,8 @@ export declare namespace GetReleaseActions {
     params: {
       releaseId: Release['id'];
     };
-    query?: Partial<Pick<Pagination, 'page' | 'pageSize'>> & {
-      groupBy: ReleaseActionGroupBy;
+    query: Partial<Pick<Pagination, 'page' | 'pageSize'>> & {
+      groupBy?: ReleaseActionGroupBy;
     };
   }
 


### PR DESCRIPTION
### What does it do?

Add the grouping UI on content-releases Details page

### How to test it?

You need to have enabled Content-Releases, then:
- Go to a release with entries
- You can group by "Content-type", "Locale" and "Action (publish/unpublish"
