### PR TITLE
fix(admin): append query params to audit logs request

### DIFF
--- a/packages/core/admin/ee/admin/src/services/auditLogs.ts
+++ b/packages/core/admin/ee/admin/src/services/auditLogs.ts
@@ -6,7 +6,9 @@ const auditLogsService = adminApi.injectEndpoints({
     getAuditLogs: builder.query<AuditLogs.GetAll.Response, AuditLogs.GetAll.Request['query']>({
       query: (params) => ({
         url: `/admin/audit-logs`,
-        params,
+        config: {
+          params,
+        },
       }),
     }),
     getAuditLog: builder.query<AuditLogs.Get.Response, AuditLogs.Get.Params['id']>({


### PR DESCRIPTION
### What does it do?

Audit logs request is not appending the query params to the url because we send the params in the wrong field.

### How to test it?

1. Go to the Audit Logs page
2. It should work when you change page, apply filters, etc...