### PR TITLE
fix(content-releases): filter releases with entry attached

### DIFF
--- a/packages/core/content-releases/server/src/controllers/__tests__/release.test.ts
+++ b/packages/core/content-releases/server/src/controllers/__tests__/release.test.ts
@@ -1,14 +1,16 @@
 import releaseController from '../release';
 
 const mockFindPage = jest.fn();
-const mockFindManyForContentTypeEntry = jest.fn();
+const mockFindManyWithContentTypeEntryAttached = jest.fn();
+const mockFindManyWithoutContentTypeEntryAttached = jest.fn();
 const mockCountActions = jest.fn();
 
 jest.mock('../../utils', () => ({
   getService: jest.fn(() => ({
     findOne: jest.fn(() => ({ id: 1 })),
     findPage: mockFindPage,
-    findManyForContentTypeEntry: mockFindManyForContentTypeEntry,
+    findManyWithContentTypeEntryAttached: mockFindManyWithContentTypeEntryAttached,
+    findManyWithoutContentTypeEntryAttached: mockFindManyWithoutContentTypeEntryAttached,
     countActions: mockCountActions,
     getContentTypesDataForActions: jest.fn(),
   })),
@@ -19,7 +21,7 @@ describe('Release controller', () => {
   describe('findMany', () => {
     it('should call findPage', async () => {
       mockFindPage.mockResolvedValue({ results: [], pagination: {} });
-      mockFindManyForContentTypeEntry.mockResolvedValue([]);
+      mockFindManyWithContentTypeEntryAttached.mockResolvedValue([]);
       const userAbility = {
         can: jest.fn(),
       };
@@ -53,9 +55,9 @@ describe('Release controller', () => {
       expect(mockFindPage).toHaveBeenCalled();
     });
 
-    it('should call findManyForContentTypeEntry', async () => {
+    it('should call findManyWithoutContentTypeEntryAttached', async () => {
       mockFindPage.mockResolvedValue({ results: [], pagination: {} });
-      mockFindManyForContentTypeEntry.mockResolvedValue([]);
+      mockFindManyWithContentTypeEntryAttached.mockResolvedValue([]);
       const userAbility = {
         can: jest.fn(),
       };
@@ -86,7 +88,7 @@ describe('Release controller', () => {
       // @ts-expect-error partial context
       await releaseController.findMany(ctx);
 
-      expect(mockFindManyForContentTypeEntry).toHaveBeenCalled();
+      expect(mockFindManyWithoutContentTypeEntryAttached).toHaveBeenCalled();
     });
   });
   describe('create', () => {

--- a/packages/core/content-releases/server/src/controllers/release.ts
+++ b/packages/core/content-releases/server/src/controllers/release.ts
@@ -40,9 +40,9 @@ const releaseController = {
       const hasEntryAttached: GetContentTypeEntryReleases.Request['query']['hasEntryAttached'] =
         typeof query.hasEntryAttached === 'string' ? JSON.parse(query.hasEntryAttached) : false;
 
-      const data = await releaseService.findManyForContentTypeEntry(contentTypeUid, entryId, {
-        hasEntryAttached,
-      });
+      const data = hasEntryAttached
+        ? await releaseService.findManyWithContentTypeEntryAttached(contentTypeUid, entryId)
+        : await releaseService.findManyWithoutContentTypeEntryAttached(contentTypeUid, entryId);
 
       ctx.body = { data };
     } else {

--- a/packages/core/content-releases/server/src/services/__tests__/release.test.ts
+++ b/packages/core/content-releases/server/src/services/__tests__/release.test.ts
@@ -279,8 +279,8 @@ describe('release service', () => {
     });
   });
 
-  describe('findManyForContentTypeEntry', () => {
-    it('should format the return value correctly when hasEntryAttached is true', async () => {
+  describe('findManyWithContentTypeEntryAttached', () => {
+    it('should format the return value correctly', async () => {
       const strapiMock = {
         ...baseStrapiMock,
         db: {
@@ -294,12 +294,9 @@ describe('release service', () => {
 
       // @ts-expect-error Ignore missing properties
       const releaseService = createReleaseService({ strapi: strapiMock });
-      const releases = await releaseService.findManyForContentTypeEntry(
+      const releases = await releaseService.findManyWithContentTypeEntryAttached(
         'api::contentType.contentType',
-        1,
-        {
-          hasEntryAttached: true,
-        }
+        1
       );
 
       expect(releases).toEqual([{ name: 'test release', action: { type: 'publish' } }]);


### PR DESCRIPTION
### What does it do?

Change the filter behaviour to fix a bug where we return all releases with 2 or more entries attached. Now only return the releases that doesn't have the entry attached when needed

### How to test it?

1. Go to the Edit View of one entry that is already attached to some release
2. Try to add the entry to a new release
3. In the dropdown you should have only releases where the entry is not attached yet
