### PR TITLE
fix(scripts): add skip cache flag

### DIFF
--- a/scripts/pre-publish.sh
+++ b/scripts/pre-publish.sh
@@ -20,5 +20,5 @@ fi
 
 # publish packages
 ./node_modules/.bin/nx run-many --target=clean --nx-ignore-cycles
-./node_modules/.bin/nx run-many --target=build --nx-ignore-cycles
+./node_modules/.bin/nx run-many --target=build --nx-ignore-cycles --skip-nx-cache
 ./node_modules/.bin/lerna publish --no-push --no-git-tag-version --force-publish --exact "$version" --dist-tag "$distTag" $@

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -12,7 +12,7 @@ read -r version
 
 # publish packages
 ./node_modules/.bin/nx run-many --target=clean --nx-ignore-cycles
-./node_modules/.bin/nx run-many --target=build --nx-ignore-cycles
+./node_modules/.bin/nx run-many --target=build --nx-ignore-cycles --skip-nx-cache
 ./node_modules/.bin/lerna publish --no-push --force-publish --dist-tag latest --exact "$version"
 
 # push main branch


### PR DESCRIPTION
### What does it do?

- Adds `--skip-nx-cache` flag to the publish and pre-publish script

### Why is it needed?

- Otherwise the release can end up having build errors

