### PR TITLE
[breaking change] Remove the TOrigin Type Param for Attribute.Relation

### DIFF
--- a/packages/core/types/src/modules/documents/params/attributes.ts
+++ b/packages/core/types/src/modules/documents/params/attributes.ts
@@ -91,8 +91,7 @@ export type GetValue<TAttribute extends Attribute.Attribute> = Utils.Expression.
       // Relation
       [
         Utils.Expression.Extends<TAttribute, Attribute.OfType<'relation'>>,
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        TAttribute extends Attribute.Relation<infer _TOrigin, infer TRelationKind, infer TTarget>
+        TAttribute extends Attribute.Relation<infer TRelationKind, infer TTarget>
           ? Utils.Expression.If<
               Utils.Expression.IsNotNever<TTarget>,
               Attribute.RelationPluralityModifier<TRelationKind, ID>

--- a/packages/core/types/src/modules/entity-service/params/attributes/index.ts
+++ b/packages/core/types/src/modules/entity-service/params/attributes/index.ts
@@ -63,8 +63,7 @@ export type GetValue<
       // Relation
       [
         Utils.Expression.Extends<TAttribute, Attribute.OfType<'relation'>>,
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        TAttribute extends Attribute.Relation<infer _TOrigin, infer TRelationKind, infer TTarget>
+        TAttribute extends Attribute.Relation<infer TRelationKind, infer TTarget>
           ? Utils.Expression.If<
               Utils.Expression.IsNotNever<TTarget>,
               RelationInputValue<TRelationKind>

--- a/packages/core/types/src/types/core/attributes/relation.ts
+++ b/packages/core/types/src/types/core/attributes/relation.ts
@@ -3,12 +3,6 @@ import type { Attribute, Common } from '..';
 import type { Utils } from '../..';
 
 export type Relation<
-  // TODO: TOrigin was originally needed to infer precise attribute literal types by doing a reverse lookup
-  // on TTarget -> TOrigin relations. Due to errors because of Attribute.Any [relation] very generic
-  // representation, type mismatches were encountered and mappedBy/inversedBy are now regular strings.
-  // It is kept to allow for future iterations without breaking the current type API
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  _TOrigin extends Common.UID.Schema = Common.UID.Schema,
   TRelationKind extends RelationKind.Any = RelationKind.Any,
   TTarget extends Common.UID.ContentType = Common.UID.ContentType
 > = Attribute.OfType<'relation'> &
@@ -107,8 +101,6 @@ export type RelationValue<
 > = RelationPluralityModifier<TRelationKind, Attribute.GetValues<TTarget>>;
 
 export type GetRelationValue<TAttribute extends Attribute.Attribute> = TAttribute extends Relation<
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  infer _TOrigin,
   infer TRelationKind,
   infer TTarget
 >
@@ -116,8 +108,6 @@ export type GetRelationValue<TAttribute extends Attribute.Attribute> = TAttribut
   : never;
 
 export type GetRelationTarget<TAttribute extends Attribute.Attribute> = TAttribute extends Relation<
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  infer _TOrigin,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   infer _TRelationKind,
   infer TTarget

--- a/packages/utils/typescript/lib/__tests__/generators/schemas/attributes.test.js
+++ b/packages/utils/typescript/lib/__tests__/generators/schemas/attributes.test.js
@@ -256,16 +256,13 @@ describe('Attributes', () => {
 
           defaultAssertions(typeNode, 'Attribute.Relation');
 
-          expect(typeNode.typeArguments).toHaveLength(3);
+          expect(typeNode.typeArguments).toHaveLength(2);
 
           expect(typeNode.typeArguments[0].kind).toBe(ts.SyntaxKind.StringLiteral);
-          expect(typeNode.typeArguments[0].text).toBe('api::foo.foo');
+          expect(typeNode.typeArguments[0].text).toBe('oneToOne');
 
           expect(typeNode.typeArguments[1].kind).toBe(ts.SyntaxKind.StringLiteral);
-          expect(typeNode.typeArguments[1].text).toBe('oneToOne');
-
-          expect(typeNode.typeArguments[2].kind).toBe(ts.SyntaxKind.StringLiteral);
-          expect(typeNode.typeArguments[2].text).toBe('api::bar.bar');
+          expect(typeNode.typeArguments[1].text).toBe('api::bar.bar');
         });
 
         test('Polymorphic relation', () => {
@@ -274,13 +271,10 @@ describe('Attributes', () => {
 
           defaultAssertions(typeNode, 'Attribute.Relation');
 
-          expect(typeNode.typeArguments).toHaveLength(2);
+          expect(typeNode.typeArguments).toHaveLength(1);
 
           expect(typeNode.typeArguments[0].kind).toBe(ts.SyntaxKind.StringLiteral);
-          expect(typeNode.typeArguments[0].text).toBe('api::foo.foo');
-
-          expect(typeNode.typeArguments[1].kind).toBe(ts.SyntaxKind.StringLiteral);
-          expect(typeNode.typeArguments[1].text).toBe('morphMany');
+          expect(typeNode.typeArguments[0].text).toBe('morphMany');
         });
       });
 

--- a/packages/utils/typescript/lib/generators/common/models/mappers.js
+++ b/packages/utils/typescript/lib/generators/common/models/mappers.js
@@ -69,7 +69,7 @@ module.exports = {
     params.push(...targetFieldParams);
 
     // If the options property is defined, transform it to
-    // a type literral node and add it to the params list
+    // a type literal node and add it to the params list
     if (_.isObject(options)) {
       params.push(toTypeLiteral(options));
     }
@@ -93,25 +93,18 @@ module.exports = {
   media() {
     return [withAttributeNamespace('Media')];
   },
-  relation({ uid, attribute }) {
+  relation({ attribute }) {
     const { relation, target } = attribute;
 
     const isMorphRelation = relation.toLowerCase().includes('morph');
 
     if (isMorphRelation) {
-      return [
-        withAttributeNamespace('Relation'),
-        [factory.createStringLiteral(uid, true), factory.createStringLiteral(relation, true)],
-      ];
+      return [withAttributeNamespace('Relation'), [factory.createStringLiteral(relation, true)]];
     }
 
     return [
       withAttributeNamespace('Relation'),
-      [
-        factory.createStringLiteral(uid, true),
-        factory.createStringLiteral(relation, true),
-        factory.createStringLiteral(target, true),
-      ],
+      [factory.createStringLiteral(relation, true), factory.createStringLiteral(target, true)],
     ];
   },
   component({ attribute }) {


### PR DESCRIPTION
### What does it do?

The `TOrigin` type param for `Attribute.Relation` was deprecated in V4 and is not used.

This PR aims to remove it completely (from the usage in the code & from the type gen)

Update unit tests

### Why is it needed?

Cleanup types

### How to test it?

Make sure types that depend on `Attribute.Relation` stills work properly and that the type generation no longer adds the `TOrigin` type param to generated types

