### PR TITLE
chore(content-releases): enforce license limits for pending releases

### DIFF
--- a/packages/core/content-releases/server/src/services/__tests__/release-validation.test.ts
+++ b/packages/core/content-releases/server/src/services/__tests__/release-validation.test.ts
@@ -114,7 +114,7 @@ describe('Release Validation service', () => {
       );
     });
   });
-  describe('validatePendingReleaseLimit', () => {
+  describe('validatePendingReleasesLimit', () => {
     it('should throw an error if the default pending release limit has been reached', () => {
       // @ts-expect-error - get is a mock
       EE.features.get.mockReturnValue({});
@@ -130,7 +130,7 @@ describe('Release Validation service', () => {
       // @ts-expect-error Ignore missing properties
       const releaseValidationService = createReleaseValidationService({ strapi: strapiMock });
 
-      expect(() => releaseValidationService.validatePendingReleaseLimit()).rejects.toThrow(
+      expect(() => releaseValidationService.validatePendingReleasesLimit()).rejects.toThrow(
         'You have reached the maximum number of pending releases'
       );
     });
@@ -150,7 +150,7 @@ describe('Release Validation service', () => {
       // @ts-expect-error Ignore missing properties
       const releaseValidationService = createReleaseValidationService({ strapi: strapiMock });
 
-      await expect(releaseValidationService.validatePendingReleaseLimit()).resolves.not.toThrow();
+      await expect(releaseValidationService.validatePendingReleasesLimit()).resolves.not.toThrow();
     });
 
     it('should throw an error if the license pending release limit has been reached', () => {
@@ -171,7 +171,7 @@ describe('Release Validation service', () => {
       // @ts-expect-error Ignore missing properties
       const releaseValidationService = createReleaseValidationService({ strapi: strapiMock });
 
-      expect(() => releaseValidationService.validatePendingReleaseLimit()).rejects.toThrow(
+      expect(() => releaseValidationService.validatePendingReleasesLimit()).rejects.toThrow(
         'You have reached the maximum number of pending releases'
       );
     });
@@ -195,7 +195,7 @@ describe('Release Validation service', () => {
       // @ts-expect-error Ignore missing properties
       const releaseValidationService = createReleaseValidationService({ strapi: strapiMock });
 
-      await expect(releaseValidationService.validatePendingReleaseLimit()).resolves.not.toThrow();
+      await expect(releaseValidationService.validatePendingReleasesLimit()).resolves.not.toThrow();
     });
   });
 });

--- a/packages/core/content-releases/server/src/services/__tests__/release-validation.test.ts
+++ b/packages/core/content-releases/server/src/services/__tests__/release-validation.test.ts
@@ -115,35 +115,56 @@ describe('Release Validation service', () => {
     });
   });
   describe('validatePendingReleaseLimit', () => {
-    it('should throw an error if the license does not have options for releases', () => {
+    it('should throw an error if the default pending release limit has been reached', () => {
+      // @ts-expect-error - get is a mock
+      EE.features.get.mockReturnValue({});
       const strapiMock = {
         ...baseStrapiMock,
         db: {
           query: jest.fn().mockReturnValue({
-            findWithCount: jest.fn().mockReturnValue([[], 3]),
+            findWithCount: jest.fn().mockReturnValue([[], 4]),
           }),
         },
       };
+
       // @ts-expect-error Ignore missing properties
       const releaseValidationService = createReleaseValidationService({ strapi: strapiMock });
 
       expect(() => releaseValidationService.validatePendingReleaseLimit()).rejects.toThrow(
-        'The license does not contain a configuration for releases'
+        'You have reached the maximum number of pending releases'
       );
     });
 
-    it('should throw an error if the pending release limit has been reached', () => {
+    it('should pass if the default pending release limit has NOT been reached', async () => {
+      // @ts-expect-error - get is a mock
+      EE.features.get.mockReturnValue({});
+      const strapiMock = {
+        ...baseStrapiMock,
+        db: {
+          query: jest.fn().mockReturnValue({
+            findWithCount: jest.fn().mockReturnValue([[], 2]),
+          }),
+        },
+      };
+
+      // @ts-expect-error Ignore missing properties
+      const releaseValidationService = createReleaseValidationService({ strapi: strapiMock });
+
+      await expect(releaseValidationService.validatePendingReleaseLimit()).resolves.not.toThrow();
+    });
+
+    it('should throw an error if the license pending release limit has been reached', () => {
       // @ts-expect-error - get is a mock
       EE.features.get.mockReturnValue({
         options: {
-          maximumReleases: 3,
+          maximumReleases: 5,
         },
       });
       const strapiMock = {
         ...baseStrapiMock,
         db: {
           query: jest.fn().mockReturnValue({
-            findWithCount: jest.fn().mockReturnValue([[], 3]),
+            findWithCount: jest.fn().mockReturnValue([[], 5]),
           }),
         },
       };
@@ -155,18 +176,18 @@ describe('Release Validation service', () => {
       );
     });
 
-    it('should not throw an error if the pending release limit has not been reached', async () => {
+    it('should pass if the license pending release limit has NOT been reached', async () => {
       // @ts-expect-error - get is a mock
       EE.features.get.mockReturnValue({
         options: {
-          maximumReleases: 3,
+          maximumReleases: 5,
         },
       });
       const strapiMock = {
         ...baseStrapiMock,
         db: {
           query: jest.fn().mockReturnValue({
-            findWithCount: jest.fn().mockReturnValue([[], 2]),
+            findWithCount: jest.fn().mockReturnValue([[], 4]),
           }),
         },
       };

--- a/packages/core/content-releases/server/src/services/release.ts
+++ b/packages/core/content-releases/server/src/services/release.ts
@@ -3,6 +3,7 @@ import { setCreatorFields, errors } from '@strapi/utils';
 import type { LoadedStrapi, EntityService, UID } from '@strapi/types';
 
 import _ from 'lodash/fp';
+
 import { RELEASE_ACTION_MODEL_UID, RELEASE_MODEL_UID } from '../constants';
 import type {
   GetReleases,
@@ -50,6 +51,8 @@ const getGroupName = (queryValue?: ReleaseActionGroupBy) => {
 const createReleaseService = ({ strapi }: { strapi: LoadedStrapi }) => ({
   async create(releaseData: CreateRelease.Request['body'], { user }: { user: UserInfo }) {
     const releaseWithCreatorFields = await setCreatorFields({ user })(releaseData);
+
+    await getService('release-validation', { strapi }).validatePendingReleaseLimit();
 
     return strapi.entityService.create(RELEASE_MODEL_UID, {
       data: releaseWithCreatorFields,

--- a/packages/core/content-releases/server/src/services/release.ts
+++ b/packages/core/content-releases/server/src/services/release.ts
@@ -52,7 +52,7 @@ const createReleaseService = ({ strapi }: { strapi: LoadedStrapi }) => ({
   async create(releaseData: CreateRelease.Request['body'], { user }: { user: UserInfo }) {
     const releaseWithCreatorFields = await setCreatorFields({ user })(releaseData);
 
-    await getService('release-validation', { strapi }).validatePendingReleaseLimit();
+    await getService('release-validation', { strapi }).validatePendingReleasesLimit();
 
     return strapi.entityService.create(RELEASE_MODEL_UID, {
       data: releaseWithCreatorFields,

--- a/packages/core/content-releases/server/src/services/validation.ts
+++ b/packages/core/content-releases/server/src/services/validation.ts
@@ -50,7 +50,7 @@ const createReleaseValidationService = ({ strapi }: { strapi: LoadedStrapi }) =>
       );
     }
   },
-  async validatePendingReleaseLimit() {
+  async validatePendingReleasesLimit() {
     // Use the maximum releases option if it exists, otherwise default to 3
     const maximumPendingReleases =
       // @ts-expect-error - options is not typed into features


### PR DESCRIPTION
### What does it do?

- Checks the license has been configured with the maximumReleases option
- Checks if the user has or has not reached the limit per their license
- If the license is missing the config a default of 3 will be set since if you have a license with the feature enabled you should have at least that limit.


This PR only handles the backend validation, another PR will handle the error on the FE 

### Why is it needed?

- To enforce the license entitlements

### How to test it?

- Ping me for a license with a limit of 3
- Then test you can't create more than 3 releases
