### PR TITLE
Make reserved attribute name validations case insensitive

### DIFF
--- a/packages/core/content-type-builder/server/src/controllers/validation/__tests__/content-type.test.ts
+++ b/packages/core/content-type-builder/server/src/controllers/validation/__tests__/content-type.test.ts
@@ -76,6 +76,41 @@ describe('Content type validator', () => {
         });
       });
     });
+
+    test('Throws when case-insensitive reserved names are used', async () => {
+      const data = {
+        contentType: {
+          singularName: 'test',
+          pluralName: 'tests',
+          displayName: 'Test',
+          attributes: {
+            THISISRESERVED: {
+              type: 'string',
+              default: '',
+            },
+          },
+        },
+      } as unknown as CreateContentTypeInput;
+
+      expect.assertions(1);
+
+      await validateUpdateContentTypeInput(data).catch((err) => {
+        expect(err).toMatchObject({
+          name: 'ValidationError',
+          message: 'Attribute keys cannot be one of __component, __contentType, thisIsReserved',
+          details: {
+            errors: [
+              {
+                path: ['contentType', 'attributes', 'THISISRESERVED'],
+                message:
+                  'Attribute keys cannot be one of __component, __contentType, thisIsReserved',
+                name: 'ValidationError',
+              },
+            ],
+          },
+        });
+      });
+    });
   });
 
   describe('validateContentTypeInput', () => {

--- a/packages/core/content-type-builder/server/src/controllers/validation/content-type.ts
+++ b/packages/core/content-type-builder/server/src/controllers/validation/content-type.ts
@@ -140,7 +140,11 @@ const forbiddenContentTypeNameValidator = () => {
     name: 'forbiddenContentTypeName',
     message: `Content Type name cannot be one of ${reservedNames.join(', ')}`,
     test(value: unknown) {
-      return !(value && reservedNames.includes(value as string));
+      // test for a case-insensitive match
+      const lowercaseValue = (value as string)?.toLowerCase();
+      return !(
+        lowercaseValue && reservedNames.map((name) => name.toLowerCase()).includes(lowercaseValue)
+      );
     },
   };
 };

--- a/packages/core/content-type-builder/server/src/controllers/validation/model-schema.ts
+++ b/packages/core/content-type-builder/server/src/controllers/validation/model-schema.ts
@@ -65,10 +65,13 @@ const createAttributesValidator = ({ types, modelType, relations }: CreateAttrib
 };
 
 const isForbiddenKey = (key: string) => {
-  return [
+  const forbiddenKeys = [
     ...FORBIDDEN_ATTRIBUTE_NAMES,
     ...getService('builder').getReservedNames().attributes,
-  ].includes(key);
+  ];
+
+  // check for a case-insensitive match
+  return forbiddenKeys.some((forbiddenKey) => forbiddenKey.toLowerCase() === key.toLowerCase());
 };
 
 const forbiddenValidator = () => {


### PR DESCRIPTION
Please don't waste time reviewing this yet until I move it out of draft, I need to do a lot of testing and some more thinking to make sure this is a valid approach (and that it's not a breaking change in v4; it's very possible that there are some reserved keywords that don't break based on case-sensitivity, and this could be a breaking change if it stops those from working unneccessarily)

### What does it do?

Makes validation on reserved attribute and content type names case-insensitive

Huge side note:

This and any follow-up PRs coming in the following days are quick-fixes to stop Strapi from breaking. Long term, we are going to investigate each restricted keyword and find out why they are restricted, and ideally fix the core issue with each one to give more flexibility in naming.

### Why is it needed?

It's a large component of the [tracking issue about reserved names](https://github.com/strapi/strapi/issues/16222).

### How to test it?

Try to create an attribute with the name 'ID' (among others) and now it should be blocked.

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/issues/16222
