### PR TITLE
Throw error when components have same collectionName

### DIFF
--- a/packages/core/content-type-builder/admin/src/components/FormModal/FormModal.tsx
+++ b/packages/core/content-type-builder/admin/src/components/FormModal/FormModal.tsx
@@ -365,6 +365,10 @@ export const FormModal = () => {
         modifiedData.category || '',
         reservedNames,
         actionType === 'edit',
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        components,
+        modifiedData.displayName || '',
         get(allDataSchema, [...pathToSchema, 'uid'], null)
         // ctbFormsAPI
       );
@@ -387,7 +391,9 @@ export const FormModal = () => {
         Object.keys(components) as Common.UID.Component[],
         get(modifiedData, 'componentToCreate.category', ''),
         reservedNames,
-        ctbFormsAPI
+        ctbFormsAPI,
+        components,
+        modifiedData.displayName || ''
       );
 
       // Check form validity for creating a 'common attribute'
@@ -440,7 +446,9 @@ export const FormModal = () => {
           Object.keys(components) as Common.UID.Component[],
           get(modifiedData, 'componentToCreate.category', ''),
           reservedNames,
-          ctbFormsAPI
+          ctbFormsAPI,
+          components,
+          modifiedData.displayName || ''
         );
       } else {
         // The form is valid

--- a/packages/core/content-type-builder/admin/src/components/FormModal/component/createComponentSchema.ts
+++ b/packages/core/content-type-builder/admin/src/components/FormModal/component/createComponentSchema.ts
@@ -8,7 +8,9 @@ import { createComponentUid } from '../utils/createUid';
 export const createComponentSchema = (
   usedComponentNames: Array<string>,
   reservedNames: Array<string>,
-  category: string
+  category: string,
+  takenCollectionNames: Array<string>,
+  currentCollectionName: string
 ) => {
   const shape = {
     displayName: yup
@@ -20,10 +22,12 @@ export const createComponentSchema = (
           if (!value) {
             return false;
           }
-
           const name = createComponentUid(value, category);
 
-          return !usedComponentNames.includes(name);
+          return (
+            !usedComponentNames.includes(name) &&
+            !takenCollectionNames.includes(currentCollectionName)
+          );
         },
       })
       .test({

--- a/packages/core/content-type-builder/admin/src/components/FormModal/forms/forms.ts
+++ b/packages/core/content-type-builder/admin/src/components/FormModal/forms/forms.ts
@@ -12,6 +12,7 @@ import { createContentTypeSchema } from '../contentType/createContentTypeSchema'
 import { dynamiczoneForm } from '../dynamiczoneForm';
 
 import { addItemsToFormSection, FormTypeOptions } from './utils/addItemsToFormSection';
+import { createComponentCollectionName } from './utils/createCollectionName';
 import { Attribute, getUsedAttributeNames, SchemaData } from './utils/getUsedAttributeNames';
 
 import type { Common } from '@strapi/types';
@@ -308,13 +309,34 @@ export const forms = {
         models: any;
       },
       isEditing = false,
+      components: Record<string, any>,
+      componentDisplayName: string,
       compoUid: Common.UID.Component | null = null
     ) {
       const takenNames = isEditing
         ? alreadyTakenAttributes.filter((uid: Common.UID.Component) => uid !== compoUid)
         : alreadyTakenAttributes;
 
-      return createComponentSchema(takenNames, reservedNames.models, componentCategory);
+      const collectionNames = Object.values(components).map((component: any) => {
+        return component?.schema?.collectionName;
+      });
+
+      const currentCollectionName = createComponentCollectionName(
+        componentDisplayName,
+        componentCategory
+      );
+
+      const takenCollectionNames = isEditing
+        ? collectionNames.filter((collectionName) => collectionName !== currentCollectionName)
+        : collectionNames;
+
+      return createComponentSchema(
+        takenNames,
+        reservedNames.models,
+        componentCategory,
+        takenCollectionNames,
+        currentCollectionName
+      );
     },
     form: {
       advanced() {

--- a/packages/core/content-type-builder/admin/src/components/FormModal/forms/utils/createCollectionName.ts
+++ b/packages/core/content-type-builder/admin/src/components/FormModal/forms/utils/createCollectionName.ts
@@ -1,0 +1,8 @@
+import { snakeCase } from 'lodash/fp';
+import pluralize from 'pluralize';
+
+const createComponentCollectionName = (name: string, category: string) => {
+  return `components_${snakeCase(category)}_${pluralize(snakeCase(name))}`;
+};
+
+export { createComponentCollectionName };

--- a/packages/core/content-type-builder/server/src/services/schema-builder/component-builder.ts
+++ b/packages/core/content-type-builder/server/src/services/schema-builder/component-builder.ts
@@ -41,6 +41,12 @@ export default function createComponentBuilder() {
         infos.category
       )}_${nameToCollectionName(pluralize(infos.displayName))}`;
 
+      this.components.forEach((compo: any) => {
+        if (compo.schema.collectionName === collectionName) {
+          throw new ApplicationError('component.alreadyExists');
+        }
+      });
+
       handler
         .setUID(uid)
         .set('collectionName', collectionName)


### PR DESCRIPTION
### What does it do?

Add checks on the server and frontend for components collection name, so server doesn't crash

### Why is it needed?

- Server crashed when adding a component that has the same plural as another component, example : new and news

### How to test it?

- create a component named new, and then try to create one named news, it should give an error message 
