### PR TITLE
feat: ignore locale parameter on non localized content types

### DIFF
--- a/api-tests/core/strapi/document-service/create.test.api.ts
+++ b/api-tests/core/strapi/document-service/create.test.api.ts
@@ -2,7 +2,7 @@ import { LoadedStrapi } from '@strapi/types';
 import { createTestSetup, destroyTestSetup } from '../../../utils/builder-helper';
 import { testInTransaction } from '../../../utils/index';
 import resources from './resources/index';
-import { ARTICLE_UID, findArticlesDb } from './utils';
+import { ARTICLE_UID, findArticlesDb, AUTHOR_UID } from './utils';
 
 describe('Document Service', () => {
   let testUtils;
@@ -115,6 +115,23 @@ describe('Document Service', () => {
         expect(article).toMatchObject({
           title: 'Article',
           publishedAt: null, // should be a draft
+        });
+      })
+    );
+
+    it(
+      'ignores locale parameter on non-localized content type',
+      testInTransaction(async () => {
+        const author = await strapi.documents(AUTHOR_UID).create({
+          // Should be ignored on non-localized content types
+          locale: 'fr',
+          data: { name: 'Author' },
+        });
+
+        // verify that the returned document was updated
+        expect(author).toMatchObject({
+          name: 'Author',
+          locale: null, // should be null, as it is not a localized content type
         });
       })
     );

--- a/api-tests/core/strapi/document-service/find-one.test.api.ts
+++ b/api-tests/core/strapi/document-service/find-one.test.api.ts
@@ -1,7 +1,7 @@
 import { LoadedStrapi } from '@strapi/types';
 import { createTestSetup, destroyTestSetup } from '../../../utils/builder-helper';
 import resources from './resources/index';
-import { ARTICLE_UID, findArticleDb } from './utils';
+import { ARTICLE_UID, findArticleDb, AUTHOR_UID, findAuthorDb } from './utils';
 
 describe('Document Service', () => {
   let testUtils;
@@ -53,6 +53,17 @@ describe('Document Service', () => {
       });
 
       expect(article).toMatchObject(articleDb);
+    });
+
+    it('ignores locale parameter on non-localized content type', async () => {
+      const authorDb = await findAuthorDb({ name: 'Author1-Draft' });
+
+      // Locale should be ignored on non-localized content types
+      const author = await strapi.documents(AUTHOR_UID).findOne(authorDb.documentId, {
+        locale: 'en',
+      });
+
+      expect(author).toMatchObject(authorDb);
     });
 
     it.todo('ignores pagination parameters');

--- a/api-tests/core/strapi/document-service/resources/fixtures/author.json
+++ b/api-tests/core/strapi/document-service/resources/fixtures/author.json
@@ -1,0 +1,16 @@
+[
+  {
+    "id": 1,
+    "documentId": "Author1",
+    "name": "Author1-Draft",
+    "publishedAt": null,
+    "locale": null
+  },
+  {
+    "id": 2,
+    "documentId": "Author2",
+    "name": "Author2-Draft",
+    "publishedAt": null,
+    "locale": null
+  }
+]

--- a/api-tests/core/strapi/document-service/resources/fixtures/index.js
+++ b/api-tests/core/strapi/document-service/resources/fixtures/index.js
@@ -5,5 +5,6 @@ module.exports = {
     // Make sure this is sorted by order to create them
     'api::category.category': require('./category.json'),
     'api::article.article': require('./article.json'),
+    'api::author.author': require('./author.json'),
   },
 };

--- a/api-tests/core/strapi/document-service/resources/schemas/author.js
+++ b/api-tests/core/strapi/document-service/resources/schemas/author.js
@@ -1,0 +1,26 @@
+'use strict';
+
+module.exports = {
+  kind: 'collectionType',
+  collectionName: 'authors',
+  singularName: 'author',
+  pluralName: 'authors',
+  displayName: 'Author',
+  description: '',
+  draftAndPublish: true,
+  pluginOptions: {
+    i18n: {
+      localized: false,
+    },
+  },
+  attributes: {
+    name: {
+      type: 'string',
+      pluginOptions: {
+        i18n: {
+          localized: false,
+        },
+      },
+    },
+  },
+};

--- a/api-tests/core/strapi/document-service/resources/schemas/index.js
+++ b/api-tests/core/strapi/document-service/resources/schemas/index.js
@@ -4,6 +4,7 @@ module.exports = {
   'content-types': {
     'api::category.category': require('./category'),
     'api::article.article': require('./article'),
+    'api::author.author': require('./author'),
   },
   components: {
     'article.comp': require('./comp'),

--- a/api-tests/core/strapi/document-service/resources/types/contentTypes.d.ts
+++ b/api-tests/core/strapi/document-service/resources/types/contentTypes.d.ts
@@ -618,6 +618,38 @@ export interface ApiArticleArticle extends Schema.CollectionType {
   };
 }
 
+export interface ApiAuthorAuthor extends Schema.CollectionType {
+  collectionName: 'authors';
+  info: {
+    singularName: 'author';
+    pluralName: 'authors';
+    displayName: 'Author';
+    description: '';
+  };
+  pluginOptions: {
+    i18n: {
+      localized: false;
+    };
+  };
+  attributes: {
+    name: Attribute.String &
+      Attribute.SetPluginOptions<{
+        i18n: {
+          localized: false;
+        };
+      }>;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<'api::author.author', 'oneToOne', 'admin::user'> &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<'api::author.author', 'oneToOne', 'admin::user'> &
+      Attribute.Private;
+    localizations: Attribute.Relation<'api::author.author', 'oneToMany', 'api::author.author'>;
+    locale: Attribute.String;
+  };
+}
+
 export interface ApiCategoryCategory extends Schema.CollectionType {
   collectionName: 'categories';
   info: {
@@ -674,6 +706,7 @@ declare module '@strapi/types' {
       'plugin::users-permissions.role': PluginUsersPermissionsRole;
       'plugin::users-permissions.user': PluginUsersPermissionsUser;
       'api::article.article': ApiArticleArticle;
+      'api::author.author': ApiAuthorAuthor;
       'api::category.category': ApiCategoryCategory;
     }
   }

--- a/api-tests/core/strapi/document-service/utils/index.ts
+++ b/api-tests/core/strapi/document-service/utils/index.ts
@@ -1,5 +1,8 @@
 import { Attribute } from '@strapi/strapi';
 
+export const AUTHOR_UID = 'api::author.author';
+export type Author = Attribute.GetAll<typeof AUTHOR_UID> & { documentId: string; id: number };
+
 export const ARTICLE_UID = 'api::article.article';
 export type Article = Attribute.GetAll<typeof ARTICLE_UID> & { documentId: string; id: number };
 
@@ -13,4 +16,16 @@ export const findArticlesDb = async (where: any) => {
 
 export const findPublishedArticlesDb = async (documentId) => {
   return findArticlesDb({ documentId, publishedAt: { $notNull: true } });
+};
+
+export const findAuthorDb = async (where: any) => {
+  return (await strapi.query(AUTHOR_UID).findOne({ where })) as Author | undefined;
+};
+
+export const findAuthorsDb = async (where: any) => {
+  return (await strapi.query(AUTHOR_UID).findMany({ where })) as Author[];
+};
+
+export const findPublishedAuthorsDb = async (documentId) => {
+  return findAuthorsDb({ documentId, publishedAt: { $notNull: true } });
 };

--- a/packages/core/core/src/services/document-service/middlewares/defaults/locales.ts
+++ b/packages/core/core/src/services/document-service/middlewares/defaults/locales.ts
@@ -1,13 +1,19 @@
 // TODO: Move to i18n
-import { Documents } from '@strapi/types';
+import { Documents, Common } from '@strapi/types';
 
 type Middleware = Documents.Middleware.Middleware<any, any>;
 
+const isLocalizedContentType = (uid: Common.UID.Schema) => {
+  const model = strapi.getModel(uid);
+  return strapi.plugin('i18n').service('content-types').isLocalizedContentType(model);
+};
+
 export const defaultLocale: Middleware = async (ctx, next) => {
+  if (!isLocalizedContentType(ctx.uid)) return next(ctx);
   if (!ctx.params) ctx.params = {};
 
-  // Default to en (TODO: Load default locale from db in i18n)
   if (!ctx.params.locale) {
+    // Default to en (TODO: Load default locale from db in i18n)
     ctx.params.locale = 'en';
   }
 
@@ -18,6 +24,7 @@ export const defaultLocale: Middleware = async (ctx, next) => {
  * Add locale lookup query to the params
  */
 export const localeToLookup: Middleware = async (ctx, next) => {
+  if (!isLocalizedContentType(ctx.uid)) return next(ctx);
   if (!ctx.params) ctx.params = {};
 
   const lookup = ctx.params.lookup || {};
@@ -34,6 +41,7 @@ export const localeToLookup: Middleware = async (ctx, next) => {
  * Translate locale status parameter into the data that will be saved
  */
 export const localeToData: Middleware = async (ctx, next) => {
+  if (!isLocalizedContentType(ctx.uid)) return next(ctx);
   if (!ctx.params) ctx.params = {};
 
   const data = ctx.params.data || {};


### PR DESCRIPTION
### What does it do?

Follow up of https://github.com/strapi/strapi/pull/19058 
On content types without i18n enabled, document service will ignore the locale parameter. So you can not look for any specific locale of a document, or create/update such a document locale

### How to test it?
See api tests
