### PR TITLE
chore: relations tests template for document service

### DIFF
--- a/api-tests/core/strapi/document-service/relations/basic.test.api.ts
+++ b/api-tests/core/strapi/document-service/relations/basic.test.api.ts
@@ -1,0 +1,76 @@
+/**
+ * Create and get relations using the document service.
+ */
+import { LoadedStrapi } from '@strapi/types';
+import { createTestSetup, destroyTestSetup } from '../../../../utils/builder-helper';
+import resources from '../resources/index';
+import { ARTICLE_UID, findArticleDb, AUTHOR_UID, findAuthorDb } from '../utils';
+
+describe('Document Service relations', () => {
+  let testUtils;
+  let strapi: LoadedStrapi;
+
+  beforeAll(async () => {
+    testUtils = await createTestSetup(resources);
+    strapi = testUtils.strapi;
+  });
+
+  afterAll(async () => {
+    await destroyTestSetup(testUtils);
+  });
+
+  // TODO: Test for all type of relations
+  describe('FindOne', () => {
+    it('Can populate top level relations', async () => {
+      const article = await strapi
+        .documents('api::article.article')
+        .findOne('Article1', { locale: 'en', populate: { categories: true } });
+
+      // TODO: Category id should be the document id
+      // expect(article.categories[0].id).toBe('Cat1-En');
+    });
+
+    it.todo('Can populate a nested relation');
+
+    it.todo('Can populate a relation in component');
+
+    it.todo('Can filter by a relation id ');
+
+    it.todo('Can filter by a relation attribute');
+
+    it.todo('Can select fields of relation');
+  });
+
+  describe('Create', () => {
+    it('Can create a document with relations', async () => {
+      const article = await strapi.documents('api::article.article').create({
+        data: {
+          title: 'Article with author',
+          // Connect document id
+          categories: ['Cat1-En'],
+        },
+        populate: { categories: true },
+      });
+
+      // TODO: Category id should be the document id
+      // expect(article.categories[0].id).toBe('Cat1-En');
+    });
+  });
+
+  describe('Update', () => {
+    it('Can update a document with relations', async () => {
+      const article = await strapi.documents('api::article.article').update('Article1', {
+        locale: 'en',
+        data: {
+          title: 'Article with author',
+          // Connect document id
+          categories: ['Cat2-En'],
+        },
+        populate: { categories: true },
+      });
+
+      // TODO: Category id should be the document id
+      // expect(article.categories[0].id).toBe('Cat2-En');
+    });
+  });
+});

--- a/api-tests/core/strapi/document-service/relations/mutations/connect.test.api.ts
+++ b/api-tests/core/strapi/document-service/relations/mutations/connect.test.api.ts
@@ -1,0 +1,44 @@
+/**
+ * Connect relations:
+ *  { connect: [ { id } ] }
+ *  { connect: [ id ] }
+ *  { connect: [ {
+ *      id,
+ *      position: {
+ *        before: id,
+ *        after: id,
+ *        start: boolean,
+ *        end: boolean
+ *      }
+ *  }]}
+ */
+
+import { LoadedStrapi } from '@strapi/types';
+import { createTestSetup, destroyTestSetup } from '../../../../../utils/builder-helper';
+import resources from '../../resources/index';
+
+describe('Connect relations', () => {
+  let testUtils;
+  let strapi: LoadedStrapi;
+
+  beforeAll(async () => {
+    testUtils = await createTestSetup(resources);
+    strapi = testUtils.strapi;
+  });
+
+  afterAll(async () => {
+    await destroyTestSetup(testUtils);
+  });
+
+  // { connect: [ id ] }
+  it.todo('Can connect with shorthand syntax');
+
+  // { connect: [ { id } ] }
+  it.todo('Can connect with longhand syntax');
+
+  // { connect: [ { id, position: { before: id } } ] }
+  it.todo('Can connect with position before');
+
+  // { connect: [ { id, position: { after: id } } ] }
+  it.todo('Can connect with position after');
+});

--- a/api-tests/core/strapi/document-service/relations/mutations/disconnect.test.api.ts
+++ b/api-tests/core/strapi/document-service/relations/mutations/disconnect.test.api.ts
@@ -1,0 +1,29 @@
+/**
+ * Disconnect relations:
+ *  { disconnect: [ { id } ] }
+ *  { disconnect: [ id ] }
+ */
+
+import { LoadedStrapi } from '@strapi/types';
+import { createTestSetup, destroyTestSetup } from '../../../../../utils/builder-helper';
+import resources from '../../resources/index';
+
+describe('Disconnect disconnect', () => {
+  let testUtils;
+  let strapi: LoadedStrapi;
+
+  beforeAll(async () => {
+    testUtils = await createTestSetup(resources);
+    strapi = testUtils.strapi;
+  });
+
+  afterAll(async () => {
+    await destroyTestSetup(testUtils);
+  });
+
+  // { disconnect: [ id ] }
+  it.todo('Can disconnect with shorthand syntax');
+
+  // { disconnect: [ { id } ] }
+  it.todo('Can disconnect with longhand syntax');
+});

--- a/api-tests/core/strapi/document-service/relations/mutations/set.test.api.ts
+++ b/api-tests/core/strapi/document-service/relations/mutations/set.test.api.ts
@@ -1,0 +1,37 @@
+/**
+ * Set relations:
+ *  { set: [ { id } ] }
+ *  { set: [ id ] }
+ *  [ id ]
+ *  [ { id } ]
+ */
+
+import { LoadedStrapi } from '@strapi/types';
+import { createTestSetup, destroyTestSetup } from '../../../../../utils/builder-helper';
+import resources from '../../resources/index';
+
+describe('Set disconnect', () => {
+  let testUtils;
+  let strapi: LoadedStrapi;
+
+  beforeAll(async () => {
+    testUtils = await createTestSetup(resources);
+    strapi = testUtils.strapi;
+  });
+
+  afterAll(async () => {
+    await destroyTestSetup(testUtils);
+  });
+
+  // { set: [ id ] }
+  it.todo('Can set with shorthand syntax');
+
+  // { set: [ { id } ] }
+  it.todo('Can set with longhand syntax');
+
+  // [ id ]
+  it.todo('Can set with array shorthand syntax');
+
+  // [ { id } ]
+  it.todo('Can set with array longhand syntax');
+});

--- a/api-tests/core/strapi/document-service/resources/fixtures/article.json
+++ b/api-tests/core/strapi/document-service/resources/fixtures/article.json
@@ -6,7 +6,8 @@
     "publishedAt": null,
     "password": "$2a$10$4EP.Y8crWYRpfk2rVmmoce8raDqGYVwMlcI//GDQdO6z06bO50igu",
     "private": "private",
-    "locale": "en"
+    "locale": "en",
+    "categories": [1]
   },
   {
     "id": 2,
@@ -15,7 +16,8 @@
     "publishedAt": null,
     "password": null,
     "private": "private",
-    "locale": "en"
+    "locale": "en",
+    "categories": []
   },
   {
     "id": 3,
@@ -24,7 +26,8 @@
     "publishedAt": null,
     "password": null,
     "private": "private",
-    "locale": "fr"
+    "locale": "fr",
+    "categories": [2]
   },
   {
     "id": 4,
@@ -33,7 +36,8 @@
     "publishedAt": null,
     "password": null,
     "private": "private",
-    "locale": "it"
+    "locale": "it",
+    "categories": [3]
   },
   {
     "id": 25,
@@ -42,6 +46,7 @@
     "publishedAt": "2019-01-01T00:00:00.000Z",
     "password": null,
     "private": "private",
-    "locale": "en"
+    "locale": "en",
+    "categories": []
   }
 ]


### PR DESCRIPTION
### What does it do?

This is the first set of tests to validate relations are working at the document service level.

The tests are not filled, this is just so you can review them and agree this is what we want to test :) 

More context of the work needed to do in [CONTENT-2132](https://strapi-inc.atlassian.net/browse/CONTENT-2132)

There will be another list of tests for D&P and i18n interactions (publishing, unpublishing, non localized content types relations, ...)

(At the moment this will work for only a many-to-many relation, but we can extend it for all types of relations in the short term)

[CONTENT-2132]: https://strapi-inc.atlassian.net/browse/CONTENT-2132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ