### PR TITLE
Update vite dependency to fix vulnerability CVE-2023-49293

### DIFF
--- a/packages/utils/pack-up/package.json
+++ b/packages/utils/pack-up/package.json
@@ -79,7 +79,7 @@
     "prompts": "2.4.2",
     "rxjs": "7.8.1",
     "typescript": "5.2.2",
-    "vite": "4.4.9",
+    "vite": "4.4.12",
     "yup": "0.32.9"
   },
   "devDependencies": {


### PR DESCRIPTION


Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

This is an updated to the `pack-up` package's dependency on `vite`. It's simply a patch version update. 

https://github.com/vitejs/vite/security/advisories/GHSA-92r3-m2mg-pj97

### Why is it needed?

It solves (CVE-2023-49293 (NVD))[https://nvd.nist.gov/vuln/detail/CVE-2023-49293]

### Related issue(s)/PR(s)

I could not see an existing issue highlighting this problem.