### PR TITLE
Case insensitive validation for model and attribute names

### DIFF
--- a/packages/core/content-type-builder/server/src/controllers/validation/__tests__/content-type.test.ts
+++ b/packages/core/content-type-builder/server/src/controllers/validation/__tests__/content-type.test.ts
@@ -15,7 +15,7 @@ describe('Content type validator', () => {
           builder: {
             getReservedNames() {
               return {
-                models: [],
+                models: ['reserved-name'],
                 attributes: ['thisIsReserved'],
               };
             },
@@ -41,7 +41,7 @@ describe('Content type validator', () => {
     });
   });
 
-  describe('Prevents use of reservedNames', () => {
+  describe('Prevents use of reservedNames in attributes', () => {
     test('Throws when reserved names are used', async () => {
       const data = {
         contentType: {
@@ -69,6 +69,79 @@ describe('Content type validator', () => {
                 path: ['contentType', 'attributes', 'thisIsReserved'],
                 message:
                   'Attribute keys cannot be one of __component, __contentType, thisIsReserved',
+                name: 'ValidationError',
+              },
+            ],
+          },
+        });
+      });
+    });
+
+    test('Throws when case-insensitive reserved names are used', async () => {
+      const data = {
+        contentType: {
+          singularName: 'test',
+          pluralName: 'tests',
+          displayName: 'Test',
+          attributes: {
+            tHISISRESERVED: {
+              type: 'string',
+              default: '',
+            },
+          },
+        },
+      } as unknown as CreateContentTypeInput;
+
+      expect.assertions(1);
+
+      await validateUpdateContentTypeInput(data).catch((err) => {
+        expect(err).toMatchObject({
+          name: 'ValidationError',
+          message: 'Attribute keys cannot be one of __component, __contentType, thisIsReserved',
+          details: {
+            errors: [
+              {
+                path: ['contentType', 'attributes', 'tHISISRESERVED'],
+                message:
+                  'Attribute keys cannot be one of __component, __contentType, thisIsReserved',
+                name: 'ValidationError',
+              },
+            ],
+          },
+        });
+      });
+    });
+  });
+
+  describe('Prevents use of reservedNames in models', () => {
+    const reservedNames = ['singularName', 'pluralName'];
+
+    test.each(reservedNames)('Throws when reserved model names are used in %s', async (name) => {
+      const data = {
+        contentType: {
+          singularName: name === 'singularName' ? 'reserved-name' : 'not-reserved-single',
+          pluralName: name === 'pluralName' ? 'reserved-name' : 'not-reserved-plural',
+          displayName: 'Test',
+          attributes: {
+            notReserved: {
+              type: 'string',
+              default: '',
+            },
+          },
+        },
+      } as unknown as CreateContentTypeInput;
+
+      expect.assertions(1);
+
+      await validateUpdateContentTypeInput(data).catch((err) => {
+        expect(err).toMatchObject({
+          name: 'ValidationError',
+          message: `Content Type name cannot be one of reserved-name`,
+          details: {
+            errors: [
+              {
+                path: ['contentType', name],
+                message: `Content Type name cannot be one of reserved-name`,
                 name: 'ValidationError',
               },
             ],

--- a/packages/core/content-type-builder/server/src/controllers/validation/content-type.ts
+++ b/packages/core/content-type-builder/server/src/controllers/validation/content-type.ts
@@ -139,7 +139,11 @@ const forbiddenContentTypeNameValidator = () => {
     name: 'forbiddenContentTypeName',
     message: `Content Type name cannot be one of ${reservedNames.join(', ')}`,
     test(value: unknown) {
-      return !(value && reservedNames.includes(value as string));
+      // test for a case-insensitive match
+      const lowercaseValue = (value as string)?.toLowerCase();
+      return !(
+        lowercaseValue && reservedNames.map((name) => name.toLowerCase()).includes(lowercaseValue)
+      );
     },
   };
 };
@@ -157,7 +161,8 @@ const nameIsAvailable = (isEdition: boolean) => {
       // don't check on edition
       if (isEdition) return true;
 
-      return !usedNames.includes(value as string);
+      const lowercaseValue = (value as string)?.toLowerCase();
+      return !usedNames.some((name: string) => name.toLowerCase() === lowercaseValue);
     },
   };
 };
@@ -165,7 +170,7 @@ const nameIsAvailable = (isEdition: boolean) => {
 const nameIsNotExistingCollectionName = (isEdition: boolean) => {
   const usedNames = Object.keys(strapi.contentTypes).map(
     (key) => strapi.contentTypes[key as UID.ContentType].collectionName
-  );
+  ) as string[];
 
   return {
     name: 'nameAlreadyUsed',
@@ -174,7 +179,8 @@ const nameIsNotExistingCollectionName = (isEdition: boolean) => {
       // don't check on edition
       if (isEdition) return true;
 
-      return !usedNames.includes(value as string);
+      const lowercaseValue = (value as string)?.toLowerCase();
+      return !usedNames.some((name: string) => name.toLowerCase() === lowercaseValue);
     },
   };
 };

--- a/packages/core/content-type-builder/server/src/controllers/validation/model-schema.ts
+++ b/packages/core/content-type-builder/server/src/controllers/validation/model-schema.ts
@@ -64,10 +64,13 @@ const createAttributesValidator = ({ types, modelType, relations }: CreateAttrib
 };
 
 const isForbiddenKey = (key: string) => {
-  return [
+  const forbiddenKeys = [
     ...FORBIDDEN_ATTRIBUTE_NAMES,
     ...getService('builder').getReservedNames().attributes,
-  ].includes(key);
+  ];
+
+  // check for a case-insensitive match
+  return forbiddenKeys.some((forbiddenKey) => forbiddenKey.toLowerCase() === key.toLowerCase());
 };
 
 const forbiddenValidator = () => {


### PR DESCRIPTION
### What does it do?

Adds case-insensitivity to the validators for:

- reserved model names
- reserved attribute names
- existing singularName and pluralName

#### NOTE

This is just one of many coming PRs for this issue. The long term goal is to eliminate reserving keywords wherever possible (for example, there's no technical reason '__component' or 'where' can't be used as 

### Why is it needed?

Most of our reserved words (like 'id') are blocked by the validation, but Strapi still breaks and won't start when a different case is used (like 'ID')

Considering we use these identifiers in various applications (database names across postgres, mysql, sqlite; graphql and rest api names) every keyword type should have a case-insensitive validation on it to ensure compatibility.

### How to test it?

Try using the CTB to create an attribute or content type with a restricted name (some examples [here](https://github.com/strapi/strapi/blob/4ec8ea5faf24f8b581420877e9bd84e8ae790a0f/packages/core/content-type-builder/server/src/services/builder.ts#L1)) or an existing name (that is, create a content type singularName "apple" and another one called "APPLE" and it should be blocked)

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/issues/16222
