### PR TITLE
fix(content-releases): using lifecycle hooks for delete actions

### DIFF
--- a/packages/core/content-releases/server/src/bootstrap.ts
+++ b/packages/core/content-releases/server/src/bootstrap.ts
@@ -1,0 +1,71 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+import type { LoadedStrapi } from '@strapi/types';
+import type { Entity as StrapiEntity } from '@strapi/types';
+import { RELEASE_ACTION_MODEL_UID } from './constants';
+
+const { features } = require('@strapi/strapi/dist/utils/ee');
+
+export const bootstrap = async ({ strapi }: { strapi: LoadedStrapi }) => {
+  if (
+    features.isEnabled('cms-content-releases') &&
+    strapi.features.future.isEnabled('contentReleases')
+  ) {
+    strapi.db.lifecycles.subscribe({
+      afterDelete(event) {
+        // @ts-expect-error TODO: lifecycles types looks like are not 100% finished
+        const { model, result } = event;
+
+        // @ts-expect-error TODO: lifecycles types looks like are not 100% finished
+        if (model.kind === 'collectionType' && model.options.draftAndPublish) {
+          const { id } = result;
+
+          strapi.db.query(RELEASE_ACTION_MODEL_UID).deleteMany({
+            where: {
+              target_type: model.uid,
+              target_id: id,
+            },
+          });
+        }
+      },
+
+      /**
+       * deleteMany hook doesn't return the deleted entries ids
+       * so we need to fetch them before deleting the entries to save the ids on our state
+       */
+      async beforeDeleteMany(event) {
+        const { model, params } = event;
+
+        // @ts-expect-error TODO: lifecycles types looks like are not 100% finished
+        if (model.kind === 'collectionType' && model.options.draftAndPublish) {
+          const { where } = params;
+
+          const entriesToDelete = await strapi.db
+            .query(model.uid)
+            .findMany({ select: ['id'], where });
+
+          event.state.entriesToDelete = entriesToDelete;
+        }
+      },
+
+      /**
+       * We delete the release actions related to deleted entries
+       * We make this only after deleteMany is succesfully executed to avoid errors
+       */
+      async afterDeleteMany(event) {
+        const { model, state } = event;
+        const entriesToDelete = state.entriesToDelete;
+
+        if (entriesToDelete) {
+          await strapi.db.query(RELEASE_ACTION_MODEL_UID).deleteMany({
+            where: {
+              target_type: model.uid,
+              target_id: {
+                $in: (entriesToDelete as Array<{ id: StrapiEntity.ID }>).map((entry) => entry.id),
+              },
+            },
+          });
+        }
+      },
+    });
+  }
+};

--- a/packages/core/content-releases/server/src/bootstrap.ts
+++ b/packages/core/content-releases/server/src/bootstrap.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-import type { LoadedStrapi } from '@strapi/types';
-import type { Entity as StrapiEntity } from '@strapi/types';
+import type { LoadedStrapi, Entity as StrapiEntity } from '@strapi/types';
 import { RELEASE_ACTION_MODEL_UID } from './constants';
 
 const { features } = require('@strapi/strapi/dist/utils/ee');

--- a/packages/core/content-releases/server/src/index.ts
+++ b/packages/core/content-releases/server/src/index.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 import { register } from './register';
+import { bootstrap } from './bootstrap';
 import { contentTypes } from './content-types';
 import { services } from './services';
 import { controllers } from './controllers';
@@ -14,6 +15,7 @@ const getPlugin = () => {
   ) {
     return {
       register,
+      bootstrap,
       contentTypes,
       services,
       controllers,


### PR DESCRIPTION
I'm using lifecycle hooks on Content-Releases plugins to listen to delete entries events and use them to delete release-actions if there is one related to the entries deleted.

### How to test it?

1. Create a release and add entries to the release.
2. Delete the entries you just added.
3. They should be deleted also from the release with no errors

