### PR TITLE
[CTB] - temporarily disable component unique field checkboxes

### DIFF
--- a/packages/core/content-type-builder/admin/src/components/FormModal/forms/forms.ts
+++ b/packages/core/content-type-builder/admin/src/components/FormModal/forms/forms.ts
@@ -41,6 +41,7 @@ type Base<TAttributesFormType extends 'base' | 'advanced'> = {
   step: string;
   attributes: any;
   extensions: any;
+  forTarget: string;
 };
 
 export const forms = {
@@ -161,7 +162,53 @@ export const forms = {
     form: {
       advanced({ data, type, step, extensions, ...rest }: Base<'advanced'>) {
         try {
-          const baseForm = attributesForm.advanced[type](data, step).sections;
+          const isComponentTarget = ['component', 'components'].includes(rest?.forTarget);
+
+          let baseForm;
+          if (isComponentTarget) {
+            const isUniqueEnabled = data?.unique ?? false;
+
+            // TODO: V5. This is a temporary measure as the behaviour of component unique fields is currently broken and will be worked on later.
+            // We are disabling the unique field checkbox if it's not enabled and if it's enabled we are explaining that it's not working and will be disabled if they change the setting.
+            // Remove this when the behaviour of component unique fields is fixed.
+            baseForm = attributesForm.advanced[type](data, step).sections.map((section) => {
+              //@ts-expect-error temporary measure
+              const filteredItems = section.items.map((item) => {
+                if (item.name !== 'unique') {
+                  return item;
+                }
+
+                if (isUniqueEnabled) {
+                  return {
+                    ...item,
+                    description: {
+                      id: 'content-type-builder.form.attribute.item.uniqueField.v5.willBeDisabled',
+                      defaultMessage:
+                        "Currently unique fields don't work correctly in components. If you disable this feature, the field will be disabled until this is fixed.",
+                    },
+                  };
+                }
+
+                return {
+                  ...item,
+                  disabled: true,
+                  description: {
+                    id: 'content-type-builder.form.attribute.item.uniqueField.v5.disabled',
+                    defaultMessage:
+                      "Currently unique fields don't work correctly in components. This field has been disabled until it's fixed.",
+                  },
+                };
+              });
+
+              return {
+                //@ts-expect-error temporary measure
+                sectionTitle: section?.sectionTitle ?? null,
+                items: filteredItems,
+              };
+            });
+          } else {
+            baseForm = attributesForm.advanced[type](data, step).sections;
+          }
           const itemsToAdd = extensions.getAdvancedForm(['attribute', type], {
             data,
             type,

--- a/packages/core/content-type-builder/admin/src/translations/en.json
+++ b/packages/core/content-type-builder/admin/src/translations/en.json
@@ -104,6 +104,8 @@
   "form.attribute.item.text.regex.description": "The text of the regular expression",
   "form.attribute.item.uniqueField": "Unique field",
   "form.attribute.item.uniqueField.description": "You won't be able to create an entry if there is an existing entry with identical content",
+  "form.attribute.item.uniqueField.v5.willBeDisabled'": "Currently unique fields don't work correctly in components. If you disable this feature, the field will be disabled until this is fixed.",
+  "form.attribute.item.uniqueField.v5.disabled": "Currently unique fields don't work correctly in components. This field has been disabled until it's fixed.",
   "form.attribute.media.allowed-types": "Select allowed types of media",
   "form.attribute.media.allowed-types.option-files": "Files",
   "form.attribute.media.allowed-types.option-images": "Images",


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Temporarily disable CTB checkboxes for component unique fields until their behaviour is fixed

### Why is it needed?

So we can release and fix this behaviour later

### Related issue(s)/PR(s)

CONTENT-2120
