### PR TITLE
Extract locale from query strings

### DIFF
--- a/api-tests/plugins/i18n/content-manager/crud.test.api.js
+++ b/api-tests/plugins/i18n/content-manager/crud.test.api.js
@@ -86,9 +86,12 @@ describe('i18n - Content API', () => {
     test('non-default locale', async () => {
       const res = await rq({
         method: 'POST',
-        url: '/content-manager/collection-types/api::category.category?plugins[i18n][locale]=ko',
+        url: '/content-manager/collection-types/api::category.category',
         body: {
           name: 'category in korean',
+        },
+        qs: {
+          locale: 'ko',
         },
       });
 
@@ -112,7 +115,8 @@ describe('i18n - Content API', () => {
           method: 'POST',
           url: `/content-manager/collection-types/api::category.category`,
           qs: {
-            plugins: { i18n: { locale, relatedEntityId: data.categories[0].id } },
+            plugins: { i18n: { relatedEntityId: data.categories[0].id } },
+            locale,
           },
           body: {
             name: `category in ${locale}`,

--- a/api-tests/plugins/i18n/locales.test.api.js
+++ b/api-tests/plugins/i18n/locales.test.api.js
@@ -398,7 +398,7 @@ describe('CRUD locales', () => {
       const { body: frenchProduct } = await rq({
         url: '/content-manager/collection-types/api::product.product',
         method: 'POST',
-        qs: { plugins: { i18n: { locale: 'fr-FR' } } },
+        qs: { locale: 'fr-FR' },
         body: { name: 'product name' },
       });
 

--- a/packages/plugins/i18n/server/src/controllers/validate-locale-creation.ts
+++ b/packages/plugins/i18n/server/src/controllers/validate-locale-creation.ts
@@ -23,7 +23,7 @@ const validateLocaleCreation: Common.MiddlewareHandler = async (ctx, next) => {
     return next();
   }
 
-  const locale = get('plugins.i18n.locale', query);
+  const locale = get('locale', query);
   const relatedEntityId = get('plugins.i18n.relatedEntityId', query);
   // cleanup to avoid creating duplicates in singletypes
   ctx.request.query = {};


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Changes where we extract the locale from in query strings

From `query.plugins.i18n.locale` to `query.locale`

### Why is it needed?

To support how we are sending locales in the CM

### How to test it?

Provide information about the environment and the path to verify the behaviour.

