### PR TITLE
fix(upload-aws-s3): prettier error in readme

### DIFF
--- a/packages/providers/upload-aws-s3/README.md
+++ b/packages/providers/upload-aws-s3/README.md
@@ -231,8 +231,8 @@ upload: {
     provider: 'aws-s3',
     providerOptions: {
       credentials: {
-          accessKeyId: process.env.AWS_ACCESS_KEY_ID,
-          secretAccessKey: process.env.AWS_ACCESS_SECRET,
+        accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+        secretAccessKey: process.env.AWS_ACCESS_SECRET,
       },
       region: process.env.AWS_REGION,
       baseUrl: `https://s3.${region}.amazonaws.com/${bucket}`, // This line sets the custom url format


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Use 2-space indentation instead of 4 in s3 readme
### Why is it needed?

It made the prettier check fail on PRs

### How to test it?

~~Check the CI~~ (edit: it won't run since it's just a readme change)
### Related issue(s)/PR(s)

#19169