### PR TITLE
fix(cm): pass params to post requests for publish & unpublish

### DIFF
--- a/api-tests/plugins/i18n/content-manager/crud.test.api.js
+++ b/api-tests/plugins/i18n/content-manager/crud.test.api.js
@@ -86,9 +86,12 @@ describe('i18n - Content API', () => {
     test('non-default locale', async () => {
       const res = await rq({
         method: 'POST',
-        url: '/content-manager/collection-types/api::category.category?plugins[i18n][locale]=ko',
+        url: '/content-manager/collection-types/api::category.category',
         body: {
           name: 'category in korean',
+        },
+        qs: {
+          locale: 'ko',
         },
       });
 
@@ -112,7 +115,8 @@ describe('i18n - Content API', () => {
           method: 'POST',
           url: `/content-manager/collection-types/api::category.category`,
           qs: {
-            plugins: { i18n: { locale, relatedEntityId: data.categories[0].id } },
+            plugins: { i18n: { relatedEntityId: data.categories[0].id } },
+            locale,
           },
           body: {
             name: `category in ${locale}`,

--- a/api-tests/plugins/i18n/locales.test.api.js
+++ b/api-tests/plugins/i18n/locales.test.api.js
@@ -398,7 +398,7 @@ describe('CRUD locales', () => {
       const { body: frenchProduct } = await rq({
         url: '/content-manager/collection-types/api::product.product',
         method: 'POST',
-        qs: { plugins: { i18n: { locale: 'fr-FR' } } },
+        qs: { locale: 'fr-FR' },
         body: { name: 'product name' },
       });
 

--- a/packages/core/admin/admin/src/content-manager/components/ContentTypeFormWrapper.tsx
+++ b/packages/core/admin/admin/src/content-manager/components/ContentTypeFormWrapper.tsx
@@ -161,6 +161,8 @@ const ContentTypeFormWrapper = ({
     };
   }, [dispatch]);
 
+  const validParams = React.useMemo(() => buildValidGetParams(query), [query]);
+
   React.useEffect(() => {
     const CancelToken = axios.CancelToken;
     const source = CancelToken.source();
@@ -175,7 +177,7 @@ const ContentTypeFormWrapper = ({
       try {
         const { data } = await fetchClient.get(requestURL, {
           cancelToken: source.token,
-          params: buildValidGetParams(query),
+          params: validParams,
         });
 
         dispatch(getDataSucceeded(cleanReceivedData(data)));
@@ -235,7 +237,7 @@ const ContentTypeFormWrapper = ({
     redirectionLink,
     toggleNotification,
     isSingleType,
-    query,
+    validParams,
   ]);
 
   const displayErrors = React.useCallback(
@@ -316,7 +318,7 @@ const ContentTypeFormWrapper = ({
             : `/content-manager/${collectionType}/${slug}`,
           isCloning ? restBody : body,
           {
-            params: query,
+            params: validParams,
           }
         );
 
@@ -360,7 +362,7 @@ const ContentTypeFormWrapper = ({
       put,
       post,
       slug,
-      query,
+      validParams,
       trackUsage,
       toggleNotification,
       setCurrentStep,
@@ -411,7 +413,11 @@ const ContentTypeFormWrapper = ({
       const { data } = await post<Contracts.CollectionTypes.Publish.Response>(
         isSingleType
           ? `/content-manager/${collectionType}/${slug}/actions/publish`
-          : `/content-manager/${collectionType}/${slug}/${id}/actions/publish`
+          : `/content-manager/${collectionType}/${slug}/${id}/actions/publish`,
+        undefined,
+        {
+          params: validParams,
+        }
       );
 
       trackUsage('didPublishEntry');
@@ -442,6 +448,7 @@ const ContentTypeFormWrapper = ({
     collectionType,
     slug,
     id,
+    validParams,
     cleanReceivedData,
     toggleNotification,
     displayErrors,
@@ -459,7 +466,7 @@ const ContentTypeFormWrapper = ({
           AxiosResponse<Contracts.CollectionTypes.Update.Response>,
           Contracts.CollectionTypes.Update.Request['body']
         >(`/content-manager/${collectionType}/${slug}/${id}`, body, {
-          params: query,
+          params: validParams,
         });
 
         trackUsage('didEditEntry', trackerProperty);
@@ -495,6 +502,7 @@ const ContentTypeFormWrapper = ({
       collectionType,
       slug,
       id,
+      validParams,
       toggleNotification,
       queryClient,
       cleanReceivedData,
@@ -511,7 +519,11 @@ const ContentTypeFormWrapper = ({
       const { data } = await post<Contracts.CollectionTypes.Unpublish.Response>(
         isSingleType
           ? `/content-manager/${collectionType}/${slug}/actions/unpublish`
-          : `/content-manager/${collectionType}/${slug}/${id}/actions/unpublish`
+          : `/content-manager/${collectionType}/${slug}/${id}/actions/unpublish`,
+        undefined,
+        {
+          params: validParams,
+        }
       );
 
       trackUsage('didUnpublishEntry');
@@ -539,6 +551,7 @@ const ContentTypeFormWrapper = ({
     collectionType,
     slug,
     id,
+    validParams,
     toggleNotification,
     cleanReceivedData,
     displayErrors,

--- a/packages/plugins/i18n/server/src/controllers/validate-locale-creation.ts
+++ b/packages/plugins/i18n/server/src/controllers/validate-locale-creation.ts
@@ -23,7 +23,7 @@ const validateLocaleCreation: Common.MiddlewareHandler = async (ctx, next) => {
     return next();
   }
 
-  const locale = get('plugins.i18n.locale', query);
+  const locale = get('locale', query);
   const relatedEntityId = get('plugins.i18n.relatedEntityId', query);
   // cleanup to avoid creating duplicates in singletypes
   ctx.request.query = {};


### PR DESCRIPTION
resolves #19289

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* passes query params to the post requests for publish & unpublish calls

### Why is it needed?

* in single-types you use the `locale` query param to understand what actions should target which entity as opposed to the ID, this was missing so all actions were directed at the default locale.

### How to test it?

* ensure single-type is localised
* publish first locale
* navigate to second locale & publish (it should publish)
* unpublish first locale
* unpublish second locale (previously this would not have worked)

### Related issue(s)/PR(s)

* resolves #19289
* resolves CONTENT-2176
