### PR TITLE
Filter out undefined controllers in startup telemetry checks

### DIFF
--- a/packages/core/strapi/src/Strapi.ts
+++ b/packages/core/strapi/src/Strapi.ts
@@ -381,7 +381,8 @@ class Strapi implements StrapiI {
           numberOfComponents: _.size(this.components),
           numberOfDynamicZones: getNumberOfDynamicZones(),
           numberOfCustomControllers: Object.values<Common.Controller>(this.controllers).filter(
-            factories.isCustomController
+            // TODO: Fix this at the content API loader level to prevent future types issues
+            (controller) => controller !== undefined && factories.isCustomController(controller)
           ).length,
           environment: this.config.environment,
           // TODO: to add back

--- a/packages/core/strapi/src/factories.ts
+++ b/packages/core/strapi/src/factories.ts
@@ -43,8 +43,8 @@ const createCoreController = <
 
     Object.setPrototypeOf(userCtrl, baseController);
 
-    const isCustomController = typeof cfg !== 'undefined';
-    if (isCustomController) {
+    const isCustom = typeof cfg !== 'undefined';
+    if (isCustom) {
       Object.defineProperty(userCtrl, symbols.CustomController, {
         writable: false,
         configurable: false,


### PR DESCRIPTION
### What does it do?

Add an `!== undefined` filtering before calling isCustomController when computing startup telemetry.

### Why is it needed?

This situation is highly unlikely but arises when the controller container is corrupted such as in https://github.com/strapi/strapi/issues/19135#issuecomment-1875202454.

The long-term solution will be to better validate controllers' format at a higher level (e.g. during the register step).
This PR aims to be a quick fix to unblock users.

### Tests

We don't have tests for the telemetry at the moment (we have to rely on manual testing) + this has to be changed anyway & shouldn't be something that we aim to support. I thus don't see the point in adding tests to this in particular.


close #19135
