### PR TITLE
fix(content-releases): redirect to the dashboard when you don't have read permission on content releases

### DIFF
--- a/packages/core/content-releases/admin/src/pages/App.tsx
+++ b/packages/core/content-releases/admin/src/pages/App.tsx
@@ -1,19 +1,19 @@
+import { CheckPagePermissions } from '@strapi/helper-plugin';
 import { Route, Switch } from 'react-router-dom';
 
+import { PERMISSIONS } from '../constants';
 import { pluginId } from '../pluginId';
 
-import { ProtectedReleaseDetailsPage } from './ReleaseDetailsPage';
-import { ProtectedReleasesPage } from './ReleasesPage';
+import { ReleaseDetailsPage } from './ReleaseDetailsPage';
+import { ReleasesPage } from './ReleasesPage';
 
 export const App = () => {
   return (
-    <Switch>
-      <Route exact path={`/plugins/${pluginId}`} component={ProtectedReleasesPage} />
-      <Route
-        exact
-        path={`/plugins/${pluginId}/:releaseId`}
-        component={ProtectedReleaseDetailsPage}
-      />
-    </Switch>
+    <CheckPagePermissions permissions={PERMISSIONS.main}>
+      <Switch>
+        <Route exact path={`/plugins/${pluginId}`} component={ReleasesPage} />
+        <Route exact path={`/plugins/${pluginId}/:releaseId`} component={ReleaseDetailsPage} />
+      </Switch>
+    </CheckPagePermissions>
   );
 };

--- a/packages/core/content-releases/admin/src/pages/ReleaseDetailsPage.tsx
+++ b/packages/core/content-releases/admin/src/pages/ReleaseDetailsPage.tsx
@@ -814,10 +814,4 @@ const ReleaseDetailsPage = () => {
   );
 };
 
-const ProtectedReleaseDetailsPage = () => (
-  <CheckPermissions permissions={PERMISSIONS.main}>
-    <ReleaseDetailsPage />
-  </CheckPermissions>
-);
-
-export { ReleaseDetailsPage, ProtectedReleaseDetailsPage };
+export { ReleaseDetailsPage };

--- a/packages/core/content-releases/admin/src/pages/ReleasesPage.tsx
+++ b/packages/core/content-releases/admin/src/pages/ReleasesPage.tsx
@@ -349,10 +349,4 @@ const ReleasesPage = () => {
   );
 };
 
-const ProtectedReleasesPage = () => (
-  <CheckPermissions permissions={PERMISSIONS.main}>
-    <ReleasesPage />
-  </CheckPermissions>
-);
-
-export { ReleasesPage, ProtectedReleasesPage };
+export { ReleasesPage };


### PR DESCRIPTION
### What does it do?

It handles the case you try to access the Releases page or the Release Details without Read permissions. In that case you will be redirected to the dashboard.

### Why is it needed?

Without this fix when you tried to reach the Releases page without read permission you will have an empty page.

### How to test it?

 - create for example an editor user and disable the Content releases read permission for its role.
 - open a new tab and login with the new editor user and try to reach this page admin/plugins/content-releases 
 - then you will be redirected to the homepage

### Related issue(s)/PR(s)

CS-469
