### PR TITLE
chore: cleanup core utils org

### DIFF
--- a/packages/core/core/src/utils/__tests__/convert-custom-field-type.test.ts
+++ b/packages/core/core/src/utils/__tests__/convert-custom-field-type.test.ts
@@ -1,4 +1,4 @@
-import convertCustomFieldType from '../convert-custom-field-type';
+import { convertCustomFieldType } from '../convert-custom-field-type';
 
 describe('format attributes', () => {
   it('replaces type customField with the underlying data type', () => {

--- a/packages/core/core/src/utils/__tests__/filepath-to-prop-path.test.ts
+++ b/packages/core/core/src/utils/__tests__/filepath-to-prop-path.test.ts
@@ -1,4 +1,4 @@
-import filePathToPropPath from '../filepath-to-prop-path';
+import { filePathToPropPath } from '../filepath-to-prop-path';
 
 const commonCases: [string, string[]][] = [
   ['./config/test.js', ['config', 'test']],

--- a/packages/core/core/src/utils/addSlash.ts
+++ b/packages/core/core/src/utils/addSlash.ts
@@ -1,9 +1,0 @@
-export default (path: string) => {
-  let tmpPath = path;
-  if (typeof tmpPath !== 'string') throw new Error('admin.url must be a string');
-  if (tmpPath === '' || tmpPath === '/') return '/';
-
-  if (tmpPath[0] !== '/') tmpPath = `/${tmpPath}`;
-  if (tmpPath[tmpPath.length - 1] !== '/') tmpPath += '/';
-  return tmpPath;
-};

--- a/packages/core/core/src/utils/convert-custom-field-type.ts
+++ b/packages/core/core/src/utils/convert-custom-field-type.ts
@@ -7,7 +7,7 @@ type InputAttributes = {
   };
 };
 
-const convertCustomFieldType = (strapi: Strapi) => {
+export const convertCustomFieldType = (strapi: Strapi) => {
   const allContentTypeSchemaAttributes = Object.values(strapi.contentTypes).map(
     (schema) => schema.attributes
   );
@@ -29,5 +29,3 @@ const convertCustomFieldType = (strapi: Strapi) => {
     }
   }
 };
-
-export default convertCustomFieldType;

--- a/packages/core/core/src/utils/ee.ts
+++ b/packages/core/core/src/utils/ee.ts
@@ -1,3 +1,1 @@
-import EE from '../ee';
-
-export default EE;
+export { default as ee } from '../ee';

--- a/packages/core/core/src/utils/fetch.ts
+++ b/packages/core/core/src/utils/fetch.ts
@@ -4,7 +4,7 @@ import { ProxyAgent } from 'undici';
 // TODO: once core Node exposes a stable way to create a ProxyAgent we will use that instead of undici
 
 // Create a wrapper for Node's Fetch API that applies a global proxy
-export function createStrapiFetch(strapi: Strapi): Fetch {
+export const createStrapiFetch = (strapi: Strapi): Fetch => {
   function strapiFetch(url: RequestInfo | URL, options?: RequestInit) {
     const fetchOptions = {
       ...(strapiFetch.dispatcher ? { dispatcher: strapiFetch.dispatcher } : {}),
@@ -22,6 +22,6 @@ export function createStrapiFetch(strapi: Strapi): Fetch {
   }
 
   return strapiFetch;
-}
+};
 
 export type { Fetch };

--- a/packages/core/core/src/utils/filepath-to-prop-path.ts
+++ b/packages/core/core/src/utils/filepath-to-prop-path.ts
@@ -3,7 +3,7 @@ import _ from 'lodash';
 /**
  * Returns a path (as an array) from a file path
  */
-export default (filePath: string, useFileNameAsKey = true) => {
+export const filePathToPropPath = (filePath: string, useFileNameAsKey = true) => {
   const cleanPath = filePath.startsWith('./') ? filePath.slice(2) : filePath;
 
   const prop = cleanPath

--- a/packages/core/core/src/utils/get-dirs.ts
+++ b/packages/core/core/src/utils/get-dirs.ts
@@ -6,7 +6,7 @@ export type Options = {
   dist: string;
 };
 
-const getDirs = (
+export const getDirs = (
   { app: appDir, dist: distDir }: Options,
   { strapi }: { strapi: Strapi }
 ): StrapiDirectories => ({
@@ -34,5 +34,3 @@ const getDirs = (
     public: resolve(appDir, strapi.config.get('server.dirs.public')),
   },
 });
-
-export default getDirs;

--- a/packages/core/core/src/utils/index.ts
+++ b/packages/core/core/src/utils/index.ts
@@ -1,5 +1,11 @@
-import openBrowser from './open-browser';
-import isInitialized from './is-initialized';
-import getDirs from './get-dirs';
-
-export { isInitialized, openBrowser, getDirs };
+export { openBrowser } from './open-browser';
+export { isInitialized } from './is-initialized';
+export { getDirs } from './get-dirs';
+export { ee } from './ee';
+export { createUpdateNotifier } from './update-notifier';
+export { createStrapiFetch, Fetch } from './fetch';
+export { convertCustomFieldType } from './convert-custom-field-type';
+export { createStartupLogger } from './startup-logger';
+export { transformContentTypesToModels } from './transform-content-types-to-models';
+export { destroyOnSignal } from './signals';
+export { LIFECYCLES } from './lifecycles';

--- a/packages/core/core/src/utils/is-initialized.ts
+++ b/packages/core/core/src/utils/is-initialized.ts
@@ -5,7 +5,7 @@ import type { Strapi } from '@strapi/types';
 /**
  * Test if the strapi application is considered as initialized (1st user has been created)
  */
-export default async function isInitialized(strapi: Strapi): Promise<boolean> {
+export const isInitialized = async (strapi: Strapi): Promise<boolean> => {
   try {
     if (isEmpty(strapi.admin)) {
       return true;
@@ -18,4 +18,4 @@ export default async function isInitialized(strapi: Strapi): Promise<boolean> {
   } catch (err) {
     strapi.stopWithError(err);
   }
-}
+};

--- a/packages/core/core/src/utils/load-files.ts
+++ b/packages/core/core/src/utils/load-files.ts
@@ -4,18 +4,18 @@ import fse from 'fs-extra';
 
 import { importDefault } from '@strapi/utils';
 import { glob } from 'glob';
-import filePathToPath from './filepath-to-prop-path';
+import { filePathToPropPath } from './filepath-to-prop-path';
 
 /**
  * Returns an Object build from a list of files matching a glob pattern in a directory
  * It builds a tree structure resembling the folder structure in dir
  */
-export async function loadFiles<T extends object>(
+export const loadFiles = async <T extends object>(
   dir: string,
   pattern: string,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   { requireFn = importDefault, shouldUseFileNameAsKey = (_: any) => true, globArgs = {} } = {}
-): Promise<T> {
+): Promise<T> => {
   const root = {};
   const files = await glob(pattern, { cwd: dir, ...globArgs });
 
@@ -39,11 +39,11 @@ export async function loadFiles<T extends object>(
       value: path.basename(file),
     });
 
-    const propPath = filePathToPath(file, shouldUseFileNameAsKey(file));
+    const propPath = filePathToPropPath(file, shouldUseFileNameAsKey(file));
 
     if (propPath.length === 0) _.merge(root, mod);
     _.merge(root, _.setWith({}, propPath, mod, Object));
   }
 
   return root as T;
-}
+};

--- a/packages/core/core/src/utils/open-browser.ts
+++ b/packages/core/core/src/utils/open-browser.ts
@@ -2,10 +2,8 @@ import open from 'open';
 
 import type { ConfigProvider } from '@strapi/types';
 
-async function openBrowser(config: ConfigProvider) {
+export const openBrowser = async (config: ConfigProvider) => {
   const url = config.get<string>('admin.absoluteUrl');
 
   return open(url);
-}
-
-export default openBrowser;
+};

--- a/packages/core/core/src/utils/startup-logger.ts
+++ b/packages/core/core/src/utils/startup-logger.ts
@@ -4,7 +4,7 @@ import _ from 'lodash/fp';
 
 import type { Strapi } from '@strapi/types';
 
-export default (app: Strapi) => {
+export const createStartupLogger = (app: Strapi) => {
   return {
     logStats() {
       const columns = Math.min(process.stderr.columns, 80) - 2;

--- a/packages/core/core/src/utils/update-notifier/index.ts
+++ b/packages/core/core/src/utils/update-notifier/index.ts
@@ -31,7 +31,7 @@ Check out the new releases at: ${releaseLink}
 `.trim();
 };
 
-const createUpdateNotifier = (strapi: Strapi) => {
+export const createUpdateNotifier = (strapi: Strapi) => {
   let config: InstanceType<typeof Configstore>;
 
   try {
@@ -101,5 +101,3 @@ const createUpdateNotifier = (strapi: Strapi) => {
     },
   };
 };
-
-export default createUpdateNotifier;


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

- Remove default exports
- Using import * to reduce number of imports and scope all the utils inside the utils folder (avoid importing sub paths)

### Why is it needed?

cleanup / prep for the lint changes

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
