### PR TITLE
fix: skip flakey test

### DIFF
--- a/packages/utils/pack-up/src/__tests__/cli.test.ts
+++ b/packages/utils/pack-up/src/__tests__/cli.test.ts
@@ -3,7 +3,7 @@ import { spawn } from '../../tests/spawn';
 /**
  * This has issues running in the CI due to how yarn3 works.
  */
-describe('cli', () => {
+describe.skip('cli', () => {
   const timeout = 1000 * 120;
 
   describe('build & check', () => {


### PR DESCRIPTION
### What does it do?

Skip pack-up build test, this is going to be removed before the v5 release and it's a bit flakey.
