### PR TITLE
chore(admin): data-transfer should be dev dep & peer dep loose

### DIFF
--- a/packages/core/admin/package.json
+++ b/packages/core/admin/package.json
@@ -72,7 +72,6 @@
     "@radix-ui/react-context": "1.0.1",
     "@radix-ui/react-toolbar": "1.0.4",
     "@reduxjs/toolkit": "1.9.7",
-    "@strapi/data-transfer": "4.17.0",
     "@strapi/design-system": "1.14.1",
     "@strapi/helper-plugin": "4.17.0",
     "@strapi/icons": "1.14.1",
@@ -173,6 +172,7 @@
   },
   "devDependencies": {
     "@strapi/admin-test-utils": "4.17.0",
+    "@strapi/data-transfer": "4.17.0",
     "@strapi/pack-up": "4.17.0",
     "@strapi/plugin-content-manager": "4.17.0",
     "@strapi/strapi": "4.17.0",
@@ -201,7 +201,7 @@
     "vite": "4.4.9"
   },
   "peerDependencies": {
-    "@strapi/data-transfer": "4.16.2",
+    "@strapi/data-transfer": "^4.16.0",
     "@strapi/strapi": "^4.3.4",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7632,7 +7632,7 @@ __metadata:
     webpack-hot-middleware: "npm:2.25.4"
     yup: "npm:0.32.9"
   peerDependencies:
-    "@strapi/data-transfer": 4.16.2
+    "@strapi/data-transfer": ^4.16.0
     "@strapi/strapi": ^4.3.4
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* sets the `@strapi/data-transfer` peerDep in `@strapi/admin` to be `^4.16.0` which is looser and won't need changing
* moves the dep to be a devDep because it's supposed to be using a peer-dep and we don't want it downloading it's own version.

### Why is it needed?

* package safety

