### PR TITLE
feat: init v5 response format with header to trigger old one

### DIFF
--- a/packages/core/core/src/core-api/controller/index.ts
+++ b/packages/core/core/src/core-api/controller/index.ts
@@ -6,6 +6,7 @@ import type { CoreApi, Schema } from '@strapi/types';
 import { transformResponse } from './transform';
 import createSingleTypeController from './single-type';
 import createCollectionTypeController from './collection-type';
+import requestCtx from '../../services/request-context';
 
 const isSingleType = (contentType: Schema.ContentType): contentType is Schema.SingleType =>
   contentTypeUtils.isSingleType(contentType);
@@ -22,7 +23,11 @@ function createController({
 }) {
   const proto: CoreApi.Controller.Base = {
     transformResponse(data, meta) {
-      return transformResponse(data, meta, { contentType });
+      const ctx = requestCtx.get();
+      return transformResponse(data, meta, {
+        contentType,
+        format: ctx?.headers?.['x-strapi-response-format'] as 'v4' | 'v5',
+      });
     },
 
     async sanitizeOutput(data, ctx) {

--- a/packages/core/core/src/core-api/controller/transform.ts
+++ b/packages/core/core/src/core-api/controller/transform.ts
@@ -19,6 +19,8 @@ type Entry = {
   [key: string]: Entry | Entry[] | string | number | null | boolean | Date;
 };
 
+type Format = 'v4' | 'v5';
+
 function isEntry(property: unknown): property is Entry | Entry[] {
   return property === null || isPlainObject(property) || Array.isArray(property);
 }
@@ -40,14 +42,19 @@ const parseBody = (ctx: Koa.Context) => {
 const transformResponse = (
   resource: any,
   meta: unknown = {},
-  opts: { contentType?: Schema.ContentType | Schema.Component } = {}
+  opts: {
+    contentType?: Schema.ContentType | Schema.Component;
+    format?: Format;
+  } = {
+    format: 'v5',
+  }
 ) => {
   if (isNil(resource)) {
     return resource;
   }
 
   return {
-    data: transformEntry(resource, opts?.contentType),
+    data: opts?.format === 'v4' ? transformEntry(resource, opts?.contentType) : resource,
     meta,
   };
 };

--- a/packages/core/core/src/core-api/service/collection-type.ts
+++ b/packages/core/core/src/core-api/service/collection-type.ts
@@ -1,6 +1,6 @@
 import { propOr } from 'lodash/fp';
 import { contentTypes } from '@strapi/utils';
-import type { CoreApi, Schema, Entity } from '@strapi/types';
+import type { CoreApi, Schema } from '@strapi/types';
 
 import {
   getPaginationInfo,
@@ -37,13 +37,13 @@ const createCollectionTypeService = ({
 
       const paginationInfo = getPaginationInfo(fetchParams);
 
-      const results = await strapi.entityService?.findMany(uid, {
+      const results = await strapi.documents.findMany(uid, {
         ...fetchParams,
         ...convertPagedToStartLimit(paginationInfo),
       });
 
       if (shouldCount(fetchParams)) {
-        const count = await strapi.entityService?.count(uid, { ...fetchParams, ...paginationInfo });
+        const count = await strapi.documents.count(uid, { ...fetchParams, ...paginationInfo });
 
         if (typeof count !== 'number') {
           throw new Error('Count should be a number');
@@ -61,8 +61,8 @@ const createCollectionTypeService = ({
       };
     },
 
-    findOne(entityId: Entity.ID, params = {}) {
-      return strapi.entityService?.findOne(uid, entityId, this.getFetchParams(params));
+    findOne(documentId: string, params = {}) {
+      return strapi.documents.findOne(uid, documentId, this.getFetchParams(params));
     },
 
     create(params = { data: {} }) {
@@ -70,17 +70,17 @@ const createCollectionTypeService = ({
 
       setPublishedAt(data);
 
-      return strapi.entityService?.create(uid, { ...params, data });
+      return strapi.documents.create(uid, { ...params, data });
     },
 
-    update(entityId: Entity.ID, params = { data: {} }) {
+    update(documentId: string, params = { data: {} }) {
       const { data } = params;
 
-      return strapi.entityService?.update(uid, entityId, { ...params, data });
+      return strapi.documents.update(uid, documentId, { ...params, data });
     },
 
-    delete(entityId: Entity.ID, params = {}) {
-      return strapi.entityService?.delete(uid, entityId, params);
+    delete(documentId: string, params = {}) {
+      return strapi.documents.delete(uid, documentId, params);
     },
   };
 };

--- a/packages/core/core/src/core-api/service/single-type.ts
+++ b/packages/core/core/src/core-api/service/single-type.ts
@@ -28,8 +28,7 @@ const createSingleTypeService = ({
      */
     find(params = {}) {
       return (
-        strapi.entityService?.findMany(uid as Common.UID.SingleType, this.getFetchParams(params)) ??
-        null
+        strapi.documents.findMany(uid as Common.UID.SingleType, this.getFetchParams(params)) ?? null
       );
     },
 
@@ -39,9 +38,10 @@ const createSingleTypeService = ({
      * @return {Promise}
      */
     async createOrUpdate({ data, ...params } = { data: {} }) {
-      const entity = await this.find({ ...params, publicationState: 'preview' });
+      const document = await this.find({ ...params, publicationState: 'preview' });
 
-      if (!entity) {
+      // TODO: v5 - manage multiple draft & published versions the count will not work as simple as this
+      if (!document) {
         const count = await strapi.query(uid).count();
         if (count >= 1) {
           throw new errors.ValidationError('singleType.alreadyExists');
@@ -49,10 +49,10 @@ const createSingleTypeService = ({
 
         setPublishedAt(data);
 
-        return strapi.entityService?.create(uid, { ...params, data });
+        return strapi.documents.create(uid, { ...params, data });
       }
 
-      return strapi.entityService?.update(uid, entity.id, { ...params, data });
+      return strapi.documents.update(uid, document.documentId, { ...params, data });
     },
 
     /**
@@ -61,11 +61,11 @@ const createSingleTypeService = ({
      * @return {Promise}
      */
     async delete(params = {}) {
-      const entity = await this.find(params);
+      const document = await this.find(params);
 
-      if (!entity) return;
+      if (!document) return;
 
-      return strapi.entityService?.delete(uid, entity.id);
+      return strapi.documents.delete(uid, document.documentId);
     },
   };
 };

--- a/packages/utils/api-tests/agent.js
+++ b/packages/utils/api-tests/agent.js
@@ -26,6 +26,9 @@ const createAgent = (strapi, initialState = {}) => {
 
     const rq = supertestAgent[method.toLowerCase()](fullUrl);
 
+    // TODO: v5 remove this and update all tests
+    rq.set('x-strapi-response-format', 'v4');
+
     if (queryString) {
       rq.query(qs.stringify(queryString));
     }


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Content API changes PR with initial change. Will be used as base branch for content api changes based on the document service

### Why is it needed?

We have to connect the content api to the doc service and return the new format will support a flag to return the old format to ease migrations

### How to test it?

Call the content-api endpoint with x-strapi-response-format = v4|v5 header

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
