### PR TITLE
fix(content-releases): TabGroup react to changes of the initialSelectedTabIndex value

### DIFF
--- a/packages/core/admin/admin/src/pages/Marketplace/MarketplacePage.tsx
+++ b/packages/core/admin/admin/src/pages/Marketplace/MarketplacePage.tsx
@@ -59,6 +59,7 @@ interface TabQuery {
 }
 
 const MarketplacePage = () => {
+  const tabRef = React.useRef<any>(null);
   const { formatMessage } = useIntl();
   const { trackUsage } = useTracking();
   const toggleNotification = useNotification();
@@ -102,6 +103,16 @@ const MarketplacePage = () => {
     possibleCategories,
     pagination,
   } = useMarketplaceData({ npmPackageType, debouncedSearch, query, tabQuery });
+
+  const indexOfNpmPackageType = ['plugin', 'provider'].indexOf(npmPackageType);
+
+  // TODO: Replace this solution with v2 of the Design System
+  // Check if the active tab index changes and call the handler of the ref to update the tab group component
+  React.useEffect(() => {
+    if (tabRef.current) {
+      tabRef.current._handlers.setSelectedTabIndex(indexOfNpmPackageType);
+    }
+  }, [indexOfNpmPackageType]);
 
   if (!isOnline) {
     return <OfflineLayout />;
@@ -173,8 +184,9 @@ const MarketplacePage = () => {
             })}
             id="tabs"
             variant="simple"
-            initialSelectedTabIndex={['plugin', 'provider'].indexOf(npmPackageType)}
+            initialSelectedTabIndex={indexOfNpmPackageType}
             onTabChange={handleTabChange}
+            ref={tabRef}
           >
             <Flex justifyContent="space-between" paddingBottom={4}>
               <Tabs>

--- a/packages/core/content-releases/admin/src/pages/ReleasesPage.tsx
+++ b/packages/core/content-releases/admin/src/pages/ReleasesPage.tsx
@@ -182,6 +182,7 @@ const INITIAL_FORM_VALUES = {
 } satisfies FormValues;
 
 const ReleasesPage = () => {
+  const tabRef = React.useRef<any>(null);
   const location = useLocation<CustomLocationState>();
   const [releaseModalShown, setReleaseModalShown] = React.useState(false);
   const toggleNotification = useNotification();
@@ -193,6 +194,8 @@ const ReleasesPage = () => {
   const [createRelease, { isLoading: isSubmittingForm }] = useCreateReleaseMutation();
 
   const { isLoading, isSuccess, isError } = response;
+  const activeTab = response?.currentData?.meta?.activeTab || 'pending';
+  const activeTabIndex = ['pending', 'done'].indexOf(activeTab);
 
   // Check if we have some errors and show a notification to the user to explain the error
   React.useEffect(() => {
@@ -211,6 +214,14 @@ const ReleasesPage = () => {
       replace({ state: null });
     }
   }, [formatMessage, location?.state?.errors, replace, toggleNotification]);
+
+  // TODO: Replace this solution with v2 of the Design System
+  // Check if the active tab index changes and call the handler of the ref to update the tab group component
+  React.useEffect(() => {
+    if (tabRef.current) {
+      tabRef.current._handlers.setSelectedTabIndex(activeTabIndex);
+    }
+  }, [activeTabIndex]);
 
   const toggleAddReleaseModal = () => {
     setReleaseModalShown((prev) => !prev);
@@ -240,8 +251,6 @@ const ReleasesPage = () => {
       },
     });
   };
-
-  const activeTab = response?.currentData?.meta?.activeTab || 'pending';
 
   const handleAddRelease = async (values: FormValues) => {
     const response = await createRelease({
@@ -283,8 +292,9 @@ const ReleasesPage = () => {
               defaultMessage: 'Releases list',
             })}
             variant="simple"
-            initialSelectedTabIndex={['pending', 'done'].indexOf(activeTab)}
+            initialSelectedTabIndex={activeTabIndex}
             onTabChange={handleTabChange}
+            ref={tabRef}
           >
             <Box paddingBottom={8}>
               <Tabs>


### PR DESCRIPTION
### What does it do?

It solves an issue we had in the TabGroup inside the CMS used in the Markeplace and Content Releases, it doesn't react to the changes of the initialSelectedTabIndex prop

### Why is it needed?

Because for example when you try to use the browser back button or you click on the side bar menu on the left the tabs are not updated with the current selection

### How to test it?

Link this DS version to your CMS and try to, for example, to the Marketplace page admin/marketplace
- then click on the tab Providers
- then use the Back button of the browser you need to see the Plugins tab selected instead of the Providers one


### Related issue(s)/PR(s)

CS-468
