### PR TITLE
chore(debugging): enable sourceMap for Typescript debugging

### DIFF
--- a/packages/utils/typescript/tsconfigs/server.json
+++ b/packages/utils/typescript/tsconfigs/server.json
@@ -6,6 +6,7 @@
     "moduleResolution": "Node",
     "lib": ["ES2020"],
     "target": "ES2019",
+    "sourceMap": true,
 
     "strict": false,
     "skipLibCheck": true,


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

When I attach a debugger from my editor (VSCode), my breakpoints don't work.
It can be obscure for many devs and it's better to make it work out of the box.

### Why is it needed?

It's a sane default and I can't think of any problem with having it 🤔 

### How to test it?

Simply generate a typescript project, launch the project, attach a debugger, try out your breakpoints.

### Related issue(s)/PR(s)

No issue related.
