### PR TITLE
fix(content-releases): Don't allow pending releases with the same name

### DIFF
--- a/packages/core/content-releases/server/src/services/__tests__/release-validation.test.ts
+++ b/packages/core/content-releases/server/src/services/__tests__/release-validation.test.ts
@@ -114,6 +114,7 @@ describe('Release Validation service', () => {
       );
     });
   });
+
   describe('validatePendingReleasesLimit', () => {
     it('should throw an error if the default pending release limit has been reached', () => {
       // @ts-expect-error - get is a mock
@@ -196,6 +197,31 @@ describe('Release Validation service', () => {
       const releaseValidationService = createReleaseValidationService({ strapi: strapiMock });
 
       await expect(releaseValidationService.validatePendingReleasesLimit()).resolves.not.toThrow();
+    });
+  });
+
+  describe('validateUniqueNameForPendingRelease', () => {
+    it('should throw an error if a release with the same name already exists', async () => {
+      const strapiMock = {
+        ...baseStrapiMock,
+        entityService: {
+          findMany: jest.fn().mockReturnValue([
+            {
+              name: 'release1',
+            },
+            {
+              name: 'release2',
+            },
+          ]),
+        },
+      };
+
+      // @ts-expect-error Ignore missing properties
+      const releaseValidationService = createReleaseValidationService({ strapi: strapiMock });
+
+      await expect(
+        releaseValidationService.validateUniqueNameForPendingRelease('release1')
+      ).rejects.toThrow('Release with name release1 already exists');
     });
   });
 });

--- a/packages/core/content-releases/server/src/services/__tests__/release-validation.test.ts
+++ b/packages/core/content-releases/server/src/services/__tests__/release-validation.test.ts
@@ -209,9 +209,6 @@ describe('Release Validation service', () => {
             {
               name: 'release1',
             },
-            {
-              name: 'release2',
-            },
           ]),
         },
       };
@@ -222,6 +219,22 @@ describe('Release Validation service', () => {
       await expect(
         releaseValidationService.validateUniqueNameForPendingRelease('release1')
       ).rejects.toThrow('Release with name release1 already exists');
+    });
+
+    it('should pass if a release with the same name does NOT already exist', async () => {
+      const strapiMock = {
+        ...baseStrapiMock,
+        entityService: {
+          findMany: jest.fn().mockReturnValue([]),
+        },
+      };
+
+      // @ts-expect-error Ignore missing properties
+      const releaseValidationService = createReleaseValidationService({ strapi: strapiMock });
+
+      await expect(
+        releaseValidationService.validateUniqueNameForPendingRelease('release1')
+      ).resolves.not.toThrow();
     });
   });
 });

--- a/packages/core/content-releases/server/src/services/release.ts
+++ b/packages/core/content-releases/server/src/services/release.ts
@@ -52,7 +52,15 @@ const createReleaseService = ({ strapi }: { strapi: LoadedStrapi }) => ({
   async create(releaseData: CreateRelease.Request['body'], { user }: { user: UserInfo }) {
     const releaseWithCreatorFields = await setCreatorFields({ user })(releaseData);
 
-    await getService('release-validation', { strapi }).validatePendingReleasesLimit();
+    const { validatePendingReleasesLimit, validateUniqueNameForPendingRelease } = getService(
+      'release-validation',
+      { strapi }
+    );
+
+    await Promise.all([
+      validatePendingReleasesLimit(),
+      validateUniqueNameForPendingRelease(releaseWithCreatorFields.name),
+    ]);
 
     return strapi.entityService.create(RELEASE_MODEL_UID, {
       data: releaseWithCreatorFields,

--- a/packages/core/content-releases/server/src/services/validation.ts
+++ b/packages/core/content-releases/server/src/services/validation.ts
@@ -75,10 +75,11 @@ const createReleaseValidationService = ({ strapi }: { strapi: LoadedStrapi }) =>
         releasedAt: {
           $null: true,
         },
+        name,
       },
     })) as Release[];
 
-    const isNameUnique = !pendingReleases.some((release) => release.name === name);
+    const isNameUnique = pendingReleases.length === 0;
 
     if (!isNameUnique) {
       throw new errors.ValidationError(`Release with name ${name} already exists`);


### PR DESCRIPTION
### What does it do?

Add a new validation to check the release user is trying to create doesn't have the same name that another pending release

### How to test it?

1. Create one release with "X" name
2. Try to create another release with the same name
3. It should show an error
