### PR TITLE
Respect autogenerate setting for JS projects

### DIFF
--- a/packages/core/admin/_internal/node/develop.ts
+++ b/packages/core/admin/_internal/node/develop.ts
@@ -230,12 +230,9 @@ const develop = async ({
     loadStrapiSpinner.text = `Loading Strapi (${prettyTime(loadStrapiDuration)})`;
     loadStrapiSpinner.succeed();
 
-    // if this is a JS project (no tsconfig) AND they have disabled type autogeneration, skip type generation
-    if (!tsconfig?.config && strapi.config.get('typescript.autogenerate') === false) {
-      logger.log('Skipping typescript autogeneration');
-    }
     // For TS projects, type generation is a requirement for the develop command so that the server can restart
-    else {
+    // For JS projects, we respect the experimental autogenerate setting
+    if (tsconfig?.config || strapi.config.get('typescript.autogenerate') !== false) {
       timer.start('generatingTS');
       const generatingTsSpinner = logger.spinner(`Generating types`).start();
 

--- a/packages/core/admin/_internal/node/develop.ts
+++ b/packages/core/admin/_internal/node/develop.ts
@@ -230,20 +230,27 @@ const develop = async ({
     loadStrapiSpinner.text = `Loading Strapi (${prettyTime(loadStrapiDuration)})`;
     loadStrapiSpinner.succeed();
 
-    timer.start('generatingTS');
-    const generatingTsSpinner = logger.spinner(`Generating types`).start();
+    // if this is a JS project (no tsconfig) AND they have disabled type autogeneration, skip type generation
+    if (!tsconfig?.config && strapi.config.get('typescript.autogenerate') === false) {
+      logger.log('Skipping typescript autogeneration');
+    }
+    // For TS projects, type generation is a requirement for the develop command so that the server can restart
+    else {
+      timer.start('generatingTS');
+      const generatingTsSpinner = logger.spinner(`Generating types`).start();
 
-    await tsUtils.generators.generate({
-      strapi: strapiInstance,
-      pwd: cwd,
-      rootDir: undefined,
-      logger: { silent: true, debug: false },
-      artifacts: { contentTypes: true, components: true },
-    });
+      await tsUtils.generators.generate({
+        strapi: strapiInstance,
+        pwd: cwd,
+        rootDir: undefined,
+        logger: { silent: true, debug: false },
+        artifacts: { contentTypes: true, components: true },
+      });
 
-    const generatingDuration = timer.end('generatingTS');
-    generatingTsSpinner.text = `Generating types (${prettyTime(generatingDuration)})`;
-    generatingTsSpinner.succeed();
+      const generatingDuration = timer.end('generatingTS');
+      generatingTsSpinner.text = `Generating types (${prettyTime(generatingDuration)})`;
+      generatingTsSpinner.succeed();
+    }
 
     if (tsconfig?.config) {
       timer.start('compilingTS');


### PR DESCRIPTION
### What does it do?

The --develop command in a JS Strapi project now skips the type generation step when config/typescript.js autogenerate = false

### Why is it needed?

Types are not a hard requirement for JS projects and it's annoying in many cases to have it update after every change.

### How to test it?

In a javascript Strapi project with a config/typescript.js containing `module.exports = { autogenerate: false }`, go to the content type builder and make some change, and see the server does not generate types

In all other project configurations, it should still generate types.

### Related issue(s)/PR(s)

Fixes #18124 (autogeneration is required on TS projects for the develop command or the server will not start)
Fixes #19195
