### PR TITLE
[Types] Fix Attributes Filtering when no registries are extended

### DIFF
--- a/packages/core/admin/admin/src/pages/Settings/pages/Roles/ListPage.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/Roles/ListPage.tsx
@@ -54,7 +54,6 @@ const ListPage = () => {
   } = useRBAC(permissions.settings?.roles);
 
   const { roles, refetch: refetchRoles } = useAdminRoles(
-    // @ts-expect-error – we know that the `admin::role` content-type has a name attribute, but the EntityService uses a registry which we don't have.
     { filters: query?._q ? { name: { $containsi: query._q } } : undefined },
     {
       cacheTime: 0,

--- a/packages/core/admin/ee/admin/src/content-manager/pages/ListView/components/StageFilter.tsx
+++ b/packages/core/admin/ee/admin/src/content-manager/pages/ListView/components/StageFilter.tsx
@@ -20,7 +20,6 @@ const StageFilter = ({ value, onChange, uid }: StageFilterProps) => {
   const {
     workflows: [workflow],
     isLoading,
-    // @ts-expect-error – we know that the `admin::review-workflow` content-type has a contentTypes attribute, but the EntityService uses a registry which we don't have.
   } = useReviewWorkflows({ filters: { contentTypes: uid } });
 
   return (

--- a/packages/core/types/src/modules/entity-service/params/filters/index.ts
+++ b/packages/core/types/src/modules/entity-service/params/filters/index.ts
@@ -43,22 +43,21 @@ export type RootLevelOperatorFiltering<TSchemaUID extends Common.UID.Schema> = {
  * Represents a type for filtering on attributes based on a given schema.
  *  @template TSchemaUID - The UID of the schema.
  */
-export type AttributesFiltering<TSchemaUID extends Common.UID.Schema> = Utils.Guard.Never<
-  // Combines filtering for scalar and nested attributes based on schema UID
-  ScalarAttributesFiltering<TSchemaUID> & NestedAttributeFiltering<TSchemaUID>,
-  // Abstract representation of the filter object tree in case we don't have access to the attributes' list
-  {
-    [TKey in string]?:
-      | AttributeCondition<TSchemaUID, never>
-      | NestedAttributeCondition<TSchemaUID, never>;
-  }
->;
-
+export type AttributesFiltering<TSchemaUID extends Common.UID.Schema> =
+  // Manually added filtering on virtual ID attribute
+  IDFiltering &
+    Utils.Expression.If<
+      Common.AreSchemaRegistriesExtended,
+      // Combines filtering for scalar and nested attributes based on schema UID
+      ScalarAttributesFiltering<TSchemaUID> & NestedAttributeFiltering<TSchemaUID>,
+      // Abstract representation of the filter object tree in case we don't have access to the attributes' list
+      AbstractAttributesFiltering<TSchemaUID>
+    >;
 /**
  * Definition of scalar attribute filtering for a given schema UID.
  * @template TSchemaUID - The UID of the schema.
  */
-export type ScalarAttributesFiltering<TSchemaUID extends Common.UID.Schema> = IDFiltering & {
+export type ScalarAttributesFiltering<TSchemaUID extends Common.UID.Schema> = {
   [TKey in AttributeUtils.GetScalarKeys<TSchemaUID>]?: AttributeCondition<TSchemaUID, TKey>;
 };
 
@@ -141,3 +140,9 @@ type NestedAttributeCondition<
   // Ensure the resolved target isn't `never`, else, fallback to Common.UID.Schema
   Utils.Guard.Never<Attribute.GetTarget<TSchemaUID, TAttributeName>, Common.UID.Schema>
 >;
+
+export type AbstractAttributesFiltering<TSchemaUID extends Common.UID.Schema> = {
+  [TKey in string]?:
+    | AttributeCondition<TSchemaUID, never>
+    | NestedAttributeCondition<TSchemaUID, never>;
+};

--- a/packages/core/types/src/types/core/common/index.ts
+++ b/packages/core/types/src/types/core/common/index.ts
@@ -1,4 +1,4 @@
-import type { Utils, Attribute, Common } from '../..';
+import type { Utils, Common, UID } from '../..';
 
 export * from './controller';
 export * from './middleware';
@@ -11,12 +11,17 @@ export * from './plugin';
 export * from './module';
 export * from './api';
 
-/**
- * Determines if the shared registries for components and content types have been extended or if they're still represented as loose mapped types
- *
- * Here we use the fact that once the registries are extended, Attribute.GetKeys<Common.UID.Schema> will resolve to either never or a more
- * deterministic value rather than string | number which represent the keys of the initial mapped type (Component & ContentType's registries)
- */
-export type AreSchemaRegistriesExtended = Utils.Expression.Not<
-  Utils.Expression.Extends<string | number, Attribute.GetKeys<Common.UID.Schema>>
+export type AreSchemaRegistriesExtended = Utils.Expression.Or<
+  IsComponentRegistryExtended,
+  IsContentTypeRegistryExtended
+>;
+
+export type IsContentTypeRegistryExtended = Utils.Expression.NotStrictEqual<
+  UID.ContentType,
+  Common.UID.ContentType
+>;
+
+export type IsComponentRegistryExtended = Utils.Expression.NotStrictEqual<
+  UID.Component,
+  Common.UID.Component
 >;

--- a/packages/core/types/src/types/utils/expression.ts
+++ b/packages/core/types/src/types/utils/expression.ts
@@ -14,6 +14,8 @@ export type IsFalse<TValue> = [TValue] extends [False] ? True : False;
 
 export type StrictEqual<TValue, TMatch> = And<Extends<TValue, TMatch>, Extends<TMatch, TValue>>;
 
+export type NotStrictEqual<TValue, TMatch> = Not<StrictEqual<TValue, TMatch>>;
+
 export type Extends<TLeft, TRight> = [TLeft] extends [TRight] ? True : False;
 
 export type DoesNotExtends<TLeft, TRight> = Not<Extends<TLeft, TRight>>;


### PR DESCRIPTION
### What does it do?

- Improved the schema registries detection strategy (ended up being unreliable in edge scenarios)
- Added a check to the attributes filtering to allow any filter when schema registries are not extended.

### Why is it needed?

- Ease the development when registries are not extended (e.g. when working in the mono-repository on internal packages)

### How to test it?

- With types not generated, head to the kitchensink-ts example project and make an entity service query to any entity. You should be able to pass filters (while still having full IntelliSense for them)
- When types are generated, it should only accept valid fields as filters, and the return type for the result should be typed accordingly (entity + fields + populate)

### Related issue(s)/PR(s)

made obvious since https://github.com/strapi/strapi/pull/19093
remove the need for https://github.com/strapi/strapi/pull/19136/commits/30ae2308e85bb8612689ca9e12c784384cad22f0 and https://github.com/strapi/strapi/pull/19136/commits/30ae2308e85bb8612689ca9e12c784384cad22f0 
