### PR TITLE
fix(cm): manage when we're creating entries derivatively in the CM

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/ContentTypeFormWrapper.tsx
+++ b/packages/core/admin/admin/src/content-manager/components/ContentTypeFormWrapper.tsx
@@ -27,6 +27,7 @@ import {
   setStatus,
   submitSucceeded,
 } from '../sharedReducers/crud/actions';
+import { buildValidGetParams } from '../utils/api';
 import { createDefaultDataStructure, removePasswordFieldsFromData } from '../utils/data';
 import { getTranslation } from '../utils/translations';
 
@@ -172,7 +173,10 @@ const ContentTypeFormWrapper = ({
       dispatch(getData());
 
       try {
-        const { data } = await fetchClient.get(requestURL, { cancelToken: source.token });
+        const { data } = await fetchClient.get(requestURL, {
+          cancelToken: source.token,
+          params: buildValidGetParams(query),
+        });
 
         dispatch(getDataSucceeded(cleanReceivedData(data)));
       } catch (err) {
@@ -231,6 +235,7 @@ const ContentTypeFormWrapper = ({
     redirectionLink,
     toggleNotification,
     isSingleType,
+    query,
   ]);
 
   const displayErrors = React.useCallback(

--- a/packages/core/admin/admin/src/content-manager/components/ContentTypeFormWrapper.tsx
+++ b/packages/core/admin/admin/src/content-manager/components/ContentTypeFormWrapper.tsx
@@ -458,7 +458,9 @@ const ContentTypeFormWrapper = ({
           Contracts.CollectionTypes.Update.Response,
           AxiosResponse<Contracts.CollectionTypes.Update.Response>,
           Contracts.CollectionTypes.Update.Request['body']
-        >(`/content-manager/${collectionType}/${slug}/${id}`, body);
+        >(`/content-manager/${collectionType}/${slug}/${id}`, body, {
+          params: query,
+        });
 
         trackUsage('didEditEntry', trackerProperty);
         toggleNotification({

--- a/packages/core/admin/admin/src/content-manager/components/ContentTypeFormWrapper.tsx
+++ b/packages/core/admin/admin/src/content-manager/components/ContentTypeFormWrapper.tsx
@@ -100,7 +100,7 @@ const ContentTypeFormWrapper = ({
   const { put, post, del } = fetchClient;
 
   const isSingleType = collectionType === 'single-types';
-  const [isCreatingEntry, setIsCreatingEntry] = React.useState(!isSingleType && !id);
+  const isCreatingEntry = !isSingleType && !id;
 
   const requestURL =
     isCreatingEntry && !origin
@@ -187,7 +187,6 @@ const ContentTypeFormWrapper = ({
           return;
         } else if (resStatus === 404 && isSingleType) {
           // Creating a single type
-          setIsCreatingEntry(true);
           dispatch(initForm(rawQuery, true));
         }
 
@@ -258,7 +257,6 @@ const ContentTypeFormWrapper = ({
         trackUsage('didDeleteEntry', trackerProperty);
 
         if (isSingleType) {
-          setIsCreatingEntry(true);
           dispatch(initForm(rawQuery, true));
         } else {
           replace(redirectionLink);
@@ -327,7 +325,6 @@ const ContentTypeFormWrapper = ({
 
         // TODO: need to find a better place, or a better abstraction
         queryClient.invalidateQueries(['relation']);
-        setIsCreatingEntry(false);
 
         dispatch(submitSucceeded(cleanReceivedData(data)));
 

--- a/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/Provider.tsx
+++ b/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/Provider.tsx
@@ -744,7 +744,8 @@ const EditViewDataManagerProvider = ({
         publishConfirmation,
       }}
     >
-      {isLoadingForData || (!isCreatingEntry && !initialData.id) ? (
+      {/* with SingleTypes, we'll never be creating the entry and there won't ever be an id because thats not how single types work. */}
+      {isLoadingForData || (!isCreatingEntry && !initialData.id && !isSingleType) ? (
         <Main aria-busy="true">
           <LoadingIndicatorPage />
         </Main>

--- a/packages/plugins/i18n/admin/src/components/CMEditViewInjectedComponents.tsx
+++ b/packages/plugins/i18n/admin/src/components/CMEditViewInjectedComponents.tsx
@@ -35,7 +35,11 @@ const CMEditViewInjectedComponents = () => {
     return null;
   }
 
-  const localizations = getLocalizationsFromData(modifiedData);
+  const localizations = [
+    ...getLocalizationsFromData(modifiedData),
+    // current locale
+    { id: currentEntityId, locale: currentLocale, publishedAt: modifiedData.publishedAt },
+  ];
 
   return (
     <Box paddingTop={6}>

--- a/packages/plugins/i18n/admin/src/components/CMEditViewLocalePicker.tsx
+++ b/packages/plugins/i18n/admin/src/components/CMEditViewLocalePicker.tsx
@@ -101,7 +101,7 @@ const CMEditViewLocalePicker = ({
 
       let status: BulletProps['status'] = 'did-not-create-locale';
 
-      if (matchingLocaleInData) {
+      if (matchingLocaleInData && matchingLocaleInData.publishedAt !== undefined) {
         status = matchingLocaleInData.publishedAt === null ? 'draft' : 'published';
       }
 

--- a/packages/plugins/i18n/admin/src/utils/data.ts
+++ b/packages/plugins/i18n/admin/src/utils/data.ts
@@ -122,7 +122,7 @@ interface ContentData extends Entity {
 
 interface Localization extends Pick<ContentData, 'id'> {
   locale: string;
-  publishedAt: string | null;
+  publishedAt?: string | null;
 }
 
 const getLocalizationsFromData = (entity: unknown): Localization[] =>


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* removes the calls of directly setting state to whether we're creating an entry or not in the CM & instead derives the state value from the URL params

### Why is it needed?

* Primarily to handle singleTypes we were originally check if there's an ID present to see if we're creating an entry, single types dont have IDs so when we've done the call to fetch the data we manually flipped this. In the case of switching locales e.g. i have an EN entry and I need to make a DE entry, we wouldn't change the state from "not creating" to "creating" leaving an infinite loop. Using an effect is probably a bad idea because we can derive from the URL if we're making an entry & because we're never making a single-type (they always exist because they're singletons) we can omit the `useState`.

### How to test it?

*locales*
* Go to an localised content-type.
* Make the default content-type & save
* Switch to a locale you've not made – it should load the create form correctly

*single-types*
* Navigate to your single-type that you've never made before
* Should show you the empty form
* fill in & save
* refresh the page
* you should see the saved data & be able to still update the form

### Related issue(s)/PR(s)

* resolves #19206
