### PR TITLE
fix(content-releases): hide the More button in the CM Edit View with no permission

### DIFF
--- a/packages/core/content-releases/admin/src/components/CMReleasesContainer.tsx
+++ b/packages/core/content-releases/admin/src/components/CMReleasesContainer.tsx
@@ -356,12 +356,14 @@ export const CMReleasesContainer = () => {
                   <Typography fontSize={2} fontWeight="bold" variant="omega" textColor="neutral700">
                     {release.name}
                   </Typography>
-                  <ReleaseActionMenu.Root hasTriggerBorder>
-                    <ReleaseActionMenu.DeleteReleaseActionItem
-                      releaseId={release.id}
-                      actionId={release.action.id}
-                    />
-                  </ReleaseActionMenu.Root>
+                  <CheckPermissions permissions={PERMISSIONS.deleteAction}>
+                    <ReleaseActionMenu.Root hasTriggerBorder>
+                      <ReleaseActionMenu.DeleteReleaseActionItem
+                        releaseId={release.id}
+                        actionId={release.action.id}
+                      />
+                    </ReleaseActionMenu.Root>
+                  </CheckPermissions>
                 </Flex>
               </Flex>
             );

--- a/packages/providers/upload-aws-s3/README.md
+++ b/packages/providers/upload-aws-s3/README.md
@@ -48,10 +48,10 @@ module.exports = ({ env }) => ({
       providerOptions: {
         baseUrl: env('CDN_URL'),
         rootPath: env('CDN_ROOT_PATH'),
-        s3Options: {  
+        s3Options: {
           credentials: {
-            accessKeyId: env("AWS_ACCESS_KEY_ID"),
-            secretAccessKey: env("AWS_ACCESS_SECRET"),
+            accessKeyId: env('AWS_ACCESS_KEY_ID'),
+            secretAccessKey: env('AWS_ACCESS_SECRET'),
           },
           region: env('AWS_REGION'),
           params: {
@@ -90,8 +90,8 @@ module.exports = ({ env }) => ({
       provider: 'aws-s3',
       providerOptions: {
         credentials: {
-          accessKeyId: env("AWS_ACCESS_KEY_ID"),
-          secretAccessKey: env("AWS_ACCESS_SECRET"),
+          accessKeyId: env('AWS_ACCESS_KEY_ID'),
+          secretAccessKey: env('AWS_ACCESS_SECRET'),
         },
         region: env('AWS_REGION'),
         params: {
@@ -124,8 +124,8 @@ module.exports = ({ env }) => ({
       provider: 'aws-s3',
       providerOptions: {
         credentials: {
-          accessKeyId: env("SCALEWAY_ACCESS_KEY_ID"),
-          secretAccessKey: env("SCALEWAY_ACCESS_SECRET"),
+          accessKeyId: env('SCALEWAY_ACCESS_KEY_ID'),
+          secretAccessKey: env('SCALEWAY_ACCESS_SECRET'),
         },
         endpoint: env('SCALEWAY_ENDPOINT'), // e.g. "s3.fr-par.scw.cloud"
         params: {


### PR DESCRIPTION
### What does it do?

it hides the More button on the Edit view if you don't have permission to remove an action from a release

### Why is it needed?

Otherwise, we show an empty dropdown

### How to test it?

- Create a new user with a Role different than super admin
- then as a super admin add an entry to a Release
- change the permission of the new user role and disable the "Remove an entry from a release" permission
- in a new tab login with the user editor and go to the Edit View of the entry added to the Release
- then in the Release action in the Edit view the more button needs to be hidden

### Related issue(s)/PR(s)

it solves this issue

https://github.com/strapi/strapi/assets/2589748/f6d774ae-974f-4e4e-8292-2df1763515ca


