### PR TITLE
fix(plugin-graphql): allow to use GET queries for graphql

### DIFF
--- a/api-tests/plugins/graphql/crud.test.api.js
+++ b/api-tests/plugins/graphql/crud.test.api.js
@@ -137,6 +137,48 @@ describe('Test Graphql API End to End', () => {
       data.posts = res.body.data.posts.data.map(({ id, attributes }) => ({ id, ...attributes }));
     });
 
+    test('List posts with GET', async () => {
+      const graphqlQueryGET = (body) => {
+        return rq({
+          url: '/graphql',
+          method: 'GET',
+          qs: body,
+        });
+      };
+
+      const res = await graphqlQueryGET({
+        query: /* GraphQL */ `
+          {
+            posts {
+              data {
+                id
+                attributes {
+                  name
+                  bigint
+                  nullable
+                  category
+                }
+              }
+            }
+          }
+        `,
+      });
+
+      const { body } = res;
+
+      expect(res.statusCode).toBe(200);
+      expect(body).toMatchObject({
+        data: {
+          posts: {
+            data: postsPayload.map((entry) => ({
+              id: expect.any(String),
+              attributes: omit('id', entry),
+            })),
+          },
+        },
+      });
+    });
+
     test('List posts with limit', async () => {
       const res = await graphqlQuery({
         query: /* GraphQL */ `

--- a/api-tests/plugins/graphql/utils.test.api.js
+++ b/api-tests/plugins/graphql/utils.test.api.js
@@ -1,0 +1,25 @@
+'use strict';
+
+// Helpers.
+const { createStrapiInstance } = require('api-tests/strapi');
+const request = require('supertest');
+
+let strapi;
+
+describe('Test Graphql Utils', () => {
+  beforeAll(async () => {
+    strapi = await createStrapiInstance();
+  });
+
+  afterAll(async () => {
+    await strapi.destroy();
+  });
+
+  test('Load Graphql playground', async () => {
+    const supertestAgent = request.agent(strapi.server.httpServer);
+    const res = await supertestAgent.get('/graphql').set('accept', 'text/html');
+
+    expect(res.statusCode).toBe(200);
+    expect(res.text).toContain('<title>GraphQL Playground</title>');
+  });
+});

--- a/packages/plugins/graphql/server/src/bootstrap.ts
+++ b/packages/plugins/graphql/server/src/bootstrap.ts
@@ -115,9 +115,6 @@ export async function bootstrap({ strapi }: { strapi: Strapi }) {
             },
           };
 
-          // allow graphql playground to load without authentication
-          if (ctx.request.method === 'GET') return next();
-
           return strapi.auth.authenticate(ctx, next);
         },
 


### PR DESCRIPTION
### What does it do?

This removes a line that wasnt required, that blocked GET queries from being authenticated on `/graphql`.

I've added a test to show, that with no authentication, the graphql playground still loads.

### Why is it needed?

GET queries are often advantagous for caching, cdns, etc.

### How to test it?

There is an API test that checks it, also, https://graphql.org/learn/serving-over-http/#get-request

### Related issue(s)/PR(s)

n/a
