### PR TITLE
chore: remove experimental logs for plugin CLI commands

### DIFF
--- a/packages/core/strapi/src/cli/commands/plugin/build.ts
+++ b/packages/core/strapi/src/cli/commands/plugin/build.ts
@@ -4,7 +4,7 @@ import chalk from 'chalk';
 import { BuildCLIOptions, ConfigBundle, build } from '@strapi/pack-up';
 
 import { forceOption } from '../../utils/commander';
-import { runAction, notifyExperimentalCommand } from '../../utils/helpers';
+import { runAction } from '../../utils/helpers';
 import { Export, loadPkg, validatePkg } from '../../utils/pkg';
 import type { CLIContext, StrapiCommand } from '../../types';
 
@@ -22,11 +22,6 @@ const action = async (
      * ALWAYS set production for using plugin build CLI.
      */
     process.env.NODE_ENV = 'production';
-    /**
-     * Notify users this is an experimental command and get them to approve first
-     * this can be opted out by setting the argument --force
-     */
-    await notifyExperimentalCommand('plugin:build', { force });
 
     const pkg = await loadPkg({ cwd, logger });
     const pkgJson = await validatePkg({ pkg });

--- a/packages/core/strapi/src/cli/commands/plugin/init/action.ts
+++ b/packages/core/strapi/src/cli/commands/plugin/init/action.ts
@@ -12,7 +12,6 @@ import {
   TemplateFile,
 } from '@strapi/pack-up';
 import { outdent } from 'outdent';
-import { notifyExperimentalCommand } from '../../../utils/helpers';
 
 import { CLIContext } from '../../../types';
 import { gitIgnoreFile } from './files/gitIgnore';
@@ -25,11 +24,6 @@ export default async (
   { logger, cwd }: CLIContext
 ) => {
   try {
-    /**
-     * Notify users this is an experimental command. We don't need to get them to approve first.
-     */
-    await notifyExperimentalCommand('plugin:init', { force: true });
-
     /**
      * Create the package // plugin
      */

--- a/packages/core/strapi/src/cli/commands/plugin/link-watch.ts
+++ b/packages/core/strapi/src/cli/commands/plugin/link-watch.ts
@@ -6,7 +6,7 @@ import path from 'node:path';
 import nodemon from 'nodemon';
 import { outdent } from 'outdent';
 
-import { notifyExperimentalCommand, runAction } from '../../utils/helpers';
+import { runAction } from '../../utils/helpers';
 import type { CLIContext, StrapiCommand } from '../../types';
 import { loadPkg, validatePkg } from '../../utils/pkg';
 
@@ -14,11 +14,6 @@ interface ActionOptions {}
 
 const action = async (_opts: ActionOptions, _cmd: unknown, { cwd, logger }: CLIContext) => {
   try {
-    /**
-     * Notify users this is an experimental command.
-     */
-    await notifyExperimentalCommand('plugin:watch:link', { force: true });
-
     const outDir = './dist';
     const extensions = 'ts,js,png,svg,gif,jpeg,css';
 

--- a/packages/core/strapi/src/cli/commands/plugin/verify.ts
+++ b/packages/core/strapi/src/cli/commands/plugin/verify.ts
@@ -2,18 +2,13 @@ import boxen from 'boxen';
 import chalk from 'chalk';
 import { CheckOptions, check } from '@strapi/pack-up';
 
-import { runAction, notifyExperimentalCommand } from '../../utils/helpers';
+import { runAction } from '../../utils/helpers';
 import type { StrapiCommand, CLIContext } from '../../types';
 
 interface ActionOptions extends CheckOptions {}
 
 const action = async (opts: ActionOptions, _cmd: unknown, { cwd, logger }: CLIContext) => {
   try {
-    /**
-     * Notify users this is an experimental command.
-     */
-    await notifyExperimentalCommand('plugin:verify', { force: true });
-
     await check({
       cwd,
       ...opts,

--- a/packages/core/strapi/src/cli/commands/plugin/watch.ts
+++ b/packages/core/strapi/src/cli/commands/plugin/watch.ts
@@ -3,7 +3,7 @@ import boxen from 'boxen';
 import chalk from 'chalk';
 import { ConfigBundle, WatchCLIOptions, watch } from '@strapi/pack-up';
 
-import { runAction, notifyExperimentalCommand } from '../../utils/helpers';
+import { runAction } from '../../utils/helpers';
 import { Export, loadPkg, validatePkg } from '../../utils/pkg';
 import type { StrapiCommand, CLIContext } from '../../types';
 
@@ -11,11 +11,6 @@ interface ActionOptions extends WatchCLIOptions {}
 
 const action = async (opts: ActionOptions, _cmd: unknown, { cwd, logger }: CLIContext) => {
   try {
-    /**
-     * Notify users this is an experimental command.
-     */
-    await notifyExperimentalCommand('plugin:watch', { force: true });
-
     const pkg = await loadPkg({ cwd, logger });
     const pkgJson = await validatePkg({ pkg });
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* removes experimental logs from the plugin commands

### Why is it needed?

* they're not experimental

### How to test it?

* there shouldn't be any logs from the plugins being built

### Related issue(s)/PR(s)

* resolves CONTENT-2151
