### PR TITLE
fix(content-manager): bug on level 2 repeatable component populate

### DIFF
--- a/packages/core/content-manager/server/src/services/utils/populate.ts
+++ b/packages/core/content-manager/server/src/services/utils/populate.ts
@@ -156,7 +156,7 @@ const getDeepPopulate = (
           model,
           {
             // @ts-expect-error - improve types
-            initialPopulate: initialPopulate?.[attributeName],
+            initialPopulate: initialPopulate?.[attributeName] || initialPopulate?.populate?.[attributeName],
             countMany,
             countOne,
             maxLevel,


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

If we consume the content-manager API with populate query on repeatable component, it will always return the count. In short: we cannot overwrite it. 

### Why is it needed?

The recursive function of getDeepPopulate tried to get `initialPopulate?.[attributeName]` meanwhile sometimes the initialPopulate value is wrapped in a "populate" attribute, so we need a fallback to `initialPopulate?.populate?.[attributeName]`

### How to test it?

Try call the content-manager controllers and pass populate query on repeatable component, for example: ```{ populate: { repeatableComponent: { field1: true }}}```, it should return the relations, not the count

### Related issue(s)/PR(s)

None
