### PR TITLE
chore(content-releases): remove prepublishOnly script

### DIFF
--- a/packages/core/content-releases/package.json
+++ b/packages/core/content-releases/package.json
@@ -44,7 +44,6 @@
     "build": "pack-up build",
     "clean": "run -T rimraf ./dist",
     "lint": "run -T eslint .",
-    "prepublishOnly": "yarn clean && yarn build",
     "test:front": "run -T cross-env IS_EE=true jest --config ./jest.config.front.js",
     "test:front:ce": "run -T cross-env IS_EE=false jest --config ./jest.config.front.js",
     "test:front:watch": "run -T cross-env IS_EE=true jest --config ./jest.config.front.js --watchAll",


### PR DESCRIPTION
### What does it do?

Remove prePublish only script from package.json

### Why is it needed?

- so the package isn't built twice

