### PR TITLE
fix(content-releases): handle the lastname null in the createdBy content

### DIFF
--- a/packages/core/content-releases/admin/src/pages/ReleaseDetailsPage.tsx
+++ b/packages/core/content-releases/admin/src/pages/ReleaseDetailsPage.tsx
@@ -269,7 +269,9 @@ export const ReleaseDetailsLayout = ({
   }
 
   const totalEntries = release.actions.meta.count || 0;
-  const createdBy = `${release.createdBy.firstname} ${release.createdBy.lastname}`;
+  const createdBy = release.createdBy.lastname
+    ? `${release.createdBy.firstname} ${release.createdBy.lastname}`
+    : `${release.createdBy.firstname}`;
 
   return (
     <Main aria-busy={isLoadingDetails}>


### PR DESCRIPTION
### What does it do?

It handles the case the lastname of the Release creator is null, to show only the firstname in the created by content.

### Why is it needed?

It is needed because otherwise we showed the null string in the created by content.

### How to test it?

- Step 1: Go to the Release Details view
- Step 2: Click on the 3 dots at the top
- Step 3: Look at the person who created the release if they don’t have a last name

### Related issue(s)/PR(s)

CS-517
