### PR TITLE
chore: remove comment about deprecation

### DIFF
--- a/packages/core/data-transfer/src/strapi/providers/remote-source/index.ts
+++ b/packages/core/data-transfer/src/strapi/providers/remote-source/index.ts
@@ -86,7 +86,6 @@ class RemoteStrapiSourceProvider implements ISourceProvider {
       }
 
       // if we get a single items instead of a batch
-      // TODO V5: in v5 only allow array
       for (const item of castArray(data)) {
         stream.push(item);
       }


### PR DESCRIPTION
### What does it do?

removes a comment for something we're not actually deprecating; support for single (non-array) items in data-transfer config 

### Why is it needed?

it's really not a problem to support it, no reason to remove it

### How to test it?



### Related issue(s)/PR(s)


