### PR TITLE
feat(history): add history-version content type

### DIFF
--- a/packages/core/content-manager/server/src/history/content-types/history-version.ts
+++ b/packages/core/content-manager/server/src/history/content-types/history-version.ts
@@ -1,0 +1,60 @@
+import type { Plugin } from '@strapi/types';
+
+const historyVersion: Plugin.LoadedPlugin['contentTypes'][string] = {
+  schema: {
+    uid: 'plugin::content-manager.history-version',
+    modelName: 'history-version',
+    globalId: 'ContentManagerHistoryVersion',
+    kind: 'collectionType',
+    modelType: 'contentType',
+    collectionName: 'strapi_history_versions',
+    info: {
+      singularName: 'history-version',
+      pluralName: 'history-versions',
+      displayName: 'History Version',
+    },
+    pluginOptions: {
+      'content-manager': {
+        visible: false,
+      },
+      'content-type-builder': {
+        visible: false,
+      },
+    },
+    attributes: {
+      contentType: {
+        type: 'string',
+        required: true,
+      },
+      // relatedId is a reserved attribute name
+      relatedDocumentId: {
+        type: 'string',
+        required: true,
+      },
+      locale: {
+        type: 'string',
+        required: false,
+      },
+      status: {
+        type: 'enumeration',
+        enum: ['draft', 'published', 'modified'],
+      },
+      data: {
+        type: 'json',
+      },
+      schema: {
+        type: 'json',
+      },
+      createdAt: {
+        type: 'date',
+      },
+      createdBy: {
+        type: 'relation',
+        relation: 'oneToOne',
+        target: 'admin::user',
+      },
+    },
+  },
+};
+
+export { historyVersion };

--- a/packages/core/content-manager/server/src/history/content-types/index.ts
+++ b/packages/core/content-manager/server/src/history/content-types/index.ts
@@ -1,0 +1,5 @@
+import { historyVersion } from './history-version';
+
+export const contentTypes = {
+  'history-version': historyVersion,
+};

--- a/packages/core/content-manager/server/src/history/index.ts
+++ b/packages/core/content-manager/server/src/history/index.ts
@@ -1,6 +1,7 @@
 import type { Plugin } from '@strapi/types';
 import { controllers } from './controllers';
 import { services } from './services';
+import { contentTypes } from './content-types';
 
 /**
  * Check once if the feature is enabled (both license info & feature flag) before loading it,
@@ -22,10 +23,15 @@ const getFeature = (): Partial<Plugin.LoadedPlugin> => {
       controllers,
       services,
       destroy,
+      contentTypes,
     };
   }
 
-  return {};
+  /**
+   * Keep returning contentTypes to avoid losing the data if the feature is disabled,
+   * or if the license expires.
+   */
+  return { contentTypes };
 };
 
 export default getFeature();

--- a/packages/core/content-manager/server/src/index.ts
+++ b/packages/core/content-manager/server/src/index.ts
@@ -5,6 +5,7 @@ import routes from './routes';
 import policies from './policies';
 import controllers from './controllers';
 import services from './services';
+import history from './history';
 
 export default () => {
   return {
@@ -15,5 +16,6 @@ export default () => {
     routes,
     policies,
     services,
+    contentTypes: history.contentTypes,
   };
 };


### PR DESCRIPTION
### What does it do?

Registers a history version content type. It's a content type for now, but it will converted to a model later when Alex finished his database model API proposal.

I had to add a few unusual fields (modelName, globalId) because they were mandatory in the type. I checked against all the other content types at runtime to make sure I matched the right format.

### Why is it needed?

To later store content history data

### How to test it?

- build strapi
- run `yarn strapi console`
- paste `strapi.contentTypes['plugin::content-manager.history-version']`
- you should see the model
