### PR TITLE
chore: remove last circular dep

### DIFF
--- a/packages/providers/upload-local/package.json
+++ b/packages/providers/upload-local/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "@strapi/pack-up": "4.17.1",
-    "@strapi/plugin-upload": "4.17.1",
+    "@strapi/types": "4.17.1",
     "@types/jest": "29.5.2",
     "eslint-config-custom": "4.17.1",
     "memfs": "4.6.0",

--- a/packages/providers/upload-local/src/__tests__/upload-local.test.ts
+++ b/packages/providers/upload-local/src/__tests__/upload-local.test.ts
@@ -5,27 +5,26 @@ jest.mock('fs', () => fs);
 
 import fse from 'fs-extra';
 
-import type { File } from '@strapi/plugin-upload';
-
 import localProvider from '../index';
 
 describe('Local provider', () => {
   beforeAll(() => {
-    globalThis.strapi = {};
-    globalThis.strapi.dirs = { static: { public: '' } };
+    global.strapi = {
+      dirs: { static: { public: '' } },
+    } as any;
 
     fse.ensureDirSync('uploads');
   });
 
   afterAll(() => {
-    globalThis.strapi.dirs = undefined;
+    global.strapi.dirs = undefined as any;
   });
 
   describe('upload', () => {
     test('Should have relative url to file object', async () => {
       const providerInstance = localProvider.init({});
 
-      const file: File = {
+      const file = {
         name: 'test',
         size: 100,
         url: '/',
@@ -34,7 +33,7 @@ describe('Local provider', () => {
         ext: '.json',
         mime: 'application/json',
         buffer: Buffer.from(''),
-      };
+      } as any;
 
       await providerInstance.upload(file);
 

--- a/packages/providers/upload-local/src/global.d.ts
+++ b/packages/providers/upload-local/src/global.d.ts
@@ -1,2 +1,0 @@
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-declare const strapi: any;

--- a/packages/providers/upload-local/src/index.ts
+++ b/packages/providers/upload-local/src/index.ts
@@ -4,6 +4,8 @@ import path from 'path';
 import fse from 'fs-extra';
 import * as utils from '@strapi/utils';
 
+import type {} from '@strapi/types';
+
 interface File {
   name: string;
   alternativeText?: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -10211,7 +10211,7 @@ __metadata:
   resolution: "@strapi/provider-upload-local@workspace:packages/providers/upload-local"
   dependencies:
     "@strapi/pack-up": "npm:4.17.1"
-    "@strapi/plugin-upload": "npm:4.17.1"
+    "@strapi/types": "npm:4.17.1"
     "@strapi/utils": "npm:4.17.1"
     "@types/jest": "npm:29.5.2"
     eslint-config-custom: "npm:4.17.1"


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

> Wait for this to be merged 1st https://github.com/strapi/strapi/pull/19261

### What does it do?

Removes the last circular deps (plugin-upload / upload-locale) and fixes the typings as `@strapi/plugin-upload` doesn't export any type at the moment

### Why is it needed?

to fix circular deps

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
