### PR TITLE
fix(dts): exclude content-releases

### DIFF
--- a/packages/core/data-transfer/src/commands/data-transfer.ts
+++ b/packages/core/data-transfer/src/commands/data-transfer.ts
@@ -117,6 +117,8 @@ const DEFAULT_IGNORED_CONTENT_TYPES = [
   'admin::transfer-token',
   'admin::transfer-token-permission',
   'admin::audit-log',
+  'plugin::content-releases.release',
+  'plugin::content-releases.release-action',
 ];
 
 const abortTransfer = async ({


### PR DESCRIPTION
What does it do?
It excludes releases from dts

Why is it needed?
The relations with user are broken, not sure on a product level if want them included
