### PR TITLE
chore(ctb): remove "new" badge on Blocks attribute

### DIFF
--- a/packages/core/content-type-builder/admin/src/components/AttributeOptions/AttributeOption.tsx
+++ b/packages/core/content-type-builder/admin/src/components/AttributeOptions/AttributeOption.tsx
@@ -14,8 +14,7 @@ import { AttributeIcon, IconByType } from '../AttributeIcon';
 
 import { OptionBoxWrapper } from './OptionBoxWrapper';
 
-// TODO: remove blocks from array on 4.16 release (after blocks stable)
-const newAttributes = ['blocks'];
+const newAttributes = [];
 
 const NewBadge = () => (
   <Flex grow={1} justifyContent="flex-end">

--- a/packages/core/content-type-builder/admin/src/components/AttributeOptions/AttributeOption.tsx
+++ b/packages/core/content-type-builder/admin/src/components/AttributeOptions/AttributeOption.tsx
@@ -14,7 +14,7 @@ import { AttributeIcon, IconByType } from '../AttributeIcon';
 
 import { OptionBoxWrapper } from './OptionBoxWrapper';
 
-const newAttributes = [];
+const newAttributes: string[] = [];
 
 const NewBadge = () => (
   <Flex grow={1} justifyContent="flex-end">


### PR DESCRIPTION
### What does it do?

Removes the new tag for blocks in the attribute picker.

I leave the badge component in place for when we'll need it in the future.

### Why is it needed?

It's not new anymore
