### PR TITLE
fix: display nested components in edit view

### DIFF
--- a/examples/getstarted/src/api/kitchensink/content-types/kitchensink/schema.json
+++ b/examples/getstarted/src/api/kitchensink/content-types/kitchensink/schema.json
@@ -89,7 +89,7 @@
     },
     "dynamiczone": {
       "type": "dynamiczone",
-      "components": ["basic.simple", "blog.test-como"]
+      "components": ["basic.simple", "blog.test-como", "default.closingperiod"]
     },
     "one_way_tag": {
       "type": "relation",

--- a/packages/core/admin/admin/src/content-manager/components/FieldComponent.tsx
+++ b/packages/core/admin/admin/src/content-manager/components/FieldComponent.tsx
@@ -7,7 +7,7 @@ import {
   useCMEditViewDataManager,
 } from '@strapi/helper-plugin';
 import { Trash } from '@strapi/icons';
-import size from 'lodash/size';
+import { get, size } from 'lodash/fp';
 import { useIntl } from 'react-intl';
 import styled from 'styled-components';
 
@@ -67,7 +67,7 @@ const FieldComponent = ({
 
   const allowedFields = isCreatingEntry ? createActionAllowedFields : updateActionAllowedFields;
 
-  const componentValue = modifiedData[name] ?? null;
+  const componentValue = get(name, modifiedData) ?? null;
   const compoName = getFieldName(name);
 
   const hasChildrenAllowedFields = React.useMemo(() => {

--- a/packages/core/admin/admin/src/content-manager/components/FieldComponent.tsx
+++ b/packages/core/admin/admin/src/content-manager/components/FieldComponent.tsx
@@ -67,6 +67,7 @@ const FieldComponent = ({
 
   const allowedFields = isCreatingEntry ? createActionAllowedFields : updateActionAllowedFields;
 
+  // Use lodash get since the name can be a nested path (e.g. "component.1.component")
   const componentValue = get(name, modifiedData) ?? null;
   const compoName = getFieldName(name);
 


### PR DESCRIPTION
### What does it do?

- Fixes an issue where nested components weren't displayed in the edit view. The data would be in the context, but you didn't get the input, it was stuck on the add an entry button
- Adds a component to the kitchensink DZ that has a nested component to make this error easier to spot

### Why is it needed?

[A previous version of the code](https://github.com/strapi/strapi/blob/29255bc953ad5e2ca1458e157bdf55819b15696f/packages/core/admin/admin/src/content-manager/components/FieldComponent/utils/select.js#L38C13-L38C13) use Lodash get to retrieve the value for this reason. This was lost at some point in the migrations.

### How to test it?

- go to the kitchensink editview
- add a "closing period" component to the dynamic zone
- you should be able to add entries to the `dish` repeatable component

You can also check the release branch if you want to confirm the issue.

