### PR TITLE
[Upgrade Tool] Add internal support for upgrading to any version

### DIFF
--- a/packages/utils/upgrade/src/cli/commands/codemods.ts
+++ b/packages/utils/upgrade/src/cli/commands/codemods.ts
@@ -1,12 +1,13 @@
 import prompts from 'prompts';
 import { loggerFactory } from '../../modules/logger';
+import { Version } from '../../modules/version';
 import { handleError } from '../errors';
 import * as tasks from '../../tasks';
 
-import type { Command } from '../types';
+import type { CodemodsCommand } from '../types';
 import type { Codemod } from '../../modules/codemod';
 
-export const codemods: Command = async (options) => {
+export const codemods: CodemodsCommand = async (options) => {
   try {
     const { silent, debug } = options;
     const logger = loggerFactory({ silent, debug });
@@ -66,9 +67,9 @@ export const codemods: Command = async (options) => {
       selectCodemods,
       dry: options.dry,
       cwd: options.projectPath,
-      target: options.target,
+      target: Version.ReleaseType.Major,
     });
   } catch (err) {
-    handleError(err);
+    handleError(err, options.silent);
   }
 };

--- a/packages/utils/upgrade/src/cli/commands/upgrade.ts
+++ b/packages/utils/upgrade/src/cli/commands/upgrade.ts
@@ -4,9 +4,9 @@ import { loggerFactory } from '../../modules/logger';
 import { handleError } from '../errors';
 import * as tasks from '../../tasks';
 
-import type { Command } from '../types';
+import type { UpgradeCommand } from '../types';
 
-export const upgrade: Command = async (options) => {
+export const upgrade: UpgradeCommand = async (options) => {
   try {
     const { silent, debug, yes } = options;
     const logger = loggerFactory({ silent, debug });
@@ -36,8 +36,9 @@ export const upgrade: Command = async (options) => {
       dry: options.dry,
       cwd: options.projectPath,
       target: options.target,
+      codemodsTarget: options.codemodsTarget,
     });
   } catch (err) {
-    handleError(err);
+    handleError(err, options.silent);
   }
 };

--- a/packages/utils/upgrade/src/cli/errors.ts
+++ b/packages/utils/upgrade/src/cli/errors.ts
@@ -1,9 +1,12 @@
 import chalk from 'chalk';
 
-export const handleError = (err: unknown) => {
-  console.error(
-    chalk.red(`[ERROR]\t[${new Date().toISOString()}]`),
-    err instanceof Error ? err.message : err
-  );
+export const handleError = (err: unknown, isSilent: boolean) => {
+  if (!isSilent) {
+    console.error(
+      chalk.red(`[ERROR]\t[${new Date().toISOString()}]`),
+      err instanceof Error ? err.message : err
+    );
+  }
+
   process.exit(1);
 };

--- a/packages/utils/upgrade/src/cli/types.ts
+++ b/packages/utils/upgrade/src/cli/types.ts
@@ -1,16 +1,38 @@
 import type { Version } from '../modules/version';
 import type { MaybePromise } from '../types';
 
-export interface CLIOptions {
-  dry: boolean;
-  debug: boolean;
-  silent: boolean;
-  yes?: boolean;
-  projectPath?: string;
+// CLI
+
+type DryOption = { dry: boolean };
+type DebugOption = { debug: boolean };
+type SilentOption = { silent: boolean };
+type YesOption = { yes?: boolean };
+type ProjectPathOption = { projectPath?: string };
+
+export type CLIUpgradeOptions = DryOption &
+  DebugOption &
+  SilentOption &
+  YesOption &
+  ProjectPathOption;
+
+export type CLIUpgradeToOptions = CLIUpgradeOptions & {
+  codemodsTarget?: Version.SemVer;
+};
+
+export type CLICodemodsOptions = DryOption & DebugOption & SilentOption & ProjectPathOption;
+
+// COMMANDS OPTIONS
+
+export interface UpgradeCommandOptions extends CLIUpgradeOptions {
+  target: Version.ReleaseType | Version.SemVer;
+  codemodsTarget?: Version.SemVer;
 }
 
-export interface CommandOptions extends CLIOptions {
-  target: Version.ReleaseType;
-}
+export interface CodemodsCommandOptions extends CLICodemodsOptions {}
 
-export type Command = (options: CommandOptions) => MaybePromise<void>;
+// COMMANDS
+
+export type Command<TOptions extends object> = (options: TOptions) => MaybePromise<void>;
+
+export type UpgradeCommand = Command<UpgradeCommandOptions>;
+export type CodemodsCommand = Command<CodemodsCommandOptions>;

--- a/packages/utils/upgrade/src/modules/codemod-runner/__tests__/codemod-runner.test.ts
+++ b/packages/utils/upgrade/src/modules/codemod-runner/__tests__/codemod-runner.test.ts
@@ -1,6 +1,6 @@
 import { vol, fs } from 'memfs';
 
-import { projectFactory } from '../../project/project';
+import { projectFactory } from '../../project';
 import { rangeFactory } from '../../version';
 import { codemodRunnerFactory } from '../codemod-runner';
 import { loggerFactory } from '../../logger';
@@ -80,7 +80,7 @@ describe('CodemodRunner', () => {
       loggerFactory({ debug: true })
     );
     const res = await codemodRunner.run(`${validCwd}/src`);
-    expect(logger.debug).toHaveBeenCalledWith(`Found codemods for 1 version(s)`);
+    expect(logger.debug).toHaveBeenCalledWith(`Found codemods for 1 version(s) using ${range}`);
     expect(res.success).toBe(true);
   });
 
@@ -104,7 +104,7 @@ describe('CodemodRunner', () => {
       .onSelectCodemods(selectCodemodsCallback);
     const res = await codemodRunner.run(`${validCwd}/src`);
     expect(selectCodemodsCallback).toHaveBeenCalled();
-    expect(logger.debug).toHaveBeenCalledWith(`Found codemods for 1 version(s)`);
+    expect(logger.debug).toHaveBeenCalledWith(`Found codemods for 1 version(s) using ${range}`);
     expect(res.success).toBe(true);
   });
 
@@ -114,7 +114,7 @@ describe('CodemodRunner', () => {
       .setLogger(logger)
       .dry();
     const res = await codemodRunner.run(`${validCwd}/src`);
-    expect(logger.debug).toHaveBeenCalledWith(`Found codemods for 1 version(s)`);
+    expect(logger.debug).toHaveBeenCalledWith(`Found codemods for 1 version(s) using ${range}`);
     expect(res.success).toBe(true);
   });
 });

--- a/packages/utils/upgrade/src/modules/npm/__tests__/package.test.ts
+++ b/packages/utils/upgrade/src/modules/npm/__tests__/package.test.ts
@@ -122,4 +122,15 @@ describe('Package class', () => {
 
     expect(packageInstance.versionExists(version)).toBeFalsy();
   });
+
+  it('should return the version if it exists', async () => {
+    const version = new semver.SemVer('1.0.0');
+    expect(packageInstance.findVersion(version)).not.toBeUndefined();
+  });
+
+  it('should return undefined if the version does not exist', async () => {
+    const version = new semver.SemVer('1.1.1');
+
+    expect(packageInstance.findVersion(version)).toBeUndefined();
+  });
 });

--- a/packages/utils/upgrade/src/modules/npm/package.ts
+++ b/packages/utils/upgrade/src/modules/npm/package.ts
@@ -4,7 +4,7 @@ import semver from 'semver';
 import * as constants from './constants';
 import { isLiteralSemVer } from '../version';
 
-import type { Package as PackageInterface, NPMPackage } from './types';
+import type { Package as PackageInterface, NPMPackage, NPMPackageVersion } from './types';
 import type { Version } from '../version';
 
 export class Package implements PackageInterface {
@@ -54,6 +54,12 @@ export class Package implements PackageInterface {
     );
   }
 
+  findVersion(version: Version.SemVer): NPMPackageVersion | undefined {
+    const versions = this.getVersionsAsList();
+
+    return versions.find((npmVersion) => semver.eq(npmVersion.version, version));
+  }
+
   async refresh() {
     const response = await fetch(this.packageURL);
 
@@ -66,10 +72,7 @@ export class Package implements PackageInterface {
   }
 
   versionExists(version: Version.SemVer) {
-    const versions = this.getVersionsAsList();
-    const searchResult = versions.find((npmVersion) => semver.eq(npmVersion.version, version));
-
-    return searchResult !== undefined;
+    return this.findVersion(version) !== undefined;
   }
 }
 

--- a/packages/utils/upgrade/src/modules/npm/types.ts
+++ b/packages/utils/upgrade/src/modules/npm/types.ts
@@ -15,6 +15,7 @@ export interface Package {
   getVersionsDict(): Record<NPMVersion, NPMPackageVersion>;
   getVersionsAsList(): NPMPackageVersion[];
 
+  findVersion(version: Version.SemVer): NPMPackageVersion | undefined;
   findVersionsInRange(range: Version.Range): NPMPackageVersion[];
 }
 

--- a/packages/utils/upgrade/src/modules/project/constants.ts
+++ b/packages/utils/upgrade/src/modules/project/constants.ts
@@ -6,6 +6,6 @@ export const PROJECT_DEFAULT_ALLOWED_EXTENSIONS = ['js', 'ts', 'json'];
 
 export const PROJECT_DEFAULT_PATTERNS = ['package.json'];
 
-export const SCOPED_STRAPI_PACKAGE_PREFIX = '@strapi';
+export const SCOPED_STRAPI_PACKAGE_PREFIX = '@strapi/';
 
-export const STRAPI_DEPENDENCY_NAME = `${SCOPED_STRAPI_PACKAGE_PREFIX}/strapi`;
+export const STRAPI_DEPENDENCY_NAME = `${SCOPED_STRAPI_PACKAGE_PREFIX}strapi`;

--- a/packages/utils/upgrade/src/modules/project/project.ts
+++ b/packages/utils/upgrade/src/modules/project/project.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert';
 import fse from 'fs-extra';
 import semver from 'semver';
 
-import { semVerFactory, isLiteralSemVer } from '../version';
+import { semVerFactory, isLiteralSemVer, isValidSemVer } from '../version';
 import { fileScannerFactory } from '../file-scanner';
 import { codeRunnerFactory } from '../runner/code';
 import { jsonRunnerFactory } from '../runner/json';
@@ -166,9 +166,8 @@ export class Project implements ProjectInterface {
     }
 
     const strapiVersion = strapiPackageJSON.version;
-    const isValidSemVer = isLiteralSemVer(strapiVersion);
 
-    if (!isValidSemVer) {
+    if (!isValidSemVer(strapiVersion)) {
       throw new Error(
         `Invalid ${constants.STRAPI_DEPENDENCY_NAME} version found in ${strapiPackageJSONPath} (${strapiVersion})`
       );

--- a/packages/utils/upgrade/src/modules/upgrader/types.ts
+++ b/packages/utils/upgrade/src/modules/upgrader/types.ts
@@ -4,9 +4,12 @@ import type { Logger } from '../logger';
 import type { ConfirmationCallback } from '../common/types';
 
 export interface Upgrader {
-  setTarget(target: Version.ReleaseType | Version.SemVer): this;
+  setTarget(target: Version.SemVer): this;
   setRequirements(requirements: Requirement.Requirement[]): this;
   setLogger(logger: Logger): this;
+
+  overrideCodemodsTarget(target: Version.SemVer): this;
+  syncCodemodsTarget(): this;
 
   dry(enabled?: boolean): this;
   onConfirm(callback: ConfirmationCallback | null): this;

--- a/packages/utils/upgrade/src/modules/upgrader/upgrader.ts
+++ b/packages/utils/upgrade/src/modules/upgrader/upgrader.ts
@@ -309,7 +309,7 @@ const resolveNPMTarget = (
   }
 
   // Release Types
-  else if (isSemVerReleaseType(target)) {
+  if (isSemVerReleaseType(target)) {
     const range = rangeFromVersions(project.strapiVersion, target);
     const npmVersionsMatches = npmPackage.findVersionsInRange(range);
 

--- a/packages/utils/upgrade/src/modules/version/__tests__/semver.test.ts
+++ b/packages/utils/upgrade/src/modules/version/__tests__/semver.test.ts
@@ -1,5 +1,5 @@
 import semver from 'semver';
-import { semVerFactory, isLiteralSemVer, isSemVer, isSemVerReleaseType } from '../semver';
+import { semVerFactory, isLiteralSemVer, isSemverInstance, isSemVerReleaseType } from '../semver';
 import * as Version from '../types';
 
 describe('Version Utilities', () => {
@@ -29,12 +29,12 @@ describe('Version Utilities', () => {
   describe('isSemVer', () => {
     it('should return true for semver.SemVer instances', () => {
       const semVerInstance = new semver.SemVer('1.0.0');
-      expect(isSemVer(semVerInstance)).toBe(true);
+      expect(isSemverInstance(semVerInstance)).toBe(true);
     });
 
     it('should return false for non-SemVer instances', () => {
-      expect(isSemVer({})).toBe(false);
-      expect(isSemVer('1.0.0')).toBe(false);
+      expect(isSemverInstance({})).toBe(false);
+      expect(isSemverInstance('1.0.0')).toBe(false);
     });
   });
 

--- a/packages/utils/upgrade/src/modules/version/range.ts
+++ b/packages/utils/upgrade/src/modules/version/range.ts
@@ -1,7 +1,7 @@
 import semver from 'semver';
 
 import * as Version from './types';
-import { isSemVer, isSemVerReleaseType } from './semver';
+import { isSemverInstance, isSemVerReleaseType } from './semver';
 
 export const rangeFactory = (range: string): Version.Range => {
   return new semver.Range(range);
@@ -37,7 +37,7 @@ export const rangeFromVersions = (
   currentVersion: Version.SemVer,
   target: Version.ReleaseType | Version.SemVer
 ) => {
-  if (isSemVer(target)) {
+  if (isSemverInstance(target)) {
     return rangeFactory(`>${currentVersion.raw} <=${target.raw}`);
   }
 

--- a/packages/utils/upgrade/src/modules/version/semver.ts
+++ b/packages/utils/upgrade/src/modules/version/semver.ts
@@ -2,7 +2,7 @@ import semver from 'semver';
 
 import * as Version from './types';
 
-export const semVerFactory = (version: Version.LiteralSemVer): Version.SemVer => {
+export const semVerFactory = (version: string): Version.SemVer => {
   return new semver.SemVer(version);
 };
 
@@ -15,7 +15,11 @@ export const isLiteralSemVer = (str: string): str is Version.LiteralSemVer => {
   );
 };
 
-export const isSemVer = (value: unknown): value is semver.SemVer => value instanceof semver.SemVer;
+export const isValidSemVer = (str: string) => semver.valid(str) !== null;
+
+export const isSemverInstance = (value: unknown): value is semver.SemVer => {
+  return value instanceof semver.SemVer;
+};
 
 export const isSemVerReleaseType = (str: string): str is Version.ReleaseType => {
   return Object.values(Version.ReleaseType).includes(str as Version.ReleaseType);

--- a/packages/utils/upgrade/src/tasks/codemods/codemods.ts
+++ b/packages/utils/upgrade/src/tasks/codemods/codemods.ts
@@ -4,7 +4,7 @@ import { timerFactory } from '../../modules/timer';
 import { projectFactory } from '../../modules/project';
 import type { RunCodemodsOptions } from './types';
 import { codemodRunnerFactory } from '../../modules/codemod-runner';
-import { Version, isSemVer, rangeFactory } from '../../modules/version';
+import { Version, isSemverInstance, rangeFactory } from '../../modules/version';
 
 export const codemods = async (options: RunCodemodsOptions) => {
   const timer = timerFactory();
@@ -35,10 +35,12 @@ const getRangeFromTarget = (
   currentVersion: Version.SemVer,
   target: Version.ReleaseType | Version.LiteralSemVer
 ) => {
-  if (isSemVer(target)) {
+  if (isSemverInstance(target)) {
     return rangeFactory(target);
   }
+
   const { major, minor, patch } = currentVersion;
+
   switch (target) {
     case Version.ReleaseType.Major:
       return rangeFactory(`${major}`);

--- a/packages/utils/upgrade/src/tasks/upgrade/types.ts
+++ b/packages/utils/upgrade/src/tasks/upgrade/types.ts
@@ -9,4 +9,5 @@ export interface UpgradeOptions {
   cwd?: string;
   dry?: boolean;
   target: Version.ReleaseType | Version.SemVer;
+  codemodsTarget?: Version.SemVer;
 }


### PR DESCRIPTION
### What does it do?

- Added a hidden `to` command
	- It takes a `<target>` parameter (should be any valid semver, including prerelease / builds)
	- It accepts an optional `-c, --codemodsTarget <codemodsTarget>` option to target codemods different than those inferred by `<target>`
- Made the project and upgrader helpers accept complex semver (instead of `x.x.x` only) 
- Added more logs
- Updated unit tests when needed

### Why is it needed?

- This is necessary to allow using the upgrade tool on experimental, alphas, betas and rc versions

### How to test it?

- `cd examples/getstarted`
#### 1. Show the help for the `to` command
- `../../packages/utils/upgrade/bin/upgrade.js help to`
or
- `../../packages/utils/upgrade/bin/upgrade.js to --help`

**Note:** executing `../../packages/utils/upgrade/bin/upgrade.js --help` should not leak the `to` command
#### 2. Upgrade the project to `4.18.1-beta.1`, but run `>current <=v5.0.0` codemods
- `../../packages/utils/upgrade/bin/upgrade.js to 4.18.1-beta.1 -c 5.0.0`
#### 3. Upgrade the project to `4.18.1-beta.1`, and let the upgrade tool infer which codemods to run (`>current <= 4.18.1`)
- `../../packages/utils/upgrade/bin/upgrade.js to 4.18.1-beta.1`
