### PR TITLE
fix(i18n): locale swapping with content-types & D&P disabled

### DIFF
--- a/packages/plugins/i18n/admin/src/components/CMEditViewLocalePicker.tsx
+++ b/packages/plugins/i18n/admin/src/components/CMEditViewLocalePicker.tsx
@@ -82,7 +82,12 @@ const CMEditViewLocalePicker = ({
       return;
     }
 
-    if (status === 'did-not-create-locale') {
+    /**
+     * TODO: if D&P is not enabled, then the status will always say there's no locale so
+     * we also should check there's no ID incase. This logic will be removed in V5 when
+     * we _always_ have D&P.
+     */
+    if (status === 'did-not-create-locale' && !id) {
       push({
         pathname: `/content-manager/collection-types/${slug}/create`,
         search: stringify(defaultParams, { encode: false }),


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* checks if there's an ID as well before we try to create a new locale entry

### Why is it needed?

* locales without D&P would be given the status of "we don't have a draft or published" which is true, but we still had the ID signifying that it existed.

### How to test it?

* Have a content-type without D&P enabled & i18n enabled
* save default locale of content-type
* swap to alternate locale (should be empty form)
* swap back to original (should be filled)

### Related issue(s)/PR(s)

* resolves CONTENT-2177
* resolves #19267
