### PR TITLE
fix(content-manager): access to non default locale documents

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/ContentTypeFormWrapper.tsx
+++ b/packages/core/admin/admin/src/content-manager/components/ContentTypeFormWrapper.tsx
@@ -27,6 +27,7 @@ import {
   setStatus,
   submitSucceeded,
 } from '../sharedReducers/crud/actions';
+import { buildValidGetParams } from '../utils/api';
 import { createDefaultDataStructure, removePasswordFieldsFromData } from '../utils/data';
 import { getTranslation } from '../utils/translations';
 
@@ -103,9 +104,8 @@ const ContentTypeFormWrapper = ({
   const [isCreatingEntry, setIsCreatingEntry] = React.useState(!isSingleType && !id);
 
   const requestURL =
-    isCreatingEntry && !origin
-      ? null
-      : `/content-manager/${collectionType}/${slug}/${origin || id}`;
+    isCreatingEntry && !origin ? null : `/content-manager/collection-types/${slug}/${origin || id}`;
+  const params = React.useMemo(() => buildValidGetParams(query), [query]);
 
   const cleanReceivedData = React.useCallback(
     (data: EntityData) => {
@@ -172,7 +172,10 @@ const ContentTypeFormWrapper = ({
       dispatch(getData());
 
       try {
-        const { data } = await fetchClient.get(requestURL, { cancelToken: source.token });
+        const { data } = await fetchClient.get(requestURL, {
+          cancelToken: source.token,
+          params,
+        });
 
         dispatch(getDataSucceeded(cleanReceivedData(data)));
       } catch (err) {
@@ -383,7 +386,10 @@ const ContentTypeFormWrapper = ({
         } = await fetchClient.get<Contracts.CollectionTypes.CountDraftRelations.Response>(
           isSingleType
             ? `/content-manager/${collectionType}/${slug}/actions/countDraftRelations`
-            : `/content-manager/${collectionType}/${slug}/${id}/actions/countDraftRelations`
+            : `/content-manager/${collectionType}/${slug}/${id}/actions/countDraftRelations`,
+          {
+            params,
+          }
         );
         trackUsage('didCheckDraftRelations');
 
@@ -398,7 +404,17 @@ const ContentTypeFormWrapper = ({
 
         return Promise.reject(err);
       }
-    }, [trackUsage, dispatch, fetchClient, isSingleType, collectionType, slug, id, displayErrors]);
+    }, [
+      trackUsage,
+      dispatch,
+      fetchClient,
+      isSingleType,
+      collectionType,
+      slug,
+      id,
+      displayErrors,
+      params,
+    ]);
 
   const onPublish: RenderChildProps['onPublish'] = React.useCallback(async () => {
     try {

--- a/packages/core/admin/admin/src/content-manager/components/ContentTypeFormWrapper.tsx
+++ b/packages/core/admin/admin/src/content-manager/components/ContentTypeFormWrapper.tsx
@@ -104,7 +104,9 @@ const ContentTypeFormWrapper = ({
   const [isCreatingEntry, setIsCreatingEntry] = React.useState(!isSingleType && !id);
 
   const requestURL =
-    isCreatingEntry && !origin ? null : `/content-manager/collection-types/${slug}/${origin || id}`;
+    isCreatingEntry && !origin
+      ? null
+      : `/content-manager/${collectionType}/${slug}/${origin || id}`;
   const params = React.useMemo(() => buildValidGetParams(query), [query]);
 
   const cleanReceivedData = React.useCallback(

--- a/packages/core/content-manager/server/src/controllers/collection-types.ts
+++ b/packages/core/content-manager/server/src/controllers/collection-types.ts
@@ -511,7 +511,8 @@ export default {
       .populateFromQuery(permissionQuery)
       .build();
 
-    const entity = await entityManager.findOne(id, model, { populate });
+    const { locale, status = 'draft' } = getDocumentDimensions(ctx.query);
+    const entity = await entityManager.findOne(id, model, { populate, locale, status });
 
     if (!entity) {
       return ctx.notFound();


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Passes the locale in the query of CM GET routes so that we can access non default locale documents in the CM

